### PR TITLE
test(library): repair the 5 radio suite failures shipped with the #46 diversity work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Repaired the five backend radio test failures that shipped silently with 1.7.0's generation-diversity work (#46): the library route tests' config mock lacked the new `generationDiversity` block, their mock chains didn't account for the diversify stage's artist lookup query, and the vibe random-filler matcher still required the `take` parameter that #46 replaced with uniform sampling. The backend "Tests + Coverage" job is a non-blocking visibility job, so the failures never turned a run red — worth revisiting alongside the CI gating gap tracked in #54.
+
 ### Changed
 
 - The native `<audio>`-element engine is now the **default** playback engine for everyone (`DEFAULT_STREAMING_ENGINE_MODE = "native"`), after soaking as the 1.7.0 opt-in. Deployments with no `STREAMING_ENGINE_MODE` set switch to the native engine on upgrade; set `STREAMING_ENGINE_MODE=howler` to stay on the legacy engine (it remains fully supported as the gated fallback, and Android WebView deployments are still pinned to it automatically). The container entrypoints and docs now report `native` as the primary default.

--- a/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
@@ -63,6 +63,10 @@ jest.mock("../../config", () => ({
             transcodeCachePath: "/tmp/soundspan-cache",
             transcodeCacheMaxGb: 1,
         },
+        generationDiversity: {
+            weightAlpha: 0.5,
+            shareCeiling: 0.3,
+        },
     },
 }));
 
@@ -591,6 +595,7 @@ describe("library vibe radio reliability compatibility", () => {
     it("uses shuffled non-vibe radio ordering and tolerates tracks without artist ids", async () => {
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "all-track-1" }, { id: "all-track-2" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 {
                     id: "all-track-1",
@@ -655,7 +660,8 @@ describe("library vibe radio reliability compatibility", () => {
                 }),
             ],
         });
-        expect(mockTrackFindMany).toHaveBeenCalledTimes(2);
+        // Pool query + diversify artist lookup (GH #46) + full track fetch.
+        expect(mockTrackFindMany).toHaveBeenCalledTimes(3);
     });
 
     it("returns 500 when radio processing throws", async () => {

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -149,6 +149,10 @@ jest.mock("../../config", () => ({
             transcodeCachePath: "/tmp/soundspan-cache",
             transcodeCacheMaxGb: 1,
         },
+        generationDiversity: {
+            weightAlpha: 0.5,
+            shareCeiling: 0.3,
+        },
     },
 }));
 
