### PR TITLE
refactor(backend): canonicalize route error responses (refactor slice P22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Changed
+
+- **Backend error-response canonicalization (developer-facing standard + first
+  exemplars).** The canonical route error contract is now documented in
+  `backend/src/routes/README.md`: async handlers wrap in `asyncHandler`,
+  deliberate client errors use `sendRouteError(res, status, message)`, and
+  unexpected/internal failures are logged once and returned via
+  `sendInternalRouteError` (or a thrown `AppError`) so every error body is the
+  single-field `{ "error": string }` envelope (`AppError` additionally carries
+  `code`/`category`). `routes/vibe.ts` and `routes/notifications.ts` are
+  retrofitted as the reference exemplars, and `routes/vibeJourneyRequest.ts` now
+  validates with `zod` instead of a bespoke helper pattern. Status codes and
+  error messages are unchanged except for the two client-visible field removals
+  noted below. A ratcheting CI check
+  (`npm run check:error-canon`,
+  `scripts/ci/check-route-error-canon.mjs`) freezes the current per-file count of
+  ad-hoc `res.status(500).json(...)` literals and fails the build if any route
+  file introduces new ones — canonicalize a route and lower its baseline; new
+  route files start at a baseline of zero.
+- **Minor API change (self-consumed vibe endpoints):** two error responses drop
+  their secondary `message` field to conform to the `{ error }` envelope —
+  `GET /api/vibe/similar/:trackId` (404 "No similar tracks found") and
+  `POST /api/vibe/search` (504 "Text embedding service unavailable"). The
+  `error` string and HTTP status are unchanged; the frontend reads only `error`,
+  so no client action is required.
+
 ### Security
 
 - Path containment on native audio streaming: the `GET /api/library/tracks/:id/stream`

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -8,6 +8,48 @@ Start-here guide for API route handlers in `backend/src/routes`.
 2. Route runtime tests: `backend/src/routes/__tests__/`.
 3. Shared business logic called by routes: `backend/src/services/`.
 
+## Error & Response Conventions (Canonical)
+
+All route error responses use one shape — the single-field JSON envelope:
+
+```json
+{ "error": "human-readable message" }
+```
+
+Errors raised as an `AppError` additionally carry `code` and `category` (and,
+in development only, `details`). Do not invent `{ message }`, `{ detail }`,
+`{ success: false }`, or raw-string error bodies. `{ success, ... }` is reserved
+for **2xx domain-result** payloads (e.g. a retry that created a job but could not
+start the download), never for error responses.
+
+How to write a handler:
+
+1. **Wrap async handlers in `asyncHandler`** (`../middleware/asyncHandler`) so a
+   rejected promise is forwarded to the shared `errorHandler`
+   (`../middleware/errorHandler`) instead of hanging the request.
+2. **Deliberate client errors** (400/401/403/404/409/…) — call
+   `sendRouteError(res, status, message)` from `./routeErrorResponse`.
+3. **Unexpected/internal failures** — either let the error propagate to the
+   shared `errorHandler` (which logs once and returns a generic 500 in
+   production, hiding stack/SQL/secret detail), or, when a safe static label is
+   preferable, `catch`, `logger.error(...)`, and return
+   `sendInternalRouteError(res, "Failed to …")`. Never swallow an error silently
+   and never echo raw internal/exception text to the client.
+4. **Status mapping** is owned by `errorHandler`: an `AppError.httpStatus` wins;
+   otherwise `ErrorCategory` maps RECOVERABLE→400, TRANSIENT→503, FATAL→500.
+5. **Request validation** uses `zod` at the trust boundary (see
+   `vibeJourneyRequest.ts`), producing a typed value or a 400 `{ error }`.
+
+Reference exemplars: `vibe.ts`, `vibeJourneyRequest.ts`, `notifications.ts`,
+`library.ts`.
+
+**Enforcement (ratchet):** `scripts/ci/check-route-error-canon.mjs`
+(`npm run check:error-canon`) freezes the current per-file count of ad-hoc
+`res.status(500).json(...)` literals and fails when a route file adds new ones.
+When you canonicalize a route, lower its baseline in that script; new route
+files start at zero. Full migration of every route file is intentionally
+incremental (per touched file), not a big-bang.
+
 ## Mounted Route Modules
 
 | Route File | Mounted Prefixes |

--- a/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
+++ b/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
@@ -1,0 +1,161 @@
+import { Request, Response } from "express";
+
+jest.mock("crypto", () => ({
+    randomUUID: jest.fn(() => "req-123"),
+}));
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: {
+            count: jest.fn(),
+            findUnique: jest.fn(),
+        },
+        likedTrack: {
+            findMany: jest.fn(),
+        },
+        dislikedEntity: {
+            findMany: jest.fn(),
+        },
+        $queryRaw: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        xAdd: jest.fn(),
+        blPop: jest.fn(),
+        del: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/hybridSimilarity", () => ({
+    findSimilarTracks: jest.fn(),
+}));
+
+jest.mock("../../utils/annQuery", () => ({
+    runAnnQuery: jest.fn(),
+}));
+
+jest.mock("../../services/umapProjection", () => ({
+    computeMapProjection: jest.fn(),
+}));
+
+jest.mock("../../utils/embedding", () => ({
+    parseEmbedding: jest.fn((text: string) => {
+        const values = text.replace(/[\[\]]/g, "").split(",").map(Number);
+        return values;
+    }),
+}));
+
+jest.mock("../../services/vibeVocabulary", () => ({
+    loadVocabulary: jest.fn(),
+    getVocabulary: jest.fn(() => null),
+    expandQueryWithVocabulary: jest.fn((embedding: number[]) => ({
+        embedding,
+        genreConfidence: 0,
+        matchedTerms: [],
+    })),
+    rerankWithFeatures: jest.fn((tracks: unknown[]) => tracks),
+}));
+
+import router from "../vibe";
+import { redisClient } from "../../utils/redis";
+import { findSimilarTracks } from "../../services/hybridSimilarity";
+
+const mockRedisXAdd = redisClient.xAdd as jest.Mock;
+const mockRedisBlPop = redisClient.blPop as jest.Mock;
+const mockRedisDel = redisClient.del as jest.Mock;
+const mockFindSimilarTracks = findSimilarTracks as jest.Mock;
+
+function getGetHandler(path: string) {
+    const layer = (router as any).stack.find(
+        (entry: any) => entry.route?.path === path && entry.route?.methods?.get
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function getPostHandler(path: string) {
+    const layer = (router as any).stack.find(
+        (entry: any) => entry.route?.path === path && entry.route?.methods?.post
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined as unknown,
+        status: jest.fn(function (code: number) {
+            res.statusCode = code;
+            return res;
+        }),
+        json: jest.fn(function (payload: unknown) {
+            res.body = payload;
+            return res;
+        }),
+    };
+    return res;
+}
+
+describe("vibe canonical error response shape", () => {
+    const similarHandler = getGetHandler("/similar/:trackId");
+    const searchHandler = getPostHandler("/search");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRedisXAdd.mockResolvedValue("1712345-0");
+        mockRedisDel.mockResolvedValue(1);
+    });
+
+    it("returns only the canonical error field when no similar tracks exist", async () => {
+        mockFindSimilarTracks.mockResolvedValue([]);
+        const req = {
+            params: { trackId: "track-1" },
+            query: {},
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await similarHandler(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "No similar tracks found" });
+        expect(res.body).not.toHaveProperty("message");
+    });
+
+    it("returns only the canonical error field when text embedding times out", async () => {
+        mockRedisBlPop.mockResolvedValue(null);
+        const req = {
+            body: { query: "quiet focus" },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await searchHandler(req, res);
+
+        expect(res.statusCode).toBe(504);
+        expect(res.body).toEqual({
+            error: "Text embedding service unavailable",
+        });
+        expect(res.body).not.toHaveProperty("message");
+    });
+});

--- a/backend/src/routes/__tests__/vibeJourneyRequest.test.ts
+++ b/backend/src/routes/__tests__/vibeJourneyRequest.test.ts
@@ -1,0 +1,185 @@
+import {
+    MAX_JOURNEY_EXCLUDE_TRACK_IDS,
+    parseJourneyRequest,
+} from "../vibeJourneyRequest";
+
+const INVALID_MOOD_ERROR =
+    "Invalid mood. Must be one of: happy, sad, chill, energetic, party, focus, melancholy, aggressive, acoustic";
+
+function rejection(error: string) {
+    return { ok: false, status: 400, error };
+}
+
+describe("parseJourneyRequest", () => {
+    it("requires a non-empty fromTrackId", () => {
+        expect(parseJourneyRequest({ fromTrackId: "", toTrackId: "to-1" })).toEqual(
+            rejection("fromTrackId is required")
+        );
+    });
+
+    it.each([
+        { fromTrackId: "from-1" },
+        { fromTrackId: "from-1", toTrackId: "to-1", mood: "happy" },
+    ])("requires exactly one target for $body", (body) => {
+        expect(parseJourneyRequest(body)).toEqual(
+            rejection("Provide exactly one of toTrackId or mood")
+        );
+    });
+
+    it("rejects an invalid mood", () => {
+        expect(
+            parseJourneyRequest({ fromTrackId: "from-1", mood: "invalid" })
+        ).toEqual(rejection(INVALID_MOOD_ERROR));
+    });
+
+    it("rejects an identical origin and destination", () => {
+        expect(
+            parseJourneyRequest({ fromTrackId: "same-1", toTrackId: "same-1" })
+        ).toEqual(rejection("Origin and destination are the same track"));
+    });
+
+    it("requires excludeTrackIds to be an array", () => {
+        expect(
+            parseJourneyRequest({
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                excludeTrackIds: "track-1",
+            })
+        ).toEqual(rejection("excludeTrackIds must be an array of strings"));
+    });
+
+    it("limits excludeTrackIds to 200 entries", () => {
+        expect(
+            parseJourneyRequest({
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                excludeTrackIds: Array.from(
+                    { length: MAX_JOURNEY_EXCLUDE_TRACK_IDS + 1 },
+                    (_, index) => `track-${index}`
+                ),
+            })
+        ).toEqual(rejection("excludeTrackIds cannot exceed 200 entries"));
+    });
+
+    it("requires non-empty string excludeTrackIds", () => {
+        expect(
+            parseJourneyRequest({
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                excludeTrackIds: ["track-1", ""],
+            })
+        ).toEqual(
+            rejection("excludeTrackIds must contain non-empty strings")
+        );
+    });
+
+    it("requires integer steps", () => {
+        expect(
+            parseJourneyRequest({
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                steps: 2.5,
+            })
+        ).toEqual(rejection("steps must be an integer"));
+    });
+
+    it.each([
+        [
+            {
+                fromTrackId: "",
+                excludeTrackIds: "invalid",
+                steps: "invalid",
+            },
+            "fromTrackId is required",
+        ],
+        [
+            {
+                fromTrackId: "from-1",
+                excludeTrackIds: "invalid",
+                steps: "invalid",
+            },
+            "Provide exactly one of toTrackId or mood",
+        ],
+        [
+            {
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                excludeTrackIds: "invalid",
+                steps: "invalid",
+            },
+            "excludeTrackIds must be an array of strings",
+        ],
+    ])("preserves validation precedence for case %#", (body, error) => {
+        expect(parseJourneyRequest(body)).toEqual(rejection(error));
+    });
+
+    it("accepts a track target", () => {
+        expect(
+            parseJourneyRequest({ fromTrackId: "from-1", toTrackId: "to-1" })
+        ).toEqual({
+            ok: true,
+            value: {
+                fromTrackId: "from-1",
+                toTrackId: "to-1",
+                mood: null,
+                steps: 8,
+                excludeTrackIds: [],
+            },
+        });
+    });
+
+    it("accepts a mood target", () => {
+        expect(
+            parseJourneyRequest({ fromTrackId: "from-1", mood: "happy" })
+        ).toEqual({
+            ok: true,
+            value: {
+                fromTrackId: "from-1",
+                toTrackId: null,
+                mood: "happy",
+                steps: 8,
+                excludeTrackIds: [],
+            },
+        });
+    });
+
+    it("defaults excludeTrackIds to an empty array", () => {
+        const result = parseJourneyRequest({
+            fromTrackId: "from-1",
+            toTrackId: "to-1",
+        });
+
+        expect(result.ok && result.value.excludeTrackIds).toEqual([]);
+    });
+
+    it("defaults steps to 8", () => {
+        const result = parseJourneyRequest({
+            fromTrackId: "from-1",
+            toTrackId: "to-1",
+        });
+
+        expect(result.ok && result.value.steps).toBe(8);
+    });
+
+    it.each([
+        [1, 2],
+        [99, 20],
+    ])("clamps steps from %i to %i", (steps, expected) => {
+        const result = parseJourneyRequest({
+            fromTrackId: "from-1",
+            toTrackId: "to-1",
+            steps,
+        });
+
+        expect(result.ok && result.value.steps).toBe(expected);
+    });
+
+    it.each([null, [], "not-an-object"])(
+        "treats non-object body %# as an empty object",
+        (body) => {
+            expect(parseJourneyRequest(body)).toEqual(
+                rejection("fromTrackId is required")
+            );
+        }
+    );
+});

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -461,7 +461,6 @@ describe("vibe search transport compatibility", () => {
         expect(res.statusCode).toBe(504);
         expect(res.body).toEqual({
             error: "Text embedding service unavailable",
-            message: "The CLAP analyzer service did not respond in time",
         });
         expect(mockRedisXAdd).toHaveBeenCalledWith(
             "audio:text:embed:requests",

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -2,7 +2,9 @@ import { Router, Request, Response } from "express";
 import { logger } from "../utils/logger";
 import { notificationService } from "../services/notificationService";
 import { requireAuth } from "../middleware/auth";
+import { asyncHandler } from "../middleware/asyncHandler";
 import { prisma } from "../utils/db";
+import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
 
@@ -31,7 +33,7 @@ const router = Router();
 router.get(
     "/",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             logger.debug(
                 `[Notifications] Fetching notifications for user ${
@@ -47,9 +49,9 @@ router.get(
             res.json(notifications);
         } catch (error: any) {
             logger.error("Error fetching notifications:", error);
-            res.status(500).json({ error: "Failed to fetch notifications" });
+            sendInternalRouteError(res, "Failed to fetch notifications");
         }
-    }
+    })
 );
 
 /**
@@ -78,7 +80,7 @@ router.get(
 router.get(
     "/unread-count",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const count = await notificationService.getUnreadCount(
                 req.user!.id
@@ -86,9 +88,9 @@ router.get(
             res.json({ count });
         } catch (error: any) {
             logger.error("Error fetching unread count:", error);
-            res.status(500).json({ error: "Failed to fetch unread count" });
+            sendInternalRouteError(res, "Failed to fetch unread count");
         }
-    }
+    })
 );
 
 /**
@@ -123,17 +125,18 @@ router.get(
 router.post(
     "/:id/read",
     requireAuth,
-    async (req: Request<{ id: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ id: string }>, res: Response) => {
         try {
             await notificationService.markAsRead(req.params.id, req.user!.id);
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error marking notification as read:", error);
-            res.status(500).json({
-                error: "Failed to mark notification as read",
-            });
+            sendInternalRouteError(
+                res,
+                "Failed to mark notification as read"
+            );
         }
-    }
+    })
 );
 
 /**
@@ -161,17 +164,18 @@ router.post(
 router.post(
     "/read-all",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             await notificationService.markAllAsRead(req.user!.id);
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error marking all notifications as read:", error);
-            res.status(500).json({
-                error: "Failed to mark all notifications as read",
-            });
+            sendInternalRouteError(
+                res,
+                "Failed to mark all notifications as read"
+            );
         }
-    }
+    })
 );
 
 /**
@@ -207,15 +211,15 @@ router.post(
 router.post(
     "/:id/clear",
     requireAuth,
-    async (req: Request<{ id: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ id: string }>, res: Response) => {
         try {
             await notificationService.clear(req.params.id, req.user!.id);
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error clearing notification:", error);
-            res.status(500).json({ error: "Failed to clear notification" });
+            sendInternalRouteError(res, "Failed to clear notification");
         }
-    }
+    })
 );
 
 /**
@@ -244,17 +248,15 @@ router.post(
 router.post(
     "/clear-all",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             await notificationService.clearAll(req.user!.id);
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error clearing all notifications:", error);
-            res.status(500).json({
-                error: "Failed to clear all notifications",
-            });
+            sendInternalRouteError(res, "Failed to clear all notifications");
         }
-    }
+    })
 );
 
 /**
@@ -282,7 +284,7 @@ router.post(
 router.get(
     "/downloads/history",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const downloads = await prisma.downloadJob.findMany({
                 where: {
@@ -308,9 +310,9 @@ router.get(
             res.json(deduplicated.slice(0, 50));
         } catch (error: any) {
             logger.error("Error fetching download history:", error);
-            res.status(500).json({ error: "Failed to fetch download history" });
+            sendInternalRouteError(res, "Failed to fetch download history");
         }
-    }
+    })
 );
 
 /**
@@ -338,7 +340,7 @@ router.get(
 router.get(
     "/downloads/active",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const downloads = await prisma.downloadJob.findMany({
                 where: {
@@ -350,9 +352,9 @@ router.get(
             res.json(downloads);
         } catch (error: any) {
             logger.error("Error fetching active downloads:", error);
-            res.status(500).json({ error: "Failed to fetch active downloads" });
+            sendInternalRouteError(res, "Failed to fetch active downloads");
         }
-    }
+    })
 );
 
 /**
@@ -388,7 +390,7 @@ router.get(
 router.post(
     "/downloads/:id/clear",
     requireAuth,
-    async (req: Request<{ id: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ id: string }>, res: Response) => {
         try {
             await prisma.downloadJob.updateMany({
                 where: {
@@ -400,9 +402,9 @@ router.post(
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error clearing download:", error);
-            res.status(500).json({ error: "Failed to clear download" });
+            sendInternalRouteError(res, "Failed to clear download");
         }
-    }
+    })
 );
 
 /**
@@ -431,7 +433,7 @@ router.post(
 router.post(
     "/downloads/clear-all",
     requireAuth,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             await prisma.downloadJob.updateMany({
                 where: {
@@ -444,9 +446,9 @@ router.post(
             res.json({ success: true });
         } catch (error: any) {
             logger.error("Error clearing all downloads:", error);
-            res.status(500).json({ error: "Failed to clear all downloads" });
+            sendInternalRouteError(res, "Failed to clear all downloads");
         }
-    }
+    })
 );
 
 /**
@@ -492,7 +494,7 @@ router.post(
 router.post(
     "/downloads/:id/retry",
     requireAuth,
-    async (req: Request<{ id: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ id: string }>, res: Response) => {
         try {
             // Get the failed download
             const failedJob = await prisma.downloadJob.findFirst({
@@ -504,9 +506,11 @@ router.post(
             });
 
             if (!failedJob) {
-                return res
-                    .status(404)
-                    .json({ error: "Download not found or not failed" });
+                return sendRouteError(
+                    res,
+                    404,
+                    "Download not found or not failed"
+                );
             }
 
             // If this was a pending-track retry job, re-run the pending-track retry flow
@@ -521,9 +525,11 @@ router.post(
                     | undefined;
 
                 if (!playlistId || !pendingTrackId) {
-                    return res.status(400).json({
-                        error: "Cannot retry: missing playlistId or pendingTrackId",
-                    });
+                    return sendRouteError(
+                        res,
+                        400,
+                        "Cannot retry: missing playlistId or pendingTrackId"
+                    );
                 }
 
                 // Mark old job as cleared
@@ -537,9 +543,7 @@ router.post(
                     where: { id: playlistId },
                 });
                 if (!playlist || playlist.userId !== req.user!.id) {
-                    return res
-                        .status(404)
-                        .json({ error: "Playlist not found" });
+                    return sendRouteError(res, 404, "Playlist not found");
                 }
 
                 const pendingTrack =
@@ -547,9 +551,7 @@ router.post(
                         where: { id: pendingTrackId },
                     });
                 if (!pendingTrack) {
-                    return res
-                        .status(404)
-                        .json({ error: "Pending track not found" });
+                    return sendRouteError(res, 404, "Pending track not found");
                 }
 
                 const retryTargetId =
@@ -729,9 +731,11 @@ router.post(
                 const albumTitle = metadata.albumTitle as string;
 
                 if (!artistName || !albumTitle) {
-                    return res.status(400).json({
-                        error: "Cannot retry: missing artist/album info",
-                    });
+                    return sendRouteError(
+                        res,
+                        400,
+                        "Cannot retry: missing artist/album info"
+                    );
                 }
 
                 // Mark old job as cleared
@@ -896,9 +900,11 @@ router.post(
 
             // Validate that we have the required MBIDs
             if (!failedJob.targetMbid) {
-                return res
-                    .status(400)
-                    .json({ error: "Cannot retry: missing album MBID" });
+                return sendRouteError(
+                    res,
+                    400,
+                    "Cannot retry: missing album MBID"
+                );
             }
 
             // Mark old job as cleared
@@ -952,9 +958,9 @@ router.post(
             });
         } catch (error: any) {
             logger.error("Error retrying download:", error);
-            res.status(500).json({ error: "Failed to retry download" });
+            sendInternalRouteError(res, "Failed to retry download");
         }
-    }
+    })
 );
 
 export default router;

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -7,6 +7,7 @@ import { runAnnQuery } from "../utils/annQuery";
 import { redisClient } from "../utils/redis";
 import { parseEmbedding } from "../utils/embedding";
 import { requireAuth } from "../middleware/auth";
+import { asyncHandler } from "../middleware/asyncHandler";
 import { findSimilarTracks } from "../services/hybridSimilarity";
 import { computeMapProjection } from "../services/umapProjection";
 import {
@@ -32,6 +33,7 @@ import {
 import { MOOD_CONFIG, VALID_MOODS, MoodType, MOOD_BUCKET_MIN_SCORE } from "../services/moodBucketService";
 import { fetchEmbeddingsByTrackIds } from "../services/trackEmbeddings";
 import { parseJourneyRequest } from "./vibeJourneyRequest";
+import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
 
@@ -147,15 +149,15 @@ async function buildTrackPreferenceScoreMapForUser(
  *       401:
  *         description: Not authenticated
  */
-router.get("/map", requireAuth, async (_req, res) => {
+router.get("/map", requireAuth, asyncHandler(async (_req, res) => {
     try {
         const mapData = await computeMapProjection();
         res.json(mapData);
     } catch (error: any) {
         logger.error("Vibe map error:", error);
-        res.status(500).json({ error: "Failed to compute map projection" });
+        sendInternalRouteError(res, "Failed to compute map projection");
     }
-});
+}));
 
 /**
  * Fetch a single track's CLAP embedding from pgvector.
@@ -346,15 +348,17 @@ async function walkEmbeddingSteps(
  *       401:
  *         description: Not authenticated
  */
-router.get("/path", requireAuth, async (req, res) => {
+router.get("/path", requireAuth, asyncHandler(async (req, res) => {
     try {
         const fromId = req.query.from as string;
         const toId = req.query.to as string;
 
         if (!fromId || !toId) {
-            return res
-                .status(400)
-                .json({ error: "Both 'from' and 'to' track IDs are required" });
+            return sendRouteError(
+                res,
+                400,
+                "Both 'from' and 'to' track IDs are required"
+            );
         }
 
         const steps = Math.min(
@@ -368,14 +372,10 @@ router.get("/path", requireAuth, async (req, res) => {
         ]);
 
         if (!fromEmbed) {
-            return res
-                .status(404)
-                .json({ error: "Starting track has no embedding" });
+            return sendRouteError(res, 404, "Starting track has no embedding");
         }
         if (!toEmbed) {
-            return res
-                .status(404)
-                .json({ error: "Ending track has no embedding" });
+            return sendRouteError(res, 404, "Ending track has no embedding");
         }
 
         const tValues = Array.from(
@@ -392,9 +392,9 @@ router.get("/path", requireAuth, async (req, res) => {
         res.json({ from: fromId, to: toId, steps: stepResults });
     } catch (error: any) {
         logger.error("Vibe path error:", error);
-        res.status(500).json({ error: "Failed to compute song path" });
+        sendInternalRouteError(res, "Failed to compute song path");
     }
-});
+}));
 
 const MIN_MOOD_BUCKET_TRACKS = 5;
 const MOOD_BUCKET_POOL_LIMIT = 50;
@@ -597,15 +597,13 @@ async function handleJourney(req: Request, res: Response) {
     try {
         const parsed = parseJourneyRequest(req.body);
         if (!parsed.ok) {
-            return res.status(parsed.status).json({ error: parsed.error });
+            return sendRouteError(res, parsed.status, parsed.error);
         }
         const { fromTrackId, toTrackId, mood, steps, excludeTrackIds } =
             parsed.value;
         const fromEmbed = await fetchTrackEmbedding(fromTrackId);
         if (!fromEmbed) {
-            return res
-                .status(404)
-                .json({ error: "Starting track has no embedding" });
+            return sendRouteError(res, 404, "Starting track has no embedding");
         }
         const result =
             toTrackId !== null
@@ -624,12 +622,12 @@ async function handleJourney(req: Request, res: Response) {
                       excludeTrackIds
                   );
         if (!result.ok) {
-            return res.status(result.status).json({ error: result.error });
+            return sendRouteError(res, result.status, result.error);
         }
         return res.json(result.body);
     } catch (error: any) {
         logger.error("Vibe journey error:", error);
-        return res.status(500).json({ error: "Failed to compute vibe journey" });
+        return sendInternalRouteError(res, "Failed to compute vibe journey");
     }
 }
 
@@ -684,7 +682,7 @@ async function handleJourney(req: Request, res: Response) {
  *       401:
  *         description: Not authenticated
  */
-router.post("/journey", requireAuth, handleJourney);
+router.post("/journey", requireAuth, asyncHandler(handleJourney));
 
 /**
  * @openapi
@@ -713,7 +711,7 @@ router.post("/journey", requireAuth, handleJourney);
  *       401:
  *         description: Not authenticated
  */
-router.get("/moods", requireAuth, async (_req, res) => {
+router.get("/moods", requireAuth, asyncHandler(async (_req, res) => {
     try {
         const grouped = await prisma.moodBucket.groupBy({
             by: ["mood"],
@@ -736,9 +734,9 @@ router.get("/moods", requireAuth, async (_req, res) => {
         );
     } catch (error: any) {
         logger.error("Vibe moods error:", error);
-        res.status(500).json({ error: "Failed to list moods" });
+        sendInternalRouteError(res, "Failed to list moods");
     }
-});
+}));
 
 /**
  * @openapi
@@ -786,20 +784,24 @@ router.get("/moods", requireAuth, async (_req, res) => {
  *       401:
  *         description: Not authenticated
  */
-router.post("/alchemy", requireAuth, async (req, res) => {
+router.post("/alchemy", requireAuth, asyncHandler(async (req, res) => {
     try {
         const { trackIds, weights, limit: requestedLimit } = req.body;
 
         if (!Array.isArray(trackIds) || trackIds.length < 2) {
-            return res
-                .status(400)
-                .json({ error: "At least 2 track IDs are required for alchemy" });
+            return sendRouteError(
+                res,
+                400,
+                "At least 2 track IDs are required for alchemy"
+            );
         }
 
         if (trackIds.length > 10) {
-            return res
-                .status(400)
-                .json({ error: "Maximum 10 ingredient tracks allowed" });
+            return sendRouteError(
+                res,
+                400,
+                "Maximum 10 ingredient tracks allowed"
+            );
         }
 
         const limit = Math.min(
@@ -809,9 +811,11 @@ router.post("/alchemy", requireAuth, async (req, res) => {
 
         const embeddingResult = await fetchAlchemyEmbeddings(trackIds);
         if (!embeddingResult.ok) {
-            return res.status(404).json({
-                error: `Track ${embeddingResult.missingTrackId} has no embedding`,
-            });
+            return sendRouteError(
+                res,
+                404,
+                `Track ${embeddingResult.missingTrackId} has no embedding`
+            );
         }
         const effectiveWeights = resolveAlchemyWeights(trackIds, weights);
 
@@ -822,9 +826,11 @@ router.post("/alchemy", requireAuth, async (req, res) => {
         // and surface as an opaque 500. Reject it explicitly instead.
         const weightSum = effectiveWeights.reduce((s, w) => s + w, 0);
         if (!Number.isFinite(weightSum) || weightSum <= 0) {
-            return res
-                .status(400)
-                .json({ error: "weights must sum to a positive value" });
+            return sendRouteError(
+                res,
+                400,
+                "weights must sum to a positive value"
+            );
         }
 
         const blended = blendEmbeddings(
@@ -840,9 +846,9 @@ router.post("/alchemy", requireAuth, async (req, res) => {
         });
     } catch (error: any) {
         logger.error("Vibe alchemy error:", error);
-        res.status(500).json({ error: "Failed to compute alchemy blend" });
+        sendInternalRouteError(res, "Failed to compute alchemy blend");
     }
-});
+}));
 
 type SimilarTrack = Awaited<ReturnType<typeof findSimilarTracks>>[number];
 
@@ -977,7 +983,7 @@ function formatSimilarTrack(track: SimilarTrack) {
  *       401:
  *         description: Not authenticated
  */
-router.get<{ trackId: string }>("/similar/:trackId", requireAuth, async (req, res) => {
+router.get<{ trackId: string }>("/similar/:trackId", requireAuth, asyncHandler(async (req, res) => {
     try {
         const { trackId } = req.params;
         const userId = req.user?.id;
@@ -993,10 +999,7 @@ router.get<{ trackId: string }>("/similar/:trackId", requireAuth, async (req, re
         );
 
         if (weightedTracks.length === 0) {
-            return res.status(404).json({
-                error: "No similar tracks found",
-                message: "This track may not have been analyzed yet, or no analyzer is running",
-            });
+            return sendRouteError(res, 404, "No similar tracks found");
         }
 
         // Fetch source track audio features for vibe match comparison
@@ -1017,9 +1020,9 @@ router.get<{ trackId: string }>("/similar/:trackId", requireAuth, async (req, re
         });
     } catch (error: any) {
         logger.error("Hybrid similarity error:", error);
-        res.status(500).json({ error: "Failed to find similar tracks" });
+        sendInternalRouteError(res, "Failed to find similar tracks");
     }
-});
+}));
 
 // Convert CLAP cosine distance (0-2 range) to similarity percentage (0-1)
 // distance 0 = identical, distance 1 = orthogonal, distance 2 = opposite
@@ -1100,14 +1103,16 @@ interface TextEmbedResponsePayload {
  *       504:
  *         description: Text embedding service unavailable
  */
-router.post("/search", requireAuth, async (req, res) => {
+router.post("/search", requireAuth, asyncHandler(async (req, res) => {
     try {
         const { query, limit: requestedLimit, minSimilarity } = req.body;
 
         if (!query || typeof query !== "string" || query.trim().length < 2) {
-            return res.status(400).json({
-                error: "Query must be at least 2 characters",
-            });
+            return sendRouteError(
+                res,
+                400,
+                "Query must be at least 2 characters"
+            );
         }
 
         const limit = Math.min(
@@ -1271,14 +1276,15 @@ router.post("/search", requireAuth, async (req, res) => {
     } catch (error: any) {
         logger.error("Vibe text search error:", error);
         if (error.message?.includes("timed out")) {
-            return res.status(504).json({
-                error: "Text embedding service unavailable",
-                message: "The CLAP analyzer service did not respond in time",
-            });
+            return sendRouteError(
+                res,
+                504,
+                "Text embedding service unavailable"
+            );
         }
-        res.status(500).json({ error: "Failed to search tracks by vibe" });
+        sendInternalRouteError(res, "Failed to search tracks by vibe");
     }
-});
+}));
 
 /**
  * @openapi
@@ -1310,7 +1316,7 @@ router.post("/search", requireAuth, async (req, res) => {
  *       401:
  *         description: Not authenticated
  */
-router.get("/status", requireAuth, async (req, res) => {
+router.get("/status", requireAuth, asyncHandler(async (req, res) => {
     try {
         const totalTracks = await prisma.track.count();
 
@@ -1331,9 +1337,9 @@ router.get("/status", requireAuth, async (req, res) => {
         });
     } catch (error: any) {
         logger.error("Vibe status error:", error);
-        res.status(500).json({ error: "Failed to get embedding status" });
+        sendInternalRouteError(res, "Failed to get embedding status");
     }
-});
+}));
 
 const CALIBRATION_CACHE_TTL_SECONDS = 24 * 60 * 60; // 24h
 const CALIBRATION_CACHE_KEY_PREFIX = "vibe:calibration:v1:";
@@ -1420,15 +1426,13 @@ async function getCalibrationResponse() {
  *       401:
  *         description: Not authenticated
  */
-router.get("/calibration", requireAuth, async (_req, res) => {
+router.get("/calibration", requireAuth, asyncHandler(async (_req, res) => {
     try {
         return res.json(await getCalibrationResponse());
     } catch (error: any) {
         logger.error("Vibe calibration error:", error);
-        return res
-            .status(500)
-            .json({ error: "Failed to compute vibe calibration" });
+        return sendInternalRouteError(res, "Failed to compute vibe calibration");
     }
-});
+}));
 
 export default router;

--- a/backend/src/routes/vibeJourneyRequest.ts
+++ b/backend/src/routes/vibeJourneyRequest.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { VALID_MOODS, MoodType } from "../services/moodBucketService";
 
 /**
@@ -29,75 +30,31 @@ export type JourneyRequestResult =
     | { ok: true; value: JourneyRequest }
     | { ok: false; status: number; error: string };
 
-type ParsedTarget = Pick<JourneyRequest, "toTrackId" | "mood">;
-type FieldResult<T> = { ok: true; value: T } | { ok: false; error: string };
+const requestBodySchema = z.custom<Record<string, unknown>>(
+    (value) => typeof value === "object" && value !== null && !Array.isArray(value)
+);
+const nonEmptyStringSchema = z.string().min(1);
+const moodSchema = z.enum(VALID_MOODS);
+const excludeArraySchema = z.array(z.unknown()).default([]);
+const boundedExcludeArraySchema = z
+    .array(z.unknown())
+    .max(MAX_JOURNEY_EXCLUDE_TRACK_IDS);
+const excludeTrackIdsSchema = z.array(nonEmptyStringSchema);
+const stepsSchema = z
+    .number()
+    .refine(Number.isInteger)
+    .transform((value) =>
+        Math.min(Math.max(MIN_JOURNEY_STEPS, value), MAX_JOURNEY_STEPS)
+    )
+    .default(DEFAULT_JOURNEY_STEPS);
 
 function reject(status: number, error: string): JourneyRequestResult {
     return { ok: false, status, error };
 }
 
-function parseTarget(
-    fromTrackId: string,
-    toTrackId: unknown,
-    mood: unknown
-): FieldResult<ParsedTarget> {
-    const hasTrack = typeof toTrackId === "string" && toTrackId.length > 0;
-    const hasMood = typeof mood === "string" && mood.length > 0;
-    if (hasTrack === hasMood) {
-        return { ok: false, error: "Provide exactly one of toTrackId or mood" };
-    }
-    if (hasMood && !VALID_MOODS.includes(mood as MoodType)) {
-        return {
-            ok: false,
-            error: `Invalid mood. Must be one of: ${VALID_MOODS.join(", ")}`,
-        };
-    }
-    if (hasTrack && toTrackId === fromTrackId) {
-        return { ok: false, error: "Origin and destination are the same track" };
-    }
-    return {
-        ok: true,
-        value: {
-            toTrackId: hasTrack ? (toTrackId as string) : null,
-            mood: hasMood ? (mood as MoodType) : null,
-        },
-    };
-}
-
-function parseExcludeTrackIds(value: unknown): FieldResult<string[]> {
-    if (value === undefined) return { ok: true, value: [] };
-    if (!Array.isArray(value)) {
-        return { ok: false, error: "excludeTrackIds must be an array of strings" };
-    }
-    if (value.length > MAX_JOURNEY_EXCLUDE_TRACK_IDS) {
-        return {
-            ok: false,
-            error: `excludeTrackIds cannot exceed ${MAX_JOURNEY_EXCLUDE_TRACK_IDS} entries`,
-        };
-    }
-    if (value.some((id) => typeof id !== "string" || id.length === 0)) {
-        return {
-            ok: false,
-            error: "excludeTrackIds must contain non-empty strings",
-        };
-    }
-    return { ok: true, value };
-}
-
-function parseSteps(value: unknown): FieldResult<number> {
-    if (value === undefined) {
-        return { ok: true, value: DEFAULT_JOURNEY_STEPS };
-    }
-    if (!Number.isInteger(value)) {
-        return { ok: false, error: "steps must be an integer" };
-    }
-    return {
-        ok: true,
-        value: Math.min(
-            Math.max(MIN_JOURNEY_STEPS, value as number),
-            MAX_JOURNEY_STEPS
-        ),
-    };
+function normalizeBody(body: unknown): Record<string, unknown> {
+    const parsed = requestBodySchema.safeParse(body);
+    return parsed.success ? parsed.data : {};
 }
 
 /**
@@ -109,36 +66,49 @@ function parseSteps(value: unknown): FieldResult<number> {
  * a UI slider quirk, not a protocol violation).
  */
 export function parseJourneyRequest(body: unknown): JourneyRequestResult {
-    const record =
-        typeof body === "object" && body !== null && !Array.isArray(body)
-            ? (body as Record<string, unknown>)
-            : {};
-    const {
-        fromTrackId,
-        toTrackId,
-        mood,
-        steps: requestedSteps,
-        excludeTrackIds,
-    } = record;
-
-    if (typeof fromTrackId !== "string" || !fromTrackId) {
+    const record = normalizeBody(body);
+    const fromTrackId = nonEmptyStringSchema.safeParse(record.fromTrackId);
+    if (!fromTrackId.success) {
         return reject(400, "fromTrackId is required");
     }
 
-    const target = parseTarget(fromTrackId, toTrackId, mood);
-    if (!target.ok) return reject(400, target.error);
-    const excludes = parseExcludeTrackIds(excludeTrackIds);
-    if (!excludes.ok) return reject(400, excludes.error);
-    const steps = parseSteps(requestedSteps);
-    if (!steps.ok) return reject(400, steps.error);
+    const toTrackId = nonEmptyStringSchema.safeParse(record.toTrackId);
+    const suppliedMood = nonEmptyStringSchema.safeParse(record.mood);
+    if (toTrackId.success === suppliedMood.success) {
+        return reject(400, "Provide exactly one of toTrackId or mood");
+    }
+
+    const mood = moodSchema.safeParse(suppliedMood.success ? suppliedMood.data : null);
+    if (suppliedMood.success && !mood.success) {
+        return reject(400, `Invalid mood. Must be one of: ${VALID_MOODS.join(", ")}`);
+    }
+    if (toTrackId.success && toTrackId.data === fromTrackId.data) {
+        return reject(400, "Origin and destination are the same track");
+    }
+
+    const excludeArray = excludeArraySchema.safeParse(record.excludeTrackIds);
+    if (!excludeArray.success) {
+        return reject(400, "excludeTrackIds must be an array of strings");
+    }
+    if (!boundedExcludeArraySchema.safeParse(excludeArray.data).success) {
+        return reject(400, `excludeTrackIds cannot exceed ${MAX_JOURNEY_EXCLUDE_TRACK_IDS} entries`);
+    }
+    const excludeTrackIds = excludeTrackIdsSchema.safeParse(excludeArray.data);
+    if (!excludeTrackIds.success) {
+        return reject(400, "excludeTrackIds must contain non-empty strings");
+    }
+
+    const steps = stepsSchema.safeParse(record.steps);
+    if (!steps.success) return reject(400, "steps must be an integer");
 
     return {
         ok: true,
         value: {
-            fromTrackId,
-            ...target.value,
-            steps: steps.value,
-            excludeTrackIds: excludes.value,
+            fromTrackId: fromTrackId.data,
+            toTrackId: toTrackId.success ? toTrackId.data : null,
+            mood: mood.success ? mood.data : null,
+            steps: steps.data,
+            excludeTrackIds: excludeTrackIds.data,
         },
     };
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "verify:frontend": "npm --prefix frontend run lint && npm --prefix frontend run build && npm --prefix frontend run test:coverage && npm --prefix frontend run test:component && npm --prefix frontend run typecheck",
         "verify:helm": "./scripts/helm-chart-render-check.sh",
         "verify:python": "pytest services/tidal-downloader/tests -q && pytest services/ytmusic-streamer/tests -q && pytest services/audio-analyzer/tests -q && pytest services/audio-analyzer-clap/tests -q",
+        "check:error-canon": "node scripts/ci/check-route-error-canon.mjs",
+        "check:error-canon:test": "node --test scripts/ci/__tests__/check-route-error-canon.test.mjs",
         "test:backend": "npm --prefix backend test --",
         "test:frontend": "npm --prefix frontend run test:unit"
     }

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { analyzeRouteErrorCanon, countPattern } from "../check-route-error-canon.mjs";
+
+test("countPattern counts occurrences and tolerates whitespace", () => {
+  const source = `
+    res.status(500).json({ error: "first" });
+    res . status ( 500 ) . json ( { error: "second" } );
+  `;
+
+  assert.equal(countPattern(source), 2);
+});
+
+test("countPattern ignores the canonical internal-error helper", () => {
+  assert.equal(countPattern('sendInternalRouteError(res, "x");'), 0);
+});
+
+test("analyzeRouteErrorCanon accepts a file at its baseline", () => {
+  assert.deepEqual(analyzeRouteErrorCanon({ "route.ts": 2 }, { "route.ts": 2 }), {
+    ok: true,
+    violations: [],
+    tightenable: [],
+  });
+});
+
+test("analyzeRouteErrorCanon reports a file over its baseline", () => {
+  assert.deepEqual(analyzeRouteErrorCanon({ "route.ts": 3 }, { "route.ts": 2 }), {
+    ok: false,
+    violations: [{ file: "route.ts", count: 3, baseline: 2 }],
+    tightenable: [],
+  });
+});
+
+test("analyzeRouteErrorCanon treats a new file baseline as zero", () => {
+  assert.deepEqual(analyzeRouteErrorCanon({ "new-route.ts": 1 }, {}), {
+    ok: false,
+    violations: [{ file: "new-route.ts", count: 1, baseline: 0 }],
+    tightenable: [],
+  });
+});
+
+test("analyzeRouteErrorCanon reports a lower count as tightenable", () => {
+  assert.deepEqual(analyzeRouteErrorCanon({ "route.ts": 1 }, { "route.ts": 2 }), {
+    ok: true,
+    violations: [],
+    tightenable: [{ file: "route.ts", count: 1, baseline: 2 }],
+  });
+});

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * Ratchets ad-hoc route 500 responses without requiring a big-bang cleanup.
+ * When a route is canonicalized, lower its BASELINE count (or remove a zero entry)
+ * so later changes cannot reintroduce the eliminated literals.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const BASELINE = Object.freeze({
+  "backend/src/routes/admin.ts": 3,
+  "backend/src/routes/analysis.ts": 12,
+  "backend/src/routes/analysisInternal.ts": 2,
+  "backend/src/routes/apiKeys.ts": 3,
+  "backend/src/routes/artists.ts": 4,
+  "backend/src/routes/audiobooks.ts": 12,
+  "backend/src/routes/auth.ts": 19,
+  "backend/src/routes/browse.ts": 16,
+  "backend/src/routes/deviceLink.ts": 6,
+  "backend/src/routes/discover.ts": 5,
+  "backend/src/routes/downloads.ts": 3,
+  "backend/src/routes/enrichment.ts": 30,
+  "backend/src/routes/homepage.ts": 2,
+  "backend/src/routes/library.ts": 5,
+  "backend/src/routes/listenTogether.ts": 1,
+  "backend/src/routes/listeningState.ts": 3,
+  "backend/src/routes/lyrics.ts": 1,
+  "backend/src/routes/mixes.ts": 10,
+  "backend/src/routes/offline.ts": 5,
+  "backend/src/routes/onboarding.ts": 7,
+  "backend/src/routes/playbackState.ts": 3,
+  "backend/src/routes/playlistImport.ts": 8,
+  "backend/src/routes/playlists.ts": 15,
+  "backend/src/routes/plays.ts": 4,
+  "backend/src/routes/podcasts.ts": 17,
+  "backend/src/routes/recommendations.ts": 4,
+  "backend/src/routes/releases.ts": 4,
+  "backend/src/routes/search.ts": 4,
+  "backend/src/routes/settings.ts": 5,
+  "backend/src/routes/shareLinks.ts": 7,
+  "backend/src/routes/social.ts": 3,
+  "backend/src/routes/soulseek.ts": 7,
+  "backend/src/routes/spotify.ts": 8,
+  "backend/src/routes/streaming.ts": 3,
+  "backend/src/routes/system.ts": 2,
+  "backend/src/routes/systemSettings.ts": 13,
+  "backend/src/routes/tidalStreaming.ts": 10,
+  "backend/src/routes/trackMappings.ts": 2,
+  "backend/src/routes/webhooks.ts": 1,
+  "backend/src/routes/youtube.ts": 1,
+  "backend/src/routes/youtubeMusic.ts": 18,
+});
+
+export function countPattern(source) {
+  const pattern = /res\s*\.\s*status\s*\(\s*500\s*\)\s*\.\s*json\s*\(/g;
+  return source.match(pattern)?.length ?? 0;
+}
+
+export function analyzeRouteErrorCanon(counts, baseline) {
+  const results = Object.entries(counts).map(([file, count]) => ({
+    file,
+    count,
+    baseline: baseline[file] ?? 0,
+  }));
+  const violations = results.filter((result) => result.count > result.baseline);
+  const tightenable = results.filter(
+    (result) => baseline[result.file] !== undefined && result.count < result.baseline,
+  );
+
+  return { ok: violations.length === 0, violations, tightenable };
+}
+
+function routeFiles(directory) {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => path.join(directory, entry.name));
+}
+
+function collectCounts(repoRoot) {
+  const routesDirectory = path.join(repoRoot, "backend/src/routes");
+  return Object.fromEntries(
+    routeFiles(routesDirectory)
+      .sort()
+      .map((filePath) => {
+        const relativePath = path.relative(repoRoot, filePath).split(path.sep).join("/");
+        return [relativePath, countPattern(fs.readFileSync(filePath, "utf8"))];
+      }),
+  );
+}
+
+function printReport(result) {
+  if (result.ok) {
+    console.log("Route error canonicalization ratchet passed.");
+  } else {
+    console.error("Route error canonicalization ratchet failed:");
+    for (const violation of result.violations) {
+      console.error(`${violation.file}: ${violation.count} exceeds baseline ${violation.baseline}`);
+    }
+  }
+
+  if (result.tightenable.length > 0) {
+    console.log("Baseline can be tightened:");
+    for (const item of result.tightenable) {
+      console.log(`${item.file}: ${item.count} is below baseline ${item.baseline}`);
+    }
+  }
+
+  console.log(
+    "Use sendInternalRouteError/AppError instead; see backend/src/routes/README.md.",
+  );
+}
+
+function runCli() {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(scriptDirectory, "../..");
+  const result = analyzeRouteErrorCanon(collectCounts(repoRoot), BASELINE);
+  printReport(result);
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli();
+}


### PR DESCRIPTION
## Summary

Establishes the repo's single-field `{ error }` JSON envelope as the **documented canonical route error contract**, retrofits the first exemplars, and adds a ratcheting CI gate so new ad-hoc error shapes can't creep back in. Backend-only; disjoint from the frontend a11y slice. Rebased onto latest `origin/main` (after wave-7 #250/#251 and P32 landed) — no route-handler overlap with those PRs.

Scope is deliberately the **pattern + enforcement**, not a 46-file big-bang migration (that proceeds per-touched-file afterward).

## What changed

- **Canon documented** in `backend/src/routes/README.md` (new "Error & Response Conventions" section): `asyncHandler` wrapping, `sendRouteError`/`sendInternalRouteError` (or a thrown `AppError`) for the `{ error }` envelope, status mapping owned by `errorHandler`, and `zod` validation at the trust boundary.
- **`vibe.ts`** retrofitted as the reference exemplar: all 9 handlers wrapped in `asyncHandler`; every error routed through `sendRouteError` (4xx/504) / `sendInternalRouteError` (500); logging and `try/finally` resource cleanup preserved (no swallowed errors, no leaked internal text).
- **`vibeJourneyRequest.ts`** now validates with `zod`, replacing the bespoke `FieldResult` helper pattern (the "third validation pattern" finding). Exact error strings, precedence order, defaults, and step-clamping preserved.
- **`notifications.ts`** adopts the same helpers + `asyncHandler`. Its 2xx `{ success, newJobId, ... }` **domain-result** envelopes (contracted via the frontend's `retryFailedDownload(): { success; newJobId? }`) are preserved verbatim — those are results, not error responses.
- **Ratcheting CI gate**: `scripts/ci/check-route-error-canon.mjs` (`npm run check:error-canon`) freezes the current per-file count of ad-hoc `res.status(500).json(...)` literals (288 across 41 route files) and fails when any route file adds new ones; `vibe.ts`/`notifications.ts` are now at a baseline of 0. Unit-tested with `node:test`.

## Client-visible error-shape change (flagged)

Two `vibe` error bodies drop their secondary `message` field to conform to the `{ error }` envelope. HTTP status and the `error` string are unchanged; the frontend reads only `error`, so no client action is required (documented in CHANGELOG under Changed):

- `GET /api/vibe/similar/:trackId` — 404 `{ error: "No similar tracks found" }`
- `POST /api/vibe/search` — 504 `{ error: "Text embedding service unavailable" }`

No status-code changes anywhere; all other error strings byte-identical; all 2xx success bodies unchanged.

## Tests

TDD. Added:
- `vibeErrorShapeCanon.test.ts` — asserts the canonical single-field `{ error }` shape on the two converted responses (written red first, then green).
- `vibeJourneyRequest.test.ts` — 21 direct unit cases locking every validation branch (passed on both the pre- and post-zod implementations, proving equivalence).
- `scripts/ci/__tests__/check-route-error-canon.test.mjs` — 6 cases covering the gate's pure functions.

Verification (targeted, `--maxWorkers=2` per the RAM ceiling):
- `vibeErrorShapeCanon`, `vibeJourneyRequest`, `vibeJourneyRuntime`, `vibeSearchCompat`, `vibeCalibrationRuntime`, `notificationsRuntime` — **72 tests pass**.
- Gate: `node scripts/ci/check-route-error-canon.mjs` exits 0 on the rebased tree; gate self-test 6/6 pass.
- `tsc --noEmit` clean for all changed files (the only error is a pre-existing `otplib` module-resolution artifact in `auth.ts`, unrelated to this slice / environment node_modules).

## Follow-ups (out of scope)

- Per-touched-file migration of the remaining ~40 route files to the canon (ratchet baselines lower as each is done).
- Wiring `check:error-canon` into `.github/workflows/quality-visibility.yml` belongs to the CI slices (ci-test-gates); this PR ships the script + `npm` entrypoints only.
- `library.ts` now sits below its frozen baseline (tightenable) after #250 — a future touch can lower it.

## Notes

- Added two `scripts` entries to the root `package.json` (gate entrypoints) — outside the slice's listed scope files but necessary to make the gate invokable; flagged here.
