### PR TITLE
fix(frontend): polling hygiene — timer leaks, forked poll chains, visibility gating (refactor slice P12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/ci/backend-coverage-summary.mjs` now exits non-zero when
   `ENFORCE_COVERAGE_GATE=true` and the coverage summary is missing, closing the
   previous fail-open path.
+- Frontend polling hygiene: album/track preview playback no longer resumes the
+  main player over an active preview (a cleanup effect fired on every state
+  change, also destroying cached preview audio elements), and both preview
+  hooks now share one behavior — when a preview ends, errors, or unmounts, the
+  main player resumes only if the preview paused it.
+- TIDAL device-code authentication (both settings sections) now runs through a
+  shared `useDeviceAuthPolling` hook: re-clicking authenticate no longer leaks
+  the previous poll interval, the expiry timer is tracked and cleared on
+  success/cancel/unmount, and code expiry surfaces its error message instead
+  of being hidden by a stale-state closure.
+- Download status polling no longer forks a permanent extra poll chain each
+  time a `download-status-changed` event fires; all scheduling now flows
+  through a single tracked timer. `addPendingDownload` no longer performs side
+  effects inside its React state updater (StrictMode-safe).
+- Raw `setInterval` pollers (feature flags, presence heartbeat, active listen
+  sessions, job status, listen-together lobby discovery, device-link status)
+  now pause while the tab is hidden and refresh once on return to visibility
+  via a shared `useVisibilityGatedInterval` hook. The features provider also
+  no longer double-fetches on tab return (duplicate `focus` +
+  `visibilitychange` listeners). Presence heartbeats stop while a tab is
+  hidden, so backgrounded tabs no longer report the user as actively present.
 - Dev tooling: repaired the broken local compose files — `docker-compose.local.yml`'s
   `audio-analysis` profile pointed its analyzers' `depends_on` and connection URLs
   at nonexistent `postgres`/`redis` services (the services are

--- a/frontend/app/device/page.tsx
+++ b/frontend/app/device/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 import { api } from "@/lib/api";
 import {
     BRAND_DEEP_LINK_SCHEME,
@@ -112,26 +113,26 @@ export default function DeviceLinkPage() {
     }, [timeRemaining, codeUsed]);
 
     // Poll for code usage
-    useEffect(() => {
-        if (!linkCode || timeRemaining <= 0 || codeUsed) return;
+    const checkCodeStatus = useCallback(async () => {
+        if (!linkCode) return;
 
-        const pollInterval = setInterval(async () => {
-            try {
-                const status = await api.request<{ status: string; deviceName?: string }>(
-                    `/device-link/status/${linkCode.code}`
-                );
-                
-                if (status.status === "used") {
-                    setCodeUsed(true);
-                    loadDevices(); // Refresh devices list
-                }
-            } catch (err) {
-                sharedFrontendLogger.error("Failed to check code status:", err);
+        try {
+            const status = await api.request<{ status: string; deviceName?: string }>(
+                `/device-link/status/${linkCode.code}`
+            );
+
+            if (status.status === "used") {
+                setCodeUsed(true);
+                loadDevices(); // Refresh devices list
             }
-        }, 2000);
+        } catch (err) {
+            sharedFrontendLogger.error("Failed to check code status:", err);
+        }
+    }, [linkCode, loadDevices]);
 
-        return () => clearInterval(pollInterval);
-    }, [linkCode, timeRemaining, codeUsed, loadDevices]);
+    useVisibilityGatedInterval(checkCodeStatus, 2000, {
+        enabled: Boolean(linkCode) && timeRemaining > 0 && !codeUsed,
+    });
 
     // Copy code to clipboard
     const copyCode = () => {

--- a/frontend/app/listen-together/page.tsx
+++ b/frontend/app/listen-together/page.tsx
@@ -34,6 +34,7 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { cn } from "@/utils/cn";
 import { TidalBadge } from "@/components/ui/TidalBadge";
 import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 import type { SyncQueueItem } from "@/lib/listen-together-socket";
 
 // ---------------------------------------------------------------------------
@@ -160,11 +161,9 @@ function LobbyView() {
 
     useEffect(() => {
         fetchDiscover();
-        const interval = setInterval(() => {
-            void fetchDiscover(true);
-        }, 5000);
-        return () => clearInterval(interval);
     }, [fetchDiscover]);
+
+    useVisibilityGatedInterval(() => void fetchDiscover(true), 5000);
 
     const handleCreate = async () => {
         if (!canUseListenTogether) {

--- a/frontend/features/discover/hooks/usePreviewPlayer.ts
+++ b/frontend/features/discover/hooks/usePreviewPlayer.ts
@@ -1,33 +1,98 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import {
+    useState,
+    useCallback,
+    useEffect,
+    useRef,
+    type Dispatch,
+    type SetStateAction,
+} from "react";
 import { toast } from "sonner";
 import { createRuntimeAudioEngine } from "@/lib/audio-engine";
 
 const playbackEngine = createRuntimeAudioEngine();
+
+function resumeMainPlayerIfPaused(pausedRef: { current: boolean }): void {
+    if (!pausedRef.current) return;
+    playbackEngine.play();
+    pausedRef.current = false;
+}
+
+function createPreviewAudio(
+    albumId: string,
+    previewUrl: string,
+    previewAudios: Map<string, HTMLAudioElement>,
+    setCurrentPreview: Dispatch<SetStateAction<string | null>>,
+    mainPlayerWasPausedRef: { current: boolean },
+): HTMLAudioElement {
+    const audio = new Audio(previewUrl);
+    audio.onended = () => {
+        setCurrentPreview(null);
+        resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
+    };
+    audio.onerror = () => {
+        toast.error("Failed to load preview");
+        setCurrentPreview(null);
+        if (previewAudios.get(albumId) === audio) {
+            previewAudios.delete(albumId);
+        }
+        resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
+    };
+    previewAudios.set(albumId, audio);
+    return audio;
+}
+
+function stopPreviewAudio(audio?: HTMLAudioElement): void {
+    if (!audio) return;
+    audio.pause();
+    audio.currentTime = 0;
+}
+
+function startPreview(
+    albumId: string,
+    previewUrl: string,
+    previewAudios: Map<string, HTMLAudioElement>,
+    setCurrentPreview: Dispatch<SetStateAction<string | null>>,
+    mainPlayerWasPausedRef: { current: boolean },
+): void {
+    if (playbackEngine.isPlaying()) {
+        playbackEngine.pause();
+        mainPlayerWasPausedRef.current = true;
+    }
+
+    const audio = previewAudios.get(albumId) ?? createPreviewAudio(
+        albumId,
+        previewUrl,
+        previewAudios,
+        setCurrentPreview,
+        mainPlayerWasPausedRef,
+    );
+    audio.play().then(() => {
+        setCurrentPreview(albumId);
+    }).catch((error) => {
+        toast.error("Failed to play preview: " + error.message);
+        setCurrentPreview(null);
+        resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
+    });
+}
 
 /**
  * Executes usePreviewPlayer.
  */
 export function usePreviewPlayer() {
     const [currentPreview, setCurrentPreview] = useState<string | null>(null);
-    const [previewAudios, setPreviewAudios] = useState<
-        Map<string, HTMLAudioElement>
-    >(new Map());
+    const previewAudiosRef = useRef<Map<string, HTMLAudioElement>>(new Map());
     const mainPlayerWasPausedRef = useRef(false);
 
     // Cleanup audio on unmount
     useEffect(() => {
         return () => {
-            previewAudios.forEach((audio) => {
+            previewAudiosRef.current.forEach((audio) => {
                 audio.pause();
                 audio.src = "";
             });
-            // Resume main player if needed
-            if (mainPlayerWasPausedRef.current) {
-                playbackEngine.play();
-                mainPlayerWasPausedRef.current = false;
-            }
+            resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
         };
-    }, [previewAudios]);
+    }, []);
 
     const handleTogglePreview = useCallback(
         (albumId: string, previewUrl: string) => {
@@ -38,64 +103,26 @@ export function usePreviewPlayer() {
 
             // Stop currently playing preview if any
             if (currentPreview && currentPreview !== albumId) {
-                const audio = previewAudios.get(currentPreview);
-                if (audio) {
-                    audio.pause();
-                    audio.currentTime = 0;
-                }
+                stopPreviewAudio(previewAudiosRef.current.get(currentPreview));
             }
 
             // Toggle the clicked preview
             if (currentPreview === albumId) {
-                const audio = previewAudios.get(albumId);
-                if (audio) {
-                    audio.pause();
-                    audio.currentTime = 0;
-                }
+                stopPreviewAudio(previewAudiosRef.current.get(albumId));
                 setCurrentPreview(null);
-                // Resume main player if it was playing before
-                if (mainPlayerWasPausedRef.current) {
-                    playbackEngine.play();
-                    mainPlayerWasPausedRef.current = false;
-                }
-            } else {
-                // Pause the main player if it's playing
-                if (playbackEngine.isPlaying()) {
-                    playbackEngine.pause();
-                    mainPlayerWasPausedRef.current = true;
-                }
-
-                let audio = previewAudios.get(albumId);
-                if (!audio) {
-                    audio = new Audio(previewUrl);
-                    audio.onended = () => {
-                        setCurrentPreview(null);
-                        // Resume main player if it was playing before
-                        if (mainPlayerWasPausedRef.current) {
-                            playbackEngine.play();
-                            mainPlayerWasPausedRef.current = false;
-                        }
-                    };
-                    audio.onerror = () => {
-                        toast.error("Failed to load preview");
-                        setCurrentPreview(null);
-                    };
-                    const newMap = new Map(previewAudios);
-                    newMap.set(albumId, audio);
-                    setPreviewAudios(newMap);
-                }
-
-                audio
-                    .play()
-                    .then(() => {
-                        setCurrentPreview(albumId);
-                    })
-                    .catch((error) => {
-                        toast.error("Failed to play preview: " + error.message);
-                    });
+                resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
+                return;
             }
+
+            startPreview(
+                albumId,
+                previewUrl,
+                previewAudiosRef.current,
+                setCurrentPreview,
+                mainPlayerWasPausedRef,
+            );
         },
-        [currentPreview, previewAudios]
+        [currentPreview],
     );
 
     return {

--- a/frontend/features/settings/components/sections/TidalSection.tsx
+++ b/frontend/features/settings/components/sections/TidalSection.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { SettingsRow, SettingsInput, SettingsSelect, SettingsToggle, IntegrationCard } from "../ui";
 import { SystemSettings } from "../../types";
 import { ExternalLink, CheckCircle, XCircle, Loader2, AlertTriangle, Music2 } from "lucide-react";
 import { InlineStatus, StatusType } from "@/components/ui/InlineStatus";
 import { api } from "@/lib/api";
+import { useDeviceAuthPolling } from "@/hooks/useDeviceAuthPolling";
 
 interface TidalCardProps {
     settings: SystemSettings;
@@ -13,8 +14,6 @@ interface TidalCardProps {
     onTest: (service: string) => Promise<{ success: boolean; version?: string; error?: string }>;
     isTesting: boolean;
 }
-
-type AuthState = "idle" | "loading" | "polling" | "success" | "error";
 
 const QUALITY_OPTIONS = [
     { value: "LOW", label: "Low (AAC 96 kbps)" },
@@ -30,18 +29,8 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
     const [testStatus, setTestStatus] = useState<StatusType>("idle");
     const [testMessage, setTestMessage] = useState("");
 
-    // Device auth flow state
-    const [authState, setAuthState] = useState<AuthState>("idle");
-    const [authUrl, setAuthUrl] = useState("");
     const [authMessage, setAuthMessage] = useState("");
-    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-    // Clean up polling on unmount
-    useEffect(() => {
-        return () => {
-            if (pollRef.current) clearInterval(pollRef.current);
-        };
-    }, []);
+    const authResultRef = useRef<Awaited<ReturnType<typeof api.tidalPollAuth>> | null>(null);
 
     const handleTest = async () => {
         setTestStatus("loading");
@@ -56,67 +45,59 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
         }
     };
 
-    const handleAuthenticate = useCallback(async () => {
-        setAuthState("loading");
-        setAuthMessage("Requesting device code...");
+    const initiateAuth = useCallback(async () => {
+        const deviceAuth = await api.tidalDeviceAuth();
+        let authLink = deviceAuth.verification_uri_complete;
+        if (authLink && !authLink.startsWith("http")) authLink = `https://${authLink}`;
+        return {
+            deviceCode: deviceAuth.device_code,
+            verificationUri: authLink,
+            userCode: deviceAuth.user_code,
+            pollIntervalMs: (deviceAuth.interval || 5) * 1000,
+            expiresAtMs: Date.now() + (deviceAuth.expires_in || 300) * 1000,
+        };
+    }, []);
 
