### PR TITLE
feat(vibe): pure map helpers + bounded sweep geometry (#203 slice 1)

### DIFF
--- a/frontend/components/vibe/flightPlan.ts
+++ b/frontend/components/vibe/flightPlan.ts
@@ -1,0 +1,61 @@
+/**
+ * flightPlan — PURE derivation of the "where the music is going" overlay.
+ *
+ * The session trail shows where you've been; the flight plan shows where
+ * you're going: an ordered list of world points from the currently playing
+ * track's dot through the next on-map tracks in the play queue. MapOverlay
+ * renders it as a dashed polyline fading toward the future, so a journey /
+ * sweep / alchemy queue becomes a visible plan on the map the moment you
+ * press play.
+ *
+ * No React, no DOM — unit-testable in isolation. Podcast episodes in the
+ * mixed-media queue and tracks that aren't plotted on the current map sample
+ * are skipped (an off-map hop simply shortens the drawn plan).
+ */
+
+import { isEpisodeQueueItem, type QueueItem } from "@/lib/queue-item";
+
+export interface PlanPoint {
+    x: number;
+    y: number;
+}
+
+/** Upcoming queue hops drawn (beyond the current track's starting point). */
+export const FLIGHT_PLAN_LIMIT = 10;
+
+/**
+ * World points for the flight-plan polyline: the current track's dot (when it
+ * is on the map) followed by up to `limit` upcoming on-map queue tracks, in
+ * queue order. Returns [] when fewer than two points resolve — a plan needs a
+ * line, not a dot.
+ */
+export function upcomingOnMapPoints(
+    queue: readonly QueueItem[] | null | undefined,
+    currentIndex: number,
+    posOf: (id: string) => PlanPoint | null,
+    limit: number = FLIGHT_PLAN_LIMIT
+): PlanPoint[] {
+    if (!queue || queue.length === 0) return [];
+
+    const pts: PlanPoint[] = [];
+    const current =
+        currentIndex >= 0 && currentIndex < queue.length
+            ? queue[currentIndex]
+            : undefined;
+    if (current && !isEpisodeQueueItem(current)) {
+        const p = posOf(current.id);
+        if (p) pts.push(p);
+    }
+
+    let upcoming = 0;
+    for (let i = currentIndex + 1; i < queue.length && upcoming < limit; i++) {
+        const item = queue[i];
+        if (isEpisodeQueueItem(item)) continue;
+        const p = posOf(item.id);
+        if (!p) continue;
+        pts.push(p);
+        upcoming++;
+    }
+
+    return pts.length >= 2 ? pts : [];
+}

--- a/frontend/components/vibe/journeyTracks.ts
+++ b/frontend/components/vibe/journeyTracks.ts
@@ -1,0 +1,85 @@
+/**
+ * journeyTracks — PURE helpers that turn vibe payloads into playable `Track`s.
+ *
+ * No React, no DOM. Shared by travel, journey and alchemy for building the
+ * queue passed to `playTracks`, and by the map for flagging which items are
+ * plotted (on-map) vs listed-only (off-map). Unit-testable in isolation.
+ *
+ * `import type { Track }` is erased at compile time, so this stays a pure module
+ * with no runtime dependency on the audio context.
+ */
+
+import type { Track } from "@/lib/audio-state-context";
+import type { MapTrack } from "./types";
+import type { VibeTrackRef } from "./travelCompass";
+
+/**
+ * Map a `/vibe` payload item (journey waypoint, alchemy result, travel
+ * neighbour — all share `{id,title,album,artist}`) to a playable `Track`.
+ * Duration is unknown in these payloads, so it defaults to 0 (the player
+ * resolves the real duration on load), matching VibeMap's dot-play shape.
+ */
+export function waypointToTrack(wp: VibeTrackRef): Track {
+    return {
+        id: wp.id,
+        title: wp.title,
+        artist: { name: wp.artist.name, id: wp.artist.id },
+        album: {
+            title: wp.album.title ?? "",
+            id: wp.album.id,
+            coverArt: wp.album.coverUrl ?? undefined,
+        },
+        duration: 0,
+    };
+}
+
+/** Map a projected `MapTrack` (artist is a bare string) to a playable `Track`. */
+export function mapTrackToTrack(t: MapTrack): Track {
+    return {
+        id: t.id,
+        title: t.title,
+        artist: { name: t.artist, id: t.artistId },
+        album: {
+            title: "", // album title is not in the map payload
+            id: t.albumId,
+            coverArt: t.coverUrl ?? undefined,
+        },
+        duration: 0,
+    };
+}
+
+/**
+ * Build the ordered queue for "Play journey": the waypoints in order, with the
+ * from-track prepended unless it is already the first waypoint (track-mode
+ * journeys end at the destination and never include the origin, so the origin
+ * is normally missing and gets prepended).
+ */
+export function journeyTracks(
+    fromTrack: Track | null,
+    waypoints: readonly VibeTrackRef[]
+): Track[] {
+    const mapped = waypoints.map(waypointToTrack);
+    if (fromTrack && waypoints[0]?.id !== fromTrack.id) {
+        return [fromTrack, ...mapped];
+    }
+    return mapped;
+}
+
+/** A vibe item tagged with whether it is plotted on the current map sample. */
+export type WithOnMap<T> = T & { onMap: boolean };
+
+/**
+ * Flag each item with `onMap` = present in `mapIndex`. Preserves order and the
+ * original 1-based sequence via `seq`, so the panel can label off-map waypoints
+ * while the map draws only the on-map ones.
+ */
+export function annotateOnMap<T extends { id: string }>(
+    items: readonly T[],
+    mapIndex: ReadonlyMap<string, unknown>
+): Array<WithOnMap<T> & { seq: number }> {
+    return items.map((item, i) => ({
+        ...item,
+        onMap: mapIndex.has(item.id),
+        seq: i + 1,
+    }));
+}

--- a/frontend/components/vibe/mapHints.ts
+++ b/frontend/components/vibe/mapHints.ts
@@ -1,0 +1,38 @@
+/**
+ * mapHints — PURE selection of the one-line contextual hint the map whispers
+ * at bottom-center. The map's grammar is modifier-key verbs (shift-drag,
+ * ctrl-click) that are otherwise invisible; the hint chip teaches exactly the
+ * verbs that matter in the current mode, and nothing else.
+ *
+ * No React, no DOM — unit-testable in isolation.
+ */
+
+import type { MapMode } from "./types";
+
+export const HINTS_DISMISSED_KEY = "vibe:hints-dismissed";
+
+export interface HintContext {
+    /** Journey's "pick on map" sub-state. */
+    picking?: boolean;
+    /** The sweep brush toggle is armed. */
+    sweepArmed?: boolean;
+}
+
+export function hintForMode(mode: MapMode, ctx: HintContext = {}): string {
+    if (ctx.sweepArmed) {
+        return "Brush armed — drag across dots to sweep them into a queue";
+    }
+    switch (mode) {
+        case "travel":
+            return "Click a glowing halo to hop there · Shift-click queues it · Esc exits";
+        case "journey":
+            return ctx.picking
+                ? "Click any dot to set the journey's destination"
+                : "Pick a destination track or mood, then start the journey";
+        case "alchemy":
+            return "Click dots to add ingredients · blend 2–10 tracks";
+        case "explore":
+        default:
+            return "Click a dot to play & travel · Shift-click queues · Ctrl-click blends";
+    }
+}

--- a/frontend/components/vibe/mapLayout.ts
+++ b/frontend/components/vibe/mapLayout.ts
@@ -1,0 +1,89 @@
+/**
+ * mapLayout — pure position-buffer builders for the vibe map's natural vs
+ * spread layout toggle.
+ *
+ * "Natural" positions are the raw UMAP projection (`track.x`/`track.y`,
+ * already 0..1). "Spread" positions rank each track along each axis
+ * independently and place it at `rank / (n - 1)`, which uniformly
+ * redistributes the same points across the 0..1 box — dense clusters spread
+ * out while each axis's relative ordering (neighbourhood) is preserved.
+ *
+ * All three builders operate on a flat, index-aligned Float32Array of
+ * `[x0, y0, x1, y1, ...]` pairs so the map can interpolate one buffer per
+ * animation frame without allocating.
+ */
+
+/** Minimal shape the pure layout core needs. */
+export interface PositionableTrack {
+    x: number;
+    y: number;
+}
+
+/** Natural layout: the raw projection coordinates, index-aligned. */
+export function buildPositions(
+    tracks: readonly PositionableTrack[]
+): Float32Array {
+    const out = new Float32Array(tracks.length * 2);
+    for (let i = 0; i < tracks.length; i++) {
+        out[i * 2] = tracks[i].x;
+        out[i * 2 + 1] = tracks[i].y;
+    }
+    return out;
+}
+
+/**
+ * Spread layout: per axis, rank tracks by that axis's value (ties broken by
+ * original index, for a stable deterministic order) and place each at
+ * `rank / (n - 1)`. A single track centers at (0.5, 0.5); zero tracks yields
+ * an empty buffer.
+ */
+export function computeSpreadPositions(
+    tracks: readonly PositionableTrack[]
+): Float32Array {
+    const n = tracks.length;
+    const out = new Float32Array(n * 2);
+    if (n === 0) return out;
+    if (n === 1) {
+        out[0] = 0.5;
+        out[1] = 0.5;
+        return out;
+    }
+
+    const denom = n - 1;
+    const order = new Array<number>(n);
+    for (let i = 0; i < n; i++) order[i] = i;
+
+    for (let axis = 0; axis < 2; axis++) {
+        const valueAt = (i: number) => (axis === 0 ? tracks[i].x : tracks[i].y);
+        order.sort((a, b) => valueAt(a) - valueAt(b) || a - b);
+        for (let rank = 0; rank < n; rank++) {
+            out[order[rank] * 2 + axis] = rank / denom;
+        }
+    }
+    return out;
+}
+
+/**
+ * Linearly interpolate from `a` to `b` by `t`, writing into (and returning)
+ * `out` — no allocation. Endpoints are exact: `t <= 0` copies `a` verbatim
+ * and `t >= 1` copies `b` verbatim, so an animation's first/last frame never
+ * drifts from the source buffers due to float rounding.
+ */
+export function lerpPositions(
+    a: Float32Array,
+    b: Float32Array,
+    t: number,
+    out: Float32Array
+): Float32Array {
+    const n = Math.min(a.length, b.length, out.length);
+    if (t <= 0) {
+        for (let i = 0; i < n; i++) out[i] = a[i];
+        return out;
+    }
+    if (t >= 1) {
+        for (let i = 0; i < n; i++) out[i] = b[i];
+        return out;
+    }
+    for (let i = 0; i < n; i++) out[i] = a[i] + (b[i] - a[i]) * t;
+    return out;
+}

--- a/frontend/components/vibe/mapSearch.ts
+++ b/frontend/components/vibe/mapSearch.ts
@@ -1,0 +1,64 @@
+/**
+ * mapSearch — pure, in-memory track/artist finder for the vibe map's
+ * spotlight pill. Separate from `api.vibeSearch` (semantic CLAP search): this
+ * is a plain case-insensitive substring match over the already-loaded map
+ * payload, so it can run on every keystroke with no network round trip.
+ *
+ * No React, no DOM — unit-testable in isolation.
+ */
+
+import type { MapTrack } from "./types";
+
+/** Below this many (trimmed) characters, matching is too noisy to bother. */
+const MIN_QUERY_LENGTH = 2;
+
+/** Match tiers, best first. Lower sorts first. */
+const RANK_TITLE_PREFIX = 0;
+const RANK_ARTIST_PREFIX = 1;
+const RANK_TITLE_SUBSTRING = 2;
+const RANK_ARTIST_SUBSTRING = 3;
+
+/** Normalise: trim, collapse internal whitespace, lowercase. */
+function normalize(s: string): string {
+    return s.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/**
+ * Case-insensitive substring search over `title`/`artist`, ranked
+ * title-prefix > artist-prefix > title-substring > artist-substring, then
+ * alphabetical by title (then artist, then id, for full determinism) within a
+ * tier. `query` is trimmed and its internal whitespace collapsed before
+ * matching; fewer than 2 resulting characters yields no matches.
+ */
+export function searchMapTracks(
+    tracks: readonly MapTrack[],
+    query: string,
+    limit = 8
+): MapTrack[] {
+    const q = normalize(query);
+    if (q.length < MIN_QUERY_LENGTH) return [];
+
+    const ranked: { track: MapTrack; rank: number }[] = [];
+    for (const track of tracks) {
+        const title = track.title.toLowerCase();
+        const artist = track.artist.toLowerCase();
+        let rank: number;
+        if (title.startsWith(q)) rank = RANK_TITLE_PREFIX;
+        else if (artist.startsWith(q)) rank = RANK_ARTIST_PREFIX;
+        else if (title.includes(q)) rank = RANK_TITLE_SUBSTRING;
+        else if (artist.includes(q)) rank = RANK_ARTIST_SUBSTRING;
+        else continue;
+        ranked.push({ track, rank });
+    }
+
+    ranked.sort((a, b) => {
+        if (a.rank !== b.rank) return a.rank - b.rank;
+        const titleCmp = a.track.title.localeCompare(b.track.title);
+        if (titleCmp !== 0) return titleCmp;
+        const artistCmp = a.track.artist.localeCompare(b.track.artist);
+        if (artistCmp !== 0) return artistCmp;
+        return a.track.id.localeCompare(b.track.id);
+    });
+
+    return ranked.slice(0, limit).map((r) => r.track);
+}

--- a/frontend/components/vibe/mapViewport.ts
+++ b/frontend/components/vibe/mapViewport.ts
@@ -1,0 +1,213 @@
+/**
+ * mapViewport — pure 2D viewport math for the vibe map.
+ *
+ * No React, no DOM. World space is the map payload's normalised 0..1 x/y.
+ * A viewport is a uniform-scale affine transform from world space to screen
+ * (CSS-pixel) space:  screen = world * scale + t.
+ *
+ * The renderer (canvas) and the overlay (DOM/SVG beacon + trail) both project
+ * through `worldToScreen`, so they always share one coordinate system.
+ */
+
+export interface Point {
+    x: number;
+    y: number;
+}
+
+/** Uniform-scale affine transform: screen = world * scale + (tx, ty). */
+export interface Viewport {
+    scale: number;
+    tx: number;
+    ty: number;
+}
+
+/** Screen dimensions in CSS pixels; used for fit, centering and clamping. */
+export interface MapDims {
+    width: number;
+    height: number;
+}
+
+/** Padding (px) kept between the fitted 0..1 world box and the canvas edge. */
+export const MAP_PADDING = 40;
+
+/** Absolute scale clamp (world 0..1 -> px). Generous, decoupled from dims. */
+export const MIN_SCALE = 40;
+export const MAX_SCALE = 24000;
+
+/** Minimum px of the world content kept on-screen so the map can't be lost. */
+const KEEP_VISIBLE = MAP_PADDING;
+
+export function clampScale(scale: number): number {
+    if (!Number.isFinite(scale)) return MIN_SCALE;
+    return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+/**
+ * Identity fit: map the 0..1 world box into the padded content region with a
+ * single uniform scale, centered (letterboxed — never distorted).
+ */
+export function fitViewport(dims: MapDims): Viewport {
+    const boxW = Math.max(1, dims.width - 2 * MAP_PADDING);
+    const boxH = Math.max(1, dims.height - 2 * MAP_PADDING);
+    const scale = clampScale(Math.min(boxW, boxH));
+    const tx = MAP_PADDING + (boxW - scale) / 2;
+    const ty = MAP_PADDING + (boxH - scale) / 2;
+    return { scale, tx, ty };
+}
+
+export function worldToScreen(vp: Viewport, p: Point): Point {
+    return { x: p.x * vp.scale + vp.tx, y: p.y * vp.scale + vp.ty };
+}
+
+export function screenToWorld(vp: Viewport, s: Point): Point {
+    return { x: (s.x - vp.tx) / vp.scale, y: (s.y - vp.ty) / vp.scale };
+}
+
+/**
+ * Clamp translation so at least KEEP_VISIBLE px of the world content box stays
+ * inside the viewport on both axes. Scale is untouched.
+ */
+export function clampViewport(vp: Viewport, bounds: MapDims): Viewport {
+    const content = vp.scale; // world spans 0..1, so screen content size == scale
+    const keep = Math.min(KEEP_VISIBLE, content);
+    const tx = Math.min(bounds.width - keep, Math.max(-content + keep, vp.tx));
+    const ty = Math.min(bounds.height - keep, Math.max(-content + keep, vp.ty));
+    return { scale: vp.scale, tx, ty };
+}
+
+/**
+ * Zoom by `factor` about a screen-space cursor point, preserving the world
+ * point currently under the cursor. When `bounds` is given the result is
+ * translation-clamped; omit it (e.g. in the zoom-invariant test) for the exact
+ * transform.
+ */
+export function zoomAt(
+    vp: Viewport,
+    cursor: Point,
+    factor: number,
+    bounds?: MapDims
+): Viewport {
+    const newScale = clampScale(vp.scale * factor);
+    // World point under the cursor before zooming.
+    const world = screenToWorld(vp, cursor);
+    // Solve tx/ty so that worldToScreen(next, world) === cursor at newScale.
+    const next: Viewport = {
+        scale: newScale,
+        tx: cursor.x - world.x * newScale,
+        ty: cursor.y - world.y * newScale,
+    };
+    return bounds ? clampViewport(next, bounds) : next;
+}
+
+/** Dot radius bounds (px) for `computeDotRadius`. */
+export const MIN_DOT_RADIUS = 2.2;
+export const MAX_DOT_RADIUS = 9;
+
+/**
+ * Dot radius that scales gently with zoom relative to the fitted ("whole
+ * map visible") scale, so zooming in reveals bigger, more comfortable dots
+ * instead of a swarm of pinpricks. `fitScale` is the current dims' fit
+ * scale (`fitViewport(dims).scale`); at that scale the ratio is 1 and the
+ * radius is the base 3.5px.
+ */
+export function computeDotRadius(scale: number, fitScale: number): number {
+    const ratio = fitScale > 0 ? scale / fitScale : 1;
+    const r = 3.5 * Math.pow(ratio, 0.3);
+    return Math.min(MAX_DOT_RADIUS, Math.max(MIN_DOT_RADIUS, r));
+}
+
+/**
+ * Return a viewport that centers `worldPt` on the screen at `targetScale`
+ * (falling back to the current scale when `targetScale` is not finite), clamped
+ * to `bounds`.
+ */
+export function flyTo(
+    vp: Viewport,
+    worldPt: Point,
+    targetScale: number,
+    bounds: MapDims
+): Viewport {
+    const newScale = clampScale(
+        Number.isFinite(targetScale) ? targetScale : vp.scale
+    );
+    const next: Viewport = {
+        scale: newScale,
+        tx: bounds.width / 2 - worldPt.x * newScale,
+        ty: bounds.height / 2 - worldPt.y * newScale,
+    };
+    return clampViewport(next, bounds);
+}
+
+/** Axis-aligned box in world (0..1) space. */
+export interface WorldBounds {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+/** Padding (px) kept around a fitted bounds box. */
+export const FIT_BOUNDS_PADDING = 80;
+
+/**
+ * Max zoom-in for `fitBounds`, as a multiple of the whole-map fit scale. Keeps
+ * a degenerate box (all points in one spot) from slamming into MAX_SCALE.
+ */
+export const FIT_BOUNDS_MAX_ZOOM = 8;
+
+/**
+ * Viewport that centers `b` on screen at the largest uniform scale that keeps
+ * the whole box visible inside `padding`, capped at FIT_BOUNDS_MAX_ZOOM × the
+ * whole-map fit scale, then translation-clamped.
+ */
+export function fitBounds(
+    b: WorldBounds,
+    bounds: MapDims,
+    padding: number = FIT_BOUNDS_PADDING
+): Viewport {
+    const w = Math.max(1e-6, b.maxX - b.minX);
+    const h = Math.max(1e-6, b.maxY - b.minY);
+    const boxW = Math.max(1, bounds.width - 2 * padding);
+    const boxH = Math.max(1, bounds.height - 2 * padding);
+    const maxScale = fitViewport(bounds).scale * FIT_BOUNDS_MAX_ZOOM;
+    const scale = clampScale(Math.min(boxW / w, boxH / h, maxScale));
+    const cx = (b.minX + b.maxX) / 2;
+    const cy = (b.minY + b.maxY) / 2;
+    return clampViewport(
+        {
+            scale,
+            tx: bounds.width / 2 - cx * scale,
+            ty: bounds.height / 2 - cy * scale,
+        },
+        bounds
+    );
+}
+
+/**
+ * Eased-camera interpolation between two viewports: the world point at screen
+ * center travels linearly while scale interpolates in log space, so combined
+ * pan+zoom flights track a stable focus instead of drifting. `t` is the eased
+ * progress in [0,1]; endpoints are returned exactly. Deliberately unclamped —
+ * callers clamp the endpoints, and transiently exceeding the pan clamp mid-
+ * flight is harmless.
+ */
+export function interpolateViewport(
+    from: Viewport,
+    to: Viewport,
+    t: number,
+    bounds: MapDims
+): Viewport {
+    if (t <= 0) return from;
+    if (t >= 1) return to;
+    const center = { x: bounds.width / 2, y: bounds.height / 2 };
+    const c0 = screenToWorld(from, center);
+    const c1 = screenToWorld(to, center);
+    const scale = from.scale * Math.pow(to.scale / from.scale, t);
+    const cx = c0.x + (c1.x - c0.x) * t;
+    const cy = c0.y + (c1.y - c0.y) * t;
+    return {
+        scale,
+        tx: center.x - cx * scale,
+        ty: center.y - cy * scale,
+    };
+}

--- a/frontend/components/vibe/sweepCollect.ts
+++ b/frontend/components/vibe/sweepCollect.ts
@@ -1,0 +1,129 @@
+/**
+ * sweepCollect — PURE stroke→dots collection for the sweep-to-queue brush.
+ *
+ * Sweeping is the map-native "draw your own playlist": the pointer becomes a
+ * brush and visible dots within the brush radius of the stroke are collected
+ * in first-touch order. This module owns the geometry: segment sampling (so a
+ * fast stroke can't skip over dots between two pointer events) and the
+ * per-sample hit collection with dedupe and a hard cap.
+ *
+ * No React, no DOM. Screen-space cursor points; world-space positions
+ * projected through the shared viewport transform — the same buffer + mask
+ * MapCanvas renders from, so the brush collects exactly what the user sees.
+ */
+
+import type { Viewport } from "./mapViewport";
+import { worldToScreen } from "./mapViewport";
+
+export interface SweepPoint {
+    x: number;
+    y: number;
+}
+
+/** Brush radius in screen px (also the stroke's rendered half-width). */
+export const SWEEP_BRUSH_RADIUS = 24;
+/** Sampling step along the stroke; ≤ radius so coverage has no gaps. */
+export const SWEEP_SAMPLE_STEP = 16;
+/** Hard cap on collected tracks per sweep. */
+export const SWEEP_CAP = 100;
+/**
+ * Hard cap on samples per segment. A pointer event pair should never be more
+ * than a screenful apart, so a segment needing more samples than this is a
+ * corrupted/hostile input (teleporting coordinates, a near-zero step) — cap
+ * the allocation instead of trusting `dist / step`. Beyond the cap the brush
+ * may skip dots along the (pathological) segment; that beats an unbounded
+ * loop on the pointer-event hot path.
+ */
+export const MAX_SEGMENT_SAMPLES = 512;
+
+function isFinitePoint(p: SweepPoint): boolean {
+    return Number.isFinite(p.x) && Number.isFinite(p.y);
+}
+
+/**
+ * Points along the segment a→b every `step` px — excluding `a` (the previous
+ * sample), always including `b`. A zero-length segment yields just `b`.
+ *
+ * Defensive geometry: a non-finite endpoint yields `[]` (a poisoned
+ * coordinate must never enter the stroke), a non-positive or non-finite
+ * `step` falls back to SWEEP_SAMPLE_STEP, and the sample count is capped at
+ * MAX_SEGMENT_SAMPLES so `dist / step` can never drive an unbounded loop.
+ */
+export function sampleSegment(
+    a: SweepPoint,
+    b: SweepPoint,
+    step: number = SWEEP_SAMPLE_STEP
+): SweepPoint[] {
+    if (!isFinitePoint(a) || !isFinitePoint(b)) return [];
+    const effectiveStep =
+        Number.isFinite(step) && step > 0 ? step : SWEEP_SAMPLE_STEP;
+    const dist = Math.hypot(b.x - a.x, b.y - a.y);
+    if (dist === 0) return [b];
+    const n = Math.min(
+        MAX_SEGMENT_SAMPLES,
+        Math.max(1, Math.ceil(dist / effectiveStep))
+    );
+    const out: SweepPoint[] = [];
+    for (let i = 1; i <= n; i++) {
+        out.push({
+            x: a.x + ((b.x - a.x) * i) / n,
+            y: a.y + ((b.y - a.y) * i) / n,
+        });
+    }
+    return out;
+}
+
+export interface CollectHitsArgs {
+    /** Brush sample point in screen px. */
+    cursor: SweepPoint;
+    /** Index-aligned track ids (parallel to `positions` / `mask`). */
+    ids: readonly { id: string }[];
+    /** Flat [x0,y0,x1,y1,...] world positions (the live layout buffer). */
+    positions: Float32Array;
+    /** Visibility mask — filtered-out dots are never collected. */
+    mask: Uint8Array;
+    viewport: Viewport;
+    radius?: number;
+    cap?: number;
+    /** Dedupe set, shared across the whole stroke (mutated). */
+    seen: Set<string>;
+    /** Ordered collection, first-touch order (mutated, capped). */
+    out: string[];
+}
+
+/**
+ * Collect every visible, not-yet-seen dot within `radius` px of `cursor` into
+ * `out` (mutating `seen`/`out`), stopping at `cap` total.
+ *
+ * `radius` falls back to SWEEP_BRUSH_RADIUS unless it is a positive finite
+ * number, and `cap` is clamped into [1, SWEEP_CAP] — SWEEP_CAP is the hard
+ * per-sweep collection bound, so a caller-supplied cap can only tighten it,
+ * never widen it. A non-finite cursor collects nothing (each distance check
+ * is NaN-safe by comparison).
+ */
+export function collectHits(args: CollectHitsArgs): void {
+    const { cursor, ids, positions, mask, viewport, seen, out } = args;
+    const radius =
+        args.radius !== undefined &&
+        Number.isFinite(args.radius) &&
+        args.radius > 0
+            ? args.radius
+            : SWEEP_BRUSH_RADIUS;
+    const cap =
+        args.cap !== undefined && Number.isFinite(args.cap) && args.cap >= 1
+            ? Math.min(args.cap, SWEEP_CAP)
+            : SWEEP_CAP;
+    for (let i = 0; i < ids.length && out.length < cap; i++) {
+        if (mask[i] === 0) continue;
+        const id = ids[i].id;
+        if (seen.has(id)) continue;
+        const s = worldToScreen(viewport, {
+            x: positions[i * 2],
+            y: positions[i * 2 + 1],
+        });
+        if (Math.hypot(cursor.x - s.x, cursor.y - s.y) <= radius) {
+            seen.add(id);
+            out.push(id);
+        }
+    }
+}

--- a/frontend/components/vibe/travelCompass.ts
+++ b/frontend/components/vibe/travelCompass.ts
@@ -1,0 +1,163 @@
+/**
+ * travelCompass — PURE module for the Travel constellation.
+ *
+ * No React, no DOM. Given the current node plus a list of similar-track
+ * candidates and a compass direction, it enriches candidates from map data,
+ * filters them to the chosen direction and returns the top-N ranked by
+ * similarity. Unit-testable in isolation.
+ *
+ * The `/vibe/similar` payload carries `audioFeatures.{energy,valence}`, but
+ * those can be null and it never carries the per-mood record. Candidates that
+ * are present on the map are therefore enriched from the map projection (which
+ * always has energy/valence + the `moods` record) via `enrichFromMap`.
+ */
+
+import type { MapTrack } from "./types";
+
+/** Compass directions offered by the segmented control. */
+export type CompassDirection =
+    | "any"
+    | "happier"
+    | "sadder"
+    | "calmer"
+    | "more-energetic";
+
+export const COMPASS_DIRECTIONS: readonly CompassDirection[] = [
+    "any",
+    "happier",
+    "sadder",
+    "calmer",
+    "more-energetic",
+] as const;
+
+/** Minimum valence delta (candidate − current) to count as happier / sadder. */
+export const VALENCE_DELTA_THRESHOLD = 0.03;
+/** Minimum energy delta (candidate − current) to count as calmer / energetic. */
+export const ENERGY_DELTA_THRESHOLD = 0.03;
+/** Default number of neighbours drawn / listed. */
+export const DEFAULT_COMPASS_COUNT = 8;
+
+/** Common vibe-track fields shared by waypoints, alchemy results and neighbours. */
+export interface VibeTrackRef {
+    id: string;
+    title: string;
+    album: { id: string; title: string; coverUrl: string | null };
+    artist: { id: string; name: string };
+}
+
+/**
+ * A travel neighbour: a similar-track candidate carrying the features the
+ * compass filters on. `energy`/`valence` may be null (unanalyzed) and `moods`
+ * may be absent until enriched from the map.
+ */
+export interface CompassCandidate extends VibeTrackRef {
+    /** 0..1 hybrid similarity; higher = closer. Used for ranking. */
+    similarity: number;
+    /** Raw pairwise CLAP cosine distance — the calibrated-% display source. */
+    distance: number;
+    energy: number | null;
+    valence: number | null;
+    /** Per-mood scores (from the map payload) used as the null-valence fallback. */
+    moods?: Record<string, number> | null;
+    /** Groove/intensity features for the Travel explainability breakdown. */
+    danceability?: number | null;
+    arousal?: number | null;
+}
+
+/** The origin node the compass measures deltas against (a `MapTrack` satisfies this). */
+export type CompassOrigin = Pick<MapTrack, "energy" | "valence" | "moods">;
+
+function delta(current: number | null, candidate: number | null): number | null {
+    if (current == null || candidate == null) return null;
+    return candidate - current;
+}
+
+function moodHappyDelta(
+    current: CompassOrigin,
+    candidate: CompassCandidate
+): number | null {
+    const c = current.moods?.moodHappy;
+    const n = candidate.moods?.moodHappy;
+    if (typeof c !== "number" || typeof n !== "number") return null;
+    return n - c;
+}
+
+/**
+ * Does `candidate` satisfy `direction` relative to `current`?
+ *
+ * - happier: valence Δ > +0.03; when valence is null on either side, fall back
+ *   to moodHappy Δ > 0. sadder is the inverse.
+ * - calmer: energy Δ < −0.03; more-energetic is the inverse. No mood fallback —
+ *   a null energy on either side simply doesn't qualify.
+ * - any: everything qualifies.
+ */
+export function matchesDirection(
+    current: CompassOrigin,
+    candidate: CompassCandidate,
+    direction: CompassDirection
+): boolean {
+    if (direction === "any") return true;
+
+    const vd = delta(current.valence, candidate.valence);
+    const ed = delta(current.energy, candidate.energy);
+
+    switch (direction) {
+        case "happier": {
+            if (vd !== null) return vd > VALENCE_DELTA_THRESHOLD;
+            const md = moodHappyDelta(current, candidate);
+            return md !== null ? md > 0 : false;
+        }
+        case "sadder": {
+            if (vd !== null) return vd < -VALENCE_DELTA_THRESHOLD;
+            const md = moodHappyDelta(current, candidate);
+            return md !== null ? md < 0 : false;
+        }
+        case "calmer":
+            return ed !== null ? ed < -ENERGY_DELTA_THRESHOLD : false;
+        case "more-energetic":
+            return ed !== null ? ed > ENERGY_DELTA_THRESHOLD : false;
+        default:
+            return true;
+    }
+}
+
+/**
+ * Fill each candidate's `energy`/`valence`/`moods` from the map projection when
+ * the candidate is on the map and its own value is missing (null/undefined).
+ * The map's features are authoritative for anything it plots, so this recovers
+ * the deltas for candidates whose `/similar` audioFeatures came back null.
+ *
+ * Pure: returns new candidate objects, input untouched.
+ */
+export function enrichFromMap(
+    candidates: readonly CompassCandidate[],
+    mapIndex: ReadonlyMap<string, MapTrack>
+): CompassCandidate[] {
+    return candidates.map((c) => {
+        const m = mapIndex.get(c.id);
+        if (!m) return c;
+        return {
+            ...c,
+            energy: c.energy ?? m.energy,
+            valence: c.valence ?? m.valence,
+            moods: c.moods ?? m.moods ?? null,
+        };
+    });
+}
+
+/**
+ * Filter candidates to the compass `direction` and return the top `topN` ranked
+ * by similarity (desc). The current node itself is always dropped.
+ */
+export function compassNeighbors(
+    current: CompassOrigin,
+    candidates: readonly CompassCandidate[],
+    direction: CompassDirection,
+    topN: number = DEFAULT_COMPASS_COUNT
+): CompassCandidate[] {
+    return candidates
+        .filter((c) => matchesDirection(current, c, direction))
+        .slice()
+        .sort((a, b) => b.similarity - a.similarity)
+        .slice(0, Math.max(0, topN));
+}

--- a/frontend/components/vibe/types.ts
+++ b/frontend/components/vibe/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared types + mood palette for the vibe map component tree.
+ *
+ * Kept free of React/DOM so pure logic modules and unit tests can import it.
+ */
+
+/** A single projected track as returned by `GET /api/vibe/map` (`api.getVibeMap`). */
+export interface MapTrack {
+    id: string;
+    /** Normalised projection coordinates, 0..1. */
+    x: number;
+    y: number;
+    title: string;
+    artist: string;
+    artistId: string;
+    albumId: string;
+    coverUrl: string | null;
+    dominantMood: string;
+    moodScore: number;
+    energy: number | null;
+    valence: number | null;
+    /** Full per-mood scores (present in payload; unused by F1, kept for F2). */
+    moods?: Record<string, number>;
+}
+
+/**
+ * Map interaction mode. F1 implemented only `explore`; F2 adds travel /
+ * journey / alchemy and branches the overlay + panels on it. The
+ * `<MapOverlay decorations>` slot is where F2 draws mode-specific map graphics.
+ */
+export type MapMode = "explore" | "travel" | "journey" | "alchemy";
+
+/** Mood key -> dot colour. Keys match the map payload's `dominantMood`. */
+export const MOOD_COLORS: Record<string, string> = {
+    moodHappy: "#facc15",
+    moodSad: "#60a5fa",
+    moodRelaxed: "#34d399",
+    moodAggressive: "#ef4444",
+    moodParty: "#f97316",
+    moodAcoustic: "#c084fc",
+    moodElectronic: "#f472b6",
+};
+
+const FALLBACK_MOOD_COLOR = "#6b7280";
+
+export function getMoodColor(mood: string): string {
+    return MOOD_COLORS[mood] ?? FALLBACK_MOOD_COLOR;
+}
+
+/**
+ * The map's non-mood accent palette — every line/glyph color that isn't a
+ * dot's mood color, in one place so MapDecorations (travel edges, journey
+ * route), MapOverlay (session trail, flight plan), NowPlayingCard's beacon
+ * fallback, and FiltersPanel's range-slider thumbs can never drift apart.
+ * Purely a naming/consolidation move — the hex values are unchanged from
+ * what each site hard-coded before.
+ */
+export const VIBE_ACCENTS = {
+    /** Travel constellation edges + current-node marker. */
+    edge: "#818cf8",
+    /** Journey route polyline + waypoint rings. */
+    route: "#a78bfa",
+    /** Session trail polyline. */
+    trail: "#a5b4fc",
+    /** Flight plan (upcoming queue) dashed polyline. */
+    plan: "#c7d2fe",
+} as const;
+
+/**
+ * The backend's `getDominantMood` fallback (`backend/src/services/umapProjection.ts`)
+ * when no mood score is confident enough to pick a named mood. Tracks with
+ * this `dominantMood` are real, filterable map dots — not a value to special-case
+ * out of the whitelist (that was the F1 bug: they were permanently invisible).
+ */
+export const NEUTRAL_MOOD = "neutral";
+
+/**
+ * Every mood key the map's filter UI should offer: the named moods plus the
+ * backend's neutral fallback, appended last. Single source for both
+ * useMapFilters' default "everything on" whitelist and FiltersPanel's chip
+ * list, so they can never drift apart again.
+ */
+export const FILTERABLE_MOODS: readonly string[] = [
+    ...Object.keys(MOOD_COLORS),
+    NEUTRAL_MOOD,
+];
+
+/** Human label for a mood chip ("moodHappy" -> "Happy"; "neutral" -> "Neutral"). */
+export function moodLabel(mood: string): string {
+    if (mood === NEUTRAL_MOOD) return "Neutral";
+    return mood.replace(/^mood/, "");
+}

--- a/frontend/components/vibe/vibeMatch.ts
+++ b/frontend/components/vibe/vibeMatch.ts
@@ -1,0 +1,140 @@
+/**
+ * vibeMatch — PURE library-calibrated similarity scoring for the vibe map's
+ * user-facing match percentages.
+ *
+ * No React, no DOM. Replaces the old fixed `1 - distance/2` linear mapping
+ * (which floors real-world unrelated pairs around ~50%, reading as inflated —
+ * "skindred shares 50% of a vibe with panic at the disco?!") with a
+ * library-calibrated score: `GET /api/vibe/calibration` samples pairwise CLAP
+ * cosine distance across the library and returns its p0..p100 percentiles
+ * (101 values, ascending). A candidate's match % is then "closer than N% of
+ * random pairs in your library" — the percentile rank of its distance within
+ * that sample, inverted.
+ *
+ * When calibration data isn't available yet (a fresh/small library —
+ * `sampleSize: 0, quantiles: []`), every caller falls back to the old linear
+ * mapping so the map never breaks; the empty `label` is the signal that a row
+ * is showing the uncalibrated number.
+ */
+
+/** p0..p100 inclusive. */
+const EXPECTED_QUANTILE_COUNT = 101;
+
+export interface CalibratedMatch {
+    /** 0..100, rounded. */
+    percent: number;
+    /** Human sentence fragment for the percent bucket, "" when uncalibrated. */
+    label: string;
+}
+
+function clampPercent(p: number): number {
+    return Math.max(0, Math.min(100, p));
+}
+
+/**
+ * Percentile rank (0..100) of `distance` within the ascending `quantiles`
+ * ladder, linearly interpolated between the two straddling quantile values.
+ * Distances at or beyond the array's ends clamp to 0 / 100.
+ */
+function percentileRank(distance: number, quantiles: readonly number[]): number {
+    const last = quantiles.length - 1;
+    if (distance <= quantiles[0]) return 0;
+    if (distance >= quantiles[last]) return last;
+    for (let i = 1; i <= last; i++) {
+        if (distance <= quantiles[i]) {
+            const lo = quantiles[i - 1];
+            const hi = quantiles[i];
+            if (hi === lo) return i; // flat segment — snap to the upper percentile
+            const frac = (distance - lo) / (hi - lo);
+            return i - 1 + frac;
+        }
+    }
+    return last;
+}
+
+function labelForPercent(percent: number): string {
+    if (percent >= 97) return "nearly identical vibe";
+    if (percent >= 90) return "same vibe";
+    if (percent >= 75) return "close neighbors";
+    if (percent >= 50) return "same neighborhood";
+    if (percent >= 25) return "distant relatives";
+    return "different worlds";
+}
+
+/**
+ * Library-calibrated match percent + label for a pairwise CLAP cosine
+ * `distance`, given the library's `quantiles` sample (`api.getVibeCalibration`,
+ * null/[] when unavailable — the pre-calibration linear mapping is used
+ * instead, with an empty label marking it uncalibrated).
+ */
+export function calibratedMatch(
+    distance: number,
+    quantiles: readonly number[] | null
+): CalibratedMatch {
+    if (!quantiles || quantiles.length !== EXPECTED_QUANTILE_COUNT) {
+        const percent = clampPercent(
+            Math.round(Math.max(0, 1 - distance / 2) * 100)
+        );
+        return { percent, label: "" };
+    }
+    const rank = percentileRank(distance, quantiles);
+    const percent = clampPercent(Math.round(100 - rank));
+    return { percent, label: labelForPercent(percent) };
+}
+
+/**
+ * Per-feature "match %" between an origin and candidate value for the
+ * Travel-mode explainability breakdown: `round((1 - |a - b|) * 100)`. Either
+ * side null (unanalyzed) yields null — the caller skips that feature's bar
+ * rather than showing a fake 0%/100%.
+ */
+export function featureMatchPercent(
+    a: number | null,
+    b: number | null
+): number | null {
+    if (a == null || b == null) return null;
+    return Math.round((1 - Math.abs(a - b)) * 100);
+}
+
+/** The constellation-edge look at the ~75% anchor (today's fixed values). */
+const EDGE_ANCHOR_PERCENT = 75;
+const EDGE_ANCHOR_OPACITY = 0.5;
+const EDGE_ANCHOR_WIDTH = 1.25;
+const EDGE_OPACITY_SLOPE = 0.01; // per percent point away from the anchor
+const EDGE_WIDTH_SLOPE = 0.01;
+const EDGE_OPACITY_MIN = 0.15;
+const EDGE_OPACITY_MAX = 0.85;
+const EDGE_WIDTH_DELTA_MAX = 0.5; // px, either direction from the anchor
+
+function clamp(v: number, lo: number, hi: number): number {
+    return Math.max(lo, Math.min(hi, v));
+}
+
+export interface MatchEdgeStyle {
+    opacity: number;
+    width: number;
+}
+
+/**
+ * Travel-mode constellation edge strokeOpacity/width, scaled by a candidate's
+ * calibrated match `percent` so on-map geometry visibly encodes true
+ * similarity. 75% (the map's typical shown-neighbour strength) reproduces
+ * today's fixed look exactly; stronger matches draw brighter/thicker, weaker
+ * ones fainter/thinner, clamped to a sane range so an edge never disappears
+ * or overwhelms the dots.
+ */
+export function matchEdgeStyle(percent: number): MatchEdgeStyle {
+    const delta = percent - EDGE_ANCHOR_PERCENT;
+    return {
+        opacity: clamp(
+            EDGE_ANCHOR_OPACITY + delta * EDGE_OPACITY_SLOPE,
+            EDGE_OPACITY_MIN,
+            EDGE_OPACITY_MAX
+        ),
+        width: clamp(
+            EDGE_ANCHOR_WIDTH + delta * EDGE_WIDTH_SLOPE,
+            EDGE_ANCHOR_WIDTH - EDGE_WIDTH_DELTA_MAX,
+            EDGE_ANCHOR_WIDTH + EDGE_WIDTH_DELTA_MAX
+        ),
+    };
+}

--- a/frontend/tests/unit/flightPlan.test.ts
+++ b/frontend/tests/unit/flightPlan.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    FLIGHT_PLAN_LIMIT,
+    upcomingOnMapPoints,
+} from "../../components/vibe/flightPlan";
+import type { QueueItem } from "../../lib/queue-item";
+
+/** Minimal track-shaped queue entry (itemType omitted == track). */
+function track(id: string): QueueItem {
+    return {
+        id,
+        title: `Track ${id}`,
+        artist: { name: "A" },
+        album: { title: "Al" },
+        duration: 100,
+    };
+}
+
+function episode(id: string): QueueItem {
+    return {
+        itemType: "episode",
+        id: `pod:${id}`,
+        title: `Ep ${id}`,
+        podcastTitle: "Pod",
+        podcastId: "pod",
+        episodeId: id,
+        coverUrl: null,
+        duration: 100,
+    };
+}
+
+/** posOf stub: ids in `onMap` resolve to distinct points, others are off-map. */
+function posOfFor(onMap: readonly string[]) {
+    const index = new Map(onMap.map((id, i) => [id, { x: i * 0.1, y: i * 0.05 }]));
+    return (id: string) => index.get(id) ?? null;
+}
+
+test("returns [] for an empty or missing queue", () => {
+    assert.deepEqual(upcomingOnMapPoints([], 0, posOfFor(["a"])), []);
+    assert.deepEqual(upcomingOnMapPoints(null, 0, posOfFor(["a"])), []);
+    assert.deepEqual(upcomingOnMapPoints(undefined, 0, posOfFor(["a"])), []);
+});
+
+test("starts at the current track's dot and walks upcoming on-map tracks in order", () => {
+    const posOf = posOfFor(["a", "b", "c"]);
+    const pts = upcomingOnMapPoints(
+        [track("a"), track("b"), track("c")],
+        0,
+        posOf
+    );
+    assert.deepEqual(pts, [posOf("a"), posOf("b"), posOf("c")]);
+});
+
+test("skips podcast episodes and off-map tracks without breaking the line", () => {
+    const posOf = posOfFor(["a", "c"]);
+    const pts = upcomingOnMapPoints(
+        [track("a"), episode("e1"), track("offmap"), track("c")],
+        0,
+        posOf
+    );
+    assert.deepEqual(pts, [posOf("a"), posOf("c")]);
+});
+
+test("returns [] when fewer than two points resolve (a plan needs a line)", () => {
+    // Only the current track is on the map.
+    assert.deepEqual(
+        upcomingOnMapPoints([track("a"), track("x")], 0, posOfFor(["a"])),
+        []
+    );
+    // Only one upcoming track is on the map and nothing is current.
+    assert.deepEqual(
+        upcomingOnMapPoints([track("x"), track("b")], -1, posOfFor(["b"])),
+        []
+    );
+});
+
+test("an off-map current track still yields a plan from the upcoming hops", () => {
+    const posOf = posOfFor(["b", "c"]);
+    const pts = upcomingOnMapPoints(
+        [track("offmap"), track("b"), track("c")],
+        0,
+        posOf
+    );
+    assert.deepEqual(pts, [posOf("b"), posOf("c")]);
+});
+
+test("caps the upcoming hops at the limit (start point not counted)", () => {
+    const ids = Array.from({ length: 20 }, (_, i) => `t${i}`);
+    const posOf = posOfFor(ids);
+    const pts = upcomingOnMapPoints(ids.map(track), 0, posOf);
+    assert.equal(pts.length, 1 + FLIGHT_PLAN_LIMIT);
+    const ptsCustom = upcomingOnMapPoints(ids.map(track), 0, posOf, 3);
+    assert.equal(ptsCustom.length, 1 + 3);
+});
+
+test("a currentIndex of -1 draws the plan over the whole queue", () => {
+    const posOf = posOfFor(["a", "b"]);
+    const pts = upcomingOnMapPoints([track("a"), track("b")], -1, posOf);
+    assert.deepEqual(pts, [posOf("a"), posOf("b")]);
+});

--- a/frontend/tests/unit/journeyQueue.test.ts
+++ b/frontend/tests/unit/journeyQueue.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    annotateOnMap,
+    journeyTracks,
+    mapTrackToTrack,
+    waypointToTrack,
+} from "../../components/vibe/journeyTracks";
+import type { VibeTrackRef } from "../../components/vibe/travelCompass";
+import type { MapTrack } from "../../components/vibe/types";
+
+function waypoint(id: string, coverUrl: string | null = null): VibeTrackRef {
+    return {
+        id,
+        title: `Title ${id}`,
+        album: { id: `al-${id}`, title: `Album ${id}`, coverUrl },
+        artist: { id: `ar-${id}`, name: `Artist ${id}` },
+    };
+}
+
+const fromTrack = {
+    id: "from",
+    title: "From Song",
+    artist: { name: "From Artist", id: "ar-from" },
+    album: { title: "From Album", id: "al-from" },
+    duration: 200,
+};
+
+test("waypointToTrack builds a well-formed Track (cover null -> undefined)", () => {
+    const t = waypointToTrack(waypoint("w1"));
+    assert.deepEqual(t, {
+        id: "w1",
+        title: "Title w1",
+        artist: { name: "Artist w1", id: "ar-w1" },
+        album: { title: "Album w1", id: "al-w1", coverArt: undefined },
+        duration: 0,
+    });
+});
+
+test("waypointToTrack maps a present coverUrl to coverArt", () => {
+    const t = waypointToTrack(waypoint("w2", "http://cover/w2.jpg"));
+    assert.equal(t.album.coverArt, "http://cover/w2.jpg");
+});
+
+test("mapTrackToTrack turns a projected dot (string artist) into a Track", () => {
+    const mt: MapTrack = {
+        id: "m1",
+        x: 0.1,
+        y: 0.2,
+        title: "Map Song",
+        artist: "Map Artist",
+        artistId: "ar-m1",
+        albumId: "al-m1",
+        coverUrl: "http://cover/m1.jpg",
+        dominantMood: "moodHappy",
+        moodScore: 0.5,
+        energy: 0.5,
+        valence: 0.5,
+    };
+    assert.deepEqual(mapTrackToTrack(mt), {
+        id: "m1",
+        title: "Map Song",
+        artist: { name: "Map Artist", id: "ar-m1" },
+        album: { title: "", id: "al-m1", coverArt: "http://cover/m1.jpg" },
+        duration: 0,
+    });
+});
+
+test("journeyTracks prepends the from-track when it isn't the first waypoint", () => {
+    const wps = [waypoint("a"), waypoint("b"), waypoint("c")];
+    const queue = journeyTracks(fromTrack, wps);
+    assert.equal(queue.length, 4);
+    assert.equal(queue[0], fromTrack, "origin is first and passed through as-is");
+    assert.deepEqual(
+        queue.map((t) => t.id),
+        ["from", "a", "b", "c"]
+    );
+});
+
+test("journeyTracks does not duplicate the from-track if it is already first", () => {
+    const wps = [waypoint("from"), waypoint("b")];
+    const queue = journeyTracks(fromTrack, wps);
+    assert.deepEqual(
+        queue.map((t) => t.id),
+        ["from", "b"]
+    );
+});
+
+test("journeyTracks with no from-track returns just the mapped waypoints", () => {
+    const wps = [waypoint("a"), waypoint("b")];
+    const queue = journeyTracks(null, wps);
+    assert.deepEqual(
+        queue.map((t) => t.id),
+        ["a", "b"]
+    );
+    // Mapped items are real Track objects.
+    assert.equal(queue[0].duration, 0);
+    assert.deepEqual(queue[0].artist, { name: "Artist a", id: "ar-a" });
+});
+
+test("annotateOnMap flags presence and preserves 1-based sequence", () => {
+    const mapIndex = new Map<string, unknown>([
+        ["a", {}],
+        ["c", {}],
+    ]);
+    const items = [waypoint("a"), waypoint("b"), waypoint("c")];
+    const out = annotateOnMap(items, mapIndex);
+    assert.deepEqual(
+        out.map((o) => ({ id: o.id, onMap: o.onMap, seq: o.seq })),
+        [
+            { id: "a", onMap: true, seq: 1 },
+            { id: "b", onMap: false, seq: 2 },
+            { id: "c", onMap: true, seq: 3 },
+        ]
+    );
+});

--- a/frontend/tests/unit/mapHints.test.ts
+++ b/frontend/tests/unit/mapHints.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hintForMode } from "../../components/vibe/mapHints";
+
+test("each mode gets its own verb hint", () => {
+    assert.match(hintForMode("explore"), /Click a dot to play & travel/);
+    assert.match(hintForMode("explore"), /Shift-click queues/);
+    assert.match(hintForMode("travel"), /halo/);
+    assert.match(hintForMode("travel"), /Esc exits/);
+    assert.match(hintForMode("journey"), /destination track or mood/);
+    assert.match(hintForMode("alchemy"), /blend 2–10 tracks/);
+});
+
+test("journey picking narrows the hint to the pick action", () => {
+    assert.match(
+        hintForMode("journey", { picking: true }),
+        /Click any dot to set the journey's destination/
+    );
+});
+
+test("an armed brush overrides every mode hint", () => {
+    for (const mode of ["explore", "travel", "journey", "alchemy"] as const) {
+        assert.match(hintForMode(mode, { sweepArmed: true }), /Brush armed/);
+    }
+});

--- a/frontend/tests/unit/mapLayout.test.ts
+++ b/frontend/tests/unit/mapLayout.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    buildPositions,
+    computeSpreadPositions,
+    lerpPositions,
+    type PositionableTrack,
+} from "../../components/vibe/mapLayout";
+
+test("buildPositions is the identity natural layout, index-aligned", () => {
+    const tracks: PositionableTrack[] = [
+        { x: 0.1, y: 0.2 },
+        { x: 0.9, y: 0.4 },
+    ];
+    const out = buildPositions(tracks);
+    const expected = new Float32Array([0.1, 0.2, 0.9, 0.4]);
+    assert.deepEqual(Array.from(out), Array.from(expected));
+});
+
+test("buildPositions on an empty track list returns an empty buffer", () => {
+    assert.equal(buildPositions([]).length, 0);
+});
+
+test("spread output is bounded 0..1 for every coordinate", () => {
+    const tracks: PositionableTrack[] = Array.from({ length: 12 }, (_, i) => ({
+        x: Math.sin(i * 12.9898) * 0.5 + 0.5,
+        y: Math.cos(i * 78.233) * 0.5 + 0.5,
+    }));
+    const out = computeSpreadPositions(tracks);
+    assert.equal(out.length, tracks.length * 2);
+    for (const v of out) {
+        assert.ok(v >= 0 && v <= 1, `expected 0..1, got ${v}`);
+    }
+});
+
+test("spread rank correctness on a known small set, including a tie", () => {
+    // x values are all distinct (0, 10, 5); y values are all tied (5, 5, 5).
+    const tracks: PositionableTrack[] = [
+        { x: 0, y: 5 }, // idx 0
+        { x: 10, y: 5 }, // idx 1
+        { x: 5, y: 5 }, // idx 2
+    ];
+    const out = computeSpreadPositions(tracks);
+    // x: idx0 (0) -> rank0 -> 0; idx2 (5) -> rank1 -> 0.5; idx1 (10) -> rank2 -> 1
+    // y: all tied -> stable tie-break by original index -> idx0=0, idx1=0.5, idx2=1
+    assert.deepEqual(Array.from(out), [0, 0, 1, 0.5, 0.5, 1]);
+});
+
+test("spread positions for a single track centers at (0.5, 0.5)", () => {
+    const out = computeSpreadPositions([{ x: 0.1, y: 0.9 }]);
+    assert.deepEqual(Array.from(out), [0.5, 0.5]);
+});
+
+test("spread positions for zero tracks is an empty buffer", () => {
+    assert.equal(computeSpreadPositions([]).length, 0);
+});
+
+test("lerpPositions endpoints are exact: t<=0 copies a, t>=1 copies b", () => {
+    const a = new Float32Array([0, 0, 1, 1, 0.25, 0.75]);
+    const b = new Float32Array([1, 1, 0, 0, 0.9, 0.1]);
+    const out = new Float32Array(6);
+
+    const r0 = lerpPositions(a, b, 0, out);
+    assert.equal(r0, out);
+    assert.deepEqual(Array.from(out), Array.from(a));
+
+    const r1 = lerpPositions(a, b, 1, out);
+    assert.equal(r1, out);
+    assert.deepEqual(Array.from(out), Array.from(b));
+
+    // Overshoot beyond [0,1] (an eased animation frame can round past 1)
+    // still clamps to the exact endpoint copy.
+    const rNeg = lerpPositions(a, b, -0.2, out);
+    assert.deepEqual(Array.from(rNeg), Array.from(a));
+    const rOver = lerpPositions(a, b, 1.2, out);
+    assert.deepEqual(Array.from(rOver), Array.from(b));
+});
+
+test("lerpPositions at the midpoint averages each coordinate", () => {
+    const a = new Float32Array([0, 0]);
+    const b = new Float32Array([1, 1]);
+    const out = new Float32Array(2);
+    lerpPositions(a, b, 0.5, out);
+    assert.deepEqual(Array.from(out), [0.5, 0.5]);
+});
+
+test("lerpPositions reuses the out-buffer: no per-frame allocation", () => {
+    const a = new Float32Array([0, 0]);
+    const b = new Float32Array([1, 1]);
+    const out = new Float32Array(2);
+
+    const frame1 = lerpPositions(a, b, 0.25, out);
+    const frame2 = lerpPositions(a, b, 0.5, out);
+    const frame3 = lerpPositions(a, b, 0.75, out);
+
+    // Every call returns the SAME buffer reference — the caller can drive an
+    // animation loop off one allocated buffer.
+    assert.equal(frame1, out);
+    assert.equal(frame2, out);
+    assert.equal(frame3, out);
+    assert.equal(frame1, frame2);
+    assert.equal(frame2, frame3);
+});

