### PR TITLE
fix(aio): harden all-in-one image — non-root, secret precedence, Postgres lockdown, real health checks (refactor slice P14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- All-in-One (AIO) backend, frontend, and analyzer processes now run under
+  supervisord as the fixed `soundspan` user (uid/gid 1000). Existing writable
+  volume paths are chowned automatically on every boot; see
+  `docs/UPGRADING.md` for bind-mount requirements.
+- AIO backend `.env` and persisted master-secret files are now owner-only
+  (`0600`, uid 1000), and `/data/secrets` is mode `0700`.
+- AIO now honors operator-supplied `SESSION_SECRET`,
+  `SETTINGS_ENCRYPTION_KEY`, and `INTERNAL_API_SECRET`, with precedence env →
+  persisted file → generated value and write-through persistence. Published
+  defaults and short `SESSION_SECRET` values fail startup; `docker-compose.aio.yml`
+  now forwards all three secrets. See `docs/UPGRADING.md`.
+- Embedded AIO Postgres now uses a generated or operator-supplied password
+  persisted under `/data/secrets`, synchronizes existing databases
+  automatically, listens only on loopback, and permits only loopback clients
+  authenticated with `scram-sha-256`.
+- AIO health checks now require both frontend health and backend readiness.
+  Helm AIO pods use shared exec liveness/readiness probes plus a generous
+  `startupProbe`, so backend or database failure is no longer reported healthy.
 - Replaced the unmaintained `speakeasy` TOTP library (last released in 2016) on
   the 2FA path with actively maintained `otplib` v13 and its audited
   `@noble/hashes` and `@scure/base` cryptography. Existing enrolled 2FA secrets
@@ -88,6 +106,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   functions, `downloadQueue`, `simpleDownloadManager`, `discoverWeekly`, and the
   discover/system-settings/onboarding routes) will be migrated onto it
   incrementally to keep each change no-regression.
+- AIO analyzer tuning from `aio.env` is now passed through to the MusicCNN and
+  CLAP runtimes instead of being dropped or overwritten by supervisord defaults.
+- AIO image build/startup hygiene: apt update/install steps are consolidated,
+  and the redundant frontend `sleep 10` startup delay is removed.
+- Removed the non-functional `HF_TOKEN` BuildKit secret path from the AIO and
+  CLAP image builds; the public model download remains SHA-256 verified.
 - Backend: moved six `@types/*` packages from production dependencies to
   devDependencies and removed `@types/speakeasy`, slimming the pruned worker
   image's production `node_modules`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,12 @@
 
 FROM node:24-bookworm-slim
 
-# Add PostgreSQL 16 repository (Debian Bookworm only has PG15 by default)
+# Add the PostgreSQL 16 repository and install runtime dependencies in one layer.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg lsb-release curl ca-certificates && \
     echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
-    apt-get update
-
-# Install system dependencies including Python for audio analysis
-RUN apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends \
     postgresql-16 \
     postgresql-contrib-16 \
     postgresql-16-pgvector \
@@ -37,6 +34,12 @@ RUN apt-get install -y --no-install-recommends \
 RUN mkdir -p /app/backend /app/frontend /app/audio-analyzer /app/models \
     /data/postgres /data/redis /run/postgresql /var/log/supervisor \
     && chown -R postgres:postgres /data/postgres /run/postgresql
+
+# The upstream Node image reserves uid/gid 1000 for "node"; replace it with
+# the fixed runtime identity expected by the chart's fsGroup.
+RUN userdel node && groupdel node && \
+    groupadd -g 1000 soundspan && \
+    useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin -d /app soundspan
 
 # ============================================
 # AUDIO ANALYZER SETUP (Essentia AI)
@@ -119,16 +122,9 @@ COPY services/audio-analyzer-clap/analyzer.py /app/audio-analyzer-clap/
 # Pinned to an immutable repo commit (not `resolve/main`) and verified against
 # a pinned sha256 digest (roadmap F38); a mismatch fails the build. Digest
 # measured 2026-07-11 (see docs/modernization-roadmap.md F38).
-RUN --mount=type=secret,id=hf_token \
-    HF_TOKEN=$(cat /run/secrets/hf_token) \
-    echo "Downloading CLAP model for vibe similarity..." && \
-    if [ -n "${HF_TOKEN}" ]; then \
-      curl -L --progress-bar -H "Authorization: Bearer ${HF_TOKEN}" -o /app/models/music_audioset_epoch_15_esc_90.14.pt \
-        "https://huggingface.co/lukewys/laion_clap/resolve/b3708341862f581175dba5c356a4ebf74a9b6651/music_audioset_epoch_15_esc_90.14.pt"; \
-    else \
-      curl -L --progress-bar -o /app/models/music_audioset_epoch_15_esc_90.14.pt \
-        "https://huggingface.co/lukewys/laion_clap/resolve/b3708341862f581175dba5c356a4ebf74a9b6651/music_audioset_epoch_15_esc_90.14.pt"; \
-    fi && \
+RUN echo "Downloading CLAP model for vibe similarity..." && \
+    curl -L --progress-bar -o /app/models/music_audioset_epoch_15_esc_90.14.pt \
+        "https://huggingface.co/lukewys/laion_clap/resolve/b3708341862f581175dba5c356a4ebf74a9b6651/music_audioset_epoch_15_esc_90.14.pt" && \
     echo "fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd  /app/models/music_audioset_epoch_15_esc_90.14.pt" | sha256sum -c - && \
     echo "CLAP model downloaded successfully" && \
     ls -lh /app/models/music_audioset_epoch_15_esc_90.14.pt
@@ -147,7 +143,7 @@ if [ -f /data/.schema_ready ]; then
 fi
 
 while [ $COUNTER -lt $TIMEOUT ]; do
-    if PGPASSWORD=soundspan psql -h localhost -U soundspan -d soundspan -c "SELECT 1 FROM \"Track\" LIMIT 1" > /dev/null 2>&1; then
+    if psql "$DATABASE_URL" -c "SELECT 1 FROM \"Track\" LIMIT 1" > /dev/null 2>&1; then
         echo "[wait-for-db] ✓ Database is ready and schema exists!"
         exit 0
     fi
@@ -162,7 +158,7 @@ done
 
 echo "[wait-for-db] ERROR: Database schema not ready after ${TIMEOUT}s"
 echo "[wait-for-db] Listing available tables:"
-PGPASSWORD=soundspan psql -h localhost -U soundspan -d soundspan -c "\dt" 2>&1 || echo "Could not list tables"
+psql "$DATABASE_URL" -c "\dt" 2>&1 || echo "Could not list tables"
 exit 1
 EOF
 
@@ -264,10 +260,11 @@ nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
+# Supervisord stays root only to drop workloads to soundspan/postgres/redis.
 user=root
 
 [program:postgres]
-command=/usr/lib/postgresql/16/bin/postgres -D /data/postgres
+command=/usr/lib/postgresql/16/bin/postgres -D /data/postgres -c listen_addresses=127.0.0.1
 user=postgres
 autostart=true
 autorestart=true
@@ -290,6 +287,7 @@ priority=20
 
 [program:backend]
 command=/bin/bash -c "/app/wait-for-db.sh 120 && cd /app/backend && node dist/index.js"
+user=soundspan
 autostart=true
 autorestart=unexpected
 startretries=3
