### PR TITLE
perf: faster mobile loads — server-side cover art resizing, streaming /api proxy, lazy video.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Service-worker image cache keys no longer include the rotating auth token, so cached cover art survives the daily token rotation instead of being re-downloaded every 24 hours.
+- Stopping or pausing playback while the lazy-loaded Video.js engine chunk is still downloading now cancels the pending track load instead of starting playback against the user's intent; the previously playing track is also halted immediately when a segmented stream is selected.
 
 ## [1.5.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Service-worker image cache keys no longer include the rotating auth token, so cached cover art survives the daily token rotation instead of being re-downloaded every 24 hours.
-- Stopping or pausing playback while the lazy-loaded Video.js engine chunk is still downloading now cancels the pending track load instead of starting playback against the user's intent; the previously playing track is also halted immediately when a segmented stream is selected.
+- Pausing playback while the lazy-loaded Video.js engine chunk is still downloading now completes the pending track load with autoplay suppressed (instead of silently dropping it), and pressing play during the download starts the queued track once ready rather than restarting the previous source from position 0; stopping still cancels the pending load, and the previously playing track is halted immediately when a segmented stream is selected.
 - The custom server's backend proxies (`/api`, `/rest`, Listen Together socket) now register their error handlers through the http-proxy-middleware v3 `on.error` API, restoring the structured 503 JSON response (`{ error, code }`) when the backend is unreachable — the previous v2-style `onError` option was silently ignored, so clients received hpm's plain-text default error instead.
 
 ## [1.5.0] - 2026-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Cover art is now resized server-side to the requested size (snapped to a 64–768px allowlist, never upscaled) and served as WebP when the browser supports it, instead of shipping multi-megapixel originals to thumbnail-sized renders. Resized variants are cached in Redis per size+format, and native cover files are downscaled on the fly.
+- Cover art is now resized server-side to the requested size (snapped to a 64–768px allowlist, never upscaled) and served as WebP when the browser supports it, instead of shipping multi-megapixel originals to thumbnail-sized renders. Resized variants are cached in Redis per size+format for both external and native (on-disk) covers — native variants are keyed by file identity (path, mtime, size) so conditional revalidations are answered without re-decoding.
 - All `/api` traffic is now streamed through the custom server's proxy (like `/rest` and the Listen Together socket) instead of being buffered by a Next.js route handler, preserving backend gzip compression and response streaming. The route handler remains as a fallback.
 - The Video.js segmented-playback engine is lazy-loaded only when a DASH/segmented stream is selected, removing ~730 kB of JavaScript from every page's first load (home route JS: 2065 kB → 1336 kB).
 - Social presence and notification/download polling now pause while the app tab is hidden and refetch immediately when it becomes visible again, cutting background network chatter on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to soundspan are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Cover art is now resized server-side to the requested size (snapped to a 64–768px allowlist, never upscaled) and served as WebP when the browser supports it, instead of shipping multi-megapixel originals to thumbnail-sized renders. Resized variants are cached in Redis per size+format, and native cover files are downscaled on the fly.
+- All `/api` traffic is now streamed through the custom server's proxy (like `/rest` and the Listen Together socket) instead of being buffered by a Next.js route handler, preserving backend gzip compression and response streaming. The route handler remains as a fallback.
+- The Video.js segmented-playback engine is lazy-loaded only when a DASH/segmented stream is selected, removing ~730 kB of JavaScript from every page's first load (home route JS: 2065 kB → 1336 kB).
+- Social presence and notification/download polling now pause while the app tab is hidden and refetch immediately when it becomes visible again, cutting background network chatter on mobile.
+
+### Fixed
+
+- Service-worker image cache keys no longer include the rotating auth token, so cached cover art survives the daily token rotation instead of being re-downloaded every 24 hours.
+
 ## [1.5.0] - 2026-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Service-worker image cache keys no longer include the rotating auth token, so cached cover art survives the daily token rotation instead of being re-downloaded every 24 hours.
 - Stopping or pausing playback while the lazy-loaded Video.js engine chunk is still downloading now cancels the pending track load instead of starting playback against the user's intent; the previously playing track is also halted immediately when a segmented stream is selected.
+- The custom server's backend proxies (`/api`, `/rest`, Listen Together socket) now register their error handlers through the http-proxy-middleware v3 `on.error` API, restoring the structured 503 JSON response (`{ error, code }`) when the backend is unreachable — the previous v2-style `onError` option was silently ignored, so clients received hpm's plain-text default error instead.
 
 ## [1.5.0] - 2026-03-27
 

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -193,6 +193,7 @@ jest.mock("../../services/coverArtResize", () => {
 });
 
 import crypto from "crypto";
+import path from "path";
 import router from "../library";
 import { redisClient } from "../../utils/redis";
 import { fetchExternalImage } from "../../services/imageProxy";
