### PR TITLE
fix(security): sidecar secret hygiene (refactor slice P6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set -euo pipefail`, resolves the repo root from its own location, checks for
   `nc` and `.env.example` before using them, and references the correct
   `postgres-local`/`redis-local` service names.
+- TIDAL admin credentials no longer travel in sidecar URL query strings: the backend now sends the access token as `Authorization: Bearer <token>` and the user ID/country code as `x-tidal-user-id`/`x-tidal-country-code` headers for `POST /search`, `/download/track`, and `/download/album`. The TIDAL sidecar accepts both the new headers and legacy query parameters for this release, logging a deprecation warning when query credentials are used; query-parameter support will be removed in the next release. Requests without an access token now return **401** with `access_token required`.
+- The TIDAL and YouTube Music FastAPI sidecars no longer expose internal exception text in HTTP responses. Client-facing errors now use short generic messages while full exception details and tracebacks remain in service logs; this also changes TIDAL album downloads' per-track `errors[].error` value to `Download failed`, with the root cause available in the TIDAL sidecar logs.
+- YouTube Music OAuth credential files (`/data/oauth_<user>.json` and `/data/client_creds_<user>.json`) are now written with owner-only mode `0600`; the next write also tightens permissions on pre-existing files with looser modes.
+- The YouTube Music streamer image no longer makes `/data` world-writable with `chmod 777`. A new entrypoint repairs `/data` ownership and drops from root to the `ytmusic` user for plain Docker/Compose starts, while explicitly non-root deployments continue directly under their configured user and rely on existing volume permissions such as the Helm chart's unchanged `runAsUser: 1000`/`fsGroup: 1000` security context.
+- YouTube Music streamer requests now strictly validate 11-character `video_id` path parameters and reject malformed values with **400** `Invalid video_id`; `/song`, `/stream`, `/proxy`, and `/yt/proxy` also accept only case-insensitive `LOW`, `MEDIUM`, `HIGH`, or `LOSSLESS` quality values and reject others with **400** `Invalid quality`. Lowercase quality values sent by the backend are now honored instead of silently falling back to `HIGH`.
 
 ### Security
 

--- a/backend/src/services/__tests__/tidalService.test.ts
+++ b/backend/src/services/__tests__/tidalService.test.ts
@@ -332,7 +332,7 @@ describe("tidalService", () => {
     });
 
     describe("search", () => {
-        it("search succeeds with encoded credential query params", async () => {
+        it("search sends credentials via Authorization header, not the URL", async () => {
             const creds = {
                 ...baseCreds,
                 accessToken: "access token/+",
@@ -344,12 +344,18 @@ describe("tidalService", () => {
 
             await expect(tidalService.search("nujabes")).resolves.toEqual(searchData);
             expect(mockClient.post).toHaveBeenCalledWith(
-                `/search?access_token=${encodeURIComponent(
-                    creds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    creds.userId
-                )}&country_code=${encodeURIComponent(creds.countryCode)}`,
-                { query: "nujabes" }
+                "/search",
+                { query: "nujabes" },
+                {
+                    headers: {
+                        Authorization: `Bearer ${creds.accessToken}`,
+                        "x-tidal-user-id": creds.userId,
+                        "x-tidal-country-code": creds.countryCode,
+                    },
+                }
+            );
+            expect(String(mockClient.post.mock.calls[0][0])).not.toContain(
+                "access_token"
             );
         });
 
@@ -472,7 +478,7 @@ describe("tidalService", () => {
     });
 
     describe("downloadTrack", () => {
-        it("downloads a track with quality and output template from credentials", async () => {
+        it("downloads a track with header credentials, quality, and output template", async () => {
             jest.spyOn(tidalService as any, "getCredentials").mockResolvedValue(baseCreds);
             const downloadResult = {
                 track_id: 9001,
@@ -488,16 +494,22 @@ describe("tidalService", () => {
 
             await expect(tidalService.downloadTrack(9001)).resolves.toEqual(downloadResult);
             expect(mockClient.post).toHaveBeenCalledWith(
-                `/download/track?access_token=${encodeURIComponent(
-                    baseCreds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    baseCreds.userId
-                )}&country_code=${encodeURIComponent(baseCreds.countryCode)}`,
+                "/download/track",
                 {
                     track_id: 9001,
                     quality: "LOSSLESS",
                     output_template: "{album.artist}/{item.title}",
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${baseCreds.accessToken}`,
+                        "x-tidal-user-id": baseCreds.userId,
+                        "x-tidal-country-code": baseCreds.countryCode,
+                    },
                 }
+            );
+            expect(String(mockClient.post.mock.calls[0][0])).not.toContain(
+                "access_token"
             );
         });
 
