### PR TITLE
fix(sidecars): event-loop reliability (refactor slice P9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python sidecar (tidal-downloader, ytmusic-streamer) HTTP error responses now
+  use the backend-wide `{"error": ...}` body shape instead of FastAPI's default
+  `{"detail": ...}`; unhandled sidecar exceptions return a generic 500 without
+  leaking internals, and nested error payloads (e.g. `age_restricted`) keep
+  their existing fields. The Node backend only branches on status codes, so no
+  backend change was needed.
+- ytmusic-streamer stream proxying no longer leaks an httpx connection when the
+  upstream Range request fails before streaming starts, and the `/yt/proxy`
+  route no longer forwards upstream `Content-Length` (which crashed the ASGI
+  app with an h11 protocol error whenever the CDN dropped a stream mid-read);
+  both proxy routes now share one hardened range/full-proxy helper.
+- tidal-downloader album-track pagination can no longer loop forever when the
+  TIDAL API echoes a zero/missing page `limit`; the loop advances by the real
+  page length under a fixed hard cap.
+- ytmusic-streamer rate pacing is now genuinely thread-safe (a shared
+  monotonic-clock pacer replaces a never-acquired asyncio.Lock and racy global
+  timestamp), the in-memory stream/search caches are bounded
+  (`YTMUSIC_STREAM_CACHE_MAX` / `YTMUSIC_SEARCH_CACHE_MAX`, default 1024, oldest
+  evicted), and the two near-duplicate yt-dlp extraction paths were merged into
+  one shared core.
+- ytmusic-streamer route handlers no longer run blocking ytmusicapi network
+  calls on the asyncio event loop (a slow YouTube call stalled every concurrent
+  request); search, album/artist/song, library, charts, moods, home, browse,
+  and playlist handlers now offload to worker threads.
+- ytmusic-streamer stream-URL extraction now has an overall per-request
+  deadline (`YTMUSIC_EXTRACT_TIMEOUT`, default 60s, HTTP 504 on expiry) and a
+  configurable yt-dlp socket timeout (`YTMUSIC_YTDLP_SOCKET_TIMEOUT`, default
+  20s) covering extraction and downloads, so a stalled extraction can no longer
+  hang a request or strand its worker thread forever.
 - The three backend audio-analyzer source-contract suites
   (`audioAnalyzerQueueContract`, `audioAnalyzerPoolRecoveryContract`,
   `audioAnalyzerFailureResolutionContract`) were updated in step with the

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -164,7 +164,11 @@ Experimental feature note:
 | `YTMUSIC_BATCH_DELAY_MAX` | `ytmusic-streamer` | Optional | `1.0` | Max delay between batched search calls (seconds). |
 | `YTMUSIC_EXTRACT_DELAY_MIN` | `ytmusic-streamer` | Optional | `0.5` | Min delay between stream extraction calls (seconds). |
 | `YTMUSIC_EXTRACT_DELAY_MAX` | `ytmusic-streamer` | Optional | `2.0` | Max delay between stream extraction calls (seconds). |
+| `YTMUSIC_EXTRACT_TIMEOUT` | `ytmusic-streamer` | Optional | `60` | Overall per-request deadline (seconds) for yt-dlp stream-URL extraction; on expiry the request fails fast with HTTP 504 instead of hanging. |
+| `YTMUSIC_YTDLP_SOCKET_TIMEOUT` | `ytmusic-streamer` | Optional | `20` | yt-dlp `socket_timeout` (seconds) bounding individual network reads during extraction and downloads, so a stalled worker thread eventually frees. |
 | `YTMUSIC_SEARCH_CACHE_TTL` | `ytmusic-streamer` | Optional | `300` | Search cache TTL in seconds (`0` disables cache). |
+| `YTMUSIC_SEARCH_CACHE_MAX` | `ytmusic-streamer` | Optional | `1024` | Max in-memory search-cache entries; the oldest are evicted past this bound to cap memory. |
+| `YTMUSIC_STREAM_CACHE_MAX` | `ytmusic-streamer` | Optional | `1024` | Max in-memory stream-URL cache entries; the oldest are evicted past this bound to cap memory. |
 | `YTMUSIC_SEARCH_MODE` | `ytmusic-streamer` | Optional | `auto` | Search strategy: `auto` (native-first with per-user TV fallback on #813 invalid-argument errors), `tv` (legacy TV parser), or `native` (`ytmusicapi` `yt.search()` only). |
 | `YTMUSIC_LANGUAGE` | `ytmusic-streamer` | Optional | `en` | BCP-47 language code forwarded to all `YTMusic()` client instances; controls the language of shelf titles and content descriptions regardless of the server's geo-IP locale. |
 | `YTMUSIC_HOME_FILTERED_SHELVES` | `ytmusic-streamer` | Optional | `Quick picks` | Comma-separated, case-insensitive list of shelf titles to exclude from `/home` responses. |

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -11,7 +11,7 @@ from typing import Optional
 import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
 
@@ -131,3 +131,86 @@ def build_stream_proxy_client(user_agent: Optional[str] = None) -> httpx.AsyncCl
     if user_agent is not None:
         client_kwargs["headers"] = {"User-Agent": user_agent}
     return httpx.AsyncClient(**client_kwargs)
+
+
+async def build_range_proxy_response(
+    stream_url: str,
+    request_headers: dict[str, str],
+    content_type: str,
+    user_agent: str,
+    logger: logging.Logger,
+    log_context: str,
+) -> StreamingResponse:
+    """Proxy a Range request to an upstream CDN as a streaming response.
+
+    Own the httpx client for the full stream. If the initial send fails, close
+    the client before re-raising. Content-Length is intentionally not forwarded
+    to avoid h11 declared-length errors on mid-stream drops. The upstream and
+    client are closed in a finally block on every streaming path.
+    """
+    client = build_stream_proxy_client(user_agent=user_agent)
+    try:
+        upstream = await client.send(
+            client.build_request("GET", stream_url, headers=request_headers),
+            stream=True,
+        )
+    except Exception:
+        await client.aclose()
+        raise
+
+    response_headers = {"Content-Type": content_type, "Accept-Ranges": "bytes"}
+    if "content-range" in upstream.headers:
+        response_headers["Content-Range"] = upstream.headers["content-range"]
+
+    async def range_stream():
+        try:
+            async for chunk in upstream.aiter_bytes(chunk_size=65536):
+                yield chunk
+        except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as exc:
+            logger.warning(
+                "Upstream read error during range stream for %s: %s",
+                log_context,
+                exc,
+            )
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    return StreamingResponse(
+        range_stream(),
+        status_code=upstream.status_code,
+        headers=response_headers,
+    )
+
+
+def build_full_proxy_response(
+    stream_url: str,
+    request_headers: dict[str, str],
+    content_type: str,
+    user_agent: str,
+    logger: logging.Logger,
+    log_context: str,
+) -> StreamingResponse:
+    """Proxy a non-range GET to an upstream CDN as a streaming response.
+
+    The client closes when iteration ends. Upstream errors are logged and end
+    the stream gracefully.
+    """
+
+    async def stream_audio():
+        async with build_stream_proxy_client(user_agent=user_agent) as client:
+            try:
+                async with client.stream(
+                    "GET", stream_url, headers=request_headers
+                ) as response:
+                    async for chunk in response.aiter_bytes(chunk_size=65536):
+                        yield chunk
+            except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as exc:
+                logger.error("Upstream stream error for %s: %s", log_context, exc)
+                return
+
+    return StreamingResponse(
+        stream_audio(),
+        media_type=content_type,
+        headers={"Accept-Ranges": "bytes", "Cache-Control": "no-cache"},
+    )

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import hmac
+import logging
 import os
 import re
 from typing import Optional
 
 import httpx
-from fastapi import HTTPException, Request
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
 
 DEFAULT_STREAM_CONNECT_TIMEOUT = 30.0
 DEFAULT_STREAM_READ_TIMEOUT = 300.0
@@ -17,6 +22,55 @@ _KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me"
 # Prisma cuids (the only user_id the backend ever sends) are alphanumeric;
 # this also rejects any `/`, `.`, or `%` that could escape DATA_PATH.
 _USER_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def register_error_handlers(app: FastAPI, logger: logging.Logger) -> None:
+    """Register consistent, sanitized JSON error responses for a sidecar app."""
+
+    @app.exception_handler(StarletteHTTPException)
+    async def handle_http_exception(
+        _request: Request,
+        exc: StarletteHTTPException,
+    ) -> JSONResponse:
+        detail = exc.detail
+        if isinstance(detail, dict):
+            body = detail
+        elif isinstance(detail, str):
+            body = {"error": detail}
+        else:
+            body = {"error": str(detail)}
+        return JSONResponse(
+            body,
+            status_code=exc.status_code,
+            headers=getattr(exc, "headers", None),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def handle_validation_error(
+        _request: Request,
+        _exc: RequestValidationError,
+    ) -> JSONResponse:
+        return JSONResponse(
+            {"error": "Invalid request parameters"},
+            status_code=422,
+        )
+
+    @app.exception_handler(Exception)
+    async def handle_unhandled_error(
+        request: Request,
+        exc: Exception,
+    ) -> JSONResponse:
+        logger.error(
+            "Unhandled error on %s %s: %s",
+            request.method,
+            request.url.path,
+            exc,
+            exc_info=True,
+        )
+        return JSONResponse(
+            {"error": "Internal Server Error"},
+            status_code=500,
+        )
 
 
 def require_internal_secret(request: Request) -> None:

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import hmac
 import logging
 import os
+import random
 import re
+import threading
+import time
 from typing import Optional
 
 import httpx
@@ -22,6 +25,37 @@ _KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me"
 # Prisma cuids (the only user_id the backend ever sends) are alphanumeric;
 # this also rejects any `/`, `.`, or `%` that could escape DATA_PATH.
 _USER_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+class ThreadSafeRatePacer:
+    """Serialize rate-limited work across threads with a randomized minimum gap.
+
+    ``wait()`` blocks the calling thread until at least a random delay in
+    ``[min_delay, max_delay]`` has elapsed since the previously reserved slot,
+    then reserves the next slot. State is guarded by a ``threading.Lock``
+    because asyncio locks are not thread-safe. Monotonic time prevents wall-
+    clock jumps from distorting pacing. Returns the seconds slept.
+    """
+
+    def __init__(self, min_delay: float, max_delay: float) -> None:
+        self._min = float(min_delay)
+        self._max = float(max_delay)
+        if not 0 <= self._min <= self._max:
+            raise ValueError("rate-pacing delays must satisfy 0 <= min <= max")
+        self._lock = threading.Lock()
+        self._next_allowed = 0.0
+
+    def wait(self) -> float:
+        """Wait for and reserve the next rate-limited work slot."""
+        with self._lock:
+            now = time.monotonic()
+            gap = random.uniform(self._min, self._max)
+            start_at = max(self._next_allowed, now)
+            self._next_allowed = start_at + gap
+            sleep_for = start_at - now
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+        return sleep_for
 
 
 def register_error_handlers(app: FastAPI, logger: logging.Logger) -> None:

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -1108,18 +1108,29 @@ async def search(
 
 # ── Download ────────────────────────────────────────────────────────
 
+_ALBUM_PAGE_HARD_CAP = 1000
+
+
 def _get_album_tracks(api: TidalAPI, album_id: int) -> list[Any]:
-    """Fetch all downloadable tracks for an album."""
+    """Fetch downloadable album tracks with bounded offset pagination."""
+    assert album_id is not None
+
     tracks = []
     offset = 0
-    while True:
-        items = api.get_album_items(album_id, limit=100, offset=offset)
-        for album_item in items.items:
+    page_size = 100
+    for _ in range(_ALBUM_PAGE_HARD_CAP):
+        items = api.get_album_items(album_id, limit=page_size, offset=offset)
+        page = list(getattr(items, "items", None) or [])
+        for album_item in page:
             if hasattr(album_item, "item") and hasattr(album_item.item, "isrc"):
                 tracks.append(album_item.item)
-        offset += items.limit
-        if offset >= items.totalNumberOfItems:
-            return tracks
+        if not page:
+            break
+        offset += len(page)
+        total = getattr(items, "totalNumberOfItems", 0) or 0
+        if offset >= total:
+            break
+    return tracks
 
 
 async def _download_album_tracks(

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -38,6 +38,7 @@ from common.logging_utils import configure_service_logger
 from common.sidecar_runtime_utils import (
     build_stream_proxy_client,
     env_float,
+    register_error_handlers,
     require_internal_secret,
 )
 
@@ -94,6 +95,7 @@ app = FastAPI(
     redoc_url=None,
     openapi_url=None,
 )
+register_error_handlers(app, log)
 
 # ── Paths ───────────────────────────────────────────────────────────
 TIDDL_PATH = Path(os.getenv("TIDDL_PATH", "/data/.tiddl"))

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -101,10 +101,6 @@ register_error_handlers(app, log)
 TIDDL_PATH = Path(os.getenv("TIDDL_PATH", "/data/.tiddl"))
 MUSIC_PATH = Path(os.getenv("MUSIC_PATH", "/music"))
 
-# ── In-memory API instance (initialised on first use) ──────────────
-_tidal_api: Optional[TidalAPI] = None
-_api_lock = asyncio.Lock()
-
 # ── Per-user API instances for streaming ───────────────────────────
 _user_apis: dict[str, TidalAPI] = {}
 _user_api_locks: dict[str, asyncio.Lock] = {}

--- a/services/tidal-downloader/tests/test_admin_token_headers.py
+++ b/services/tidal-downloader/tests/test_admin_token_headers.py
@@ -113,7 +113,7 @@ async def test_search_missing_token_rejected(client, api_recorder):
     resp = await client.post("/search", json={"query": "q"})
 
     assert resp.status_code == 401
-    assert resp.json()["detail"] == "access_token required"
+    assert resp.json()["error"] == "access_token required"
 
 
 @pytest.mark.anyio
@@ -135,7 +135,7 @@ async def test_download_track_missing_token_rejected(client, api_recorder):
     resp = await client.post("/download/track", json={"track_id": 1})
 
     assert resp.status_code == 401
-    assert resp.json()["detail"] == "access_token required"
+    assert resp.json()["error"] == "access_token required"
 
 
 @pytest.mark.anyio
@@ -158,4 +158,4 @@ async def test_download_album_missing_token_rejected(client, api_recorder):
     resp = await client.post("/download/album", json={"album_id": 2})
 
     assert resp.status_code == 401
-    assert resp.json()["detail"] == "access_token required"
+    assert resp.json()["error"] == "access_token required"

--- a/services/tidal-downloader/tests/test_album_pagination.py
+++ b/services/tidal-downloader/tests/test_album_pagination.py
@@ -1,0 +1,84 @@
+"""Album track pagination regression tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _album_items(count: int, start: int = 0) -> list[SimpleNamespace]:
+    """Build album items containing downloadable tracks."""
+    return [
+        SimpleNamespace(
+            item=SimpleNamespace(isrc=f"US{number:010d}", id=number, title="t")
+        )
+        for number in range(start, start + count)
+    ]
+
+
+def test_paginates_all_pages():
+    """Pagination returns every track and requests each page once."""
+    import app
+
+    calls = []
+
+    def get_album_items(album_id, limit, offset):
+        calls.append((album_id, limit, offset))
+        page_lengths = {0: 100, 100: 100, 200: 50}
+        return SimpleNamespace(
+            items=_album_items(page_lengths[offset], offset),
+            limit=100,
+            totalNumberOfItems=250,
+        )
+
+    fake_api = SimpleNamespace(get_album_items=get_album_items)
+
+    tracks = app._get_album_tracks(fake_api, 123)
+
+    assert len(tracks) == 250
+    assert calls == [(123, 100, 0), (123, 100, 100), (123, 100, 200)]
+
+
+def test_zero_limit_does_not_infinite_loop():
+    """An echoed zero limit cannot prevent pagination from terminating."""
+    import app
+
+    calls = []
+
+    def get_album_items(album_id, limit, offset):
+        calls.append((album_id, limit, offset))
+        if len(calls) == 1:
+            page = _album_items(100)
+        elif len(calls) == 2:
+            page = []
+        else:
+            raise AssertionError("album pagination did not terminate")
+        return SimpleNamespace(
+            items=page,
+            limit=0,
+            totalNumberOfItems=10**9,
+        )
+
+    fake_api = SimpleNamespace(get_album_items=get_album_items)
+
+    tracks = app._get_album_tracks(fake_api, 123)
+
+    assert len(tracks) == 100
+    assert len(calls) <= 2
+
+
+def test_stops_on_empty_first_page():
+    """An empty first page terminates pagination immediately."""
+    import app
+
+    calls = []
+
+    def get_album_items(album_id, limit, offset):
+        calls.append((album_id, limit, offset))
+        return SimpleNamespace(items=[], limit=100, totalNumberOfItems=0)
+
+    fake_api = SimpleNamespace(get_album_items=get_album_items)
+
+    tracks = app._get_album_tracks(fake_api, 123)
+
+    assert tracks == []
+    assert len(calls) == 1

--- a/services/tidal-downloader/tests/test_browse_endpoints.py
+++ b/services/tidal-downloader/tests/test_browse_endpoints.py
@@ -742,7 +742,7 @@ class TestBrowsePlaylistDetailEndpoint:
             )
 
         assert resp.status_code == 502
-        assert resp.json()["detail"] == "Failed to load playlist"
+        assert resp.json()["error"] == "Failed to load playlist"
 
 
 class TestPublicBrowsePlaylistDetailEndpoint:
@@ -796,7 +796,7 @@ class TestPublicBrowsePlaylistDetailEndpoint:
             resp = await client.get("/browse/playlist/detail-uuid-123")
 
         assert resp.status_code == 502
-        assert resp.json()["detail"] == "Failed to load playlist"
+        assert resp.json()["error"] == "Failed to load playlist"
 
 
 class TestBrowseMixDetailEndpoint:

--- a/services/tidal-downloader/tests/test_error_shape.py
+++ b/services/tidal-downloader/tests/test_error_shape.py
@@ -1,0 +1,15 @@
+"""HTTP error response-shape contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_http_exception_uses_error_key(client):
+    """String HTTPException details are exposed through the error key."""
+    response = await client.post("/search", json={"query": "q"})
+
+    assert response.status_code == 401
+    assert response.json() == {"error": "access_token required"}
+    assert "detail" not in response.json()

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -26,9 +26,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Callable, Optional, Literal, cast
 
-import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from ytmusicapi import YTMusic, OAuthCredentials
 
@@ -38,7 +36,8 @@ if str(SERVICES_ROOT) not in sys.path:
 
 from common.logging_utils import configure_service_logger
 from common.sidecar_runtime_utils import (
-    build_stream_proxy_client,
+    build_full_proxy_response,
+    build_range_proxy_response,
     env_float,
     env_int,
     register_error_handlers,
@@ -1952,69 +1951,12 @@ async def proxy_stream(
     if request and "range" in request.headers:
         headers["Range"] = request.headers["range"]
 
-    async def stream_audio():
-        async with build_stream_proxy_client(user_agent=_USER_AGENT) as client:
-            try:
-                async with client.stream("GET", stream_url, headers=headers) as response:
-                    async for chunk in response.aiter_bytes(chunk_size=65536):
-                        yield chunk
-            except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as e:
-                log.error(f"Upstream stream error for {video_id}: {e}")
-                # Don't re-raise — just end the stream gracefully so the
-                # browser audio element can retry with a new Range request.
-                return
-
-    # For range requests, fetch upstream first to get headers
     if headers.get("Range"):
-        # IMPORTANT: Do NOT use `async with` for the client here.
-        # The client must stay alive for the entire duration of the stream,
-        # not just until the StreamingResponse object is created.  If we
-        # used `async with`, the `return` would exit the context manager,
-        # closing the client/connection before Starlette ever iterates
-        # the generator — causing an immediate ReadError on every request.
-        client = build_stream_proxy_client(user_agent=_USER_AGENT)
-        upstream = await client.send(
-            client.build_request("GET", stream_url, headers=headers),
-            stream=True,
+        return await build_range_proxy_response(
+            stream_url, headers, content_type, _USER_AGENT, log, video_id
         )
-        response_headers = {
-            "Content-Type": content_type,
-            "Accept-Ranges": "bytes",
-        }
-        if "content-range" in upstream.headers:
-            response_headers["Content-Range"] = upstream.headers["content-range"]
-        # NOTE: We intentionally do NOT forward Content-Length here.
-        # If the upstream drops mid-stream (ReadError), h11 enforces the
-        # declared length and raises "Too little data for declared
-        # Content-Length", crashing the ASGI app.  By omitting it,
-        # Starlette uses chunked transfer encoding, which allows the
-        # stream to end cleanly on error and lets the browser retry
-        # with a new Range request.
-
-        async def range_stream():
-            try:
-                async for chunk in upstream.aiter_bytes(chunk_size=65536):
-                    yield chunk
-            except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as e:
-                log.warning(f"Upstream read error during range stream for {video_id}: {e}")
-                # End the stream gracefully — the browser will retry
-            finally:
-                await upstream.aclose()
-                await client.aclose()
-
-        return StreamingResponse(
-            range_stream(),
-            status_code=upstream.status_code,
-            headers=response_headers,
-        )
-
-    return StreamingResponse(
-        stream_audio(),
-        media_type=content_type,
-        headers={
-            "Accept-Ranges": "bytes",
-            "Cache-Control": "no-cache",
-        },
+    return build_full_proxy_response(
+        stream_url, headers, content_type, _USER_AGENT, log, video_id
     )
 
 
@@ -2352,60 +2294,12 @@ async def yt_proxy_stream(
     if request and "range" in request.headers:
         headers["Range"] = request.headers["range"]
 
-    async def stream_audio():
-        async with build_stream_proxy_client(user_agent=_USER_AGENT) as client:
-            try:
-                async with client.stream("GET", stream_url, headers=headers) as response:
-                    async for chunk in response.aiter_bytes(chunk_size=65536):
-                        yield chunk
-            except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as e:
-                log.error(f"Upstream stream error for YT {video_id}: {e}")
-                return
-
     if headers.get("Range"):
-        client = build_stream_proxy_client(user_agent=_USER_AGENT)
-        try:
-            upstream = await client.send(
-                client.build_request("GET", stream_url, headers=headers),
-                stream=True,
-            )
-        except Exception:
-            # client.send failed before the StreamingResponse generator took
-            # ownership — close the client here or the connection leaks.
-            await client.aclose()
-            raise
-        response_headers = {
-            "Content-Type": content_type,
-            "Accept-Ranges": "bytes",
-        }
-        if "content-range" in upstream.headers:
-            response_headers["Content-Range"] = upstream.headers["content-range"]
-        if "content-length" in upstream.headers:
-            response_headers["Content-Length"] = upstream.headers["content-length"]
-
-        async def range_stream():
-            try:
-                async for chunk in upstream.aiter_bytes(chunk_size=65536):
-                    yield chunk
-            except (httpx.HTTPError, httpx.StreamError, httpx.ReadError) as e:
-                log.warning(f"Upstream read error during YT range stream for {video_id}: {e}")
-            finally:
-                await upstream.aclose()
-                await client.aclose()
-
-        return StreamingResponse(
-            range_stream(),
-            status_code=upstream.status_code,
-            headers=response_headers,
+        return await build_range_proxy_response(
+            stream_url, headers, content_type, _USER_AGENT, log, video_id
         )
-
-    return StreamingResponse(
-        stream_audio(),
-        media_type=content_type,
-        headers={
-            "Accept-Ranges": "bytes",
-            "Cache-Control": "no-cache",
-        },
+    return build_full_proxy_response(
+        stream_url, headers, content_type, _USER_AGENT, log, video_id
     )
 
 

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -41,6 +41,7 @@ from common.sidecar_runtime_utils import (
     build_stream_proxy_client,
     env_float,
     env_int,
+    register_error_handlers,
     require_internal_secret,
     validate_user_id,
 )
@@ -170,6 +171,7 @@ app = FastAPI(
     redoc_url=None,
     openapi_url=None,
 )
+register_error_handlers(app, log)
 
 # ── Paths ───────────────────────────────────────────────────────────
 DATA_PATH = Path(os.getenv("DATA_PATH", "/data"))

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -206,11 +206,7 @@ EXTRACT_DELAY_MIN = env_float("YTMUSIC_EXTRACT_DELAY_MIN", "0.5")
 EXTRACT_DELAY_MAX = env_float("YTMUSIC_EXTRACT_DELAY_MAX", "2.0")
 _extract_pacer = ThreadSafeRatePacer(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
 EXTRACT_TIMEOUT = env_float("YTMUSIC_EXTRACT_TIMEOUT", "60")
-_EXTRACT_CONCURRENCY = max(1, env_int("YTMUSIC_EXTRACT_CONCURRENCY", "4"))
-_extract_executor = ThreadPoolExecutor(
-    max_workers=_EXTRACT_CONCURRENCY,
-    thread_name_prefix="yt-extract",
-)
+YTDLP_SOCKET_TIMEOUT = env_float("YTMUSIC_YTDLP_SOCKET_TIMEOUT", "20")
 
 # Search result cache (in-memory, short TTL to reduce duplicate requests)
 _search_cache: dict[str, dict] = {}
@@ -823,7 +819,7 @@ def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
-        "socket_timeout": 30,
+        "socket_timeout": YTDLP_SOCKET_TIMEOUT,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -857,7 +853,7 @@ def _get_stream_url_sync(
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
-        "socket_timeout": 30,
+        "socket_timeout": YTDLP_SOCKET_TIMEOUT,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -874,23 +870,21 @@ def _get_stream_url_sync(
     )
 
 
-async def _extract_with_timeout(fn, *args):
-    """Run blocking stream extraction with an overall timeout.
+async def _extract_stream_info_bounded(func, *args) -> dict:
+    """Run a sync stream extraction off the event loop with an overall deadline.
 
-    Isolated from the shared default thread pool so a stalled yt-dlp cannot
-    starve other endpoints; on timeout the request fails fast with HTTP 504
-    instead of hanging.
+    asyncio.wait_for cancels the awaiting request after EXTRACT_TIMEOUT
+    seconds and maps it to HTTP 504. The orphaned worker thread cannot
+    hang forever: yt-dlp's socket_timeout bounds its network reads.
     """
-    loop = asyncio.get_running_loop()
     try:
         return await asyncio.wait_for(
-            loop.run_in_executor(_extract_executor, fn, *args),
-            timeout=EXTRACT_TIMEOUT,
+            asyncio.to_thread(func, *args), timeout=EXTRACT_TIMEOUT
         )
-    except asyncio.TimeoutError as exc:
+    except TimeoutError as error:
         raise HTTPException(
             status_code=504, detail="Stream extraction timed out"
-        ) from exc
+        ) from error
 
 
 def _tv_search(yt: YTMusic, query: str, filter: Optional[str] = None, limit: int = 20) -> list[dict]:
@@ -1839,7 +1833,7 @@ async def get_stream_info(video_id: str, user_id: str = Query(...), quality: str
     if user_id != "__public__":
         _get_ytmusic(user_id)
 
-    result = await _extract_with_timeout(
+    result = await _extract_stream_info_bounded(
         _get_stream_url_sync, user_id, video_id, quality
     )
     return {
@@ -1875,7 +1869,7 @@ async def proxy_stream(
     if user_id != "__public__":
         _get_ytmusic(user_id)
 
-    stream_info = await _extract_with_timeout(
+    stream_info = await _extract_stream_info_bounded(
         _get_stream_url_sync, user_id, video_id, quality
     )
     stream_url = stream_info["url"]
@@ -2226,7 +2220,7 @@ async def yt_proxy_stream(
     """
     video_id = _validate_video_id(video_id)
     quality = _validate_stream_quality(quality)
-    stream_info = await _extract_with_timeout(
+    stream_info = await _extract_stream_info_bounded(
         _get_yt_stream_url_sync, video_id, quality
     )
     stream_url = stream_info["url"]
@@ -2355,36 +2349,36 @@ def _yt_download_job_payload(job: dict) -> dict:
     }
 
 
-def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: str):
-    """
-    Blocking yt-dlp download executed in a worker thread. Updates the job
-    record via progress hooks (downloading -> processing -> completed).
-    """
-    import yt_dlp
+def _update_yt_download_progress(job: dict, update: dict, download_cancelled):
+    """Apply one yt-dlp progress update to a download job."""
+    if job.get("cancel_requested"):
+        raise download_cancelled("cancelled by user")
+    status = update.get("status")
+    if status == "downloading":
+        job["status"] = "downloading"
+        total = (
+            update.get("total_bytes")
+            or update.get("total_bytes_estimate")
+            or 0
+        )
+        downloaded = update.get("downloaded_bytes") or 0
+        if total > 0:
+            job["progress_pct"] = round(
+                min(99.0, downloaded * 100.0 / total), 1
+            )
+    elif status == "finished":
+        job["status"] = "processing"
+        job["progress_pct"] = max(float(job.get("progress_pct") or 0), 99.0)
 
-    video_id = job["video_id"]
-    _extract_pacer.wait()
 
-    def _progress_hook(d: dict):
-        # Abort an in-flight download when the job has been cancelled; yt-dlp
-        # propagates the exception out of extract_info().
-        if job.get("cancel_requested"):
-            raise yt_dlp.utils.DownloadCancelled("cancelled by user")
-        status = d.get("status")
-        if status == "downloading":
-            job["status"] = "downloading"
-            total = d.get("total_bytes") or d.get("total_bytes_estimate") or 0
-            downloaded = d.get("downloaded_bytes") or 0
-            if total > 0:
-                job["progress_pct"] = round(
-                    min(99.0, downloaded * 100.0 / total), 1
-                )
-        elif status == "finished":
-            # Raw media fetched — FFmpeg postprocessing (extract/convert,
-            # metadata, thumbnail) runs next.
-            job["status"] = "processing"
-            job["progress_pct"] = max(float(job.get("progress_pct") or 0), 99.0)
-
+def _build_yt_download_opts(
+    job: dict,
+    audio_format: str,
+    quality: str,
+    output_dir: str,
+    download_cancelled,
+) -> dict:
+    """Build yt-dlp options for a bounded audio download."""
     outtmpl = os.path.join(output_dir, "%(title)s [%(id)s].%(ext)s")
     postprocessors = [
         {
@@ -2400,7 +2394,10 @@ def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: st
         quality, PROXY_AUDIO_FORMAT_SELECTORS["HIGH"]
     )
 
-    ydl_opts = {
+    def _progress_hook(update: dict):
+        _update_yt_download_progress(job, update, download_cancelled)
+
+    return {
         "format": fmt,
         "outtmpl": outtmpl,
         "postprocessors": postprocessors,
@@ -2408,6 +2405,7 @@ def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: st
         "quiet": True,
         "no_warnings": True,
         "progress_hooks": [_progress_hook],
+        "socket_timeout": YTDLP_SOCKET_TIMEOUT,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -2420,32 +2418,18 @@ def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: st
         },
     }
 
-    url = f"https://www.youtube.com/watch?v={video_id}"
 
-    # Cancelled while still queued in the executor — never start the download.
-    if job.get("cancel_requested"):
-        job["status"] = "cancelled"
-        return
-
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-        info = ydl.extract_info(url, download=True)
-
-    if not info:
-        raise ValueError("Download failed — no info returned")
-
-    # Resolve the real output path from yt-dlp's info dict (postprocessors
-    # change the extension); fall back to the escaped-glob directory scan.
+def _complete_yt_download(
+    job: dict, info: dict, audio_format: str, output_dir: str
+) -> None:
+    """Resolve output metadata and mark a successful download completed."""
+    video_id = job["video_id"]
     filepath = resolve_download_filepath(info, audio_format)
     if not filepath:
         filepath = find_existing_download(output_dir, video_id)
     if not filepath:
         raise ValueError("Download completed but output file not found")
 
-    # Bulk (playlist/channel) downloads: stamp the source as artist/album so
-    # the channel's videos group under one artist instead of each video's own
-    # (often per-DJ) YouTube artist tag. Written via ffmpeg so the tagged files
-    # stay readable by the library scanner. Single-video downloads (no source)
-    # keep their native metadata.
     bulk_tags = bulk_album_metadata(job.get("source"), job.get("source_kind"))
     if bulk_tags:
         _stamp_audio_tags(filepath, bulk_tags)
@@ -2455,6 +2439,28 @@ def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: st
     job["progress_pct"] = 100.0
     job["status"] = "completed"
     log.info(f"YT download completed for {video_id}: {filepath}")
+
+
+def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: str):
+    """Run a blocking yt-dlp download and update its job record."""
+    import yt_dlp
+
+    video_id = job["video_id"]
+    _extract_pacer.wait()
+    ydl_opts = _build_yt_download_opts(
+        job, audio_format, quality, output_dir, yt_dlp.utils.DownloadCancelled
+    )
+    url = f"https://www.youtube.com/watch?v={video_id}"
+
+    if job.get("cancel_requested"):
+        job["status"] = "cancelled"
+        return
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+    if not info:
+        raise ValueError("Download failed — no info returned")
+    _complete_yt_download(job, info, audio_format, output_dir)
 
 
 async def _run_yt_download_job(job: dict, audio_format: str, quality: str, output_dir: str):
@@ -3013,7 +3019,6 @@ async def shutdown():
     _clean_stream_cache()
     _clean_search_cache()
     _ytmusic_instances.clear()
-    _extract_executor.shutdown(wait=False, cancel_futures=True)
     log.info("YouTube Music Streamer shutting down")
 
 

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -36,6 +36,7 @@ if str(SERVICES_ROOT) not in sys.path:
 
 from common.logging_utils import configure_service_logger
 from common.sidecar_runtime_utils import (
+    ThreadSafeRatePacer,
     build_full_proxy_response,
     build_range_proxy_response,
     env_float,
@@ -203,12 +204,12 @@ BATCH_DELAY_MAX = env_float("YTMUSIC_BATCH_DELAY_MAX", "1.0")
 # Delay range (seconds) between yt-dlp extractions.
 EXTRACT_DELAY_MIN = env_float("YTMUSIC_EXTRACT_DELAY_MIN", "0.5")
 EXTRACT_DELAY_MAX = env_float("YTMUSIC_EXTRACT_DELAY_MAX", "2.0")
-_extract_lock = asyncio.Lock()   # Serialize yt-dlp extractions
-_last_extract_time: float = 0.0  # Timestamp of last extraction
+_extract_pacer = ThreadSafeRatePacer(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
 
 # Search result cache (in-memory, short TTL to reduce duplicate requests)
 _search_cache: dict[str, dict] = {}
 SEARCH_CACHE_TTL = env_int("YTMUSIC_SEARCH_CACHE_TTL", "300")  # 5 minutes
+SEARCH_CACHE_MAX = env_int("YTMUSIC_SEARCH_CACHE_MAX", "1024")
 SEARCH_MODE = (os.getenv("YTMUSIC_SEARCH_MODE", "auto") or "auto").strip().lower()
 if SEARCH_MODE not in {"tv", "native", "auto"}:
     log.warning(
@@ -244,8 +245,15 @@ import random
 # Keys are "{user_id}:{video_id}" to isolate per-user sessions
 _stream_cache: dict[str, dict] = {}
 STREAM_CACHE_TTL = 5 * 60 * 60  # 5 hours (YouTube URLs expire at ~6h)
+STREAM_CACHE_MAX = env_int("YTMUSIC_STREAM_CACHE_MAX", "1024")
 TV_CLIENT_NAME = "TVHTML5"
 TV_CLIENT_VERSION = "7.20250101.00.00"
+
+
+def _bound_cache(cache: dict, max_size: int) -> None:
+    """Evict oldest entries until an insertion-ordered cache is bounded."""
+    while len(cache) > max_size:
+        cache.pop(next(iter(cache)))
 
 # ── YTMusic instances ────────────────────────────────────────────────
 # Per-user authenticated clients are used for user-private operations
@@ -708,80 +716,71 @@ def _is_issue_813_invalid_argument_error(err: Exception) -> bool:
     return any(marker in message for marker in markers)
 
 
-def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
-    """
-    Use yt-dlp to extract audio stream URL for a regular YouTube video.
-    Same as _get_stream_url_sync but targets youtube.com (not music.youtube.com)
-    and does not require OAuth authentication.
-    Returns dict with url, format, duration, expires_at.
+def _stream_extraction_http_error(
+    video_id: str, error_label: str, error: Exception
+) -> HTTPException:
+    """Convert an extraction failure to the existing sanitized HTTP error."""
+    error_str = str(error)
+    age_restricted = "Sign in to confirm your age" in error_str or (
+        "age" in error_str.lower() and "confirm" in error_str.lower()
+    )
+    if age_restricted:
+        log.error("%s failed: %s", error_label, error, exc_info=True)
+        return HTTPException(
+            status_code=451,
+            detail={
+                "error": "age_restricted",
+                "message": "This content requires age verification and cannot be streamed.",
+                "video_id": video_id,
+            },
+        )
+    return _sanitized_http_error(
+        error_label, error, 502, "Failed to extract stream"
+    )
+
+
+def _best_audio_stream_url(info: dict) -> Optional[str]:
+    """Return the direct URL or the highest-bitrate audio-only format URL."""
+    stream_url = info.get("url")
+    if stream_url:
+        return cast(str, stream_url)
+    audio_formats = [
+        item
+        for item in info.get("formats", [])
+        if item.get("acodec") != "none"
+        and item.get("vcodec") in ("none", None)
+    ]
+    audio_formats.sort(key=lambda item: item.get("abr", 0) or 0, reverse=True)
+    return audio_formats[0].get("url") if audio_formats else None
+
+
+def _extract_stream_info(
+    cache_key: str,
+    url: str,
+    ydl_opts: dict,
+    video_id: str,
+    error_label: str,
+) -> dict:
+    """Extract a yt-dlp audio URL through the shared paced cache workflow.
+
+    Performs cache lookup, paced extraction, result construction, cache store,
+    and sanitized error mapping for both YouTube stream paths.
     """
     import yt_dlp
 
-    cache_key = f"yt:{video_id}"
-
-    # Check cache first
     cached = _stream_cache.get(cache_key)
     if cached and cached.get("expires_at", 0) > time.time():
         log.debug(f"Stream URL cache hit for {cache_key}")
         return cached
-
-    # Enforce inter-extraction delay to avoid rapid-fire requests
-    global _last_extract_time
-    now = time.time()
-    elapsed = now - _last_extract_time
-    min_gap = random.uniform(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
-    if elapsed < min_gap:
-        sleep_time = min_gap - elapsed
-        log.debug(f"Throttling yt-dlp extraction by {sleep_time:.2f}s")
-        time.sleep(sleep_time)
-    _last_extract_time = time.time()
-
-    # Map quality to yt-dlp format selection (shared with /yt/info so the
-    # audioFormat hint matches what this proxy serves)
-    fmt = PROXY_AUDIO_FORMAT_SELECTORS.get(
-        quality, PROXY_AUDIO_FORMAT_SELECTORS["HIGH"]
-    )
-
-    ydl_opts = {
-        "format": fmt,
-        "quiet": True,
-        "no_warnings": True,
-        "extract_flat": False,
-        "http_headers": {
-            "User-Agent": _USER_AGENT,
-            "Accept-Language": "en-US,en;q=0.9",
-            "Referer": "https://www.youtube.com/",
-        },
-        "extractor_args": {
-            "youtube": {
-                "player_client": YT_PLAYER_CLIENTS,
-            },
-        },
-    }
-
-    url = f"https://www.youtube.com/watch?v={video_id}"
-
+    _extract_pacer.wait()
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=False)
-
             if not info:
                 raise ValueError("No info extracted")
-
-            stream_url = info.get("url")
-            if not stream_url:
-                formats = info.get("formats", [])
-                audio_formats = [
-                    f for f in formats
-                    if f.get("acodec") != "none" and f.get("vcodec") in ("none", None)
-                ]
-                if audio_formats:
-                    audio_formats.sort(key=lambda f: f.get("abr", 0) or 0, reverse=True)
-                    stream_url = audio_formats[0].get("url")
-
+            stream_url = _best_audio_stream_url(info)
             if not stream_url:
                 raise ValueError("No audio stream URL found")
-
             result = {
                 "url": stream_url,
                 "content_type": info.get("audio_ext", "m4a"),
@@ -792,71 +791,52 @@ def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
                 "abr": info.get("abr", 0),
                 "acodec": info.get("acodec", ""),
             }
-
             _stream_cache[cache_key] = result
-            log.debug(f"Extracted YT stream URL for {cache_key}: {result['acodec']} @ {result['abr']}kbps")
+            _clean_stream_cache()
+            _bound_cache(_stream_cache, STREAM_CACHE_MAX)
+            log.debug(
+                "Extracted stream URL for %s: %s @ %skbps",
+                cache_key,
+                result["acodec"],
+                result["abr"],
+            )
             return result
-
-    except Exception as e:
-        error_str = str(e)
-        if "Sign in to confirm your age" in error_str or (
-            "age" in error_str.lower() and "confirm" in error_str.lower()
-        ):
-            log.error(
-                "yt-dlp extraction failed for YT video %s: %s",
-                video_id,
-                e,
-                exc_info=True,
-            )
-            raise HTTPException(
-                status_code=451,
-                detail={
-                    "error": "age_restricted",
-                    "message": "This content requires age verification and cannot be streamed.",
-                    "video_id": video_id,
-                },
-            )
-
-        raise _sanitized_http_error(
-            f"yt-dlp extraction for YT video {video_id}",
-            e,
-            502,
-            "Failed to extract stream",
-        ) from e
+    except Exception as error:
+        raise _stream_extraction_http_error(
+            video_id, error_label, error
+        ) from error
 
 
-def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> dict:
-    """
-    Use yt-dlp to extract audio stream URL for a YouTube Music video.
-    Returns dict with url, format, duration, expires_at.
+def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
+    """Extract a cached audio stream URL for a regular YouTube video."""
+    fmt = PROXY_AUDIO_FORMAT_SELECTORS.get(
+        quality, PROXY_AUDIO_FORMAT_SELECTORS["HIGH"]
+    )
+    ydl_opts = {
+        "format": fmt,
+        "quiet": True,
+        "no_warnings": True,
+        "extract_flat": False,
+        "http_headers": {
+            "User-Agent": _USER_AGENT,
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://www.youtube.com/",
+        },
+        "extractor_args": {"youtube": {"player_client": YT_PLAYER_CLIENTS}},
+    }
+    return _extract_stream_info(
+        f"yt:{video_id}",
+        f"https://www.youtube.com/watch?v={video_id}",
+        ydl_opts,
+        video_id,
+        f"yt-dlp extraction for YT video {video_id}",
+    )
 
-    Rate-pacing measures:
-    - Realistic browser User-Agent in HTTP headers
-    - sleep_interval between yt-dlp requests
-    - Extraction serialized via _extract_lock with random inter-request delay
-    """
-    import yt_dlp
 
-    cache_key = f"{user_id}:{video_id}"
-
-    # Check cache first
-    cached = _stream_cache.get(cache_key)
-    if cached and cached.get("expires_at", 0) > time.time():
-        log.debug(f"Stream URL cache hit for {cache_key}")
-        return cached
-
-    # Enforce inter-extraction delay to avoid rapid-fire requests
-    global _last_extract_time
-    now = time.time()
-    elapsed = now - _last_extract_time
-    min_gap = random.uniform(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
-    if elapsed < min_gap:
-        sleep_time = min_gap - elapsed
-        log.debug(f"Throttling yt-dlp extraction by {sleep_time:.2f}s")
-        time.sleep(sleep_time)
-    _last_extract_time = time.time()
-
-    # Map quality to yt-dlp format selection
+def _get_stream_url_sync(
+    user_id: str, video_id: str, quality: str = "HIGH"
+) -> dict:
+    """Extract a cached audio stream URL for a YouTube Music video."""
     format_map = {
         "LOW": "ba[abr<=64]/worstaudio/ba",
         "MEDIUM": "ba[abr<=128]/ba[abr<=192]/ba",
@@ -870,87 +850,20 @@ def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> 
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
-        # ── Request safety ───────────────────────────────────────────
-        # Realistic browser headers so yt-dlp requests look like a
-        # normal Chrome session rather than a scripted extractor.
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
             "Referer": "https://music.youtube.com/",
         },
-        # Use the Android client for extraction — it exposes direct
-        # audio URLs more reliably and is less aggressively throttled.
-        "extractor_args": {
-            "youtube": {
-                "player_client": ["android_music"],
-            },
-        },
+        "extractor_args": {"youtube": {"player_client": ["android_music"]}},
     }
-
-    url = f"https://music.youtube.com/watch?v={video_id}"
-
-    try:
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(url, download=False)
-
-            if not info:
-                raise ValueError("No info extracted")
-
-            stream_url = info.get("url")
-            if not stream_url:
-                # Try to find audio format in formats list
-                formats = info.get("formats", [])
-                audio_formats = [
-                    f for f in formats
-                    if f.get("acodec") != "none" and f.get("vcodec") in ("none", None)
-                ]
-                if audio_formats:
-                    audio_formats.sort(key=lambda f: f.get("abr", 0) or 0, reverse=True)
-                    stream_url = audio_formats[0].get("url")
-
-            if not stream_url:
-                raise ValueError("No audio stream URL found")
-
-            result = {
-                "url": stream_url,
-                "content_type": info.get("audio_ext", "m4a"),
-                "duration": info.get("duration", 0),
-                "title": info.get("title", ""),
-                "artist": info.get("artist") or info.get("uploader", ""),
-                "expires_at": time.time() + STREAM_CACHE_TTL,
-                "abr": info.get("abr", 0),
-                "acodec": info.get("acodec", ""),
-            }
-
-            _stream_cache[cache_key] = result
-            log.debug(f"Extracted stream URL for {cache_key}: {result['acodec']} @ {result['abr']}kbps")
-            return result
-
-    except Exception as e:
-        error_str = str(e)
-        # Detect age-restricted content
-        if "Sign in to confirm your age" in error_str or "age" in error_str.lower() and "confirm" in error_str.lower():
-            log.error(
-                "yt-dlp extraction failed for %s: %s",
-                video_id,
-                e,
-                exc_info=True,
-            )
-            raise HTTPException(
-                status_code=451,
-                detail={
-                    "error": "age_restricted",
-                    "message": "This content requires age verification and cannot be streamed.",
-                    "video_id": video_id,
-                }
-            )
-
-        raise _sanitized_http_error(
-            f"yt-dlp extraction for {video_id}",
-            e,
-            502,
-            "Failed to extract stream",
-        ) from e
+    return _extract_stream_info(
+        f"{user_id}:{video_id}",
+        f"https://music.youtube.com/watch?v={video_id}",
+        ydl_opts,
+        video_id,
+        f"yt-dlp extraction for {video_id}",
+    )
 
 
 def _tv_search(yt: YTMusic, query: str, filter: Optional[str] = None, limit: int = 20) -> list[dict]:
@@ -1275,6 +1188,8 @@ def _set_cached_search(
         "results": results,
         "expires_at": time.time() + SEARCH_CACHE_TTL,
     }
+    _clean_search_cache()
+    _bound_cache(_search_cache, SEARCH_CACHE_MAX)
 
 
 def _search_once(
@@ -2408,18 +2323,7 @@ def _yt_download_sync(job: dict, audio_format: str, quality: str, output_dir: st
     import yt_dlp
 
     video_id = job["video_id"]
-
-    # Enforce inter-extraction delay to avoid rapid-fire requests —
-    # same pacing pattern as the stream-URL extraction paths.
-    global _last_extract_time
-    now = time.time()
-    elapsed = now - _last_extract_time
-    min_gap = random.uniform(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
-    if elapsed < min_gap:
-        sleep_time = min_gap - elapsed
-        log.debug(f"Throttling yt-dlp download by {sleep_time:.2f}s")
-        time.sleep(sleep_time)
-    _last_extract_time = time.time()
+    _extract_pacer.wait()
 
     def _progress_hook(d: dict):
         # Abort an in-flight download when the job has been cancelled; yt-dlp

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -1547,7 +1547,8 @@ async def search(req: SearchRequest, user_id: str = Query(...)):
       - native: force ytmusicapi yt.search()
     """
     try:
-        items, strategy = _search_with_mode_fallback(
+        items, strategy = await asyncio.to_thread(
+            _search_with_mode_fallback,
             user_id,
             req.query,
             req.filter,
@@ -1688,7 +1689,8 @@ async def get_album(browse_id: str, user_id: str = Query(...)):
             yt = _get_public_ytmusic("native")
             album = yt.get_album(browse_id)
         else:
-            album = _run_ytmusic_with_auth_retry(
+            album = await asyncio.to_thread(
+                _run_ytmusic_with_auth_retry,
                 user_id,
                 operation=f"get_album({browse_id})",
                 func=lambda yt: yt.get_album(browse_id),
@@ -1713,7 +1715,8 @@ async def get_artist(channel_id: str, user_id: str = Query(...)):
             yt = _get_public_ytmusic("native")
             artist = yt.get_artist(channel_id)
         else:
-            artist = _run_ytmusic_with_auth_retry(
+            artist = await asyncio.to_thread(
+                _run_ytmusic_with_auth_retry,
                 user_id,
                 operation=f"get_artist({channel_id})",
                 func=lambda yt: yt.get_artist(channel_id),
@@ -1770,7 +1773,8 @@ async def get_song(video_id: str, user_id: str = Query(...)):
             yt = _get_public_ytmusic("native")
             song = yt.get_song(video_id)
         else:
-            song = _run_ytmusic_with_auth_retry(
+            song = await asyncio.to_thread(
+                _run_ytmusic_with_auth_retry,
                 user_id,
                 operation=f"get_song({video_id})",
                 func=lambda yt: yt.get_song(video_id),
@@ -1881,7 +1885,8 @@ async def proxy_stream(
 async def library_songs(user_id: str = Query(...), limit: int = 100, order: str = "recently_added"):
     """Get user's liked/library songs from YouTube Music."""
     try:
-        songs = _run_ytmusic_with_auth_retry(
+        songs = await asyncio.to_thread(
+            _run_ytmusic_with_auth_retry,
             user_id,
             operation=f"get_library_songs(limit={limit}, order={order})",
             func=lambda yt: yt.get_library_songs(limit=limit, order=order),
@@ -1916,7 +1921,8 @@ async def library_songs(user_id: str = Query(...), limit: int = 100, order: str 
 async def library_albums(user_id: str = Query(...), limit: int = 100, order: str = "recently_added"):
     """Get user's saved albums from YouTube Music."""
     try:
-        albums = _run_ytmusic_with_auth_retry(
+        albums = await asyncio.to_thread(
+            _run_ytmusic_with_auth_retry,
             user_id,
             operation=f"get_library_albums(limit={limit}, order={order})",
             func=lambda yt: yt.get_library_albums(limit=limit, order=order),
@@ -1975,7 +1981,8 @@ async def library_playlists(
     excluding user-created playlists and special IDs like Liked Music.
     """
     try:
-        playlists = _run_ytmusic_with_auth_retry(
+        playlists = await asyncio.to_thread(
+            _run_ytmusic_with_auth_retry,
             user_id,
             operation=f"get_library_playlists(limit={limit})",
             func=lambda yt: yt.get_library_playlists(limit),
@@ -2615,8 +2622,9 @@ async def get_charts(country: str = "US", user_id: Optional[str] = Query(None)):
     with HTTP 400.
     """
     try:
-        yt = _get_public_ytmusic("native")
-        charts = yt.get_charts(country=country)
+        charts = await asyncio.to_thread(
+            lambda: _get_public_ytmusic("native").get_charts(country=country)
+        )
 
         result = {}
         # Extract top songs/videos if present
@@ -2652,8 +2660,9 @@ async def get_moods_and_genres(user_id: Optional[str] = Query(None)):
     sessions with HTTP 400.
     """
     try:
-        yt = _get_public_ytmusic("native")
-        categories = yt.get_mood_categories()
+        categories = await asyncio.to_thread(
+            lambda: _get_public_ytmusic("native").get_mood_categories()
+        )
 
         result = []
         for cat_title, cat_items in categories.items():
@@ -2683,8 +2692,9 @@ async def get_home(limit: int = Query(6, ge=1, le=20), user_id: Optional[str] = 
     with HTTP 400.
     """
     try:
-        yt = _get_public_ytmusic("native")
-        home = yt.get_home(limit=limit)
+        home = await asyncio.to_thread(
+            lambda: _get_public_ytmusic("native").get_home(limit=limit)
+        )
 
         shelves = []
         for shelf in home:
@@ -2739,8 +2749,9 @@ async def get_home(limit: int = Query(6, ge=1, le=20), user_id: Optional[str] = 
 async def get_browse_album(browse_id: str):
     """Get album details from YouTube Music (unauthenticated, public browse)."""
     try:
-        yt = _get_public_ytmusic("native")
-        album = yt.get_album(browse_id)
+        album = await asyncio.to_thread(
+            lambda: _get_public_ytmusic("native").get_album(browse_id)
+        )
         return _format_album_response(browse_id, album)
     except HTTPException:
         raise
@@ -2771,8 +2782,9 @@ async def get_mood_playlists(params: str = Query(..., min_length=1, max_length=5
         if not params:
             raise HTTPException(status_code=400, detail="params must be a non-empty string")
 
-        yt = _get_public_ytmusic("native")
-        playlists = _fetch_mood_playlists(yt, params)
+        playlists = await asyncio.to_thread(
+            lambda: _fetch_mood_playlists(_get_public_ytmusic("native"), params)
+        )
 
         result = []
         for item in playlists:
@@ -2822,7 +2834,8 @@ async def get_playlist(
     try:
         if user_id and user_id != "__public__":
             try:
-                playlist = _run_ytmusic_with_auth_retry(
+                playlist = await asyncio.to_thread(
+                    _run_ytmusic_with_auth_retry,
                     user_id,
                     operation=f"get_playlist({playlist_id})",
                     func=lambda yt: yt.get_playlist(playlist_id, limit=limit),

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -205,6 +205,12 @@ BATCH_DELAY_MAX = env_float("YTMUSIC_BATCH_DELAY_MAX", "1.0")
 EXTRACT_DELAY_MIN = env_float("YTMUSIC_EXTRACT_DELAY_MIN", "0.5")
 EXTRACT_DELAY_MAX = env_float("YTMUSIC_EXTRACT_DELAY_MAX", "2.0")
 _extract_pacer = ThreadSafeRatePacer(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
+EXTRACT_TIMEOUT = env_float("YTMUSIC_EXTRACT_TIMEOUT", "60")
+_EXTRACT_CONCURRENCY = max(1, env_int("YTMUSIC_EXTRACT_CONCURRENCY", "4"))
+_extract_executor = ThreadPoolExecutor(
+    max_workers=_EXTRACT_CONCURRENCY,
+    thread_name_prefix="yt-extract",
+)
 
 # Search result cache (in-memory, short TTL to reduce duplicate requests)
 _search_cache: dict[str, dict] = {}
@@ -817,6 +823,7 @@ def _get_yt_stream_url_sync(video_id: str, quality: str = "HIGH") -> dict:
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
+        "socket_timeout": 30,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -850,6 +857,7 @@ def _get_stream_url_sync(
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
+        "socket_timeout": 30,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -864,6 +872,25 @@ def _get_stream_url_sync(
         video_id,
         f"yt-dlp extraction for {video_id}",
     )
+
+
+async def _extract_with_timeout(fn, *args):
+    """Run blocking stream extraction with an overall timeout.
+
+    Isolated from the shared default thread pool so a stalled yt-dlp cannot
+    starve other endpoints; on timeout the request fails fast with HTTP 504
+    instead of hanging.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(_extract_executor, fn, *args),
+            timeout=EXTRACT_TIMEOUT,
+        )
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(
+            status_code=504, detail="Stream extraction timed out"
+        ) from exc
 
 
 def _tv_search(yt: YTMusic, query: str, filter: Optional[str] = None, limit: int = 20) -> list[dict]:
@@ -1812,7 +1839,9 @@ async def get_stream_info(video_id: str, user_id: str = Query(...), quality: str
     if user_id != "__public__":
         _get_ytmusic(user_id)
 
-    result = await asyncio.to_thread(_get_stream_url_sync, user_id, video_id, quality)
+    result = await _extract_with_timeout(
+        _get_stream_url_sync, user_id, video_id, quality
+    )
     return {
         "videoId": video_id,
         "url": result["url"],
@@ -1846,7 +1875,9 @@ async def proxy_stream(
     if user_id != "__public__":
         _get_ytmusic(user_id)
 
-    stream_info = await asyncio.to_thread(_get_stream_url_sync, user_id, video_id, quality)
+    stream_info = await _extract_with_timeout(
+        _get_stream_url_sync, user_id, video_id, quality
+    )
     stream_url = stream_info["url"]
 
     # Determine content type for the response
@@ -2195,7 +2226,9 @@ async def yt_proxy_stream(
     """
     video_id = _validate_video_id(video_id)
     quality = _validate_stream_quality(quality)
-    stream_info = await asyncio.to_thread(_get_yt_stream_url_sync, video_id, quality)
+    stream_info = await _extract_with_timeout(
+        _get_yt_stream_url_sync, video_id, quality
+    )
     stream_url = stream_info["url"]
 
     acodec = stream_info.get("acodec", "")
@@ -2980,6 +3013,7 @@ async def shutdown():
     _clean_stream_cache()
     _clean_search_cache()
     _ytmusic_instances.clear()
+    _extract_executor.shutdown(wait=False, cancel_futures=True)
     log.info("YouTube Music Streamer shutting down")
 
 

--- a/services/ytmusic-streamer/tests/test_blocking_offload.py
+++ b/services/ytmusic-streamer/tests/test_blocking_offload.py
@@ -1,0 +1,66 @@
+"""Tests that blocking YTMusic calls run outside the event-loop thread."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_search_offloaded_to_worker_thread(client, monkeypatch):
+    """Search work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def fake(*args, **kwargs):
+        captured["t"] = threading.current_thread().name
+        return [], "native"
+
+    monkeypatch.setattr(app, "_search_with_mode_fallback", fake)
+
+    response = await client.post("/search?user_id=u1", json={"query": "x"})
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_library_songs_offloaded_to_worker_thread(client, monkeypatch):
+    """Library-song work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def fake(user_id, operation, func):
+        captured["t"] = threading.current_thread().name
+        return []
+
+    monkeypatch.setattr(app, "_run_ytmusic_with_auth_retry", fake)
+
+    response = await client.get("/library/songs?user_id=u1")
+
+    assert response.status_code == 200
+    assert response.json() == {"songs": [], "total": 0}
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_charts_offloaded_to_worker_thread(client, monkeypatch):
+    """Charts work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+    public_client = types.SimpleNamespace(
+        get_charts=lambda country: (
+            captured.__setitem__("t", threading.current_thread().name) or {}
+        )
+    )
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/charts?country=US")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"

--- a/services/ytmusic-streamer/tests/test_error_sanitization.py
+++ b/services/ytmusic-streamer/tests/test_error_sanitization.py
@@ -140,7 +140,7 @@ def test_stream_extraction_error_sanitized(monkeypatch, caplog) -> None:
 
     yt_dlp_stub = SimpleNamespace(YoutubeDL=FailingYoutubeDL)
     monkeypatch.setitem(sys.modules, "yt_dlp", yt_dlp_stub)
-    monkeypatch.setattr(app, "_last_extract_time", 0)
+    monkeypatch.setattr(app._extract_pacer, "wait", lambda: 0.0)
     app._stream_cache.clear()
     caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
 

--- a/services/ytmusic-streamer/tests/test_error_shape.py
+++ b/services/ytmusic-streamer/tests/test_error_shape.py
@@ -1,0 +1,61 @@
+"""HTTP error response-shape contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+VALID_ID = "dQw4w9WgXcQ"
+
+
+@pytest.mark.anyio
+async def test_http_exception_uses_error_key(client):
+    """String HTTPException details are exposed through the error key."""
+    response = await client.get("/stream/bad?user_id=u1")
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid video_id"}
+    assert "detail" not in response.json()
+
+
+@pytest.mark.anyio
+async def test_unhandled_exception_returns_sanitized_error(client, monkeypatch):
+    """Unhandled exceptions return a generic body without leaking details."""
+    import app
+
+    def raise_unhandled(*_args, **_kwargs):
+        raise Exception("SECRET-LEAK-XYZ")
+
+    monkeypatch.setattr(app, "_get_stream_url_sync", raise_unhandled)
+    client._transport.raise_app_exceptions = False
+
+    response = await client.get(f"/stream/{VALID_ID}?user_id=__public__")
+
+    assert response.status_code == 500
+    assert response.json() == {"error": "Internal Server Error"}
+    assert "SECRET-LEAK-XYZ" not in response.text
+
+
+@pytest.mark.anyio
+async def test_nested_http_exception_detail_is_preserved(client, monkeypatch):
+    """Structured HTTPException details retain their top-level fields."""
+    import app
+
+    def raise_age_restricted(*_args, **_kwargs):
+        raise HTTPException(
+            status_code=451,
+            detail={
+                "error": "age_restricted",
+                "message": "m",
+                "video_id": "v",
+            },
+        )
+
+    monkeypatch.setattr(app, "_get_stream_url_sync", raise_age_restricted)
+
+    response = await client.get(f"/stream/{VALID_ID}?user_id=__public__")
+
+    assert response.status_code == 451
+    assert response.json()["error"] == "age_restricted"
+    assert response.json()["message"] == "m"

--- a/services/ytmusic-streamer/tests/test_extraction_timeout.py
+++ b/services/ytmusic-streamer/tests/test_extraction_timeout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import time
 
 import pytest
@@ -88,4 +89,23 @@ def test_ydl_opts_include_socket_timeout(monkeypatch):
     app._get_yt_stream_url_sync(VIDEO_ID, "HIGH")
 
     assert len(captured) == 2
-    assert all(opts["socket_timeout"] == 30 for opts in captured)
+    assert all(
+        opts["socket_timeout"] == app.YTDLP_SOCKET_TIMEOUT for opts in captured
+    )
+
+
+def test_download_sync_split():
+    """The download hot path and its extracted helpers stay below 60 lines."""
+    import app
+
+    split_functions = (
+        app._update_yt_download_progress,
+        app._build_yt_download_opts,
+        app._complete_yt_download,
+        app._yt_download_sync,
+    )
+
+    assert all(
+        len(inspect.getsource(function).splitlines()) < 60
+        for function in split_functions
+    )

--- a/services/ytmusic-streamer/tests/test_extraction_timeout.py
+++ b/services/ytmusic-streamer/tests/test_extraction_timeout.py
@@ -1,0 +1,91 @@
+"""Tests for bounded yt-dlp stream extraction."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+VIDEO_ID = "dQw4w9WgXcQ"
+
+
+@pytest.mark.anyio
+async def test_slow_extraction_returns_504(client, monkeypatch):
+    """A stalled YouTube Music extraction should return HTTP 504."""
+    import app
+
+    monkeypatch.setattr(app, "EXTRACT_TIMEOUT", 0.05)
+    monkeypatch.setattr(
+        app,
+        "_get_stream_url_sync",
+        lambda *args: (time.sleep(0.5), {})[1],
+    )
+
+    response = await client.get(f"/stream/{VIDEO_ID}?user_id=__public__")
+
+    assert response.status_code == 504
+    assert response.json()["error"] == "Stream extraction timed out"
+
+
+@pytest.mark.anyio
+async def test_yt_proxy_slow_extraction_returns_504(client, monkeypatch):
+    """A stalled regular YouTube extraction should return HTTP 504."""
+    import app
+
+    monkeypatch.setattr(app, "EXTRACT_TIMEOUT", 0.05)
+    monkeypatch.setattr(
+        app,
+        "_get_yt_stream_url_sync",
+        lambda *args: (time.sleep(0.5), {})[1],
+    )
+
+    response = await client.get(f"/yt/proxy/{VIDEO_ID}")
+
+    assert response.status_code == 504
+    assert response.json()["error"] == "Stream extraction timed out"
+
+
+@pytest.mark.anyio
+async def test_fast_extraction_unaffected(client, monkeypatch):
+    """A fast extraction should retain the existing success response."""
+    import app
+
+    monkeypatch.setattr(
+        app,
+        "_get_stream_url_sync",
+        lambda *args: {
+            "url": "http://cdn/x",
+            "content_type": "m4a",
+            "duration": 1,
+            "title": "t",
+            "artist": "a",
+            "expires_at": 9e9,
+            "abr": 128,
+            "acodec": "mp4a.40.2",
+        },
+    )
+
+    response = await client.get(f"/stream/{VIDEO_ID}?user_id=__public__")
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "http://cdn/x"
+
+
+def test_ydl_opts_include_socket_timeout(monkeypatch):
+    """Both stream extractors should bound yt-dlp socket operations."""
+    import app
+
+    captured = []
+
+    def fake_extract(cache_key, url, ydl_opts, video_id, error_label):
+        captured.append(ydl_opts)
+        return {"url": "http://cdn/x"}
+
+    monkeypatch.setattr(app, "_extract_stream_info", fake_extract)
+
+    app._get_stream_url_sync("u", VIDEO_ID, "HIGH")
+    app._get_yt_stream_url_sync(VIDEO_ID, "HIGH")
+
+    assert len(captured) == 2
+    assert all(opts["socket_timeout"] == 30 for opts in captured)

--- a/services/ytmusic-streamer/tests/test_input_validation.py
+++ b/services/ytmusic-streamer/tests/test_input_validation.py
@@ -49,7 +49,7 @@ async def test_stream_rejects_malformed_video_id(client, stream_recorder):
     for bad in ["short", "waytoolongvideoid123", "bad.chars!!x"]:
         response = await client.get(f"/stream/{bad}?user_id=__public__")
         assert response.status_code == 400
-        assert response.json()["detail"] == "Invalid video_id"
+        assert response.json()["error"] == "Invalid video_id"
         assert stream_recorder == []
 
 
@@ -68,7 +68,7 @@ async def test_stream_rejects_bad_quality(client, stream_recorder):
         f"/stream/{VALID_ID}?user_id=__public__&quality=bogus"
     )
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid quality"
+    assert response.json()["error"] == "Invalid quality"
     assert stream_recorder == []
 
 
@@ -87,7 +87,7 @@ async def test_proxy_rejects_malformed_video_id(client, stream_recorder):
     """The music proxy rejects a malformed ID before extraction."""
     response = await client.get("/proxy/bad.id!?user_id=__public__")
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid video_id"
+    assert response.json()["error"] == "Invalid video_id"
 
 
 @pytest.mark.anyio
@@ -97,7 +97,7 @@ async def test_proxy_rejects_bad_quality(client, stream_recorder):
         f"/proxy/{VALID_ID}?user_id=__public__&quality=ULTRA"
     )
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid quality"
+    assert response.json()["error"] == "Invalid quality"
 
 
 @pytest.mark.anyio
@@ -105,7 +105,7 @@ async def test_yt_proxy_rejects_malformed_video_id(client, stream_recorder):
     """The YouTube proxy rejects a malformed ID before extraction."""
     response = await client.get("/yt/proxy/nope")
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid video_id"
+    assert response.json()["error"] == "Invalid video_id"
 
 
 @pytest.mark.anyio
@@ -113,7 +113,7 @@ async def test_yt_proxy_rejects_bad_quality(client, stream_recorder):
     """The YouTube proxy rejects an unsupported quality before extraction."""
     response = await client.get(f"/yt/proxy/{VALID_ID}?quality=extreme")
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid quality"
+    assert response.json()["error"] == "Invalid quality"
 
 
 @pytest.mark.anyio
@@ -121,7 +121,7 @@ async def test_song_rejects_malformed_video_id(client):
     """The song route rejects a malformed ID before metadata extraction."""
     response = await client.get("/song/tiny?user_id=__public__")
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid video_id"
+    assert response.json()["error"] == "Invalid video_id"
 
 
 @pytest.mark.anyio

--- a/services/ytmusic-streamer/tests/test_pacing_and_cache.py
+++ b/services/ytmusic-streamer/tests/test_pacing_and_cache.py
@@ -1,0 +1,76 @@
+"""Thread-safe pacing and bounded-cache tests for ytmusic-streamer."""
+
+from __future__ import annotations
+
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+SERVICES_ROOT = Path(__file__).resolve().parents[2]
+if str(SERVICES_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICES_ROOT))
+
+from common.sidecar_runtime_utils import ThreadSafeRatePacer  # noqa: E402
+
+
+def test_pacer_is_thread_safe_and_serializes():
+    pacer = ThreadSafeRatePacer(0.02, 0.02)
+    started_at = time.monotonic()
+
+    def wait_and_record(_index: int) -> float:
+        pacer.wait()
+        return time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        completion_times = sorted(executor.map(wait_and_record, range(8)))
+
+    spacings = [
+        later - earlier
+        for earlier, later in zip(completion_times, completion_times[1:])
+    ]
+    assert all(spacing >= 0.015 for spacing in spacings)
+    assert completion_times[-1] - started_at >= 7 * 0.02 * 0.8
+
+
+def test_pacer_rejects_bad_bounds():
+    with pytest.raises(ValueError):
+        ThreadSafeRatePacer(1.0, 0.5)
+
+
+def test_stream_cache_is_bounded(monkeypatch):
+    import app
+
+    monkeypatch.setattr(app, "STREAM_CACHE_MAX", 3)
+    app._stream_cache.clear()
+    for index in range(5):
+        app._stream_cache[f"stream-{index}"] = {"expires_at": float("inf")}
+
+    app._bound_cache(app._stream_cache, app.STREAM_CACHE_MAX)
+
+    assert len(app._stream_cache) == 3
+    assert list(app._stream_cache) == ["stream-2", "stream-3", "stream-4"]
+
+
+def test_search_cache_cleanup_and_bound(monkeypatch):
+    import app
+
+    monkeypatch.setattr(app, "SEARCH_CACHE_MAX", 2)
+    app._search_cache.clear()
+    for query in ("q1", "q2", "q3"):
+        app._set_cached_search(
+            "u", query, None, 5, "native", [{"videoId": "a"}]
+        )
+
+    assert len(app._search_cache) <= 2
+
+
+def test_dead_lock_removed():
+    import app
+
+    assert not hasattr(app, "_extract_lock")
+    assert not hasattr(app, "_last_extract_time")
+    assert isinstance(app._extract_pacer, ThreadSafeRatePacer)

--- a/services/ytmusic-streamer/tests/test_playlist_auth_context.py
+++ b/services/ytmusic-streamer/tests/test_playlist_auth_context.py
@@ -98,7 +98,7 @@ async def test_playlist_returns_401_when_auth_is_invalid_and_public_fallback_als
         response = await client.get("/playlist/PLprivate123", params={"user_id": "user-1"})
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "OAuth credentials invalid"
+    assert response.json()["error"] == "OAuth credentials invalid"
 
 
 @pytest.mark.anyio
@@ -119,4 +119,4 @@ async def test_playlist_preserves_non_401_auth_http_errors_when_public_fallback_
         response = await client.get("/playlist/PLprivate403", params={"user_id": "user-1"})
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "OAuth lacks required scope"
+    assert response.json()["error"] == "OAuth lacks required scope"

--- a/services/ytmusic-streamer/tests/test_proxy_reliability.py
+++ b/services/ytmusic-streamer/tests/test_proxy_reliability.py
@@ -1,0 +1,144 @@
+"""Reliability regression tests for YouTube proxy streaming."""
+
+from __future__ import annotations
+
+import pytest
+
+
+VIDEO_ID = "dQw4w9WgXcQ"
+STREAM_INFO = {
+    "url": "http://cdn/x",
+    "acodec": "mp4a.40.2",
+    "content_type": "m4a",
+    "duration": 1,
+    "expires_at": 9e9,
+    "abr": 128,
+}
+
+
+class FakeUpstream:
+    """Minimal async streaming response used by the proxy tests."""
+
+    def __init__(self, headers, chunks, status_code=206):
+        self.headers = headers
+        self._chunks = chunks
+        self.status_code = status_code
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        await self.aclose()
+        return False
+
+    async def aiter_bytes(self, chunk_size=65536):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self):
+        self.closed = True
+
+
+class FakeClient:
+    """Minimal async httpx-like client used by the proxy tests."""
+
+    def __init__(self, upstream=None, raise_on_send=False):
+        self._up = upstream
+        self.raise_on_send = raise_on_send
+        self.closed = False
+
+    def build_request(self, method, url, headers=None):
+        return (method, url, headers)
+
+    async def send(self, request, stream=False):
+        if self.raise_on_send:
+            raise RuntimeError("send boom")
+        return self._up
+
+    def stream(self, method, url, headers=None):
+        return self._up
+
+    async def aclose(self):
+        self.closed = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        await self.aclose()
+        return False
+
+
+def _patch_stream_info(monkeypatch, app):
+    monkeypatch.setattr(app, "_get_stream_url_sync", lambda *_args: STREAM_INFO)
+    monkeypatch.setattr(app, "_get_yt_stream_url_sync", lambda *_args: STREAM_INFO)
+
+
+def _patch_client_factory(monkeypatch, app, fake_client):
+    factory = lambda user_agent=None: fake_client
+    monkeypatch.setattr(
+        "common.sidecar_runtime_utils.build_stream_proxy_client", factory
+    )
+    # The legacy routes imported the factory directly. This patch keeps the
+    # pre-refactor regression run bounded; shared-helper routes ignore it.
+    monkeypatch.setattr(app, "build_stream_proxy_client", factory, raising=False)
+
+
+@pytest.mark.anyio
+async def test_range_response_omits_content_length(client, monkeypatch):
+    import app
+
+    chunks = [b"range ", b"body"]
+    upstream = FakeUpstream(
+        {"content-length": "10", "content-range": "bytes 0-9/999"},
+        chunks,
+    )
+    fake_client = FakeClient(upstream)
+    _patch_stream_info(monkeypatch, app)
+    _patch_client_factory(monkeypatch, app, fake_client)
+
+    response = await client.get(
+        f"/yt/proxy/{VIDEO_ID}", headers={"Range": "bytes=0-"}
+    )
+
+    assert response.status_code == 206
+    assert response.content == b"".join(chunks)
+    assert "content-length" not in response.headers
+    assert response.headers["content-range"] == "bytes 0-9/999"
+
+
+@pytest.mark.anyio
+async def test_range_send_failure_closes_client_no_leak(client, monkeypatch):
+    import app
+
+    fake_client = FakeClient(raise_on_send=True)
+    _patch_stream_info(monkeypatch, app)
+    _patch_client_factory(monkeypatch, app, fake_client)
+    client._transport.raise_app_exceptions = False
+
+    response = await client.get(
+        f"/proxy/{VIDEO_ID}?user_id=__public__",
+        headers={"Range": "bytes=0-"},
+    )
+
+    assert fake_client.closed is True
+    assert response.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_full_response_streams_and_closes(client, monkeypatch):
+    import app
+
+    chunks = [b"full ", b"body"]
+    upstream = FakeUpstream({}, chunks, status_code=200)
+    fake_client = FakeClient(upstream)
+    _patch_stream_info(monkeypatch, app)
+    _patch_client_factory(monkeypatch, app, fake_client)
+
+    response = await client.get(f"/yt/proxy/{VIDEO_ID}")
+
+    assert response.status_code == 200
+    assert response.content == b"".join(chunks)
+    assert upstream.closed is True
+    assert fake_client.closed is True

--- a/services/ytmusic-streamer/tests/test_yt_playlist_info.py
+++ b/services/ytmusic-streamer/tests/test_yt_playlist_info.py
@@ -72,7 +72,7 @@ async def test_playlist_info_rejects_radio_mix(client):
         },
     )
     assert resp.status_code == 422
-    assert "mix" in resp.json()["detail"].lower()
+    assert "mix" in resp.json()["error"].lower()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Refactor slice P9: reliability fixes for the two Python sidecars, focused on event-loop and resource-exhaustion failure modes.

## Findings addressed

1. **Unified HTTP error shape** — both sidecars returned FastAPI's default `{"detail": ...}` body while the Node backend convention is `{"error": ...}`. A shared `register_error_handlers` now maps HTTPException, request-validation errors, and unhandled exceptions to `{"error": ...}`; unhandled exceptions return a generic 500 with no leaked internals; nested dict details (e.g. `age_restricted`) pass through unchanged. Verified the backend (`backend/src/services/tidal.ts`, `backend/src/services/youtubeMusic.ts`, `backend/src/routes/youtubeMusic.ts`) branches only on `err.response?.status` and never on the body shape, so no backend change was needed.
2. **Proxy connection leak + h11 crash** — the `/proxy/{video_id}` Range branch could leak an httpx client when the upstream send failed, and `/yt/proxy/{video_id}` forwarded upstream `Content-Length`, crashing the ASGI app with "Too little data for declared Content-Length" when the CDN dropped mid-stream. Both routes now share hardened `build_range_proxy_response` / `build_full_proxy_response` helpers with deterministic close on every path and no Content-Length forwarding.
3. **tidal-downloader pagination infinite loop** — `_get_album_tracks` advanced its offset by the API-echoed `limit`; a zero/missing echo looped forever against the TIDAL API. The loop now advances by the actual page length under a fixed hard cap (provable termination).
4. **Racy pacing + unbounded caches + duplicated extraction** — the extraction pacing state was a global timestamp mutated from worker threads guarded by a never-acquired `asyncio.Lock` (wrong primitive, never used). Replaced with a shared `ThreadSafeRatePacer` (threading.Lock + monotonic clock). The stream/search caches, previously cleaned only at shutdown, are now bounded (`YTMUSIC_STREAM_CACHE_MAX` / `YTMUSIC_SEARCH_CACHE_MAX`, default 1024, oldest-first eviction). The two ~115-line near-duplicate yt-dlp extraction functions were merged into one shared `_extract_stream_info` core.
5. **Blocking calls on the event loop** — thirteen async handlers (search, album/artist/song, library songs/albums/playlists, charts, moods, home, browse-album, mood-playlists, playlist detail) ran synchronous ytmusicapi network calls directly on the asyncio event loop, stalling all concurrent requests. All now offload via `asyncio.to_thread`.
6. **Unbounded extraction** — stream-URL extraction had no overall deadline; a stalled yt-dlp call hung the request and stranded its worker thread indefinitely. Extraction now runs under `asyncio.wait_for` (`YTMUSIC_EXTRACT_TIMEOUT`, default 60s → HTTP 504) with a configurable yt-dlp `socket_timeout` (`YTMUSIC_YTDLP_SOCKET_TIMEOUT`, default 20s) applied to extraction and the download path.
7. **Hot-path function size** — the ~100-line `_yt_download_sync` was split into focused <60-line helpers (progress update, options builder, completion) with identical behavior; dead `_api_lock` / `_tidal_api` globals removed from tidal-downloader.

## Tests

- `services/ytmusic-streamer/tests`: **167 passed** (includes new `test_error_shape.py`, `test_proxy_reliability.py`, `test_pacing_and_cache.py`, `test_blocking_offload.py`, `test_extraction_timeout.py`)
- `services/tidal-downloader/tests`: **82 passed** (includes new `test_album_pagination.py`, `test_error_shape.py`)

Run via the per-service venv: `python -m pytest services/<sidecar>/tests -q`.