-        try {
-            const deviceAuth = await api.tidalDeviceAuth();
+    const pollAuth = useCallback(async (deviceCode: string) => {
+        const result = await api.tidalPollAuth(deviceCode);
+        if (!result.success) return { status: "pending" } as const;
+        authResultRef.current = result;
+        return { status: "success" } as const;
+    }, []);
 
-            // Ensure the URL has a protocol — TIDAL sometimes returns bare domain
-            let authLink = deviceAuth.verification_uri_complete;
-            if (authLink && !authLink.startsWith("http")) {
-                authLink = `https://${authLink}`;
-            }
+    const handleAuthSuccess = useCallback(() => {
+        const result = authResultRef.current;
+        if (!result) return;
+        setAuthMessage(`Authenticated as ${result.username || result.user_id}`);
+        onUpdate({
+            tidalEnabled: true,
+            tidalConnected: true,
+            tidalUserId: result.user_id || "",
+            tidalCountryCode: result.country_code || "US",
+        });
+    }, [onUpdate]);
 
-            setAuthUrl(authLink);
-            setAuthState("polling");
+    const {
+        phase: authState,
+        session: authSession,
+        error: authError,
+        start: startAuthentication,
+    } = useDeviceAuthPolling({
+        initiate: initiateAuth,
+        poll: pollAuth,
+        onSessionStarted: (session) => {
             setAuthMessage("Waiting for you to approve...");
-
-            // Open auth URL in new tab
-            window.open(authLink, "_blank", "noopener,noreferrer");
-
-            // Start polling for token
-            const deviceCode = deviceAuth.device_code;
-            const interval = (deviceAuth.interval || 5) * 1000;
-
-            pollRef.current = setInterval(async () => {
-                try {
-                    const result = await api.tidalPollAuth(deviceCode);
-
-                    if (result.success) {
-                        // Tokens are saved on the backend
-                        if (pollRef.current) clearInterval(pollRef.current);
-                        setAuthState("success");
-                        setAuthMessage(`Authenticated as ${result.username || result.user_id}`);
-                        onUpdate({
-                            tidalEnabled: true,
-                            tidalConnected: true,
-                            tidalUserId: result.user_id || "",
-                            tidalCountryCode: result.country_code || "US",
-                        });
-                    }
-                    // If status is "pending", keep polling
-                } catch {
-                    // Backend error — keep polling (could be transient)
-                }
-            }, interval);
-
-            // Auto-stop polling after the code expires
-            setTimeout(() => {
-                if (pollRef.current) {
-                    clearInterval(pollRef.current);
-                    if (authState === "polling") {
-                        setAuthState("error");
-                        setAuthMessage("Device code expired. Please try again.");
-                    }
-                }
-            }, (deviceAuth.expires_in || 300) * 1000);
-        } catch (err: any) {
-            setAuthState("error");
-            setAuthMessage(err.message || "Failed to start device auth");
-        }
-    }, [onUpdate, authState]);
+            window.open(session.verificationUri, "_blank", "noopener,noreferrer");
+        },
+        onSuccess: handleAuthSuccess,
+        expiredMessage: "Device code expired. Please try again.",
+        startErrorMessage: "Failed to start device auth",
+    });
+    const authUrl = authSession?.verificationUri || "";
+    const handleAuthenticate = useCallback(async () => {
+        setAuthMessage("Requesting device code...");
+        await startAuthentication();
+    }, [startAuthentication]);
 
     const isAuthenticated = !!(settings.tidalConnected && settings.tidalEnabled);
 
@@ -227,7 +208,7 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
 
                         {authState === "error" && (
                             <p className="text-xs text-red-400 flex items-center gap-1">
-                                <XCircle className="w-3 h-3" /> {authMessage}
+                                <XCircle className="w-3 h-3" /> {authError}
                             </p>
                         )}
                     </div>

--- a/frontend/features/settings/components/sections/TidalStreamingSection.tsx
+++ b/frontend/features/settings/components/sections/TidalStreamingSection.tsx
@@ -5,13 +5,12 @@ import { SettingsRow, SettingsSelect, SettingsToggle, IntegrationCard } from "..
 import { UserSettings } from "../../types";
 import { CheckCircle, XCircle, Loader2, ExternalLink, Copy, AlertTriangle, Music2 } from "lucide-react";
 import { api } from "@/lib/api";
+import { useDeviceAuthPolling } from "@/hooks/useDeviceAuthPolling";
 
 interface TidalStreamingCardProps {
     settings: UserSettings;
     onUpdate: (updates: Partial<UserSettings>) => void;
 }