@@ -302,7 +300,8 @@ directory=/app/backend
 priority=30
 
 [program:frontend]
-command=/bin/bash -c "sleep 10 && cd /app/frontend && npm start"
+command=/bin/bash -c "cd /app/frontend && npm start"
+user=soundspan
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
@@ -314,6 +313,7 @@ priority=40
 
 [program:audio-analyzer]
 command=/bin/bash -c "/app/wait-for-db.sh 120 && cd /app/audio-analyzer && python3 analyzer.py"
+user=soundspan
 autostart=true
 autorestart=unexpected
 startretries=3
@@ -322,11 +322,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=DATABASE_URL="postgresql://soundspan:soundspan@localhost:5432/soundspan",REDIS_URL="redis://localhost:6379",MUSIC_PATH="/music",BATCH_SIZE="10",SLEEP_INTERVAL="5",MAX_ANALYZE_SECONDS="90",BRPOP_TIMEOUT="30",MODEL_IDLE_TIMEOUT="300",NUM_WORKERS="2",THREADS_PER_WORKER="1",CUDA_VISIBLE_DEVICES=""
+environment=DATABASE_URL="%(ENV_DATABASE_URL)s",REDIS_URL="%(ENV_REDIS_URL)s",MUSIC_PATH="%(ENV_MUSIC_PATH)s",BATCH_SIZE="%(ENV_BATCH_SIZE)s",SLEEP_INTERVAL="%(ENV_SLEEP_INTERVAL)s",MAX_ANALYZE_SECONDS="%(ENV_MAX_ANALYZE_SECONDS)s",BRPOP_TIMEOUT="%(ENV_BRPOP_TIMEOUT)s",MODEL_IDLE_TIMEOUT="%(ENV_MODEL_IDLE_TIMEOUT)s",NUM_WORKERS="%(ENV_NUM_WORKERS)s",THREADS_PER_WORKER="%(ENV_THREADS_PER_WORKER)s",AUDIO_REDIS_SOCKET_TIMEOUT="%(ENV_AUDIO_REDIS_SOCKET_TIMEOUT)s",CUDA_VISIBLE_DEVICES="%(ENV_CUDA_VISIBLE_DEVICES)s"
 priority=50
 
 [program:audio-analyzer-clap]
 command=/bin/bash -c "/app/wait-for-db.sh 120 && cd /app/audio-analyzer-clap && python3 analyzer.py"
+user=soundspan
 autostart=true
 autorestart=unexpected
 startretries=3
@@ -335,7 +336,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=DATABASE_URL="postgresql://soundspan:soundspan@localhost:5432/soundspan",REDIS_URL="redis://localhost:6379",MUSIC_PATH="/music",BACKEND_URL="http://localhost:3006",SLEEP_INTERVAL="5",NUM_WORKERS="1",MODEL_IDLE_TIMEOUT="300",INTERNAL_API_SECRET="%(ENV_INTERNAL_API_SECRET)s"
+environment=DATABASE_URL="%(ENV_DATABASE_URL)s",REDIS_URL="%(ENV_REDIS_URL)s",MUSIC_PATH="%(ENV_MUSIC_PATH)s",BACKEND_URL="http://localhost:3006",SLEEP_INTERVAL="%(ENV_SLEEP_INTERVAL)s",NUM_WORKERS="%(ENV_CLAP_NUM_WORKERS)s",THREADS_PER_WORKER="%(ENV_THREADS_PER_WORKER)s",MODEL_IDLE_TIMEOUT="%(ENV_MODEL_IDLE_TIMEOUT)s",CLAP_REDIS_SOCKET_TIMEOUT="%(ENV_CLAP_REDIS_SOCKET_TIMEOUT)s",INTERNAL_API_SECRET="%(ENV_INTERNAL_API_SECRET)s",CUDA_VISIBLE_DEVICES="%(ENV_CUDA_VISIBLE_DEVICES)s"
 priority=60
 EOF
 
@@ -376,7 +377,10 @@ echo "Using PostgreSQL from: $PG_BIN"
 
 # Prepare data directories (bind-mount safe)
 echo "Preparing data directories..."
-mkdir -p /data/postgres /data/redis /run/postgresql
+mkdir -p /data/postgres /data/redis /run/postgresql \
+    /data/cache/covers /data/cache/transcodes /data/cache/home /data/secrets /app/backend/logs
+chmod 700 /data/secrets
+chown -R soundspan:soundspan /data/cache /data/secrets /app/backend/logs
 
 if id postgres >/dev/null 2>&1; then
     chown -R postgres:postgres /data/postgres /run/postgresql 2>/dev/null || true
@@ -402,6 +406,65 @@ if id redis >/dev/null 2>&1; then
     fi
 fi
 
+# Resolve application secrets: operator environment, persisted file, generated.
+if [ -n "$SESSION_SECRET" ]; then
+    printf '%s' "$SESSION_SECRET" > /data/secrets/session_secret
+elif [ -f /data/secrets/session_secret ]; then
+    SESSION_SECRET=$(cat /data/secrets/session_secret)
+else
+    SESSION_SECRET=$(openssl rand -hex 32)
+    printf '%s' "$SESSION_SECRET" > /data/secrets/session_secret
+fi
+chmod 600 /data/secrets/session_secret
+chown soundspan:soundspan /data/secrets/session_secret 2>/dev/null || true
+if [ "$SESSION_SECRET" = "changeme-generate-secure-key" ] || [ "${#SESSION_SECRET}" -lt 32 ]; then
+    echo "ERROR: SESSION_SECRET must be at least 32 characters and must not use the published default." >&2
+    exit 1
+fi
+
+if [ -n "$SETTINGS_ENCRYPTION_KEY" ]; then
+    printf '%s' "$SETTINGS_ENCRYPTION_KEY" > /data/secrets/encryption_key
+elif [ -f /data/secrets/encryption_key ]; then
+    SETTINGS_ENCRYPTION_KEY=$(cat /data/secrets/encryption_key)
+else
+    SETTINGS_ENCRYPTION_KEY=$(openssl rand -hex 32)
+    printf '%s' "$SETTINGS_ENCRYPTION_KEY" > /data/secrets/encryption_key
+fi
+chmod 600 /data/secrets/encryption_key
+chown soundspan:soundspan /data/secrets/encryption_key 2>/dev/null || true
+if [ "$SETTINGS_ENCRYPTION_KEY" = "default-encryption-key-change-me" ]; then
+    echo "ERROR: SETTINGS_ENCRYPTION_KEY must not use the published default." >&2
+    exit 1
+fi
+
+if [ -n "$INTERNAL_API_SECRET" ]; then
+    printf '%s' "$INTERNAL_API_SECRET" > /data/secrets/internal_api_secret
+elif [ -f /data/secrets/internal_api_secret ]; then
+    INTERNAL_API_SECRET=$(cat /data/secrets/internal_api_secret)
+else
+    INTERNAL_API_SECRET=$(openssl rand -hex 32)
+    printf '%s' "$INTERNAL_API_SECRET" > /data/secrets/internal_api_secret
+fi
+chmod 600 /data/secrets/internal_api_secret
+chown soundspan:soundspan /data/secrets/internal_api_secret 2>/dev/null || true
+if [ "$INTERNAL_API_SECRET" = "soundspan-internal-secret-change-me" ]; then
+    echo "ERROR: INTERNAL_API_SECRET must not use the published default." >&2
+    exit 1
+fi
+
+# Resolve and persist the PostgreSQL password for fresh and existing volumes.
+if [ -n "$POSTGRES_PASSWORD" ]; then
+    printf '%s' "$POSTGRES_PASSWORD" > /data/secrets/postgres_password
+elif [ -f /data/secrets/postgres_password ]; then
+    POSTGRES_PASSWORD=$(cat /data/secrets/postgres_password)
+else
+    POSTGRES_PASSWORD=$(openssl rand -hex 32)
+    printf '%s' "$POSTGRES_PASSWORD" > /data/secrets/postgres_password
+fi
+chmod 600 /data/secrets/postgres_password
+chown soundspan:soundspan /data/secrets/postgres_password 2>/dev/null || true
+DATABASE_URL="postgresql://soundspan:${POSTGRES_PASSWORD}@localhost:5432/soundspan"
+
 # Clean up stale PID file if exists
 rm -f /data/postgres/postmaster.pid 2>/dev/null || true
 
