### PR TITLE
fix(security): reject refresh tokens as access tokens; consolidate JWT verification (refactor slice P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Security
+
+- Long-lived (30-day) refresh tokens carrying `type: "refresh"` were accepted
+  anywhere an access token was, including Bearer headers, streaming `?token=`
+  query parameters, and the Listen Together socket. JWT verification is now
+  consolidated in a single `verifyAccessToken` accessor that pins HS256,
+  requires a well-formed payload, and rejects any token carrying a `type` claim,
+  while `/api/auth/refresh` continues to accept refresh tokens for exchange
+  only.
+
 ### Added
 
 ### Changed

--- a/backend/src/middleware/__tests__/authTokenBehavior.test.ts
+++ b/backend/src/middleware/__tests__/authTokenBehavior.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Behavioral token-validation tests for the auth middleware.
+ *
+ * Unlike `auth.test.ts` (which mocks `jsonwebtoken` to unit-test branch
+ * logic), this suite exercises REAL token signing and verification so
+ * token-type confusion, expiry, wrong-secret, and `alg: none` handling are
+ * proven against the actual `jsonwebtoken` implementation and cannot regress
+ * behind a mock.
+ */
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        user: {
+            findUnique: jest.fn(),
+        },
+        apiKey: {
+            findUnique: jest.fn(),
+            update: jest.fn(),
+        },
+    },
+}));
+
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { prisma } from "../../utils/db";
+
+// API-key hashing needs a pepper at call time; provide one explicitly so this
+// suite never depends on ambient SESSION_SECRET state (mirrors auth.test.ts).
+process.env.SETTINGS_ENCRYPTION_KEY =
+    process.env.SETTINGS_ENCRYPTION_KEY ||
+    "auth-behavior-test-api-key-pepper-123456789";
+
+const TEST_SECRET = "behavioral-test-jwt-secret";
+const WRONG_SECRET = "some-other-secret-entirely";
+
+const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
+
+type AuthModule = typeof import("../auth") & {
+    verifyAccessToken?: (token: string) => import("../auth").JWTPayload;
+};
+
+let authModule: AuthModule;
+
+const testUser = {
+    id: "user-1",
+    username: "alice",
+    role: "user",
+    tokenVersion: 3,
+};
+
+function base64url(value: object): string {
+    return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/** Craft an unsigned token claiming `alg: none`. */
+function makeAlgNoneToken(payload: object): string {
+    return `${base64url({ alg: "none", typ: "JWT" })}.${base64url(payload)}.`;
+}
+
+type TestRequest = {
+    session: Record<string, unknown>;
+    headers: Record<string, unknown>;
+    query: Record<string, unknown>;
+    user?: { id: string; username: string; role: string };
+};
+
+function createReq(overrides: Partial<TestRequest> = {}): TestRequest {
+    return { session: {}, headers: {}, query: {}, ...overrides };
+}
+
+type TestResponse = {
+    statusCode: number;
+    body: unknown;
+    status: jest.Mock;
+    json: jest.Mock;
+};
+
+function createRes(): TestResponse {
+    const res = {} as TestResponse;
+    res.statusCode = 200;
+    res.body = undefined;
+    res.status = jest.fn((code: number) => {
+        res.statusCode = code;
+        return res;
+    });
+    res.json = jest.fn((payload: unknown) => {
+        res.body = payload;
+        return res;
+    });
+    return res;
+}
+
+const asReq = (req: TestRequest) => req as unknown as Request;
+const asRes = (res: TestResponse) => res as unknown as Response;
+const asNext = (next: jest.Mock) => next as unknown as NextFunction;
+
+describe("auth middleware behavioral token validation (real jsonwebtoken)", () => {
+    const originalJwtSecret = process.env.JWT_SECRET;
+    const originalSessionSecret = process.env.SESSION_SECRET;
+
+    beforeAll(() => {
+        process.env.JWT_SECRET = TEST_SECRET;
+        delete process.env.SESSION_SECRET;
+        authModule = require("../auth") as AuthModule;
+    });
+
+    afterAll(() => {
+        if (originalJwtSecret === undefined) {
+            delete process.env.JWT_SECRET;
+        } else {
+            process.env.JWT_SECRET = originalJwtSecret;
+        }
+        if (originalSessionSecret === undefined) {
+            delete process.env.SESSION_SECRET;
+        } else {
+            process.env.SESSION_SECRET = originalSessionSecret;
+        }
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUserFindUnique.mockResolvedValue({ ...testUser });
+    });
+
+    function accessToken(): string {
+        return authModule.generateToken(testUser);
+    }
+
+    function refreshToken(): string {
+        return authModule.generateRefreshToken(testUser);
+    }
+
+    async function runRequireAuth(req: TestRequest) {
+        const res = createRes();
+        const next = jest.fn();
+        await authModule.requireAuth(asReq(req), asRes(res), asNext(next));
+        return { req, res, next };
+    }
+
+    async function runRequireAuthOrToken(req: TestRequest) {
+        const res = createRes();
+        const next = jest.fn();
+        await authModule.requireAuthOrToken(
+            asReq(req),
+            asRes(res),
+            asNext(next)
+        );
+        return { req, res, next };
+    }
+
+    function expectRejected(result: {
+        res: TestResponse;
+        next: jest.Mock;
+    }): void {
+        expect(result.next).not.toHaveBeenCalled();
+        expect(result.res.statusCode).toBe(401);
+    }
+
+    describe("requireAuth (Bearer)", () => {
+        it("accepts a real access token", async () => {
+            const result = await runRequireAuth(
+                createReq({
+                    headers: { authorization: `Bearer ${accessToken()}` },
+                })
+            );
+
+            expect(result.next).toHaveBeenCalled();
+            expect(result.req.user).toEqual({
+                id: testUser.id,
+                username: testUser.username,
+                role: testUser.role,
+            });
+        });
+
+        it("rejects a refresh token presented as a Bearer access token", async () => {
+            const result = await runRequireAuth(
+                createReq({
+                    headers: { authorization: `Bearer ${refreshToken()}` },
+                })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects a token with an unexpected type claim", async () => {
+            const unexpectedType = jwt.sign(
+                {
+                    userId: testUser.id,
+                    username: testUser.username,
+                    role: testUser.role,
+                    tokenVersion: testUser.tokenVersion,
+                    type: "device-link",
+                },
+                TEST_SECRET,
+                { expiresIn: "24h" }
+            );
+
+            const result = await runRequireAuth(
+                createReq({
+                    headers: {
+                        authorization: `Bearer ${unexpectedType}`,
+                    },
+                })
+            );
+
+            expectRejected(result);
+        });
+
+        it("ignores ?token= even when it carries a valid access token", async () => {
+            const result = await runRequireAuth(
+                createReq({ query: { token: accessToken() } })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects an expired access token", async () => {
+            const expired = jwt.sign(
+                {
+                    userId: testUser.id,
+                    username: testUser.username,
+                    role: testUser.role,
+                    tokenVersion: testUser.tokenVersion,
+                },
+                TEST_SECRET,
+                { expiresIn: "-1s" }
+            );
+
+            const result = await runRequireAuth(
+                createReq({ headers: { authorization: `Bearer ${expired}` } })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects a token signed with the wrong secret", async () => {
+            const forged = jwt.sign(
+                {
+                    userId: testUser.id,
+                    username: testUser.username,
+                    role: testUser.role,
+                    tokenVersion: testUser.tokenVersion,
+                },
+                WRONG_SECRET,
+                { expiresIn: "24h" }
+            );
+
+            const result = await runRequireAuth(
+                createReq({ headers: { authorization: `Bearer ${forged}` } })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects an unsigned alg:none token", async () => {
+            const none = makeAlgNoneToken({
+                userId: testUser.id,
+                username: testUser.username,
+                role: testUser.role,
+                tokenVersion: testUser.tokenVersion,
+            });
+
+            const result = await runRequireAuth(
+                createReq({ headers: { authorization: `Bearer ${none}` } })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects an access token whose tokenVersion does not match", async () => {
+            mockUserFindUnique.mockResolvedValue({
+                ...testUser,
+                tokenVersion: testUser.tokenVersion + 1,
+            });
+
+            const result = await runRequireAuth(
+                createReq({
+                    headers: { authorization: `Bearer ${accessToken()}` },
+                })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects an otherwise-valid token that carries no tokenVersion", async () => {
+            const versionless = jwt.sign(
+                {
+                    userId: testUser.id,
+                    username: testUser.username,
+                    role: testUser.role,
+                },
+                TEST_SECRET,
+                { expiresIn: "24h" }
+            );
+
+            const result = await runRequireAuth(
+                createReq({
+                    headers: { authorization: `Bearer ${versionless}` },
+                })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects an object-payload token without a userId claim", async () => {
+            const noUserId = jwt.sign({ foo: "bar" }, TEST_SECRET, {
+                expiresIn: "24h",
+            });
+
+            const result = await runRequireAuth(
+                createReq({
+                    headers: { authorization: `Bearer ${noUserId}` },
+                })
+            );
+
+            expectRejected(result);
+        });
+    });
+
+    describe("requireAuthOrToken (query + Bearer)", () => {
+        it("accepts a real access token via ?token=", async () => {
+            const result = await runRequireAuthOrToken(
+                createReq({ query: { token: accessToken() } })
+            );
+
+            expect(result.next).toHaveBeenCalled();
+            expect(result.req.user).toEqual({
+                id: testUser.id,
+                username: testUser.username,
+                role: testUser.role,
+            });
+        });
+
+        it("rejects a refresh token via ?token=", async () => {
+            const result = await runRequireAuthOrToken(
+                createReq({ query: { token: refreshToken() } })
+            );
+
+            expectRejected(result);
+        });
+
+        it("rejects a refresh token presented as a Bearer access token", async () => {
+            const result = await runRequireAuthOrToken(
+                createReq({
+                    headers: { authorization: `Bearer ${refreshToken()}` },
+                })
+            );
+
+            expectRejected(result);
+        });
+    });
+
+    describe("verifyAccessToken", () => {
+        it("is exported from the auth middleware module", () => {
+            expect(typeof authModule.verifyAccessToken).toBe("function");
+        });
+
+        it("returns the decoded payload for a valid access token", () => {
+            expect(authModule.verifyAccessToken).toBeDefined();
+            const payload = authModule.verifyAccessToken!(accessToken());
+
+            expect(payload.userId).toBe(testUser.id);
+            expect(payload.tokenVersion).toBe(testUser.tokenVersion);
+        });
+
+        it("throws when given a refresh token", () => {
+            expect(authModule.verifyAccessToken).toBeDefined();
+            expect(() =>
+                authModule.verifyAccessToken!(refreshToken())
+            ).toThrow();
+        });
+
+        it("throws when given a token with an unexpected type claim", () => {
+            const unexpectedType = jwt.sign(
+                {
+                    userId: testUser.id,
+                    username: testUser.username,
+                    role: testUser.role,
+                    tokenVersion: testUser.tokenVersion,
+                    type: "device-link",
+                },
+                TEST_SECRET,
+                { expiresIn: "24h" }
+            );
+
+            expect(authModule.verifyAccessToken).toBeDefined();
+            expect(() =>
+                authModule.verifyAccessToken!(unexpectedType)
+            ).toThrow();
+        });
+
+        it("throws when given a bare string payload", () => {
+            const stringPayload = jwt.sign("not-an-object", TEST_SECRET);
+
+            expect(authModule.verifyAccessToken).toBeDefined();
+            expect(() =>
+                authModule.verifyAccessToken!(stringPayload)
+            ).toThrow();
+        });
+
+        it("throws when given an object payload without a userId claim", () => {
+            const noUserId = jwt.sign({ foo: "bar" }, TEST_SECRET, {
+                expiresIn: "24h",
+            });
+
+            expect(authModule.verifyAccessToken).toBeDefined();
+            expect(() =>
+                authModule.verifyAccessToken!(noUserId)
+            ).toThrow();
+        });
+
+        it("throws when given an unsigned alg:none token", () => {
+            expect(authModule.verifyAccessToken).toBeDefined();
+            expect(() =>
+                authModule.verifyAccessToken!(
+                    makeAlgNoneToken({ userId: testUser.id })
+                )
+            ).toThrow();
+        });
+    });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -38,10 +38,19 @@ export interface AuthenticatedRequest extends Request {
 
 export interface JWTPayload {
     userId: string;
-    username: string;
-    role: string;
+    username?: string;
+    role?: string;
     tokenVersion?: number;
     type?: string;
+}
+
+function isJwtPayloadShape(value: unknown): value is { userId: string } {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "userId" in value &&
+        typeof value.userId === "string"
+    );
 }
 
 /** Creates a short-lived access token for authenticated API/session flows. */
@@ -80,16 +89,64 @@ export function generateRefreshToken(user: {
 }
 
 /**
- * Verify an HS256 access/refresh token against the validated JWT secret. The
- * `algorithms` pin prevents a token from being accepted under a different
- * (weaker or `none`) algorithm, and centralizes secret resolution so callers
- * never re-read `process.env` inline. Throws, like `jwt.verify`, on an invalid,
- * expired, or wrong-algorithm token.
+ * Verify an HS256 access/refresh token against the validated JWT secret and
+ * require an object payload with a string `userId`. The `algorithms` pin
+ * prevents a token from being accepted under a different (weaker or `none`)
+ * algorithm, and centralizes secret resolution so callers never re-read
+ * `process.env` inline. Throws on an invalid, expired, wrong-algorithm, or
+ * malformed token.
  */
 export function verifyAuthToken(token: string): JWTPayload {
-    return jwt.verify(token, JWT_SECRET_VALIDATED, {
+    const payload = jwt.verify(token, JWT_SECRET_VALIDATED, {
         algorithms: ["HS256"],
-    }) as unknown as JWTPayload;
+    });
+    if (!isJwtPayloadShape(payload)) {
+        throw new Error("Malformed token payload");
+    }
+    // Runtime validation above establishes the required JWTPayload invariant.
+    return payload as JWTPayload;
+}
+
+/**
+ * Verify a credential presented for direct API/socket access as a short-lived
+ * access token. Delegates to `verifyAuthToken` (HS256-pinned, single validated
+ * secret) and rejects all non-access token types, including refresh tokens.
+ * Only tokens minted without a `type` claim are accepted. Throws on an invalid,
+ * expired, wrong-algorithm, malformed, or non-access token.
+ */
+export function verifyAccessToken(token: string): JWTPayload {
+    const payload = verifyAuthToken(token);
+    if (payload.type !== undefined) {
+        throw new Error("Token is not an access token");
+    }
+    return payload;
+}
+
+/**
+ * Resolve an access token to its user, enforcing token type (via
+ * `verifyAccessToken`) and `tokenVersion` freshness. Returns `null` when the
+ * user no longer exists or the token predates a password change; throws when
+ * the token itself fails verification.
+ */
+async function resolveAccessTokenUser(
+    token: string
+): Promise<{ id: string; username: string; role: string } | null> {
+    const decoded = verifyAccessToken(token);
+    const user = await prisma.user.findUnique({
+        where: { id: decoded.userId },
+        select: { id: true, username: true, role: true, tokenVersion: true },
+    });
+    if (!user) {
+        return null;
+    }
+    // Validate tokenVersion - reject if password was changed
+    if (
+        decoded.tokenVersion === undefined ||
+        decoded.tokenVersion !== user.tokenVersion
+    ) {
+        return null;
+    }
+    return { id: user.id, username: user.username, role: user.role };
 }
 
 /**
@@ -151,18 +208,8 @@ async function authenticateRequest(
         const tokenParam = req.query.token as string;
         if (tokenParam) {
             try {
-                const decoded = verifyAuthToken(tokenParam);
-                const user = await prisma.user.findUnique({
-                    where: { id: decoded.userId },
-                    select: { id: true, username: true, role: true, tokenVersion: true },
-                });
-                if (user) {
-                    // Validate tokenVersion - reject if password was changed
-                    if (decoded.tokenVersion === undefined || decoded.tokenVersion !== user.tokenVersion) {
-                        return null;
-                    }
-                    return { id: user.id, username: user.username, role: user.role };
-                }
+                const user = await resolveAccessTokenUser(tokenParam);
+                if (user) return user;
             } catch (error) {
                 logger.debug("Query token validation failed", error);
             }
@@ -177,18 +224,8 @@ async function authenticateRequest(
 
     if (token) {
         try {
-            const decoded = verifyAuthToken(token);
-            const user = await prisma.user.findUnique({
-                where: { id: decoded.userId },
-                select: { id: true, username: true, role: true, tokenVersion: true },
-            });
-            if (user) {
-                // Validate tokenVersion - reject if password was changed
-                if (decoded.tokenVersion === undefined || decoded.tokenVersion !== user.tokenVersion) {
-                    return null;
-                }
-                return { id: user.id, username: user.username, role: user.role };
-            }
+            const user = await resolveAccessTokenUser(token);
+            if (user) return user;
         } catch (error) {
             logger.debug("Bearer token validation failed", error);
         }
@@ -283,20 +320,10 @@ export async function requireAuthOrToken(
     const tokenParam = req.query.token as string;
     if (tokenParam) {
         try {
-            const decoded = verifyAuthToken(tokenParam);
-            const user = await prisma.user.findUnique({
-                where: { id: decoded.userId },
-                select: { id: true, username: true, role: true, tokenVersion: true },
-            });
-
+            const user = await resolveAccessTokenUser(tokenParam);
             if (user) {
-                // Validate tokenVersion - reject if password was changed
-                if (decoded.tokenVersion === undefined || decoded.tokenVersion !== user.tokenVersion) {
-                    // Token was issued before password change, reject
-                } else {
-                    req.user = { id: user.id, username: user.username, role: user.role };
-                    return next();
-                }
+                req.user = user;
+                return next();
             }
         } catch (error) {
             logger.debug("Query token validation failed in requireAuthOrToken", error);
@@ -311,20 +338,10 @@ export async function requireAuthOrToken(
 
     if (token) {
         try {
-            const decoded = verifyAuthToken(token);
-            const user = await prisma.user.findUnique({
-                where: { id: decoded.userId },
-                select: { id: true, username: true, role: true, tokenVersion: true },
-            });
-
+            const user = await resolveAccessTokenUser(token);
             if (user) {
-                // Validate tokenVersion - reject if password was changed
-                if (decoded.tokenVersion === undefined || decoded.tokenVersion !== user.tokenVersion) {
-                    // Token was issued before password change, reject
-                } else {
-                    req.user = { id: user.id, username: user.username, role: user.role };
-                    return next();
-                }
+                req.user = user;
+                return next();
             }
         } catch (error) {
             logger.debug("Bearer token validation failed in requireAuthOrToken", error);

--- a/backend/src/services/__tests__/listenTogetherSocketRuntime.test.ts
+++ b/backend/src/services/__tests__/listenTogetherSocketRuntime.test.ts
@@ -566,7 +566,9 @@ describe("listen together socket runtime behavior", () => {
         expect(() => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             require("../listenTogetherSocket");
-        }).toThrow("JWT_SECRET or SESSION_SECRET is required for Socket.IO auth");
+        }).toThrow(
+            "JWT_SECRET or SESSION_SECRET environment variable is required for authentication"
+        );
     });
 
     it("handles auth middleware success and failure branches", async () => {
@@ -620,6 +622,18 @@ describe("listen together socket runtime behavior", () => {
         const invalidTokenNext = jest.fn();
         await authMiddleware(makeSocket("token"), invalidTokenNext);
         expect(invalidTokenNext.mock.calls[0][0].message).toBe("Invalid token");
+
+        // Token-type confusion: a long-lived refresh token must never
+        // authenticate a socket, even though it verifies under the same secret.
+        mocks.jwtVerify.mockReturnValueOnce({
+            userId: "user-1",
+            tokenVersion: 1,
+            type: "refresh",
+        });
+        const refreshTokenNext = jest.fn();
+        await authMiddleware(makeSocket("token"), refreshTokenNext);
+        expect(refreshTokenNext.mock.calls[0][0]).toBeInstanceOf(Error);
+        expect(refreshTokenNext.mock.calls[0][0].message).toBe("Invalid token");
 
         const successSocket: any = makeSocket("token");
         const successNext = jest.fn();

--- a/backend/src/services/listenTogetherSocket.ts
+++ b/backend/src/services/listenTogetherSocket.ts
@@ -9,8 +9,8 @@
 
 import type { Server as HttpServer } from "http";
 import { Server, type Namespace, type Socket } from "socket.io";
-import jwt from "jsonwebtoken";
 import { randomUUID } from "crypto";
+import { verifyAccessToken } from "../middleware/auth";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { config } from "../config";
@@ -44,17 +44,10 @@ import { trackMappingService } from "./trackMappingService";
 // Auth
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || process.env.SESSION_SECRET;
-if (!JWT_SECRET) {
-    throw new Error("JWT_SECRET or SESSION_SECRET is required for Socket.IO auth");
-}
-
-interface JWTPayload {
-    userId: string;
-    username: string;
-    role: string;
-    tokenVersion?: number;
-}
+// Token verification is delegated to the shared `verifyAccessToken` accessor
+// in ../middleware/auth: one validated secret source, HS256 pinned, and
+// refresh tokens rejected. Importing that module also fail-fasts at startup
+// when neither JWT_SECRET nor SESSION_SECRET is configured.
 
 interface AuthenticatedSocket extends Socket {
     data: {
@@ -631,11 +624,10 @@ export function setupListenTogetherSocket(httpServer: HttpServer): Server {
                 return next(new Error("Authentication required"));
             }
 
-            // Pin the algorithm so a token can't be accepted under a weaker or
-            // `none` algorithm (F36).
-            const decoded = jwt.verify(token, JWT_SECRET!, {
-                algorithms: ["HS256"],
-            }) as unknown as JWTPayload;
+            // Shared accessor pins HS256 (a token can't be accepted under a
+            // weaker or `none` algorithm, F36) and rejects refresh tokens
+            // presented as access credentials.
+            const decoded = verifyAccessToken(token);
 
             // Verify user exists and tokenVersion matches
             const user = await prisma.user.findUnique({


### PR DESCRIPTION
## Vulnerability

Token-type confusion (P1). `generateRefreshToken` mints 30-day tokens with `type: "refresh"`, but only the `/api/auth/refresh` exchange endpoint ever checked that claim. `authenticateRequest`, `requireAuthOrToken`, and the Listen Together socket handshake all verified signature/expiry only, so a long-lived refresh token was accepted as a bearer credential everywhere: `Authorization: Bearer`, streaming `?token=` query parameters, and the Socket.IO auth handshake. The socket path also duplicated `jwt.verify` with its own secret resolution and an `as unknown as` double-cast.

## Fix

- New `verifyAccessToken` accessor in `backend/src/middleware/auth.ts` is now the single verification path for direct API/socket access: HS256 pinned, payload runtime-narrowed to a non-null object with a string `userId` (replacing the `as unknown as JWTPayload` double-cast with a type predicate plus one contained, commented assertion), and any token carrying a `type` claim rejected deny-by-default — access tokens are minted without one, so this rejects refresh tokens and any future non-access type.
- `authenticateRequest` (query + bearer), `requireAuthOrToken` (query + bearer), and the Listen Together socket middleware all route through a shared `resolveAccessTokenUser` helper; the socket's local `JWT_SECRET` resolution, local `JWTPayload` interface, and inline `jwt.verify` are gone. `tokenVersion` enforcement semantics are unchanged.
- `/api/auth/refresh` still uses `verifyAuthToken` and still requires `type === "refresh"` — the exchange flow is unchanged.
- `JWTPayload.username`/`role` are now optional, matching what refresh tokens actually carry (`tsc --noEmit` clean, no ripple).

## Frontend compatibility check

Verified read-only against `frontend/lib/api.ts` before changing behavior: the Bearer header is built exclusively from `this.token` (localStorage `auth_token`, the access token); `?token=` stream/cover/profile URLs use `getCurrentToken()`, which reads only `auth_token`; the Listen Together socket sends `api.getToken()` (same access token). The refresh token (`refresh_token` key) is only ever sent in the POST body to `/api/auth/refresh`. No client relies on refresh-as-bearer, so rejecting it is not a breaking change.

## New behavioral tests

`backend/src/middleware/__tests__/authTokenBehavior.test.ts` — 20 tests against the **real** `jsonwebtoken` implementation (previously JWT handling was only ever tested behind a mocked module):

- refresh token as Bearer on `requireAuth` → 401; via `?token=` and Bearer on `requireAuthOrToken` → 401
- token with an unexpected `type` claim (e.g. `device-link`) → 401 / throw (deny-by-default)
- expired token → 401; wrong-secret token → 401; unsigned `alg: none` token → 401
- correctly-signed bare-string payload and object payload without `userId` → rejected (proves the runtime narrowing)
- stale or missing `tokenVersion` → 401 (guard preserved)
- valid access token via `?token=` ignored on `requireAuth` routes → 401, but accepted on `requireAuthOrToken`

`listenTogetherSocketRuntime.test.ts` additionally proves a refresh-type payload fails socket auth.

## Verification

- verify: `npx jest src/middleware/__tests__/authTokenBehavior.test.ts src/middleware/__tests__/auth.test.ts src/routes/__tests__/authRuntime.test.ts src/services/__tests__/listenTogetherSocketRuntime.test.ts --maxWorkers=2` — 4 suites, 87 tests, all passing
- verify: `npx tsc --noEmit` (backend) — exit 0
- TDD: the new negative tests were written and confirmed failing before the deny-by-default and payload-narrowing changes landed

## Out of scope (discovered, not fixed here)

`backend/src/routes/onboarding.ts` (`GET` status handler, ~line 635) verifies its optional Bearer token with `verifyAuthToken` — a refresh token is still accepted there. Impact is limited to disclosing `onboardingComplete` for the token's user; it should move to `verifyAccessToken` in a follow-up.
