### PR TITLE
fix(frontend): session/auth reliability — single-flight refresh + resilient poll (refactor slice P11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Frontend token refresh is now single-flight, so simultaneous 401 responses
+  share one `/auth/refresh` request instead of racing refresh-token rotation
+  and forcing a logout.
+- Audio-state polling now detects expired sessions from HTTP 401 status without
+  permanently stopping after a transient failure, and audiobook/podcast
+  restore failures are logged instead of surfacing as unhandled rejections.
 - Python sidecar (tidal-downloader, ytmusic-streamer) HTTP error responses now
   use the backend-wide `{"error": ...}` body shape instead of FastAPI's default
   `{"detail": ...}`; unhandled sidecar exceptions return a generic 500 without

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -407,6 +407,7 @@ class ApiClient {
     private token: string | null = null;
     private tokenInitialized: boolean = false;
     private readonly inFlightGetRequests = new Map<string, Promise<unknown>>();
+    private refreshPromise: Promise<boolean> | null = null;
 
     constructor(baseUrl?: string) {
         // Don't set baseUrl in constructor - determine it dynamically on each request
@@ -522,7 +523,7 @@ class ApiClient {
      * Refresh the access token using the refresh token
      * @returns true if refresh succeeded, false otherwise
      */
-    private async refreshAccessToken(): Promise<boolean> {
+    private async performTokenRefresh(): Promise<boolean> {
         const refreshToken = this.getRefreshToken();
         if (!refreshToken) {
             return false;
@@ -579,6 +580,26 @@ class ApiClient {
             sharedFrontendLogger.error("[API] Token refresh failed:", error);
             this.clearToken();
             return false;
+        }
+    }
+
+    /**
+     * Refresh the access token using the refresh token.
+     * Single-flight: concurrent callers share one in-flight refresh so N
+     * simultaneous 401s trigger exactly one POST /api/auth/refresh (mirrors the
+     * inFlightGetRequests dedup pattern). The shared promise is always cleared
+     * in `finally`, on both success and failure.
+     * @returns true if refresh succeeded, false otherwise
+     */
+    private async refreshAccessToken(): Promise<boolean> {
+        if (this.refreshPromise) {
+            return this.refreshPromise;
+        }
+        this.refreshPromise = this.performTokenRefresh();
+        try {
+            return await this.refreshPromise;
+        } finally {
+            this.refreshPromise = null;
         }
     }
 

--- a/frontend/lib/audio-state-context.tsx
+++ b/frontend/lib/audio-state-context.tsx
@@ -47,6 +47,18 @@ import {
 } from "@/lib/queue-item";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 
+/**
+ * Returns true when an error represents an expired or invalid session (HTTP
+ * 401). Uses the ApiError `status` field rather than a fragile error-message
+ * string comparison so message-copy changes cannot silently break detection.
+ */
+export function isAuthExpiryError(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) {
+        return false;
+    }
+    return (error as { status?: unknown }).status === 401;
+}
+
 function queueDebugEnabled(): boolean {
     try {
         return (
@@ -487,38 +499,50 @@ export function AudioStateProvider({ children }: { children: ReactNode }) {
                     serverPlaybackType === "audiobook" &&
                     serverState.audiobookId
                 ) {
-                    api.getAudiobook(serverState.audiobookId).then(
-                        (audiobook) => {
+                    api.getAudiobook(serverState.audiobookId)
+                        .then((audiobook) => {
                             setCurrentAudiobook(audiobook);
                             setPlaybackType("audiobook");
                             setCurrentTrack(null);
                             setCurrentPodcast(null);
-                        }
-                    );
+                        })
+                        .catch((err: unknown) =>
+                            sharedFrontendLogger.error(
+                                "[AudioState] Failed to restore audiobook playback state:",
+                                err
+                            )
+                        );
                 } else if (
                     serverPlaybackType === "podcast" &&
                     serverState.podcastId
                 ) {
                     const [podcastId, episodeId] =
                         serverState.podcastId.split(":");
-                    api.getPodcast(podcastId).then((podcast: { title: string; coverUrl: string; episodes?: Episode[] }) => {
-                        const episode = podcast.episodes?.find(
-                            (ep: Episode) => ep.id === episodeId
+                    api.getPodcast(podcastId)
+                        .then((podcast: { title: string; coverUrl: string; episodes?: Episode[] }) => {
+                            const episode = podcast.episodes?.find(
+                                (ep: Episode) => ep.id === episodeId
+                            );
+                            if (episode) {
+                                setCurrentPodcast({
+                                    id: serverState.podcastId,
+                                    title: episode.title,
+                                    podcastTitle: podcast.title,
+                                    coverUrl: podcast.coverUrl,
+                                    duration: episode.duration,
+                                    progress: episode.progress,
+                                });
+                                setPlaybackType("podcast");
+                                setCurrentTrack(null);
+                                setCurrentAudiobook(null);
+                            }
+                        })
+                        .catch((err: unknown) =>
+                            sharedFrontendLogger.error(
+                                "[AudioState] Failed to restore podcast playback state:",
+                                err
+                            )
                         );
-                        if (episode) {
-                            setCurrentPodcast({
-                                id: serverState.podcastId,
-                                title: episode.title,
-                                podcastTitle: podcast.title,
-                                coverUrl: podcast.coverUrl,
-                                duration: episode.duration,
-                                progress: episode.progress,
-                            });
-                            setPlaybackType("podcast");
-                            setCurrentTrack(null);
-                            setCurrentAudiobook(null);
-                        }
-                    });
                 }
                 if (
                     serverQueue &&
@@ -682,7 +706,6 @@ export function AudioStateProvider({ children }: { children: ReactNode }) {
         if (!isHydrated) return;
         if (typeof document === "undefined") return;
 
-        let isAuthenticated = true;
         let mounted = true;
         let isVisible = !document.hidden;
 
@@ -694,8 +717,8 @@ export function AudioStateProvider({ children }: { children: ReactNode }) {
 
         let pollInterval: ReturnType<typeof setInterval> | null = null;
         const pollCallback = async () => {
-            // Skip polling when tab is hidden, unmounted, or not authenticated
-            if (!isAuthenticated || !mounted || !isVisible) return;
+            // Skip polling when tab is hidden or unmounted
+            if (!mounted || !isVisible) return;
             // Prevent overlapping async poll calls
             if (pollInFlightRef.current) return;
             pollInFlightRef.current = true;
@@ -938,10 +961,18 @@ export function AudioStateProvider({ children }: { children: ReactNode }) {
                     setLastServerSync(serverUpdatedAt);
                 }
             } catch (err: unknown) {
-                if (err instanceof Error && err.message === "Not authenticated") {
-                    isAuthenticated = false;
-                    if (pollInterval) clearInterval(pollInterval);
+                if (isAuthExpiryError(err)) {
+                    // Session expired. ConditionalAudioProvider unmounts this
+                    // provider on genuine logout and remounts it on re-login,
+                    // which restarts polling. Skip this cycle instead of
+                    // permanently disabling the interval so a single (possibly
+                    // transient) 401 can never permanently kill polling.
+                    return;
                 }
+                sharedFrontendLogger.error(
+                    "[AudioState] Playback state poll failed:",
+                    err
+                );
             } finally {
                 pollInFlightRef.current = false;
             }

--- a/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
+++ b/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+
+const originalFetch = globalThis.fetch;
+
+after(() => {
+    if (originalFetch) {
+        (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    } else {
+        delete (globalThis as { fetch?: typeof fetch }).fetch;
+    }
+    GlobalRegistrator.unregister();
+});
+
+test("shares one token refresh across concurrent 401 responses", async () => {
+    const { api } = await import("../../lib/api");
+    const requestedUrls: string[] = [];
+    let refreshCount = 0;
+
+    api.setToken("access-old", "refresh-old");
+    (globalThis as { fetch: typeof fetch }).fetch = (async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1]
+    ) => {
+        const url = String(input);
+        requestedUrls.push(url);
+
+        if (url.endsWith("/api/auth/refresh")) {
+            refreshCount += 1;
+            return new Promise<Response>((resolve) => {
+                setTimeout(() => {
+                    resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            token: "access-new",
+                            refreshToken: "refresh-new",
+                        }),
+                    } as Response);
+                }, 5);
+            });
+        }
+
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (authorization === "Bearer access-old") {
+            return {
+                ok: false,
+                status: 401,
+                statusText: "Unauthorized",
+                json: async () => ({ error: "unauthorized" }),
+            } as Response;
+        }
+        if (authorization === "Bearer access-new") {
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({ ok: true }),
+            } as Response;
+        }
+
+        throw new Error(`Unexpected Authorization header for ${url}`);
+    }) as typeof fetch;
+
+    const results = await Promise.all([
+        api.post("/x/a"),
+        api.post("/x/b"),
+        api.post("/x/c"),
+    ]);
+
+    assert.equal(refreshCount, 1);
+    assert.deepEqual(results, [{ ok: true }, { ok: true }, { ok: true }]);
+    assert.equal(requestedUrls.filter((url) => url.endsWith("/api/auth/refresh")).length, 1);
+});

--- a/frontend/tests/unit/audioStateAuthExpiry.test.ts
+++ b/frontend/tests/unit/audioStateAuthExpiry.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isAuthExpiryError } from "../../lib/audio-state-context";
+
+test("detects authentication expiry from an HTTP 401 status", () => {
+    const apiError = new Error("Session expired");
+    (apiError as Error & { status: number }).status = 401;
+
+    assert.equal(isAuthExpiryError({ status: 401 }), true);
+    assert.equal(isAuthExpiryError(apiError), true);
+});
+
+test("rejects non-401 and unstructured errors", () => {
+    assert.equal(isAuthExpiryError({ status: 500 }), false);
+    assert.equal(isAuthExpiryError(new Error("Not authenticated")), false);
+    assert.equal(isAuthExpiryError(null), false);
+    assert.equal(isAuthExpiryError(undefined), false);
+    assert.equal(isAuthExpiryError("401"), false);
+    assert.equal(isAuthExpiryError(401), false);
+});


### PR DESCRIPTION
## Slice: frontend-session-reliability (refactor slice P11)

Auth/session reliability in the frontend data layer. Depends on **auth-token-hardening (P1, merged)**; builds on the merged **frontend-polling-hygiene (P12)** poll refs/gating without duplicating them. All changes go through the `frontend/lib/api.ts` boundary. Scope was limited to `frontend/lib/api.ts` and `frontend/lib/audio-state-context.tsx` plus new tests.

### Findings addressed
1. **No single-flight guard on token refresh — concurrent 401s stampede `/auth/refresh`.** With refresh-token rotation now live, N simultaneous 401s each POST `/api/auth/refresh`; the first rotates the token and the rest fail with the now-invalid old refresh token, force-logging-out the user. Fixed with a single-flight `refreshPromise` that mirrors the existing `inFlightGetRequests` dedup pattern — exactly one refresh request is in flight; concurrent callers await it and retry with the new token. The shared promise is cleared in `finally` on both success and failure.
2. **audio-state-context: unhandled restore rejections + permanently-dead poll after one transient 401.**
   - The mount restore effect's `getAudiobook`/`getPodcast` `.then` chains had no `.catch`, surfacing as unhandled promise rejections; both now catch and log via the shared frontend logger (matching the sibling progress-refresh handlers).
   - The poll caught a 401 by fragile message-string match (`err.message === "Not authenticated"`) and then latched a mutable flag false and `clearInterval`, permanently killing polling for the life of the mount. Replaced with a robust, status-based `isAuthExpiryError(err)` (checks the `ApiError` 401 status) and a skip-this-cycle policy instead of a permanent kill. Genuine logout tears the provider down and re-login remounts it (via `ConditionalAudioProvider`'s existing auth-gated mount), which restarts polling — verified there is no in-mount latch that can survive a transient failure. Non-auth poll errors are now logged rather than silently swallowed.

### Changes
- `frontend/lib/api.ts` — extract `performTokenRefresh()`; `refreshAccessToken()` becomes a single-flight wrapper.
- `frontend/lib/audio-state-context.tsx` — exported `isAuthExpiryError` helper; robust 401 detection; skip-not-kill poll policy; restore-effect `.catch` handlers; non-auth error logging.

### Tests (targeted only; no full suites/coverage)
- `frontend/tests/component/apiRefreshSingleFlight.component.test.ts` (happy-dom) — three concurrent 401'd POSTs trigger exactly **one** `/api/auth/refresh` and all resolve with the retried result. Fails before the fix (`3 !== 1`).
- `frontend/tests/unit/audioStateAuthExpiry.test.ts` — `isAuthExpiryError` true for `{status:401}` / Error-with-status; false for 500, message-only `Error`, `null`, `undefined`, string, number. Fails before the fix (symbol absent).

Verification (from `frontend/`):
- `node --test --experimental-test-module-mocks --import tsx tests/component/apiRefreshSingleFlight.component.test.ts` — pass.
- `node --test --import tsx tests/unit/audioStateAuthExpiry.test.ts` — pass.
- `npx tsc --noEmit` — exit 0, no errors.

### Breaking / UPGRADING
None. No public API, storage, or protocol changes.

### Escalations
None.