@@ -410,17 +473,25 @@ if [ ! -f /data/postgres/PG_VERSION ]; then
     echo "Initializing PostgreSQL database..."
     gosu postgres $PG_BIN/initdb -D /data/postgres
 
-    # Configure PostgreSQL
-    echo "host all all 0.0.0.0/0 md5" >> /data/postgres/pg_hba.conf
-    echo "listen_addresses='*'" >> /data/postgres/postgresql.conf
+    # Configure PostgreSQL for authenticated loopback access only.
+    echo "host all all 127.0.0.1/32 scram-sha-256" >> /data/postgres/pg_hba.conf
+    echo "host all all ::1/128 scram-sha-256" >> /data/postgres/pg_hba.conf
+    echo "listen_addresses='localhost'" >> /data/postgres/postgresql.conf
+fi
+
+# Harden authentication rules migrated from older persistent volumes.
+sed -i '/0\.0\.0\.0\/0/d' /data/postgres/pg_hba.conf 2>/dev/null || true
+if ! grep -q "host all all 127.0.0.1/32 scram-sha-256" /data/postgres/pg_hba.conf; then
+    echo "host all all 127.0.0.1/32 scram-sha-256" >> /data/postgres/pg_hba.conf
 fi
 
 # Start PostgreSQL temporarily to create database and user
-gosu postgres $PG_BIN/pg_ctl -D /data/postgres -w start
+gosu postgres $PG_BIN/pg_ctl -D /data/postgres -o "-c listen_addresses=127.0.0.1" -w start
 
-# Create user and database if they don't exist
+# Create the user if needed, then always synchronize its persisted password.
 gosu postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname = 'soundspan'" | grep -q 1 || \
-    gosu postgres psql -c "CREATE USER soundspan WITH PASSWORD 'soundspan';"
+    gosu postgres psql -c "CREATE USER soundspan WITH PASSWORD '${POSTGRES_PASSWORD}';"
+gosu postgres psql -c "ALTER USER soundspan WITH PASSWORD '${POSTGRES_PASSWORD}';"
 gosu postgres psql -tc "SELECT 1 FROM pg_database WHERE datname = 'soundspan'" | grep -q 1 || \
     gosu postgres psql -c "CREATE DATABASE soundspan OWNER soundspan;"
 
@@ -430,7 +501,7 @@ gosu postgres psql -d soundspan -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
 # Run Prisma migrations
 cd /app/backend
-export DATABASE_URL="postgresql://soundspan:soundspan@localhost:5432/soundspan"
+export DATABASE_URL
 echo "Running Prisma migrations..."
 ls -la prisma/migrations/ || echo "No migrations directory!"
 
@@ -491,52 +562,41 @@ echo "✓ Schema ready flag created"
 # Stop PostgreSQL (supervisord will start it)
 gosu postgres $PG_BIN/pg_ctl -D /data/postgres -w stop
 
-# Create persistent cache directories in /data volume
-mkdir -p /data/cache/covers /data/cache/transcodes /data/secrets
-
-# Load or generate persistent secrets
-if [ -f /data/secrets/session_secret ]; then
-    SESSION_SECRET=$(cat /data/secrets/session_secret)
-    echo "Loaded existing SESSION_SECRET"
-else
-    SESSION_SECRET=$(openssl rand -hex 32)
-    echo "$SESSION_SECRET" > /data/secrets/session_secret
-    chmod 600 /data/secrets/session_secret
-    echo "Generated and saved new SESSION_SECRET"
-fi
-
-if [ -f /data/secrets/encryption_key ]; then
-    SETTINGS_ENCRYPTION_KEY=$(cat /data/secrets/encryption_key)
-    echo "Loaded existing SETTINGS_ENCRYPTION_KEY"
-else
-    SETTINGS_ENCRYPTION_KEY=$(openssl rand -hex 32)
-    echo "$SETTINGS_ENCRYPTION_KEY" > /data/secrets/encryption_key
-    chmod 600 /data/secrets/encryption_key
-    echo "Generated and saved new SETTINGS_ENCRYPTION_KEY"
-fi
-
-if [ -f /data/secrets/internal_api_secret ]; then
-    INTERNAL_API_SECRET=$(cat /data/secrets/internal_api_secret)
-    echo "Loaded existing INTERNAL_API_SECRET"
-else
-    INTERNAL_API_SECRET=$(openssl rand -hex 32)
-    echo "$INTERNAL_API_SECRET" > /data/secrets/internal_api_secret
-    chmod 600 /data/secrets/internal_api_secret
-    echo "Generated and saved new INTERNAL_API_SECRET"
-fi
+# Map AIO/chart tuning variables to the analyzer runtime contract.
+export NUM_WORKERS="${AUDIO_ANALYSIS_WORKERS:-2}"
+export THREADS_PER_WORKER="${AUDIO_ANALYSIS_THREADS_PER_WORKER:-1}"
+export BATCH_SIZE="${AUDIO_ANALYSIS_BATCH_SIZE:-10}"
+export BRPOP_TIMEOUT="${AUDIO_BRPOP_TIMEOUT:-30}"
+export MAX_ANALYZE_SECONDS="${MAX_ANALYZE_SECONDS:-90}"
+export MODEL_IDLE_TIMEOUT="${AUDIO_MODEL_IDLE_TIMEOUT:-300}"
+export SLEEP_INTERVAL="${SLEEP_INTERVAL:-5}"
+export CLAP_NUM_WORKERS="${CLAP_WORKERS:-1}"
+export AUDIO_REDIS_SOCKET_TIMEOUT="${AUDIO_REDIS_SOCKET_TIMEOUT:-35}"
+export CLAP_REDIS_SOCKET_TIMEOUT="${CLAP_REDIS_SOCKET_TIMEOUT:-10}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-}"
+export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
+export MUSIC_PATH="${MUSIC_PATH:-/music}"
+export DATABASE_URL
+export SESSION_SECRET SETTINGS_ENCRYPTION_KEY INTERNAL_API_SECRET
+export NODE_ENV=production
+export PORT=3006
+export HOME=/data/cache/home
+export XDG_CACHE_HOME=/data/cache/home/.cache
 
 # Write environment file for backend
 cat > /app/backend/.env << ENVEOF
 NODE_ENV=production