-
-type AuthState = "idle" | "loading" | "polling" | "success" | "error";
 
 const QUALITY_OPTIONS = [
     { value: "LOW", label: "Low (AAC 96 kbps)" },
@@ -35,46 +34,12 @@ export function TidalStreamingCard({
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
-    // Device auth flow state
-    const [authState, setAuthState] = useState<AuthState>("idle");
-    const [authUrl, setAuthUrl] = useState("");
-    const [userCode, setUserCode] = useState("");
     const [copied, setCopied] = useState(false);
-    const [expiresAt, setExpiresAt] = useState<number | null>(null);
-    const [timeLeft, setTimeLeft] = useState<number | null>(null);
-    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const authResultRef = useRef<Awaited<ReturnType<typeof api.pollTidalAuth>> | null>(null);
 
     // Check TIDAL streaming status on mount
     useEffect(() => {
         checkStatus();
-    }, []);
-
-    // Expiration countdown
-    useEffect(() => {
-        if (!expiresAt || authState !== "polling") {
-            setTimeLeft(null);
-            return;
-        }
-
-        const tick = () => {
-            const remaining = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
-            setTimeLeft(remaining);
-            if (remaining <= 0) {
-                handleCancelLink();
-                setError("The sign-in code has expired. Please try again.");
-            }
-        };
-
-        tick();
-        const interval = setInterval(tick, 1000);
-        return () => clearInterval(interval);
-    }, [expiresAt, authState]);
-
-    // Clean up polling on unmount
-    useEffect(() => {
-        return () => {
-            if (pollRef.current) clearInterval(pollRef.current);
-        };
     }, []);
 
     const checkStatus = useCallback(async () => {
@@ -90,98 +55,91 @@ export function TidalStreamingCard({
         setStatusLoading(false);
     }, []);
 
+    const initiateAuth = useCallback(async () => {
+        const deviceAuth = await api.initiateTidalAuth();
+        let authLink = deviceAuth.verification_uri_complete || deviceAuth.verification_uri;
+        if (authLink && !authLink.startsWith("http")) authLink = `https://${authLink}`;
+        return {
+            deviceCode: deviceAuth.device_code,
+            verificationUri: authLink,
+            userCode: deviceAuth.user_code || "",
+            pollIntervalMs: (deviceAuth.interval || 5) * 1000,
+            expiresAtMs: Date.now() + (deviceAuth.expires_in || 300) * 1000,
+        };
+    }, []);
+
+    const pollAuth = useCallback(async (deviceCode: string) => {
+        const result = await api.pollTidalAuth(deviceCode);
+        if (result.status === "pending") return { status: "pending" } as const;
+        if (result.status === "error") {
+            return { status: "error", message: result.error || "Authentication failed" } as const;
+        }
+        authResultRef.current = result;
+        return { status: "success" } as const;
+    }, []);
+
+    const handleSessionStarted = useCallback(async (session: {
+        userCode?: string;
+        verificationUri: string;
+    }) => {
+        try {
+            await navigator.clipboard.writeText(session.userCode || "");
+            setCopied(true);
+            setTimeout(() => setCopied(false), 3000);
+        } catch {
+            // Clipboard may not be available
+        }
+        window.open(session.verificationUri, "_blank", "noopener,noreferrer");
+    }, []);
+
+    const handleAuthSuccess = useCallback(() => {
+        const result = authResultRef.current;
+        if (!result) return;
+        setSuccess(`Connected as ${result.username || "TIDAL user"}`);
+        setError(null);
+        setIsAuthenticated(true);
+    }, []);
+
+    const {
+        phase: authState,
+        session: authSession,
+        error: authError,
+        timeLeftSeconds: timeLeft,
+        start: startAuthentication,
+        cancel: cancelAuthentication,
+    } = useDeviceAuthPolling({
+        initiate: initiateAuth,
+        poll: pollAuth,
+        onSessionStarted: handleSessionStarted,
+        onSuccess: handleAuthSuccess,
+        expiredMessage: "The sign-in code has expired. Please try again.",
+        startErrorMessage: "Failed to start TIDAL auth",
+    });
+    const authUrl = authSession?.verificationUri || "";
+    const userCode = authSession?.userCode || "";
+
     const handleLinkAccount = useCallback(async () => {
-        setAuthState("loading");
         setError(null);
         setSuccess(null);
-
-        try {
-            const deviceAuth = await api.initiateTidalAuth();
-
-            // Ensure URL has protocol
-            let authLink =
-                deviceAuth.verification_uri_complete ||
-                deviceAuth.verification_uri;
-            if (authLink && !authLink.startsWith("http")) {
-                authLink = `https://${authLink}`;
-            }
-
-            setAuthUrl(authLink);
-            setUserCode(deviceAuth.user_code || "");
-            setAuthState("polling");
-            setExpiresAt(Date.now() + (deviceAuth.expires_in || 300) * 1000);
-
-            // Copy code to clipboard
-            try {
-                await navigator.clipboard.writeText(deviceAuth.user_code || "");
-                setCopied(true);
-                setTimeout(() => setCopied(false), 3000);
-            } catch {
-                // Clipboard may not be available
-            }
-
-            // Open auth URL in new tab
-            window.open(authLink, "_blank", "noopener,noreferrer");
-
-            // Start polling for token
-            const deviceCode = deviceAuth.device_code;
-            const interval = (deviceAuth.interval || 5) * 1000;
-
-            pollRef.current = setInterval(async () => {
-                try {
-                    const result = await api.pollTidalAuth(deviceCode);
-
-                    if (result.status === "success") {
-                        if (pollRef.current) clearInterval(pollRef.current);
-                        setAuthState("success");
-                        setUserCode("");
-                        setAuthUrl("");
-                        setExpiresAt(null);
-                        setSuccess(`Connected as ${result.username || "TIDAL user"}`);
-                        setError(null);
-                        setIsAuthenticated(true);
-                    } else if (result.status === "error") {
-                        if (pollRef.current) clearInterval(pollRef.current);
-                        setAuthState("error");
-                        setUserCode("");
-                        setAuthUrl("");
-                        setExpiresAt(null);
-                        setError(result.error || "Authentication failed");
-                    }
-                    // If status is "pending", keep polling
-                } catch {
-                    // Transient error — keep polling
-                }
-            }, interval);
-        } catch (err: any) {
-            setAuthState("error");
-            setError(err.message || "Failed to start TIDAL auth");
-        }
-    }, []);
+        await startAuthentication();
+    }, [startAuthentication]);
 
     const handleCancelLink = useCallback(() => {
-        if (pollRef.current) {
-            clearInterval(pollRef.current);
-            pollRef.current = null;
-        }
-        setAuthState("idle");
-        setUserCode("");
-        setAuthUrl("");
-        setExpiresAt(null);
+        cancelAuthentication();
         setError(null);
-    }, []);
+    }, [cancelAuthentication]);
 
     const handleDisconnect = useCallback(async () => {
         try {
             await api.clearTidalStreamingAuth();
             setIsAuthenticated(false);
-            setAuthState("idle");
+            cancelAuthentication();
             setSuccess(null);
             setError(null);
         } catch (err: any) {
             setError(err.message || "Failed to disconnect");
         }
-    }, []);
+    }, [cancelAuthentication]);
 
     const handleCopyCode = useCallback(async () => {
         if (!userCode) return;
@@ -345,10 +303,10 @@ export function TidalStreamingCard({
                         </div>
                     )}
 
-                    {error && (
+                    {(authError || error) && (
                         <div className="flex items-start gap-2 text-sm text-red-400">
                             <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                            <span>{error}</span>
+                            <span>{authError || error}</span>
                         </div>
                     )}
 

--- a/frontend/hooks/downloadStatusPolling.ts
+++ b/frontend/hooks/downloadStatusPolling.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolves the next download-status polling delay from the current job counts.
+ */
+export function resolveDownloadPollDelayMs(
+    activeCount: number,
+    totalCount: number
+): number {
+    if (activeCount > 0) {
+        return 5_000;
+    }
+
+    return totalCount > 0 ? 10_000 : 30_000;
+}
+
+/**
+ * Resolves exponential download-status retry backoff capped at two minutes.
+ */
+export function resolveDownloadErrorBackoffMs(
+    baseIntervalMs: number,
+    errorCount: number
+): number {
+    return Math.min(baseIntervalMs * 2 ** errorCount, 120_000);
+}

--- a/frontend/hooks/useActiveListenSessions.ts
+++ b/frontend/hooks/useActiveListenSessions.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { resolvePollingJitter } from "@/hooks/pollingCadence";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 
 const POLL_INTERVAL_MS = 30_000; // 30 seconds
 
@@ -14,7 +15,7 @@ const POLL_INTERVAL_MS = 30_000; // 30 seconds
 export function useActiveListenSessions(): boolean {
     const { isAuthenticated } = useAuth();
     const [hasActiveSessions, setHasActiveSessions] = useState(false);
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [jitterElapsed, setJitterElapsed] = useState(false);
     const mountedRef = useRef(true);
 
     const fetchCount = useCallback(async () => {
@@ -28,11 +29,18 @@ export function useActiveListenSessions(): boolean {
         }
     }, []);
 
+    useVisibilityGatedInterval(fetchCount, POLL_INTERVAL_MS, {
+        enabled: isAuthenticated && jitterElapsed,
+    });
+
     useEffect(() => {
         mountedRef.current = true;
+        setJitterElapsed(false);
 
         if (!isAuthenticated) {
-            return;
+            return () => {
+                mountedRef.current = false;
+            };
         }
 
         // Defer initial fetch to avoid synchronous setState in effect body
@@ -41,17 +49,13 @@ export function useActiveListenSessions(): boolean {
         // Start polling with jitter to prevent alignment with other intervals
         const jitterDelay = resolvePollingJitter(5000);
         const jitterTimeout = setTimeout(() => {
-            intervalRef.current = setInterval(fetchCount, POLL_INTERVAL_MS);
+            setJitterElapsed(true);
         }, jitterDelay);
 
         return () => {
             mountedRef.current = false;
             clearTimeout(initialTimeout);
             clearTimeout(jitterTimeout);
-            if (intervalRef.current) {
-                clearInterval(intervalRef.current);
-                intervalRef.current = null;
-            }
         };
     }, [isAuthenticated, fetchCount]);
 

--- a/frontend/hooks/useDeviceAuthPolling.ts
+++ b/frontend/hooks/useDeviceAuthPolling.ts
@@ -1,0 +1,244 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Lifecycle phase for a device-code authentication attempt. */
+export type DeviceAuthPhase = "idle" | "loading" | "polling" | "success" | "error";
+
+/** Normalized device-code session returned by an authentication initiator. */
+export interface DeviceAuthSession {
+    deviceCode: string;
+    verificationUri: string;
+    userCode?: string;
+    pollIntervalMs: number;
+    expiresAtMs: number;
+}
+
+/** Result of one device-code authentication poll. */
+export type DeviceAuthPollOutcome =
+    | { status: "pending" }
+    | { status: "success" }
+    | { status: "error"; message: string };
+
+/** Callbacks and messages used by the device authentication polling state machine. */
+export interface UseDeviceAuthPollingOptions {
+    initiate: () => Promise<DeviceAuthSession>;
+    poll: (deviceCode: string) => Promise<DeviceAuthPollOutcome>;
+    onSessionStarted?: (session: DeviceAuthSession) => void;
+    onSuccess?: () => void;
+    expiredMessage?: string;
+    startErrorMessage?: string;
+}
+
+/** Observable state and controls returned by {@link useDeviceAuthPolling}. */
+export interface UseDeviceAuthPollingReturn {
+    phase: DeviceAuthPhase;
+    session: DeviceAuthSession | null;
+    error: string | null;
+    timeLeftSeconds: number | null;
+    start: () => Promise<void>;
+    cancel: () => void;
+}
+
+interface TimerStore {
+    schedulePoll: (callback: () => void, delay: number) => void;
+    scheduleCountdown: (callback: () => void) => void;
+    clearPoll: () => void;
+    clearCountdown: () => void;
+    clearAll: () => void;
+}
+
+function createTimerStore(): TimerStore {
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+    let countdownTimer: ReturnType<typeof setInterval> | null = null;
+    const clearPoll = () => {
+        if (pollTimer === null) return;
+        clearTimeout(pollTimer);
+        pollTimer = null;
+    };
+    const clearCountdown = () => {
+        if (countdownTimer === null) return;
+        clearInterval(countdownTimer);
+        countdownTimer = null;
+    };
+    return {
+        schedulePoll: (callback, delay) => {
+            clearPoll();
+            pollTimer = setTimeout(callback, delay);
+        },
+        scheduleCountdown: (callback) => {
+            clearCountdown();
+            countdownTimer = setInterval(callback, 1_000);
+        },
+        clearPoll,
+        clearCountdown,
+        clearAll: () => {
+            clearPoll();
+            clearCountdown();
+        },
+    };
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+    return error instanceof Error && error.message ? error.message : fallback;
+}
+
+/** Owns initiation, recursive polling, expiry, cancellation, and timer cleanup. */
+export function useDeviceAuthPolling(
+    options: UseDeviceAuthPollingOptions,
+): UseDeviceAuthPollingReturn {
+    const [phase, setPhase] = useState<DeviceAuthPhase>("idle");
+    const [session, setSession] = useState<DeviceAuthSession | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [timeLeftSeconds, setTimeLeftSeconds] = useState<number | null>(null);
+    const [timers] = useState(createTimerStore);
+    const optionsRef = useRef(options);
+    const generationRef = useRef(0);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        optionsRef.current = options;
+    }, [options]);
+
+    const invalidate = useCallback((): number => {
+        generationRef.current += 1;
+        timers.clearAll();
+        return generationRef.current;
+    }, [timers]);
+
+    const cancel = useCallback(() => {
+        invalidate();
+        setPhase("idle");
+        setSession(null);
+        setError(null);
+        setTimeLeftSeconds(null);
+    }, [invalidate]);
+
+    const start = useCallback(async () => {
+        const runId = invalidate();
+        setPhase("loading");
+        setSession(null);
+        setError(null);
+        setTimeLeftSeconds(null);
+        try {
+            const nextSession = await optionsRef.current.initiate();
+            if (!mountedRef.current || generationRef.current !== runId) return;
+            setSession(nextSession);
+            setPhase("polling");
+            optionsRef.current.onSessionStarted?.(nextSession);
+        } catch (caught) {
+            if (!mountedRef.current || generationRef.current !== runId) return;
+            const fallback = optionsRef.current.startErrorMessage ??
+                "Failed to start device authentication";
+            setPhase("error");
+            setError(errorMessage(caught, fallback));
+        }
+    }, [invalidate]);
+
+    usePolling({ phase, session, generationRef, timers, invalidate, optionsRef,
+        setPhase, setError, setTimeLeftSeconds });
+    useExpiry({ phase, session, generationRef, timers, invalidate,
+        optionsRef, setPhase, setError, setTimeLeftSeconds });
+
+    useEffect(() => {
+        // Re-arm on every mount so Strict Mode's simulated unmount/remount
+        // cycle cannot leave the hook permanently marked as unmounted.
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            invalidate();
+        };
+    }, [invalidate]);
+
+    return { phase, session, error, timeLeftSeconds, start, cancel };
+}
+
+interface PollingEffectArgs {
+    phase: DeviceAuthPhase;
+    session: DeviceAuthSession | null;
+    generationRef: React.MutableRefObject<number>;
+    timers: TimerStore;
+    invalidate: () => number;
+    optionsRef: React.MutableRefObject<UseDeviceAuthPollingOptions>;
+    setPhase: React.Dispatch<React.SetStateAction<DeviceAuthPhase>>;
+    setError: React.Dispatch<React.SetStateAction<string | null>>;
+    setTimeLeftSeconds: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+function usePolling({ phase, session, generationRef, timers, invalidate, optionsRef,
+    setPhase, setError, setTimeLeftSeconds }: PollingEffectArgs): void {
+    useEffect(() => {
+        if (phase !== "polling" || !session) return;
+        const runId = generationRef.current;
+        const delay = Math.max(1, session.pollIntervalMs);
+        const active = () => generationRef.current === runId;
+        const schedule = () => {
+            timers.schedulePoll(execute, delay);
+        };
+        const finish = (outcome: Exclude<DeviceAuthPollOutcome, { status: "pending" }>) => {
+            invalidate();
+            setTimeLeftSeconds(null);
+            setPhase(outcome.status);
+            if (outcome.status === "error") setError(outcome.message);
+            else optionsRef.current.onSuccess?.();
+        };
+        async function execute() {
+            if (!active()) return;
+            let outcome: DeviceAuthPollOutcome;
+            try {
+                outcome = await optionsRef.current.poll(session.deviceCode);
+            } catch {
+                if (active()) schedule();
+                return;
+            }
+            if (!active()) return;
+            if (outcome.status === "pending") schedule();
+            else finish(outcome);
+        }
+        schedule();
+        return timers.clearPoll;
+    }, [phase, session, generationRef, timers, invalidate, optionsRef, setPhase,
+        setError, setTimeLeftSeconds]);
+}
+
+interface ExpiryEffectArgs {
+    phase: DeviceAuthPhase;
+    session: DeviceAuthSession | null;
+    generationRef: React.MutableRefObject<number>;
+    timers: TimerStore;
+    invalidate: () => number;
+    optionsRef: React.MutableRefObject<UseDeviceAuthPollingOptions>;
+    setPhase: React.Dispatch<React.SetStateAction<DeviceAuthPhase>>;
+    setError: React.Dispatch<React.SetStateAction<string | null>>;
+    setTimeLeftSeconds: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+function useExpiry({ phase, session, generationRef, timers, invalidate, optionsRef,
+    setPhase, setError, setTimeLeftSeconds }: ExpiryEffectArgs): void {
+    useEffect(() => {
+        if (phase !== "polling" || !session) {
+            setTimeLeftSeconds(null);
+            return;
+        }
+        const runId = generationRef.current;
+        const tick = () => {
+            if (generationRef.current !== runId) return;
+            const remaining = Math.max(
+                0,
+                Math.floor((session.expiresAtMs - Date.now()) / 1_000),
+            );
+            if (remaining > 0) {
+                setTimeLeftSeconds(remaining);
+                return;
+            }
+            invalidate();
+            setTimeLeftSeconds(null);
+            setPhase("error");
+            setError(optionsRef.current.expiredMessage ?? "Device code expired");
+        };
+        tick();
+        timers.scheduleCountdown(tick);
+        return timers.clearCountdown;
+    }, [phase, session, generationRef, timers, invalidate, optionsRef, setPhase,
+        setError, setTimeLeftSeconds]);
+}

--- a/frontend/hooks/useDownloadStatus.ts
+++ b/frontend/hooks/useDownloadStatus.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import { createFrontendLogger } from "@/lib/logger";
+import {
+    resolveDownloadErrorBackoffMs,
+    resolveDownloadPollDelayMs,
+} from "@/hooks/downloadStatusPolling";
 
 const logger = createFrontendLogger("Hooks.useDownloadStatus");
 
@@ -28,6 +32,121 @@ export interface DownloadStatus {
     failedDownloads: DownloadJob[];
 }
 
+function classifyDownloads(
+    downloads: DownloadJob[],
+    now: Date
+): DownloadStatus {
+    const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
+    const activeDownloads = downloads.filter(
+        (job) => job.status === "pending" || job.status === "processing"
+    );
+    const isRecent = (job: DownloadJob) =>
+        new Date(job.completedAt || job.createdAt) > fiveMinutesAgo;
+    const recentDownloads = downloads.filter(
+        (job) =>
+            (job.status === "completed" || job.status === "failed") &&
+            isRecent(job)
+    );
+    const failedDownloads = downloads.filter(
+        (job) => job.status === "failed" && isRecent(job)
+    );
+
+    return {
+        activeDownloads,
+        recentDownloads,
+        hasActiveDownloads: activeDownloads.length > 0,
+        failedDownloads,
+    };
+}
+
+interface DownloadPollingState {
+    active: boolean;
+    errorCount: number;
+    pollTimeout: ReturnType<typeof setTimeout> | null;
+    pollingInterval: number;
+    publishStatus: (status: DownloadStatus) => void;
+    poll: () => void;
+}
+
+function scheduleDownloadPoll(
+    state: DownloadPollingState,
+    delayMs: number
+): void {
+    if (state.pollTimeout !== null) {
+        clearTimeout(state.pollTimeout);
+    }
+    state.pollTimeout = setTimeout(state.poll, delayMs);
+}
+
+function handleDownloadPollError(
+    state: DownloadPollingState,
+    error: unknown
+): void {
+    state.errorCount += 1;
+    const backoffDelay = resolveDownloadErrorBackoffMs(
+        state.pollingInterval,
+        state.errorCount
+    );
+    if (!(error instanceof Error) || error.message !== "Too Many Requests") {
+        logger.error("Download polling error", {
+            errorCount: state.errorCount,
+            backoffDelay,
+            error,
+        });
+    }
+    if (state.active) scheduleDownloadPoll(state, backoffDelay);
+}
+
+function handleDownloadPollSuccess(
+    state: DownloadPollingState,
+    response: DownloadJob[]
+): void {
+    state.errorCount = 0;
+    const nextStatus = classifyDownloads(response, new Date());
+    state.publishStatus(nextStatus);
+    if (state.active) {
+        scheduleDownloadPoll(state, resolveDownloadPollDelayMs(
+            nextStatus.activeDownloads.length,
+            response.length
+        ));
+    }
+}
+
+async function pollDownloads(state: DownloadPollingState): Promise<void> {
+    try {
+        const response = await api.getDownloads(50);
+        if (state.active) handleDownloadPollSuccess(state, response);
+    } catch (error: unknown) {
+        handleDownloadPollError(state, error);
+    }
+}
+
+function startDownloadPolling(
+    pollingInterval: number,
+    publishStatus: (status: DownloadStatus) => void
+): () => void {
+    const state: DownloadPollingState = {
+        active: true,
+        errorCount: 0,
+        pollTimeout: null,
+        pollingInterval,
+        publishStatus,
+        poll: () => undefined,
+    };
+    state.poll = () => void pollDownloads(state);
+    const handleStatusChanged = () => {
+        if (state.active) scheduleDownloadPoll(state, 0);
+    };
+
+    state.poll();
+    window.addEventListener("download-status-changed", handleStatusChanged);
+    return () => {
+        state.active = false;
+        if (state.pollTimeout !== null) clearTimeout(state.pollTimeout);
+        window.removeEventListener("download-status-changed", handleStatusChanged);
+    };
+}
+
 /**
  * Hook to monitor download job status
  * Polls for active downloads and keeps track of recent completions/failures
@@ -46,122 +165,8 @@ export function useDownloadStatus(
     });
 
     useEffect(() => {
-        // Don't poll if user is not authenticated
-        if (!isAuthenticated) {
-            return;
-        }
-
-        let mounted = true;
-        let pollTimeout: NodeJS.Timeout | null = null;
-        let errorCount = 0;
-
-        const pollDownloads = async () => {
-            try {
-                // Fetch recent download jobs (last 50)
-                const response = await api.getDownloads(50);
-
-                if (!mounted) return;
-
-                // Reset error count on successful request
-                errorCount = 0;
-
-                const now = new Date();
-                const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
-
-                const activeDownloads = response.filter(
-                    (job) =>
-                        job.status === "pending" || job.status === "processing"
-                );
-
-                const recentDownloads = response.filter(
-                    (job) =>
-                        (job.status === "completed" ||
-                            job.status === "failed") &&
-                        new Date(job.completedAt || job.createdAt) >
-                            fiveMinutesAgo
-                );
-
-                const failedDownloads = response.filter(
-                    (job) =>
-                        job.status === "failed" &&
-                        new Date(job.completedAt || job.createdAt) >
-                            fiveMinutesAgo
-                );
-
-                setStatus({
-                    activeDownloads,
-                    recentDownloads,
-                    hasActiveDownloads: activeDownloads.length > 0,
-                    failedDownloads,
-                });
-
-                if (!mounted) return;
-
-                // Continue polling if there are active downloads
-                if (activeDownloads.length > 0) {
-                    // Poll faster when downloads are active (5 seconds)
-                    pollTimeout = setTimeout(pollDownloads, 5000);
-                } else if (
-                    activeDownloads.length === 0 &&
-                    response.length > 0
-                ) {
-                    // Some jobs exist but none active - check again in 10 seconds
-                    // to catch newly created jobs
-                    pollTimeout = setTimeout(pollDownloads, 10000);
-                } else {
-                    // No downloads at all - check again in 30 seconds
-                    pollTimeout = setTimeout(pollDownloads, 30000);
-                }
-            } catch (error: unknown) {
-                // Increment error count
-                errorCount++;
-
-                // Exponential backoff on errors (max 2 minutes)
-                const backoffDelay = Math.min(
-                    pollingInterval * Math.pow(2, errorCount),
-                    120000
-                );
-
-                // Silently continue on rate limit errors - don't spam console
-                if (!(error instanceof Error) || error.message !== "Too Many Requests") {
-                    logger.error("Download polling error", {
-                        errorCount,
-                        backoffDelay,
-                        error,
-                    });
-                }
-
-                // Retry with backoff
-                if (mounted) {
-                    pollTimeout = setTimeout(pollDownloads, backoffDelay);
-                }
-            }
-        };
-
-        // Start polling
-        pollDownloads();
-
-        // Listen for download status changes (e.g., when user clears history)
-        const handleDownloadStatusChanged = () => {
-            if (mounted) {
-                pollDownloads();
-            }
-        };
-        window.addEventListener(
-            "download-status-changed",
-            handleDownloadStatusChanged
-        );
-
-        return () => {
-            mounted = false;
-            if (pollTimeout) {
-                clearTimeout(pollTimeout);
-            }
-            window.removeEventListener(
-                "download-status-changed",
-                handleDownloadStatusChanged
-            );
-        };
+        if (!isAuthenticated) return;
+        return startDownloadPolling(pollingInterval, setStatus);
     }, [pollingInterval, isAuthenticated]);
 
     return status;

--- a/frontend/hooks/useJobStatus.ts
+++ b/frontend/hooks/useJobStatus.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "@/lib/api";
 import { createFrontendLogger } from "@/lib/logger";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 
 const logger = createFrontendLogger("Hooks.useJobStatus");
 
@@ -87,6 +88,10 @@ export function useJobStatus(
         }
     }, [jobId, jobType]);
 
+    useVisibilityGatedInterval(checkStatus, pollInterval, {
+        enabled: isPolling && Boolean(jobId),
+    });
+
     // Start/stop polling when the job identity changes.
     useEffect(() => {
         if (!jobId) {
@@ -103,15 +108,17 @@ export function useJobStatus(
         cancelledRef.current = false;
 
         // Defer initial check to avoid synchronous setState in effect
-        const initialTimeout = setTimeout(checkStatus, 0);
-        const interval = setInterval(checkStatus, pollInterval);
+        const initialTimeout = setTimeout(() => {
+            if (document.visibilityState === "visible") {
+                void checkStatus();
+            }
+        }, 0);
 
         return () => {
             cancelledRef.current = true;
             clearTimeout(initialTimeout);
-            clearInterval(interval);
         };
-    }, [isPolling, jobId, checkStatus, pollInterval]);
+    }, [isPolling, jobId, checkStatus]);
 
     return {
         jobStatus,

--- a/frontend/hooks/usePresenceHeartbeat.ts
+++ b/frontend/hooks/usePresenceHeartbeat.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 
@@ -11,41 +12,23 @@ const PRESENCE_HEARTBEAT_INTERVAL_MS = 25_000;
  */
 export function usePresenceHeartbeat() {
     const { isAuthenticated } = useAuth();
+    const sendHeartbeat = useCallback(async () => {
+        try {
+            await api.post("/social/presence/heartbeat");
+        } catch {
+            // Intentionally silent: social presence should not interrupt playback/navigation.
+        }
+    }, []);
+
+    useVisibilityGatedInterval(sendHeartbeat, PRESENCE_HEARTBEAT_INTERVAL_MS, {
+        enabled: isAuthenticated,
+    });
 
     useEffect(() => {
         if (!isAuthenticated) {
             return;
         }
 
-        const sendHeartbeat = async () => {
-            try {
-                await api.post("/social/presence/heartbeat");
-            } catch {
-                // Intentionally silent: social presence should not interrupt playback/navigation.
-            }
-        };
-
         void sendHeartbeat();
-
-        const intervalId = setInterval(() => {
-            void sendHeartbeat();
-        }, PRESENCE_HEARTBEAT_INTERVAL_MS);
-
-        const handleVisibilityChange = () => {
-            if (!document.hidden) {
-                void sendHeartbeat();
-            }
-        };
-
-        document.addEventListener("visibilitychange", handleVisibilityChange);
-
-        return () => {
-            clearInterval(intervalId);
-            document.removeEventListener(
-                "visibilitychange",
-                handleVisibilityChange
-            );
-        };
-    }, [isAuthenticated]);
+    }, [isAuthenticated, sendHeartbeat]);
 }
-

--- a/frontend/hooks/useTrackPreview.ts
+++ b/frontend/hooks/useTrackPreview.ts
@@ -11,6 +11,15 @@ interface PreviewableTrack {
     title: string;
 }
 
+function resumeMainPlayerIfPaused(pausedRef: { current: boolean }): void {
+    if (!pausedRef.current) return;
+    playbackEngine.play();
+    pausedRef.current = false;
+}
+
+/**
+ * Manages fetching, playback, and lifecycle state for track previews.
+ */
 export function useTrackPreview<T extends PreviewableTrack>() {
     const [previewTrack, setPreviewTrack] = useState<string | null>(null);
     const [previewPlaying, setPreviewPlaying] = useState(false);
@@ -103,13 +112,14 @@ export function useTrackPreview<T extends PreviewableTrack>() {
             audio.onended = () => {
                 setPreviewPlaying(false);
                 setPreviewTrack(null);
-                mainPlayerWasPausedRef.current = false;
+                resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
             };
 
             audio.onerror = () => {
                 toast.error("Failed to play preview");
                 setPreviewPlaying(false);
                 setPreviewTrack(null);
+                resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
             };
 
             try {
@@ -139,6 +149,7 @@ export function useTrackPreview<T extends PreviewableTrack>() {
             toast.error("Failed to play preview");
             setPreviewPlaying(false);
             setPreviewTrack(null);
+            resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
         } finally {
             if (inFlightTrackIdRef.current === track.id) {
                 inFlightTrackIdRef.current = null;
@@ -169,7 +180,7 @@ export function useTrackPreview<T extends PreviewableTrack>() {
                 previewAudioRef.current.pause();
                 previewAudioRef.current = null;
             }
-            mainPlayerWasPausedRef.current = false;
+            resumeMainPlayerIfPaused(mainPlayerWasPausedRef);
         };
     }, []);
 

--- a/frontend/hooks/useVisibilityGatedInterval.ts
+++ b/frontend/hooks/useVisibilityGatedInterval.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { resolvePollingEnabled } from "./pollingCadence";
+import { useDocumentVisible } from "./useDocumentVisibility";
+
+/**
+ * Runs a fresh callback on a fixed interval only while polling is enabled and
+ * the document is visible. Optionally runs once after a hidden-to-visible
+ * transition; it never invokes the callback on initial mount.
+ */
+export function useVisibilityGatedInterval(
+    callback: () => void,
+    intervalMs: number,
+    options: { enabled?: boolean; leadingOnVisible?: boolean } = {}
+): void {
+    const isDocumentVisible = useDocumentVisible();
+    const enabled = resolvePollingEnabled(options.enabled);
+    const leadingOnVisible = options.leadingOnVisible ?? true;
+    const callbackRef = useRef(callback);
+    const wasHiddenRef = useRef(false);
+
+    useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    useEffect(() => {
+        if (!isDocumentVisible) {
+            wasHiddenRef.current = true;
+            return;
+        }
+
+        const returnedToVisibility = wasHiddenRef.current;
+        wasHiddenRef.current = false;
+        if (returnedToVisibility && enabled && leadingOnVisible) {
+            callbackRef.current();
+        }
+    }, [enabled, isDocumentVisible, leadingOnVisible]);
+
+    useEffect(() => {
+        if (!enabled || !isDocumentVisible) {
+            return;
+        }
+
+        const intervalId = window.setInterval(() => {
+            callbackRef.current();
+        }, intervalMs);
+        return () => window.clearInterval(intervalId);
+    }, [enabled, intervalMs, isDocumentVisible]);
+}

--- a/frontend/lib/download-context.tsx
+++ b/frontend/lib/download-context.tsx
@@ -8,6 +8,7 @@ import {
     useEffect,
     useMemo,
     useCallback,
+    useRef,
 } from "react";
 import { useDownloadStatus, DownloadJob } from "@/hooks/useDownloadStatus";
 import { useAuth } from "@/lib/auth-context";
@@ -53,11 +54,16 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
     const [pendingDownloads, setPendingDownloads] = useState<PendingDownload[]>(
         []
     );
+    const pendingRef = useRef(pendingDownloads);
     const { isAuthenticated, user } = useAuth();
     const shouldPollDownloads =
         isAuthenticated && user?.role === "admin";
     const downloadStatus = useDownloadStatus(15000, shouldPollDownloads);
     const [downloadsEnabled, setDownloadsEnabled] = useState(false);
+
+    useEffect(() => {
+        pendingRef.current = pendingDownloads;
+    }, [pendingDownloads]);
 
     // Fetch download service availability on mount / when auth changes
     // Downloads are only shown to admin users
@@ -131,29 +137,26 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
         subject: string,
         mbid: string
     ): string | null => {
-        // Check synchronously first to avoid race conditions
-        let result: string | null = null;
+        if (pendingRef.current.some((download) => download.mbid === mbid)) {
+            return null;
+        }
 
-        setPendingDownloads((prev) => {
-            // Check if already downloading this MBID
-            if (prev.some((d) => d.mbid === mbid)) {
-                return prev;
-            }
-
-            const id = `${Date.now()}-${Math.random()}`;
-            const download: PendingDownload = {
-                id,
-                type,
-                subject,
-                mbid,
-                timestamp: Date.now(),
-            };
-
-            result = id;
-            return [...prev, download];
-        });
-
-        return result;
+        const timestamp = Date.now();
+        const id = `${timestamp}-${Math.random()}`;
+        const download: PendingDownload = {
+            id,
+            type,
+            subject,
+            mbid,
+            timestamp,
+        };
+        pendingRef.current = [...pendingRef.current, download];
+        setPendingDownloads((prev) =>
+            prev.some((pending) => pending.mbid === mbid)
+                ? prev
+                : [...prev, download]
+        );
+        return id;
     }, []);
 
     const removePendingDownload = useCallback((id: string) => {

--- a/frontend/lib/features-context.tsx
+++ b/frontend/lib/features-context.tsx
@@ -8,9 +8,11 @@ import {
     useMemo,
     ReactNode,
     useCallback,
+    useRef,
 } from "react";
 import { api } from "./api";
-import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
+import { useVisibilityGatedInterval } from "../hooks/useVisibilityGatedInterval";
+import { frontendLogger as sharedFrontendLogger } from "./logger";
 
 interface FeaturesState {
     musicCNN: boolean;
@@ -43,6 +45,7 @@ const FeaturesContext = createContext<FeaturesState | undefined>(undefined);
  */
 export function FeaturesProvider({ children }: { children: ReactNode }) {
     const [state, setState] = useState<FeaturesState>(defaultState);
+    const isMountedRef = useRef(false);
     const refreshFeatures = useCallback(async () => {
         try {
             const [features, uiSettings] = await Promise.all([
@@ -76,37 +79,20 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
         }
     }, []);
 
-    useEffect(() => {
-        let isMounted = true;
-
-        const safeRefresh = async () => {
-            if (!isMounted) return;
-            await refreshFeatures();
-        };
-
-        void safeRefresh();
-
-        const interval = window.setInterval(
-            safeRefresh,
-            FEATURES_REFRESH_INTERVAL_MS
-        );
-
-        const onVisibilityChange = () => {
-            if (document.visibilityState === "visible") {
-                void safeRefresh();
-            }
-        };
-
-        window.addEventListener("focus", onVisibilityChange);
-        document.addEventListener("visibilitychange", onVisibilityChange);
-
-        return () => {
-            isMounted = false;
-            window.clearInterval(interval);
-            window.removeEventListener("focus", onVisibilityChange);
-            document.removeEventListener("visibilitychange", onVisibilityChange);
-        };
+    const safeRefresh = useCallback(async () => {
+        if (!isMountedRef.current) return;
+        await refreshFeatures();
     }, [refreshFeatures]);
+
+    useVisibilityGatedInterval(safeRefresh, FEATURES_REFRESH_INTERVAL_MS);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        void safeRefresh();
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, [safeRefresh]);
 
     const value = useMemo(() => state, [state]);
 

--- a/frontend/tests/component/downloadContext.component.test.ts
+++ b/frontend/tests/component/downloadContext.component.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const emptyDownloadStatus = {
+    activeDownloads: [],
+    recentDownloads: [],
+    hasActiveDownloads: false,
+    failedDownloads: [],
+};
+
+mock.module("@/hooks/useDownloadStatus", {
+    namedExports: {
+        useDownloadStatus: () => emptyDownloadStatus,
+    },
+});
+
+mock.module("@/lib/auth-context", {
+    namedExports: {
+        useAuth: () => ({
+            isAuthenticated: true,
+            user: { role: "admin" },
+        }),
+    },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getDownloadAvailability: async () => ({ enabled: false }),
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+type DownloadContextApi = ReturnType<
+    typeof import("../../lib/download-context").useDownloadContext
+>;
+
+async function mountDownloadProvider(strictMode = false) {
+    const { DownloadProvider, useDownloadContext } = await import(
+        "../../lib/download-context"
+    );
+    const { createRoot } = await import("react-dom/client");
+    const latestRef: { current: DownloadContextApi | null } = { current: null };
+
+    function Probe() {
+        latestRef.current = useDownloadContext();
+        return null;
+    }
+
+    const provider = React.createElement(
+        DownloadProvider,
+        null,
+        React.createElement(Probe)
+    );
+    const tree = strictMode
+        ? React.createElement(React.StrictMode, null, provider)
+        : provider;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => root.render(tree));
+
+    return {
+        latest: () => {
+            assert.ok(latestRef.current, "context did not render");
+            return latestRef.current;
+        },
+        act: async (fn: () => void) => {
+            await React.act(async () => fn());
+        },
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+test("adding a pending download returns its id and synchronously rejects duplicates", async () => {
+    const harness = await mountDownloadProvider();
+    let firstId: string | null = null;
+    await harness.act(() => {
+        firstId = harness.latest().addPendingDownload("album", "Album", "mbid-1");
+    });
+
+    assert.equal(typeof firstId, "string");
+    assert.equal(harness.latest().isPendingByMbid("mbid-1"), true);
+    let duplicateId: string | null = "unexpected";
+    await harness.act(() => {
+        duplicateId = harness.latest().addPendingDownload(
+            "album",
+            "Album",
+            "mbid-1"
+        );
+    });
+    assert.equal(duplicateId, null);
+    assert.equal(harness.latest().pendingDownloads.length, 1);
+    await harness.unmount();
+});
+
+test("pending additions remain singular and usable under StrictMode", async () => {
+    const harness = await mountDownloadProvider(true);
+    await harness.act(() => {
+        harness.latest().addPendingDownload("artist", "Artist One", "mbid-1");
+    });
+    assert.equal(harness.latest().pendingDownloads.length, 1);
+    assert.equal(harness.latest().isPendingByMbid("mbid-1"), true);
+
+    await harness.act(() => {
+        harness.latest().addPendingDownload("artist", "Artist Two", "mbid-2");
+    });
+    assert.equal(harness.latest().pendingDownloads.length, 2);
+    assert.equal(harness.latest().isPendingByMbid("mbid-2"), true);
+    await harness.unmount();
+});

--- a/frontend/tests/component/featuresContext.component.test.ts
+++ b/frontend/tests/component/featuresContext.component.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const apiState = {
+    featuresCalls: 0,
+    uiSettingsCalls: 0,
+};
+
+const apiExports = {
+    api: {
+        getFeatures: async () => {
+            apiState.featuresCalls += 1;
+            return {
+                musicCNN: false,
+                vibeEmbeddings: false,
+                audioAnalysis: true,
+                discovery: true,
+                autoPlaylists: true,
+            };
+        },
+        getUiSettings: async () => {
+            apiState.uiSettingsCalls += 1;
+            return { showVersion: false };
+        },
+    },
+};
+
+mock.module("@/lib/api", {
+    namedExports: apiExports,
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    apiState.featuresCalls = 0;
+    apiState.uiSettingsCalls = 0;
+    setVisibility("visible");
+});
+
+function setVisibility(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: state,
+    });
+}
+
+async function changeVisibility(state: DocumentVisibilityState): Promise<void> {
+    await React.act(async () => {
+        setVisibility(state);
+        document.dispatchEvent(new Event("visibilitychange"));
+    });
+}
+
+async function flushMicrotasks(): Promise<void> {
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+async function mountProvider() {
+    const { FeaturesProvider } = await import("../../lib/features-context");
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(FeaturesProvider, null, "content")
+        );
+    });
+    await flushMicrotasks();
+
+    return {
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+async function dispatchTabReturn(): Promise<void> {
+    await React.act(async () => {
+        setVisibility("visible");
+        window.dispatchEvent(new Event("focus"));
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("refreshes exactly once when a hidden tab becomes visible", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    const harness = await mountProvider();
+    t.after(harness.unmount);
+    assert.equal(apiState.featuresCalls, 1);
+    assert.equal(apiState.uiSettingsCalls, 1);
+
+    await changeVisibility("hidden");
+    await dispatchTabReturn();
+
+    assert.equal(apiState.featuresCalls, 2);
+    assert.equal(apiState.uiSettingsCalls, 2);
+});
+
+test("does not refresh on the interval while hidden", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    const harness = await mountProvider();
+    t.after(harness.unmount);
+    assert.equal(apiState.featuresCalls, 1);
+    assert.equal(apiState.uiSettingsCalls, 1);
+
+    await changeVisibility("hidden");
+    await React.act(async () => {
+        t.mock.timers.tick(60_000);
+        await Promise.resolve();
+    });
+
+    assert.equal(apiState.featuresCalls, 1);
+    assert.equal(apiState.uiSettingsCalls, 1);
+});

--- a/frontend/tests/component/useDeviceAuthPolling.component.test.ts
+++ b/frontend/tests/component/useDeviceAuthPolling.component.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+import type {
+    DeviceAuthPollOutcome,
+    DeviceAuthSession,
+    UseDeviceAuthPollingOptions,
+    UseDeviceAuthPollingReturn,
+} from "../../hooks/useDeviceAuthPolling";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+function deferred<T>() {
+    let resolveRef!: (value: T) => void;
+    let rejectRef!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolve, reject) => {
+        resolveRef = resolve;
+        rejectRef = reject;
+    });
+    return { promise, resolve: resolveRef, reject: rejectRef };
+}
+
+function session(deviceCode: string, expiresAtMs = 10_000): DeviceAuthSession {
+    return {
+        deviceCode,
+        verificationUri: `https://tidal.example/${deviceCode}`,
+        userCode: `user-${deviceCode}`,
+        pollIntervalMs: 1_000,
+        expiresAtMs,
+    };
+}
+
+async function mountHook(options: UseDeviceAuthPollingOptions) {
+    const { useDeviceAuthPolling } = await import("../../hooks/useDeviceAuthPolling");
+    const { createRoot } = await import("react-dom/client");
+    const latestRef: { current: UseDeviceAuthPollingReturn | null } = { current: null };
+
+    function Probe() {
+        latestRef.current = useDeviceAuthPolling(options);
+        return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => root.render(React.createElement(Probe)));
+
+    return {
+        latest: () => {
+            assert.ok(latestRef.current, "hook did not render");
+            return latestRef.current;
+        },
+        act: async (fn: () => void | Promise<void>) => {
+            await React.act(async () => {
+                await fn();
+            });
+        },
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+async function advance(
+    harness: Awaited<ReturnType<typeof mountHook>>,
+    tick: (milliseconds: number) => void,
+    milliseconds: number,
+) {
+    await harness.act(async () => {
+        tick(milliseconds);
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("start transitions through loading to polling and reports the session", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    const initiated = deferred<DeviceAuthSession>();
+    const started: DeviceAuthSession[] = [];
+    const harness = await mountHook({
+        initiate: () => initiated.promise,
+        poll: async () => ({ status: "pending" }),
+        onSessionStarted: (value) => started.push(value),
+    });
+
+    let startPromise!: Promise<void>;
+    await harness.act(() => {
+        startPromise = harness.latest().start();
+    });
+    assert.equal(harness.latest().phase, "loading");
+
+    const activeSession = session("first");
+    await harness.act(async () => {
+        initiated.resolve(activeSession);
+        await startPromise;
+    });
+    assert.equal(harness.latest().phase, "polling");
+    assert.deepEqual(harness.latest().session, activeSession);
+    assert.deepEqual(started, [activeSession]);
+    await harness.unmount();
+});
+
+test("a successful poll stops all future polling and calls onSuccess", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    const polledCodes: string[] = [];
+    let successCalls = 0;
+    const harness = await mountHook({
+        initiate: async () => session("success"),
+        poll: async (deviceCode) => {
+            polledCodes.push(deviceCode);
+            return { status: "success" };
+        },
+        onSuccess: () => {
+            successCalls += 1;
+        },
+    });
+
+    await harness.act(() => harness.latest().start());
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 1_000);
+    assert.equal(harness.latest().phase, "success");
+    assert.equal(successCalls, 1);
+    assert.deepEqual(polledCodes, ["success"]);
+
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 20_000);
+    assert.deepEqual(polledCodes, ["success"]);
+    await harness.unmount();
+});
+
+test("a re-entrant start cancels the first polling chain", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    const sessions = [session("first"), session("second")];
+    const polledCodes: string[] = [];
+    let initiationIndex = 0;
+    const harness = await mountHook({
+        initiate: async () => sessions[initiationIndex++],
+        poll: async (deviceCode) => {
+            polledCodes.push(deviceCode);
+            return { status: "pending" };
+        },
+    });
+
+    await harness.act(() => harness.latest().start());
+    assert.equal(harness.latest().session?.deviceCode, "first");
+    await harness.act(() => harness.latest().start());
+    assert.equal(harness.latest().session?.deviceCode, "second");
+
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 3_000);
+    assert.deepEqual(polledCodes, ["second"]);
+    await harness.unmount();
+});
+
+test("expiry stops polling and surfaces the configured message", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    let pollCalls = 0;
+    const harness = await mountHook({
+        initiate: async () => ({ ...session("expiring", 2_000), pollIntervalMs: 5_000 }),
+        poll: async () => {
+            pollCalls += 1;
+            return { status: "pending" };
+        },
+        expiredMessage: "The code expired",
+    });
+
+    await harness.act(() => harness.latest().start());
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 2_000);
+    assert.equal(harness.latest().phase, "error");
+    assert.equal(harness.latest().error, "The code expired");
+    assert.equal(harness.latest().timeLeftSeconds, null);
+
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 10_000);
+    assert.equal(pollCalls, 0);
+    await harness.unmount();
+});
+
+test("unmount cancels polling without post-unmount React errors", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    const errors: unknown[][] = [];
+    t.mock.method(console, "error", (...args: unknown[]) => errors.push(args));
+    let pollCalls = 0;
+    const harness = await mountHook({
+        initiate: async () => session("unmounted"),
+        poll: async () => {
+            pollCalls += 1;
+            return { status: "pending" };
+        },
+    });
+
+    await harness.act(() => harness.latest().start());
+    await harness.unmount();
+    t.mock.timers.tick(10_000);
+    await Promise.resolve();
+    assert.equal(pollCalls, 0);
+    assert.deepEqual(errors, []);
+});
+
+test("transient rejection retries, then an error outcome stops polling", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+    const outcomes: Array<DeviceAuthPollOutcome | Error> = [
+        new Error("temporary"),
+        { status: "error", message: "Authorization denied" },
+    ];
+    let pollCalls = 0;
+    const harness = await mountHook({
+        initiate: async () => session("retry"),
+        poll: async () => {
+            pollCalls += 1;
+            const outcome = outcomes.shift();
+            if (outcome instanceof Error) throw outcome;
+            assert.ok(outcome);
+            return outcome;
+        },
+    });
+
+    await harness.act(() => harness.latest().start());
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 1_000);
+    assert.equal(harness.latest().phase, "polling");
+    assert.equal(pollCalls, 1);
+
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 1_000);
+    assert.equal(harness.latest().phase, "error");
+    assert.equal(harness.latest().error, "Authorization denied");
+    assert.equal(pollCalls, 2);
+
+    await advance(harness, t.mock.timers.tick.bind(t.mock.timers), 10_000);
+    assert.equal(pollCalls, 2);
+    await harness.unmount();
+});

--- a/frontend/tests/component/useDownloadStatus.component.test.ts
+++ b/frontend/tests/component/useDownloadStatus.component.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+type DownloadResponse = Array<{
+    id: string;
+    type: "artist" | "album";
+    subject: string;
+    targetMbid: string;
+    status: "pending" | "processing" | "completed" | "failed";
+    createdAt: string;
+}>;
+
+const apiState: {
+    calls: number;
+    getDownloads: () => Promise<DownloadResponse>;
+} = {
+    calls: 0,
+    getDownloads: async () => [],
+};
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getDownloads: async () => {
+                apiState.calls += 1;
+                return apiState.getDownloads();
+            },
+        },
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        createFrontendLogger: () => ({ error: () => undefined }),
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    apiState.calls = 0;
+    apiState.getDownloads = async () => [];
+});
+
+async function flushMicrotasks(): Promise<void> {
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+async function mountDownloadStatus() {
+    const { useDownloadStatus } = await import("../../hooks/useDownloadStatus");
+    const { createRoot } = await import("react-dom/client");
+
+    function Probe() {
+        useDownloadStatus(15_000, true);
+        return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => root.render(React.createElement(Probe)));
+    await flushMicrotasks();
+
+    return {
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function activeDownload(): DownloadResponse[number] {
+    return {
+        id: "job-1",
+        type: "album",
+        subject: "Album",
+        targetMbid: "mbid-1",
+        status: "processing",
+        createdAt: new Date().toISOString(),
+    };
+}
+
+test("download status events preserve exactly one polling chain", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    const harness = await mountDownloadStatus();
+    t.after(harness.unmount);
+    assert.equal(apiState.calls, 1);
+
+    for (let eventCount = 0; eventCount < 3; eventCount += 1) {
+        await React.act(async () => {
+            window.dispatchEvent(new Event("download-status-changed"));
+            t.mock.timers.tick(0);
+            await Promise.resolve();
+        });
+    }
+    assert.equal(apiState.calls, 4);
+
+    await React.act(async () => {
+        t.mock.timers.tick(30_000);
+        await Promise.resolve();
+    });
+    assert.equal(apiState.calls, 5);
+});
+
+test("active downloads use five-second cadence before returning to idle cadence", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    apiState.getDownloads = async () => apiState.calls === 1 ? [activeDownload()] : [];
+    const harness = await mountDownloadStatus();
+    t.after(harness.unmount);
+
+    t.mock.timers.tick(4_999);
+    assert.equal(apiState.calls, 1);
+    await React.act(async () => {
+        t.mock.timers.tick(1);
+        await Promise.resolve();
+    });
+    assert.equal(apiState.calls, 2);
+
+    t.mock.timers.tick(29_999);
+    assert.equal(apiState.calls, 2);
+    await React.act(async () => {
+        t.mock.timers.tick(1);
+        await Promise.resolve();
+    });
+    assert.equal(apiState.calls, 3);
+});
+
+test("unmount clears download polling and its event listener", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    const harness = await mountDownloadStatus();
+    assert.equal(apiState.calls, 1);
+    await harness.unmount();
+
+    window.dispatchEvent(new Event("download-status-changed"));
+    t.mock.timers.tick(10 * 60 * 1_000);
+    await flushMicrotasks();
+    assert.equal(apiState.calls, 1);
+});
+
+test("errors back off and a success resets polling to idle cadence", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    apiState.getDownloads = async () => {
+        if (apiState.calls === 1) {
+            throw new Error("network failure");
+        }
+        return [];
+    };
+    const harness = await mountDownloadStatus();
+    t.after(harness.unmount);
+    assert.equal(apiState.calls, 1);
+
+    t.mock.timers.tick(29_999);
+    assert.equal(apiState.calls, 1);
+    await React.act(async () => {
+        t.mock.timers.tick(1);
+        await Promise.resolve();
+    });
+    assert.equal(apiState.calls, 2);
+
+    t.mock.timers.tick(29_999);
+    assert.equal(apiState.calls, 2);
+    await React.act(async () => {
+        t.mock.timers.tick(1);
+        await Promise.resolve();
+    });
+    assert.equal(apiState.calls, 3);
+});

