### PR TITLE
feat(vibe): playlist save observability — failed ids returned, logged, surfaced as warnings (#203 slice 2)

### DIFF
--- a/frontend/components/vibe/savePlaylist.ts
+++ b/frontend/components/vibe/savePlaylist.ts
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * savePlaylist — turns an ordered list of vibe-map track ids into a saved
+ * playlist. Shared by the three "Save as playlist" affordances (journey,
+ * sweep, session-history trail): create the playlist, then add tracks
+ * sequentially — order matters, it becomes the playlist's track order — and
+ * tolerate individual add failures (a single already-deleted/unanalyzed track
+ * shouldn't abort the whole save). Failures are OBSERVABLE, not silent: each
+ * failed id is logged and returned in `failedTrackIds`, and callers surface
+ * partial saves through `describeSaveResult` (a warning, never an
+ * unconditional success toast).
+ *
+ * All HTTP goes through `@/lib/api` (the api.ts boundary rule); this module
+ * only orchestrates two existing endpoints, no new ones.
+ */
+
+import { api } from "@/lib/api";
+import { frontendLogger } from "@/lib/logger";
+
+const logger = frontendLogger.child("vibe:savePlaylist");
+
+export interface SaveTracksAsPlaylistResult {
+    id: string;
+    /** Tracks actually added, in playlist order. */
+    added: number;
+    /** Deduped track ids whose individual add failed, in attempt order. */
+    failedTrackIds: string[];
+}
+
+/** Dedupe `ids`, preserving the order of each id's first occurrence. */
+export function dedupePreserveOrder(ids: readonly string[]): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const id of ids) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        out.push(id);
+    }
+    return out;
+}
+
+/**
+ * Create a playlist named `name` and add `trackIds` to it in order (dedupe
+ * first — playlist order is the caller's intended listening order). Adds run
+ * sequentially, not in parallel, so the resulting playlist order is
+ * deterministic; a failed individual add never aborts the rest — it is
+ * logged, collected into `failedTrackIds`, and excluded from `added`.
+ */
+export async function saveTracksAsPlaylist(
+    name: string,
+    trackIds: readonly string[]
+): Promise<SaveTracksAsPlaylistResult> {
+    const deduped = dedupePreserveOrder(trackIds);
+    const playlist = await api.createPlaylist(name);
+    let added = 0;
+    const failedTrackIds: string[] = [];
+    for (const trackId of deduped) {
+        try {
+            await api.addTrackToPlaylist(playlist.id, { trackId });
+            added++;
+        } catch (error) {
+            // Tolerate the failure (the rest of the save continues) but never
+            // hide it: collect the id for the caller's partial-save warning.
+            failedTrackIds.push(trackId);
+            logger.warn("Failed to add track to playlist", {
+                playlistId: playlist.id,
+                playlistName: name,
+                trackId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+    if (failedTrackIds.length > 0) {
+        logger.warn("Playlist saved partially", {
+            playlistId: playlist.id,
+            playlistName: name,
+            added,
+            failed: failedTrackIds.length,
+        });
+    }
+    return { id: playlist.id, added, failedTrackIds };
+}
+
+export interface SaveResultMessage {
+    /** "success" = every track landed; "warning" = a partial save. */
+    tone: "success" | "warning";
+    message: string;
+}
+
+/**
+ * The one honest toast for a save result: a full save reads as success, a
+ * partial save reads as a warning naming how many tracks were skipped.
+ * Callers map `tone` onto their toast flavor (e.g. sonner's `toast.success`
+ * vs `toast.warning`) instead of unconditionally reporting success.
+ */
+export function describeSaveResult(
+    name: string,
+    result: SaveTracksAsPlaylistResult
+): SaveResultMessage {
+    const failed = result.failedTrackIds.length;
+    if (failed === 0) {
+        return {
+            tone: "success",
+            message: `Saved ${result.added} track${result.added === 1 ? "" : "s"} to ${name}`,
+        };
+    }
+    return {
+        tone: "warning",
+        message: `Saved ${result.added} of ${result.added + failed} tracks to ${name} — ${failed} track${failed === 1 ? "" : "s"} couldn't be added`,
+    };
+}
+
+const MONTH_LABELS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+] as const;
+
+/**
+ * Format a date as "MMM D" (e.g. "Jul 15", no zero-padding) for default
+ * playlist names — deliberately not `toLocaleDateString` so the format is
+ * locale-independent and unit-testable without an ICU dependency.
+ */
+export function formatPlaylistDate(date: Date = new Date()): string {
+    return `${MONTH_LABELS[date.getMonth()]} ${date.getDate()}`;
+}

--- a/frontend/tests/component/savePlaylist.component.test.ts
+++ b/frontend/tests/component/savePlaylist.component.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { beforeEach, mock, test } from "node:test";
+
+/**
+ * `@/lib/api` is mocked once at module scope (node:test's mock.module + a
+ * dynamic re-import both only take effect the first time a given specifier is
+ * resolved), so each mocked method here is a stable wrapper that delegates to
+ * a per-test-mutable `state` object — the same indirection pattern used by
+ * the component tests (e.g. playlistRename.component.test.ts) for api calls
+ * whose behaviour needs to vary test-to-test. `@/lib/logger` is mocked the
+ * same way so partial-save observability (the logged warnings) is assertable.
+ */
+
+const state: {
+    createImpl: (name: string) => Promise<{ id: string }>;
+    addImpl: (playlistId: string, ref: unknown) => Promise<unknown>;
+} = {
+    createImpl: async () => ({ id: "pl1" }),
+    addImpl: async () => ({}),
+};
+
+const warnCalls: Array<{ message: string; context: unknown }> = [];
+
+const stubLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: (message: string, context: unknown) => {
+        warnCalls.push({ message, context });
+    },
+    error: () => {},
+    child: () => stubLogger,
+};
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            createPlaylist: (name: string) => state.createImpl(name),
+            addTrackToPlaylist: (playlistId: string, ref: unknown) =>
+                state.addImpl(playlistId, ref),
+        },
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: stubLogger,
+    },
+});
+
+beforeEach(() => {
+    state.createImpl = async () => ({ id: "pl1" });
+    state.addImpl = async () => ({});
+    warnCalls.length = 0;
+});
+
+test("saveTracksAsPlaylist creates the playlist then adds tracks sequentially, in order", async () => {
+    const calls: string[] = [];
+    state.createImpl = async (name) => {
+        calls.push(`create:${name}`);
+        return { id: "pl-seq" };
+    };
+    state.addImpl = async (playlistId, ref) => {
+        calls.push(`add:${playlistId}:${(ref as { trackId: string }).trackId}`);
+        return {};
+    };
+    const { saveTracksAsPlaylist } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+
+    const result = await saveTracksAsPlaylist("My Journey", ["t1", "t2", "t3"]);
+
+    assert.deepEqual(calls, [
+        "create:My Journey",
+        "add:pl-seq:t1",
+        "add:pl-seq:t2",
+        "add:pl-seq:t3",
+    ]);
+    assert.deepEqual(result, { id: "pl-seq", added: 3, failedTrackIds: [] });
+    assert.equal(warnCalls.length, 0);
+});
+
+test("saveTracksAsPlaylist dedupes track ids, preserving first occurrence order", async () => {
+    const added: string[] = [];
+    state.createImpl = async () => ({ id: "pl-dedupe" });
+    state.addImpl = async (_playlistId, ref) => {
+        added.push((ref as { trackId: string }).trackId);
+        return {};
+    };
+    const { saveTracksAsPlaylist } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+
+    const result = await saveTracksAsPlaylist("Dupes", ["a", "b", "a", "c", "b"]);
+
+    assert.deepEqual(added, ["a", "b", "c"]);
+    assert.equal(result.added, 3);
+    assert.deepEqual(result.failedTrackIds, []);
+});
+
+test("a partial save returns the failed ids and logs each failure", async () => {
+    state.createImpl = async () => ({ id: "pl-partial" });
+    state.addImpl = async (_playlistId, ref) => {
+        const trackId = (ref as { trackId: string }).trackId;
+        if (trackId === "bad-1" || trackId === "bad-2") {
+            throw new Error(`no such track: ${trackId}`);
+        }
+        return {};
+    };
+    const { saveTracksAsPlaylist } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+
+    const result = await saveTracksAsPlaylist("Partial", [
+        "good1",
+        "bad-1",
+        "good2",
+        "bad-2",
+    ]);
+
+    // The failures are in the RESULT — a caller can never mistake this for a
+    // full save.
+    assert.deepEqual(result, {
+        id: "pl-partial",
+        added: 2,
+        failedTrackIds: ["bad-1", "bad-2"],
+    });
+
+    // And they were logged through the shared frontend logger: one warning
+    // per failed add plus one partial-save summary.
+    assert.equal(warnCalls.length, 3);
+    const perTrack = warnCalls.filter(
+        (c) => c.message === "Failed to add track to playlist"
+    );
+    assert.deepEqual(
+        perTrack.map((c) => (c.context as { trackId: string }).trackId),
+        ["bad-1", "bad-2"]
+    );
+    const summary = warnCalls.find(
+        (c) => c.message === "Playlist saved partially"
+    );
+    assert.ok(summary);
+    assert.deepEqual(summary.context, {
+        playlistId: "pl-partial",
+        playlistName: "Partial",
+        added: 2,
+        failed: 2,
+    });
+});
+
+test("a fully-failed save still resolves, reporting every id as failed", async () => {
+    state.createImpl = async () => ({ id: "pl-doomed" });
+    state.addImpl = async () => {
+        throw new Error("db down");
+    };
+    const { saveTracksAsPlaylist } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+
+    const result = await saveTracksAsPlaylist("Doomed", ["a", "b"]);
+
+    assert.deepEqual(result, {
+        id: "pl-doomed",
+        added: 0,
+        failedTrackIds: ["a", "b"],
+    });
+});
+
+test("saveTracksAsPlaylist with an empty track list still creates the playlist with 0 added", async () => {
+    let created = false;
+    state.createImpl = async () => {
+        created = true;
+        return { id: "pl-empty" };
+    };
+    state.addImpl = async () => {
+        throw new Error("should not be called");
+    };
+    const { saveTracksAsPlaylist } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+
+    const result = await saveTracksAsPlaylist("Empty", []);
+
+    assert.equal(created, true);
+    assert.deepEqual(result, { id: "pl-empty", added: 0, failedTrackIds: [] });
+});
+
+test("describeSaveResult: a full save reads as success", async () => {
+    const { describeSaveResult } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+    assert.deepEqual(
+        describeSaveResult("Mix", { id: "p", added: 5, failedTrackIds: [] }),
+        { tone: "success", message: "Saved 5 tracks to Mix" }
+    );
+    assert.deepEqual(
+        describeSaveResult("Mix", { id: "p", added: 1, failedTrackIds: [] }),
+        { tone: "success", message: "Saved 1 track to Mix" }
+    );
+});
+
+test("describeSaveResult: a partial save is a warning naming the miss count", async () => {
+    const { describeSaveResult } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+    assert.deepEqual(
+        describeSaveResult("Mix", {
+            id: "p",
+            added: 3,
+            failedTrackIds: ["x"],
+        }),
+        {
+            tone: "warning",
+            message:
+                "Saved 3 of 4 tracks to Mix — 1 track couldn't be added",
+        }
+    );
+    assert.equal(
+        describeSaveResult("Mix", {
+            id: "p",
+            added: 0,
+            failedTrackIds: ["x", "y"],
+        }).tone,
+        "warning"
+    );
+});
+
+test("formatPlaylistDate renders 'MMM D' (e.g. Jul 15)", async () => {
+    const { formatPlaylistDate } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+    // Local-time construction avoids UTC-offset day-boundary flakiness.
+    const d = new Date(2026, 6, 15, 12, 0, 0); // July 15 2026, noon local
+    assert.equal(formatPlaylistDate(d), "Jul 15");
+});
+
+test("formatPlaylistDate does not zero-pad the day", async () => {
+    const { formatPlaylistDate } = await import(
+        "../../components/vibe/savePlaylist"
+    );
+    const d = new Date(2026, 0, 5, 12, 0, 0); // January 5
+    assert.equal(formatPlaylistDate(d), "Jan 5");
+});