-DATABASE_URL=postgresql://soundspan:soundspan@localhost:5432/soundspan
-REDIS_URL=redis://localhost:6379
+DATABASE_URL=$DATABASE_URL
+REDIS_URL=$REDIS_URL
 PORT=3006
-MUSIC_PATH=/music
+MUSIC_PATH=$MUSIC_PATH
 TRANSCODE_CACHE_PATH=/data/cache/transcodes
 SESSION_SECRET=$SESSION_SECRET
 SETTINGS_ENCRYPTION_KEY=$SETTINGS_ENCRYPTION_KEY
 INTERNAL_API_SECRET=$INTERNAL_API_SECRET
 ENVEOF
+chmod 600 /app/backend/.env
+chown soundspan:soundspan /app/backend/.env 2>/dev/null || true
 
 # Normalize runtime streaming engine mode (consumed by frontend /runtime-config route).
 ENGINE_MODE="${STREAMING_ENGINE_MODE:-}"
@@ -550,16 +610,10 @@ case "$ENGINE_MODE" in
 esac
 
 echo "Frontend runtime STREAMING_ENGINE_MODE: ${ENGINE_MODE:-native (primary default)}"
+export STREAMING_ENGINE_MODE="$ENGINE_MODE"
 
 echo "Starting soundspan..."
-exec env \
-    NODE_ENV=production \
-    DATABASE_URL="postgresql://soundspan:soundspan@localhost:5432/soundspan" \
-    SESSION_SECRET="$SESSION_SECRET" \
-    SETTINGS_ENCRYPTION_KEY="$SETTINGS_ENCRYPTION_KEY" \
-    INTERNAL_API_SECRET="$INTERNAL_API_SECRET" \
-    STREAMING_ENGINE_MODE="$ENGINE_MODE" \
-    /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 EOF
 
 # Fix Windows line endings (CRLF -> LF) and make executable