@@ -4637,6 +4641,7 @@ describe("library catalog list runtime coverage", () => {
 
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "u1" }, { id: "u2" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("u1"),
                 createRadioTrack("u2"),
@@ -4653,6 +4658,7 @@ describe("library catalog list runtime coverage", () => {
 
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "u3" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("lp1"),
                 createRadioTrack("lp2"),
@@ -4677,6 +4683,7 @@ describe("library catalog list runtime coverage", () => {
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "w1" }])
             .mockResolvedValueOnce([{ id: "w3" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("w1"),
                 createRadioTrack("w2"),
@@ -5143,11 +5150,14 @@ describe("library catalog list runtime coverage", () => {
             if (
                 Array.isArray(args.where?.id?.notIn) &&
                 args.select?.id &&
-                typeof args.take === "number" &&
                 !args.where?.album &&
                 !args.include
             ) {
-                return Array.from({ length: args.take }, (_unused, index) => ({
+                // Fallback D dropped `take` for sampleUniform (GH #46);
+                // return a generous pool for the sampler to draw from.
+                const fillerCount =
+                    typeof args.take === "number" ? args.take : 60;
+                return Array.from({ length: fillerCount }, (_unused, index) => ({
                     id: `rnd-d${index + 1}`,
                 }));
             }
@@ -5208,7 +5218,9 @@ describe("library catalog list runtime coverage", () => {
 
     it("covers favorites, decade, genre, mood, and all radio branches", async () => {
         mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "fav-1", play_count: 15n }]);
-        mockTrackFindMany.mockResolvedValueOnce([createRadioTrack("fav-1")]);
+        mockTrackFindMany
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
+            .mockResolvedValueOnce([createRadioTrack("fav-1")]);
         const favoritesReq = {
             query: { type: "favorites", limit: "1" },
             user: { id: "user-1" },
@@ -5223,6 +5235,7 @@ describe("library catalog list runtime coverage", () => {
         mockPrismaQueryRaw.mockResolvedValueOnce([]);
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "rand-fav-1" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("rand-fav-1")]);
         const fallbackFavoritesReq = {
             query: { type: "favorites", limit: "1" },
@@ -5235,6 +5248,7 @@ describe("library catalog list runtime coverage", () => {
 
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "dec-1" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("dec-1")]);
         const decadeReq = {
             query: { type: "decade", value: "1990", limit: "1" },
@@ -5247,7 +5261,9 @@ describe("library catalog list runtime coverage", () => {
         expect(decadeRes.body.tracks[0].id).toBe("dec-1");
 
         mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "genre-1" }]);
-        mockTrackFindMany.mockResolvedValueOnce([createRadioTrack("genre-1")]);
+        mockTrackFindMany
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
+            .mockResolvedValueOnce([createRadioTrack("genre-1")]);
         const genreReq = {
             query: { type: "genre", value: "rock", limit: "1" },
             user: { id: "user-1" },
@@ -5259,6 +5275,7 @@ describe("library catalog list runtime coverage", () => {
 
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "mood-1" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("mood-1")]);
         const moodReq = {
             query: { type: "mood", value: "chill", limit: "1" },
@@ -5271,6 +5288,7 @@ describe("library catalog list runtime coverage", () => {
 
         mockTrackFindMany
             .mockResolvedValueOnce([{ id: "mood-2" }])
+            .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("mood-2")]);
         const defaultMoodReq = {
             query: { type: "mood", value: "obscure-tag", limit: "1" },
@@ -5292,6 +5310,7 @@ describe("library catalog list runtime coverage", () => {
         for (const [moodValue, trackId] of additionalMoodCases) {
             mockTrackFindMany
                 .mockResolvedValueOnce([{ id: trackId }])
+                .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
                 .mockResolvedValueOnce([createRadioTrack(trackId)]);
             const req = {
                 query: { type: "mood", value: moodValue, limit: "1" },


### PR DESCRIPTION
Repairs the backend radio test failures that shipped silently inside 1.7.0's generation-diversity work (#46). They never affected runtime behavior — production config always has the values the test mocks lacked — but they've made `Backend Tests + Coverage` red on main (and on every PR based on it) since the 1.7.0 train landed.

## What broke (three gaps, all test-side)

1. **Config mock predates #46**: `libraryRuntime.test.ts` and `libraryRadioVibeReliabilityCompat.test.ts` mock `../../config` without the new `generationDiversity` block, so every non-vibe radio request 500'd on `config.generationDiversity.weightAlpha`.
2. **Mock chains miss the diversify query**: #46's weighted-selection stage adds one `prisma.track.findMany` (pool→artist lookup) per generated-radio request; the `mockResolvedValueOnce` chains never queued it, so once the config mock was fixed, every subsequent mock shifted by one and responses came back empty.
3. **Vibe filler matcher requires a removed parameter**: vibe Fallback D dropped `take` in favor of `sampleUniform` (#46), so the test's random-filler matcher stopped matching and vibe queues topped out at 5/55 tracks.

Also updates the compat test's call-count assertion (2 → 3) for the new artist-lookup query.

## Why CI stayed green

`Backend Tests + Coverage` is a non-blocking visibility job — job-level failure, run-level success. The broader CI-gating gap is tracked in #54.

## Verification

- `npx jest src/routes/__tests__/libraryRuntime.test.ts src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts` — 114/114 pass.
- Full backend suite run locally to confirm no other main breakage (results in the merge-train summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zSncUkZwSsBMoDhsS5qPk