### PR DESCRIPTION
Part of #203 — slice 2 of 6 rebuilding the interactive vibe map (superseded PR #163, reviewed head `421f0fa`).

## Review finding addressed (silent partial playlist saves)

`saveTracksAsPlaylist` previously swallowed individual add failures in a bare `catch` and returned only a success count — a partial save was indistinguishable from a full one, and callers toasted unconditional success.

- The result now carries **`failedTrackIds`** (attempt order) alongside `added`.
- Every failed add is **logged through `frontend/lib/logger.ts`** (scoped `vibe:savePlaylist`): one warning per failed track (with playlist id/name, track id, error message) plus a partial-save summary warning.
- New **`describeSaveResult`** maps a result onto the one honest toast: `success` only when every track landed, otherwise a `warning` naming how many tracks were skipped ("Saved 3 of 4 tracks to X — 1 track couldn't be added"). Callers pick their toast flavor from its `tone` — the call sites adopt it in slices 5/6.

Sequential adds (playlist order is the caller's listening order) and one-bad-track-never-aborts-the-rest semantics are unchanged.

## Tests

Component suite covers: sequential ordering, dedupe, **partial save** (failed ids in the result + the logged-warning contract), **fully-failed save**, empty save, and the `describeSaveResult` success/warning messages.

## Verification

verify: savePlaylist component suite 9/9 pass; frontend `tsc --noEmit` exit 0; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)