### PR TITLE
refactor(frontend): split playback context into progress + status (refactor slice P27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Frontend playback context split for playback re-render hygiene: the single
+  `AudioPlaybackContext` is now served as two contexts by the same
+  `AudioPlaybackProvider` — a high-frequency progress context (`currentTime`,
+  read via the new `usePlaybackProgress()` hook) and a low-frequency status
+  context (`isPlaying`, `duration`, `streamProfile`, seek/buffer flags, and all
+  setters, read via the new `usePlaybackStatus()` hook). Status-only consumers
+  (the album/playlist/discover pages, `LibraryTracksList`, and the playback
+  quality badge) were migrated to `usePlaybackStatus()` so they no longer
+  re-render on every ~1 Hz clock tick during playback. `useAudioPlayback()` is
+  retained unchanged as a deprecated composite (same shape, same referential
+  stability, same out-of-provider error) for the remaining consumers; no
+  playback behavior changed. Prefer the two granular hooks going forward.
 - Media-source contract: the hand-copied `local`/`tidal`/`youtube`/`youtube-direct`
   source unions scattered across the frontend and backend now derive from
   `CanonicalMediaSource` in `@soundspan/media-metadata-contract` instead of being

--- a/frontend/app/album/[id]/page.tsx
+++ b/frontend/app/album/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useAudioState, useAudioPlayback, useAudioControls } from "@/lib/audio-context";
+import { useAudioState, usePlaybackStatus, useAudioControls } from "@/lib/audio-context";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
 import { useImageColor } from "@/hooks/useImageColor";
 import { api } from "@/lib/api";