--- a/frontend/tests/unit/mapSearch.test.ts
+++ b/frontend/tests/unit/mapSearch.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { searchMapTracks } from "../../components/vibe/mapSearch";
+import type { MapTrack } from "../../components/vibe/types";
+
+function track(overrides: Partial<MapTrack> & { id: string }): MapTrack {
+    return {
+        id: overrides.id,
+        x: 0.5,
+        y: 0.5,
+        title: overrides.title ?? "Untitled",
+        artist: overrides.artist ?? "Unknown Artist",
+        artistId: `artist-${overrides.id}`,
+        albumId: `album-${overrides.id}`,
+        coverUrl: null,
+        dominantMood: "moodHappy",
+        moodScore: 0.5,
+        energy: 0.5,
+        valence: 0.5,
+        ...overrides,
+    };
+}
+
+const library: MapTrack[] = [
+    track({ id: "1", title: "Midnight City", artist: "M83" }),
+    track({ id: "2", title: "City Lights", artist: "Aurora" }),
+    track({ id: "3", title: "Starlight", artist: "Muse" }),
+    track({ id: "4", title: "Fireflies", artist: "Owl City" }),
+    track({ id: "5", title: "Aurora Borealis", artist: "Some Band" }),
+    track({ id: "6", title: "Zebra", artist: "City Sleepers" }),
+];
+
+test("query shorter than 2 characters (after trim) returns no matches", () => {
+    assert.deepEqual(searchMapTracks(library, ""), []);
+    assert.deepEqual(searchMapTracks(library, "a"), []);
+    assert.deepEqual(searchMapTracks(library, "  a  "), []);
+});
+
+test("matches case-insensitively on title or artist substrings", () => {
+    const results = searchMapTracks(library, "MIDNIGHT");
+    assert.deepEqual(
+        results.map((t) => t.id),
+        ["1"]
+    );
+
+    const byArtist = searchMapTracks(library, "muse");
+    assert.deepEqual(
+        byArtist.map((t) => t.id),
+        ["3"]
+    );
+});
+
+test("trims and collapses internal whitespace before matching", () => {
+    const results = searchMapTracks(library, "  city   lights  ");
+    assert.deepEqual(
+        results.map((t) => t.id),
+        ["2"]
+    );
+});
+
+test("ranks title-prefix above artist-prefix above title-substring above artist-substring", () => {
+    // "city" hits all four tiers across the fixture library:
+    //  "2" City Lights          -> title starts with "city"      (title-prefix)
+    //  "6" Zebra / City Sleepers -> artist starts with "city"     (artist-prefix)
+    //  "1" Midnight City         -> title contains, doesn't start (title-substring)
+    //  "4" Fireflies / Owl City  -> artist contains, doesn't start (artist-substring)
+    const results = searchMapTracks(library, "city");
+    assert.deepEqual(
+        results.map((t) => t.id),
+        ["2", "6", "1", "4"]
+    );
+});
+
+test("alphabetical tie-break within the same rank tier", () => {
+    const tied: MapTrack[] = [
+        track({ id: "b", title: "Blue Horizon", artist: "X" }),
+        track({ id: "a", title: "Amber Horizon", artist: "Y" }),
+        track({ id: "c", title: "Cyan Horizon", artist: "Z" }),
+    ];
+    const results = searchMapTracks(tied, "horizon");
+    assert.deepEqual(
+        results.map((t) => t.id),
+        ["a", "b", "c"]
+    );
+});
+
+test("respects the limit parameter (default 8)", () => {
+    const many: MapTrack[] = Array.from({ length: 20 }, (_, i) =>
+        track({ id: `t${i}`, title: `Vibe Track ${i}`, artist: "A" })
+    );
+    assert.equal(searchMapTracks(many, "vibe").length, 8);
+    assert.equal(searchMapTracks(many, "vibe", 3).length, 3);
+    assert.equal(searchMapTracks(many, "vibe", 20).length, 20);
+});
+
+test("returns [] when nothing matches", () => {
+    assert.deepEqual(searchMapTracks(library, "nonexistentquery"), []);
+});
+
+test("a track matching in multiple ways is not duplicated in the results", () => {
+    const t = track({ id: "dup", title: "Aurora Aurora", artist: "Aurora" });
+    const results = searchMapTracks([t], "aurora");
+    assert.equal(results.length, 1);
+});

