### PR TITLE
feat(helm): harden chart — pod security, Secret-ref API keys, analyzer probes, GPU wiring (refactor slice P15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3.11 with the TensorFlow 2.15 exception set (`docs/SECURITY.md`). No runtime
   behavior change; the analysis pipeline and MusiCNN classification heads are
   unchanged.
+- Helm chart pod hardening: all chart-managed workloads now set
+  `seccompProfile: RuntimeDefault`, drop all Linux capabilities on the
+  application containers, and set `automountServiceAccountToken: false` (no
+  chart workload calls the Kubernetes API). Postgres and Redis keep their
+  existing user-switching entrypoints (seccomp added, capabilities untouched).
+- Helm chart no longer renders third-party API keys/tokens (`LIDARR_API_KEY`,
+  `AUDIOBOOKSHELF_TOKEN`, `LASTFM_API_KEY`, `FANART_API_KEY`, `OPENAI_API_KEY`)
+  as plaintext `value:` env in pod specs. When the chart manages its own Secret
+  (default), they are injected via `secretKeyRef` from that Secret. Deployments
+  using `secrets.existingSecret` keep the legacy plaintext behavior for
+  backward compatibility unless `secrets.apiKeysInExistingSecret=true`, which
+  reads the keys from the existing Secret via `secretKeyRef`. See
+  `docs/UPGRADING.md`.
 - All-in-One (AIO) backend, frontend, and analyzer processes now run under
   supervisord as the fixed `soundspan` user (uid/gid 1000). Existing writable
   volume paths are chowned automatically on every boot; see
@@ -133,6 +146,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Helm chart: the individual-mode audio-analyzer and CLAP-analyzer Deployments
+  now have liveness/readiness probes (exec `pgrep`, mirroring the compose
+  healthcheck), closing the compose/chart probe-parity gap. Both are
+  configurable via `audioAnalyzer.livenessProbe`/`readinessProbe` and the CLAP
+  equivalents (set to `null` to disable).
+- Helm chart: `aio.gpu.enabled`, `audioAnalyzer.gpu.enabled`, and
+  `audioAnalyzerClap.gpu.enabled` are now wired — previously no-ops. When
+  enabled they add an `nvidia.com/gpu: <gpu.count>` resource limit (default 1)
+  and an optional pod `runtimeClassName` (`gpu.runtimeClassName`) for clusters
+  requiring a non-default GPU runtime. Requires the NVIDIA device plugin.
+- Helm chart: the AIO default memory request/limit was raised from `1Gi`/`4Gi`
+  to `2Gi`/`8Gi`. The AIO image bundles the backend, frontend, Postgres, Redis,
+  and (by default) the Essentia + CLAP analyzers in one container, whose models
+  alone peak well above the old 4Gi ceiling.
+- Helm chart: the frontend pod now runs as UID/GID `1001` (the published image's
+  `nextjs` user) via a `frontend.podSecurityContext` override merged over the
+  chart-wide `1000`, fixing the UID/file-ownership mismatch until the image is
+  realigned.
 - Backend: introduced a single consolidated, typed Lidarr HTTP client
   (`backend/src/services/lidarr/lidarrHttpClient.ts`) as the standard boundary
   for outbound Lidarr calls. It wraps one reusable axios instance with bounded
@@ -253,6 +284,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer prematurely unload models, mis-fire a resize, or corrupt the reported
   throughput. The cross-process `audio:worker:heartbeat` timestamp remains
   wall-clock epoch milliseconds by design.
+- `scripts/k8s-rollout-slo-check.sh` sampled SLO warning logs from only one pod
+  per Deployment (`kubectl logs deploy/...`), so reconnect/scheduler SLO
+  breaches emitted by other replicas in an HA deployment were missed and the
+  gate could pass when it should fail. It now aggregates `--since` logs across
+  every backend and backend-worker pod (by `app.kubernetes.io/component` label,
+  with a name-prefix fallback).
 - The three backend audio-analyzer source-contract suites
   (`audioAnalyzerQueueContract`, `audioAnalyzerPoolRecoveryContract`,
   `audioAnalyzerFailureResolutionContract`) were updated in step with the

--- a/charts/soundspan/README.md
+++ b/charts/soundspan/README.md
@@ -213,6 +213,30 @@ secrets:
 ```
 
 Expected keys: `SESSION_SECRET`, `SETTINGS_ENCRYPTION_KEY`, `INTERNAL_API_SECRET`.
+
+#### Third-party API keys
+
+Optional integration keys (`config.lidarrApiKey`, `config.audiobookshelfToken`,
+`config.lastfmApiKey`, `config.fanartApiKey`, `config.openaiApiKey`) are **not**
+rendered as plaintext env in pod specs. When the chart manages its own Secret
+(default), they are stored in that Secret and injected via `secretKeyRef`.
+
+If you use `existingSecret`, these keys stay plaintext (legacy behavior) unless
+you add them to your Secret (`LIDARR_API_KEY`, `AUDIOBOOKSHELF_TOKEN`,
+`LASTFM_API_KEY`, `FANART_API_KEY`, `OPENAI_API_KEY`) and set:
+
+```yaml
+secrets:
+  existingSecret: my-soundspan-secrets
+  apiKeysInExistingSecret: true
+```
+
+#### Pod security
+
+All chart-managed pods run with `seccompProfile: RuntimeDefault`, drop all Linux
+capabilities on the application containers, and disable ServiceAccount token
+automounting (`global.automountServiceAccountToken: false`). Set it to `true`
+only if you add a sidecar that needs Kubernetes API access.
 Add `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` when using chart-managed PostgreSQL or host/port external PostgreSQL (not needed if `postgresql.external.url` is set).
 
 ### Music Library
@@ -541,20 +565,31 @@ You can inject additional values with:
 
 For audio analysis with NVIDIA GPU:
 
+Requires the [NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin)
+on the cluster. Enabling GPU adds an `nvidia.com/gpu: <count>` resource limit
+and, if set, a pod `runtimeClassName` for clusters that require a non-default
+runtime for GPU pods.
+
 ```yaml
 # AIO mode
 aio:
   gpu:
     enabled: true
+    count: 1              # nvidia.com/gpu limit
+    runtimeClassName: ""  # e.g. "nvidia" if your cluster requires it
 
 # Individual mode
 audioAnalyzer:
   gpu:
     enabled: true
+    count: 1
+    runtimeClassName: ""
 
 audioAnalyzerClap:
   gpu:
     enabled: true
+    count: 1
+    runtimeClassName: ""
 ```
 
 ## All Values

--- a/charts/soundspan/templates/_helpers.tpl
+++ b/charts/soundspan/templates/_helpers.tpl
@@ -193,3 +193,36 @@ HA mode helpers (individual mode only)
 {{- .Values.backendWorker.replicas | int -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Render one env entry for an optional third-party API key/token, preferring a
+Secret reference over a plaintext value in the pod spec.
+Precedence:
+  1. explicit per-workload env override (envMap has the var) -> plaintext value
+  2. enabled + chart-managed Secret (no existingSecret)      -> secretKeyRef (chart Secret)
+  3. enabled + existingSecret + apiKeysInExistingSecret=true  -> secretKeyRef (existing Secret, optional)
+  4. enabled + existingSecret (legacy default)               -> plaintext value (back-compat)
+  5. not enabled                                             -> nothing
+Usage:
+  {{ include "soundspan.optionalSecretEnv" (dict "ctx" $ "name" "LIDARR_API_KEY" "secretKey" "LIDARR_API_KEY" "value" $.Values.config.lidarrApiKey "enabled" $.Values.config.lidarrEnabled "envMap" $backendEnv) | nindent 12 }}
+*/}}
+{{- define "soundspan.optionalSecretEnv" -}}
+{{- $ctx := .ctx -}}
+{{- $envMap := .envMap | default dict -}}
+{{- if hasKey $envMap .name -}}
+- name: {{ .name }}
+  value: {{ index $envMap .name | quote }}
+{{- else if .enabled -}}
+{{- if or (not $ctx.Values.secrets.existingSecret) $ctx.Values.secrets.apiKeysInExistingSecret -}}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "soundspan.secretName" $ctx }}
+      key: {{ .secretKey }}
+      optional: true
+{{- else -}}
+- name: {{ .name }}
+  value: {{ .value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -29,9 +29,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- if and .Values.aio.gpu.enabled .Values.aio.gpu.runtimeClassName }}
+      runtimeClassName: {{ .Values.aio.gpu.runtimeClassName | quote }}
+      {{- end }}
       # AIO container runs its own postgres/redis internally — needs writable FS
       securityContext:
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: {{ .Values.aio.terminationGracePeriodSeconds | default 45 }}
       containers:
         - name: soundspan
@@ -176,13 +182,7 @@ spec:
             - name: LIDARR_URL
               value: {{ .Values.config.lidarrUrl | quote }}
             {{- end }}
-            {{- if hasKey $aioEnv "LIDARR_API_KEY" }}
-            - name: LIDARR_API_KEY
-              value: {{ index $aioEnv "LIDARR_API_KEY" | quote }}
-            {{- else if .Values.config.lidarrEnabled }}
-            - name: LIDARR_API_KEY
-              value: {{ .Values.config.lidarrApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LIDARR_API_KEY" "secretKey" "LIDARR_API_KEY" "value" .Values.config.lidarrApiKey "enabled" .Values.config.lidarrEnabled "envMap" $aioEnv) | nindent 12 }}
             {{- if hasKey $aioEnv "AUDIOBOOKSHELF_URL" }}
             - name: AUDIOBOOKSHELF_URL
               value: {{ index $aioEnv "AUDIOBOOKSHELF_URL" | quote }}
@@ -190,34 +190,10 @@ spec:
             - name: AUDIOBOOKSHELF_URL
               value: {{ .Values.config.audiobookshelfUrl | quote }}
             {{- end }}
-            {{- if hasKey $aioEnv "AUDIOBOOKSHELF_TOKEN" }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ index $aioEnv "AUDIOBOOKSHELF_TOKEN" | quote }}
-            {{- else if .Values.config.audiobookshelfUrl }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ .Values.config.audiobookshelfToken | quote }}
-            {{- end }}
-            {{- if hasKey $aioEnv "LASTFM_API_KEY" }}
-            - name: LASTFM_API_KEY
-              value: {{ index $aioEnv "LASTFM_API_KEY" | quote }}
-            {{- else if .Values.config.lastfmApiKey }}
-            - name: LASTFM_API_KEY
-              value: {{ .Values.config.lastfmApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $aioEnv "FANART_API_KEY" }}
-            - name: FANART_API_KEY
-              value: {{ index $aioEnv "FANART_API_KEY" | quote }}
-            {{- else if .Values.config.fanartApiKey }}
-            - name: FANART_API_KEY
-              value: {{ .Values.config.fanartApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $aioEnv "OPENAI_API_KEY" }}
-            - name: OPENAI_API_KEY
-              value: {{ index $aioEnv "OPENAI_API_KEY" | quote }}
-            {{- else if .Values.config.openaiApiKey }}
-            - name: OPENAI_API_KEY
-              value: {{ .Values.config.openaiApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "AUDIOBOOKSHELF_TOKEN" "secretKey" "AUDIOBOOKSHELF_TOKEN" "value" .Values.config.audiobookshelfToken "enabled" .Values.config.audiobookshelfUrl "envMap" $aioEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LASTFM_API_KEY" "secretKey" "LASTFM_API_KEY" "value" .Values.config.lastfmApiKey "enabled" .Values.config.lastfmApiKey "envMap" $aioEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "FANART_API_KEY" "secretKey" "FANART_API_KEY" "value" .Values.config.fanartApiKey "enabled" .Values.config.fanartApiKey "envMap" $aioEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "OPENAI_API_KEY" "secretKey" "OPENAI_API_KEY" "value" .Values.config.openaiApiKey "enabled" .Values.config.openaiApiKey "envMap" $aioEnv) | nindent 12 }}
           {{- $globalEnv := .Values.global.env | default (dict) }}
           {{- $globalEnvFrom := .Values.global.envFrom | default (list) }}
           {{- $aioEnvFrom := .Values.aio.envFrom | default (list) }}
@@ -259,10 +235,15 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 3
           resources:
+            {{- if .Values.aio.gpu.enabled }}
+            requests:
+              {{- toYaml .Values.aio.resources.requests | nindent 14 }}
+            limits:
+              {{- toYaml .Values.aio.resources.limits | nindent 14 }}
+              nvidia.com/gpu: {{ .Values.aio.gpu.count | default 1 }}
+            {{- else }}
             {{- toYaml .Values.aio.resources | nindent 12 }}
-          {{- if .Values.aio.gpu.enabled }}
-          # GPU acceleration for audio analysis
-          {{- end }}
+            {{- end }}
       volumes:
         - name: music
           {{- if .Values.music.persistence.existingClaim }}

--- a/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
@@ -27,6 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- if and .Values.audioAnalyzerClap.gpu.enabled .Values.audioAnalyzerClap.gpu.runtimeClassName }}
+      runtimeClassName: {{ .Values.audioAnalyzerClap.gpu.runtimeClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
@@ -145,8 +149,24 @@ spec:
             - name: music
               mountPath: /music
               readOnly: true
+          {{- with .Values.audioAnalyzerClap.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.audioAnalyzerClap.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
+            {{- if .Values.audioAnalyzerClap.gpu.enabled }}
+            requests:
+              {{- toYaml .Values.audioAnalyzerClap.resources.requests | nindent 14 }}
+            limits:
+              {{- toYaml .Values.audioAnalyzerClap.resources.limits | nindent 14 }}
+              nvidia.com/gpu: {{ .Values.audioAnalyzerClap.gpu.count | default 1 }}
+            {{- else }}
             {{- toYaml .Values.audioAnalyzerClap.resources | nindent 12 }}
+            {{- end }}
       volumes:
         - name: music
           {{- if .Values.music.persistence.existingClaim }}

--- a/charts/soundspan/templates/individual/audio-analyzer.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer.yaml
@@ -27,6 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- if and .Values.audioAnalyzer.gpu.enabled .Values.audioAnalyzer.gpu.runtimeClassName }}
+      runtimeClassName: {{ .Values.audioAnalyzer.gpu.runtimeClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
@@ -130,8 +134,24 @@ spec:
             - name: music
               mountPath: /music
               readOnly: true
+          {{- with .Values.audioAnalyzer.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.audioAnalyzer.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
+            {{- if .Values.audioAnalyzer.gpu.enabled }}
+            requests:
+              {{- toYaml .Values.audioAnalyzer.resources.requests | nindent 14 }}
+            limits:
+              {{- toYaml .Values.audioAnalyzer.resources.limits | nindent 14 }}
+              nvidia.com/gpu: {{ .Values.audioAnalyzer.gpu.count | default 1 }}
+            {{- else }}
             {{- toYaml .Values.audioAnalyzer.resources | nindent 12 }}
+            {{- end }}
       volumes:
         - name: music
           {{- if .Values.music.persistence.existingClaim }}

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
@@ -324,13 +325,7 @@ spec:
             - name: LIDARR_URL
               value: {{ .Values.config.lidarrUrl | quote }}
             {{- end }}
-            {{- if hasKey $backendWorkerEnv "LIDARR_API_KEY" }}
-            - name: LIDARR_API_KEY
-              value: {{ index $backendWorkerEnv "LIDARR_API_KEY" | quote }}
-            {{- else if .Values.config.lidarrEnabled }}
-            - name: LIDARR_API_KEY
-              value: {{ .Values.config.lidarrApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LIDARR_API_KEY" "secretKey" "LIDARR_API_KEY" "value" .Values.config.lidarrApiKey "enabled" .Values.config.lidarrEnabled "envMap" $backendWorkerEnv) | nindent 12 }}
             {{- if hasKey $backendWorkerEnv "AUDIOBOOKSHELF_URL" }}
             - name: AUDIOBOOKSHELF_URL
               value: {{ index $backendWorkerEnv "AUDIOBOOKSHELF_URL" | quote }}
@@ -338,34 +333,10 @@ spec:
             - name: AUDIOBOOKSHELF_URL
               value: {{ .Values.config.audiobookshelfUrl | quote }}
             {{- end }}
-            {{- if hasKey $backendWorkerEnv "AUDIOBOOKSHELF_TOKEN" }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ index $backendWorkerEnv "AUDIOBOOKSHELF_TOKEN" | quote }}
-            {{- else if .Values.config.audiobookshelfUrl }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ .Values.config.audiobookshelfToken | quote }}
-            {{- end }}
-            {{- if hasKey $backendWorkerEnv "LASTFM_API_KEY" }}
-            - name: LASTFM_API_KEY
-              value: {{ index $backendWorkerEnv "LASTFM_API_KEY" | quote }}
-            {{- else if .Values.config.lastfmApiKey }}
-            - name: LASTFM_API_KEY
-              value: {{ .Values.config.lastfmApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $backendWorkerEnv "FANART_API_KEY" }}
-            - name: FANART_API_KEY
-              value: {{ index $backendWorkerEnv "FANART_API_KEY" | quote }}
-            {{- else if .Values.config.fanartApiKey }}
-            - name: FANART_API_KEY
-              value: {{ .Values.config.fanartApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $backendWorkerEnv "OPENAI_API_KEY" }}
-            - name: OPENAI_API_KEY
-              value: {{ index $backendWorkerEnv "OPENAI_API_KEY" | quote }}
-            {{- else if .Values.config.openaiApiKey }}
-            - name: OPENAI_API_KEY
-              value: {{ .Values.config.openaiApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "AUDIOBOOKSHELF_TOKEN" "secretKey" "AUDIOBOOKSHELF_TOKEN" "value" .Values.config.audiobookshelfToken "enabled" .Values.config.audiobookshelfUrl "envMap" $backendWorkerEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LASTFM_API_KEY" "secretKey" "LASTFM_API_KEY" "value" .Values.config.lastfmApiKey "enabled" .Values.config.lastfmApiKey "envMap" $backendWorkerEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "FANART_API_KEY" "secretKey" "FANART_API_KEY" "value" .Values.config.fanartApiKey "enabled" .Values.config.fanartApiKey "envMap" $backendWorkerEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "OPENAI_API_KEY" "secretKey" "OPENAI_API_KEY" "value" .Values.config.openaiApiKey "enabled" .Values.config.openaiApiKey "envMap" $backendWorkerEnv) | nindent 12 }}
             {{- range $key := keys $backendWorkerEnv | sortAlpha }}
             {{- if not (hasKey $backendWorkerExplicitEnvKeys $key) }}
             - name: {{ $key }}

--- a/charts/soundspan/templates/individual/backend.yaml
+++ b/charts/soundspan/templates/individual/backend.yaml
@@ -59,6 +59,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds | default 45 }}
@@ -421,13 +422,7 @@ spec:
             - name: LIDARR_URL
               value: {{ .Values.config.lidarrUrl | quote }}
             {{- end }}
-            {{- if hasKey $backendEnv "LIDARR_API_KEY" }}
-            - name: LIDARR_API_KEY
-              value: {{ index $backendEnv "LIDARR_API_KEY" | quote }}
-            {{- else if .Values.config.lidarrEnabled }}
-            - name: LIDARR_API_KEY
-              value: {{ .Values.config.lidarrApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LIDARR_API_KEY" "secretKey" "LIDARR_API_KEY" "value" .Values.config.lidarrApiKey "enabled" .Values.config.lidarrEnabled "envMap" $backendEnv) | nindent 12 }}
             {{- if hasKey $backendEnv "AUDIOBOOKSHELF_URL" }}
             - name: AUDIOBOOKSHELF_URL
               value: {{ index $backendEnv "AUDIOBOOKSHELF_URL" | quote }}
@@ -435,34 +430,10 @@ spec:
             - name: AUDIOBOOKSHELF_URL
               value: {{ .Values.config.audiobookshelfUrl | quote }}
             {{- end }}
-            {{- if hasKey $backendEnv "AUDIOBOOKSHELF_TOKEN" }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ index $backendEnv "AUDIOBOOKSHELF_TOKEN" | quote }}
-            {{- else if .Values.config.audiobookshelfUrl }}
-            - name: AUDIOBOOKSHELF_TOKEN
-              value: {{ .Values.config.audiobookshelfToken | quote }}
-            {{- end }}
-            {{- if hasKey $backendEnv "LASTFM_API_KEY" }}
-            - name: LASTFM_API_KEY
-              value: {{ index $backendEnv "LASTFM_API_KEY" | quote }}
-            {{- else if .Values.config.lastfmApiKey }}
-            - name: LASTFM_API_KEY
-              value: {{ .Values.config.lastfmApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $backendEnv "FANART_API_KEY" }}
-            - name: FANART_API_KEY
-              value: {{ index $backendEnv "FANART_API_KEY" | quote }}
-            {{- else if .Values.config.fanartApiKey }}
-            - name: FANART_API_KEY
-              value: {{ .Values.config.fanartApiKey | quote }}
-            {{- end }}
-            {{- if hasKey $backendEnv "OPENAI_API_KEY" }}
-            - name: OPENAI_API_KEY
-              value: {{ index $backendEnv "OPENAI_API_KEY" | quote }}
-            {{- else if .Values.config.openaiApiKey }}
-            - name: OPENAI_API_KEY
-              value: {{ .Values.config.openaiApiKey | quote }}
-            {{- end }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "AUDIOBOOKSHELF_TOKEN" "secretKey" "AUDIOBOOKSHELF_TOKEN" "value" .Values.config.audiobookshelfToken "enabled" .Values.config.audiobookshelfUrl "envMap" $backendEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "LASTFM_API_KEY" "secretKey" "LASTFM_API_KEY" "value" .Values.config.lastfmApiKey "enabled" .Values.config.lastfmApiKey "envMap" $backendEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "FANART_API_KEY" "secretKey" "FANART_API_KEY" "value" .Values.config.fanartApiKey "enabled" .Values.config.fanartApiKey "envMap" $backendEnv) | nindent 12 }}
+            {{- include "soundspan.optionalSecretEnv" (dict "ctx" . "name" "OPENAI_API_KEY" "secretKey" "OPENAI_API_KEY" "value" .Values.config.openaiApiKey "enabled" .Values.config.openaiApiKey "envMap" $backendEnv) | nindent 12 }}
             {{- range $key := keys $backendEnv | sortAlpha }}
             {{- if not (hasKey $backendExplicitEnvKeys $key) }}
             - name: {{ $key }}

--- a/charts/soundspan/templates/individual/frontend.yaml
+++ b/charts/soundspan/templates/individual/frontend.yaml
@@ -3,6 +3,7 @@
 {{- $frontendReplicas := include "soundspan.frontendReplicas" . | int }}
 {{- $frontendPdbEnabled := and (gt $frontendReplicas 1) (ternary .Values.haMode.pdb.enabled .Values.frontend.pdb.enabled $haEnabled) }}
 {{- $ltAllowPolling := ternary .Values.haMode.runtime.listenTogetherAllowPolling .Values.config.listenTogetherAllowPolling $haEnabled }}
+{{- $frontendPodSecurityContext := merge (deepCopy (.Values.frontend.podSecurityContext | default dict)) .Values.global.podSecurityContext }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,8 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
-        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+        {{- toYaml $frontendPodSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds | default 30 }}
       containers:
         - name: frontend

--- a/charts/soundspan/templates/individual/postgresql.yaml
+++ b/charts/soundspan/templates/individual/postgresql.yaml
@@ -28,8 +28,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"

--- a/charts/soundspan/templates/individual/redis.yaml
+++ b/charts/soundspan/templates/individual/redis.yaml
@@ -28,11 +28,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"

--- a/charts/soundspan/templates/individual/tidal.yaml
+++ b/charts/soundspan/templates/individual/tidal.yaml
@@ -29,6 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/soundspan/templates/individual/ytmusic.yaml
+++ b/charts/soundspan/templates/individual/ytmusic.yaml
@@ -29,6 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/soundspan/templates/secret.yaml
+++ b/charts/soundspan/templates/secret.yaml
@@ -34,4 +34,19 @@ stringData:
   POSTGRES_USER: {{ .Values.secrets.postgresUser | quote }}
   POSTGRES_PASSWORD: {{ $postgresPassword | quote }}
   POSTGRES_DB: {{ .Values.secrets.postgresDatabase | quote }}
+  {{- if .Values.config.lidarrEnabled }}
+  LIDARR_API_KEY: {{ .Values.config.lidarrApiKey | quote }}
+  {{- end }}
+  {{- if .Values.config.audiobookshelfUrl }}
+  AUDIOBOOKSHELF_TOKEN: {{ .Values.config.audiobookshelfToken | quote }}
+  {{- end }}
+  {{- if .Values.config.lastfmApiKey }}
+  LASTFM_API_KEY: {{ .Values.config.lastfmApiKey | quote }}
+  {{- end }}
+  {{- if .Values.config.fanartApiKey }}
+  FANART_API_KEY: {{ .Values.config.fanartApiKey | quote }}
+  {{- end }}
+  {{- if .Values.config.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.config.openaiApiKey | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/soundspan/templates/serviceaccount.yaml
+++ b/charts/soundspan/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
 {{- end }}

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -32,10 +32,18 @@ global:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   # Container-level security context used by chart-managed workloads.
   securityContext:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # Do not auto-mount the ServiceAccount API token; no chart workload calls the
+  # Kubernetes API. Set true only if you add a sidecar that needs cluster access.
+  automountServiceAccountToken: false
   # Global scheduling defaults (service-specific values still take precedence).
   nodeSelector: {}
   tolerations: []
@@ -88,12 +96,15 @@ aio:
   lifecycle:
     preStopSleepSeconds: 8
 
-  # -- Resource limits for the AIO container
+  # -- Resource limits for the AIO container. The AIO image bundles the backend,
+  #    frontend, Postgres, Redis, and (by default) the Essentia + CLAP analyzers
+  #    in one container; the analyzer models alone peak well above 4Gi. Lower
+  #    limits.memory only if you disable analysis (config.features.audioAnalysis).
   resources:
     requests:
-      memory: 1Gi
+      memory: 2Gi
     limits:
-      memory: 4Gi
+      memory: 8Gi
 
   # -- Persistence for /data (postgres, redis, cache, secrets)
   persistence:
@@ -121,10 +132,13 @@ aio:
   #       name: soundspan-extra-env
   envFrom: []
 
-  # -- GPU acceleration for audio analysis (NVIDIA)
+  # -- GPU acceleration for audio analysis (NVIDIA). Requires the NVIDIA device
+  #    plugin on the cluster. Adds an nvidia.com/gpu limit; set runtimeClassName
+  #    if your cluster requires a non-default runtime for GPU pods.
   gpu:
     enabled: false
-    # count: 1
+    count: 1
+    runtimeClassName: ""
 
 # =============================================================================
 # INDIVIDUAL MODE — Service-specific configuration
@@ -264,6 +278,13 @@ frontend:
     tag: 1.9.0
     pullPolicy: Always
   replicas: 1
+  # The published frontend image's `nextjs` user is UID/GID 1001, not the
+  # chart-wide 1000. Override here so file ownership in the image matches the
+  # runtime user until the image is realigned (docker-image-hygiene slice).
+  podSecurityContext:
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -492,6 +513,23 @@ audioAnalyzer:
       memory: 256Mi
     limits:
       memory: 1536Mi
+  # Exec liveness/readiness: the analyzer is a Redis queue-consumer loop with no
+  # HTTP server, so we check the worker process is alive (mirrors the compose
+  # healthcheck). Set either probe to null to disable.
+  livenessProbe:
+    exec:
+      command: ["pgrep", "-f", "python.*analyzer"]
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    exec:
+      command: ["pgrep", "-f", "python.*analyzer"]
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
   env:
     BATCH_SIZE: "10"
     SLEEP_INTERVAL: "5"
@@ -516,6 +554,8 @@ audioAnalyzer:
   affinity: {}
   gpu:
     enabled: false
+    count: 1
+    runtimeClassName: ""
 
 audioAnalyzerClap:
   enabled: false
@@ -529,6 +569,23 @@ audioAnalyzerClap:
       memory: 1Gi
     limits:
       memory: 5Gi
+  # Exec liveness/readiness: the analyzer is a Redis queue-consumer loop with no
+  # HTTP server, so we check the worker process is alive (mirrors the compose
+  # healthcheck). Set either probe to null to disable.
+  livenessProbe:
+    exec:
+      command: ["pgrep", "-f", "python.*analyzer"]
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    exec:
+      command: ["pgrep", "-f", "python.*analyzer"]
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
   env:
     SLEEP_INTERVAL: "5"
     CLAP_REDIS_SOCKET_TIMEOUT: "10"
@@ -551,6 +608,8 @@ audioAnalyzerClap:
   affinity: {}
   gpu:
     enabled: false
+    count: 1
+    runtimeClassName: ""
 
 # =============================================================================
 # SHARED CONFIGURATION
@@ -617,6 +676,11 @@ secrets:
   postgresUser: soundspan
   postgresPassword: "" # (auto: 32 char random)
   postgresDatabase: soundspan
+  # -- When using existingSecret, set true if that Secret ALSO carries the
+  #    optional third-party API keys (LIDARR_API_KEY, AUDIOBOOKSHELF_TOKEN,
+  #    LASTFM_API_KEY, FANART_API_KEY, OPENAI_API_KEY). Default false keeps the
+  #    legacy behavior of injecting config.* API keys as plaintext env.
+  apiKeysInExistingSecret: false
 
 # -- Common environment variables applied to backend (both modes)
 config:
@@ -639,6 +703,9 @@ config:
   audiobookshelfUrl: ""
   audiobookshelfToken: ""
   # -- Optional API keys
+  # NOTE: when the chart manages its own Secret (secrets.existingSecret unset),
+  # the keys below are injected via secretKeyRef, not plaintext pod-spec env.
+  # With an existingSecret, they stay plaintext unless secrets.apiKeysInExistingSecret=true.
   lastfmApiKey: ""
   fanartApiKey: ""
   openaiApiKey: ""
@@ -738,7 +805,6 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
-
 
 
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -125,8 +125,13 @@ Note: AIO image runs as root internally due to supervisord orchestration; indivi
 | YT Music Streamer | 100m | 1000m | 128Mi | 512Mi |
 | Audio Analyzer | 500m | 4000m | 1Gi | 6Gi |
 | Audio Analyzer CLAP | 500m | 4000m | 1Gi | 3Gi |
+| AIO (all-in-one) | — | — | 2Gi | 8Gi |
 
-Treat these as baseline estimates, then tune per library size and workload.
+Treat these as baseline estimates, then tune per library size and workload. The
+AIO container bundles the backend, frontend, Postgres, Redis, and (by default)
+both analyzers in one pod, so its memory limit must cover the analyzer model
+footprint; lower `aio.resources.limits.memory` only if you disable analysis
+(`config.features.audioAnalysis: false`).
 
 ## Rollout Hardening (Individual Mode)
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -54,6 +54,55 @@ complete.
 
 ---
 
+## Helm chart hardening (pod security, API-key Secret refs, AIO memory, frontend UID)
+
+**Who this affects:** Helm chart users. No action is required for a default
+install, but review the notes below if you use `secrets.existingSecret`, pin
+tight resource quotas, run custom sidecars in chart pods, or have GPU nodes.
+
+- **Pod security context.** All chart-managed workloads now set
+  `seccompProfile: RuntimeDefault`, drop all Linux capabilities on the
+  application containers, and set `automountServiceAccountToken: false`. If you
+  inject a custom sidecar that needs Linux capabilities or Kubernetes API
+  access, add them back on that container/pod (or set
+  `global.automountServiceAccountToken: true`). Postgres and Redis keep their
+  capabilities (their images switch users at entrypoint).
+
+- **Third-party API keys are now Secret-referenced.** `config.lidarrApiKey`,
+  `config.audiobookshelfToken`, `config.lastfmApiKey`, `config.fanartApiKey`,
+  and `config.openaiApiKey` are no longer rendered as plaintext `value:` env in
+  pod specs. With the chart-managed Secret (default) they are written into that
+  Secret and injected via `secretKeyRef` — no change needed. **If you use
+  `secrets.existingSecret`,** the legacy plaintext behavior is preserved by
+  default (your inline `config.*` values still work). To move these keys into
+  your existing Secret, add them (keys `LIDARR_API_KEY`, `AUDIOBOOKSHELF_TOKEN`,
+  `LASTFM_API_KEY`, `FANART_API_KEY`, `OPENAI_API_KEY`) and set
+  `secrets.apiKeysInExistingSecret: true`.
+
+- **AIO default memory raised.** `aio.resources` now defaults to `2Gi` request /
+  `8Gi` limit (was `1Gi`/`4Gi`); the bundled analyzers peak above the old 4Gi
+  ceiling. If your namespace has a tight `LimitRange`/`ResourceQuota`, either
+  raise it or set `aio.resources.limits.memory` back down (and disable analysis
+  with `config.features.audioAnalysis: false` if you do).
+
+- **Frontend runs as UID 1001.** The chart now runs the frontend pod as
+  UID/GID `1001` to match the published image's `nextjs` user. If you mount a
+  pre-existing writable volume for the frontend (e.g. `.next/cache`), its
+  ownership may need updating; the default cache is an `emptyDir` and needs no
+  action.
+
+- **Analyzer probes.** Individual-mode audio-analyzer and CLAP Deployments now
+  have exec (`pgrep`) liveness/readiness probes. Disable per analyzer by setting
+  `audioAnalyzer.livenessProbe`/`readinessProbe` (and CLAP equivalents) to
+  `null`.
+
+- **GPU values now function.** `aio.gpu.enabled` / `audioAnalyzer.gpu.enabled` /
+  `audioAnalyzerClap.gpu.enabled` were previously no-ops; enabling them now adds
+  an `nvidia.com/gpu` limit (`gpu.count`, default 1) and optional
+  `gpu.runtimeClassName`. Requires the NVIDIA device plugin on the cluster.
+
+---
+
 ## ⚠️ Breaking: no more shipped default secrets; fail-fast startup; Postgres/Redis bound to loopback
 
 **Who this affects:** every split-stack (`docker-compose.yml`) deployment that relied on

--- a/scripts/k8s-rollout-slo-check.sh
+++ b/scripts/k8s-rollout-slo-check.sh
@@ -111,6 +111,23 @@ print_component_pods() {
   k -n "${NAMESPACE}" get pods --no-headers | grep -E "^${workload_name}-" || true
 }
 
+collect_component_logs() {
+  # Aggregate --since logs across EVERY pod of a component so SLO breaches on
+  # any HA replica are seen (kubectl logs deploy/... only reads one pod).
+  local component="$1"
+  local workload_name="$2"
+  local pods
+  pods="$(k -n "${NAMESPACE}" get pods -l "app.kubernetes.io/component=${component}" -o name 2>/dev/null || true)"
+  if [[ -z "${pods}" ]]; then
+    # Fallback for installs without consistent component labels.
+    pods="$(k -n "${NAMESPACE}" get pods --no-headers 2>/dev/null | awk -v p="${workload_name}-" '$1 ~ "^"p {print "pod/"$1}' || true)"
+  fi
+  local pod
+  for pod in ${pods}; do
+    k -n "${NAMESPACE}" logs "${pod}" --all-containers=true --since="${WINDOW}" 2>/dev/null || true
+  done
+}
+
 workload_desired_replicas() {
   local workload="$1"
   k -n "${NAMESPACE}" get "${workload}" -o jsonpath='{.spec.replicas}'
@@ -188,10 +205,10 @@ if [[ -n "${WORKER_WORKLOAD}" ]]; then
 fi
 
 echo "[3/4] Checking SLO warning channels..."
-backend_logs="$(k -n "${NAMESPACE}" logs "${BACKEND_WORKLOAD}" --since="${WINDOW}" || true)"
+backend_logs="$(collect_component_logs "backend" "${BACKEND_WORKLOAD##*/}")"
 worker_logs=""
 if [[ -n "${WORKER_WORKLOAD}" ]]; then
-  worker_logs="$(k -n "${NAMESPACE}" logs "${WORKER_WORKLOAD}" --since="${WINDOW}" || true)"
+  worker_logs="$(collect_component_logs "backend-worker" "${WORKER_WORKLOAD##*/}")"
 fi
 
 backend_reconnect_breaches="$(printf '%s\n' "${backend_logs}" | find_matches "ListenTogether/SLO.*exceeded target")"


### PR DESCRIPTION
## Summary
Helm chart hardening (refactor campaign slice P15). Depends on P14/#239 (AIO image hardening, merged). Also wires `gpu.enabled`, deferred from P14.

## Findings addressed
- **Plaintext API keys in pod specs** → `LIDARR_API_KEY`, `AUDIOBOOKSHELF_TOKEN`, `LASTFM_API_KEY`, `FANART_API_KEY`, `OPENAI_API_KEY` now injected via `secretKeyRef` from the chart-managed Secret. New `soundspan.optionalSecretEnv` helper owns per-key precedence (explicit env override → managed-Secret ref → existing-Secret ref when `secrets.apiKeysInExistingSecret=true` → legacy plaintext for existingSecret users). Zero change for default installs.
- **Pod hardening gaps** → `seccompProfile: RuntimeDefault` chart-wide, `capabilities.drop: [ALL]` on application containers, `automountServiceAccountToken: false` on all pods + the ServiceAccount. Postgres/Redis keep caps (entrypoint user-switch) but gain seccomp.
- **Analyzer Deployments had no probes** → audio-analyzer and CLAP now have exec (`pgrep`) liveness/readiness probes (compose/chart parity), configurable per analyzer, disableable via `null`.
- **AIO 4Gi limit below workload** → default raised to `2Gi` request / `8Gi` limit to cover the bundled Essentia + CLAP analyzers.
- **SLO gate sampled one pod per deployment** → `scripts/k8s-rollout-slo-check.sh` now aggregates `--since` logs across every backend/worker pod (by component label, name-prefix fallback).
- **Frontend UID 1000 vs image 1001** → `frontend.podSecurityContext` override (merged over the chart-wide `1000`) runs the frontend pod as UID/GID 1001; global seccomp preserved. Interim until docker-image-hygiene realigns the image.
- **`gpu.enabled` was a no-op** (deferred from P14) → AIO + both analyzers now add `nvidia.com/gpu: <count>` limits and optional `runtimeClassName`.

## Verification (no cluster calls)
- `helm lint` clean; `scripts/helm-chart-render-check.sh` → `[OK] Helm render checks passed`.
- `helm template` succeeds for AIO default, individual, HA + worker split, and all sidecars/analyzers enabled.
- Targeted render assertions confirmed: all four API-key precedence paths (managed-Secret ref / plaintext back-compat / existing-Secret ref / explicit override), `nvidia.com/gpu` limit + `runtimeClassName` on GPU enable, analyzer probes, frontend UID 1001 with seccomp, cap-drop on 6 app containers, automount=false everywhere, secret.yaml carries the optional keys.
- `bash -n` on the SLO script passes.

## Breaking / UPGRADING
Documented in `docs/UPGRADING.md` (new top section) + `docs/KUBERNETES.md` + chart README. No action for default installs. Review if you: use `secrets.existingSecret` (API keys stay plaintext unless `apiKeysInExistingSecret=true`), run custom sidecars needing caps/API-token in chart pods, pin tight memory quotas (AIO now 8Gi limit), mount a pre-existing writable frontend volume (UID 1001), or use GPU nodes.

## Escalations / follow-ups
- **ytmusic `/data` chmod 777** finding is image-side (entrypoint), not chart-expressible; owned by sidecar-secret-hygiene / docker-image-hygiene. Chart applies fsGroup + non-root via `global.podSecurityContext`.
- Analyzer probes use the compose-proven `pgrep` process check rather than the Redis heartbeat (`audio:worker:heartbeat` / `clap:worker:heartbeat`) the analyzers publish; a heartbeat-freshness exec probe could be a future upgrade if analyzer-reliability exposes it via a local mechanism (redis-cli not guaranteed in-image).
- Frontend UID 1001 is a chart-side interim; pairs with docker-image-hygiene's image change.