### PR TITLE
fix(security): SSRF guard on podcast egress + drop credentialed Origin reflection (refactor slice P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requires a well-formed payload, and rejects any token carrying a `type` claim,
   while `/api/auth/refresh` continues to accept refresh tokens for exchange
   only.
+- SSRF: podcast episode audio (stream + background download) is now validated by the DNS-resolving outbound-safety guard at fetch time, with every redirect hop re-validated (public CDN redirects and HTTP Range streaming preserved); attacker-controlled enclosure URLs can no longer reach private/loopback/link-local/metadata addresses.
+- CORS: the authenticated podcast stream and cover routes no longer reflect an arbitrary request Origin together with credentials; credentialed CORS is owned solely by the allowlist-enforcing global middleware.
 
 ### Added
 

--- a/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from "express";
 
+const mockLookup = jest.fn();
+jest.mock("dns/promises", () => ({
+    lookup: (...args: unknown[]) => mockLookup(...args),
+}));
+
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
@@ -321,6 +326,9 @@ describe("podcasts streaming/runtime behavior", () => {
         getSimilarPodcasts.mockResolvedValue([]);
 
         mockParseRangeHeader.mockReturnValue({ ok: true, start: 0, end: 99 });
+        mockLookup.mockResolvedValue([
+            { address: "93.184.216.34", family: 4 },
+        ]);
         mockAxiosGet.mockReset();
         mockAxiosHead.mockReset();
         mockAxiosIsCancel.mockReturnValue(false);
@@ -650,6 +658,7 @@ describe("podcasts streaming/runtime behavior", () => {
 
         const upstream = createStream();
         mockAxiosGet.mockResolvedValueOnce({
+            status: 200,
             data: upstream,
             headers: { "content-length": "3000" },
         });
@@ -683,6 +692,7 @@ describe("podcasts streaming/runtime behavior", () => {
 
         const upstream = createStream();
         mockAxiosGet.mockResolvedValueOnce({
+            status: 200,
             data: upstream,
             headers: { "content-length": "12345" },
         });
@@ -728,6 +738,42 @@ describe("podcasts streaming/runtime behavior", () => {
         expect(upstream.destroy).toHaveBeenCalled();
     });
 
+    it("does not reflect arbitrary Origin with credentials on the authenticated stream", async () => {
+        prisma.podcastEpisode.findUnique.mockResolvedValueOnce({
+            id: "ep-untrusted-origin",
+            title: "Episode Untrusted Origin",
+            guid: "guid-untrusted-origin",
+            audioUrl: "https://audio.example/episode.mp3",
+            mimeType: "audio/mpeg",
+            fileSize: 1000,
+        });
+        getCachedFilePath.mockResolvedValueOnce(null);
+
+        const upstream = createStream();
+        mockAxiosGet.mockResolvedValueOnce({
+            status: 200,
+            data: upstream,
+            headers: { "content-length": "1000" },
+        });
+
+        const req = {
+            params: {
+                podcastId: "pod-1",
+                episodeId: "ep-untrusted-origin",
+            },
+            user: { id: "user-1" },
+            headers: { origin: "https://evil.test" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(res.headers["Access-Control-Allow-Origin"]).toBeUndefined();
+        expect(res.headers["Access-Control-Allow-Credentials"]).toBeUndefined();
+        expect(res.statusCode).toBe(200);
+        expect(upstream.pipe).toHaveBeenCalledWith(res);
+    });
+
     it("returns 500 when uncached full-file stream fails before headers", async () => {
         prisma.podcastEpisode.findUnique.mockResolvedValueOnce({
             id: "ep-norange-fail",
@@ -750,7 +796,10 @@ describe("podcasts streaming/runtime behavior", () => {
 
         await streamHandler(req, res);
 
-        expect(mockAxiosHead).toHaveBeenCalledWith("https://audio/ep-norange-fail.mp3");
+        expect(mockAxiosHead).toHaveBeenCalledWith(
+            "https://audio/ep-norange-fail.mp3",
+            { maxRedirects: 0, timeout: 30000 }
+        );
         expect(downloadInBackground).toHaveBeenCalledWith(
             "ep-norange-fail",
             "https://audio/ep-norange-fail.mp3",
@@ -776,6 +825,7 @@ describe("podcasts streaming/runtime behavior", () => {
 
         const upstream = createStream();
         mockAxiosGet.mockResolvedValueOnce({
+            status: 200,
             data: upstream,
             headers: {},
         });
@@ -789,7 +839,10 @@ describe("podcasts streaming/runtime behavior", () => {
 
         await streamHandler(req, res);
 
-        expect(mockAxiosHead).toHaveBeenCalledWith("https://audio/ep-head-fail.mp3");
+        expect(mockAxiosHead).toHaveBeenCalledWith(
+            "https://audio/ep-head-fail.mp3",
+            { maxRedirects: 0, timeout: 30000 }
+        );
         expect(mockAxiosGet).toHaveBeenCalledTimes(1);
         expect(res.statusCode).toBe(200);
         expect(upstream.pipe).toHaveBeenCalledWith(res);
@@ -925,6 +978,7 @@ describe("podcasts streaming/runtime behavior", () => {
         mockAxiosGet
             .mockRejectedValueOnce(rangeError)
             .mockResolvedValueOnce({
+                status: 200,
                 data: fallbackStream,
                 headers: {},
             });
@@ -1052,6 +1106,134 @@ describe("podcasts streaming/runtime behavior", () => {
         expect(res.body).toEqual({
             error: "Failed to stream episode",
         });
+    });
+
+    it("blocks private podcast audio targets before uncached fetches", async () => {
+        const audioUrl = "http://169.254.169.254/meta.mp3";
+        prisma.podcastEpisode.findUnique.mockResolvedValueOnce({
+            id: "ep-private",
+            title: "Private Target",
+            guid: "guid-private",
+            audioUrl,
+            mimeType: "audio/mpeg",
+            fileSize: null,
+        });
+
+        const req = {
+            params: { podcastId: "pod-1", episodeId: "ep-private" },
+            user: { id: "user-1" },
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(res.statusCode).toBe(502);
+        expect(res.body).toEqual({
+            error: "Upstream audio source not allowed",
+        });
+        expect(mockAxiosHead).not.toHaveBeenCalled();
+        expect(mockAxiosGet).not.toHaveBeenCalledWith(
+            audioUrl,
+            expect.anything()
+        );
+    });
+
+    it("blocks private redirect targets during uncached range streaming", async () => {
+        const audioUrl = "https://audio.example/episode.mp3";
+        const privateUrl = "http://10.0.0.5/evil.mp3";
+        const interimStream = createStream();
+        prisma.podcastEpisode.findUnique.mockResolvedValueOnce({
+            id: "ep-private-redirect",
+            title: "Private Redirect",
+            guid: "guid-private-redirect",
+            audioUrl,
+            mimeType: "audio/mpeg",
+            fileSize: 4000,
+        });
+        mockParseRangeHeader.mockReturnValueOnce({
+            ok: true,
+            start: 100,
+            end: 199,
+        });
+        mockAxiosGet.mockResolvedValueOnce({
+            status: 302,
+            data: interimStream,
+            headers: { location: privateUrl },
+        });
+
+        const req = {
+            params: { podcastId: "pod-1", episodeId: "ep-private-redirect" },
+            user: { id: "user-1" },
+            headers: { range: "bytes=100-199" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(res.statusCode).toBe(502);
+        expect(res.body).toEqual({
+            error: "Upstream audio source not allowed",
+        });
+        expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+        expect(mockAxiosGet).not.toHaveBeenCalledWith(
+            privateUrl,
+            expect.anything()
+        );
+        expect(interimStream.destroy).toHaveBeenCalled();
+    });
+
+    it("preserves 206 range streaming across a public redirect", async () => {
+        const audioUrl = "https://audio.example/episode.mp3";
+        const cdnUrl = "https://cdn.example/episode.mp3";
+        const interimStream = createStream();
+        const upstream = createStream();
+        prisma.podcastEpisode.findUnique.mockResolvedValueOnce({
+            id: "ep-public-redirect",
+            title: "Public Redirect",
+            guid: "guid-public-redirect",
+            audioUrl,
+            mimeType: "audio/mpeg",
+            fileSize: 4000,
+        });
+        mockParseRangeHeader.mockReturnValueOnce({
+            ok: true,
+            start: 100,
+            end: 199,
+        });
+        mockAxiosGet
+            .mockResolvedValueOnce({
+                status: 302,
+                data: interimStream,
+                headers: { location: cdnUrl },
+            })
+            .mockResolvedValueOnce({
+                status: 206,
+                data: upstream,
+                headers: { "content-length": "100" },
+            });
+
+        const req = {
+            params: { podcastId: "pod-1", episodeId: "ep-public-redirect" },
+            user: { id: "user-1" },
+            headers: { range: "bytes=100-199" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(
+            2,
+            cdnUrl,
+            expect.objectContaining({
+                headers: { Range: "bytes=100-199" },
+                maxRedirects: 0,
+            })
+        );
+        expect(interimStream.destroy).toHaveBeenCalled();
+        expect(res.statusCode).toBe(206);
+        expect(res.headers["Content-Range"]).toBe("bytes 100-199/4000");
+        expect(upstream.pipe).toHaveBeenCalledWith(res);
     });
 
     it("updates and clears episode progress with error handling", async () => {
@@ -1188,9 +1370,12 @@ describe("podcasts streaming/runtime behavior", () => {
         await podcastCoverOptionsHandler(podcastReq, podcastRes);
 
         expect(podcastRes.statusCode).toBe(204);
-        expect(podcastRes.headers["Access-Control-Allow-Origin"]).toBe(
-            "https://app.test"
-        );
+        expect(
+            podcastRes.headers["Access-Control-Allow-Origin"]
+        ).toBeUndefined();
+        expect(
+            podcastRes.headers["Access-Control-Allow-Credentials"]
+        ).toBeUndefined();
         expect(podcastRes.headers["Access-Control-Allow-Methods"]).toBe(
             "GET, OPTIONS"
         );
@@ -1206,8 +1391,19 @@ describe("podcasts streaming/runtime behavior", () => {
         const episodeRes = createRes();
         await episodeCoverOptionsHandler(episodeReq, episodeRes);
         expect(episodeRes.statusCode).toBe(204);
-        expect(episodeRes.headers["Access-Control-Allow-Origin"]).toBe("*");
-        expect(episodeRes.headers["Access-Control-Allow-Credentials"]).toBe("true");
+        expect(
+            episodeRes.headers["Access-Control-Allow-Origin"]
+        ).toBeUndefined();
+        expect(
+            episodeRes.headers["Access-Control-Allow-Credentials"]
+        ).toBeUndefined();
+        expect(episodeRes.headers["Access-Control-Allow-Methods"]).toBe(
+            "GET, OPTIONS"
+        );
+        expect(episodeRes.headers["Access-Control-Allow-Headers"]).toBe(
+            "Content-Type"
+        );
+        expect(episodeRes.headers["Access-Control-Max-Age"]).toBe("86400");
     });
 
     it("handles podcast and episode cover serving branches", async () => {

--- a/backend/src/routes/podcasts.ts
+++ b/backend/src/routes/podcasts.ts
@@ -5,13 +5,66 @@ import { prisma, Prisma } from "../utils/db";
 import { rssParserService, RSSFeedNotModifiedError } from "../services/rss-parser";
 import { podcastCacheService } from "../services/podcastCache";
 import { parseRangeHeader } from "../utils/rangeParser";
-import { normalizeSafeOutboundUrl } from "../services/outboundUrlSafety";
+import {
+    normalizeSafeOutboundUrl,
+    resolveSafeOutboundRedirectTarget,
+    resolveSafeOutboundUrl,
+} from "../services/outboundUrlSafety";
 import axios from "axios";
 import fs from "fs";
 
 const router = Router();
 const ITUNES_DISCOVER_TIMEOUT_MS = 10000;
 const PODCAST_PRISMA_RETRY_ATTEMPTS = 3;
+const MAX_AUDIO_REDIRECTS = 5;
+
+class PodcastEgressBlockedError extends Error {
+    constructor(url: string) {
+        super(`Blocked SSRF-unsafe podcast audio target: ${url}`);
+        this.name = "PodcastEgressBlockedError";
+    }
+}
+
+async function openSafeAudioStream(
+    rawUrl: string,
+    opts: {
+        headers?: Record<string, string>;
+        timeoutMs: number;
+        signal: AbortSignal;
+        validateStatus: (status: number) => boolean;
+    }
+): Promise<import("axios").AxiosResponse> {
+    let current = await resolveSafeOutboundUrl(rawUrl);
+    if (!current) throw new PodcastEgressBlockedError(rawUrl);
+
+    for (let hop = 0; ; hop += 1) {
+        const response = await axios.get(current, {
+            responseType: "stream",
+            timeout: opts.timeoutMs,
+            signal: opts.signal,
+            maxRedirects: 0,
+            headers: opts.headers,
+            validateStatus: (status) =>
+                opts.validateStatus(status) ||
+                (status >= 300 && status < 400),
+        });
+        if (response.status < 300) return response;
+        if (response.data && typeof response.data.destroy === "function") {
+            response.data.destroy();
+        }
+        if (hop >= MAX_AUDIO_REDIRECTS) {
+            throw new PodcastEgressBlockedError(current);
+        }
+        const location =
+            typeof response.headers?.location === "string"
+                ? response.headers.location
+                : undefined;
+        if (!location) throw new PodcastEgressBlockedError(current);
+        const next = await resolveSafeOutboundRedirectTarget(location, current);
+        if (!next) throw new PodcastEgressBlockedError(location);
+        current = next;
+    }
+}
 
 function isRetryablePodcastPrismaError(error: unknown): boolean {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -1319,9 +1372,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                         "Content-Length": chunkSize,
                         "Content-Type": episode.mimeType || "audio/mpeg",
                         "Cache-Control": "public, max-age=3600",
-                        "Access-Control-Allow-Origin":
-                            req.headers.origin || "*",
-                        "Access-Control-Allow-Credentials": "true",
                     });
 
                     const fileStream = fs.createReadStream(cachedPath, {
@@ -1355,8 +1405,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                     "Content-Length": fileSize,
                     "Accept-Ranges": "bytes",
                     "Cache-Control": "public, max-age=3600",
-                    "Access-Control-Allow-Origin": req.headers.origin || "*",
-                    "Access-Control-Allow-Credentials": "true",
                 });
 
                 const fileStream = fs.createReadStream(cachedPath);
@@ -1400,7 +1448,16 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
         let fileSize = episode.fileSize;
         if (!fileSize) {
             try {
-                const headResponse = await axios.head(episode.audioUrl);
+                const safeHeadUrl = await resolveSafeOutboundUrl(
+                    episode.audioUrl
+                );
+                if (!safeHeadUrl) {
+                    throw new PodcastEgressBlockedError(episode.audioUrl);
+                }
+                const headResponse = await axios.head(safeHeadUrl, {
+                    maxRedirects: 0,
+                    timeout: 30000,
+                });
                 // axios >=1.18 types indexed header access as a union; coerce to string.
                 fileSize = parseInt(
                     String(headResponse.headers["content-length"] ?? "0")
@@ -1441,12 +1498,11 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
 
             try {
                 // Try range request first
-                const response = await axios.get(episode.audioUrl, {
+                const response = await openSafeAudioStream(episode.audioUrl, {
                     headers: { Range: `bytes=${start}-${end}` },
-                    responseType: "stream",
                     validateStatus: (status) =>
                         status === 206 || status === 200,
-                    timeout: 30000,
+                    timeoutMs: 30000,
                     signal: controller.signal,
                 });
 
@@ -1464,9 +1520,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                             response.headers["content-length"] || fileSize
                         ),
                         "Cache-Control": "public, max-age=3600",
-                        "Access-Control-Allow-Origin":
-                            req.headers.origin || "*",
-                        "Access-Control-Allow-Credentials": "true",
                     });
                 } else {
                     // Send 206 Partial Content with proper range
@@ -1476,9 +1529,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                         "Content-Length": chunkSize,
                         "Content-Type": episode.mimeType || "audio/mpeg",
                         "Cache-Control": "public, max-age=3600",
-                        "Access-Control-Allow-Origin":
-                            req.headers.origin || "*",
-                        "Access-Control-Allow-Credentials": "true",
                     });
                 }
 
@@ -1502,6 +1552,9 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                 response.data.pipe(res);
                 return;
             } catch (rangeError: any) {
+                if (rangeError instanceof PodcastEgressBlockedError) {
+                    throw rangeError;
+                }
                 if (axios.isCancel(rangeError)) {
                     logger.debug("    Request aborted by client");
                     return;
@@ -1515,10 +1568,11 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                 );
 
                 // Stream full file instead - browser will handle seeking locally
-                const response = await axios.get(episode.audioUrl, {
-                    responseType: "stream",
-                    timeout: 60000,
+                const response = await openSafeAudioStream(episode.audioUrl, {
+                    timeoutMs: 60000,
                     signal: controller.signal,
+                    validateStatus: (status) =>
+                        status >= 200 && status < 300,
                 });
 
                 const contentLength = response.headers["content-length"];
@@ -1530,8 +1584,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                         "Content-Length": String(contentLength),
                     }),
                     "Cache-Control": "public, max-age=3600",
-                    "Access-Control-Allow-Origin": req.headers.origin || "*",
-                    "Access-Control-Allow-Credentials": "true",
                 });
 
                 // Handle stream errors to prevent process crash
@@ -1566,9 +1618,11 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
             });
 
             try {
-                const response = await axios.get(episode.audioUrl, {
-                    responseType: "stream",
+                const response = await openSafeAudioStream(episode.audioUrl, {
+                    timeoutMs: 60000,
                     signal: controller.signal,
+                    validateStatus: (status) =>
+                        status >= 200 && status < 300,
                 });
 
                 const contentLength = response.headers["content-length"];
@@ -1580,8 +1634,6 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
                         "Content-Length": String(contentLength),
                     }),
                     "Cache-Control": "public, max-age=3600",
-                    "Access-Control-Allow-Origin": req.headers.origin || "*",
-                    "Access-Control-Allow-Credentials": "true",
                 });
 
                 // Handle stream errors to prevent process crash
@@ -1614,6 +1666,15 @@ router.get("/:podcastId/episodes/:episodeId/stream", async (req, res) => {
         }
     } catch (error: any) {
         logger.error("\n [PODCAST STREAM] Error:", error.message);
+        if (
+            error instanceof PodcastEgressBlockedError &&
+            !res.headersSent
+        ) {
+            res.status(502).json({
+                error: "Upstream audio source not allowed",
+            });
+            return;
+        }
         if (!res.headersSent) {
             res.status(500).json({
                 error: "Failed to stream episode",
@@ -1953,9 +2014,6 @@ router.get("/:id/similar", async (req, res) => {
  * Handle CORS preflight request for podcast cover images
  */
 router.options("/:id/cover", (req, res) => {
-    const origin = req.headers.origin || "*";
-    res.setHeader("Access-Control-Allow-Origin", origin);
-    res.setHeader("Access-Control-Allow-Credentials", "true");
     res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
     res.setHeader("Access-Control-Max-Age", "86400"); // 24 hours
@@ -2009,11 +2067,6 @@ router.get("/:id/cover", async (req, res) => {
                 "Cache-Control",
                 "public, max-age=31536000, immutable"
             );
-            res.setHeader(
-                "Access-Control-Allow-Origin",
-                req.headers.origin || "*"
-            );
-            res.setHeader("Access-Control-Allow-Credentials", "true");
             res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
             return res.sendFile(podcast.localCoverPath);
         }
@@ -2054,9 +2107,6 @@ router.get("/:id/cover", async (req, res) => {
  * Handle CORS preflight request for episode cover images
  */
 router.options("/episodes/:episodeId/cover", (req, res) => {
-    const origin = req.headers.origin || "*";
-    res.setHeader("Access-Control-Allow-Origin", origin);
-    res.setHeader("Access-Control-Allow-Credentials", "true");
     res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
     res.setHeader("Access-Control-Max-Age", "86400"); // 24 hours
@@ -2110,11 +2160,6 @@ router.get("/episodes/:episodeId/cover", async (req, res) => {
                 "Cache-Control",
                 "public, max-age=31536000, immutable"
             );
-            res.setHeader(
-                "Access-Control-Allow-Origin",
-                req.headers.origin || "*"
-            );
-            res.setHeader("Access-Control-Allow-Credentials", "true");
             res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
             return res.sendFile(episode.localCoverPath);
         }

--- a/backend/src/services/__tests__/podcastDownloadRuntime.test.ts
+++ b/backend/src/services/__tests__/podcastDownloadRuntime.test.ts
@@ -67,6 +67,7 @@ describe("podcast download runtime behavior", () => {
         };
 
         const axiosGet = jest.fn(async () => ({
+            status: 200,
             headers: { "content-length": "0" },
             data: {
                 on: jest.fn(),
@@ -74,6 +75,9 @@ describe("podcast download runtime behavior", () => {
                 pipe: jest.fn(),
             },
         }));
+        const lookup = jest.fn(async () => [
+            { address: "93.184.216.34", family: 4 },
+        ]);
 
         jest.doMock("../../utils/db", () => ({ prisma, Prisma }));
         jest.doMock("../../utils/logger", () => ({ logger }));
@@ -91,6 +95,7 @@ describe("podcast download runtime behavior", () => {
             default: { get: axiosGet },
             get: axiosGet,
         }));
+        jest.doMock("dns/promises", () => ({ lookup }));
 
         return {
             Prisma,
@@ -99,6 +104,7 @@ describe("podcast download runtime behavior", () => {
             fsPromises,
             fsModule,
             axiosGet,
+            lookup,
         };
     }
 
@@ -217,6 +223,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -273,6 +280,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "0" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -416,6 +424,7 @@ describe("podcast download runtime behavior", () => {
             };
 
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: dataStream,
             };
@@ -524,6 +533,7 @@ describe("podcast download runtime behavior", () => {
         });
 
         (mocks.axiosGet as jest.Mock).mockResolvedValue({
+            status: 200,
             headers: { "content-length": "3" },
             data: {
                 on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -567,6 +577,7 @@ describe("podcast download runtime behavior", () => {
             fileSize: 30,
         });
         (mocks.axiosGet as jest.Mock).mockResolvedValue({
+            status: 200,
             headers: { "content-length": "3" },
             data: {
                 on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -610,6 +621,7 @@ describe("podcast download runtime behavior", () => {
             fileSize: 3,
         });
         (mocks.axiosGet as jest.Mock).mockResolvedValue({
+            status: 200,
             headers: { "content-length": "0" },
             data: {
                 on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -655,6 +667,7 @@ describe("podcast download runtime behavior", () => {
         (mocks.axiosGet as jest.Mock)
             .mockRejectedValueOnce(new Error("network flake"))
             .mockResolvedValueOnce({
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -692,6 +705,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -749,6 +763,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -806,6 +821,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -867,6 +883,7 @@ describe("podcast download runtime behavior", () => {
             const control: Record<string, (...args: any[]) => void> = {};
             streamControls.push(control);
             return {
+                status: 200,
                 headers: { "content-length": "3" },
                 data: {
                     on: jest.fn((event: string, cb: (...args: any[]) => void) => {
@@ -918,6 +935,165 @@ describe("podcast download runtime behavior", () => {
             "stream error"
         );
         setTimeoutSpy.mockRestore();
+    });
+
+    it("blocks private audio URLs without fetching or writing a final file", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        mocks.fsPromises.access.mockRejectedValue(new Error("not found"));
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        podcastDownload.downloadInBackground(
+            "episode-private",
+            "http://169.254.169.254/latest.mp3",
+            "user-1"
+        );
+        for (let i = 0; i < 5; i += 1) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+
+        expect(mocks.axiosGet).not.toHaveBeenCalled();
+        expect(mocks.fsPromises.rename).not.toHaveBeenCalled();
+        expect(mocks.prisma.podcastDownload.upsert).not.toHaveBeenCalled();
+        expect(mocks.logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Background download failed for episode-private"
+            ),
+            expect.stringContaining("Blocked SSRF-unsafe podcast download target")
+        );
+    });
+
+    it("blocks a private redirect without fetching the private host", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const privateUrl = "http://10.0.0.5/x.mp3";
+        const interimStream = { destroy: jest.fn() };
+        mocks.fsPromises.access.mockRejectedValue(new Error("not found"));
+        (mocks.axiosGet as jest.Mock).mockResolvedValueOnce({
+            status: 302,
+            headers: { location: privateUrl },
+            data: interimStream,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        podcastDownload.downloadInBackground(
+            "episode-private-redirect",
+            "https://audio.example/episode.mp3",
+            "user-1"
+        );
+        for (let i = 0; i < 5; i += 1) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+
+        expect(mocks.axiosGet).toHaveBeenCalledTimes(1);
+        expect(mocks.axiosGet).not.toHaveBeenCalledWith(
+            privateUrl,
+            expect.anything()
+        );
+        expect(interimStream.destroy).toHaveBeenCalled();
+        expect(mocks.fsPromises.rename).not.toHaveBeenCalled();
+    });
+
+    it("downloads across a public redirect chain", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const cdnUrl = "https://cdn.example/episode.mp3";
+        const interimStream = { destroy: jest.fn() };
+        const writeStream = (mocks.fsModule.createWriteStream as jest.Mock)();
+        (mocks.fsModule.createWriteStream as jest.Mock).mockReturnValue(writeStream);
+        mocks.fsPromises.access.mockRejectedValue(new Error("not found"));
+        (mocks.fsPromises.stat as jest.Mock).mockImplementation(
+            async (targetPath: string) =>
+                targetPath.endsWith(".tmp")
+                    ? { size: 3 }
+                    : { size: 1_048_576 }
+        );
+        (mocks.axiosGet as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 302,
+                headers: { location: cdnUrl },
+                data: interimStream,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                headers: { "content-length": "3" },
+                data: {
+                    on: jest.fn(
+                        (event: string, cb: (...args: any[]) => void) => {
+                            if (event === "data") cb(Buffer.from("abc"));
+                            if (event === "end") cb();
+                        }
+                    ),
+                    pipe: jest.fn(),
+                    destroy: jest.fn(),
+                },
+            });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        podcastDownload.downloadInBackground(
+            "episode-public-redirect",
+            "https://audio.example/episode.mp3",
+            "user-1"
+        );
+        for (let i = 0; i < 6; i += 1) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+
+        expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+            2,
+            cdnUrl,
+            expect.objectContaining({ maxRedirects: 0 })
+        );
+        expect(interimStream.destroy).toHaveBeenCalled();
+        expect(mocks.fsPromises.rename).toHaveBeenCalled();
+        expect(mocks.prisma.podcastDownload.upsert).toHaveBeenCalled();
+    });
+
+    it("warns and continues when Content-Length persistence fails", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const writeStream = (mocks.fsModule.createWriteStream as jest.Mock)();
+        (mocks.fsModule.createWriteStream as jest.Mock).mockReturnValue(writeStream);
+        mocks.fsPromises.access.mockRejectedValue(new Error("not found"));
+        (mocks.fsPromises.stat as jest.Mock).mockImplementation(
+            async (targetPath: string) =>
+                targetPath.endsWith(".tmp")
+                    ? { size: 3 }
+                    : { size: 1_048_576 }
+        );
+        (mocks.prisma.podcastEpisode.findUnique as jest.Mock).mockResolvedValue({
+            fileSize: 0,
+        });
+        (mocks.prisma.podcastEpisode.update as jest.Mock).mockRejectedValue(
+            new Error("fileSize update failed")
+        );
+        (mocks.axiosGet as jest.Mock).mockResolvedValue({
+            status: 200,
+            headers: { "content-length": "3" },
+            data: {
+                on: jest.fn((event: string, cb: (...args: any[]) => void) => {
+                    if (event === "data") cb(Buffer.from("abc"));
+                    if (event === "end") cb();
+                }),
+                pipe: jest.fn(),
+                destroy: jest.fn(),
+            },
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        podcastDownload.downloadInBackground(
+            "episode-file-size-warning",
+            "https://audio.example/warn.mp3",
+            "user-1"
+        );
+        for (let i = 0; i < 6; i += 1) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("fileSize update failed")
+        );
+        expect(mocks.prisma.podcastDownload.upsert).toHaveBeenCalled();
     });
 
     it("logs cleanup errors and continues processing remaining expired entries", async () => {

--- a/backend/src/services/podcastDownload.ts
+++ b/backend/src/services/podcastDownload.ts
@@ -5,6 +5,10 @@ import fs from "fs/promises";
 import path from "path";
 import axios from "axios";
 import { BRAND_USER_AGENT } from "../config/brand";
+import {
+    resolveSafeOutboundRedirectTarget,
+    resolveSafeOutboundUrl,
+} from "./outboundUrlSafety";
 
 /**
  * PodcastDownloadService - Background download and caching of podcast episodes
@@ -25,6 +29,53 @@ interface DownloadProgress {
 }
 const downloadProgress = new Map<string, DownloadProgress>();
 const PODCAST_DOWNLOAD_PRISMA_RETRY_ATTEMPTS = 3;
+const MAX_PODCAST_DOWNLOAD_REDIRECTS = 5;
+
+class PodcastDownloadBlockedError extends Error {
+    constructor(url: string) {
+        super(`Blocked SSRF-unsafe podcast download target: ${url}`);
+        this.name = "PodcastDownloadBlockedError";
+    }
+}
+
+async function openSafePodcastDownloadStream(
+    rawUrl: string
+): Promise<import("axios").AxiosResponse> {
+    let current = await resolveSafeOutboundUrl(rawUrl);
+    if (!current) throw new PodcastDownloadBlockedError(rawUrl);
+
+    for (let hop = 0; ; hop += 1) {
+        const response = await axios.get(current, {
+            responseType: "stream",
+            timeout: 600000,
+            maxRedirects: 0,
+            headers: { "User-Agent": BRAND_USER_AGENT },
+            decompress: false,
+            validateStatus: (status) =>
+                (status >= 200 && status < 300) ||
+                (status >= 300 && status < 400),
+        });
+        if (response.status < 300) return response;
+        if (response.data && typeof response.data.destroy === "function") {
+            response.data.destroy();
+        }
+        if (hop >= MAX_PODCAST_DOWNLOAD_REDIRECTS) {
+            throw new PodcastDownloadBlockedError(current);
+        }
+        const location =
+            typeof response.headers?.location === "string"
+                ? response.headers.location
+                : undefined;
+        if (!location) throw new PodcastDownloadBlockedError(current);
+        const next = await resolveSafeOutboundRedirectTarget(location, current);
+        if (!next) throw new PodcastDownloadBlockedError(location);
+        current = next;
+    }
+}
+
+function describePodcastDownloadError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
 
 function isRetryablePodcastDownloadPrismaError(error: unknown): boolean {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -271,15 +322,7 @@ async function performDownload(
         await fs.unlink(tempPath).catch(() => {});
         
         // Download the file with longer timeout for large podcasts
-        const response = await axios.get(audioUrl, {
-            responseType: 'stream',
-            timeout: 600000, // 10 minute timeout for large files (3+ hour podcasts)
-            headers: {
-                "User-Agent": BRAND_USER_AGENT,
-            },
-            // Don't let axios decompress - we want raw bytes
-            decompress: false
-        });
+        const response = await openSafePodcastDownloadStream(audioUrl);
         
         // axios >=1.18 types indexed header access as a union; coerce to string.
         const contentLength = parseInt(String(response.headers["content-length"] ?? "0"), 10);
@@ -320,8 +363,10 @@ async function performDownload(
                         );
                     }
                 }
-            } catch {
-                // Non-fatal
+            } catch (error) {
+                logger.warn(
+                    `[PODCAST-DL] Failed to persist Content-Length as episode fileSize: ${describePodcastDownloadError(error)}`
+                );
             }
         } else {
             // Fallback: use DB fileSize if present (better than nothing)
@@ -337,7 +382,11 @@ async function performDownload(
                 if (episode?.fileSize && episode.fileSize > 0) {
                     expectedBytes = episode.fileSize;
                 }
-            } catch {}
+            } catch (error) {
+                logger.warn(
+                    `[PODCAST-DL] Failed to read fallback episode fileSize: ${describePodcastDownloadError(error)}`
+                );
+            }
         }
 
         logger.debug(
@@ -450,6 +499,10 @@ async function performDownload(
         // Clean up temp file and progress tracking on error
         await fs.unlink(tempPath).catch(() => {});
         downloadProgress.delete(episodeId);
+
+        if (error instanceof PodcastDownloadBlockedError) {
+            throw error;
+        }
         
         // Retry on failure
         if (attempt < maxAttempts) {


### PR DESCRIPTION
## Summary

Podcast **P2 security slice** (`podcast-ssrf-egress`). Closes a verified full SSRF read primitive plus a credentialed CORS Origin-reflection weakness.

### The vulnerabilities

1. **SSRF (fetch-time).** Podcast episode enclosure (`audioUrl`) values are attacker-controlled — they come from parsed RSS feeds and are persisted to the DB. The stream route (`GET /:podcastId/episodes/:episodeId/stream`) and the background download service (`performDownload`) fetched these URLs with **no outbound-safety guard**, and axios auto-followed redirects (default `maxRedirects: 5`) **without revalidating hops**. An attacker could point an enclosure — or a redirect from a public-looking one — at `169.254.169.254`, `10.0.0.0/8`, loopback, etc., and have the response piped back to them.
2. **CORS.** The authenticated stream and cover routes set `Access-Control-Allow-Origin: <reflected request Origin>` together with `Access-Control-Allow-Credentials: true`, reflecting *any* origin with credentials and defeating the same-origin policy on authenticated responses.

### The fix

- **Fetch-time validation** (not just ingest — stored rows predate any guard): both the stream route and `performDownload` now run `audioUrl` through the existing DNS-resolving `resolveSafeOutboundUrl` guard before fetching. The existing helper was **reused**, not reinvented.
- **Per-hop redirect revalidation** mirroring the established `rss-parser.ts` pattern: redirects are followed manually (`maxRedirects: 0`) and every hop is re-validated with `resolveSafeOutboundRedirectTarget`, so **legit CDN redirect chains keep working** while each hop is range-checked. Interim redirect streams are destroyed; hop count is bounded (5).
- HEAD size-probe guarded; a bounded timeout added to the previously unbounded no-range stream fetch. Blocked targets return **502** on the stream route and skip download retries.
- Previously silent `catch {}` blocks around Content-Length/`fileSize` persistence in `performDownload` are now explicit logged warnings (still non-fatal).
- **CORS**: route-local `Access-Control-Allow-Origin`/`Access-Control-Allow-Credentials` reflection removed from the stream (6 sites) and cover GET/OPTIONS handlers; credentialed CORS is owned solely by the allowlist-enforcing global middleware. **Global CORS config (`utils/cors.ts`, `index.ts`) deliberately untouched** — owned by a separate slice.

### Range / streaming regression coverage

HTTP Range behavior is explicitly regression-tested: cached 206, uncached 206 across a public redirect, 200-when-upstream-ignores-range, and range-fallback paths all covered and passing.

## Tests

TDD (failing tests first, then implementation):
- `podcastsStreamingRuntime.test.ts`: private target → 502; private redirect hop blocked (no fetch to private host, interim stream destroyed); public redirect → 206 preserved; no arbitrary-Origin+credentials reflection; preflight assertions updated.
- `podcastDownloadRuntime.test.ts`: private URL never fetched/written; private redirect blocked; public redirect chain downloads; fileSize-persistence failure now warns and continues.

### Verification
- `verify:` jest (podcast suites, `--maxWorkers=2`, flock-serialized): **176 tests, all pass** (155 + 21 across 11 suites).
- `verify:` `tsc --noEmit` exit 0.
- Backend has no eslint config/script; verification is tsc + jest per AGENTS.md.

## Files changed
- `backend/src/routes/podcasts.ts`
- `backend/src/services/podcastDownload.ts`
- `backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts`
- `backend/src/services/__tests__/podcastDownloadRuntime.test.ts`
- `CHANGELOG.md` (Security section)

## Notes / out-of-scope discoveries
- `rss-parser.ts` and `podcastCache.ts` (both in the slice's file list) already applied the SSRF guard correctly — no change needed.
- The SSRF helper's own docstring notes a residual **DNS-rebinding** gap (resolve-time check vs. connect-time IP pinning) — pre-existing, larger follow-up, not in this slice's scope.