--- a/frontend/tests/component/usePreviewPlayer.component.test.ts
+++ b/frontend/tests/component/usePreviewPlayer.component.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+type EngineListener = () => void;
+
+const engineState = {
+    playing: false,
+    playCalls: 0,
+    pauseCalls: 0,
+    listeners: new Map<string, Set<EngineListener>>(),
+};
+
+const playbackEngine = {
+    play: () => {
+        engineState.playCalls += 1;
+        engineState.playing = true;
+    },
+    pause: () => {
+        engineState.pauseCalls += 1;
+        engineState.playing = false;
+    },
+    isPlaying: () => engineState.playing,
+    on: (event: string, listener: EngineListener) => {
+        const listeners = engineState.listeners.get(event) ?? new Set();
+        listeners.add(listener);
+        engineState.listeners.set(event, listeners);
+    },
+    off: (event: string, listener: EngineListener) => {
+        engineState.listeners.get(event)?.delete(listener);
+    },
+};
+
+const audioEngineExports = {
+    createRuntimeAudioEngine: () => playbackEngine,
+};
+
+mock.module("@/lib/audio-engine", { namedExports: audioEngineExports });
+
+const toast = Object.assign(() => undefined, { error: () => undefined });
+mock.module("sonner", { namedExports: { toast } });
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getTrackPreview: async () => ({ videoId: "v" }),
+            getPreviewStreamUrl: () => "url",
+        },
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: { error: () => undefined },
+    },
+});
+
+class FakeAudio {
+    static instances: FakeAudio[] = [];
+
+    currentTime = 0;
+    onended: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    pauseCalls = 0;
+    playCalls = 0;
+    src: string;
+
+    constructor(src: string) {
+        this.src = src;
+        FakeAudio.instances.push(this);
+    }
+
+    play(): Promise<void> {
+        this.playCalls += 1;
+        return Promise.resolve();
+    }
+
+    pause(): void {
+        this.pauseCalls += 1;
+    }
+}
+
+Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    writable: true,
+    value: FakeAudio,
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    engineState.playing = false;
+    engineState.playCalls = 0;
+    engineState.pauseCalls = 0;
+    engineState.listeners.clear();
+    FakeAudio.instances = [];
+});
+
+type PreviewPlayerApi = ReturnType<
+    typeof import("../../features/discover/hooks/usePreviewPlayer").usePreviewPlayer
+>;
+
+type TrackPreviewApi = ReturnType<
+    typeof import("../../hooks/useTrackPreview").useTrackPreview<{
+        id: string;
+        title: string;
+    }>
+>;
+
+async function mountHook<T>(useHook: () => T) {
+    const { createRoot } = await import("react-dom/client");
+    const latestRef: { current: T | null } = { current: null };
+
+    function Probe() {
+        latestRef.current = useHook();
+        return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => root.render(React.createElement(Probe)));
+
+    return {
+        latest: () => {
+            assert.ok(latestRef.current, "hook did not render");
+            return latestRef.current;
+        },
+        act: async (fn: () => void | Promise<void>) => {
+            await React.act(async () => {
+                await fn();
+            });
+        },
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+async function mountPreviewPlayer() {
+    const { usePreviewPlayer } = await import(
+        "../../features/discover/hooks/usePreviewPlayer"
+    );
+    return mountHook<PreviewPlayerApi>(usePreviewPlayer);
+}
+
+async function mountTrackPreview() {
+    const { useTrackPreview } = await import("../../hooks/useTrackPreview");
+    return mountHook<TrackPreviewApi>(() => useTrackPreview());
+}
+
+const clickEvent = {
+    stopPropagation: () => undefined,
+} as React.MouseEvent;
+
+test("switching preview albums does not resume the paused main player", async () => {
+    engineState.playing = true;
+    const harness = await mountPreviewPlayer();
+
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    assert.equal(engineState.pauseCalls, 1);
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.act(() => harness.latest().handleTogglePreview("b", "url-b"));
+    assert.equal(engineState.playCalls, 0);
+    await harness.unmount();
+});
+
+test("switching back to an album reuses its intact cached audio", async () => {
+    const harness = await mountPreviewPlayer();
+
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    const firstAudio = FakeAudio.instances[0];
+    await harness.act(() => harness.latest().handleTogglePreview("b", "url-b"));
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+
+    assert.equal(FakeAudio.instances.length, 2);
+    assert.equal(FakeAudio.instances[0], firstAudio);
+    assert.equal(firstAudio.src, "url-a");
+    assert.equal(firstAudio.playCalls, 2);
+    await harness.unmount();
+});
+
+test("preview end resumes the main player that it paused", async () => {
+    engineState.playing = true;
+    const harness = await mountPreviewPlayer();
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.act(() => FakeAudio.instances[0].onended?.());
+    assert.equal(engineState.playCalls, 1);
+    await harness.unmount();
+});
+
+test("preview-player unmount pauses cached audio and resumes the main player", async () => {
+    engineState.playing = true;
+    const harness = await mountPreviewPlayer();
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    await harness.act(() => harness.latest().handleTogglePreview("b", "url-b"));
+    const [firstAudio, secondAudio] = FakeAudio.instances;
+    const firstPauseCallsBeforeUnmount = firstAudio.pauseCalls;
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.unmount();
+    assert.equal(firstAudio.pauseCalls, firstPauseCallsBeforeUnmount + 1);
+    assert.equal(secondAudio.pauseCalls, 1);
+    assert.equal(engineState.playCalls, 1);
+});
+
+test("preview error resumes the main player and evicts the failed audio", async () => {
+    engineState.playing = true;
+    const harness = await mountPreviewPlayer();
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.act(() => FakeAudio.instances[0].onerror?.());
+    assert.equal(engineState.playCalls, 1);
+    await harness.act(() => harness.latest().handleTogglePreview("a", "url-a"));
+    assert.equal(FakeAudio.instances.length, 2);
+    await harness.unmount();
+});
+
+test("track preview end resumes the main player that it paused", async () => {
+    engineState.playing = true;
+    const harness = await mountTrackPreview();
+    await harness.act(() =>
+        harness.latest().handlePreview(
+            { id: "track-a", title: "Track A" },
+            "Artist",
+            clickEvent,
+        )
+    );
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.act(() => FakeAudio.instances[0].onended?.());
+    assert.equal(engineState.playCalls, 1);
+    await harness.unmount();
+});
+
+test("track-preview unmount resumes the main player that it paused", async () => {
+    engineState.playing = true;
+    const harness = await mountTrackPreview();
+    await harness.act(() =>
+        harness.latest().handlePreview(
+            { id: "track-a", title: "Track A" },
+            "Artist",
+            clickEvent,
+        )
+    );
+    assert.equal(engineState.playCalls, 0);
+
+    await harness.unmount();
+    assert.equal(FakeAudio.instances[0].pauseCalls, 1);
+    assert.equal(engineState.playCalls, 1);
+});

--- a/frontend/tests/component/useVisibilityGatedInterval.component.test.ts
+++ b/frontend/tests/component/useVisibilityGatedInterval.component.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    setVisibility("visible");
+});
+
+function setVisibility(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: state,
+    });
+}
+
+async function changeVisibility(state: DocumentVisibilityState): Promise<void> {
+    await React.act(async () => {
+        setVisibility(state);
+        document.dispatchEvent(new Event("visibilitychange"));
+    });
+}
+
+async function mountHook(
+    callback: () => void,
+    options?: { enabled?: boolean; leadingOnVisible?: boolean }
+) {
+    const { useVisibilityGatedInterval } = await import(
+        "../../hooks/useVisibilityGatedInterval"
+    );
+    const { createRoot } = await import("react-dom/client");
+
+    function Probe({ onTick }: { onTick: () => void }) {
+        useVisibilityGatedInterval(onTick, 1_000, options);
+        return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () =>
+        root.render(React.createElement(Probe, { onTick: callback }))
+    );
+
+    return {
+        rerender: async (onTick: () => void) => {
+            await React.act(async () =>
+                root.render(React.createElement(Probe, { onTick }))
+            );
+        },
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+test("ticks at the configured interval while visible", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let calls = 0;
+    const harness = await mountHook(() => {
+        calls += 1;
+    });
+    t.after(harness.unmount);
+
+    t.mock.timers.tick(2_000);
+
+    assert.equal(calls, 2);
+});
+
+test("does not tick while hidden", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    setVisibility("hidden");
+    let calls = 0;
+    const harness = await mountHook(() => {
+        calls += 1;
+    });
+    t.after(harness.unmount);
+
+    t.mock.timers.tick(10_000);
+
+    assert.equal(calls, 0);
+});
+
+test("fires once on return to visibility and resumes the interval", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let calls = 0;
+    const harness = await mountHook(() => {
+        calls += 1;
+    });
+    t.after(harness.unmount);
+
+    await changeVisibility("hidden");
+    t.mock.timers.tick(10_000);
+    await changeVisibility("visible");
+    assert.equal(calls, 1);
+
+    t.mock.timers.tick(1_000);
+    assert.equal(calls, 2);
+});
+
+test("does not fire a leading call on first mount", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let calls = 0;
+    const harness = await mountHook(() => {
+        calls += 1;
+    });
+    t.after(harness.unmount);
+
+    assert.equal(calls, 0);
+});
+
+test("does not tick when disabled", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let calls = 0;
+    const harness = await mountHook(
+        () => {
+            calls += 1;
+        },
+        { enabled: false }
+    );
+    t.after(harness.unmount);
+
+    t.mock.timers.tick(10_000);
+
+    assert.equal(calls, 0);
+});
+
+test("cleans up the interval on unmount", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let calls = 0;
+    const harness = await mountHook(() => {
+        calls += 1;
+    });
+
+    await harness.unmount();
+    t.mock.timers.tick(10_000);
+
+    assert.equal(calls, 0);
+});
+
+test("uses the latest callback after rerender", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const harness = await mountHook(() => {
+        firstCalls += 1;
+    });
+    t.after(harness.unmount);
+
+    await harness.rerender(() => {
+        secondCalls += 1;
+    });
+    t.mock.timers.tick(1_000);
+
+    assert.equal(firstCalls, 0);
+    assert.equal(secondCalls, 1);
+});

