### PR TITLE
fix(playback-state): clear queue must also delete the legacy device row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Clearing the queue actually sticks now (#52). `DELETE /api/playback-state` removed only the caller's device row, while `GET /api/playback-state` still fell back to the shared pre-device `legacy` row and opportunistically re-migrated it onto the device — so the next playback-state poll resurrected the entire cleared queue within a minute. An explicit clear now deletes the legacy row along with the device row; the GET fallback's legacy migration for genuinely new devices is unchanged.
+
 ### Changed
 
 - The native `<audio>`-element engine is now the **default** playback engine for everyone (`DEFAULT_STREAMING_ENGINE_MODE = "native"`), after soaking as the 1.7.0 opt-in. Deployments with no `STREAMING_ENGINE_MODE` set switch to the native engine on upgrade; set `STREAMING_ENGINE_MODE=howler` to stay on the legacy engine (it remains fully supported as the gated fallback, and Android WebView deployments are still pinned to it automatically). The container entrypoints and docs now report `native` as the primary default.

--- a/backend/src/routes/__tests__/playbackStateRuntime.test.ts
+++ b/backend/src/routes/__tests__/playbackStateRuntime.test.ts
@@ -544,7 +544,7 @@ describe("playbackState routes runtime", () => {
         await deleteState(req, res);
 
         expect(mockDeleteMany).toHaveBeenCalledWith({
-            where: { userId: "u1", deviceId: "mobile" },
+            where: { userId: "u1", deviceId: { in: ["mobile", "legacy"] } },
         });
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({ success: true });

--- a/backend/src/routes/playbackState.ts
+++ b/backend/src/routes/playbackState.ts
@@ -468,8 +468,11 @@ router.delete("/", requireAuth, async (req, res) => {
         const userId = req.user!.id;
         const deviceId = getPlaybackDeviceId(req);
 
+        // An explicit clear must also remove the shared "legacy" row;
+        // otherwise the GET fallback re-migrates it onto this device and
+        // the cleared queue resurrects on the next playback-state poll.
         await prisma.playbackState.deleteMany({
-            where: { userId, deviceId },
+            where: { userId, deviceId: { in: [deviceId, "legacy"] } },
         });
         publishSocialPresenceUpdate({
             userId,


### PR DESCRIPTION
Fixes #52.

## Problem

Clearing the queue emptied it locally and deleted the caller's **device row**, but the shared pre-device `legacy` row survived. `GET /api/playback-state` falls back to that legacy row when the device row is missing and **re-migrates it onto the device** with a fresh `updatedAt` — so the next 30s playback-state poll adopted the resurrected server state and the whole queue came back within a minute. A clear could never stick for any account that still has a legacy row.

## Fix

`DELETE /api/playback-state` now deletes both the device row and the `legacy` row:

```ts
await prisma.playbackState.deleteMany({
    where: { userId, deviceId: { in: [deviceId, "legacy"] } },
});
```

An explicit user clear outranks the opportunistic legacy-migration convenience. The GET fallback itself is unchanged, so a genuinely new device (no clear involved) still adopts legacy state exactly as before.

## Verification

- `npx jest src/routes/__tests__/playbackStateRuntime.test.ts` — 12/12 pass; the DELETE test now asserts the two-row delete shape.
- `npm run build` (backend tsc) — clean.
- Manual acceptance after deploy: clear queue → wait ≥2 poll cycles (≥90s) and reload → queue stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zSncUkZwSsBMoDhsS5qPk