### PR TITLE
fix(downloads): honor "Skip" when the primary download source is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The "When Primary Source Fails: Skip" setting is now honored when the primary download source is unavailable *before* dispatch. Previously the album download processor silently rerouted to any other available source (which is how downloads configured TIDAL-primary-with-Skip ended up in Lidarr); now an unavailable primary with Skip fails the job with a clear error, an explicitly configured fallback is dispatched only if that fallback service is itself available (failing the job otherwise, even when a third source is up), and only legacy settings rows with no stored fallback preference keep the old auto-detect rerouting. Pre-existing limitation, unchanged by this fix: manual album downloads have two dispatch pipelines (TIDAL, and the Lidarr-backed download manager), so a non-TIDAL selection — including a `soulseek` fallback — is still executed by the Lidarr-backed manager.
 - Saving system settings can no longer silently wipe the admin TIDAL download connection. `POST /api/system-settings` previously accepted `tidalAccessToken`/`tidalRefreshToken`/`tidalUserId` and wrote whatever the settings form round-tripped — so any Save from a page loaded before (or without) the device auth overwrote the stored tokens with empty values, after which downloads silently rerouted away from TIDAL. These credential fields are now ignored by the general settings save and are managed exclusively by the `/api/system-settings/tidal-auth` device flow.
 
 ### Security

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -499,6 +499,9 @@ describe("downloads routes runtime", () => {
                 data: expect.objectContaining({
                     status: "failed",
                     error: expect.stringContaining("Skip"),
+                    metadata: expect.objectContaining({
+                        statusText: "tidal unavailable — skipped",
+                    }),
                 }),
             })
         );