--- a/frontend/tests/unit/mapViewport.test.ts
+++ b/frontend/tests/unit/mapViewport.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    clampViewport,
+    fitBounds,
+    FIT_BOUNDS_MAX_ZOOM,
+    fitViewport,
+    flyTo,
+    interpolateViewport,
+    MAX_SCALE,
+    MIN_SCALE,
+    screenToWorld,
+    worldToScreen,
+    zoomAt,
+    type Viewport,
+} from "../../components/vibe/mapViewport";
+
+function approx(actual: number, expected: number, eps = 1e-6): void {
+    assert.ok(
+        Math.abs(actual - expected) <= eps,
+        `expected ~${expected}, got ${actual}`
+    );
+}
+
+test("worldToScreen and screenToWorld round-trip", () => {
+    const vp: Viewport = { scale: 512, tx: 33, ty: 71 };
+    for (const p of [
+        { x: 0, y: 0 },
+        { x: 0.5, y: 0.5 },
+        { x: 1, y: 1 },
+        { x: 0.137, y: 0.884 },
+    ]) {
+        const back = screenToWorld(vp, worldToScreen(vp, p));
+        approx(back.x, p.x);
+        approx(back.y, p.y);
+    }
+});
+
+test("fitViewport centers the 0..1 box inside the padded region", () => {
+    const vp = fitViewport({ width: 800, height: 600 });
+    // Uniform scale = min(width-80, height-80) = min(720, 520) = 520.
+    approx(vp.scale, 520);
+    const topLeft = worldToScreen(vp, { x: 0, y: 0 });
+    const bottomRight = worldToScreen(vp, { x: 1, y: 1 });
+    // Content is centered: equal slack on both sides of each axis.
+    approx(topLeft.x, 800 - bottomRight.x);
+    approx(topLeft.y, 600 - bottomRight.y);
+    // Stays within the 40px padded region.
+    assert.ok(topLeft.x >= 40 - 1e-6 && bottomRight.x <= 760 + 1e-6);
+    assert.ok(topLeft.y >= 40 - 1e-6 && bottomRight.y <= 560 + 1e-6);
+});
+
+test("zoomAt keeps the world point under the cursor fixed", () => {
+    const vp: Viewport = { scale: 600, tx: 25, ty: 40 };
+    const cursors = [
+        { x: 0, y: 0 },
+        { x: 150, y: 320 },
+        { x: 640, y: 480 },
+        { x: 400, y: 300 },
+    ];
+    const factors = [1.3, 0.5, 2.5, 1 / 1.3, 4];
+    for (const cursor of cursors) {
+        const worldUnder = screenToWorld(vp, cursor);
+        for (const factor of factors) {
+            // No bounds -> exact transform (clamping can't perturb the invariant).
+            const next = zoomAt(vp, cursor, factor);
+            const projected = worldToScreen(next, worldUnder);
+            approx(projected.x, cursor.x, 1e-6);
+            approx(projected.y, cursor.y, 1e-6);
+        }
+    }
+});
+
+test("zoomAt clamps scale to [MIN_SCALE, MAX_SCALE]", () => {
+    const vp: Viewport = { scale: 600, tx: 0, ty: 0 };
+    assert.equal(zoomAt(vp, { x: 10, y: 10 }, 10_000).scale, MAX_SCALE);
+    assert.equal(zoomAt(vp, { x: 10, y: 10 }, 0.00001).scale, MIN_SCALE);
+});
+
+test("flyTo centers the target world point on screen", () => {
+    const vp: Viewport = { scale: 300, tx: 10, ty: 10 };
+    const bounds = { width: 800, height: 600 };
+    const worldPt = { x: 0.5, y: 0.5 };
+    const result = flyTo(vp, worldPt, 500, bounds);
+    approx(result.scale, 500);
+    const screen = worldToScreen(result, worldPt);
+    approx(screen.x, 400); // width / 2
+    approx(screen.y, 300); // height / 2
+});
+
+test("flyTo falls back to current scale when targetScale is not finite", () => {
+    const vp: Viewport = { scale: 321, tx: 0, ty: 0 };
+    const result = flyTo(vp, { x: 0.5, y: 0.5 }, Number.NaN, {
+        width: 800,
+        height: 600,
+    });
+    approx(result.scale, 321);
+});
+
+test("clampViewport keeps the content from being lost off-screen", () => {
+    const bounds = { width: 800, height: 600 };
+    const scale = 400;
+    // Pushed far past the right/bottom edge.
+    const clampedFar = clampViewport({ scale, tx: 100000, ty: 100000 }, bounds);
+    assert.ok(clampedFar.tx <= 800 - 40 + 1e-6);
+    assert.ok(clampedFar.ty <= 600 - 40 + 1e-6);
+    // Pushed far past the left/top edge.
+    const clampedNeg = clampViewport({ scale, tx: -100000, ty: -100000 }, bounds);
+    assert.ok(clampedNeg.tx >= -scale + 40 - 1e-6);
+    assert.ok(clampedNeg.ty >= -scale + 40 - 1e-6);
+    // A viewport already on-screen is untouched.
+    const ok: Viewport = { scale, tx: 50, ty: 50 };
+    assert.deepEqual(clampViewport(ok, bounds), ok);
+});
+
+test("zoomAt with bounds still clamps translation", () => {
+    const bounds = { width: 800, height: 600 };
+    // Zoom out hard at a corner; result must remain on-screen.
+    const next = zoomAt({ scale: 4000, tx: -3000, ty: -3000 }, { x: 0, y: 0 }, 0.1, bounds);
+    assert.ok(next.tx <= 800 - 40 + 1e-6 && next.tx >= -next.scale + 40 - 1e-6);
+    assert.ok(next.ty <= 600 - 40 + 1e-6 && next.ty >= -next.scale + 40 - 1e-6);
+});
+
+test("fitBounds centers the box and keeps it inside the padding", () => {
+    const bounds = { width: 800, height: 600 };
+    const box = { minX: 0.2, minY: 0.4, maxX: 0.6, maxY: 0.6 };
+    const vp = fitBounds(box, bounds);
+    // Box center lands on screen center.
+    const center = worldToScreen(vp, { x: 0.4, y: 0.5 });
+    approx(center.x, 400);
+    approx(center.y, 300);
+    // The whole box fits within the 80px padded region.
+    const tl = worldToScreen(vp, { x: box.minX, y: box.minY });
+    const br = worldToScreen(vp, { x: box.maxX, y: box.maxY });
+    assert.ok(tl.x >= 80 - 1e-6 && br.x <= 720 + 1e-6);
+    assert.ok(tl.y >= 80 - 1e-6 && br.y <= 520 + 1e-6);
+});
+
+test("fitBounds caps a degenerate (single-point) box at the max-zoom multiple", () => {
+    const bounds = { width: 800, height: 600 };
+    const vp = fitBounds({ minX: 0.5, minY: 0.5, maxX: 0.5, maxY: 0.5 }, bounds);
+    const cap = fitViewport(bounds).scale * FIT_BOUNDS_MAX_ZOOM;
+    assert.ok(vp.scale <= cap + 1e-6, `scale ${vp.scale} exceeds cap ${cap}`);
+});
+
+test("interpolateViewport returns exact endpoints and a stable focus path", () => {
+    const bounds = { width: 800, height: 600 };
+    const from: Viewport = { scale: 520, tx: 140, ty: 40 };
+    const to: Viewport = { scale: 2600, tx: -900, ty: -700 };
+    assert.deepEqual(interpolateViewport(from, to, 0, bounds), from);
+    assert.deepEqual(interpolateViewport(from, to, 1, bounds), to);
+
+    // The world point at screen center travels monotonically from the from-
+    // center to the to-center while scale grows monotonically (log-lerped).
+    const center = { x: 400, y: 300 };
+    const c0 = screenToWorld(from, center);
+    const c1 = screenToWorld(to, center);
+    let prevScale = from.scale;
+    let prevX = c0.x;
+    for (const t of [0.25, 0.5, 0.75]) {
+        const mid = interpolateViewport(from, to, t, bounds);
+        assert.ok(mid.scale > prevScale, "scale must grow monotonically");
+        prevScale = mid.scale;
+        const cMid = screenToWorld(mid, center);
+        // Center-x moves toward c1 without overshooting.
+        const dir = Math.sign(c1.x - c0.x);
+        assert.ok(cMid.x * dir >= prevX * dir - 1e-9);
+        assert.ok(cMid.x * dir <= c1.x * dir + 1e-9);
+        prevX = cMid.x;
+        // And the mid-flight center is the exact linear blend.
+        approx(cMid.x, c0.x + (c1.x - c0.x) * t, 1e-9);
+        approx(cMid.y, c0.y + (c1.y - c0.y) * t, 1e-9);
+    }
+});