@@ -536,7 +548,7 @@ describe("tidalService", () => {
     });
 
     describe("downloadAlbum", () => {
-        it("downloads an album with quality and output template from credentials", async () => {
+        it("downloads an album with header credentials, quality, and output template", async () => {
             jest.spyOn(tidalService as any, "getCredentials").mockResolvedValue(baseCreds);
             const albumPayload = {
                 album_id: 77,
@@ -552,16 +564,22 @@ describe("tidalService", () => {
 
             await expect(tidalService.downloadAlbum(77)).resolves.toEqual(albumPayload);
             expect(mockClient.post).toHaveBeenCalledWith(
-                `/download/album?access_token=${encodeURIComponent(
-                    baseCreds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    baseCreds.userId
-                )}&country_code=${encodeURIComponent(baseCreds.countryCode)}`,
+                "/download/album",
                 {
                     album_id: 77,
                     quality: "LOSSLESS",
                     output_template: "{album.artist}/{item.title}",
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${baseCreds.accessToken}`,
+                        "x-tidal-user-id": baseCreds.userId,
+                        "x-tidal-country-code": baseCreds.countryCode,
+                    },
                 }
+            );
+            expect(String(mockClient.post.mock.calls[0][0])).not.toContain(
+                "access_token"
             );
         });
 

--- a/backend/src/services/tidal.ts
+++ b/backend/src/services/tidal.ts
@@ -151,6 +151,23 @@ class TidalService {
     // ── Token helpers ──────────────────────────────────────────────
 
     /**
+     * Build per-request credential headers for the sidecar.
+     * Tokens travel in Authorization (never the URL) so they can't leak
+     * into access logs or proxies.
+     */
+    private buildCredentialHeaders(creds: {
+        accessToken: string;
+        userId: string;
+        countryCode: string;
+    }): Record<string, string> {
+        return {
+            Authorization: `Bearer ${creds.accessToken}`,
+            "x-tidal-user-id": creds.userId,
+            "x-tidal-country-code": creds.countryCode,
+        };
+    }
+
+    /**
      * Read & decrypt credentials from SystemSettings.
      */
     private async getCredentials(): Promise<{
@@ -321,12 +338,9 @@ class TidalService {
 
         try {
             const res = await this.client.post(
-                `/search?access_token=${encodeURIComponent(
-                    creds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    creds.userId
-                )}&country_code=${encodeURIComponent(creds.countryCode)}`,
-                { query }
+                "/search",
+                { query },
+                { headers: this.buildCredentialHeaders(creds) }
             );
             return res.data;
         } catch (err: any) {
@@ -390,16 +404,13 @@ class TidalService {
 
         try {
             const res = await this.client.post(
-                `/download/track?access_token=${encodeURIComponent(
-                    creds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    creds.userId
-                )}&country_code=${encodeURIComponent(creds.countryCode)}`,
+                "/download/track",
                 {
                     track_id: trackId,
                     quality: creds.quality,
                     output_template: creds.fileTemplate,
-                }
+                },
+                { headers: this.buildCredentialHeaders(creds) }
             );
             return res.data;
         } catch (err: any) {
@@ -423,16 +434,13 @@ class TidalService {
 
         try {
             const res = await this.client.post(
-                `/download/album?access_token=${encodeURIComponent(
-                    creds.accessToken
-                )}&user_id=${encodeURIComponent(
-                    creds.userId
-                )}&country_code=${encodeURIComponent(creds.countryCode)}`,
+                "/download/album",
                 {
                     album_id: albumId,
                     quality: creds.quality,
                     output_template: creds.fileTemplate,
-                }
+                },
+                { headers: this.buildCredentialHeaders(creds) }
             );
             return res.data;
         } catch (err: any) {

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -5,6 +5,38 @@ isn't listed here, the upgrade is drop-in.
 
 ---
 
+## TIDAL token header migration + ytmusic-streamer entrypoint change
+
+**Who this affects:** deployments that pin backend and `tidal-downloader` image
+versions independently, or customize the `ytmusic-streamer` container user or
+`/data` volume permissions.
+
+**What changed.** The backend now sends TIDAL access tokens and account metadata in
+headers instead of URL query strings. For this release, the TIDAL sidecar accepts
+both the new headers and legacy query credentials, so backend and sidecar images may
+roll independently; a deprecation warning in the sidecar logs identifies callers
+still using query credentials. Once both images are on this release, there is
+nothing to do. The query fallback is removed in the **next release**.
+
+The `ytmusic-streamer` image no longer runs `chmod 777 /data` and no longer sets a
+Dockerfile `USER`. Under the plain Docker/Compose default it starts as root, repairs
+legacy `/data` ownership, and immediately drops privileges to the `ytmusic` user.
+Deployments that force a non-root user, including the chart's Kubernetes security
+context or a Compose `user:`, behave exactly as before but must ensure `/data` is
+writable by that UID; the chart's existing `fsGroup: 1000` already provides this.
+YouTube Music OAuth credential files are now written with owner-only mode `0600`.
+
+**Action required:** a backend from this release or later sends header credentials,
+which a `tidal-downloader` image older than this release does not understand — so do
+not run a new backend against a pre-this-release TIDAL sidecar image. In the **next
+release**, the sidecar drops the query fallback, so backends older than this release
+will stop working against it. During this release,
+check TIDAL sidecar logs for the deprecation warning and update any custom callers
+before the fallback is removed. Custom non-root YouTube Music deployments should
+also confirm that their `/data` volume is writable by the configured UID.
+
+---
+
 ## ⚠️ Breaking: HTTP sidecars now require `INTERNAL_API_SECRET` (F31)
 
 **Who this affects:** any deployment that uses the YouTube Music (`ytmusic-streamer`)

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -8,7 +8,8 @@ with this service over HTTP on port 8585.
 Supports **per-user** streaming: each soundspan user connects their own
 TIDAL account via device-code OAuth. User credentials are scoped by
 user_id query parameters. Admin credentials (for downloading) remain
-in SystemSettings and are passed via request headers.
+in SystemSettings and use an Authorization: Bearer header, with deprecated
+query-parameter support retained for one release.
 """
 
 import asyncio
@@ -20,12 +21,12 @@ import sys
 import time
 from base64 import b64decode
 from pathlib import Path
-from typing import Any, Callable, Optional, Literal
+from typing import Any, Callable, NamedTuple, Optional, Literal
 from xml.etree.ElementTree import fromstring as xml_fromstring
 
 import httpx
 import tidalapi
-from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -254,9 +255,66 @@ class BatchSearchQuery(BaseModel):
     limit: int = 5
 
 
+class AdminCredentials(NamedTuple):
+    """Admin TIDAL credentials extracted from an incoming request."""
+
+    access_token: str
+    user_id: str
+    country_code: str
+
+
 # ════════════════════════════════════════════════════════════════════
 # Helpers
 # ════════════════════════════════════════════════════════════════════
+
+def _parse_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    """Return a nonempty bearer token from an Authorization header."""
+    if not authorization:
+        return None
+    parts = authorization.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip() or None
+
+
+def require_admin_credentials(
+    authorization: Optional[str] = Header(None),
+    x_tidal_user_id: Optional[str] = Header(None),
+    x_tidal_country_code: Optional[str] = Header(None),
+    access_token: str = Query(""),
+    user_id: str = Query(""),
+    country_code: str = Query("US"),
+) -> AdminCredentials:
+    """Resolve admin credentials from headers or the deprecated query fallback."""
+    bearer_token = _parse_bearer_token(authorization)
+    if bearer_token is not None:
+        resolved_user_id = x_tidal_user_id if x_tidal_user_id is not None else user_id
+        resolved_country = (
+            x_tidal_country_code
+            if x_tidal_country_code is not None
+            else country_code
+        )
+        return AdminCredentials(bearer_token, resolved_user_id, resolved_country)
+
+    if not access_token:
+        raise HTTPException(status_code=401, detail="access_token required")
+    log.warning(
+        "access_token via query string is deprecated; send Authorization: "
+        "Bearer — query support will be removed next release"
+    )
+    return AdminCredentials(access_token, user_id, country_code)
+
+
+def _sanitized_http_error(
+    operation: str,
+    exc: Exception,
+    status_code: int,
+    detail: str,
+) -> HTTPException:
+    """Log full exception detail; return a generic client-facing HTTPException."""
+    log.error("%s failed: %s", operation, exc, exc_info=True)
+    return HTTPException(status_code=status_code, detail=detail)
+
 
 def _sanitize_path_component(name: str) -> str:
     """Remove or replace chars that are invalid on most filesystems."""
@@ -909,8 +967,12 @@ async def auth_device():
             "interval": device_auth.interval,
         }
     except Exception as e:
-        log.error(f"Device auth failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "device auth",
+            e,
+            500,
+            "Failed to initiate TIDAL device authorization",
+        ) from e
 
 
 @app.post("/auth/token")
@@ -936,8 +998,9 @@ async def auth_token(req: AuthTokenRequest):
             "error_description": e.error_description,
         })
     except Exception as e:
-        log.error(f"Token exchange failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "TIDAL token exchange", e, 500, "TIDAL token exchange failed"
+        ) from e
 
 
 @app.post("/auth/refresh")
@@ -960,8 +1023,9 @@ async def auth_refresh(req: RefreshRequest):
             "error_description": e.error_description,
         })
     except Exception as e:
-        log.error(f"Token refresh failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "TIDAL token refresh", e, 500, "TIDAL token refresh failed"
+        ) from e
 
 
 @app.post("/auth/session")
@@ -977,21 +1041,24 @@ async def auth_session(tokens: SessionCheckPayload):
             "country_code": session.countryCode,
         }
     except ApiError as e:
-        raise HTTPException(status_code=401, detail=str(e))
+        raise _sanitized_http_error(
+            "TIDAL session validation", e, 401, "TIDAL session invalid"
+        ) from e
     except Exception as e:
-        log.error(f"Session check failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "TIDAL session check", e, 500, "TIDAL session check failed"
+        ) from e
 
 
 # ── Search ──────────────────────────────────────────────────────────
 
 @app.post("/search")
-async def search(req: SearchRequest, access_token: str = "", user_id: str = "", country_code: str = "US"):
-    """Search TIDAL for tracks, albums, and artists."""
-    if not access_token:
-        raise HTTPException(status_code=401, detail="access_token header required")
-
-    api = _build_api(access_token, user_id, country_code)
+async def search(
+    req: SearchRequest,
+    creds: AdminCredentials = Depends(require_admin_credentials),
+):
+    """Search using bearer-header auth or the one-release query fallback."""
+    api = _build_api(creds.access_token, creds.user_id, creds.country_code)
     try:
         results = api.get_search(req.query)
         return {
@@ -1031,23 +1098,73 @@ async def search(req: SearchRequest, access_token: str = "", user_id: str = "", 
             ],
         }
     except ApiError as e:
-        raise HTTPException(status_code=e.status if hasattr(e, "status") else 500, detail=str(e))
+        status_code = e.status if hasattr(e, "status") else 500
+        raise _sanitized_http_error(
+            "TIDAL search", e, status_code, "TIDAL search failed"
+        ) from e
 
 
 # ── Download ────────────────────────────────────────────────────────
 
+def _get_album_tracks(api: TidalAPI, album_id: int) -> list[Any]:
+    """Fetch all downloadable tracks for an album."""
+    tracks = []
+    offset = 0
+    while True:
+        items = api.get_album_items(album_id, limit=100, offset=offset)
+        for album_item in items.items:
+            if hasattr(album_item, "item") and hasattr(album_item.item, "isrc"):
+                tracks.append(album_item.item)
+        offset += items.limit
+        if offset >= items.totalNumberOfItems:
+            return tracks
+
+
+async def _download_album_tracks(
+    api: TidalAPI,
+    tracks: list[Any],
+    req: DownloadAlbumRequest,
+) -> tuple[list[dict], list[dict]]:
+    """Download album tracks sequentially and return successes and failures."""
+    results = []
+    errors = []
+    for index, track in enumerate(tracks):
+        if index > 0:
+            delay = env_float("TIDAL_TRACK_DELAY", "3")
+            log.debug(
+                "Rate limit: waiting %ss before track %s/%s",
+                delay,
+                index + 1,
+                len(tracks),
+            )
+            await asyncio.sleep(delay)
+        try:
+            result = await asyncio.to_thread(
+                _download_track_sync,
+                api=api,
+                track_id=track.id,
+                quality=req.quality,
+                output_template=req.output_template,
+                dest_base=MUSIC_PATH,
+            )
+            results.append(result)
+        except Exception as e:
+            log.error("Failed to download track %s (%s): %s", track.id, track.title, e)
+            errors.append({
+                "track_id": track.id,
+                "title": track.title,
+                "error": "Download failed",
+            })
+    return results, errors
+
+
 @app.post("/download/track")
 async def download_track(
     req: DownloadTrackRequest,
-    access_token: str = "",
-    user_id: str = "",
-    country_code: str = "US",
+    creds: AdminCredentials = Depends(require_admin_credentials),
 ):
-    """Download a single track from TIDAL."""
-    if not access_token:
-        raise HTTPException(status_code=401, detail="access_token required")
-
-    api = _build_api(access_token, user_id, country_code)
+    """Download using bearer-header auth or the one-release query fallback."""
+    api = _build_api(creds.access_token, creds.user_id, creds.country_code)
 
     try:
         result = await asyncio.to_thread(
@@ -1060,69 +1177,29 @@ async def download_track(
         )
         return result
     except ApiError as e:
-        log.error(f"TIDAL API error downloading track {req.track_id}: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL API download for track {req.track_id}",
+            e,
+            400,
+            "TIDAL API error",
+        ) from e
     except Exception as e:
-        log.error(f"Download failed for track {req.track_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"download for track {req.track_id}", e, 500, "Download failed"
+        ) from e
 
 
 @app.post("/download/album")
 async def download_album(
     req: DownloadAlbumRequest,
-    access_token: str = "",
-    user_id: str = "",
-    country_code: str = "US",
+    creds: AdminCredentials = Depends(require_admin_credentials),
 ):
-    """Download all tracks from a TIDAL album."""
-    if not access_token:
-        raise HTTPException(status_code=401, detail="access_token required")
-
-    api = _build_api(access_token, user_id, country_code)
-
+    """Download using bearer-header auth or the one-release query fallback."""
+    api = _build_api(creds.access_token, creds.user_id, creds.country_code)
     try:
         album = api.get_album(req.album_id)
-
-        # Fetch all tracks
-        tracks = []
-        offset = 0
-        while True:
-            items = api.get_album_items(req.album_id, limit=100, offset=offset)
-            for album_item in items.items:
-                if hasattr(album_item, "item") and hasattr(album_item.item, "isrc"):
-                    tracks.append(album_item.item)
-            offset += items.limit
-            if offset >= items.totalNumberOfItems:
-                break
-
-        results = []
-        errors = []
-
-        for i, track in enumerate(tracks):
-            # Rate-limit: wait between tracks to avoid TIDAL API bans
-            if i > 0:
-                delay = env_float("TIDAL_TRACK_DELAY", "3")
-                log.debug(f"Rate limit: waiting {delay}s before track {i+1}/{len(tracks)}")
-                await asyncio.sleep(delay)
-
-            try:
-                result = await asyncio.to_thread(
-                    _download_track_sync,
-                    api=api,
-                    track_id=track.id,
-                    quality=req.quality,
-                    output_template=req.output_template,
-                    dest_base=MUSIC_PATH,
-                )
-                results.append(result)
-            except Exception as e:
-                log.error(f"Failed to download track {track.id} ({track.title}): {e}")
-                errors.append({
-                    "track_id": track.id,
-                    "title": track.title,
-                    "error": str(e),
-                })
-
+        tracks = _get_album_tracks(api, req.album_id)
+        results, errors = await _download_album_tracks(api, tracks, req)
         return {
             "album_id": req.album_id,
             "album_title": album.title,
@@ -1134,16 +1211,72 @@ async def download_album(
             "errors": errors,
         }
     except ApiError as e:
-        log.error(f"TIDAL API error downloading album {req.album_id}: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL API download for album {req.album_id}",
+            e,
+            400,
+            "TIDAL API error",
+        ) from e
     except Exception as e:
-        log.error(f"Album download failed for {req.album_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"download for album {req.album_id}", e, 500, "Download failed"
+        ) from e
 
 
 # ════════════════════════════════════════════════════════════════════
 # Per-user streaming routes
 # ════════════════════════════════════════════════════════════════════
+
+def _store_user_session(
+    soundspan_user_id: str,
+    api: TidalAPI,
+    access_token: str,
+    refresh_token: str,
+    tidal_user_id: str,
+    country_code: str,
+) -> None:
+    """Store a verified per-user API and invalidate stale browse sessions."""
+    _user_apis[soundspan_user_id] = api
+    _user_auth_state[soundspan_user_id] = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "tidal_user_id": tidal_user_id,
+        "country_code": country_code,
+    }
+    for key in [
+        key for key in _browse_sessions if key.startswith(f"{soundspan_user_id}:")
+    ]:
+        _browse_sessions.pop(key, None)
+
+
+def _refresh_and_restore_user(
+    req: UserAuthRestoreRequest,
+    soundspan_user_id: str,
+) -> dict:
+    """Refresh expired TIDAL credentials and restore the per-user session."""
+    auth_response = AuthAPI().refresh_token(req.refresh_token)
+    new_token = auth_response.access_token
+    new_user_id = str(auth_response.user.userId)
+    new_country = auth_response.user.countryCode
+    api = _build_api(new_token, new_user_id, new_country)
+    api.get_session()
+    _store_user_session(
+        soundspan_user_id,
+        api,
+        new_token,
+        req.refresh_token,
+        new_user_id,
+        new_country,
+    )
+    log.info("Refreshed and restored TIDAL session for user %s", soundspan_user_id)
+    return {
+        "success": True,
+        "refreshed": True,
+        "access_token": new_token,
+        "user_id": new_user_id,
+        "country_code": new_country,
+    }
+
 
 @app.get("/user/auth/status")
 async def user_auth_status(user_id: str = Query(...)):
@@ -1154,25 +1287,18 @@ async def user_auth_status(user_id: str = Query(...)):
 
 @app.post("/user/auth/restore")
 async def user_auth_restore(req: UserAuthRestoreRequest, user_id: str = Query(...)):
-    """
-    Restore a user's TIDAL credentials from the Node.js backend.
-    Called lazily on first request that needs this user's session.
-    If the access token is expired, refresh it automatically.
-    """
+    """Restore a user's credentials, refreshing an expired token if needed."""
     try:
         api = _build_api(req.access_token, req.user_id, req.country_code)
-        # Verify the session is valid
-        session = api.get_session()
-        _user_apis[user_id] = api
-        _user_auth_state[user_id] = {
-            "access_token": req.access_token,
-            "refresh_token": req.refresh_token,
-            "tidal_user_id": req.user_id,
-            "country_code": req.country_code,
-        }
-        # Invalidate browse sessions that may hold stale tokens
-        for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
-            _browse_sessions.pop(key, None)
+        api.get_session()
+        _store_user_session(
+            user_id,
+            api,
+            req.access_token,
+            req.refresh_token,
+            req.user_id,
+            req.country_code,
+        )
         log.info(f"Restored TIDAL session for user {user_id} (tidal_user={req.user_id})")
         return {
             "success": True,
@@ -1180,42 +1306,22 @@ async def user_auth_restore(req: UserAuthRestoreRequest, user_id: str = Query(..
             "country_code": req.country_code,
         }
     except ApiError as e:
-        # Token expired — try refreshing
         log.warning(f"TIDAL session expired for user {user_id}, attempting refresh: {e}")
         try:
-            auth_api = AuthAPI()
-            auth_response = auth_api.refresh_token(req.refresh_token)
-            new_token = auth_response.access_token
-            new_user_id = str(auth_response.user.userId)
-            new_country = auth_response.user.countryCode
-
-            # Build a new API with the refreshed token
-            api = _build_api(new_token, new_user_id, new_country)
-            session = api.get_session()
-            _user_apis[user_id] = api
-            _user_auth_state[user_id] = {
-                "access_token": new_token,
-                "refresh_token": req.refresh_token,
-                "tidal_user_id": new_user_id,
-                "country_code": new_country,
-            }
-            # Invalidate browse sessions that may hold stale tokens
-            for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
-                _browse_sessions.pop(key, None)
-            log.info(f"Refreshed and restored TIDAL session for user {user_id}")
-            return {
-                "success": True,
-                "refreshed": True,
-                "access_token": new_token,
-                "user_id": new_user_id,
-                "country_code": new_country,
-            }
+            return _refresh_and_restore_user(req, user_id)
         except Exception as refresh_err:
             log.error(f"Token refresh also failed for user {user_id}: {refresh_err}")
-            raise HTTPException(status_code=401, detail=f"Invalid TIDAL credentials and refresh failed: {e}")
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid TIDAL credentials and refresh failed",
+            ) from refresh_err
     except Exception as e:
-        log.error(f"Failed to restore TIDAL session for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL session restore for user {user_id}",
+            e,
+            500,
+            "Failed to restore TIDAL session",
+        ) from e
 
 
 @app.post("/user/auth/clear")
@@ -1276,9 +1382,12 @@ async def user_search(
             ],
         }
     except ApiError as e:
-        raise HTTPException(
-            status_code=getattr(e, "status", 500), detail=str(e)
-        )
+        raise _sanitized_http_error(
+            "TIDAL user search",
+            e,
+            getattr(e, "status", 500),
+            "TIDAL search failed",
+        ) from e
 
 
 @app.post("/user/search/batch")
@@ -1340,8 +1449,12 @@ async def user_stream_info(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Stream info failed for track {track_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"stream info for track {track_id}",
+            e,
+            500,
+            "Failed to resolve stream info",
+        ) from e
 
 
 @app.get("/user/stream/{track_id}")
@@ -1629,9 +1742,12 @@ async def user_get_track(
             },
         }
     except ApiError as e:
-        raise HTTPException(
-            status_code=getattr(e, "status", 500), detail=str(e)
-        )
+        raise _sanitized_http_error(
+            f"TIDAL track lookup {track_id}",
+            e,
+            getattr(e, "status", 500),
+            "TIDAL track lookup failed",
+        ) from e
 
 
 # ── Browse (tidalapi) ──────────────────────────────────────────────
@@ -1647,8 +1763,12 @@ async def user_browse_home(user_id: str = Query(...), limit: int = Query(6), qua
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse home failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse home for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL home",
+        ) from e
 
 @app.get("/user/browse/explore")
 async def user_browse_explore(user_id: str = Query(...), limit: int = Query(6), quality: str | None = Query(None)):
@@ -1661,8 +1781,12 @@ async def user_browse_explore(user_id: str = Query(...), limit: int = Query(6), 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse explore failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse explore for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL explore",
+        ) from e
 
 @app.get("/user/browse/genres")
 async def user_browse_genres(user_id: str = Query(...), quality: str | None = Query(None)):
@@ -1675,8 +1799,12 @@ async def user_browse_genres(user_id: str = Query(...), quality: str | None = Qu
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse genres failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse genres for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL genres",
+        ) from e
 
 @app.get("/user/browse/moods")
 async def user_browse_moods(user_id: str = Query(...), quality: str | None = Query(None)):
@@ -1689,8 +1817,12 @@ async def user_browse_moods(user_id: str = Query(...), quality: str | None = Que
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse moods failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse moods for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL moods",
+        ) from e
 
 @app.get("/user/browse/mixes")
 async def user_browse_mixes(user_id: str = Query(...), quality: str | None = Query(None)):
@@ -1706,8 +1838,12 @@ async def user_browse_mixes(user_id: str = Query(...), quality: str | None = Que
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse mixes failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse mixes for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL mixes",
+        ) from e
 
 @app.get("/user/browse/genre-playlists")
 async def user_browse_genre_playlists(
@@ -1739,8 +1875,12 @@ async def user_browse_genre_playlists(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"TIDAL browse genre-playlists failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"TIDAL browse genre playlists for user {user_id}",
+            e,
+            500,
+            "Failed to load TIDAL genre playlists",
+        ) from e
 
 @app.get("/browse/playlist/{playlist_uuid}")
 async def browse_playlist(

--- a/services/tidal-downloader/tests/test_admin_token_headers.py
+++ b/services/tidal-downloader/tests/test_admin_token_headers.py
@@ -1,0 +1,161 @@
+"""Future admin endpoint contract for TIDAL credentials in request headers."""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+
+def _stub_api() -> types.SimpleNamespace:
+    """Return the minimal TIDAL API surface exercised by these tests."""
+    return types.SimpleNamespace(
+        get_search=lambda q: types.SimpleNamespace(
+            tracks=types.SimpleNamespace(items=[]),
+            albums=types.SimpleNamespace(items=[]),
+            artists=types.SimpleNamespace(items=[]),
+        ),
+        get_album=lambda album_id: types.SimpleNamespace(
+            title="Album",
+            artist=types.SimpleNamespace(name="Artist"),
+            cover=None,
+        ),
+        get_album_items=lambda album_id, limit=100, offset=0: types.SimpleNamespace(
+            items=[], limit=100, totalNumberOfItems=0
+        ),
+    )
+
+
+@pytest.fixture()
+def api_recorder(monkeypatch):
+    """Record credentials passed to the TIDAL API factory and stub downloads."""
+    import app
+
+    calls = []
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda access_token, user_id, country_code: (
+            calls.append((access_token, user_id, country_code)) or _stub_api()
+        ),
+    )
+    monkeypatch.setattr(
+        app,
+        "_download_track_sync",
+        lambda **kwargs: {
+            "track_id": 1,
+            "title": "t",
+            "artist": "a",
+            "album": "al",
+            "quality": "HIGH",
+            "file_path": "/x",
+            "relative_path": "x",
+            "file_size": 1,
+        },
+    )
+    yield calls
+
+
+@pytest.mark.anyio
+async def test_search_accepts_bearer_header(client, api_recorder):
+    """Search accepts a bearer token and optional TIDAL identity headers."""
+    resp = await client.post(
+        "/search",
+        json={"query": "q"},
+        headers={
+            "Authorization": "Bearer tok-header",
+            "x-tidal-user-id": "u1",
+            "x-tidal-country-code": "DE",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert api_recorder[-1] == ("tok-header", "u1", "DE")
+
+
+@pytest.mark.anyio
+async def test_search_legacy_query_params_warn_deprecated(
+    client, api_recorder, caplog
+):
+    """Legacy search credential query parameters work with a warning."""
+    with caplog.at_level(logging.WARNING):
+        resp = await client.post(
+            "/search?access_token=tok-q&user_id=u2&country_code=FR",
+            json={"query": "q"},
+        )
+
+    assert resp.status_code == 200
+    assert api_recorder[-1] == ("tok-q", "u2", "FR")
+    assert "deprecated" in caplog.text.lower()
+
+
+@pytest.mark.anyio
+async def test_search_header_wins_over_query(client, api_recorder):
+    """Search header credentials take precedence over legacy query values."""
+    resp = await client.post(
+        "/search?access_token=tok-q&user_id=u-query&country_code=FR",
+        json={"query": "q"},
+        headers={
+            "Authorization": "Bearer tok-header",
+            "x-tidal-user-id": "u-header",
+            "x-tidal-country-code": "DE",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert api_recorder[-1] == ("tok-header", "u-header", "DE")
+
+
+@pytest.mark.anyio
+async def test_search_missing_token_rejected(client, api_recorder):
+    """Search rejects requests that provide no token in either location."""
+    resp = await client.post("/search", json={"query": "q"})
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "access_token required"
+
+
+@pytest.mark.anyio
+async def test_download_track_accepts_bearer_header(client, api_recorder):
+    """Track download accepts a bearer token header."""
+    resp = await client.post(
+        "/download/track",
+        json={"track_id": 1},
+        headers={"Authorization": "Bearer tok-header"},
+    )
+
+    assert resp.status_code == 200
+    assert api_recorder[-1][0] == "tok-header"
+
+
+@pytest.mark.anyio
+async def test_download_track_missing_token_rejected(client, api_recorder):
+    """Track download rejects requests with no token."""
+    resp = await client.post("/download/track", json={"track_id": 1})
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "access_token required"
+
+
+@pytest.mark.anyio
+async def test_download_album_accepts_bearer_header(client, api_recorder):
+    """Album download accepts a bearer token header."""
+    resp = await client.post(
+        "/download/album",
+        json={"album_id": 2},
+        headers={"Authorization": "Bearer tok-header"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["downloaded"] == 0
+    assert api_recorder[-1][0] == "tok-header"
+
+
+@pytest.mark.anyio
+async def test_download_album_missing_token_rejected(client, api_recorder):
+    """Album download rejects requests with no token."""
+    resp = await client.post("/download/album", json={"album_id": 2})
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "access_token required"

--- a/services/tidal-downloader/tests/test_error_sanitization.py
+++ b/services/tidal-downloader/tests/test_error_sanitization.py
@@ -1,0 +1,179 @@
+"""Future contract for sanitizing internal errors in HTTP responses."""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+
+MARKER = "sekrit-token-abc123"
+
+
+@pytest.mark.anyio
+async def test_auth_device_error_sanitized(client, monkeypatch, caplog):
+    """Device-auth failures are logged without exposing internal details."""
+    import app
+
+    class FailingAuthAPI:
+        def get_device_auth(self):
+            raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "AuthAPI", FailingAuthAPI)
+
+    with caplog.at_level(logging.ERROR, logger="tidal-downloader"):
+        resp = await client.post("/auth/device")
+
+    assert resp.status_code == 500
+    assert MARKER not in resp.text
+    assert MARKER in caplog.text
+
+
+@pytest.mark.anyio
+async def test_auth_session_api_error_sanitized(client, monkeypatch, caplog):
+    """Session API errors are logged without exposing internal details."""
+    import app
+
+    def _raise_api_error(*_args, **_kwargs):
+        raise app.ApiError(MARKER)
+
+    monkeypatch.setattr(app, "_build_api", _raise_api_error)
+
+    with caplog.at_level(logging.ERROR, logger="tidal-downloader"):
+        resp = await client.post(
+            "/auth/session",
+            json={"access_token": "a", "user_id": "u", "country_code": "US"},
+        )
+
+    assert resp.status_code == 401
+    assert MARKER not in resp.text
+    assert MARKER in caplog.text
+
+
+@pytest.mark.anyio
+async def test_search_api_error_sanitized(client, monkeypatch, caplog):
+    """Search API errors are logged without exposing internal details."""
+    import app
+
+    def _raise_api_error(_query):
+        raise app.ApiError(MARKER)
+
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            get_search=_raise_api_error
+        ),
+    )
+
+    with caplog.at_level(logging.ERROR, logger="tidal-downloader"):
+        resp = await client.post(
+            "/search?access_token=t&user_id=u&country_code=US",
+            json={"query": "q"},
+        )
+
+    assert resp.status_code == 500
+    assert MARKER not in resp.text
+    assert MARKER in caplog.text
+
+
+@pytest.mark.anyio
+async def test_user_auth_restore_failure_sanitized(client, monkeypatch, caplog):
+    """Credential restore failures expose neither session nor refresh details."""
+    import app
+
+    def _raise_api_error():
+        raise app.ApiError(MARKER)
+
+    class FailingAuthAPI:
+        def refresh_token(self, _refresh_token):
+            raise Exception("refresh-marker-xyz")
+
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            get_session=_raise_api_error
+        ),
+    )
+    monkeypatch.setattr(app, "AuthAPI", FailingAuthAPI)
+
+    with caplog.at_level(logging.WARNING, logger="tidal-downloader"):
+        resp = await client.post(
+            "/user/auth/restore?user_id=u1",
+            json={
+                "access_token": "a",
+                "refresh_token": "r",
+                "user_id": "tu",
+                "country_code": "US",
+            },
+        )
+
+    assert resp.status_code == 401
+    assert MARKER not in resp.text
+    assert "refresh-marker-xyz" not in resp.text
+    assert MARKER in caplog.text
+
+
+@pytest.mark.anyio
+async def test_browse_home_error_sanitized(client, monkeypatch, caplog):
+    """Browse-home failures are logged without exposing internal details."""
+    import app
+
+    def _boom():
+        raise Exception(MARKER)
+
+    monkeypatch.setattr(
+        app,
+        "_build_browse_session",
+        lambda user_id, quality=None: types.SimpleNamespace(home=_boom),
+    )
+
+    with caplog.at_level(logging.ERROR, logger="tidal-downloader"):
+        resp = await client.get("/user/browse/home?user_id=u1")
+
+    assert resp.status_code == 500
+    assert MARKER not in resp.text
+    assert MARKER in caplog.text
+
+
+@pytest.mark.anyio
+async def test_download_album_per_track_error_sanitized(
+    client, monkeypatch, caplog
+):
+    """Per-track album failures are logged without exposing internal details."""
+    import app
+
+    api = types.SimpleNamespace(
+        get_album=lambda album_id: types.SimpleNamespace(
+            title="Album",
+            artist=types.SimpleNamespace(name="Artist"),
+            cover=None,
+        ),
+        get_album_items=lambda album_id, limit=100, offset=0: types.SimpleNamespace(
+            items=[
+                types.SimpleNamespace(
+                    item=types.SimpleNamespace(isrc="x", id=11, title="T")
+                )
+            ],
+            limit=100,
+            totalNumberOfItems=1,
+        ),
+    )
+
+    def _raise_download_error(**_kwargs):
+        raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "_build_api", lambda *_args, **_kwargs: api)
+    monkeypatch.setattr(app, "_download_track_sync", _raise_download_error)
+
+    with caplog.at_level(logging.ERROR, logger="tidal-downloader"):
+        resp = await client.post(
+            "/download/album?access_token=t&user_id=u",
+            json={"album_id": 2},
+        )
+
+    assert resp.status_code == 200
+    assert MARKER not in resp.json()["errors"][0]["error"]
+    assert MARKER in caplog.text

--- a/services/ytmusic-streamer/Dockerfile
+++ b/services/ytmusic-streamer/Dockerfile
@@ -35,25 +35,26 @@ RUN pip install --no-cache-dir -r requirements-exempt.txt
 COPY services/ytmusic-streamer/app.py ./app.py
 COPY services/ytmusic-streamer/yt_download.py ./yt_download.py
 COPY services/common ./common
+COPY services/ytmusic-streamer/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Create writable directories and non-root user
 # - /data: ytmusicapi OAuth token storage
-# chmod 777 ensures compatibility with pre-existing Docker volumes that may
-# have been created with root ownership before the non-root user was added.
 RUN useradd -m -u 1000 ytmusic && \
     mkdir -p /data && \
-    chown -R ytmusic:ytmusic /app /data && \
-    chmod 777 /data
+    chown -R ytmusic:ytmusic /app /data
 
 ENV PYTHONUNBUFFERED=1
 
-# Drop to non-root user (compatible with K8s runAsNonRoot / runAsUser: 1000)
-USER ytmusic
+# The entrypoint repairs legacy /data ownership, then drops to ytmusic via
+# setpriv. Kubernetes deployments still enforce runAsNonRoot/runAsUser 1000
+# through the chart securityContext; there the chown branch is skipped and
+# fsGroup handles volume permissions.
 
 EXPOSE 8586
 
 # tini handles PID 1 reaping and signal forwarding (SIGTERM from K8s)
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8586/health || exit 1

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -234,6 +234,8 @@ _USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/131.0.0.0 Safari/537.36"
 )
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+_ALLOWED_STREAM_QUALITIES = {"LOW", "MEDIUM", "HIGH", "LOSSLESS"}
 
 import random
 
@@ -299,6 +301,39 @@ class BatchSearchRequest(BaseModel):
 # ════════════════════════════════════════════════════════════════════
 # Helpers
 # ════════════════════════════════════════════════════════════════════
+
+def _validate_video_id(video_id: str) -> str:
+    """Reject video ids that are not exactly 11 URL-safe characters."""
+    if not _VIDEO_ID_RE.fullmatch(video_id or ""):
+        raise HTTPException(status_code=400, detail="Invalid video_id")
+    return video_id
+
+
+def _validate_stream_quality(quality: str) -> str:
+    """Normalize and validate a requested stream quality."""
+    normalized = (quality or "").strip().upper()
+    if normalized not in _ALLOWED_STREAM_QUALITIES:
+        raise HTTPException(status_code=400, detail="Invalid quality")
+    return normalized
+
+
+def _write_private_file(path: Path, content: str) -> None:
+    """Write credentials with owner-only permissions, tightening existing files."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(content)
+    os.chmod(path, 0o600)
+
+
+def _sanitized_http_error(
+    operation: str,
+    exc: Exception,
+    status_code: int,
+    detail: str,
+) -> HTTPException:
+    """Log full exception detail; return a generic client-facing HTTPException."""
+    log.error("%s failed: %s", operation, exc, exc_info=True)
+    return HTTPException(status_code=status_code, detail=detail)
 
 def _oauth_file(user_id: str) -> Path:
     """Return the OAuth JSON path for a given user."""
@@ -763,11 +798,15 @@ def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
 
     except Exception as e:
         error_str = str(e)
-        log.error(f"yt-dlp extraction failed for YT video {video_id}: {error_str}")
-
         if "Sign in to confirm your age" in error_str or (
             "age" in error_str.lower() and "confirm" in error_str.lower()
         ):
+            log.error(
+                "yt-dlp extraction failed for YT video %s: %s",
+                video_id,
+                e,
+                exc_info=True,
+            )
             raise HTTPException(
                 status_code=451,
                 detail={
@@ -777,7 +816,12 @@ def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
                 },
             )
 
-        raise HTTPException(status_code=502, detail=f"Failed to extract stream: {error_str}")
+        raise _sanitized_http_error(
+            f"yt-dlp extraction for YT video {video_id}",
+            e,
+            502,
+            "Failed to extract stream",
+        ) from e
 
 
 def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> dict:
@@ -883,10 +927,14 @@ def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> 
 
     except Exception as e:
         error_str = str(e)
-        log.error(f"yt-dlp extraction failed for {video_id}: {error_str}")
-
         # Detect age-restricted content
         if "Sign in to confirm your age" in error_str or "age" in error_str.lower() and "confirm" in error_str.lower():
+            log.error(
+                "yt-dlp extraction failed for %s: %s",
+                video_id,
+                e,
+                exc_info=True,
+            )
             raise HTTPException(
                 status_code=451,
                 detail={
@@ -896,7 +944,12 @@ def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> 
                 }
             )
 
-        raise HTTPException(status_code=502, detail=f"Failed to extract stream: {error_str}")
+        raise _sanitized_http_error(
+            f"yt-dlp extraction for {video_id}",
+            e,
+            502,
+            "Failed to extract stream",
+        ) from e
 
 
 def _tv_search(yt: YTMusic, query: str, filter: Optional[str] = None, limit: int = 20) -> list[dict]:
@@ -1396,7 +1449,16 @@ async def auth_status(user_id: str = Query(...)):
         _get_ytmusic(user_id)
         return {"authenticated": True}
     except Exception as e:
-        return {"authenticated": False, "reason": str(e)}
+        log.error(
+            "Stored credentials failed to load for user %s: %s",
+            user_id,
+            e,
+            exc_info=True,
+        )
+        return {
+            "authenticated": False,
+            "reason": "Stored credentials failed to load",
+        }
 
 
 @app.post("/auth/restore")
@@ -1418,14 +1480,14 @@ async def auth_restore(req: Request, user_id: str = Query(...)):
         raise HTTPException(status_code=400, detail="Invalid JSON in oauth_json")
 
     DATA_PATH.mkdir(parents=True, exist_ok=True)
-    _oauth_file(user_id).write_text(oauth_json)
+    _write_private_file(_oauth_file(user_id), oauth_json)
 
     # Save client credentials if provided
     client_id = body.get("client_id")
     client_secret = body.get("client_secret")
     if client_id and client_secret:
         creds_path = _client_creds_file(user_id)
-        creds_path.write_text(json.dumps({
+        _write_private_file(creds_path, json.dumps({
             "client_id": client_id,
             "client_secret": client_secret,
         }))
@@ -1474,11 +1536,12 @@ async def auth_device_code(req: DeviceCodeRequest):
             "interval": code.get("interval", 5),
         }
     except Exception as e:
-        log.error(f"Device code initiation failed: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to initiate device code flow: {str(e)}",
-        )
+        raise _sanitized_http_error(
+            "Device code initiation",
+            e,
+            500,
+            "Failed to initiate device code flow",
+        ) from e
 
 
 @app.post("/auth/device-code/poll")
@@ -1516,11 +1579,11 @@ async def auth_device_code_poll(req: DeviceCodePollRequest, user_id: str = Query
         # Success — we have a token. Save it for this user.
         DATA_PATH.mkdir(parents=True, exist_ok=True)
         token_json = json.dumps(dict(token), indent=True)
-        _oauth_file(user_id).write_text(token_json)
+        _write_private_file(_oauth_file(user_id), token_json)
 
         # Save client credentials alongside so _get_ytmusic can use them
         creds_path = _client_creds_file(user_id)
-        creds_path.write_text(json.dumps({
+        _write_private_file(creds_path, json.dumps({
             "client_id": req.client_id,
             "client_secret": req.client_secret,
         }))
@@ -1545,11 +1608,12 @@ async def auth_device_code_poll(req: DeviceCodePollRequest, user_id: str = Query
                 log.warning(f"Device code poll error for user {user_id}: {error_key}")
                 return {"status": "error", "error": friendly_msg}
 
-        log.error(f"Device code poll failed for user {user_id}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to poll device code: {str(e)}",
-        )
+        raise _sanitized_http_error(
+            f"Device code poll for user {user_id}",
+            e,
+            500,
+            "Failed to poll device code",
+        ) from e
 
 
 # ── Search ──────────────────────────────────────────────────────────
@@ -1586,8 +1650,12 @@ async def search(req: SearchRequest, user_id: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Search failed for user {user_id} query={req.query!r} filter={req.filter!r}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Search for user {user_id} query={req.query!r} filter={req.filter!r}",
+            e,
+            500,
+            "Search failed",
+        ) from e
 
 
 @app.post("/search/batch")
@@ -1601,6 +1669,7 @@ async def search_batch(req: BatchSearchRequest, user_id: str = Query(...)):
     inter-request delays instead of firing all N simultaneously.
     """
     async def _run_one(q: BatchSearchQuery) -> dict:
+        """Execute and sanitize one query in the batch."""
         # Check primary cache first — avoids consuming a semaphore slot.
         strategy = _resolve_user_search_strategy(user_id)
         cached = _get_cached_search(user_id, q.query, q.filter, q.limit, strategy)
@@ -1625,7 +1694,7 @@ async def search_batch(req: BatchSearchRequest, user_id: str = Query(...)):
                 raise
             except Exception as e:
                 log.warning(f"Batch search failed for query={q.query!r}: {e}")
-                return {"results": [], "total": 0, "error": str(e)}
+                return {"results": [], "total": 0, "error": "search failed"}
 
     log.debug(f"Batch search: {len(req.queries)} queries for user {user_id} "
               f"(concurrency={BATCH_CONCURRENCY})")
@@ -1653,8 +1722,9 @@ async def search_debug(req: SearchRequest, user_id: str = Query(...)):
         raw = yt._send_request("search", body)
         return {"raw": raw}
     except Exception as e:
-        log.error(f"Debug search failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "Debug search", e, 500, "Debug search failed"
+        ) from e
 
 
 def _format_album_response(browse_id: str, album: dict) -> dict:
@@ -1711,8 +1781,9 @@ async def get_album(browse_id: str, user_id: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get album failed for {browse_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get album {browse_id}", e, 500, "Failed to load album"
+        ) from e
 
 
 @app.get("/artist/{channel_id}")
@@ -1766,8 +1837,9 @@ async def get_artist(channel_id: str, user_id: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get artist failed for {channel_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get artist {channel_id}", e, 500, "Failed to load artist"
+        ) from e
 
 
 @app.get("/song/{video_id}")
@@ -1776,6 +1848,7 @@ async def get_song(video_id: str, user_id: str = Query(...)):
 
     When user_id is "__public__", uses an unauthenticated YTMusic instance.
     """
+    video_id = _validate_video_id(video_id)
     try:
         if user_id == "__public__":
             yt = _get_public_ytmusic("native")
@@ -1800,8 +1873,9 @@ async def get_song(video_id: str, user_id: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get song failed for {video_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get song {video_id}", e, 500, "Failed to load song"
+        ) from e
 
 
 # ── Streaming ───────────────────────────────────────────────────────
@@ -1812,6 +1886,8 @@ async def get_stream_info(video_id: str, user_id: str = Query(...), quality: str
 
     When user_id is "__public__", skips OAuth verification.
     """
+    video_id = _validate_video_id(video_id)
+    quality = _validate_stream_quality(quality)
     # Skip OAuth check for public/unauthenticated streaming
     if user_id != "__public__":
         _get_ytmusic(user_id)
@@ -1844,6 +1920,8 @@ async def proxy_stream(
     extraction is unauthenticated). This enables free-tier streaming
     for users without YT Music OAuth connected.
     """
+    video_id = _validate_video_id(video_id)
+    quality = _validate_stream_quality(quality)
     # Skip OAuth check for public/unauthenticated streaming
     if user_id != "__public__":
         _get_ytmusic(user_id)
@@ -1967,8 +2045,12 @@ async def library_songs(user_id: str = Query(...), limit: int = 100, order: str 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get library songs failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get library songs for user {user_id}",
+            e,
+            500,
+            "Failed to load library songs",
+        ) from e
 
 
 @app.get("/library/albums")
@@ -1996,8 +2078,12 @@ async def library_albums(user_id: str = Query(...), limit: int = 100, order: str
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get library albums failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get library albums for user {user_id}",
+            e,
+            500,
+            "Failed to load library albums",
+        ) from e
 
 
 # Auto-generated / personalized playlist ID prefixes.
@@ -2054,8 +2140,12 @@ async def library_playlists(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Get library playlists failed for user {user_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Get library playlists for user {user_id}",
+            e,
+            500,
+            "Failed to load library playlists",
+        ) from e
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -2128,8 +2218,12 @@ async def yt_video_info(url: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"yt-dlp info extraction failed for {url}: {e}")
-        raise HTTPException(status_code=502, detail=f"Failed to fetch video info: {e}")
+        raise _sanitized_http_error(
+            f"yt-dlp info extraction for {url}",
+            e,
+            502,
+            "Failed to fetch video info",
+        ) from e
 
 
 @app.get("/yt/playlist-info")
@@ -2214,11 +2308,12 @@ async def yt_playlist_info(url: str = Query(...)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"yt-dlp playlist enumeration failed for {url}: {e}")
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to enumerate playlist/channel: {e}",
-        )
+        raise _sanitized_http_error(
+            f"yt-dlp playlist enumeration for {url}",
+            e,
+            502,
+            "Failed to enumerate playlist/channel",
+        ) from e
 
 
 @app.get("/yt/proxy/{video_id}")
@@ -2232,6 +2327,8 @@ async def yt_proxy_stream(
     No OAuth required — uses anonymous yt-dlp extraction.
     Same Range-request handling as the YouTube Music proxy.
     """
+    video_id = _validate_video_id(video_id)
+    quality = _validate_stream_quality(quality)
     stream_info = await asyncio.to_thread(_get_yt_stream_url_sync, video_id, quality)
     stream_url = stream_info["url"]
 
@@ -2741,8 +2838,9 @@ async def get_charts(country: str = "US", user_id: Optional[str] = Query(None)):
                 result[section_key] = items
         return result
     except Exception as e:
-        log.error(f"Charts fetch failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "Charts fetch", e, 500, "Failed to load charts"
+        ) from e
 
 
 @app.get("/moods-and-genres")
@@ -2768,8 +2866,12 @@ async def get_moods_and_genres(user_id: Optional[str] = Query(None)):
             result.append({"title": cat_title, "items": entries})
         return result
     except Exception as e:
-        log.error(f"Moods/genres fetch failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "Moods and genres fetch",
+            e,
+            500,
+            "Failed to load moods and genres",
+        ) from e
 
 
 @app.get("/home")
@@ -2828,8 +2930,9 @@ async def get_home(limit: int = Query(6, ge=1, le=20), user_id: Optional[str] = 
 
         return shelves
     except Exception as e:
-        log.error(f"Home fetch failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "Home fetch", e, 500, "Failed to load home"
+        ) from e
 
 
 @app.get("/browse-album/{browse_id}")
@@ -2845,8 +2948,12 @@ async def get_browse_album(browse_id: str):
         error_str = str(e).lower()
         if "not found" in error_str or "unable to find" in error_str:
             raise HTTPException(status_code=404, detail=f"Album not found: {browse_id}")
-        log.error(f"Browse album fetch failed for {browse_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Browse album fetch for {browse_id}",
+            e,
+            500,
+            "Failed to load album",
+        ) from e
 
 
 @app.get("/mood-playlists")
@@ -2892,8 +2999,12 @@ async def get_mood_playlists(params: str = Query(..., min_length=1, max_length=5
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Mood playlists fetch failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            "Mood playlists fetch",
+            e,
+            500,
+            "Failed to load mood playlists",
+        ) from e
 
 
 @app.get("/playlist/{playlist_id}")
@@ -2969,8 +3080,12 @@ async def get_playlist(
     except Exception as e:
         if isinstance(auth_error, HTTPException):
             raise auth_error
-        log.error(f"Playlist fetch failed for {playlist_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _sanitized_http_error(
+            f"Playlist fetch for {playlist_id}",
+            e,
+            500,
+            "Failed to load playlist",
+        ) from e
 
 
 def _fetch_mood_playlists(yt: YTMusic, params: str) -> list[dict]:

--- a/services/ytmusic-streamer/docker-entrypoint.sh
+++ b/services/ytmusic-streamer/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+# Legacy /data volumes may be root-owned (created before this image ran as a
+# non-root user; older images papered over that with chmod 777). When the
+# container starts as root (plain docker/compose default), repair ownership
+# and drop privileges to the ytmusic user via setpriv (util-linux, present in
+# python:*-slim). Under Kubernetes runAsUser/fsGroup the process starts
+# non-root already and this is a no-op passthrough.
+if [ "$(id -u)" = "0" ]; then
+  chown -R ytmusic:ytmusic /data
+  exec setpriv --reuid=ytmusic --regid=ytmusic --init-groups "$@"
+fi
+exec "$@"

--- a/services/ytmusic-streamer/tests/test_credential_file_permissions.py
+++ b/services/ytmusic-streamer/tests/test_credential_file_permissions.py
@@ -1,0 +1,74 @@
+"""Future private-permission contract for OAuth credential files."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def data_path(monkeypatch, tmp_path):
+    """Redirect credential writes to a temporary directory."""
+    import app
+
+    monkeypatch.setattr(app, "DATA_PATH", tmp_path)
+    yield tmp_path
+
+
+@pytest.mark.anyio
+async def test_auth_restore_writes_0600(client, data_path):
+    """Restore creates OAuth and client credential files with mode 0600."""
+    response = await client.post(
+        "/auth/restore?user_id=userx",
+        json={
+            "oauth_json": "{\"tok\": 1}",
+            "client_id": "cid",
+            "client_secret": "sec",
+        },
+    )
+    assert response.status_code == 200
+    for name in ["oauth_userx.json", "client_creds_userx.json"]:
+        mode = (data_path / name).stat().st_mode & 0o777
+        assert mode == 0o600
+
+
+@pytest.mark.anyio
+async def test_auth_restore_tightens_existing_file(client, data_path):
+    """Restore tightens a pre-existing OAuth file with loose permissions."""
+    oauth_path = data_path / "oauth_usery.json"
+    oauth_path.write_text("{}")
+    oauth_path.chmod(0o644)
+
+    response = await client.post(
+        "/auth/restore?user_id=usery", json={"oauth_json": "{}"}
+    )
+    assert response.status_code == 200
+    assert oauth_path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.anyio
+async def test_device_code_poll_success_writes_0600(
+    client, data_path, monkeypatch
+):
+    """Successful device polling writes both credential files as mode 0600."""
+    import app
+
+    class SuccessfulOAuthCredentials:
+        """Return a deterministic successful device-code token."""
+
+        def __init__(self, client_id, client_secret):
+            pass
+
+        def token_from_code(self, device_code):
+            return {"access_token": "at", "refresh_token": "rt"}
+
+    monkeypatch.setattr(app, "OAuthCredentials", SuccessfulOAuthCredentials)
+    response = await client.post(
+        "/auth/device-code/poll?user_id=userz",
+        json={"client_id": "c", "client_secret": "s", "device_code": "d"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    for name in ["oauth_userz.json", "client_creds_userz.json"]:
+        path = data_path / name
+        assert path.exists()
+        assert path.stat().st_mode & 0o777 == 0o600

--- a/services/ytmusic-streamer/tests/test_dockerfile_hardening.py
+++ b/services/ytmusic-streamer/tests/test_dockerfile_hardening.py
@@ -1,0 +1,44 @@
+"""Future-contract file tests for hardening the sidecar container startup."""
+
+import os
+from pathlib import Path
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = SERVICE_ROOT / "Dockerfile"
+ENTRYPOINT_SCRIPT = SERVICE_ROOT / "docker-entrypoint.sh"
+
+
+def test_dockerfile_has_no_world_writable_chmod() -> None:
+    """The image build must not grant world-write permission with chmod 777."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "chmod 777" not in dockerfile
+
+
+def test_dockerfile_uses_entrypoint_script() -> None:
+    """The tini entrypoint must delegate startup through docker-entrypoint.sh."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    entrypoint_lines = [
+        line for line in dockerfile.splitlines() if line.strip().startswith("ENTRYPOINT")
+    ]
+
+    assert any(
+        "tini" in line and "docker-entrypoint.sh" in line for line in entrypoint_lines
+    )
+
+
+def test_entrypoint_script_fixes_legacy_volume_ownership() -> None:
+    """Startup must repair /data ownership and then support non-root execution."""
+    assert ENTRYPOINT_SCRIPT.exists()
+
+    script = ENTRYPOINT_SCRIPT.read_text(encoding="utf-8")
+    assert "chown" in script
+    assert "setpriv" in script
+    assert "/data" in script
+    assert 'exec "$@"' in script
+
+
+def test_entrypoint_script_is_executable() -> None:
+    """The startup entrypoint script must have an executable mode bit."""
+    assert os.access(ENTRYPOINT_SCRIPT, os.X_OK)

--- a/services/ytmusic-streamer/tests/test_error_sanitization.py
+++ b/services/ytmusic-streamer/tests/test_error_sanitization.py
@@ -1,0 +1,157 @@
+"""Future-contract tests for sanitizing internal errors in HTTP responses."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+
+MARKER = "sekrit-yt-abc123"
+LOGGER_NAME = "ytmusic-streamer"
+
+
+@pytest.mark.anyio
+async def test_auth_status_reason_sanitized(client, monkeypatch, tmp_path, caplog) -> None:
+    """Auth status must log internal detail without returning it to clients."""
+    import app
+
+    monkeypatch.setattr(app, "DATA_PATH", tmp_path)
+    (tmp_path / "oauth_u1.json").write_text("{}", encoding="utf-8")
+
+    def raise_internal_error(user_id):
+        """Simulate credential initialization exposing sensitive detail."""
+        raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "_get_ytmusic", raise_internal_error)
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    response = await client.get("/auth/status?user_id=u1")
+
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is False
+    assert MARKER not in response.text
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno >= logging.WARNING
+        and MARKER in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_device_code_init_error_sanitized(client, monkeypatch, caplog) -> None:
+    """Device-code failures must keep logged exception details out of responses."""
+    import app
+
+    class FailingOAuthCredentials:
+        """Raise sensitive detail while constructing OAuth credentials."""
+
+        def __init__(self, client_id, client_secret):
+            raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "OAuthCredentials", FailingOAuthCredentials)
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    response = await client.post(
+        "/auth/device-code",
+        json={"client_id": "c", "client_secret": "s"},
+    )
+
+    assert response.status_code == 500
+    assert MARKER not in response.text
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno >= logging.WARNING
+        and MARKER in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_search_error_sanitized(client, monkeypatch, caplog) -> None:
+    """Search failures must keep logged exception details out of responses."""
+    import app
+
+    def raise_internal_error(user_id, query, filter_, limit, use_unauth_client=True):
+        """Simulate a search implementation failure with sensitive detail."""
+        raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "_search_with_mode_fallback", raise_internal_error)
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    response = await client.post("/search?user_id=u1", json={"query": "q"})
+
+    assert response.status_code == 500
+    assert MARKER not in response.text
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno >= logging.WARNING
+        and MARKER in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_home_error_sanitized(client, monkeypatch, caplog) -> None:
+    """Home failures must keep logged exception details out of responses."""
+    import app
+
+    def raise_internal_error(mode):
+        """Simulate public YTMusic client creation failing with sensitive detail."""
+        raise Exception(MARKER)
+
+    monkeypatch.setattr(app, "_get_public_ytmusic", raise_internal_error)
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    response = await client.get("/home?user_id=u1")
+
+    assert response.status_code == 500
+    assert MARKER not in response.text
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno >= logging.WARNING
+        and MARKER in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_stream_extraction_error_sanitized(monkeypatch, caplog) -> None:
+    """Stream extraction must log internal detail but return a generic 502."""
+    import app
+
+    class FailingYoutubeDL:
+        """Minimal yt-dlp context manager that fails during extraction."""
+
+        def __init__(self, options):
+            self.options = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def extract_info(self, url, download):
+            raise Exception(MARKER)
+
+    yt_dlp_stub = SimpleNamespace(YoutubeDL=FailingYoutubeDL)
+    monkeypatch.setitem(sys.modules, "yt_dlp", yt_dlp_stub)
+    monkeypatch.setattr(app, "_last_extract_time", 0)
+    app._stream_cache.clear()
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    with pytest.raises(HTTPException) as excinfo:
+        app._get_yt_stream_url_sync("dQw4w9WgXcQ", "HIGH")
+
+    assert excinfo.value.status_code == 502
+    assert MARKER not in str(excinfo.value.detail)
+    assert any(
+        record.name == LOGGER_NAME
+        and record.levelno >= logging.WARNING
+        and MARKER in record.getMessage()
+        for record in caplog.records
+    )

--- a/services/ytmusic-streamer/tests/test_input_validation.py
+++ b/services/ytmusic-streamer/tests/test_input_validation.py
@@ -1,0 +1,149 @@
+"""Future input-validation contract for stream and song routes."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+VALID_ID = "dQw4w9WgXcQ"
+
+
+@pytest.fixture()
+def stream_recorder(monkeypatch):
+    """Record extraction calls while returning deterministic stream metadata."""
+    import app
+
+    calls = []
+    stub = {
+        "url": "http://upstream/x",
+        "content_type": "m4a",
+        "duration": 10,
+        "title": "t",
+        "artist": "a",
+        "expires_at": 9999999999.0,
+        "abr": 128,
+        "acodec": "aac",
+    }
+    monkeypatch.setattr(
+        app,
+        "_get_stream_url_sync",
+        lambda user_id, video_id, quality="HIGH": (
+            calls.append((user_id, video_id, quality)) or stub
+        ),
+    )
+    monkeypatch.setattr(
+        app,
+        "_get_yt_stream_url_sync",
+        lambda video_id, quality="HIGH": (
+            calls.append(("yt", video_id, quality)) or stub
+        ),
+    )
+    yield calls
+
+
+@pytest.mark.anyio
+async def test_stream_rejects_malformed_video_id(client, stream_recorder):
+    """Malformed stream IDs are rejected before extraction begins."""
+    for bad in ["short", "waytoolongvideoid123", "bad.chars!!x"]:
+        response = await client.get(f"/stream/{bad}?user_id=__public__")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid video_id"
+        assert stream_recorder == []
+
+
+@pytest.mark.anyio
+async def test_stream_accepts_valid_video_id(client, stream_recorder):
+    """A valid stream ID reaches extraction with the default quality."""
+    response = await client.get(f"/stream/{VALID_ID}?user_id=__public__")
+    assert response.status_code == 200
+    assert stream_recorder[-1] == ("__public__", VALID_ID, "HIGH")
+
+
+@pytest.mark.anyio
+async def test_stream_rejects_bad_quality(client, stream_recorder):
+    """An unsupported stream quality is rejected before extraction."""
+    response = await client.get(
+        f"/stream/{VALID_ID}?user_id=__public__&quality=bogus"
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid quality"
+    assert stream_recorder == []
+
+
+@pytest.mark.anyio
+async def test_stream_normalizes_lowercase_quality(client, stream_recorder):
+    """A supported lowercase stream quality is normalized before use."""
+    response = await client.get(
+        f"/stream/{VALID_ID}?user_id=__public__&quality=lossless"
+    )
+    assert response.status_code == 200
+    assert stream_recorder[-1][2] == "LOSSLESS"
+
+
+@pytest.mark.anyio
+async def test_proxy_rejects_malformed_video_id(client, stream_recorder):
+    """The music proxy rejects a malformed ID before extraction."""
+    response = await client.get("/proxy/bad.id!?user_id=__public__")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid video_id"
+
+
+@pytest.mark.anyio
+async def test_proxy_rejects_bad_quality(client, stream_recorder):
+    """The music proxy rejects an unsupported quality before extraction."""
+    response = await client.get(
+        f"/proxy/{VALID_ID}?user_id=__public__&quality=ULTRA"
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid quality"
+
+
+@pytest.mark.anyio
+async def test_yt_proxy_rejects_malformed_video_id(client, stream_recorder):
+    """The YouTube proxy rejects a malformed ID before extraction."""
+    response = await client.get("/yt/proxy/nope")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid video_id"
+
+
+@pytest.mark.anyio
+async def test_yt_proxy_rejects_bad_quality(client, stream_recorder):
+    """The YouTube proxy rejects an unsupported quality before extraction."""
+    response = await client.get(f"/yt/proxy/{VALID_ID}?quality=extreme")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid quality"
+
+
+@pytest.mark.anyio
+async def test_song_rejects_malformed_video_id(client):
+    """The song route rejects a malformed ID before metadata extraction."""
+    response = await client.get("/song/tiny?user_id=__public__")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid video_id"
+
+
+@pytest.mark.anyio
+async def test_song_accepts_valid_video_id(client, monkeypatch):
+    """The song route accepts a valid ID and returns its metadata."""
+    import app
+
+    monkeypatch.setattr(
+        app,
+        "_get_public_ytmusic",
+        lambda strategy="native": types.SimpleNamespace(
+            get_song=lambda vid: {
+                "videoDetails": {
+                    "videoId": vid,
+                    "title": "T",
+                    "author": "A",
+                    "lengthSeconds": "10",
+                    "thumbnail": {"thumbnails": []},
+                }
+            }
+        ),
+    )
+    response = await client.get(f"/song/{VALID_ID}?user_id=__public__")
+    assert response.status_code == 200
+    assert response.json()["videoId"] == VALID_ID


### PR DESCRIPTION
Refactor-campaign slice P6: security fixes in the Python sidecars plus one coordinated backend change.

## Findings fixed

1. **TIDAL tokens in URL query strings** — `backend/src/services/tidal.ts` sent `access_token` (plus user id / country) as query params to the tidal-downloader on `POST /search`, `/download/track`, `/download/album`, where they can leak into access logs and proxies. The backend now sends `Authorization: Bearer <token>` + `x-tidal-user-id` / `x-tidal-country-code` headers.
2. **Exception text leaked into HTTP responses** — both FastAPI sidecars returned `str(e)` / f-string exception detail in error bodies across auth, search, download, stream, library, and browse endpoints. All those sites now return short generic messages; the full exception (with traceback) is logged service-side via the shared service logger. This includes the TIDAL album download per-track `errors[].error` field (now `"Download failed"`).
3. **World-readable OAuth credential files** — ytmusic-streamer wrote `oauth_<user>.json` / `client_creds_<user>.json` with default umask. They are now created via `os.open(..., 0o600)` and pre-existing files are tightened on rewrite.
4. **`chmod 777 /data` in the ytmusic image** — replaced with an entrypoint ownership repair: the image no longer sets a Dockerfile `USER`; when started as root (plain docker/compose) the new `docker-entrypoint.sh` chowns `/data` to `ytmusic` (legacy root-owned volumes keep working) and drops privileges via `setpriv`; non-root starts (k8s `runAsUser: 1000` + `fsGroup`) pass straight through unchanged. Verified on the built image: default start runs uid 1000 with `/data` owned by `ytmusic`; `--user 1000` start passes through.
5. **Missing trust-boundary validation** — ytmusic-streamer now validates `video_id` (`^[A-Za-z0-9_-]{11}$`, else 400 `Invalid video_id`) and `quality` (case-insensitive `LOW|MEDIUM|HIGH|LOSSLESS`, else 400 `Invalid quality`) on `/song`, `/stream`, `/proxy`, `/yt/proxy` before any extraction/proxy work. Side-effect fix: the lowercase quality values the backend sends are now honored instead of silently falling back to HIGH.

## Compatibility window (token header migration)

Backend and tidal-downloader images can roll independently for **one release**: the sidecar accepts both the new headers and the legacy query params, logging a deprecation warning when query credentials are used (header wins when both are present; no token at all → 401 `access_token required`). The query fallback is removed next release. Operator notes added to `docs/UPGRADING.md`; `CHANGELOG.md` updated.

## Tests (TDD — red first, then implemented to green)

New suites:
- `services/tidal-downloader/tests/test_admin_token_headers.py` (8 tests: bearer accepted, legacy query + deprecation warning, header precedence, 401s)
- `services/tidal-downloader/tests/test_error_sanitization.py` (6 tests: marker never in body, always in logs)
- `services/ytmusic-streamer/tests/test_input_validation.py` (10 tests), `test_credential_file_permissions.py` (3 tests, incl. tightening pre-existing 0644 files), `test_error_sanitization.py` (5 tests), `test_dockerfile_hardening.py` (4 tests)
- `backend/src/services/__tests__/tidalService.test.ts`: 3 URL-assertion tests rewritten to the header contract + `access_token`-absent-from-URL assertions.

Verification:
- `pytest services/tidal-downloader/tests` — 78 passed
- `pytest services/ytmusic-streamer/tests` — 148 passed
- `npx jest src/services/__tests__/tidalService.test.ts --maxWorkers=2` — 27 passed
- backend `npx tsc --noEmit` — 0 errors; `npx eslint` on touched backend files — clean
- ytmusic image docker build + entrypoint runtime check (root start → uid 1000 + chowned `/data`; `--user 1000` passthrough) — pass

## Out of scope / noted

- `/yt/download` job status still stores `str(e)` in `job["error"]` (async job result surfaced via job-status endpoints). Left as-is deliberately; flagged for a follow-up slice.
- `/yt/info`'s 400 detail echoes the caller-supplied URL in a controlled ValueError message (own message, not an internal leak) — unchanged.
