### PR TITLE
fix(analyzer): reliability — requeue semantics, resource leaks, races (refactor slice P10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The three backend audio-analyzer source-contract suites
+  (`audioAnalyzerQueueContract`, `audioAnalyzerPoolRecoveryContract`,
+  `audioAnalyzerFailureResolutionContract`) were updated in step with the
+  analyzer reliability refactor: the marker strings they scrape from
+  `analyzer.py` moved into the new `_claim_tracks_for_processing` /
+  `_consume_batch_results` helpers and the module-level
+  `_RESOLVE_AUDIO_FAILURES_SQL` constant, so the tests now assert against
+  those boundaries (and additionally prove `_save_results` executes the
+  failure-resolution SQL).
 - Audio analyzer sidecar no longer runs a PostgreSQL worker-count query at
   module import. Because the service uses multiprocessing spawn mode, every
   spawned worker process re-imported the module and re-executed that query;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Audio analyzer batch-timeout retry semantics (analyzer reliability slice):
+  when an analysis batch hits `BATCH_ANALYSIS_TIMEOUT_SECONDS`, tracks that
+  never started running are now re-queued as `pending` WITHOUT consuming any
+  retry budget, and tracks that were genuinely in flight fail non-permanently
+  (consuming exactly one retry unit, retried up to `MAX_RETRIES`). Previously
+  every unfinished track in a timed-out batch was failed permanently — a single
+  slow batch could silently and irreversibly shrink the analyzed library.
+  Results that completed just as the timeout fired are now drained and saved
+  instead of being dropped.
+
 ### Fixed
 
+- Audio analyzer sidecar no longer runs a PostgreSQL worker-count query at
+  module import. Because the service uses multiprocessing spawn mode, every
+  spawned worker process re-imported the module and re-executed that query;
+  worker-count resolution now happens once, explicitly, at service startup in
+  the parent process.
+- CLAP sidecar idle monitor no longer leaks a new Redis connection pool on
+  every idle-check iteration; it now reuses a single injected client that is
+  deterministically closed on shutdown (as is the idle DB connection, which
+  previously stayed open if the main loop exited via an exception).
+- CLAP sidecar worker/text-embed/control daemon threads are now supervised:
+  if any thread dies, the service logs a critical error, stops cleanly, and
+  exits non-zero so the container orchestrator restarts it instead of leaving
+  a zombie pod that consumes no work.
+- CLAP model unload/inference race fixed: idle unloading and embedding
+  inference now serialize on one re-entrant lock, and embedding calls reload
+  the model under that lock if an idle unload wins the race — previously the
+  race raised mid-call, spuriously failing the track and burning its vibe
+  retry budget.
+- Python sidecars no longer use deprecated `datetime.utcnow()`; analyzer
+  timestamps are timezone-aware UTC (`datetime.now(timezone.utc)`).
 - Dev tooling: repaired the broken local compose files — `docker-compose.local.yml`'s
   `audio-analysis` profile pointed its analyzers' `depends_on` and connection URLs
   at nonexistent `postgres`/`redis` services (the services are

--- a/backend/src/__tests__/audioAnalyzerFailureResolutionContract.test.ts
+++ b/backend/src/__tests__/audioAnalyzerFailureResolutionContract.test.ts
@@ -20,16 +20,22 @@ describe("audio analyzer stale failure resolution contract", () => {
             "../../../services/audio-analyzer/analyzer.py"
         );
         const source = fs.readFileSync(analyzerPath, "utf8");
+        const resolveFailuresSqlSection = extractSection(
+            source,
+            "_RESOLVE_AUDIO_FAILURES_SQL = ",
+            "def _analysis_result_values"
+        );
         const saveResultsSection = extractSection(
             source,
             "def _save_results",
             "def _save_failed"
         );
 
-        expect(saveResultsSection).toContain(`UPDATE "EnrichmentFailure"`);
-        expect(saveResultsSection).toContain(`"entityType" = 'audio'`);
-        expect(saveResultsSection).toContain(`"entityId" = %s`);
-        expect(saveResultsSection).toContain("resolved = true");
-        expect(saveResultsSection).toContain(`resolved = false`);
+        expect(resolveFailuresSqlSection).toContain(`UPDATE "EnrichmentFailure"`);
+        expect(resolveFailuresSqlSection).toContain(`"entityType" = 'audio'`);
+        expect(resolveFailuresSqlSection).toContain(`"entityId" = %s`);
+        expect(resolveFailuresSqlSection).toContain("resolved = true");
+        expect(resolveFailuresSqlSection).toContain(`resolved = false`);
+        expect(saveResultsSection).toContain("_RESOLVE_AUDIO_FAILURES_SQL");
     });
 });