--- a/frontend/tests/unit/sweepCollect.test.ts
+++ b/frontend/tests/unit/sweepCollect.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    collectHits,
+    sampleSegment,
+    MAX_SEGMENT_SAMPLES,
+    SWEEP_CAP,
+} from "../../components/vibe/sweepCollect";
+import type { Viewport } from "../../components/vibe/mapViewport";
+
+// Identity-ish viewport: world 0..1 -> screen 0..1000.
+const VP: Viewport = { scale: 1000, tx: 0, ty: 0 };
+
+function fixtures(coords: Array<[number, number]>, maskBits?: number[]) {
+    const ids = coords.map((_, i) => ({ id: `t${i}` }));
+    const positions = new Float32Array(coords.flat());
+    const mask = new Uint8Array(
+        maskBits ?? Array.from({ length: coords.length }, () => 1)
+    );
+    return { ids, positions, mask };
+}
+
+test("sampleSegment covers the segment without gaps and always ends at b", () => {
+    const a = { x: 0, y: 0 };
+    const b = { x: 100, y: 0 };
+    const pts = sampleSegment(a, b, 16);
+    assert.deepEqual(pts[pts.length - 1], b);
+    // No two consecutive samples (incl. the start) further apart than step.
+    let prev = a;
+    for (const p of pts) {
+        assert.ok(Math.hypot(p.x - prev.x, p.y - prev.y) <= 16 + 1e-9);
+        prev = p;
+    }
+    // Zero-length segment yields just b (so a stationary pointer still samples).
+    assert.deepEqual(sampleSegment(a, a, 16), [a]);
+});
+
+test("sampleSegment rejects non-finite endpoints", () => {
+    const good = { x: 10, y: 10 };
+    for (const bad of [
+        { x: NaN, y: 0 },
+        { x: 0, y: NaN },
+        { x: Infinity, y: 0 },
+        { x: 0, y: -Infinity },
+    ]) {
+        assert.deepEqual(sampleSegment(bad, good, 16), []);
+        assert.deepEqual(sampleSegment(good, bad, 16), []);
+    }
+});
+
+test("sampleSegment falls back to the default step on a non-positive or non-finite step", () => {
+    const a = { x: 0, y: 0 };
+    const b = { x: 100, y: 0 };
+    const expected = sampleSegment(a, b); // default SWEEP_SAMPLE_STEP
+    for (const badStep of [0, -5, NaN, Infinity, -Infinity]) {
+        const pts = sampleSegment(a, b, badStep);
+        assert.deepEqual(pts, expected);
+        assert.deepEqual(pts[pts.length - 1], b);
+    }
+});
+
+test("sampleSegment caps the sample count on an oversized segment", () => {
+    const a = { x: 0, y: 0 };
+    // A "teleport" far beyond any real pointer-event pair: uncapped, this
+    // segment would demand ~62.5 million samples at the default step.
+    const b = { x: 1e9, y: 0 };
+    const pts = sampleSegment(a, b);
+    assert.equal(pts.length, MAX_SEGMENT_SAMPLES);
+    // The final sample is still exactly b, so the stroke stays anchored.
+    assert.deepEqual(pts[pts.length - 1], b);
+});
+
+test("collectHits collects only visible dots within the radius", () => {
+    // Dots at screen (100,100), (110,100), (400,400); middle one filtered out.
+    const { ids, positions, mask } = fixtures(
+        [
+            [0.1, 0.1],
+            [0.11, 0.1],
+            [0.4, 0.4],
+        ],
+        [1, 0, 1]
+    );
+    const seen = new Set<string>();
+    const out: string[] = [];
+    collectHits({
+        cursor: { x: 100, y: 100 },
+        ids,
+        positions,
+        mask,
+        viewport: VP,
+        radius: 24,
+        seen,
+        out,
+    });
+    // t0 in radius; t1 in radius but masked; t2 far away.
+    assert.deepEqual(out, ["t0"]);
+});
+
+test("collectHits dedupes across calls and preserves first-touch order", () => {
+    const { ids, positions, mask } = fixtures([
+        [0.1, 0.1], // t0 @ (100,100)
+        [0.2, 0.1], // t1 @ (200,100)
+    ]);
+    const seen = new Set<string>();
+    const out: string[] = [];
+    const args = { ids, positions, mask, viewport: VP, radius: 24, seen, out };
+    collectHits({ ...args, cursor: { x: 100, y: 100 } }); // catches t0
+    collectHits({ ...args, cursor: { x: 200, y: 100 } }); // catches t1
+    collectHits({ ...args, cursor: { x: 100, y: 100 } }); // t0 again — deduped
+    assert.deepEqual(out, ["t0", "t1"]);
+});
+
+test("collectHits stops at the cap", () => {
+    // 150 dots stacked on the same spot.
+    const coords = Array.from({ length: 150 }, () => [0.5, 0.5] as [number, number]);
+    const { ids, positions, mask } = fixtures(coords);
+    const seen = new Set<string>();
+    const out: string[] = [];
+    collectHits({
+        cursor: { x: 500, y: 500 },
+        ids,
+        positions,
+        mask,
+        viewport: VP,
+        seen,
+        out,
+    });
+    assert.equal(out.length, SWEEP_CAP);
+    // And a custom cap is honored too.
+    const out2: string[] = [];
+    collectHits({
+        cursor: { x: 500, y: 500 },
+        ids,
+        positions,
+        mask,
+        viewport: VP,
+        cap: 5,
+        seen: new Set<string>(),
+        out: out2,
+    });
+    assert.equal(out2.length, 5);
+});
+
+test("collectHits clamps an oversized or invalid cap to the hard sweep cap", () => {
+    // More dots than SWEEP_CAP stacked on one spot — a caller-supplied cap
+    // can tighten the bound but never widen it past SWEEP_CAP.
+    const coords = Array.from(
+        { length: SWEEP_CAP + 50 },
+        () => [0.5, 0.5] as [number, number]
+    );
+    const { ids, positions, mask } = fixtures(coords);
+    for (const badCap of [SWEEP_CAP + 1000, Infinity, NaN, 0, -3]) {
+        const out: string[] = [];
+        collectHits({
+            cursor: { x: 500, y: 500 },
+            ids,
+            positions,
+            mask,
+            viewport: VP,
+            cap: badCap,
+            seen: new Set<string>(),
+            out,
+        });
+        assert.equal(out.length, SWEEP_CAP, `cap=${badCap}`);
+    }
+});
+
+test("collectHits falls back to the default radius on a non-positive or non-finite radius", () => {
+    // One dot 30px from the cursor: outside the 24px default brush radius —
+    // an absurd radius (Infinity would swallow the whole map) must not widen
+    // the brush, and a non-positive one must not disable it.
+    const { ids, positions, mask } = fixtures([[0.53, 0.5]]);
+    for (const badRadius of [Infinity, NaN, 0, -10]) {
+        const out: string[] = [];
+        collectHits({
+            cursor: { x: 500, y: 500 },
+            ids,
+            positions,
+            mask,
+            viewport: VP,
+            radius: badRadius,
+            seen: new Set<string>(),
+            out,
+        });
+        assert.deepEqual(out, [], `radius=${badRadius}`);
+    }
+    // Sanity: a legitimate wider radius still collects it.
+    const out: string[] = [];
+    collectHits({
+        cursor: { x: 500, y: 500 },
+        ids,
+        positions,
+        mask,
+        viewport: VP,
+        radius: 40,
+        seen: new Set<string>(),
+        out,
+    });
+    assert.deepEqual(out, ["t0"]);
+});