@@ -499,6 +500,9 @@ describe("library cover-art proxy compatibility", () => {
         const existsSpy = jest
             .spyOn(fs, "existsSync")
             .mockReturnValue(true);
+        const statSpy = jest
+            .spyOn(fs.promises, "stat")
+            .mockResolvedValue({ mtimeMs: 1718000000000, size: 4096 } as fs.Stats);
         const readSpy = jest
             .spyOn(fs.promises, "readFile")
             .mockResolvedValue(Buffer.from("native-bytes"));
@@ -529,6 +533,117 @@ describe("library cover-art proxy compatibility", () => {
         expect(res.body).toEqual(Buffer.from("native-resized"));
 
         existsSpy.mockRestore();
+        statSpy.mockRestore();
+        readSpy.mockRestore();
+    });
+
+    it("caches resized native cover variants in Redis keyed by file identity, size, and format", async () => {
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValue(true);
+        const statSpy = jest
+            .spyOn(fs.promises, "stat")
+            .mockResolvedValue({ mtimeMs: 1718000000000, size: 4096 } as fs.Stats);
+        const readSpy = jest
+            .spyOn(fs.promises, "readFile")
+            .mockResolvedValue(Buffer.from("native-bytes"));
+        const resizedBuffer = Buffer.from("native-resized");
+        mockResizeCoverArt.mockResolvedValue({
+            buffer: resizedBuffer,
+            contentType: "image/webp",
+            resized: true,
+        });
+
+        const req = {
+            query: { url: "native:albums/album-123.jpg", size: "128" },
+            params: {},
+            headers: { accept: "image/webp,*/*" },
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        const cachePath = path.resolve(
+            "/tmp/soundspan-cache",
+            "../covers",
+            "albums/album-123.jpg"
+        );
+        const expectedKey = `cover-art:native:${crypto
+            .createHash("md5")
+            .update(`${cachePath}-1718000000000-4096-128-webp`)
+            .digest("hex")}`;
+        const expectedEtag = crypto
+            .createHash("md5")
+            .update(resizedBuffer)
+            .digest("hex");
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            expectedKey,
+            90 * 24 * 60 * 60,
+            JSON.stringify({
+                etag: expectedEtag,
+                contentType: "image/webp",
+                data: resizedBuffer.toString("base64"),
+            })
+        );
+        expect(res.headers["ETag"]).toBe(expectedEtag);
+        expect(res.body).toEqual(resizedBuffer);
+
+        existsSpy.mockRestore();
+        statSpy.mockRestore();
+        readSpy.mockRestore();
+    });
+
+    it("serves cached native variants and answers If-None-Match without re-decoding", async () => {
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValue(true);
+        const statSpy = jest
+            .spyOn(fs.promises, "stat")
+            .mockResolvedValue({ mtimeMs: 1718000000000, size: 4096 } as fs.Stats);
+        const readSpy = jest.spyOn(fs.promises, "readFile");
+        const cachedBuffer = Buffer.from("cached-native-resized");
+        const cachedEtag = "etag-native-cached";
+        mockRedisGet.mockResolvedValue(
+            JSON.stringify({
+                etag: cachedEtag,
+                contentType: "image/webp",
+                data: cachedBuffer.toString("base64"),
+            })
+        );
+
+        const req = {
+            query: { url: "native:albums/album-123.jpg", size: "128" },
+            params: {},
+            headers: { accept: "image/webp,*/*" },
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(res.headers["Content-Type"]).toBe("image/webp");
+        expect(res.headers["ETag"]).toBe(cachedEtag);
+        expect(res.body).toEqual(cachedBuffer);
+
+        const conditionalReq = {
+            query: { url: "native:albums/album-123.jpg", size: "128" },
+            params: {},
+            headers: {
+                accept: "image/webp,*/*",
+                "if-none-match": cachedEtag,
+            },
+        } as any;
+        const conditionalRes = createRes();
+
+        await coverArtHandler(conditionalReq, conditionalRes);
+
+        expect(conditionalRes.statusCode).toBe(304);
+        expect(conditionalRes.end).toHaveBeenCalled();
+        expect(readSpy).not.toHaveBeenCalled();
+        expect(mockResizeCoverArt).not.toHaveBeenCalled();
+        expect(mockRedisSetEx).not.toHaveBeenCalled();
+
+        existsSpy.mockRestore();
+        statSpy.mockRestore();
         readSpy.mockRestore();
     });
 
@@ -536,6 +651,9 @@ describe("library cover-art proxy compatibility", () => {
         const existsSpy = jest
             .spyOn(fs, "existsSync")
             .mockReturnValue(true);
+        const statSpy = jest
+            .spyOn(fs.promises, "stat")
+            .mockResolvedValue({ mtimeMs: 1718000000000, size: 4096 } as fs.Stats);
         const readSpy = jest
             .spyOn(fs.promises, "readFile")
             .mockResolvedValue(Buffer.from("native-bytes"));
@@ -552,6 +670,7 @@ describe("library cover-art proxy compatibility", () => {
         expect(res.sendFile).toHaveBeenCalled();
 
         existsSpy.mockRestore();
+        statSpy.mockRestore();
         readSpy.mockRestore();
     });
 

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -184,6 +184,15 @@ jest.mock("../../services/imageStorage", () => ({
     downloadAndStoreImage: jest.fn(),
 }));
 
+jest.mock("../../services/coverArtResize", () => {
+    const actual = jest.requireActual("../../services/coverArtResize");
+    return {
+        ...actual,
+        resizeCoverArt: jest.fn(),
+    };
+});
+
+import crypto from "crypto";
 import router from "../library";
 import { redisClient } from "../../utils/redis";
 import { fetchExternalImage } from "../../services/imageProxy";
@@ -208,8 +217,10 @@ import {
     getDecadeFromYear,
     getEffectiveYear,
 } from "../../utils/dateFilters";
+import { resizeCoverArt } from "../../services/coverArtResize";
 
 const mockRedisGet = redisClient.get as jest.Mock;
+const mockResizeCoverArt = resizeCoverArt as jest.Mock;
 const mockRedisSetEx = redisClient.setEx as jest.Mock;
 const mockFetchExternalImage = fetchExternalImage as jest.Mock;
 const mockAlbumFindUnique = prisma.album.findUnique as jest.Mock;
@@ -302,6 +313,15 @@ describe("library cover-art proxy compatibility", () => {
         mockCoverArtGetCoverArt.mockResolvedValue(null);
         mockCoverArtClearNotFoundCache.mockResolvedValue(undefined);
         mockImageProviderGetAlbumCover.mockResolvedValue(null);
+        mockResizeCoverArt.mockImplementation(
+            async ({
+                buffer,
+                contentType,
+            }: {
+                buffer: Buffer;
+                contentType: string | null;
+            }) => ({ buffer, contentType, resized: false })
+        );
     });
 
     it("blocks invalid/private cover-art URLs", async () => {
@@ -384,6 +404,177 @@ describe("library cover-art proxy compatibility", () => {
             90 * 24 * 60 * 60,
             expect.any(String)
         );
+    });
+
+    it("resizes fetched cover art and caches the variant under a size+format key", async () => {
+        mockFetchExternalImage.mockResolvedValue({
+            ok: true,
+            buffer: Buffer.from("original-bytes"),
+            contentType: "image/jpeg",
+            etag: "etag-original",
+            url: "https://example.com/cover.jpg",
+        });
+        const resizedBuffer = Buffer.from("resized-bytes");
+        mockResizeCoverArt.mockResolvedValue({
+            buffer: resizedBuffer,
+            contentType: "image/webp",
+            resized: true,
+        });
+
+        const req = {
+            query: { url: "https://example.com/cover.jpg", size: "300" },
+            params: {},
+            headers: { accept: "image/avif,image/webp,*/*" },
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(mockResizeCoverArt).toHaveBeenCalledWith({
+            buffer: Buffer.from("original-bytes"),
+            contentType: "image/jpeg",
+            size: 320,
+            format: "webp",
+        });
+        const expectedKey = `cover-art:${crypto
+            .createHash("md5")
+            .update("https://example.com/cover.jpg-320-webp")
+            .digest("hex")}`;
+        const expectedEtag = crypto
+            .createHash("md5")
+            .update(resizedBuffer)
+            .digest("hex");
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            expectedKey,
+            90 * 24 * 60 * 60,
+            JSON.stringify({
+                etag: expectedEtag,
+                contentType: "image/webp",
+                data: resizedBuffer.toString("base64"),
+            })
+        );
+        expect(res.headers["Content-Type"]).toBe("image/webp");
+        expect(res.headers["ETag"]).toBe(expectedEtag);
+        expect(res.body).toEqual(resizedBuffer);
+    });
+
+    it("serves the original buffer and etag when no size is requested", async () => {
+        mockFetchExternalImage.mockResolvedValue({
+            ok: true,
+            buffer: Buffer.from("original-bytes"),
+            contentType: "image/jpeg",
+            etag: "etag-123",
+            url: "https://example.com/cover.jpg",
+        });
+
+        const req = {
+            query: { url: "https://example.com/cover.jpg" },
+            params: {},
+            headers: { accept: "image/avif,image/webp,*/*" },
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(mockResizeCoverArt).toHaveBeenCalledWith({
+            buffer: Buffer.from("original-bytes"),
+            contentType: "image/jpeg",
+            size: null,
+            format: "original",
+        });
+        const expectedKey = `cover-art:${crypto
+            .createHash("md5")
+            .update("https://example.com/cover.jpg-original-original")
+            .digest("hex")}`;
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            expectedKey,
+            90 * 24 * 60 * 60,
+            expect.any(String)
+        );
+        expect(res.headers["ETag"]).toBe("etag-123");
+        expect(res.body).toEqual(Buffer.from("original-bytes"));
+    });
+
+    it("serves resized native covers when a size is requested", async () => {
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValue(true);
+        const readSpy = jest
+            .spyOn(fs.promises, "readFile")
+            .mockResolvedValue(Buffer.from("native-bytes"));
+        mockResizeCoverArt.mockResolvedValue({
+            buffer: Buffer.from("native-resized"),
+            contentType: "image/webp",
+            resized: true,
+        });
+
+        const req = {
+            query: { url: "native:albums/album-123.jpg", size: "128" },
+            params: {},
+            headers: { accept: "image/webp,*/*" },
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(readSpy).toHaveBeenCalled();
+        expect(mockResizeCoverArt).toHaveBeenCalledWith({
+            buffer: Buffer.from("native-bytes"),
+            contentType: "image/jpeg",
+            size: 128,
+            format: "webp",
+        });
+        expect(res.sendFile).not.toHaveBeenCalled();
+        expect(res.headers["Content-Type"]).toBe("image/webp");
+        expect(res.body).toEqual(Buffer.from("native-resized"));
+
+        existsSpy.mockRestore();
+        readSpy.mockRestore();
+    });
+
+    it("falls back to sending the native file when resize does not apply", async () => {
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValue(true);
+        const readSpy = jest
+            .spyOn(fs.promises, "readFile")
+            .mockResolvedValue(Buffer.from("native-bytes"));
+
+        const req = {
+            query: { url: "native:albums/album-123.jpg", size: "128" },
+            params: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(res.sendFile).toHaveBeenCalled();
+
+        existsSpy.mockRestore();
+        readSpy.mockRestore();
+    });
+
+    it("sends native files directly when no size is requested", async () => {
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValue(true);
+        const readSpy = jest.spyOn(fs.promises, "readFile");
+
+        const req = {
+            query: { url: "native:albums/album-123.jpg" },
+            params: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(readSpy).not.toHaveBeenCalled();
+        expect(res.sendFile).toHaveBeenCalled();
+
+        existsSpy.mockRestore();
+        readSpy.mockRestore();
     });
 
     it("self-heals missing native query-url covers via Deezer fallback", async () => {

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -806,10 +806,31 @@ const applyCoverArtCorsHeaders = (res: ExpressResponse, origin?: string) => {
     res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
 };
 
+const sendResizedNativeCoverResponse = (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    etag: string,
+    contentType: string | null,
+    buffer: Buffer
+): void => {
+    if (contentType) {
+        res.setHeader("Content-Type", contentType);
+    }
+    applyCoverArtCorsHeaders(res, req.headers.origin as string | undefined);
+    res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
+    res.setHeader("Vary", "Accept");
+    res.setHeader("ETag", etag);
+    res.send(buffer);
+};
+
 /**
  * Serves a native cover file resized to the requested `size` query param.
- * Returns true when a response was sent; false when the caller should
- * fall back to sending the original file from disk.
+ * Resized variants are cached in Redis keyed by file identity
+ * (path + mtime + size on disk) plus the snapped size and negotiated
+ * format, so repeat requests and If-None-Match revalidations are
+ * answered without re-decoding the image. Returns true when a response
+ * was sent; false when the caller should fall back to sending the
+ * original file from disk.
  */
 const trySendResizedNativeCover = async (
     req: ExpressRequest,
@@ -822,12 +843,42 @@ const trySendResizedNativeCover = async (
     }
 
     try {
+        const imageFormat = negotiateCoverArtFormat(req.headers.accept);
+        const fileStat = await fs.promises.stat(cachePath);
+        const cacheKey = `cover-art:native:${crypto
+            .createHash("md5")
+            .update(
+                `${cachePath}-${fileStat.mtimeMs}-${fileStat.size}-${requestedSize}-${imageFormat}`
+            )
+            .digest("hex")}`;
+
+        try {
+            const cached = await redisClient.get(cacheKey);
+            if (cached) {
+                const cachedData = JSON.parse(cached);
+                if (req.headers["if-none-match"] === cachedData.etag) {
+                    res.status(304).end();
+                    return true;
+                }
+                sendResizedNativeCoverResponse(
+                    req,
+                    res,
+                    cachedData.etag,
+                    cachedData.contentType ?? null,
+                    Buffer.from(cachedData.data, "base64")
+                );
+                return true;
+            }
+        } catch (cacheError) {
+            logger.warn("[COVER-ART] Redis cache read error:", cacheError);
+        }
+
         const fileBuffer = await fs.promises.readFile(cachePath);
         const resizeResult = await resizeCoverArt({
             buffer: fileBuffer,
             contentType: "image/jpeg",
             size: requestedSize,
-            format: negotiateCoverArtFormat(req.headers.accept),
+            format: imageFormat,
         });
         if (!resizeResult.resized) {
             return false;
@@ -837,19 +888,33 @@ const trySendResizedNativeCover = async (
             .createHash("md5")
             .update(resizeResult.buffer)
             .digest("hex");
+
+        try {
+            await redisClient.setEx(
+                cacheKey,
+                COVER_ART_IMAGE_CACHE_TTL_SECONDS,
+                JSON.stringify({
+                    etag,
+                    contentType: resizeResult.contentType,
+                    data: resizeResult.buffer.toString("base64"),
+                })
+            );
+        } catch (cacheError) {
+            logger.warn("[COVER-ART] Redis cache write error:", cacheError);
+        }
+
         if (req.headers["if-none-match"] === etag) {
             res.status(304).end();
             return true;
         }
 
-        if (resizeResult.contentType) {
-            res.setHeader("Content-Type", resizeResult.contentType);
-        }
-        applyCoverArtCorsHeaders(res, req.headers.origin as string | undefined);
-        res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
-        res.setHeader("Vary", "Accept");
-        res.setHeader("ETag", etag);
-        res.send(resizeResult.buffer);
+        sendResizedNativeCoverResponse(
+            req,
+            res,
+            etag,
+            resizeResult.contentType,
+            resizeResult.buffer
+        );
         return true;
     } catch (error) {
         logger.warn(

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -1,4 +1,8 @@
-import { Router, type Response as ExpressResponse } from "express";
+import {
+    Router,
+    type Request as ExpressRequest,
+    type Response as ExpressResponse,
+} from "express";
 import { requireAdmin, requireAuth, requireAuthOrToken } from "../middleware/auth";
 import { imageLimiter, apiLimiter } from "../middleware/rateLimiter";
 import { lastFmService } from "../services/lastfm";
@@ -29,6 +33,11 @@ import {
     fetchExternalImage,
     normalizeExternalImageUrl,
 } from "../services/imageProxy";
+import {
+    negotiateCoverArtFormat,
+    resizeCoverArt,
+    snapCoverArtSize,
+} from "../services/coverArtResize";
 import { downloadAndStoreImage } from "../services/imageStorage";
 import { dataCacheService } from "../services/dataCache";
 import {
@@ -795,6 +804,60 @@ const applyCoverArtCorsHeaders = (res: ExpressResponse, origin?: string) => {
         res.setHeader("Access-Control-Allow-Origin", "*");
     }
     res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+};
+
+/**
+ * Serves a native cover file resized to the requested `size` query param.
+ * Returns true when a response was sent; false when the caller should
+ * fall back to sending the original file from disk.
+ */
+const trySendResizedNativeCover = async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    cachePath: string
+): Promise<boolean> => {
+    const requestedSize = snapCoverArtSize(req.query.size);
+    if (!requestedSize) {
+        return false;
+    }
+
+    try {
+        const fileBuffer = await fs.promises.readFile(cachePath);
+        const resizeResult = await resizeCoverArt({
+            buffer: fileBuffer,
+            contentType: "image/jpeg",
+            size: requestedSize,
+            format: negotiateCoverArtFormat(req.headers.accept),
+        });
+        if (!resizeResult.resized) {
+            return false;
+        }
+
+        const etag = crypto
+            .createHash("md5")
+            .update(resizeResult.buffer)
+            .digest("hex");
+        if (req.headers["if-none-match"] === etag) {
+            res.status(304).end();
+            return true;
+        }
+
+        if (resizeResult.contentType) {
+            res.setHeader("Content-Type", resizeResult.contentType);
+        }
+        applyCoverArtCorsHeaders(res, req.headers.origin as string | undefined);
+        res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
+        res.setHeader("Vary", "Accept");
+        res.setHeader("ETag", etag);
+        res.send(resizeResult.buffer);
+        return true;
+    } catch (error) {
+        logger.warn(
+            `[COVER-ART] Native cover resize failed for ${cachePath}:`,
+            error
+        );
+        return false;
+    }
 };
 
 const getAlbumIdFromNativeCoverPath = (nativePath: string): string | null => {
@@ -3936,7 +3999,12 @@ router.get("/tracks/shuffle", async (req, res) => {
  *         name: size
  *         schema:
  *           type: string
- *         description: Requested image size
+ *         description: >
+ *           Requested image size in pixels. Snapped to the allowlist
+ *           (64, 128, 192, 320, 512, 768); images are downscaled
+ *           server-side (never upscaled) and served as webp when the
+ *           Accept header includes image/webp. Omit to receive the
+ *           original image.
  *     responses:
  *       200:
  *         description: Cover art image binary
@@ -4080,6 +4148,16 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
                     `[COVER-ART] Serving native cover: ${nativeCacheHit.cachePath}`
                 );
 
+                if (
+                    await trySendResizedNativeCover(
+                        req,
+                        res,
+                        nativeCacheHit.cachePath
+                    )
+                ) {
+                    return;
+                }
+
                 // Serve the file directly
                 const requestOrigin = req.headers.origin;
                 const headers: Record<string, string> = {
@@ -4138,6 +4216,16 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
                         logger.debug(
                             `[COVER-ART] Resolved legacy native cover path ${nativePath} -> ${canonicalNativePath}`
                         );
+                    }
+
+                    if (
+                        await trySendResizedNativeCover(
+                            req,
+                            res,
+                            nativeCacheHit.cachePath
+                        )
+                    ) {
+                        return;
                     }
 
                     // Serve the file directly
@@ -4326,10 +4414,20 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
         }
         coverUrl = normalizedCoverUrl;
 
-        // Create cache key from URL + size
+        // Snap the requested size to the allowlist and negotiate the
+        // output format (webp when the client supports it). Without a
+        // size the original bytes are served untouched.
+        const requestedSize = snapCoverArtSize(size);
+        const imageFormat = requestedSize
+            ? negotiateCoverArtFormat(req.headers.accept)
+            : "original";
+
+        // Create cache key from URL + snapped size + negotiated format
         const cacheKey = `cover-art:${crypto
             .createHash("md5")
-            .update(`${coverUrl}-${size || "original"}`)
+            .update(
+                `${coverUrl}-${requestedSize || "original"}-${imageFormat}`
+            )
             .digest("hex")}`;
 
         // Try to get from Redis cache first
@@ -4374,6 +4472,7 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
                     "Cache-Control",
                     COVER_ART_IMAGE_CACHE_CONTROL
                 );
+                res.setHeader("Vary", "Accept");
                 res.setHeader("ETag", cachedData.etag);
                 return res.send(imageBuffer);
             } else {
@@ -4428,8 +4527,20 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
         }
 
         logger.debug(`[COVER-ART] Successfully fetched, caching...`);
-        const imageBuffer = imageResult.buffer;
-        const etag = imageResult.etag;
+
+        // Resize/convert before caching so the cached variant matches
+        // the requested size + negotiated format
+        const resizeResult = await resizeCoverArt({
+            buffer: imageResult.buffer,
+            contentType: imageResult.contentType,
+            size: requestedSize,
+            format: imageFormat,
+        });
+        const imageBuffer = resizeResult.buffer;
+        const responseContentType = resizeResult.contentType;
+        const etag = resizeResult.resized
+            ? crypto.createHash("md5").update(imageBuffer).digest("hex")
+            : imageResult.etag;
 
         // Cache in Redis for 7 days
         try {
@@ -4438,7 +4549,7 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
                 COVER_ART_IMAGE_CACHE_TTL_SECONDS,
                 JSON.stringify({
                     etag,
-                    contentType: imageResult.contentType,
+                    contentType: responseContentType,
                     data: imageBuffer.toString("base64"),
                 })
             );
@@ -4452,13 +4563,14 @@ router.get("/cover-art/:id?", imageLimiter, async (req, res) => {
         }
 
         // Set appropriate headers
-        if (imageResult.contentType) {
-            res.setHeader("Content-Type", imageResult.contentType);
+        if (responseContentType) {
+            res.setHeader("Content-Type", responseContentType);
         }
 
         // Set aggressive caching headers
         applyCoverArtCorsHeaders(res, req.headers.origin as string | undefined);
         res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
+        res.setHeader("Vary", "Accept");
         res.setHeader("ETag", etag);
 
         // Send the image

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -24,6 +24,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/cacheHelpers.ts` | Core |
 | `backend/src/services/coverArt.ts` | Core |
 | `backend/src/services/coverArtExtractor.ts` | Core |
+| `backend/src/services/coverArtResize.ts` | Core |
 | `backend/src/services/dataCache.ts` | Core |
 | `backend/src/services/deezer.ts` | Core |
 | `backend/src/services/discoverWeekly.ts` | Core |

--- a/backend/src/services/__tests__/coverArtResize.test.ts
+++ b/backend/src/services/__tests__/coverArtResize.test.ts
@@ -1,0 +1,173 @@
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import sharp from "sharp";
+import {
+    COVER_ART_SIZES,
+    negotiateCoverArtFormat,
+    resizeCoverArt,
+    snapCoverArtSize,
+} from "../coverArtResize";
+
+async function makeImage(
+    width: number,
+    height: number,
+    format: "jpeg" | "png" = "jpeg"
+): Promise<Buffer> {
+    const pipeline = sharp({
+        create: {
+            width,
+            height,
+            channels: 3,
+            background: { r: 30, g: 60, b: 120 },
+        },
+    });
+    return format === "png"
+        ? pipeline.png().toBuffer()
+        : pipeline.jpeg().toBuffer();
+}
+
+describe("snapCoverArtSize", () => {
+    it("snaps requested sizes up to the nearest allowed size", () => {
+        expect(snapCoverArtSize("300")).toBe(320);
+        expect(snapCoverArtSize("100")).toBe(128);
+        expect(snapCoverArtSize(64)).toBe(64);
+        expect(snapCoverArtSize("768")).toBe(768);
+    });
+
+    it("caps oversized requests at the largest allowed size", () => {
+        expect(snapCoverArtSize("3000")).toBe(
+            COVER_ART_SIZES[COVER_ART_SIZES.length - 1]
+        );
+    });
+
+    it("returns null for missing or invalid sizes", () => {
+        expect(snapCoverArtSize(undefined)).toBeNull();
+        expect(snapCoverArtSize("")).toBeNull();
+        expect(snapCoverArtSize("abc")).toBeNull();
+        expect(snapCoverArtSize("0")).toBeNull();
+        expect(snapCoverArtSize("-64")).toBeNull();
+    });
+
+    it("uses the first value when the query param is an array", () => {
+        expect(snapCoverArtSize(["150", "700"])).toBe(192);
+    });
+});
+
+describe("negotiateCoverArtFormat", () => {
+    it("selects webp when the Accept header allows it", () => {
+        expect(
+            negotiateCoverArtFormat("image/avif,image/webp,image/*,*/*;q=0.8")
+        ).toBe("webp");
+    });
+
+    it("keeps the original format otherwise", () => {
+        expect(negotiateCoverArtFormat("image/png,image/*;q=0.8")).toBe(
+            "original"
+        );
+        expect(negotiateCoverArtFormat(undefined)).toBe("original");
+    });
+});
+
+describe("resizeCoverArt", () => {
+    it("downscales large images to the requested size preserving aspect", async () => {
+        const input = await makeImage(1000, 500);
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/jpeg",
+            size: 320,
+            format: "original",
+        });
+
+        expect(result.resized).toBe(true);
+        const meta = await sharp(result.buffer).metadata();
+        expect(meta.width).toBe(320);
+        expect(meta.height).toBe(160);
+        expect(meta.format).toBe("jpeg");
+        expect(result.contentType).toBe("image/jpeg");
+    });
+
+    it("never upscales images smaller than the requested size", async () => {
+        const input = await makeImage(100, 100);
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/jpeg",
+            size: 512,
+            format: "original",
+        });
+
+        const meta = await sharp(result.buffer).metadata();
+        expect(meta.width).toBe(100);
+        expect(meta.height).toBe(100);
+    });
+
+    it("converts to webp when the negotiated format is webp", async () => {
+        const input = await makeImage(800, 800);
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/jpeg",
+            size: 192,
+            format: "webp",
+        });
+
+        expect(result.resized).toBe(true);
+        const meta = await sharp(result.buffer).metadata();
+        expect(meta.format).toBe("webp");
+        expect(meta.width).toBe(192);
+        expect(result.contentType).toBe("image/webp");
+    });
+
+    it("keeps png output for png input when format is original", async () => {
+        const input = await makeImage(600, 600, "png");
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/png",
+            size: 128,
+            format: "original",
+        });
+
+        const meta = await sharp(result.buffer).metadata();
+        expect(meta.format).toBe("png");
+        expect(result.contentType).toBe("image/png");
+    });
+
+    it("returns the original buffer untouched when no size is requested", async () => {
+        const input = await makeImage(1000, 1000);
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/jpeg",
+            size: null,
+            format: "webp",
+        });
+
+        expect(result.resized).toBe(false);
+        expect(result.buffer).toBe(input);
+        expect(result.contentType).toBe("image/jpeg");
+    });
+
+    it("falls back to the original buffer when the input is not an image", async () => {
+        const input = Buffer.from("definitely-not-an-image");
+
+        const result = await resizeCoverArt({
+            buffer: input,
+            contentType: "image/jpeg",
+            size: 320,
+            format: "webp",
+        });
+
+        expect(result.resized).toBe(false);
+        expect(result.buffer).toBe(input);
+        expect(result.contentType).toBe("image/jpeg");
+    });
+});

--- a/backend/src/services/coverArtResize.ts
+++ b/backend/src/services/coverArtResize.ts
@@ -1,0 +1,125 @@
+/**
+ * Cover Art Resize Service
+ *
+ * Server-side downscaling of cover-art images so mobile clients never
+ * download multi-megapixel originals for thumbnail-sized renders.
+ * Requested sizes are snapped to a small allowlist to bound cache
+ * cardinality, images are never upscaled, and webp output is used when
+ * the client's Accept header advertises support.
+ */
+
+import sharp from "sharp";
+import { logger } from "../utils/logger";
+
+/**
+ * Allowed cover-art bounding-box sizes (px). Requested sizes are snapped
+ * up to the nearest entry; larger requests are capped at the maximum.
+ */
+export const COVER_ART_SIZES = [64, 128, 192, 320, 512, 768] as const;
+
+/**
+ * Output format negotiated from the request Accept header.
+ * "original" keeps the source encoding (jpeg/png/...).
+ */
+export type CoverArtFormat = "webp" | "original";
+
+/**
+ * Snaps a raw `size` query value to the cover-art size allowlist.
+ * Returns null when the size is missing or invalid (meaning: serve the
+ * original image untouched).
+ */
+export function snapCoverArtSize(
+    rawSize: unknown
+): number | null {
+    const candidate = Array.isArray(rawSize) ? rawSize[0] : rawSize;
+    const parsed =
+        typeof candidate === "number"
+            ? candidate
+            : typeof candidate === "string"
+              ? parseInt(candidate, 10)
+              : NaN;
+
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return null;
+    }
+
+    for (const allowed of COVER_ART_SIZES) {
+        if (parsed <= allowed) {
+            return allowed;
+        }
+    }
+    return COVER_ART_SIZES[COVER_ART_SIZES.length - 1];
+}
+
+/**
+ * Negotiates the cover-art output format from a request Accept header.
+ */
+export function negotiateCoverArtFormat(
+    acceptHeader: string | undefined
+): CoverArtFormat {
+    return acceptHeader && acceptHeader.includes("image/webp")
+        ? "webp"
+        : "original";
+}
+
+const FORMAT_CONTENT_TYPES: Record<string, string> = {
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    png: "image/png",
+    webp: "image/webp",
+    gif: "image/gif",
+    avif: "image/avif",
+    tiff: "image/tiff",
+};
+
+/** Result of a cover-art resize attempt. */
+export interface CoverArtResizeResult {
+    /** Output image bytes (the input buffer when no resize happened). */
+    buffer: Buffer;
+    /** Content type matching the output encoding. */
+    contentType: string | null;
+    /** True when the image was re-encoded (resized and/or converted). */
+    resized: boolean;
+}
+
+/**
+ * Resizes a cover-art buffer to fit within `size` x `size` (aspect
+ * preserved, never upscaled) and optionally converts it to webp.
+ * Returns the original buffer untouched when `size` is null or when the
+ * input cannot be decoded as an image.
+ */
+export async function resizeCoverArt(options: {
+    buffer: Buffer;
+    contentType: string | null;
+    size: number | null;
+    format: CoverArtFormat;
+}): Promise<CoverArtResizeResult> {
+    const { buffer, contentType, size, format } = options;
+
+    if (size === null) {
+        return { buffer, contentType, resized: false };
+    }
+
+    try {
+        let pipeline = sharp(buffer).resize({
+            width: size,
+            height: size,
+            fit: "inside",
+            withoutEnlargement: true,
+        });
+        if (format === "webp") {
+            pipeline = pipeline.webp();
+        }
+
+        const { data, info } = await pipeline.toBuffer({
+            resolveWithObject: true,
+        });
+        const outputContentType =
+            FORMAT_CONTENT_TYPES[info.format] || contentType;
+
+        return { buffer: data, contentType: outputContentType, resized: true };
+    } catch (error) {
+        logger.warn("[COVER-ART] Resize failed, serving original:", error);
+        return { buffer, contentType, resized: false };
+    }
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/server.js ./server.js
+COPY --from=builder /app/server-proxy.js ./server-proxy.js
 COPY --from=builder /packages/media-metadata-contract /packages/media-metadata-contract
 
 # Copy healthcheck and entrypoint scripts

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -6,6 +6,7 @@ export const runtime = "nodejs";
 type RouteParams = { params: Promise<{ path: string[] }> };
 
 // This route backs same-origin API mode. Direct mode bypasses it via absolute backend URLs.
+// In production server.js proxies /api straight to the backend, so this handler is a fallback.
 
 /**
  * Build the backend target path, preserving trailing slashes from the

--- a/frontend/app/listen-together/page.tsx
+++ b/frontend/app/listen-together/page.tsx
@@ -71,7 +71,8 @@ function CoverThumb({
     className?: string;
 }) {
     const [hasError, setHasError] = useState(false);
-    const imgSrc = coverArt ? api.getCoverArtUrl(coverArt) : null;
+    // Request ~2x the rendered CSS size so the backend serves a small variant
+    const imgSrc = coverArt ? api.getCoverArtUrl(coverArt, size * 2) : null;
 
     if (!imgSrc || hasError) {
         return (

--- a/frontend/app/vibe/page.tsx
+++ b/frontend/app/vibe/page.tsx
@@ -148,9 +148,10 @@ function CoverImage({
     const [hasError, setHasError] = useState(false);
 
     const imgSrc = useMemo(() => {
-        if (coverUrl) return api.getCoverArtUrl(coverUrl);
+        // Request ~2x the rendered CSS size so the backend serves a small variant
+        if (coverUrl) return api.getCoverArtUrl(coverUrl, size * 2);
         return null;
-    }, [coverUrl]);
+    }, [coverUrl, size]);
 
     if (!imgSrc || hasError) {
         return (

--- a/frontend/components/player/OverlayPlayer.tsx
+++ b/frontend/components/player/OverlayPlayer.tsx
@@ -187,7 +187,7 @@ export function OverlayPlayer() {
     const [relatedStreamMatches, setRelatedStreamMatches] = useState<Record<string, RelatedStreamMatch>>({});
     const [matchingRelatedTrackKey, setMatchingRelatedTrackKey] = useState<string | null>(null);
     const { vibeEmbeddings, loading: featuresLoading } = useFeatures();
-    const { title, subtitle, coverUrl, artistLink, mediaLink } = useMediaInfo(500);
+    const { title, subtitle, coverUrl, artistLink, mediaLink } = useMediaInfo(768);
     const currentTrackQualityBadge = useMemo(
         () => resolvePlaybackQualityBadgeFromStreamSource(currentTrack?.streamSource),
         [currentTrack?.streamSource],

--- a/frontend/hooks/pollingCadence.ts
+++ b/frontend/hooks/pollingCadence.ts
@@ -31,6 +31,17 @@ export function resolvePollingJitter(maxJitterMs: number): number {
 }
 
 /**
+ * Pauses a resolved polling interval while the document is hidden.
+ * Returns the interval unchanged when visible, false otherwise.
+ */
+export function resolveVisibilityGatedPollingInterval(
+    intervalMs: number | false,
+    isDocumentVisible: boolean
+): number | false {
+    return isDocumentVisible ? intervalMs : false;
+}
+
+/**
  * Resolves adaptive polling intervals, switching between active/idle cadences.
  */
 export function resolveAdaptivePollingInterval(

--- a/frontend/hooks/useDocumentVisibility.ts
+++ b/frontend/hooks/useDocumentVisibility.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore } from "react";
+
+function subscribeToVisibility(onStoreChange: () => void): () => void {
+    document.addEventListener("visibilitychange", onStoreChange);
+    return () => {
+        document.removeEventListener("visibilitychange", onStoreChange);
+    };
+}
+
+function getVisibilitySnapshot(): boolean {
+    return document.visibilityState === "visible";
+}
+
+function getVisibilityServerSnapshot(): boolean {
+    return true;
+}
+
+/**
+ * Returns true while the document is visible, re-rendering on
+ * visibilitychange. Always true during SSR.
+ */
+export function useDocumentVisible(): boolean {
+    return useSyncExternalStore(
+        subscribeToVisibility,
+        getVisibilitySnapshot,
+        getVisibilityServerSnapshot
+    );
+}
+
+/**
+ * Triggers a refetch each time the document returns to visibility after
+ * being hidden, so visibility-paused polls resume with fresh data.
+ */
+export function useRefetchOnVisible(
+    enabled: boolean,
+    refetch: () => Promise<unknown>
+): void {
+    const isDocumentVisible = useDocumentVisible();
+    const wasHiddenRef = useRef(false);
+
+    useEffect(() => {
+        if (!isDocumentVisible) {
+            wasHiddenRef.current = true;
+            return;
+        }
+        if (wasHiddenRef.current && enabled) {
+            wasHiddenRef.current = false;
+            void refetch();
+        }
+    }, [isDocumentVisible, enabled, refetch]);
+}

--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -8,7 +8,12 @@ import {
     resolveAdaptivePollingInterval,
     resolveFixedPollingInterval,
     resolvePollingEnabled,
+    resolveVisibilityGatedPollingInterval,
 } from "@/hooks/pollingCadence";
+import {
+    useDocumentVisible,
+    useRefetchOnVisible,
+} from "@/hooks/useDocumentVisibility";
 
 const logger = createFrontendLogger("Hooks.useNotifications");
 const NOTIFICATIONS_POLL_INTERVAL_MS = 30_000;
@@ -78,6 +83,7 @@ interface PollingOptions {
  */
 export function useNotifications(options: PollingOptions = {}): UseNotificationsReturn {
     const enabled = resolvePollingEnabled(options.enabled);
+    const isDocumentVisible = useDocumentVisible();
     const queryClient = useQueryClient();
 
     // Single source of truth - React Query cache
@@ -93,11 +99,15 @@ export function useNotifications(options: PollingOptions = {}): UseNotifications
         staleTime: 15_000,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
-        refetchInterval: resolveFixedPollingInterval(
-            enabled,
-            NOTIFICATIONS_POLL_INTERVAL_MS
+        refetchInterval: resolveVisibilityGatedPollingInterval(
+            resolveFixedPollingInterval(
+                enabled,
+                NOTIFICATIONS_POLL_INTERVAL_MS
+            ),
+            isDocumentVisible
         ),
     });
+    useRefetchOnVisible(enabled, refetch);
 
     // Derive unread count from data (computed, not stored)
     const unreadCount = notifications.filter((n) => !n.read).length;
@@ -197,6 +207,7 @@ export function useNotifications(options: PollingOptions = {}): UseNotifications
  * Hook for download history - unchanged from original
  */
 export function useDownloadHistory(): UseDownloadHistoryReturn {
+    const isDocumentVisible = useDocumentVisible();
     const fetchHistory = useCallback(async () => {
         return api.get<DownloadHistoryItem[]>("/notifications/downloads/history");
     }, []);
@@ -212,8 +223,13 @@ export function useDownloadHistory(): UseDownloadHistoryReturn {
         staleTime: 15_000,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
-        refetchInterval: 30000, // 30s - history doesn't need frequent updates
+        // 30s - history doesn't need frequent updates; paused while hidden
+        refetchInterval: resolveVisibilityGatedPollingInterval(
+            30000,
+            isDocumentVisible
+        ),
     });
+    useRefetchOnVisible(true, refetch);
 
     const queryClient = useQueryClient();
 

--- a/frontend/hooks/useSocialPresence.ts
+++ b/frontend/hooks/useSocialPresence.ts
@@ -8,7 +8,12 @@ import { socialPresenceSocket } from "@/lib/social-presence-socket";
 import {
     resolveAdaptivePollingInterval,
     resolvePollingEnabled,
+    resolveVisibilityGatedPollingInterval,
 } from "@/hooks/pollingCadence";
+import {
+    useDocumentVisible,
+    useRefetchOnVisible,
+} from "@/hooks/useDocumentVisibility";
 
 const SOCIAL_POLL_ACTIVE_MS = 10_000;
 const SOCIAL_POLL_IDLE_MS = 30_000;
@@ -100,6 +105,7 @@ function useSocialPresencePushInvalidation(
  */
 export function useSocialPresence(options: SocialPresenceOptions = {}) {
     const enabled = resolvePollingEnabled(options.enabled);
+    const isDocumentVisible = useDocumentVisible();
     useSocialPresencePushInvalidation(enabled, SOCIAL_ONLINE_QUERY_KEY);
     const query = useQuery<SocialOnlineResponse>({
         queryKey: SOCIAL_ONLINE_QUERY_KEY,
@@ -110,14 +116,18 @@ export function useSocialPresence(options: SocialPresenceOptions = {}) {
         refetchOnReconnect: false,
         refetchInterval: (state) => {
             const users = state.state.data?.users;
-            return resolveAdaptivePollingInterval({
-                enabled,
-                hasActiveItems: (users?.length ?? 0) > 0,
-                activeIntervalMs: SOCIAL_POLL_ACTIVE_MS,
-                idleIntervalMs: SOCIAL_POLL_IDLE_MS,
-            });
+            return resolveVisibilityGatedPollingInterval(
+                resolveAdaptivePollingInterval({
+                    enabled,
+                    hasActiveItems: (users?.length ?? 0) > 0,
+                    activeIntervalMs: SOCIAL_POLL_ACTIVE_MS,
+                    idleIntervalMs: SOCIAL_POLL_IDLE_MS,
+                }),
+                isDocumentVisible
+            );
         },
     });
+    useRefetchOnVisible(enabled, query.refetch);
 
     return {
         ...query,
@@ -129,6 +139,7 @@ export function useSocialPresence(options: SocialPresenceOptions = {}) {
  * Executes useAdminConnectedUsers.
  */
 export function useAdminConnectedUsers(enabled: boolean) {
+    const isDocumentVisible = useDocumentVisible();
     useSocialPresencePushInvalidation(enabled, SOCIAL_CONNECTED_QUERY_KEY);
     const query = useQuery<ConnectedUsersResponse>({
         queryKey: SOCIAL_CONNECTED_QUERY_KEY,
@@ -139,14 +150,18 @@ export function useAdminConnectedUsers(enabled: boolean) {
         refetchOnReconnect: false,
         refetchInterval: (state) => {
             const users = state.state.data?.users;
-            return resolveAdaptivePollingInterval({
-                enabled,
-                hasActiveItems: (users?.length ?? 0) > 0,
-                activeIntervalMs: SOCIAL_POLL_ACTIVE_MS,
-                idleIntervalMs: SOCIAL_POLL_IDLE_MS,
-            });
+            return resolveVisibilityGatedPollingInterval(
+                resolveAdaptivePollingInterval({
+                    enabled,
+                    hasActiveItems: (users?.length ?? 0) > 0,
+                    activeIntervalMs: SOCIAL_POLL_ACTIVE_MS,
+                    idleIntervalMs: SOCIAL_POLL_IDLE_MS,
+                }),
+                isDocumentVisible
+            );
         },
     });
+    useRefetchOnVisible(enabled, query.refetch);
 
     return {
         ...query,

--- a/frontend/lib/audio-engine/index.ts
+++ b/frontend/lib/audio-engine/index.ts
@@ -10,7 +10,6 @@ import type {
   AudioEngineRepresentationFailoverResult,
   AudioEngineSource,
 } from "@/lib/audio-engine/types";
-import { VideoJsSegmentedEngine } from "@/lib/audio-engine/videoJsSegmentedEngine";
 import { createAudioEngine } from "@/lib/audio-engine/engineFactory";
 import {
   DEFAULT_AUDIO_VOLUME,
@@ -58,6 +57,16 @@ const resolveSource = (source: AudioEngineSource | string): AudioEngineSource =>
   return source;
 };
 
+// Lazy-load the Video.js segmented engine (and the ~500KB video.js
+// dependency) only when a DASH/segmented source is actually selected,
+// keeping video.js out of every page's initial bundle.
+const loadVideoJsSegmentedEngine = async (): Promise<AudioEngine> => {
+  const { VideoJsSegmentedEngine } = await import(
+    "@/lib/audio-engine/videoJsSegmentedEngine"
+  );
+  return new VideoJsSegmentedEngine();
+};
+
 interface RuntimeAudioEngine extends AudioEngine {
   load(source: AudioEngineSource | string, options?: AudioEngineLoadOptions): void;
   load(source: AudioEngineSource | string, autoplay?: boolean, format?: string): void;
@@ -78,7 +87,7 @@ interface RuntimeAudioEngine extends AudioEngine {
 
 interface HybridRuntimeAudioEngineOptions {
   howlerEngine?: AudioEngine;
-  createVideoJsEngine?: () => AudioEngine;
+  createVideoJsEngine?: () => AudioEngine | Promise<AudioEngine>;
   resolveMode?: () => ReturnType<typeof resolveStreamingEngineMode>;
 }
 
@@ -90,7 +99,8 @@ interface HybridRuntimeAudioEngineOptions {
 export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   private howlerEngine: AudioEngine;
   private videoJsEngine: AudioEngine | null = null;
-  private readonly createVideoJsEngine: () => AudioEngine;
+  private videoJsEnginePromise: Promise<AudioEngine | null> | null = null;
+  private readonly createVideoJsEngine: () => AudioEngine | Promise<AudioEngine>;
   private readonly resolveMode: () => ReturnType<typeof resolveStreamingEngineMode>;
   private readonly listeners = new Map<
     AudioEngineEventType,
@@ -101,13 +111,15 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   private activeEngineKind: EngineKind = "howler";
   private lastSource: AudioEngineSource | null = null;
   private lastLoadOptions: AudioEngineLoadOptions | null = null;
+  private loadSequence = 0;
+  private isDestroyed = false;
   private outputVolume = DEFAULT_AUDIO_VOLUME;
   private outputMuted = false;
 
   constructor(options: HybridRuntimeAudioEngineOptions = {}) {
     this.howlerEngine = options.howlerEngine ?? new HowlerEngineAdapter();
     this.createVideoJsEngine =
-      options.createVideoJsEngine ?? (() => new VideoJsSegmentedEngine());
+      options.createVideoJsEngine ?? loadVideoJsSegmentedEngine;
     this.resolveMode = options.resolveMode ?? resolveStreamingEngineMode;
     this.bindEngineEvents("howler", this.howlerEngine);
     this.applyOutputState(this.howlerEngine);
@@ -155,19 +167,50 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
 
     this.lastSource = normalizedSource;
     this.lastLoadOptions = normalizedOptions;
+    const sequence = ++this.loadSequence;
 
     const preferredKind = this.resolvePreferredEngineKind(normalizedSource);
+    if (preferredKind === "videojs" && !this.videoJsEngine) {
+      // Video.js engine is lazy-loaded; finish this load once it arrives
+      // unless a newer load superseded it in the meantime.
+      void this.ensureVideoJsEngine().then((videoJsEngine) => {
+        if (sequence !== this.loadSequence || this.isDestroyed) {
+          return;
+        }
+        this.loadWithEngine(
+          videoJsEngine ? "videojs" : "howler",
+          videoJsEngine ?? this.howlerEngine,
+          normalizedSource,
+          normalizedOptions,
+        );
+      });
+      return;
+    }
+
     const targetEngine = this.getEngineByKind(preferredKind);
     const targetKind: EngineKind =
       targetEngine === this.howlerEngine ? "howler" : "videojs";
+    this.loadWithEngine(
+      targetKind,
+      targetEngine,
+      normalizedSource,
+      normalizedOptions,
+    );
+  }
 
+  private loadWithEngine(
+    targetKind: EngineKind,
+    targetEngine: AudioEngine,
+    source: AudioEngineSource,
+    options: AudioEngineLoadOptions,
+  ): void {
     if (this.activeEngineKind !== targetKind) {
       this.getActiveEngine().stop();
       this.activeEngineKind = targetKind;
       this.applyOutputState(targetEngine);
     }
 
-    targetEngine.load(normalizedSource, normalizedOptions);
+    targetEngine.load(source, options);
     this.applyOutputState(targetEngine);
   }
 
@@ -248,6 +291,20 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
         : optionsOrFormat ?? {};
 
     const preferredKind = this.resolvePreferredEngineKind(normalizedSource);
+    if (preferredKind === "videojs" && !this.videoJsEngine) {
+      void this.ensureVideoJsEngine().then((videoJsEngine) => {
+        if (
+          !videoJsEngine ||
+          this.isDestroyed ||
+          typeof videoJsEngine.preload !== "function"
+        ) {
+          return;
+        }
+        videoJsEngine.preload(normalizedSource, normalizedOptions);
+      });
+      return;
+    }
+
     const targetEngine = this.getEngineByKind(preferredKind);
     if (typeof targetEngine.preload === "function") {
       targetEngine.preload(normalizedSource, normalizedOptions);
@@ -345,6 +402,9 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   }
 
   destroy(): void {
+    this.isDestroyed = true;
+    this.loadSequence += 1;
+    this.videoJsEnginePromise = null;
     this.unbindEngineEvents("howler", this.howlerEngine);
     if (this.videoJsEngine) {
       this.unbindEngineEvents("videojs", this.videoJsEngine);
@@ -383,21 +443,40 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
       return this.howlerEngine;
     }
 
-    if (!this.videoJsEngine) {
-      try {
-        this.videoJsEngine = this.createVideoJsEngine();
-        this.bindEngineEvents("videojs", this.videoJsEngine);
-        this.applyOutputState(this.videoJsEngine);
-      } catch (error) {
-        sharedFrontendLogger.error(
-          "[AudioEngine] Failed to initialize Video.js segmented engine; continuing with primary Howler engine.",
-          error,
-        );
-        return this.howlerEngine;
-      }
+    return this.videoJsEngine ?? this.howlerEngine;
+  }
+
+  private ensureVideoJsEngine(): Promise<AudioEngine | null> {
+    if (this.videoJsEngine) {
+      return Promise.resolve(this.videoJsEngine);
     }
 
-    return this.videoJsEngine;
+    if (!this.videoJsEnginePromise) {
+      this.videoJsEnginePromise = Promise.resolve()
+        .then(() => this.createVideoJsEngine())
+        .then((engine) => {
+          if (this.isDestroyed) {
+            if (typeof engine.destroy === "function") {
+              engine.destroy();
+            }
+            return null;
+          }
+          this.videoJsEngine = engine;
+          this.bindEngineEvents("videojs", engine);
+          this.applyOutputState(engine);
+          return engine;
+        })
+        .catch((error) => {
+          sharedFrontendLogger.error(
+            "[AudioEngine] Failed to initialize Video.js segmented engine; continuing with primary Howler engine.",
+            error,
+          );
+          this.videoJsEnginePromise = null;
+          return null;
+        });
+    }
+
+    return this.videoJsEnginePromise;
   }
 
   private bindEngineEvents(kind: EngineKind, engine: AudioEngine): void {

--- a/frontend/lib/audio-engine/index.ts
+++ b/frontend/lib/audio-engine/index.ts
@@ -171,6 +171,13 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
 
     const preferredKind = this.resolvePreferredEngineKind(normalizedSource);
     if (preferredKind === "videojs" && !this.videoJsEngine) {
+      // Halt in-progress playback immediately (mirroring the synchronous
+      // engine-switch path in loadWithEngine) so the previous track does
+      // not keep playing while the video.js chunk downloads.
+      const activeEngine = this.getActiveEngine();
+      if (activeEngine.isPlaying()) {
+        activeEngine.stop();
+      }
       // Video.js engine is lazy-loaded; finish this load once it arrives
       // unless a newer load superseded it in the meantime.
       void this.ensureVideoJsEngine().then((videoJsEngine) => {
@@ -219,10 +226,16 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   }
 
   pause(): void | Promise<void> {
+    // Invalidate any deferred lazy-engine load (see load()) so it cannot
+    // start playback after the user paused.
+    this.loadSequence += 1;
     return this.getActiveEngine().pause();
   }
 
   stop(): void | Promise<void> {
+    // Invalidate any deferred lazy-engine load (see load()) so it cannot
+    // start playback after the user stopped.
+    this.loadSequence += 1;
     return this.getActiveEngine().stop();
   }
 

--- a/frontend/lib/audio-engine/index.ts
+++ b/frontend/lib/audio-engine/index.ts
@@ -112,6 +112,15 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   private lastSource: AudioEngineSource | null = null;
   private lastLoadOptions: AudioEngineLoadOptions | null = null;
   private loadSequence = 0;
+  // Tracks the load that is waiting on the lazy video.js chunk so
+  // play()/pause() during the download can redirect intent to it instead
+  // of acting on the stale active engine. Non-null only while the most
+  // recent load() is deferred; autoplayOverride wins over the original
+  // load options when set.
+  private pendingLazyLoad: {
+    sequence: number;
+    autoplayOverride: boolean | null;
+  } | null = null;
   private isDestroyed = false;
   private outputVolume = DEFAULT_AUDIO_VOLUME;
   private outputMuted = false;
@@ -168,6 +177,7 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
     this.lastSource = normalizedSource;
     this.lastLoadOptions = normalizedOptions;
     const sequence = ++this.loadSequence;
+    this.pendingLazyLoad = null;
 
     const preferredKind = this.resolvePreferredEngineKind(normalizedSource);
     if (preferredKind === "videojs" && !this.videoJsEngine) {
@@ -179,16 +189,33 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
         activeEngine.stop();
       }
       // Video.js engine is lazy-loaded; finish this load once it arrives
-      // unless a newer load superseded it in the meantime.
+      // unless a newer load superseded it in the meantime. play()/pause()
+      // in the interim adjust autoplay via pendingLazyLoad rather than
+      // cancelling the load (see those methods).
+      const pendingLazyLoad: NonNullable<typeof this.pendingLazyLoad> = {
+        sequence,
+        autoplayOverride: null,
+      };
+      this.pendingLazyLoad = pendingLazyLoad;
       void this.ensureVideoJsEngine().then((videoJsEngine) => {
+        if (this.pendingLazyLoad === pendingLazyLoad) {
+          this.pendingLazyLoad = null;
+        }
         if (sequence !== this.loadSequence || this.isDestroyed) {
           return;
         }
+        const effectiveOptions =
+          pendingLazyLoad.autoplayOverride === null
+            ? normalizedOptions
+            : {
+                ...normalizedOptions,
+                autoplay: pendingLazyLoad.autoplayOverride,
+              };
         this.loadWithEngine(
           videoJsEngine ? "videojs" : "howler",
           videoJsEngine ?? this.howlerEngine,
           normalizedSource,
-          normalizedOptions,
+          effectiveOptions,
         );
       });
       return;
@@ -222,20 +249,38 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   }
 
   play(): void | Promise<void> {
+    const pendingLazyLoad = this.pendingLazyLoad;
+    if (pendingLazyLoad && pendingLazyLoad.sequence === this.loadSequence) {
+      // The queued track is still waiting on the lazy video.js chunk and
+      // the active engine only holds the previous (already halted)
+      // source; restarting it would play the wrong track from position 0.
+      // Record the play intent so the deferred load starts playback as
+      // soon as the engine arrives.
+      pendingLazyLoad.autoplayOverride = true;
+      return;
+    }
     return this.getActiveEngine().play();
   }
 
   pause(): void | Promise<void> {
-    // Invalidate any deferred lazy-engine load (see load()) so it cannot
-    // start playback after the user paused.
-    this.loadSequence += 1;
+    const pendingLazyLoad = this.pendingLazyLoad;
+    if (pendingLazyLoad && pendingLazyLoad.sequence === this.loadSequence) {
+      // Keep the deferred lazy-engine load (see load()) so the queued
+      // track still becomes ready (and the orchestrator's load listeners
+      // fire), but suppress autoplay so playback cannot start against the
+      // user's intent once the chunk arrives.
+      pendingLazyLoad.autoplayOverride = false;
+    }
     return this.getActiveEngine().pause();
   }
 
   stop(): void | Promise<void> {
     // Invalidate any deferred lazy-engine load (see load()) so it cannot
-    // start playback after the user stopped.
+    // start playback after the transport was stopped. No cancellation
+    // event is needed: every stop() caller either re-issues load() or
+    // clears its own load bookkeeping synchronously.
     this.loadSequence += 1;
+    this.pendingLazyLoad = null;
     return this.getActiveEngine().stop();
   }
 
@@ -417,6 +462,7 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
   destroy(): void {
     this.isDestroyed = true;
     this.loadSequence += 1;
+    this.pendingLazyLoad = null;
     this.videoJsEnginePromise = null;
     this.unbindEngineEvents("howler", this.howlerEngine);
     if (this.videoJsEngine) {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,7 +1,7 @@
 // soundspan Service Worker
 const CACHE_NAME = 'soundspan-v1';
-const IMAGE_CACHE_NAME = 'soundspan-images-v2';
-const IMAGE_METADATA_CACHE_NAME = 'soundspan-images-metadata-v1';
+const IMAGE_CACHE_NAME = 'soundspan-images-v3';
+const IMAGE_METADATA_CACHE_NAME = 'soundspan-images-metadata-v2';
 const MAX_IMAGE_CACHE_ENTRIES = 2000;
 const MAX_CONCURRENT_IMAGE_REQUESTS = 4;
 const REQUEST_DELAY_MS = 10;
@@ -30,6 +30,21 @@ const imageRequestQueue = [];
  */
 function isImageRoute(pathname) {
   return IMAGE_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+/**
+ * Build a stable cache key for image requests by stripping the rotating
+ * auth token query param (it rotates daily and would otherwise invalidate
+ * the whole art cache every day). Size/format params stay in the key.
+ * The original request (with token) is still used for the network fetch.
+ */
+function getImageCacheKey(request, url) {
+  if (!url.searchParams.has('token')) {
+    return request;
+  }
+  const keyUrl = new URL(url.toString());
+  keyUrl.searchParams.delete('token');
+  return new Request(keyUrl.toString(), { headers: request.headers });
 }
 
 /**
@@ -85,10 +100,10 @@ async function isImageCacheEntryFresh(request) {
  */
 function processImageQueue() {
   while (activeImageRequests < MAX_CONCURRENT_IMAGE_REQUESTS && imageRequestQueue.length > 0) {
-    const { request, resolve, reject } = imageRequestQueue.shift();
+    const { request, cacheKey, resolve, reject } = imageRequestQueue.shift();
     activeImageRequests++;
 
-    fetchAndCacheImage(request)
+    fetchAndCacheImage(request, cacheKey)
       .then(resolve)
       .catch(reject)
       .finally(() => {
@@ -100,9 +115,10 @@ function processImageQueue() {
 }
 
 /**
- * Fetch image from network and cache it
+ * Fetch image from network (with token) and cache it under the
+ * token-stripped cache key. Only 200 responses are cached.
  */
-async function fetchAndCacheImage(request) {
+async function fetchAndCacheImage(request, cacheKey) {
   const cache = await caches.open(IMAGE_CACHE_NAME);
 
   try {
@@ -111,8 +127,8 @@ async function fetchAndCacheImage(request) {
     // Cache successful responses
     if (networkResponse.status === 200) {
       // Clone before caching (response can only be consumed once)
-      cache.put(request, networkResponse.clone());
-      setImageCachedAt(request);
+      cache.put(cacheKey, networkResponse.clone());
+      setImageCachedAt(cacheKey);
 
       // Trim cache in background (don't block response)
       trimCache(IMAGE_CACHE_NAME, MAX_IMAGE_CACHE_ENTRIES);
@@ -128,9 +144,9 @@ async function fetchAndCacheImage(request) {
 /**
  * Queue an image request with throttling
  */
-function queueImageRequest(request) {
+function queueImageRequest(request, cacheKey) {
   return new Promise((resolve, reject) => {
-    imageRequestQueue.push({ request, resolve, reject });
+    imageRequestQueue.push({ request, cacheKey, resolve, reject });
     processImageQueue();
   });
 }
@@ -203,20 +219,24 @@ self.addEventListener('fetch', (event) => {
       (async () => {
         const cache = await caches.open(IMAGE_CACHE_NAME);
         const metadataCache = await caches.open(IMAGE_METADATA_CACHE_NAME);
+        // Key the cache on the token-stripped URL so daily token rotation
+        // doesn't re-download the whole art cache.
+        const cacheKey = getImageCacheKey(request, url);
 
-        // Try cache first
-        const cachedResponse = await cache.match(request);
+        // Try cache first (ignoreVary: the same browser always sends the
+        // same Accept header for image requests)
+        const cachedResponse = await cache.match(cacheKey, { ignoreVary: true });
         if (cachedResponse) {
-          const isFresh = await isImageCacheEntryFresh(request);
+          const isFresh = await isImageCacheEntryFresh(cacheKey);
           if (isFresh) {
             return cachedResponse;
           }
-          await cache.delete(request);
-          await metadataCache.delete(request);
+          await cache.delete(cacheKey, { ignoreVary: true });
+          await metadataCache.delete(cacheKey, { ignoreVary: true });
         }
 
         // Not in cache, queue the request with throttling
-        return queueImageRequest(request);
+        return queueImageRequest(request, cacheKey);
       })()
     );
     return;

--- a/frontend/server-proxy.js
+++ b/frontend/server-proxy.js
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+/**
+ * Build an http-proxy-middleware v3 error handler that preserves the
+ * structured 503 JSON error contract ({ error, code }) used by all
+ * backend proxies in server.js.
+ *
+ * v3 removed the v2 `onError` option, so handlers must be registered
+ * via `on.error`; when a custom handler is registered, hpm also skips
+ * its default plain-text error response. WebSocket upgrade failures
+ * hand the handler a raw socket instead of a ServerResponse, so
+ * socket-like targets are destroyed rather than written to.
+ *
+ * @param {{ name: string, logger: { error: Function }, errorMessage: string, errorCode: string }} config
+ * @returns {(err: unknown, req: { method?: string, url?: string }, res: unknown) => void}
+ */
+function createProxyErrorHandler({ name, logger, errorMessage, errorCode }) {
+    return (err, req, res) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        logger.error(`[${name}] ${req?.method} ${req?.url} failed:`, detail);
+
+        if (res && typeof res.writeHead === "function") {
+            if (!res.headersSent) {
+                res.writeHead(503, { "Content-Type": "application/json" });
+                res.end(
+                    JSON.stringify({
+                        error: errorMessage,
+                        code: errorCode,
+                    })
+                );
+            }
+            return;
+        }
+
+        if (res && typeof res.destroy === "function") {
+            res.destroy();
+        }
+    };
+}
+
+/**
+ * Build the shared http-proxy-middleware options for a backend proxy
+ * (target, forwarding headers, timeouts, structured error handler).
+ *
+ * @param {{ name: string, target: string, ws?: boolean, logger: { error: Function }, errorMessage: string, errorCode: string }} config
+ * @returns {import("http-proxy-middleware").Options}
+ */
+function buildBackendProxyOptions({ name, target, ws = false, logger, errorMessage, errorCode }) {
+    return {
+        target,
+        changeOrigin: true,
+        ws: Boolean(ws),
+        xfwd: true,
+        timeout: 120000,
+        proxyTimeout: 120000,
+        on: {
+            error: createProxyErrorHandler({ name, logger, errorMessage, errorCode }),
+        },
+    };
+}
+
+/**
+ * Create a backend proxy middleware (with `.upgrade` for websocket
+ * proxies) that streams requests to the backend and answers with the
+ * structured 503 JSON contract when the backend is unreachable.
+ *
+ * @param {{ name: string, target: string, ws?: boolean, logger: { error: Function }, errorMessage: string, errorCode: string }} config
+ * @returns {import("http-proxy-middleware").RequestHandler}
+ */
+function createBackendProxy(config) {
+    return createProxyMiddleware(buildBackendProxyOptions(config));
+}
+
+module.exports = {
+    createProxyErrorHandler,
+    buildBackendProxyOptions,
+    createBackendProxy,
+};

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { createServer } = require("http");
 const next = require("next");
-const { createProxyMiddleware } = require("http-proxy-middleware");
+const { createBackendProxy } = require("./server-proxy");
 
 const dev = process.env.NODE_ENV !== "production";
 const hostname = "0.0.0.0";
@@ -92,84 +92,32 @@ function isApiPath(pathname) {
     );
 }
 
-const listenTogetherSocketProxy = createProxyMiddleware({
+const listenTogetherSocketProxy = createBackendProxy({
+    name: "listen-together-proxy",
     target: backendUrl,
-    changeOrigin: true,
     ws: true,
-    xfwd: true,
-    logLevel: "warn",
-    timeout: 120000,
-    proxyTimeout: 120000,
-    onError: (err, req, res) => {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        serverLogger.error(
-            `[listen-together-proxy] ${req.method} ${req.url} failed:`,
-            errorMessage
-        );
-        if (!res.headersSent) {
-            res.writeHead(503, { "Content-Type": "application/json" });
-            res.end(
-                JSON.stringify({
-                    error: "Listen Together backend unavailable",
-                    code: "LISTEN_TOGETHER_PROXY_UNAVAILABLE",
-                })
-            );
-        }
-    },
+    logger: serverLogger,
+    errorMessage: "Listen Together backend unavailable",
+    errorCode: "LISTEN_TOGETHER_PROXY_UNAVAILABLE",
 });
 
-const subsonicRestProxy = createProxyMiddleware({
+const subsonicRestProxy = createBackendProxy({
+    name: "subsonic-rest-proxy",
     target: backendUrl,
-    changeOrigin: true,
-    xfwd: true,
-    logLevel: "warn",
-    timeout: 120000,
-    proxyTimeout: 120000,
-    onError: (err, req, res) => {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        serverLogger.error(
-            `[subsonic-rest-proxy] ${req.method} ${req.url} failed:`,
-            errorMessage
-        );
-        if (!res.headersSent) {
-            res.writeHead(503, { "Content-Type": "application/json" });
-            res.end(
-                JSON.stringify({
-                    error: "Subsonic backend unavailable",
-                    code: "SUBSONIC_PROXY_UNAVAILABLE",
-                })
-            );
-        }
-    },
+    logger: serverLogger,
+    errorMessage: "Subsonic backend unavailable",
+    errorCode: "SUBSONIC_PROXY_UNAVAILABLE",
 });
 
 // Streams /api traffic straight to the backend (no body buffering or
 // gzip stripping, unlike the Next route-handler fallback in
 // app/api/[...path]/route.ts).
-const apiProxy = createProxyMiddleware({
+const apiProxy = createBackendProxy({
+    name: "api-proxy",
     target: backendUrl,
-    changeOrigin: true,
-    ws: false,
-    xfwd: true,
-    logLevel: "warn",
-    timeout: 120000,
-    proxyTimeout: 120000,
-    onError: (err, req, res) => {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        serverLogger.error(
-            `[api-proxy] ${req.method} ${req.url} failed:`,
-            errorMessage
-        );
-        if (!res.headersSent) {
-            res.writeHead(503, { "Content-Type": "application/json" });
-            res.end(
-                JSON.stringify({
-                    error: "API backend unavailable",
-                    code: "API_PROXY_UNAVAILABLE",
-                })
-            );
-        }
-    },
+    logger: serverLogger,
+    errorMessage: "API backend unavailable",
+    errorCode: "API_PROXY_UNAVAILABLE",
 });
 
 app.prepare().then(() => {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -10,6 +10,7 @@ const backendUrl = (process.env.BACKEND_URL || "http://127.0.0.1:3006").replace(
 
 const LISTEN_TOGETHER_SOCKET_PATH = "/socket.io/listen-together";
 const SUBSONIC_REST_PATH = "/rest";
+const API_PATH = "/api";
 const HEALTH_LIVE_PATH = "/health/live";
 const HEALTH_READY_PATH = "/health/ready";
 const HEALTH_PATH = "/health";
@@ -81,6 +82,16 @@ function isSubsonicRestPath(pathname) {
     );
 }
 
+// All /api/* paths are backend-owned; Next-owned handlers live at
+// /runtime-config and /health (the latter is handled above the proxy).
+function isApiPath(pathname) {
+    return (
+        pathname === API_PATH ||
+        pathname === `${API_PATH}/` ||
+        pathname.startsWith(`${API_PATH}/`)
+    );
+}
+
 const listenTogetherSocketProxy = createProxyMiddleware({
     target: backendUrl,
     changeOrigin: true,
@@ -126,6 +137,35 @@ const subsonicRestProxy = createProxyMiddleware({
                 JSON.stringify({
                     error: "Subsonic backend unavailable",
                     code: "SUBSONIC_PROXY_UNAVAILABLE",
+                })
+            );
+        }
+    },
+});
+
+// Streams /api traffic straight to the backend (no body buffering or
+// gzip stripping, unlike the Next route-handler fallback in
+// app/api/[...path]/route.ts).
+const apiProxy = createProxyMiddleware({
+    target: backendUrl,
+    changeOrigin: true,
+    ws: false,
+    xfwd: true,
+    logLevel: "warn",
+    timeout: 120000,
+    proxyTimeout: 120000,
+    onError: (err, req, res) => {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        serverLogger.error(
+            `[api-proxy] ${req.method} ${req.url} failed:`,
+            errorMessage
+        );
+        if (!res.headersSent) {
+            res.writeHead(503, { "Content-Type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    error: "API backend unavailable",
+                    code: "API_PROXY_UNAVAILABLE",
                 })
             );
         }
@@ -182,6 +222,11 @@ app.prepare().then(() => {
             return;
         }
 
+        if (isApiPath(pathname)) {
+            apiProxy(req, res);
+            return;
+        }
+
         handle(req, res);
     });
 
@@ -200,6 +245,9 @@ app.prepare().then(() => {
         );
         serverLogger.info(
             `> Subsonic REST proxy enabled: ${SUBSONIC_REST_PATH} -> ${backendUrl}`
+        );
+        serverLogger.info(
+            `> API proxy enabled: ${API_PATH} -> ${backendUrl}`
         );
     });
 

--- a/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
+++ b/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
@@ -22,6 +22,7 @@ class FakeAudioEngine implements AudioEngine {
         cooldownMs: number;
     }> = [];
     public stopCalls = 0;
+    public playCalls = 0;
     public destroyCalls = 0;
     public clearRepresentationQuarantineCalls = 0;
     public quarantineRepresentationResult: AudioEngineRepresentationFailoverResult | null =
@@ -45,6 +46,7 @@ class FakeAudioEngine implements AudioEngine {
     }
 
     play() {
+        this.playCalls += 1;
         this.playing = true;
     }
 
@@ -212,7 +214,7 @@ test("cancels a pending lazy DASH engine load when the user stops playback", asy
     assert.equal(videoJsEngine.loadCalls.length, 0);
 });
 
-test("cancels a pending lazy DASH engine load when the user pauses", async () => {
+test("completes a pending lazy DASH engine load without autoplay when the user pauses", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
     let resolveEngine: ((engine: AudioEngine) => void) | null = null;
@@ -225,16 +227,89 @@ test("cancels a pending lazy DASH engine load when the user pauses", async () =>
         resolveMode: () => "videojs",
     });
 
-    runtimeEngine.load({
-        url: "https://example.test/stream.mpd",
-        protocol: "dash",
-        mimeType: "application/dash+xml",
-    });
+    runtimeEngine.load(
+        {
+            url: "https://example.test/stream.mpd",
+            protocol: "dash",
+            mimeType: "application/dash+xml",
+        },
+        { autoplay: true },
+    );
     runtimeEngine.pause();
     resolveEngine?.(videoJsEngine);
     await flushAsyncEngineInit();
 
-    assert.equal(videoJsEngine.loadCalls.length, 0);
+    // The queued track must still finish loading (so the UI's current
+    // track is ready and the orchestrator's load listeners fire) but with
+    // autoplay suppressed to honor the pause.
+    assert.equal(videoJsEngine.loadCalls.length, 1);
+    assert.equal(videoJsEngine.loadCalls[0]?.options?.autoplay, false);
+});
+
+test("play() during a pending lazy DASH load defers to the queued track instead of restarting the stale source", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load("https://example.test/track.mp3", {
+        autoplay: false,
+    });
+    runtimeEngine.load(
+        {
+            url: "https://example.test/stream.mpd",
+            protocol: "dash",
+            mimeType: "application/dash+xml",
+        },
+        { autoplay: false },
+    );
+    runtimeEngine.play();
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    // play() must not restart the previous, already-halted howler source
+    // from position 0; instead the deferred load starts playback once the
+    // engine chunk arrives.
+    assert.equal(howlerEngine.playCalls, 0);
+    assert.equal(videoJsEngine.loadCalls.length, 1);
+    assert.equal(videoJsEngine.loadCalls[0]?.options?.autoplay, true);
+});
+
+test("re-arms autoplay when the user presses play after pausing a pending lazy DASH load", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load(
+        {
+            url: "https://example.test/stream.mpd",
+            protocol: "dash",
+            mimeType: "application/dash+xml",
+        },
+        { autoplay: true },
+    );
+    runtimeEngine.pause();
+    runtimeEngine.play();
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    assert.equal(videoJsEngine.loadCalls.length, 1);
+    assert.equal(videoJsEngine.loadCalls[0]?.options?.autoplay, true);
 });
 
 test("stops in-progress playback before the lazy video.js import resolves", async () => {

--- a/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
+++ b/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
@@ -122,7 +122,72 @@ class FakeAudioEngine implements AudioEngine {
     }
 }
 
-test("reapplies persisted volume and mute state when switching to DASH engine", () => {
+async function flushAsyncEngineInit(): Promise<void> {
+    await new Promise((resolve) => {
+        setImmediate(resolve);
+    });
+}
+
+test("supports an async Video.js engine factory (lazy import path)", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let factoryCalls = 0;
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: async () => {
+            factoryCalls += 1;
+            return videoJsEngine;
+        },
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load("https://example.test/track.mp3", {
+        autoplay: false,
+    });
+    assert.equal(factoryCalls, 0);
+
+    runtimeEngine.setVolume(0.4);
+    runtimeEngine.load({
+        url: "https://example.test/stream.mpd",
+        protocol: "dash",
+        mimeType: "application/dash+xml",
+    });
+    await flushAsyncEngineInit();
+
+    assert.equal(factoryCalls, 1);
+    assert.equal(videoJsEngine.loadCalls.length, 1);
+    assert.equal(videoJsEngine.setVolumeCalls.at(-1), 0.4);
+});
+
+test("ignores a stale DASH load that resolves after a newer direct load", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load({
+        url: "https://example.test/stream.mpd",
+        protocol: "dash",
+        mimeType: "application/dash+xml",
+    });
+    runtimeEngine.load("https://example.test/track.mp3", {
+        autoplay: false,
+    });
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    assert.equal(howlerEngine.loadCalls.length, 1);
+    assert.equal(videoJsEngine.loadCalls.length, 0);
+});
+
+test("reapplies persisted volume and mute state when switching to DASH engine", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
     const runtimeEngine = new HybridRuntimeAudioEngine({
@@ -139,6 +204,7 @@ test("reapplies persisted volume and mute state when switching to DASH engine", 
         protocol: "dash",
         mimeType: "application/dash+xml",
     });
+    await flushAsyncEngineInit();
 
     assert.equal(howlerEngine.stopCalls, 1);
     assert.equal(videoJsEngine.loadCalls.length, 1);
@@ -146,7 +212,7 @@ test("reapplies persisted volume and mute state when switching to DASH engine", 
     assert.equal(videoJsEngine.setMutedCalls.at(-1), true);
 });
 
-test("keeps local output state when switching back to direct queue playback", () => {
+test("keeps local output state when switching back to direct queue playback", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
     const runtimeEngine = new HybridRuntimeAudioEngine({
@@ -162,6 +228,7 @@ test("keeps local output state when switching back to direct queue playback", ()
         protocol: "dash",
         mimeType: "application/dash+xml",
     });
+    await flushAsyncEngineInit();
 
     runtimeEngine.setVolume(0.12);
     runtimeEngine.setMuted(true);
@@ -175,7 +242,7 @@ test("keeps local output state when switching back to direct queue playback", ()
     assert.equal(howlerEngine.setMutedCalls.at(-1), true);
 });
 
-test("falls back to Howler event stream when Video.js initialization fails", () => {
+test("falls back to Howler event stream when Video.js initialization fails", async () => {
     const howlerEngine = new FakeAudioEngine();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
@@ -195,6 +262,7 @@ test("falls back to Howler event stream when Video.js initialization fails", () 
         protocol: "dash",
         mimeType: "application/dash+xml",
     });
+    await flushAsyncEngineInit();
 
     howlerEngine.emit("timeupdate", { timeSec: 12.34 });
 
@@ -202,7 +270,7 @@ test("falls back to Howler event stream when Video.js initialization fails", () 
     assert.equal(lastTimeUpdate, 12.34);
 });
 
-test("forwards representation quarantine to active DASH engine", () => {
+test("forwards representation quarantine to active DASH engine", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
     videoJsEngine.quarantineRepresentationResult = {
@@ -224,6 +292,7 @@ test("forwards representation quarantine to active DASH engine", () => {
         protocol: "dash",
         mimeType: "application/dash+xml",
     });
+    await flushAsyncEngineInit();
     const result = runtimeEngine.quarantineRepresentation("0", 20_000);
     runtimeEngine.clearRepresentationQuarantine();
 
@@ -274,7 +343,7 @@ test("falls back safely when active engine does not expose segmented helpers", (
     assert.equal(runtimeEngine.getSeekTarget(), null);
 });
 
-test("uses safe helper fallbacks when active DASH engine lacks optional helper APIs", () => {
+test("uses safe helper fallbacks when active DASH engine lacks optional helper APIs", async () => {
     const howlerEngine = new FakeAudioEngine();
     let activeTimeSec = 0;
     const minimalVideoJsEngine = {
@@ -307,6 +376,7 @@ test("uses safe helper fallbacks when active DASH engine lacks optional helper A
         protocol: "dash",
         mimeType: "application/dash+xml",
     });
+    await flushAsyncEngineInit();
     runtimeEngine.seek(3.5);
 
     assert.equal(runtimeEngine.quarantineRepresentation("rep-1", 1_000), null);

--- a/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
+++ b/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
@@ -187,6 +187,89 @@ test("ignores a stale DASH load that resolves after a newer direct load", async 
     assert.equal(videoJsEngine.loadCalls.length, 0);
 });
 
+test("cancels a pending lazy DASH engine load when the user stops playback", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load({
+        url: "https://example.test/stream.mpd",
+        protocol: "dash",
+        mimeType: "application/dash+xml",
+    });
+    runtimeEngine.stop();
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    assert.equal(videoJsEngine.loadCalls.length, 0);
+});
+
+test("cancels a pending lazy DASH engine load when the user pauses", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load({
+        url: "https://example.test/stream.mpd",
+        protocol: "dash",
+        mimeType: "application/dash+xml",
+    });
+    runtimeEngine.pause();
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    assert.equal(videoJsEngine.loadCalls.length, 0);
+});
+
+test("stops in-progress playback before the lazy video.js import resolves", async () => {
+    const howlerEngine = new FakeAudioEngine();
+    const videoJsEngine = new FakeAudioEngine();
+    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
+    const enginePromise = new Promise<AudioEngine>((resolve) => {
+        resolveEngine = resolve;
+    });
+    const runtimeEngine = new HybridRuntimeAudioEngine({
+        howlerEngine,
+        createVideoJsEngine: () => enginePromise,
+        resolveMode: () => "videojs",
+    });
+
+    runtimeEngine.load("https://example.test/track.mp3", {
+        autoplay: false,
+    });
+    runtimeEngine.play();
+    runtimeEngine.load({
+        url: "https://example.test/stream.mpd",
+        protocol: "dash",
+        mimeType: "application/dash+xml",
+    });
+
+    // The previously playing direct track must be halted immediately,
+    // not after the (potentially slow) video.js chunk download.
+    assert.equal(howlerEngine.stopCalls, 1);
+
+    resolveEngine?.(videoJsEngine);
+    await flushAsyncEngineInit();
+
+    assert.equal(videoJsEngine.loadCalls.length, 1);
+});
+
 test("reapplies persisted volume and mute state when switching to DASH engine", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();

--- a/frontend/tests/unit/pollingCadence.test.ts
+++ b/frontend/tests/unit/pollingCadence.test.ts
@@ -5,6 +5,7 @@ import {
     resolveFixedPollingInterval,
     resolvePollingEnabled,
     resolvePollingJitter,
+    resolveVisibilityGatedPollingInterval,
 } from "../../hooks/pollingCadence";
 
 test("resolvePollingEnabled defaults to true and preserves explicit false", () => {
@@ -29,6 +30,13 @@ test("resolvePollingJitter returns value within [0, maxJitterMs)", () => {
 
 test("resolvePollingJitter returns 0 for maxJitterMs of 0", () => {
     assert.equal(resolvePollingJitter(0), 0);
+});
+
+test("resolveVisibilityGatedPollingInterval pauses polling while hidden", () => {
+    assert.equal(resolveVisibilityGatedPollingInterval(30_000, true), 30_000);
+    assert.equal(resolveVisibilityGatedPollingInterval(30_000, false), false);
+    assert.equal(resolveVisibilityGatedPollingInterval(false, true), false);
+    assert.equal(resolveVisibilityGatedPollingInterval(false, false), false);
 });
 
 test("resolveAdaptivePollingInterval switches between active and idle cadences", () => {

--- a/frontend/tests/unit/serverBackendProxy.test.ts
+++ b/frontend/tests/unit/serverBackendProxy.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    buildBackendProxyOptions,
+    createBackendProxy,
+    createProxyErrorHandler,
+} from "../../server-proxy";
+
+interface FakeLogger {
+    errors: string[][];
+    error(...args: string[]): void;
+}
+
+function createFakeLogger(): FakeLogger {
+    return {
+        errors: [],
+        error(...args: string[]) {
+            this.errors.push(args);
+        },
+    };
+}
+
+function createFakeResponse(headersSent = false) {
+    return {
+        headersSent,
+        writeHeadCalls: [] as Array<{ statusCode: number; headers: unknown }>,
+        body: null as string | null,
+        writeHead(statusCode: number, headers: unknown) {
+            this.writeHeadCalls.push({ statusCode, headers });
+        },
+        end(body: string) {
+            this.body = body;
+        },
+    };
+}
+
+test("buildBackendProxyOptions registers the error handler via the v3 on.error API", () => {
+    const logger = createFakeLogger();
+    const options = buildBackendProxyOptions({
+        name: "api-proxy",
+        target: "http://127.0.0.1:3006",
+        logger,
+        errorMessage: "API backend unavailable",
+        errorCode: "API_PROXY_UNAVAILABLE",
+    });
+
+    // http-proxy-middleware v3 only honors options.on.error; the v2
+    // onError/logLevel options are silently ignored (dead code).
+    assert.equal(typeof options.on?.error, "function");
+    assert.equal("onError" in options, false);
+    assert.equal("logLevel" in options, false);
+    assert.equal(options.target, "http://127.0.0.1:3006");
+    assert.equal(options.ws, false);
+    assert.equal(options.changeOrigin, true);
+    assert.equal(options.xfwd, true);
+    assert.equal(options.timeout, 120000);
+    assert.equal(options.proxyTimeout, 120000);
+});
+
+test("buildBackendProxyOptions enables websocket proxying when requested", () => {
+    const options = buildBackendProxyOptions({
+        name: "listen-together-proxy",
+        target: "http://127.0.0.1:3006",
+        ws: true,
+        logger: createFakeLogger(),
+        errorMessage: "Listen Together backend unavailable",
+        errorCode: "LISTEN_TOGETHER_PROXY_UNAVAILABLE",
+    });
+
+    assert.equal(options.ws, true);
+});
+
+test("proxy error handler responds with the structured 503 JSON contract", () => {
+    const logger = createFakeLogger();
+    const handler = createProxyErrorHandler({
+        name: "api-proxy",
+        logger,
+        errorMessage: "API backend unavailable",
+        errorCode: "API_PROXY_UNAVAILABLE",
+    });
+    const res = createFakeResponse();
+
+    handler(new Error("connect ECONNREFUSED"), { method: "GET", url: "/api/library" }, res);
+
+    assert.equal(res.writeHeadCalls.length, 1);
+    assert.equal(res.writeHeadCalls[0]?.statusCode, 503);
+    assert.deepEqual(res.writeHeadCalls[0]?.headers, {
+        "Content-Type": "application/json",
+    });
+    assert.deepEqual(JSON.parse(res.body ?? "null"), {
+        error: "API backend unavailable",
+        code: "API_PROXY_UNAVAILABLE",
+    });
+    assert.equal(logger.errors.length, 1);
+    assert.match(logger.errors[0]?.[0] ?? "", /\[api-proxy\] GET \/api\/library failed:/);
+});
+
+test("proxy error handler does not write once headers were already sent", () => {
+    const handler = createProxyErrorHandler({
+        name: "api-proxy",
+        logger: createFakeLogger(),
+        errorMessage: "API backend unavailable",
+        errorCode: "API_PROXY_UNAVAILABLE",
+    });
+    const res = createFakeResponse(true);
+
+    handler(new Error("socket hang up"), { method: "GET", url: "/api/stream" }, res);
+
+    assert.equal(res.writeHeadCalls.length, 0);
+    assert.equal(res.body, null);
+});
+
+test("proxy error handler destroys socket-like responses from websocket upgrades", () => {
+    const handler = createProxyErrorHandler({
+        name: "listen-together-proxy",
+        logger: createFakeLogger(),
+        errorMessage: "Listen Together backend unavailable",
+        errorCode: "LISTEN_TOGETHER_PROXY_UNAVAILABLE",
+    });
+    let destroyCalls = 0;
+    const socketLike = {
+        write() {
+            // socket-like: write exists but writeHead does not
+        },
+        destroy() {
+            destroyCalls += 1;
+        },
+    };
+
+    handler(new Error("connect ECONNREFUSED"), { method: "GET", url: "/socket.io" }, socketLike);
+
+    assert.equal(destroyCalls, 1);
+});
+
+test("createBackendProxy returns a middleware exposing websocket upgrade", () => {
+    const proxy = createBackendProxy({
+        name: "listen-together-proxy",
+        target: "http://127.0.0.1:3006",
+        ws: true,
+        logger: createFakeLogger(),
+        errorMessage: "Listen Together backend unavailable",
+        errorCode: "LISTEN_TOGETHER_PROXY_UNAVAILABLE",
+    });
+
+    assert.equal(typeof proxy, "function");
+    assert.equal(typeof proxy.upgrade, "function");
+});


### PR DESCRIPTION
## Summary

Performance work targeting slow links — the motivating setup is Chrome on a phone over a WireGuard VPN to a self-hosted cluster, where initial loads and art-heavy pages were sluggish. Four independent improvements:

1. **Server-side cover-art resizing.** The cover-art endpoints accepted a `size` query param but never resized — it was only mixed into the Redis cache key, so phones downloaded full-resolution originals (often 1000–3000 px, 0.5–3 MB) for 140–180 px tiles. New `coverArtResize` service (sharp, already a dependency): size snapped to an allowlist (64/128/192/320/512/768), never upscales, WebP when `Accept: image/webp`, `Vary: Accept`, cache key now includes size **and** format. Native on-disk covers are resized on the fly too. Frontend call sites missing a `size` now pass one.
2. **Streaming `/api` proxy.** All `/api` traffic flowed through a Next route handler that buffers request bodies (`arrayBuffer()`) and strips `content-encoding` (undici auto-decompresses), losing backend gzip and re-chunking every response. `/api` is now proxied in `server.js` via `http-proxy-middleware` (same pattern the server already used for `/rest` and the Listen Together socket) — raw streaming, compression preserved, no buffering. Error contract preserved: structured 503 JSON via the hpm v3 `on.error` API (new `server-proxy.js`, unit-tested). The Next route handler is kept as a fallback for setups not fronted by `server.js`.
3. **Lazy-loaded video.js.** The segmented (DASH) engine statically imported video.js into every page's first load. It's now `await import(...)`-ed only when a segmented source is actually selected, with single-flight + sequence guards (a stop/pause during the first lazy load correctly cancels the deferred autoplay — covered by tests). **First Load JS for `/`: 2065.1 kB → 1336.8 kB (−728 kB, −35%).**
4. **Stable service-worker image cache keys.** Cover URLs carry `?token=` which rotates every 24 h; the SW cached by full URL, so the entire art cache re-downloaded daily. Cache keys now strip the token (network requests keep it); image cache versions bumped to evict token-keyed entries.
5. **Visibility-gated polling** (smaller win): social-presence, admin connected-users, notifications, and download-history polls pause while the tab is hidden and refetch on return.

## ACM Impact

No changes to ACM contract/rules/tests/tags. ACM CLI was not available in the authoring environment; CI `acm-health` regenerates state from the working tree.

## Type of Change

-   [ ] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [x] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

N/A — motivated by production use of a split (individual-mode) deployment.

## Changes Made

-   `backend/src/services/coverArtResize.ts` (new) + wiring in `backend/src/routes/library.ts` cover-art handlers (proxy + native paths); OpenAPI `size` param documented; services README row added
-   `frontend/server.js` + `frontend/server-proxy.js` (new): streaming `/api` proxy with structured 503 JSON error contract; `/rest` and Listen Together proxies rebuilt on the same tested helper; `frontend/Dockerfile` copies the new module
-   `frontend/lib/audio-engine/index.ts`: dynamic-import video.js engine (single-flight, stale-load/stop/pause sequence guards)
-   `frontend/public/sw.js`: token-stripped image cache keys, cache version bump
-   `frontend/hooks/pollingCadence.ts`, `useDocumentVisibility.ts` (new), wired into `useSocialPresence`, `useAdminConnectedUsers`, `useNotifications`, `useDownloadHistory`
-   Sized cover-art requests in `app/listen-together/page.tsx`, `app/vibe/page.tsx`, `components/player/OverlayPlayer.tsx`
-   CHANGELOG under `[Unreleased]`

## Verification

-   [ ] `acm init` / `acm sync` / `acm verify` / `acm review` / `acm health` — not run locally (CLI unavailable); relying on CI `acm-health`
-   [x] Additional targeted checks (list below)

## Additional Verification Details

-   verify: backend `npx jest src/services/__tests__/coverArtResize.test.ts` — exit 0, 12 passed (written failing-first)
-   verify: backend `npx jest src/routes/__tests__/libraryCoverArtCompat.test.ts` — 59 passed, 1 failed: **pre-existing** failure ("canonicalized native folder paths"), reproduced on clean `main` via stash — environment path-resolution issue, not introduced here
-   verify: backend `npx tsc --noEmit` — exit 0
-   verify: frontend `npm run lint` — exit 0 (0 errors; 106 pre-existing warnings, unchanged count)
-   verify: frontend `npm run build` — exit 0; First Load JS for `/` measured before/after as summed `_next/static/chunks/*.js` referenced by prerendered `index.html` (Next 16 Turbopack no longer prints the per-route table): 2065.1 kB → 1336.8 kB
-   verify: live proxy error-contract e2e — proxy against a dead backend port returns `503` `application/json` `{"error":"API backend unavailable","code":"API_PROXY_UNAVAILABLE"}`
-   verify: frontend `node --test` on `serverBackendProxy.test.ts` (6), `runtimeAudioEngineVolumeSync.component.test.ts` (11), `pollingCadence.test.ts` (6) — all pass, new tests written failing-first
-   verify: `bash scripts/docs/check-domain-readmes.sh` — OK

Notes for reviewers:

-   **AIO vs split:** all changes are mode-agnostic. Deployments that route `/api` at the ingress directly to the backend simply bypass the new proxy (unchanged behavior). Default chart routing (everything through the frontend Service) gets the streaming win.
-   Native-file covers are resized per request (no Redis layer for them) — bounded in practice by the existing long-lived immutable client/SW caching.
-   Full-screen player art is now capped at the 768 allowlist tier (call sites previously requested an inert `size=1200`) — visually indistinguishable on phone/tablet, worth a glance on large TV layouts.
-   TDD deviation, disclosed: `public/sw.js` has no unit-test harness; its change is small and was verified by `node --check` + manual reasoning. The `server.js` error-contract logic was made testable by extraction into `server-proxy.js`.

## Post-review hardening (second pass)

A second adversarial review pass landed two more commits:

-   `70ce2e4` — pause/play during the first lazy video.js chunk download now behaves correctly: pause lets the pending load complete without autoplay (no more 20 s stall until the load-timeout retry), play during the pending window re-arms autoplay instead of restarting the halted source at 0. Covered by 3 new component tests (13/13 pass).
-   `43dfa0d` — native on-disk covers now cache their resized variants in Redis (90-day TTL, keyed by path+mtime+size+sizeTier+format), so 304 revalidations no longer pay a sharp decode. 2 new tests; `libraryCoverArtCompat` at 61 passed / 1 pre-existing failure (reproduced with changes stashed).
