### PR TITLE
fix(player): declare auto-advance play intent; retry hidden-tab autoplay on visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Queue auto-advance can no longer land on a silently paused next track (#53). Track-end advancement now *declares* play intent — the end handler stamps a bounded (30s) intent that the next load consumes for its autoplay decision — instead of inferring it from transient UI playing state, which raced the element's `pause`→`ended` event pair under the native engine (the element's pause fires before ended, so both the isPlaying mirror and `engine.isPlaying()` could read false by load time). And when autoplay is rejected with `NotAllowedError` in a hidden tab (auto-advance while tabbed away), the native engine now retries `play()` once on the hidden→visible transition instead of sitting silent until a user gesture; the one-shot gesture retry stays armed as the fallback, and a user pause in between is respected.
+
 ### Changed
 
 - The native `<audio>`-element engine is now the **default** playback engine for everyone (`DEFAULT_STREAMING_ENGINE_MODE = "native"`), after soaking as the 1.7.0 opt-in. Deployments with no `STREAMING_ENGINE_MODE` set switch to the native engine on upgrade; set `STREAMING_ENGINE_MODE=howler` to stay on the legacy engine (it remains fully supported as the gated fallback, and Android WebView deployments are still pinned to it automatically). The container entrypoints and docs now report `native` as the primary default.

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -57,6 +57,7 @@ import {
 import { shouldAutoMatchVibeAtQueueEnd } from "./autoMatchVibePlayback";
 import {
     createEmptySegmentedStartupRecoveryStageAttempts,
+    isAdvancePlayIntentFresh,
     resolveLoadAutoplayDecision,
     resolvePlaybackDuration,
     resolveRemoteStreamFormat,
@@ -647,6 +648,10 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
     const lastTrackIdRef = useRef<string | null>(null);
     const hasSeenTrackLoadRef = useRef<boolean>(false);
     const lastPlayingStateRef = useRef<boolean>(isPlaying);
+    // Timestamp of the last track-end auto-advance. Declares that the next
+    // load must autoplay regardless of transient isPlaying commits between
+    // the element's pause/ended pair and the load effect (GH #53).
+    const advancePlayIntentAtMsRef = useRef<number | null>(null);
     const progressSaveIntervalRef = useRef<NodeJS.Timeout | null>(null);
     const lastProgressSaveRef = useRef<number>(0);
     const isUserInitiatedRef = useRef<boolean>(false);
@@ -4329,6 +4334,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
                 if (podcastAdvance.kind === "stop") {
                     pause();
                 } else {
+                    advancePlayIntentAtMsRef.current = Date.now();
                     next();
                 }
             } else if (playbackType === "audiobook") {
@@ -4387,6 +4393,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
                     });
 
                     if (!shouldAutoMatchVibe || !currentTrack?.id) {
+                        advancePlayIntentAtMsRef.current = Date.now();
                         next();
                         return;
                     }
@@ -4396,6 +4403,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
                         force: true,
                     }).finally(() => {
                         if (currentTrackRef.current?.id !== endedTrackId) return;
+                        advancePlayIntentAtMsRef.current = Date.now();
                         next();
                     });
                 }
