### PR TITLE
refactor(contract): derive media-source unions from CanonicalMediaSource (refactor slice P20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Media-source contract: the hand-copied `local`/`tidal`/`youtube`/`youtube-direct`
+  source unions scattered across the frontend and backend now derive from
+  `CanonicalMediaSource` in `@soundspan/media-metadata-contract` instead of being
+  re-typed by hand. Two documented derived types were added —
+  `RemoteMediaSource` (`Exclude<CanonicalMediaSource, "local">`, for stream-source
+  hints) and `ResolvedMediaSource` (`Exclude<CanonicalMediaSource, "youtube-direct">`,
+  for resolved/origin sources, since `youtube-direct` is a container variant of
+  `youtube` and never an independent resolution target) — and every exported symbol
+  in the contract package is now documented. No allowed string value changed and
+  there is no runtime behavior change; this only removes drift risk between the
+  copies. Consumers updated: `trackRef.ts`, `audio-state-context.tsx`,
+  `listen-together-socket.ts`, `api.ts` (annotations only), `listenTogetherManager.ts`,
+  `listenTogetherResolution.ts`, and `playlistImportService.ts`.
 - Helm chart: the individual-mode audio-analyzer and CLAP-analyzer Deployments
   now have liveness/readiness probes (exec `pgrep`, mirroring the compose
   healthcheck), closing the compose/chart probe-parity gap. Both are

--- a/backend/src/services/listenTogetherManager.ts
+++ b/backend/src/services/listenTogetherManager.ts
@@ -11,6 +11,8 @@
 import type {
     CanonicalMediaProviderIdentity,
     CanonicalMediaSource,
+    RemoteMediaSource,
+    ResolvedMediaSource,
 } from "@soundspan/media-metadata-contract";
 import { logger } from "../utils/logger";
 
@@ -28,7 +30,7 @@ export interface SyncQueueItem {
     album: { id: string; title: string; coverArt: string | null };
     mediaSource?: CanonicalMediaSource;
     provider?: CanonicalMediaProviderIdentity;
-    streamSource?: "tidal" | "youtube" | "youtube-direct";
+    streamSource?: RemoteMediaSource;
     tidalTrackId?: number;
     youtubeVideoId?: string;
     /** Audio container hint for "youtube-direct" streams (webm for opus, mp4 for AAC). */
@@ -37,7 +39,7 @@ export interface SyncQueueItem {
     trackTidalId?: string;
     trackYtMusicId?: string;
     trackMappingId?: string;
-    originSource?: "local" | "tidal" | "youtube";
+    originSource?: ResolvedMediaSource;
 }
 
 export interface GroupMember {

--- a/backend/src/services/listenTogetherResolution.ts
+++ b/backend/src/services/listenTogetherResolution.ts
@@ -1,3 +1,4 @@
+import type { ResolvedMediaSource } from "@soundspan/media-metadata-contract";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 
@@ -43,7 +44,7 @@ export interface TrackResolutionInput {
     trackYtMusicId?: string;
     tidalTrackId?: number;
     youtubeVideoId?: string;
-    originSource?: "local" | "tidal" | "youtube";
+    originSource?: ResolvedMediaSource;
 }
 
 const PROFILE_CACHE_TTL_MS = 60_000;

--- a/backend/src/services/playlistImportService.ts
+++ b/backend/src/services/playlistImportService.ts
@@ -6,6 +6,7 @@
  * provider FKs.
  */
 
+import type { ResolvedMediaSource } from "@soundspan/media-metadata-contract";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { decrypt } from "../utils/encryption";
@@ -108,7 +109,7 @@ export interface ResolvedTrack {
     /** TrackTidal record ID, if resolved */
     trackTidalId?: string;
     /** Resolution source */
-    source: "local" | "youtube" | "tidal" | "unresolved";
+    source: ResolvedMediaSource | "unresolved";
     /** Match confidence (0-100) */
     confidence: number;
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,7 @@ import type {
 } from "./youtube-bulk-download";
 import type {
     CanonicalMediaSearchResult,
+    ResolvedMediaSource,
     SegmentedStreamingSourceType,
 } from "@soundspan/media-metadata-contract";
 
@@ -262,13 +263,13 @@ export interface LikedPlaylistTrack {
     trackNo: number | null;
     filePath: string | null;
     likedAt: string;
-    source?: "local" | "tidal" | "youtube";
+    source?: ResolvedMediaSource;
     provider?: {
         tidalTrackId: number | null;
         youtubeVideoId: string | null;
     };
     /** Present on remote (YouTube/Tidal) liked tracks */
-    streamSource?: "youtube" | "tidal";
+    streamSource?: Exclude<ResolvedMediaSource, "local">;
     /** YouTube video ID — present when streamSource is "youtube" */
     youtubeVideoId?: string;
     /** Tidal track ID — present when streamSource is "tidal" */

--- a/frontend/lib/audio-state-context.tsx
+++ b/frontend/lib/audio-state-context.tsx
@@ -13,6 +13,7 @@ import { api } from "@/lib/api";
 import type {
     CanonicalMediaProviderIdentity,
     CanonicalMediaSource,
+    RemoteMediaSource,
 } from "@soundspan/media-metadata-contract";
 import type { Episode } from "@/features/podcast/types";
 import {
@@ -108,7 +109,7 @@ export interface Track {
     // Streaming source fields
     mediaSource?: CanonicalMediaSource;
     provider?: CanonicalMediaProviderIdentity;
-    streamSource?: "tidal" | "youtube" | "youtube-direct";
+    streamSource?: RemoteMediaSource;
     tidalTrackId?: number;
     youtubeVideoId?: string;
     /** Audio container reported by /api/youtube/info for youtube-direct tracks. */

--- a/frontend/lib/listen-together-socket.ts
+++ b/frontend/lib/listen-together-socket.ts
@@ -10,6 +10,8 @@ import { api } from "./api";
 import type {
     CanonicalMediaProviderIdentity,
     CanonicalMediaSource,
+    RemoteMediaSource,
+    ResolvedMediaSource,
 } from "@soundspan/media-metadata-contract";
 
 // ---------------------------------------------------------------------------
@@ -24,7 +26,7 @@ export interface SyncQueueItem {
     album: { id: string; title: string; coverArt: string | null };
     mediaSource?: CanonicalMediaSource;
     provider?: CanonicalMediaProviderIdentity;
-    streamSource?: "tidal" | "youtube" | "youtube-direct";
+    streamSource?: RemoteMediaSource;
     tidalTrackId?: number;
     youtubeVideoId?: string;
     /** Audio container hint for "youtube-direct" streams (webm for opus, mp4 for AAC). */
@@ -33,7 +35,7 @@ export interface SyncQueueItem {
     trackTidalId?: string;
     trackYtMusicId?: string;
     trackMappingId?: string;
-    originSource?: "local" | "tidal" | "youtube";
+    originSource?: ResolvedMediaSource;
 }
 
 export interface GroupSnapshot {
@@ -94,7 +96,7 @@ export interface QueueTrackInput {
 export interface AvailabilityItem {
     queueIndex: number;
     available: boolean;
-    source?: "local" | "tidal" | "youtube";
+    source?: ResolvedMediaSource;
     localTrackId?: string;
     tidalTrackId?: number;
     youtubeVideoId?: string;

--- a/frontend/lib/trackRef.ts
+++ b/frontend/lib/trackRef.ts
@@ -1,3 +1,5 @@
+import type { CanonicalMediaSource } from "@soundspan/media-metadata-contract";
+
 export type TrackRef =
     | { trackId: string }
     | { tidalTrackId: number }
@@ -22,7 +24,7 @@ export type AddToPlaylistRef =
         thumbnailUrl?: string;
     };
 
-type ProviderSource = "local" | "tidal" | "youtube" | "youtube-direct";
+type ProviderSource = CanonicalMediaSource;
 
 type TrackRefInput = {
     id?: string | null;

--- a/frontend/tests/unit/mediaSourceContract.test.ts
+++ b/frontend/tests/unit/mediaSourceContract.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    CANONICAL_MEDIA_SOURCE_VALUES,
+    normalizeCanonicalMediaSource,
+    resolveCanonicalMediaSource,
+    toAudioEngineSourceType,
+    toLegacyStreamFields,
+} from "@soundspan/media-metadata-contract";
+import type {
+    CanonicalMediaSource,
+    RemoteMediaSource,
+    ResolvedMediaSource,
+} from "@soundspan/media-metadata-contract";
+
+const _canonicalSource: CanonicalMediaSource = "local";
+const _r1: RemoteMediaSource = "youtube-direct";
+const _r2: RemoteMediaSource = "tidal";
+const _s1: ResolvedMediaSource = "local";
+const _s2: ResolvedMediaSource = "youtube";
+// @ts-expect-error RemoteMediaSource excludes local media.
+const _rBad: RemoteMediaSource = "local";
+// @ts-expect-error ResolvedMediaSource excludes direct YouTube media.
+const _sBad: ResolvedMediaSource = "youtube-direct";
+
+void _canonicalSource;
+void _r1;
+void _r2;
+void _s1;
+void _s2;
+void _rBad;
+void _sBad;
+
+test("CANONICAL_MEDIA_SOURCE_VALUES lists every canonical media source", () => {
+    assert.deepEqual(CANONICAL_MEDIA_SOURCE_VALUES, [
+        "local",
+        "tidal",
+        "youtube",
+        "youtube-direct",
+    ]);
+});
+
+test("normalizeCanonicalMediaSource normalizes supported source values", () => {
+    assert.equal(normalizeCanonicalMediaSource("ytmusic"), "youtube");
+    assert.equal(normalizeCanonicalMediaSource("local"), "local");
+    assert.equal(normalizeCanonicalMediaSource("tidal"), "tidal");
+    assert.equal(normalizeCanonicalMediaSource("youtube"), "youtube");
+    assert.equal(
+        normalizeCanonicalMediaSource("youtube-direct"),
+        "youtube-direct",
+    );
+    assert.equal(normalizeCanonicalMediaSource("unknown"), null);
+    assert.equal(normalizeCanonicalMediaSource(null), null);
+    assert.equal(normalizeCanonicalMediaSource(5), null);
+});
+
+test("resolveCanonicalMediaSource resolves explicit and inferred sources", () => {
+    assert.equal(resolveCanonicalMediaSource({ mediaSource: "tidal" }), "tidal");
+    assert.equal(
+        resolveCanonicalMediaSource({ streamSource: "ytmusic" }),
+        "youtube",
+    );
+    assert.equal(resolveCanonicalMediaSource({ tidalTrackId: 5 }), "tidal");
+    assert.equal(
+        resolveCanonicalMediaSource({ youtubeVideoId: "abc" }),
+        "youtube",
+    );
+    assert.equal(resolveCanonicalMediaSource({}), "local");
+    assert.equal(
+        resolveCanonicalMediaSource({
+            mediaSource: "youtube",
+            streamSource: "tidal",
+        }),
+        "youtube",
+    );
+});
+
+test("toLegacyStreamFields maps canonical identities to legacy fields", () => {
+    assert.deepEqual(toLegacyStreamFields({ source: "tidal", tidalTrackId: 5 }), {
+        streamSource: "tidal",
+        tidalTrackId: 5,
+    });
+    assert.deepEqual(
+        toLegacyStreamFields({ source: "youtube", youtubeVideoId: "x" }),
+        {
+            streamSource: "youtube",
+            youtubeVideoId: "x",
+        },
+    );
+    assert.deepEqual(
+        toLegacyStreamFields({
+            source: "youtube-direct",
+            youtubeVideoId: "x",
+            youtubeAudioFormat: "webm",
+        }),
+        {
+            streamSource: "youtube-direct",
+            youtubeVideoId: "x",
+            youtubeAudioFormat: "webm",
+        },
+    );
+    assert.deepEqual(toLegacyStreamFields({ source: "local" }), {});
+    assert.deepEqual(toLegacyStreamFields(null), {});
+});
+
+test("toAudioEngineSourceType maps canonical sources to engine sources", () => {
+    assert.equal(toAudioEngineSourceType("youtube"), "ytmusic");
+    assert.equal(toAudioEngineSourceType("youtube-direct"), "ytmusic");
+    assert.equal(toAudioEngineSourceType("local"), "local");
+    assert.equal(toAudioEngineSourceType("tidal"), "tidal");
+});

--- a/packages/media-metadata-contract/src/index.ts
+++ b/packages/media-metadata-contract/src/index.ts
@@ -1,5 +1,7 @@
+/** Version identifier for the central media metadata contract. */
 export const CENTRAL_MEDIA_METADATA_CONTRACT_VERSION = "1.0.0";
 
+/** Complete runtime list of canonical media source identifiers. */
 export const CANONICAL_MEDIA_SOURCE_VALUES = [
     "local",
     "tidal",
@@ -7,12 +9,25 @@ export const CANONICAL_MEDIA_SOURCE_VALUES = [
     "youtube-direct",
 ] as const;
 
+/** Canonical source identifier shared across media metadata consumers. */
 export type CanonicalMediaSource = (typeof CANONICAL_MEDIA_SOURCE_VALUES)[number];
 
+/** Non-local media sources backed by remote providers. */
+export type RemoteMediaSource = Exclude<CanonicalMediaSource, "local">;
+
+/** Media sources a queue item can be resolved to for playback. "youtube-direct" is a container/transport variant of "youtube", never an independent resolution target, so it is intentionally excluded. */
+export type ResolvedMediaSource = Exclude<
+    CanonicalMediaSource,
+    "youtube-direct"
+>;
+
+/** Canonical sources supported by segmented streaming sessions. */
 export type SegmentedStreamingSourceType = Extract<CanonicalMediaSource, "local">;
 
+/** Source identifiers accepted by the audio engine boundary. */
 export type AudioEngineSourceType = "local" | "tidal" | "ytmusic";
 
+/** Canonical provider identity and optional provider-specific track metadata. */
 export interface CanonicalMediaProviderIdentity {
     source: CanonicalMediaSource;
     providerTrackId?: string;
@@ -22,14 +37,16 @@ export interface CanonicalMediaProviderIdentity {
     youtubeAudioFormat?: "mp4" | "webm";
 }
 
+/** Legacy provider fields retained for compatibility with existing stream payloads. */
 export interface LegacyStreamFields {
-    streamSource?: "tidal" | "youtube" | "youtube-direct";
+    streamSource?: RemoteMediaSource;
     tidalTrackId?: number;
     youtubeVideoId?: string;
     /** Audio container hint carried for "youtube-direct" streams only. */
     youtubeAudioFormat?: "mp4" | "webm";
 }
 
+/** Normalized search result returned by remote media providers. */
 export interface CanonicalMediaSearchResult {
     source: Exclude<CanonicalMediaSource, "local">;
     provider: "tidal" | "ytmusic";
@@ -66,6 +83,7 @@ const normalizeYoutubeAudioFormat = (
     return undefined;
 };
 
+/** Normalizes a source identifier, mapping legacy YT Music naming to YouTube and returning null for invalid values. */
 export const normalizeCanonicalMediaSource = (
     value: unknown,
 ): CanonicalMediaSource | null => {
@@ -83,6 +101,7 @@ export const normalizeCanonicalMediaSource = (
     return null;
 };
 
+/** Resolves explicit or inferred media metadata to a canonical source, returning local when no valid remote source can be determined. */
 export const resolveCanonicalMediaSource = (value: {
     mediaSource?: unknown;
     streamSource?: unknown;
@@ -106,6 +125,7 @@ export const resolveCanonicalMediaSource = (value: {
     return "local";
 };
 
+/** Normalizes provider metadata into a canonical identity, falling back to a local identity when the input has no valid remote source. */
 export const normalizeCanonicalMediaProviderIdentity = (value: {
     mediaSource?: unknown;
     streamSource?: unknown;
@@ -154,6 +174,7 @@ export const normalizeCanonicalMediaProviderIdentity = (value: {
     return { source: "local" };
 };
 
+/** Converts a canonical provider identity into compatible legacy stream fields. */
 export const toLegacyStreamFields = (
     provider: CanonicalMediaProviderIdentity | null | undefined,
 ): LegacyStreamFields => {
@@ -182,6 +203,7 @@ export const toLegacyStreamFields = (
     return {};
 };
 
+/** Maps a canonical media source to the source identifier used by the audio engine. */
 export const toAudioEngineSourceType = (
     source: CanonicalMediaSource,
 ): AudioEngineSourceType => {


### PR DESCRIPTION
## Summary (refactor slice P20 — media-source-contract)

The `@soundspan/media-metadata-contract` package exists to own the media-source unions, yet the `local`/`tidal`/`youtube`/`youtube-direct` union was hand-copied in 6+ places across the frontend and backend, and the copies had already drifted (`youtube-direct` unrepresentable in two of the three unions in `listen-together-socket.ts`). This slice makes every copy derive from `CanonicalMediaSource` and documents the contract package's exports.

### Findings addressed
- Media-source unions were hand-duplicated instead of derived from the contract package, and the copies disagreed.
- Every exported symbol in the contract package was undocumented.

### Changes
- **Contract package** (`packages/media-metadata-contract/src/index.ts`):
  - Added two documented derived types:
    - `RemoteMediaSource = Exclude<CanonicalMediaSource, "local">` (stream-source hints; `tidal | youtube | youtube-direct`).
    - `ResolvedMediaSource = Exclude<CanonicalMediaSource, "youtube-direct">` (resolved/origin sources; `local | tidal | youtube`). `youtube-direct` is a container/transport variant of `youtube`, never an independent resolution target, so it is **intentionally excluded via `Exclude<>` with a comment** (per the slice risk note) rather than widened in.
  - `LegacyStreamFields.streamSource` now uses `RemoteMediaSource` (identical set).
  - Added JSDoc to **every** exported symbol (all 15).
- **Consumers derive from the contract** (type-only imports):
  - `frontend/lib/trackRef.ts` — `ProviderSource = CanonicalMediaSource`.
  - `frontend/lib/audio-state-context.tsx` — `Track.streamSource: RemoteMediaSource`.
  - `frontend/lib/listen-together-socket.ts` — `SyncQueueItem.streamSource: RemoteMediaSource`, `SyncQueueItem.originSource: ResolvedMediaSource`, `AvailabilityItem.source: ResolvedMediaSource`.
  - `frontend/lib/api.ts` — **annotations only** (P34 owns api.ts typing): `LikedPlaylistTrack.source: ResolvedMediaSource`, `streamSource: Exclude<ResolvedMediaSource, "local">`.
  - `backend/src/services/listenTogetherManager.ts` — `SyncQueueItem.streamSource/originSource` derived.
  - `backend/src/services/listenTogetherResolution.ts` — `TrackResolutionInput.originSource: ResolvedMediaSource`.
  - `backend/src/services/playlistImportService.ts` — `ResolvedTrack.source: ResolvedMediaSource | "unresolved"`.

**No allowed string value changed anywhere and there is no runtime behavior change** — each union keeps the exact same value set; the win is a single source of truth that cannot drift. Consistent with the risk note, the two narrowed unions were encoded with `Exclude<>` + comment rather than widened, since `youtube-direct` is never a resolved/origin source (verified: `ResolvedSource` in `listenTogetherResolution.ts` only ever produces `local`/`tidal`/`youtube`). No `switch`/exhaustive branch over these unions exists.

### Tests
- New `frontend/tests/unit/mediaSourceContract.test.ts` (TDD, written failing first): runtime assertions for `CANONICAL_MEDIA_SOURCE_VALUES`, `normalizeCanonicalMediaSource`, `resolveCanonicalMediaSource`, `toLegacyStreamFields`, `toAudioEngineSourceType` (the normalizers had **no** prior tests), plus compile-time `@ts-expect-error` assertions pinning the `RemoteMediaSource`/`ResolvedMediaSource` exclusions.

verify:
- contract build (`tsc -p packages/media-metadata-contract/tsconfig.json`): exit 0
- frontend typecheck (`tsc --noEmit --incremental false`): exit 0, 0 errors
- backend typecheck (`tsc --noEmit -p tsconfig.json`): exit 0, 0 errors
- frontend unit (`node --test` mediaSourceContract + trackRef): 22/22 pass
- backend jest (`playlistTrackResolution` + `listenTogetherSocketRuntime`): 35/35 pass

### Breaking / UPGRADING
None. Type-only + docs; no runtime, API, or value changes.

### Escalations
None.

### Coordination notes
- `frontend/lib/api.ts` touched minimally (two type annotations only) — full api.ts client-typing/split remains for slice P34 (api-client-typing).
- Follow-up (out of scope, discovered): `ResolvedSource` in `listenTogetherResolution.ts` and the `z.enum([...])` in `playlistImport.ts` still use inline `local`/`tidal`/`youtube` literals — left intentionally (discriminated-union discriminants and a runtime validator, respectively).
