### PR TITLE
docs(contract): sync repo contract with implemented behavior (refactor slice P32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,20 @@ Repository contract for soundspan.
 
 - **API boundary:** Use `frontend/lib/api.ts` as the frontend API boundary. No direct `fetch` calls from components.
 - **Backend config:** Read env through `backend/src/config.ts`.
-- **Database access:** All DB access through Prisma. No raw SQL.
-- **Logging helpers:** Use shared logging helpers in runtime code:
+- **Database access:** Prefer Prisma for all DB access. Raw SQL (`$queryRaw`/`$executeRaw`) is permitted **only** for the classes of query Prisma cannot express, namely:
+  - **pgvector similarity / ANN** — ivfflat probe tuning and `<=>`/`<->` distance ordering over embedding columns (e.g. `backend/src/utils/annQuery.ts`, `backend/src/services/trackEmbeddings.ts`, `backend/src/services/hybridSimilarity.ts`).
+  - **PostgreSQL full-text search** — `tsvector`/`to_tsquery`/`ts_rank` ranking (e.g. `backend/src/services/search.ts`).
+  - **Row-level & advisory locking** — `FOR UPDATE SKIP LOCKED` job claiming and `pg_advisory_*` locks (e.g. `backend/src/routes/downloads.ts`, worker claim loops).
+
+  Constraints on any permitted raw SQL: use Prisma tagged-template `$queryRaw`/`$executeRaw` so every value is bound as a parameter; **never** `$queryRawUnsafe`/`$executeRawUnsafe` with interpolated external input (dynamic identifiers must come from code-owned allowlists); back it with a behavioral test against real PostgreSQL, not a source-text assertion (see Testing below). Anything a Prisma query can express — plain filters, counts, existence checks — must use Prisma, not raw SQL.
+- **Logging helpers:** Use shared logging helpers in runtime code, and scope logs with `logger.child({ scope: "..." })` rather than ad hoc `[bracket-tag]` message prefixes so scope is a structured field:
   - frontend: `frontend/lib/logger.ts`
   - backend: `backend/src/utils/logger.ts`
   - python sidecars: `services/common/logging_utils.py`
+- **Naming & placement conventions:** `camelCase` TypeScript source files; one route module per mounted prefix under `backend/src/routes/` (indexed in `backend/src/routes/README.md`); frontend domain modules live under `frontend/features/<domain>/` and are indexed in `frontend/features/README.md`; scheduled/background processors belong in `backend/src/workers/`. Known drift (colocated vs. tree tests, `components/vibe` placement) is documented in the relevant README rather than silently tolerated — follow the README when extending an area.
 - **Changelog:** Keep `CHANGELOG.md` updated for user-visible or behavior-changing work.
-- **Documentation coverage:** Exported TypeScript symbols, runtime Python modules, and implemented OpenAPI routes should remain fully documented when touched.
+- **Testing conventions:** Assert on **behavior**, not source text. The source-scraping `*Contract` suites that `readFileSync` a module and `.toContain(...)` a code snippet (e.g. the `backend/src/__tests__/audioAnalyzer*Contract.test.ts` set that greps `services/audio-analyzer/analyzer.py`) are **deprecated**: do not add new tests of that shape, and replace an existing one with a behavioral test whenever you touch the code it guards.
+- **Documentation coverage:** Exported TypeScript symbols, runtime Python modules, and implemented OpenAPI routes should remain fully documented when touched. **Exemption:** the Subsonic-compatible `/rest` surface (`backend/src/routes/subsonic.ts`) is contract-documented in [`docs/OPENSUBSONIC_COMPATIBILITY.md`](docs/OPENSUBSONIC_COMPATIBILITY.md) instead of per-endpoint OpenAPI annotations; keep that document current in lieu of `@openapi` blocks for `/rest`.
 - **Storage:** SQLite at `.awm/context.db` by default. Configure `AWM_PG_DSN` for multi-agent coordination.
 
 ## Local Setup & Pre-PR Verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `npx prisma migrate deploy` via a locally reinstalled Prisma CLI.
 - Backend and frontend runtime artifacts now use `COPY --chown` instead of a
   duplicated recursive `chown -R /app` layer.
+- Docs/contract sync (refactor slice): `AGENTS.md` now scopes the "no raw SQL"
+  rule to the three query classes Prisma cannot express (pgvector similarity/ANN,
+  PostgreSQL full-text search, and row/advisory locking) with a parameterized-only
+  constraint, records that the Subsonic `/rest` surface is contract-documented in
+  `docs/OPENSUBSONIC_COMPATIBILITY.md` instead of per-endpoint OpenAPI, documents
+  the `logger.child` scope and file naming/placement conventions, deprecates the
+  source-scraping `*Contract` test pattern, and indexes the `components/vibe`
+  location as a recognized (owner-decision-pending) exception in
+  `frontend/features/README.md`. The two trivially-expressible profile-picture
+  presence checks in `routes/settings.ts` (`$queryRaw COUNT(*)` → `prisma.user.count`)
+  and `routes/social.ts` (two `$queryRaw SELECT id` → `prisma.user.findMany`) were
+  migrated to Prisma with no behavior change (the profile-picture blob is still not
+  loaded).
 - Backend: introduced a single consolidated, typed Lidarr HTTP client
   (`backend/src/services/lidarr/lidarrHttpClient.ts`) as the standard boundary
   for outbound Lidarr calls. It wraps one reusable axios instance with bounded

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -76,6 +76,14 @@ Exception: the CLAP analyzer machine callbacks in
 `AUDIO_ANALYSIS_ENABLED=false`, so analyzers draining in-flight work can still
 report results.
 
+## Conventions
+
+- **One module per mounted prefix.** Each file here owns a single `/api/*` (or `/rest`) prefix listed above; add a new prefix as a new `camelCase` module and register it in `backend/src/index.ts` and in the table above.
+- **Routes orchestrate; services decide.** Keep parsing, validation, authorization decisions, and data access in `backend/src/services/` (and background processors in `backend/src/workers/`); route handlers coordinate and stay within the repository function-size gate.
+- **Data access.** Use Prisma. Raw SQL is limited to the pgvector / full-text-search / row-locking exceptions defined in [`AGENTS.md`](../../../AGENTS.md) and must use parameterized tagged templates.
+- **`/rest` OpenAPI exemption.** `subsonic.ts` implements the Subsonic-compatible `/rest` surface, which is contract-documented in [`docs/OPENSUBSONIC_COMPATIBILITY.md`](../../../docs/OPENSUBSONIC_COMPATIBILITY.md) rather than per-endpoint `@openapi` annotations (see `AGENTS.md`). Update that document when `/rest` behavior changes.
+- **Tests assert behavior.** Prefer runtime tests in `backend/src/routes/__tests__/`; do not add source-scraping `*Contract` tests that `readFileSync` a module and assert on its text (deprecated pattern — see `AGENTS.md`).
+
 ## Update Rule
 
 - When adding, removing, or changing endpoints in this directory, update this README if the entrypoint or test-navigation guidance changes and keep impacted route tests current in the same change set.

--- a/backend/src/routes/__tests__/settingsCore.test.ts
+++ b/backend/src/routes/__tests__/settingsCore.test.ts
@@ -53,10 +53,10 @@ jest.mock("../../utils/db", () => ({
             upsert: jest.fn(),
         },
         user: {
+            count: jest.fn(),
             findUnique: jest.fn(),
             update: jest.fn(),
         },
-        $queryRaw: jest.fn(),
     },
 }));
 