--- a/frontend/tests/unit/downloadStatusPolling.test.ts
+++ b/frontend/tests/unit/downloadStatusPolling.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    resolveDownloadErrorBackoffMs,
+    resolveDownloadPollDelayMs,
+} from "../../hooks/downloadStatusPolling";
+
+test("download polling cadence follows active, existing, and empty boundaries", () => {
+    assert.equal(resolveDownloadPollDelayMs(1, 1), 5_000);
+    assert.equal(resolveDownloadPollDelayMs(2, 0), 5_000);
+    assert.equal(resolveDownloadPollDelayMs(0, 1), 10_000);
+    assert.equal(resolveDownloadPollDelayMs(0, 0), 30_000);
+});
+
+test("download error backoff grows exponentially and caps at 120 seconds", () => {
+    assert.equal(resolveDownloadErrorBackoffMs(15_000, 0), 15_000);
+    assert.equal(resolveDownloadErrorBackoffMs(15_000, 1), 30_000);
+    assert.equal(resolveDownloadErrorBackoffMs(15_000, 2), 60_000);
+    assert.equal(resolveDownloadErrorBackoffMs(15_000, 3), 120_000);
+    assert.equal(resolveDownloadErrorBackoffMs(15_000, 10), 120_000);
+});


### PR DESCRIPTION
Frontend-only slice of the enterprise refactor campaign: poller correctness bugs sharing one shape (untracked timers, stale closures, forked chains), plus listener/effect hygiene. No backend changes; disjoint from the backend refactor PRs.

