### PR TITLE
refactor(player): isolate playback-progress subscription from AudioPlaybackOrchestrator (refactor slice P33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Frontend audio orchestrator decomposition (first increment).** The
+  `AudioPlaybackOrchestrator` no longer reads the deprecated composite
+  `useAudioPlayback()` context; its body now subscribes only to
+  `usePlaybackStatus()`. The high-frequency playback-clock subscription is
+  isolated into a new focused child component,
+  `components/player/PlaybackProgressSnapshot`, which owns the
+  `usePlaybackProgress()` read and keeps the orchestrator's trusted
+  position/track-id snapshot refs in sync. As a result the orchestrator body no
+  longer re-renders on every clock tick. Playback behavior is unchanged
+  (verified by the existing orchestrator component suite plus a new render-count
+  regression test).
 - **Backend error-response canonicalization (developer-facing standard + first
   exemplars).** The canonical route error contract is now documented in
   `backend/src/routes/README.md`: async handlers wrap in `asyncHandler`,

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useAudioState } from "@/lib/audio-state-context";
-import { useAudioPlayback } from "@/lib/audio-playback-context";
+import { usePlaybackStatus } from "@/lib/audio-playback-context";
 import { useAudioControls } from "@/lib/audio-controls-context";
+import { PlaybackProgressSnapshot } from "@/components/player/PlaybackProgressSnapshot";
 import {
     shouldAllowInitialPersistedTrackResume,
     shouldPreemptInFlightAudioLoad,
@@ -626,7 +627,6 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
     // Playback context
     const {
         isPlaying,
-        currentTime,
         setCurrentTime,
         setCurrentTimeFromEngine,
         setDuration,
@@ -638,7 +638,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
         setCanSeek,
         setDownloadProgress,
         setStreamProfile,
-    } = useAudioPlayback();
+    } = usePlaybackStatus();
 
     // Controls context
     const { pause, next, startVibeMode } = useAudioControls();
@@ -709,7 +709,7 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
     // switches tabs (the old hadPlayIntent ref was never cleared on pause).
     const wasPlayingWhenHiddenRef = useRef(false);
     const currentTrackRef = useRef(currentTrack);
-    const currentTimeSnapshotRef = useRef<number>(currentTime);
+    const currentTimeSnapshotRef = useRef<number>(0);
     const currentTimeSnapshotTrackIdRef = useRef<string | null>(
         playbackType === "track" ? currentTrack?.id ?? null : null,
     );
@@ -3154,12 +3154,6 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
             };
         }
     }, []);
-
-    useEffect(() => {
-        currentTimeSnapshotRef.current = currentTime;
-        currentTimeSnapshotTrackIdRef.current =
-            playbackType === "track" ? currentTrackRef.current?.id ?? null : null;
-    }, [currentTime, playbackType]);
 
     const requestAutoMatchVibe = useCallback(
         (
@@ -7133,6 +7127,12 @@ export const AudioPlaybackOrchestrator = memo(function AudioPlaybackOrchestrator
         clearSegmentedHandoffLoadListeners,
     ]);
 
-    // This component doesn't render anything visible
-    return null;
+    return (
+        <PlaybackProgressSnapshot
+            snapshotRef={currentTimeSnapshotRef}
+            snapshotTrackIdRef={currentTimeSnapshotTrackIdRef}
+            currentTrackRef={currentTrackRef}
+            playbackType={playbackType}
+        />
+    );
 });

--- a/frontend/components/player/PlaybackProgressSnapshot.tsx
+++ b/frontend/components/player/PlaybackProgressSnapshot.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { memo, useEffect, type MutableRefObject } from "react";
+import { usePlaybackProgress } from "@/lib/audio-playback-context";
+import type { Track, useAudioState } from "@/lib/audio-state-context";
+
+type PlaybackType = ReturnType<typeof useAudioState>["playbackType"];
+
+interface PlaybackProgressSnapshotProps {
+    snapshotRef: MutableRefObject<number>;
+    snapshotTrackIdRef: MutableRefObject<string | null>;
+    currentTrackRef: MutableRefObject<Track | null>;
+    playbackType: PlaybackType;
+}
+
+/**
+ * Keeps trusted playback snapshots current while isolating per-clock-tick
+ * re-renders from the audio playback orchestrator body.
+ */
+export const PlaybackProgressSnapshot = memo(
+    function PlaybackProgressSnapshot({
+        snapshotRef,
+        snapshotTrackIdRef,
+        currentTrackRef,
+        playbackType,
+    }: PlaybackProgressSnapshotProps) {
+        const { currentTime } = usePlaybackProgress();
+
+        useEffect(() => {
+            snapshotRef.current = currentTime;
+            snapshotTrackIdRef.current =
+                playbackType === "track"
+                    ? currentTrackRef.current?.id ?? null
+                    : null;
+        }, [
+            currentTime,
+            playbackType,
+            snapshotRef,
+            snapshotTrackIdRef,
+            currentTrackRef,
+        ]);
+
+        return null;
+    },
+);

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -604,6 +604,14 @@ mock.module("react", {
     },
 });
 
