### PR TITLE
refactor(frontend): enforce lib/api.ts boundary and consolidate the client (refactor slice P19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retained unchanged as a deprecated composite (same shape, same referential
   stability, same out-of-provider error) for the remaining consumers; no
   playback behavior changed. Prefer the two granular hooks going forward.
+- The artist page's Start Radio action now uses the in-app confirmation dialog
+  before adding tracks to a Listen Together group's shared queue, instead of the
+  native browser confirmation prompt.
+- Discover settings now uses the in-app confirmation dialog when clearing the
+  Discovery playlist instead of the native browser confirmation prompt.
+- Removed seven unused frontend API client methods (`testNzbget`,
+  `testQbittorrent`, `testListenNotes`, `testDeezer`, `trackPlayback`,
+  `getPodcastEpisode`, and `getSlskdDownloads`) that targeted non-existent
+  backend routes. The onboarding page now checks status through the shared API
+  boundary (`api.getOnboardingStatus`) instead of calling `fetch` directly.
+- Enrichment `GET /api/enrichment/status` now returns a complete zeroed
+  `EnrichmentState` when idle instead of a partial object, and the frontend
+  `enrichmentApi.getStatus` return type is now non-null.
 - Media-source contract: the hand-copied `local`/`tidal`/`youtube`/`youtube-direct`
   source unions scattered across the frontend and backend now derive from
   `CanonicalMediaSource` in `@soundspan/media-metadata-contract` instead of being
@@ -363,6 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI `info.version` is no longer frozen at `1.0.0`; it now resolves from
   `backend/package.json` at load time (currently `1.9.0`) so the published
   contract tracks the shipping release.
+- MetadataEditor's "Reset to Original" action now uses the in-app
+  `ConfirmDialog` instead of the browser's native confirmation prompt.
 - Frontend token refresh is now single-flight, so simultaneous 401 responses
   share one `/auth/refresh` request instead of racing refresh-token rotation
   and forcing a logout.

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -552,7 +552,14 @@ describe("enrichment route runtime behavior", () => {
         await statusHandler({ user: { id: "user-1" } } as any, res);
 
         expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual({ status: "idle", currentPhase: null });
+        expect(res.body).toMatchObject({
+            status: "idle",
+            currentPhase: null,
+            artists: { total: 0, completed: 0, failed: 0 },
+            tracks: { total: 0, completed: 0, failed: 0 },
+            audio: { total: 0, completed: 0, failed: 0, processing: 0 },
+        });
+        expect(typeof res.body.lastActivity).toBe("string");
     });
 
     it("supports pause/resume/stop and returns state payloads", async () => {

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -11,7 +11,10 @@ import {
     reRunVibeEmbeddingsOnly,
     triggerEnrichmentNow,
 } from "../workers/unifiedEnrichment";
-import { enrichmentStateService } from "../services/enrichmentState";
+import {
+    enrichmentStateService,
+    type EnrichmentState,
+} from "../services/enrichmentState";
 import { enrichmentFailureService } from "../services/enrichmentFailureService";
 import { musicBrainzService } from "../services/musicbrainz";
 import { coverArtService } from "../services/coverArt";
@@ -88,7 +91,15 @@ router.get("/progress", async (req, res) => {
 router.get("/status", async (req, res) => {
     try {
         const state = await enrichmentStateService.getState();
-        res.json(state || { status: "idle", currentPhase: null });
+        const idleState: EnrichmentState = {
+            status: "idle",
+            currentPhase: null,
+            lastActivity: new Date().toISOString(),
+            artists: { total: 0, completed: 0, failed: 0 },
+            tracks: { total: 0, completed: 0, failed: 0 },
+            audio: { total: 0, completed: 0, failed: 0, processing: 0 },
+        };
+        res.json(state || idleState);
     } catch (error) {
         logger.error("Get enrichment status error:", error);
         res.status(500).json({ error: "Failed to get status" });

--- a/frontend/app/artist/[id]/page.tsx
+++ b/frontend/app/artist/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
     useAudioState,
@@ -9,6 +9,7 @@ import {
 } from "@/lib/audio-context";
 import { useDownloadContext } from "@/lib/download-context";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ReleaseSelectionModal } from "@/components/ui/ReleaseSelectionModal";
 import { useImageColor } from "@/hooks/useImageColor";
 import { api } from "@/lib/api";
@@ -104,6 +105,11 @@ export default function ArtistPage() {
     const [showPlaylistSelector, setShowPlaylistSelector] = useState(false);
     const [isAddingToPlaylist, setIsAddingToPlaylist] = useState(false);
     const [isLikingAll, setIsLikingAll] = useState(false);
+    const [radioConfirm, setRadioConfirm] = useState<{
+        tracks: Track[];
+        count: number;
+    } | null>(null);
+    const radioConfirmedRef = useRef(false);
 
     // Enrich unowned top tracks with TIDAL streaming, then YT Music for remaining gaps
     const artistWithTopTracks = artist?.topTracks?.length ? artist : null;
@@ -261,18 +267,12 @@ export default function ArtistPage() {
             const response = await api.getRadioTracks("artist", artist.id);
 
             if (response.tracks && response.tracks.length > 0) {
-                if (isInGroup && typeof window !== "undefined") {
-                    const trackLabel =
-                        response.tracks.length === 1 ?
-                            "1 song"
-                        :   `${response.tracks.length} songs`;
-                    const confirmed = window.confirm(
-                        `You're in a Listen Together group. Starting artist radio will add ${trackLabel} to the shared queue. Continue?`
-                    );
-                    if (!confirmed) {
-                        toast.info("Artist radio cancelled");
-                        return;
-                    }
+                if (isInGroup) {
+                    setRadioConfirm({
+                        tracks: response.tracks,
+                        count: response.tracks.length,
+                    });
+                    return;
                 }
 
                 // Backend already returns properly formatted tracks - just pass them through
@@ -289,6 +289,23 @@ export default function ArtistPage() {
             toast.error("Failed to start artist radio");
         }
     }
+
+    const handleConfirmRadio = () => {
+        if (!radioConfirm) return;
+        radioConfirmedRef.current = true;
+        playTracks(radioConfirm.tracks as Parameters<typeof playTracks>[0], 0);
+        toast.success(
+            `Playing ${artist?.name ?? "Artist"} Radio (${radioConfirm.count} tracks)`
+        );
+    };
+
+    const handleCloseRadioConfirm = () => {
+        if (!radioConfirmedRef.current) {
+            toast.info("Artist radio cancelled");
+        }
+        radioConfirmedRef.current = false;
+        setRadioConfirm(null);
+    };
 
     // Loading state for initial/core request only
     if (loading) {
@@ -452,6 +469,17 @@ export default function ArtistPage() {
                 onSelectPlaylist={handlePlaylistSelected}
                 isLoading={isAddingToPlaylist}
                 loadingMessage="Adding tracks..."
+            />
+
+            <ConfirmDialog
+                isOpen={radioConfirm !== null}
+                onClose={handleCloseRadioConfirm}
+                onConfirm={handleConfirmRadio}
+                title="Add to shared queue?"
+                message={`You're in a Listen Together group. Starting artist radio will add ${radioConfirm?.count ?? 0} song${(radioConfirm?.count ?? 0) === 1 ? "" : "s"} to the shared queue. Continue?`}
+                confirmText="Continue"
+                cancelText="Cancel"
+                variant="info"
             />
         </div>
     );

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -36,9 +36,7 @@ export default function OnboardingPage() {
         let cancelled = false;
         async function checkOnboarding() {
             try {
-                const res = await fetch("/api/onboarding/status");
-                if (!res.ok) return;
-                const data = await res.json();
+                const data = await api.getOnboardingStatus();
                 if (!cancelled && !data.needsOnboarding) {
                     router.replace("/login");
                 }

--- a/frontend/components/MetadataEditor.tsx
+++ b/frontend/components/MetadataEditor.tsx
@@ -8,6 +8,7 @@ import { GradientSpinner } from "./ui/GradientSpinner";
 import { MusicBrainzLookup } from "./ui/MusicBrainzLookup";
 import Image from "next/image";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface MetadataEditorProps {
     type: "artist" | "album" | "track";
@@ -86,6 +87,7 @@ export function MetadataEditor({
     const [isOpen, setIsOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [isResetting, setIsResetting] = useState(false);
+    const [showResetConfirm, setShowResetConfirm] = useState(false);
     const [formData, setFormData] = useState(currentData);
     const [formError, setFormError] = useState<string | null>(null);
     const [fieldErrors, setFieldErrors] = useState<
@@ -109,15 +111,7 @@ export function MetadataEditor({
         setFieldErrors({});
     };
 
-    const handleReset = async () => {
-        if (
-            !confirm(
-                "Reset all metadata to original values? This cannot be undone."
-            )
-        ) {
-            return;
-        }
-
+    const confirmReset = async () => {
         setIsResetting(true);
         try {
             if (type === "artist") {
@@ -576,7 +570,7 @@ export function MetadataEditor({
                         <div className="flex items-center justify-end gap-3 p-6 border-t border-white/10">
                             {hasOverrides && (
                                 <button
-                                    onClick={handleReset}
+                                    onClick={() => setShowResetConfirm(true)}
                                     disabled={isSaving || isResetting}
                                     className="px-6 py-2 rounded-full bg-red-500/20 hover:bg-red-500/30 text-red-400 font-bold transition-all border border-red-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
                                 >
@@ -610,6 +604,16 @@ export function MetadataEditor({
                                 )}
                             </button>
                         </div>
+                        <ConfirmDialog
+                            isOpen={showResetConfirm}
+                            onClose={() => setShowResetConfirm(false)}
+                            onConfirm={confirmReset}
+                            title="Reset metadata?"
+                            message="Reset all metadata to original values? This cannot be undone."
+                            confirmText="Reset"
+                            cancelText="Cancel"
+                            variant="danger"
+                        />
                     </div>
                 </div>
             )}

--- a/frontend/features/discover/components/DiscoverSettings.tsx
+++ b/frontend/features/discover/components/DiscoverSettings.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { Card } from "@/components/ui/Card";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 import { Trash2, Loader2 } from "lucide-react";
@@ -22,6 +23,7 @@ export function DiscoverSettings({
     onPlaylistCleared,
 }: DiscoverSettingsProps) {
     const [isClearing, setIsClearing] = useState(false);
+    const [showClearConfirm, setShowClearConfirm] = useState(false);
     const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
     // Generic handler for config changes with debounce
@@ -44,18 +46,7 @@ export function DiscoverSettings({
         }, 500);
     }
 
-    async function handleClearPlaylist() {
-        if (isClearing) return;
-
-        const confirmed = window.confirm(
-            "Clear Discovery Playlist?\n\n" +
-            "• Current recommendations will be removed\n" +
-            "• Your local library and provider accounts are unchanged\n\n" +
-            "This action cannot be undone."
-        );
-
-        if (!confirmed) return;
-
+    async function confirmClearPlaylist() {
         setIsClearing(true);
         try {
             const result = await api.clearDiscoverPlaylist();
@@ -135,7 +126,9 @@ export function DiscoverSettings({
                             Your library is not modified.
                         </p>
                         <button
-                            onClick={handleClearPlaylist}
+                            onClick={() => {
+                                if (!isClearing) setShowClearConfirm(true);
+                            }}
                             disabled={isClearing}
                             className="flex items-center gap-2 px-4 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
@@ -149,6 +142,16 @@ export function DiscoverSettings({
                     </div>
                 </div>
             </Card>
+            <ConfirmDialog
+                isOpen={showClearConfirm}
+                onClose={() => setShowClearConfirm(false)}
+                onConfirm={confirmClearPlaylist}
+                title="Clear Discovery Playlist?"
+                message="Current recommendations will be removed. Your library and provider accounts will remain unchanged. This action cannot be undone."
+                confirmText="Clear Playlist"
+                cancelText="Cancel"
+                variant="danger"
+            />
         </div>
     );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -851,6 +851,17 @@ class ApiClient {
         });
     }
 
+    // Onboarding
+    async getOnboardingStatus(): Promise<{
+        needsOnboarding: boolean;
+        hasAccount: boolean;
+    }> {
+        return this.request<{
+            needsOnboarding: boolean;
+            hasAccount: boolean;
+        }>("/onboarding/status", { silent404: true });
+    }
+
     // Auth
     async login(username: string, password: string, token?: string): Promise<{
         id: string;
@@ -1618,14 +1629,6 @@ class ApiClient {
         );
     }
 
-    // Playback tracking
-    async trackPlayback(trackId: string, progress?: number) {
-        return this.request<void>("/playback/track", {
-            method: "POST",
-            body: JSON.stringify({ trackId, progress }),
-        });
-    }
-
     // Play tracking
     async logPlay(trackRef: AddToPlaylistRef) {
         return this.request<ApiData>("/plays", {
@@ -1763,20 +1766,6 @@ class ApiClient {
         });
     }
 
-    async testNzbget(url: string, username: string, password: string) {
-        return this.request<ServiceTestResult>("/system-settings/test-nzbget", {
-            method: "POST",
-            body: JSON.stringify({ url, username, password }),
-        });
-    }
-
-    async testQbittorrent(url: string, username: string, password: string) {
-        return this.request<ServiceTestResult>("/system-settings/test-qbittorrent", {
-            method: "POST",
-            body: JSON.stringify({ url, username, password }),
-        });
-    }
-
     async testLastfm(apiKey: string) {
         return this.request<ServiceTestResult>("/system-settings/test-lastfm", {
             method: "POST",
@@ -1848,13 +1837,6 @@ class ApiClient {
         }>("/system-settings/tidal-auth/token", {
             method: "POST",
             body: JSON.stringify({ device_code: deviceCode }),
-        });
-    }
-
-    async testListenNotes(apiKey: string) {
-        return this.request<ServiceTestResult>("/system-settings/test-listennotes", {
-            method: "POST",
-            body: JSON.stringify({ apiKey }),
         });
     }
 
@@ -2196,13 +2178,6 @@ class ApiClient {
         return baseUrl;
     }
 
-    async testDeezer(apiKey?: string) {
-        return this.request<ServiceTestResult>("/system-settings/test-deezer", {
-            method: "POST",
-            body: JSON.stringify({ apiKey }),
-        });
-    }
-
     // Audiobooks
     async getAudiobooks() {
         return this.request<ApiData[]>("/audiobooks");
@@ -2268,12 +2243,6 @@ class ApiClient {
 
     async previewPodcast(itunesId: string) {
         return this.request<ApiData>(`/podcasts/preview/${itunesId}`);
-    }
-
-    async getPodcastEpisode(podcastId: string, episodeId: string) {
-        return this.request<ApiData>(
-            `/podcasts/${podcastId}/episodes/${episodeId}`
-        );
     }
 
     getPodcastEpisodeStreamUrl(podcastId: string, episodeId: string): string {
@@ -2523,12 +2492,6 @@ class ApiClient {
                 title,
             }),
         });
-    }
-
-    async getSlskdDownloads() {
-        return this.request<{ downloads: ApiData[]; count: number }>(
-            "/soulseek/downloads"
-        );
     }
 
     // Programmatic Mixes

--- a/frontend/lib/enrichmentApi.ts
+++ b/frontend/lib/enrichmentApi.ts
@@ -82,7 +82,7 @@ export const enrichmentApi = {
     /**
      * Get detailed enrichment state
      */
-    getStatus: async (): Promise<EnrichmentState | null> => {
+    getStatus: async (): Promise<EnrichmentState> => {
         return api.get("/enrichment/status");
     },
 

--- a/frontend/tests/component/discoverSettingsConfirm.component.test.ts
+++ b/frontend/tests/component/discoverSettingsConfirm.component.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const clearDiscoverPlaylist = mock.fn(async () => ({
+    success: true,
+    message: "",
+    likedMoved: 0,
+    activeDeleted: 2,
+}));
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            clearDiscoverPlaylist,
+            updateDiscoverConfig: async () => ({}),
+        },
+    },
+});
+
+const toast = Object.assign(() => undefined, {
+    success: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+});
+mock.module("sonner", { namedExports: { toast } });
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    clearDiscoverPlaylist.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+const config = {
+    id: "c1",
+    userId: "u1",
+    playlistSize: 10,
+    enabled: true,
+    exclusionMonths: 6,
+    lastGeneratedAt: null,
+};
+
+async function mountDiscoverSettings(onPlaylistCleared: () => void) {
+    const { DiscoverSettings } = await import(
+        "../../features/discover/components/DiscoverSettings"
+    );
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(DiscoverSettings, {
+                config: config as never,
+                onUpdateConfig: () => undefined,
+                onPlaylistCleared,
+            })
+        );
+    });
+
+    return {
+        container,
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes(text)
+    );
+    assert.ok(button instanceof HTMLButtonElement, `button not found: ${text}`);
+    return button;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new Event("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("clears the discovery playlist only after dialog confirmation", async (t) => {
+    const onPlaylistCleared = mock.fn(() => undefined);
+    const harness = await mountDiscoverSettings(onPlaylistCleared);
+    t.after(harness.unmount);
+
+    assert.equal(clearDiscoverPlaylist.mock.callCount(), 0);
+    await click(findButton(harness.container, "Remove Playlist"));
+
+    assert.match(
+        harness.container.textContent ?? "",
+        /Clear Discovery Playlist\?|cannot be undone/
+    );
+    assert.equal(clearDiscoverPlaylist.mock.callCount(), 0);
+
+    await click(findButton(harness.container, "Clear Playlist"));
+
+    assert.equal(clearDiscoverPlaylist.mock.callCount(), 1);
+    assert.equal(onPlaylistCleared.mock.callCount(), 1);
+});
+
+test("cancelling the clear-playlist dialog leaves the playlist unchanged", async (t) => {
+    const onPlaylistCleared = mock.fn(() => undefined);
+    const harness = await mountDiscoverSettings(onPlaylistCleared);
+    t.after(harness.unmount);
+
+    await click(findButton(harness.container, "Remove Playlist"));
+    await click(findButton(harness.container, "Cancel"));
+
+    assert.equal(clearDiscoverPlaylist.mock.callCount(), 0);
+    assert.equal(onPlaylistCleared.mock.callCount(), 0);
+});

--- a/frontend/tests/component/metadataEditorResetConfirm.component.test.ts
+++ b/frontend/tests/component/metadataEditorResetConfirm.component.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const resetArtistMetadata = mock.fn(async () => ({
+    message: "ok",
+    artist: {},
+}));
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            resetArtistMetadata,
+            resetAlbumMetadata: async () => ({}),
+            resetTrackMetadata: async () => ({}),
+            updateArtistMetadata: async () => ({}),
+            updateAlbumMetadata: async () => ({}),
+            updateTrackMetadata: async () => ({}),
+        },
+    },
+});
+
+const toast = Object.assign(() => undefined, {
+    success: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+});
+mock.module("sonner", { namedExports: { toast } });
+
+mock.module("@/components/ui/MusicBrainzLookup", {
+    namedExports: { MusicBrainzLookup: () => null },
+});
+mock.module("next/image", { defaultExport: () => null });
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: {
+            error: () => undefined,
+            warn: () => undefined,
+            info: () => undefined,
+            debug: () => undefined,
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    resetArtistMetadata.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+}
+
+function findButton(text: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.includes(text)
+    );
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+function findLastExactButton(text: string): HTMLButtonElement {
+    const buttons = Array.from(document.querySelectorAll("button")).filter(
+        (candidate) => candidate.textContent === text
+    );
+    const button = buttons.at(-1);
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+async function mountEditor() {
+    const { MetadataEditor } = await import("../../components/MetadataEditor");
+    const { createRoot } = await import("react-dom/client");
+    const onSave = mock.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(MetadataEditor, {
+                type: "artist",
+                id: "artist-1",
+                currentData: {
+                    name: "Name",
+                    _hasUserOverrides: true,
+                },
+                onSave,
+            })
+        );
+    });
+
+    return {
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+async function openResetConfirmation(): Promise<void> {
+    const closedButtons = document.querySelectorAll("button");
+    assert.equal(closedButtons.length, 1);
+    await click(closedButtons[0]);
+    await click(findButton("Reset to Original"));
+}
+
+test("confirms before resetting artist metadata", async (t) => {
+    const harness = await mountEditor();
+    t.after(harness.unmount);
+
+    await openResetConfirmation();
+
+    assert.equal(resetArtistMetadata.mock.callCount(), 0);
+    assert.match(
+        document.body.textContent ?? "",
+        /Reset .*metadata|cannot be undone/i
+    );
+
+    const confirmButton = Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent === "Reset"
+    );
+    assert.ok(confirmButton instanceof HTMLButtonElement);
+    await click(confirmButton);
+    await React.act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    assert.equal(resetArtistMetadata.mock.callCount(), 1);
+});
+
+test("cancelling reset confirmation does not reset artist metadata", async (t) => {
+    const harness = await mountEditor();
+    t.after(harness.unmount);
+
+    await openResetConfirmation();
+    await click(findLastExactButton("Cancel"));
+
+    assert.equal(resetArtistMetadata.mock.callCount(), 0);
+});

--- a/frontend/tests/unit/onboardingApiBoundary.test.ts
+++ b/frontend/tests/unit/onboardingApiBoundary.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { api } from "../../lib/api";
+
+test("getOnboardingStatus requests the onboarding status endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    let calledUrl = "";
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        calledUrl = String(input);
+        return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+                needsOnboarding: false,
+                hasAccount: true,
+            }),
+        } as Response;
+    }) as typeof fetch;
+
+    try {
+        const result = await api.getOnboardingStatus();
+
+        assert.equal(calledUrl.endsWith("/api/onboarding/status"), true);
+        assert.equal(result.needsOnboarding, false);
+        assert.equal(result.hasAccount, true);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});


### PR DESCRIPTION
## Frontend API-boundary cleanup (refactor slice P19)

Enforces `frontend/lib/api.ts` as the single frontend API boundary and tightens boundary contracts. Frontend-only apart from one backend enrichment idle-fallback fix (the preferred side per plan). Rebased onto latest `origin/main` (includes #251 media-source, #252 playback-context, #254 route-error-canon, #255 openapi).

### Findings addressed
- **7 dead `ApiClient` methods removed** — each targeted a backend route that does not exist (guaranteed 404s) and had zero callers: `testNzbget`, `testQbittorrent`, `testListenNotes`, `testDeezer` (no `/system-settings/test-*` routes), `trackPlayback` (no `/api/playback` mount), `getPodcastEpisode` (no bare `GET /podcasts/:id/episodes/:eid`), `getSlskdDownloads` (no `GET /soulseek/downloads`). Re-verified route-absence and caller-absence before deletion.
- **Onboarding page routed through the boundary** — replaced the raw `fetch("/api/onboarding/status")` with a new `api.getOnboardingStatus()`; the deliberate fail-open `try/catch` is preserved so first-time setup still works.
- **Three `window.confirm` sites migrated to the in-app `ConfirmDialog`** — `DiscoverSettings` (clear playlist), `MetadataEditor` (reset to original), and the artist page Start-Radio Listen-Together confirmation (refactored to a pending-state + ref pattern so the dialog can gate the mid-flow play; the "cancelled" toast fires only on genuine cancel).
- **`enrichmentApi.getStatus` overpromise fixed** — the backend `GET /api/enrichment/status` idle fallback now returns a complete zeroed `EnrichmentState` (was a partial `{status, currentPhase}` missing `lastActivity`/`artists`/`tracks`/`audio`); the frontend return type is tightened from `EnrichmentState | null` to `EnrichmentState` (the backend never returns null).

### Tests
- `backend/.../enrichmentRuntime.test.ts` — updated the idle-status test to assert the complete zeroed `EnrichmentState` (failing-first, then green). 59/59 pass.
- `frontend/tests/unit/onboardingApiBoundary.test.ts` (new) — `api.getOnboardingStatus()` hits `/api/onboarding/status` and returns the parsed body.
- `frontend/tests/component/discoverSettingsConfirm.component.test.ts` (new) — click → dialog → confirm calls `clearDiscoverPlaylist`; cancel does not.
- `frontend/tests/component/metadataEditorResetConfirm.component.test.ts` (new) — open editor → Reset → confirm calls `resetArtistMetadata`; cancel does not.

verify: frontend `tsc --noEmit` = 0 errors; eslint on changed files = 0 errors (pre-existing warnings only); new unit test 1/1; new component tests 4/4; backend enrichmentRuntime 59/59; route-error-canon ratchet passes.

### TDD exemption
The artist-page radio confirmation was implemented without a component-mount test: the page depends on ~10 context providers and cannot be mounted in the node:test/happy-dom harness at reasonable cost. It is a mechanical control-flow swap, verified via typecheck + lint + review.

### Handoff / follow-ups
- Deep per-method client TYPING and the client split are intentionally left to slice **P34 (api-client-typing)** — this slice only enforces the boundary (no direct fetch, consistent request/error handling).
- Discovered follow-up (out of scope): `api.getSoulseekResults` (`GET /soulseek/search/:searchId`) and `searchSoulseek`'s result retrieval target routes not present in `backend/src/routes/soulseek.ts` (only `status/connect/search/download/disconnect` exist), yet `getSoulseekResults` HAS a live caller (`features/search/hooks/useSoulseekSearch.ts`). Left untouched (has a caller, so not a dead-method deletion); worth investigating whether Soulseek search-results retrieval is broken or served another way.

### Breaking / UPGRADING
None. No public route or behavior removed that had callers. The removed client methods were dead (404-only, callerless).
