### PR TITLE
feat(queue): drag-and-drop reorder for the Now Playing list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Queue ("Now Playing") drag-and-drop reordering: the grip handle on each upcoming queue row — previously decorative — now actually drags, with the same hover-reveal handle, drop-indicator line, and pure drop math as playlist reordering. Podcast episode rows in the queue gained the same handle. Reorders route through a new `moveQueueItem` primitive shared with the Move up/down actions, which also fixes a latent bug: the old move handlers didn't remap the shuffle order, so moving tracks while shuffle was on silently corrupted which tracks would play next. Upcoming items only (the playing row and history stay fixed) and disabled in Listen Together sessions, matching the existing move semantics.
+
 ### Changed
 
 - The native `<audio>`-element engine is now the **default** playback engine for everyone (`DEFAULT_STREAMING_ENGINE_MODE = "native"`), after soaking as the 1.7.0 opt-in. Deployments with no `STREAMING_ENGINE_MODE` set switch to the native engine on upgrade; set `STREAMING_ENGINE_MODE=howler` to stay on the legacy engine (it remains fully supported as the gated fallback, and Android WebView deployments are still pinned to it automatically). The container entrypoints and docs now report `native` as the primary default.

--- a/frontend/app/queue/page.tsx
+++ b/frontend/app/queue/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Virtuoso } from "react-virtuoso";
@@ -8,6 +8,11 @@ import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useAudioState, useAudioControls } from "@/lib/audio-context";
+import {
+    resolveDropPosition,
+    resolveDropTargetIndex,
+    type DropPosition,
+} from "@/components/track/reorderDnd";
 import type { Track } from "@/lib/audio-state-context";
 import {
     isEpisodeQueueItem,
@@ -45,8 +50,8 @@ import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 export default function QueuePage() {
     const router = useRouter();
     const { isAuthenticated } = useAuth();
-    const { queue, currentTrack, currentIndex, setQueue } = useAudioState();
-    const { playQueueIndex, removeFromQueue, clearQueue } = useAudioControls();
+    const { queue, currentTrack, currentIndex } = useAudioState();
+    const { playQueueIndex, removeFromQueue, clearQueue, moveQueueItem } = useAudioControls();
     const { toast } = useToast();
     const listenTogether = useListenTogether();
     const { isInGroup, isHost, syncSetTrack } = listenTogether;
@@ -103,31 +108,96 @@ export default function QueuePage() {
         toast.success("Playing from queue");
     };
 
+    // Both the arrow actions and drag-and-drop route through the shared
+    // moveQueueItem primitive (LT/current/bounds guards + shuffle-index
+    // remapping live there).
     const handleMoveUp = (index: number) => {
-        if (isInGroup) return;
-        if (index <= currentIndex + 1) return;
-        setQueue((prev) => {
-            const newQueue = [...prev];
-            [newQueue[index], newQueue[index - 1]] = [
-                newQueue[index - 1],
-                newQueue[index],
-            ];
-            return newQueue;
-        });
+        moveQueueItem(index, index - 1);
     };
 
     const handleMoveDown = (index: number) => {
-        if (isInGroup) return;
-        if (index >= queue.length - 1 || index <= currentIndex) return;
-        setQueue((prev) => {
-            const newQueue = [...prev];
-            [newQueue[index], newQueue[index + 1]] = [
-                newQueue[index + 1],
-                newQueue[index],
-            ];
-            return newQueue;
-        });
+        moveQueueItem(index, index + 1);
     };
+
+    // Drag-and-drop reorder for the Next Up list (same mechanic and pure
+    // drop math as playlist reordering). Indexes here are positions
+    // WITHIN nextTracks; moveQueueItem receives absolute queue indexes.
+    const dragFromIdxRef = useRef<number | null>(null);
+    const [dragFromIdx, setDragFromIdx] = useState<number | null>(null);
+    const [dragOver, setDragOver] = useState<{
+        idx: number;
+        position: DropPosition;
+    } | null>(null);
+
+    const clearQueueDragState = () => {
+        dragFromIdxRef.current = null;
+        setDragFromIdx(null);
+        setDragOver(null);
+    };
+
+    const buildDragHandleProps = (idx: number) =>
+        isInGroup
+            ? undefined
+            : {
+                  draggable: true,
+                  onClick: (e: React.MouseEvent) => e.stopPropagation(),
+                  onDragStart: (e: React.DragEvent) => {
+                      dragFromIdxRef.current = idx;
+                      setDragFromIdx(idx);
+                      e.dataTransfer.effectAllowed = "move";
+                      e.dataTransfer.setData("text/plain", String(idx));
+                      const row = (e.currentTarget as HTMLElement).closest(
+                          "[data-queue-dnd-row]"
+                      );
+                      if (row instanceof HTMLElement) {
+                          e.dataTransfer.setDragImage(
+                              row,
+                              16,
+                              row.clientHeight / 2
+                          );
+                      }
+                  },
+                  onDragEnd: clearQueueDragState,
+              };
+
+    const buildRowDropProps = (idx: number) => ({
+        "data-queue-dnd-row": true,
+        onDragOver: (e: React.DragEvent) => {
+            if (dragFromIdxRef.current === null) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+            const rect = e.currentTarget.getBoundingClientRect();
+            setDragOver({
+                idx,
+                position: resolveDropPosition(
+                    e.clientY - rect.top,
+                    rect.height
+                ),
+            });
+        },
+        onDragLeave: (e: React.DragEvent) => {
+            if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+            setDragOver((current) => (current?.idx === idx ? null : current));
+        },
+        onDrop: (e: React.DragEvent) => {
+            const fromIdx = dragFromIdxRef.current;
+            if (fromIdx === null) return;
+            e.preventDefault();
+            const rect = e.currentTarget.getBoundingClientRect();
+            const toIdx = resolveDropTargetIndex(
+                fromIdx,
+                idx,
+                resolveDropPosition(e.clientY - rect.top, rect.height)
+            );
+            clearQueueDragState();
+            if (toIdx !== fromIdx) {
+                moveQueueItem(
+                    currentIndex + 1 + fromIdx,
+                    currentIndex + 1 + toIdx
+                );
+            }
+        },
+    });
 
     const [showSaveDialog, setShowSaveDialog] = useState(false);
     const [playlistName, setPlaylistName] = useState("");
@@ -354,24 +424,22 @@ export default function QueuePage() {
                                 itemContent={(idx) => {
                                     const item = nextTracks[idx];
                                     const queueIndex = currentIndex + 1 + idx;
-                                    if (isEpisodeQueueItem(item)) {
-                                        return (
-                                            <EpisodeQueueRow
-                                                episode={item}
-                                                onPlay={
-                                                    isInGroup
-                                                        ? undefined
-                                                        : () => handlePlayFromQueue(queueIndex)
-                                                }
-                                                onRemove={
-                                                    isInGroup
-                                                        ? undefined
-                                                        : () => handleRemoveTrack(queueIndex)
-                                                }
-                                            />
-                                        );
-                                    }
-                                    return (
+                                    const row = isEpisodeQueueItem(item) ? (
+                                        <EpisodeQueueRow
+                                            episode={item}
+                                            onPlay={
+                                                isInGroup
+                                                    ? undefined
+                                                    : () => handlePlayFromQueue(queueIndex)
+                                            }
+                                            onRemove={
+                                                isInGroup
+                                                    ? undefined
+                                                    : () => handleRemoveTrack(queueIndex)
+                                            }
+                                            dragHandleProps={buildDragHandleProps(idx)}
+                                        />
+                                    ) : (
                                         <NextTrackRow
                                             track={item}
                                             queueIndex={queueIndex}
@@ -384,7 +452,30 @@ export default function QueuePage() {
                                             onPlay={handlePlayFromQueue}
                                             onRemove={handleRemoveTrack}
                                             trackAvailability={trackAvailability}
+                                            dragHandleProps={buildDragHandleProps(idx)}
                                         />
+                                    );
+                                    return (
+                                        <div
+                                            className={
+                                                dragFromIdx === idx
+                                                    ? "relative opacity-50"
+                                                    : "relative"
+                                            }
+                                            {...buildRowDropProps(idx)}
+                                        >
+                                            {dragOver?.idx === idx &&
+                                                dragFromIdx !== idx && (
+                                                    <div
+                                                        className={`pointer-events-none absolute left-0 right-0 h-0.5 rounded bg-blue-400 z-10 ${
+                                                            dragOver.position === "before"
+                                                                ? "top-0"
+                                                                : "bottom-0"
+                                                        }`}
+                                                    />
+                                                )}
+                                            {row}
+                                        </div>
                                     );
                                 }}
                             />
@@ -482,16 +573,29 @@ function EpisodeQueueRow({
     played = false,
     onPlay,
     onRemove,
+    dragHandleProps,
 }: {
     episode: EpisodeQueueItem;
     played?: boolean;
     onPlay?: () => void;
     onRemove?: () => void;
+    dragHandleProps?: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        draggable?: boolean;
+    };
 }) {
     return (
         <div
             className={`flex items-center gap-4 p-4 hover:bg-[#1a1a1a] transition-colors group border-b border-[#1c1c1c] ${played ? "opacity-50" : ""}`}
         >
+            {dragHandleProps && (
+                <button
+                    {...dragHandleProps}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
+                    title="Drag to reorder"
+                >
+                    <GripVertical className="w-5 h-5" />
+                </button>
+            )}
             <div className="relative flex-shrink-0 w-12 h-12">
                 {episode.coverUrl ? (
                     <Image
@@ -559,6 +663,7 @@ function NextTrackRow({
     onPlay,
     onRemove,
     trackAvailability,
+    dragHandleProps,
 }: {
     track: Track;
     queueIndex: number;
@@ -571,6 +676,9 @@ function NextTrackRow({
     onPlay: (index: number) => void;
     onRemove: (index: number) => void;
     trackAvailability: Map<number, AvailabilityItem>;
+    dragHandleProps?: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        draggable?: boolean;
+    };
 }) {
     const availability = isInGroup ? trackAvailability.get(queueIndex) : undefined;
     const isUnavailable = availability?.available === false;
@@ -580,8 +688,9 @@ function NextTrackRow({
         <div
             className={`flex items-center gap-4 p-4 hover:bg-[#1a1a1a] transition-colors group border-b border-[#1c1c1c] ${isUnavailable ? "opacity-50" : ""}`}
         >
-            {!isInGroup && (
+            {!isInGroup && dragHandleProps && (
                 <button
+                    {...dragHandleProps}
                     className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
                     title="Drag to reorder"
                 >

--- a/frontend/lib/audio-controls-context.tsx
+++ b/frontend/lib/audio-controls-context.tsx
@@ -33,6 +33,8 @@ import { toast } from "sonner";
 import {
     computePlayNowInsertion,
     computePodcastContextPlacement,
+    moveItemInList,
+    remapShuffleIndicesForMove,
 } from "./queue-utils";
 import {
     resolveEpisodeProgressSaveOnSwitch,
@@ -311,6 +313,14 @@ interface AudioControlsContextType {
     addTracksToQueue: (tracks: Track[], options?: { silent?: boolean }) => void;
     playQueueIndex: (index: number) => void; // Jump to a queue item (track or episode)
     removeFromQueue: (index: number) => void;
+    /**
+     * Move an UPCOMING queue item (index > currentIndex) to another
+     * upcoming position with splice semantics. No-op in Listen Together
+     * sessions, for out-of-range indexes, and for history/current rows;
+     * shuffle indices are remapped so the shuffle order keeps pointing
+     * at the same items.
+     */
+    moveQueueItem: (fromIndex: number, toIndex: number) => void;
     clearQueue: () => void;
     setUpcoming: (tracks: Track[], preserveOrder?: boolean) => void; // Replace queue after current track
 
@@ -1691,6 +1701,35 @@ export function AudioControlsProvider({ children }: { children: ReactNode }) {
         ]
     );
 
+    const moveQueueItem = useCallback(
+        (fromIndex: number, toIndex: number) => {
+            // Listen Together queues are server-owned; local reorder would
+            // desync (matches the existing move-up/down behavior).
+            if (getActiveListenTogetherSession()) {
+                return;
+            }
+            // Only upcoming items move; the current row and history are
+            // fixed, so currentIndex never needs adjustment.
+            if (
+                fromIndex <= state.currentIndex ||
+                toIndex <= state.currentIndex
+            ) {
+                return;
+            }
+            const nextQueue = moveItemInList(state.queue, fromIndex, toIndex);
+            if (nextQueue === state.queue) {
+                return;
+            }
+            state.setQueue(nextQueue);
+            if (state.isShuffle) {
+                state.setShuffleIndices((prev) =>
+                    remapShuffleIndicesForMove(prev, fromIndex, toIndex)
+                );
+            }
+        },
+        [state, getActiveListenTogetherSession]
+    );
+
     const clearQueue = useCallback(() => {
         const ltSession = getActiveListenTogetherSession();
         if (ltSession) {
@@ -2099,6 +2138,7 @@ export function AudioControlsProvider({ children }: { children: ReactNode }) {
             addTracksToQueue,
             playQueueIndex,
             removeFromQueue,
+            moveQueueItem,
             clearQueue,
             setUpcoming,
             toggleShuffle,
@@ -2132,6 +2172,7 @@ export function AudioControlsProvider({ children }: { children: ReactNode }) {
             addTracksToQueue,
             playQueueIndex,
             removeFromQueue,
+            moveQueueItem,
             clearQueue,
             setUpcoming,
             toggleShuffle,

--- a/frontend/lib/queue-utils.ts
+++ b/frontend/lib/queue-utils.ts
@@ -157,3 +157,57 @@ export function computePodcastContextPlacement<T extends { id: string }>(
         newShuffleIndices,
     };
 }
+
+/**
+ * Move one item to a new index with splice semantics (remove `fromIndex`,
+ * insert at `toIndex`). Returns the input unchanged (same reference) for
+ * no-op moves or out-of-range indexes; never mutates the input.
+ */
+export function moveItemInList<T>(
+    list: T[],
+    fromIndex: number,
+    toIndex: number,
+): T[] {
+    if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= list.length ||
+        toIndex >= list.length
+    ) {
+        return list;
+    }
+    const next = [...list];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    return next;
+}
+
+/**
+ * Remap shuffle indices after a queue move so every shuffle entry keeps
+ * pointing at the same item it referenced before the move (GH queue
+ * reorder; the pre-existing move handlers skipped this, silently
+ * corrupting the shuffle order). Returns the input unchanged for no-ops.
+ */
+export function remapShuffleIndicesForMove(
+    indices: number[],
+    fromIndex: number,
+    toIndex: number,
+): number[] {
+    if (fromIndex === toIndex) {
+        return indices;
+    }
+    return indices.map((position) => {
+        if (position === fromIndex) return toIndex;
+        if (fromIndex < toIndex) {
+            // Positions between the old and new slots shift down by one.
+            return position > fromIndex && position <= toIndex
+                ? position - 1
+                : position;
+        }
+        // Backward move: positions between the new and old slots shift up.
+        return position >= toIndex && position < fromIndex
+            ? position + 1
+            : position;
+    });
+}

--- a/frontend/tests/component/audioControlsQueueUx.component.test.ts
+++ b/frontend/tests/component/audioControlsQueueUx.component.test.ts
@@ -464,3 +464,61 @@ test("rapid next() skips advance past an episode while its progress lookup is pe
     assert.equal((state.currentPodcast as { id: string }).id, ep2.id);
     assert.equal(playback.isPlaying, true);
 });
+
+test("moveQueueItem moves an upcoming item and remaps shuffle indices in lockstep", async () => {
+    const tracks = ["t1", "t2", "t3", "t4", "t5"].map((id) => ({
+        id,
+        title: id,
+        artist: { name: "a" },
+        album: { title: "al" },
+        duration: 100,
+    }));
+    const state = createDeferredAudioState({
+        queue: tracks,
+        currentIndex: 0,
+        isShuffle: true,
+        // Shuffle order references queue POSITIONS.
+        shuffleIndices: [0, 4, 2, 1, 3],
+    });
+    const playback = createPlaybackStub({ currentTime: 0, duration: 100 });
+    const controls = await renderControls({ state, playback });
+
+    // Move position 1 (t2) to position 3.
+    controls.moveQueueItem(1, 3);
+    state.commit();
+
+    assert.deepEqual(
+        (state.queue as Array<{ id: string }>).map((t) => t.id),
+        ["t1", "t3", "t4", "t2", "t5"],
+    );
+    // Every shuffle entry still points at the same TRACK it did before:
+    // old positions map 0->0, 1->3, 2->1, 3->2, 4->4.
+    assert.deepEqual(state.shuffleIndices, [0, 4, 1, 3, 2]);
+});
+
+test("moveQueueItem refuses to move the current row or cross into history", async () => {
+    const tracks = ["t1", "t2", "t3"].map((id) => ({
+        id,
+        title: id,
+        artist: { name: "a" },
+        album: { title: "al" },
+        duration: 100,
+    }));
+    const state = createDeferredAudioState({
+        queue: tracks,
+        currentIndex: 1,
+    });
+    const playback = createPlaybackStub({ currentTime: 0, duration: 100 });
+    const controls = await renderControls({ state, playback });
+
+    controls.moveQueueItem(1, 2); // current row itself
+    controls.moveQueueItem(2, 1); // upcoming into the current slot
+    controls.moveQueueItem(2, 0); // upcoming into history
+    state.commit();
+
+    assert.deepEqual(
+        (state.queue as Array<{ id: string }>).map((t) => t.id),
+        ["t1", "t2", "t3"],
+    );
+    assert.equal(state.currentIndex, 1);
+});

--- a/frontend/tests/unit/queueItemMove.test.ts
+++ b/frontend/tests/unit/queueItemMove.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    moveItemInList,
+    remapShuffleIndicesForMove,
+} from "../../lib/queue-utils";
+
+const list = () => ["a", "b", "c", "d", "e"];
+
+test("moveItemInList moves forward and backward with splice semantics", () => {
+    assert.deepEqual(moveItemInList(list(), 1, 3), ["a", "c", "d", "b", "e"]);
+    assert.deepEqual(moveItemInList(list(), 3, 1), ["a", "d", "b", "c", "e"]);
+    assert.deepEqual(moveItemInList(list(), 0, 4), ["b", "c", "d", "e", "a"]);
+});
+
+test("moveItemInList returns the same reference for no-ops and invalid indexes", () => {
+    const input = list();
+    assert.equal(moveItemInList(input, 2, 2), input);
+    assert.equal(moveItemInList(input, -1, 2), input);
+    assert.equal(moveItemInList(input, 2, 5), input);
+    assert.equal(moveItemInList(input, 5, 2), input);
+});
+
+test("moveItemInList never mutates its input", () => {
+    const input = list();
+    moveItemInList(input, 1, 3);
+    assert.deepEqual(input, list());
+});
+
+test("remapShuffleIndicesForMove keeps every index pointing at the same item", () => {
+    // Items at positions [0..4]; shuffle order references positions.
+    // Move position 1 -> 3: old positions map 0->0, 1->3, 2->1, 3->2, 4->4.
+    assert.deepEqual(
+        remapShuffleIndicesForMove([4, 1, 0, 3, 2], 1, 3),
+        [4, 3, 0, 2, 1],
+    );
+    // Move position 3 -> 1: old positions map 0->0, 1->2, 2->3, 3->1, 4->4.
+    assert.deepEqual(
+        remapShuffleIndicesForMove([4, 1, 0, 3, 2], 3, 1),
+        [4, 2, 0, 1, 3],
+    );
+});
+
+test("remapShuffleIndicesForMove is identity for no-op moves", () => {
+    const indices = [2, 0, 1];
+    assert.equal(remapShuffleIndicesForMove(indices, 1, 1), indices);
+});


### PR DESCRIPTION
Same intent and mechanic as the playlist reorder (#27/#47), applied to the queue page's "Next Up" list — where the grip handle already existed but was **decorative** (a cursor-grab button with a "Drag to reorder" tooltip and no drag wiring).

## What

- The grip now drags: hover-revealed handle, midpoint-split drop indicator line, dimmed source row — reusing the pure `reorderDnd` drop math from the playlist implementation, wired locally around the queue page's Virtuoso rows. Podcast episode rows in Next Up gained the same handle (they previously had no move affordance at all).
- **New `moveQueueItem(fromIndex, toIndex)` primitive** in the audio controls context, used by both drag-and-drop and the existing Move up/down actions. Guards: Listen Together sessions (queues are server-owned — matches existing disabled behavior), the currently-playing row and history (upcoming items only, matching existing semantics), and bounds. `currentIndex` is never touched since moves stay strictly after it.
- **Fixes a latent shuffle bug**: the old swap handlers mutated `queue` without remapping `shuffleIndices` (while `removeFromQueue` remapped correctly), so any move with shuffle on silently corrupted which positions play next. `moveQueueItem` remaps every shuffle entry to keep pointing at the same item.

## Testing

- 5 unit tests for the pure helpers (`moveItemInList` splice semantics/no-op identity/no mutation; `remapShuffleIndicesForMove` forward/backward/identity).
- 2 new component tests for the context primitive (queue+shuffle move in lockstep; current-row/history guards).
- Frontend: 651/651 unit tests, ESLint 0 errors, `next build` clean. Component suite: both new tests pass; the suite carries **33 pre-existing failures on main** (identical count with this change stashed) — worth a separate look since `test:component` isn't in the CI gate table.
- Cross-LLM review gate: PASS (first round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zSncUkZwSsBMoDhsS5qPk