@@ -5356,6 +5364,14 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
         if (streamUrl) {
             setCurrentTime(Math.max(0, startTime));
             const wasEnginePlayingBeforeLoad = audioEngine.isPlaying();
+            // Consume a declared auto-advance play intent (stamped by the
+            // track-end handler). Captured once so the load-time and the
+            // deferred (handleLoaded) autoplay decisions agree.
+            const hasAdvancePlayIntent = isAdvancePlayIntentFresh(
+                advancePlayIntentAtMsRef.current,
+                Date.now(),
+            );
+            advancePlayIntentAtMsRef.current = null;
 
             const fallbackDuration =
                 currentTrack?.duration ||
@@ -6004,6 +6020,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
                 const shouldAutoPlayOnLoad = resolveLoadAutoplayDecision({
                     wasPlayingBeforeLoad:
                         lastPlayingStateRef.current || wasEnginePlayingBeforeLoad,
+                    hasAdvancePlayIntent,
                     // Followers start playback via the LT play-at/delta
                     // resume, never from local state (audible-blip fix).
                     isListenTogetherFollower: Boolean(
@@ -6106,6 +6123,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
                         wasPlayingBeforeLoad:
                             lastPlayingStateRef.current ||
                             wasEnginePlayingBeforeLoad,
+                        hasAdvancePlayIntent,
                         // Same follower rule as the load-time decision: the
                         // deferred (seek-then-play) path must not start
                         // follower playback from local state either.

--- a/frontend/components/player/audioPlaybackOrchestratorPolicy.ts
+++ b/frontend/components/player/audioPlaybackOrchestratorPolicy.ts
@@ -80,11 +80,40 @@ export function shouldAttemptSegmentedRecoveryOnUnexpectedPause(
 export function resolveLoadAutoplayDecision(input: {
     wasPlayingBeforeLoad: boolean;
     isListenTogetherFollower: boolean;
+    hasAdvancePlayIntent?: boolean;
 }): boolean {
     if (input.isListenTogetherFollower) {
         return false;
     }
-    return input.wasPlayingBeforeLoad;
+    return input.wasPlayingBeforeLoad || Boolean(input.hasAdvancePlayIntent);
+}
+
+/**
+ * Validity window for a queue-advance play intent. Generous enough to
+ * cover the async advance paths (auto-match-vibe request before next())
+ * yet bounded so a stalled advance can't autoplay an unrelated load
+ * minutes later.
+ */
+export const ADVANCE_PLAY_INTENT_TTL_MS = 30_000;
+
+/**
+ * A track-end auto-advance DECLARES that the next load must play; it is
+ * never inferred from transient UI playing state. Under the native
+ * engine the element's `pause` fires before `ended`, so by load time
+ * both the isPlaying mirror ref and engine.isPlaying() can read false —
+ * the advance would land paused (GH #53). The intent is a timestamp
+ * stamped when the end handler advances the queue and consumed by the
+ * next load.
+ */
+export function isAdvancePlayIntentFresh(
+    intentAtMs: number | null,
+    nowMs: number,
+): boolean {
+    if (intentAtMs === null || !Number.isFinite(intentAtMs)) {
+        return false;
+    }
+    const ageMs = nowMs - intentAtMs;
+    return ageMs >= 0 && ageMs < ADVANCE_PLAY_INTENT_TTL_MS;
 }
 
 export type SegmentedHandoffRecoveryStartupSkipReason =

--- a/frontend/lib/audio-engine/nativeAudioElementEngine.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementEngine.ts
@@ -186,6 +186,7 @@ export class NativeAudioElementEngine implements AudioEngine {
     private retryTimerId: unknown = null;
     private tickerId: unknown = null;
     private gestureCleanups: Array<() => void> = [];
+    private visibilityRetryCleanup: (() => void) | null = null;
     private pageShowCleanup: (() => void) | null = null;
     private elementCleanups: Array<() => void> = [];
     private isDestroyed = false;
@@ -398,6 +399,7 @@ export class NativeAudioElementEngine implements AudioEngine {
         this.cancelRetryTimer();
         this.stopTicker();
         this.disarmGestureRetry();
+        this.disarmVisibilityRetry();
         this.pageShowCleanup?.();
         this.pageShowCleanup = null;
         this.elementCleanups.forEach((cleanup) => cleanup());
@@ -449,6 +451,10 @@ export class NativeAudioElementEngine implements AudioEngine {
                 return this.armGestureRetry();
             case "disarmGestureRetry":
                 return this.disarmGestureRetry();
+            case "armVisibilityRetry":
+                return this.armVisibilityRetry();
+            case "disarmVisibilityRetry":
+                return this.disarmVisibilityRetry();
             case "reloadFromSource":
                 return this.reloadFromSource(
                     effect.resumeAtSec,
@@ -587,6 +593,7 @@ export class NativeAudioElementEngine implements AudioEngine {
                     type: "PLAY_PROMISE_REJECTED",
                     errorName,
                     errorMessage,
+                    isPageHidden: this.isPageHidden(),
                     nowMs: this.now(),
                 });
             });
@@ -680,6 +687,30 @@ export class NativeAudioElementEngine implements AudioEngine {
     private disarmGestureRetry(): void {
         this.gestureCleanups.forEach((cleanup) => cleanup());
         this.gestureCleanups = [];
+    }
+
+    private armVisibilityRetry(): void {
+        this.disarmVisibilityRetry();
+        this.visibilityRetryCleanup = this.bindGlobalListener(
+            "document",
+            "visibilitychange",
+            () => {
+                if (this.isPageHidden()) {
+                    return;
+                }
+                this.dispatch({
+                    type: "VISIBILITY_RETRY_FIRED",
+                    nowMs: this.now(),
+                });
+            },
+        );
+    }
+
+    private disarmVisibilityRetry(): void {
+        if (this.visibilityRetryCleanup) {
+            this.visibilityRetryCleanup();
+            this.visibilityRetryCleanup = null;
+        }
     }
 
     // ------------------------------------------------------------------

--- a/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
@@ -120,9 +120,11 @@ export type NativeEnginePolicyEvent =
           type: "PLAY_PROMISE_REJECTED";
           errorName: string;
           errorMessage: string;
+          isPageHidden: boolean;
           nowMs: number;
       }
     | { type: "GESTURE_RETRY_FIRED"; nowMs: number }
+    | { type: "VISIBILITY_RETRY_FIRED"; nowMs: number }
     | { type: "RETRY_TIMER_FIRED"; nowMs: number }
     | { type: "RELOAD_REQUESTED"; nowMs: number }
     | {
@@ -146,6 +148,8 @@ export type NativeEnginePolicyEffect =
     | { kind: "cancelRetry" }
     | { kind: "armGestureRetry" }
     | { kind: "disarmGestureRetry" }
+    | { kind: "armVisibilityRetry" }
+    | { kind: "disarmVisibilityRetry" }
     | {
           kind: "reloadFromSource";
           resumeAtSec: number;
@@ -757,6 +761,14 @@ const handlePlayPromiseRejected = (
         if (!state.gestureRetryUsed) {
             effects.push({ kind: "armGestureRetry" });
         }
+        // Autoplay rejected in a hidden tab (e.g. a queue auto-advance
+        // while the user is tabbed away) is not a gesture problem: the
+        // same play() is typically allowed once the page is visible.
+        // Retry once on the hidden→visible transition instead of sitting
+        // silent until the user happens to click (GH #53).
+        if (event.isPageHidden) {
+            effects.push({ kind: "armVisibilityRetry" });
+        }
         return {
             state: {
                 ...state,
@@ -793,6 +805,23 @@ const handleGestureRetryFired = (state: State): Transition => {
     return {
         state,
         effects: [{ kind: "callPlay" }, { kind: "disarmGestureRetry" }],
+    };
+};
+
+const handleVisibilityRetryFired = (state: State): Transition => {
+    // One-shot: whatever happens, the arm is spent. A user pause between
+    // the rejection and the tab return must stay a pause, so only a
+    // still-externally-paused source is retried.
+    if (
+        state.status !== "paused" ||
+        !state.hasSource ||
+        state.pauseClassification === "user"
+    ) {
+        return { state, effects: [{ kind: "disarmVisibilityRetry" }] };
+    }
+    return {
+        state,
+        effects: [{ kind: "callPlay" }, { kind: "disarmVisibilityRetry" }],
     };
 };
 
@@ -894,6 +923,8 @@ export function transitionNativeEngine(
             return handlePlayPromiseRejected(state, event);
         case "GESTURE_RETRY_FIRED":
             return handleGestureRetryFired(state);
+        case "VISIBILITY_RETRY_FIRED":
+            return handleVisibilityRetryFired(state);
         case "RETRY_TIMER_FIRED":
             return handleRetryTimerFired(state);
         case "RELOAD_REQUESTED":

--- a/frontend/tests/unit/loadAutoplayDecision.test.ts
+++ b/frontend/tests/unit/loadAutoplayDecision.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveLoadAutoplayDecision } from "../../components/player/audioPlaybackOrchestratorPolicy";
+import {
+    ADVANCE_PLAY_INTENT_TTL_MS,
+    isAdvancePlayIntentFresh,
+    resolveLoadAutoplayDecision,
+} from "../../components/player/audioPlaybackOrchestratorPolicy";
 
 test("solo/host loads autoplay from local playing state (existing behavior)", () => {
     assert.equal(
@@ -38,4 +42,44 @@ test("Listen Together follower loads never autoplay from local state", () => {
         }),
         false,
     );
+});
+
+test("a declared queue-advance intent forces autoplay even when playing state reads false", () => {
+    // Under the native engine the element's pause fires before ended, so
+    // both the isPlaying mirror and engine.isPlaying() can be false by the
+    // time the advanced track loads (GH #53).
+    assert.equal(
+        resolveLoadAutoplayDecision({
+            wasPlayingBeforeLoad: false,
+            isListenTogetherFollower: false,
+            hasAdvancePlayIntent: true,
+        }),
+        true,
+    );
+});
+
+test("advance intent never overrides the Listen Together follower rule", () => {
+    assert.equal(
+        resolveLoadAutoplayDecision({
+            wasPlayingBeforeLoad: false,
+            isListenTogetherFollower: true,
+            hasAdvancePlayIntent: true,
+        }),
+        false,
+    );
+});
+
+test("advance play intent freshness is bounded by the TTL", () => {
+    assert.equal(isAdvancePlayIntentFresh(null, 10_000), false);
+    assert.equal(isAdvancePlayIntentFresh(10_000, 10_001), true);
+    assert.equal(
+        isAdvancePlayIntentFresh(10_000, 10_000 + ADVANCE_PLAY_INTENT_TTL_MS - 1),
+        true,
+    );
+    assert.equal(
+        isAdvancePlayIntentFresh(10_000, 10_000 + ADVANCE_PLAY_INTENT_TTL_MS),
+        false,
+    );
+    // A clock that moved backwards must not validate a future stamp.
+    assert.equal(isAdvancePlayIntentFresh(10_000, 9_000), false);
 });

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -906,3 +906,64 @@ test("destroy releases elements, timers, and global listeners", () => {
     assert.equal(harness.mainElement().src, "");
     assert.equal(harness.engine.isPlaying(), false);
 });
+
+test("NotAllowedError in a hidden tab retries automatically when the page becomes visible", async () => {
+    let hidden = true;
+    const harness = createHarness({ isPageHidden: () => hidden });
+    harness.engine.load("https://stream.example/track.flac", {
+        autoplay: true,
+    });
+    harness.mainElement().playBehavior = {
+        kind: "reject",
+        name: "NotAllowedError",
+        message: "background tab autoplay blocked",
+    };
+    harness.mainElement().fireLoadedMetadata(200);
+    await flushMicrotasks();
+
+    const visibilityBindings = harness.bindings.filter(
+        (binding) =>
+            binding.target === "document" &&
+            binding.type === "visibilitychange" &&
+            !binding.removed,
+    );
+    assert.equal(visibilityBindings.length, 1, "visibility retry armed");
+
+    // A visibility event while still hidden must not retry.
+    visibilityBindings[0].handler({});
+    await flushMicrotasks();
+    assert.equal(harness.mainElement().playCalls, 1);
+
+    // Tab returns to the foreground: exactly one automatic retry.
+    hidden = false;
+    harness.mainElement().playBehavior = { kind: "resolve" };
+    visibilityBindings[0].handler({});
+    await flushMicrotasks();
+    assert.equal(harness.mainElement().playCalls, 2);
+    assert.ok(
+        harness.bindings
+            .filter((binding) => binding.type === "visibilitychange")
+            .every((binding) => binding.removed),
+        "visibility retry disarmed after firing",
+    );
+});
+
+test("NotAllowedError in a visible tab does not arm a visibility retry", async () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/track.flac", {
+        autoplay: true,
+    });
+    harness.mainElement().playBehavior = {
+        kind: "reject",
+        name: "NotAllowedError",
+        message: "user gesture required",
+    };
+    harness.mainElement().fireLoadedMetadata(200);
+    await flushMicrotasks();
+    assert.equal(
+        harness.bindings.filter(
+            (binding) => binding.type === "visibilitychange",
+        ).length,
+        0,
+    );
+});

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -1037,6 +1037,7 @@ test("NotAllowedError parks paused, surfaces the gesture requirement, and arms o
             type: "PLAY_PROMISE_REJECTED",
             errorName: "NotAllowedError",
             errorMessage: "play() failed because the user didn't interact",
+            isPageHidden: false,
             nowMs: 2_000,
         },
     );
@@ -1053,12 +1054,14 @@ test("a second NotAllowedError does not re-arm the gesture retry (never loop)", 
         type: "PLAY_PROMISE_REJECTED",
         errorName: "NotAllowedError",
         errorMessage: "blocked",
+        isPageHidden: false,
         nowMs: 2_000,
     });
     const second = transitionNativeEngine(first.state, {
         type: "PLAY_PROMISE_REJECTED",
         errorName: "NotAllowedError",
         errorMessage: "blocked",
+        isPageHidden: false,
         nowMs: 2_100,
     });
     assert.equal(kinds(second.effects).includes("armGestureRetry"), false);
@@ -1071,6 +1074,7 @@ test("GESTURE_RETRY_FIRED plays once and disarms", () => {
             type: "PLAY_PROMISE_REJECTED",
             errorName: "NotAllowedError",
             errorMessage: "blocked",
+            isPageHidden: false,
             nowMs: 2_000,
         },
     );
@@ -1087,6 +1091,7 @@ test("AbortError from an interrupted play() is ignored", () => {
         type: "PLAY_PROMISE_REJECTED",
         errorName: "AbortError",
         errorMessage: "interrupted by a new load request",
+        isPageHidden: false,
         nowMs: 2_000,
     });
     assert.deepEqual(effects, []);
@@ -1099,6 +1104,7 @@ test("NotSupportedError from play() surfaces a play error in error state", () =>
             type: "PLAY_PROMISE_REJECTED",
             errorName: "NotSupportedError",
             errorMessage: "no supported source",
+            isPageHidden: false,
             nowMs: 2_000,
         },
     );
@@ -1160,4 +1166,82 @@ test("PAGE_RESTORED with a consistent state is a no-op", () => {
         nowMs: 7_000,
     });
     assert.deepEqual(effects, []);
+});
+
+// ---------------------------------------------------------------------------
+// Visibility retry (GH #53): autoplay rejected while the page is hidden
+// ---------------------------------------------------------------------------
+
+test("NotAllowedError while hidden arms a visibility retry alongside the gesture retry", () => {
+    const { state, effects } = transitionNativeEngine(
+        loadedState({ autoplay: true }),
+        {
+            type: "PLAY_PROMISE_REJECTED",
+            errorName: "NotAllowedError",
+            errorMessage: "blocked in background tab",
+            isPageHidden: true,
+            nowMs: 2_000,
+        },
+    );
+    assert.equal(state.status, "paused");
+    assert.ok(kinds(effects).includes("armVisibilityRetry"));
+    assert.ok(kinds(effects).includes("armGestureRetry"));
+});
+
+test("NotAllowedError while visible does not arm a visibility retry", () => {
+    const { effects } = transitionNativeEngine(loadedState({ autoplay: true }), {
+        type: "PLAY_PROMISE_REJECTED",
+        errorName: "NotAllowedError",
+        errorMessage: "blocked",
+        isPageHidden: false,
+        nowMs: 2_000,
+    });
+    assert.equal(kinds(effects).includes("armVisibilityRetry"), false);
+});
+
+test("VISIBILITY_RETRY_FIRED plays once and disarms", () => {
+    const { state: blocked } = transitionNativeEngine(
+        loadedState({ autoplay: true }),
+        {
+            type: "PLAY_PROMISE_REJECTED",
+            errorName: "NotAllowedError",
+            errorMessage: "blocked in background tab",
+            isPageHidden: true,
+            nowMs: 2_000,
+        },
+    );
+    const { effects } = transitionNativeEngine(blocked, {
+        type: "VISIBILITY_RETRY_FIRED",
+        nowMs: 3_000,
+    });
+    assert.ok(kinds(effects).includes("callPlay"));
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
+});
+
+test("VISIBILITY_RETRY_FIRED after a user pause disarms without playing", () => {
+    const { state: blocked } = transitionNativeEngine(
+        loadedState({ autoplay: true }),
+        {
+            type: "PLAY_PROMISE_REJECTED",
+            errorName: "NotAllowedError",
+            errorMessage: "blocked in background tab",
+            isPageHidden: true,
+            nowMs: 2_000,
+        },
+    );
+    const { effects } = transitionNativeEngine(
+        { ...blocked, pauseClassification: "user" },
+        { type: "VISIBILITY_RETRY_FIRED", nowMs: 3_000 },
+    );
+    assert.equal(kinds(effects).includes("callPlay"), false);
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
+});
+
+test("VISIBILITY_RETRY_FIRED while already playing only disarms", () => {
+    const { effects } = transitionNativeEngine(playingState(), {
+        type: "VISIBILITY_RETRY_FIRED",
+        nowMs: 3_000,
+    });
+    assert.equal(kinds(effects).includes("callPlay"), false);
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
 });


### PR DESCRIPTION
Fixes #53.

## Problem

Two ways a queue auto-advance could land silent under the native engine:

1. **Foreground (occasional):** at natural track end the element fires `pause` **before** `ended`. The pause handler sets UI `isPlaying` false; the end handler advances the queue; the next load then *infers* autoplay from `lastPlayingStateRef.current || audioEngine.isPlaying()` — and under the native engine `isPlaying()` is always false at that point (status `ended`), so the decision hinged on transient UI-state commit ordering. Lose the race and the next track loads paused with the Play button showing.
2. **Background tab (deterministic):** the advance works, but `element.play()` on a fresh `src` in a hidden tab can reject with `NotAllowedError`. The policy armed only a **gesture** retry, so the tab sat silent until the user clicked or returned.

## Fix

- **Advance intent is now declared, not inferred.** The track-end handler stamps a TTL-bounded (30s) play intent before every advance path (direct `next()`, auto-match-vibe deferred `next()`, podcast advance); the load effect consumes it once and feeds both autoplay decision sites (`resolveLoadAutoplayDecision` gains `hasAdvancePlayIntent`). The Listen Together follower rule still wins — followers never autoplay from local state.
- **Visibility retry for hidden-tab autoplay rejection.** `PLAY_PROMISE_REJECTED` now carries `isPageHidden`; a `NotAllowedError` while hidden arms a one-shot `visibilitychange` retry (policy effect + engine listener via the injectable `bindGlobalListener`). It only replays a source that is still externally paused — a user pause in between is respected — and the existing single gesture retry stays armed as fallback.

## Verification

- `npx tsx --test tests/unit/loadAutoplayDecision.test.ts tests/unit/nativeAudioElementPolicy.test.ts tests/unit/nativeAudioElementEngine.test.ts` — 111/111 pass (5 new policy cases, 2 new engine cases, 3 new decision cases).
- `npx tsc --noEmit` — no new errors vs main; `npm run lint` — 0 errors; `npm run build` — clean.
- Cross-LLM review gate (codex/gpt-5.5, high): PASS on the full 8-file diff.

## Manual soak checklist

- Multi-track queue advances audibly every time in the foreground.
- Track ends while tabbed away → audio resumes automatically on tab return without a click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zSncUkZwSsBMoDhsS5qPk