### PR TITLE
refactor(lidarr): consolidated typed bounded HTTP client (refactor slice P-lidarr-consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Backend: introduced a single consolidated, typed Lidarr HTTP client
+  (`backend/src/services/lidarr/lidarrHttpClient.ts`) as the standard boundary
+  for outbound Lidarr calls. It wraps one reusable axios instance with bounded
+  reliability the previous scattered call-sites lacked: a consistent request
+  timeout, capped exponential-backoff retries (idempotent methods and classified
+  transient failures only — 408/425/429/5xx/network/timeout; `POST` is not
+  retried unless explicitly opted in; `Retry-After` is honored and capped), a
+  concurrency limiter, a typed `LidarrHttpError` (status/method/path/attempts/
+  isTransient) that never leaks the API key or host, connection resolution from
+  system settings with `.env` fallback and URL validation, and the shared
+  logger. The discovery album-lifecycle deletion path now routes through this
+  client; remaining Lidarr consumers (the `lidarr.ts` queue/history helper
+  functions, `downloadQueue`, `simpleDownloadManager`, `discoverWeekly`, and the
+  discover/system-settings/onboarding routes) will be migrated onto it
+  incrementally to keep each change no-regression.
 - Backend: moved six `@types/*` packages from production dependencies to
   devDependencies and removed `@types/speakeasy`, slimming the pruned worker
   image's production `node_modules`.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
     preset: 'ts-jest',
     // The otplib v13 dependency tree (@scure/base v2, @noble/hashes v2, nested under @otplib plugins) is ESM-only.
-    transformIgnorePatterns: ['/node_modules/(?!(@scure/|@noble/|@otplib/|otplib/))'],
+    transformIgnorePatterns: ['/node_modules/(?!(@scure/|@noble/|@otplib/|otplib/|p-limit/|yocto-queue/))'],
     transform: {
         '^.+\\.ts$': ['ts-jest', {}],
         '^.+\\.js$': ['ts-jest', { tsconfig: { allowJs: true } }],

--- a/backend/src/services/discovery/__tests__/discoveryAlbumLifecycle.test.ts
+++ b/backend/src/services/discovery/__tests__/discoveryAlbumLifecycle.test.ts
@@ -29,12 +29,27 @@ jest.mock('../../../utils/db', () => ({
     },
 }));
 
-jest.mock('axios');
+jest.mock('../../../config', () => ({
+    config: { lidarr: undefined },
+}));
+jest.mock('../../../utils/systemSettings', () => ({
+    getSystemSettings: jest.fn(),
+}));
+jest.mock('axios', () => {
+    const request = jest.fn();
+    const create = jest.fn(() => ({ request }));
+    return {
+        __esModule: true,
+        default: { create, request },
+        create,
+    };
+});
 jest.mock('../../artistCountsService', () => ({
     updateArtistCounts: jest.fn(),
 }));
 
-const mockAxios = axios as jest.Mocked<typeof axios>;
+const mockAxios = axios as jest.Mocked<typeof axios> & { request: jest.Mock };
+const mockRequest = mockAxios.request;
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockUpdateArtistCounts = updateArtistCounts as jest.Mock;
 
@@ -182,21 +197,22 @@ describe('DiscoveryAlbumLifecycle', () => {
         };
 
         it('should delete from Lidarr when enabled', async () => {
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(null);
             (mockPrisma.discoveryTrack.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.discoveryAlbum.update as jest.Mock).mockResolvedValue({});
 
             await lifecycle.deleteRejectedAlbum(mockAlbum, mockSettings);
 
-            expect(mockAxios.delete).toHaveBeenCalledWith(
-                'http://lidarr:8686/api/v1/album/456',
-                {
-                    params: { deleteFiles: true },
-                    headers: { 'X-Api-Key': 'test-api-key' },
-                    timeout: 10000,
-                }
-            );
+            expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+                method: 'DELETE',
+                url: '/api/v1/album/456',
+                params: { deleteFiles: true },
+            }));
+            expect(mockAxios.create).toHaveBeenCalledWith(expect.objectContaining({
+                baseURL: 'http://lidarr:8686',
+                headers: { 'X-Api-Key': 'test-api-key' },
+            }));
         });
 
         it('should skip Lidarr deletion when disabled', async () => {
@@ -207,7 +223,7 @@ describe('DiscoveryAlbumLifecycle', () => {
 
             await lifecycle.deleteRejectedAlbum(mockAlbum, disabledSettings);
 
-            expect(mockAxios.delete).not.toHaveBeenCalled();
+            expect(mockRequest).not.toHaveBeenCalled();
         });
 
         it('should skip Lidarr deletion when album has no lidarrAlbumId', async () => {
@@ -221,12 +237,12 @@ describe('DiscoveryAlbumLifecycle', () => {
 
             await lifecycle.deleteRejectedAlbum(albumWithoutLidarr, mockSettings);
 
-            expect(mockAxios.delete).not.toHaveBeenCalled();
+            expect(mockRequest).not.toHaveBeenCalled();
         });
 
         it('should ignore Lidarr 404 errors', async () => {
             const error = { response: { status: 404 }, message: 'Not Found' };
-            mockAxios.delete.mockRejectedValue(error);
+            mockRequest.mockRejectedValue(error);
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(null);
             (mockPrisma.discoveryTrack.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.discoveryAlbum.update as jest.Mock).mockResolvedValue({});
@@ -236,7 +252,7 @@ describe('DiscoveryAlbumLifecycle', () => {
 
         it('should delete tracks and album from database', async () => {
             const dbAlbum = { id: 'album-db-1' };
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(dbAlbum);
             (mockPrisma.track.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.album.delete as jest.Mock).mockResolvedValue({});
@@ -254,7 +270,7 @@ describe('DiscoveryAlbumLifecycle', () => {
         });
 
         it('should delete discovery track records', async () => {
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(null);
             (mockPrisma.discoveryTrack.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.discoveryAlbum.update as jest.Mock).mockResolvedValue({});
@@ -267,7 +283,7 @@ describe('DiscoveryAlbumLifecycle', () => {
         });
 
         it('should mark discovery album as DELETED', async () => {
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(null);
             (mockPrisma.discoveryTrack.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.discoveryAlbum.update as jest.Mock).mockResolvedValue({});
@@ -281,7 +297,7 @@ describe('DiscoveryAlbumLifecycle', () => {
         });
 
         it('should throw error when database operation fails', async () => {
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockRejectedValue(new Error('DB Error'));
 
             await expect(lifecycle.deleteRejectedAlbum(mockAlbum, mockSettings)).rejects.toThrow('DB Error');
@@ -348,7 +364,7 @@ describe('DiscoveryAlbumLifecycle', () => {
             ];
 
             (mockPrisma.discoveryAlbum.findMany as jest.Mock).mockResolvedValue(discoveryAlbums);
-            mockAxios.delete.mockResolvedValue({ status: 200 });
+            mockRequest.mockResolvedValue({ data: {}, status: 200 });
             (mockPrisma.album.findFirst as jest.Mock).mockResolvedValue(null);
             (mockPrisma.discoveryTrack.deleteMany as jest.Mock).mockResolvedValue({});
             (mockPrisma.discoveryAlbum.update as jest.Mock).mockResolvedValue({});

--- a/backend/src/services/discovery/discoveryAlbumLifecycle.ts
+++ b/backend/src/services/discovery/discoveryAlbumLifecycle.ts
@@ -7,10 +7,10 @@
  * - Processing albums before new discovery generation
  */
 
-import axios from 'axios';
 import { prisma } from '../../utils/db';
 import { logger } from '../../utils/logger';
 import { updateArtistCounts } from '../artistCountsService';
+import { LidarrHttpClient, LidarrHttpError } from '../lidarr/lidarrHttpClient';
 
 export interface DiscoveryAlbumInfo {
     id: string;
@@ -89,19 +89,19 @@ export class DiscoveryAlbumLifecycle {
             settings.lidarrApiKey &&
             album.lidarrAlbumId
         ) {
+            const client = new LidarrHttpClient({
+                baseUrl: settings.lidarrUrl,
+                apiKey: settings.lidarrApiKey,
+            });
             try {
-                await axios.delete(
-                    `${settings.lidarrUrl}/api/v1/album/${album.lidarrAlbumId}`,
-                    {
-                        params: { deleteFiles: true },
-                        headers: { 'X-Api-Key': settings.lidarrApiKey },
-                        timeout: 10000,
-                    }
+                await client.delete(
+                    `/api/v1/album/${album.lidarrAlbumId}`,
+                    { deleteFiles: true }
                 );
-            } catch (lidarrError: any) {
-                if (lidarrError.response?.status !== 404) {
+            } catch (error: unknown) {
+                if (error instanceof LidarrHttpError ? error.status !== 404 : true) {
                     logger.debug(
-                        `[DiscoveryLifecycle] Lidarr delete failed: ${lidarrError.message}`
+                        `[DiscoveryLifecycle] Lidarr delete failed: ${error instanceof Error ? error.message : String(error)}`
                     );
                 }
             }

--- a/backend/src/services/lidarr/__tests__/lidarrHttpClient.test.ts
+++ b/backend/src/services/lidarr/__tests__/lidarrHttpClient.test.ts
@@ -1,0 +1,297 @@
+import axios from "axios";
+import { config } from "../../../config";
+import { logger } from "../../../utils/logger";
+import { getSystemSettings } from "../../../utils/systemSettings";
+import {
+    LidarrHttpClient,
+    LidarrHttpError,
+    resolveLidarrConnection,
+} from "../lidarrHttpClient";
+
+jest.mock("axios");
+
+jest.mock("../../../config", () => ({
+    config: { lidarr: undefined },
+}));
+
+jest.mock("../../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+}));
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const API_KEY = "super-secret-key";
+const BASE_URL = "https://lidarr.internal.example";
+const mockAxiosCreate = axios.create as jest.Mock;
+const mockRequest = jest.fn();
+const mockSleep = jest.fn<Promise<void>, [number]>(() => Promise.resolve());
+const mockGetSystemSettings = getSystemSettings as jest.Mock;
+
+function createClient(
+    options: ConstructorParameters<typeof LidarrHttpClient>[1] = {}
+): LidarrHttpClient {
+    return new LidarrHttpClient(
+        { baseUrl: BASE_URL, apiKey: API_KEY },
+        {
+            maxRetries: 2,
+            baseBackoffMs: 1,
+            maxBackoffMs: 10,
+            sleep: mockSleep,
+            ...options,
+        }
+    );
+}
+
+function httpError(status: number, headers: Record<string, unknown> = {}) {
+    return { response: { status, headers } };
+}
+
+function allLogOutput(): string {
+    return JSON.stringify([
+        ...(logger.debug as jest.Mock).mock.calls,
+        ...(logger.warn as jest.Mock).mock.calls,
+        ...(logger.error as jest.Mock).mock.calls,
+    ]);
+}
+
+async function flushPromises(): Promise<void> {
+    for (let turn = 0; turn < 10; turn += 1) {
+        await Promise.resolve();
+    }
+}
+
+describe("LidarrHttpClient", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRequest.mockReset();
+        mockAxiosCreate.mockReturnValue({ request: mockRequest });
+        Object.assign(config, { lidarr: undefined });
+    });
+
+    it("returns response data through one configured axios instance", async () => {
+        mockRequest.mockResolvedValueOnce({ data: { records: [1] }, status: 200 });
+        const client = createClient();
+
+        await expect(client.get<{ records: number[] }>("/api/v1/queue")).resolves.toEqual(
+            { records: [1] }
+        );
+
+        expect(mockAxiosCreate).toHaveBeenCalledTimes(1);
+        expect(mockAxiosCreate).toHaveBeenCalledWith({
+            baseURL: BASE_URL,
+            timeout: 15_000,
+            headers: { "X-Api-Key": API_KEY },
+        });
+        expect(mockRequest).toHaveBeenCalledWith({
+            method: "GET",
+            url: "/api/v1/queue",
+            params: undefined,
+            data: undefined,
+        });
+        expect(allLogOutput()).not.toContain(API_KEY);
+        expect(allLogOutput()).not.toContain("lidarr.internal.example");
+    });
+
+    it("retries a transient GET failure and returns the second result", async () => {
+        mockRequest
+            .mockRejectedValueOnce(httpError(503))
+            .mockResolvedValueOnce({ data: { ok: true }, status: 200 });
+
+        await expect(createClient().get<{ ok: boolean }>("/api/v1/system/status"))
+            .resolves.toEqual({ ok: true });
+        expect(mockRequest).toHaveBeenCalledTimes(2);
+        expect(mockSleep).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.debug).toHaveBeenCalledTimes(1);
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("throws a safe typed error after retry exhaustion", async () => {
+        mockRequest.mockRejectedValue(httpError(503));
+
+        const promise = createClient().get("/api/v1/queue");
+        await expect(promise).rejects.toMatchObject({
+            name: "LidarrHttpError",
+            isTransient: true,
+            attempts: 3,
+            status: 503,
+            method: "GET",
+            path: "/api/v1/queue",
+        });
+        await promise.catch((error: unknown) => {
+            expect(error).toBeInstanceOf(LidarrHttpError);
+            expect((error as Error).message).not.toContain(API_KEY);
+            expect((error as Error).message).not.toContain("lidarr.internal.example");
+        });
+        expect(mockRequest).toHaveBeenCalledTimes(3);
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+        expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry a non-transient status", async () => {
+        mockRequest.mockRejectedValue(httpError(404));
+
+        await expect(createClient().get("/api/v1/artist/1")).rejects.toMatchObject({
+            isTransient: false,
+            attempts: 1,
+            status: 404,
+        });
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+        expect(mockSleep).not.toHaveBeenCalled();
+    });
+
+    it("does not retry POST unless explicitly overridden", async () => {
+        mockRequest.mockRejectedValue(httpError(503));
+        const client = createClient({ maxRetries: 1 });
+
+        await expect(client.post("/api/v1/command", { name: "scan" }))
+            .rejects.toMatchObject({ attempts: 1, isTransient: true });
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+
+        mockRequest.mockClear();
+        await expect(client.request({
+            method: "POST",
+            path: "/api/v1/command",
+            data: { name: "scan" },
+            retryable: true,
+        })).rejects.toMatchObject({ attempts: 2, isTransient: true });
+        expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries no-response timeouts and reports no status on exhaustion", async () => {
+        mockRequest.mockRejectedValue({ code: "ECONNABORTED" });
+
+        await expect(createClient({ maxRetries: 1 }).get("/api/v1/queue"))
+            .rejects.toMatchObject({
+                isTransient: true,
+                attempts: 2,
+                status: undefined,
+            });
+        expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("caps numeric Retry-After seconds at maxBackoffMs", async () => {
+        mockRequest
+            .mockRejectedValueOnce(httpError(429, { "retry-after": "60" }))
+            .mockResolvedValueOnce({ data: "ok", status: 200 });
+
+        await expect(createClient({ maxBackoffMs: 25 }).get("/api/v1/queue"))
+            .resolves.toBe("ok");
+        expect(mockSleep).toHaveBeenCalledWith(25);
+    });
+
+    it("limits five queued requests to two in flight", async () => {
+        let inFlight = 0;
+        let maximumInFlight = 0;
+        const releases: Array<() => void> = [];
+        mockRequest.mockImplementation(() => new Promise((resolve) => {
+            inFlight += 1;
+            maximumInFlight = Math.max(maximumInFlight, inFlight);
+            releases.push(() => {
+                inFlight -= 1;
+                resolve({ data: "done", status: 200 });
+            });
+        }));
+        const client = createClient({ concurrency: 2 });
+        const requests = Array.from({ length: 5 }, (_, index) =>
+            client.get<string>(`/api/v1/item/${index}`)
+        );
+
+        await flushPromises();
+        expect(inFlight).toBe(2);
+        releases.splice(0, 2).forEach((release) => release());
+        await flushPromises();
+        expect(inFlight).toBe(2);
+        releases.splice(0, 2).forEach((release) => release());
+        await flushPromises();
+        expect(inFlight).toBe(1);
+        releases.splice(0).forEach((release) => release());
+
+        await expect(Promise.all(requests)).resolves.toEqual(Array(5).fill("done"));
+        expect(maximumInFlight).toBe(2);
+    });
+
+    it("rejects invalid connection, options, and paths", async () => {
+        expect(() => new LidarrHttpClient({ baseUrl: "ftp://x", apiKey: "k" }))
+            .toThrow("Lidarr base URL must use HTTP or HTTPS");
+        expect(() => new LidarrHttpClient({ baseUrl: "http://h", apiKey: "" }))
+            .toThrow("Lidarr API key must be a non-empty string");
+        expect(() => createClient({ maxRetries: -1 })).toThrow();
+        expect(() => createClient({ concurrency: 0 })).toThrow();
+
+        await expect(createClient().get("api/v1/queue"))
+            .rejects.toThrow("Lidarr request path must start with /");
+        await expect(createClient().get("//untrusted.example/api/v1/queue"))
+            .rejects.toThrow("Lidarr request path must be relative");
+        expect(mockRequest).not.toHaveBeenCalled();
+    });
+});
+
+describe("resolveLidarrConnection", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.assign(config, { lidarr: undefined });
+    });
+
+    it("prefers a complete enabled database connection", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            lidarrEnabled: true,
+            lidarrUrl: "https://db-lidarr.example",
+            lidarrApiKey: "opaque-db-key",
+        });
+
+        await expect(resolveLidarrConnection()).resolves.toEqual({
+            baseUrl: "https://db-lidarr.example",
+            apiKey: "opaque-db-key",
+        });
+    });
+
+    it("returns null when database and environment settings are unavailable", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            lidarrEnabled: false,
+            lidarrUrl: "https://disabled.example",
+            lidarrApiKey: "disabled-key",
+        });
+
+        await expect(resolveLidarrConnection()).resolves.toBeNull();
+    });
+
+    it("returns null without throwing for an invalid database URL", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            lidarrEnabled: true,
+            lidarrUrl: "not-a-url",
+            lidarrApiKey: "opaque-db-key",
+        });
+
+        await expect(resolveLidarrConnection()).resolves.toBeNull();
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(allLogOutput()).not.toContain("opaque-db-key");
+        expect(allLogOutput()).not.toContain("not-a-url");
+    });
+
+    it("falls back to enabled environment settings after a database read error", async () => {
+        mockGetSystemSettings.mockRejectedValue(new Error("database unavailable"));
+        Object.assign(config, {
+            lidarr: {
+                enabled: true,
+                url: "http://env-lidarr.example",
+                apiKey: "opaque-env-key",
+            },
+        });
+
+        await expect(resolveLidarrConnection()).resolves.toEqual({
+            baseUrl: "http://env-lidarr.example",
+            apiKey: "opaque-env-key",
+        });
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(allLogOutput()).not.toContain("opaque-env-key");
+        expect(allLogOutput()).not.toContain("env-lidarr.example");
+    });
+});

--- a/backend/src/services/lidarr/lidarrHttpClient.ts
+++ b/backend/src/services/lidarr/lidarrHttpClient.ts
@@ -1,0 +1,350 @@
+import assert from "node:assert";
+import axios, { type AxiosInstance } from "axios";
+import pLimit, { type LimitFunction } from "p-limit";
+import { config } from "../../config";
+import { logger } from "../../utils/logger";
+import { getSystemSettings } from "../../utils/systemSettings";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_BASE_BACKOFF_MS = 300;
+const DEFAULT_MAX_BACKOFF_MS = 3_000;
+const TRANSIENT_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/** Connection values required to authenticate requests to one Lidarr server. */
+export interface LidarrConnection {
+    baseUrl: string;
+    apiKey: string;
+}
+
+interface LidarrHttpErrorDetails {
+    status?: number;
+    method: string;
+    path: string;
+    attempts: number;
+    isTransient: boolean;
+    cause?: unknown;
+}
+
+/** Safe, typed failure returned by the Lidarr HTTP boundary. */
+export class LidarrHttpError extends Error {
+    readonly status?: number;
+    readonly method: string;
+    readonly path: string;
+    readonly attempts: number;
+    readonly isTransient: boolean;
+    readonly cause?: unknown;
+
+    /** Creates a safe Lidarr failure without connection details or bodies. */
+    constructor(details: LidarrHttpErrorDetails) {
+        super(
+            `Lidarr ${details.method} ${details.path} failed after ${details.attempts} attempt(s)`
+        );
+        this.name = "LidarrHttpError";
+        this.status = details.status;
+        this.method = details.method;
+        this.path = details.path;
+        this.attempts = details.attempts;
+        this.isTransient = details.isTransient;
+        this.cause = details.cause;
+        Error.captureStackTrace?.(this, LidarrHttpError);
+    }
+}
+
+/** Runtime bounds and injectable delay behavior for a Lidarr client. */
+export interface LidarrHttpClientOptions {
+    timeoutMs?: number;
+    maxRetries?: number;
+    concurrency?: number;
+    baseBackoffMs?: number;
+    maxBackoffMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+}
+
+/** Typed request accepted by the consolidated Lidarr HTTP boundary. */
+export interface LidarrRequestConfig {
+    method: "GET" | "POST" | "PUT" | "DELETE";
+    path: string;
+    params?: Record<string, unknown>;
+    data?: unknown;
+    retryable?: boolean;
+}
+
+interface ResolvedOptions {
+    timeoutMs: number;
+    maxRetries: number;
+    concurrency: number;
+    baseBackoffMs: number;
+    maxBackoffMs: number;
+    sleep: (ms: number) => Promise<void>;
+}
+
+interface ErrorResponse {
+    status?: unknown;
+    headers?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function getErrorResponse(error: unknown): ErrorResponse | undefined {
+    if (!isRecord(error) || !isRecord(error.response)) return undefined;
+    return error.response;
+}
+
+function getStatus(error: unknown): number | undefined {
+    const status = getErrorResponse(error)?.status;
+    return typeof status === "number" ? status : undefined;
+}
+
+function isTransient(error: unknown): boolean {
+    const response = getErrorResponse(error);
+    if (!response) return true;
+    const status = getStatus(error);
+    return status !== undefined && TRANSIENT_STATUSES.has(status);
+}
+
+function classifyRetry(config: LidarrRequestConfig, error: unknown): boolean {
+    const methodAllowsRetry = config.retryable ?? config.method !== "POST";
+    return methodAllowsRetry && isTransient(error);
+}
+
+function computeBackoffMs(attempt: number, base: number, max: number): number {
+    const exponential = base * 2 ** (attempt - 1);
+    const jitter = Math.random() * base;
+    return Math.min(max, exponential + jitter);
+}
+
+function readHeader(headers: unknown, name: string): unknown {
+    if (!isRecord(headers)) return undefined;
+    const getter = headers.get;
+    if (typeof getter === "function") return getter.call(headers, name);
+    const entry = Object.entries(headers).find(
+        ([key]) => key.toLowerCase() === name.toLowerCase()
+    );
+    return entry?.[1];
+}
+
+function retryAfterMs(error: unknown, maxBackoffMs: number): number | null {
+    const status = getStatus(error);
+    if (status !== 429 && status !== 503) return null;
+    const value = readHeader(getErrorResponse(error)?.headers, "retry-after");
+    if (typeof value !== "string" && typeof value !== "number") return null;
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    return Math.min(maxBackoffMs, seconds * 1_000);
+}
+
+function buildError(
+    config: LidarrRequestConfig,
+    error: unknown,
+    attempts: number
+): LidarrHttpError {
+    return new LidarrHttpError({
+        status: getStatus(error),
+        method: config.method,
+        path: config.path,
+        attempts,
+        isTransient: isTransient(error),
+        cause: error,
+    });
+}
+
+function defaultSleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function requireInteger(value: number, minimum: number, name: string): void {
+    if (!Number.isSafeInteger(value) || value < minimum) {
+        throw new Error(`${name} must be an integer greater than or equal to ${minimum}`);
+    }
+}
+
+function requireFinite(value: number, minimum: number, name: string): void {
+    if (!Number.isFinite(value) || value < minimum) {
+        throw new Error(`${name} must be greater than or equal to ${minimum}`);
+    }
+}
+
+function resolveOptions(options: LidarrHttpClientOptions): ResolvedOptions {
+    const resolved = {
+        timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxRetries: options.maxRetries ?? DEFAULT_MAX_RETRIES,
+        concurrency: options.concurrency ?? DEFAULT_CONCURRENCY,
+        baseBackoffMs: options.baseBackoffMs ?? DEFAULT_BASE_BACKOFF_MS,
+        maxBackoffMs: options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS,
+        sleep: options.sleep ?? defaultSleep,
+    };
+    requireInteger(resolved.timeoutMs, 1, "timeoutMs");
+    requireInteger(resolved.maxRetries, 0, "maxRetries");
+    requireInteger(resolved.concurrency, 1, "concurrency");
+    requireFinite(resolved.baseBackoffMs, 0, "baseBackoffMs");
+    requireFinite(resolved.maxBackoffMs, 0, "maxBackoffMs");
+    return resolved;
+}
+
+function validateBaseUrl(baseUrl: string): boolean {
+    try {
+        const parsed = new URL(baseUrl);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
+function validateConnection(connection: LidarrConnection): void {
+    if (!validateBaseUrl(connection.baseUrl)) {
+        throw new Error("Lidarr base URL must use HTTP or HTTPS");
+    }
+    if (typeof connection.apiKey !== "string" || connection.apiKey.trim() === "") {
+        throw new Error("Lidarr API key must be a non-empty string");
+    }
+}
+
+function assertRelativePath(path: string): void {
+    assert(path.startsWith("/"), "Lidarr request path must start with /");
+    assert(!path.startsWith("//"), "Lidarr request path must be relative");
+}
+
+async function executeAttempt<T>(
+    instance: AxiosInstance,
+    config: LidarrRequestConfig
+): Promise<{ data: T; status: number }> {
+    return instance.request<T>({
+        method: config.method,
+        url: config.path,
+        params: config.params,
+        data: config.data,
+    });
+}
+
+/** Bounded, typed HTTP client shared by backend Lidarr integrations. */
+export class LidarrHttpClient {
+    private readonly instance: AxiosInstance;
+    private readonly limit: LimitFunction;
+    private readonly options: ResolvedOptions;
+
+    /** Creates one reusable axios instance and one concurrency limiter. */
+    constructor(
+        connection: LidarrConnection,
+        options: LidarrHttpClientOptions = {}
+    ) {
+        validateConnection(connection);
+        this.options = resolveOptions(options);
+        this.instance = axios.create({
+            baseURL: connection.baseUrl,
+            timeout: this.options.timeoutMs,
+            headers: { "X-Api-Key": connection.apiKey },
+        });
+        this.limit = pLimit(this.options.concurrency);
+    }
+
+    /** Executes one bounded request, including eligible retry attempts. */
+    async request<T>(requestConfig: LidarrRequestConfig): Promise<T> {
+        assertRelativePath(requestConfig.path);
+        return this.limit(async () => {
+            const maxAttempts = this.options.maxRetries + 1;
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+                try {
+                    const response = await executeAttempt<T>(this.instance, requestConfig);
+                    logger.debug("Lidarr HTTP request succeeded", {
+                        method: requestConfig.method,
+                        path: requestConfig.path,
+                        status: response.status,
+                        attempt,
+                    });
+                    return response.data as T;
+                } catch (error: unknown) {
+                    const shouldRetry = classifyRetry(requestConfig, error)
+                        && attempt < maxAttempts;
+                    if (!shouldRetry) {
+                        logger.error("Lidarr HTTP request failed", {
+                            method: requestConfig.method,
+                            path: requestConfig.path,
+                            status: getStatus(error),
+                            attempt,
+                            isTransient: isTransient(error),
+                        });
+                        throw buildError(requestConfig, error, attempt);
+                    }
+                    const delay = retryAfterMs(error, this.options.maxBackoffMs)
+                        ?? computeBackoffMs(
+                            attempt,
+                            this.options.baseBackoffMs,
+                            this.options.maxBackoffMs
+                        );
+                    logger.warn("Retrying Lidarr HTTP request", {
+                        method: requestConfig.method,
+                        path: requestConfig.path,
+                        status: getStatus(error),
+                        attempt,
+                        delayMs: delay,
+                    });
+                    await this.options.sleep(delay);
+                }
+            }
+            throw new Error("Lidarr request attempt bound was violated");
+        });
+    }
+
+    /** Sends a typed GET request. */
+    get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+        return this.request<T>({ method: "GET", path, params });
+    }
+
+    /** Sends a typed POST request. */
+    post<T>(path: string, data?: unknown): Promise<T> {
+        return this.request<T>({ method: "POST", path, data });
+    }
+
+    /** Sends a typed PUT request. */
+    put<T>(path: string, data?: unknown): Promise<T> {
+        return this.request<T>({ method: "PUT", path, data });
+    }
+
+    /** Sends a typed DELETE request. */
+    delete<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+        return this.request<T>({ method: "DELETE", path, params });
+    }
+}
+
+/** Resolves a valid enabled Lidarr connection from database or environment settings. */
+export async function resolveLidarrConnection(): Promise<LidarrConnection | null> {
+    let settings: Awaited<ReturnType<typeof getSystemSettings>> = null;
+    try {
+        settings = await getSystemSettings();
+    } catch {
+        logger.error("Unable to read Lidarr system settings; checking environment");
+    }
+    if (
+        settings?.lidarrEnabled
+        && settings.lidarrUrl
+        && settings.lidarrApiKey
+    ) {
+        if (!validateBaseUrl(settings.lidarrUrl)) {
+            logger.warn("Configured Lidarr database URL is invalid");
+            return null;
+        }
+        return { baseUrl: settings.lidarrUrl, apiKey: settings.lidarrApiKey };
+    }
+    const environment = config.lidarr;
+    if (environment?.enabled && environment.url && environment.apiKey) {
+        if (!validateBaseUrl(environment.url)) {
+            logger.warn("Configured Lidarr environment URL is invalid");
+            return null;
+        }
+        return { baseUrl: environment.url, apiKey: environment.apiKey };
+    }
+    return null;
+}
+
+/** Creates a bounded Lidarr client when a valid enabled connection is configured. */
+export async function createLidarrClient(
+    options?: LidarrHttpClientOptions
+): Promise<LidarrHttpClient | null> {
+    const connection = await resolveLidarrConnection();
+    if (!connection) return null;
+    return new LidarrHttpClient(connection, options);
+}


### PR DESCRIPTION
Enterprise-refactor campaign slice: consolidate divergent, unbounded Lidarr HTTP call-sites onto one typed, bounded client. Backend-only; disjoint from other in-flight slices. TDD with mocked HTTP — no real Lidarr is contacted.

## What this fixes

The backend talked to Lidarr from ~10 different files, each hand-rolling an axios call with `X-Api-Key` and an inconsistent (5s/10s/30s) or **missing** timeout, no retries, no concurrency bound, and ad-hoc error handling. Notably the five `lidarr.ts` queue/history helpers (`getQueue`, `getQueueCount`, `isDownloadActive`, `cleanStuckDownloads`, `getRecentCompletedDownloads`) had **no timeout at all** — an unbounded external call inside worker polling loops.

## Added

- **`backend/src/services/lidarr/lidarrHttpClient.ts`** — one consolidated, typed, bounded Lidarr HTTP boundary:
  - single reusable `axios.create` instance per connection (baseURL + `X-Api-Key`), consistent request **timeout** (default 15s).
  - **capped exponential-backoff retries** with jitter (default 2 retries / 3 attempts), gated by a small pure classifier: retry only **idempotent** methods (GET/PUT/DELETE; POST must opt in via `retryable`) on **classified transient** failures (network / timeout / 408 / 425 / 429 / 500 / 502 / 503 / 504). `Retry-After` is honored and capped at the max backoff.
  - **concurrency limiter** via the existing `p-limit` dependency.
  - **typed `LidarrHttpError`** (`status` / `method` / `path` / `attempts` / `isTransient`) whose message never contains the API key or host; body/URL/secret never logged. One boundary log per outcome (debug success / warn retry / error final).
  - **connection resolution** (`resolveLidarrConnection` / `createLidarrClient`) from system settings with `.env` fallback and http/https URL validation; returns `null` (never throws) when Lidarr is not configured, preserving callers' graceful-degradation contracts.
  - every exported symbol is JSDoc-documented; every function is well under the 60-line gate (loop core kept small via extracted pure helpers `classifyRetry` / `computeBackoffMs` / `retryAfterMs` / `buildError`).

## Changed

- `services/discovery/discoveryAlbumLifecycle.ts` — the rejected-album Lidarr deletion now routes through the client (still best-effort: 404 ignored, other failures logged at debug, never rethrown), and now benefits from the client's bounded retry/timeout. Its test was updated to the new axios-instance mock shape.

## Tests (TDD, all new/updated green)

- `services/lidarr/__tests__/lidarrHttpClient.test.ts` — 13 cases: success + auth header, retry-then-success, retry exhaustion (exactly maxRetries+1 attempts, `isTransient`/`attempts`/`status` on the error, **no secret/host in the message**), non-retryable 4xx short-circuit, POST-not-retried vs opt-in, timeout/network classification with `status===undefined`, **concurrency never exceeds the limit**, URL/apiKey validation, and `resolveLidarrConnection` enabled/disabled/invalid-URL paths. All HTTP mocked via `jest.mock("axios")`; injectable `sleep` keeps it timer-free.
- `services/discovery/__tests__/discoveryAlbumLifecycle.test.ts` — updated to the client mock shape (19 pass).

verify (targeted, under the shared jest lock, `--maxWorkers=2`):
- new suites: **32 tests pass** (13 client + 19 lifecycle).
- regression: existing `services/__tests__/lidarrService.test.ts` **137 tests pass** (unchanged behavior).
- `tsc --noEmit -p backend/tsconfig.json`: new/changed files contribute **zero** errors. (One unrelated pre-existing `src/routes/auth.ts` "Cannot find module 'otplib'" error is an install artifact of the shared node_modules in this environment, not introduced by this slice — it does not touch auth.ts.)
- `jest.config.js`: added `p-limit`/`yocto-queue` to `transformIgnorePatterns` (p-limit v7 is ESM-only; required for ts-jest to load it).

## No breaking changes / no UPGRADING

No API, env var, or user-facing behavior changes. No new dependencies (`axios` + `p-limit` already present).

## Follow-ups discovered (declared, out of scope here)

The client is now the standard boundary; the remaining Lidarr consumers should adopt it incrementally (each carries a non-trivial rewrite of an existing brittle test suite and a deliberate error-semantics shift — transient 5xx becomes retryable — so they are split out to keep every change no-regression):
- `services/lidarr.ts` — the five queue/history helper functions + the `LidarrService` class's two `axios.create` sites (the `lidarrService.test.ts` suite is 4590 lines and asserts on bare `axios.get/post/delete`).
- `services/downloadQueue.ts`, `services/simpleDownloadManager.ts`, `services/discoverWeekly.ts` — queue/command/album/artist call-sites in worker loops.
- `routes/discover.ts`, `routes/systemSettings.ts`, `routes/onboarding.ts` — request-time album/artist mutations and connection-validation pings (route-layer; already time-bounded).