--- a/frontend/tests/unit/travelCompass.test.ts
+++ b/frontend/tests/unit/travelCompass.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    compassNeighbors,
+    enrichFromMap,
+    matchesDirection,
+    VALENCE_DELTA_THRESHOLD,
+    ENERGY_DELTA_THRESHOLD,
+    DEFAULT_COMPASS_COUNT,
+    type CompassCandidate,
+    type CompassOrigin,
+} from "../../components/vibe/travelCompass";
+import type { MapTrack } from "../../components/vibe/types";
+
+function candidate(
+    id: string,
+    similarity: number,
+    energy: number | null,
+    valence: number | null,
+    moods?: Record<string, number> | null
+): CompassCandidate {
+    return {
+        id,
+        title: id,
+        album: { id: `al-${id}`, title: "", coverUrl: null },
+        artist: { id: `ar-${id}`, name: `Artist ${id}` },
+        similarity,
+        // Mirrors the backend's Math.max(0, 1 - distance/2) so fixtures built
+        // from a target similarity stay internally consistent.
+        distance: Math.max(0, 2 * (1 - similarity)),
+        energy,
+        valence,
+        moods: moods ?? null,
+    };
+}
+
+function mapTrack(id: string, overrides: Partial<MapTrack> = {}): MapTrack {
+    return {
+        id,
+        x: 0.5,
+        y: 0.5,
+        title: id,
+        artist: `Artist ${id}`,
+        artistId: `ar-${id}`,
+        albumId: `al-${id}`,
+        coverUrl: null,
+        dominantMood: "moodHappy",
+        moodScore: 0.5,
+        energy: 0.5,
+        valence: 0.5,
+        ...overrides,
+    };
+}
+
+const origin: CompassOrigin = {
+    energy: 0.5,
+    valence: 0.5,
+    moods: { moodHappy: 0.4 },
+};
+
+test("thresholds are the documented deltas", () => {
+    assert.equal(VALENCE_DELTA_THRESHOLD, 0.03);
+    assert.equal(ENERGY_DELTA_THRESHOLD, 0.03);
+    assert.equal(DEFAULT_COMPASS_COUNT, 8);
+});
+
+test("valence-present direction filtering (happier / sadder)", () => {
+    const happier = candidate("h", 0.9, 0.5, 0.6); // +0.1 valence
+    const barely = candidate("b", 0.8, 0.5, 0.51); // +0.01, under threshold
+    const sadder = candidate("s", 0.7, 0.5, 0.3); // -0.2 valence
+
+    assert.equal(matchesDirection(origin, happier, "happier"), true);
+    assert.equal(matchesDirection(origin, barely, "happier"), false);
+    assert.equal(matchesDirection(origin, sadder, "happier"), false);
+
+    assert.equal(matchesDirection(origin, sadder, "sadder"), true);
+    assert.equal(matchesDirection(origin, happier, "sadder"), false);
+});
+
+test("energy-present direction filtering (calmer / more-energetic)", () => {
+    const calmer = candidate("c", 0.6, 0.2, 0.5); // -0.3 energy
+    const flat = candidate("f", 0.6, 0.5, 0.5); // 0 energy delta
+    const hot = candidate("e", 0.6, 0.9, 0.5); // +0.4 energy
+
+    assert.equal(matchesDirection(origin, calmer, "calmer"), true);
+    assert.equal(matchesDirection(origin, flat, "calmer"), false);
+    assert.equal(matchesDirection(origin, hot, "more-energetic"), true);
+    assert.equal(matchesDirection(origin, calmer, "more-energetic"), false);
+});
+
+test("null valence falls back to moodHappy delta", () => {
+    const happyByMood = candidate("hm", 0.9, 0.5, null, { moodHappy: 0.7 }); // +0.3
+    const sadByMood = candidate("sm", 0.9, 0.5, null, { moodHappy: 0.2 }); // -0.2
+    const noSignal = candidate("ns", 0.9, 0.5, null, null); // no valence, no moods
+
+    assert.equal(matchesDirection(origin, happyByMood, "happier"), true);
+    assert.equal(matchesDirection(origin, happyByMood, "sadder"), false);
+    assert.equal(matchesDirection(origin, sadByMood, "sadder"), true);
+    assert.equal(matchesDirection(origin, sadByMood, "happier"), false);
+    // Nothing to compare on → excluded from both directional filters.
+    assert.equal(matchesDirection(origin, noSignal, "happier"), false);
+    assert.equal(matchesDirection(origin, noSignal, "sadder"), false);
+});
+
+test("null energy is excluded from calmer / more-energetic (no mood fallback)", () => {
+    const nullEnergy = candidate("ne", 0.9, null, 0.5);
+    assert.equal(matchesDirection(origin, nullEnergy, "calmer"), false);
+    assert.equal(matchesDirection(origin, nullEnergy, "more-energetic"), false);
+});
+
+test("'any' keeps everything", () => {
+    const c = candidate("x", 0.1, null, null, null);
+    assert.equal(matchesDirection(origin, c, "any"), true);
+});
+
+test("compassNeighbors ranks by similarity desc within a direction", () => {
+    const cands = [
+        candidate("low", 0.4, 0.5, 0.7), // happier
+        candidate("high", 0.95, 0.5, 0.8), // happier
+        candidate("mid", 0.6, 0.5, 0.66), // happier
+        candidate("sad", 0.99, 0.5, 0.2), // sadder — filtered out
+    ];
+    const out = compassNeighbors(origin, cands, "happier");
+    assert.deepEqual(
+        out.map((c) => c.id),
+        ["high", "mid", "low"]
+    );
+});
+
+test("compassNeighbors caps to top-N", () => {
+    const cands = Array.from({ length: 12 }, (_, i) =>
+        candidate(`t${i}`, i / 12, 0.5, 0.5)
+    );
+    const out = compassNeighbors(origin, cands, "any", 3);
+    assert.equal(out.length, 3);
+    // Highest similarities: t11, t10, t9.
+    assert.deepEqual(
+        out.map((c) => c.id),
+        ["t11", "t10", "t9"]
+    );
+});
+
+test("compassNeighbors defaults to DEFAULT_COMPASS_COUNT", () => {
+    const cands = Array.from({ length: 20 }, (_, i) =>
+        candidate(`t${i}`, i, 0.5, 0.5)
+    );
+    assert.equal(compassNeighbors(origin, cands, "any").length, 8);
+});
+
+test("enrichFromMap fills only missing energy/valence/moods for on-map candidates", () => {
+    const mapIndex = new Map<string, MapTrack>([
+        [
+            "onmap",
+            mapTrack("onmap", {
+                energy: 0.8,
+                valence: 0.9,
+                moods: { moodHappy: 0.7 },
+            }),
+        ],
+    ]);
+
+    const missing = candidate("onmap", 0.5, null, null, null);
+    const present = candidate("onmap", 0.5, 0.1, 0.2, { moodHappy: 0.1 });
+    const offMap = candidate("offmap", 0.5, null, null, null);
+
+    const [enrichedMissing] = enrichFromMap([missing], mapIndex);
+    assert.equal(enrichedMissing.energy, 0.8);
+    assert.equal(enrichedMissing.valence, 0.9);
+    assert.deepEqual(enrichedMissing.moods, { moodHappy: 0.7 });
+
+    const [enrichedPresent] = enrichFromMap([present], mapIndex);
+    assert.equal(enrichedPresent.energy, 0.1, "own value is kept");
+    assert.equal(enrichedPresent.valence, 0.2);
+    assert.deepEqual(enrichedPresent.moods, { moodHappy: 0.1 });
+
+    const [untouched] = enrichFromMap([offMap], mapIndex);
+    assert.equal(untouched.energy, null, "off-map candidate is not enriched");
+    assert.equal(untouched, offMap, "off-map candidate returned by reference");
+});
+
+test("enrichFromMap recovers deltas so a null-valence candidate can be directional", () => {
+    const mapIndex = new Map<string, MapTrack>([
+        ["n", mapTrack("n", { valence: 0.9, energy: 0.5 })],
+    ]);
+    const raw = candidate("n", 0.9, 0.5, null); // valence unknown from /similar
+    // Before enrichment the valence delta is unknown → not happier.
+    assert.equal(matchesDirection(origin, raw, "happier"), false);
+    const [enriched] = enrichFromMap([raw], mapIndex);
+    // After enrichment valence 0.9 vs 0.5 → +0.4 → happier.
+    assert.equal(matchesDirection(origin, enriched, "happier"), true);
+});

