### PR TITLE
fix(scanner): resolve albums by release-group MBID so same-titled albums don't merge

### DIFF
--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -327,6 +327,84 @@ describe("MusicScannerService.scanLibrary", () => {
         expect(mockBackfillAllArtistCounts).toHaveBeenCalledTimes(1);
     });
 
+    it("resolves albums by release-group MBID so same-titled albums never merge", async () => {
+        const scanner = new MusicScannerService();
+
+        jest.spyOn(
+            MusicScannerService.prototype as any,
+            "findAudioFiles"
+        ).mockResolvedValue(["/music/Crystal Castles/Crystal Castles/01.flac"]);
+        // A tagged file from the 2010 self-titled album (distinct release group).
+        mockParseFile.mockResolvedValue({
+            common: {
+                title: "Fainting Spells",
+                track: { no: 1 },
+                disk: { no: 1 },
+                album: "Crystal Castles",
+                albumartist: "Crystal Castles",
+                year: 2010,
+                musicbrainz_releasegroupid: "rg-2010",
+            },
+            format: { duration: 200, codec: "audio/flac" },
+        } as any);
+        // No existing album carries this release group.
+        mockPrisma.album.findFirst.mockResolvedValue(null);
+        mockPrisma.album.create.mockResolvedValue({
+            id: "album-2010",
+            title: "Crystal Castles",
+            coverUrl: null,
+            location: "LIBRARY",
+            rgMbid: "rg-2010",
+        });
+
+        await scanner.scanLibrary("/music");
+
+        // The lookup keys on the unique release-group MBID — NOT the title —
+        // so the 2010 album is not found by the 2008 album's title and merged.
+        expect(mockPrisma.album.findFirst).toHaveBeenCalledWith({
+            where: { artistId: "artist-1", rgMbid: "rg-2010" },
+        });
+        // Not found by rgMbid -> a separate album is created.
+        expect(mockPrisma.album.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    title: "Crystal Castles",
+                    rgMbid: "rg-2010",
+                }),
+            })
+        );
+    });
+
+    it("falls back to a temp-rgMbid title match only for un-tagged files", async () => {
+        const scanner = new MusicScannerService();
+
+        jest.spyOn(
+            MusicScannerService.prototype as any,
+            "findAudioFiles"
+        ).mockResolvedValue(["/music/Artist/Untagged.flac"]);
+        // Default parseFile mock has no musicbrainz_releasegroupid (un-tagged).
+        mockPrisma.album.findFirst.mockResolvedValue(null);
+        mockPrisma.album.create.mockResolvedValue({
+            id: "album-temp",
+            title: "Test Album",
+            coverUrl: null,
+            location: "LIBRARY",
+            rgMbid: "temp-x",
+        });
+
+        await scanner.scanLibrary("/music");
+
+        // Un-tagged files match by title but only against other un-tagged
+        // (temp-rgMbid) albums, never a properly MBID-identified album.
+        expect(mockPrisma.album.findFirst).toHaveBeenCalledWith({
+            where: {
+                artistId: "artist-1",
+                title: "Test Album",
+                rgMbid: { startsWith: "temp-" },
+            },
+        });
+    });
+
     it("marks missing tracks as unhealthy without deleting library context", async () => {
         const scanner = new MusicScannerService();
 
@@ -1537,8 +1615,8 @@ describe("MusicScannerService.processAudioFile artist fallbacks", () => {
             normalizedName: "album band",
             mbid: null,
         });
-        mockPrisma.album.findFirst.mockResolvedValueOnce(null);
-        mockPrisma.album.findUnique.mockResolvedValueOnce({
+        // The album is resolved directly by its release-group MBID.
+        mockPrisma.album.findFirst.mockResolvedValueOnce({
             id: "album-release",
             title: "Album Name",
             coverUrl: null,
@@ -1552,8 +1630,8 @@ describe("MusicScannerService.processAudioFile artist fallbacks", () => {
             "/music"
         );
 
-        expect(mockPrisma.album.findUnique).toHaveBeenCalledWith({
-            where: { rgMbid: "rg-123" },
+        expect(mockPrisma.album.findFirst).toHaveBeenCalledWith({
+            where: { artistId: "artist-release", rgMbid: "rg-123" },
         });
         expect(mockPrisma.album.create).not.toHaveBeenCalled();
     });

--- a/backend/src/services/musicScanner.ts
+++ b/backend/src/services/musicScanner.ts
@@ -823,38 +823,42 @@ export class MusicScannerService {
         const isDiscoveryAlbum =
             isDiscoveryByPath || isDiscoveryByJob || isDiscoveryArtist;
 
-        // Get or create album
-        let album = await prisma.album.findFirst({
-            where: {
-                artistId: artist.id,
-                title: albumTitle,
-            },
-        });
+        // Get or create album.
+        //
+        // Resolve on the UNIQUE MusicBrainz release-group MBID first, so two
+        // albums that share a title but are different release groups — e.g.
+        // the two self-titled Crystal Castles albums (2008 and 2010) — never
+        // merge into one. Only un-tagged files (no release-group id) fall back
+        // to a title match, and only against other un-tagged (temp-rgMbid)
+        // albums, so an un-tagged file is never merged into a properly
+        // MBID-identified album of a possibly-different release.
+        let album = albumMbid
+            ? await prisma.album.findFirst({
+                  where: { artistId: artist.id, rgMbid: albumMbid },
+              })
+            : await prisma.album.findFirst({
+                  where: {
+                      artistId: artist.id,
+                      title: albumTitle,
+                      rgMbid: { startsWith: "temp-" },
+                  },
+              });
 
         if (!album) {
-            // Try to find by release group MBID if available
-            if (albumMbid) {
-                album = await prisma.album.findUnique({
-                    where: { rgMbid: albumMbid },
-                });
-            }
+            // Create new album (un-tagged files get a unique temporary MBID).
+            const rgMbid =
+                albumMbid || `temp-${Date.now()}-${Math.random()}`;
 
-            if (!album) {
-                // Create new album (use a temporary MBID for now)
-                const rgMbid =
-                    albumMbid || `temp-${Date.now()}-${Math.random()}`;
-
-                album = await prisma.album.create({
-                    data: {
-                        title: albumTitle,
-                        artistId: artist.id,
-                        rgMbid,
-                        year,
-                        primaryType: "Album",
-                        location: isDiscoveryAlbum ? "DISCOVER" : "LIBRARY",
-                    },
-                });
-            }
+            album = await prisma.album.create({
+                data: {
+                    title: albumTitle,
+                    artistId: artist.id,
+                    rgMbid,
+                    year,
+                    primaryType: "Album",
+                    location: isDiscoveryAlbum ? "DISCOVER" : "LIBRARY",
+                },
+            });
 
             // Extract cover art if we have an extractor
             // Re-extract if: no cover, OR native cover file is missing


### PR DESCRIPTION
## Problem
The library scanner resolved albums with `findFirst({ where: { artistId, title } })` **first**, only checking the MusicBrainz release-group MBID as a fallback. So two albums that share a title but are different release groups — e.g. the two self-titled Crystal Castles albums (2008 and 2010) — merged into one: the second album's tracks matched the first by title.

## Fix
Resolve on the unique release-group MBID first when the file is tagged; only un-tagged files fall back to a title match, and only against other un-tagged (`temp-`) albums, so an un-tagged file is never merged into a properly MBID-identified album of a possibly-different release. Drops the now-redundant `findUnique({ rgMbid })`.

Note: fixes future scans; already-merged albums separate on a re-scan. Requires files to carry `musicbrainz_releasegroupid` tags to distinguish same-titled albums.

## Tests
Two `scanLibrary` regression tests (tagged → looks up by rgMbid and creates a separate album; un-tagged → title match scoped to temp rgMbids); updated the existing reuse-by-rgMbid test to the new `findFirst` path. 41 scanner + 25 scan-processor tests pass; `musicScanner.ts` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)