### PR TITLE
feat(a11y): keyboard + AT support for seek, dialogs, track reorder (refactor slice P26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Accessibility
+
+- The player seek slider now exposes screen-reader slider semantics and supports
+  Arrow, Page Up/Down, Home, and End keyboard seeking without changing pointer
+  or touch seeking behavior.
+- The shared Modal now exposes labelled dialog semantics, traps and initializes
+  focus, and restores focus on close; ConfirmDialog now composes that hardened
+  Modal instead of maintaining a separate overlay implementation.
+- Track lists now support keyboard reordering from labelled grip buttons,
+  clickable track rows expose button semantics with Enter/Space activation,
+  queue icon controls have accessible labels, and scoped jsx-a11y lint guards
+  protect the hardened accessibility components.
+
 ### Changed
 
 - **Backend error-response canonicalization (developer-facing standard + first

--- a/frontend/app/queue/page.tsx
+++ b/frontend/app/queue/page.tsx
@@ -592,6 +592,7 @@ function EpisodeQueueRow({
                     {...dragHandleProps}
                     className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
                     title="Drag to reorder"
+                    aria-label="Drag to reorder"
                 >
                     <GripVertical className="w-5 h-5" />
                 </button>
@@ -628,6 +629,7 @@ function EpisodeQueueRow({
                             onClick={onPlay}
                             className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors"
                             title="Play now"
+                            aria-label="Play now"
                         >
                             <Play className="w-4 h-4" />
                         </button>
@@ -693,6 +695,7 @@ function NextTrackRow({
                     {...dragHandleProps}
                     className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
                     title="Drag to reorder"
+                    aria-label="Drag to reorder"
                 >
                     <GripVertical className="w-5 h-5" />
                 </button>
@@ -739,6 +742,7 @@ function NextTrackRow({
                             disabled={queueIndex <= currentIndex + 1}
                             className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                             title="Move up"
+                            aria-label="Move up"
                         >
                             <ChevronUp className="w-4 h-4" />
                         </button>
@@ -747,6 +751,7 @@ function NextTrackRow({
                             disabled={queueIndex >= queueLength - 1}
                             className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                             title="Move down"
+                            aria-label="Move down"
                         >
                             <ChevronDown className="w-4 h-4" />
                         </button>
@@ -757,6 +762,7 @@ function NextTrackRow({
                     disabled={isUnavailable}
                     className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                     title="Play now"
+                    aria-label="Play now"
                 >
                     <Play className="w-4 h-4" />
                 </button>

--- a/frontend/components/player/SeekSlider.tsx
+++ b/frontend/components/player/SeekSlider.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { cn } from "@/utils/cn";
+import { formatTime } from "@/utils/formatTime";
+import { resolveSeekTime } from "./seekKeyboard";
 
 interface SeekSliderProps {
     /** Current progress percentage (0-100) */
@@ -30,6 +32,8 @@ interface SeekSliderProps {
     handleClassName?: string;
     /** Extra padding classes for an invisible hit zone around the track (e.g. "pb-5") */
     hitZoneClassName?: string;
+    /** Accessible label for the seek control */
+    ariaLabel?: string;
 }
 
 /**
@@ -38,7 +42,7 @@ interface SeekSliderProps {
 export function SeekSlider({
     progress,
     duration,
-    currentTime: _currentTime,
+    currentTime,
     onSeek,
     canSeek,
     hasMedia,
@@ -49,6 +53,7 @@ export function SeekSlider({
     variant = "default",
     handleClassName,
     hitZoneClassName,
+    ariaLabel = "Seek",
 }: SeekSliderProps) {
     const [isDragging, setIsDragging] = useState(false);
     const [previewProgress, setPreviewProgress] = useState<number | null>(null);
@@ -175,6 +180,17 @@ export function SeekSlider({
         [isDragging, canSeek, calculateProgress, duration, onSeek]
     );
 
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (!canSeek) return;
+            const nextTime = resolveSeekTime(e.key, { currentTime, duration });
+            if (nextTime === null) return;
+            e.preventDefault();
+            onSeek(nextTime);
+        },
+        [canSeek, currentTime, duration, onSeek]
+    );
+
     // Add global mouse event listeners when dragging
     useEffect(() => {
         if (isDragging) {
@@ -190,6 +206,10 @@ export function SeekSlider({
 
     const displayProgress =
         previewProgress !== null ? previewProgress : progress;
+    const currentSeconds =
+        previewProgress !== null
+            ? (previewProgress / 100) * duration
+            : currentTime;
     const isActive = canSeek && hasMedia;
 
     // Determine tooltip text
@@ -247,6 +267,20 @@ export function SeekSlider({
         onClick: handleClick,
     };
 
+    const accessibilityProps = {
+        role: "slider" as const,
+        tabIndex: canSeek ? 0 : -1,
+        "aria-label": ariaLabel,
+        "aria-orientation": "horizontal" as const,
+        "aria-valuemin": 0,
+        "aria-valuemax":
+            Number.isFinite(duration) && duration > 0 ? Math.round(duration) : 0,
+        "aria-valuenow": Math.round(currentSeconds),
+        "aria-valuetext": `${formatTime(currentSeconds)} of ${formatTime(duration)}`,
+        "aria-disabled": !canSeek,
+        onKeyDown: handleKeyDown,
+    };
+
     const track = (
         <div
             ref={sliderRef}
@@ -259,6 +293,7 @@ export function SeekSlider({
                 className
             )}
             {...(!hitZoneClassName ? interactionProps : {})}
+            {...(!hitZoneClassName ? accessibilityProps : {})}
             title={getTooltipText()}
         >
             <div
@@ -302,6 +337,7 @@ export function SeekSlider({
         <div
             className={cn(hitZoneClassName, isActive ? "cursor-pointer" : "cursor-not-allowed")}
             {...interactionProps}
+            {...accessibilityProps}
             title={getTooltipText()}
         >
             {track}

--- a/frontend/components/player/seekKeyboard.ts
+++ b/frontend/components/player/seekKeyboard.ts
@@ -1,0 +1,45 @@
+interface SeekTimeOptions {
+    currentTime: number;
+    duration: number;
+    step?: number;
+    largeStep?: number;
+}
+
+/**
+ * Resolves a slider keyboard command to a seek time clamped to the media duration.
+ */
+export function resolveSeekTime(
+    key: string,
+    { currentTime, duration, step = 5, largeStep = 10 }: SeekTimeOptions,
+): number | null {
+    if (!Number.isFinite(duration) || duration <= 0) return null;
+    if (!Number.isFinite(currentTime)) return null;
+
+    let nextTime: number;
+    switch (key) {
+        case "ArrowRight":
+        case "ArrowUp":
+            nextTime = currentTime + step;
+            break;
+        case "ArrowLeft":
+        case "ArrowDown":
+            nextTime = currentTime - step;
+            break;
+        case "PageUp":
+            nextTime = currentTime + largeStep;
+            break;
+        case "PageDown":
+            nextTime = currentTime - largeStep;
+            break;
+        case "Home":
+            nextTime = 0;
+            break;
+        case "End":
+            nextTime = duration;
+            break;
+        default:
+            return null;
+    }
+
+    return Math.min(duration, Math.max(0, nextTime));
+}

--- a/frontend/components/track/TrackList.tsx
+++ b/frontend/components/track/TrackList.tsx
@@ -10,6 +10,7 @@ import { TrackRow } from "./TrackRow";
 import {
     resolveDropPosition,
     resolveDropTargetIndex,
+    resolveKeyboardReorderTarget,
     type DropPosition,
 } from "./reorderDnd";
 import type { TrackListProps } from "./types";
@@ -27,8 +28,8 @@ interface DragOverState {
  * domain types; `onPlay`, `rowSlots`, and `rowOverflow` receive the original `T`.
  *
  * With the optional `reorder` prop (non-virtualized lists only), each row
- * gains a hover-revealed grip handle in its left padding gutter for
- * drag-and-drop reordering (GH #27); all decision math lives in the pure
+ * gains a hover-revealed grip handle in its left padding gutter for pointer
+ * and keyboard reordering (GH #27); all decision math lives in the pure
  * reorderDnd module. Without the prop the render output is unchanged.
  */
 export function TrackList<T>({
@@ -123,6 +124,7 @@ export function TrackList<T>({
             <div key={key}>
                 {sep}
                 <div
+                    role="group"
                     className={cn(
                         "relative group/reorder",
                         dragIndex === index && "opacity-50",
@@ -178,12 +180,23 @@ export function TrackList<T>({
                             )}
                         />
                     )}
-                    {/* Hover-revealed drag handle in the row's left padding
-                        gutter. HTML5 drag only — hidden on touch-first
-                        breakpoints where the menu actions cover reordering. */}
-                    <div
+                    {/* Hover-revealed reorder handle in the row's left padding
+                        gutter. Pointer dragging is hidden on touch-first
+                        breakpoints where menu actions cover reordering. */}
+                    <button
+                        type="button"
                         draggable
                         onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                            const target = resolveKeyboardReorderTarget(
+                                e.key,
+                                index,
+                                items.length,
+                            );
+                            if (target === null) return;
+                            e.preventDefault();
+                            reorder?.onReorder(index, target);
+                        }}
                         onDragStart={(e) => {
                             dragIndexRef.current = index;
                             setDragIndex(index);
@@ -201,6 +214,7 @@ export function TrackList<T>({
                         }}
                         onDragEnd={clearDragState}
                         title="Drag to reorder"
+                        aria-label={`Reorder ${rowItem.title}, use arrow keys to move`}
                         className={cn(
                             "absolute left-0 top-0 bottom-0 z-10 hidden md:flex w-4 cursor-grab touch-none",
                             "items-center justify-center text-gray-500 hover:text-white",
@@ -209,7 +223,7 @@ export function TrackList<T>({
                         )}
                     >
                         <GripVertical className="h-4 w-4" />
-                    </div>
+                    </button>
                     {row}
                 </div>
             </div>

--- a/frontend/components/track/TrackRow.tsx
+++ b/frontend/components/track/TrackRow.tsx
@@ -51,9 +51,11 @@ export function TrackRow({
             data-tv-card
             data-tv-card-index={index}
             onClick={onPlay}
+            role="button"
+            aria-label={`Play ${item.displayTitle ?? item.title} by ${item.artistName}`}
             tabIndex={0}
             onKeyDown={(e) => {
-                if (e.key === "Enter" && onPlay) {
+                if ((e.key === "Enter" || e.key === " ") && onPlay) {
                     e.preventDefault();
                     onPlay();
                 }

--- a/frontend/components/track/reorderDnd.ts
+++ b/frontend/components/track/reorderDnd.ts
@@ -38,3 +38,30 @@ export function resolveDropTargetIndex(
         fromIndex < insertionIndex ? insertionIndex - 1 : insertionIndex;
     return target;
 }
+
+/**
+ * Resolves the destination index for keyboard reordering.
+ * Returns `null` when the key or requested movement cannot reorder the item.
+ */
+export function resolveKeyboardReorderTarget(
+    key: string,
+    index: number,
+    count: number,
+): number | null {
+    if (count <= 1 || index < 0 || index >= count) {
+        return null;
+    }
+    if (key === "ArrowUp") {
+        return index > 0 ? index - 1 : null;
+    }
+    if (key === "ArrowDown") {
+        return index < count - 1 ? index + 1 : null;
+    }
+    if (key === "Home") {
+        return index > 0 ? 0 : null;
+    }
+    if (key === "End") {
+        return index < count - 1 ? count - 1 : null;
+    }
+    return null;
+}

--- a/frontend/components/ui/ConfirmDialog.tsx
+++ b/frontend/components/ui/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
+import { Modal } from "./Modal";
 
 interface ConfirmDialogProps {
     isOpen: boolean;
@@ -12,6 +13,24 @@ interface ConfirmDialogProps {
     cancelText?: string;
     variant?: "danger" | "warning" | "info";
 }
+
+const variantStyles = {
+    danger: {
+        icon: "text-red-500",
+        iconBg: "bg-red-500/10",
+        confirmButton: "bg-red-500 hover:bg-red-600 text-white",
+    },
+    warning: {
+        icon: "text-yellow-500",
+        iconBg: "bg-yellow-500/10",
+        confirmButton: "bg-yellow-500 hover:bg-yellow-600 text-black",
+    },
+    info: {
+        icon: "text-blue-500",
+        iconBg: "bg-blue-500/10",
+        confirmButton: "bg-blue-500 hover:bg-blue-600 text-white",
+    },
+};
 
 /**
  * Renders the ConfirmDialog component.
@@ -26,26 +45,6 @@ export function ConfirmDialog({
     cancelText = "Cancel",
     variant = "danger",
 }: ConfirmDialogProps) {
-    if (!isOpen) return null;
-
-    const variantStyles = {
-        danger: {
-            icon: "text-red-500",
-            iconBg: "bg-red-500/10",
-            confirmButton: "bg-red-500 hover:bg-red-600 text-white",
-        },
-        warning: {
-            icon: "text-yellow-500",
-            iconBg: "bg-yellow-500/10",
-            confirmButton: "bg-yellow-500 hover:bg-yellow-600 text-black",
-        },
-        info: {
-            icon: "text-blue-500",
-            iconBg: "bg-blue-500/10",
-            confirmButton: "bg-blue-500 hover:bg-blue-600 text-white",
-        },
-    };
-
     const styles = variantStyles[variant];
 
     const handleConfirm = () => {
@@ -54,37 +53,12 @@ export function ConfirmDialog({
     };
 
     return (
-        <div
-            className="fixed inset-0 bg-black/75 flex items-center justify-center z-50 p-4 animate-fadeIn"
-            onClick={onClose}
-        >
-            <div
-                className="bg-[#121212] rounded-xl max-w-md w-full overflow-hidden border border-white/10 shadow-2xl animate-slideUp"
-                onClick={(e) => e.stopPropagation()}
-            >
-                {/* Header */}
-                <div className="flex items-start gap-4 p-6 border-b border-white/10">
-                    <div
-                        className={`w-12 h-12 rounded-full ${styles.iconBg} flex items-center justify-center flex-shrink-0`}
-                    >
-                        <AlertTriangle className={`w-6 h-6 ${styles.icon}`} />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                        <h2 className="text-xl font-bold text-white mb-2">
-                            {title}
-                        </h2>
-                        <p className="text-sm text-gray-400">{message}</p>
-                    </div>
-                    <button
-                        onClick={onClose}
-                        className="p-1 hover:bg-white/10 rounded-full transition-colors text-gray-400 hover:text-white flex-shrink-0"
-                    >
-                        <X className="w-5 h-5" />
-                    </button>
-                </div>
-
-                {/* Actions */}
-                <div className="flex gap-3 p-6 bg-[#0a0a0a]/50">
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={title}
+            footer={
+                <>
                     <button
                         onClick={onClose}
                         className="flex-1 px-4 py-3 bg-white/5 hover:bg-white/10 text-white font-semibold rounded-lg transition-all border border-white/10"
@@ -97,38 +71,17 @@ export function ConfirmDialog({
                     >
                         {confirmText}
                     </button>
+                </>
+            }
+        >
+            <div className="flex items-start gap-4">
+                <div
+                    className={`w-12 h-12 rounded-full ${styles.iconBg} flex items-center justify-center flex-shrink-0`}
+                >
+                    <AlertTriangle className={`w-6 h-6 ${styles.icon}`} />
                 </div>
+                <p className="flex-1 min-w-0 text-sm text-gray-400">{message}</p>
             </div>
-
-            <style jsx global>{`
-                @keyframes fadeIn {
-                    from {
-                        opacity: 0;
-                    }
-                    to {
-                        opacity: 1;
-                    }
-                }
-
-                @keyframes slideUp {
-                    from {
-                        transform: translateY(20px);
-                        opacity: 0;
-                    }
-                    to {
-                        transform: translateY(0);
-                        opacity: 1;
-                    }
-                }
-
-                .animate-fadeIn {
-                    animation: fadeIn 0.2s ease-out;
-                }
-
-                .animate-slideUp {
-                    animation: slideUp 0.3s ease-out;
-                }
-            `}</style>
-        </div>
+        </Modal>
     );
 }

--- a/frontend/components/ui/Modal.tsx
+++ b/frontend/components/ui/Modal.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useId, useRef } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { Button } from "./Button";
+import { nextFocusIndex } from "./focusTrapMath";
+
+const FOCUSABLE_SELECTOR =
+    "a:not([tabindex='-1']), button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex='-1'])";
 
 export interface ModalProps {
     isOpen: boolean;
@@ -12,6 +16,70 @@ export interface ModalProps {
     children: ReactNode;
     footer?: ReactNode;
     className?: string;
+}
+
+function useEscapeAndScrollLock(isOpen: boolean, onClose: () => void) {
+    useEffect(() => {
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape") onClose();
+        };
+
+        if (isOpen) {
+            document.addEventListener("keydown", handleEscape);
+            document.body.style.overflow = "hidden";
+        }
+
+        return () => {
+            document.removeEventListener("keydown", handleEscape);
+            document.body.style.overflow = "unset";
+        };
+    }, [isOpen, onClose]);
+}
+
+function useDialogFocus(
+    isOpen: boolean,
+    dialogRef: React.RefObject<HTMLDivElement | null>,
+    previouslyFocusedRef: React.RefObject<HTMLElement | null>,
+) {
+    useEffect(() => {
+        if (!isOpen) return;
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+
+        previouslyFocusedRef.current =
+            document.activeElement instanceof HTMLElement
+                ? document.activeElement
+                : null;
+        const handleTab = (event: KeyboardEvent) => {
+            if (event.key !== "Tab") return;
+            const elements = Array.from(
+                dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+            );
+            const currentIndex = elements.indexOf(
+                document.activeElement as HTMLElement,
+            );
+            const nextIndex = nextFocusIndex(
+                elements.length,
+                currentIndex,
+                event.shiftKey,
+            );
+            event.preventDefault();
+            if (nextIndex === -1) {
+                dialog.focus();
+                return;
+            }
+            elements[nextIndex]?.focus();
+        };
+
+        dialog.addEventListener("keydown", handleTab);
+        dialog.focus();
+        return () => {
+            dialog.removeEventListener("keydown", handleTab);
+            const previouslyFocused = previouslyFocusedRef.current;
+            previouslyFocusedRef.current = null;
+            if (previouslyFocused?.isConnected) previouslyFocused.focus();
+        };
+    }, [dialogRef, isOpen, previouslyFocusedRef]);
 }
 
 /**
@@ -25,27 +93,22 @@ export function Modal({
     footer,
     className,
 }: ModalProps) {
-    useEffect(() => {
-        const handleEscape = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
-        };
-
-        if (isOpen) {
-            document.addEventListener("keydown", handleEscape);
-            document.body.style.overflow = "hidden";
-        }
-
-        return () => {
-            document.removeEventListener("keydown", handleEscape);
-            document.body.style.overflow = "unset";
-        };
-    }, [isOpen, onClose]);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+    const titleId = useId();
+    useEscapeAndScrollLock(isOpen, onClose);
+    useDialogFocus(isOpen, dialogRef, previouslyFocusedRef);
 
     if (!isOpen) return null;
 
     return (
         <div className="fixed inset-0 z-[10010] flex items-center justify-center p-4 bg-black/60 ">
             <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                tabIndex={-1}
                 className={cn(
                     "bg-gradient-to-br from-[#141414] to-[#0f0f0f] border border-[#262626] rounded-sm shadow-2xl max-w-md w-full p-6",
                     className
@@ -53,10 +116,13 @@ export function Modal({
             >
                 {/* Header */}
                 <div className="flex items-center justify-between mb-4 pb-4 border-b border-[#1c1c1c]">
-                    <h2 className="text-lg font-medium text-white">{title}</h2>
+                    <h2 id={titleId} className="text-lg font-medium text-white">
+                        {title}
+                    </h2>
                     <Button
                         variant="icon"
                         onClick={onClose}
+                        aria-label="Close"
                         className="hover:text-gray-300"
                     >
                         <X className="w-5 h-5" />

--- a/frontend/components/ui/focusTrapMath.ts
+++ b/frontend/components/ui/focusTrapMath.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns the next focusable-element index for Tab navigation within a trap.
+ */
+export function nextFocusIndex(
+    count: number,
+    currentIndex: number,
+    shiftKey: boolean,
+): number {
+    if (count <= 0) return -1;
+    if (currentIndex === -1) return shiftKey ? count - 1 : 0;
+    if (shiftKey) return (currentIndex - 1 + count) % count;
+    return (currentIndex + 1) % count;
+}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -24,9 +24,27 @@ const eslintConfig = defineConfig([
       "react-hooks/preserve-manual-memoization": "warn",
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/immutability": "warn",
+      // Advisory guards for the repo-wide a11y-core campaign.
+      "jsx-a11y/click-events-have-key-events": "warn",
+      "jsx-a11y/no-static-element-interactions": "warn",
+      "jsx-a11y/interactive-supports-focus": "warn",
       // New compiler rule in eslint-plugin-react-hooks 7.1; flags Date.now()
       // in app/discover/page.tsx useMemo. Same debt bucket as the rules above.
       "react-hooks/purity": "warn",
+    },
+  },
+  {
+    files: [
+      "components/player/SeekSlider.tsx",
+      "components/ui/Modal.tsx",
+      "components/ui/ConfirmDialog.tsx",
+      "components/track/TrackRow.tsx",
+      "components/track/TrackList.tsx",
+    ],
+    rules: {
+      "jsx-a11y/click-events-have-key-events": "error",
+      "jsx-a11y/no-static-element-interactions": "error",
+      "jsx-a11y/interactive-supports-focus": "error",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/frontend/tests/component/confirmDialogA11y.component.test.ts
+++ b/frontend/tests/component/confirmDialogA11y.component.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const Icon = (props: Record<string, unknown>) => React.createElement("i", props);
+
+mock.module("lucide-react", {
+    namedExports: { AlertTriangle: Icon, X: Icon },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+async function mountConfirmDialog(onConfirm: () => void, onClose: () => void) {
+    const { createRoot } = await import("react-dom/client");
+    const { ConfirmDialog } = await import("../../components/ui/ConfirmDialog");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(ConfirmDialog, {
+                isOpen: true,
+                onClose,
+                onConfirm,
+                title: "Delete playlist?",
+                message: "This action cannot be undone.",
+                confirmText: "Delete",
+                cancelText: "Keep playlist",
+            }),
+        );
+    });
+
+    return { container, root };
+}
+
+async function unmountDialog(
+    mounted: Awaited<ReturnType<typeof mountConfirmDialog>>,
+) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+test("ConfirmDialog renders its content and actions in a dialog", async () => {
+    const mounted = await mountConfirmDialog(() => undefined, () => undefined);
+    assert.ok(mounted.container.querySelector('[role="dialog"]'));
+    assert.match(mounted.container.textContent, /Delete playlist\?/);
+    assert.match(mounted.container.textContent, /This action cannot be undone\./);
+
+    const labels = Array.from(mounted.container.querySelectorAll("button"), (button) =>
+        button.textContent?.trim(),
+    );
+    assert.ok(labels.includes("Keep playlist"));
+    assert.ok(labels.includes("Delete"));
+    await unmountDialog(mounted);
+});
+
+test("ConfirmDialog confirms once and closes once", async () => {
+    let confirmCalls = 0;
+    let closeCalls = 0;
+    const mounted = await mountConfirmDialog(
+        () => {
+            confirmCalls += 1;
+        },
+        () => {
+            closeCalls += 1;
+        },
+    );
+    const confirmButton = Array.from(
+        mounted.container.querySelectorAll("button"),
+    ).find((button) => button.textContent?.trim() === "Delete");
+    assert.ok(confirmButton, "expected the confirm button");
+
+    await React.act(async () => {
+        confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    assert.equal(confirmCalls, 1);
+    assert.equal(closeCalls, 1);
+    await unmountDialog(mounted);
+});

--- a/frontend/tests/component/modalA11y.component.test.ts
+++ b/frontend/tests/component/modalA11y.component.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const Icon = (props: Record<string, unknown>) => React.createElement("i", props);
+
+mock.module("lucide-react", {
+    namedExports: { X: Icon },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+async function mountModal(onClose: () => void = () => undefined) {
+    const { createRoot } = await import("react-dom/client");
+    const { Modal } = await import("../../components/ui/Modal");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const render = async (isOpen: boolean) => {
+        await React.act(async () => {
+            root.render(
+                React.createElement(
+                    Modal,
+                    {
+                        isOpen,
+                        onClose,
+                        title: "Accessible modal",
+                        children: React.createElement("button", null, "Modal action"),
+                    },
+                ),
+            );
+        });
+    };
+    await render(true);
+
+    return { container, render, root };
+}
+
+async function unmountModal(mounted: Awaited<ReturnType<typeof mountModal>>) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+test("Modal exposes labelled modal dialog semantics", async () => {
+    const mounted = await mountModal();
+    const dialog = mounted.container.querySelector('[role="dialog"]');
+    assert.ok(dialog, "expected a dialog panel");
+    assert.equal(dialog.getAttribute("aria-modal"), "true");
+
+    const titleId = dialog.getAttribute("aria-labelledby");
+    assert.ok(titleId, "expected the dialog to reference its title");
+    const title = mounted.container.querySelector(`h2[id="${titleId}"]`);
+    assert.equal(title?.textContent, "Accessible modal");
+    assert.ok(
+        mounted.container.querySelector('button[aria-label="Close"]'),
+        "expected an accessible close button name",
+    );
+
+    await unmountModal(mounted);
+});
+
+test("Modal moves initial focus inside the dialog", async () => {
+    const mounted = await mountModal();
+    const dialog = mounted.container.querySelector('[role="dialog"]');
+    assert.ok(dialog, "expected a dialog panel");
+    assert.ok(dialog.contains(document.activeElement));
+    await unmountModal(mounted);
+});
+
+test("Modal closes when Escape is pressed", async () => {
+    let closeCalls = 0;
+    const mounted = await mountModal(() => {
+        closeCalls += 1;
+    });
+
+    await React.act(async () => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    assert.equal(closeCalls, 1);
+    await unmountModal(mounted);
+});
+
+test("Modal restores focus when it closes", async () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const mounted = await mountModal();
+
+    await mounted.render(false);
+
+    assert.equal(document.activeElement, trigger);
+    await unmountModal(mounted);
+    trigger.remove();
+});

--- a/frontend/tests/component/modalA11y.component.test.ts
+++ b/frontend/tests/component/modalA11y.component.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, mock, test } from "node:test";
 import React from "react";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { ModalProps } from "../../components/ui/Modal";
 
 GlobalRegistrator.register();
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -37,8 +38,8 @@ async function mountModal(onClose: () => void = () => undefined) {
                         isOpen,
                         onClose,
                         title: "Accessible modal",
-                        children: React.createElement("button", null, "Modal action"),
-                    },
+                    } as ModalProps, // children is supplied via createElement's third argument, so this is sound at runtime.
+                    React.createElement("button", null, "Modal action"),
                 ),
             );
         });

--- a/frontend/tests/component/seekSlider.component.test.ts
+++ b/frontend/tests/component/seekSlider.component.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+mock.module("@/utils/formatTime", {
+    namedExports: {
+        formatTime: (seconds: number) => {
+            const safeSeconds = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+            const minutes = Math.floor(safeSeconds / 60);
+            const remainder = Math.floor(safeSeconds % 60);
+            return `${minutes}:${remainder.toString().padStart(2, "0")}`;
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+async function mountSeekSlider(overrides: Record<string, unknown> = {}) {
+    const { createRoot } = await import("react-dom/client");
+    const { SeekSlider } = await import("../../components/player/SeekSlider");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const props = {
+        progress: 15,
+        duration: 200,
+        currentTime: 30,
+        onSeek: () => undefined,
+        canSeek: true,
+        hasMedia: true,
+        ...overrides,
+    };
+    await React.act(async () => {
+        root.render(React.createElement(SeekSlider, props));
+    });
+    return { container, root };
+}
+
+async function unmount(mounted: Awaited<ReturnType<typeof mountSeekSlider>>) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+test("renders slider semantics and current value when seeking is enabled", async () => {
+    const mounted = await mountSeekSlider();
+    const slider = mounted.container.querySelector('[role="slider"]');
+
+    assert.ok(slider, "expected an element with slider semantics");
+    assert.equal(slider.getAttribute("aria-valuemin"), "0");
+    assert.equal(slider.getAttribute("aria-valuemax"), "200");
+    assert.equal(slider.getAttribute("aria-valuenow"), "30");
+    assert.equal(slider.getAttribute("aria-label"), "Seek");
+    assert.equal((slider as HTMLElement).tabIndex, 0);
+
+    await unmount(mounted);
+});
+
+test("slider keyboard commands seek relative to the current time", async () => {
+    const seekCalls: number[] = [];
+    const mounted = await mountSeekSlider({
+        onSeek: (time: number) => seekCalls.push(time),
+    });
+    const slider = mounted.container.querySelector('[role="slider"]') as HTMLElement | null;
+    assert.ok(slider, "expected an element with slider semantics");
+
+    slider.focus();
+    for (const key of ["ArrowRight", "ArrowLeft", "Home", "End"]) {
+        await React.act(async () => {
+            slider.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+        });
+    }
+
+    assert.deepEqual(seekCalls, [35, 25, 0, 200]);
+    await unmount(mounted);
+});
+
+test("disabled slider is removed from tab order and ignores seek keys", async () => {
+    const seekCalls: number[] = [];
+    const mounted = await mountSeekSlider({
+        canSeek: false,
+        onSeek: (time: number) => seekCalls.push(time),
+    });
+    const slider = mounted.container.querySelector('[role="slider"]') as HTMLElement | null;
+    assert.ok(slider, "expected an element with slider semantics");
+    assert.equal(slider.tabIndex, -1);
+
+    await React.act(async () => {
+        slider.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+        );
+    });
+
+    assert.deepEqual(seekCalls, []);
+    await unmount(mounted);
+});

--- a/frontend/tests/component/trackListKeyboardReorder.component.test.ts
+++ b/frontend/tests/component/trackListKeyboardReorder.component.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const Icon = (props: Record<string, unknown>) => React.createElement("svg", props);
+
+mock.module("lucide-react", {
+    namedExports: {
+        AudioLines: Icon,
+        GripVertical: Icon,
+        Music: Icon,
+        Play: Icon,
+    },
+});
+
+mock.module("@/utils/formatTime", {
+    namedExports: { formatTime: (seconds: number) => `t:${seconds}` },
+});
+
+mock.module("@/components/ui/CachedImage", {
+    namedExports: {
+        CachedImage: ({ src, alt }: { src: string; alt: string }) =>
+            React.createElement("img", { src, alt }),
+    },
+});
+
+mock.module("@/components/ui/TrackOverflowMenu", {
+    namedExports: { TrackOverflowMenu: () => null },
+});
+
+mock.module("@/components/player/TrackPreferenceButtons", {
+    namedExports: { TrackPreferenceButtons: () => null },
+});
+
+mock.module("@/lib/audio-state-context", {
+    namedExports: { useAudioState: () => ({ currentTrack: null }) },
+});
+
+mock.module("@/hooks/useQueuedTrackIds", {
+    namedExports: { useQueuedTrackIds: () => new Set() },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+const items = [
+    { id: "track-1", title: "First Track", artist: "First Artist" },
+    { id: "track-2", title: "Second Track", artist: "Second Artist" },
+    { id: "track-3", title: "Third Track", artist: "Third Artist" },
+];
+
+function toRowItem(item: (typeof items)[number]) {
+    return {
+        id: item.id,
+        title: item.title,
+        artistName: item.artist,
+        duration: 180,
+        coverArtUrl: null,
+    };
+}
+
+async function mountTrackList(
+    reorderCalls: Array<[number, number]>,
+    playCalls: string[],
+) {
+    const { createRoot } = await import("react-dom/client");
+    const { TrackList } = await import("../../components/track");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(TrackList, {
+                items,
+                toRowItem,
+                onPlay: (item: (typeof items)[number]) => playCalls.push(item.id),
+                reorder: {
+                    onReorder: (from: number, to: number) =>
+                        reorderCalls.push([from, to]),
+                },
+            }),
+        );
+    });
+
+    return { container, root };
+}
+
+async function unmount(mounted: Awaited<ReturnType<typeof mountTrackList>>) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+test("each reorder grip is a labelled button", async () => {
+    const mounted = await mountTrackList([], []);
+    const grips = mounted.container.querySelectorAll('button[aria-label*="Reorder"]');
+
+    assert.equal(grips.length, 3);
+    await unmount(mounted);
+});
+
+test("reorder grip supports ArrowDown and ignores ArrowUp at the first boundary", async () => {
+    const reorderCalls: Array<[number, number]> = [];
+    const mounted = await mountTrackList(reorderCalls, []);
+    const grip = mounted.container.querySelector(
+        'button[aria-label*="Reorder"]',
+    ) as HTMLButtonElement | null;
+    assert.ok(grip);
+
+    grip.focus();
+    await React.act(async () => {
+        grip.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+        );
+    });
+    await React.act(async () => {
+        grip.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+        );
+    });
+
+    assert.deepEqual(reorderCalls, [[0, 1]]);
+    await unmount(mounted);
+});
+
+test("track row exposes button semantics and plays on Space", async () => {
+    const playCalls: string[] = [];
+    const mounted = await mountTrackList([], playCalls);
+    const row = mounted.container.querySelector(
+        '[data-tv-card][role="button"][aria-label^="Play"]',
+    ) as HTMLElement | null;
+    assert.ok(row);
+
+    await React.act(async () => {
+        row.dispatchEvent(
+            new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+        );
+    });
+
+    assert.deepEqual(playCalls, ["track-1"]);
+    await unmount(mounted);
+});

--- a/frontend/tests/unit/focusTrapMath.test.ts
+++ b/frontend/tests/unit/focusTrapMath.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { nextFocusIndex } from "../../components/ui/focusTrapMath";
+
+test("nextFocusIndex wraps forward from the final element", () => {
+    assert.equal(nextFocusIndex(3, 2, false), 0);
+});
+
+test("nextFocusIndex wraps backward from the first element", () => {
+    assert.equal(nextFocusIndex(3, 0, true), 2);
+});
+
+test("nextFocusIndex keeps a single element selected", () => {
+    assert.equal(nextFocusIndex(1, 0, false), 0);
+    assert.equal(nextFocusIndex(1, 0, true), 0);
+});
+
+test("nextFocusIndex returns -1 when no focusable elements exist", () => {
+    assert.equal(nextFocusIndex(0, -1, false), -1);
+});
+
+test("nextFocusIndex enters from outside in the tab direction", () => {
+    assert.equal(nextFocusIndex(3, -1, false), 0);
+    assert.equal(nextFocusIndex(3, -1, true), 2);
+});

--- a/frontend/tests/unit/seekKeyboard.test.ts
+++ b/frontend/tests/unit/seekKeyboard.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveSeekTime } from "../../components/player/seekKeyboard";
+
+const baseOptions = { currentTime: 30, duration: 200 };
+
+test("arrow keys seek by the default five-second step", () => {
+    assert.equal(resolveSeekTime("ArrowRight", baseOptions), 35);
+    assert.equal(resolveSeekTime("ArrowUp", baseOptions), 35);
+    assert.equal(resolveSeekTime("ArrowLeft", baseOptions), 25);
+    assert.equal(resolveSeekTime("ArrowDown", baseOptions), 25);
+});
+
+test("page keys seek by the default ten-second large step", () => {
+    assert.equal(resolveSeekTime("PageUp", baseOptions), 40);
+    assert.equal(resolveSeekTime("PageDown", baseOptions), 20);
+});
+
+test("Home and End seek to the duration boundaries", () => {
+    assert.equal(resolveSeekTime("Home", baseOptions), 0);
+    assert.equal(resolveSeekTime("End", baseOptions), 200);
+});
+
+test("relative seeks clamp at both duration boundaries", () => {
+    assert.equal(
+        resolveSeekTime("ArrowLeft", { currentTime: 2, duration: 200 }),
+        0,
+    );
+    assert.equal(
+        resolveSeekTime("ArrowRight", { currentTime: 198, duration: 200 }),
+        200,
+    );
+});
+
+test("custom step values override the defaults", () => {
+    assert.equal(
+        resolveSeekTime("ArrowRight", { ...baseOptions, step: 7 }),
+        37,
+    );
+    assert.equal(
+        resolveSeekTime("PageUp", { ...baseOptions, largeStep: 25 }),
+        55,
+    );
+});
+
+test("unknown keys do not resolve a seek time", () => {
+    assert.equal(resolveSeekTime("Enter", baseOptions), null);
+});
+
+test("invalid durations do not resolve a seek time", () => {
+    for (const duration of [0, Number.NaN, Number.POSITIVE_INFINITY]) {
+        assert.equal(resolveSeekTime("ArrowRight", { currentTime: 30, duration }), null);
+    }
+});
+
+test("a non-finite current time does not resolve a seek time", () => {
+    assert.equal(
+        resolveSeekTime("ArrowRight", { currentTime: Number.NaN, duration: 200 }),
+        null,
+    );
+});

--- a/frontend/tests/unit/trackListReorderDnd.test.ts
+++ b/frontend/tests/unit/trackListReorderDnd.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
     resolveDropPosition,
     resolveDropTargetIndex,
+    resolveKeyboardReorderTarget,
 } from "../../components/track/reorderDnd";
 
 test("resolveDropPosition splits a row at its vertical midpoint", () => {
@@ -39,4 +40,27 @@ test("dropping onto the dragged row's own position is a no-op", () => {
 test("boundaries: drop before first and after last", () => {
     assert.equal(resolveDropTargetIndex(5, 0, "before"), 0);
     assert.equal(resolveDropTargetIndex(0, 9, "after"), 9);
+});
+
+test("keyboard ArrowUp and ArrowDown reorder an item in the middle", () => {
+    assert.equal(resolveKeyboardReorderTarget("ArrowUp", 1, 3), 0);
+    assert.equal(resolveKeyboardReorderTarget("ArrowDown", 1, 3), 2);
+});
+
+test("keyboard arrow reordering stops at list boundaries", () => {
+    assert.equal(resolveKeyboardReorderTarget("ArrowUp", 0, 3), null);
+    assert.equal(resolveKeyboardReorderTarget("ArrowDown", 2, 3), null);
+});
+
+test("keyboard Home and End reorder to the list boundaries", () => {
+    assert.equal(resolveKeyboardReorderTarget("Home", 2, 4), 0);
+    assert.equal(resolveKeyboardReorderTarget("End", 1, 4), 3);
+});
+
+test("keyboard reordering is disabled for a single-item list", () => {
+    assert.equal(resolveKeyboardReorderTarget("ArrowDown", 0, 1), null);
+});
+
+test("keyboard reordering ignores unknown keys", () => {
+    assert.equal(resolveKeyboardReorderTarget("Enter", 1, 3), null);
 });


### PR DESCRIPTION
## Summary (refactor slice P26 — a11y-core)

Core WCAG fixes for the three verified blockers in the slice plan, frontend-only, all API via `frontend/lib/api.ts`. Follows the existing "pure decision module + thin component wiring" pattern (like `reorderDnd.ts`) so every keyboard/focus decision is unit-testable.

### Findings addressed
1. **Seek control had zero keyboard/AT support** — `SeekSlider` was a `div` widget. Now carries `role="slider"` + `aria-valuemin/max/now/valuetext/orientation/label/disabled`, is tab-focusable when seekable, and handles Arrow/PageUp-Down/Home/End via new pure `seekKeyboard.ts` (`resolveSeekTime`). The existing mouse/touch/click drag state machine is untouched; the a11y props ride the same interaction element in both the plain and hit-zone render branches.
2. **Modal/dialog layer had no dialog semantics, focus trap, or focus restoration** — `Modal` now renders `role="dialog"` + `aria-modal` + `aria-labelledby`, moves initial focus into the panel, traps Tab/Shift+Tab (pure `focusTrapMath.ts` `nextFocusIndex`), restores focus to the previously-focused element on close, and gives the close button an accessible name. `ConfirmDialog` now **composes** the hardened Modal instead of being a 14th ad-hoc overlay (variant icon/colors preserved).
3. **Drag-only track reordering had no keyboard alternative** — the `TrackList` reorder grip is now a labelled `<button>` supporting Arrow/Home/End reordering via new pure `resolveKeyboardReorderTarget`, routing through the same `onReorder` path as drag. `TrackRow` gains `role="button"` + accessible name + Enter/**Space** activation. Queue-page icon buttons (drag, move up/down, play) get `aria-label`s.
4. **Lint guard** — `eslint.config.mjs` adds three `jsx-a11y` interaction rules repo-wide at `warn` (campaign-advisory, non-blocking) plus a scoped `error`-level override on the five hardened components so they cannot regress.

### Tests (TDD, RED→GREEN; targeted only, never full suite)
- Unit (`node:test`): `seekKeyboard.test.ts`, `focusTrapMath.test.ts`, keyboard cases appended to `trackListReorderDnd.test.ts` — 23 pass.
- Component (happy-dom real-DOM harness): `seekSlider`, `modalA11y`, `confirmDialogA11y`, `trackListKeyboardReorder` — 12 pass; regressions `trackPrimitives`, `shareLinkModal`, `playlistRename`, `queuePageOverflowMenu` still green.
- verify: `npm run typecheck` exit 0; scoped `eslint` exit 0 (0 errors); full lint exit 0 (4 pre-existing advisory warnings in `app/queue/page.tsx:521/525`, out of scope).

### Breaking / UPGRADING
None. `ConfirmDialog`/`Modal`/`SeekSlider` public props are unchanged (`SeekSlider` gains an optional `ariaLabel`). `ConfirmDialog` now renders inside the shared Modal shell (cosmetic: Modal header + close button; backdrop-click-to-dismiss removed — intentional for destructive confirms).

### Follow-ups (out of scope, reported not actioned)
- Migrating the remaining ~13 ad-hoc overlays onto the hardened Modal (per slice riskNotes: per-touched-file follow-up).
- Two advisory jsx-a11y warnings at `app/queue/page.tsx:521,525` (static-element click handlers) — the campaign-wide warn rules now surface them for a future queue-page pass.
