### PR TITLE
fix(dev): repair broken dev compose profiles + harden dev-setup (refactor slice P16)

### DIFF
--- a/.github/workflows/compose-config-check.yml
+++ b/.github/workflows/compose-config-check.yml
@@ -1,0 +1,43 @@
+name: Compose Config Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - docker-compose.local.yml
+      - docker-compose.dev.yml
+      - .github/workflows/compose-config-check.yml
+  push:
+    branches: [main]
+    paths:
+      - docker-compose.local.yml
+      - docker-compose.dev.yml
+      - .github/workflows/compose-config-check.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compose-config-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-config:
+    name: Compose Config Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Validate local compose config
+        run: docker compose -f docker-compose.local.yml config --quiet
+
+      - name: Validate local audio analysis profile
+        run: docker compose -f docker-compose.local.yml --profile audio-analysis config --quiet
+
+      - name: Validate dev compose config
+        run: docker compose -f docker-compose.dev.yml config --quiet
+
+      - name: Validate dev audio analysis profile
+        run: docker compose -f docker-compose.dev.yml --profile audio-analysis config --quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dev tooling: repaired the broken local compose files — `docker-compose.local.yml`'s
+  `audio-analysis` profile pointed its analyzers' `depends_on` and connection URLs
+  at nonexistent `postgres`/`redis` services (the services are
+  `postgres-local`/`redis-local`), and the `docker-compose.dev.yml` compatibility
+  shim's `extends` targets referenced the same stale names, so
+  `docker compose config` failed for both. `scripts/dev-setup.sh` now runs under
+  `set -euo pipefail`, resolves the repo root from its own location, checks for
+  `nc` and `.env.example` before using them, and references the correct
+  `postgres-local`/`redis-local` service names.
+
 ## [1.9.0] - 2026-08-08
 
 ### Added

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,22 +13,22 @@ services:
     postgres-local:
         extends:
             file: docker-compose.local.yml
-            service: postgres
+            service: postgres-local
 
     redis-local:
         extends:
             file: docker-compose.local.yml
-            service: redis
+            service: redis-local
 
     audio-analyzer-local:
         extends:
             file: docker-compose.local.yml
-            service: audio-analyzer
+            service: audio-analyzer-local
 
     audio-analyzer-clap:
         extends:
             file: docker-compose.local.yml
-            service: audio-analyzer-clap
+            service: audio-analyzer-clap-local
 
 volumes:
     postgres_local_data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,7 @@
 # - Avoid common local port collisions via +1 host mappings.
 #
 # Typical usage:
-#   docker compose -f docker-compose.local.yml up -d postgres redis
+#   docker compose -f docker-compose.local.yml up -d postgres-local redis-local
 #   cd backend && npm run dev
 #   cd frontend && PORT=3031 BACKEND_URL=http://127.0.0.1:3007 npm run dev
 #
@@ -54,8 +54,8 @@ services:
             context: ./services/audio-analyzer
         environment:
             # Connect to host machine's services (or Docker services)
-            REDIS_URL: redis://redis:6379
-            DATABASE_URL: postgresql://soundspan:soundspan@postgres:5432/soundspan
+            REDIS_URL: redis://redis-local:6379
+            DATABASE_URL: postgresql://soundspan:soundspan@postgres-local:5432/soundspan
             # Music path inside container (mounted from host)
             MUSIC_PATH: /music
             BATCH_SIZE: 10
@@ -67,9 +67,9 @@ services:
             # Host music path; override MUSIC_PATH in your shell/.env as needed.
             - "${MUSIC_PATH:-./music}:/music:ro"
         depends_on:
-            postgres:
+            postgres-local:
                 condition: service_healthy
-            redis:
+            redis-local:
                 condition: service_healthy
         restart: unless-stopped
 
@@ -79,8 +79,8 @@ services:
         build:
             context: ./services/audio-analyzer-clap
         environment:
-            REDIS_URL: redis://redis:6379
-            DATABASE_URL: postgresql://soundspan:soundspan@postgres:5432/soundspan
+            REDIS_URL: redis://redis-local:6379
+            DATABASE_URL: postgresql://soundspan:soundspan@postgres-local:5432/soundspan
             # Host-run backend URL (frontend/backend run outside compose in local dev)
             BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:3007}
             MUSIC_PATH: /music
@@ -95,9 +95,9 @@ services:
         extra_hosts:
             - "host.docker.internal:host-gateway"
         depends_on:
-            postgres:
+            postgres-local:
                 condition: service_healthy
