### PR TITLE
refactor(types): drop the 2nd gratuitous (job as any).lidarrAlbumId cast (F3) — stacked on #23

### DIFF
--- a/backend/src/services/simpleDownloadManager.ts
+++ b/backend/src/services/simpleDownloadManager.ts
@@ -1526,8 +1526,11 @@ class SimpleDownloadManager {
                 }
             }
 
-            // Clean up from Lidarr queue if possible
-            const lidarrAlbumId = (job as any).lidarrAlbumId;
+            // Clean up from Lidarr queue if possible. `job` is a DownloadJob
+            // from prisma.downloadJob.findMany (no select), and lidarrAlbumId is
+            // a real typed column (Int?), so no `as any` is needed — the cast
+            // only disabled type checking on the field that drives dedup/retry.
+            const lidarrAlbumId = job.lidarrAlbumId;
             if (lidarrAlbumId && job.lidarrRef) {
                 await this.blocklistAndRetry(job.lidarrRef, lidarrAlbumId);
             }

--- a/docs/modernization-roadmap.md
+++ b/docs/modernization-roadmap.md
@@ -19,7 +19,7 @@ The audit found **0 true false positives** but several packaging/measurement err
 | F46 | "~480 `@ts-ignore`" → **1** (480 is `eslint-disable`). |
 | F35 | "helmet ships without HSTS/CSP" → helmet **does** ship both by default. |
 | F28 | "breaking / keys re-issued" → **no re-issue** (HMAC-in-place; keys keep working). |
-| F3 | shipped **1 of 4 steps**; a 2nd identical cast remains at `simpleDownloadManager.ts:1530`. |
+| F3 | both gratuitous casts now removed (line-433 in #21, line-1530 in `feat/f3-second-cast`); the `DownloadJobMetadata` typing / discoverWeekly / backend ESLint steps remain deferred. |
 | F7 / F49 | undercounts: retry predicate in **8** files; a 2nd Express-5 break at `subsonic.ts:6667`. |
 | F22 | omits a 4th regenerated key (`INTERNAL_API_SECRET`). |
 | Status | F3/F18/F24 are **partial**, not complete; F6 re-homed out of #14; severities recalibrated (F20/F23/F24/F35/F36/F47). |
@@ -151,7 +151,9 @@ _(includes F54; dimension tallies double-count the F2/F44 and F17/F47 duplicate 
 
 **🟡 partial (PR #21)** · dimension: readability · severity: high · effort: L · risk: medium · epic: #15
 
-> **Audit note.** ✓ Only step 1 of 4 shipped (the line-433 cast). A SECOND identical cast remains at `simpleDownloadManager.ts:1530` (`(job as any).lidarrAlbumId`), not yet removed. The `DownloadJobMetadata` interface / discoverWeekly typing / backend ESLint are unbuilt; a partial helper `utils/downloadJobMetadata.ts` already exists to build on.
+> **Audit note.** ✓ Originally only step 1 of 4 shipped (the line-433 cast).
+>
+> **Update** (`feat/f3-second-cast`). The SECOND identical cast at `simpleDownloadManager.ts:1530` (`(job as any).lidarrAlbumId`) is now removed too — `job` is a `DownloadJob` from `findMany` (no select) and `lidarrAlbumId` is a typed `Int?` column, so the cast was gratuitous (tsc clean; 88/88 simpleDownloadManager tests pass). Both gratuitous casts are gone. Still 🟡: the `DownloadJobMetadata` interface / `parseMetadata`, the discoverWeekly typing, and the backend ESLint gate are deferred — typing the heterogeneous `Json?` metadata and rewiring `resolveDownloadJobMetadata`'s 3 callers is a regression-prone change better shipped as its own typed-metadata PR under #15.
 
 **Files:** `backend/src/services/simpleDownloadManager.ts`, `backend/src/services/discoverWeekly.ts`, `backend/src/routes/library.ts`
 


### PR DESCRIPTION
## Finish the F3 cast removal

The first F3 step (PR #21) removed the gratuitous `(j as any).lidarrAlbumId` cast at `simpleDownloadManager.ts:433`, but the audit (§2.4) found a **second identical cast** at line 1530 that the shipped fix missed. This removes it.

`job` there is a `DownloadJob` from `prisma.downloadJob.findMany` (no `select`), and `lidarrAlbumId` is a real typed column (`Int?`) already read un-cast elsewhere in the file. The `as any` was gratuitous — it only disabled type checking on the exact field that drives Lidarr dedup / blocklist-retry. Both gratuitous casts are now gone.

Type-only change with identical runtime, so **`tsc` is the guard** (no CHANGELOG entry, no behavioral test — matching the first F3 step, a pure type-level no-op).

`verify:` `tsc --noEmit` exit 0; jest simpleDownloadManager + branch-coverage 88/88 pass.

**Deferred (honest partial):** the rest of F3 — the `DownloadJobMetadata` interface / `parseMetadata`, threading types through `discoverWeekly`, and the backend ESLint gate. Typing the heterogeneous `Json?` metadata and rewiring `resolveDownloadJobMetadata`'s 3 callers is a regression-prone change that deserves its own typed-metadata PR under #15, not a rider on this cast removal.

---
Part of #15 (type-safety ratchet). **Stacked on #23** → #22 → #21 → #3.