### PR TITLE
fix(frontend): restructure two pinned coverage-gate files to avoid a Node coverage line-attribution artifact (#111)

### DIFF
--- a/frontend/components/layout/activityPanelTabs.ts
+++ b/frontend/components/layout/activityPanelTabs.ts
@@ -15,17 +15,21 @@ export interface ActivityPanelBadgeState {
     hasActivity: boolean;
 }
 
+// Named on purpose (issue #111) instead of an inline multi-line `{ ... }`
+// type literal — see check-targeted-coverage.mjs / #111 for why.
+export interface GetActivityPanelBadgeStateInput {
+    unreadCount: number;
+    activeDownloadCount: number;
+    socialUserCount: number;
+    isAdmin: boolean;
+}
+
 export function getActivityPanelBadgeState({
     unreadCount,
     activeDownloadCount,
     socialUserCount,
     isAdmin,
-}: {
-    unreadCount: number;
-    activeDownloadCount: number;
-    socialUserCount: number;
-    isAdmin: boolean;
-}): ActivityPanelBadgeState {
+}: GetActivityPanelBadgeStateInput): ActivityPanelBadgeState {
     const notificationBadge = unreadCount > 0 ? unreadCount : null;
     const activeBadge =
         isAdmin && activeDownloadCount > 0 ? activeDownloadCount : null;

--- a/frontend/components/layout/socialNavigation.ts
+++ b/frontend/components/layout/socialNavigation.ts
@@ -17,7 +17,7 @@ export const SIDEBAR_NAVIGATION: SidebarNavigationItem[] = [
     { name: "Audiobooks", href: "/audiobooks" },
     { name: "Podcasts", href: "/podcasts" },
 ];
-
+// No blank line above on purpose (issue #111) — see check-targeted-coverage.mjs.
 export const MOBILE_QUICK_LINKS: MobileQuickLinkItem[] = [
     { name: "Home", href: "/" },
     { name: "Explore", href: "/explore" },


### PR DESCRIPTION
## Summary

`npm run test:coverage` (`node --test --experimental-test-coverage`) measured two of the three pinned coverage modules differently in local node:24 docker vs CI on byte-identical trees — local red (99.01 / 97.06) vs CI green (100.00 / 100.00) on the same commit, node version, and lockfile. Root-caused in #111: the divergence is a line-attribution artifact in Node's experimental V8-coverage→source-map remapping, not a real coverage difference. This PR restructures the two trigger shapes, behavior-neutral:

- `activityPanelTabs.ts`: named `GetActivityPanelBadgeStateInput` interface replaces an inline multi-line parameter type literal (the flagged "line" was literally `}: {`, a tsx-erased boundary).
- `socialNavigation.ts`: removes a blank line between two array literals (the other flagged "line").

No pins loosened — `check-targeted-coverage.mjs` untouched, line pins stay exactly 100; measured branch% for the two touched files is unchanged (97.73 / 93.75), at/above the checker's floors (97.62 / 93.75; the third pinned file's 94.12 floor is untouched by this PR).

## Root cause (short — full A/B table in the #111 resolution comment)

- branch% was bit-identical local vs CI in every paired run (measured 97.73 / 93.75, at/above the checker's floors of 97.62 / 93.75), showing execution/hit-counts were identical; only line attribution diverged.
- The arithmetic: 99.01% = 100/101 and 97.06% = 33/34 — the local run counts exactly one phantom "coverable line" per file, always a non-code boundary position.
- Execution-side variables exhausted one at a time with zero effect: `--test-concurrency=1`, `--experimental-test-isolation=none`, `CI`/`GITHUB_ACTIONS` env, `--jitless`, CPU affinity (4-core), `--no-flush-bytecode`. Same node 24.18.0 / npm 11.16.0 / tsx 4.23.0 / esbuild 0.28.1 both sides.
- Matches the known upstream class for Node's experimental coverage engine (nodejs/node#53719, #57435).

## Verification

verify: tree `fix/111-coverage-determinism` @ fe4ddd9 (node:24 docker, fresh `npm ci` per #111's own repro recipe — the environment that previously failed): `npm run test:coverage` → exit 0, "targeted coverage check passed", deterministic across 3 repeated runs.
verify: `npm run lint` → 0 errors; `npm run build` → exit 0; `npm run test:unit` → 666/666 pass (same tree).
verify: pre-fix red reproduced on the same environment at 431fb3f and at current main before the restructure (99.01/97.06), so the A/B pair isolates the shape change as the only variable.

Honest caveat (also recorded in #111): the artifact is shape/position-sensitive — padding experiments moved it to other multi-line constructs — so this fixes the concrete divergence and documents the class; recurrence under future edits to the pinned files is possible until Node's coverage engine is fixed upstream. #111 records the mitigation (run the local-docker coverage check whenever the three pinned files change).

Part of the #59 CI-gates follow-through.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