--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -239,21 +239,24 @@ spec:
               mountPath: /music
             - name: data
               mountPath: /data
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 30
+          startupProbe:
+            exec:
+              command: ["node", "/app/healthcheck.js"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
             timeoutSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 60
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 30
+            exec:
+              command: ["node", "/app/healthcheck.js"]
             periodSeconds: 10
             timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["node", "/app/healthcheck.js"]
+            periodSeconds: 30
+            timeoutSeconds: 10
             failureThreshold: 3
           resources:
             {{- toYaml .Values.aio.resources | nindent 12 }}

--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -24,9 +24,13 @@ services:
       - soundspan_data:/data
     environment:
       - TZ=${TZ:-UTC}
+      # AIO honors operator-supplied secrets; they take precedence and persist to /data/secrets.
+      # Empty values generate and persist stable values on first boot.
       - SESSION_SECRET=${SESSION_SECRET:-}
-      # Runtime streaming-engine selector. Keep unset for primary howler (direct).
-      # Set to videojs (segmented, experimental) only for explicit evaluation.
+      - SETTINGS_ENCRYPTION_KEY=${SETTINGS_ENCRYPTION_KEY:-}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
+      # Runtime streaming-engine selector. Accepted: native | howler | videojs.
+      # Leave unset to use the server's built-in default engine.
       - STREAMING_ENGINE_MODE=${STREAMING_ENGINE_MODE:-}
       # Preserve Redis streams/groups across restarts unless explicitly overridden
       - REDIS_FLUSH_ON_STARTUP=${REDIS_FLUSH_ON_STARTUP:-false}

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -61,10 +61,10 @@ Experimental feature note:
 | `DATABASE_URL` | `backend`, `backend-worker`, `audio-analyzer`, `audio-analyzer-clap` | Required | `postgresql://soundspan:changeme@postgres:5432/soundspan` (split stack) | PostgreSQL connection string. |
 | `REDIS_URL` | `backend`, `backend-worker`, `audio-analyzer`, `audio-analyzer-clap` | Required | `redis://redis:6379` (split stack) | Redis connection for queues, sessions, claims, realtime state. |
 | `POSTGRES_USER` | `backend`, `backend-worker`, `postgres` | Required | `soundspan` | PostgreSQL username (and used to build `DATABASE_URL`). |
-| `POSTGRES_PASSWORD` | `backend`, `backend-worker`, `postgres` | Required (production) | `changeme` | PostgreSQL password (and used to build `DATABASE_URL`). |
+| `POSTGRES_PASSWORD` | `backend`, `backend-worker`, `postgres`, `soundspan` (AIO) | Required (production) | split stack: `changeme`; AIO: generated when unset | PostgreSQL password (and used to build `DATABASE_URL`). In AIO, an operator value is honored and persisted to `/data/secrets/postgres_password`; otherwise a strong value is generated once and persisted there. |
 | `POSTGRES_DB` | `backend`, `backend-worker`, `postgres` | Required | `soundspan` | PostgreSQL database name (and used to build `DATABASE_URL`). |
-| `SESSION_SECRET` | `backend`, `soundspan` (AIO) | Required | split stack: none (compose refuses to start without it); AIO: generated & persisted at `/data/secrets/session_secret` | Session/JWT signing secret; must be stable and 32+ chars. The backend image's entrypoint fails fast when it is unset, still the old published default, or shorter than 32 chars (generate with `openssl rand -base64 32`). |
-| `SETTINGS_ENCRYPTION_KEY` | `backend` | Required | split stack: none (compose refuses to start without it); AIO: generated & persisted at `/data/secrets/encryption_key` | Encrypts stored credentials/settings. The backend image's entrypoint fails fast when it is unset or the insecure default (generate with `openssl rand -base64 32`); it must stay stable or encrypted data becomes unreadable. |
+| `SESSION_SECRET` | `backend`, `soundspan` (AIO) | Required | split stack: none (compose refuses to start without it); AIO: operator value honored, else persisted/generated at `/data/secrets/session_secret` | Session/JWT signing secret; must be stable and 32+ chars. The backend image's entrypoint fails fast when it is unset, still the old published default, or shorter than 32 chars (generate with `openssl rand -base64 32`). In AIO, an operator value takes precedence and is written through to `/data/secrets`; otherwise the persisted or a newly generated value is used. |
+| `SETTINGS_ENCRYPTION_KEY` | `backend`, `soundspan` (AIO) | Required | split stack: none (compose refuses to start without it); AIO: operator value honored, else persisted/generated at `/data/secrets/encryption_key` | Encrypts stored credentials/settings. The backend image's entrypoint fails fast when it is unset or the insecure default (generate with `openssl rand -base64 32`); it must stay stable or encrypted data becomes unreadable. In AIO, an operator value takes precedence and is written through to `/data/secrets`; otherwise the persisted or a newly generated value is used. |
 | `MUSIC_PATH` | `backend`, `backend-worker`, `tidal-downloader`, analyzers; also mount control in compose | Required | split stack host mount: `./music`; AIO sample: `/path/to/your/music`; container path: `/music` | Library root path/mount. |
 | `PORT` | `backend` (runtime), `frontend` (runtime), `soundspan` (AIO host publish var) | Optional | backend: `3006`; frontend: `3030`; AIO publish: `3030` | Service bind/publish port control (context-dependent by container). |
 | `NODE_ENV` | `backend`, `backend-worker`, `frontend` | Optional | `production` (compose) | Runtime mode. |
@@ -95,7 +95,7 @@ Experimental feature note:
 
 | Variable | Used In Container(s) | Required | Default | What It Does |
 | --- | --- | --- | --- | --- |
-| `INTERNAL_API_SECRET` | `backend`, `backend-worker`, `audio-analyzer-clap` (+ local CLAP), `ytmusic-streamer`, `tidal-downloader` | Required | none — `docker-compose.yml` refuses to start without it (generate with `openssl rand -base64 32`), and the HTTP sidecars reject the old published `soundspan-internal-secret-change-me` value as unconfigured | Auth secret for internal analyzer callbacks, trusted internal routes, and backend→HTTP-sidecar auth (F31). The ytmusic-streamer/tidal-downloader FastAPI sidecars now **reject** any request without the matching `x-internal-secret` header (fail-closed; `/health` is exempt), so this must be set to the same value on the backend and both HTTP sidecars. |
+| `INTERNAL_API_SECRET` | `backend`, `backend-worker`, `soundspan` (AIO), `audio-analyzer-clap` (+ local CLAP), `ytmusic-streamer`, `tidal-downloader` | Required | none — `docker-compose.yml` refuses to start without it (generate with `openssl rand -base64 32`), and the HTTP sidecars reject the old published `soundspan-internal-secret-change-me` value as unconfigured; AIO honors an operator value, else generates & persists when unset | Auth secret for internal analyzer callbacks, trusted internal routes, and backend→HTTP-sidecar auth (F31). The ytmusic-streamer/tidal-downloader FastAPI sidecars now **reject** any request without the matching `x-internal-secret` header (fail-closed; `/health` is exempt), so this must be set to the same value on the backend and both HTTP sidecars. In AIO, an operator value takes precedence and is persisted to `/data/secrets/internal_api_secret`; otherwise the persisted or a newly generated value is used. |
 | `LISTEN_TOGETHER_REDIS_ADAPTER_ENABLED` | `backend` | Optional | `true` | Enables Redis adapter fanout for cross-replica Socket.IO. |
 | `LISTEN_TOGETHER_STATE_SYNC_ENABLED` | `backend` | Optional | `true` | Enables Redis pub/sub state sync for Listen Together. |
 | `LISTEN_TOGETHER_STATE_STORE_ENABLED` | `backend` | Optional | `true` | Enables Redis-backed authoritative group state snapshots. |
@@ -173,15 +173,19 @@ Experimental feature note:
 
 ## Analyzer Variables
 
+The AIO image maps its deployment-facing analyzer variables into the MusicCNN
+and CLAP runtime names; values set through Helm `aio.env` or the AIO container
+environment are effective.
+
 | Variable | Used In Container(s) | Required | Default | What It Does |
 | --- | --- | --- | --- | --- |
-| `AUDIO_ANALYSIS_BATCH_SIZE` | compose host variable mapping to `audio-analyzer:BATCH_SIZE` | Optional | `10` | Batch size for MusicCNN analyzer. |
+| `AUDIO_ANALYSIS_BATCH_SIZE` | `soundspan` (AIO) and compose host variable mapping to `audio-analyzer:BATCH_SIZE` | Optional | `10` | Batch size for MusicCNN analyzer. |
 | `AUDIO_ANALYSIS_INTERVAL` | compose host variable mapping to `audio-analyzer:SLEEP_INTERVAL` | Optional | `5` | Loop interval between analyzer cycles (seconds). |
-| `AUDIO_BRPOP_TIMEOUT` | compose host variable mapping to `audio-analyzer:BRPOP_TIMEOUT` | Optional | `30` | Redis blocking pop timeout for analyzer worker (seconds). |
+| `AUDIO_BRPOP_TIMEOUT` | `soundspan` (AIO) and compose host variable mapping to `audio-analyzer:BRPOP_TIMEOUT` | Optional | `30` | Redis blocking pop timeout for analyzer worker (seconds). |
 | `AUDIO_REDIS_SOCKET_TIMEOUT` | `soundspan` (AIO) and `audio-analyzer` | Optional | `35` | Redis socket read timeout for the MusicCNN queue worker (seconds). The runtime enforces an effective minimum of `BRPOP_TIMEOUT + 5` so blocking queue polls complete before the socket deadline. |
-| `AUDIO_MODEL_IDLE_TIMEOUT` | compose host variable mapping to `audio-analyzer:MODEL_IDLE_TIMEOUT` | Optional | `300` | Idle timeout before unloading analyzer ML models (seconds). |
-| `AUDIO_ANALYSIS_WORKERS` | compose host variable mapping to `audio-analyzer:NUM_WORKERS` | Optional | `2` | Parallel MusicCNN analyzer workers. |
-| `AUDIO_ANALYSIS_THREADS_PER_WORKER` | compose host variable mapping to `audio-analyzer:THREADS_PER_WORKER` | Optional | `1` | CPU threads per MusicCNN analyzer worker. |
+| `AUDIO_MODEL_IDLE_TIMEOUT` | `soundspan` (AIO) and compose host variable mapping to `audio-analyzer:MODEL_IDLE_TIMEOUT` | Optional | `300` | Idle timeout before unloading analyzer ML models (seconds). |
+| `AUDIO_ANALYSIS_WORKERS` | `soundspan` (AIO) and compose host variable mapping to `audio-analyzer:NUM_WORKERS` | Optional | `2` | Parallel MusicCNN analyzer workers. |
+| `AUDIO_ANALYSIS_THREADS_PER_WORKER` | `soundspan` (AIO) and compose host variable mapping to `audio-analyzer:THREADS_PER_WORKER` | Optional | `1` | CPU threads per MusicCNN analyzer worker. |
 | `MAX_FILE_SIZE_MB` | `audio-analyzer` | Optional | `500` | Hard file-size cap for analysis candidates (`0` disables cap). |
 | `BATCH_ANALYSIS_TIMEOUT_SECONDS` | `audio-analyzer` | Optional | `900` | Timeout for a batch before failure handling. |
 | `MAX_RETRIES` | `audio-analyzer` | Optional | `3` | Max retries for failed analyzer jobs. |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -93,6 +93,41 @@ binding, which also works. Set a strong `POSTGRES_PASSWORD` before exposing 5432
 
 ---
 
+## All-in-One (AIO) image hardening: non-root services, generated Postgres password, honored secrets
+
+Routine upgrades need **no manual steps**. Existing named volumes are migrated
+automatically on startup, and the Helm chart already supplies the required
+filesystem group and first-boot migration budget.
+
+**Service permissions.** The AIO backend, frontend, and both Python analyzers now
+run as the fixed `soundspan` user (uid/gid 1000). The entrypoint chowns existing
+`/data/cache`, `/data/secrets`, and `/app/backend/logs` paths on every boot. Named
+volumes work automatically, and the Helm chart's `fsGroup: 1000` handles pod
+volume access. If you bind-mount `/data`, ensure uid/gid 1000 can write it.
+
+**Embedded Postgres.** The former fixed password is replaced by a strong value
+generated once and persisted at `/data/secrets/postgres_password`. On an existing
+volume, startup synchronizes the database role with `ALTER USER`; no action is
+required. Set `POSTGRES_PASSWORD` if you want to pin the value explicitly. The
+embedded server now accepts only loopback connections using `scram-sha-256`.
+
+**AIO secrets.** `SESSION_SECRET`, `SETTINGS_ENCRYPTION_KEY`, and
+`INTERNAL_API_SECRET` now resolve in this order: operator environment → persisted
+`/data/secrets` file → freshly generated value. Operator values are written
+through to the persisted files, so they remain stable. If you relied on generated
+secrets, nothing changes. If you set `SETTINGS_ENCRYPTION_KEY`, keep it stable or
+previously encrypted settings become unreadable. `docker-compose.aio.yml` now
+forwards `SETTINGS_ENCRYPTION_KEY` and `INTERNAL_API_SECRET` as well as
+`SESSION_SECRET`.
+
+**Health behavior.** The container and AIO pod now fail health checks when the
+backend or its database dependencies are unavailable, rather than checking only
+the frontend. Expect a genuine backend failure to trigger a restart. Helm's new
+`startupProbe` gives first-boot migrations a generous window before liveness and
+readiness enforcement begins.
+
+---
+
 ## ⚠️ Breaking: CORS is deny-by-default and the Lidarr webhook fails closed
 
 Two authorization hardening changes ship secure-by-default with explicit env

--- a/healthcheck-prod.js
+++ b/healthcheck-prod.js
@@ -1,22 +1,36 @@
-// Production health check script - checks frontend on port 3030
 const http = require('http');
 
-const options = {
-  hostname: 'localhost',
-  port: 3030,
-  path: '/',
-  method: 'GET',
-  timeout: 5000,
-};
+function checkEndpoint({ port, path }) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (healthy) => {
+      if (!settled) {
+        settled = true;
+        resolve(healthy);
+      }
+    };
 
-const req = http.request(options, (res) => {
-  process.exit(res.statusCode >= 200 && res.statusCode < 400 ? 0 : 1);
+    const req = http.get({
+      hostname: 'localhost',
+      port,
+      path,
+      timeout: 5000,
+    }, (res) => {
+      res.resume();
+      finish(res.statusCode >= 200 && res.statusCode < 400);
+    });
+
+    req.on('error', () => finish(false));
+    req.on('timeout', () => {
+      req.destroy();
+      finish(false);
+    });
+  });
+}
+
+Promise.all([
+  checkEndpoint({ port: 3030, path: '/' }),
+  checkEndpoint({ port: 3006, path: '/health/ready' }),
+]).then((results) => {
+  process.exit(results.every(Boolean) ? 0 : 1);
 });