@@ -173,9 +173,9 @@ const app = createRouteTestApp("/api/settings", router);
 const mockUserSettingsFindUnique = prisma.userSettings.findUnique as jest.Mock;
 const mockUserSettingsCreate = prisma.userSettings.create as jest.Mock;
 const mockUserSettingsUpsert = prisma.userSettings.upsert as jest.Mock;
+const mockUserCount = prisma.user.count as jest.Mock;
 const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
 const mockUserUpdate = prisma.user.update as jest.Mock;
-const mockPrismaQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockCleanupAll = staleJobCleanupService.cleanupAll as jest.Mock;
 const mockClearUserQualityCache =
     tidalStreamingService.clearUserQualityCache as jest.Mock;
@@ -213,7 +213,7 @@ describe("settings routes integration", () => {
         }));
         mockUserFindUnique.mockResolvedValue({ displayName: "Jane Doe" });
         mockUserUpdate.mockResolvedValue({ id: "user-1" });
-        mockPrismaQueryRaw.mockResolvedValue([{ count: BigInt(0) }]);
+        mockUserCount.mockResolvedValue(0);
         mockCleanupAll.mockResolvedValue({
             discoveryBatches: 2,
             downloadJobs: 4,
@@ -225,7 +225,7 @@ describe("settings routes integration", () => {
     });
 
     it("returns existing settings with displayName and hasProfilePicture", async () => {
-        mockPrismaQueryRaw.mockResolvedValueOnce([{ count: BigInt(1) }]);
+        mockUserCount.mockResolvedValueOnce(1);
 
         const res = await request(app)
             .get("/api/settings")

--- a/backend/src/routes/__tests__/settingsDisplayNameCompat.test.ts
+++ b/backend/src/routes/__tests__/settingsDisplayNameCompat.test.ts
@@ -34,10 +34,10 @@ jest.mock("../../utils/db", () => ({
             upsert: jest.fn(),
         },
         user: {
+            count: jest.fn(),
             findUnique: jest.fn(),
             update: jest.fn(),
         },
-        $queryRaw: jest.fn(),
     },
 }));
 
@@ -48,9 +48,9 @@ import { staleJobCleanupService } from "../../services/staleJobCleanup";
 const mockUserSettingsFindUnique = prisma.userSettings.findUnique as jest.Mock;
 const mockUserSettingsCreate = prisma.userSettings.create as jest.Mock;
 const mockUserSettingsUpsert = prisma.userSettings.upsert as jest.Mock;
+const mockUserCount = prisma.user.count as jest.Mock;
 const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
 const mockUserUpdate = prisma.user.update as jest.Mock;
-const mockPrismaQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockStaleJobCleanup = staleJobCleanupService.cleanupAll as jest.Mock;
 
 function getGetHandler(path: string) {
@@ -92,7 +92,7 @@ describe("settings displayName compatibility", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockPrismaQueryRaw.mockResolvedValue([{ count: BigInt(0) }]);
+        mockUserCount.mockResolvedValue(0);
     });
 
     it("returns displayName alongside user settings", async () => {

--- a/backend/src/routes/__tests__/socialCompat.test.ts
+++ b/backend/src/routes/__tests__/socialCompat.test.ts
@@ -26,7 +26,6 @@ jest.mock("../../utils/redis", () => ({
 
 jest.mock("../../utils/db", () => ({
     prisma: {
-        $queryRaw: jest.fn(),
         user: {
             findMany: jest.fn(),
         },
@@ -43,7 +42,6 @@ import { prisma } from "../../utils/db";
 const mockScanIterator = redisClient.scanIterator as jest.Mock;
 const mockMGet = redisClient.mGet as jest.Mock;
 const mockSet = redisClient.set as jest.Mock;
-const mockPrismaQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockUserFindMany = prisma.user.findMany as jest.Mock;
 const mockSyncGroupMemberFindMany = prisma.syncGroupMember.findMany as jest.Mock;
 
@@ -101,7 +99,7 @@ describe("social presence compatibility", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockPrismaQueryRaw.mockResolvedValue([]);
+        mockUserFindMany.mockResolvedValue([]);
     });
 
     it("returns online roster with privacy filtering and listen-together indicator", async () => {
@@ -118,7 +116,7 @@ describe("social presence compatibility", () => {
             String(now - 1000),
             String(now - 2000),
         ]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -255,7 +253,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -357,7 +355,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -395,7 +393,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -433,7 +431,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -479,7 +477,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -525,7 +523,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-ghost",
                 username: "ghost",
@@ -601,7 +599,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -657,7 +655,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -700,7 +698,7 @@ describe("social presence compatibility", () => {
             ])
         );
         mockMGet.mockResolvedValue([String(now), String(now - 1000)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -778,7 +776,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-1",
                 username: "alice",
@@ -818,7 +816,7 @@ describe("social presence compatibility", () => {
             asScanIterable(["social:presence:user:user-1"])
         );
         mockMGet.mockResolvedValue([String(now)]);
-        mockUserFindMany.mockResolvedValue([
+        mockUserFindMany.mockResolvedValueOnce([
             {
                 id: "user-ghost",
                 username: "ghost",

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -77,12 +77,9 @@ router.get("/", async (req, res) => {
 
         // Check if user has a profile picture without loading the blob
         const hasProfilePicture =
-            (
-                await prisma.$queryRaw<{ count: bigint }[]>`
-                    SELECT COUNT(*)::bigint as count FROM "User"
-                    WHERE id = ${userId} AND "profilePicture" IS NOT NULL
-                `
-            )[0]?.count > 0n;
+            (await prisma.user.count({
+                where: { id: userId, profilePicture: { not: null } },
+            })) > 0;
 
         let settings = existingSettings;
 

--- a/backend/src/routes/social.ts
+++ b/backend/src/routes/social.ts
@@ -346,11 +346,13 @@ router.get("/online", async (_req, res) => {
             }),
         ]);
 
-        const usersWithPictures = await prisma.$queryRaw<{ id: string }[]>`
-            SELECT id FROM "User"
-            WHERE id = ANY(${onlineUserIds})
-            AND "profilePicture" IS NOT NULL
-        `;
+        const usersWithPictures = await prisma.user.findMany({
+            where: {
+                id: { in: onlineUserIds },
+                profilePicture: { not: null },
+            },
+            select: { id: true },
+        });
 
         const inListenTogether = new Set(
             activeMemberships.map((entry) => entry.userId)
@@ -476,11 +478,13 @@ router.get("/connected", requireAdmin, async (req, res) => {
             },
         });
 
-        const usersWithPicturesConnected = await prisma.$queryRaw<{ id: string }[]>`
-            SELECT id FROM "User"
-            WHERE id = ANY(${onlineUserIds})
-            AND "profilePicture" IS NOT NULL
-        `;
+        const usersWithPicturesConnected = await prisma.user.findMany({
+            where: {
+                id: { in: onlineUserIds },
+                profilePicture: { not: null },
+            },
+            select: { id: true },
+        });
 
         const hasProfilePictureSet = new Set(
             usersWithPicturesConnected.map((u) => u.id)

--- a/docs/OPENSUBSONIC_COMPATIBILITY.md
+++ b/docs/OPENSUBSONIC_COMPATIBILITY.md
@@ -6,6 +6,8 @@ Last updated: 2026-02-14
 
 This document defines the current `/rest` compatibility contract implemented in this fork and captures readiness evidence used to close the current OpenSubsonic phase gate.
 
+> **Contract authority / OpenAPI exemption.** This document is the authoritative contract for the Subsonic-compatible `/rest` surface (`backend/src/routes/subsonic.ts`). Those endpoints follow the published OpenSubsonic/Subsonic API rather than soundspan's own REST shape, so they are **intentionally exempt** from per-endpoint OpenAPI (`@openapi`) annotation — see the Documentation-coverage rule in [`AGENTS.md`](../AGENTS.md). Keep the endpoint surface below current when `/rest` behavior changes; that is the substitute for OpenAPI coverage on this prefix.
+
 ## Milestone Status
 
 - Current OpenSubsonic compatibility milestone: `Complete` (for soundspan's in-scope music client surface)

--- a/frontend/features/README.md
+++ b/frontend/features/README.md
@@ -23,6 +23,12 @@ Start-here index for domain modules under `frontend/features`.
 | `search` | `frontend/features/search/README.md` | `frontend/app/browse/playlists/page.tsx`<br>`frontend/app/search/page.tsx` |
 | `settings` | `frontend/features/settings/README.md` | `frontend/app/device/page.tsx`<br>`frontend/app/settings/page.tsx` |
 
+## Recognized Exception: Vibe Map
+
+The Vibe Map — the interactive vibe navigator (`#203`) and currently the newest major frontend surface — does **not** live under `frontend/features/`. Its components, hooks, and model live in `frontend/components/vibe/` (entrypoint `VibeMapTab.tsx` / `VibeMapView.tsx`), its route is `frontend/app/vibe/page.tsx`, and its unit coverage is `frontend/tests/unit/` (`mapSearch`, `vibeMapModel`, `vibeModeMachine`, `travelCompass`, and siblings). It is indexed here so the surface is discoverable and its placement is a documented, recognized location rather than undocumented drift.
+
+Relocating it to `frontend/features/vibe/` to match the domain-module convention is an owner decision (large import churn across `frontend/components/vibe/**` and the tests above) and has not been made; until then, extend the Vibe Map in place under `frontend/components/vibe/`.
+
 ## Update Rule
 
 - Whenever feature behavior changes materially, update or verify this index and the affected `frontend/features/*/README.md` file in the same change set.


### PR DESCRIPTION
## Contract/docs sync (refactor slice P32)

Brings written contracts back in line with implemented behavior so the rules regain authority, plus two trivial raw-SQL→Prisma migrations. Deps: none.

### Findings addressed
- **"No raw SQL" contradicted by 19 modules.** `AGENTS.md` now scopes the rule to the three query classes Prisma genuinely cannot express — pgvector similarity/ANN (`annQuery.ts`, `trackEmbeddings.ts`, `hybridSimilarity.ts`), PostgreSQL full-text search (`search.ts`), and row/advisory locking (`downloads.ts`, worker claim loops) — with a parameterized-tagged-template-only constraint (never `*Unsafe` with interpolated input) and a behavioral-test requirement. Anything Prisma can express must use Prisma.
- **Two trivially-expressible raw sites migrated:** `routes/settings.ts` `$queryRaw COUNT(*)` → `prisma.user.count`; `routes/social.ts` two `$queryRaw SELECT id … IS NOT NULL` → `prisma.user.findMany({ select: { id: true } })`. Behavior identical; the `profilePicture` blob is still never loaded. Behavioral tests updated to match.
- **/rest undocumented in OpenAPI:** recorded an explicit exemption in `AGENTS.md` pointing at `docs/OPENSUBSONIC_COMPATIBILITY.md` as the authoritative `/rest` contract, cross-linked from that doc and `routes/README.md`.
- **Vibe surface ignores the features/ convention:** indexed `frontend/components/vibe/` in `frontend/features/README.md` as a recognized, owner-decision-pending exception (see Escalations).
- **Naming/placement + logging drift:** documented `camelCase`, one-module-per-prefix, `workers/` placement, and `logger.child({ scope })` over `[bracket-tag]` prefixes in `AGENTS.md` (convention-setting; mechanical per-file migration lands opportunistically later).
- **Source-scraping contract tests:** deprecated the `readFileSync` + `.toContain` `*Contract` pattern (e.g. `backend/src/__tests__/audioAnalyzer*Contract.test.ts`) in `AGENTS.md`; new tests must assert behavior, and existing greps get replaced with behavioral twins when the guarded code is touched.

### Verification
- verify: targeted jest (flock-wrapped, `--maxWorkers=2`) `settingsCore.test.ts` + `socialCompat.test.ts` → 2 suites passed, 37/37 tests (after `prisma generate` in the worktree; the routes type-check clean via ts-jest).
- verify: doc cross-reference link targets resolve (AGENTS.md ↔ OPENSUBSONIC_COMPATIBILITY.md ↔ routes/README.md).
- No markdown/OpenAPI lint tooling is configured in the repo ("as available" → none); no OpenAPI spec files were modified.

### Breaking / UPGRADING
None. Docs + internal refactor only; no runtime behavior change.

### Escalations (owner sign-off needed — surfaced, not assumed)
- **Relocating `components/vibe` → `features/vibe`**: taken the doc-amendment (legitimize-in-place) path per the slice rationale; the physical move is large import churn and left as an owner decision.
- **>1,500-line-file "no new handlers" ratchet**: NOT added — needs owner sign-off; surfaced only.

### Discovered follow-ups (out of scope here)
- 17 remaining raw-SQL modules are now legitimized by category; if any contain a Prisma-expressible query beyond the three exception classes, migrate it opportunistically when touched.
- The deprecated `audioAnalyzer*Contract` source-scraping suites (4 files) remain in place; replace with behavioral tests when the analyzer code they guard is next changed.
