### PR TITLE
feat(worker): event-loop stall watchdog with job attribution + probe headroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to soundspan are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Worker event-loop stall watchdog (#43), with two attribution paths. Stalls the loop recovers from: the worker samples `monitorEventLoopDelay` and, when a stall exceeds the warn threshold (default 1s, `WORKER_EVENT_LOOP_WARN_MS`), logs the Bull jobs active at that moment. Stalls that end in a liveness kill: the watchdog's interval can never fire while the loop is pegged, so the heavy queues (`worker-scheduler`, `library-scan`) log an unconditional `job-start` breadcrumb — the last log line before the kill names the culprit. Sample cadence is configurable via `WORKER_EVENT_LOOP_SAMPLE_MS` (default 5s).
+
+### Changed
+
+- The Helm chart's backend-worker liveness probe gets busy-loop headroom: `timeoutSeconds` 10 → 25 and `failureThreshold` 3 → 4 (~2 minutes of sustained event-loop saturation before a kill, up from ~90 seconds). `/health/live` answers unconditionally, so probe timeouts indicate a busy single-threaded worker, not a dead one; true deadlocks still get killed.
+
 ## [1.6.1] - 2026-07-08
 
 ### Fixed

--- a/backend/src/__tests__/workerEntrypointBehavior.test.ts
+++ b/backend/src/__tests__/workerEntrypointBehavior.test.ts
@@ -118,6 +118,10 @@ describe("worker entrypoint behavior", () => {
             config: {
                 databaseUrl: "postgresql://soundspan:secret@db.example:5432/soundspan",
                 redisUrl: "redis://redis.example:6379/0",
+                workerEventLoop: {
+                    warnThresholdMs: 1000,
+                    sampleIntervalMs: 5000,
+                },
             },
             initializeMusicConfig: jest.fn(
                 initializeMusicConfigImpl || (async () => undefined)

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -93,6 +93,20 @@ export const config = {
     // real reverse-proxy depth (usually 1) to enable spoof protection.
     trustProxy: (trustProxyHops >= 0 ? trustProxyHops : true) as number | boolean,
 
+    // Worker event-loop stall watchdog (issue #43): a stall above the warn
+    // threshold logs the active Bull jobs so liveness-probe kills can be
+    // attributed to the job that pegged the loop.
+    workerEventLoop: {
+        warnThresholdMs: parseEnvInt(
+            process.env.WORKER_EVENT_LOOP_WARN_MS,
+            1000
+        ),
+        sampleIntervalMs: parseEnvInt(
+            process.env.WORKER_EVENT_LOOP_SAMPLE_MS,
+            5000
+        ),
+    },
+
     // Music library configuration (self-contained native music system)
     // Access via config.music - will be updated after initialization
     get music() {

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -100,6 +100,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/vibeAnalysisCleanup.ts` | Core |
 | `backend/src/services/vibeVocabulary.ts` | Core |
 | `backend/src/services/wikidata.ts` | Core |
+| `backend/src/services/workerEventLoopMonitor.ts` | Core |
 | `backend/src/services/youtubeDownload.ts` | Core |
 | `backend/src/services/youtubeMusic.ts` | Core |
 

--- a/backend/src/services/__tests__/workerEventLoopMonitor.test.ts
+++ b/backend/src/services/__tests__/workerEventLoopMonitor.test.ts
@@ -1,0 +1,128 @@
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import {
+    evaluateEventLoopSample,
+    trackJobStart,
+    trackJobEnd,
+    getActiveJobs,
+    clearActiveJobsForTest,
+    runMonitorTick,
+    type EventLoopSampleMs,
+} from "../workerEventLoopMonitor";
+import { logger } from "../../utils/logger";
+
+const mockWarn = logger.warn as jest.Mock;
+
+const sample = (overrides: Partial<EventLoopSampleMs> = {}): EventLoopSampleMs => ({
+    maxMs: 10,
+    p99Ms: 5,
+    meanMs: 2,
+    ...overrides,
+});
+
+describe("active job registry", () => {
+    beforeEach(() => {
+        clearActiveJobsForTest();
+    });
+
+    it("tracks job start and end", () => {
+        trackJobStart("library-scan", "16", "scan", 1_000);
+        expect(getActiveJobs()).toEqual([
+            expect.objectContaining({
+                queue: "library-scan",
+                jobId: "16",
+                jobName: "scan",
+                startedAtMs: 1_000,
+            }),
+        ]);
+
+        trackJobEnd("library-scan", "16");
+        expect(getActiveJobs()).toEqual([]);
+    });
+
+    it("ignores ends for unknown jobs and keys jobs by queue+id", () => {
+        trackJobStart("worker-scheduler", "a", "lidarr-cleanup-cycle", 0);
+        trackJobEnd("library-scan", "a");
+        expect(getActiveJobs()).toHaveLength(1);
+    });
+});
+
+describe("evaluateEventLoopSample", () => {
+    beforeEach(() => {
+        clearActiveJobsForTest();
+    });
+
+    it("returns null below the threshold", () => {
+        expect(
+            evaluateEventLoopSample(sample({ maxMs: 999 }), [], 1000, 0)
+        ).toBeNull();
+    });
+
+    it("names the active jobs with their age when the loop stalls", () => {
+        trackJobStart("worker-scheduler", "r1", "download-reconciliation-cycle", 5_000);
+        const warning = evaluateEventLoopSample(
+            sample({ maxMs: 2400, p99Ms: 1800 }),
+            getActiveJobs(),
+            1000,
+            65_000
+        );
+
+        expect(warning).not.toBeNull();
+        expect(warning!.message).toContain("max=2400ms");
+        expect(warning!.message).toContain("p99=1800ms");
+        expect(warning!.message).toContain(
+            "worker-scheduler/download-reconciliation-cycle#r1 age=60s"
+        );
+    });
+
+    it("says none when the loop stalls with no attributed job", () => {
+        const warning = evaluateEventLoopSample(
+            sample({ maxMs: 1500 }),
+            [],
+            1000,
+            0
+        );
+        expect(warning!.message).toContain("activeJobs=none");
+    });
+});
+
+describe("runMonitorTick", () => {
+    beforeEach(() => {
+        clearActiveJobsForTest();
+        mockWarn.mockClear();
+    });
+
+    const NS_PER_MS = 1_000_000;
+
+    const histogramLike = (maxMs: number) => ({
+        max: maxMs * NS_PER_MS,
+        mean: 2 * NS_PER_MS,
+        percentile: jest.fn(() => 3 * NS_PER_MS),
+        reset: jest.fn(),
+    });
+
+    it("warns and resets the histogram on a stall", () => {
+        const h = histogramLike(3000);
+        runMonitorTick(h, 1000, () => 0);
+
+        expect(mockWarn).toHaveBeenCalledWith(
+            expect.stringContaining("max=3000ms")
+        );
+        expect(h.reset).toHaveBeenCalled();
+    });
+
+    it("stays silent and still resets below the threshold", () => {
+        const h = histogramLike(200);
+        runMonitorTick(h, 1000, () => 0);
+
+        expect(mockWarn).not.toHaveBeenCalled();
+        expect(h.reset).toHaveBeenCalled();
+    });
+});

--- a/backend/src/services/workerEventLoopMonitor.ts
+++ b/backend/src/services/workerEventLoopMonitor.ts
@@ -1,0 +1,179 @@
+import { monitorEventLoopDelay } from "perf_hooks";
+import { logger } from "../utils/logger";
+
+/**
+ * Worker event-loop stall watchdog (issue #43).
+ *
+ * The worker's liveness probe (`/health/live`) answers unconditionally, so a
+ * probe timeout always means the event loop itself was blocked. Historically
+ * that ended in a kubelet kill with no indication of WHICH job pegged the
+ * loop. This module samples `monitorEventLoopDelay` and, when the observed
+ * delay crosses a threshold, logs a warning naming the Bull jobs that were
+ * active during the stall — so the next incident names its culprit instead
+ * of requiring log archaeology.
+ *
+ * The registry is fed by the queue observability handlers in
+ * `workers/index.ts` (every queue already routes `active`/`completed`/
+ * `failed` events through one function). Attribution is best-effort:
+ * concurrent jobs all get listed.
+ */
+
+export interface ActiveJobRecord {
+    queue: string;
+    jobId: string;
+    jobName: string;
+    startedAtMs: number;
+}
+
+export interface EventLoopSampleMs {
+    maxMs: number;
+    p99Ms: number;
+    meanMs: number;
+}
+
+export interface StallWarning {
+    message: string;
+}
+
+const activeJobs = new Map<string, ActiveJobRecord>();
+
+function jobKey(queue: string, jobId: string): string {
+    return `${queue}:${jobId}`;
+}
+
+export function trackJobStart(
+    queue: string,
+    jobId: string,
+    jobName: string,
+    startedAtMs: number = Date.now()
+): void {
+    activeJobs.set(jobKey(queue, jobId), {
+        queue,
+        jobId,
+        jobName,
+        startedAtMs,
+    });
+}
+
+export function trackJobEnd(queue: string, jobId: string): void {
+    activeJobs.delete(jobKey(queue, jobId));
+}
+
+export function getActiveJobs(): ActiveJobRecord[] {
+    return Array.from(activeJobs.values());
+}
+
+export function clearActiveJobsForTest(): void {
+    activeJobs.clear();
+}
+
+/**
+ * Pure decision: given a sampled event-loop delay window and the jobs active
+ * at evaluation time, produce a stall warning or null.
+ */
+export function evaluateEventLoopSample(
+    sample: EventLoopSampleMs,
+    jobs: ActiveJobRecord[],
+    warnThresholdMs: number,
+    nowMs: number
+): StallWarning | null {
+    if (sample.maxMs < warnThresholdMs) return null;
+
+    const jobList =
+        jobs.length === 0
+            ? "none"
+            : jobs
+                  .map((job) => {
+                      const ageSeconds = Math.max(
+                          0,
+                          Math.round((nowMs - job.startedAtMs) / 1000)
+                      );
+                      return `${job.queue}/${job.jobName}#${job.jobId} age=${ageSeconds}s`;
+                  })
+                  .join(", ");
+
+    return {
+        message:
+            `[WorkerEventLoop] stall detected: max=${Math.round(sample.maxMs)}ms ` +
+            `p99=${Math.round(sample.p99Ms)}ms mean=${Math.round(sample.meanMs)}ms ` +
+            `activeJobs=${jobList}`,
+    };
+}
+
+interface HistogramLike {
+    max: number;
+    mean: number;
+    percentile(p: number): number;
+    reset(): void;
+}
+
+const NS_PER_MS = 1e6;
+
+/**
+ * One sampling tick: read the histogram (nanoseconds), evaluate, warn if
+ * stalled, and reset the window either way.
+ */
+export function runMonitorTick(
+    histogram: HistogramLike,
+    warnThresholdMs: number,
+    now: () => number = Date.now
+): void {
+    const sample: EventLoopSampleMs = {
+        maxMs: histogram.max / NS_PER_MS,
+        p99Ms: histogram.percentile(99) / NS_PER_MS,
+        meanMs: histogram.mean / NS_PER_MS,
+    };
+
+    const warning = evaluateEventLoopSample(
+        sample,
+        getActiveJobs(),
+        warnThresholdMs,
+        now()
+    );
+    if (warning) {
+        logger.warn(warning.message);
+    }
+
+    histogram.reset();
+}
+
+let stopMonitor: (() => void) | null = null;
+
+export interface WorkerEventLoopMonitorOptions {
+    warnThresholdMs: number;
+    sampleIntervalMs: number;
+}
+
+/**
+ * Start the watchdog. Idempotent; returns a stop function. The interval is
+ * unref'd so it never keeps the process alive. Options come from
+ * `config.workerEventLoop` at the call site — this module stays free of the
+ * config import chain so it can be unit-tested without a database.
+ */
+export function startWorkerEventLoopMonitor(
+    options?: Partial<WorkerEventLoopMonitorOptions>
+): () => void {
+    if (stopMonitor) return stopMonitor;
+
+    const warnThresholdMs = options?.warnThresholdMs ?? 1000;
+    const sampleIntervalMs = options?.sampleIntervalMs ?? 5000;
+
+    const histogram = monitorEventLoopDelay({ resolution: 20 });
+    histogram.enable();
+
+    const interval = setInterval(() => {
+        runMonitorTick(histogram, warnThresholdMs);
+    }, sampleIntervalMs);
+    interval.unref();
+
+    logger.info(
+        `[WorkerEventLoop] stall watchdog started (warn>=${warnThresholdMs}ms, sample every ${sampleIntervalMs}ms)`
+    );
+
+    stopMonitor = () => {
+        clearInterval(interval);
+        histogram.disable();
+        stopMonitor = null;
+    };
+    return stopMonitor;
+}

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -201,6 +201,14 @@ async function startWorkerRuntime() {
     await import("./workers");
     workersInitialized = true;
 
+    // Event-loop stall watchdog: attributes liveness-probe-visible stalls
+    // to the Bull jobs running at the time (issue #43)
+    const { startWorkerEventLoopMonitor } = await import(
+        "./services/workerEventLoopMonitor"
+    );
+    const { config } = await import("./config");
+    startWorkerEventLoopMonitor(config.workerEventLoop);
+
     logger.debug(
         "Background enrichment enabled for owned content (genres, MBIDs, etc.)"
     );

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -312,6 +312,56 @@ describe("workers runtime behavior", () => {
         );
     });
 
+    it("feeds the event-loop watchdog registry and logs a start breadcrumb for heavy-queue jobs", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const monitor = require("../../services/workerEventLoopMonitor");
+        monitor.clearActiveJobsForTest();
+
+        const findHandler = (queue: { on: jest.Mock }, event: string) =>
+            queue.on.mock.calls.find(([name]: [string]) => name === event)?.[1];
+
+        const schedulerActive = findHandler(mocks.schedulerQueue, "active");
+        const schedulerCompleted = findHandler(mocks.schedulerQueue, "completed");
+        expect(schedulerActive).toBeDefined();
+        expect(schedulerCompleted).toBeDefined();
+
+        schedulerActive({ id: "r1", name: "download-reconciliation-cycle" });
+        expect(monitor.getActiveJobs()).toEqual([
+            expect.objectContaining({
+                queue: "worker-scheduler",
+                jobId: "r1",
+                jobName: "download-reconciliation-cycle",
+            }),
+        ]);
+        // Unconditional start breadcrumb: a job that pegs the loop until the
+        // kubelet kills the process never lets the watchdog interval fire,
+        // so this must be the last log line naming the culprit.
+        expect(mocks.logger.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "job-start queue=worker-scheduler jobId=r1 jobName=download-reconciliation-cycle"
+            )
+        );
+
+        schedulerCompleted({ id: "r1", name: "download-reconciliation-cycle" });
+        expect(monitor.getActiveJobs()).toEqual([]);
+
+        // Image queue jobs are registered for attribution too (no breadcrumb)
+        const imageActive = findHandler(mocks.imageQueue, "active");
+        expect(imageActive).toBeDefined();
+        imageActive({ id: "i1", name: "optimize" });
+        expect(monitor.getActiveJobs()).toEqual([
+            expect.objectContaining({ queue: "image-optimization", jobId: "i1" }),
+        ]);
+        monitor.clearActiveJobsForTest();
+    });
+
     it("exposes queue exports for downstream consumers", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -1,5 +1,9 @@
 import { logger } from "../utils/logger";
 import { randomUUID } from "crypto";
+import {
+    trackJobStart,
+    trackJobEnd,
+} from "../services/workerEventLoopMonitor";
 import type Bull from "bull";
 import type Redis from "ioredis";
 import {
@@ -98,6 +102,25 @@ function recordQueueProcessorEvent(
     job: Bull.Job<any>
 ): void {
     queueProcessorCounters[event] += 1;
+
+    // Feed the event-loop stall watchdog's attribution registry (issue #43)
+    const jobId = String(job?.id ?? "unknown");
+    const jobName = String(job?.name ?? "unknown");
+    if (event === "active") {
+        trackJobStart(queueName, jobId, jobName);
+        // Unconditional start breadcrumb for the heavy queues: a job that
+        // pegs the loop until the kubelet kills the process never lets the
+        // watchdog interval fire, so the last log line before death must
+        // already name the culprit. Scheduler cycles and library scans are
+        // the known stall suspects; other queues stay on sampled logging.
+        if (queueName === "worker-scheduler" || queueName === "library-scan") {
+            logger.info(
+                `[WorkerEventLoop] job-start queue=${queueName} jobId=${jobId} jobName=${jobName}`
+            );
+        }
+    } else {
+        trackJobEnd(queueName, jobId);
+    }
 
     if (
         event === "failed" ||
@@ -1040,6 +1063,10 @@ imageQueue.on("failed", (job, err) => {
     logger.error(`Image job ${job.id} failed (workerId=${WORKER_PROCESSOR_ID}):`, err.message);
 });
 
+imageQueue.on("active", (job) => {
+    recordQueueProcessorEvent("image-optimization", "active", job);
+});
+
 // Event handlers for validation queue
 validationQueue.on("completed", (job, result) => {
     recordQueueProcessorEvent("file-validation", "completed", job);
@@ -1056,6 +1083,13 @@ validationQueue.on("failed", (job, err) => {
 validationQueue.on("active", (job) => {
     recordQueueProcessorEvent("file-validation", "active", job);
     logger.debug(` Validation job ${job.id} started (workerId=${WORKER_PROCESSOR_ID})`);
+});
+
+// The scheduler queue runs the heavy maintenance cycles (metadata refresh,
+// reconciliation, artist-count backfills) — the primary stall suspects — so
+// it MUST feed the event-loop watchdog's attribution registry.
+schedulerQueue.on("active", (job) => {
+    recordQueueProcessorEvent("worker-scheduler", "active", job);
 });
 
 schedulerQueue.on("completed", (job) => {

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -394,8 +394,12 @@ spec:
               port: health
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 10
-            failureThreshold: 3
+            # /health/live answers unconditionally, so a timeout means the
+            # single-threaded worker is BUSY (event loop pegged by a heavy
+            # job), not dead. Give legitimate work ~2 minutes of headroom
+            # before the kubelet kills the pod; true deadlocks still die.
+            timeoutSeconds: 25
+            failureThreshold: 4
           readinessProbe:
             httpGet:
               path: /health/ready

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,6 +177,8 @@ For small deployments, `all` is fine. For scale-out, run separate `api` and `wor
 
 Coarse feature flags (`AUDIO_ANALYSIS_ENABLED`, `DISCOVERY_ENABLED`, `AUTO_PLAYLISTS_ENABLED`, all default `true`) gate both sides: with a flag off, the API process does not mount the subsystem's routes (requests get `404` with `code: FEATURE_DISABLED`) and the worker process does not register its queues/crons. The flags are exposed through Helm values (`config.features.*`) and forwarded by the docker-compose files.
 
+The worker process runs an event-loop stall watchdog (`services/workerEventLoopMonitor.ts`): its `/health/live` endpoint answers unconditionally, so a liveness-probe timeout always means the single-threaded event loop was blocked. Attribution has two paths: stalls the loop recovers from are logged by a `monitorEventLoopDelay` sampler naming the active Bull jobs (threshold `WORKER_EVENT_LOOP_WARN_MS`, default 1s); stalls that end in a kubelet kill can never reach that sampler (a pegged loop runs no timers), so the heavy queues (`worker-scheduler`, `library-scan`) log an unconditional `job-start` breadcrumb whose final occurrence before death names the culprit.
+
 ## Key Runtime Boundaries
 
 - **Frontend API boundary:** `frontend/lib/api.ts` — all HTTP calls go through here

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -70,6 +70,8 @@ Experimental feature note:
 | `NODE_ENV` | `backend`, `backend-worker`, `frontend` | Optional | `production` (compose) | Runtime mode. |
 | `BACKEND_PROCESS_ROLE` | `backend`, `backend-worker` | Optional | split stack: `all`; HA override for backend: `api`; worker: `worker` | Role split for API/worker processes. |
 | `WORKER_HEALTH_PORT` | `backend-worker` | Optional | `3010` | Worker health endpoint port (`/health/live`, `/health/ready`). |
+| `WORKER_EVENT_LOOP_WARN_MS` | `backend-worker` | Optional | `1000` | Event-loop stall watchdog: stalls at or above this many milliseconds log a warning naming the active Bull jobs. |
+| `WORKER_EVENT_LOOP_SAMPLE_MS` | `backend-worker` | Optional | `5000` | Event-loop stall watchdog sampling interval in milliseconds. |
 | `LOG_LEVEL` | `backend`, `backend-worker`, python sidecars using shared logger | Optional | backend-worker compose: `warn`; otherwise env-dependent defaults | Shared logger verbosity (`debug`, `info`, `warn`, `error`, `silent` for TS; Python also supports `critical`). |
 | `DATABASE_POOL_SIZE` | `backend`, `backend-worker` | Optional | role-aware: `api=8`, `worker=4`, `all=12` | Prisma DB pool connection limit. |
 | `DATABASE_POOL_TIMEOUT` | `backend`, `backend-worker` | Optional | `30` | Prisma DB pool timeout in seconds. |


### PR DESCRIPTION
Implements the instrumentation + defense-in-depth steps of #43 (the "fix the culprit job" step waits for the data this produces).

## What
Worker liveness kills (exit 137) have been observed with no indication of which job pegged the event loop — `/health/live` answers unconditionally, so probe timeouts always mean a blocked loop. This adds **two attribution paths**:

1. **Recoverable stalls** — a `monitorEventLoopDelay` sampler (5s cadence, unref'd interval) logs a warning when the observed max delay crosses `WORKER_EVENT_LOOP_WARN_MS` (default 1s), naming the Bull jobs active at that moment with their ages: `[WorkerEventLoop] stall detected: max=2400ms p99=1800ms mean=2ms activeJobs=worker-scheduler/download-reconciliation-cycle#r1 age=60s`.
2. **Fatal stalls** — a loop pegged until the kubelet kills the process never runs any timer, so the sampler can't fire (review-gate finding). The heavy queues (`worker-scheduler`, `library-scan`) therefore log an unconditional `job-start` breadcrumb; the last one before death names the culprit.

The registry hooks the existing `recordQueueProcessorEvent` choke point. Two gaps found on the way: `imageQueue` and `schedulerQueue` had no `active` handlers at all — the scheduler runs the heavy maintenance cycles (metadata refresh, reconciliation, backfills), i.e. the primary suspects, and would have been invisible to attribution. Both were caught by the repo's cross-LLM review gate.

**Chart**: worker `livenessProbe` gets busy-loop headroom — `timeoutSeconds` 10→25, `failureThreshold` 3→4 (~2 minutes of sustained saturation before a kill, up from ~90s). Busy ≠ dead for a single-threaded worker; true deadlocks still die. (AIO deployment probes API `/health` — different semantics, untouched.)

## Config
`WORKER_EVENT_LOOP_WARN_MS` (default 1000), `WORKER_EVENT_LOOP_SAMPLE_MS` (default 5000) — routed through `config.ts`, documented in `docs/ENVIRONMENT_VARIABLES.md`. The monitor module takes options by injection so it stays outside the config→Prisma import chain and unit-tests without a database.

## Testing
- TDD red-first: 7 unit tests for the pure evaluation/registry/tick logic, plus a runtime test proving the scheduler/image `active` handlers feed the registry and the breadcrumb logs.
- Affected suites green: `workerEventLoopMonitor` (7), `indexRuntime` (37), `workerEntrypointBehavior` + health contract (30). Backend tsc clean.
- `awm verify`: all gates pass including helm chart render; cross-LLM review gate: PASS after fixing its two findings (missing scheduler/image `active` handlers; fatal-stall attribution gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auefjjuuu5FjjtCrn3YAXc