@@ -562,11 +565,16 @@ describe("downloads routes runtime", () => {
         // Soulseek being available must NOT rescue the job — the user chose lidarr
         expect(mockStartDownload).not.toHaveBeenCalled();
         expect(mockTidalFindAlbum).not.toHaveBeenCalled();
+        // The status text must say the fallback was unavailable — NOT "skipped",
+        // which would misrepresent a non-Skip failure in the UI
         expect(mockDownloadUpdate).toHaveBeenCalledWith(
             expect.objectContaining({
                 data: expect.objectContaining({
                     status: "failed",
                     error: expect.stringContaining("unavailable"),
+                    metadata: expect.objectContaining({
+                        statusText: "tidal and fallback lidarr unavailable",
+                    }),
                 }),
             })
         );

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -468,6 +468,140 @@ describe("downloads routes runtime", () => {
         );
     });
 
+    it("fails the job instead of rerouting when the primary source is unavailable and fallback is Skip", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "tidal",
+            primaryFailureFallback: "none",
+        });
+        mockTidalAvailable.mockResolvedValue(false);
+        mockLidarrIsEnabled.mockResolvedValue(true);
+        mockSoulseekAvailable.mockResolvedValue(true);
+
+        const req = {
+            body: {
+                type: "album",
+                mbid: "rg-skip",
+                subject: "Ella Langley - Hungover",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await createJobHandler(req, res);
+        await flushAsyncWork();
+
+        expect(res.statusCode).toBe(200);
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(mockTidalFindAlbum).not.toHaveBeenCalled();
+        expect(mockDownloadUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: expect.stringContaining("Skip"),
+                }),
+            })
+        );
+    });
+
+    it("uses the explicitly configured fallback source when the primary is unavailable", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "tidal",
+            primaryFailureFallback: "lidarr",
+        });
+        mockTidalAvailable.mockResolvedValue(false);
+        mockLidarrIsEnabled.mockResolvedValue(true);
+        mockSoulseekAvailable.mockResolvedValue(false);
+
+        const req = {
+            body: {
+                type: "album",
+                mbid: "rg-fb",
+                subject: "Artist - Album",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await createJobHandler(req, res);
+        await flushAsyncWork();
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-fb",
+            "user-1"
+        );
+    });
+
+    it("fails the job when both the primary and its configured fallback are unavailable", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "tidal",
+            primaryFailureFallback: "lidarr",
+        });
+        mockTidalAvailable.mockResolvedValue(false);
+        mockLidarrIsEnabled.mockResolvedValue(false);
+        mockSoulseekAvailable.mockResolvedValue(true);
+
+        const req = {
+            body: {
+                type: "album",
+                mbid: "rg-fb-down",
+                subject: "Artist - Album",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await createJobHandler(req, res);
+        await flushAsyncWork();
+
+        // Soulseek being available must NOT rescue the job — the user chose lidarr
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(mockTidalFindAlbum).not.toHaveBeenCalled();
+        expect(mockDownloadUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: expect.stringContaining("unavailable"),
+                }),
+            })
+        );
+    });
+
+    it("keeps legacy auto-detect rerouting when no fallback preference is stored", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "tidal",
+        });
+        mockTidalAvailable.mockResolvedValue(false);
+        mockLidarrIsEnabled.mockResolvedValue(true);
+        mockSoulseekAvailable.mockResolvedValue(true);
+
+        const req = {
+            body: {
+                type: "album",
+                mbid: "rg-legacy",
+                subject: "Artist - Album",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await createJobHandler(req, res);
+        await flushAsyncWork();
+
+        expect(mockStartDownload).toHaveBeenCalled();
+        expect(mockDownloadUpdate).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ status: "failed" }),
+            })
+        );
+    });
+
     it("returns existing active job for P2002 race-condition collisions", async () => {
         mockTransaction.mockRejectedValueOnce({ code: "P2002" });
         mockDownloadFindFirst.mockResolvedValueOnce({
@@ -1463,7 +1597,7 @@ describe("downloads routes runtime", () => {
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
             downloadSource: "tidal",
-            primaryFailureFallback: "none",
+            primaryFailureFallback: "soulseek",
         });
         mockTidalAvailable.mockResolvedValue(false);
         mockSoulseekAvailable.mockResolvedValue(true);
@@ -1512,7 +1646,7 @@ describe("downloads routes runtime", () => {
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
             downloadSource: "soulseek",
-            primaryFailureFallback: "none",
+            primaryFailureFallback: "tidal",
         });
         mockTidalAvailable.mockResolvedValue(true);
         mockSoulseekAvailable.mockResolvedValue(false);
@@ -1577,7 +1711,7 @@ describe("downloads routes runtime", () => {
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
             downloadSource: "lidarr",
-            primaryFailureFallback: "none",
+            primaryFailureFallback: "soulseek",
         });
         mockTidalAvailable.mockResolvedValue(false);
         mockSoulseekAvailable.mockResolvedValue(true);

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -597,6 +597,35 @@ async function processArtistDownload(
     }
 }
 
+/**
+ * Mark a download job failed before any source was contacted — used when
+ * the configured source is unavailable and the fallback setting forbids
+ * rerouting. Mirrors the failure shape of processTidalDownload's catch.
+ */
+async function failJobWithoutDispatch(
+    jobId: string,
+    jobMetadata: unknown,
+    source: string,
+    message: string
+) {
+    logger.error(`[Downloads] ${message} — job ${jobId} not dispatched`);
+
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            status: "failed",
+            error: message,
+            completedAt: new Date(),
+            metadata: {
+                ...((jobMetadata as Record<string, unknown>) || {}),
+                currentSource: source,
+                statusText: `${source} unavailable — skipped`,
+                failedAt: new Date().toISOString(),
+            },
+        },
+    });
+}
+
 // Background download processor
 async function processDownload(
     jobId: string,
@@ -639,17 +668,56 @@ async function processDownload(
             lidarrService.isEnabled(),
             soulseekService.isAvailable(),
         ]);
+        const availability: Record<string, boolean> = {
+            tidal: tidalAvail,
+            lidarr: lidarrAvail,
+            soulseek: soulseekAvail,
+        };
 
-        // Determine effective download source:
-        // 1. Use configured source if that service is available
-        // 2. Otherwise auto-detect: prefer Tidal > Soulseek > Lidarr
+        // Determine effective download source. When the configured primary
+        // is unavailable, the user's "When primary source fails" setting
+        // decides what happens: "none" (Skip) fails the job outright, an
+        // explicit fallback source is used only if it is itself available,
+        // and only legacy rows with no stored preference keep the old
+        // auto-detect rerouting.
         let effectiveSource = configuredSource;
