### PR TITLE
refactor(frontend): dedup device-auth, explore cards & time helpers (refactor slice P25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nextjs` user) via a `frontend.podSecurityContext` override merged over the
   chart-wide `1000`, fixing the UID/file-ownership mismatch until the image is
   realigned.
+- Frontend (refactor slice P25, frontend-dedup): mechanical duplication
+  collapse across the frontend, no user-visible behavior change.
+  - YouTube Music account linking (`YouTubeMusicSection`) now uses the shared
+    `useDeviceAuthPolling` hook instead of a third hand-rolled device-code
+    polling/expiry/countdown state machine, matching the Tidal sections. This
+    inherits the hook's bounded, race-safe polling, tracked timers with
+    deterministic cleanup, and generation-guarded cancellation.
+  - Extracted the duplicated device-code linking UI shared by the TIDAL and
+    YouTube Music settings sections into one presentational component
+    (`features/settings/components/ui/DeviceAuthLinkPanel`).
+  - Extracted the copy-pasted Explore media card (square thumbnail + title +
+    subtitle) into a shared `features/explore/components/BrowseCard`, adopted by
+    the featured-shelves and mixes sections for both TIDAL and YouTube Music.
+  - Consolidated nine local time/duration re-implementations onto
+    `utils/formatTime`, adding a documented `formatRelativeTime` helper for the
+    activity tabs (History, Notifications, Active Downloads).
+  - Replaced index-based React keys with stable content-derived keys in
+    `PreviewEpisodes` and `SyncedLyrics`.
+
 - Backend: introduced a single consolidated, typed Lidarr HTTP client
   (`backend/src/services/lidarr/lidarrHttpClient.ts`) as the standard boundary
   for outbound Lidarr calls. It wraps one reusable axios instance with bounded

--- a/frontend/app/device/page.tsx
+++ b/frontend/app/device/page.tsx
@@ -9,6 +9,7 @@ import {
     BRAND_DEEP_LINK_SCHEME,
 } from "@/lib/brand";
 import { cn } from "@/utils/cn";
+import { formatTime } from "@/utils/formatTime";
 import { QRCodeSVG } from "qrcode.react";
 import { Card } from "@/components/ui/Card";
 import { GradientSpinner } from "@/components/ui/GradientSpinner";
@@ -153,13 +154,6 @@ export default function DeviceLinkPage() {
         } catch (err) {
             sharedFrontendLogger.error("Failed to revoke device:", err);
         }
-    };
-
-    // Format time remaining
-    const formatTime = (seconds: number) => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins}:${secs.toString().padStart(2, "0")}`;
     };
 
     // Build QR code URL (contains code and server URL)

--- a/frontend/app/listen-together/page.tsx
+++ b/frontend/app/listen-together/page.tsx
@@ -32,6 +32,7 @@ import { GradientSpinner } from "@/components/ui/GradientSpinner";
 import { EqBars } from "@/components/ui/EqBars";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { cn } from "@/utils/cn";
+import { formatTime } from "@/utils/formatTime";
 import { TidalBadge } from "@/components/ui/TidalBadge";
 import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
