### PR TITLE
fix(backend): media path containment + subsonic cover-art resize dedup (refactor slice P17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Path containment on native audio streaming: the `GET /api/library/tracks/:id/stream`
+  handler now resolves the DB-sourced `track.filePath` through `safeResolvePath`
+  and returns `404 Track not available` when the resolved path escapes the
+  configured music root (via `../` traversal or an absolute path), instead of
+  joining it under the root with a bare `path.join`. The containment check runs
+  once, before the streaming service is constructed, and covers both the primary
+  and FFmpeg-fallback branches. This brings the route in line with the sibling
+  Subsonic and share-link streaming paths, which already enforce containment.
+- **Cover-art hardening (Subsonic dimensions change):** the OpenSubsonic
+  `getCoverArt` endpoint no longer resizes with an inline `sharp` pipeline that
+  dropped the shared service's guards. It now delegates to the hardened
+  `coverArtResize` service, gaining the ~50MP decode ceiling (decompression-bomb
+  protection) and `Accept: image/webp` format negotiation, and it snaps the
+  requested `size` to the cover-art allowlist (`64/128/192/320/512/768`) instead
+  of honouring arbitrary `16..2048` values. Requested sizes that fall between
+  allowlist entries now return the next larger bounding box (e.g. `size=300`
+  returns a 320px-bounded image); clients that display cover art scaled to their
+  own layout are unaffected.
 - At-rest secret hygiene for the `.env` sync: `writeEnvFile` now writes the
   secrets-bearing `.env` (which holds `SETTINGS_ENCRYPTION_KEY` and decrypted
   integration API keys) with owner-only `0600` permissions and **atomically**

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -1094,6 +1094,46 @@ describe("library stream runtime coverage", () => {
         expect(mockAudioStreamingCtor).not.toHaveBeenCalled();
     });
 
+    it("returns 404 when the DB file path traverses outside the music root", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({ filePath: "../../../etc/passwd" })
+        );
+
+        const req = {
+            params: { id: "track-1" },
+            query: {},
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "Track not available" });
+        expect(mockAudioStreamingCtor).not.toHaveBeenCalled();
+        expect(mockStreamWithRangeSupport).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the DB file path is an absolute path outside the root", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({ filePath: "/etc/shadow" })
+        );
+
+        const req = {
+            params: { id: "track-1" },
+            query: {},
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "Track not available" });
+        expect(mockAudioStreamingCtor).not.toHaveBeenCalled();
+        expect(mockStreamWithRangeSupport).not.toHaveBeenCalled();
+    });
+
     it("creates a play record only when no recent play exists", async () => {
         const req = {
             params: { id: "track-1" },

--- a/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
@@ -137,6 +137,7 @@ import {
 function buildReq(query: Record<string, unknown>): Request {
 	return {
 		query,
+		headers: {},
 		user: {
 			id: "user-1",
 			username: "alice",

--- a/backend/src/routes/__tests__/subsonicCoverArtResizeDedup.test.ts
+++ b/backend/src/routes/__tests__/subsonicCoverArtResizeDedup.test.ts
@@ -1,0 +1,171 @@
+import fs from "fs";
+import { Request, Response } from "express";
+
+jest.mock("../../middleware/subsonicAuth", () => ({
+    requireSubsonicAuth: (_req: Request, _res: Response, next: () => void) => next(),
+    subsonicRateLimiter: (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/subsonicResponse", () => ({
+    getResponseFormat: jest.fn(() => "json"),
+    sendSubsonicError: jest.fn(),
+    sendSubsonicSuccess: jest.fn(),
+    SubsonicErrorCode: {
+        MISSING_PARAMETER: 10,
+        NOT_FOUND: 70,
+        GENERIC: 0,
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: { findFirst: jest.fn() },
+        album: { findFirst: jest.fn() },
+        artist: { findFirst: jest.fn() },
+        playlist: { findFirst: jest.fn() },
+    },
+}));
+
+jest.mock("../../workers/queues", () => ({
+    scanQueue: {
+        getActive: jest.fn(),
+        getWaiting: jest.fn(),
+        getDelayed: jest.fn(),
+        add: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/audioStreaming", () => ({
+    AudioStreamingService: jest.fn(),
+}));
+
+jest.mock("../../services/lyrics", () => ({
+    getLyrics: jest.fn(),
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        music: {
+            musicPath: "/music",
+            transcodeCachePath: "/var/soundspan/transcode",
+            transcodeCacheMaxGb: 2,
+        },
+    },
+}));
+
+// Partially mock the hardened cover-art service: keep the real pure helpers
+// (snapCoverArtSize / negotiateCoverArtFormat) so the allowlist snapping is
+// exercised, but spy on resizeCoverArt to assert the handler delegates to it.
+jest.mock("../../services/coverArtResize", () => {
+    const actual = jest.requireActual("../../services/coverArtResize");
+    return {
+        ...actual,
+        resizeCoverArt: jest.fn(),
+    };
+});
+
+import { prisma } from "../../utils/db";
+import { sendSubsonicError } from "../../utils/subsonicResponse";
+import { resizeCoverArt } from "../../services/coverArtResize";
+import { handleGetCoverArt } from "../subsonic";
+
+const mockAlbumFindFirst = prisma.album.findFirst as jest.Mock;
+const mockSendError = sendSubsonicError as jest.Mock;
+const mockResizeCoverArt = resizeCoverArt as jest.Mock;
+
+function buildReq(
+    query: Record<string, unknown>,
+    headers: Record<string, unknown> = {},
+): Request {
+    return {
+        query,
+        headers,
+        user: { id: "user-1", username: "alice", role: "user" },
+    } as unknown as Request;
+}
+
+function buildRes(): Response {
+    const res: Partial<Response> = {
+        setHeader: jest.fn(),
+        status: jest.fn(),
+        send: jest.fn(),
+        headersSent: false,
+    };
+    (res.status as jest.Mock).mockReturnValue(res);
+    return res as Response;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockResizeCoverArt.mockReset();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe("handleGetCoverArt cover-art resize dedup", () => {
+    const nativeCoverPath = "/var/soundspan/covers/album/cover.png";
+
+    it("delegates resizing to the hardened service with a snapped size and negotiated format", async () => {
+        mockAlbumFindFirst.mockResolvedValue({
+            coverUrl: "native:album/cover.png",
+        });
+        jest
+            .spyOn(fs, "existsSync")
+            .mockImplementation((p: fs.PathLike) => p === nativeCoverPath);
+        jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from("png-bytes"));
+        mockResizeCoverArt.mockResolvedValue({
+            buffer: Buffer.from("resized-webp"),
+            contentType: "image/webp",
+            resized: true,
+        });
+
+        const res = buildRes();
+        await handleGetCoverArt(
+            buildReq({ id: "al-album-1", size: "300" }, { accept: "image/webp" }),
+            res,
+        );
+
+        expect(mockSendError).not.toHaveBeenCalled();
+        // "300" must snap up to the 320 allowlist entry, and webp Accept
+        // must negotiate the webp output format.
+        expect(mockResizeCoverArt).toHaveBeenCalledWith({
+            buffer: expect.any(Buffer),
+            contentType: "image/png",
+            size: 320,
+            format: "webp",
+        });
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "image/webp");
+        expect(res.send).toHaveBeenCalledWith(Buffer.from("resized-webp"));
+    });
+
+    it("serves the original bytes untouched when no size is requested", async () => {
+        mockAlbumFindFirst.mockResolvedValue({
+            coverUrl: "native:album/cover.png",
+        });
+        jest
+            .spyOn(fs, "existsSync")
+            .mockImplementation((p: fs.PathLike) => p === nativeCoverPath);
+        jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from("png-bytes"));
+        mockResizeCoverArt.mockImplementation(
+            async (opts: { buffer: Buffer; contentType: string | null }) => ({
+                buffer: opts.buffer,
+                contentType: opts.contentType,
+                resized: false,
+            }),
+        );
+
+        const res = buildRes();
+        await handleGetCoverArt(buildReq({ id: "al-album-1" }), res);
+
+        expect(mockResizeCoverArt).toHaveBeenCalledWith({
+            buffer: expect.any(Buffer),
+            contentType: "image/png",
+            size: null,
+            format: "original",
+        });
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+});

--- a/backend/src/routes/__tests__/subsonicMetadataCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicMetadataCompat.test.ts
@@ -82,6 +82,7 @@ import {
 function buildReq(query: Record<string, unknown>): Request {
     return {
         query,
+        headers: {},
         user: {
             id: "user-1",
             username: "alice",

--- a/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
+++ b/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
@@ -82,6 +82,7 @@ import { handleGetCoverArt, handleStream } from "../subsonic";
 function buildReq(query: Record<string, unknown>): Request {
     return {
         query,
+        headers: {},
         user: {
             id: "user-1",
             username: "alice",

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -4900,20 +4900,24 @@ router.get("/tracks/:id/stream", async (req, res) => {
         // === NATIVE FILE STREAMING ===
         // Check if track has native file path
         if (track.filePath && track.fileModified) {
+            const normalizedFilePath = track.filePath.replace(/\\/g, "/");
+            const absolutePath = safeResolvePath(
+                config.music.musicPath,
+                normalizedFilePath
+            );
+            if (!absolutePath) {
+                logger.warn(
+                    `[STREAM] Rejected out-of-root file path for track ${track.id}`
+                );
+                return sendRouteError(res, 404, "Track not available");
+            }
+
             try {
                 // Initialize streaming service
                 const streamingService = new AudioStreamingService(
                     config.music.musicPath,
                     config.music.transcodeCachePath,
                     config.music.transcodeCacheMaxGb
-                );
-
-                // Get absolute path to source file
-                // Normalize path separators for cross-platform compatibility (Windows -> Linux)
-                const normalizedFilePath = track.filePath.replace(/\\/g, "/");
-                const absolutePath = path.join(
-                    config.music.musicPath,
-                    normalizedFilePath
                 );
 
                 logger.debug(
@@ -4957,12 +4961,6 @@ router.get("/tracks/:id/stream", async (req, res) => {
                     logger.warn(
                         `[STREAM] FFmpeg not available, falling back to original quality`
                     );
-                    const fallbackFilePath = track.filePath.replace(/\\/g, "/");
-                    const absolutePath = path.join(
-                        config.music.musicPath,
-                        fallbackFilePath
-                    );
-
                     const streamingService = new AudioStreamingService(
                         config.music.musicPath,
                         config.music.transcodeCachePath,

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -3,7 +3,6 @@ import fs from "fs";
 import { Request, Response, Router } from "express";
 import { Prisma } from "@prisma/client";
 import { requireSubsonicAuth, subsonicRateLimiter } from "../middleware/subsonicAuth";
-import sharp from "sharp";
 import { prisma } from "../utils/db";
 import { seededShuffle } from "../services/artistSlotAllocation";
 import {
@@ -21,13 +20,17 @@ import {
     type SubsonicEntityType,
 } from "../utils/subsonicIds";
 import { AudioStreamingService } from "../services/audioStreaming";
+import {
+    negotiateCoverArtFormat,
+    resizeCoverArt,
+    snapCoverArtSize,
+} from "../services/coverArtResize";
 import { config } from "../config";
 import { BRAND_SLUG, BRAND_USER_AGENT } from "../config/brand";
 import { getLyrics } from "../services/lyrics";
 import { scanQueue } from "../workers/queues";
 import {
     isPublicCoverArtUrl,
-    parseCoverArtSize,
     resolveSubsonicStreamQuality,
     resolveTrackPathWithinRoot,
 } from "../utils/subsonicMedia";
@@ -560,36 +563,6 @@ async function fetchCoverArtBuffer(
         buffer: Buffer.from(arrayBuffer),
         contentType,
     };
-}
-
-async function maybeResizeCoverArt(
-    buffer: Buffer,
-    contentType: string,
-    size?: number,
-): Promise<{ buffer: Buffer; contentType: string }> {
-    if (!size) {
-        return { buffer, contentType };
-    }
-
-    try {
-        const isPng = contentType.toLowerCase().includes("png");
-        const resized = isPng
-            ? await sharp(buffer)
-                .resize({ width: size, height: size, fit: "inside", withoutEnlargement: true })
-                .png()
-                .toBuffer()
-            : await sharp(buffer)
-                .resize({ width: size, height: size, fit: "inside", withoutEnlargement: true })
-                .jpeg({ quality: 90 })
-                .toBuffer();
-
-        return {
-            buffer: resized,
-            contentType: isPng ? "image/png" : "image/jpeg",
-        };
-    } catch {
-        return { buffer, contentType };
-    }
 }
 
 function resolveNativeCoverPath(nativeCoverPath: string): string | null {
@@ -4833,7 +4806,7 @@ export async function handleGetCoverArt(req: Request, res: Response): Promise<vo
         return;
     }
 
-    const requestedSize = parseCoverArtSize(req.query.size);
+    const requestedSize = snapCoverArtSize(req.query.size);
 
     let type: SubsonicEntityType | undefined;
     let entityId = rawId;
@@ -4901,13 +4874,15 @@ export async function handleGetCoverArt(req: Request, res: Response): Promise<vo
             contentType = fetched.contentType;
         }
 
-        const resized = await maybeResizeCoverArt(
-            imageBuffer,
+        const imageFormat = negotiateCoverArtFormat(req.headers.accept);
+        const resized = await resizeCoverArt({
+            buffer: imageBuffer,
             contentType,
-            requestedSize,
-        );
+            size: requestedSize,
+            format: imageFormat,
+        });
 
-        res.setHeader("Content-Type", resized.contentType);
+        res.setHeader("Content-Type", resized.contentType ?? contentType);
         res.setHeader("Cache-Control", SUBSONIC_COVER_CACHE_CONTROL);
         res.setHeader("Accept-Ranges", "bytes");
         res.status(200).send(resized.buffer);


### PR DESCRIPTION
## Summary

Closes the two weaker-pattern gaps in slice **path-containment-cover-dedup** (P17): bare `path.join` on DB-sourced file paths in the library streaming route, and Subsonic's inline `sharp` cover-art resize that bypassed the hardened service's guards.

## Findings addressed

1. **Missing path-containment check when joining DB file paths under `musicPath`** — `GET /api/library/tracks/:id/stream` joined `track.filePath` under the music root with a bare `path.join`, so a `../` or absolute path in the DB could escape the root. It now resolves through `safeResolvePath` and returns `404 Track not available` on rejection. The check runs once, before `AudioStreamingService` is constructed, and is reused by the FFmpeg-fallback branch. This matches the sibling Subsonic (`resolveTrackPathWithinRoot`) and share-link (`safeResolvePath`) streaming paths that already enforce containment.
2. **Subsonic reimplements cover-art resizing without the hardened service's guards** — `handleGetCoverArt` now delegates to `coverArtResize` (`snapCoverArtSize` + `negotiateCoverArtFormat` + `resizeCoverArt`), gaining the ~50MP decode ceiling (decompression-bomb protection), `Accept: image/webp` negotiation, and cover-art size-allowlist snapping. Removed the local `maybeResizeCoverArt`, the `sharp` import, and the `parseCoverArtSize` import.

## Tests (TDD, failing-first)

- `libraryRuntime.test.ts` — stream route returns 404 (and never constructs the streaming service) for `../` traversal and for absolute out-of-root paths.
- `subsonicCoverArtResizeDedup.test.ts` (new) — `getCoverArt` delegates to `resizeCoverArt` with the snapped size (`300 → 320`) and negotiated format; serves original bytes untouched when no size is requested.
- Fixed under-specified `buildReq` mocks (missing `req.headers`) in `subsonicStreamCoverArtHandlers`, `subsonicBranchCoverage`, and `subsonicMetadataCompat` to match real Express requests.

verify: targeted Jest — 5 suites / 184 tests green (`subsonicCoverArtResizeDedup`, `subsonicStreamCoverArtHandlers`, `subsonicBranchCoverage`, `subsonicMetadataCompat`, `libraryRuntime`); related `subsonicMedia`, `coverArtResize`, `libraryCoverArtCompat` — 3 suites / 92 tests green; `tsc --noEmit` exit 0.

## Breaking / behavior change

- **Subsonic `getCoverArt` returned dimensions:** requested `size` now snaps to the cover-art allowlist (`64/128/192/320/512/768`) instead of honouring arbitrary `16..2048` values. Sizes between entries return the next larger bounding box (e.g. `size=300` → 320px-bounded). Clients that scale cover art to their own layout are unaffected; the OpenSubsonic `size` parameter is a scaling hint. Documented in CHANGELOG under Unreleased → Security.

## Discovered follow-ups (out of scope — reported, not changed)

- `library.ts` has the same bare-`path.join(musicPath, track.filePath)` pattern in the **delete** handlers (`DELETE /tracks/:id`, `DELETE /albums/:id`) and the **audio-info** reader (`resolveAudioInfoAbsolutePath`, `GET /tracks/:id/audio-info`). These are admin/owner-gated but would benefit from the same containment guard. The album-folder cleanup joins `artist.name`/`album.title` unbounded as well.
- `parseCoverArtSize` in `utils/subsonicMedia.ts` is now unused at runtime (still exported + unit-tested); a later cleanup could remove it.
