### PR TITLE
refactor(mixes): data-driven curated vibe mix catalog (refactor slice programmatic-playlists-datadriven)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   image's production `node_modules`.
 - Frontend: removed the deprecated `@types/dompurify` stub; `dompurify` 3.x and
   later ship their own type definitions.
+- Backend: the 13 curated daily "vibe" mixes (Sad Girl Sundays, Main Character
+  Energy, Villain Era, 3AM Thoughts, Hot Girl Walk, Rage Cleaning, Golden Hour,
+  Shower Karaoke, In My Feelings, Midnight Drive, Romanticize Your Life, That
+  Girl Era, Unhinged) are now data-driven: their filters, names, descriptions,
+  colors, pool sizes, and weekday gates live in a single declarative catalog
+  (`backend/src/services/curatedVibeMixDefinitions.ts`) consumed by one shared
+  generator, replacing ~13 near-identical hardcoded methods (net −433 lines in
+  `programmaticPlaylists.ts`). Behavior, mix ids/types, and the public
+  `generate*` method surface are unchanged; artist-diversity selection is
+  preserved.
 - Audio analyzer batch-timeout retry semantics (analyzer reliability slice):
   when an analysis batch hits `BATCH_ANALYSIS_TIMEOUT_SECONDS`, tracks that
   never started running are now re-queued as `pending` WITHOUT consuming any

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -26,6 +26,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/coverArt.ts` | Core |
 | `backend/src/services/coverArtExtractor.ts` | Core |
 | `backend/src/services/coverArtResize.ts` | Core |
+| `backend/src/services/curatedVibeMixDefinitions.ts` | Data-driven curated vibe mix catalog |
 | `backend/src/services/dataCache.ts` | Core |
 | `backend/src/services/deezer.ts` | Core |
 | `backend/src/services/discoverWeekly.ts` | Core |

--- a/backend/src/services/__tests__/programmaticPlaylistsDataDriven.test.ts
+++ b/backend/src/services/__tests__/programmaticPlaylistsDataDriven.test.ts
@@ -1,0 +1,206 @@
+import { CURATED_VIBE_MIXES, CuratedVibeMixDefinition } from "../curatedVibeMixDefinitions";
+import { ProgrammaticMix, ProgrammaticPlaylistService } from "../programmaticPlaylists";
+import { prisma } from "../../utils/db";
+
+jest.mock("../../config", () => ({
+    config: {
+        generationDiversity: { weightAlpha: 0.5, shareCeiling: 0.3 },
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: {
+            findMany: jest.fn(),
+            count: jest.fn(),
+        },
+    },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/artistNormalization", () => ({
+    normalizeArtistName: (name: string) => name.toLowerCase(),
+}));
+
+jest.mock("../lastfm", () => ({
+    lastFmService: {
+        getSimilarArtists: jest.fn(),
+    },
+}));
+
+jest.mock("../moodBucketService", () => ({
+    moodBucketService: {
+        getUserMoodMix: jest.fn(),
+        getMoodMix: jest.fn(),
+    },
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function makeTracks(count: number, prefix: string) {
+    return Array.from({ length: count }, (_, i) => ({
+        id: `${prefix}-${i}`,
+        albumId: `${prefix}-album-${i}`,
+        album: {
+            coverUrl: `${prefix}-cover-${i}.jpg`,
+            artist: {
+                id: `${prefix}-artist-${Math.floor(i / 2)}`,
+            },
+        },
+    }));
+}
+
+type CuratedVibeMixGenerator =
+    | "generateSadGirlSundays"
+    | "generateMainCharacterEnergy"
+    | "generateVillainEra"
+    | "generate3AMThoughts"
+    | "generateHotGirlWalk"
+    | "generateRageCleaning"
+    | "generateGoldenHour"
+    | "generateShowerKaraoke"
+    | "generateInMyFeelings"
+    | "generateMidnightDrive"
+    | "generateRomanticizeYourLife"
+    | "generateThatGirlEra"
+    | "generateUnhinged";
+
+const GENERATOR_METHOD_BY_TYPE: Record<
+    CuratedVibeMixDefinition["type"],
+    CuratedVibeMixGenerator
+> = {
+    "sad-girl-sundays": "generateSadGirlSundays",
+    "main-character": "generateMainCharacterEnergy",
+    "villain-era": "generateVillainEra",
+    "3am-thoughts": "generate3AMThoughts",
+    "hot-girl-walk": "generateHotGirlWalk",
+    "rage-cleaning": "generateRageCleaning",
+    "golden-hour": "generateGoldenHour",
+    "shower-karaoke": "generateShowerKaraoke",
+    "in-my-feelings": "generateInMyFeelings",
+    "midnight-drive": "generateMidnightDrive",
+    romanticize: "generateRomanticizeYourLife",
+    "that-girl-era": "generateThatGirlEra",
+    unhinged: "generateUnhinged",
+};
+
+const KNOWN_CURATED_VIBE_MIX_TYPES = [
+    "sad-girl-sundays",
+    "main-character",
+    "villain-era",
+    "3am-thoughts",
+    "hot-girl-walk",
+    "rage-cleaning",
+    "golden-hour",
+    "shower-karaoke",
+    "in-my-feelings",
+    "midnight-drive",
+    "romanticize",
+    "that-girl-era",
+    "unhinged",
+];
+
+describe("ProgrammaticPlaylistService data-driven curated vibe mixes", () => {
+    let service: ProgrammaticPlaylistService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+        service = new ProgrammaticPlaylistService();
+        (mockPrisma.track.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("catalog contains exactly the 13 known curated vibe mix types", () => {
+        expect(new Set(CURATED_VIBE_MIXES.map((definition) => definition.type))).toEqual(
+            new Set(KNOWN_CURATED_VIBE_MIX_TYPES)
+        );
+        expect(CURATED_VIBE_MIXES.length).toBe(13);
+    });
+
+    it("every definition is well-formed", () => {
+        for (const definition of CURATED_VIBE_MIXES) {
+            expect(typeof definition.type === "string" && definition.type.length > 0).toBe(
+                true
+            );
+            expect(typeof definition.name === "string" && definition.name.length > 0).toBe(
+                true
+            );
+            expect(
+                typeof definition.description === "string" &&
+                    definition.description.length > 0
+            ).toBe(true);
+            expect(
+                typeof definition.colorKey === "string" && definition.colorKey.length > 0
+            ).toBe(true);
+            expect(definition.take).toBeGreaterThanOrEqual(50);
+            expect(typeof definition.where).toBe("object");
+            expect(definition.where).not.toBeNull();
+        }
+    });
+
+    it("each definition drives its generator's output and query", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2026-02-22T12:00:00Z"));
+
+        for (const definition of CURATED_VIBE_MIXES) {
+            (mockPrisma.track.findMany as jest.Mock).mockReset();
+            (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(
+                makeTracks(30, definition.type)
+            );
+
+            const methodName = GENERATOR_METHOD_BY_TYPE[definition.type];
+            const mix: ProgrammaticMix | null = await service[methodName](
+                "user-1",
+                "2026-02-17"
+            );
+
+            expect(mix).not.toBeNull();
+            expect(mix!.type).toBe(definition.type);
+            expect(mix!.name).toBe(definition.name);
+            expect(mix!.description).toBe(definition.description);
+            expect(mix!.id).toBe(`${definition.type}-2026-02-17`);
+            expect(mix!.trackCount).toBe(10);
+            expect(typeof mix!.color === "string" && mix!.color.length > 0).toBe(true);
+
+            const calls = (mockPrisma.track.findMany as jest.Mock).mock.calls;
+            const mostRecentCall = calls[calls.length - 1];
+            expect(mostRecentCall[0]).toEqual({
+                where: {
+                    analysisStatus: "completed",
+                    ...definition.where,
+                },
+                include: {
+                    album: {
+                        select: {
+                            coverUrl: true,
+                        },
+                    },
+                },
+                take: definition.take,
+            });
+        }
+    });
+
+    it("sad-girl-sundays is gated to Sunday", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2026-02-24T12:00:00Z"));
+        (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(
+            makeTracks(30, "sad-girl-sundays")
+        );
+
+        await expect(
+            service.generateSadGirlSundays("user-1", "2026-02-17")
+        ).resolves.toBeNull();
+
+        const sadGirlSundays = CURATED_VIBE_MIXES.find(
+            (definition) => definition.type === "sad-girl-sundays"
+        );
+        expect(sadGirlSundays?.dayOfWeek).toBe(0);
+    });
+});

--- a/backend/src/services/curatedVibeMixDefinitions.ts
+++ b/backend/src/services/curatedVibeMixDefinitions.ts
@@ -1,0 +1,302 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * Declarative definition of a "curated daily vibe mix". These mixes all share
+ * the same generation pipeline (filter completed-analysis tracks, apply
+ * artist-diversity selection, build a 10-track mix); only the query filter and
+ * presentation metadata differ. Centralizing them here keeps the catalog
+ * data-driven instead of duplicated across ~13 near-identical methods.
+ */
+export interface CuratedVibeMixDefinition {
+    /** Stable mix type/slug; also the id prefix (`${type}-${today}`). */
+    type: string;
+    /** Human-readable mix name. */
+    name: string;
+    /** Short description shown in the UI. */
+    description: string;
+    /** Key into the mix color palette (see getMixColor). */
+    colorKey: string;
+    /** Prisma `take` for the candidate pool query. */
+    take: number;
+    /** Prisma filter (merged with `analysisStatus: "completed"`). */
+    where: Prisma.TrackWhereInput;
+    /**
+     * Optional minimum candidate pool size before a mix is produced.
+     * Defaults to the service's daily minimum when omitted.
+     */
+    minTracks?: number;
+    /**
+     * Optional day-of-week gate (0 = Sunday). When set, the mix is only
+     * generated on that weekday.
+     */
+    dayOfWeek?: number;
+}
+
+/** The full curated daily vibe mix catalog. */
+export const CURATED_VIBE_MIXES: readonly CuratedVibeMixDefinition[] = [
+    {
+        type: "sad-girl-sundays",
+        name: "Sad Girl Sundays",
+        description: "Melancholic introspection and feelings",
+        colorKey: "sad-girl-sundays",
+        take: 50,
+        dayOfWeek: 0,
+        where: {
+            OR: [
+                { AND: [{ valence: { lte: 0.35 } }, { keyScale: "minor" }] },
+                { AND: [{ valence: { lte: 0.3 } }, { arousal: { lte: 0.4 } }] },
+                {
+                    lastfmTags: {
+                        hasSome: ["sad", "melancholic", "heartbreak", "emotional"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "main-character",
+        name: "Main Character Energy",
+        description: "You're the protagonist today",
+        colorKey: "main-character",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { valence: { gte: 0.55 } },
+                        { energy: { gte: 0.55 } },
+                        { danceability: { gte: 0.5 } },
+                    ],
+                },
+                {
+                    lastfmTags: {
+                        hasSome: ["empowering", "confident", "uplifting", "anthemic"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "villain-era",
+        name: "Villain Era",
+        description: "Embrace your dark side",
+        colorKey: "villain-era",
+        take: 50,
+        where: {
+            OR: [
+                { AND: [{ keyScale: "minor" }, { energy: { gte: 0.65 } }] },
+                { moodTags: { hasSome: ["aggressive", "dark", "intense"] } },
+                {
+                    lastfmTags: {
+                        hasSome: ["dark", "aggressive", "intense", "powerful"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "3am-thoughts",
+        name: "3AM Thoughts",
+        description: "Late night overthinking companion",
+        colorKey: "3am-thoughts",
+        take: 50,
+        where: {
+            AND: [
+                { arousal: { lte: 0.4 } },
+                { energy: { lte: 0.5 } },
+                { bpm: { lte: 110 } },
+                {
+                    OR: [
+                        { valence: { lte: 0.5 } },
+                        { acousticness: { gte: 0.3 } },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        type: "hot-girl-walk",
+        name: "Hot Girl Walk",
+        description: "Confidence boost for your walk",
+        colorKey: "confidence-boost",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { danceability: { gte: 0.65 } },
+                        { bpm: { gte: 95, lte: 135 } },
+                        { energy: { gte: 0.55 } },
+                    ],
+                },
+                { AND: [{ valence: { gte: 0.6 } }, { energy: { gte: 0.6 } }] },
+            ],
+        },
+    },
+    {
+        type: "rage-cleaning",
+        name: "Rage Cleaning",
+        description: "Aggressive productivity fuel",
+        colorKey: "workout",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { energy: { gte: 0.75 } },
+                        { arousal: { gte: 0.65 } },
+                        { bpm: { gte: 125 } },
+                    ],
+                },
+                {
+                    AND: [
+                        { energy: { gte: 0.8 } },
+                        { danceability: { gte: 0.6 } },
+                    ],
+                },
+                { moodTags: { hasSome: ["aggressive", "energetic"] } },
+            ],
+        },
+    },
+    {
+        type: "golden-hour",
+        name: "Golden Hour",
+        description: "Warm sunset vibes",
+        colorKey: "golden-hour",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { valence: { gte: 0.45 } },
+                        { acousticness: { gte: 0.35 } },
+                        { energy: { gte: 0.25, lte: 0.65 } },
+                    ],
+                },
+                {
+                    lastfmTags: {
+                        hasSome: ["warm", "sunset", "dreamy", "peaceful"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "shower-karaoke",
+        name: "Shower Karaoke",
+        description: "Belters you can't help but sing",
+        colorKey: "happy",
+        take: 50,
+        where: {
+            AND: [
+                { instrumentalness: { lte: 0.35 } },
+                { energy: { gte: 0.55 } },
+                { valence: { gte: 0.45 } },
+            ],
+        },
+    },
+    {
+        type: "in-my-feelings",
+        name: "In My Feelings",
+        description: "Let it all out",
+        colorKey: "heartbreak-hotel",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { valence: { lte: 0.4 } },
+                        { arousal: { lte: 0.55 } },
+                        { acousticness: { gte: 0.25 } },
+                    ],
+                },
+                {
+                    lastfmTags: {
+                        hasSome: ["emotional", "heartbreak", "feelings", "vulnerable"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "midnight-drive",
+        name: "Midnight Drive",
+        description: "Perfect for late night cruising",
+        colorKey: "night-drive",
+        take: 50,
+        where: {
+            AND: [
+                { energy: { gte: 0.3, lte: 0.65 } },
+                { bpm: { gte: 80, lte: 130 } },
+                {
+                    OR: [
+                        { arousal: { lte: 0.6 } },
+                        { valence: { gte: 0.3, lte: 0.7 } },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        type: "romanticize",
+        name: "Romanticize Your Life",
+        description: "Make every moment aesthetic",
+        colorKey: "golden-hour",
+        take: 50,
+        where: {
+            OR: [
+                {
+                    AND: [
+                        { valence: { gte: 0.35, lte: 0.75 } },
+                        { arousal: { gte: 0.25, lte: 0.65 } },
+                        { acousticness: { gte: 0.25 } },
+                    ],
+                },
+                {
+                    lastfmTags: {
+                        hasSome: ["dreamy", "aesthetic", "cinematic", "romantic"],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        type: "that-girl-era",
+        name: "That Girl Era",
+        description: "Self-improvement mode activated",
+        colorKey: "confidence-boost",
+        take: 50,
+        where: {
+            AND: [
+                { valence: { gte: 0.55 } },
+                { energy: { gte: 0.45 } },
+                { danceability: { gte: 0.45 } },
+            ],
+        },
+    },
+    {
+        type: "unhinged",
+        name: "Unhinged",
+        description: "Embrace the chaos",
+        colorKey: "dance-floor",
+        take: 100,
+        where: {
+            OR: [
+                { energy: { gte: 0.85 } },
+                { energy: { lte: 0.15 } },
+                { valence: { gte: 0.9 } },
+                { valence: { lte: 0.1 } },
+                { bpm: { gte: 160 } },
+                { bpm: { lte: 70 } },
+                { danceability: { gte: 0.9 } },
+            ],
+        },
+    },
+];
+
+/** Lookup of curated vibe mix definitions by their `type`. */
+export const CURATED_VIBE_MIXES_BY_TYPE: Readonly<
+    Record<string, CuratedVibeMixDefinition>
+> = Object.fromEntries(
+    CURATED_VIBE_MIXES.map((definition) => [definition.type, definition])
+);

--- a/backend/src/services/programmaticPlaylists.ts
+++ b/backend/src/services/programmaticPlaylists.ts
@@ -17,6 +17,10 @@ import {
 } from "./artistSlotAllocation";
 import { config } from "../config";
 import { separateArtists } from "../utils/separateArtists";
+import {
+    CURATED_VIBE_MIXES_BY_TYPE,
+    type CuratedVibeMixDefinition,
+} from "./curatedVibeMixDefinitions";
 export {
     applyArtistCap,
     type ArtistCapTrack,
@@ -2897,6 +2901,53 @@ export class ProgrammaticPlaylistService {
         };
     }
 
+    /**
+     * Shared generator for data-driven curated daily vibe mixes. Applies the
+     * definition's optional weekday gate, queries the candidate pool with the
+     * definition's Prisma filter (always constrained to completed analysis),
+     * enforces the minimum pool size, then builds a diversity-selected mix.
+     */
+    private async generateCuratedVibeMix(
+        today: string,
+        definition: CuratedVibeMixDefinition
+    ): Promise<ProgrammaticMix | null> {
+        if (
+            definition.dayOfWeek !== undefined &&
+            new Date().getDay() !== definition.dayOfWeek
+        ) {
+            return null;
+        }
+
+        const tracks = await prisma.track.findMany({
+            where: { analysisStatus: "completed", ...definition.where },
+            include: { album: { select: { coverUrl: true } } },
+            take: definition.take,
+        });
+
+        const minTracks = definition.minTracks ?? this.MIN_TRACKS_DAILY;
+        if (tracks.length < minTracks) return null;
+
+        const shuffled = await selectTracksWithArtistDiversityForMix(
+            tracks,
+            this.DAILY_TRACK_LIMIT
+        );
+        const coverUrls = shuffled
+            .filter((t) => t.album.coverUrl)
+            .slice(0, 4)
+            .map((t) => t.album.coverUrl!);
+
+        return {
+            id: `${definition.type}-${today}`,
+            type: definition.type,
+            name: definition.name,
+            description: definition.description,
+            trackIds: shuffled.map((t) => t.id),
+            coverUrls,
+            trackCount: shuffled.length,
+            color: getMixColor(definition.colorKey),
+        };
+    }
+
     // CURATED VIBE MIXES (Daily, 10 tracks)
 
     /**
@@ -2908,60 +2959,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        // Only generate on Sundays (day 0)
-        const dayOfWeek = new Date().getDay();
-        if (dayOfWeek !== 0) return null;
-
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { valence: { lte: 0.35 } },
-                            { keyScale: "minor" },
-                        ],
-                    },
-                    {
-                        AND: [
-                            { valence: { lte: 0.3 } },
-                            { arousal: { lte: 0.4 } },
-                        ],
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: [
-                                "sad",
-                                "melancholic",
-                                "heartbreak",
-                                "emotional",
-                            ],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `sad-girl-sundays-${today}`,
-            type: "sad-girl-sundays",
-            name: "Sad Girl Sundays",
-            description: "Melancholic introspection and feelings",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("sad-girl-sundays"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["sad-girl-sundays"]
+        );
     }
 
     /**
@@ -2972,51 +2973,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { valence: { gte: 0.55 } },
-                            { energy: { gte: 0.55 } },
-                            { danceability: { gte: 0.5 } },
-                        ],
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: [
-                                "empowering",
-                                "confident",
-                                "uplifting",
-                                "anthemic",
-                            ],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `main-character-${today}`,
-            type: "main-character",
-            name: "Main Character Energy",
-            description: "You're the protagonist today",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("main-character"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["main-character"]
+        );
     }
 
     /**
@@ -3027,52 +2987,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [{ keyScale: "minor" }, { energy: { gte: 0.65 } }],
-                    },
-                    {
-                        moodTags: {
-                            hasSome: ["aggressive", "dark", "intense"],
-                        },
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: [
-                                "dark",
-                                "aggressive",
-                                "intense",
-                                "powerful",
-                            ],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `villain-era-${today}`,
-            type: "villain-era",
-            name: "Villain Era",
-            description: "Embrace your dark side",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("villain-era"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["villain-era"]
+        );
     }
 
     /**
@@ -3083,44 +3001,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        // STRICT criteria: truly late-night introspective tracks only
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                AND: [
-                    { arousal: { lte: 0.4 } },
-                    { energy: { lte: 0.5 } },
-                    { bpm: { lte: 110 } },
-                    {
-                        OR: [
-                            { valence: { lte: 0.5 } },
-                            { acousticness: { gte: 0.3 } },
-                        ],
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < this.MIN_TRACKS_DAILY) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `3am-thoughts-${today}`,
-            type: "3am-thoughts",
-            name: "3AM Thoughts",
-            description: "Late night overthinking companion",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("3am-thoughts"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["3am-thoughts"]
+        );
     }
 
     /**
@@ -3131,47 +3015,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { danceability: { gte: 0.65 } },
-                            { bpm: { gte: 95, lte: 135 } },
-                            { energy: { gte: 0.55 } },
-                        ],
-                    },
-                    {
-                        AND: [
-                            { valence: { gte: 0.6 } },
-                            { energy: { gte: 0.6 } },
-                        ],
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `hot-girl-walk-${today}`,
-            type: "hot-girl-walk",
-            name: "Hot Girl Walk",
-            description: "Confidence boost for your walk",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("confidence-boost"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["hot-girl-walk"]
+        );
     }
 
     /**
@@ -3182,50 +3029,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { energy: { gte: 0.75 } },
-                            { arousal: { gte: 0.65 } },
-                            { bpm: { gte: 125 } },
-                        ],
-                    },
-                    {
-                        AND: [
-                            { energy: { gte: 0.8 } },
-                            { danceability: { gte: 0.6 } },
-                        ],
-                    },
-                    {
-                        moodTags: { hasSome: ["aggressive", "energetic"] },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `rage-cleaning-${today}`,
-            type: "rage-cleaning",
-            name: "Rage Cleaning",
-            description: "Aggressive productivity fuel",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("workout"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["rage-cleaning"]
+        );
     }
 
     /**
@@ -3236,46 +3043,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { valence: { gte: 0.45 } },
-                            { acousticness: { gte: 0.35 } },
-                            { energy: { gte: 0.25, lte: 0.65 } },
-                        ],
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: ["warm", "sunset", "dreamy", "peaceful"],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `golden-hour-${today}`,
-            type: "golden-hour",
-            name: "Golden Hour",
-            description: "Warm sunset vibes",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("golden-hour"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["golden-hour"]
+        );
     }
 
     /**
@@ -3286,37 +3057,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                AND: [
-                    { instrumentalness: { lte: 0.35 } },
-                    { energy: { gte: 0.55 } },
-                    { valence: { gte: 0.45 } },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `shower-karaoke-${today}`,
-            type: "shower-karaoke",
-            name: "Shower Karaoke",
-            description: "Belters you can't help but sing",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("happy"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["shower-karaoke"]
+        );
     }
 
     /**
@@ -3327,51 +3071,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { valence: { lte: 0.4 } },
-                            { arousal: { lte: 0.55 } },
-                            { acousticness: { gte: 0.25 } },
-                        ],
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: [
-                                "emotional",
-                                "heartbreak",
-                                "feelings",
-                                "vulnerable",
-                            ],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `in-my-feelings-${today}`,
-            type: "in-my-feelings",
-            name: "In My Feelings",
-            description: "Let it all out",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("heartbreak-hotel"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["in-my-feelings"]
+        );
     }
 
     /**
@@ -3382,46 +3085,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        // STRICT criteria: contemplative driving music only
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                AND: [
-                    // MUST be moderate energy (not too mellow, not too intense)
-                    { energy: { gte: 0.3, lte: 0.65 } },
-                    // MUST have cruising tempo
-                    { bpm: { gte: 80, lte: 130 } },
-                    // Plus mellow mood indicator
-                    {
-                        OR: [
-                            { arousal: { lte: 0.6 } },
-                            { valence: { gte: 0.3, lte: 0.7 } },
-                        ],
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < this.MIN_TRACKS_DAILY) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `midnight-drive-${today}`,
-            type: "midnight-drive",
-            name: "Midnight Drive",
-            description: "Perfect for late night cruising",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("night-drive"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["midnight-drive"]
+        );
     }
 
     /**
@@ -3534,51 +3201,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    {
-                        AND: [
-                            { valence: { gte: 0.35, lte: 0.75 } },
-                            { arousal: { gte: 0.25, lte: 0.65 } },
-                            { acousticness: { gte: 0.25 } },
-                        ],
-                    },
-                    {
-                        lastfmTags: {
-                            hasSome: [
-                                "dreamy",
-                                "aesthetic",
-                                "cinematic",
-                                "romantic",
-                            ],
-                        },
-                    },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `romanticize-${today}`,
-            type: "romanticize",
-            name: "Romanticize Your Life",
-            description: "Make every moment aesthetic",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("golden-hour"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["romanticize"]
+        );
     }
 
     /**
@@ -3589,37 +3215,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                AND: [
-                    { valence: { gte: 0.55 } },
-                    { energy: { gte: 0.45 } },
-                    { danceability: { gte: 0.45 } },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 50,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `that-girl-era-${today}`,
-            type: "that-girl-era",
-            name: "That Girl Era",
-            description: "Self-improvement mode activated",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("confidence-boost"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["that-girl-era"]
+        );
     }
 
     /**
@@ -3630,42 +3229,10 @@ export class ProgrammaticPlaylistService {
         userId: string,
         today: string
     ): Promise<ProgrammaticMix | null> {
-        // Get a variety of tracks with extreme features
-        const tracks = await prisma.track.findMany({
-            where: {
-                analysisStatus: "completed",
-                OR: [
-                    { energy: { gte: 0.85 } },
-                    { energy: { lte: 0.15 } },
-                    { valence: { gte: 0.9 } },
-                    { valence: { lte: 0.1 } },
-                    { bpm: { gte: 160 } },
-                    { bpm: { lte: 70 } },
-                    { danceability: { gte: 0.9 } },
-                ],
-            },
-            include: { album: { select: { coverUrl: true } } },
-            take: 100,
-        });
-
-        if (tracks.length < 8) return null;
-
-        const shuffled = await selectTracksWithArtistDiversityForMix(tracks, this.DAILY_TRACK_LIMIT);
-        const coverUrls = shuffled
-            .filter((t) => t.album.coverUrl)
-            .slice(0, 4)
-            .map((t) => t.album.coverUrl!);
-
-        return {
-            id: `unhinged-${today}`,
-            type: "unhinged",
-            name: "Unhinged",
-            description: "Embrace the chaos",
-            trackIds: shuffled.map((t) => t.id),
-            coverUrls,
-            trackCount: shuffled.length,
-            color: getMixColor("dance-floor"),
-        };
+        return this.generateCuratedVibeMix(
+            today,
+            CURATED_VIBE_MIXES_BY_TYPE["unhinged"]
+        );
     }
 
     // WEEKLY CURATED MIXES (20 tracks)


### PR DESCRIPTION
## Summary

Makes the programmatic **curated daily "vibe" mixes** data-driven instead of hardcoded (refactor slice `programmatic-playlists-datadriven`).

Previously `backend/src/services/programmaticPlaylists.ts` contained 13 near-identical generator methods (Sad Girl Sundays, Main Character Energy, Villain Era, 3AM Thoughts, Hot Girl Walk, Rage Cleaning, Golden Hour, Shower Karaoke, In My Feelings, Midnight Drive, Romanticize Your Life, That Girl Era, Unhinged) that differed only in their Prisma filter, name, description, color, pool size, and (for Sad Girl Sundays) a weekday gate. Each hand-rolled the same pipeline: query completed-analysis tracks → min-pool check → artist-diversity selection → cover-art mosaic → build mix.

This slice extracts those differences into a single declarative catalog and routes all 13 through one shared generator.

## Findings fixed

- **Hardcoded mix catalog → data-driven.** New `backend/src/services/curatedVibeMixDefinitions.ts` exports `CURATED_VIBE_MIXES` (typed `CuratedVibeMixDefinition[]`, `where: Prisma.TrackWhereInput`) and a `CURATED_VIBE_MIXES_BY_TYPE` lookup. Adding/tuning a vibe mix is now a data edit, not a new method.
- **Duplication removed.** One private `generateCuratedVibeMix(today, definition)` replaces 13 method bodies; each public `generate*` method is now a one-line delegation. Net **-433 lines** in `programmaticPlaylists.ts` (+95 / -528).

## Behavior preserved (no regression)

- Public `generate*` method names/signatures unchanged (consumed by `generateAllMixes`' rotation and spied on by existing tests).
- Mix `id`/`type`/`name`/`description`/`color`, `analysisStatus: "completed"` constraint, `take` sizes, `MIN_TRACKS_DAILY` gating, Sunday-only gate for Sad Girl Sundays, and the 2-arg artist-diversity selection are all identical to `HEAD`.
- `generateCoffeeShopVibes` (different pipeline: unique-first + library backfill) and the weekly/algorithmic mixes (Deep Cuts, Key Journey, Tempo Flow, Vocal Detox, Minor Key) are intentionally left untouched — out of scope for a uniform-filter data extraction.

## Tests

TDD: new failing test authored first, then implementation to green.

- New `backend/src/services/__tests__/programmaticPlaylistsDataDriven.test.ts`: catalog completeness (exactly 13 types), definition well-formedness, and per-definition data→query→output wiring (asserts the emitted `prisma.track.findMany` arg deep-equals `{ where: { analysisStatus: "completed", ...def.where }, include: {...}, take: def.take }` and the returned mix reflects the definition), plus the Sunday gate.
- Verified green together with the existing `programmaticPlaylistsCuratedMixes.test.ts` and `programmaticPlaylistsBehavior.test.ts`: **3 suites, 62 tests passing** (`--maxWorkers=2`).
- `tsc -p tsconfig.production.json --noEmit`: the two changed/added files produce **zero** errors (repo has ~68 pre-existing unrelated backend tsc errors, unchanged by this PR).

## Breaking changes

None. No API, schema, config, or output changes.

## Docs

- `CHANGELOG.md` (Unreleased → Changed).
- `backend/src/services/README.md` service inventory row for the new module.
- All exported symbols in the new module carry JSDoc.