--- a/frontend/tests/unit/vibeMatch.test.ts
+++ b/frontend/tests/unit/vibeMatch.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    calibratedMatch,
+    featureMatchPercent,
+    matchEdgeStyle,
+} from "../../components/vibe/vibeMatch";
+
+/**
+ * A synthetic 101-point quantile ladder (p0..p100), evenly spaced from 0 to 2
+ * (pgvector cosine distance's plausible range) — quantiles[i] = i/50, so
+ * percentile rank i0..100 maps back onto i by construction, which keeps the
+ * expected values in each test easy to hand-verify.
+ */
+const EVEN_QUANTILES: number[] = Array.from({ length: 101 }, (_, i) => i / 50);
+
+test("calibratedMatch falls back to the old linear mapping when quantiles are null", () => {
+    const { percent, label } = calibratedMatch(0.2, null);
+    assert.equal(percent, Math.round(Math.max(0, 1 - 0.2 / 2) * 100));
+    assert.equal(label, "");
+});
+
+test("calibratedMatch falls back to the old linear mapping when quantiles are empty", () => {
+    const { percent, label } = calibratedMatch(1, []);
+    assert.equal(percent, Math.round(Math.max(0, 1 - 1 / 2) * 100));
+    assert.equal(label, "");
+});
+
+test("calibratedMatch fallback clamps at 0 for a distance beyond 2", () => {
+    const { percent } = calibratedMatch(3, null);
+    assert.equal(percent, 0);
+});
+
+test("calibratedMatch: an exact quantile hit maps to 100 minus its percentile index", () => {
+    // EVEN_QUANTILES[9] === 0.18 -> percentile rank 9 -> 100 - 9 = 91.
+    const { percent } = calibratedMatch(0.18, EVEN_QUANTILES);
+    assert.equal(percent, 91);
+});
+
+test("calibratedMatch interpolates linearly between two straddling quantiles", () => {
+    // Halfway between quantiles[9]=0.18 and quantiles[10]=0.2 -> rank 9.5 -> 90.5 -> rounds to 91 or 90.
+    const { percent } = calibratedMatch(0.19, EVEN_QUANTILES);
+    assert.ok(percent === 90 || percent === 91, `expected ~90.5, got ${percent}`);
+});
+
+test("calibratedMatch clamps a distance below the lowest quantile to 100%", () => {
+    const { percent } = calibratedMatch(-1, EVEN_QUANTILES);
+    assert.equal(percent, 100);
+});
+
+test("calibratedMatch clamps a distance above the highest quantile to 0%", () => {
+    const { percent } = calibratedMatch(100, EVEN_QUANTILES);
+    assert.equal(percent, 0);
+});
+
+test("calibratedMatch labels: nearly identical vibe >= 97", () => {
+    // rank 2 -> percent 98
+    assert.equal(calibratedMatch(EVEN_QUANTILES[2], EVEN_QUANTILES).label, "nearly identical vibe");
+});
+
+test("calibratedMatch labels: same vibe >= 90", () => {
+    // rank 10 -> percent 90
+    assert.equal(calibratedMatch(EVEN_QUANTILES[10], EVEN_QUANTILES).label, "same vibe");
+});
+
+test("calibratedMatch labels: close neighbors >= 75", () => {
+    // rank 25 -> percent 75
+    assert.equal(calibratedMatch(EVEN_QUANTILES[25], EVEN_QUANTILES).label, "close neighbors");
+});
+
+test("calibratedMatch labels: same neighborhood >= 50", () => {
+    // rank 50 -> percent 50
+    assert.equal(calibratedMatch(EVEN_QUANTILES[50], EVEN_QUANTILES).label, "same neighborhood");
+});
+
+test("calibratedMatch labels: distant relatives >= 25", () => {
+    // rank 75 -> percent 25
+    assert.equal(calibratedMatch(EVEN_QUANTILES[75], EVEN_QUANTILES).label, "distant relatives");
+});
+
+test("calibratedMatch labels: different worlds below 25", () => {
+    // rank 76 -> percent 24
+    assert.equal(calibratedMatch(EVEN_QUANTILES[76], EVEN_QUANTILES).label, "different worlds");
+});
+
+test("calibratedMatch treats a flat quantile segment by snapping to the upper percentile", () => {
+    const flat = [...EVEN_QUANTILES];
+    flat[10] = flat[9]; // p9 === p10, a degenerate flat run
+    const { percent } = calibratedMatch(flat[9], flat);
+    assert.ok(Number.isFinite(percent));
+});
+
+test("featureMatchPercent: identical values are a 100% match", () => {
+    assert.equal(featureMatchPercent(0.5, 0.5), 100);
+});
+
+test("featureMatchPercent: maximal delta (0 vs 1) is a 0% match", () => {
+    assert.equal(featureMatchPercent(0, 1), 0);
+});
+
+test("featureMatchPercent: partial delta rounds to the nearest percent", () => {
+    assert.equal(featureMatchPercent(0.2, 0.5), 70); // 1 - 0.3 = 0.7
+});
+
+test("featureMatchPercent: null on either side yields null (skip the feature)", () => {
+    assert.equal(featureMatchPercent(null, 0.5), null);
+    assert.equal(featureMatchPercent(0.5, null), null);
+    assert.equal(featureMatchPercent(null, null), null);
+});
+
+test("matchEdgeStyle: 75% is the anchor — unchanged current look", () => {
+    const { opacity, width } = matchEdgeStyle(75);
+    assert.equal(opacity, 0.5);
+    assert.equal(width, 1.25);
+});
+
+test("matchEdgeStyle: higher percent widens/brightens the edge", () => {
+    const anchor = matchEdgeStyle(75);
+    const stronger = matchEdgeStyle(100);
+    assert.ok(stronger.opacity > anchor.opacity);
+    assert.ok(stronger.width > anchor.width);
+});
+
+test("matchEdgeStyle: lower percent thins/dims the edge, clamped to a sane floor", () => {
+    const anchor = matchEdgeStyle(75);
+    const weaker = matchEdgeStyle(0);
+    assert.ok(weaker.opacity < anchor.opacity);
+    assert.ok(weaker.width < anchor.width);
+    assert.ok(weaker.opacity > 0, "opacity never fully disappears");
+    assert.ok(weaker.width > 0, "width never collapses to 0 or negative");
+});
+
+test("matchEdgeStyle: width never strays more than ~0.5px from the anchor", () => {
+    for (const p of [0, 25, 50, 75, 90, 100]) {
+        const { width } = matchEdgeStyle(p);
+        assert.ok(Math.abs(width - 1.25) <= 0.5 + 1e-9, `width ${width} at percent ${p} out of range`);
+    }
+});