-
-req.on('error', () => process.exit(1));
-req.on('timeout', () => {
-  req.destroy();
-  process.exit(1);
-});
-
-req.end();

--- a/services/audio-analyzer-clap/Dockerfile
+++ b/services/audio-analyzer-clap/Dockerfile
@@ -36,15 +36,9 @@ RUN mkdir -p /app/models
 # Pinned to an immutable repo commit (not `resolve/main`, which can move) and
 # verified against a pinned sha256 digest (roadmap F38); a mismatch fails the
 # build. Digest measured 2026-07-11 (see docs/modernization-roadmap.md F38).
-RUN --mount=type=secret,id=hf_token \
-    HF_TOKEN=$(cat /run/secrets/hf_token) \
-    set -e; \
+RUN set -e; \
     MODEL_URL="https://huggingface.co/lukewys/laion_clap/resolve/b3708341862f581175dba5c356a4ebf74a9b6651/music_audioset_epoch_15_esc_90.14.pt"; \
-    if [ -n "${HF_TOKEN}" ]; then \
-        curl -L -H "Authorization: Bearer ${HF_TOKEN}" -o /app/models/music_audioset_epoch_15_esc_90.14.pt "${MODEL_URL}"; \
-    else \
-        curl -L -o /app/models/music_audioset_epoch_15_esc_90.14.pt "${MODEL_URL}"; \
-    fi; \
+    curl -L -o /app/models/music_audioset_epoch_15_esc_90.14.pt "${MODEL_URL}"; \
     echo "fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd  /app/models/music_audioset_epoch_15_esc_90.14.pt" | sha256sum -c -
 
 # Verify model loads correctly

--- a/services/audio-analyzer-clap/tests/test_dockerfile_hardening.py
+++ b/services/audio-analyzer-clap/tests/test_dockerfile_hardening.py
@@ -1,0 +1,36 @@
+"""Future-contract file tests for hardening the CLAP analyzer image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = SERVICE_ROOT / "Dockerfile"
+
+
+def test_no_dead_hf_token_secret_mount() -> None:
+    """The public model download must not retain a dead build-secret contract."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "hf_token" not in dockerfile
+    assert "HF_TOKEN" not in dockerfile
+    assert "/run/secrets/hf_token" not in dockerfile
+
+
+def test_model_integrity_check_retained() -> None:
+    """The pinned CLAP model must retain its build-time integrity check."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert (
+        "fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd"
+        in dockerfile
+    )
+    assert "sha256sum -c" in dockerfile
+
+
+def test_runs_as_nonroot() -> None:
+    """The CLAP analyzer process must continue to run as its non-root user."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "USER analyzer" in dockerfile