@@ -57,7 +57,7 @@ export default function AlbumPage({ params }: AlbumPageProps) {
     const router = useRouter();
     // Use split hooks to avoid re-renders from currentTime updates
     const { currentTrack } = useAudioState();
-    const { isPlaying } = useAudioPlayback();
+    const { isPlaying } = usePlaybackStatus();
     const { pause } = useAudioControls();
     const { isInGroup } = useListenTogether();
 

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -7,7 +7,7 @@ import { api } from "@/lib/api";
 import { toast } from "sonner";
 import { cn } from "@/utils/cn";
 import { GradientSpinner } from "@/components/ui/GradientSpinner";
-import { useAudioState, useAudioPlayback } from "@/lib/audio-context";
+import { useAudioState, usePlaybackStatus } from "@/lib/audio-context";
 import { useDiscoverData } from "@/features/discover/hooks/useDiscoverData";
 import { useDiscoverActions } from "@/features/discover/hooks/useDiscoverActions";
 import { useDiscoverProviderGapFill } from "@/features/discover/hooks/useDiscoverProviderGapFill";
@@ -65,7 +65,7 @@ export default function DiscoverWeeklyPage() {
 function DiscoverWeeklyPageContent() {
     // Use split hooks to avoid re-renders from currentTime updates
     const { currentTrack } = useAudioState();
-    const { isPlaying } = useAudioPlayback();
+    const { isPlaying } = usePlaybackStatus();
     const [showSettings, setShowSettings] = useState(false);
     const [showPlaylistSelector, setShowPlaylistSelector] = useState(false);
     const [isAddingToPlaylist, setIsAddingToPlaylist] = useState(false);

--- a/frontend/app/playlist/[id]/page.tsx
+++ b/frontend/app/playlist/[id]/page.tsx
@@ -7,7 +7,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { CoverMosaic } from "@/components/ui/CoverMosaic";
 import { createMosaicCandidates, selectMosaicCovers } from "@/utils/mosaicCoverSelection";
 import { api } from "@/lib/api";
-import { useAudioState, useAudioPlayback, useAudioControls, Track as AudioTrack } from "@/lib/audio-context";
+import { useAudioState, usePlaybackStatus, useAudioControls, Track as AudioTrack } from "@/lib/audio-context";
 import { cn } from "@/utils/cn";
 import { shuffleArray } from "@/utils/shuffle";
 import { formatTime } from "@/utils/formatTime";
@@ -164,7 +164,7 @@ export default function PlaylistDetailPage() {
     const { toast } = useToast();
     // Use split hooks to avoid re-renders from currentTime updates
     const { currentTrack } = useAudioState();
-    const { isPlaying } = useAudioPlayback();
+    const { isPlaying } = usePlaybackStatus();
     const { playTracks, playNow, pause, resume, addTracksToQueue } = useAudioControls();
     const playlistId = params.id as string;
 

--- a/frontend/components/player/PlaybackQualityBadgeWithStats.tsx
+++ b/frontend/components/player/PlaybackQualityBadgeWithStats.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { X } from "lucide-react";
 import { useAudioState } from "@/lib/audio-state-context";
-import { useAudioPlayback } from "@/lib/audio-playback-context";
+import { usePlaybackStatus } from "@/lib/audio-playback-context";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import {
     useStreamBitrate,
@@ -66,7 +66,7 @@ export function PlaybackQualityBadgeWithStats({
     const isMobile = useIsMobile();
 
     const { currentTrack } = useAudioState();
-    const { streamProfile } = useAudioPlayback();
+    const { streamProfile } = usePlaybackStatus();
     const { tidalQuality, localQuality, bitrate, codec } = useStreamBitrate();
 
     const clearCloseTimeout = useCallback(() => {

--- a/frontend/features/search/components/LibraryTracksList.tsx
+++ b/frontend/features/search/components/LibraryTracksList.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { Play, Pause } from "lucide-react";
 import Link from "next/link";
 import { useAudioState } from "@/lib/audio-state-context";
-import { useAudioPlayback } from "@/lib/audio-playback-context";
+import { usePlaybackStatus } from "@/lib/audio-playback-context";
 import { useAudioControls } from "@/lib/audio-controls-context";
 import { api } from "@/lib/api";
 import { formatTime } from "@/utils/formatTime";
@@ -34,7 +34,7 @@ function toRowItem(track: LibraryTrack): TrackRowItem {
  */
 export function LibraryTracksList({ tracks, limit = 10 }: LibraryTracksListProps) {
     const { currentTrack } = useAudioState();
-    const { isPlaying } = useAudioPlayback();
+    const { isPlaying } = usePlaybackStatus();
     const { playTracks, pause, resume } = useAudioControls();
     const allTracks = tracks ?? [];
     const visibleTracks =

--- a/frontend/lib/audio-context.tsx
+++ b/frontend/lib/audio-context.tsx
@@ -21,7 +21,11 @@ export { AudioControlsProvider } from "./audio-controls-context";
 
 // Re-export individual hooks
 export { useAudioState } from "./audio-state-context";
-export { useAudioPlayback } from "./audio-playback-context";
+export {
+    useAudioPlayback,
+    usePlaybackProgress,
+    usePlaybackStatus,
+} from "./audio-playback-context";
 export { useAudioControls } from "./audio-controls-context";
 
 // Re-export the unified hook (backward compatibility)

--- a/frontend/lib/audio-playback-context.tsx
+++ b/frontend/lib/audio-playback-context.tsx
@@ -52,7 +52,8 @@ export interface PlaybackStreamProfile {
     bitrateKbps: number | null;
 }
 
-interface AudioPlaybackContextType {
+/** Composite playback state retained for backward-compatible consumers. */
+export interface AudioPlaybackContextType {
     isPlaying: boolean;
     currentTime: number;
     duration: number;
@@ -81,8 +82,45 @@ interface AudioPlaybackContextType {
     clearAudioError: () => void; // Clear the audio error state
 }
 
-const AudioPlaybackContext = createContext<
-    AudioPlaybackContextType | undefined
+/** Playback progress values that change on published clock ticks. */
+export interface PlaybackProgressContextType {
+    currentTime: number;
+}
+
+/** Playback status values and setters that do not depend on currentTime. */
+export interface PlaybackStatusContextType {
+    isPlaying: boolean;
+    duration: number;
+    isBuffering: boolean;
+    targetSeekPosition: number | null;
+    canSeek: boolean;
+    downloadProgress: number | null;
+    isSeekLocked: boolean;
+    audioError: string | null;
+    playbackState: PlaybackState;
+    streamProfile: PlaybackStreamProfile | null;
+    setIsPlaying: (playing: boolean) => void;
+    setCurrentTime: (time: number) => void;
+    setCurrentTimeFromEngine: (
+        time: number,
+        invocationTrackId?: string | null
+    ) => void;
+    setDuration: (duration: number) => void;
+    setIsBuffering: (buffering: boolean) => void;
+    setTargetSeekPosition: (position: number | null) => void;
+    setCanSeek: (canSeek: boolean) => void;
+    setDownloadProgress: (progress: number | null) => void;
+    setStreamProfile: (profile: PlaybackStreamProfile | null) => void;
+    lockSeek: (targetTime: number) => void;
+    unlockSeek: () => void;
+    clearAudioError: () => void;
+}
+
+const PlaybackProgressContext = createContext<
+    PlaybackProgressContextType | undefined
+>(undefined);
+const PlaybackStatusContext = createContext<
+    PlaybackStatusContextType | undefined
 >(undefined);
 
 // LocalStorage keys
@@ -640,11 +678,15 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
         };
     }, [isHydrated, savePlaybackProgressToServer]);
 
+    const progressValue = useMemo(
+        () => ({ currentTime }),
+        [currentTime]
+    );
+
     // Memoize to prevent re-renders when values haven't changed
-    const value = useMemo(
+    const statusValue = useMemo(
         () => ({
             isPlaying,
-            currentTime,
             duration,
             isBuffering,
             targetSeekPosition,
@@ -671,7 +713,6 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
         }),
         [
             isPlaying,
-            currentTime,
             duration,
             isBuffering,
             targetSeekPosition,
@@ -690,21 +731,59 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
     );
 
     return (
-        <AudioPlaybackContext.Provider value={value}>
-            {children}
-        </AudioPlaybackContext.Provider>
+        <PlaybackStatusContext.Provider value={statusValue}>
+            <PlaybackProgressContext.Provider value={progressValue}>
+                {children}
+            </PlaybackProgressContext.Provider>
+        </PlaybackStatusContext.Provider>
     );
 }
 
 /**
- * Executes useAudioPlayback.
+ * Reads playback status and playback setter state.
  */
-export function useAudioPlayback() {
-    const context = useContext(AudioPlaybackContext);
+export function usePlaybackStatus(): PlaybackStatusContextType {
+    const context = useContext(PlaybackStatusContext);
     if (!context) {
         throw new Error(
-            "useAudioPlayback must be used within AudioPlaybackProvider"
+            "usePlaybackStatus must be used within AudioPlaybackProvider"
         );
     }
     return context;
+}
+
+/**
+ * Reads the current playback progress.
+ */
+export function usePlaybackProgress(): PlaybackProgressContextType {
+    const context = useContext(PlaybackProgressContext);
+    if (!context) {
+        throw new Error(
+            "usePlaybackProgress must be used within AudioPlaybackProvider"
+        );
+    }
+    return context;
+}
+
+/**
+ * Reads the composite playback context.
+ *
+ * @deprecated Use usePlaybackStatus and usePlaybackProgress instead.
+ */
+export function useAudioPlayback(): AudioPlaybackContextType {
+    const status = useContext(PlaybackStatusContext);
+    const progress = useContext(PlaybackProgressContext);
+    const composite = useMemo(
+        () =>
+            status && progress
+                ? { ...status, currentTime: progress.currentTime }
+                : null,
+        [status, progress]
+    );
+    if (!composite) {
+        throw new Error(
+            'useAudioPlayback must be used within AudioPlaybackProvider'
+        );
+    }
+    return composite;
 }

--- a/frontend/tests/component/libraryTracksList.component.test.ts
+++ b/frontend/tests/component/libraryTracksList.component.test.ts
@@ -32,6 +32,9 @@ mock.module("@/lib/audio-playback-context", {
         useAudioPlayback: () => ({
             isPlaying: playbackState.isPlaying,
         }),
+        usePlaybackStatus: () => ({
+            isPlaying: playbackState.isPlaying,
+        }),
     },
 });
 

--- a/frontend/tests/component/miniPlayerEnhancements.component.test.ts
+++ b/frontend/tests/component/miniPlayerEnhancements.component.test.ts
@@ -154,6 +154,9 @@ mock.module("@/lib/audio-playback-context", {
         useAudioPlayback: () => ({
             streamProfile: null,
         }),
+        usePlaybackStatus: () => ({
+            streamProfile: null,
+        }),
     },
 });
 

--- a/frontend/tests/component/playbackContextSplit.component.test.ts
+++ b/frontend/tests/component/playbackContextSplit.component.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Guards the playback-context split so high-frequency clock updates re-render
+ * progress and composite consumers without re-rendering status consumers.
+ */
+
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+// Any api method resolves to null so mount-time playback-state hydration is a
+// no-op and cannot change the render counts under test.
+const apiStub = new Proxy(
+    {},
+    { get: () => async () => null },
+) as Record<string, unknown>;
+mock.module("@/lib/api", { namedExports: { api: apiStub } });
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
+
+test("playback status consumers do not re-render on clock ticks after the context split", async () => {
+    localStorage.clear();
+    const { createRoot } = await import("react-dom/client");
+    const { AudioStateProvider } = await import("../../lib/audio-state-context");
+    const {
+        AudioPlaybackProvider,
+        usePlaybackStatus,
+        usePlaybackProgress,
+        useAudioPlayback,
+    } = await import("../../lib/audio-playback-context");
+
+    const statusRendersRef = { current: 0 };
+    const progressRendersRef = { current: 0 };
+    const compositeRendersRef = { current: 0 };
+    const capturedEngineTickRef = { current: null as EngineTickFn | null };
+
+    const StatusProbe = () => {
+        const status = usePlaybackStatus();
+        void status.isPlaying;
+        capturedEngineTickRef.current = status.setCurrentTimeFromEngine;
+        statusRendersRef.current += 1;
+        return null;
+    };
+
+    const ProgressProbe = () => {
+        const progress = usePlaybackProgress();
+        void progress.currentTime;
+        progressRendersRef.current += 1;
+        return null;
+    };
+
+    const CompositeProbe = () => {
+        const composite = useAudioPlayback();
+        void composite.currentTime;
+        void composite.isPlaying;
+        compositeRendersRef.current += 1;
+        return null;
+    };
+
+    const tree = React.createElement(
+        AudioStateProvider,
+        null,
+        React.createElement(
+            AudioPlaybackProvider,
+            null,
+            React.createElement(StatusProbe),
+            React.createElement(ProgressProbe),
+            React.createElement(CompositeProbe),
+        ),
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(tree);
+    });
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    const mountStatusRenders = statusRendersRef.current;
+    const mountProgressRenders = progressRendersRef.current;
+    const mountCompositeRenders = compositeRendersRef.current;
+    assert.ok(
+        capturedEngineTickRef.current,
+        "expected the playback provider's engine-tick setter to be captured",
+    );
+
+    const ticks = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+    for (const time of ticks) {
+        await React.act(async () => {
+            capturedEngineTickRef.current!(time, null);
+        });
+    }
+
+    const tickStatusRenders = statusRendersRef.current - mountStatusRenders;
+    const tickProgressRenders = progressRendersRef.current - mountProgressRenders;
+    const tickCompositeRenders =
+        compositeRendersRef.current - mountCompositeRenders;
+
+    assert.equal(
+        tickStatusRenders,
+        0,
+        `status consumers must render 0 times across 8 clock ticks (got ${tickStatusRenders})`,
+    );
+    assert.equal(
+        tickProgressRenders,
+        2,
+        `progress consumers must render exactly at the 2 display-second boundaries (got ${tickProgressRenders})`,
+    );
+    assert.equal(
+        tickCompositeRenders,
+        2,
+        `backward-compatible composite consumers must track the 2 clock publishes (got ${tickCompositeRenders})`,
+    );
+
+    await React.act(async () => {
+        root.unmount();
+    });
+});

--- a/frontend/tests/component/playlistDetailProviderPlayability.component.test.ts
+++ b/frontend/tests/component/playlistDetailProviderPlayability.component.test.ts
@@ -133,6 +133,9 @@ mock.module("@/lib/audio-context", {
         useAudioPlayback: () => ({
             isPlaying: state.isPlaying,
         }),
+        usePlaybackStatus: () => ({
+            isPlaying: state.isPlaying,
+        }),
         useAudioControls: () => ({
             playTracks: () => undefined,
             playNow: () => undefined,

--- a/frontend/tests/component/playlistRename.component.test.ts
+++ b/frontend/tests/component/playlistRename.component.test.ts
@@ -130,6 +130,9 @@ mock.module("@/lib/audio-context", {
         useAudioPlayback: () => ({
             isPlaying: state.isPlaying,
         }),
+        usePlaybackStatus: () => ({
+            isPlaying: state.isPlaying,
+        }),
         useAudioControls: () => ({
             playTracks: () => undefined,
             playNow: () => undefined,

--- a/frontend/tests/component/streamingRoutes.component.test.ts
+++ b/frontend/tests/component/streamingRoutes.component.test.ts
@@ -154,6 +154,9 @@ mock.module("@/lib/audio-context", {
         useAudioPlayback: () => ({
             isPlaying: false,
         }),
+        usePlaybackStatus: () => ({
+            isPlaying: false,
+        }),
         useAudioControls: () => ({
             pause: () => undefined,
             playTracks: () => undefined,


### PR DESCRIPTION
## Summary

Structural split of the frontend playback context to stop high-frequency clock ticks from re-rendering status-only consumers. `currentTime` updates ~1 Hz during playback and previously forced **every** `useAudioPlayback()` consumer (including large pages that only read `isPlaying`) to re-render each second.

The single `AudioPlaybackContext` is now served as **two** contexts by the same `AudioPlaybackProvider`:

- **Progress context** — `{ currentTime }`, read via new `usePlaybackProgress()` (high-frequency).
- **Status context** — `isPlaying`, `duration`, `isBuffering`, `targetSeekPosition`, `canSeek`, `downloadProgress`, `isSeekLocked`, `audioError`, `playbackState`, `streamProfile`, and **all setters** (incl. `setCurrentTime`, `setCurrentTimeFromEngine`), read via new `usePlaybackStatus()` (low-frequency).

`useAudioPlayback()` is retained as a **deprecated composite** with identical shape, identical referential stability (memoized on `[status, progress]`), and identical out-of-provider error message, so the remaining `currentTime` consumers (FullPlayer, AudioPlaybackOrchestrator, NowPlayingConnected, `useAudio`, controls context) work unchanged. No playback behavior changed.

### Consumers migrated to `usePlaybackStatus()` (status/streamProfile only)
- `app/album/[id]/page.tsx`, `app/playlist/[id]/page.tsx`, `app/discover/page.tsx`
- `features/search/components/LibraryTracksList.tsx`
- `components/player/PlaybackQualityBadgeWithStats.tsx`

Barrel `lib/audio-context.tsx` now re-exports the two new hooks.

## Findings addressed
- Playback context re-renders full page components every second during playback (slice P27 sole finding).

## Tests
TDD: new failing-first render-count regression `frontend/tests/component/playbackContextSplit.component.test.ts` (modeled on the existing `universalPlayerRenderCount` harness) drives 8 engine ticks and asserts **exactly**: status consumers re-render **0** times, progress consumers **2** times (display-second boundaries), composite consumers **2** times (backward-compat, non-vacuity control).

- verify: `frontend test:component` full suite — 491 tests, 491 pass, 0 fail.
- verify: `frontend typecheck` (tsc --noEmit) — exit 0.
- verify: ESLint on changed files — 0 errors (only pre-existing warnings in untouched effect code; the split introduced no new warnings).

Five existing component-test mocks that stub the migrated components' context module were updated to export `usePlaybackStatus` alongside `useAudioPlayback` (mock parity, per the opportunistic-replacement rule).

## Breaking / UPGRADING
None. `useAudioPlayback()` is unchanged for callers; the two new hooks are additive.

## Escalations
None.

## Follow-ups (discovered, out of scope)
- FullPlayer / AudioPlaybackOrchestrator / NowPlayingConnected still read `currentTime` via the composite and re-render per second by necessity; the orchestrator's move to granular hooks belongs to the dependent `orchestrator-decomposition` slice (P33), which this slice is sequenced before.
- The worktree lacked `frontend/node_modules`; symlinked to the main checkout's (lockfiles differ only by the dev-only `tsx` patch and `@types/dompurify`) to run tests/typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)