## Findings fixed

1. **usePreviewPlayer cleanup ran on every state change** — its cleanup effect depended on the audio-element map state, so adding a preview audio resumed the main player *over the active preview* and destroyed the cached audio elements. The cache now lives in a ref with unmount-only cleanup; failed elements are evicted for clean retries.
2. **Unified resume-after-preview behavior** (decision applied to both `usePreviewPlayer` and `useTrackPreview`): when a preview ends, errors, or the hook unmounts, the main player resumes iff the preview paused it; a user-initiated preview *pause* does not resume it.
3. **Tidal device-auth polling** (`TidalSection` + `TidalStreamingSection`): re-clicking authenticate orphaned the previous poll interval; the expiry `setTimeout` was untracked (fired after unmount, never cleared on success); and a stale `authState` closure meant the "Device code expired" error could never render. Both sections now share a new **`useDeviceAuthPolling`** hook (per the slice risk note preferring one shared hook over patching sections individually) with generation-guarded timers, effect-derived expiry countdown, and full cleanup. StrictMode-safe.
4. **useDownloadStatus forked a permanent extra poll chain** on every `download-status-changed` event (N events ⇒ N+1 parallel self-scheduling chains). All scheduling now flows through a single clear-before-set timer; cadence/backoff decisions extracted to pure, unit-tested helpers (`downloadStatusPolling.ts`).
5. **download-context `addPendingDownload`** performed side effects inside its React state updater and returned updater-computed state; now computes outside with a synced ref and a pure updater (StrictMode double-invoke safe).
6. **Raw-interval pollers ignored the repo's visibility-gating/cadence helpers** — new **`useVisibilityGatedInterval`** hook (interval only while visible + enabled; one leading refresh on hidden→visible; callback ref freshness) adopted by:
   - `features-context` — also removes the `focus` + `visibilitychange` **double-fire** on tab return
   - `usePresenceHeartbeat` — hidden tabs stop heartbeating, so backgrounded tabs no longer report the user as actively present (per-plan correctness decision; presence expires via existing server TTL and resumes with an immediate beat on tab return)
   - `useActiveListenSessions` (keeps startup jitter), `useJobStatus` (immediate check on tab return), listen-together lobby 5s discover poll, device-link 2s status poll