--- a/tests/test_aio_image_hardening.py
+++ b/tests/test_aio_image_hardening.py
@@ -1,0 +1,304 @@
+"""Future-contract file tests for hardening the all-in-one image."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+HEALTHCHECK = REPO_ROOT / "healthcheck-prod.js"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.aio.yml"
+CHART_DEPLOYMENT = REPO_ROOT / "charts/soundspan/templates/aio/deployment.yaml"
+
+
+def _heredoc(dockerfile: str, target: str) -> str:
+    """Return the body of a single-quoted Dockerfile heredoc for target."""
+    marker = f"RUN cat > {target} << 'EOF'\n"
+    start = dockerfile.index(marker) + len(marker)
+    end = dockerfile.index("\nEOF", start)
+    return dockerfile[start:end]
+
+
+def _program_block(supervisor_config: str, name: str) -> str:
+    """Return one supervisord program block without adjacent program blocks."""
+    match = re.search(
+        rf"(?ms)^\[program:{re.escape(name)}\]\n(.*?)(?=^\[program:|\Z)",
+        supervisor_config,
+    )
+    assert match is not None, f"missing supervisord block: {name}"
+    return match.group(1)
+
+
+def _run_blocks(dockerfile: str) -> list[str]:
+    """Return top-level Dockerfile RUN instruction blocks."""
+    instruction = re.compile(
+        r"(?m)^(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|"
+        r"LABEL|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\b"
+    )
+    matches = list(instruction.finditer(dockerfile))
+    blocks: list[str] = []
+    for index, match in enumerate(matches):
+        if not match.group(0).startswith("RUN"):
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(dockerfile)
+        blocks.append(dockerfile[match.start() : end])
+    return blocks
+
+
+def _assert_operator_secret_precedes_file_read(
+    start_script: str, env_name: str, secret_file: str
+) -> None:
+    """Require an operator-secret branch before the persisted secret is read."""
+    condition = re.search(
+        rf'if\s+\[\s+-n\s+"\$(?:\{{{env_name}\}}|{env_name})"\s+\]',
+        start_script,
+    )
+    file_read = re.search(rf"cat\s+[\"']?{re.escape(secret_file)}", start_script)
+    assert condition is not None, f"missing operator override check for {env_name}"
+    assert file_read is not None, f"missing persisted secret read for {env_name}"
+    assert condition.start() < file_read.start()
+
+
+def test_dockerfile_creates_nonroot_app_user() -> None:
+    """The AIO image must create the fixed-UID soundspan runtime user."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert re.search(
+        r"(?s)\b(?:useradd|adduser)\b.*?(?:-u|--uid)\s+1000\b.*?\bsoundspan\b",
+        dockerfile,
+    )
+
+
+def test_supervisord_runs_services_as_nonroot() -> None:
+    """Every application service must run as soundspan while stores retain users."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    supervisor_config = _heredoc(
+        dockerfile, "/etc/supervisor/conf.d/soundspan.conf"
+    )
+
+    for name in ("backend", "frontend", "audio-analyzer", "audio-analyzer-clap"):
+        block = _program_block(supervisor_config, name)
+        assert re.search(r"(?m)^user=soundspan\s*$", block), name
+        assert not re.search(r"(?m)^user=root\s*$", block), name
+
+    assert re.search(
+        r"(?m)^user=postgres\s*$", _program_block(supervisor_config, "postgres")
+    )
+    assert re.search(
+        r"(?m)^user=redis\s*$", _program_block(supervisor_config, "redis")
+    )
+
+
+def test_start_sh_honors_operator_session_secret_env() -> None:
+    """Operator-provided secrets must take precedence over persisted values."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    _assert_operator_secret_precedes_file_read(
+        start_script, "SESSION_SECRET", "/data/secrets/session_secret"
+    )
+    _assert_operator_secret_precedes_file_read(
+        start_script, "SETTINGS_ENCRYPTION_KEY", "/data/secrets/encryption_key"
+    )
+    _assert_operator_secret_precedes_file_read(
+        start_script, "INTERNAL_API_SECRET", "/data/secrets/internal_api_secret"
+    )
+
+
+def test_start_sh_writes_secrets_through_to_data() -> None:
+    """Operator-supplied secrets must be persisted to the data volume."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    assert re.search(r'>\s*"?/data/secrets/session_secret"?', start_script)
+    assert re.search(r'>\s*"?/data/secrets/encryption_key"?', start_script)
+    assert re.search(r'>\s*"?/data/secrets/internal_api_secret"?', start_script)
+
+
+def test_start_sh_rejects_known_default_secrets() -> None:
+    """Startup must fail fast when any published default secret is supplied."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    assert "changeme-generate-secure-key" in start_script
+    assert "default-encryption-key-change-me" in start_script
+    assert "soundspan-internal-secret-change-me" in start_script
+    assert "exit 1" in start_script
+
+
+def test_secret_files_are_chmod_600() -> None:
+    """Persisted secrets and the backend environment file must be owner-only."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    assert re.search(r"chmod\s+700\s+/data/secrets\b", start_script)
+    for secret_file in (
+        "/data/secrets/session_secret",
+        "/data/secrets/encryption_key",
+        "/data/secrets/internal_api_secret",
+    ):
+        assert re.search(rf"chmod\s+600\s+{re.escape(secret_file)}\b", start_script)
+    assert re.search(
+        r"ENVEOF\s*\n\s*chmod\s+600\s+/app/backend/\.env\b", start_script
+    )
+
+
+def test_postgres_password_not_hardcoded_weak() -> None:
+    """The AIO database password must be persisted and absent from weak DSNs."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "postgresql://soundspan:soundspan@localhost" not in dockerfile
+    assert "/data/secrets/postgres_password" in dockerfile
+
+
+def test_postgres_listen_localhost_only() -> None:
+    """Embedded PostgreSQL must listen only on the container loopback interface."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "listen_addresses='*'" not in dockerfile
+    assert re.search(
+        r"listen_addresses=(?:'localhost'|127\.0\.0\.1)|"
+        r"-c\s+listen_addresses=127\.0\.0\.1",
+        dockerfile,
+    )
+
+
+def test_postgres_pg_hba_not_world_open() -> None:
+    """Embedded PostgreSQL authentication must be restricted to loopback clients."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "0.0.0.0/0" not in dockerfile
+    assert "127.0.0.1/32" in dockerfile
+
+
+def test_postgres_password_migration_for_existing_volumes() -> None:
+    """Startup must synchronize the password for new and existing database users."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    assert re.search(r"CREATE\s+USER\s+soundspan\b", start_script, re.IGNORECASE)
+    assert re.search(r"ALTER\s+USER\s+soundspan\b", start_script, re.IGNORECASE)
+
+
+def test_analyzer_tuning_env_is_parameterized() -> None:
+    """Analyzer worker and batch tuning must use exported supervisord values."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    supervisor_config = _heredoc(
+        dockerfile, "/etc/supervisor/conf.d/soundspan.conf"
+    )
+    analyzer = _program_block(supervisor_config, "audio-analyzer")
+    clap = _program_block(supervisor_config, "audio-analyzer-clap")
+
+    assert 'NUM_WORKERS="2"' not in analyzer
+    assert "%(ENV_NUM_WORKERS)s" in analyzer
+    assert "%(ENV_BATCH_SIZE)s" in analyzer
+    assert re.search(r"%\(ENV_[A-Z0-9_]*WORKERS?[A-Z0-9_]*\)s", clap)
+
+
+def test_every_supervisord_env_placeholder_is_exported() -> None:
+    """Every supervisord ENV placeholder must be guaranteed before supervisor starts."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+    before_supervisord = start_script[: start_script.index("/usr/bin/supervisord")]
+    placeholders = set(re.findall(r"%\(ENV_([A-Z0-9_]+)\)s", dockerfile))
+    start_script_exports = {
+        "INTERNAL_API_SECRET",
+        "SESSION_SECRET",
+        "SETTINGS_ENCRYPTION_KEY",
+        "DATABASE_URL",
+        "REDIS_URL",
+        "MUSIC_PATH",
+    }
+
+    for name in placeholders:
+        assigned = re.search(
+            rf"(?m)^\s*(?:export\s+)?{re.escape(name)}=", before_supervisord
+        )
+        assert assigned is not None or name in start_script_exports, name
+
+
+def test_start_sh_maps_aio_tuning_names() -> None:
+    """Startup must map deployment tuning names to analyzer runtime variables."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    start_script = _heredoc(dockerfile, "/app/start.sh")
+
+    assert "AUDIO_ANALYSIS_WORKERS" in start_script
+    assert "AUDIO_ANALYSIS_BATCH_SIZE" in start_script
+    assert "AUDIO_BRPOP_TIMEOUT" in start_script
+    assert "AUDIO_MODEL_IDLE_TIMEOUT" in start_script
+
+
+def test_no_hf_token_build_secret() -> None:
+    """The public CLAP download must not retain a dead build-secret contract."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "hf_token" not in dockerfile
+    assert "HF_TOKEN" not in dockerfile
+    assert "/run/secrets/hf_token" not in dockerfile
+    assert (
+        "fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd"
+        in dockerfile
+    )
+
+
+def test_apt_update_install_same_layer() -> None:
+    """Every apt install must refresh package indexes in the same RUN layer."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    install_blocks = [
+        block for block in _run_blocks(dockerfile) if "apt-get install" in block
+    ]
+
+    assert install_blocks
+    for block in install_blocks:
+        assert "apt-get update" in block, block
+
+
+def test_frontend_startup_not_race_based() -> None:
+    """Frontend startup must not depend on an arbitrary fixed sleep."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    supervisor_config = _heredoc(
+        dockerfile, "/etc/supervisor/conf.d/soundspan.conf"
+    )
+    frontend = _program_block(supervisor_config, "frontend")
+
+    assert "sleep 10" not in frontend
+
+
+def test_healthcheck_observes_backend() -> None:
+    """Container health must aggregate frontend and backend readiness."""
+    healthcheck = HEALTHCHECK.read_text(encoding="utf-8")
+
+    assert "3030" in healthcheck
+    assert "3006" in healthcheck
+    assert "/health/ready" in healthcheck
+
+
+def test_compose_passes_encryption_key_and_internal_secret() -> None:
+    """Compose must pass optional operator secrets through with empty defaults."""
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert "SESSION_SECRET=${SESSION_SECRET:-}" in compose
+    assert "SETTINGS_ENCRYPTION_KEY=${SETTINGS_ENCRYPTION_KEY:-}" in compose
+    assert "INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}" in compose
+    assert "SETTINGS_ENCRYPTION_KEY=${SETTINGS_ENCRYPTION_KEY:?" not in compose
+    assert "INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?" not in compose
+
+
+def test_compose_engine_mode_comment_lists_native() -> None:
+    """The compose engine-mode guidance must mention the native runtime option."""
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+    setting = compose.index("STREAMING_ENGINE_MODE")
+    nearby_comment = compose[max(0, setting - 300) : setting + 300].lower()
+
+    assert "native" in nearby_comment
+
+
+def test_chart_probes_use_aggregated_healthcheck() -> None:
+    """All chart probes must execute the shared healthcheck after startup gating."""
+    deployment = CHART_DEPLOYMENT.read_text(encoding="utf-8")
+
+    assert "/app/healthcheck.js" in deployment
+    assert "startupProbe" in deployment
+    assert "exec:" in deployment


### PR DESCRIPTION
## AIO image hardening (refactor slice P14)

Hardens the All-in-One image so it is stable, least-privilege, and secure-by-default, and aligns its secret bootstrap with the split-stack semantics from slice P4 (#232) so both deployment shapes feel like one system.

### Findings fixed (from the refactor plan)
- **Services ran as root.** Backend, frontend, and both Python analyzers now run under supervisord as a fixed non-root user `soundspan` (uid/gid 1000). supervisord stays root only to spawn the per-service users; postgres/redis keep their own users. The entrypoint chowns `/data/cache`, `/data/secrets`, and `/app/backend/logs` to uid 1000 on every boot — an automatic migration for existing volumes. A writable `HOME` (`/data/cache/home`) is set so the ML runtimes' caches work non-root.
- **Master secrets written world-readable.** The backend `.env` and `/data/secrets/*` are now mode `0600` (uid 1000); `/data/secrets` is `0700`.
- **AIO ignored operator secrets (dead compose/chart wiring).** The image now honors operator-supplied `SESSION_SECRET` / `SETTINGS_ENCRYPTION_KEY` / `INTERNAL_API_SECRET` with precedence **env → persisted `/data/secrets` file → generated**, and writes an operator value through to `/data/secrets` for continuity. Startup fails fast (naming the key) on published-default values or a `SESSION_SECRET` shorter than 32 chars — mirroring the P4 entrypoint semantics. `docker-compose.aio.yml` now forwards all three secrets (empty = generate; not the split-stack `:?` fail-fast form, because AIO generates).
- **Postgres hardcoded weak creds + open network.** A strong password is generated once and persisted to `/data/secrets/postgres_password` (operator `POSTGRES_PASSWORD` honored); existing volumes are synchronized with `ALTER USER` on boot. Postgres listens on loopback only (config + `-c listen_addresses=127.0.0.1` on the supervisord command) and `pg_hba` allows only `127.0.0.1/32` + `::1/128` with `scram-sha-256`. World-open host lines are stripped from pre-existing volumes on boot. (Was: password `soundspan`, `listen_addresses='*'`, `host all all 0.0.0.0/0`.)
- **Health only watched the frontend.** The container HEALTHCHECK and the Helm k8s probes now observe backend readiness (`/health/ready` on 3006) **and** the frontend via one shared `healthcheck.js`. The chart uses `exec` liveness/readiness probes plus a `startupProbe` (generous budget for first-boot migrations), so a dead backend/DB is no longer reported healthy.
- **Chart AIO analyzer tuning was a no-op.** `aio.env` (`AUDIO_ANALYSIS_WORKERS`, `…_THREADS_PER_WORKER`, `…_BATCH_SIZE`, `AUDIO_BRPOP_TIMEOUT`, `AUDIO_MODEL_IDLE_TIMEOUT`, `AUDIO_REDIS_SOCKET_TIMEOUT`, `CLAP_REDIS_SOCKET_TIMEOUT`) is now effective: the entrypoint maps these deployment names to the analyzer runtime variables, supervisord reads them via `%(ENV_*)s`, and the launcher inherits the full environment (previously dropped by a minimal-env `exec` and overridden by hardcoded supervisord values).
- **Dead HF_TOKEN build secret.** Removed from the AIO and CLAP Dockerfiles (the `HF_TOKEN=$(cat …)` prefix only applied to the following `echo`, never the `curl`, so the authenticated branch could never run). The model is public and remains sha256-verified.
- **Dockerfile layer hygiene.** Merged the split apt `update`/`install` into one RUN; removed the frontend `sleep 10` startup race (the proxy already returns 503 while the backend starts); corrected the stale streaming-engine comment in the AIO compose file.

### Tests
- New hermetic file-contract tests (static parsing, no build/helm/network):
  - `tests/test_aio_image_hardening.py` (20 tests): non-root users, secret precedence/write-through/perms/fail-fast, Postgres lockdown + password migration, analyzer-tuning parameterization, a guard that **every** `%(ENV_*)s` placeholder is exported before supervisord starts, HF_TOKEN removal, apt-layer hygiene, frontend race, aggregated healthcheck, compose secret passthrough, chart exec-probes + startupProbe.
  - `services/audio-analyzer-clap/tests/test_dockerfile_hardening.py` (3 tests): no HF_TOKEN, sha256 retained, non-root.
- All 23 pass. `bash -n` on the embedded `start.sh` / `wait-for-db.sh` and `node --check healthcheck-prod.js` pass.

### Verification (config-only, no image builds per constraints)
- `docker compose -f docker-compose.aio.yml config` — PASS.
- `helm lint charts/soundspan --set deploymentMode=aio` — PASS; `helm template` renders valid YAML and confirms operator `aio.env` secret + analyzer-tuning overrides flow through and exec probes + startupProbe render.

### Breaking changes / UPGRADING
No manual steps for a routine upgrade — all migrations are automatic and secret precedence is backward compatible. See the new **All-in-One (AIO) image hardening** section in `docs/UPGRADING.md` for bind-mount uid/gid 1000 requirements, the automatic Postgres password rotation, and the health-behavior change (a genuine backend/DB failure now restarts the container/pod).

### Deferred / escalations
- `charts/…/aio.gpu.enabled` remains a no-op; wiring it is **deferred to the `helm-chart-hardening` slice** per the plan's riskNotes (not in this slice).
- Full end-to-end image **boot** testing (long build) is out of scope for this config-only verification and is recommended before release, per the plan's riskNotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24