@@ -853,7 +854,7 @@ function QueueItem({
 
             {/* Duration */}
             <span className="text-xs text-[#525252] flex-shrink-0 tabular-nums">
-                {formatDuration(item.duration)}
+                {formatTime(item.duration)}
             </span>
 
             {/* Overflow Menu */}
@@ -881,12 +882,6 @@ function QueueItem({
             />
         </div>
     );
-}
-
-function formatDuration(seconds: number): string {
-    const m = Math.floor(seconds / 60);
-    const s = Math.floor(seconds % 60);
-    return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/components/activity/ActiveDownloadsTab.tsx
+++ b/frontend/components/activity/ActiveDownloadsTab.tsx
@@ -5,6 +5,7 @@ import { Download, Loader2, Music, Disc, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { createFrontendLogger } from "@/lib/logger";
 import { cn } from "@/utils/cn";
+import { formatRelativeTime } from "@/utils/formatTime";
 import { GradientSpinner } from "../ui/GradientSpinner";
 import {
     useActiveDownloads,
@@ -79,17 +80,6 @@ export function ActiveDownloadsTab({
         } finally {
             setCancelling(new Set());
         }
-    };
-
-    const formatTime = (dateStr: string) => {
-        const date = new Date(dateStr);
-        const now = new Date();
-        const diff = now.getTime() - date.getTime();
-
-        if (diff < 60000) return "Just started";
-        if (diff < 3600000) return `${Math.floor(diff / 60000)}m`;
-        if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`;
-        return date.toLocaleDateString();
     };
 
     if (loading) {
@@ -206,7 +196,10 @@ export function ActiveDownloadsTab({
                                         •
                                     </span>
                                     <span className="text-xs text-white/30">
-                                        {formatTime(download.createdAt)}
+                                        {formatRelativeTime(download.createdAt, {
+                                            justNowLabel: "Just started",
+                                            suffix: "",
+                                        })}
                                     </span>
                                 </div>
                             </div>

--- a/frontend/components/activity/HistoryTab.tsx
+++ b/frontend/components/activity/HistoryTab.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 import { useDownloadContext } from "@/lib/download-context";
 import { createFrontendLogger } from "@/lib/logger";
 import { cn } from "@/utils/cn";
+import { formatRelativeTime } from "@/utils/formatTime";
 
 const logger = createFrontendLogger("Activity.HistoryTab");
 
@@ -190,17 +191,6 @@ function HistoryItem({
     const isCompleted = item.status === "completed";
     const isFailed = item.status === "failed" || item.status === "exhausted";
 
-    const formatTime = (dateStr: string) => {
-        const date = new Date(dateStr);
-        const now = new Date();
-        const diff = now.getTime() - date.getTime();
-        
-        if (diff < 60000) return "Just now";
-        if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
-        if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
-        return date.toLocaleDateString();
-    };
-
     return (
         <div className="px-3 py-3 border-b border-white/5 hover:bg-white/5 transition-colors group">
             <div className="flex items-start gap-3">
@@ -226,7 +216,7 @@ function HistoryItem({
                         </span>
                         <span className="text-xs text-white/30">•</span>
                         <span className="text-xs text-white/30">
-                            {formatTime(item.completedAt || item.createdAt)}
+                            {formatRelativeTime(item.completedAt || item.createdAt)}
                         </span>
                     </div>
                     {item.error && (

--- a/frontend/components/activity/NotificationsTab.tsx
+++ b/frontend/components/activity/NotificationsTab.tsx
@@ -17,6 +17,7 @@ import {
     type Notification,
 } from "@/hooks/useNotifications";
 import { createFrontendLogger } from "@/lib/logger";
+import { formatRelativeTime } from "@/utils/formatTime";
 
 const logger = createFrontendLogger("Activity.NotificationsTab");
 
@@ -112,17 +113,6 @@ export function NotificationsTab({
         return null;
     };
 
-    const formatTime = (dateStr: string) => {
-        const date = new Date(dateStr);
-        const now = new Date();
-        const diff = now.getTime() - date.getTime();
-
-        if (diff < 60000) return "Just now";
-        if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
-        if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
-        return date.toLocaleDateString();
-    };
-
     if (loading) {
         return (
             <div className="flex items-center justify-center py-8">
@@ -201,7 +191,7 @@ export function NotificationsTab({
                                     )}
                                     <div className="flex items-center gap-2 mt-1.5">
                                         <span className="text-[10px] text-white/30">
-                                            {formatTime(notification.createdAt)}
+                                            {formatRelativeTime(notification.createdAt)}
                                         </span>
                                         {link && (
                                             <Link

--- a/frontend/components/player/SyncedLyrics.tsx
+++ b/frontend/components/player/SyncedLyrics.tsx
@@ -178,7 +178,7 @@ export function SyncedLyrics({
                 <div className="space-y-2 max-w-3xl mx-auto">
                     {plainLyrics.split("\n").map((line, i) => (
                         <p
-                            key={i}
+                            key={`${i}-${line}`}
                             className={cn(
                                 "text-base text-gray-300 leading-relaxed transition-colors text-center",
                                 line.trim() === "" && "h-4"
@@ -213,7 +213,7 @@ export function SyncedLyrics({
 
                     return (
                         <div
-                            key={i}
+                            key={`${line.time}-${i}`}
                             ref={isActive ? activeLineRef : undefined}
                             onClick={() => !isEmpty && handleLineClick(line.time)}
                             className={cn(

--- a/frontend/features/audiobook/components/AudiobookActionBar.tsx
+++ b/frontend/features/audiobook/components/AudiobookActionBar.tsx
@@ -2,6 +2,7 @@
 
 import { Play, Pause, RotateCcw, CheckCircle, Loader2 } from "lucide-react";
 import { usePlayButtonFeedback } from "@/hooks/usePlayButtonFeedback";
+import { formatTime as defaultFormatTime } from "@/utils/formatTime";
 import type { Audiobook } from "../types";
 
 interface AudiobookActionBarProps {
@@ -26,7 +27,7 @@ export function AudiobookActionBar({
   onPlayPause,
   onResetProgress,
   onMarkAsCompleted,
-  formatTime = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`,
+  formatTime = defaultFormatTime,
 }: AudiobookActionBarProps) {
   const { showSpinner, triggerPlayFeedback } = usePlayButtonFeedback();
   const hasProgress = audiobook.progress && audiobook.progress.progress > 0;

--- a/frontend/features/explore/components/BrowseCard.tsx
+++ b/frontend/features/explore/components/BrowseCard.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+
+/** Normalized data for one Explore browse card (thumbnail + title + optional subtitle). */
+export interface BrowseCardProps {
+    href: string | null;
+    imageUrl: string | null;
+    title: string;
+    subtitle?: string | null;
+}
+
+/** Renders a square-thumbnail browse card, linked when href is provided. */
+export function BrowseCard({ href, imageUrl, title, subtitle }: BrowseCardProps) {
+    const inner = (
+        <>
+            <div className="aspect-square rounded-md bg-white/5 overflow-hidden mb-2">
+                {imageUrl && (
+                    <img
+                        src={imageUrl}
+                        alt={title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                    />
+                )}
+            </div>
+            <p className="text-sm text-white truncate">{title}</p>
+            {subtitle && <p className="text-xs text-gray-400 truncate">{subtitle}</p>}
+        </>
+    );
+    if (href) {
+        return <Link href={href} className="group cursor-pointer">{inner}</Link>;
+    }
+    return <div className="group">{inner}</div>;
+}

--- a/frontend/features/explore/components/FeaturedShelvesSection.tsx
+++ b/frontend/features/explore/components/FeaturedShelvesSection.tsx
@@ -4,11 +4,11 @@
  * Shows YT Music curated featured shelves.
  */
 
-import Link from "next/link";
 import { SectionHeader } from "@/features/home/components/SectionHeader";
 import { api } from "@/lib/api";
 import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 import type { YtMusicHomeShelf } from "@/hooks/useQueries";
+import { BrowseCard } from "./BrowseCard";
 
 interface FeaturedShelvesSectionProps {
     homeShelves: YtMusicHomeShelf[];
@@ -44,42 +44,14 @@ export function FeaturedShelvesSection({
                                 : item.browseId && item.type === "album"
                                   ? `/explore/yt-playlist/${encodeURIComponent(item.browseId)}?type=album`
                                   : null;
-                            const inner = (
-                                <>
-                                    <div className="aspect-square rounded-md bg-white/5 overflow-hidden mb-2">
-                                        {item.thumbnailUrl && (
-                                            <img
-                                                src={api.getBrowseImageUrl(item.thumbnailUrl)}
-                                                alt={item.title ?? ""}
-                                                className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                                            />
-                                        )}
-                                    </div>
-                                    <p className="text-sm text-white truncate">
-                                        {item.title}
-                                    </p>
-                                    {item.subtitle && (
-                                        <p className="text-xs text-gray-400 truncate">
-                                            {item.subtitle}
-                                        </p>
-                                    )}
-                                </>
-                            );
-                            return href ? (
-                                <Link
+                            return (
+                                <BrowseCard
                                     key={item.playlistId ?? item.browseId ?? item.videoId ?? i}
                                     href={href}
-                                    className="group cursor-pointer"
-                                >
-                                    {inner}
-                                </Link>
-                            ) : (
-                                <div
-                                    key={item.playlistId ?? item.browseId ?? item.videoId ?? i}
-                                    className="group"
-                                >
-                                    {inner}
-                                </div>
+                                    imageUrl={item.thumbnailUrl ? api.getBrowseImageUrl(item.thumbnailUrl) : null}
+                                    title={item.title ?? ""}
+                                    subtitle={item.subtitle}
+                                />
                             );
                         })}
                     </div>

--- a/frontend/features/explore/components/TidalFeaturedShelvesSection.tsx
+++ b/frontend/features/explore/components/TidalFeaturedShelvesSection.tsx
@@ -4,11 +4,11 @@
  * Shows TIDAL curated home + explore shelves combined.
  */
 
-import Link from "next/link";
 import { SectionHeader } from "@/features/home/components/SectionHeader";
 import { api } from "@/lib/api";
 import { TidalBadge } from "@/components/ui/TidalBadge";
 import type { TidalBrowseShelf, TidalBrowseShelfItem } from "@/hooks/useQueries";
+import { BrowseCard } from "./BrowseCard";
 
 interface TidalFeaturedShelvesSectionProps {
     homeShelves: TidalBrowseShelf[];
@@ -59,46 +59,15 @@ export function TidalFeaturedShelvesSection({
                         badge={<TidalBadge />}
                     />
                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-                        {shelf.contents?.slice(0, 12).map((item, i) => {
-                            const href = getItemHref(item);
-                            const inner = (
-                                <>
-                                    <div className="aspect-square rounded-md bg-white/5 overflow-hidden mb-2">
-                                        {item.thumbnailUrl && (
-                                            <img
-                                                src={api.getTidalBrowseImageUrl(item.thumbnailUrl)}
-                                                alt={item.title ?? ""}
-                                                className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                                            />
-                                        )}
-                                    </div>
-                                    <p className="text-sm text-white truncate">
-                                        {item.title}
-                                    </p>
-                                    {item.subtitle && (
-                                        <p className="text-xs text-gray-400 truncate">
-                                            {item.subtitle}
-                                        </p>
-                                    )}
-                                </>
-                            );
-                            return href ? (
-                                <Link
-                                    key={getItemKey(item, i)}
-                                    href={href}
-                                    className="group cursor-pointer"
-                                >
-                                    {inner}
-                                </Link>
-                            ) : (
-                                <div
-                                    key={getItemKey(item, i)}
-                                    className="group"
-                                >
-                                    {inner}
-                                </div>
-                            );
-                        })}
+                        {shelf.contents?.slice(0, 12).map((item, i) => (
+                            <BrowseCard
+                                key={getItemKey(item, i)}
+                                href={getItemHref(item)}
+                                imageUrl={item.thumbnailUrl ? api.getTidalBrowseImageUrl(item.thumbnailUrl) : null}
+                                title={item.title ?? ""}
+                                subtitle={item.subtitle}
+                            />
+                        ))}
                     </div>
                 </section>
             ))}

--- a/frontend/features/explore/components/TidalMixesSection.tsx
+++ b/frontend/features/explore/components/TidalMixesSection.tsx
@@ -4,12 +4,12 @@
  * Shows a carousel of personal TIDAL mixes using HorizontalCarousel.
  */
 
-import Link from "next/link";
 import { SectionHeader } from "@/features/home/components/SectionHeader";
 import { TidalBadge } from "@/components/ui/TidalBadge";
 import { HorizontalCarousel, CarouselItem } from "@/components/ui/HorizontalCarousel";
 import { api } from "@/lib/api";
 import type { TidalMixPreview } from "@/hooks/useQueries";
+import { BrowseCard } from "./BrowseCard";
 
 interface TidalMixesSectionProps {
     mixes: TidalMixPreview[];
@@ -27,24 +27,12 @@ export function TidalMixesSection({ mixes }: TidalMixesSectionProps) {
             <HorizontalCarousel gap="lg">
                 {mixes.map((mix) => (
                     <CarouselItem key={mix.mixId}>
-                        <Link
+                        <BrowseCard
                             href={`/explore/tidal-mix/${encodeURIComponent(mix.mixId)}`}
-                            className="group"
-                        >
-                            <div className="aspect-square rounded-md bg-white/5 overflow-hidden mb-2">
-                                {mix.thumbnailUrl && (
-                                    <img
-                                        src={api.getTidalBrowseImageUrl(mix.thumbnailUrl)}
-                                        alt={mix.title}
-                                        className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                                    />
-                                )}
-                            </div>
-                            <p className="text-sm text-white truncate">{mix.title}</p>
-                            {mix.subTitle && (
-                                <p className="text-xs text-gray-400 truncate">{mix.subTitle}</p>
-                            )}
-                        </Link>
+                            imageUrl={mix.thumbnailUrl ? api.getTidalBrowseImageUrl(mix.thumbnailUrl) : null}
+                            title={mix.title}
+                            subtitle={mix.subTitle}
+                        />
                     </CarouselItem>
                 ))}
             </HorizontalCarousel>

--- a/frontend/features/explore/components/YtMusicMixesSection.tsx
+++ b/frontend/features/explore/components/YtMusicMixesSection.tsx
@@ -10,12 +10,12 @@
  * render. Revisit when ytmusicapi resolves #813.
  */
 
-import Link from "next/link";
 import { SectionHeader } from "@/features/home/components/SectionHeader";
 import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 import { HorizontalCarousel, CarouselItem } from "@/components/ui/HorizontalCarousel";
 import { api } from "@/lib/api";
 import type { YtMusicMixPreview } from "@/hooks/useQueries";
+import { BrowseCard } from "./BrowseCard";
 
 interface YtMusicMixesSectionProps {
     mixes: YtMusicMixPreview[];
@@ -36,24 +36,12 @@ export function YtMusicMixesSection({ mixes }: YtMusicMixesSectionProps) {
                         ?? mix.thumbnails?.[0];
                     return (
                         <CarouselItem key={mix.playlistId}>
-                            <Link
+                            <BrowseCard
                                 href={`/explore/yt-playlist/${encodeURIComponent(mix.playlistId)}`}
-                                className="group"
-                            >
-                                <div className="aspect-square rounded-md bg-white/5 overflow-hidden mb-2">
-                                    {thumbnail?.url && (
-                                        <img
-                                            src={api.getBrowseImageUrl(thumbnail.url)}
-                                            alt={mix.title}
-                                            className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                                        />
-                                    )}
-                                </div>
-                                <p className="text-sm text-white truncate">{mix.title}</p>
-                                {mix.description && (
-                                    <p className="text-xs text-gray-400 truncate">{mix.description}</p>
-                                )}
-                            </Link>
+                                imageUrl={thumbnail?.url ? api.getBrowseImageUrl(thumbnail.url) : null}
+                                title={mix.title}
+                                subtitle={mix.description}
+                            />
                         </CarouselItem>
                     );
                 })}

--- a/frontend/features/podcast/components/PreviewEpisodes.tsx
+++ b/frontend/features/podcast/components/PreviewEpisodes.tsx
@@ -34,7 +34,7 @@ export function PreviewEpisodes({
                         <div className="space-y-1">
                             {previewData.previewEpisodes.map((episode, index) => (
                                 <div
-                                    key={index}
+                                    key={`${episode.publishedAt}-${episode.title}`}
                                     className="flex items-center gap-4 px-3 py-3 rounded-md opacity-60 cursor-not-allowed"
                                 >
                                     {/* Number */}

--- a/frontend/features/search/components/YouTubePreviewCard.tsx
+++ b/frontend/features/search/components/YouTubePreviewCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { Play, Download, Loader2, ChevronDown } from "lucide-react";
 import type { YtVideoInfo } from "../hooks/useYouTubeUrl";
+import { formatTime } from "@/utils/formatTime";
 
 interface YouTubePreviewCardProps {
     videoInfo: YtVideoInfo;
@@ -25,16 +26,6 @@ const FORMAT_OPTIONS = [
     { label: "Opus", format: "opus", quality: "HIGH" },
     { label: "FLAC", format: "flac", quality: "LOSSLESS" },
 ] as const;
-
-function formatDuration(seconds: number): string {
-    const h = Math.floor(seconds / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    const s = seconds % 60;
-    if (h > 0) {
-        return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-    }
-    return `${m}:${s.toString().padStart(2, "0")}`;
-}
 
 export function YouTubePreviewCard({
     videoInfo,
@@ -100,7 +91,7 @@ export function YouTubePreviewCard({
                                 {videoInfo.uploader}
                             </p>
                             <p className="text-sm text-gray-500 mt-1">
-                                {formatDuration(videoInfo.duration)}
+                                {formatTime(videoInfo.duration)}
                             </p>
                         </div>
 

--- a/frontend/features/settings/components/sections/TidalStreamingSection.tsx
+++ b/frontend/features/settings/components/sections/TidalStreamingSection.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { SettingsRow, SettingsSelect, SettingsToggle, IntegrationCard } from "../ui";
+import { DeviceAuthLinkPanel, SettingsRow, SettingsSelect, SettingsToggle, IntegrationCard } from "../ui";
 import { UserSettings } from "../../types";
-import { CheckCircle, XCircle, Loader2, ExternalLink, Copy, AlertTriangle, Music2 } from "lucide-react";
+import { CheckCircle, XCircle, AlertTriangle, Music2 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useDeviceAuthPolling } from "@/hooks/useDeviceAuthPolling";
 
@@ -159,12 +159,6 @@ export function TidalStreamingCard({
         }
     }, [userCode]);
 
-    const formatTimeLeft = (seconds: number): string => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins}:${secs.toString().padStart(2, "0")}`;
-    };
-
     // Derived card state
     const isDisabled = !statusLoading && (!tidalEnabled || !tidalAvailable);
     const disabledReason = !tidalEnabled
@@ -216,91 +210,18 @@ export function TidalStreamingCard({
                 <div className="space-y-3">
                     {/* In linking flow — show device code + verification URL */}
                     {userCode && authState === "polling" && (
-                        <div className="p-4 bg-[#252525] rounded-lg border border-[#333] space-y-4">
-                            <div className="space-y-3">
-                                <p className="text-sm text-gray-300">
-                                    A TIDAL authorization page should have opened.
-                                    If it didn&apos;t, click the link below.
-                                </p>
-
-                                {/* Step 1 — Paste code */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">1</span>
-                                    <div className="space-y-2">
-                                        <p className="text-sm text-gray-300">
-                                            Enter this code on the TIDAL page
-                                            <span className="text-gray-500 text-xs ml-1">(it&apos;s already on your clipboard)</span>
-                                        </p>
-                                        <div className="flex items-center gap-3">
-                                            <code className="px-4 py-2 text-lg font-mono font-bold tracking-wider bg-[#1a1a1a] text-white rounded-lg border border-[#444] select-all">
-                                                {userCode}
-                                            </code>
-                                            <button
-                                                onClick={handleCopyCode}
-                                                className="p-2 text-gray-400 hover:text-white transition-colors"
-                                                title="Copy code"
-                                            >
-                                                {copied ? (
-                                                    <CheckCircle className="w-4 h-4 text-green-400" />
-                                                ) : (
-                                                    <Copy className="w-4 h-4" />
-                                                )}
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {/* Step 2 — Sign in */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">2</span>
-                                    <p className="text-sm text-gray-300">
-                                        Sign in with your TIDAL account and click <strong className="text-white">Allow</strong>
-                                    </p>
-                                </div>
-
-                                {/* Step 3 — Come back */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">3</span>
-                                    <p className="text-sm text-gray-300">
-                                        Return here — this page will update automatically
-                                    </p>
-                                </div>
-                            </div>
-
-                            {authUrl && (
-                                <a
-                                    href={authUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-blue-600/20 text-blue-400 rounded-full
-                                        hover:bg-blue-600/30 border border-blue-500/30 transition-colors"
-                                >
-                                    <ExternalLink className="w-4 h-4" />
-                                    Open TIDAL Authorization Page
-                                </a>
-                            )}
-
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2 text-sm text-gray-400">
-                                    <Loader2 className="w-3 h-3 animate-spin" />
-                                    <span>Waiting for you to complete sign-in...</span>
-                                </div>
-                                {timeLeft !== null && (
-                                    <span className={`text-xs tabular-nums ${
-                                        timeLeft < 120 ? "text-amber-400/70" : "text-gray-500"
-                                    }`}>
-                                        Expires in {formatTimeLeft(timeLeft)}
-                                    </span>
-                                )}
-                            </div>
-
-                            <button
-                                onClick={handleCancelLink}
-                                className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
-                            >
-                                Cancel
-                            </button>
-                        </div>
+                        <DeviceAuthLinkPanel
+                            userCode={userCode}
+                            verificationUrl={authUrl}
+                            timeLeftSeconds={timeLeft}
+                            copied={copied}
+                            onCopyCode={handleCopyCode}
+                            onCancel={handleCancelLink}
+                            introText="A TIDAL authorization page should have opened. If it didn't, click the link below."
+                            pasteInstruction="Enter this code on the TIDAL page"
+                            signInInstruction={<>Sign in with your TIDAL account and click <strong className="text-white">Allow</strong></>}
+                            openLinkLabel="Open TIDAL Authorization Page"
+                        />
                     )}
 
                     {(authError || error) && (

--- a/frontend/features/settings/components/sections/YouTubeMusicSection.tsx
+++ b/frontend/features/settings/components/sections/YouTubeMusicSection.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { SettingsSection, SettingsRow, SettingsToggle, SettingsSelect, SettingsInput, IntegrationCard } from "../ui";
+import { DeviceAuthLinkPanel, SettingsSection, SettingsRow, SettingsToggle, SettingsSelect, SettingsInput, IntegrationCard } from "../ui";
 import { UserSettings, SystemSettings } from "../../types";
 import { api } from "@/lib/api";
 import { createFrontendLogger } from "@/lib/logger";
+import { useDeviceAuthPolling } from "@/hooks/useDeviceAuthPolling";
 // lucide-react 1.x removed brand icons (Youtube included); SquarePlay is the closest generic stand-in.
-import { CheckCircle, XCircle, Loader2, ExternalLink, Copy, AlertTriangle, SquarePlay, ChevronDown, ChevronRight } from "lucide-react";
+import { CheckCircle, XCircle, AlertTriangle, SquarePlay, ChevronDown, ChevronRight } from "lucide-react";
 
 const logger = createFrontendLogger("Settings.YouTubeMusicSection");
 
@@ -134,102 +135,7 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
-    // Device code flow state
-    const [deviceCode, setDeviceCode] = useState<string | null>(null);
-    const [userCode, setUserCode] = useState<string | null>(null);
-    const [verificationUrl, setVerificationUrl] = useState<string | null>(null);
-    const [linking, setLinking] = useState(false);
-    const [polling, setPolling] = useState(false);
     const [copied, setCopied] = useState(false);
-    const [expiresAt, setExpiresAt] = useState<number | null>(null);
-    const [timeLeft, setTimeLeft] = useState<number | null>(null);
-
-    // Check status on mount
-    useEffect(() => {
-        checkStatus();
-    }, []);
-
-    // Expiration countdown
-    useEffect(() => {
-        if (!expiresAt || !polling) {
-            setTimeLeft(null);
-            return;
-        }
-
-        const tick = () => {
-            const remaining = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
-            setTimeLeft(remaining);
-            if (remaining <= 0) {
-                // Device code expired — cancel the flow
-                setPolling(false);
-                setDeviceCode(null);
-                setUserCode(null);
-                setVerificationUrl(null);
-                setExpiresAt(null);
-                setError("The sign-in code has expired. Please try again.");
-            }
-        };
-
-        tick();
-        const interval = setInterval(tick, 1000);
-        return () => clearInterval(interval);
-    }, [expiresAt, polling]);
-
-    // Polling effect — uses recursive setTimeout so the next poll only
-    // starts after the previous one completes (prevents overlapping requests
-    // that cause the device code to be consumed then re-used → invalid_grant)
-    useEffect(() => {
-        if (!polling || !deviceCode) return;
-
-        let cancelled = false;
-        let timer: ReturnType<typeof setTimeout>;
-
-        const poll = async () => {
-            if (cancelled) return;
-            try {
-                const result = await api.pollYtMusicAuth(deviceCode);
-                if (cancelled) return;
-
-                if (result.status === "success") {
-                    setPolling(false);
-                    setDeviceCode(null);
-                    setUserCode(null);
-                    setVerificationUrl(null);
-                    setExpiresAt(null);
-                    setSuccess("YouTube Music account connected successfully!");
-                    setError(null);
-                    await checkStatus();
-                    window.dispatchEvent(new Event("ytmusic-auth-changed"));
-                    return; // done — don't schedule another poll
-                } else if (result.status === "error") {
-                    setPolling(false);
-                    setDeviceCode(null);
-                    setUserCode(null);
-                    setVerificationUrl(null);
-                    setExpiresAt(null);
-                    setError(result.error || "Authorization failed. Please try again.");
-                    return; // done — don't schedule another poll
-                }
-                // "pending" — schedule next poll
-            } catch (err: any) {
-                // Don't stop polling on transient errors
-                logger.debug("YouTube Music poll error; retrying", {
-                    error: err,
-                });
-            }
-            if (!cancelled) {
-                timer = setTimeout(poll, 5000);
-            }
-        };
-
-        // First poll after a 5-second delay
-        timer = setTimeout(poll, 5000);
-
-        return () => {
-            cancelled = true;
-            clearTimeout(timer);
-        };
-    }, [polling, deviceCode]);
 
     const checkStatus = useCallback(async () => {
         setStatusLoading(true);
@@ -243,46 +149,84 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
         }
     }, []);
 
-    const handleLinkAccount = async () => {
-        setLinking(true);
+    // Check status on mount
+    useEffect(() => {
+        void checkStatus();
+    }, [checkStatus]);
+
+    const initiateAuth = useCallback(async () => {
+        const r = await api.initiateYtMusicAuth();
+        return {
+            deviceCode: r.device_code,
+            verificationUri: r.verification_url,
+            userCode: r.user_code,
+            pollIntervalMs: (r.interval || 5) * 1000,
+            expiresAtMs: Date.now() + r.expires_in * 1000,
+        };
+    }, []);
+
+    const pollAuth = useCallback(async (deviceCode: string) => {
+        const r = await api.pollYtMusicAuth(deviceCode);
+        if (r.status === "success") return { status: "success" } as const;
+        if (r.status === "error") {
+            return {
+                status: "error",
+                message: r.error || "Authorization failed. Please try again.",
+            } as const;
+        }
+        return { status: "pending" } as const;
+    }, []);
+
+    const handleSessionStarted = useCallback(async (session: {
+        userCode?: string;
+        verificationUri: string;
+    }) => {
+        try {
+            await navigator.clipboard.writeText(session.userCode || "");
+            setCopied(true);
+            setTimeout(() => setCopied(false), 3000);
+        } catch {
+            // Clipboard is optional.
+        }
+        window.open(session.verificationUri, "_blank", "noopener,noreferrer");
+    }, []);
+
+    const handleAuthSuccess = useCallback(() => {
+        setSuccess("YouTube Music account connected successfully!");
+        setError(null);
+        void checkStatus();
+        window.dispatchEvent(new Event("ytmusic-auth-changed"));
+    }, [checkStatus]);
+
+    const {
+        phase: authState,
+        session: authSession,
+        error: authError,
+        timeLeftSeconds: timeLeft,
+        start: startAuthentication,
+        cancel: cancelAuthentication,
+    } = useDeviceAuthPolling({
+        initiate: initiateAuth,
+        poll: pollAuth,
+        onSessionStarted: handleSessionStarted,
+        onSuccess: handleAuthSuccess,
+        expiredMessage: "The sign-in code has expired. Please try again.",
+        startErrorMessage: "Failed to start authentication. Check admin credentials.",
+    });
+    const userCode = authSession?.userCode || "";
+    const verificationUrl = authSession?.verificationUri || "";
+    const polling = authState === "polling";
+
+    const handleLinkAccount = useCallback(async () => {
         setError(null);
         setSuccess(null);
+        await startAuthentication();
+    }, [startAuthentication]);
 
-        try {
-            const result = await api.initiateYtMusicAuth();
-            setDeviceCode(result.device_code);
-            setUserCode(result.user_code);
-            setVerificationUrl(result.verification_url);
-            setExpiresAt(Date.now() + result.expires_in * 1000);
-            setPolling(true);
-
-            // Copy code to clipboard so user can paste it on Google's page
-            try {
-                await navigator.clipboard.writeText(result.user_code);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 3000);
-            } catch {
-                // Clipboard may not be available — user can copy manually
-            }
-
-            // Open the Google device code entry page (without ?user_code= which
-            // adds an unnecessary confirmation step before the real entry page)
-            window.open(result.verification_url, "_blank", "noopener,noreferrer");
-        } catch (err: any) {
-            setError(err.message || "Failed to start authentication. Check admin credentials.");
-        } finally {
-            setLinking(false);
-        }
-    };
-
-    const handleCancelLink = () => {
-        setPolling(false);
-        setDeviceCode(null);
-        setUserCode(null);
-        setVerificationUrl(null);
-        setExpiresAt(null);
+    const handleCancelLink = useCallback(() => {
+        cancelAuthentication();
         setError(null);
-    };
+    }, [cancelAuthentication]);
 
     const handleClearAuth = async () => {
         try {
@@ -313,12 +257,6 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         }
-    };
-
-    const formatTimeLeft = (seconds: number): string => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins}:${secs.toString().padStart(2, "0")}`;
     };
 
     const qualityOptions = [
@@ -376,14 +314,14 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
             connected={isConnected}
             onConnect={canLinkAccount ? handleLinkAccount : undefined}
             onDisconnect={handleClearAuth}
-            isLoading={statusLoading || linking}
+            isLoading={statusLoading || authState === "loading"}
             expanded={isExpanded}
             disabled={isDisabled}
             disabledReason={disabledReason}
             warning={warningBanner}
         >
             {/* Account linking hint when OAuth is available but not linked */}
-            {!isConnected && canLinkAccount && status?.available && !polling && !error && !success && (
+            {!isConnected && canLinkAccount && status?.available && !polling && !authError && !error && !success && (
                 <p className="text-sm text-gray-500">
                     Link your Google account for personal library access (optional).
                 </p>
@@ -394,95 +332,24 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
                 <div className="space-y-3">
                     {/* In linking flow — show device code + verification URL */}
                     {userCode && verificationUrl && polling && (
-                        <div className="p-4 bg-[#252525] rounded-lg border border-[#333] space-y-4">
-                            <div className="space-y-3">
-                                <p className="text-sm text-gray-300">
-                                    A Google sign-in page should have opened.
-                                    If it didn&apos;t, click the link below.
-                                </p>
-
-                                {/* Step 1 — Paste code */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">1</span>
-                                    <div className="space-y-2">
-                                        <p className="text-sm text-gray-300">
-                                            Paste this code on the Google page
-                                            <span className="text-gray-500 text-xs ml-1">(it&apos;s already on your clipboard)</span>
-                                        </p>
-                                        <div className="flex items-center gap-3">
-                                            <code className="px-4 py-2 text-lg font-mono font-bold tracking-wider bg-[#1a1a1a] text-white rounded-lg border border-[#444] select-all">
-                                                {userCode}
-                                            </code>
-                                            <button
-                                                onClick={handleCopyCode}
-                                                className="p-2 text-gray-400 hover:text-white transition-colors"
-                                                title="Copy code"
-                                            >
-                                                {copied ? (
-                                                    <CheckCircle className="w-4 h-4 text-green-400" />
-                                                ) : (
-                                                    <Copy className="w-4 h-4" />
-                                                )}
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {/* Step 2 — Sign in */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">2</span>
-                                    <p className="text-sm text-gray-300">
-                                        Sign in with your Google account and click <strong className="text-white">Allow</strong>
-                                    </p>
-                                </div>
-
-                                {/* Step 3 — Come back */}
-                                <div className="flex items-start gap-3">
-                                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">3</span>
-                                    <p className="text-sm text-gray-300">
-                                        Return here — this page will update automatically
-                                    </p>
-                                </div>
-                            </div>
-
-                            <a
-                                href={verificationUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-blue-600/20 text-blue-400 rounded-full
-                                    hover:bg-blue-600/30 border border-blue-500/30 transition-colors"
-                            >
-                                <ExternalLink className="w-4 h-4" />
-                                Open Google Sign-In Page
-                            </a>
-
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2 text-sm text-gray-400">
-                                    <Loader2 className="w-3 h-3 animate-spin" />
-                                    <span>Waiting for you to complete sign-in...</span>
-                                </div>
-                                {timeLeft !== null && (
-                                    <span className={`text-xs tabular-nums ${
-                                        timeLeft < 120 ? "text-amber-400/70" : "text-gray-500"
-                                    }`}>
-                                        Expires in {formatTimeLeft(timeLeft)}
-                                    </span>
-                                )}
-                            </div>
-
-                            <button
-                                onClick={handleCancelLink}
-                                className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
-                            >
-                                Cancel
-                            </button>
-                        </div>
+                        <DeviceAuthLinkPanel
+                            userCode={userCode}
+                            verificationUrl={verificationUrl}
+                            timeLeftSeconds={timeLeft}
+                            copied={copied}
+                            onCopyCode={handleCopyCode}
+                            onCancel={handleCancelLink}
+                            introText="A Google sign-in page should have opened. If it didn't, click the link below."
+                            pasteInstruction="Paste this code on the Google page"
+                            signInInstruction={<>Sign in with your Google account and click <strong className="text-white">Allow</strong></>}
+                            openLinkLabel="Open Google Sign-In Page"
+                        />
                     )}
 
-                    {error && (
+                    {(authError || error) && (
                         <div className="flex items-start gap-2 text-sm text-red-400">
                             <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                            <span>{error}</span>
+                            <span>{authError || error}</span>
                         </div>
                     )}
 

--- a/frontend/features/settings/components/ui/DeviceAuthLinkPanel.tsx
+++ b/frontend/features/settings/components/ui/DeviceAuthLinkPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { CheckCircle, Copy, ExternalLink, Loader2, type LucideIcon } from "lucide-react";
+import { formatTime } from "@/utils/formatTime";
+
+/** Content and controls displayed by the shared device-code linking panel. */
+export interface DeviceAuthLinkPanelProps {
+    userCode: string;
+    verificationUrl: string;
+    timeLeftSeconds: number | null;
+    copied: boolean;
+    onCopyCode: () => void;
+    onCancel: () => void;
+    introText: string;
+    pasteInstruction: string;
+    signInInstruction: ReactNode;
+    openLinkLabel: string;
+}
+
+interface NumberedStepProps {
+    number: number;
+    children: ReactNode;
+}
+
+function PanelIcon({
+    icon: Icon,
+    className,
+}: {
+    icon: LucideIcon;
+    className: string;
+}) {
+    if (!Icon) return null;
+    return <Icon className={className} />;
+}
+
+function NumberedStep({ number, children }: NumberedStepProps) {
+    return (
+        <div className="flex items-start gap-3">
+            <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center font-bold mt-0.5">
+                {number}
+            </span>
+            {children}
+        </div>
+    );
+}
+
+function CodeStep({ userCode, copied, onCopyCode, pasteInstruction }: Pick<
+    DeviceAuthLinkPanelProps,
+    "userCode" | "copied" | "onCopyCode" | "pasteInstruction"
+>) {
+    return (
+        <NumberedStep number={1}>
+            <div className="space-y-2">
+                <p className="text-sm text-gray-300">
+                    {pasteInstruction}
+                    <span className="text-gray-500 text-xs ml-1">
+                        (it&apos;s already on your clipboard)
+                    </span>
+                </p>
+                <div className="flex items-center gap-3">
+                    <code className="px-4 py-2 text-lg font-mono font-bold tracking-wider bg-[#1a1a1a] text-white rounded-lg border border-[#444] select-all">
+                        {userCode}
+                    </code>
+                    <button onClick={onCopyCode} className="p-2 text-gray-400 hover:text-white transition-colors" title="Copy code">
+                        {copied
+                            ? <PanelIcon icon={CheckCircle} className="w-4 h-4 text-green-400" />
+                            : <PanelIcon icon={Copy} className="w-4 h-4" />}
+                    </button>
+                </div>
+            </div>
+        </NumberedStep>
+    );
+}
+
+function WaitingRow({ timeLeftSeconds }: Pick<DeviceAuthLinkPanelProps, "timeLeftSeconds">) {
+    return (
+        <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 text-sm text-gray-400">
+                <PanelIcon icon={Loader2} className="w-3 h-3 animate-spin" />
+                <span>Waiting for you to complete sign-in...</span>
+            </div>
+            {timeLeftSeconds !== null && (
+                <span className={`text-xs tabular-nums ${
+                    timeLeftSeconds < 120 ? "text-amber-400/70" : "text-gray-500"
+                }`}>
+                    Expires in {formatTime(timeLeftSeconds)}
+                </span>
+            )}
+        </div>
+    );
+}
+
+/** Renders reusable instructions and controls for a device-code authentication session. */
+export function DeviceAuthLinkPanel(props: DeviceAuthLinkPanelProps) {
+    return (
+        <div className="p-4 bg-[#252525] rounded-lg border border-[#333] space-y-4">
+            <div className="space-y-3">
+                <p className="text-sm text-gray-300">{props.introText}</p>
+                <CodeStep {...props} />
+                <NumberedStep number={2}>
+                    <p className="text-sm text-gray-300">{props.signInInstruction}</p>
+                </NumberedStep>
+                <NumberedStep number={3}>
+                    <p className="text-sm text-gray-300">
+                        Return here — this page will update automatically
+                    </p>
+                </NumberedStep>
+            </div>
+            {props.verificationUrl && (
+                <a
+                    href={props.verificationUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-blue-600/20 text-blue-400 rounded-full
+                        hover:bg-blue-600/30 border border-blue-500/30 transition-colors"
+                >
+                    <PanelIcon icon={ExternalLink} className="w-4 h-4" />
+                    {props.openLinkLabel}
+                </a>
+            )}
+            <WaitingRow timeLeftSeconds={props.timeLeftSeconds} />
+            <button onClick={props.onCancel} className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+                Cancel
+            </button>
+        </div>
+    );
+}

--- a/frontend/features/settings/components/ui/index.ts
+++ b/frontend/features/settings/components/ui/index.ts
@@ -8,4 +8,4 @@ export { SettingsInput } from "./SettingsInput";
 export { ConnectionCard } from "./ConnectionCard";
 export { IntegrationCard } from "./IntegrationCard";
 export { InfoTooltip } from "./InfoTooltip";
-
+export { DeviceAuthLinkPanel } from "./DeviceAuthLinkPanel";

--- a/frontend/tests/component/deviceAuthLinkPanel.component.test.ts
+++ b/frontend/tests/component/deviceAuthLinkPanel.component.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("lucide-react", {
+    namedExports: {},
+});
+
+const baseProps = {
+    userCode: "ABCD-1234",
+    verificationUrl: "https://example.com/device",
+    timeLeftSeconds: 270,
+    copied: false,
+    onCopyCode: () => undefined,
+    onCancel: () => undefined,
+    introText: "Open the authorization page.",
+    pasteInstruction: "Paste this code on the page",
+    signInInstruction: React.createElement("span", null, "Sign in and allow access"),
+    openLinkLabel: "Open Authorization Page",
+};
+
+test("DeviceAuthLinkPanel renders device-code instructions and expiry", async () => {
+    const { DeviceAuthLinkPanel } = await import(
+        "../../features/settings/components/ui/DeviceAuthLinkPanel"
+    );
+    const html = renderToStaticMarkup(
+        React.createElement(DeviceAuthLinkPanel, baseProps)
+    );
+
+    assert.match(html, /ABCD-1234/);
+    assert.match(
+        html,
+        /<a[^>]+href="https:\/\/example\.com\/device"[^>]*>.*Open Authorization Page.*<\/a>/
+    );
+    assert.match(html, /Open the authorization page\./);
+    assert.match(html, /Paste this code on the page/);
+    assert.match(html, /Return here — this page will update automatically/);
+    assert.match(html, /Expires in 4:30/);
+});
+
+test("DeviceAuthLinkPanel omits expiry when no countdown is available", async () => {
+    const { DeviceAuthLinkPanel } = await import(
+        "../../features/settings/components/ui/DeviceAuthLinkPanel"
+    );
+    const html = renderToStaticMarkup(
+        React.createElement(DeviceAuthLinkPanel, {
+            ...baseProps,
+            timeLeftSeconds: null,
+        })
+    );
+
+    assert.doesNotMatch(html, /Expires in/);
+});

--- a/frontend/tests/component/exploreBrowseCard.component.test.ts
+++ b/frontend/tests/component/exploreBrowseCard.component.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const distinctiveSubtitle = "Distinctive subtitle";
+
+mock.module("next/link", {
+    defaultExport: ({ children, href }: { children: React.ReactNode; href: string }) =>
+        React.createElement("a", { href }, children),
+});
+
+test("BrowseCard renders a linked image, title, and subtitle", async () => {
+    const { BrowseCard } = await import("../../features/explore/components/BrowseCard");
+    const html = renderToStaticMarkup(
+        React.createElement(BrowseCard, {
+            href: "/explore/example",
+            imageUrl: "/images/example.jpg",
+            title: "Example title",
+            subtitle: distinctiveSubtitle,
+        })
+    );
+
+    assert.match(html, /<a href="\/explore\/example">/);
+    assert.match(html, /Example title/);
+    assert.match(html, new RegExp(distinctiveSubtitle));
+    assert.match(html, /<img[^>]*src="\/images\/example\.jpg"/);
+});
+
+test("BrowseCard renders without a link when href is null", async () => {
+    const { BrowseCard } = await import("../../features/explore/components/BrowseCard");
+    const html = renderToStaticMarkup(
+        React.createElement(BrowseCard, {
+            href: null,
+            imageUrl: null,
+            title: "Unlinked title",
+        })
+    );
+
+    assert.doesNotMatch(html, /<a(?:\s|>)/);
+    assert.match(html, /Unlinked title/);
+});
+
+test("BrowseCard omits the subtitle paragraph when subtitle is undefined", async () => {
+    const { BrowseCard } = await import("../../features/explore/components/BrowseCard");
+    const html = renderToStaticMarkup(
+        React.createElement(BrowseCard, {
+            href: null,
+            imageUrl: null,
+            title: "Title without subtitle",
+        })
+    );
+
+    assert.doesNotMatch(html, new RegExp(distinctiveSubtitle));
+    assert.doesNotMatch(html, /text-xs text-gray-400 truncate/);
+});
+
+test("BrowseCard omits the image when imageUrl is null", async () => {
+    const { BrowseCard } = await import("../../features/explore/components/BrowseCard");
+    const html = renderToStaticMarkup(
+        React.createElement(BrowseCard, {
+            href: null,
+            imageUrl: null,
+            title: "Image-free title",
+        })
+    );
+
+    assert.doesNotMatch(html, /<img(?:\s|>)/);
+});

--- a/frontend/tests/unit/formatTimeUtilities.test.ts
+++ b/frontend/tests/unit/formatTimeUtilities.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 import {
     clampTime,
     formatDuration,
+    formatRelativeTime,
     formatTime,
     formatTimeRemaining,
 } from "../../utils/formatTime";
@@ -60,6 +61,40 @@ describe("formatDuration", () => {
         assert.equal(formatDuration(60), "1m");
         assert.equal(formatDuration(3600), "1h");
         assert.equal(formatDuration(5400), "1h 30m");
+    });
+});
+
+describe("formatRelativeTime", () => {
+    test("formats relative dates with default labels", () => {
+        const justNow = new Date(Date.now() - 30_000);
+        const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000);
+        const twoHoursAgo = new Date(Date.now() - 2 * 3_600_000);
+        const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000);
+
+        assert.equal(formatRelativeTime(justNow), "Just now");
+        assert.equal(formatRelativeTime(fiveMinutesAgo), "5m ago");
+        assert.equal(formatRelativeTime(twoHoursAgo), "2h ago");
+        assert.equal(
+            formatRelativeTime(threeDaysAgo),
+            threeDaysAgo.toLocaleDateString()
+        );
+    });
+
+    test("formats relative dates with custom labels", () => {
+        const options = { justNowLabel: "Just started", suffix: "" };
+
+        assert.equal(
+            formatRelativeTime(new Date(Date.now() - 30_000), options),
+            "Just started"
+        );
+        assert.equal(
+            formatRelativeTime(new Date(Date.now() - 5 * 60_000), options),
+            "5m"
+        );
+        assert.equal(
+            formatRelativeTime(new Date(Date.now() - 2 * 3_600_000), options),
+            "2h"
+        );
     });
 });
 

--- a/frontend/utils/formatTime.ts
+++ b/frontend/utils/formatTime.ts
@@ -37,6 +37,30 @@ export function formatDuration(seconds: number): string {
     return `${mins}m`;
 }
 
+/** Custom labels used when formatting compact relative times. */
+export interface RelativeTimeOptions {
+    justNowLabel?: string;
+    suffix?: string;
+}
+
+/**
+ * Format a date as a compact relative time or a locale date when older than a day.
+ */
+export function formatRelativeTime(
+    dateInput: string | number | Date,
+    options?: RelativeTimeOptions
+): string {
+    const justNowLabel = options?.justNowLabel ?? "Just now";
+    const suffix = options?.suffix ?? " ago";
+    const date = new Date(dateInput);
+    const diff = Date.now() - date.getTime();
+
+    if (diff < 60000) return justNowLabel;
+    if (diff < 3600000) return `${Math.floor(diff / 60000)}m${suffix}`;
+    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h${suffix}`;
+    return date.toLocaleDateString();
+}
+
 /**
  * Clamp a time value to be within valid bounds
  * Ensures currentTime never exceeds duration


### PR DESCRIPTION
## Summary (refactor slice P25 — frontend-dedup)

Mechanical duplication collapse across the frontend. **No user-visible behavior change** — pure de-duplication behind identical rendered output and existing behavior.

Depends on: P12 frontend-polling-hygiene (MERGED, #236) which introduced the shared `useDeviceAuthPolling` hook.

## Findings addressed

- **3rd hand-rolled device-auth flow** (owner-decisions #6): `YouTubeMusicSection` now uses the shared `useDeviceAuthPolling` hook instead of its own device-code polling/expiry/countdown effects — matching the two Tidal sections. Inherits the hook's bounded, race-safe recursive polling, tracked timers with deterministic cleanup, and generation-guarded cancellation. Success still refreshes status + dispatches `ytmusic-auth-changed`; expiry/clipboard/`window.open`/error copy all preserved.
- **Duplicated device-code linking UI**: extracted the byte-identical 3-step "paste code / sign in / return" panel shared by the TIDAL and YouTube Music settings sections into one presentational `features/settings/components/ui/DeviceAuthLinkPanel`.
- **Copy-pasted Explore provider cards**: extracted the square-thumbnail+title+subtitle card into shared `features/explore/components/BrowseCard`, adopted by the featured-shelves and mixes sections for both TIDAL and YouTube Music. Per-provider badges, filtering, hrefs, image-proxy builders, and grid/carousel layouts stay local to each section.
- **Nine local time/duration re-implementations**: consolidated onto `utils/formatTime`, adding a documented `formatRelativeTime(dateInput, { justNowLabel, suffix })` helper (output byte-matches the History/Notifications/Active-Downloads copies). Also collapses the two settings `formatTimeLeft` copies and the device/listen-together/YouTubePreviewCard/AudiobookActionBar duplicates.
- **Index-as-key**: replaced with stable content-derived keys in `PreviewEpisodes` (`publishedAt-title`) and `SyncedLyrics` (`time`/content composite).

## Scope decisions (reported, not silently dropped)

- The `MoodsGenresSection` / `TidalMoodsGenresSection` pair was **not** merged into a single component. Their drilldown card is a distinct visual variant (`bg-[#282828]`, `shadow-lg`, `h3`, fallback icon) and each owns a different drilldown state machine + API; a forced 6→1 "one BrowseSection" merge would create a leaky god-component and carry real visual/behavioral regression risk on the Explore page. The shared `BrowseCard` collapses the actual copy-pasted card markup (4 of 6 sections) without that risk. Recommend a follow-up only if a shared drilldown/pill abstraction proves worthwhile.
- `PagedGridCarousel` page-indicator dots keep `key={index}` deliberately — index **is** the correct positional identity for those dots.
- `AlbumHero.formatDuration` ("N hr N min") left as-is — distinct output format, not a shadow of `utils/formatTime`.

## Tests

TDD (failing test first) via node:test + `renderToStaticMarkup`:
- `tests/unit/formatTimeUtilities.test.ts` — new `formatRelativeTime` cases (default + custom labels).
- `tests/component/deviceAuthLinkPanel.component.test.ts` — new panel presentational tests.
- `tests/component/exploreBrowseCard.component.test.ts` — new shared-card tests (linked/unlinked, subtitle/image omission).

verify: targeted node:test — deviceAuthLinkPanel + exploreBrowseCard + formatTimeUtilities: 17 pass, 0 fail
verify: useDeviceAuthPolling.component.test.ts: pass, 0 fail
verify: regression batch (explore Featured/Tidal shelves, MadeForYou, MoodsGenres tab, ProviderTab, explorePage, activityPanel, socialTab, youtubePreviewCard): 64 pass, 0 fail
verify: frontend typecheck (`tsc --noEmit --incremental false`) exit 0, 0 errors
verify: eslint on all changed/new files exit 0 (0 errors; 9 pre-existing-style warnings within the repo warning budget)

Targeted testing only per the 23GB-box RAM constraint; no full suites/coverage/image builds run.

## Breaking / UPGRADING

None. No API, config, or behavior changes.

## Escalations

None.
