### PR TITLE
test(frontend): repair all 33 failing component tests (#54 buckets 1-3)

### DIFF
--- a/frontend/tests/component/activityPanel.component.test.ts
+++ b/frontend/tests/component/activityPanel.component.test.ts
@@ -111,6 +111,12 @@ mock.module("@/components/activity/SocialTab", {
     },
 });
 
+mock.module("@/components/activity/ImportsTab", {
+    namedExports: {
+        ImportsTab: tab("imports-tab"),
+    },
+});
+
 mock.module("@/utils/cn", {
     namedExports: {
         cn: (...values: Array<string | false | null | undefined>) =>
@@ -122,6 +128,7 @@ mock.module("lucide-react", {
     namedExports: {
         Bell: Icon,
         Download: Icon,
+        FileInput: Icon,
         History: Icon,
         Users: Icon,
         ChevronLeft: Icon,

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -560,32 +560,32 @@ const applyValue = <T>(
 };
 
 mock.module("react", {
-    defaultExport: {
-        createElement: (..._args: unknown[]) => ({ __mocked: true }),
-        createContext: <T>(defaultValue: T) => ({
-            __defaultValue: defaultValue,
-        }),
-        useContext: (context: { __defaultValue: unknown } | null) =>
-            context?.__defaultValue ?? { prefetchQuery: async () => undefined },
-        useRef: <T>(value: T) => hookRuntime.useRef(value),
-        useCallback: <T extends (...args: unknown[]) => unknown>(
-            fn: T,
-            deps?: readonly unknown[],
-        ) => hookRuntime.useCallback(fn, deps),
-        useEffect: (effect: EffectCallback, deps?: readonly unknown[]) =>
-            hookRuntime.useEffect(effect, deps),
-        useLayoutEffect: (effect: EffectCallback, deps?: readonly unknown[]) =>
-            hookRuntime.useLayoutEffect(effect, deps),
-        useState: <T>(initial: T | (() => T)) => [
-            typeof initial === "function" ? (initial as () => T)() : initial,
-            () => undefined,
-        ],
-        useMemo: <T>(factory: () => T) => factory(),
-        memo: <T>(component: T) => component,
-        forwardRef: <T>(render: T) => render,
-        Fragment: "mock-fragment",
-    },
-    namedExports: {
+    exports: {
+        default: {
+            createElement: (..._args: unknown[]) => ({ __mocked: true }),
+            createContext: <T>(defaultValue: T) => ({
+                __defaultValue: defaultValue,
+            }),
+            useContext: (context: { __defaultValue: unknown } | null) =>
+                context?.__defaultValue ?? { prefetchQuery: async () => undefined },
+            useRef: <T>(value: T) => hookRuntime.useRef(value),
+            useCallback: <T extends (...args: unknown[]) => unknown>(
+                fn: T,
+                deps?: readonly unknown[],
+            ) => hookRuntime.useCallback(fn, deps),
+            useEffect: (effect: EffectCallback, deps?: readonly unknown[]) =>
+                hookRuntime.useEffect(effect, deps),
+            useLayoutEffect: (effect: EffectCallback, deps?: readonly unknown[]) =>
+                hookRuntime.useLayoutEffect(effect, deps),
+            useState: <T>(initial: T | (() => T)) => [
+                typeof initial === "function" ? (initial as () => T)() : initial,
+                () => undefined,
+            ],
+            useMemo: <T>(factory: () => T) => factory(),
+            memo: <T>(component: T) => component,
+            forwardRef: <T>(render: T) => render,
+            Fragment: "mock-fragment",
+        },
         memo: <T>(component: T) => component,
         createContext: <T>(defaultValue: T) => ({
             __defaultValue: defaultValue,
@@ -605,13 +605,13 @@ mock.module("react", {
 });
 
 mock.module("@/lib/audio-engine", {
-    namedExports: {
+    exports: {
         createRuntimeAudioEngine: () => engine,
     },
 });
 
 mock.module("@/lib/audio-state-context", {
-    namedExports: {
+    exports: {
         useAudioState: () => ({
             currentTrack: audioState.currentTrack,
             currentAudiobook: audioState.currentAudiobook,
@@ -645,7 +645,7 @@ mock.module("@/lib/audio-state-context", {
 });
 
 mock.module("@/lib/audio-playback-context", {
-    namedExports: {
+    exports: {
         useAudioPlayback: () => ({
             isPlaying: playbackState.isPlaying,
             currentTime: playbackState.currentTime,
@@ -689,7 +689,7 @@ mock.module("@/lib/audio-playback-context", {
 });
 
 mock.module("@/lib/audio-controls-context", {
-    namedExports: {
+    exports: {
         useAudioControls: () => ({
             pause: () => {
                 controlCalls.pause += 1;
@@ -709,7 +709,7 @@ mock.module("@/lib/audio-controls-context", {
 });
 
 mock.module("@/lib/audio-load-preemption", {
-    namedExports: {
+    exports: {
         shouldAllowInitialPersistedTrackResume: () => false,
         shouldPreemptInFlightAudioLoad: (input: {
             currentMediaId: string | null;
@@ -728,7 +728,7 @@ mock.module("@/lib/audio-load-preemption", {
 });
 
 mock.module("@/lib/api", {
-    namedExports: {
+    exports: {
         api: {
             getStreamUrl: (trackId: string) => {
                 apiCalls.getStreamUrl.push(trackId);
@@ -822,14 +822,14 @@ mock.module("@/lib/api", {
 });
 
 mock.module("@/lib/audio-engine/engineMode", {
-    namedExports: {
+    exports: {
         resolveStreamingEngineMode: () => runtimeEngineMode,
         isSegmentedModeEnabled: () => runtimeEngineMode === "videojs",
     },
 });
 
 mock.module("@/lib/audio-engine/recoveryPolicy", {
-    namedExports: {
+    exports: {
         resolveLocalAuthoritativeRecovery: (
             local: { positionSec: number; shouldPlay: boolean },
             server?: { resumeAtSec?: number },
@@ -849,13 +849,13 @@ mock.module("@/lib/audio-engine/recoveryPolicy", {
 });
 
 mock.module("@/lib/audio-engine/segmentedStartupPolicy", {
-    namedExports: {
+    exports: {
         resolveSegmentedPrewarmMaxRetries: () => 0,
     },
 });
 
 mock.module("@/lib/audio-engine/segmentedPlaybackRegressionPolicy", {
-    namedExports: {
+    exports: {
         isSeekWithinTolerance: (_actual: number, _target: number) =>
             seekToleranceOverride ?? true,
         resolveHeartbeatGuardedRefreshDecision: () => ({
@@ -902,7 +902,7 @@ mock.module("@/lib/audio-engine/segmentedPlaybackRegressionPolicy", {
 });
 
 mock.module("@/lib/audio-engine/segmentedRepresentationPolicy", {
-    namedExports: {
+    exports: {
         resolveSegmentAssetNameFromUri: (uri: string | null | undefined) => {
             if (!uri) return null;
             const parts = uri.split("/");
@@ -916,7 +916,7 @@ mock.module("@/lib/audio-engine/segmentedRepresentationPolicy", {
 });
 
 mock.module("@/lib/audio-seek-emitter", {
-    namedExports: {
+    exports: {
         audioSeekEmitter: {
             subscribe: (handler: (time: number) => void | Promise<void>) => {
                 seekSubscribers.add(handler);
@@ -929,13 +929,13 @@ mock.module("@/lib/audio-seek-emitter", {
 });
 
 mock.module("@/lib/query-events", {
-    namedExports: {
+    exports: {
         dispatchQueryEvent: () => undefined,
     },
 });
 
 mock.module("@/lib/listen-together-session", {
-    namedExports: {
+    exports: {
         enqueueLatestListenTogetherHostTrackOperation: async () => undefined,
         getListenTogetherSessionSnapshot: () => listenTogetherSnapshot,
         isListenTogetherActiveOrPending: () => false,
@@ -954,7 +954,7 @@ mock.module("@/lib/listen-together-session", {
 });
 
 mock.module("@/lib/storage-migration", {
-    namedExports: {
+    exports: {
         createMigratingStorageKey: (key: string) => key,
         PODCAST_DEBUG_STORAGE_KEY: "podcast_debug",
         readMigratingStorageItem: () => null,
@@ -1027,7 +1027,7 @@ class MockHeartbeatMonitor {
 }
 
 mock.module("@/lib/audio", {
-    namedExports: {
+    exports: {
         playbackStateMachine: {
             transition: (next: string) => {
                 playbackMachine.state = next;
@@ -1050,7 +1050,7 @@ mock.module("@/lib/audio", {
 });
 
 mock.module("@tanstack/react-query", {
-    namedExports: {
+    exports: {
         useQueryClient: () => ({
             prefetchQuery: async () => undefined,
         }),
@@ -1058,7 +1058,7 @@ mock.module("@tanstack/react-query", {
 });
 
 mock.module("@/hooks/useLyrics", {
-    namedExports: {
+    exports: {
         fetchLyrics: async () => null,
         lyricsQueryKeys: {
             lyrics: (trackId: string) => ["lyrics", trackId],
@@ -1067,13 +1067,13 @@ mock.module("@/hooks/useLyrics", {
 });
 
 mock.module("@/lib/lyrics-cache-policy", {
-    namedExports: {
+    exports: {
         LYRICS_QUERY_STALE_TIME: 60_000,
     },
 });
 
 mock.module("sonner", {
-    namedExports: {
+    exports: {
         toast: {
             error: (message: string) => {
                 toastErrors.push(message);
@@ -1083,7 +1083,7 @@ mock.module("sonner", {
 });
 
 mock.module("@/lib/logger", {
-    namedExports: {
+    exports: {
         frontendLogger: {
             info: (...args: unknown[]) => {
                 loggerCalls.info.push(args);
@@ -1099,7 +1099,7 @@ mock.module("@/lib/logger", {
 });
 
 mock.module("@soundspan/media-metadata-contract", {
-    namedExports: {
+    exports: {
         normalizeCanonicalMediaProviderIdentity: (input: {
             streamSource?: "local" | "tidal" | "youtube";
             tidalTrackId?: number;

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -168,6 +168,14 @@ class FakeAudioEngine {
         return this.playing;
     }
 
+    // Mirrors HybridRuntimeAudioEngine.getActiveEngineDescriptor() (GH #42
+    // native-engine soak): reports "videojs" while the segmented engine is
+    // active, else the direct-slot descriptor. This fake has one slot, so it
+    // keys off the same runtimeEngineMode the engineMode mock uses.
+    getActiveEngineDescriptor(): "howler" | "videojs" {
+        return runtimeEngineMode === "videojs" ? "videojs" : "howler";
+    }
+
     quarantineRepresentation(): null {
         return null;
     }
@@ -816,6 +824,7 @@ mock.module("@/lib/api", {
 mock.module("@/lib/audio-engine/engineMode", {
     namedExports: {
         resolveStreamingEngineMode: () => runtimeEngineMode,
+        isSegmentedModeEnabled: () => runtimeEngineMode === "videojs",
     },
 });
 

--- a/frontend/tests/component/playlistDetailProviderPlayability.component.test.ts
+++ b/frontend/tests/component/playlistDetailProviderPlayability.component.test.ts
@@ -38,6 +38,11 @@ mock.module("lucide-react", {
         GlobeLock: Icon,
         Pencil: Icon,
         Share2: Icon,
+        GripVertical: Icon,
+        ArrowUp: Icon,
+        ArrowDown: Icon,
+        ArrowUpToLine: Icon,
+        AudioLines: Icon,
     },
 });
 

--- a/frontend/tests/component/playlistRename.component.test.ts
+++ b/frontend/tests/component/playlistRename.component.test.ts
@@ -37,6 +37,11 @@ mock.module("lucide-react", {
         GlobeLock: Icon,
         Pencil: Icon,
         Share2: Icon,
+        GripVertical: Icon,
+        ArrowUp: Icon,
+        ArrowDown: Icon,
+        ArrowUpToLine: Icon,
+        AudioLines: Icon,
     },
 });
 

--- a/frontend/tests/component/streamingRoutes.component.test.ts
+++ b/frontend/tests/component/streamingRoutes.component.test.ts
@@ -179,6 +179,20 @@ mock.module("@/lib/listen-together-context", {
     },
 });
 
+mock.module("@/lib/features-context", {
+    namedExports: {
+        useFeatures: () => ({
+            musicCNN: false,
+            vibeEmbeddings: false,
+            audioAnalysis: true,
+            discovery: true,
+            autoPlaylists: true,
+            showVersion: false,
+            loading: false,
+        }),
+    },
+});
+
 mock.module("@/hooks/useImageColor", {
     namedExports: {
         useImageColor: () => ({

--- a/frontend/tests/component/streamingRoutes.component.test.ts
+++ b/frontend/tests/component/streamingRoutes.component.test.ts
@@ -138,7 +138,7 @@ const capture = {
 };
 
 mock.module("next/navigation", {
-    namedExports: {
+    exports: {
         useRouter: () => ({
             push: () => undefined,
             back: () => undefined,
@@ -147,7 +147,7 @@ mock.module("next/navigation", {
 });
 
 mock.module("@/lib/audio-context", {
-    namedExports: {
+    exports: {
         useAudioState: () => ({
             currentTrack: null,
         }),
@@ -163,7 +163,7 @@ mock.module("@/lib/audio-context", {
 });
 
 mock.module("@/lib/download-context", {
-    namedExports: {
+    exports: {
         useDownloadContext: () => ({
             isPendingByMbid: () => false,
             downloadsEnabled: true,
@@ -172,7 +172,7 @@ mock.module("@/lib/download-context", {
 });
 
 mock.module("@/lib/listen-together-context", {
-    namedExports: {
+    exports: {
         useListenTogether: () => ({
             isInGroup: false,
         }),
@@ -180,7 +180,7 @@ mock.module("@/lib/listen-together-context", {
 });
 
 mock.module("@/lib/features-context", {
-    namedExports: {
+    exports: {
         useFeatures: () => ({
             musicCNN: false,
             vibeEmbeddings: false,
@@ -194,7 +194,7 @@ mock.module("@/lib/features-context", {
 });
 
 mock.module("@/hooks/useImageColor", {
-    namedExports: {
+    exports: {
         useImageColor: () => ({
             colors: {
                 vibrant: "#4488ee",
@@ -205,7 +205,7 @@ mock.module("@/hooks/useImageColor", {
 });
 
 mock.module("@/lib/api", {
-    namedExports: {
+    exports: {
         api: {
             getCoverArtUrl: (id: string, size: number) =>
                 `/cover/${encodeURIComponent(id)}?size=${size}`,
@@ -223,27 +223,27 @@ mock.module("@/lib/api", {
 });
 
 mock.module("@/components/ui/LoadingScreen", {
-    namedExports: {
+    exports: {
         LoadingScreen: ({ message }: { message?: string }) =>
             React.createElement("div", null, "loading-screen", message ?? ""),
     },
 });
 
 mock.module("@/components/ui/GradientSpinner", {
-    namedExports: {
+    exports: {
         GradientSpinner: marker("gradient-spinner"),
     },
 });
 
 mock.module("lucide-react", {
-    namedExports: {
+    exports: {
         RefreshCw: Icon,
         Music2: Icon,
     },
 });
 
 mock.module("sonner", {
-    namedExports: {
+    exports: {
         toast: {
             success: () => undefined,
             error: () => undefined,
@@ -253,7 +253,7 @@ mock.module("sonner", {
 });
 
 mock.module("@/features/album/hooks/useAlbumData", {
-    namedExports: {
+    exports: {
         useAlbumData: () => ({
             album: albumState.album,
             source: albumState.source,
@@ -265,7 +265,7 @@ mock.module("@/features/album/hooks/useAlbumData", {
 });
 
 mock.module("@/features/album/hooks/useTidalGapFill", {
-    namedExports: {
+    exports: {
         useTidalGapFill: () => ({
             enrichedTracks: albumState.tidalGapFill.enrichedTracks,
             isMatching: albumState.tidalGapFill.isMatching,
@@ -275,7 +275,7 @@ mock.module("@/features/album/hooks/useTidalGapFill", {
 });
 
 mock.module("@/features/album/hooks/useYtMusicGapFill", {
-    namedExports: {
+    exports: {
         useYtMusicGapFill: () => ({
             enrichedTracks: albumState.ytGapFill.enrichedTracks,
             isMatching: albumState.ytGapFill.isMatching,
@@ -285,7 +285,7 @@ mock.module("@/features/album/hooks/useYtMusicGapFill", {
 });
 
 mock.module("@/features/album/hooks/useAlbumActions", {
-    namedExports: {
+    exports: {
         useAlbumActions: () => ({
             playAlbum: () => undefined,
             shufflePlay: () => undefined,
@@ -300,19 +300,19 @@ mock.module("@/features/album/hooks/useAlbumActions", {
 });
 
 mock.module("@/components/ui/PlaylistSelector", {
-    namedExports: {
+    exports: {
         PlaylistSelector: marker("playlist-selector"),
     },
 });
 
 mock.module("@/features/album/components/AlbumHero", {
-    namedExports: {
+    exports: {
         AlbumHero: marker("album-hero"),
     },
 });
 
 mock.module("@/features/album/components/AlbumActionBar", {
-    namedExports: {
+    exports: {
         AlbumActionBar: (props: Record<string, unknown>) => {
             capture.albumActionBar = props;
             return React.createElement("div", null, "album-action-bar");
@@ -321,7 +321,7 @@ mock.module("@/features/album/components/AlbumActionBar", {
 });
 
 mock.module("@/features/album/components/TrackList", {
-    namedExports: {
+    exports: {
         TrackList: (props: Record<string, unknown>) => {
             capture.albumTrackList = props;
             return React.createElement("div", null, "album-track-list");
@@ -330,13 +330,13 @@ mock.module("@/features/album/components/TrackList", {
 });
 
 mock.module("@/features/album/components/SimilarAlbums", {
-    namedExports: {
+    exports: {
         SimilarAlbums: marker("similar-albums"),
     },
 });
 
 mock.module("@/features/artist/hooks/useArtistData", {
-    namedExports: {
+    exports: {
         useArtistData: () => ({
             artist: artistState.artist,
             albums: artistState.albums,
@@ -352,7 +352,7 @@ mock.module("@/features/artist/hooks/useArtistData", {
 });
 
 mock.module("@/features/artist/hooks/useArtistActions", {
-    namedExports: {
+    exports: {
         useArtistActions: () => ({
             playAll: () => undefined,
             shufflePlay: () => undefined,
@@ -362,7 +362,7 @@ mock.module("@/features/artist/hooks/useArtistActions", {
 });
 
 mock.module("@/features/artist/hooks/useDownloadActions", {
-    namedExports: {
+    exports: {
         useDownloadActions: () => ({
             downloadArtist: () => undefined,
             downloadAlbum: () => undefined,
@@ -371,7 +371,7 @@ mock.module("@/features/artist/hooks/useDownloadActions", {
 });
 
 mock.module("@/features/artist/hooks/useTidalTopTracks", {
-    namedExports: {
+    exports: {
         useTidalTopTracks: () => ({
             enrichedTopTracks: artistState.tidalTopTracks.enrichedTopTracks,
             isMatching: artistState.tidalTopTracks.isMatching,
@@ -381,7 +381,7 @@ mock.module("@/features/artist/hooks/useTidalTopTracks", {
 });
 
 mock.module("@/features/artist/hooks/useYtMusicTopTracks", {
-    namedExports: {
+    exports: {
         useYtMusicTopTracks: () => ({
             enrichedTopTracks: artistState.ytTopTracks.enrichedTopTracks,
             isMatching: artistState.ytTopTracks.isMatching,
@@ -391,13 +391,13 @@ mock.module("@/features/artist/hooks/useYtMusicTopTracks", {
 });
 
 mock.module("@/features/artist/components/ArtistHero", {
-    namedExports: {
+    exports: {
         ArtistHero: marker("artist-hero"),
     },
 });
 
 mock.module("@/features/artist/components/ArtistActionBar", {
-    namedExports: {
+    exports: {
         ArtistActionBar: (props: Record<string, unknown>) => {
             capture.artistActionBar = props;
             return React.createElement("div", null, "artist-action-bar");
@@ -406,13 +406,13 @@ mock.module("@/features/artist/components/ArtistActionBar", {
 });
 
 mock.module("@/features/artist/components/ArtistBio", {
-    namedExports: {
+    exports: {
         ArtistBio: marker("artist-bio"),
     },
 });
 
 mock.module("@/features/artist/components/PopularTracks", {
-    namedExports: {
+    exports: {
         PopularTracks: (props: Record<string, unknown>) => {
             capture.artistPopularTracks = props;
             return React.createElement("div", null, "popular-tracks");
@@ -421,31 +421,31 @@ mock.module("@/features/artist/components/PopularTracks", {
 });
 
 mock.module("@/features/artist/components/Discography", {
-    namedExports: {
+    exports: {
         Discography: marker("discography"),
     },
 });
 
 mock.module("@/features/artist/components/AvailableAlbums", {
-    namedExports: {
+    exports: {
         AvailableAlbums: marker("available-albums"),
     },
 });
 
 mock.module("@/features/artist/components/SimilarArtists", {
-    namedExports: {
+    exports: {
         SimilarArtists: marker("similar-artists"),
     },
 });
 
 mock.module("@/components/ui/ReleaseSelectionModal", {
-    namedExports: {
+    exports: {
         ReleaseSelectionModal: marker("release-selection-modal"),
     },
 });
 
 mock.module("@/features/discover/hooks/useDiscoverData", {
-    namedExports: {
+    exports: {
         useDiscoverData: () => ({
             playlist: discoverState.playlist,
             config: discoverState.config,
@@ -461,7 +461,7 @@ mock.module("@/features/discover/hooks/useDiscoverData", {
 });
 
 mock.module("@/features/discover/hooks/useDiscoverProviderGapFill", {
-    namedExports: {
+    exports: {
         useDiscoverProviderGapFill: () => ({
             tracks:
                 discoverState.providerTracks ||
@@ -474,7 +474,7 @@ mock.module("@/features/discover/hooks/useDiscoverProviderGapFill", {
 });
 
 mock.module("@/features/discover/hooks/useDiscoverActions", {
-    namedExports: {
+    exports: {
         useDiscoverActions: () => ({
             handleGenerate: () => undefined,
             handlePlayPlaylist: () => undefined,
@@ -485,7 +485,7 @@ mock.module("@/features/discover/hooks/useDiscoverActions", {
 });
 
 mock.module("@/features/discover/hooks/usePreviewPlayer", {
-    namedExports: {
+    exports: {
         usePreviewPlayer: () => ({
             currentPreview: null,
             handleTogglePreview: () => undefined,
@@ -494,13 +494,13 @@ mock.module("@/features/discover/hooks/usePreviewPlayer", {
 });
 
 mock.module("@/features/discover/components/DiscoverHero", {
-    namedExports: {
+    exports: {
         DiscoverHero: marker("discover-hero"),
     },
 });
 
 mock.module("@/features/discover/components/DiscoverActionBar", {
-    namedExports: {
+    exports: {
         DiscoverActionBar: (props: Record<string, unknown>) => {
             capture.discoverActionBar = props;
             return React.createElement("div", null, "discover-action-bar");
@@ -509,25 +509,25 @@ mock.module("@/features/discover/components/DiscoverActionBar", {
 });
 
 mock.module("@/features/discover/components/DiscoverSettings", {
-    namedExports: {
+    exports: {
         DiscoverSettings: marker("discover-settings"),
     },
 });
 
 mock.module("@/features/discover/components/TrackList", {
-    namedExports: {
+    exports: {
         TrackList: marker("discover-track-list"),
     },
 });
 
 mock.module("@/features/discover/components/UnavailableAlbums", {
-    namedExports: {
+    exports: {
         UnavailableAlbums: marker("unavailable-albums"),
     },
 });
 
 mock.module("@/features/discover/components/HowItWorks", {
-    namedExports: {
+    exports: {
         HowItWorks: marker("how-it-works"),
     },
 });


### PR DESCRIPTION
Part of #54.

Repairs all 33 pre-existing `test:component` failures on main, exactly per the issue's bucket characterization. Test files only — zero product-code changes; per the repo's shipping convention, test-only work carries no CHANGELOG entry (the CI gate that makes this suite enforceable lands in the follow-up stacked PR).

## What was wrong, per bucket

- **Bucket 1 (17)** — `audioPlaybackOrchestrator.component.test.ts`: the `mock.module("@/lib/audio-engine/engineMode")` stub predated `isSegmentedModeEnabled`, which `AudioPlaybackOrchestrator.tsx:14` now imports. Added the mirroring mock export (keyed off the test's `runtimeEngineMode`, matching `engineMode.ts:52-56`). Fixing that unmasked a second stale-double gap: the test's `FakeAudioEngine` lacked `getActiveEngineDescriptor()`, which `logPlaybackClientMetric()` now calls unconditionally — added to the fake with the real engine's semantics. No stale `!== "howler"` assertions were found.
- **Bucket 2 (11)** — `activityPanel` / `playlistRename` / `playlistDetailProviderPlayability`: the SSR `Element type is invalid ... got: undefined` failures were stale exact-match module mocks, not a product bug. The components gained new imports (the admin Imports tab's `FileInput` icon + `ImportsTab`; TrackList's `GripVertical` reorder handle; the playlist move arrows) that the mocks' allow-lists never covered — unmocked named imports resolve to `undefined` only in the render states that reach them, which is why failing tests interleaved with passing siblings. Extended the mocks (17 insertions), incl. `AudioLines` defensively (the TrackRow playing-indicator would have bitten next).
- **Bucket 3 (5)** — `streamingRoutes.component.test.ts`: the discover route calls `useFeatures()` with no provider in the SSR harness. Mocked `@/lib/features-context` directly, matching how this file (and five sibling test files) stub their other contexts.
- **Also done** (from the issue's "also worth doing"): migrated `mock.module` `namedExports`/`defaultExport` → `exports` in the two bucket-1/3 files; behavior-identical (suite counts unchanged before/after) and the deprecation warnings for these files are gone.

## Verification

`verify: test:component (node:24 container, this branch): 345 tests / 345 pass / 0 fail` (baseline on main: 345/312/33). Each bucket was also verified per-file at 0 failures. Note the suite requires `--experimental-test-module-mocks` (Node ≥ 20; CI-gate PR runs it on Node 24).

A maintainability observation from the bucket-2 diagnosis, for future reference: any SSR component test that mocks `lucide-react`/subcomponents with an exact allow-list silently breaks the moment the component under test gains a new icon/subcomponent reached in a tested render state — worth knowing when adding icons to actively-tested surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)