### PR DESCRIPTION
Part of #203 — slice 1 of 6 rebuilding the interactive vibe map (superseded PR #163, reviewed head `421f0fa`).

## What this is

The pure, React-free foundation modules of the map, lifted from the reviewed head with the slice-1 hardening #203 asks for: viewport math (`mapViewport`), layout buffers (`mapLayout`), in-memory spotlight search (`mapSearch`), sweep stroke geometry (`sweepCollect`), flight-plan/journey/compass derivations (`flightPlan`, `journeyTracks`, `travelCompass`), calibrated match scoring (`vibeMatch`), hint copy (`mapHints`), and the shared `types`. Nothing imports them yet — slice 5 consumes them.

## Review findings addressed (bounded sweep geometry)

- `sampleSegment` now **rejects non-finite endpoints** (returns `[]` — a poisoned coordinate never enters the stroke), **falls back to the default step** on a non-positive/non-finite sampling step, and **caps samples per segment at `MAX_SEGMENT_SAMPLES` (512)** so `dist / step` can never drive an unbounded loop on the pointer-event hot path (previously a 0/NaN step meant an infinite loop; a teleporting coordinate meant a ~62.5M-sample allocation).
- `collectHits` clamps a caller-supplied cap into `[1, SWEEP_CAP]` (a cap can tighten the hard bound, never widen it) and ignores non-positive/non-finite radii instead of widening the brush.
- `mapHints` takes the shared `MapMode` type from `types.ts`, keeping this slice free of hook imports.

## Tests

Unit suites for every module, including the new negative/oversized-input coverage: non-finite endpoints, invalid steps, the 512-sample cap (last sample still lands exactly on `b`), oversized/invalid caps and radii.

## Verification

verify: 87/87 unit tests pass (`node --test` over the nine suites); frontend `tsc --noEmit` (standalone typecheck) exit 0; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)