--- a/backend/src/__tests__/audioAnalyzerPoolRecoveryContract.test.ts
+++ b/backend/src/__tests__/audioAnalyzerPoolRecoveryContract.test.ts
@@ -23,8 +23,8 @@ describe("audio analyzer process-pool recovery contract", () => {
         const source = fs.readFileSync(analyzerPath, "utf8");
         const processSection = extractSection(
             source,
-            "def _process_tracks_parallel",
-            "def _save_results"
+            "def _consume_batch_results",
+            "def _handle_batch_timeout"
         );
 
         expect(processSection).toContain("self._is_pool_crash_error(e)");

--- a/backend/src/__tests__/audioAnalyzerQueueContract.test.ts
+++ b/backend/src/__tests__/audioAnalyzerQueueContract.test.ts
@@ -23,8 +23,8 @@ describe("audio analyzer queue contract", () => {
 
         const processBatchSection = extractSection(
             analyzerSource,
-            "def _process_tracks_parallel",
-            "def _save_results"
+            "def _claim_tracks_for_processing",
+            "def _save_completed_future"
         );
 
         expect(processBatchSection).toContain(
@@ -60,8 +60,8 @@ describe("audio analyzer queue contract", () => {
         );
         const processBatchSection = extractSection(
             analyzerSource,
-            "def _process_tracks_parallel",
-            "def _save_results"
+            "def _claim_tracks_for_processing",
+            "def _save_completed_future"
         );
 
         const producersPreclaimProcessing =
@@ -75,4 +75,3 @@ describe("audio analyzer queue contract", () => {
         expect(consumerAcceptsProcessing).toBe(true);
     });
 });
-

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -17,6 +17,7 @@ Architecture:
 - CLAPAnalyzer: Model loading and embedding generation
 - Worker: Queue consumer that processes tracks and stores embeddings
 - TextEmbedHandler: Real-time text embedding via Redis Streams consumer groups
+- Supervised main loop: Detects failed service threads and manages idle unloading
 """
 
 import os
@@ -27,7 +28,7 @@ import time
 import gc
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 import traceback
 import numpy as np
@@ -88,6 +89,7 @@ REDIS_SOCKET_TIMEOUT = get_blocking_socket_timeout(
 NUM_WORKERS = get_int_env('NUM_WORKERS', 2)
 BACKEND_URL = os.getenv('BACKEND_URL', 'http://backend:3006')
 MODEL_IDLE_TIMEOUT = get_int_env('MODEL_IDLE_TIMEOUT', 300)
+IDLE_POLL_SECONDS = 5
 
 # Queue and channel names
 ANALYSIS_QUEUE = 'audio:clap:queue'
@@ -114,13 +116,15 @@ class CLAPAnalyzer:
 
     Uses HTSAT-base architecture with the music_audioset checkpoint,
     optimized for music similarity tasks. Supports idle model unloading
-    to free memory when no work is pending.
+    to free memory when no work is pending. Inference and unloading serialize
+    on one re-entrant lock; embedding calls reload under that lock if an idle
+    unload wins the race after the optimistic preload.
     """
 
     def __init__(self):
         """Initialize analyzer state and lazy model-loading controls."""
         self.model = None
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self.last_work_time: float = time.time()
         self._model_loaded = False
 
@@ -249,6 +253,8 @@ class CLAPAnalyzer:
             logger.debug(f"Loaded audio: {len(audio)/sr:.1f}s at {sr}Hz")
 
             with self._lock:
+                if self.model is None:
+                    self.load_model()
                 # Use get_audio_embedding_from_data for pre-loaded audio
                 # This gives us control over memory usage
                 embeddings = self.model.get_audio_embedding_from_data(
@@ -288,6 +294,8 @@ class CLAPAnalyzer:
 
         try:
             with self._lock:
+                if self.model is None:
+                    self.load_model()
                 # CLAP expects a list of text prompts
                 embeddings = self.model.get_text_embedding(
                     [text],
@@ -351,7 +359,7 @@ class DatabaseConnection:
         self.connect()
 
     def get_cursor(self) -> RealDictCursor:
-        """Get a database cursor, reconnecting if necessary"""
+        """Reconnect if needed and return a RealDictCursor-factory cursor."""
         if not self.is_connected():
             self.reconnect()
         return self.conn.cursor(cursor_factory=RealDictCursor)
@@ -479,7 +487,7 @@ class Worker:
                     "vibeAnalysisStatus" = %s,
                     "vibeAnalysisStatusUpdatedAt" = %s
                 WHERE id = %s
-            """, (status, datetime.utcnow(), track_id))
+            """, (status, datetime.now(timezone.utc), track_id))
             self.db.commit()
         except Exception as e:
             logger.error(f"Failed to update track vibe status: {e}")
@@ -504,7 +512,7 @@ class Worker:
                     "vibeAnalysisRetryCount" = COALESCE("vibeAnalysisRetryCount", 0) + 1,
                     "vibeAnalysisStatusUpdatedAt" = %s
                 WHERE id = %s
-            """, (error[:500], datetime.utcnow(), track_id))
+            """, (error[:500], datetime.now(timezone.utc), track_id))
             self.db.commit()
             logger.error(f"Track {track_id} failed: {error}")
 
@@ -549,7 +557,7 @@ class Worker:
                     embedding = EXCLUDED.embedding,
                     model_version = EXCLUDED.model_version,
                     analyzed_at = EXCLUDED.analyzed_at
-            """, (track_id, embedding_list, MODEL_VERSION, datetime.utcnow()))
+            """, (track_id, embedding_list, MODEL_VERSION, datetime.now(timezone.utc)))
 
             self.db.commit()
             return True
@@ -833,8 +841,90 @@ class ControlHandler:
             traceback.print_exc()
 
 
-def main():
-    """Main entry point"""
+def find_dead_threads(threads: list[threading.Thread]) -> list[str]:
+    """Return the names of supervised threads that are no longer alive."""
+    return [thread.name for thread in threads if not thread.is_alive()]
+
+
+def _check_for_completed_work(analyzer, idle_db, queue_client):
+    """Unload the model when the database and analysis queue have no work."""
+    try:
+        cursor = idle_db.get_cursor()
+        try:
+            cursor.execute("""
+                SELECT COUNT(*) as cnt FROM "Track" t
+                LEFT JOIN track_embeddings te ON t.id = te.track_id
+                WHERE te.track_id IS NULL AND t."filePath" IS NOT NULL
+            """)
+            remaining = cursor.fetchone()['cnt']
+        finally:
+            cursor.close()
+
+        queue_len = queue_client.llen(ANALYSIS_QUEUE)
+        if remaining == 0 and queue_len == 0:
+            analyzer.unload_model()
+            logger.info("All tracks have embeddings, model unloaded (will reload when work arrives)")
+    except Exception as e:
+        logger.debug(f"Idle check failed: {e}")
+        idle_db.reconnect()
+
+
+def run_idle_monitor(analyzer, stop_event, idle_db, queue_client, threads):
+    """Supervise service threads and unload the model during idle periods."""
+    while not stop_event.is_set():
+        dead = find_dead_threads(threads)
+        if dead:
+            logger.critical(f"Service thread(s) stopped unexpectedly: {', '.join(dead)}")
+            stop_event.set()
+            return False
+
+        if analyzer._model_loaded:
+            idle_seconds = time.time() - analyzer.last_work_time
+            if idle_seconds >= MODEL_IDLE_TIMEOUT > 0:
+                analyzer.unload_model()
+                logger.info(
+                    f"Model idle for {idle_seconds:.0f}s, unloaded to free memory "
+                    "(will reload when work arrives)"
+                )
+            elif idle_seconds >= SLEEP_INTERVAL * 2:
+                _check_for_completed_work(analyzer, idle_db, queue_client)
+
+        stop_event.wait(IDLE_POLL_SECONDS)
+    return True
+
+
+def _start_threads(
+    analyzer: CLAPAnalyzer,
+    stop_event: threading.Event,
+) -> list[threading.Thread]:
+    """Construct and start the worker, text-embedding, and control threads."""
+    threads = []
+    for i in range(NUM_WORKERS):
+        worker = Worker(i, analyzer, stop_event)
+        thread = threading.Thread(target=worker.start, name=f"Worker-{i}")
+        thread.daemon = True
+        thread.start()
+        threads.append(thread)
+        logger.info(f"Started worker thread {i}")
+
+    text_handler = TextEmbedHandler(analyzer, stop_event)
+    text_thread = threading.Thread(target=text_handler.start, name="TextEmbedHandler")
+    text_thread.daemon = True
+    text_thread.start()
+    threads.append(text_thread)
+    logger.info("Started text embed handler thread")
+
+    control_handler = ControlHandler(stop_event)
+    control_thread = threading.Thread(target=control_handler.start, name="ControlHandler")
+    control_thread.daemon = True
+    control_thread.start()
+    threads.append(control_thread)
+    logger.info("Started control handler thread")
+    return threads
+
+
+def _log_startup_configuration():
+    """Log the effective CLAP analyzer runtime configuration."""
     logger.info("=" * 60)
     logger.info("CLAP Audio Analyzer Service")
     logger.info("=" * 60)
@@ -847,89 +937,58 @@ def main():
     logger.info(f"  Model idle timeout: {MODEL_IDLE_TIMEOUT}s")
     logger.info("=" * 60)
 
-    # Load model once (shared across all workers)
+
+def main():
+    """Start and supervise the CLAP analyzer service until shutdown."""
+    _log_startup_configuration()
     analyzer = CLAPAnalyzer()
     analyzer.load_model()
-
-    # Stop event for graceful shutdown
     stop_event = threading.Event()
 
     def signal_handler(signum, frame):
+        """Request graceful shutdown after an operating-system signal."""
         logger.info(f"Received signal {signum}, initiating graceful shutdown...")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
-
-    threads = []
-
-    # Start worker threads
-    for i in range(NUM_WORKERS):
-        worker = Worker(i, analyzer, stop_event)
-        thread = threading.Thread(target=worker.start, name=f"Worker-{i}")
-        thread.daemon = True
-        thread.start()
-        threads.append(thread)
-        logger.info(f"Started worker thread {i}")
-
-    # Start text embed handler thread
-    text_handler = TextEmbedHandler(analyzer, stop_event)
-    text_thread = threading.Thread(target=text_handler.start, name="TextEmbedHandler")
-    text_thread.daemon = True
-    text_thread.start()
-    threads.append(text_thread)
-    logger.info("Started text embed handler thread")
-
-    # Start control handler thread (listens for worker count changes)
-    control_handler = ControlHandler(stop_event)
-    control_thread = threading.Thread(target=control_handler.start, name="ControlHandler")
-    control_thread.daemon = True
-    control_thread.start()
-    threads.append(control_thread)
-    logger.info("Started control handler thread")
-
-    # Main loop: monitor idle state and unload model when not needed
+    threads = _start_threads(analyzer, stop_event)
     idle_db = DatabaseConnection(DATABASE_URL)
-    idle_db.connect()
+    queue_client = None
+    healthy = False
     try:
-        while not stop_event.is_set():
-            time.sleep(5)
-            if analyzer._model_loaded:
-                idle_seconds = time.time() - analyzer.last_work_time
-                if idle_seconds >= MODEL_IDLE_TIMEOUT > 0:
-                    analyzer.unload_model()
-                    logger.info(f"Model idle for {idle_seconds:.0f}s, unloaded to free memory (will reload when work arrives)")
-                elif idle_seconds >= SLEEP_INTERVAL * 2:
-                    # Check if all work is truly done -- unload immediately
-                    try:
-                        cursor = idle_db.get_cursor()
-                        cursor.execute("""
-                            SELECT COUNT(*) as cnt FROM "Track" t
-                            LEFT JOIN track_embeddings te ON t.id = te.track_id
-                            WHERE te.track_id IS NULL AND t."filePath" IS NOT NULL
-                        """)
-                        remaining = cursor.fetchone()['cnt']
-                        cursor.close()
-                        queue_len = redis.from_url(REDIS_URL).llen(ANALYSIS_QUEUE)
-                        if remaining == 0 and queue_len == 0:
-                            analyzer.unload_model()
-                            logger.info("All tracks have embeddings, model unloaded (will reload when work arrives)")
-                    except Exception as e:
-                        logger.debug(f"Idle check failed: {e}")
-                        idle_db.reconnect()
+        idle_db.connect()
+        queue_client = redis.from_url(
+            REDIS_URL,
+            socket_timeout=REDIS_SOCKET_TIMEOUT,
+        )
+        healthy = run_idle_monitor(analyzer, stop_event, idle_db, queue_client, threads)
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt received")
         stop_event.set()
+        healthy = True
+    except Exception as e:
+        logger.critical(f"CLAP Analyzer service failed: {e}")
+        stop_event.set()
+    finally:
+        try:
+            idle_db.close()
+        except Exception as e:
+            logger.warning(f"Failed to close idle database: {e}")
+        if queue_client is not None:
+            try:
+                queue_client.close()
+            except Exception as e:
+                logger.warning(f"Failed to close idle Redis client: {e}")
 
-    # Cleanup
-    idle_db.close()
-
-    # Wait for threads to finish
     logger.info("Waiting for threads to finish...")
     for thread in threads:
         thread.join(timeout=10)
 
-    logger.info("CLAP Analyzer service stopped")
+    if not healthy:
+        logger.critical("CLAP Analyzer service unhealthy; exiting for container restart")
+        sys.exit(1)
+    logger.info("CLAP Analyzer service stopped cleanly")
 
 
 if __name__ == '__main__':

--- a/services/audio-analyzer-clap/tests/test_reliability.py
+++ b/services/audio-analyzer-clap/tests/test_reliability.py
@@ -1,0 +1,376 @@
+"""Red-phase contracts for CLAP analyzer runtime reliability."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Iterator
+
+import numpy as np
+import pytest
+
+
+ANALYZER_PATH = Path(__file__).resolve().parents[1] / "analyzer.py"
+
+
+class RealDictCursor:
+    """Placeholder cursor factory used by the analyzer import."""
+
+
+class ResponseError(Exception):
+    """Placeholder Redis response error used by handler exception clauses."""
+
+
+class FakeRedisClient:
+    """Placeholder client returned by the recording Redis constructor."""
+
+
+def _stub_torch() -> ModuleType:
+    """Build the minimal CPU-only torch module used during import."""
+    torch_stub = ModuleType("torch")
+
+    class Cuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    torch_stub.set_num_threads = lambda _count: None  # type: ignore[attr-defined]
+    torch_stub.cuda = Cuda()  # type: ignore[attr-defined]
+    torch_stub.device = lambda name: name  # type: ignore[attr-defined]
+    return torch_stub
+
+
+def _stub_redis(
+    from_url_calls: list[tuple[Any, ...]],
+) -> tuple[ModuleType, ModuleType]:
+    """Build Redis modules whose constructor calls remain inspectable."""
+    redis_stub = ModuleType("redis")
+    exceptions_stub = ModuleType("redis.exceptions")
+
+    def from_url(*args: Any, **kwargs: Any) -> FakeRedisClient:
+        from_url_calls.append((*args, kwargs))
+        return FakeRedisClient()
+
+    redis_stub.from_url = from_url  # type: ignore[attr-defined]
+    redis_stub.exceptions = exceptions_stub  # type: ignore[attr-defined]
+    exceptions_stub.ResponseError = ResponseError  # type: ignore[attr-defined]
+    return redis_stub, exceptions_stub
+
+
+def _stub_psycopg2(
+    connect_calls: list[tuple[Any, ...]],
+) -> tuple[ModuleType, ModuleType]:
+    """Build psycopg2 modules with a recording, fail-closed connector."""
+    psycopg2_stub = ModuleType("psycopg2")
+    extras_stub = ModuleType("psycopg2.extras")
+
+    def connect(*args: Any, **kwargs: Any) -> None:
+        connect_calls.append((*args, kwargs))
+        raise RuntimeError("stubbed PostgreSQL connection")
+
+    psycopg2_stub.connect = connect  # type: ignore[attr-defined]
+    psycopg2_stub.Error = Exception  # type: ignore[attr-defined]
+    psycopg2_stub.extras = extras_stub  # type: ignore[attr-defined]
+    extras_stub.RealDictCursor = RealDictCursor  # type: ignore[attr-defined]
+    return psycopg2_stub, extras_stub
+
+
+def _stub_pgvector() -> tuple[ModuleType, ModuleType]:
+    """Build pgvector modules with a no-op registration hook."""
+    pgvector_stub = ModuleType("pgvector")
+    psycopg2_stub = ModuleType("pgvector.psycopg2")
+    psycopg2_stub.register_vector = lambda _conn: None  # type: ignore[attr-defined]
+    pgvector_stub.psycopg2 = psycopg2_stub  # type: ignore[attr-defined]
+    return pgvector_stub, psycopg2_stub
+
+
+def _stub_requests(post_calls: list[tuple[Any, ...]]) -> ModuleType:
+    """Build requests with a recording post function."""
+    requests_stub = ModuleType("requests")
+
+    def post(*args: Any, **kwargs: Any) -> None:
+        post_calls.append((*args, kwargs))
+
+    requests_stub.post = post  # type: ignore[attr-defined]
+    return requests_stub
+
+
+@pytest.fixture(scope="module")
+def loaded_analyzer() -> Iterator[tuple[ModuleType, list[tuple[Any, ...]]]]:
+    """Load analyzer.py once with hand-rolled dependency stubs."""
+    monkeypatch = pytest.MonkeyPatch()
+    from_url_calls: list[tuple[Any, ...]] = []
+    connect_calls: list[tuple[Any, ...]] = []
+    post_calls: list[tuple[Any, ...]] = []
+
+    torch_stub = _stub_torch()
+    redis_stub, redis_exceptions_stub = _stub_redis(from_url_calls)
+    psycopg2_stub, extras_stub = _stub_psycopg2(connect_calls)
+    pgvector_stub, pgvector_psycopg2_stub = _stub_pgvector()
+    librosa_stub = ModuleType("librosa")
+    requests_stub = _stub_requests(post_calls)
+
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    monkeypatch.setitem(sys.modules, "redis", redis_stub)
+    monkeypatch.setitem(sys.modules, "redis.exceptions", redis_exceptions_stub)
+    monkeypatch.setitem(sys.modules, "psycopg2", psycopg2_stub)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", extras_stub)
+    monkeypatch.setitem(sys.modules, "pgvector", pgvector_stub)
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", pgvector_psycopg2_stub)
+    monkeypatch.setitem(sys.modules, "librosa", librosa_stub)
+    monkeypatch.setitem(sys.modules, "requests", requests_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "clap_analyzer_module",
+        ANALYZER_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    assert connect_calls == []
+    yield module, from_url_calls
+    monkeypatch.undo()
+
+
+def test_get_audio_embedding_survives_unload_between_ensure_and_inference(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module, _ = loaded_analyzer
+    analyzer = module.CLAPAnalyzer()
+    load_calls: list[bool] = []
+
+    class FakeModel:
+        def get_audio_embedding_from_data(
+            self,
+            audio_list: list[np.ndarray],
+            use_tensor: bool = False,
+        ) -> np.ndarray:
+            assert len(audio_list) == 1
+            assert use_tensor is False
+            return np.zeros((1, 512), dtype=np.float32)
+
+    def load_model() -> None:
+        load_calls.append(True)
+        analyzer.model = FakeModel()
+        analyzer._model_loaded = True
+
+    def load_audio_chunk(
+        _audio_path: str,
+        _duration_hint: float | None = None,
+    ) -> tuple[np.ndarray, int]:
+        analyzer.unload_model()
+        return np.zeros(48000, dtype=np.float32), 48000
+
+    monkeypatch.setattr(analyzer, "load_model", load_model)
+    monkeypatch.setattr(analyzer, "_load_audio_chunk", load_audio_chunk)
+    audio_path = tmp_path / "track.flac"
+    audio_path.touch()
+
+    embedding = analyzer.get_audio_embedding(str(audio_path))
+
+    assert isinstance(embedding, np.ndarray)
+    assert embedding.shape == (512,)
+    assert load_calls == [True, True]
+
+
+def test_unload_model_blocks_while_inference_holds_the_lock(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    analyzer = module.CLAPAnalyzer()
+    inference_started = threading.Event()
+    release = threading.Event()
+    scheduling_window = threading.Event()
+    result: list[np.ndarray | None] = []
+
+    class FakeBlockingModel:
+        def get_text_embedding(
+            self,
+            text_list: list[str],
+            use_tensor: bool = False,
+        ) -> np.ndarray:
+            assert text_list == ["mellow jazz"]
+            assert use_tensor is False
+            inference_started.set()
+            assert release.wait(timeout=5)
+            return np.zeros((1, 512), dtype=np.float32)
+
+    analyzer.model = FakeBlockingModel()
+    analyzer._model_loaded = True
+    inference_thread = threading.Thread(
+        target=lambda: result.append(analyzer.get_text_embedding("mellow jazz")),
+        name="InferenceThread",
+    )
+    unload_thread = threading.Thread(
+        target=analyzer.unload_model,
+        name="UnloadThread",
+    )
+
+    inference_thread.start()
+    assert inference_started.wait(timeout=5)
+    unload_thread.start()
+    assert not scheduling_window.wait(timeout=0.05)
+    try:
+        assert unload_thread.is_alive()
+        assert analyzer.model is not None
+    finally:
+        release.set()
+        inference_thread.join(timeout=5)
+        unload_thread.join(timeout=5)
+
+    assert not inference_thread.is_alive()
+    assert not unload_thread.is_alive()
+    assert result and result[0] is not None
+    assert analyzer.model is None
+    assert isinstance(analyzer._lock, type(threading.RLock()))
+
+
+def test_find_dead_threads_reports_only_finished_threads(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    find_dead_threads = module.find_dead_threads
+    release = threading.Event()
+    finished_thread = threading.Thread(target=lambda: None, name="FinishedThread")
+
+    def wait_until_released() -> None:
+        assert release.wait(timeout=5)
+
+    alive_thread = threading.Thread(target=wait_until_released, name="AliveThread")
+
+    finished_thread.start()
+    finished_thread.join(timeout=5)
+    assert not finished_thread.is_alive()
+    alive_thread.start()
+    try:
+        assert find_dead_threads([finished_thread, alive_thread]) == ["FinishedThread"]
+    finally:
+        release.set()
+        alive_thread.join(timeout=5)
+    assert not alive_thread.is_alive()
+
+
+def test_run_idle_monitor_stops_and_reports_when_a_thread_dies(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, from_url_calls = loaded_analyzer
+
+    class FakeAnalyzer:
+        _model_loaded = False
+        last_work_time = time.time()
+
+        def unload_model(self) -> None:
+            pass
+
+    class FakeIdleDatabase:
+        def get_cursor(self) -> None:
+            raise AssertionError("idle database must not be queried")
+
+    class FakeQueueClient:
+        def __init__(self) -> None:
+            self.llen_calls: list[str] = []
+
+        def llen(self, name: str) -> int:
+            self.llen_calls.append(name)
+            return 0
+
+    finished_thread = threading.Thread(target=lambda: None, name="DeadWorker")
+    finished_thread.start()
+    finished_thread.join(timeout=5)
+    assert not finished_thread.is_alive()
+    stop_event = threading.Event()
+    queue_client = FakeQueueClient()
+    initial_from_url_calls = len(from_url_calls)
+
+    clean_stop = module.run_idle_monitor(
+        FakeAnalyzer(),
+        stop_event,
+        FakeIdleDatabase(),
+        queue_client,
+        [finished_thread],
+    )
+
+    assert clean_stop is False
+    assert stop_event.is_set()
+    assert len(from_url_calls) == initial_from_url_calls
+
+
+def test_run_idle_monitor_uses_injected_queue_client_for_early_unload(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, from_url_calls = loaded_analyzer
+    assert module.IDLE_POLL_SECONDS == 5
+    run_idle_monitor = module.run_idle_monitor
+    stop_event = threading.Event()
+    unload_calls: list[bool] = []
+    release = threading.Event()
+
+    class FakeAnalyzer:
+        _model_loaded = True
+        last_work_time = time.time() - (module.SLEEP_INTERVAL * 2 + 1)
+
+        def unload_model(self) -> None:
+            unload_calls.append(True)
+            self._model_loaded = False
+            stop_event.set()
+
+    class FakeCursor:
+        def execute(self, _query: str) -> None:
+            pass
+
+        def fetchone(self) -> dict[str, int]:
+            return {"cnt": 0}
+
+        def close(self) -> None:
+            pass
+
+    class FakeIdleDatabase:
+        def get_cursor(self) -> FakeCursor:
+            return FakeCursor()
+
+    class FakeQueueClient:
+        def __init__(self) -> None:
+            self.llen_calls: list[str] = []
+
+        def llen(self, name: str) -> int:
+            self.llen_calls.append(name)
+            return 0
+
+    def wait_until_released() -> None:
+        assert release.wait(timeout=5)
+
+    healthy_thread = threading.Thread(target=wait_until_released, name="HealthyWorker")
+    queue_client = FakeQueueClient()
+    initial_from_url_calls = len(from_url_calls)
+    healthy_thread.start()
+    try:
+        clean_stop = run_idle_monitor(
+            FakeAnalyzer(),
+            stop_event,
+            FakeIdleDatabase(),
+            queue_client,
+            [healthy_thread],
+        )
+    finally:
+        release.set()
+        healthy_thread.join(timeout=5)
+
+    assert not healthy_thread.is_alive()
+    assert clean_stop is True
+    assert unload_calls == [True]
+    assert queue_client.llen_calls == [module.ANALYSIS_QUEUE]
+    assert len(from_url_calls) == initial_from_url_calls
+
+
+def test_clap_analyzer_source_does_not_use_deprecated_datetime_utcnow() -> None:
+    source = ANALYZER_PATH.read_text(encoding="utf-8")
+
+    assert "datetime.utcnow" not in source
+    assert "utcnow()" not in source

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -70,7 +70,7 @@ import json
 import time
 import gc
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Tuple
 import traceback
 import numpy as np
@@ -164,7 +164,8 @@ RESIZE_DEBOUNCE_SECONDS = 5
 # Set to 0 to disable file-size guardrail.
 # Default is tuned for FLAC-heavy libraries with larger hi-res tracks.
 MAX_FILE_SIZE_MB = get_int_env('MAX_FILE_SIZE_MB', 500)
-# Hard timeout for an entire analysis batch before remaining tracks are failed permanently.
+# Hard timeout for an entire analysis batch. Never-started tracks are requeued
+# without retry cost; in-flight tracks fail non-permanently and consume one retry.
 BATCH_ANALYSIS_TIMEOUT_SECONDS = get_int_env('BATCH_ANALYSIS_TIMEOUT_SECONDS', 900)
 
 
@@ -190,7 +191,7 @@ class DatabaseConnection:
         logger.info("Connected to PostgreSQL with UTF-8 encoding")
 
     def get_cursor(self) -> RealDictCursor:
-        """Get a database cursor"""
+        """Lazily connect and return a RealDictCursor-factory cursor."""
         if not self.conn:
             self.connect()
         return self.conn.cursor(cursor_factory=RealDictCursor)
@@ -250,8 +251,7 @@ def _get_workers_from_db() -> int:
 # Conservative default: 2 workers (stable on any system)
 # Previous default used auto-scaling which could cause OOM on memory-constrained systems
 DEFAULT_WORKERS = 2
-# Try to load from database first, fall back to env var or default
-NUM_WORKERS = _get_workers_from_db()
+NUM_WORKERS = get_int_env('NUM_WORKERS', DEFAULT_WORKERS)
 ESSENTIA_VERSION = '2.1b6-enhanced-v3'
 
 # Retry configuration
@@ -263,6 +263,101 @@ ANALYSIS_QUEUE = 'audio:analysis:queue'
 
 # Control channel for enrichment coordination
 CONTROL_CHANNEL = 'audio:analysis:control'
+
+
+def initialize_worker_count() -> int:
+    """Resolve worker count from the database once in the parent process.
+
+    This is called only from ``main()`` in normal worker mode so spawn-mode
+    child processes never query PostgreSQL while importing this module.
+    """
+    global NUM_WORKERS
+    NUM_WORKERS = _get_workers_from_db()
+    return NUM_WORKERS
+
+
+def partition_unfinished_tracks(futures_map, finalized_track_ids):
+    """Partition timeout work into completed, never-started, and attempted tracks."""
+    completed_unconsumed = []
+    never_started = []
+    attempted = []
+
+    for future, track_info in futures_map.items():
+        track_id, _ = track_info
+        if future.done():
+            if track_id not in finalized_track_ids:
+                completed_unconsumed.append(track_info)
+        elif future.cancel():
+            never_started.append(track_info)
+        else:
+            attempted.append(track_info)
+
+    return completed_unconsumed, never_started, attempted
+
+
+_SAVE_ANALYSIS_RESULTS_SQL = """
+    UPDATE "Track"
+    SET
+        bpm = %s,
+        "beatsCount" = %s,
+        key = %s,
+        "keyScale" = %s,
+        "keyStrength" = %s,
+        energy = %s,
+        loudness = %s,
+        "dynamicRange" = %s,
+        danceability = %s,
+        valence = %s,
+        arousal = %s,
+        instrumentalness = %s,
+        acousticness = %s,
+        speechiness = %s,
+        "moodTags" = %s,
+        "essentiaGenres" = %s,
+        "moodHappy" = %s,
+        "moodSad" = %s,
+        "moodRelaxed" = %s,
+        "moodAggressive" = %s,
+        "moodParty" = %s,
+        "moodAcoustic" = %s,
+        "moodElectronic" = %s,
+        "danceabilityMl" = %s,
+        "analysisMode" = %s,
+        "analysisStatus" = 'completed',
+        "analysisStartedAt" = NULL,
+        "analysisVersion" = %s,
+        "analyzedAt" = %s,
+        "analysisError" = NULL,
+        "updatedAt" = NOW()
+    WHERE id = %s
+"""
+
+_RESOLVE_AUDIO_FAILURES_SQL = """
+    UPDATE "EnrichmentFailure"
+    SET
+        resolved = true,
+        "resolvedAt" = NOW()
+    WHERE "entityType" = 'audio'
+    AND "entityId" = %s
+    AND resolved = false
+"""
+
+
+def _analysis_result_values(track_id: str, features: Dict[str, Any]) -> Tuple[Any, ...]:
+    """Build database values for one successfully analyzed track."""
+    return (
+        features['bpm'], features['beatsCount'], features['key'],
+        features['keyScale'], features['keyStrength'], features['energy'],
+        features['loudness'], features['dynamicRange'], features['danceability'],
+        features['valence'], features['arousal'], features['instrumentalness'],
+        features['acousticness'], features['speechiness'], features['moodTags'],
+        features['essentiaGenres'], features.get('moodHappy'),
+        features.get('moodSad'), features.get('moodRelaxed'),
+        features.get('moodAggressive'), features.get('moodParty'),
+        features.get('moodAcoustic'), features.get('moodElectronic'),
+        features.get('danceabilityMl'), features.get('analysisMode', 'standard'),
+        ESSENTIA_VERSION, datetime.now(timezone.utc), track_id,
+    )
 
 # Model paths (pre-packaged in Docker image)
 MODEL_DIR = '/app/models'
@@ -1740,14 +1835,11 @@ class AnalysisWorker:
         self._process_tracks_parallel(queued_jobs)
         return True
     
-    def _process_tracks_parallel(self, tracks: List[Tuple[str, str]]):
-        """Process multiple tracks in parallel using the process pool"""
-        if not tracks:
-            return
-
-        self._ensure_pool()
-        logger.info(f"Processing batch of {len(tracks)} tracks with {NUM_WORKERS} workers...")
-        
+    def _claim_tracks_for_processing(
+        self,
+        tracks: List[Tuple[str, str]],
+    ) -> List[Tuple[str, str]]:
+        """Mark eligible tracks as processing and discard stale queue entries."""
         # Queue producers may pre-claim tracks as 'processing' before enqueueing
         # (e.g. DB reconciliation / unified enrichment). Accept both 'pending'
         # and 'processing' rows here so freshly queued work is not dropped.
@@ -1773,172 +1865,160 @@ class AnalysisWorker:
 
             if not tracks:
                 logger.info("No pending tracks left in batch after status guard")
-                return
+            return tracks
         except Exception as e:
             logger.error(f"Failed to mark tracks as processing: {e}")
             self.db.rollback()
-            return
+            return []
         finally:
             cursor.close()
-        
-        # Submit all tracks to the process pool
-        start_time = time.time()
+
+    def _save_completed_future(self, future) -> Tuple[str, int, int, int]:
+        """Persist one completed future and return its outcome counters."""
+        track_id, file_path, features = future.result()
+        if features.get('_error'):
+            is_permanent = bool(features.get('_permanent'))
+            self._save_failed(track_id, features['_error'], permanent=is_permanent)
+            if is_permanent:
+                logger.warning(f"⊘ Permanently failed: {file_path} - {features['_error']}")
+                return track_id, 0, 0, 1
+            logger.error(f"✗ Failed: {file_path} - {features['_error']}")
+            return track_id, 0, 1, 0
+
+        self._save_results(track_id, file_path, features)
+        logger.info(f"✓ Completed: {file_path}")
+        return track_id, 1, 0, 0
+
+    def _consume_batch_results(self, futures, tracks, finalized_track_ids, counts):
+        """Consume batch futures while preserving process-pool crash recovery."""
+        for future in as_completed(futures, timeout=BATCH_ANALYSIS_TIMEOUT_SECONDS):
+            try:
+                track_id, succeeded, retryable, permanent = (
+                    self._save_completed_future(future)
+                )
+                finalized_track_ids.add(track_id)
+                counts['completed'] += succeeded
+                counts['failed'] += retryable
+                counts['permanent_failed'] += permanent
+            except Exception as e:
+                if self._is_pool_crash_error(e):
+                    logger.error(f"Process pool worker crash detected: {e}")
+                    for other_future in futures:
+                        if not other_future.done():
+                            other_future.cancel()
+                    remaining_tracks = [
+                        track for track in tracks if track[0] not in finalized_track_ids
+                    ]
+                    self._requeue_tracks_for_retry(
+                        remaining_tracks,
+                        "Analyzer worker process crashed; re-queued for retry",
+                    )
+                    raise BrokenProcessPool(str(e))
+
+                track_info = futures[future]
+                error_message = f"Timeout or error: {e}"
+                is_permanent = "memoryerror" in str(e).lower()
+                self._save_failed(track_info[0], error_message, permanent=is_permanent)
+                finalized_track_ids.add(track_info[0])
+                if is_permanent:
+                    counts['permanent_failed'] += 1
+                    logger.warning(f"⊘ Permanently failed: {track_info[1]} - {e}")
+                else:
+                    counts['failed'] += 1
+                    logger.error(f"✗ Failed: {track_info[1]} - {e}")
+
+    def _handle_batch_timeout(self, futures_map, finalized_track_ids):
+        """Recover unfinished batch work according to its actual attempt state."""
+        completed_tracks, never_started, attempted = partition_unfinished_tracks(
+            futures_map,
+            finalized_track_ids,
+        )
+        futures_by_track_id = {
+            track_info[0]: future for future, track_info in futures_map.items()
+        }
         completed = 0
         failed = 0
         permanent_failed = 0
-        finalized_track_ids = set()
-        
-        futures = {self.executor.submit(_analyze_track_in_process, t): t for t in tracks}
 
-        try:
-            for future in as_completed(futures, timeout=BATCH_ANALYSIS_TIMEOUT_SECONDS):
-                try:
-                    track_id, file_path, features = future.result()
-
-                    if features.get('_error'):
-                        is_permanent = bool(features.get('_permanent'))
-                        self._save_failed(track_id, features['_error'], permanent=is_permanent)
-                        finalized_track_ids.add(track_id)
-                        if is_permanent:
-                            permanent_failed += 1
-                            logger.warning(f"⊘ Permanently failed: {file_path} - {features['_error']}")
-                        else:
-                            failed += 1
-                            logger.error(f"✗ Failed: {file_path} - {features['_error']}")
-                    else:
-                        self._save_results(track_id, file_path, features)
-                        finalized_track_ids.add(track_id)
-                        completed += 1
-                        logger.info(f"✓ Completed: {file_path}")
-                except Exception as e:
-                    if self._is_pool_crash_error(e):
-                        logger.error(f"Process pool worker crash detected: {e}")
-                        for other_future in futures:
-                            if not other_future.done():
-                                other_future.cancel()
-                        remaining_tracks = [
-                            track for track in tracks if track[0] not in finalized_track_ids
-                        ]
-                        self._requeue_tracks_for_retry(
-                            remaining_tracks,
-                            "Analyzer worker process crashed; re-queued for retry",
-                        )
-                        raise BrokenProcessPool(str(e))
-
-                    track_info = futures[future]
-                    error_message = f"Timeout or error: {e}"
-                    is_permanent = "memoryerror" in str(e).lower()
-                    self._save_failed(track_info[0], error_message, permanent=is_permanent)
-                    finalized_track_ids.add(track_info[0])
-                    if is_permanent:
-                        permanent_failed += 1
-                        logger.warning(f"⊘ Permanently failed: {track_info[1]} - {e}")
-                    else:
-                        failed += 1
-                        logger.error(f"✗ Failed: {track_info[1]} - {e}")
-        except FuturesTimeoutError:
-            logger.error(
-                f"Batch timed out after {BATCH_ANALYSIS_TIMEOUT_SECONDS}s - failing unfinished tracks permanently"
-            )
-            for future, track_info in futures.items():
-                if future.done():
-                    continue
-                future.cancel()
-                self._save_failed(
-                    track_info[0],
-                    f"Batch timeout after {BATCH_ANALYSIS_TIMEOUT_SECONDS}s",
-                    permanent=True,
+        for expected_track_id, expected_file_path in completed_tracks:
+            future = futures_by_track_id[expected_track_id]
+            try:
+                _, succeeded, retryable, permanent = self._save_completed_future(
+                    future
                 )
-                permanent_failed += 1
-                logger.warning(f"⊘ Permanently failed (batch timeout): {track_info[1]}")
-        
+                completed += succeeded
+                failed += retryable
+                permanent_failed += permanent
+            except Exception as e:
+                error = f"Batch timeout result error for {expected_file_path}: {e}"
+                logger.error(error)
+                self._save_failed(expected_track_id, error, permanent=False)
+                failed += 1
+
+        requeue_reason = "Batch timeout; no retry budget was consumed"
+        self._requeue_tracks_for_retry(never_started, requeue_reason)
+        timeout_error = f"Batch timeout after {BATCH_ANALYSIS_TIMEOUT_SECONDS}s"
+        for track_id, _ in attempted:
+            self._save_failed(track_id, timeout_error, permanent=False)
+            failed += 1
+
+        requeued = len(never_started)
+        logger.warning(
+            "Batch timeout outcome: %s completed, %s failed, %s permanently "
+            "failed, %s requeued without retry cost",
+            completed, failed, permanent_failed, requeued,
+        )
+        return completed, failed, permanent_failed, requeued
+
+    def _process_tracks_parallel(self, tracks: List[Tuple[str, str]]):
+        """Claim and process one track batch using the process pool."""
+        if not tracks:
+            return
+
+        self._ensure_pool()
+        logger.info(f"Processing batch of {len(tracks)} tracks with {NUM_WORKERS} workers...")
+        tracks = self._claim_tracks_for_processing(tracks)
+        if not tracks:
+            return
+
+        start_time = time.time()
+        finalized_track_ids = set()
+        futures = {self.executor.submit(_analyze_track_in_process, t): t for t in tracks}
+        counts = {'completed': 0, 'failed': 0, 'permanent_failed': 0}
+        requeued = 0
+        try:
+            self._consume_batch_results(
+                futures,
+                tracks,
+                finalized_track_ids,
+                counts,
+            )
+        except FuturesTimeoutError:
+            timeout_completed, timeout_failed, timeout_permanent, requeued = (
+                self._handle_batch_timeout(futures, finalized_track_ids)
+            )
+            counts['completed'] += timeout_completed
+            counts['failed'] += timeout_failed
+            counts['permanent_failed'] += timeout_permanent
+
         elapsed = time.time() - start_time
         rate = len(tracks) / elapsed if elapsed > 0 else 0
         logger.info(
-            f"Batch complete: {completed} succeeded, {failed} failed, {permanent_failed} permanently failed in {elapsed:.1f}s ({rate:.1f} tracks/sec)"
+            f"Batch complete: {counts['completed']} succeeded, {counts['failed']} failed, {counts['permanent_failed']} permanently failed, {requeued} requeued in {elapsed:.1f}s ({rate:.1f} tracks/sec)"
         )
     
     def _save_results(self, track_id: str, file_path: str, features: Dict[str, Any]):
         """Save analysis results to database and resolve stale audio failures."""
         cursor = self.db.get_cursor()
         try:
-            cursor.execute("""
-                UPDATE "Track"
-                SET
-                    bpm = %s,
-                    "beatsCount" = %s,
-                    key = %s,
-                    "keyScale" = %s,
-                    "keyStrength" = %s,
-                    energy = %s,
-                    loudness = %s,
-                    "dynamicRange" = %s,
-                    danceability = %s,
-                    valence = %s,
-                    arousal = %s,
-                    instrumentalness = %s,
-                    acousticness = %s,
-                    speechiness = %s,
-                    "moodTags" = %s,
-                    "essentiaGenres" = %s,
-                    "moodHappy" = %s,
-                    "moodSad" = %s,
-                    "moodRelaxed" = %s,
-                    "moodAggressive" = %s,
-                    "moodParty" = %s,
-                    "moodAcoustic" = %s,
-                    "moodElectronic" = %s,
-                    "danceabilityMl" = %s,
-                    "analysisMode" = %s,
-                    "analysisStatus" = 'completed',
-                    "analysisStartedAt" = NULL,
-                    "analysisVersion" = %s,
-                    "analyzedAt" = %s,
-                    "analysisError" = NULL,
-                    "updatedAt" = NOW()
-                WHERE id = %s
-            """, (
-                features['bpm'],
-                features['beatsCount'],
-                features['key'],
-                features['keyScale'],
-                features['keyStrength'],
-                features['energy'],
-                features['loudness'],
-                features['dynamicRange'],
-                features['danceability'],
-                features['valence'],
-                features['arousal'],
-                features['instrumentalness'],
-                features['acousticness'],
-                features['speechiness'],
-                features['moodTags'],
-                features['essentiaGenres'],
-                features.get('moodHappy'),
-                features.get('moodSad'),
-                features.get('moodRelaxed'),
-                features.get('moodAggressive'),
-                features.get('moodParty'),
-                features.get('moodAcoustic'),
-                features.get('moodElectronic'),
-                features.get('danceabilityMl'),
-                features.get('analysisMode', 'standard'),
-                ESSENTIA_VERSION,
-                datetime.utcnow(),
-                track_id
-            ))
+            cursor.execute(
+                _SAVE_ANALYSIS_RESULTS_SQL,
+                _analysis_result_values(track_id, features),
+            )
 
             # Successful analysis should clear stale unresolved audio failures
             # for this track so UI failure counts remain accurate across reruns.
-            cursor.execute("""
-                UPDATE "EnrichmentFailure"
-                SET
-                    resolved = true,
-                    "resolvedAt" = NOW()
-                WHERE "entityType" = 'audio'
-                AND "entityId" = %s
-                AND resolved = false
-            """, (track_id,))
+            cursor.execute(_RESOLVE_AUDIO_FAILURES_SQL, (track_id,))
 
             self.db.commit()
         except Exception as e:
@@ -2039,7 +2119,7 @@ class AnalysisWorker:
 
 
 def main():
-    """Main entry point"""
+    """Run single-file test mode or start the parent analysis worker."""
     if len(sys.argv) > 1 and sys.argv[1] == '--test':
         # Test mode: analyze a single file
         if len(sys.argv) < 3:
@@ -2052,6 +2132,7 @@ def main():
         return
     
     # Normal worker mode
+    initialize_worker_count()
     worker = AnalysisWorker()
     worker.start()
 

--- a/services/audio-analyzer/tests/test_batch_timeout_requeue.py
+++ b/services/audio-analyzer/tests/test_batch_timeout_requeue.py
@@ -1,0 +1,239 @@
+"""Red-phase contracts for audio analyzer batch-timeout reliability."""
+
+from concurrent.futures import Future
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Any, Iterator
+
+import pytest
+
+
+ANALYZER_PATH = Path(__file__).resolve().parents[1] / "analyzer.py"
+
+
+class Json:
+    """Minimal psycopg2.extras.Json passthrough used during module loading."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class RealDictCursor:
+    """Placeholder cursor factory used by the analyzer's type annotations."""
+
+
+class FakeCursor:
+    """Record SQL and provide programmable database results."""
+
+    def __init__(self, rows: list[dict[str, str]] | None = None) -> None:
+        self.executions: list[tuple[str, Any]] = []
+        self.rows = rows or []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executions.append((sql, params))
+
+    def fetchall(self) -> list[dict[str, str]]:
+        return self.rows
+
+    def fetchone(self) -> dict[str, str] | None:
+        return self.rows[0] if self.rows else None
+
+    def close(self) -> None:
+        pass
+
+
+class FakeDatabaseConnection:
+    """Expose the database operations used by timeout recovery paths."""
+
+    def __init__(self, rows: list[dict[str, str]] | None = None) -> None:
+        self.cursor = FakeCursor(rows)
+
+    def get_cursor(self) -> FakeCursor:
+        return self.cursor
+
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class FakePipeline:
+    """Record queue pushes made by retry recovery."""
+
+    def __init__(self) -> None:
+        self.pushes: list[tuple[str, str]] = []
+        self.executed = False
+
+    def rpush(self, queue: str, payload: str) -> None:
+        self.pushes.append((queue, payload))
+
+    def execute(self) -> None:
+        self.executed = True
+
+
+class FakeRedis:
+    """Provide a recording pipeline without making network calls."""
+
+    def __init__(self) -> None:
+        self.queue_pipeline = FakePipeline()
+
+    def pipeline(self) -> FakePipeline:
+        return self.queue_pipeline
+
+
+@pytest.fixture(scope="module")
+def loaded_analyzer() -> Iterator[tuple[ModuleType, list[tuple[Any, ...]]]]:
+    """Load analyzer.py once with hand-rolled Redis and psycopg2 stubs."""
+    monkeypatch = pytest.MonkeyPatch()
+    connect_calls: list[tuple[Any, ...]] = []
+
+    redis_stub = ModuleType("redis")
+
+    class Redis:
+        @staticmethod
+        def from_url(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError("Redis must not be created by these unit tests")
+
+    redis_stub.Redis = Redis  # type: ignore[attr-defined]
+
+    psycopg2_stub = ModuleType("psycopg2")
+    extras_stub = ModuleType("psycopg2.extras")
+
+    def connect(*args: Any, **kwargs: Any) -> None:
+        connect_calls.append((*args, kwargs))
+        raise RuntimeError("stubbed PostgreSQL connection")
+
+    psycopg2_stub.connect = connect  # type: ignore[attr-defined]
+    psycopg2_stub.extras = extras_stub  # type: ignore[attr-defined]
+    extras_stub.RealDictCursor = RealDictCursor  # type: ignore[attr-defined]
+    extras_stub.Json = Json  # type: ignore[attr-defined]
+
+    monkeypatch.delenv("NUM_WORKERS", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stubbed-audio-analyzer")
+    monkeypatch.setitem(sys.modules, "redis", redis_stub)
+    monkeypatch.setitem(sys.modules, "psycopg2", psycopg2_stub)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", extras_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "audio_analyzer_module",
+        ANALYZER_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    yield module, connect_calls
+    monkeypatch.undo()
+
+
+def test_module_import_does_not_query_database_and_uses_default_workers(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, connect_calls = loaded_analyzer
+
+    assert connect_calls == []
+    assert module.NUM_WORKERS == 2
+
+
+def test_partition_unfinished_tracks_classifies_each_future_state(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    finalized = Future()
+    finalized.set_result(("finalized", "/finalized.flac", {}))
+    completed = Future()
+    completed.set_result(("completed", "/completed.flac", {}))
+    pending = Future()
+    running = Future()
+    assert running.set_running_or_notify_cancel() is True
+    futures_map = {
+        finalized: ("finalized", "/finalized.flac"),
+        completed: ("completed", "/completed.flac"),
+        pending: ("pending", "/pending.flac"),
+        running: ("running", "/running.flac"),
+    }
+
+    completed_unconsumed, never_started, attempted = (
+        module.partition_unfinished_tracks(futures_map, {"finalized"})
+    )
+
+    assert completed_unconsumed == [("completed", "/completed.flac")]
+    assert never_started == [("pending", "/pending.flac")]
+    assert attempted == [("running", "/running.flac")]
+    assert pending.cancelled() is True
+
+
+def test_handle_batch_timeout_drains_requeues_and_fails_by_attempt_state(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, _ = loaded_analyzer
+    success_features = {"bpm": 120.0}
+    permanent_features = {"_error": "unsupported audio", "_permanent": True}
+    finalized = Future()
+    finalized.set_result(("finalized", "/finalized.flac", success_features))
+    successful = Future()
+    successful.set_result(("successful", "/successful.flac", success_features))
+    permanent = Future()
+    permanent.set_result(("permanent", "/permanent.flac", permanent_features))
+    pending = Future()
+    running = Future()
+    assert running.set_running_or_notify_cancel() is True
+    futures_map = {
+        finalized: ("finalized", "/finalized.flac"),
+        successful: ("successful", "/successful.flac"),
+        permanent: ("permanent", "/permanent.flac"),
+        pending: ("pending", "/pending.flac"),
+        running: ("running", "/running.flac"),
+    }
+    worker = object.__new__(module.AnalysisWorker)
+    worker.db = FakeDatabaseConnection([{"id": "pending"}])
+    worker.redis = FakeRedis()
+    saved_results: list[tuple[str, str, dict[str, Any]]] = []
+    saved_failures: list[tuple[str, str, bool]] = []
+    requeues: list[tuple[list[tuple[str, str]], str]] = []
+
+    monkeypatch.setattr(worker, "_save_results", lambda *args: saved_results.append(args))
+    monkeypatch.setattr(
+        worker,
+        "_save_failed",
+        lambda track_id, error, permanent=False: saved_failures.append(
+            (track_id, error, permanent)
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "_requeue_tracks_for_retry",
+        lambda tracks, reason: requeues.append((tracks, reason)),
+    )
+
+    counts = worker._handle_batch_timeout(futures_map, {"finalized"})
+
+    assert counts == (1, 1, 1, 1)
+    assert saved_results == [
+        ("successful", "/successful.flac", success_features),
+    ]
+    assert ("permanent", "unsupported audio", True) in saved_failures
+    running_failure = next(call for call in saved_failures if call[0] == "running")
+    assert "batch timeout" in running_failure[1].lower()
+    assert running_failure[2] is False
+    assert len(requeues) == 1
+    assert requeues[0][0] == [("pending", "/pending.flac")]
+    assert "batch timeout" in requeues[0][1].lower()
+    assert pending.cancelled() is True
+
+
+def test_analyzer_source_does_not_use_deprecated_datetime_utcnow() -> None:
+    source = ANALYZER_PATH.read_text(encoding="utf-8")
+
+    assert "datetime.utcnow" not in source
+    assert "utcnow()" not in source


### PR DESCRIPTION
## Summary

Correctness/reliability fixes in the audio analyzer sidecars (`services/audio-analyzer/analyzer.py`, `services/audio-analyzer-clap/analyzer.py`), scoped to the analyzer-reliability refactor slice. Dockerfiles deliberately untouched (reserved for the analyzer-py311-rebase slice).

### audio-analyzer

- **Batch-timeout retry semantics (behavior change, in CHANGELOG):** a timed-out batch previously failed *every* unfinished track permanently — tracks that never even reached a pool worker were irreversibly dropped from the analyzed library. Unfinished work is now partitioned by actual attempt state via `future.cancel()`: never-started tracks are re-queued as `pending` **without consuming retry budget** (same pattern as the existing pool-crash requeue path); genuinely in-flight tracks fail **non-permanently**, consuming exactly one retry unit; results that completed just as the timeout fired are drained and saved instead of dropped. Semantics were checked against the backend queue contract (`audioAnalysisCleanup` consumes budget for stale-processing resets; `pending` rows under `MAX_RETRIES` are re-queued by reconciliation) — no backend change needed.
- **Module-scope DB query removed:** `NUM_WORKERS = _get_workers_from_db()` ran at import, so every spawn-mode worker process re-executed a Postgres query. Worker-count resolution now happens once via `initialize_worker_count()` called from `main()` in the parent process only.
- `datetime.utcnow()` → `datetime.now(timezone.utc)`; `get_cursor` docstring/annotation reviewed (annotation is accurate — psycopg2 instantiates the given `cursor_factory`).
- Timeout/claim/drain logic extracted into focused functions (`partition_unfinished_tracks`, `_claim_tracks_for_processing`, `_save_completed_future`, `_consume_batch_results`, `_handle_batch_timeout`), all under the 60-line gate. Additions stay Python 3.8-compatible (this sidecar's runtime).

### audio-analyzer-clap

- **Redis connection-pool leak fixed:** the idle monitor created `redis.from_url(...)` (a fresh connection pool) on *every* idle-check iteration and never closed it. One client is now created in `main()`, injected into the loop, and deterministically closed on shutdown — as is the idle DB connection, which previously leaked if the main loop exited via an exception.
- **Zombie-pod fix — thread supervision:** worker/text-embed/control daemon threads were unmonitored; a dead thread left the pod running but doing no work. The main loop (`run_idle_monitor`/`find_dead_threads`) now detects dead threads, logs critical, stops cleanly, and exits non-zero so the orchestrator restarts the pod.
- **Model unload/inference race fixed:** idle unload could null `self.model` between a call's optimistic `ensure_model()` and its locked inference, raising mid-call and burning the track's vibe retry budget. Unload and inference now serialize on one re-entrant lock and embedding calls reload under that lock if an unload wins the race; audio decoding stays outside the lock.
- `datetime.utcnow()` (3 sites) → timezone-aware UTC.

## Tests (TDD — failing tests written first, stubbed Redis/Postgres, no real models/network)

- `services/audio-analyzer/tests/test_batch_timeout_requeue.py` — import performs no DB query; `partition_unfinished_tracks` classification with real `Future` objects; `_handle_batch_timeout` drains/requeues/fails by attempt state (requeue without budget, non-permanent fail for attempted); no `utcnow` in source.
- `services/audio-analyzer-clap/tests/test_reliability.py` — embedding survives an unload racing mid-call (and reloads under the lock); unload blocks while inference holds the lock (bounded, event-coordinated); `find_dead_threads`; idle monitor stops + reports on thread death and uses only the injected queue client (no `redis.from_url` in the loop); no `utcnow` in source.

```
verify: .venv/bin/python -m pytest services/audio-analyzer/tests services/audio-analyzer-clap/tests -q → 25 passed
verify: python -m py_compile on both analyzers → exit 0
```

Full pipeline-suite authoring remains out of scope for this slice; coverage here targets the queue/timeout/retry/supervision logic that changed.