-        if (configuredSource === "tidal" && !tidalAvail) {
-            effectiveSource = soulseekAvail ? "soulseek" : lidarrAvail ? "lidarr" : "soulseek";
-        } else if (configuredSource === "soulseek" && !soulseekAvail) {
-            effectiveSource = tidalAvail ? "tidal" : lidarrAvail ? "lidarr" : "soulseek";
-        } else if (configuredSource === "lidarr" && !lidarrAvail) {
-            effectiveSource = tidalAvail ? "tidal" : soulseekAvail ? "soulseek" : "lidarr";
+        if (!availability[configuredSource]) {
+            const fallback = settings?.primaryFailureFallback;
+
+            if (fallback === "none" || fallback === configuredSource) {
+                await failJobWithoutDispatch(
+                    jobId,
+                    job.metadata,
+                    configuredSource,
+                    `${configuredSource} is unavailable and "When primary source fails" is set to Skip`
+                );
+                return;
+            }
+
+            if (
+                fallback === "tidal" ||
+                fallback === "lidarr" ||
+                fallback === "soulseek"
+            ) {
+                if (!availability[fallback]) {
+                    await failJobWithoutDispatch(
+                        jobId,
+                        job.metadata,
+                        configuredSource,
+                        `${configuredSource} is unavailable and the configured fallback (${fallback}) is also unavailable`
+                    );
+                    return;
+                }
+                effectiveSource = fallback;
+            } else if (configuredSource === "tidal") {
+                // Legacy auto-detect (no stored fallback preference):
+                // prefer Tidal > Soulseek > Lidarr
+                effectiveSource = soulseekAvail ? "soulseek" : lidarrAvail ? "lidarr" : "soulseek";
+            } else if (configuredSource === "soulseek") {
+                effectiveSource = tidalAvail ? "tidal" : lidarrAvail ? "lidarr" : "soulseek";
+            } else {
+                effectiveSource = tidalAvail ? "tidal" : soulseekAvail ? "soulseek" : "lidarr";
+            }
         }
 
         logger.debug(`Download source: configured=${configuredSource}, effective=${effectiveSource}`);
@@ -657,7 +725,10 @@ async function processDownload(
         if (effectiveSource === "tidal" && tidalAvail) {
             await processTidalDownload(jobId, parsedArtist, parsedAlbum, job.userId);
         } else {
-            // Use simple download manager for Lidarr/Soulseek downloads
+            // Non-TIDAL dispatch goes through simpleDownloadManager, which
+            // is Lidarr-backed — there is no per-source dispatch below this
+            // point, so a "soulseek" selection is executed by the Lidarr
+            // manager (pre-existing pipeline limitation).
             const result = await simpleDownloadManager.startDownload(
                 jobId,
                 parsedArtist,

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -611,6 +611,16 @@ async function failJobWithoutDispatch(
 ) {
     logger.error(`[Downloads] ${message} — job ${jobId} not dispatched`);
 
+    // metadata is a Prisma Json column, so it can legally hold a string,
+    // array, or scalar — spreading those would corrupt the shape
+    // (e.g. "abc" → {0:"a",1:"b",2:"c"}). Only spread plain objects.
+    const baseMetadata =
+        jobMetadata &&
+        typeof jobMetadata === "object" &&
+        !Array.isArray(jobMetadata)
+            ? (jobMetadata as Record<string, unknown>)
+            : {};
+
     await prisma.downloadJob.update({
         where: { id: jobId },
         data: {
@@ -618,7 +628,7 @@ async function failJobWithoutDispatch(
             error: message,
             completedAt: new Date(),
             metadata: {
-                ...((jobMetadata as Record<string, unknown>) || {}),
+                ...baseMetadata,
                 currentSource: source,
                 statusText,
                 failedAt: new Date().toISOString(),
@@ -686,11 +696,17 @@ async function processDownload(
             const fallback = settings?.primaryFailureFallback;
 
             if (fallback === "none" || fallback === configuredSource) {
+                // A fallback equal to the (unavailable) primary cannot rescue
+                // the job either — same outcome as Skip, but say so honestly.
+                const reason =
+                    fallback === "none"
+                        ? `${configuredSource} is unavailable and "When primary source fails" is set to Skip`
+                        : `${configuredSource} is unavailable and the configured fallback is also ${configuredSource}`;
                 await failJobWithoutDispatch(
                     jobId,
                     job.metadata,
                     configuredSource,
-                    `${configuredSource} is unavailable and "When primary source fails" is set to Skip`,
+                    reason,
                     `${configuredSource} unavailable — skipped`
                 );
                 return;

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -606,7 +606,8 @@ async function failJobWithoutDispatch(
     jobId: string,
     jobMetadata: unknown,
     source: string,
-    message: string
+    message: string,
+    statusText: string
 ) {
     logger.error(`[Downloads] ${message} — job ${jobId} not dispatched`);
 
@@ -619,7 +620,7 @@ async function failJobWithoutDispatch(
             metadata: {
                 ...((jobMetadata as Record<string, unknown>) || {}),
                 currentSource: source,
-                statusText: `${source} unavailable — skipped`,
+                statusText,
                 failedAt: new Date().toISOString(),
             },
         },
@@ -689,7 +690,8 @@ async function processDownload(
                     jobId,
                     job.metadata,
                     configuredSource,
-                    `${configuredSource} is unavailable and "When primary source fails" is set to Skip`
+                    `${configuredSource} is unavailable and "When primary source fails" is set to Skip`,
+                    `${configuredSource} unavailable — skipped`
                 );
                 return;
             }
@@ -704,14 +706,15 @@ async function processDownload(
                         jobId,
                         job.metadata,
                         configuredSource,
-                        `${configuredSource} is unavailable and the configured fallback (${fallback}) is also unavailable`
+                        `${configuredSource} is unavailable and the configured fallback (${fallback}) is also unavailable`,
+                        `${configuredSource} and fallback ${fallback} unavailable`
                     );
                     return;
                 }
                 effectiveSource = fallback;
             } else if (configuredSource === "tidal") {
                 // Legacy auto-detect (no stored fallback preference):
-                // prefer Tidal > Soulseek > Lidarr
+                // TIDAL is down, so prefer Soulseek, then Lidarr
                 effectiveSource = soulseekAvail ? "soulseek" : lidarrAvail ? "lidarr" : "soulseek";
             } else if (configuredSource === "soulseek") {
                 effectiveSource = tidalAvail ? "tidal" : lidarrAvail ? "lidarr" : "soulseek";


### PR DESCRIPTION
Final piece of the TIDAL-downloads-going-to-Lidarr incident (follows #35/#36).

## Problem
`processDownload` checked the configured source's availability and, on failure, silently rerouted to whatever else was up — `primaryFailureFallback` was never consulted at this stage (it was only honored deep inside the TIDAL path after a search miss). With the admin TIDAL tokens wiped (#35's bug), every download configured TIDAL-primary + Skip was quietly handed to Lidarr, which then timed out.

## Fix
Pre-dispatch source selection now implements the setting:
- **`none` (Skip):** the job is marked `failed` with `error: "<source> is unavailable and \"When primary source fails\" is set to Skip"` and a `statusText` of `<source> unavailable — skipped`. No reroute.
- **Explicit fallback:** used only if that service is itself available; if not, the job fails even when a third source is up (the user chose their fallback — soulseek being alive must not rescue a lidarr fallback).
- **Legacy rows with no stored preference:** keep the previous auto-detect rerouting, matching `acquisitionService`'s treatment of null/undefined.

Documented pre-existing limitation (unchanged): non-TIDAL dispatch runs through the Lidarr-backed `simpleDownloadManager`, so a `soulseek` selection is still executed by the Lidarr manager. Fixing that is the larger pipeline-unification item.

## Testing
- TDD: 4 new tests written red-first (Skip fails without contacting any source; explicit fallback dispatched; primary+fallback both down fails despite a third source being up; legacy auto-detect preserved).
- 3 existing tests that locked in the silent-reroute-with-Skip behavior updated to configure the fallback they assert.
- `downloadsRuntime.test.ts` 62/62 green, backend tsc clean, all `awm verify` gates pass.
- Cross-LLM review gate: PASS (after tightening the changelog/comment to state the Lidarr-backed dispatch limitation honestly — the reviewer correctly flagged the original wording as overpromising).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auefjjuuu5FjjtCrn3YAXc