-            redis:
+            redis-local:
                 condition: service_healthy
         restart: unless-stopped
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,22 +1,34 @@
 #!/bin/bash
 # Development environment setup script
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 echo "🚀 Setting up soundspan development environment..."
 
 # Check if .env exists
 if [ ! -f backend/.env ]; then
     echo "📝 Creating backend/.env from .env.example..."
+    if [ ! -f .env.example ]; then
+        echo "❌ .env.example not found"
+        exit 1
+    fi
     cp .env.example backend/.env
     # Backend dev uses 3007 in our local +1 port convention.
     sed -i 's/^PORT=3030$/PORT=3007/' backend/.env
     echo "⚠️  Please update backend/.env with your configuration"
 fi
 
+if ! command -v nc >/dev/null 2>&1; then
+    echo "❌ 'nc' (netcat) is required but not installed"
+    exit 1
+fi
+
 # Check PostgreSQL
 echo "🔍 Checking PostgreSQL (port 5433)..."
 if ! nc -z localhost 5433 2>/dev/null; then
     echo "❌ PostgreSQL not running on port 5433"
-    echo "   Start with: docker compose -f docker-compose.local.yml up -d postgres"
+    echo "   Start with: docker compose -f docker-compose.local.yml up -d postgres-local"
     exit 1
 fi
 
@@ -24,13 +36,13 @@ fi
 echo "🔍 Checking Redis (port 6380)..."
 if ! nc -z localhost 6380 2>/dev/null; then
     echo "❌ Redis not running on port 6380"
-    echo "   Start with: docker compose -f docker-compose.local.yml up -d redis"
+    echo "   Start with: docker compose -f docker-compose.local.yml up -d redis-local"
     exit 1
 fi
 
 echo "✅ All services are running!"
 echo "📦 Installing dependencies..."
-cd backend && npm install && cd ..
+npm --prefix backend install
 
 echo "🎉 Setup complete!"
 echo "   Recommended local dev start:"


### PR DESCRIPTION
## Summary

Small, zero-production-risk dev-tooling slice: repairs the two broken dev compose files, hardens `scripts/dev-setup.sh`, and adds a CI smoke check so compose service renames can't silently break these files again.

### What was broken (reproduced before fixing)

```
$ docker compose -f docker-compose.local.yml --profile audio-analysis config --quiet
service "audio-analyzer-clap-local" depends on undefined service "postgres": invalid compose project   (exit 1)

$ docker compose -f docker-compose.dev.yml config --quiet
cannot extend service "redis-local" ... service "redis" not found in docker-compose.local.yml          (exit 1)
```

The services in `docker-compose.local.yml` are named `postgres-local`/`redis-local`/`audio-analyzer-local`/`audio-analyzer-clap-local`, but the analyzers' `depends_on` + connection URLs, the header usage comment, the dev shim's `extends` targets, and `dev-setup.sh`'s help messages all still referenced the pre-rename `postgres`/`redis`/`audio-analyzer`/`audio-analyzer-clap` names.

### Changes

- **docker-compose.local.yml** — analyzers' `depends_on` and `REDIS_URL`/`DATABASE_URL` hostnames now point at `postgres-local`/`redis-local` (the old hostnames also wouldn't have resolved on the compose network); usage comment corrected. No service renames.
- **docker-compose.dev.yml** — the shim's four `extends: service:` targets corrected to the `-local` names. The shim's own service keys (the compatibility surface) are untouched; `profiles` are inherited via `extends` (verified with compose v5.4.0), so plain `up` still starts only postgres/redis.
- **scripts/dev-setup.sh** — `set -euo pipefail`; resolves the repo root from its own location instead of assuming cwd; guards for `nc` and `.env.example` before use; `npm --prefix backend install` instead of `cd` chains; corrected service names in help output.
- **.github/workflows/compose-config-check.yml** (separate `ci(dev)` commit) — blocking smoke job running `docker compose -f <file> [--profile audio-analysis] config --quiet` for both files, path-filtered; no builds or container starts.
- **CHANGELOG.md** — entry under Unreleased → Fixed.

### Verification (after fix)

```
verify: docker compose -f docker-compose.local.yml config --quiet                            exit 0
verify: docker compose -f docker-compose.local.yml --profile audio-analysis config --quiet   exit 0
verify: docker compose -f docker-compose.dev.yml config --quiet                              exit 0  (services: postgres-local, redis-local)
verify: docker compose -f docker-compose.dev.yml --profile audio-analysis config --quiet     exit 0  (+ audio-analyzer-local, audio-analyzer-clap)
verify: bash -n scripts/dev-setup.sh                                                         exit 0
```

shellcheck is not installed on the dev box, so only `bash -n` ran locally. No images built, no containers started.
