### PR TITLE
perf(player): stop the player root's 4Hz re-render; quantize the published clock (F12 items A+B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The animated player UI (the mini/overlay/full-player shell) no longer
+  re-renders 4×/second during playback — smoother UI with less battery drain and
+  jank on mobile. The player render root now subscribes to the granular playback
+  *state* context instead of the merged clock hook, and the engine clock is
+  published to React state at display-second granularity while a full-precision
+  clock is preserved for seek-lock and resume/progress persistence (roadmap F12
+  items A+B).
 - Documentation and agent-context truth pass from the 2026-07-10 drift audit (#58).
   The modernization roadmap header no longer claims long-merged PRs are awaiting
   merge (the nine Wave-1 continuation PRs merged 2026-07-08; F53 flipped to 🟡

--- a/docs/modernization-roadmap.md
+++ b/docs/modernization-roadmap.md
@@ -35,7 +35,7 @@ The audit found **0 true false positives** but several packaging/measurement err
 | #13 | Background-job idempotency, retries & reconciler dedup | 2 / 1 / 8 |
 | #14 | Backend error-handling unification & route god-file decomposition | 0 / 0 / 6 |
 | #15 | Type-safety ratchet (backend any + frontend strict + typed API) | 0 / 1 / 2 |
-| #16 | Frontend consolidation, decomposition & render performance | 0 / 0 / 5 |
+| #16 | Frontend consolidation, decomposition & render performance | 0 / 1 / 5 |
 | #17 | Database & streaming performance | 1 / 3 / 5 |
 | #18 | Provider abstractions: acquisition, streaming & engine seams | 0 / 0 / 4 |
 | #19 | Framework & production-image modernization | 0 / 0 / 6 |
@@ -69,7 +69,7 @@ _(includes F54; dimension tallies double-count the F2/F44 and F17/F47 duplicate 
 | [F9](#f9) | ⬜ | readability | medium | M | low |  | #16 | Two parallel frontend systems each duplicated: dual toast renderers (sonner + custom) a… |
 | [F10](#f10) | ⬜ | readability | medium | M | low |  | #16 | Per-page god-components and duplicated cover-art widgets: VibePage (1247 LOC, 16 useSta… |
 | [F11](#f11) | ⬜ | readability | medium | M | medium |  | #14 | Three near-identical auth resolvers duplicate the credential ladder and carry a permane… |
-| [F12](#f12) | ⬜ | performance | high | M | medium |  | #16 | Player UI re-renders 4×/second during playback: useAudio() pipes the high-frequency cur… |
+| [F12](#f12) | 🟡 | performance | high | M | medium |  | #16 | Player UI re-renders 4×/second during playback: useAudio() pipes the high-frequency cur… |
 | [F13](#f13) | 🟡 | performance | high | L | medium |  | #17 | Per-track/per-candidate N+1 query loops dominate Spotify import and Discover Weekly hot… |
 | [F14](#f14) | ✅ | performance | high | M | medium |  | #17 | pgvector ANN searches never set ivfflat.probes — every 'similar tracks' / vibe query sc… |
 | [F15](#f15) | 🟡 | performance | medium | M | medium |  | #17 | ORDER BY RANDOM() full-table scans on Track / track_embeddings for radio, random tracks… |
@@ -289,7 +289,27 @@ _(includes F54; dimension tallies double-count the F2/F44 and F17/F47 duplicate 
 
 ### F12 — Player UI re-renders 4×/second during playback: useAudio() pipes the high-frequency currentTime context into the heaviest player trees
 
-**⬜ open** · dimension: performance · severity: high · effort: M · risk: medium · epic: #16
+**🟡 partial (PR #TBD-CYCLE3-C)** · dimension: performance · severity: high · effort: M · risk: medium · epic: #16
+
+> **Fix shipped (partial).** Tightened-plan items (A) + (B) landed, frontend-only.
+> (A) `UniversalPlayer` — the animated render root that mounts
+> OverlayPlayer/MiniPlayer/FullPlayer inside AnimatePresence/LayoutGroup — moved
+> off `useAudio()` onto the granular `useAudioState()`, so it no longer re-renders
+> that whole subtree on every clock tick. (B) `setCurrentTimeFromEngine` now
+> publishes to React state only at display-second (`Math.floor`) boundaries (or on
+> a forced discontinuity), a decision extracted to the pure, unit-tested
+> `lib/audio-clock-policy.ts`; an authoritative full-precision `currentTimeRef` is
+> written on every accepted tick and by every discontinuity setter, and the former
+> state→ref sync effect was removed — so server-progress persistence
+> (`savePlaybackProgressToServer`) now reads engine-fresh precision rather than a
+> quantized copy. howler-engine's 250ms tick is unchanged. **Render evidence**
+> (real provider stack under happy-dom, 8 ticks / 2 simulated seconds): the
+> `UniversalPlayer` subtree re-renders **8 → 0**, and playback-state publishes
+> **8 → 2** (quantized to the 1.0s/2.0s boundaries). Tests:
+> `audioClockPolicy.test.ts` (unit), `universalPlayerSubscription.component.test.ts`
+> and `universalPlayerRenderCount.component.test.ts` (component). **Still open:**
+> leaf extraction in OverlayPlayer/MiniPlayer/TVLayout (item C) and any F5
+> orchestrator work.
 
 **Files:** `frontend/lib/audio-hooks.tsx:16`, `frontend/lib/audio-playback-context.tsx:303`, `frontend/lib/howler-engine.ts:736`, `frontend/lib/howler-engine.ts:739`, `frontend/components/player/OverlayPlayer.tsx:157`, `frontend/components/player/MiniPlayer.tsx:43`, `frontend/components/player/UniversalPlayer.tsx`, `frontend/components/layout/TVLayout.tsx`
 

--- a/docs/modernization-roadmap.md
+++ b/docs/modernization-roadmap.md
@@ -300,14 +300,24 @@ _(includes F54; dimension tallies double-count the F2/F44 and F17/F47 duplicate 
 > a forced discontinuity), a decision extracted to the pure, unit-tested
 > `lib/audio-clock-policy.ts`; an authoritative full-precision `currentTimeRef` is
 > written on every accepted tick and by every discontinuity setter, and the former
-> state→ref sync effect was removed — so server-progress persistence
-> (`savePlaybackProgressToServer`) now reads engine-fresh precision rather than a
-> quantized copy. howler-engine's 250ms tick is unchanged. **Render evidence**
+> state→ref sync effect was removed — so persistence now reads engine-fresh
+> precision in BOTH paths: server progress (`savePlaybackProgressToServer`) and
+> the throttled localStorage resume snapshot (`<brand>_current_time`) that
+> `AudioPlaybackOrchestrator` reads to compute the engine's resume `startTime`
+> after a reload/crash. howler-engine's 250ms tick is unchanged. **Known minor
+> trade-off (accepted):** relative-seek actions that compute from the *published*
+> clock — TVLayout ±10s, keyboard-shortcut ±10s, media-session seek handlers
+> (`seekOffset` default 10s), controls `skipForward`/`skipBackward` (default 30s)
+> — now read a value up to ~1s stale instead of ~250ms; these are inherently
+> coarse actions, and precision work on those consumers belongs to item (C)'s
+> leaf-extraction follow-up. **Render evidence**
 > (real provider stack under happy-dom, 8 ticks / 2 simulated seconds): the
 > `UniversalPlayer` subtree re-renders **8 → 0**, and playback-state publishes
-> **8 → 2** (quantized to the 1.0s/2.0s boundaries). Tests:
-> `audioClockPolicy.test.ts` (unit), `universalPlayerSubscription.component.test.ts`
-> and `universalPlayerRenderCount.component.test.ts` (component). **Still open:**
+> **8 → 2** (quantized to the 1.0s/2.0s boundaries; both asserted as exact
+> counts). Tests: `audioClockPolicy.test.ts` (unit),
+> `universalPlayerSubscription.component.test.ts`,
+> `universalPlayerRenderCount.component.test.ts`, and
+> `audioPlaybackStoragePrecision.component.test.ts` (component). **Still open:**
 > leaf extraction in OverlayPlayer/MiniPlayer/TVLayout (item C) and any F5
 > orchestrator work.
 

--- a/docs/modernization-roadmap.md
+++ b/docs/modernization-roadmap.md
@@ -289,7 +289,7 @@ _(includes F54; dimension tallies double-count the F2/F44 and F17/F47 duplicate 
 
 ### F12 — Player UI re-renders 4×/second during playback: useAudio() pipes the high-frequency currentTime context into the heaviest player trees
 
-**🟡 partial (PR #TBD-CYCLE3-C)** · dimension: performance · severity: high · effort: M · risk: medium · epic: #16
+**🟡 partial (PR #109)** · dimension: performance · severity: high · effort: M · risk: medium · epic: #16
 
 > **Fix shipped (partial).** Tightened-plan items (A) + (B) landed, frontend-only.
 > (A) `UniversalPlayer` — the animated render root that mounts

--- a/frontend/components/player/UniversalPlayer.tsx
+++ b/frontend/components/player/UniversalPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAudio } from "@/lib/audio-context";
+import { useAudioState } from "@/lib/audio-state-context";
 import { useIsMobile, useIsTablet } from "@/hooks/useMediaQuery";
 import { MiniPlayer } from "./MiniPlayer";
 import { FullPlayer } from "./FullPlayer";
@@ -18,8 +18,14 @@ import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
  * - No full-width player on mobile
  */
 export function UniversalPlayer() {
+    // Subscribe to the granular state context only: this component needs
+    // playerMode + the three "what's loaded" fields, none of which tick. Using
+    // the compat useAudio() here would re-subscribe to the 250ms currentTime
+    // clock and re-render this AnimatePresence/LayoutGroup render root — and the
+    // OverlayPlayer/MiniPlayer/FullPlayer subtree it mounts — 4x/second during
+    // playback (roadmap F12, item A).
     const { playerMode, currentTrack, currentAudiobook, currentPodcast } =
-        useAudio();
+        useAudioState();
     const isMobile = useIsMobile();
     const isTablet = useIsTablet();
     const isMobileOrTablet = isMobile || isTablet;

--- a/frontend/lib/audio-clock-policy.ts
+++ b/frontend/lib/audio-clock-policy.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure clock-publish policy extracted from AudioPlaybackProvider for testability.
+ *
+ * The audio engine emits `timeupdate` events 4x/second (every 250ms — see
+ * `lib/howler-engine.ts`). Publishing every tick into React state produces a new
+ * playback-context object 4x/sec, re-rendering every subscriber for the whole
+ * duration of a track. Since the player UI only ever displays whole seconds, we
+ * publish to React state only when the *displayed second* changes (or on a forced
+ * discontinuity such as a seek landing). The full-precision value is kept in a ref
+ * by the caller (for seek-target matching and server-progress persistence); this
+ * module only governs the far coarser STATE publish cadence.
+ *
+ * This mirrors the house pattern of `lib/audio-playback-persistence-guards.ts`:
+ * a pure decision function, unit-testable without React.
+ */
+
+import type { EngineTimeUpdateDecision } from "./audio-playback-persistence-guards";
+
+export interface ClockPublishDecisionInput {
+    /** Full-precision engine time of the current accepted tick, in seconds. */
+    time: number;
+    /**
+     * Last value published to React state, or null if nothing has been published
+     * yet. Compared at `Math.floor` (display-second) granularity.
+     */
+    lastPublishedTime: number | null;
+    /**
+     * Force a publish regardless of the second boundary. Used for discontinuities
+     * (seek landing / seek-unlock, track change, resume-from-restore, duration
+     * edge) where the displayed value must update immediately rather than wait for
+     * the next whole-second crossing.
+     */
+    forcePublish?: boolean;
+    /**
+     * Optional staleness safety bound, in seconds. If set (and >= 1) and at least
+     * this many seconds of engine time have elapsed since the last publish without
+     * a display-second crossing, publish anyway. Not required during normal
+     * monotonic playback at 4Hz (every whole second WILL cross a boundary) — it is
+     * only a defensive valve. Values < 1s are intentionally ignored so this can
+     * never degenerate into publishing every 250ms tick (which would make the
+     * whole optimization a no-op).
+     */
+    stalenessBoundSeconds?: number;
+}
+
+/**
+ * Decide whether an already-ACCEPTED engine tick should be published to React
+ * state. Publishes at display-second (`Math.floor`) boundaries, on forced
+ * discontinuities, and — only if a valid (>= 1s) bound is supplied — past a
+ * staleness bound. Never inspects the seek-lock guard: rejection is handled by
+ * the caller BEFORE this runs (rejected ticks must write neither ref nor state).
+ */
+export function shouldPublishClockTime(input: ClockPublishDecisionInput): boolean {
+    const {
+        time,
+        lastPublishedTime,
+        forcePublish = false,
+        stalenessBoundSeconds,
+    } = input;
+
+    if (forcePublish) {
+        return true;
+    }
+
+    // Nothing published yet — establish the baseline.
+    if (lastPublishedTime === null) {
+        return true;
+    }
+
+    // The displayed whole second changed.
+    if (Math.floor(time) !== Math.floor(lastPublishedTime)) {
+        return true;
+    }
+
+    // Defensive staleness valve (opt-in; only honoured at >= 1s so it can never
+    // collapse into a per-tick publish).
+    if (
+        typeof stalenessBoundSeconds === "number" &&
+        stalenessBoundSeconds >= 1 &&
+        Math.abs(time - lastPublishedTime) >= stalenessBoundSeconds
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Classify whether an engine-tick guard decision represents a discontinuity that
+ * must force an immediate state publish. `"unlock-accept"` means the seek lock
+ * just released at the landing position — the displayed time jumps and must be
+ * reflected at once, not deferred to the next whole-second boundary. A plain
+ * `"accept"` is ordinary forward playback and follows the second-boundary cadence.
+ *
+ * (`"reject"` never reaches this classifier: the caller returns before the publish
+ * stage on a rejected decision.)
+ */
+export function isEngineTickDiscontinuity(
+    decision: EngineTimeUpdateDecision,
+): boolean {
+    return decision === "unlock-accept";
+}

--- a/frontend/lib/audio-playback-context.tsx
+++ b/frontend/lib/audio-playback-context.tsx
@@ -40,6 +40,10 @@ import {
     type ActivePlaybackSelection,
     type PlaybackPersistenceSnapshot,
 } from "@/lib/audio-playback-persistence-guards";
+import {
+    isEngineTickDiscontinuity,
+    shouldPublishClockTime,
+} from "@/lib/audio-clock-policy";
 
 export interface PlaybackStreamProfile {
     mode: "direct" | "dash";
@@ -134,7 +138,15 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
     const lastSaveTimeRef = useRef<number>(0);
     const lastServerProgressSaveRef = useRef<number>(0);
     const initialIsPlayingRef = useRef(isPlaying);
+    // Authoritative FULL-PRECISION clock. Written on every accepted engine tick
+    // and by every discontinuity publish; read by server-progress persistence
+    // (savePlaybackProgressToServer) and seek-target matching. This must NEVER be
+    // regressed to the coarser published state value (roadmap F12 ref-sync trap).
     const currentTimeRef = useRef<number>(currentTime);
+    // Last value published to React state, tracked at full precision so the
+    // publish gate can compare display-second (Math.floor) boundaries without
+    // reading the (intentionally stale, up-to-1s-behind) currentTime state.
+    const lastPublishedTimeRef = useRef<number>(currentTime);
     const state = useAudioState();
     const initialTrackId =
         state.playbackType === "track" ? state.currentTrack?.id ?? null : null;
@@ -279,10 +291,31 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
         }
     }, []);
 
-    // setCurrentTimeFromEngine - for timeupdate events from Howler
-    // Respects seek lock to prevent stale updates causing flicker
+    // publishCurrentTime - the discontinuity clock setter exposed to the rest of
+    // the app (seek, updateCurrentTime, track-start / resume in the controls
+    // context and orchestrator). It writes the full-precision ref FIRST (so a
+    // concurrent progress save reads the correct value) and then publishes to
+    // state. Every non-engine setCurrentTime call is a discontinuity, so these
+    // always publish. This replaces the removed state->ref sync effect for all
+    // external callers (roadmap F12 ref-sync trap).
+    const publishCurrentTime = useCallback((time: number) => {
+        currentTimeRef.current = time;
+        lastPublishedTimeRef.current = time;
+        setCurrentTime(time);
+    }, []);
+
+    // setCurrentTimeFromEngine - for timeupdate events from Howler (4x/sec).
+    // Three ORDERED stages (order is correctness-critical, roadmap F12):
+    //   (i)  guard on RAW engine time — a rejected tick writes NEITHER ref NOR
+    //        state (prevents seek-lock flap and post-track-change stale writes);
+    //   (ii) any non-rejected tick (accept OR unlock-accept) updates the
+    //        full-precision ref unconditionally;
+    //   (iii) publish to state only when the displayed second changes, or when a
+    //        discontinuity (seek unlock) forces it — quantizing the 4Hz clock to
+    //        ~1Hz of setState churn while keeping the ref continuously fresh.
     const setCurrentTimeFromEngine = useCallback(
         (time: number, invocationTrackId: string | null = null) => {
+            // Stage (i): reject on RAW time before any write.
             const decision = shouldAcceptEngineTimeUpdate(
                 invocationTrackId,
                 activePlaybackSelectionRef.current,
@@ -300,16 +333,30 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
                     seekLockTimeoutRef.current = null;
                 }
             }
-            setCurrentTime(time);
+            // Stage (ii): full-precision ref tracks every accepted tick.
+            currentTimeRef.current = time;
+            // Stage (iii): gated state publish (display-second granularity).
+            if (
+                shouldPublishClockTime({
+                    time,
+                    lastPublishedTime: lastPublishedTimeRef.current,
+                    forcePublish: isEngineTickDiscontinuity(decision),
+                })
+            ) {
+                lastPublishedTimeRef.current = time;
+                setCurrentTime(time);
+            }
         },
         [isSeekLocked],
     );
 
-    // currentTime and isHydrated are initialized via lazy useState from localStorage
-
-    useEffect(() => {
-        currentTimeRef.current = currentTime;
-    }, [currentTime]);
+    // currentTime and isHydrated are initialized via lazy useState from localStorage.
+    // NOTE: the former `currentTimeRef.current = currentTime` sync effect was
+    // removed — it clobbered the fresh full-precision ref with the quantized
+    // (up-to-1s-stale) published state. The ref is now written directly at every
+    // authoritative point instead: init, accepted engine ticks (stage ii),
+    // publishCurrentTime (all discontinuity/external setters), and the
+    // track-change reset below.
 
     useEffect(() => {
         if (!isHydrated || typeof window === "undefined") return;
@@ -360,9 +407,10 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
                 ? state.currentAudiobook?.progress?.currentTime
                 : null;
         if (audiobookProgress) {
-            setCurrentTime((prev) =>
-                prev === audiobookProgress ? prev : audiobookProgress
-            );
+            // Discontinuity (resume-from-restore): publishCurrentTime forces the
+            // publish AND keeps the full-precision ref in sync (React bails out of
+            // the state update when the value is unchanged).
+            publishCurrentTime(audiobookProgress);
             return;
         }
 
@@ -371,9 +419,7 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
                 ? state.currentPodcast?.progress?.currentTime
                 : null;
         if (podcastProgress) {
-            setCurrentTime((prev) =>
-                prev === podcastProgress ? prev : podcastProgress
-            );
+            publishCurrentTime(podcastProgress);
         }
     }, [
         isHydrated,
@@ -381,6 +427,7 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
         state.playbackType,
         state.currentAudiobook?.progress?.currentTime,
         state.currentPodcast?.progress?.currentTime,
+        publishCurrentTime,
     ]);
 
     // Cleanup seek lock timeout on unmount
@@ -404,6 +451,7 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
         if (currentTrackEpoch === lastTrackResetEpochRef.current) return;
         lastTrackResetEpochRef.current = currentTrackEpoch;
         currentTimeRef.current = 0;
+        lastPublishedTimeRef.current = 0;
         // eslint-disable-next-line react-hooks/set-state-in-effect -- must zero local playback state immediately on active track swap
         setCurrentTime((prev) => prev === 0 ? prev : 0);
         lastSaveTimeRef.current = 0;
@@ -600,7 +648,9 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
             playbackState,
             streamProfile,
             setIsPlaying,
-            setCurrentTime,
+            // Exposed under the stable public name; routes every external setter
+            // through the ref-syncing full-precision publisher (roadmap F12).
+            setCurrentTime: publishCurrentTime,
             setCurrentTimeFromEngine,
             setDuration,
             setIsBuffering,
@@ -624,6 +674,7 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
             audioError,
             playbackState,
             streamProfile,
+            publishCurrentTime,
             setCurrentTimeFromEngine,
             lockSeek,
             unlockSeek,

--- a/frontend/lib/audio-playback-context.tsx
+++ b/frontend/lib/audio-playback-context.tsx
@@ -494,9 +494,16 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
 
         lastSaveTimeRef.current = now;
         try {
+            // Write the FULL-PRECISION ref, not the quantized `currentTime`
+            // state: AudioPlaybackOrchestrator reads this key on initial track
+            // load to compute the engine's resume startTime, so writing the
+            // published state would regress resume-after-reload precision from
+            // ~250ms to ~1s. `currentTime` stays in the dep array purely as the
+            // ~1Hz re-check trigger; the ref is fresh at write time. Mirrors
+            // savePlaybackProgressToServer, which reads the same ref.
             writeMigratingStorageItem(
                 STORAGE_KEYS.CURRENT_TIME,
-                currentTime.toString()
+                currentTimeRef.current.toString()
             );
             if (state.playbackType === "track" && invocationTrackId) {
                 writeMigratingStorageItem(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "video.js": "^8.23.9"
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "20.10.6",
         "@next/bundle-analyzer": "^16.2.10",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
@@ -43,6 +44,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
+        "happy-dom": "20.10.6",
         "tailwindcss": "^4",
         "tsx": "^4.23.0",
         "typescript": "^5"
@@ -947,6 +949,20 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@happy-dom/global-registrator": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.10.6.tgz",
+      "integrity": "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "happy-dom": "^20.10.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2414,6 +2430,23 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.1.tgz",
@@ -3396,6 +3429,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3967,6 +4013,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5070,6 +5129,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/has-bigints": {
@@ -8233,6 +8333,16 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "video.js": "^8.23.9"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "20.10.6",
     "@next/bundle-analyzer": "^16.2.10",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
@@ -70,6 +71,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "happy-dom": "20.10.6",
     "tailwindcss": "^4",
     "tsx": "^4.23.0",
     "typescript": "^5"

--- a/frontend/tests/component/audioPlaybackStoragePrecision.component.test.ts
+++ b/frontend/tests/component/audioPlaybackStoragePrecision.component.test.ts
@@ -62,11 +62,15 @@ test("localStorage resume snapshot stores the full-precision engine clock, not t
     const currentTimeKey = createMigratingStorageKey("current_time");
 
     type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
-    let capturedEngineTick: EngineTickFn | null = null;
+    // Ref-shaped mutation container: the react-hooks lint rule forbids
+    // reassigning outer variables inside a component, but allows writes to the
+    // `.current` field of *Ref-named values (house pattern, see
+    // audioContextHookGuards.component.test.ts).
+    const capturedEngineTickRef = { current: null as EngineTickFn | null };
 
     const Probe = () => {
         const playback = useAudioPlayback();
-        capturedEngineTick = playback.setCurrentTimeFromEngine;
+        capturedEngineTickRef.current = playback.setCurrentTimeFromEngine;
         return null;
     };
 
@@ -94,7 +98,7 @@ test("localStorage resume snapshot stores the full-precision engine clock, not t
     });
 
     assert.ok(
-        capturedEngineTick,
+        capturedEngineTickRef.current,
         "expected the playback provider's engine-tick setter to be captured",
     );
     assert.equal(
@@ -109,8 +113,8 @@ test("localStorage resume snapshot stores the full-precision engine clock, not t
     // after the batch with published state 1.02 but ref 1.27.
     t.mock.timers.tick(6000);
     await React.act(async () => {
-        capturedEngineTick!(1.02, null);
-        capturedEngineTick!(1.27, null);
+        capturedEngineTickRef.current!(1.02, null);
+        capturedEngineTickRef.current!(1.27, null);
     });
 
     assert.equal(

--- a/frontend/tests/component/audioPlaybackStoragePrecision.component.test.ts
+++ b/frontend/tests/component/audioPlaybackStoragePrecision.component.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+/**
+ * Behavioural pin for the F12 localStorage persistence path.
+ *
+ * The playback provider's throttled "save currentTime to localStorage" effect
+ * must write the FULL-PRECISION engine clock (currentTimeRef), not the quantized
+ * published state: AudioPlaybackOrchestrator reads that key
+ * (`<brand>_current_time`) on initial track load to compute the engine's resume
+ * startTime, so a quantized write regresses resume-after-reload precision from
+ * ~250ms to ~1s.
+ *
+ * Mechanism exercised end-to-end with the REAL State+Playback providers under
+ * happy-dom: two accepted engine ticks land in one act() batch — 1.02 crosses a
+ * display-second boundary (published to state), 1.27 does not (ref-only). The
+ * save effect then fires (triggered by the 1.02 publish) while the ref already
+ * holds 1.27, so the stored value distinguishes ref (1.27, correct) from
+ * published state (1.02, the regression).
+ *
+ * The effect's 5s wall-clock throttle is controlled with node:test's mocked
+ * Date: at mount Date.now() is 0 so the mount-time run is throttled (writes
+ * nothing), then the clock is advanced past the throttle before the ticks.
+ */
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+// Any api method resolves to null so mount-time playback-state hydration is a
+// no-op. The audio contexts and the storage-migration module stay REAL.
+const apiStub = new Proxy(
+    {},
+    { get: () => async () => null },
+) as Record<string, unknown>;
+mock.module("@/lib/api", { namedExports: { api: apiStub } });
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+test("localStorage resume snapshot stores the full-precision engine clock, not the quantized published value", async (t) => {
+    // Date.now() = 0 at mount -> the save effect's mount run is throttled
+    // (0 - 0 < 5000) and writes nothing.
+    t.mock.timers.enable({ apis: ["Date"], now: 0 });
+    localStorage.clear();
+
+    const { createRoot } = await import("react-dom/client");
+    const { AudioStateProvider } = await import("../../lib/audio-state-context");
+    const { AudioPlaybackProvider, useAudioPlayback } = await import(
+        "../../lib/audio-playback-context"
+    );
+    const { createMigratingStorageKey, readMigratingStorageItem } = await import(
+        "../../lib/storage-migration"
+    );
+    const currentTimeKey = createMigratingStorageKey("current_time");
+
+    type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
+    let capturedEngineTick: EngineTickFn | null = null;
+
+    const Probe = () => {
+        const playback = useAudioPlayback();
+        capturedEngineTick = playback.setCurrentTimeFromEngine;
+        return null;
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(
+                AudioStateProvider,
+                null,
+                React.createElement(
+                    AudioPlaybackProvider,
+                    null,
+                    React.createElement(Probe),
+                ),
+            ),
+        );
+    });
+    // Flush mount effects + the mocked (immediately-resolving) api promises.
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    assert.ok(
+        capturedEngineTick,
+        "expected the playback provider's engine-tick setter to be captured",
+    );
+    assert.equal(
+        readMigratingStorageItem(currentTimeKey),
+        null,
+        "precondition: the throttled mount run must not have written the key",
+    );
+
+    // Open the 5s throttle, then land two accepted ticks in ONE batch:
+    // 1.02 crosses the 0->1 display-second boundary (published), 1.27 stays in
+    // the same displayed second (full-precision ref only). The save effect runs
+    // after the batch with published state 1.02 but ref 1.27.
+    t.mock.timers.tick(6000);
+    await React.act(async () => {
+        capturedEngineTick!(1.02, null);
+        capturedEngineTick!(1.27, null);
+    });
+
+    assert.equal(
+        readMigratingStorageItem(currentTimeKey),
+        "1.27",
+        "the resume snapshot must carry the full-precision engine clock (1.27), " +
+            "not the quantized published state (1.02)",
+    );
+
+    await React.act(async () => {
+        root.unmount();
+    });
+});

--- a/frontend/tests/component/universalPlayerRenderCount.component.test.ts
+++ b/frontend/tests/component/universalPlayerRenderCount.component.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+/**
+ * TRUE render-count regression for roadmap F12 item (A)+(B).
+ *
+ * Mounts the REAL AudioStateProvider + AudioPlaybackProvider and the REAL
+ * UniversalPlayer under happy-dom with react-dom/client, then drives 8 engine
+ * timeupdate ticks (2 simulated seconds at 4Hz) through the playback provider and
+ * counts how many times the UniversalPlayer subtree renders.
+ *
+ * Only leaves are mocked (network api, the three heavy child players,
+ * framer-motion, the media-query hooks, the controls context); the STATE and
+ * PLAYBACK contexts are the real ones, so this measures the actual subscription
+ * behaviour. Post-fix UniversalPlayer reads only the granular state context, so
+ * clock ticks must not re-render it; the pre-fix tree (useAudio) re-rendered it
+ * on every tick.
+ *
+ * Measurement note: React.Profiler is wired for the subtree, but in this
+ * react-dom + happy-dom combination its onRender does NOT fire for context-only
+ * re-renders that mutate no host DOM (verified: on the pre-fix tree the Profiler
+ * reported 0 while UniversalPlayer actually re-rendered 8x). So the AUTHORITATIVE
+ * count is a child-stub render counter (a mocked child re-renders exactly when
+ * UniversalPlayer does): pre-fix child-render tick-phase = 8, post-fix = 0.
+ */
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+// --- leaf mocks (audio contexts stay REAL) ---------------------------------
+// Any api method resolves to null so the mount-time playback-state restore is a
+// no-op and nothing sets a track (which would re-render UniversalPlayer).
+const apiStub = new Proxy(
+    {},
+    { get: () => async () => null },
+) as Record<string, unknown>;
+mock.module("@/lib/api", { namedExports: { api: apiStub } });
+
+mock.module("@/hooks/useMediaQuery", {
+    namedExports: {
+        useIsMobile: () => false,
+        useIsTablet: () => false,
+    },
+});
+
+// Stub the CONTROLS context so we can mount only the State + Playback providers
+// (the real controls provider drags in listen-together sockets). This is what
+// lets the SAME test render on the pre-fix tree too: there UniversalPlayer calls
+// useAudio(), which internally calls useAudioControls(). Controls are stable
+// actions that never change on a clock tick, so stubbing them cannot affect the
+// re-render count on either tree; post-fix UniversalPlayer never calls it at all.
+mock.module("@/lib/audio-controls-context", {
+    namedExports: {
+        useAudioControls: () => ({}),
+    },
+});
+
+// A child stub re-renders exactly when UniversalPlayer re-renders (no memo
+// boundary between them), giving a Profiler-independent count of UniversalPlayer
+// renders as a cross-check.
+const childRenderCounts = { "full-player-stub": 0, "mini-player-stub": 0, "overlay-player-stub": 0 };
+const childStub =
+    (label: keyof typeof childRenderCounts) =>
+    () => {
+        childRenderCounts[label] += 1;
+        return React.createElement("div", { "data-stub": label }, label);
+    };
+mock.module("../../components/player/MiniPlayer.tsx", {
+    namedExports: { MiniPlayer: childStub("mini-player-stub") },
+});
+mock.module("../../components/player/FullPlayer.tsx", {
+    namedExports: { FullPlayer: childStub("full-player-stub") },
+});
+mock.module("../../components/player/OverlayPlayer.tsx", {
+    namedExports: { OverlayPlayer: childStub("overlay-player-stub") },
+});
+
+mock.module("framer-motion", {
+    namedExports: {
+        AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement(React.Fragment, null, children),
+        LayoutGroup: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement(React.Fragment, null, children),
+        motion: {
+            div: ({ children }: { children?: React.ReactNode }) =>
+                React.createElement("div", null, children),
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
+
+test("UniversalPlayer commits <= 2 renders across 8 clock ticks (real provider stack)", async (t) => {
+    const { createRoot } = await import("react-dom/client");
+    const { AudioStateProvider } = await import("../../lib/audio-state-context");
+    const { AudioPlaybackProvider, useAudioPlayback } = await import(
+        "../../lib/audio-playback-context"
+    );
+    const { UniversalPlayer } = await import(
+        "../../components/player/UniversalPlayer"
+    );
+
+    let commitCount = 0;
+    let playbackRenders = 0;
+    let capturedEngineTick: EngineTickFn | null = null;
+
+    // A real playback subscriber. It re-renders whenever the ticking clock is
+    // published to state — the A/B control that proves the ticks actually drive
+    // state changes (otherwise a "0 UniversalPlayer renders" result would be
+    // vacuous). UniversalPlayer must NOT track this counter.
+    const Probe = () => {
+        const playback = useAudioPlayback();
+        capturedEngineTick = playback.setCurrentTimeFromEngine;
+        playbackRenders += 1;
+        return null;
+    };
+
+    const tree = React.createElement(
+        AudioStateProvider,
+        null,
+        React.createElement(
+            AudioPlaybackProvider,
+            null,
+            React.createElement(Probe),
+            React.createElement(
+                React.Profiler,
+                {
+                    id: "universal-player",
+                    onRender: () => {
+                        commitCount += 1;
+                    },
+                },
+                React.createElement(UniversalPlayer),
+            ),
+        ),
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(tree);
+    });
+    // Flush mount effects + the mocked (immediately-resolving) api calls so any
+    // post-mount state settles BEFORE we start counting clock-tick commits.
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    const mountCommits = commitCount;
+    const mountPlaybackRenders = playbackRenders;
+    const mountChildRenders = childRenderCounts["full-player-stub"];
+    assert.ok(
+        capturedEngineTick,
+        "expected the playback provider's engine-tick setter to be captured",
+    );
+
+    // 8 ticks = 2 simulated seconds at 4Hz. With no active track the guard accepts
+    // every tick; post-fix these publish only at the 1.0s and 2.0s boundaries and,
+    // crucially, UniversalPlayer subscribes to STATE (not the clock) so it should
+    // not re-render at all.
+    const ticks = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+    for (const time of ticks) {
+        await React.act(async () => {
+            capturedEngineTick!(time, null);
+        });
+    }
+
+    const tickCommits = commitCount - mountCommits;
+    const tickPlaybackRenders = playbackRenders - mountPlaybackRenders;
+    const tickChildRenders =
+        childRenderCounts["full-player-stub"] - mountChildRenders;
+    t.diagnostic(
+        `UniversalPlayer commits — mount:${mountCommits} tick-phase(Profiler):${tickCommits} ` +
+            `tick-phase(child-render):${tickChildRenders} total:${commitCount}; ` +
+            `playback-subscriber tick-phase renders:${tickPlaybackRenders}`,
+    );
+
+    // Non-vacuity control: the same 8 ticks DID re-render a real playback
+    // subscriber, so a 0 for UniversalPlayer is a genuine isolation result.
+    assert.ok(
+        tickPlaybackRenders >= 1,
+        `sanity: clock ticks must re-render a playback subscriber (got ${tickPlaybackRenders})`,
+    );
+
+    // Weak secondary signal (see the header note — the Profiler under-reports
+    // context-only re-renders here, so this passes trivially on both trees).
+    assert.ok(
+        tickCommits <= 2,
+        `UniversalPlayer Profiler commits must be <= 2 across 8 clock ticks (got ${tickCommits})`,
+    );
+    // AUTHORITATIVE guard: the child stub re-renders exactly when UniversalPlayer
+    // does. Pre-fix this is 8 (re-render every tick) and fails; post-fix it is 0.
+    assert.ok(
+        tickChildRenders <= 2,
+        `UniversalPlayer subtree must render <= 2 times across 8 clock ticks (child-render count ${tickChildRenders})`,
+    );
+
+    await React.act(async () => {
+        root.unmount();
+    });
+});

--- a/frontend/tests/component/universalPlayerRenderCount.component.test.ts
+++ b/frontend/tests/component/universalPlayerRenderCount.component.test.ts
@@ -24,6 +24,15 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
  * reported 0 while UniversalPlayer actually re-rendered 8x). So the AUTHORITATIVE
  * count is a child-stub render counter (a mocked child re-renders exactly when
  * UniversalPlayer does): pre-fix child-render tick-phase = 8, post-fix = 0.
+ *
+ * The assertions are EXACT (=== 0 subtree renders, === 2 clock publishes), not
+ * bounds: a loose >=1/<=2 band would keep passing if quantization silently
+ * regressed to publishing every tick (8 publishes) while the subscription fix
+ * held. Exactness is deterministic here because the baseline is fully
+ * controlled: localStorage is cleared before mount (initial published clock 0),
+ * the tick sequence 0.25..2.0 crosses exactly two display-second boundaries
+ * (1.0 and 2.0), each tick runs in its own act() flush, and no timers or
+ * real audio are involved.
  */
 
 GlobalRegistrator.register();
@@ -101,7 +110,10 @@ after(() => {
 
 type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
 
-test("UniversalPlayer commits <= 2 renders across 8 clock ticks (real provider stack)", async (t) => {
+test("UniversalPlayer renders exactly 0 times across 8 clock ticks; clock publishes exactly 2 (real provider stack)", async (t) => {
+    // Deterministic baseline: the playback provider lazily restores currentTime
+    // from localStorage, so start from a clean slate (initial published clock 0).
+    localStorage.clear();
     const { createRoot } = await import("react-dom/client");
     const { AudioStateProvider } = await import("../../lib/audio-state-context");
     const { AudioPlaybackProvider, useAudioPlayback } = await import(
@@ -189,24 +201,30 @@ test("UniversalPlayer commits <= 2 renders across 8 clock ticks (real provider s
             `playback-subscriber tick-phase renders:${tickPlaybackRenders}`,
     );
 
-    // Non-vacuity control: the same 8 ticks DID re-render a real playback
-    // subscriber, so a 0 for UniversalPlayer is a genuine isolation result.
-    assert.ok(
-        tickPlaybackRenders >= 1,
-        `sanity: clock ticks must re-render a playback subscriber (got ${tickPlaybackRenders})`,
+    // Non-vacuity control AND quantization guard (item B): the 8 ticks must
+    // publish to state EXACTLY at the two display-second crossings (1.0, 2.0).
+    // More than 2 means quantization silently regressed toward per-tick
+    // publishing (pre-fix: 8); fewer means ticks stopped reaching state at all.
+    assert.equal(
+        tickPlaybackRenders,
+        2,
+        `clock ticks must publish exactly at the 2 display-second boundaries (got ${tickPlaybackRenders} playback-subscriber renders)`,
     );
 
     // Weak secondary signal (see the header note — the Profiler under-reports
-    // context-only re-renders here, so this passes trivially on both trees).
-    assert.ok(
-        tickCommits <= 2,
-        `UniversalPlayer Profiler commits must be <= 2 across 8 clock ticks (got ${tickCommits})`,
+    // context-only re-renders here; kept as a tripwire for renderer changes).
+    assert.equal(
+        tickCommits,
+        0,
+        `UniversalPlayer Profiler commits must be 0 across 8 clock ticks (got ${tickCommits})`,
     );
-    // AUTHORITATIVE guard: the child stub re-renders exactly when UniversalPlayer
-    // does. Pre-fix this is 8 (re-render every tick) and fails; post-fix it is 0.
-    assert.ok(
-        tickChildRenders <= 2,
-        `UniversalPlayer subtree must render <= 2 times across 8 clock ticks (child-render count ${tickChildRenders})`,
+    // AUTHORITATIVE guard (item A): the child stub re-renders exactly when
+    // UniversalPlayer does. Pre-fix this is 8 (re-render every tick); post-fix
+    // the subtree must not render at all during the tick phase.
+    assert.equal(
+        tickChildRenders,
+        0,
+        `UniversalPlayer subtree must render 0 times across 8 clock ticks (child-render count ${tickChildRenders})`,
     );
 
     await React.act(async () => {

--- a/frontend/tests/component/universalPlayerRenderCount.component.test.ts
+++ b/frontend/tests/component/universalPlayerRenderCount.component.test.ts
@@ -71,12 +71,14 @@ mock.module("@/lib/audio-controls-context", {
 // boundary between them), giving a Profiler-independent count of UniversalPlayer
 // renders as a cross-check.
 const childRenderCounts = { "full-player-stub": 0, "mini-player-stub": 0, "overlay-player-stub": 0 };
-const childStub =
-    (label: keyof typeof childRenderCounts) =>
-    () => {
+const childStub = (label: keyof typeof childRenderCounts) => {
+    const ChildStub = () => {
         childRenderCounts[label] += 1;
         return React.createElement("div", { "data-stub": label }, label);
     };
+    ChildStub.displayName = `ChildStub(${label})`;
+    return ChildStub;
+};
 mock.module("../../components/player/MiniPlayer.tsx", {
     namedExports: { MiniPlayer: childStub("mini-player-stub") },
 });
@@ -124,8 +126,12 @@ test("UniversalPlayer renders exactly 0 times across 8 clock ticks; clock publis
     );
 
     let commitCount = 0;
-    let playbackRenders = 0;
-    let capturedEngineTick: EngineTickFn | null = null;
+    // Ref-shaped mutation containers: the react-hooks lint rule forbids
+    // reassigning outer variables inside a component, but allows writes to the
+    // `.current` field of *Ref-named values (house pattern, see
+    // audioContextHookGuards.component.test.ts).
+    const playbackRendersRef = { current: 0 };
+    const capturedEngineTickRef = { current: null as EngineTickFn | null };
 
     // A real playback subscriber. It re-renders whenever the ticking clock is
     // published to state — the A/B control that proves the ticks actually drive
@@ -133,8 +139,8 @@ test("UniversalPlayer renders exactly 0 times across 8 clock ticks; clock publis
     // vacuous). UniversalPlayer must NOT track this counter.
     const Probe = () => {
         const playback = useAudioPlayback();
-        capturedEngineTick = playback.setCurrentTimeFromEngine;
-        playbackRenders += 1;
+        capturedEngineTickRef.current = playback.setCurrentTimeFromEngine;
+        playbackRendersRef.current += 1;
         return null;
     };
 
@@ -173,10 +179,10 @@ test("UniversalPlayer renders exactly 0 times across 8 clock ticks; clock publis
     });
 
     const mountCommits = commitCount;
-    const mountPlaybackRenders = playbackRenders;
+    const mountPlaybackRenders = playbackRendersRef.current;
     const mountChildRenders = childRenderCounts["full-player-stub"];
     assert.ok(
-        capturedEngineTick,
+        capturedEngineTickRef.current,
         "expected the playback provider's engine-tick setter to be captured",
     );
 
@@ -187,12 +193,12 @@ test("UniversalPlayer renders exactly 0 times across 8 clock ticks; clock publis
     const ticks = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
     for (const time of ticks) {
         await React.act(async () => {
-            capturedEngineTick!(time, null);
+            capturedEngineTickRef.current!(time, null);
         });
     }
 
     const tickCommits = commitCount - mountCommits;
-    const tickPlaybackRenders = playbackRenders - mountPlaybackRenders;
+    const tickPlaybackRenders = playbackRendersRef.current - mountPlaybackRenders;
     const tickChildRenders =
         childRenderCounts["full-player-stub"] - mountChildRenders;
     t.diagnostic(

--- a/frontend/tests/component/universalPlayerSubscription.component.test.ts
+++ b/frontend/tests/component/universalPlayerSubscription.component.test.ts
@@ -67,10 +67,12 @@ mock.module("@/hooks/useMediaQuery", {
     },
 });
 
-const childStub =
-    (label: string) =>
-    () =>
+const childStub = (label: string) => {
+    const ChildStub = () =>
         React.createElement("div", { "data-stub": label }, label);
+    ChildStub.displayName = `ChildStub(${label})`;
+    return ChildStub;
+};
 
 mock.module("../../components/player/MiniPlayer.tsx", {
     namedExports: { MiniPlayer: childStub("mini-player-stub") },

--- a/frontend/tests/component/universalPlayerSubscription.component.test.ts
+++ b/frontend/tests/component/universalPlayerSubscription.component.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { beforeEach, mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+/**
+ * Regression guard for roadmap F12 item (A): UniversalPlayer — the animated
+ * render root that mounts OverlayPlayer/MiniPlayer/FullPlayer — must subscribe to
+ * the granular useAudioState() only, NEVER the compat useAudio() or
+ * useAudioPlayback() that carry the 250ms currentTime tick. Re-subscribing would
+ * re-render this whole AnimatePresence/LayoutGroup subtree 4x/second.
+ *
+ * The clock hooks are mocked as call-recording tripwires; the assertion is that
+ * they are never invoked while useAudioState is.
+ */
+
+const calls = { useAudioState: 0, useAudio: 0, useAudioPlayback: 0 };
+
+const stubState: {
+    playerMode: string;
+    currentTrack: unknown;
+    currentAudiobook: unknown;
+    currentPodcast: unknown;
+} = {
+    playerMode: "full",
+    currentTrack: null,
+    currentAudiobook: null,
+    currentPodcast: null,
+};
+
+const media = { isMobile: false, isTablet: false };
+
+mock.module("@/lib/audio-state-context", {
+    namedExports: {
+        useAudioState: () => {
+            calls.useAudioState += 1;
+            return stubState;
+        },
+    },
+});
+
+// Tripwires: a re-subscription regression calls one of these -> the count assert
+// fails. They return broad stubs (rather than throwing) so a regression still
+// renders and the failure is a clean assertion, not an opaque render crash.
+mock.module("@/lib/audio-context", {
+    namedExports: {
+        useAudio: () => {
+            calls.useAudio += 1;
+            return { ...stubState, currentTime: 0, isPlaying: false };
+        },
+    },
+});
+
+mock.module("@/lib/audio-playback-context", {
+    namedExports: {
+        useAudioPlayback: () => {
+            calls.useAudioPlayback += 1;
+            return { currentTime: 0, isPlaying: false };
+        },
+    },
+});
+
+mock.module("@/hooks/useMediaQuery", {
+    namedExports: {
+        useIsMobile: () => media.isMobile,
+        useIsTablet: () => media.isTablet,
+    },
+});
+
+const childStub =
+    (label: string) =>
+    () =>
+        React.createElement("div", { "data-stub": label }, label);
+
+mock.module("../../components/player/MiniPlayer.tsx", {
+    namedExports: { MiniPlayer: childStub("mini-player-stub") },
+});
+mock.module("../../components/player/FullPlayer.tsx", {
+    namedExports: { FullPlayer: childStub("full-player-stub") },
+});
+mock.module("../../components/player/OverlayPlayer.tsx", {
+    namedExports: { OverlayPlayer: childStub("overlay-player-stub") },
+});
+
+mock.module("framer-motion", {
+    namedExports: {
+        AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement(React.Fragment, null, children),
+        LayoutGroup: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement(React.Fragment, null, children),
+        motion: {
+            div: ({ children }: { children?: React.ReactNode }) =>
+                React.createElement("div", null, children),
+        },
+    },
+});
+
+beforeEach(() => {
+    calls.useAudioState = 0;
+    calls.useAudio = 0;
+    calls.useAudioPlayback = 0;
+    stubState.playerMode = "full";
+    stubState.currentTrack = null;
+    stubState.currentAudiobook = null;
+    stubState.currentPodcast = null;
+    media.isMobile = false;
+    media.isTablet = false;
+});
+
+test("desktop: renders via useAudioState and never calls the ticking clock hooks", async () => {
+    const { UniversalPlayer } = await import(
+        "../../components/player/UniversalPlayer"
+    );
+
+    const html = renderToStaticMarkup(React.createElement(UniversalPlayer));
+
+    assert.match(html, /full-player-stub/);
+    assert.ok(
+        calls.useAudioState >= 1,
+        "UniversalPlayer must read the granular audio STATE context",
+    );
+    assert.equal(
+        calls.useAudio,
+        0,
+        "UniversalPlayer must NOT re-subscribe to the merged useAudio() (250ms clock)",
+    );
+    assert.equal(
+        calls.useAudioPlayback,
+        0,
+        "UniversalPlayer must NOT subscribe to useAudioPlayback() (250ms clock)",
+    );
+});
+
+test("mobile overlay: drives playerMode + currentTrack from state, still no clock hooks", async () => {
+    media.isMobile = true;
+    stubState.playerMode = "overlay";
+    stubState.currentTrack = { id: "track-1" };
+
+    const { UniversalPlayer } = await import(
+        "../../components/player/UniversalPlayer"
+    );
+
+    const html = renderToStaticMarkup(React.createElement(UniversalPlayer));
+
+    assert.match(html, /overlay-player-stub/);
+    assert.ok(calls.useAudioState >= 1);
+    assert.equal(calls.useAudio, 0);
+    assert.equal(calls.useAudioPlayback, 0);
+});

--- a/frontend/tests/unit/audioClockPolicy.test.ts
+++ b/frontend/tests/unit/audioClockPolicy.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    isEngineTickDiscontinuity,
+    shouldPublishClockTime,
+} from "../../lib/audio-clock-policy";
+import {
+    shouldAcceptEngineTimeUpdate,
+    type ActivePlaybackSelection,
+    type EngineTimeUpdateDecision,
+    type SeekState,
+} from "../../lib/audio-playback-persistence-guards";
+
+/**
+ * Behaviour of the F12 clock-quantization wiring, exercised through the SAME pure
+ * functions the AudioPlaybackProvider wires together, in the SAME order:
+ *   (i)   shouldAcceptEngineTimeUpdate on the RAW time,
+ *   (ii)  a rejected decision writes NEITHER the ref NOR a publish,
+ *   (iii) any accepted tick writes the full-precision ref, and publishes to state
+ *         only on a display-second boundary (or a forced discontinuity).
+ * This models the context so the test proves the observable cadence, not the
+ * internals of any single function.
+ */
+
+interface SimTick {
+    time: number;
+    invocationTrackId?: string | null;
+}
+
+function simulatePlaybackClock(
+    ticks: SimTick[],
+    opts: {
+        activeSelection: ActivePlaybackSelection;
+        seekState: SeekState;
+        initialPublished: number | null;
+    },
+): { refWrites: number[]; published: number[] } {
+    const refWrites: number[] = []; // stage (ii): full-precision ref writes
+    const published: number[] = []; // stage (iii): React-state publishes
+    let lastPublished = opts.initialPublished;
+    let lockState: SeekState = { ...opts.seekState };
+
+    for (const tick of ticks) {
+        // Stage (i): guard runs on RAW engine time.
+        const decision = shouldAcceptEngineTimeUpdate(
+            tick.invocationTrackId ?? null,
+            opts.activeSelection,
+            lockState,
+            tick.time,
+        );
+        if (decision === "reject") {
+            continue; // writes neither ref nor state
+        }
+        if (decision === "unlock-accept") {
+            lockState = { isSeekLocked: false, seekTarget: null };
+        }
+        // Stage (ii): every non-rejected tick writes the ref at full precision.
+        refWrites.push(tick.time);
+        // Stage (iii): gated publish.
+        if (
+            shouldPublishClockTime({
+                time: tick.time,
+                lastPublishedTime: lastPublished,
+                forcePublish: isEngineTickDiscontinuity(decision),
+            })
+        ) {
+            lastPublished = tick.time;
+            published.push(tick.time);
+        }
+    }
+
+    return { refWrites, published };
+}
+
+const TRACK_SELECTION: ActivePlaybackSelection = {
+    playbackType: "track",
+    trackId: "track-1",
+    audiobookId: null,
+    podcastId: null,
+    trackEpoch: 1,
+};
+
+const NO_SEEK: SeekState = { isSeekLocked: false, seekTarget: null };
+
+function fourHzSweep(from: number, to: number): SimTick[] {
+    const ticks: SimTick[] = [];
+    // Step 0.25s, re-rounding each step to 2dp to avoid float drift while keeping
+    // the fractional offset off the integer second boundaries.
+    for (let t = from; t <= to + 1e-9; t = Math.round((t + 0.25) * 100) / 100) {
+        ticks.push({ time: t, invocationTrackId: "track-1" });
+    }
+    return ticks;
+}
+
+test("publishes exactly once per display-second across a 4Hz sweep; ref gets every tick", () => {
+    const ticks = fourHzSweep(42.01, 45.99);
+    // 42.01,42.26,...,45.76 -> 16 accepted ticks spanning seconds 42..45.
+    assert.equal(ticks.length, 16);
+
+    const { refWrites, published } = simulatePlaybackClock(ticks, {
+        activeSelection: TRACK_SELECTION,
+        seekState: NO_SEEK,
+        // Display already sits at second 42 (as after a restore/track start).
+        initialPublished: 42.0,
+    });
+
+    // Stage (ii): the full-precision value of EVERY accepted tick reached the ref.
+    assert.deepEqual(
+        refWrites,
+        ticks.map((t) => t.time),
+    );
+    assert.equal(refWrites.length, 16);
+
+    // Stage (iii): publishes happen ONLY at the second boundaries 42->43->44->45,
+    // i.e. 1Hz, three crossings — and each is the first tick of its new second.
+    assert.deepEqual(published, [43.01, 44.01, 45.01]);
+    assert.equal(published.length, 3);
+    const publishedSeconds = published.map((t) => Math.floor(t));
+    assert.deepEqual(publishedSeconds, [43, 44, 45]);
+    // Strictly monotonic display seconds, no duplicates (no intra-second publish).
+    assert.equal(new Set(publishedSeconds).size, published.length);
+});
+
+test("rejected (stale-track) ticks write neither the ref nor a publish", () => {
+    const { refWrites, published } = simulatePlaybackClock(
+        [
+            { time: 43.01, invocationTrackId: "track-1" },
+            { time: 99.0, invocationTrackId: "stale-track" }, // guard rejects
+            { time: 43.26, invocationTrackId: "track-1" },
+        ],
+        {
+            activeSelection: TRACK_SELECTION,
+            seekState: NO_SEEK,
+            initialPublished: 42.0,
+        },
+    );
+
+    assert.ok(!refWrites.includes(99.0), "rejected tick must not reach the ref");
+    assert.ok(!published.includes(99.0), "rejected tick must not publish");
+    assert.deepEqual(refWrites, [43.01, 43.26]);
+    assert.deepEqual(published, [43.01]); // only the boundary crossing 42->43
+});
+
+test("a seek landing within the same displayed second still forces a publish", () => {
+    const { refWrites, published } = simulatePlaybackClock(
+        [
+            // Far stale tick during the lock is rejected (|43-30| >= 2).
+            { time: 43.0, invocationTrackId: "track-1" },
+            // Near-target tick releases the lock (unlock-accept) at 30.1 — same
+            // displayed second (30) as the pre-seek publish, but forced.
+            { time: 30.1, invocationTrackId: "track-1" },
+        ],
+        {
+            activeSelection: TRACK_SELECTION,
+            seekState: { isSeekLocked: true, seekTarget: 30.0 },
+            initialPublished: 30.0,
+        },
+    );
+
+    assert.ok(!refWrites.includes(43.0), "far tick during seek lock is rejected");
+    assert.ok(!published.includes(43.0));
+    assert.deepEqual(refWrites, [30.1]);
+    // Publishes despite Math.floor(30.1) === Math.floor(30.0): the discontinuity
+    // forces it so the seek result shows immediately.
+    assert.deepEqual(published, [30.1]);
+});
+
+test("shouldPublishClockTime: boundary, force, baseline, and staleness semantics", () => {
+    // No baseline yet -> always publish.
+    assert.equal(
+        shouldPublishClockTime({ time: 5.4, lastPublishedTime: null }),
+        true,
+    );
+    // Same displayed second, no force -> suppress.
+    assert.equal(
+        shouldPublishClockTime({ time: 5.9, lastPublishedTime: 5.1 }),
+        false,
+    );
+    // Crossed into a new second -> publish.
+    assert.equal(
+        shouldPublishClockTime({ time: 6.02, lastPublishedTime: 5.9 }),
+        true,
+    );
+    // Force overrides the same-second suppression.
+    assert.equal(
+        shouldPublishClockTime({
+            time: 5.9,
+            lastPublishedTime: 5.1,
+            forcePublish: true,
+        }),
+        true,
+    );
+    // Staleness bound < 1s is IGNORED (would otherwise degenerate to per-tick).
+    assert.equal(
+        shouldPublishClockTime({
+            time: 5.9,
+            lastPublishedTime: 5.1,
+            stalenessBoundSeconds: 0.25,
+        }),
+        false,
+    );
+    // A valid (>= 1s) staleness bound publishes once enough time elapses.
+    assert.equal(
+        shouldPublishClockTime({
+            time: 6.9,
+            lastPublishedTime: 5.9,
+            stalenessBoundSeconds: 1,
+        }),
+        true,
+    );
+});
+
+test("isEngineTickDiscontinuity flags only unlock-accept", () => {
+    const cases: Array<[EngineTimeUpdateDecision, boolean]> = [
+        ["accept", false],
+        ["unlock-accept", true],
+        ["reject", false],
+    ];
+    for (const [decision, expected] of cases) {
+        assert.equal(isEngineTickDiscontinuity(decision), expected);
+    }
+});


### PR DESCRIPTION
During playback, the animated player shell (the render root mounting MiniPlayer/OverlayPlayer/FullPlayer inside AnimatePresence/LayoutGroup) re-rendered **4×/second for the whole duration of every track** — the engine ticks `timeupdate` every 250ms, the playback context published every tick, and `UniversalPlayer` subscribed to the merged `useAudio()` hook. Measured under the real provider stack: **8 subtree renders per 8 ticks before → 0 after**, with clock state publishes quantized **8 → 2** (display-second boundaries).

Part of #16 · Part of #65 (WS3 item 3) · roadmap **F12 → 🟡** (tightened-plan items A+B; item C leaf extraction and any F5 orchestrator work stay open — #59 risk 4 draws that line explicitly)

## What changed

- **(A)** `UniversalPlayer.tsx` subscribes to the granular `useAudioState()` instead of the merged `useAudio()` — it consumes only `playerMode` + the three "what's loaded" fields, none of which tick (the finding's audit note identifies this as the single highest-leverage fix: the root cascaded every tick into the whole animated subtree).
- **(B)** The published clock is quantized in `audio-playback-context.tsx` with a strictly ordered three-stage flow: (i) the existing seek-lock/track-identity guard runs FIRST on raw engine time — rejected ticks write *nothing*; (ii) any non-rejected tick writes the full-precision `currentTimeRef` (both `accept` and `unlock-accept`); (iii) the state publish is gated by a new pure policy module `lib/audio-clock-policy.ts` (house pattern: `audio-playback-persistence-guards.ts`) — publish on display-second (`Math.floor`) boundary changes, forced on discontinuities (seek landing, track change, resume-from-restore). The engine's 250ms tick itself is untouched.
- The former state→ref sync effect is **removed** (it would have clobbered the fresh ref with the quantized state); the context's public `setCurrentTime` is now a publisher that writes the ref first, so every external setter (seek, resume, track start) keeps ref and state coherent by construction.
- **Persistence gets more precise, not less**: both progress-save paths — server progress and the localStorage resume snapshot the orchestrator reads to seek the engine on boot — now read the engine-fresh full-precision ref instead of a state copy.
- Known minor trade-off, disclosed: relative-seek actions that compute from published state (TV layout ±10s, keyboard ±10s, media-session ±30s) read a value up to ~1s stale (was ~250ms) — inherently coarse actions; precision work on those consumers belongs to item (C)'s follow-up.

## Render evidence (the render-count assertion #65 requires)

Same test file run on both trees (real State+Playback providers under happy-dom, `react-dom/client` + `React.act`, 8 engine ticks = 2 simulated seconds):

| | UniversalPlayer subtree renders / 8 ticks | clock state publishes / 8 ticks |
|---|---:|---:|
| before (fdd2c05) | 8 | 8 |
| after (this branch) | **0** | **2** (the 1.0s / 2.0s boundaries) |

Three shipped test layers: a pure policy unit suite (4Hz sequence → publishes exactly at second boundaries; rejected ticks reach neither ref nor state; discontinuities force publish), a subscription tripwire (UniversalPlayer must never call `useAudio`/`useAudioPlayback` — exact-count assertion, fails on any re-subscription), and the render-count test above with exact-value assertions (`0` child renders, `2` publishes) plus a live playback-subscriber control proving the ticks really flow (guards against the vacuous-pass trap: React Profiler alone under-reports context-only re-renders and read 0 on BOTH trees — caught during development and replaced as the authoritative counter).

An independent adversarial cross-review swept every consumer of the published clock for sub-second dependencies (none broken; no lyrics/crossfade/A-B code exists; the sleep timer runs its own interval), verified no periodic path routes through the always-publishing public setter (all 26 call sites are one-shot handlers; the only periodic binding funnels through the quantized engine path), and confirmed reject-path integrity including the track-change race (the selection ref updates in a pre-paint `useLayoutEffect`, so stale old-track ticks are rejected by identity before any write).

## Verification

- `verify:` unit suite 666+/666+ green; component suite 348+/348+ green (345 base + 3 new files) — node:24 docker.
- `verify:` `npm run build` clean (the house-mandated real type-check).
- `verify:` type-error parity — `tsc --noEmit` count = **92 on base, 92 on this branch** (zero new; the frontend-typecheck job's 92 pre-existing errors are the 1.10.0 error-budget work, per #65's bar).
- `verify:` scope proof — `git diff` on `AudioPlaybackOrchestrator.tsx` is empty; `howler-engine.ts` untouched.
- Dev-only dependency addition: `happy-dom` + `@happy-dom/global-registrator`, exact-pinned `20.10.6`, used only by the render-count test file; lockfile diff is purely additive.

CHANGELOG bullet under `### Fixed`; roadmap flipped in all four places (status 🟡 + Fix-shipped note quoting the 8→0/8→2 evidence and naming what remains, index row, epic #16 count).
## Base & sibling note

Cut from current `main` (431fb3f, after #60–#64 and the Dependabot waves
through #97/#106 landed) — this PR is independent and mergeable on its own,
in any order relative to its WS3 siblings. The only sibling overlap is `CHANGELOG.md`
`[Unreleased]` bullets and the roadmap epic-count cells: whichever WS3 PR
merges later may need a trivial same-line rebase, which I'll do within a day
of each merge.

Epic-count arithmetic across the set: each PR bumps its finding's epic-table
cell by its own +1; after all four merge, epic #17 reads `1 / 3 / 5`
(F14 ✅, F13 🟡, F15 🟡, F18 pre-existing 🟡) and epic #16 reads `0 / 1 / 5`
(F12 🟡).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEss3YrE9yRYU8zB414mra
