### PR TITLE
chore: retire stale TODO anchors and the phantom swagger include glob

### DIFF
--- a/backend/src/config/__tests__/swagger.test.ts
+++ b/backend/src/config/__tests__/swagger.test.ts
@@ -41,7 +41,7 @@ describe("config/swagger", () => {
                         }),
                     }),
                 }),
-                apis: ["./src/routes/*.ts", "./src/config/swaggerSchemas.ts"],
+                apis: ["./src/routes/*.ts"],
             })
         );
         expect(swaggerSpec).toBe(mockedSpec);

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -102,7 +102,7 @@ const options: swaggerJsdoc.Options = {
         },
         security: [{ sessionAuth: [] }, { apiKeyAuth: [] }],
     },
-    apis: ["./src/routes/*.ts", "./src/config/swaggerSchemas.ts"],
+    apis: ["./src/routes/*.ts"],
 };
 
 export const swaggerSpec = swaggerJsdoc(options);

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -285,8 +285,8 @@ router.post("/download/:albumMbid", async (req, res) => {
 
         logger.debug(`[Releases] Download requested for album: ${albumMbid}`);
 
-        // TODO: Implement downloadAlbum method on LidarrService
-        // For now, return not implemented error
+        // Release-radar downloads are intentionally unimplemented; this endpoint
+        // returns 501 until that feature is built.
         res.status(501).json({
             error: "Download feature not yet implemented for release radar"
         });

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -198,7 +198,6 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                         title="Notifications"
                     >
                         <Bell className="w-5 h-5" />
-                        {/* TODO: Add notification badge in Phase 3 */}
                     </button>
                 </>
             ) : (

--- a/frontend/components/ui/PullToRefresh.tsx
+++ b/frontend/components/ui/PullToRefresh.tsx
@@ -8,11 +8,11 @@ interface PullToRefreshProps {
 }
 
 /**
- * HOTFIX v1.3.2: Pull-to-refresh temporarily disabled - was blocking mobile scrolling
- * TODO: Re-implement in v1.4 with fixes:
+ * Pull-to-refresh has been disabled since v1.3.2 - it was blocking mobile scrolling.
+ * The full implementation is preserved in git history. Re-implementation is currently
+ * unscheduled. Notes for whoever revives it:
  *   1) h-full breaks flex layout - use "relative flex-1 flex flex-col min-h-0" instead
  *   2) Touch handlers may interfere with normal scroll
- * See git history for full implementation.
  */
 export function PullToRefresh({ children }: PullToRefreshProps) {
     return <>{children}</>;


### PR DESCRIPTION
Behavior-neutral cleanup of the four in-code crumbs from the 2026-07-10 drift audit (#58 Tier-1 item 13's doc-drift half + the Tier-2 stale TODOs), per the 1.9.0 plan's WS1.4 (#59). Companion to the docs-wave PR; either merges alone.

## Changes

- **`frontend/components/ui/PullToRefresh.tsx`** — the comment promising "re-implement in v1.4" (current release: 1.8.0) becomes an honest "disabled since 1.3.2, re-implementation unscheduled" note; both technical requirements for a future revival are preserved verbatim.
- **`frontend/components/layout/TopBar.tsx`** — deletes an untracked "Phase 3" notification-badge TODO (no Phase 3 exists in any tracker).
- **`backend/src/routes/releases.ts`** — the TODO naming `LidarrService.downloadAlbum` (a method that exists nowhere) now describes reality: the endpoint intentionally returns 501. Response byte-identical; the route's @openapi block untouched (its declared auth becomes true when #59 WS4 adds `requireAuth` at the mount — deliberately not this PR).
- **`backend/src/config/swagger.ts`** — drops `./src/config/swaggerSchemas.ts` from the `apis` globs. The file exists in **no git ref** (`git log --all` empty for that path), so the element never matched anything and its removal cannot change the served spec.
- **`backend/src/config/__tests__/swagger.test.ts`** — the one assertion pinning that literal array updated to match (smallest fix; the test's implementation-coupled shape is noted for a future pass).

No CHANGELOG entry: nothing user-visible or behavior-changing (soundspan-shipping's precondition, same class as test-only work).

## Verification

- Served-spec invariant: the swagger spec built from `./src/routes/*.ts` has **388 paths before and after** the glob removal (config-free swagger-jsdoc probe; the `/api/docs` route serves exactly this object).
- `verify.sh src/config/__tests__/swagger.test.ts`: backend tsc clean, suite 1/1 pass.
- Full backend gate on this tree: `npm run verify:backend` — 297/297 suites, 4500/4500 tests, exit 0.
- Frontend `npx tsc --noEmit`: no errors in shipped dirs (pre-existing `tests/**` fixture noise only, per AGENTS.md:86; local Node 18.19.1 is below the `next build` floor, so the documented tsc fallback was used).
- Independent adversarial cross-review confirmed behavior-neutrality: zero `@openapi` annotation lines changed, 501 path byte-identical, glob element absent from all history.

Part of #58. Part of #59 (WS1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