+mock.module("react/jsx-runtime", {
+    exports: {
+        Fragment: "mock-fragment",
+        jsx: (..._args: unknown[]) => ({ __mocked: true }),
+        jsxs: (..._args: unknown[]) => ({ __mocked: true }),
+    },
+});
+
 mock.module("@/lib/audio-engine", {
     exports: {
         createRuntimeAudioEngine: () => engine,
@@ -646,9 +654,8 @@ mock.module("@/lib/audio-state-context", {
 
 mock.module("@/lib/audio-playback-context", {
     exports: {
-        useAudioPlayback: () => ({
+        usePlaybackStatus: () => ({
             isPlaying: playbackState.isPlaying,
-            currentTime: playbackState.currentTime,
             setCurrentTime: (value: number) => {
                 playbackState.currentTime = value;
                 playbackCalls.setCurrentTime.push(value);
@@ -684,6 +691,9 @@ mock.module("@/lib/audio-playback-context", {
             setStreamProfile: (value: unknown) => {
                 playbackCalls.setStreamProfile.push(value);
             },
+        }),
+        usePlaybackProgress: () => ({
+            currentTime: playbackState.currentTime,
         }),
     },
 });

--- a/frontend/tests/component/playbackProgressSnapshot.component.test.ts
+++ b/frontend/tests/component/playbackProgressSnapshot.component.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+const apiStub = new Proxy(
+    {},
+    { get: () => async () => null },
+) as Record<string, unknown>;
+if (typeof mock.module === "function") {
+    mock.module("@/lib/api", { namedExports: { api: apiStub } });
+}
+
+type EngineTickFn = (time: number, invocationTrackId?: string | null) => void;
+
+let cleanup: (() => Promise<void>) | null = null;
+
+after(async () => {
+    if (cleanup) await cleanup();
+    GlobalRegistrator.unregister();
+});
+
+test("progress ticks update snapshots without re-rendering status consumers", async () => {
+    localStorage.clear();
+    const { createRoot } = await import("react-dom/client");
+    const { AudioStateProvider } = await import("../../lib/audio-state-context");
+    const { AudioPlaybackProvider, usePlaybackStatus } =
+        await import("../../lib/audio-playback-context");
+    const { PlaybackProgressSnapshot } =
+        await import("../../components/player/PlaybackProgressSnapshot");
+    const snapshotRef = { current: -1 };
+    const snapshotTrackIdRef = { current: null as string | null };
+    const currentTrackRef = {
+        current: { id: "track-1" } as { id: string } | null,
+    };
+    const engineTickRef = { current: null as EngineTickFn | null };
+    let statusRenders = 0;
+    const StatusProbe = () => {
+        engineTickRef.current = usePlaybackStatus().setCurrentTimeFromEngine;
+        statusRenders += 1;
+        return null;
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    cleanup = async () => {
+        await React.act(async () => root.unmount());
+        container.remove();
+    };
+    await React.act(async () => {
+        root.render(
+            React.createElement(
+                AudioStateProvider,
+                null,
+                React.createElement(
+                    AudioPlaybackProvider,
+                    null,
+                    React.createElement(StatusProbe),
+                    React.createElement(PlaybackProgressSnapshot, {
+                        snapshotRef,
+                        snapshotTrackIdRef,
+                        currentTrackRef: currentTrackRef as never,
+                        playbackType: "track",
+                    }),
+                ),
+            ),
+        );
+    });
+    assert.equal(statusRenders, 1);
+    assert.equal(container.childElementCount, 0);
+    assert.ok(engineTickRef.current);
+    await React.act(async () => engineTickRef.current!(5, "track-1"));
+    assert.equal(snapshotRef.current, 5);
+    assert.equal(snapshotTrackIdRef.current, "track-1");
+    await React.act(async () => engineTickRef.current!(9, "track-1"));
+    assert.equal(snapshotRef.current, 9);
+    assert.equal(statusRenders, 1);
+});


### PR DESCRIPTION
## Summary

First incremental extraction from the 7,138-line `AudioPlaybackOrchestrator` god-component (roadmap **F5**, refactor slice **P33**), building on the P27 playback-context split.

The orchestrator body **stops reading the deprecated composite `useAudioPlayback()`** and now consumes only `usePlaybackStatus()`. The single high-frequency concern it took from the composite — the `currentTime` clock, used only to keep two trusted-position snapshot refs in sync — is extracted into a new focused child component, `components/player/PlaybackProgressSnapshot`, which owns the `usePlaybackProgress()` subscription and updates the refs via the same effect logic. Because the orchestrator body no longer subscribes to the per-tick progress clock, it no longer re-renders every second of playback.

This is deliberately one small, behavior-preserving hook/subscription extraction, per the slice's high-risk guidance (one extraction per commit, component tests green after each, no single rewrite).

## Findings addressed

- `AudioPlaybackOrchestrator` reads the deprecated composite playback context and re-renders on every clock tick — now isolated behind the split contexts from P27.

## Changes

- `frontend/components/player/PlaybackProgressSnapshot.tsx` (new): memoized, headless child that subscribes to `usePlaybackProgress()` and mirrors `currentTime` / active track id into the orchestrator's snapshot refs. Returns `null`.
- `frontend/components/player/AudioPlaybackOrchestrator.tsx`: swap `useAudioPlayback()` → `usePlaybackStatus()` (drops the `currentTime` body binding); snapshot ref inits to `0`; the currentTime→snapshot sync effect is removed (moved to the child); the component now renders `<PlaybackProgressSnapshot .../>` instead of returning bare `null`.
- `frontend/tests/component/playbackProgressSnapshot.component.test.ts` (new, TDD): happy-dom + `react-dom/client` render-count test proving progress ticks update the snapshot refs while a `usePlaybackStatus()` consumer does not re-render.
- `frontend/tests/component/audioPlaybackOrchestrator.component.test.ts`: mock update — `useAudioPlayback` → `usePlaybackStatus` + added `usePlaybackProgress`, plus a `react/jsx-runtime` mock (the orchestrator now returns JSX).
- `CHANGELOG.md`: Unreleased → Changed entry.

## Tests / verification

- verify: `audioPlaybackOrchestrator.component.test.ts` — 20/20 pass (unchanged behavior net).
- verify: new `playbackProgressSnapshot.component.test.ts` — 1/1 pass (red before the component existed).
- verify: other orchestrator-importing suites green — `audioPlaybackTimeGuard` 10/10, `audioPlaybackStoragePrecision` 1/1, `engineModeGateContract` 2/2.
- verify: P27 guards still green — `playbackContextSplit` 1/1, `universalPlayerRenderCount` 1/1.
- verify: `npm run typecheck` (standalone tsc) — exit 0, 0 errors.
- verify: full-frontend `npm run lint` — 0 errors, 174 warnings; **0 new warnings** (the one `exhaustive-deps` warning in the orchestrator is pre-existing, previously line 5150, now 5144 after the effect deletion).

`next build` and full jest/coverage were intentionally not run per the repo's RAM/disk constraints (targeted testing only); the standalone tsc gate already type-checks the full frontend project graph.

## Breaking changes / UPGRADING

None. Behavior-preserving, frontend-only. The deprecated `useAudioPlayback()` composite remains exported for other consumers.

## Follow-ups (not in this slice)

- Continue the F5 extraction program: `useEngineEventBridge`, `useSegmentedStartupRecovery`, `useSegmentedHandoff`, `useProgressPersistence`, `useForegroundRecovery`, `usePrewarmValidation`, `useTransientErrorRecovery`, one per PR, adding the missing ref-mirrors (queue/currentIndex/shuffleIndices/isShuffle/repeatMode/currentAudiobook/currentPodcast) before shrinking the 39-entry engine-rebind dep array.
- Manual device-matrix soak remains advisable before considering the god-component teardown "done" (per the audio-engine memory notes).

## Escalations

None.