## Tests (all new, node:test + happy-dom harness per repo conventions)

- `tests/component/useDeviceAuthPolling.component.test.ts` — 6 cases (re-entrant start kills old chain, expiry, unmount, transient vs terminal poll errors)
- `tests/component/usePreviewPlayer.component.test.ts` — 7 cases covering both preview hooks (no resume-over-preview, cache reuse, resume on end/error/unmount)
- `tests/unit/downloadStatusPolling.test.ts` + `tests/component/useDownloadStatus.component.test.ts` — no-fork regression (asserts exactly one surviving chain after 3 events), cadence, backoff, unmount
- `tests/component/downloadContext.component.test.ts` — dedup + StrictMode purity
- `tests/component/useVisibilityGatedInterval.component.test.ts` + `tests/component/featuresContext.component.test.ts` — gating matrix incl. the double-fire regression

verify: targeted new suites all pass (6+7+2+6+9); impacted existing suites pass (40+36+24 across sidebar/activityPanel/homePage/fullPlayer/streamingRoutes/explore/playlist/skipSeconds + useTrackPreview/pollingCadence units); `tsc --noEmit --incremental false` exit 0; `eslint` 0 errors (182 pre-existing warnings untouched).

## Behavior changes of note (no breaking changes, no UPGRADING needed)

- Presence semantics: hidden tabs stop sending heartbeats (this is the fix, flagged in the slice plan as a deliberate correctness decision).
- Preview end in `useTrackPreview` now resumes the main player (previously it silently cleared the flag) — the unified behavior decision.
- Background tabs no longer poll features/downloads/jobs/discovery; each refreshes immediately on tab return.

## Escalations / follow-ups discovered

- `YouTubeMusicSection.tsx` has a third hand-rolled device-auth flow (healthier — no bugs found) that should adopt `useDeviceAuthPolling` when `frontend-dedup` touches that file (out of scope here).
- `useJobStatus` passes `statusData.result?.error` (typed `unknown`) where a `string` is expected — pre-existing type looseness left for the api-client typing slice.
