### PR TITLE
refactor(frontend): centralize design tokens + fix contrast (refactor slice P28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer re-renders on every clock tick. Playback behavior is unchanged
   (verified by the existing orchestrator component suite plus a new render-count
   regression test).
+- Frontend soundspan colors now have a centralized Tailwind v4 CSS-first
+  `@theme` palette, with synchronized TypeScript tokens and contrast guards for
+  accessible text and settings focus indicators.
+- **Accessibility:** Raised low-contrast gray body text to the WCAG-AA gray-400
+  floor, gave settings inputs a visible (>=3:1) brand focus ring, and added a
+  ratchet guard against new hardcoded arbitrary-hex Tailwind classes.
 - **Backend error-response canonicalization (developer-facing standard + first
   exemplars).** The canonical route error contract is now documented in
   `backend/src/routes/README.md`: async handlers wrap in `asyncHandler`,

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -194,7 +194,7 @@ export default function AdminPage() {
 
     if (authLoading) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-[#0a0a0a]">
+            <div className="flex items-center justify-center min-h-screen bg-surface">
                 <GradientSpinner size="md" />
             </div>
         );
@@ -206,7 +206,7 @@ export default function AdminPage() {
 
     if (systemSettingsLoading) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-[#0a0a0a]">
+            <div className="flex items-center justify-center min-h-screen bg-surface">
                 <GradientSpinner size="md" />
             </div>
         );
@@ -214,7 +214,7 @@ export default function AdminPage() {
 
     if (systemSettingsLoadError || !systemSettings) {
         return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#0a0a0a] gap-4 px-4">
+            <div className="flex flex-col items-center justify-center min-h-screen bg-surface gap-4 px-4">
                 <p className="text-red-400 text-sm text-center">
                     Failed to load settings from the server. Settings cannot be edited until they are loaded.
                 </p>
@@ -295,7 +295,7 @@ export default function AdminPage() {
                         >
                             {isSaving ? "Saving..." : "Save"}
                         </button>
-                        <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-[#0a0a0a]/90 backdrop-blur-sm px-3 py-0.5 rounded-full">
+                        <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-surface/90 backdrop-blur-sm px-3 py-0.5 rounded-full">
                             <InlineStatus {...saveStatus.props} />
                         </div>
                     </div>

--- a/frontend/app/audiobooks/[id]/page.tsx
+++ b/frontend/app/audiobooks/[id]/page.tsx
@@ -45,7 +45,7 @@ export default function AudiobookDetailPage() {
     if (!audiobook) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <p className="text-gray-500">Audiobook not found</p>
+                <p className="text-gray-400">Audiobook not found</p>
             </div>
         );
     }
@@ -113,7 +113,7 @@ export default function AudiobookDetailPage() {
                         <section>
                             <h2 className="text-xl font-bold mb-4">Series</h2>
                             <div className="flex items-center gap-3 text-sm">
-                                <span className="text-[#3b82f6] font-medium">
+                                <span className="text-brand font-medium">
                                     {audiobook.series.name}
                                 </span>
                                 <span className="text-white/40">•</span>

--- a/frontend/app/audiobooks/page.tsx
+++ b/frontend/app/audiobooks/page.tsx
@@ -279,11 +279,11 @@ export default function AudiobooksPage() {
                 {/* Background gradient */}
                 <div className="absolute inset-0 pointer-events-none">
                     <div
-                        className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                        className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                         style={{ height: "35vh" }}
                     />
                     <div
-                        className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                        className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                         style={{ height: "25vh" }}
                     />
                 </div>
@@ -302,7 +302,7 @@ export default function AudiobooksPage() {
 
                     {/* Setup Steps - Horizontal Cards */}
                     <div className="grid md:grid-cols-3 gap-6 mb-12">
-                        <div className="bg-gradient-to-br from-[#121212] to-[#0a0a0a] rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
+                        <div className="bg-gradient-to-br from-surface-sunken to-surface rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
                             <div className="text-4xl font-black text-blue-400/20 mb-4">
                                 01
                             </div>
@@ -315,7 +315,7 @@ export default function AudiobooksPage() {
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-[#121212] to-[#0a0a0a] rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
+                        <div className="bg-gradient-to-br from-surface-sunken to-surface rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
                             <div className="text-4xl font-black text-blue-400/20 mb-4">
                                 02
                             </div>
@@ -328,7 +328,7 @@ export default function AudiobooksPage() {
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-[#121212] to-[#0a0a0a] rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
+                        <div className="bg-gradient-to-br from-surface-sunken to-surface rounded-xl p-6 border border-white/5 hover:border-white/10 transition-all">
                             <div className="text-4xl font-black text-blue-400/20 mb-4">
                                 03
                             </div>
@@ -370,7 +370,7 @@ export default function AudiobooksPage() {
 
                     {/* Footer Link */}
                     <div className="text-center">
-                        <p className="text-gray-500 text-sm mb-2">Need help?</p>
+                        <p className="text-gray-400 text-sm mb-2">Need help?</p>
                         <a
                             href="https://github.com/advplyr/audiobookshelf"
                             target="_blank"
@@ -390,11 +390,11 @@ export default function AudiobooksPage() {
             {/* Background gradient */}
             <div className="absolute inset-0 pointer-events-none">
                 <div
-                    className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                    className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                     style={{ height: "35vh" }}
                 />
                 <div
-                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                     style={{ height: "25vh" }}
                 />
             </div>
@@ -440,7 +440,7 @@ export default function AudiobooksPage() {
                         {/* Shuffle Button */}
                         <button
                             onClick={handleShuffleAudiobooks}
-                            className="flex items-center gap-2 px-4 py-2 bg-[#60a5fa] hover:bg-[#3b82f6] text-black font-medium rounded-full transition-all hover:scale-105"
+                            className="flex items-center gap-2 px-4 py-2 bg-brand-hover hover:bg-brand text-black font-medium rounded-full transition-all hover:scale-105"
                         >
                             <Shuffle className="w-4 h-4" />
                             <span className="hidden sm:inline">Random Book</span>
@@ -460,7 +460,7 @@ export default function AudiobooksPage() {
                             onChange={(e) =>
                                 setSortBy(e.target.value as SortType)
                             }
-                            className="px-4 py-2 bg-[#1a1a1a] border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 focus:bg-[#252525] transition-all [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                            className="px-4 py-2 bg-surface-hover border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 focus:bg-[#252525] transition-all [&>option]:bg-surface-hover [&>option]:text-white"
                         >
                             <option value="title">Title</option>
                             <option value="author">Author</option>
@@ -489,7 +489,7 @@ export default function AudiobooksPage() {
                                 onChange={(e) =>
                                     setSelectedGenre(e.target.value || null)
                                 }
-                                className="flex-1 min-w-0 md:flex-initial md:min-w-[140px] px-4 py-2 bg-[#1a1a1a] border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 focus:bg-[#252525] transition-all truncate [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                                className="flex-1 min-w-0 md:flex-initial md:min-w-[140px] px-4 py-2 bg-surface-hover border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 focus:bg-[#252525] transition-all truncate [&>option]:bg-surface-hover [&>option]:text-white"
                             >
                                 <option value="">All Genres</option>
                                 {allGenres.map((genre) => (
@@ -507,7 +507,7 @@ export default function AudiobooksPage() {
                                 setItemsPerPage(Number(e.target.value));
                                 setCurrentPage(1);
                             }}
-                            className="px-4 py-2 bg-[#1a1a1a] border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                            className="px-4 py-2 bg-surface-hover border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-blue-500 [&>option]:bg-surface-hover [&>option]:text-white"
                         >
                             <option value={25}>25 per page</option>
                             <option value={50}>50 per page</option>

--- a/frontend/app/audiobooks/series/[name]/page.tsx
+++ b/frontend/app/audiobooks/series/[name]/page.tsx
@@ -88,7 +88,7 @@ export default function SeriesDetailPage() {
     if (isLoading) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <Loader2 className="w-8 h-8 text-[#2323FF] animate-spin" />
+                <Loader2 className="w-8 h-8 text-ai animate-spin" />
             </div>
         );
     }
@@ -96,7 +96,7 @@ export default function SeriesDetailPage() {
     if (books.length === 0) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <p className="text-gray-500">No books found in this series</p>
+                <p className="text-gray-400">No books found in this series</p>
             </div>
         );
     }
@@ -113,7 +113,7 @@ export default function SeriesDetailPage() {
                 <div className="max-w-7xl mx-auto px-8 py-12">
                     <div className="flex flex-col md:flex-row gap-8 items-start">
                         {/* Series Cover */}
-                        <div className="relative w-64 h-64 flex-shrink-0 rounded-lg overflow-hidden shadow-2xl bg-[#181818]">
+                        <div className="relative w-64 h-64 flex-shrink-0 rounded-lg overflow-hidden shadow-2xl bg-surface-elevated">
                             {firstBook.coverUrl &&
                             getCoverUrl(firstBook.coverUrl, 500) ? (
                                 <Image
@@ -126,7 +126,7 @@ export default function SeriesDetailPage() {
                                 />
                             ) : (
                                 <div className="w-full h-full flex items-center justify-center">
-                                    <Book className="w-24 h-24 text-gray-600" />
+                                    <Book className="w-24 h-24 text-gray-400" />
                                 </div>
                             )}
                         </div>
@@ -190,7 +190,7 @@ export default function SeriesDetailPage() {
                         return (
                             <Card
                                 key={book.id}
-                                className="p-4 hover:bg-[#181818] transition-colors group"
+                                className="p-4 hover:bg-surface-elevated transition-colors group"
                             >
                                 <div className="flex items-center gap-4">
                                     {/* Book Number */}
@@ -199,8 +199,8 @@ export default function SeriesDetailPage() {
                                             <div className="flex items-center justify-center">
                                                 <div className="w-4 h-4 flex items-center justify-center">
                                                     <div className="grid grid-cols-2 gap-0.5">
-                                                        <div className="w-1 h-3 bg-[#2323FF] animate-pulse" />
-                                                        <div className="w-1 h-3 bg-[#2323FF] animate-pulse delay-75" />
+                                                        <div className="w-1 h-3 bg-ai animate-pulse" />
+                                                        <div className="w-1 h-3 bg-ai animate-pulse delay-75" />
                                                     </div>
                                                 </div>
                                             </div>
@@ -214,7 +214,7 @@ export default function SeriesDetailPage() {
 
                                     {/* Book Cover (small) */}
                                     <Link href={`/audiobooks/${book.id}`}>
-                                        <div className="relative w-12 h-12 rounded overflow-hidden bg-[#181818] flex-shrink-0 cursor-pointer">
+                                        <div className="relative w-12 h-12 rounded overflow-hidden bg-surface-elevated flex-shrink-0 cursor-pointer">
                                             {book.coverUrl &&
                                             getCoverUrl(book.coverUrl, 100) ? (
                                                 <Image
@@ -227,7 +227,7 @@ export default function SeriesDetailPage() {
                                                 />
                                             ) : (
                                                 <div className="w-full h-full flex items-center justify-center">
-                                                    <Book className="w-6 h-6 text-gray-600" />
+                                                    <Book className="w-6 h-6 text-gray-400" />
                                                 </div>
                                             )}
                                         </div>
@@ -252,9 +252,9 @@ export default function SeriesDetailPage() {
                                     ) : book.progress &&
                                       book.progress.progress > 0 ? (
                                         <div className="flex items-center gap-2 flex-shrink-0">
-                                            <div className="w-24 h-1 bg-[#181818] rounded-full overflow-hidden">
+                                            <div className="w-24 h-1 bg-surface-elevated rounded-full overflow-hidden">
                                                 <div
-                                                    className="h-full bg-[#2323FF]"
+                                                    className="h-full bg-ai"
                                                     style={{
                                                         width: `${book.progress.progress}%`,
                                                     }}

--- a/frontend/app/device/page.tsx
+++ b/frontend/app/device/page.tsx
@@ -175,7 +175,7 @@ export default function DeviceLinkPage() {
         <div className="min-h-screen relative pb-24">
             {/* Header gradient */}
             <div className="absolute inset-0 pointer-events-none">
-                <div className="absolute inset-0 bg-gradient-to-b from-[#2323FF]/10 via-transparent to-transparent" style={{ height: "50vh" }} />
+                <div className="absolute inset-0 bg-gradient-to-b from-ai/10 via-transparent to-transparent" style={{ height: "50vh" }} />
             </div>
 
             <div className="relative max-w-4xl mx-auto px-6 md:px-8 py-8">
@@ -187,7 +187,7 @@ export default function DeviceLinkPage() {
                     <p className="text-gray-400">
                         Scan the QR code or enter the code in a compatible client to link your device
                     </p>
-                    <p className="text-gray-500 text-sm mt-2">
+                    <p className="text-gray-400 text-sm mt-2">
                         Mobile direction is PWA-first. For native mobile clients, use Subsonic-compatible apps.
                     </p>
                 </div>
@@ -214,7 +214,7 @@ export default function DeviceLinkPage() {
                                 </p>
                                 <button
                                     onClick={generateCode}
-                                    className="px-6 py-3 bg-[#60a5fa] hover:bg-[#3b82f6] text-black font-medium rounded-full transition-all hover:scale-105"
+                                    className="px-6 py-3 bg-brand-hover hover:bg-brand text-black font-medium rounded-full transition-all hover:scale-105"
                                 >
                                     Generate Code
                                 </button>
@@ -260,7 +260,7 @@ export default function DeviceLinkPage() {
                                         </p>
                                         <button
                                             onClick={generateCode}
-                                            className="px-4 py-2 bg-[#60a5fa] hover:bg-[#3b82f6] text-black font-medium rounded-full transition-all"
+                                            className="px-4 py-2 bg-brand-hover hover:bg-brand text-black font-medium rounded-full transition-all"
                                         >
                                             <RefreshCw className="w-4 h-4 inline mr-2" />
                                             Generate New Code
@@ -273,7 +273,7 @@ export default function DeviceLinkPage() {
                                                 Client link URI scheme:
                                             </p>
                                             <div className="inline-flex rounded-lg border border-white/10 bg-white/5 p-1 gap-1">
-                                                <span className="px-3 py-1.5 rounded-md text-xs font-medium bg-[#3b82f6] text-black">
+                                                <span className="px-3 py-1.5 rounded-md text-xs font-medium bg-brand text-black">
                                                     {BRAND_DEEP_LINK_SCHEME}://
                                                 </span>
                                             </div>
@@ -353,14 +353,14 @@ export default function DeviceLinkPage() {
                                         className="flex items-center justify-between p-3 bg-white/5 rounded-lg"
                                     >
                                         <div className="flex items-center gap-3">
-                                            <div className="w-10 h-10 rounded-full bg-[#2323FF]/20 flex items-center justify-center">
-                                                <Smartphone className="w-5 h-5 text-[#5b5bff]" />
+                                            <div className="w-10 h-10 rounded-full bg-ai/20 flex items-center justify-center">
+                                                <Smartphone className="w-5 h-5 text-ai-hover" />
                                             </div>
                                             <div>
                                                 <p className="text-white font-medium">
                                                     {device.name}
                                                 </p>
-                                                <p className="text-gray-500 text-sm">
+                                                <p className="text-gray-400 text-sm">
                                                     Last used:{" "}
                                                     {new Date(device.lastUsed).toLocaleDateString()}
                                                 </p>
@@ -387,25 +387,25 @@ export default function DeviceLinkPage() {
                     </h2>
                     <ol className="space-y-3 text-gray-400">
                         <li className="flex gap-3">
-                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6]/20 text-[#3b82f6] text-sm font-bold flex items-center justify-center">
+                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-brand/20 text-brand text-sm font-bold flex items-center justify-center">
                                 1
                             </span>
                             <span>Open a compatible mobile client on your device</span>
                         </li>
                         <li className="flex gap-3">
-                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6]/20 text-[#3b82f6] text-sm font-bold flex items-center justify-center">
+                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-brand/20 text-brand text-sm font-bold flex items-center justify-center">
                                 2
                             </span>
                             <span>Tap &quot;Scan QR Code&quot; or &quot;Enter Code&quot; if that client supports this flow</span>
                         </li>
                         <li className="flex gap-3">
-                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6]/20 text-[#3b82f6] text-sm font-bold flex items-center justify-center">
+                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-brand/20 text-brand text-sm font-bold flex items-center justify-center">
                                 3
                             </span>
                             <span>Scan the QR code above, or manually enter the 6-digit code</span>
                         </li>
                         <li className="flex gap-3">
-                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6]/20 text-[#3b82f6] text-sm font-bold flex items-center justify-center">
+                            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-brand/20 text-brand text-sm font-bold flex items-center justify-center">
                                 4
                             </span>
                             <span>Your device will be linked to your account after the client completes verification</span>

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -49,9 +49,9 @@ export default function DiscoverWeeklyPage() {
                 <h1 className="text-xl font-semibold text-white mb-4">
                     Discover Weekly
                 </h1>
-                <div className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-lg p-6">
-                    <p className="text-[#a3a3a3] mb-2">Feature not available</p>
-                    <p className="text-sm text-[#737373]">
+                <div className="bg-surface-raised border border-surface-active rounded-lg p-6">
+                    <p className="text-content-secondary mb-2">Feature not available</p>
+                    <p className="text-sm text-content-muted">
                         Discovery is disabled on this server.
                     </p>
                 </div>
@@ -249,20 +249,20 @@ function DiscoverWeeklyPageContent() {
                             <h3 className="mt-4 text-lg font-medium text-white">
                                 Loading your latest Discover Weekly
                             </h3>
-                            <p className="mt-1 text-sm text-gray-500 max-w-md">
+                            <p className="mt-1 text-sm text-gray-400 max-w-md">
                                 Your playlist has been generated and can take a few
                                 seconds to fully appear.
                             </p>
                         </div>
                     ) : (
                         <div className="flex flex-col items-center justify-center py-24 text-center">
-                            <div className="w-20 h-20 bg-gradient-to-br from-[#1a1acc]/20 to-yellow-600/20 rounded-full flex items-center justify-center mb-4 shadow-xl border border-white/10">
-                                <Music2 className="w-10 h-10 text-[#5b5bff]" />
+                            <div className="w-20 h-20 bg-gradient-to-br from-ai-dark/20 to-yellow-600/20 rounded-full flex items-center justify-center mb-4 shadow-xl border border-white/10">
+                                <Music2 className="w-10 h-10 text-ai-hover" />
                             </div>
                             <h3 className="text-lg font-medium text-white mb-1">
                                 No Discover Weekly Yet
                             </h3>
-                            <p className="text-sm text-gray-500 mb-6 max-w-md">
+                            <p className="text-sm text-gray-400 mb-6 max-w-md">
                                 Generate your first playlist based on your
                                 listening history!
                             </p>
@@ -273,7 +273,7 @@ function DiscoverWeeklyPageContent() {
                                     "flex items-center gap-2 px-6 py-3 rounded-full text-white font-semibold transition-all",
                                     isGenerating
                                         ? "bg-white/5 cursor-not-allowed opacity-50"
-                                        : "bg-[#1a1acc]/20 hover:bg-[#1a1acc]/30 border border-[#2323FF]/30 hover:scale-105"
+                                        : "bg-ai-dark/20 hover:bg-ai-dark/30 border border-ai/30 hover:scale-105"
                                 )}
                             >
                                 {isGenerating ? (

--- a/frontend/app/explore/tidal-mix/[id]/page.tsx
+++ b/frontend/app/explore/tidal-mix/[id]/page.tsx
@@ -378,7 +378,7 @@ function TidalMixDetailPageContent() {
                     </button>
                     <div className="flex flex-col items-center justify-center py-20 text-center">
                         <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center mb-4">
-                            <Music2 className="w-8 h-8 text-gray-500" />
+                            <Music2 className="w-8 h-8 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-2">
                             Mix not found
@@ -401,10 +401,10 @@ function TidalMixDetailPageContent() {
     return (
         <div className="min-h-screen">
             {/* Hero Section */}
-            <div className="relative bg-gradient-to-b from-[#00BFFF]/20 via-[#1a1a1a] to-transparent pt-16 pb-10 px-4 md:px-8">
+            <div className="relative bg-gradient-to-b from-[#00BFFF]/20 via-surface-hover to-transparent pt-16 pb-10 px-4 md:px-8">
                 <div className="flex items-end gap-6">
                     {/* Cover Art */}
-                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden">
+                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden">
                         {mix.thumbnailUrl ? (
                             <Image
                                 src={api.getTidalBrowseImageUrl(mix.thumbnailUrl)}
@@ -416,7 +416,7 @@ function TidalMixDetailPageContent() {
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-[#00BFFF]/30 to-[#00BFFF]/10">
-                                <Music2 className="w-16 h-16 text-gray-600" />
+                                <Music2 className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>
@@ -448,7 +448,7 @@ function TidalMixDetailPageContent() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {/* Play Button (cyan) */}
                     <button
@@ -504,7 +504,7 @@ function TidalMixDetailPageContent() {
                                 isApplyingLikeAll
                                     ? "cursor-not-allowed text-white/35"
                                     : isAllLiked
-                                        ? "text-[#3b82f6] hover:bg-white/10"
+                                        ? "text-brand hover:bg-white/10"
                                         : "text-white/60 hover:bg-white/10 hover:text-white"
                             )}
                             title={isAllLiked ? "Unlike all tracks" : "Like all tracks"}
@@ -539,13 +539,13 @@ function TidalMixDetailPageContent() {
                     />
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
-                        <div className="w-20 h-20 bg-[#282828] rounded-full flex items-center justify-center mb-4">
-                            <Music2 className="w-10 h-10 text-gray-500" />
+                        <div className="w-20 h-20 bg-surface-highlight rounded-full flex items-center justify-center mb-4">
+                            <Music2 className="w-10 h-10 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-1">
                             No tracks found
                         </h3>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-400">
                             This mix appears to be empty
                         </p>
                     </div>

--- a/frontend/app/explore/tidal-playlist/[id]/page.tsx
+++ b/frontend/app/explore/tidal-playlist/[id]/page.tsx
@@ -378,7 +378,7 @@ function TidalPlaylistDetailPageContent() {
                     </button>
                     <div className="flex flex-col items-center justify-center py-20 text-center">
                         <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center mb-4">
-                            <Music2 className="w-8 h-8 text-gray-500" />
+                            <Music2 className="w-8 h-8 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-2">
                             Playlist not found
@@ -401,10 +401,10 @@ function TidalPlaylistDetailPageContent() {
     return (
         <div className="min-h-screen">
             {/* Hero Section */}
-            <div className="relative bg-gradient-to-b from-[#00BFFF]/20 via-[#1a1a1a] to-transparent pt-16 pb-10 px-4 md:px-8">
+            <div className="relative bg-gradient-to-b from-[#00BFFF]/20 via-surface-hover to-transparent pt-16 pb-10 px-4 md:px-8">
                 <div className="flex items-end gap-6">
                     {/* Cover Art */}
-                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden">
+                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden">
                         {playlist.thumbnailUrl ? (
                             <Image
                                 src={api.getTidalBrowseImageUrl(playlist.thumbnailUrl)}
@@ -416,7 +416,7 @@ function TidalPlaylistDetailPageContent() {
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-[#00BFFF]/30 to-[#00BFFF]/10">
-                                <Music2 className="w-16 h-16 text-gray-600" />
+                                <Music2 className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>
@@ -448,7 +448,7 @@ function TidalPlaylistDetailPageContent() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {/* Play Button (cyan) */}
                     <button
@@ -504,7 +504,7 @@ function TidalPlaylistDetailPageContent() {
                                 isApplyingLikeAll
                                     ? "cursor-not-allowed text-white/35"
                                     : isAllLiked
-                                        ? "text-[#3b82f6] hover:bg-white/10"
+                                        ? "text-brand hover:bg-white/10"
                                         : "text-white/60 hover:bg-white/10 hover:text-white"
                             )}
                             title={isAllLiked ? "Unlike all tracks" : "Like all tracks"}
@@ -539,13 +539,13 @@ function TidalPlaylistDetailPageContent() {
                     />
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
-                        <div className="w-20 h-20 bg-[#282828] rounded-full flex items-center justify-center mb-4">
-                            <Music2 className="w-10 h-10 text-gray-500" />
+                        <div className="w-20 h-20 bg-surface-highlight rounded-full flex items-center justify-center mb-4">
+                            <Music2 className="w-10 h-10 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-1">
                             No tracks found
                         </h3>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-400">
                             This playlist appears to be empty
                         </p>
                     </div>

--- a/frontend/app/explore/yt-playlist/[id]/page.tsx
+++ b/frontend/app/explore/yt-playlist/[id]/page.tsx
@@ -536,7 +536,7 @@ function YtMusicPlaylistDetailPageContent() {
                     </button>
                     <div className="flex flex-col items-center justify-center py-20 text-center">
                         <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center mb-4">
-                            <Music2 className="w-8 h-8 text-gray-500" />
+                            <Music2 className="w-8 h-8 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-2">
                             Playlist not found
@@ -559,10 +559,10 @@ function YtMusicPlaylistDetailPageContent() {
     return (
         <div className="min-h-screen">
             {/* Hero Section */}
-            <div className="relative bg-gradient-to-b from-red-600/20 via-[#1a1a1a] to-transparent pt-16 pb-10 px-4 md:px-8">
+            <div className="relative bg-gradient-to-b from-red-600/20 via-surface-hover to-transparent pt-16 pb-10 px-4 md:px-8">
                 <div className="flex items-end gap-6">
                     {/* Cover Art */}
-                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden">
+                    <div className="relative w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden">
                         {playlist.thumbnailUrl ? (
                             <Image
                                 src={api.getBrowseImageUrl(playlist.thumbnailUrl)}
@@ -574,7 +574,7 @@ function YtMusicPlaylistDetailPageContent() {
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-red-500/30 to-red-500/10">
-                                <Music2 className="w-16 h-16 text-gray-600" />
+                                <Music2 className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>
@@ -608,7 +608,7 @@ function YtMusicPlaylistDetailPageContent() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {/* Play Button (red) */}
                     <button
@@ -664,7 +664,7 @@ function YtMusicPlaylistDetailPageContent() {
                                 isApplyingLikeAll
                                     ? "cursor-not-allowed text-white/35"
                                     : isAllLiked
-                                        ? "text-[#3b82f6] hover:bg-white/10"
+                                        ? "text-brand hover:bg-white/10"
                                         : "text-white/60 hover:bg-white/10 hover:text-white"
                             )}
                             title={isAllLiked ? "Unlike all tracks" : "Like all tracks"}
@@ -699,13 +699,13 @@ function YtMusicPlaylistDetailPageContent() {
                     />
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
-                        <div className="w-20 h-20 bg-[#282828] rounded-full flex items-center justify-center mb-4">
-                            <Music2 className="w-10 h-10 text-gray-500" />
+                        <div className="w-20 h-20 bg-surface-highlight rounded-full flex items-center justify-center mb-4">
+                            <Music2 className="w-10 h-10 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-1">
                             No tracks found
                         </h3>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-400">
                             This playlist appears to be empty
                         </p>
                     </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,10 +1,43 @@
 @import "tailwindcss";
 
 @theme {
+    /* Brand */
     --color-brand: #3b82f6;
+    --color-brand-dark: #2563eb;
     --color-brand-hover: #60a5fa;
     --color-brand-light: #93c5fd;
-    --color-brand-dark: #2563eb;
+
+    /* AI */
+    --color-ai: #2323ff;
+    --color-ai-dark: #1a1acc;
+    --color-ai-hover: #5b5bff;
+
+    /* Surfaces */
+    --color-surface: #0a0a0a;
+    --color-surface-active: #1c1c1c;
+    --color-surface-elevated: #181818;
+    --color-surface-highlight: #282828;
+    --color-surface-hover: #1a1a1a;
+    --color-surface-overlay: #141414;
+    --color-surface-raised: #0f0f0f;
+    --color-surface-sunken: #121212;
+
+    /* Lines */
+    --color-line: #262626;
+    --color-line-muted: #404040;
+    --color-line-strong: #333333;
+
+    /* Content */
+    --color-content: #ffffff;
+    --color-content-body: #e5e5e5;
+    --color-content-disabled: #525252;
+    --color-content-muted: #737373;
+    --color-content-secondary: #a3a3a3;
+
+    /* Status */
+    --color-error: #ef4444;
+    --color-success: #22c55e;
+    --color-warning: #f59e0b;
 }
 
 :root {

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -148,7 +148,7 @@ export function PreviewTrackResolutionList({
 }) {
     if (tracks.length === 0) {
         return (
-            <div className="p-4 text-sm text-gray-500">
+            <div className="p-4 text-sm text-gray-400">
                 No tracks found in this playlist.
             </div>
         );
@@ -162,7 +162,7 @@ export function PreviewTrackResolutionList({
                     className="px-4 py-3 hover:bg-white/5"
                 >
                     <div className="flex items-start gap-3">
-                        <span className="text-xs text-gray-600 w-6 text-right pt-0.5">
+                        <span className="text-xs text-gray-400 w-6 text-right pt-0.5">
                             {idx + 1}
                         </span>
                         <div className="flex-1 min-w-0">
@@ -173,7 +173,7 @@ export function PreviewTrackResolutionList({
                                 {track.artist}
                                 {track.album ? ` • ${track.album}` : ""}
                             </div>
-                            <div className="text-[11px] text-gray-500 mt-1">
+                            <div className="text-[11px] text-gray-400 mt-1">
                                 {getResolutionSubtitle(track)}
                             </div>
                         </div>
@@ -181,7 +181,7 @@ export function PreviewTrackResolutionList({
                             <ImportResolutionBadge source={track.source} />
                             {typeof track.duration === "number" &&
                                 track.duration > 0 && (
-                                    <span className="text-[11px] text-gray-600">
+                                    <span className="text-[11px] text-gray-400">
                                         {formatTime(track.duration)}
                                     </span>
                                 )}
@@ -367,11 +367,11 @@ function ImportPageContent() {
         <div className="min-h-screen relative">
             <div className="absolute inset-0 pointer-events-none">
                 <div
-                    className="absolute inset-0 bg-linear-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                    className="absolute inset-0 bg-linear-to-b from-brand/15 via-blue-900/10 to-transparent"
                     style={{ height: "35vh" }}
                 />
                 <div
-                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                     style={{ height: "25vh" }}
                 />
             </div>
@@ -435,13 +435,13 @@ function ImportPageContent() {
                                             setUrl(event.target.value)
                                         }
                                         placeholder="Paste a Spotify, Deezer, YouTube Music, or TIDAL playlist URL"
-                                        className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#3b82f6]/50 focus:border-[#3b82f6] transition-colors"
+                                        className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand transition-colors"
                                         onKeyDown={(event) =>
                                             event.key === "Enter" &&
                                             void fetchPreview(url)
                                         }
                                     />
-                                    <p className="text-xs text-gray-500 mt-2">
+                                    <p className="text-xs text-gray-400 mt-2">
                                         Paste a{" "}
                                         <span className="text-[#1DB954]">Spotify</span>,{" "}
                                         <span className="text-[#AD47FF]">Deezer</span>,{" "}
@@ -454,7 +454,7 @@ function ImportPageContent() {
                                 <button
                                     onClick={() => void fetchPreview(url)}
                                     disabled={isPreviewLoading || !url.trim()}
-                                    className="w-full py-3 rounded-full font-medium bg-[#3b82f6] text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+                                    className="w-full py-3 rounded-full font-medium bg-brand text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
                                 >
                                     {isPreviewLoading ? (
                                         <>
@@ -478,7 +478,7 @@ function ImportPageContent() {
                                         onClick={() => fileInputRef.current?.click()}
                                         className="w-full bg-white/5 border border-dashed border-white/20 rounded-lg px-4 py-8 text-center cursor-pointer hover:border-white/40 hover:bg-white/[0.07] transition-colors"
                                     >
-                                        <FileUp className="w-8 h-8 text-gray-500 mx-auto mb-2" />
+                                        <FileUp className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                                         {m3uFileName ? (
                                             <p className="text-sm text-white">{m3uFileName}</p>
                                         ) : (
@@ -494,7 +494,7 @@ function ImportPageContent() {
                                         className="hidden"
                                         onChange={handleM3uFileSelect}
                                     />
-                                    <p className="text-xs text-gray-500 mt-2">
+                                    <p className="text-xs text-gray-400 mt-2">
                                         Tracks are matched against your local library using file paths and metadata
                                     </p>
                                 </div>
@@ -510,14 +510,14 @@ function ImportPageContent() {
                                                 setM3uPlaylistName(event.target.value)
                                             }
                                             placeholder="Enter playlist name"
-                                            className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#3b82f6]/50 focus:border-[#3b82f6] transition-colors"
+                                            className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand transition-colors"
                                         />
                                     </div>
                                 )}
                                 <button
                                     onClick={() => void fetchM3uPreview()}
                                     disabled={isPreviewLoading || !m3uContent}
-                                    className="w-full py-3 rounded-full font-medium bg-[#3b82f6] text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+                                    className="w-full py-3 rounded-full font-medium bg-brand text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
                                 >
                                     {isPreviewLoading ? (
                                         <>
@@ -552,7 +552,7 @@ function ImportPageContent() {
                                     href={url}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="text-gray-400 hover:text-[#3b82f6] transition-colors"
+                                    className="text-gray-400 hover:text-brand transition-colors"
                                 >
                                     <ExternalLink className="w-4 h-4" />
                                 </a>
@@ -564,7 +564,7 @@ function ImportPageContent() {
                                 <div className="text-xl font-bold text-white">
                                     {preview.summary.total}
                                 </div>
-                                <div className="text-xs text-gray-500">
+                                <div className="text-xs text-gray-400">
                                     Total
                                 </div>
                             </div>
@@ -572,7 +572,7 @@ function ImportPageContent() {
                                 <div className="text-xl font-bold text-emerald-300">
                                     {preview.summary.local}
                                 </div>
-                                <div className="text-xs text-gray-500">
+                                <div className="text-xs text-gray-400">
                                     Local
                                 </div>
                             </div>
@@ -580,7 +580,7 @@ function ImportPageContent() {
                                 <div className="text-xl font-bold text-red-300">
                                     {preview.summary.youtube}
                                 </div>
-                                <div className="text-xs text-gray-500">
+                                <div className="text-xs text-gray-400">
                                     YouTube
                                 </div>
                             </div>
@@ -588,7 +588,7 @@ function ImportPageContent() {
                                 <div className="text-xl font-bold text-[#00BFFF]">
                                     {preview.summary.tidal}
                                 </div>
-                                <div className="text-xs text-gray-500">
+                                <div className="text-xs text-gray-400">
                                     TIDAL
                                 </div>
                             </div>
@@ -596,7 +596,7 @@ function ImportPageContent() {
                                 <div className="text-xl font-bold text-red-400">
                                     {preview.summary.unresolved}
                                 </div>
-                                <div className="text-xs text-gray-500">
+                                <div className="text-xs text-gray-400">
                                     Unresolved
                                 </div>
                             </div>
@@ -624,7 +624,7 @@ function ImportPageContent() {
                                     setPlaylistName(event.target.value)
                                 }
                                 placeholder="Enter playlist name"
-                                className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#1DB954]/50 focus:border-[#1DB954] transition-colors"
+                                className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#1DB954]/50 focus:border-[#1DB954] transition-colors"
                             />
                         </div>
 
@@ -727,7 +727,7 @@ export default function ImportPage() {
         <Suspense
             fallback={
                 <div className="min-h-screen flex items-center justify-center">
-                    <Loader2 className="w-8 h-8 text-[#3b82f6] animate-spin" />
+                    <Loader2 className="w-8 h-8 text-brand animate-spin" />
                 </div>
             }
         >

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -391,7 +391,7 @@ export default function LibraryPage() {
                         {/* Shuffle Button */}
                         <button
                             onClick={handleShuffleLibrary}
-                            className="flex items-center justify-center w-8 h-8 rounded-full bg-[#60a5fa] hover:bg-[#3b82f6] text-black transition-all hover:scale-105"
+                            className="flex items-center justify-center w-8 h-8 rounded-full bg-brand-hover hover:bg-brand text-black transition-all hover:scale-105"
                             title="Shuffle Library"
                         >
                             <Shuffle className="w-4 h-4" />
@@ -433,7 +433,7 @@ export default function LibraryPage() {
                                     onClick={() => setFilter("owned")}
                                     className={`px-3 py-1.5 text-xs font-medium rounded-full transition-all ${
                                         filter === "owned" ?
-                                            "bg-[#3b82f6] text-black"
+                                            "bg-brand text-black"
                                         :   "bg-white/5 text-gray-400 hover:text-white hover:bg-white/10"
                                     }`}
                                 >
@@ -443,7 +443,7 @@ export default function LibraryPage() {
                                     onClick={() => setFilter("discovery")}
                                     className={`px-3 py-1.5 text-xs font-medium rounded-full transition-all ${
                                         filter === "discovery" ?
-                                            "bg-[#2323FF] text-white"
+                                            "bg-ai text-white"
                                         :   "bg-white/5 text-gray-400 hover:text-white hover:bg-white/10"
                                     }`}
                                 >
@@ -468,7 +468,7 @@ export default function LibraryPage() {
                             onChange={(e) =>
                                 setSortBy(e.target.value as SortOption)
                             }
-                            className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                            className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-surface-hover [&>option]:text-white"
                         >
                             <option value="name">Name (A-Z)</option>
                             <option value="name-desc">Name (Z-A)</option>
@@ -486,7 +486,7 @@ export default function LibraryPage() {
                             onChange={(e) =>
                                 setItemsPerPage(Number(e.target.value))
                             }
-                            className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                            className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-surface-hover [&>option]:text-white"
                         >
                             <option value={24}>24 per page</option>
                             <option value={40}>40 per page</option>

--- a/frontend/app/listen-together/page.tsx
+++ b/frontend/app/listen-together/page.tsx
@@ -80,13 +80,13 @@ function CoverThumb({
         return (
             <div
                 className={cn(
-                    "flex items-center justify-center bg-[#1a1a1a] rounded flex-shrink-0",
+                    "flex items-center justify-center bg-surface-hover rounded flex-shrink-0",
                     className
                 )}
                 style={{ width: size, height: size }}
             >
                 <Disc3
-                    className="text-[#525252]"
+                    className="text-content-disabled"
                     style={{ width: size * 0.45, height: size * 0.45 }}
                 />
             </div>
@@ -95,7 +95,7 @@ function CoverThumb({
 
     return (
         <div
-            className={cn("relative overflow-hidden bg-[#1a1a1a] rounded flex-shrink-0", className)}
+            className={cn("relative overflow-hidden bg-surface-hover rounded flex-shrink-0", className)}
             style={{ width: size, height: size }}
         >
             <Image
@@ -257,8 +257,8 @@ function LobbyView() {
             )}
 
             {routeChecking && !routeBlocked && (
-                <div className="flex items-center gap-2 text-sm text-[#a3a3a3] px-1">
-                    <Wifi className="h-3.5 w-3.5 animate-pulse text-[#3b82f6]" />
+                <div className="flex items-center gap-2 text-sm text-content-secondary px-1">
+                    <Wifi className="h-3.5 w-3.5 animate-pulse text-brand" />
                     Verifying socket route...
                 </div>
             )}
@@ -272,7 +272,7 @@ function LobbyView() {
                         <h3 className="text-sm font-medium text-white mb-1">
                             Create a Group
                         </h3>
-                        <p className="text-xs text-[#737373] mb-4">
+                        <p className="text-xs text-content-muted mb-4">
                             Start a session and invite friends
                         </p>
 
@@ -283,14 +283,14 @@ function LobbyView() {
                                 onChange={(e) => setGroupName(e.target.value)}
                             />
 
-                            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[#0f0f0f] border border-[#1c1c1c]">
+                            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-surface-raised border border-surface-active">
                                 <div className="flex items-center gap-2">
                                     {isPublic ? (
-                                        <Globe className="w-4 h-4 text-[#3b82f6]" />
+                                        <Globe className="w-4 h-4 text-brand" />
                                     ) : (
-                                        <Lock className="w-4 h-4 text-[#525252]" />
+                                        <Lock className="w-4 h-4 text-content-disabled" />
                                     )}
-                                    <span className="text-sm text-[#e5e5e5]">
+                                    <span className="text-sm text-content-body">
                                         {isPublic
                                             ? "Public Group"
                                             : "Private Group"}
@@ -304,7 +304,7 @@ function LobbyView() {
                                     className={cn(
                                         "relative h-6 w-11 rounded-full transition-colors",
                                         isPublic
-                                            ? "bg-[#3b82f6]"
+                                            ? "bg-brand"
                                             : "bg-[#3a3a3a]"
                                     )}
                                 >
@@ -319,10 +319,10 @@ function LobbyView() {
                                 </button>
                             </div>
 
-                            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[#0f0f0f] border border-[#1c1c1c]">
+                            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-surface-raised border border-surface-active">
                                 <div className="flex items-center gap-2">
-                                    <Music className="w-4 h-4 text-[#3b82f6]" />
-                                    <span className="text-sm text-[#e5e5e5]">
+                                    <Music className="w-4 h-4 text-brand" />
+                                    <span className="text-sm text-content-body">
                                         Use current queue
                                     </span>
                                 </div>
@@ -336,7 +336,7 @@ function LobbyView() {
                                     className={cn(
                                         "relative h-6 w-11 rounded-full transition-colors",
                                         useCurrentQueue
-                                            ? "bg-[#3b82f6]"
+                                            ? "bg-brand"
                                             : "bg-[#3a3a3a]"
                                     )}
                                 >
@@ -352,7 +352,7 @@ function LobbyView() {
                             </div>
 
                             <button
-                                className="w-full inline-flex items-center justify-center rounded-sm font-medium px-4 py-2.5 transition-colors bg-[#60a5fa] hover:bg-[#3b82f6] text-black shadow-lg shadow-[#3b82f6]/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="w-full inline-flex items-center justify-center rounded-sm font-medium px-4 py-2.5 transition-colors bg-brand-hover hover:bg-brand text-black shadow-lg shadow-brand/10 disabled:opacity-50 disabled:cursor-not-allowed"
                                 onClick={handleCreate}
                                 disabled={
                                     isCreating ||
@@ -375,7 +375,7 @@ function LobbyView() {
                         <h3 className="text-sm font-medium text-white mb-1">
                             Join a Group
                         </h3>
-                        <p className="text-xs text-[#737373] mb-4">
+                        <p className="text-xs text-content-muted mb-4">
                             Enter an invite code to join
                         </p>
 
@@ -392,7 +392,7 @@ function LobbyView() {
                                 className="font-mono tracking-wider text-center uppercase"
                             />
                             <button
-                                className="sm:min-w-[120px] inline-flex items-center justify-center rounded-sm font-medium px-4 py-2.5 transition-colors bg-[#60a5fa] hover:bg-[#3b82f6] text-black shadow-lg shadow-[#3b82f6]/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="sm:min-w-[120px] inline-flex items-center justify-center rounded-sm font-medium px-4 py-2.5 transition-colors bg-brand-hover hover:bg-brand text-black shadow-lg shadow-brand/10 disabled:opacity-50 disabled:cursor-not-allowed"
                                 onClick={handleJoin}
                                 disabled={
                                     isJoining ||
@@ -421,7 +421,7 @@ function LobbyView() {
                             <h3 className="text-sm font-medium text-white mb-0.5">
                                 Public Groups
                             </h3>
-                            <p className="text-xs text-[#737373]">
+                            <p className="text-xs text-content-muted">
                                 Join an open session
                             </p>
                         </div>
@@ -430,7 +430,7 @@ function LobbyView() {
                                 void fetchDiscover(false);
                             }}
                             disabled={isLoadingDiscover}
-                            className="p-1.5 text-[#525252] hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
+                            className="p-1.5 text-content-disabled hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
                         >
                             {isLoadingDiscover ? (
                                 <GradientSpinner size="sm" />
@@ -446,10 +446,10 @@ function LobbyView() {
                         </div>
                     ) : discoverGroups.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-14 text-center">
-                            <div className="w-14 h-14 mx-auto mb-3 rounded-full bg-gradient-to-br from-[#3b82f6]/10 to-amber-600/10 flex items-center justify-center">
-                                <Users className="w-6 h-6 text-[#525252]" />
+                            <div className="w-14 h-14 mx-auto mb-3 rounded-full bg-gradient-to-br from-brand/10 to-amber-600/10 flex items-center justify-center">
+                                <Users className="w-6 h-6 text-content-disabled" />
                             </div>
-                            <p className="text-sm text-[#525252]">
+                            <p className="text-sm text-content-disabled">
                                 No public groups right now
                             </p>
                         </div>
@@ -464,23 +464,23 @@ function LobbyView() {
                                         !canUseListenTogether ||
                                         routeChecking
                                     }
-                                    className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-[#141414] transition-colors text-left group"
+                                    className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-surface-overlay transition-colors text-left group"
                                 >
                                     <div className="flex items-center gap-3 min-w-0">
-                                        <div className="w-8 h-8 rounded-full bg-[#3b82f6]/10 flex items-center justify-center flex-shrink-0">
-                                            <Users className="w-3.5 h-3.5 text-[#3b82f6]" />
+                                        <div className="w-8 h-8 rounded-full bg-brand/10 flex items-center justify-center flex-shrink-0">
+                                            <Users className="w-3.5 h-3.5 text-brand" />
                                         </div>
                                         <div className="min-w-0">
                                             <p className="text-sm font-medium text-white truncate">
                                                 {group.name}
                                             </p>
-                                            <p className="text-xs text-[#525252]">
+                                            <p className="text-xs text-content-disabled">
                                                 {group.memberCount} listener
                                                 {group.memberCount === 1
                                                     ? ""
                                                     : "s"}
                                                 {group.currentTrack && (
-                                                    <span className="text-[#737373]">
+                                                    <span className="text-content-muted">
                                                         {" "}
                                                         &middot;{" "}
                                                         {
@@ -492,7 +492,7 @@ function LobbyView() {
                                             </p>
                                         </div>
                                     </div>
-                                    <span className="text-xs text-[#525252] opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                                    <span className="text-xs text-content-disabled opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
                                         Join
                                     </span>
                                 </button>
@@ -593,8 +593,8 @@ function ActiveGroupView() {
                             className="rounded-lg"
                         />
                     ) : (
-                        <div className="w-12 h-12 rounded-lg bg-[#3b82f6]/10 flex items-center justify-center flex-shrink-0">
-                            <Radio className="w-5 h-5 text-[#3b82f6]" />
+                        <div className="w-12 h-12 rounded-lg bg-brand/10 flex items-center justify-center flex-shrink-0">
+                            <Radio className="w-5 h-5 text-brand" />
                         </div>
                     )}
                     <div className="min-w-0">
@@ -605,7 +605,7 @@ function ActiveGroupView() {
                             <Badge variant="ai">
                                 {isHost ? "Host" : "Follower"}
                             </Badge>
-                            <span className="flex items-center gap-1 text-xs text-[#525252]">
+                            <span className="flex items-center gap-1 text-xs text-content-disabled">
                                 {routeBlocked ? (
                                     <>
                                         <WifiOff className="w-3 h-3 text-red-500" />{" "}
@@ -623,21 +623,21 @@ function ActiveGroupView() {
                                     </>
                                 ) : (
                                     <>
-                                        <Wifi className="w-3 h-3 text-[#3b82f6] animate-pulse" />{" "}
+                                        <Wifi className="w-3 h-3 text-brand animate-pulse" />{" "}
                                         Connecting...
                                     </>
                                 )}
                             </span>
                         </div>
                         {currentTrack ? (
-                            <p className="mt-1.5 text-sm text-[#a3a3a3] truncate">
+                            <p className="mt-1.5 text-sm text-content-secondary truncate">
                                 {currentTrack.title}{" "}
-                                <span className="text-[#525252]">
+                                <span className="text-content-disabled">
                                     &middot; {currentTrack.artist.name}
                                 </span>
                             </p>
                         ) : (
-                            <p className="mt-1.5 text-sm text-[#525252]">
+                            <p className="mt-1.5 text-sm text-content-disabled">
                                 Nothing playing yet
                             </p>
                         )}
@@ -646,30 +646,30 @@ function ActiveGroupView() {
 
                 <button
                     onClick={copyCode}
-                    className="flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-[#0f0f0f] border border-[#1c1c1c] hover:border-[#3b82f6]/30 transition-colors self-start md:self-center"
+                    className="flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-surface-raised border border-surface-active hover:border-brand/30 transition-colors self-start md:self-center"
                     title="Copy join code"
                 >
-                    <span className="font-mono text-sm font-bold text-[#3b82f6] tracking-widest">
+                    <span className="font-mono text-sm font-bold text-brand tracking-widest">
                         {joinCode}
                     </span>
-                    <Copy className="w-3.5 h-3.5 text-[#525252]" />
+                    <Copy className="w-3.5 h-3.5 text-content-disabled" />
                 </button>
             </div>
 
             {/* Separator */}
-            <div className="h-px bg-[#1c1c1c]" />
+            <div className="h-px bg-surface-active" />
 
             {/* Queue + Members grid */}
             <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] gap-6 items-start">
                 {/* Queue */}
                 <section>
                     <div className="flex items-center justify-between mb-3">
-                        <h3 className="text-xs font-medium text-[#737373] uppercase tracking-wider">
+                        <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider">
                             Queue ({playback.queue.length})
                         </h3>
                         {canEditQueue && playback.queue.length > 0 && (
                             <button
-                                className="flex items-center gap-1 text-xs text-[#525252] hover:text-white transition-colors"
+                                className="flex items-center gap-1 text-xs text-content-disabled hover:text-white transition-colors"
                                 onClick={syncClearQueue}
                             >
                                 <Trash2 className="w-3 h-3" />
@@ -680,10 +680,10 @@ function ActiveGroupView() {
 
                     {playback.queue.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-16 text-center">
-                            <div className="w-14 h-14 mb-3 rounded-full bg-gradient-to-br from-[#3b82f6]/10 to-amber-600/10 flex items-center justify-center">
-                                <Music className="w-6 h-6 text-[#525252]" />
+                            <div className="w-14 h-14 mb-3 rounded-full bg-gradient-to-br from-brand/10 to-amber-600/10 flex items-center justify-center">
+                                <Music className="w-6 h-6 text-content-disabled" />
                             </div>
-                            <p className="text-sm text-[#525252]">
+                            <p className="text-sm text-content-disabled">
                                 Queue is empty
                             </p>
                             <p className="text-xs text-[#3f3f3f] mt-1">
@@ -717,18 +717,18 @@ function ActiveGroupView() {
                 {/* Members + Leave */}
                 <div className="space-y-6">
                     <section>
-                        <h3 className="text-xs font-medium text-[#737373] uppercase tracking-wider mb-3">
+                        <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider mb-3">
                             Listeners ({members.length})
                         </h3>
                         <div className="space-y-1">
                             {members.map((member) => (
                                 <div
                                     key={member.userId}
-                                    className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-[#141414] transition-colors"
+                                    className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-surface-overlay transition-colors"
                                 >
                                     <div className="flex items-center gap-3">
-                                        <div className="w-7 h-7 rounded-full bg-[#3b82f6]/10 flex items-center justify-center">
-                                            <span className="text-[10px] font-bold text-[#3b82f6]">
+                                        <div className="w-7 h-7 rounded-full bg-brand/10 flex items-center justify-center">
+                                            <span className="text-[10px] font-bold text-brand">
                                                 {member.username?.[0]?.toUpperCase() ??
                                                     "?"}
                                             </span>
@@ -749,7 +749,7 @@ function ActiveGroupView() {
                                                 "w-2 h-2 rounded-full",
                                                 member.isConnected
                                                     ? "bg-green-500"
-                                                    : "bg-[#525252]"
+                                                    : "bg-content-disabled"
                                             )}
                                             title={
                                                 member.isConnected
@@ -803,8 +803,8 @@ function QueueItem({
             className={cn(
                 "flex items-center gap-3 px-3 py-2 rounded-lg transition-colors group",
                 isCurrentTrack
-                    ? "bg-[#3b82f6]/8 border-l-2 border-[#3b82f6]"
-                    : "hover:bg-[#141414]"
+                    ? "bg-brand/8 border-l-2 border-brand"
+                    : "hover:bg-surface-overlay"
             )}
         >
             {/* Track Number / EQ / Play */}
@@ -814,12 +814,12 @@ function QueueItem({
                 ) : canStartPlayback ? (
                     <button
                         onClick={onPlay}
-                        className="text-[#525252] group-hover:text-white transition-colors"
+                        className="text-content-disabled group-hover:text-white transition-colors"
                     >
                         <span className="text-xs">{index + 1}</span>
                     </button>
                 ) : (
-                    <span className="text-xs text-[#525252]">{index + 1}</span>
+                    <span className="text-xs text-content-disabled">{index + 1}</span>
                 )}
             </div>
 
@@ -838,7 +838,7 @@ function QueueItem({
                         className={cn(
                             "text-sm truncate",
                             isCurrentTrack
-                                ? "text-[#3b82f6] font-medium"
+                                ? "text-brand font-medium"
                                 : "text-white"
                         )}
                     >
@@ -847,13 +847,13 @@ function QueueItem({
                     {item.streamSource === "tidal" && <TidalBadge />}
                     {item.streamSource === "youtube" && <YouTubeBadge />}
                 </div>
-                <p className="text-xs text-[#525252] truncate">
+                <p className="text-xs text-content-disabled truncate">
                     {item.artist.name} &middot; {item.album.title}
                 </p>
             </div>
 
             {/* Duration */}
-            <span className="text-xs text-[#525252] flex-shrink-0 tabular-nums">
+            <span className="text-xs text-content-disabled flex-shrink-0 tabular-nums">
                 {formatTime(item.duration)}
             </span>
 
@@ -912,10 +912,10 @@ export default function ListenTogetherPage() {
         <div className="min-h-screen relative">
             {/* Ambient background */}
             <div className="fixed inset-0 pointer-events-none overflow-hidden">
-                <div className="absolute -top-20 -right-20 w-[600px] h-[600px] rounded-full bg-[#3b82f6]/8 blur-[140px]" />
+                <div className="absolute -top-20 -right-20 w-[600px] h-[600px] rounded-full bg-brand/8 blur-[140px]" />
                 <div className="absolute -bottom-40 -left-40 w-[400px] h-[400px] rounded-full bg-[#1d4ed8]/6 blur-[100px]" />
             </div>
-            <div className="absolute inset-x-0 top-0 h-[220px] bg-gradient-to-b from-[#3b82f6]/12 via-[#1d4ed8]/6 to-transparent pointer-events-none" />
+            <div className="absolute inset-x-0 top-0 h-[220px] bg-gradient-to-b from-brand/12 via-[#1d4ed8]/6 to-transparent pointer-events-none" />
 
             {/* Content */}
             <div className="relative px-4 md:px-8 py-6 pb-32">
@@ -933,7 +933,7 @@ export default function ListenTogetherPage() {
                             {...fadeSlide}
                         >
                             <GradientSpinner size="lg" />
-                            <p className="text-sm text-[#525252] mt-4">
+                            <p className="text-sm text-content-disabled mt-4">
                                 Loading...
                             </p>
                         </motion.div>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -189,7 +189,7 @@ export default function LoginPage() {
             {/* Animated Background with Artist Images */}
             <div className="absolute inset-0 bg-[#000]">
                 {/* Subtle accent gradient */}
-                <div className="absolute inset-0 bg-gradient-to-br from-[#3b82f6]/5 via-transparent to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-br from-brand/5 via-transparent to-transparent" />
 
                 {/* Ultra-subtle starfield texture (dialed down vs the main app) */}
                 <div className="opacity-[0.08]">
@@ -420,7 +420,7 @@ export default function LoginPage() {
                             <button
                                 type="submit"
                                 disabled={isLoading}
-                                className="w-full py-3 bg-[#3b82f6] text-black font-bold rounded-lg hover:bg-[#2563eb] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="w-full py-3 bg-brand text-black font-bold rounded-lg hover:bg-brand-dark transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <span className="flex items-center justify-center gap-2">
                                     {isLoading ? (
@@ -454,7 +454,7 @@ export default function LoginPage() {
                             Have an invite code?{" "}
                             <Link
                                 href="/register"
-                                className="text-[#3b82f6] hover:text-[#60a5fa] transition-colors"
+                                className="text-brand hover:text-brand-hover transition-colors"
                             >
                                 Create an account
                             </Link>

--- a/frontend/app/mix/[id]/page.tsx
+++ b/frontend/app/mix/[id]/page.tsx
@@ -54,9 +54,9 @@ export default function MixPage() {
         return (
             <div className="p-6">
                 <h1 className="text-xl font-semibold text-white mb-4">Mix</h1>
-                <div className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-lg p-6">
-                    <p className="text-[#a3a3a3] mb-2">Feature not available</p>
-                    <p className="text-sm text-[#737373]">
+                <div className="bg-surface-raised border border-surface-active rounded-lg p-6">
+                    <p className="text-content-secondary mb-2">Feature not available</p>
+                    <p className="text-sm text-content-muted">
                         Auto-generated mixes are disabled on this server.
                     </p>
                 </div>
@@ -216,7 +216,7 @@ function MixPageContent() {
     if (!mix) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <p className="text-gray-500">Mix not found</p>
+                <p className="text-gray-400">Mix not found</p>
             </div>
         );
     }
@@ -234,11 +234,11 @@ function MixPageContent() {
             >
                 <div className="flex items-end gap-6">
                         {/* Cover Art Mosaic */}
-                        <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden">
+                        <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden">
                             <CoverMosaic
                                 coverUrls={(mix.coverUrls || []).slice(0, 4).map((url: string) => api.getCoverArtUrl(url, 200))}
                                 imageSizes="96px"
-                                emptyState={<Music className="w-16 h-16 text-gray-600" />}
+                                emptyState={<Music className="w-16 h-16 text-gray-400" />}
                             />
                         </div>
 
@@ -264,13 +264,13 @@ function MixPageContent() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {/* Play Button */}
                     {mix.tracks && mix.tracks.length > 0 && (
                         <button
                             onClick={handlePlayMix}
-                            className="h-12 w-12 rounded-full bg-[#60a5fa] hover:bg-[#3b82f6] hover:scale-105 flex items-center justify-center shadow-lg transition-all"
+                            className="h-12 w-12 rounded-full bg-brand-hover hover:bg-brand hover:scale-105 flex items-center justify-center shadow-lg transition-all"
                         >
                             {showPlaySpinner ? (
                                 <Loader2 className="w-5 h-5 animate-spin text-black" />
@@ -333,7 +333,7 @@ function MixPageContent() {
                                             isCurrentlyPlaying && "bg-white/10",
                                             isInQueue &&
                                                 !isCurrentlyPlaying &&
-                                                "bg-[#3b82f6]/[0.06]"
+                                                "bg-brand/[0.06]"
                                         )}
                                     >
                                         {/* Track Number / Play Icon */}
@@ -341,11 +341,11 @@ function MixPageContent() {
                                             <span
                                                 className={cn(
                                                     "text-sm group-hover:hidden",
-                                                    isCurrentlyPlaying ? "text-[#3b82f6]" : "text-gray-400"
+                                                    isCurrentlyPlaying ? "text-brand" : "text-gray-400"
                                                 )}
                                             >
                                                 {isCurrentlyPlaying && isPlaying ? (
-                                                    <Music className="w-4 h-4 text-[#3b82f6] animate-pulse" />
+                                                    <Music className="w-4 h-4 text-brand animate-pulse" />
                                                 ) : (
                                                     index + 1
                                                 )}
@@ -355,7 +355,7 @@ function MixPageContent() {
 
                                         {/* Title + Artist */}
                                         <div className="flex items-center gap-3 min-w-0">
-                                            <div className="relative w-10 h-10 bg-[#282828] rounded shrink-0 overflow-hidden">
+                                            <div className="relative w-10 h-10 bg-surface-highlight rounded shrink-0 overflow-hidden">
                                                 {track.album?.coverUrl ? (
                                                     <Image
                                                         src={api.getCoverArtUrl(track.album.coverUrl, 100)}
@@ -367,7 +367,7 @@ function MixPageContent() {
                                                     />
                                                 ) : (
                                                     <div className="w-full h-full flex items-center justify-center">
-                                                        <Music className="w-5 h-5 text-gray-600" />
+                                                        <Music className="w-5 h-5 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -375,14 +375,14 @@ function MixPageContent() {
                                                 <p
                                                     className={cn(
                                                         "text-sm font-medium flex items-center gap-2 min-w-0",
-                                                        isCurrentlyPlaying ? "text-[#3b82f6]" : "text-white"
+                                                        isCurrentlyPlaying ? "text-brand" : "text-white"
                                                     )}
                                                 >
                                                     <span className="truncate">
                                                         {track.title}
                                                     </span>
                                                     {isInQueue && (
-                                                        <span className="shrink-0 text-[10px] bg-[#3b82f6]/15 text-[#93c5fd] px-1.5 py-0.5 rounded border border-[#3b82f6]/30 font-medium">
+                                                        <span className="shrink-0 text-[10px] bg-brand/15 text-brand-light px-1.5 py-0.5 rounded border border-brand/30 font-medium">
                                                             IN QUEUE
                                                         </span>
                                                     )}
@@ -421,11 +421,11 @@ function MixPageContent() {
                     </div>
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
-                        <div className="w-20 h-20 bg-[#282828] rounded-full flex items-center justify-center mb-4">
-                            <Music className="w-10 h-10 text-gray-500" />
+                        <div className="w-20 h-20 bg-surface-highlight rounded-full flex items-center justify-center mb-4">
+                            <Music className="w-10 h-10 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-1">No tracks</h3>
-                        <p className="text-sm text-gray-500">This mix is empty</p>
+                        <p className="text-sm text-gray-400">This mix is empty</p>
                     </div>
                 )}
             </div>

--- a/frontend/app/my-history/page.tsx
+++ b/frontend/app/my-history/page.tsx
@@ -176,10 +176,10 @@ export default function MyHistoryPage() {
                             {streamSource === "tidal" ? <TidalBadge /> : <YouTubeBadge />}
                         </div>
                     )}
-                    <p className="text-[11px] text-gray-500 truncate">
+                    <p className="text-[11px] text-gray-400 truncate">
                         {track.album?.title || "Unknown Album"}
                     </p>
-                    <p className="text-[11px] text-gray-500 mt-1">
+                    <p className="text-[11px] text-gray-400 mt-1">
                         Played {formatPlayedAt(entry.playedAt)}
                     </p>
                 </>
@@ -196,7 +196,7 @@ export default function MyHistoryPage() {
     }
 
     return (
-        <div className="min-h-screen bg-[#0a0a0a]">
+        <div className="min-h-screen bg-surface">
             <div className="max-w-4xl mx-auto p-4 md:p-8 space-y-6">
                 <PageHeader
                     title="My History"
@@ -258,9 +258,9 @@ export default function MyHistoryPage() {
                                 onPlay={handlePlayFromHistory}
                                 rowSlots={historyRowSlots}
                                 rowOverflow={historyRowOverflow}
-                                rowClassName="grid-cols-[1fr_auto] p-4 hover:bg-[#1a1a1a]"
+                                rowClassName="grid-cols-[1fr_auto] p-4 hover:bg-surface-hover"
                                 preferenceMode="up-only"
-                                className="divide-y divide-[#1c1c1c]"
+                                className="divide-y divide-surface-active"
                             />
                         </Card>
                     </section>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -196,7 +196,7 @@ export default function OnboardingPage() {
         <div className="min-h-screen relative overflow-hidden">
             {/* Dark background (matches login) */}
             <div className="absolute inset-0 bg-[#000]">
-                <div className="absolute inset-0 bg-gradient-to-br from-[#3b82f6]/5 via-transparent to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-br from-brand/5 via-transparent to-transparent" />
             </div>
 
             {/* Show loading spinner while checking session */}
@@ -246,7 +246,7 @@ export default function OnboardingPage() {
                                         <div
                                             className={`w-9 h-9 rounded-lg flex items-center justify-center font-bold text-sm transition-all ${
                                                 s.num === step
-                                                    ? "bg-[#3b82f6] text-black shadow-lg shadow-[#3b82f6]/20 scale-110"
+                                                    ? "bg-brand text-black shadow-lg shadow-brand/20 scale-110"
                                                     : s.num < step
                                                     ? "bg-white/5 text-white/80 border border-white/10"
                                                     : "bg-white/5 text-white/40 border border-white/10"
@@ -268,7 +268,7 @@ export default function OnboardingPage() {
                                         <div
                                             className={`w-16 h-0.5 mx-4 mb-6 transition-all ${
                                                 s.num < step
-                                                    ? "bg-[#3b82f6]/25"
+                                                    ? "bg-brand/25"
                                                     : "bg-white/10"
                                             }`}
                                         />
@@ -369,7 +369,7 @@ export default function OnboardingPage() {
                                             <button
                                                 type="submit"
                                                 disabled={loading}
-                                                className="w-full py-3.5 bg-[#3b82f6] text-black font-bold rounded-lg hover:bg-[#2563eb] transition-all disabled:opacity-50 disabled:cursor-not-allowed relative group overflow-hidden mt-8 focus:outline-none focus:ring-2 focus:ring-brand/30"
+                                                className="w-full py-3.5 bg-brand text-black font-bold rounded-lg hover:bg-brand-dark transition-all disabled:opacity-50 disabled:cursor-not-allowed relative group overflow-hidden mt-8 focus:outline-none focus:ring-2 focus:ring-brand/30"
                                             >
                                                 <span className="relative z-10 flex items-center justify-center gap-2">
                                                     {loading ? (
@@ -554,7 +554,7 @@ export default function OnboardingPage() {
                                                 onKeyDown={(e) => e.key === 'Enter' && !loading && handleNextStep()}
                                                 disabled={loading}
                                                 tabIndex={0}
-                                                className="flex-1 py-3.5 bg-[#3b82f6] text-black font-bold rounded-lg hover:bg-[#2563eb] transition-all disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-brand/30"
+                                                className="flex-1 py-3.5 bg-brand text-black font-bold rounded-lg hover:bg-brand-dark transition-all disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-brand/30"
                                             >
                                                 {loading
                                                     ? "Saving..."
@@ -575,7 +575,7 @@ export default function OnboardingPage() {
                                             </p>
                                         </div>
 
-                                        <div className="bg-[#0f0f0f] border border-white/10 rounded-lg p-6 mt-8">
+                                        <div className="bg-surface-raised border border-white/10 rounded-lg p-6 mt-8">
                                             <h3 className="text-lg font-semibold text-white mb-4">
                                                 Detected Analysis Features
                                             </h3>
@@ -589,10 +589,10 @@ export default function OnboardingPage() {
                                                 <div className="space-y-4">
                                                     <div className={`p-4 rounded-lg border ${musicCNN ? "bg-green-500/5 border-green-500/20" : "bg-white/5 border-white/10"}`}>
                                                         <div className="flex items-center gap-3 mb-2">
-                                                            <span className={musicCNN ? "text-green-400" : "text-gray-500"}>
+                                                            <span className={musicCNN ? "text-green-400" : "text-gray-400"}>
                                                                 {musicCNN ? "\u2713" : "\u2014"}
                                                             </span>
-                                                            <span className={`font-medium ${musicCNN ? "text-white" : "text-gray-500"}`}>
+                                                            <span className={`font-medium ${musicCNN ? "text-white" : "text-gray-400"}`}>
                                                                 MusicCNN Audio Analysis
                                                             </span>
                                                         </div>
@@ -602,10 +602,10 @@ export default function OnboardingPage() {
                                                     </div>
                                                     <div className={`p-4 rounded-lg border ${vibeEmbeddings ? "bg-green-500/5 border-green-500/20" : "bg-white/5 border-white/10"}`}>
                                                         <div className="flex items-center gap-3 mb-2">
-                                                            <span className={vibeEmbeddings ? "text-green-400" : "text-gray-500"}>
+                                                            <span className={vibeEmbeddings ? "text-green-400" : "text-gray-400"}>
                                                                 {vibeEmbeddings ? "\u2713" : "\u2014"}
                                                             </span>
-                                                            <span className={`font-medium ${vibeEmbeddings ? "text-white" : "text-gray-500"}`}>
+                                                            <span className={`font-medium ${vibeEmbeddings ? "text-white" : "text-gray-400"}`}>
                                                                 CLAP Vibe Embeddings
                                                             </span>
                                                         </div>
@@ -639,11 +639,11 @@ export default function OnboardingPage() {
                                             </div>
                                         </div>
 
-                                        <div className="bg-[#0f0f0f] border border-white/10 rounded-lg p-6">
+                                        <div className="bg-surface-raised border border-white/10 rounded-lg p-6">
                                             <div className="flex items-start gap-4">
-                                                <div className="w-12 h-12 bg-[#3b82f6]/10 border border-[#3b82f6]/20 rounded-lg flex items-center justify-center flex-shrink-0">
+                                                <div className="w-12 h-12 bg-brand/10 border border-brand/20 rounded-lg flex items-center justify-center flex-shrink-0">
                                                     <svg
-                                                        className="w-6 h-6 text-[#3b82f6]"
+                                                        className="w-6 h-6 text-brand"
                                                         fill="none"
                                                         stroke="currentColor"
                                                         viewBox="0 0 24 24"
@@ -683,7 +683,7 @@ export default function OnboardingPage() {
                                                 onClick={handleNextStep}
                                                 onKeyDown={(e) => e.key === 'Enter' && !loading && handleNextStep()}
                                                 disabled={loading}
-                                                className="w-full py-3.5 bg-[#3b82f6] text-black font-bold rounded-lg hover:bg-[#2563eb] transition-all duration-200 disabled:opacity-50 disabled:hover:scale-100 relative group overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand/30"
+                                                className="w-full py-3.5 bg-brand text-black font-bold rounded-lg hover:bg-brand-dark transition-all duration-200 disabled:opacity-50 disabled:hover:scale-100 relative group overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand/30"
                                             >
                                                 <span className="relative z-10 flex items-center justify-center gap-2">
                                                     {loading ? (
@@ -756,7 +756,7 @@ function IntegrationCard({
         <div
             className={`border rounded-lg transition-all ${
                 enabled
-                    ? "bg-[#0f0f0f] border-brand/25"
+                    ? "bg-surface-raised border-brand/25"
                     : "bg-white/5 border-white/10"
             }`}
         >
@@ -766,7 +766,7 @@ function IntegrationCard({
                         <div
                             className={`w-9 h-9 rounded-lg flex items-center justify-center ${
                                 enabled
-                                    ? "bg-[#3b82f6]/10 border border-[#3b82f6]/20 text-[#3b82f6]"
+                                    ? "bg-brand/10 border border-brand/20 text-brand"
                                     : "bg-white/5 border border-white/10 text-white/40"
                             }`}
                         >
@@ -784,11 +784,11 @@ function IntegrationCard({
                         onKeyDown={(e) => e.key === 'Enter' && onToggle()}
                         tabIndex={0}
                         className={`relative w-11 h-6 rounded-lg transition-all ${
-                            enabled ? "bg-[#3b82f6]" : "bg-white/20"
+                            enabled ? "bg-brand" : "bg-white/20"
                         } focus:outline-none focus:ring-2 focus:ring-brand/30`}
                     >
                         <div
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-[#3b82f6] rounded-lg transition-all shadow-lg ${
+                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-brand rounded-lg transition-all shadow-lg ${
                                 enabled ? "translate-x-5" : ""
                             }`}
                         />
@@ -889,7 +889,7 @@ function SoulseekCard({
         <div
             className={`border rounded-lg transition-all ${
                 enabled
-                    ? "bg-[#0f0f0f] border-brand/25"
+                    ? "bg-surface-raised border-brand/25"
                     : "bg-white/5 border-white/10"
             }`}
         >
@@ -899,7 +899,7 @@ function SoulseekCard({
                         <div
                             className={`w-9 h-9 rounded-lg flex items-center justify-center ${
                                 enabled
-                                    ? "bg-[#3b82f6]/10 border border-[#3b82f6]/20 text-[#3b82f6]"
+                                    ? "bg-brand/10 border border-brand/20 text-brand"
                                     : "bg-white/5 border border-white/10 text-white/40"
                             }`}
                         >
@@ -929,11 +929,11 @@ function SoulseekCard({
                         onKeyDown={(e) => e.key === 'Enter' && onToggle()}
                         tabIndex={0}
                         className={`relative w-11 h-6 rounded-lg transition-all ${
-                            enabled ? "bg-[#3b82f6]" : "bg-white/20"
+                            enabled ? "bg-brand" : "bg-white/20"
                         } focus:outline-none focus:ring-2 focus:ring-brand/30`}
                     >
                         <div
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-[#3b82f6] rounded-lg transition-all shadow-lg ${
+                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-brand rounded-lg transition-all shadow-lg ${
                                 enabled ? "translate-x-5" : ""
                             }`}
                         />
@@ -962,7 +962,7 @@ function SoulseekCard({
                                 href="https://www.slsknet.org/news/node/1"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="text-[#3b82f6] hover:underline"
+                                className="text-brand hover:underline"
                             >
                                 slsknet.org
                             </a>

--- a/frontend/app/playlist/[id]/page.tsx
+++ b/frontend/app/playlist/[id]/page.tsx
@@ -660,7 +660,7 @@ export default function PlaylistDetailPage() {
     if (!playlist) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <p className="text-gray-500">Playlist not found</p>
+                <p className="text-gray-400">Playlist not found</p>
             </div>
         );
     }
@@ -668,10 +668,10 @@ export default function PlaylistDetailPage() {
     return (
         <div className="min-h-screen">
             {/* Compact Hero - Spotify Style */}
-            <div className="relative bg-gradient-to-b from-[#3d2a1e] via-[#1a1a1a] to-transparent pt-16 pb-10 px-4 md:px-8">
+            <div className="relative bg-gradient-to-b from-[#3d2a1e] via-surface-hover to-transparent pt-16 pb-10 px-4 md:px-8">
                 <div className="flex items-end gap-6">
                     {/* Cover Art */}
-                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden">
+                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden">
                         <CoverMosaic
                             coverUrls={coverUrls}
                             imageSizes="96px"
@@ -743,13 +743,13 @@ export default function PlaylistDetailPage() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {/* Play Button */}
                     {trackItems.length > 0 && (
                         <button
                             onClick={handlePlayPlaylist}
-                            className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-[#60a5fa] hover:bg-[#3b82f6] hover:scale-105 shadow-lg transition-all font-semibold text-sm text-black"
+                            className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-brand-hover hover:bg-brand hover:scale-105 shadow-lg transition-all font-semibold text-sm text-black"
                         >
                             {showPlaySpinner ? (
                                 <Loader2 className="w-5 h-5 animate-spin" />
@@ -799,7 +799,7 @@ export default function PlaylistDetailPage() {
                                 isApplyingLikeAll
                                     ? "cursor-not-allowed text-white/35"
                                     : isAllLiked
-                                        ? "text-[#3b82f6] hover:bg-white/10"
+                                        ? "text-brand hover:bg-white/10"
                                         : "text-white/60 hover:bg-white/10 hover:text-white"
                             )}
                             title={isAllLiked ? "Unlike all tracks" : "Like all tracks"}
@@ -834,7 +834,7 @@ export default function PlaylistDetailPage() {
                             className={cn(
                                 "h-8 w-8 rounded-full flex items-center justify-center transition-all",
                                 playlist.isPublic
-                                    ? "text-[#3b82f6] hover:text-[#2563eb]"
+                                    ? "text-brand hover:text-brand-dark"
                                     : "text-white/40 hover:text-white",
                                 isTogglingShare && "opacity-50 cursor-not-allowed"
                             )}
@@ -867,7 +867,7 @@ export default function PlaylistDetailPage() {
                         className={cn(
                             "h-8 w-8 rounded-full flex items-center justify-center transition-all",
                             playlist.isHidden
-                                ? "text-[#3b82f6] hover:text-[#2563eb]"
+                                ? "text-brand hover:text-brand-dark"
                                 : "text-white/40 hover:text-white",
                             isHiding && "opacity-50 cursor-not-allowed"
                         )}
@@ -943,14 +943,14 @@ export default function PlaylistDetailPage() {
                                         <AlertCircle className="w-4 h-4 text-red-400" />
                                     </div>
                                     <div className="flex items-center gap-3 min-w-0">
-                                        <div className="w-10 h-10 bg-[#282828] rounded shrink-0 overflow-hidden flex items-center justify-center">
+                                        <div className="w-10 h-10 bg-surface-highlight rounded shrink-0 overflow-hidden flex items-center justify-center">
                                             <button
                                                 onClick={() => handlePlayPreview(pending.id)}
                                                 className="w-full h-full flex items-center justify-center hover:bg-white/10 transition-colors"
                                                 title="Play 30s Deezer preview"
                                             >
                                                 {isPreviewPlaying ? (
-                                                    <Volume2 className="w-5 h-5 text-[#3b82f6] animate-pulse" />
+                                                    <Volume2 className="w-5 h-5 text-brand animate-pulse" />
                                                 ) : (
                                                     <Play className="w-5 h-5 text-gray-400 hover:text-white" />
                                                 )}
@@ -958,17 +958,17 @@ export default function PlaylistDetailPage() {
                                         </div>
                                         <div className="min-w-0">
                                             <p className="text-sm font-medium truncate text-gray-400">{pending.title}</p>
-                                            <p className="text-xs text-gray-500 truncate">{pending.artist}</p>
+                                            <p className="text-xs text-gray-400 truncate">{pending.artist}</p>
                                         </div>
                                     </div>
-                                    <p className="hidden md:flex items-center text-sm text-gray-500 truncate">{pending.album}</p>
+                                    <p className="hidden md:flex items-center text-sm text-gray-400 truncate">{pending.album}</p>
                                     <div className="flex items-center justify-end gap-1">
                                         <span className="text-xs text-red-400 mr-2 hidden sm:inline">Failed</span>
                                         {downloadsEnabled && (
                                             <button
                                                 onClick={(e) => { e.stopPropagation(); handleRetryPendingTrack(pending.id); }}
                                                 disabled={isRetrying}
-                                                className={cn("p-1.5 rounded-full hover:bg-white/10 transition-all", isRetrying ? "text-[#3b82f6]" : "text-gray-400 hover:text-white")}
+                                                className={cn("p-1.5 rounded-full hover:bg-white/10 transition-all", isRetrying ? "text-brand" : "text-gray-400 hover:text-white")}
                                                 title="Retry download"
                                             >
                                                 {isRetrying ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
@@ -1088,7 +1088,7 @@ export default function PlaylistDetailPage() {
 
                                         return (
                                             <div className="flex items-center justify-end gap-1">
-                                                <span className="hidden sm:inline text-xs text-gray-500 w-10 text-right tabular-nums">
+                                                <span className="hidden sm:inline text-xs text-gray-400 w-10 text-right tabular-nums">
                                                     {track?.duration ? formatTime(track.duration) : "--:--"}
                                                 </span>
                                                 {canShowLocalActions && (
@@ -1179,13 +1179,13 @@ export default function PlaylistDetailPage() {
                     </div>
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
-                        <div className="w-20 h-20 bg-[#282828] rounded-full flex items-center justify-center mb-4">
-                            <ListMusic className="w-10 h-10 text-gray-500" />
+                        <div className="w-20 h-20 bg-surface-highlight rounded-full flex items-center justify-center mb-4">
+                            <ListMusic className="w-10 h-10 text-gray-400" />
                         </div>
                         <h3 className="text-lg font-medium text-white mb-1">
                             No tracks yet
                         </h3>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-400">
                             Add some tracks to get started
                         </p>
                     </div>

--- a/frontend/app/playlist/my-liked/page.tsx
+++ b/frontend/app/playlist/my-liked/page.tsx
@@ -85,7 +85,7 @@ function LikedTrackList({ tracks, likedTrackIds, removingTrackId, onPlay, onUnli
                 ),
                 trailingActions: (
                     <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
-                        <span className="hidden sm:inline text-xs text-gray-500 w-10 text-right tabular-nums">
+                        <span className="hidden sm:inline text-xs text-gray-400 w-10 text-right tabular-nums">
                             {formatTime(track.duration)}
                         </span>
                         <TrackPreferenceButtons
@@ -350,17 +350,17 @@ export default function MyLikedPlaylistPage() {
             <div className="relative pt-16 pb-10 px-4 md:px-8">
                 <div className="absolute inset-0 pointer-events-none">
                     <div
-                        className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                        className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                         style={{ height: "35vh" }}
                     />
                     <div
-                        className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                        className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                         style={{ height: "25vh" }}
                     />
                 </div>
                 <div className="relative flex items-end gap-6">
                     {/* Cover Art / Icon */}
-                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden relative">
+                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden relative">
                         {coverUrl ? (
                             <CachedImage
                                 src={coverUrl}
@@ -370,8 +370,8 @@ export default function MyLikedPlaylistPage() {
                                 sizes="192px"
                             />
                         ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-[#3b82f6]/20 to-[#1e3a5f]/30">
-                                <Heart className="h-16 w-16 text-[#60a5fa]" />
+                            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-brand/20 to-[#1e3a5f]/30">
+                                <Heart className="h-16 w-16 text-brand-hover" />
                             </div>
                         )}
                         <div className="absolute bottom-2 right-2 drop-shadow-lg">
@@ -404,12 +404,12 @@ export default function MyLikedPlaylistPage() {
             </div>
 
             {/* Action Bar */}
-            <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+            <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
                 <div className="flex items-center gap-4">
                     {likedTracks.length > 0 && (
                         <button
                             onClick={handlePlayAll}
-                            className="flex items-center gap-2 rounded-full bg-[#60a5fa] px-5 py-2.5 text-sm font-semibold text-black shadow-lg transition-all hover:bg-[#3b82f6] hover:scale-105"
+                            className="flex items-center gap-2 rounded-full bg-brand-hover px-5 py-2.5 text-sm font-semibold text-black shadow-lg transition-all hover:bg-brand hover:scale-105"
                         >
                             {showPlaySpinner ? (
                                 <Loader2 className="h-5 w-5 animate-spin" />

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -70,10 +70,10 @@ function PlaylistMosaic({
             showEmptyCellIcon
             emptyState={
                 <div className={cn(
-                    "w-full h-full flex items-center justify-center bg-gradient-to-br from-[#282828] to-[#181818]",
+                    "w-full h-full flex items-center justify-center bg-gradient-to-br from-surface-highlight to-surface-elevated",
                     greyed && "opacity-50"
                 )}>
-                    <Music className="w-10 h-10 text-gray-600" />
+                    <Music className="w-10 h-10 text-gray-400" />
                 </div>
             }
         />
@@ -121,7 +121,7 @@ function PlaylistCard({
                 tabIndex={0}
             >
                 {/* Cover Image */}
-                <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-[#282828] shadow-lg">
+                <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-surface-highlight shadow-lg">
                     <PlaylistMosaic
                         items={playlist.items}
                         greyed={isHiddenView}
@@ -191,7 +191,7 @@ function PlaylistCard({
                 </h3>
                 <p className="text-xs text-gray-400 mt-0.5 truncate">
                     {isShared && playlist.user?.username ? (
-                        <span className="text-gray-500">
+                        <span className="text-gray-400">
                             By {playlist.user.username} ·{" "}
                         </span>
                     ) : null}
@@ -307,11 +307,11 @@ export default function PlaylistsPage() {
             {/* Quick gradient fade - yellow to purple */}
             <div className="absolute inset-0 pointer-events-none">
                 <div
-                    className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                    className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                     style={{ height: "35vh" }}
                 />
                 <div
-                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                     style={{ height: "25vh" }}
                 />
             </div>
@@ -336,7 +336,7 @@ export default function PlaylistsPage() {
                             </Link>
                             <Link
                                 href="/explore"
-                                className="px-4 py-2 rounded-full text-sm font-medium bg-[#3b82f6] text-black hover:brightness-110 transition-all"
+                                className="px-4 py-2 rounded-full text-sm font-medium bg-brand text-black hover:brightness-110 transition-all"
                             >
                                 Explore Playlists
                             </Link>
@@ -387,7 +387,7 @@ export default function PlaylistsPage() {
                                     data-tv-card-index={0}
                                     tabIndex={0}
                                 >
-                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden shadow-lg bg-gradient-to-br from-[#3b82f6] to-[#1d4ed8] flex items-center justify-center">
+                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden shadow-lg bg-gradient-to-br from-brand to-[#1d4ed8] flex items-center justify-center">
                                         <Heart className="w-12 h-12 text-white fill-white/80" />
                                     </div>
                                     <h3 className="text-sm font-semibold truncate text-white">
@@ -415,7 +415,7 @@ export default function PlaylistsPage() {
                 ) : (
                     <div className="flex flex-col items-center justify-center py-24 text-center">
                         <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center mb-4">
-                            <Music className="w-8 h-8 text-gray-500" />
+                            <Music className="w-8 h-8 text-gray-400" />
                         </div>
                         <h2 className="text-lg font-semibold text-white mb-1">
                             {showHiddenTab
@@ -430,7 +430,7 @@ export default function PlaylistsPage() {
                         {!showHiddenTab && (
                             <Link
                                 href="/explore"
-                                className="mt-6 px-5 py-2.5 rounded-full text-sm font-medium bg-[#3b82f6] text-black hover:brightness-110 transition-all"
+                                className="mt-6 px-5 py-2.5 rounded-full text-sm font-medium bg-brand text-black hover:brightness-110 transition-all"
                             >
                                 Explore Playlists
                             </Link>

--- a/frontend/app/podcasts/[id]/page.tsx
+++ b/frontend/app/podcasts/[id]/page.tsx
@@ -64,7 +64,7 @@ export default function PodcastDetailPage() {
     if (!podcast && !previewData) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <p className="text-gray-500">Podcast not found</p>
+                <p className="text-gray-400">Podcast not found</p>
             </div>
         );
     }

--- a/frontend/app/podcasts/genre/[genreId]/page.tsx
+++ b/frontend/app/podcasts/genre/[genreId]/page.tsx
@@ -119,7 +119,7 @@ export default function GenrePage() {
     }
 
     return (
-        <div className="min-h-screen bg-gradient-to-b from-black to-[#121212] text-white p-6 md:p-8">
+        <div className="min-h-screen bg-gradient-to-b from-black to-surface-sunken text-white p-6 md:p-8">
             {/* Header */}
             <div className="mb-8">
                 <button
@@ -141,9 +141,9 @@ export default function GenrePage() {
                     <div
                         key={podcast.id}
                         onClick={() => handlePodcastClick(podcast)}
-                        className="bg-gradient-to-br from-[#121212] to-[#121212] hover:from-[#181818] hover:to-[#1a1a1a] transition-all p-4 rounded-lg cursor-pointer group border border-[#1c1c1c]"
+                        className="bg-gradient-to-br from-surface-sunken to-surface-sunken hover:from-surface-elevated hover:to-surface-hover transition-all p-4 rounded-lg cursor-pointer group border border-surface-active"
                     >
-                        <div className="relative w-full aspect-square bg-[#181818] rounded-full mb-3 overflow-hidden">
+                        <div className="relative w-full aspect-square bg-surface-elevated rounded-full mb-3 overflow-hidden">
                             {podcast.coverUrl ? (
                                 <Image
                                     src={podcast.coverUrl}
@@ -155,7 +155,7 @@ export default function GenrePage() {
                                 />
                             ) : (
                                 <div className="w-full h-full flex items-center justify-center">
-                                    <Mic2 className="w-16 h-16 text-gray-700" />
+                                    <Mic2 className="w-16 h-16 text-gray-400" />
                                 </div>
                             )}
                         </div>
@@ -189,7 +189,7 @@ export default function GenrePage() {
             {/* No results */}
             {!loading && podcasts.length === 0 && (
                 <div className="text-center py-20">
-                    <Mic2 className="w-16 h-16 text-gray-700 mx-auto mb-4" />
+                    <Mic2 className="w-16 h-16 text-gray-400 mx-auto mb-4" />
                     <p className="text-gray-400">No podcasts found</p>
                 </div>
             )}

--- a/frontend/app/podcasts/page.tsx
+++ b/frontend/app/podcasts/page.tsx
@@ -220,11 +220,11 @@ export default function PodcastsPage() {
             {/* Quick gradient fade - yellow to purple */}
             <div className="absolute inset-0 pointer-events-none">
                 <div
-                    className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                    className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                     style={{ height: "35vh" }}
                 />
                 <div
-                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                     style={{ height: "25vh" }}
                 />
             </div>
@@ -244,13 +244,13 @@ export default function PodcastsPage() {
                         className="relative w-full md:w-96 md:ml-auto"
                         ref={dropdownRef}
                     >
-                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 z-10" />
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 z-10" />
                         <input
                             type="text"
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
                             placeholder="Quick add..."
-                            className="w-full pl-11 pr-4 py-3 bg-white/5 border border-white/10 rounded-full text-white placeholder-gray-500 focus:outline-none focus:border-[#2323FF] focus:bg-white/10 transition-all text-sm"
+                            className="w-full pl-11 pr-4 py-3 bg-white/5 border border-white/10 rounded-full text-white placeholder-gray-500 focus:outline-none focus:border-ai focus:bg-white/10 transition-all text-sm"
                         />
                         {isSearching && (
                             <div className="absolute right-4 top-1/2 -translate-y-1/2 z-10">
@@ -260,7 +260,7 @@ export default function PodcastsPage() {
 
                         {/* Dropdown Results */}
                         {showDropdown && searchResults.length > 0 && (
-                            <div className="absolute top-full left-0 mt-2 w-full bg-[#121212] border border-white/10 rounded-lg shadow-2xl overflow-hidden z-50 max-h-96 overflow-y-auto">
+                            <div className="absolute top-full left-0 mt-2 w-full bg-surface-sunken border border-white/10 rounded-lg shadow-2xl overflow-hidden z-50 max-h-96 overflow-y-auto">
                                 {searchResults.map((result) => {
                                     const imageUrl = getProxiedImageUrl(result.coverUrl);
                                     return (
@@ -275,7 +275,7 @@ export default function PodcastsPage() {
                                             }}
                                         >
                                             {/* Cover Art */}
-                                            <div className="w-12 h-12 rounded-full bg-[#181818] flex-shrink-0 overflow-hidden relative">
+                                            <div className="w-12 h-12 rounded-full bg-surface-elevated flex-shrink-0 overflow-hidden relative">
                                                 {imageUrl ? (
                                                     <Image
                                                         src={imageUrl}
@@ -287,7 +287,7 @@ export default function PodcastsPage() {
                                                     />
                                                 ) : (
                                                     <div className="w-full h-full flex items-center justify-center">
-                                                        <Mic2 className="w-6 h-6 text-gray-600" />
+                                                        <Mic2 className="w-6 h-6 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -304,7 +304,7 @@ export default function PodcastsPage() {
 
                                             {/* Add Button */}
                                             <div className="flex-shrink-0">
-                                                <div className="w-8 h-8 rounded-full bg-[#2323FF] hover:bg-[#5b5bff] flex items-center justify-center transition-colors">
+                                                <div className="w-8 h-8 rounded-full bg-ai hover:bg-ai-hover flex items-center justify-center transition-colors">
                                                     <Plus className="w-4 h-4 text-white" />
                                                 </div>
                                             </div>
@@ -319,7 +319,7 @@ export default function PodcastsPage() {
                             searchResults.length === 0 &&
                             !isSearching &&
                             searchQuery.length >= 2 && (
-                                <div className="absolute top-full left-0 mt-2 w-full bg-[#121212] border border-white/10 rounded-lg shadow-2xl p-4 z-50">
+                                <div className="absolute top-full left-0 mt-2 w-full bg-surface-sunken border border-white/10 rounded-lg shadow-2xl p-4 z-50">
                                     <p className="text-gray-400 text-sm text-center">
                                         No podcasts found for &quot;{searchQuery}&quot;
                                     </p>
@@ -331,7 +331,7 @@ export default function PodcastsPage() {
                     <div className="w-full md:w-96 md:ml-auto mt-3">
                         <div className="flex items-center gap-2">
                             <div className="relative flex-1">
-                                <Link2 className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 z-10" />
+                                <Link2 className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 z-10" />
                                 <input
                                     type="url"
                                     value={rssUrl}
@@ -343,13 +343,13 @@ export default function PodcastsPage() {
                                         }
                                     }}
                                     placeholder="Add by RSS URL..."
-                                    className="w-full pl-11 pr-4 py-3 bg-white/5 border border-white/10 rounded-full text-white placeholder-gray-500 focus:outline-none focus:border-[#2323FF] focus:bg-white/10 transition-all text-sm"
+                                    className="w-full pl-11 pr-4 py-3 bg-white/5 border border-white/10 rounded-full text-white placeholder-gray-500 focus:outline-none focus:border-ai focus:bg-white/10 transition-all text-sm"
                                 />
                             </div>
                             <button
                                 onClick={handleAddByRss}
                                 disabled={isAddingRss}
-                                className="h-11 px-4 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] text-black font-semibold text-sm transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                                className="h-11 px-4 rounded-full bg-brand-hover hover:bg-brand-light text-black font-semibold text-sm transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                             >
                                 {isAddingRss ? "Adding..." : "Add RSS"}
                             </button>
@@ -377,7 +377,7 @@ export default function PodcastsPage() {
                                 <select
                                     value={sortBy}
                                     onChange={(e) => setSortBy(e.target.value as SortOption)}
-                                    className="px-4 py-2 bg-[#1a1a1a] border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-[#2323FF] [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                                    className="px-4 py-2 bg-surface-hover border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-ai [&>option]:bg-surface-hover [&>option]:text-white"
                                     disabled={showMyPodcastsSkeleton}
                                 >
                                     <option value="title">Title (A-Z)</option>
@@ -392,7 +392,7 @@ export default function PodcastsPage() {
                                         setItemsPerPage(Number(e.target.value));
                                         setCurrentPage(1);
                                     }}
-                                    className="px-4 py-2 bg-[#1a1a1a] border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-[#2323FF] [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                                    className="px-4 py-2 bg-surface-hover border border-white/10 rounded-full text-white text-sm focus:outline-none focus:border-ai [&>option]:bg-surface-hover [&>option]:text-white"
                                     disabled={showMyPodcastsSkeleton}
                                 >
                                     <option value={25}>25 per page</option>
@@ -426,7 +426,7 @@ export default function PodcastsPage() {
                                             tabIndex={0}
                                             className="bg-transparent hover:bg-white/5 transition-all p-3 rounded-md cursor-pointer group"
                                         >
-                                            <div className="w-full aspect-square bg-[#282828] rounded-full mb-2.5 overflow-hidden relative shadow-lg">
+                                            <div className="w-full aspect-square bg-surface-highlight rounded-full mb-2.5 overflow-hidden relative shadow-lg">
                                                 {imageUrl ? (
                                                     <Image
                                                         src={imageUrl}
@@ -438,7 +438,7 @@ export default function PodcastsPage() {
                                                     />
                                                 ) : (
                                                     <div className="w-full h-full flex items-center justify-center">
-                                                        <Mic2 className="w-16 h-16 text-gray-700" />
+                                                        <Mic2 className="w-16 h-16 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -519,7 +519,7 @@ export default function PodcastsPage() {
                                             tabIndex={0}
                                             className="bg-transparent hover:bg-white/5 transition-all p-3 rounded-md cursor-pointer group"
                                         >
-                                            <div className="w-full aspect-square bg-[#282828] rounded-full mb-2.5 overflow-hidden relative shadow-lg">
+                                            <div className="w-full aspect-square bg-surface-highlight rounded-full mb-2.5 overflow-hidden relative shadow-lg">
                                                 {imageUrl ? (
                                                     <Image
                                                         src={imageUrl}
@@ -531,7 +531,7 @@ export default function PodcastsPage() {
                                                     />
                                                 ) : (
                                                     <div className="w-full h-full flex items-center justify-center">
-                                                        <Mic2 className="w-16 h-16 text-gray-700" />
+                                                        <Mic2 className="w-16 h-16 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -606,7 +606,7 @@ export default function PodcastsPage() {
                                             tabIndex={0}
                                             className="bg-transparent hover:bg-white/5 transition-all p-3 rounded-md cursor-pointer group"
                                         >
-                                            <div className="w-full aspect-square bg-[#282828] rounded-full mb-2.5 overflow-hidden relative shadow-lg">
+                                            <div className="w-full aspect-square bg-surface-highlight rounded-full mb-2.5 overflow-hidden relative shadow-lg">
                                                 {imageUrl ? (
                                                     <Image
                                                         src={imageUrl}
@@ -618,7 +618,7 @@ export default function PodcastsPage() {
                                                     />
                                                 ) : (
                                                     <div className="w-full h-full flex items-center justify-center">
-                                                        <Mic2 className="w-16 h-16 text-gray-700" />
+                                                        <Mic2 className="w-16 h-16 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -643,7 +643,7 @@ export default function PodcastsPage() {
                     podcasts.length === 0 &&
                     topPodcasts.length === 0 && (
                     <div className="flex flex-col items-center justify-center py-24">
-                        <Mic2 className="w-24 h-24 text-gray-700 mb-6" />
+                        <Mic2 className="w-24 h-24 text-gray-400 mb-6" />
                         <h2 className="text-2xl font-bold text-white mb-2">
                             Discover Podcasts
                         </h2>

--- a/frontend/app/queue/page.tsx
+++ b/frontend/app/queue/page.tsx
@@ -245,14 +245,14 @@ export default function QueuePage() {
     const isCurrentUnavailable = currentAvailability?.available === false;
 
     return (
-        <div className="min-h-screen bg-[#0a0a0a]">
+        <div className="min-h-screen bg-surface">
             <div className="max-w-4xl mx-auto p-4 md:p-8 space-y-6">
                 {/* Header */}
                 <PageHeader
                     title={isInGroup ? "Listen Together Queue" : "Queue"}
                     subtitle={`${queue.length} item${queue.length !== 1 ? "s" : ""} in queue`}
                     icon={ListMusic}
-                    iconClassName="text-[#3b82f6]"
+                    iconClassName="text-brand"
                     className="mb-8"
                     actions={
                         queue.length > 0 ? (
@@ -296,7 +296,7 @@ export default function QueuePage() {
                             Now Playing
                         </h2>
                         <Card>
-                            <div className={`flex items-center gap-4 p-4 bg-[#1a1a1a] border-l-2 border-[#2323FF] group ${isCurrentUnavailable ? "opacity-50" : ""}`}>
+                            <div className={`flex items-center gap-4 p-4 bg-surface-hover border-l-2 border-ai group ${isCurrentUnavailable ? "opacity-50" : ""}`}>
                                 <div className="relative flex-shrink-0 w-16 h-16">
                                     {currentTrack.album?.coverArt ? (
                                         <Image
@@ -311,16 +311,16 @@ export default function QueuePage() {
                                             unoptimized
                                         />
                                     ) : (
-                                        <div className="w-16 h-16 bg-[#0a0a0a] rounded-sm flex items-center justify-center">
-                                            <Music className="w-6 h-6 text-gray-600" />
+                                        <div className="w-16 h-16 bg-surface rounded-sm flex items-center justify-center">
+                                            <Music className="w-6 h-6 text-gray-400" />
                                         </div>
                                     )}
                                     <div className="absolute inset-0 flex items-center justify-center">
-                                        <Play className="w-6 h-6 text-[#5b5bff] fill-[#5b5bff] animate-pulse" />
+                                        <Play className="w-6 h-6 text-ai-hover fill-ai-hover animate-pulse" />
                                     </div>
                                 </div>
                                 <div className="flex-1 min-w-0">
-                                    <h3 className="text-sm font-medium text-[#5b5bff] truncate">
+                                    <h3 className="text-sm font-medium text-ai-hover truncate">
                                         {currentTrack.displayTitle ??
                                             currentTrack.title}
                                     </h3>
@@ -340,12 +340,12 @@ export default function QueuePage() {
                                             <YouTubeBadge />
                                         ) : null}
                                     </div>
-                                    <p className="text-xs text-gray-500 truncate">
+                                    <p className="text-xs text-gray-400 truncate">
                                         {currentTrack.album?.title}
                                     </p>
                                 </div>
                                 <div className="flex items-center gap-1">
-                                    <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                                    <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                                         {formatTime(currentTrack.duration)}
                                     </span>
                                     <TrackPreferenceButtons
@@ -373,7 +373,7 @@ export default function QueuePage() {
                             Now Playing
                         </h2>
                         <Card>
-                            <div className="flex items-center gap-4 p-4 bg-[#1a1a1a] border-l-2 border-[#2323FF]">
+                            <div className="flex items-center gap-4 p-4 bg-surface-hover border-l-2 border-ai">
                                 <div className="relative flex-shrink-0 w-16 h-16">
                                     {currentEpisode.coverUrl ? (
                                         <Image
@@ -385,23 +385,23 @@ export default function QueuePage() {
                                             unoptimized
                                         />
                                     ) : (
-                                        <div className="w-16 h-16 bg-[#0a0a0a] rounded-sm flex items-center justify-center">
-                                            <Music className="w-6 h-6 text-gray-600" />
+                                        <div className="w-16 h-16 bg-surface rounded-sm flex items-center justify-center">
+                                            <Music className="w-6 h-6 text-gray-400" />
                                         </div>
                                     )}
                                     <div className="absolute inset-0 flex items-center justify-center">
-                                        <Play className="w-6 h-6 text-[#5b5bff] fill-[#5b5bff] animate-pulse" />
+                                        <Play className="w-6 h-6 text-ai-hover fill-ai-hover animate-pulse" />
                                     </div>
                                 </div>
                                 <div className="flex-1 min-w-0">
-                                    <h3 className="text-sm font-medium text-[#5b5bff] truncate">
+                                    <h3 className="text-sm font-medium text-ai-hover truncate">
                                         {currentEpisode.title}
                                     </h3>
                                     <p className="text-sm text-gray-400 truncate">
                                         {currentEpisode.podcastTitle}
                                     </p>
                                 </div>
-                                <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                                <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                                     {formatTime(currentEpisode.duration)}
                                 </span>
                             </div>
@@ -523,7 +523,7 @@ export default function QueuePage() {
                     onClick={() => setShowSaveDialog(false)}
                 >
                     <div
-                        className="bg-[#121212] rounded-xl max-w-md w-full overflow-hidden border border-white/10 shadow-2xl"
+                        className="bg-surface-sunken rounded-xl max-w-md w-full overflow-hidden border border-white/10 shadow-2xl"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <div className="p-6">
@@ -541,7 +541,7 @@ export default function QueuePage() {
                                 onChange={(e) => setPlaylistName(e.target.value)}
                                 onKeyDown={(e) => e.key === "Enter" && handleSaveAsPlaylist()}
                                 placeholder={`Queue — ${new Date().toLocaleDateString()}`}
-                                className="w-full px-3 py-2 bg-[#1a1a1a] border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#3b82f6]/50"
+                                className="w-full px-3 py-2 bg-surface-hover border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-brand/50"
                                 autoFocus
                             />
                         </div>
@@ -555,7 +555,7 @@ export default function QueuePage() {
                             <button
                                 onClick={handleSaveAsPlaylist}
                                 disabled={isSaving}
-                                className="flex-1 px-4 py-2.5 bg-[#3b82f6] hover:bg-[#2563eb] text-white font-medium rounded-lg transition-colors disabled:opacity-50"
+                                className="flex-1 px-4 py-2.5 bg-brand hover:bg-brand-dark text-white font-medium rounded-lg transition-colors disabled:opacity-50"
                             >
                                 {isSaving ? "Saving..." : "Save"}
                             </button>
@@ -585,12 +585,12 @@ function EpisodeQueueRow({
 }) {
     return (
         <div
-            className={`flex items-center gap-4 p-4 hover:bg-[#1a1a1a] transition-colors group border-b border-[#1c1c1c] ${played ? "opacity-50" : ""}`}
+            className={`flex items-center gap-4 p-4 hover:bg-surface-hover transition-colors group border-b border-surface-active ${played ? "opacity-50" : ""}`}
         >
             {dragHandleProps && (
                 <button
                     {...dragHandleProps}
-                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-white cursor-grab active:cursor-grabbing"
                     title="Drag to reorder"
                     aria-label="Drag to reorder"
                 >
@@ -608,8 +608,8 @@ function EpisodeQueueRow({
                         unoptimized
                     />
                 ) : (
-                    <div className="w-12 h-12 bg-[#0a0a0a] rounded-sm flex items-center justify-center">
-                        <Music className="w-5 h-5 text-gray-600" />
+                    <div className="w-12 h-12 bg-surface rounded-sm flex items-center justify-center">
+                        <Music className="w-5 h-5 text-gray-400" />
                     </div>
                 )}
             </div>
@@ -620,14 +620,14 @@ function EpisodeQueueRow({
                 <p className="text-sm text-gray-400 truncate">
                     {episode.podcastTitle}
                 </p>
-                <p className="text-[11px] text-gray-500 truncate">Podcast episode</p>
+                <p className="text-[11px] text-gray-400 truncate">Podcast episode</p>
             </div>
             {(onPlay || onRemove) && (
                 <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                     {onPlay && (
                         <button
                             onClick={onPlay}
-                            className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors"
+                            className="p-2 hover:bg-surface rounded-md transition-colors"
                             title="Play now"
                             aria-label="Play now"
                         >
@@ -637,7 +637,7 @@ function EpisodeQueueRow({
                     {onRemove && (
                         <button
                             onClick={onRemove}
-                            className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors text-red-400 hover:text-red-300"
+                            className="p-2 hover:bg-surface rounded-md transition-colors text-red-400 hover:text-red-300"
                             title="Remove from queue"
                         >
                             <X className="w-4 h-4" />
@@ -645,7 +645,7 @@ function EpisodeQueueRow({
                     )}
                 </div>
             )}
-            <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+            <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                 {formatTime(episode.duration)}
             </span>
         </div>
@@ -688,12 +688,12 @@ function NextTrackRow({
 
     return (
         <div
-            className={`flex items-center gap-4 p-4 hover:bg-[#1a1a1a] transition-colors group border-b border-[#1c1c1c] ${isUnavailable ? "opacity-50" : ""}`}
+            className={`flex items-center gap-4 p-4 hover:bg-surface-hover transition-colors group border-b border-surface-active ${isUnavailable ? "opacity-50" : ""}`}
         >
             {!isInGroup && dragHandleProps && (
                 <button
                     {...dragHandleProps}
-                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-white cursor-grab active:cursor-grabbing"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-white cursor-grab active:cursor-grabbing"
                     title="Drag to reorder"
                     aria-label="Drag to reorder"
                 >
@@ -711,8 +711,8 @@ function NextTrackRow({
                         unoptimized
                     />
                 ) : (
-                    <div className="w-12 h-12 bg-[#0a0a0a] rounded-sm flex items-center justify-center">
-                        <Music className="w-5 h-5 text-gray-600" />
+                    <div className="w-12 h-12 bg-surface rounded-sm flex items-center justify-center">
+                        <Music className="w-5 h-5 text-gray-400" />
                     </div>
                 )}
             </div>
@@ -731,7 +731,7 @@ function NextTrackRow({
                     {isInGroup && resolvedSource === "youtube" ? <YouTubeBadge /> : null}
                 </div>
                 {track.album?.title && (
-                    <p className="text-[11px] text-gray-500 truncate">{track.album.title}</p>
+                    <p className="text-[11px] text-gray-400 truncate">{track.album.title}</p>
                 )}
             </div>
             <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -740,7 +740,7 @@ function NextTrackRow({
                         <button
                             onClick={() => onMoveUp(queueIndex)}
                             disabled={queueIndex <= currentIndex + 1}
-                            className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                            className="p-2 hover:bg-surface rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                             title="Move up"
                             aria-label="Move up"
                         >
@@ -749,7 +749,7 @@ function NextTrackRow({
                         <button
                             onClick={() => onMoveDown(queueIndex)}
                             disabled={queueIndex >= queueLength - 1}
-                            className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                            className="p-2 hover:bg-surface rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                             title="Move down"
                             aria-label="Move down"
                         >
@@ -760,7 +760,7 @@ function NextTrackRow({
                 <button
                     onClick={() => onPlay(queueIndex)}
                     disabled={isUnavailable}
-                    className="p-2 hover:bg-[#0a0a0a] rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="p-2 hover:bg-surface rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                     title="Play now"
                     aria-label="Play now"
                 >
@@ -768,7 +768,7 @@ function NextTrackRow({
                 </button>
             </div>
             <div className="flex items-center gap-1">
-                <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                     {formatTime(track.duration)}
                 </span>
                 <TrackPreferenceButtons
@@ -819,7 +819,7 @@ function PreviousTrackRow({
 
     return (
         <div
-            className={`flex items-center gap-4 p-4 hover:bg-[#1a1a1a] transition-colors group opacity-50 border-b border-[#1c1c1c] ${isUnavailable ? "opacity-30" : ""}`}
+            className={`flex items-center gap-4 p-4 hover:bg-surface-hover transition-colors group opacity-50 border-b border-surface-active ${isUnavailable ? "opacity-30" : ""}`}
         >
             <div className="relative flex-shrink-0 w-12 h-12">
                 {track.album?.coverArt ? (
@@ -832,8 +832,8 @@ function PreviousTrackRow({
                         unoptimized
                     />
                 ) : (
-                    <div className="w-12 h-12 bg-[#0a0a0a] rounded-sm flex items-center justify-center">
-                        <Music className="w-5 h-5 text-gray-600" />
+                    <div className="w-12 h-12 bg-surface rounded-sm flex items-center justify-center">
+                        <Music className="w-5 h-5 text-gray-400" />
                     </div>
                 )}
             </div>
@@ -850,11 +850,11 @@ function PreviousTrackRow({
                     {isInGroup && resolvedSource === "youtube" ? <YouTubeBadge /> : null}
                 </div>
                 {track.album?.title && (
-                    <p className="text-[11px] text-gray-500 truncate">{track.album.title}</p>
+                    <p className="text-[11px] text-gray-400 truncate">{track.album.title}</p>
                 )}
             </div>
             <div className="flex items-center gap-1">
-                <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                     {formatTime(track.duration)}
                 </span>
                 <TrackPreferenceButtons

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -109,7 +109,7 @@ export default function RegisterPage() {
 
             {/* Background */}
             <div className="absolute inset-0 bg-[#000]">
-                <div className="absolute inset-0 bg-gradient-to-br from-[#3b82f6]/5 via-transparent to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-br from-brand/5 via-transparent to-transparent" />
                 <div className="opacity-[0.08]">
                     <GalaxyBackground
                         primaryColor="#3b82f6"
@@ -293,7 +293,7 @@ export default function RegisterPage() {
                             <button
                                 type="submit"
                                 disabled={isLoading}
-                                className="w-full py-3 bg-[#3b82f6] text-black font-bold rounded-lg hover:bg-[#2563eb] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="w-full py-3 bg-brand text-black font-bold rounded-lg hover:bg-brand-dark transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <span className="flex items-center justify-center gap-2">
                                     {isLoading ? (
@@ -312,7 +312,7 @@ export default function RegisterPage() {
                             Already have an account?{" "}
                             <Link
                                 href="/login"
-                                className="text-[#3b82f6] hover:text-[#60a5fa] transition-colors"
+                                className="text-brand hover:text-brand-hover transition-colors"
                             >
                                 Sign in
                             </Link>

--- a/frontend/app/releases/page.tsx
+++ b/frontend/app/releases/page.tsx
@@ -119,7 +119,7 @@ export default function ReleasesPage() {
             {/* Hero Section */}
             <div className="relative h-64 md:h-80 overflow-hidden">
                 <div className="absolute inset-0 bg-gradient-to-br from-amber-500/20 via-orange-600/10 to-transparent" />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0A0A0A] via-transparent to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent" />
                 
                 <div className="relative h-full flex flex-col justify-end p-6 md:p-8">
                     <div className="flex items-center gap-3 mb-2">

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -524,7 +524,7 @@ export default function SearchPage() {
                                   !libraryResults.audiobooks?.length &&
                                   !libraryResults.episodes?.length))) && (
                         <div className="flex flex-col items-center justify-center py-24 text-center">
-                            <SearchIcon className="w-16 h-16 text-gray-700 mb-4" />
+                            <SearchIcon className="w-16 h-16 text-gray-400 mb-4" />
                             <h3 className="text-xl font-bold text-white mb-2">
                                 {isPodcastTab ? "No podcasts found" : "No results found"}
                             </h3>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -105,7 +105,7 @@ export default function SettingsPage() {
 
     if (authLoading) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-[#0a0a0a]">
+            <div className="flex items-center justify-center min-h-screen bg-surface">
                 <GradientSpinner size="md" />
             </div>
         );
@@ -117,7 +117,7 @@ export default function SettingsPage() {
 
     if (userSettingsLoading) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-[#0a0a0a]">
+            <div className="flex items-center justify-center min-h-screen bg-surface">
                 <GradientSpinner size="md" />
             </div>
         );
@@ -169,7 +169,7 @@ export default function SettingsPage() {
                         {isSaving ? "Saving..." : "Save"}
                     </button>
                     {/* Status appears below button, absolutely positioned */}
-                    <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-[#0a0a0a]/90 backdrop-blur-sm px-3 py-0.5 rounded-full">
+                    <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-surface/90 backdrop-blur-sm px-3 py-0.5 rounded-full">
                         <InlineStatus {...saveStatus.props} />
                     </div>
                 </div>

--- a/frontend/app/share/[token]/page.tsx
+++ b/frontend/app/share/[token]/page.tsx
@@ -447,9 +447,9 @@ export default function SharePage() {
 
 	if (loading) {
 		return (
-			<main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] px-4 text-white">
+			<main className="flex min-h-screen items-center justify-center bg-surface px-4 text-white">
 				<div className="flex items-center gap-3 text-gray-300">
-					<Loader2 className="h-5 w-5 animate-spin text-[#3b82f6]" />
+					<Loader2 className="h-5 w-5 animate-spin text-brand" />
 					<span>Loading shared link...</span>
 				</div>
 			</main>
@@ -458,8 +458,8 @@ export default function SharePage() {
 
 	if (error || !data) {
 		return (
-			<main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] px-4 text-white">
-				<div className="w-full max-w-2xl rounded-xl border border-[#262626] bg-[#111111]/60 p-8 text-center">
+			<main className="flex min-h-screen items-center justify-center bg-surface px-4 text-white">
+				<div className="w-full max-w-2xl rounded-xl border border-line bg-[#111111]/60 p-8 text-center">
 					<div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-red-500/30 bg-red-500/10">
 						<AlertCircle className="h-7 w-7 text-red-400" />
 					</div>
@@ -467,7 +467,7 @@ export default function SharePage() {
 					<p className="mt-2 text-sm text-gray-400">
 						This share link is invalid, expired, or no longer available.
 					</p>
-					<p className="mt-8 text-xs text-gray-600">soundspan™</p>
+					<p className="mt-8 text-xs text-gray-400">soundspan™</p>
 				</div>
 			</main>
 		);
@@ -514,30 +514,30 @@ export default function SharePage() {
 			<div className="flex h-full flex-col md:flex-row">
 					<div className="flex flex-col items-center justify-center overflow-y-auto px-8 py-12 md:h-full md:w-1/2 md:pl-12 md:pr-6">
 						{data.resourceType === "track" ? (
-							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-[#60a5fa]/30 bg-[#60a5fa]/10 px-2.5 py-1 text-xs uppercase tracking-widest text-[#60a5fa]">
+							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-brand-hover/30 bg-brand-hover/10 px-2.5 py-1 text-xs uppercase tracking-widest text-brand-hover">
 								<Disc3 className="h-3 w-3" />
 								Shared Track
 							</span>
 						) : data.resourceType === "album" ? (
-							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-[#60a5fa]/30 bg-[#60a5fa]/10 px-2.5 py-1 text-xs uppercase tracking-widest text-[#60a5fa]">
+							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-brand-hover/30 bg-brand-hover/10 px-2.5 py-1 text-xs uppercase tracking-widest text-brand-hover">
 								<Disc3 className="h-3 w-3" />
 								Shared Album
 							</span>
 						) : (
-							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-[#60a5fa]/30 bg-[#60a5fa]/10 px-2.5 py-1 text-xs uppercase tracking-widest text-[#60a5fa]">
+							<span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-brand-hover/30 bg-brand-hover/10 px-2.5 py-1 text-xs uppercase tracking-widest text-brand-hover">
 								<ListMusic className="h-3 w-3" />
 								Shared Playlist
 							</span>
 						)}
 
 						<div className="relative mx-auto mb-6 w-full max-w-[min(92vw,52vh)] md:max-w-[min(40vw,calc(100vh-20rem))]">
-							<div className="absolute inset-0 rounded-2xl blur-2xl opacity-50 bg-gradient-to-br from-[#60a5fa]/20 via-transparent to-[#3b82f6]/20" />
-							<div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] shadow-2xl">
+							<div className="absolute inset-0 rounded-2xl blur-2xl opacity-50 bg-gradient-to-br from-brand-hover/20 via-transparent to-brand/20" />
+							<div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-gradient-to-br from-[#2a2a2a] to-surface-hover shadow-2xl">
 								{leftPanelCoverUrl ? (
 									<img src={leftPanelCoverUrl} alt="Cover art" className="h-full w-full object-cover" />
 								) : (
 									<div className="flex h-full w-full items-center justify-center">
-										<Music className="h-24 w-24 text-gray-600" />
+										<Music className="h-24 w-24 text-gray-400" />
 									</div>
 								)}
 							</div>
@@ -550,18 +550,18 @@ export default function SharePage() {
 							{leftPanelSubtitle}
 						</p>
 						{!currentTrack && data.resourceType === "album" && (
-							<p className="mt-1 text-sm text-gray-500 text-center">{trackQueue.length} tracks</p>
+							<p className="mt-1 text-sm text-gray-400 text-center">{trackQueue.length} tracks</p>
 						)}
 						{!currentTrack && data.resourceType === "playlist" && (
 							<>
-								<p className="mt-1 text-sm text-gray-500 text-center">{trackQueue.length} items</p>
-								<p className="mt-0.5 text-sm text-gray-500 text-center">
+								<p className="mt-1 text-sm text-gray-400 text-center">{trackQueue.length} items</p>
+								<p className="mt-0.5 text-sm text-gray-400 text-center">
 									by {(data.resource as PlaylistResource).user?.username ?? "Unknown user"}
 								</p>
 							</>
 						)}
 						{!currentTrack && data.resourceType === "track" && (
-							<p className="mt-0.5 text-sm text-gray-500 text-center">
+							<p className="mt-0.5 text-sm text-gray-400 text-center">
 								{(data.resource as TrackResource).album.title}
 							</p>
 						)}
@@ -573,9 +573,9 @@ export default function SharePage() {
 					<div className="flex h-full flex-col overflow-hidden">
 							<div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b border-white/[0.08] px-4 py-3">
 								<div className="flex items-center gap-2">
-									<ListMusic className="h-4 w-4 text-[#60a5fa]" />
+									<ListMusic className="h-4 w-4 text-brand-hover" />
 									<h2 className="text-sm font-semibold text-white">Up Next</h2>
-									<span className="text-xs text-gray-500">
+									<span className="text-xs text-gray-400">
 										{trackQueue.length} {data.resourceType === "playlist" ? "items" : "tracks"}
 									</span>
 								</div>
@@ -612,35 +612,35 @@ export default function SharePage() {
 											className={cn(
 												"mb-1.5 flex items-center gap-2 rounded-md px-2 py-2 transition-colors cursor-pointer",
 												isCurrentTrack
-													? "bg-[#60a5fa]/10"
+													? "bg-brand-hover/10"
 													: "hover:bg-white/[0.06]",
 											)}
 										>
 											<button type="button" onClick={() => playTrack(track)} className="flex min-w-0 flex-1 items-center gap-2 text-left">
-												<span className={cn("w-5 flex-shrink-0 text-center text-[11px] tabular-nums", isCurrentTrack ? "text-[#60a5fa]" : "text-gray-500")}>
+												<span className={cn("w-5 flex-shrink-0 text-center text-[11px] tabular-nums", isCurrentTrack ? "text-brand-hover" : "text-gray-400")}>
 													{index + 1}
 												</span>
 
-												<div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-[#1a1a1a]">
+												<div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
 													{track.coverUrl ? (
 														<img src={track.coverUrl} alt={track.title} className="h-full w-full object-cover" />
 													) : (
 														<div className="flex h-full w-full items-center justify-center">
-															<Music className="h-4 w-4 text-gray-600" />
+															<Music className="h-4 w-4 text-gray-400" />
 														</div>
 													)}
 												</div>
 
 												<div className="min-w-0 flex-1">
-													<p className={cn("min-w-0 truncate text-sm", isCurrentTrack ? "text-[#60a5fa]" : "text-white")}>{track.title}</p>
+													<p className={cn("min-w-0 truncate text-sm", isCurrentTrack ? "text-brand-hover" : "text-white")}>{track.title}</p>
 													<div className="mt-0.5 flex min-w-0 items-center gap-1.5">
 														<p className="min-w-0 truncate text-xs text-gray-400">{track.artist}</p>
 														{isCurrentTrack && (
-															<span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[#60a5fa]/40 bg-[#60a5fa]/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#60a5fa]">
+															<span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
 																<span className="inline-flex items-end gap-0.5">
-																	<span className="h-2 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.2s]" />
-																	<span className="h-2.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa]" />
-																	<span className="h-1.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.35s]" />
+																	<span className="h-2 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.2s]" />
+																	<span className="h-2.5 w-0.5 animate-bounce rounded-full bg-brand-hover" />
+																	<span className="h-1.5 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.35s]" />
 																</span>
 																Playing
 															</span>
@@ -648,7 +648,7 @@ export default function SharePage() {
 													</div>
 												</div>
 
-												<span className={cn("text-[11px] tabular-nums", isCurrentTrack ? "text-[#60a5fa]" : "text-gray-500")}>
+												<span className={cn("text-[11px] tabular-nums", isCurrentTrack ? "text-brand-hover" : "text-gray-400")}>
 													{formatTime(track.duration)}
 												</span>
 											</button>
@@ -656,7 +656,7 @@ export default function SharePage() {
 											<a
 												href={getDownloadUrl(track.id)}
 												download
-												className="ml-1 flex-shrink-0 p-1 text-gray-500 transition-colors hover:text-white"
+												className="ml-1 flex-shrink-0 p-1 text-gray-400 transition-colors hover:text-white"
 												onClick={(e) => e.stopPropagation()}
 												title="Download track"
 											>
@@ -666,7 +666,7 @@ export default function SharePage() {
 									);
 								})}
 							</div>
-							<p className="flex-shrink-0 py-3 text-center text-xs text-gray-700">soundspan™</p>
+							<p className="flex-shrink-0 py-3 text-center text-xs text-gray-400">soundspan™</p>
 							</div>
 					</div>
 				</div>
@@ -703,7 +703,7 @@ export default function SharePage() {
 
 						<div className="flex min-w-0 items-center gap-3 mr-4">
 							<div className="relative h-14 w-14 shrink-0">
-								<div className="relative h-full w-full overflow-hidden rounded-lg bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] shadow-lg flex items-center justify-center">
+								<div className="relative h-full w-full overflow-hidden rounded-lg bg-gradient-to-br from-[#2a2a2a] to-surface-hover shadow-lg flex items-center justify-center">
 									{currentTrack.coverUrl ? (
 										<img
 											src={currentTrack.coverUrl}
@@ -711,7 +711,7 @@ export default function SharePage() {
 											className="h-full w-full object-cover"
 										/>
 									) : (
-										<Music className="h-6 w-6 text-gray-500" />
+										<Music className="h-6 w-6 text-gray-400" />
 									)}
 								</div>
 							</div>
@@ -781,7 +781,7 @@ export default function SharePage() {
 						<div
 								ref={volumePopupRef}
 								className={cn(
-									"absolute bottom-full left-1/2 mb-2 -translate-x-1/2 overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] px-1.5 py-3 shadow-xl transition-all duration-200",
+									"absolute bottom-full left-1/2 mb-2 -translate-x-1/2 overflow-hidden rounded-lg border border-white/10 bg-surface-hover px-1.5 py-3 shadow-xl transition-all duration-200",
 									showVolumePopup ? "pointer-events-auto scale-100 opacity-100" : "pointer-events-none scale-95 opacity-0",
 								)}
 							>

--- a/frontend/app/vibe/page.tsx
+++ b/frontend/app/vibe/page.tsx
@@ -156,16 +156,16 @@ function CoverImage({
     if (!imgSrc || hasError) {
         return (
             <div
-                className={cn("bg-[#282828] flex items-center justify-center", className)}
+                className={cn("bg-surface-highlight flex items-center justify-center", className)}
                 style={{ width: size, height: size }}
             >
-                <Disc3 className="text-[#525252]" style={{ width: size * 0.3, height: size * 0.3 }} />
+                <Disc3 className="text-content-disabled" style={{ width: size * 0.3, height: size * 0.3 }} />
             </div>
         );
     }
 
     return (
-        <div className={cn("relative overflow-hidden bg-[#1a1a1a]", className)} style={{ width: size, height: size }}>
+        <div className={cn("relative overflow-hidden bg-surface-hover", className)} style={{ width: size, height: size }}>
             <Image
                 src={imgSrc}
                 alt={title}
@@ -192,7 +192,7 @@ function SimilarityBadge({ similarity, size = "md" }: { similarity: number; size
         <div className={cn(
             "relative flex items-center justify-center rounded-full font-semibold",
             sizeClasses[size],
-            percent >= 80 ? "text-[#22c55e]" : percent >= 60 ? "text-[#2323FF]" : "text-[#737373]"
+            percent >= 80 ? "text-success" : percent >= 60 ? "text-ai" : "text-content-muted"
         )}>
             {/* Outer ring */}
             <svg className="absolute inset-0 w-full h-full -rotate-90">
@@ -239,28 +239,28 @@ function FeatureComparison({
                 return (
                     <div key={key} className="group">
                         <div className="flex items-center justify-between mb-1">
-                            <span className="text-xs text-[#737373] uppercase tracking-wide">{label}</span>
+                            <span className="text-xs text-content-muted uppercase tracking-wide">{label}</span>
                             <span className={cn(
                                 "text-xs tabular-nums transition-colors",
-                                matchPct >= 80 ? "text-[#22c55e]" : "text-[#525252] group-hover:text-[#737373]"
+                                matchPct >= 80 ? "text-success" : "text-content-disabled group-hover:text-content-muted"
                             )}>
                                 {matchPct}%
                             </span>
                         </div>
-                        <div className="relative h-1.5 bg-[#1a1a1a] rounded-full overflow-hidden">
+                        <div className="relative h-1.5 bg-surface-hover rounded-full overflow-hidden">
                             {/* Source bar */}
                             <motion.div
                                 initial={{ width: 0 }}
                                 animate={{ width: `${sVal * 100}%` }}
                                 transition={{ duration: 0.5, ease: "easeOut" }}
-                                className="absolute h-full bg-[#3b82f6]/50 rounded-full"
+                                className="absolute h-full bg-brand/50 rounded-full"
                             />
                             {/* Match indicator */}
                             <motion.div
                                 initial={{ left: 0 }}
                                 animate={{ left: `calc(${mVal * 100}% - 4px)` }}
                                 transition={{ duration: 0.5, ease: "easeOut" }}
-                                className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-[#2323FF] shadow-[0_0_8px_rgba(35,35,255,0.5)]"
+                                className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-ai shadow-[0_0_8px_rgba(35,35,255,0.5)]"
                             />
                         </div>
                     </div>
@@ -291,13 +291,13 @@ function MoodGrid({ source, match }: { source: TrackData; match: TrackData }) {
                         key={key}
                         className={cn(
                             "px-2.5 py-2 rounded-md text-center transition-colors",
-                            matchPct >= 80 ? "bg-[#22c55e]/10" : "bg-[#1a1a1a]"
+                            matchPct >= 80 ? "bg-success/10" : "bg-surface-hover"
                         )}
                     >
-                        <div className="text-xs text-[#737373] mb-0.5">{label}</div>
+                        <div className="text-xs text-content-muted mb-0.5">{label}</div>
                         <div className={cn(
                             "text-sm font-medium tabular-nums",
-                            matchPct >= 80 ? "text-[#22c55e]" : "text-[#a3a3a3]"
+                            matchPct >= 80 ? "text-success" : "text-content-secondary"
                         )}>
                             {matchPct}%
                         </div>
@@ -319,9 +319,9 @@ function TagPills({ source, match }: { source: TrackData; match: TrackData }) {
     return (
         <div>
             <div className="flex items-center gap-2 mb-2">
-                <span className="text-xs text-[#737373] uppercase tracking-wide">Tags</span>
+                <span className="text-xs text-content-muted uppercase tracking-wide">Tags</span>
                 {sharedTags.length > 0 && (
-                    <span className="text-xs text-[#22c55e]">{sharedTags.length} shared</span>
+                    <span className="text-xs text-success">{sharedTags.length} shared</span>
                 )}
             </div>
             <div className="flex flex-wrap gap-1.5">
@@ -333,8 +333,8 @@ function TagPills({ source, match }: { source: TrackData; match: TrackData }) {
                             className={cn(
                                 "px-2 py-0.5 text-xs rounded-full transition-colors",
                                 isShared
-                                    ? "bg-[#22c55e]/15 text-[#22c55e] ring-1 ring-[#22c55e]/30"
-                                    : "bg-[#1a1a1a] text-[#737373]"
+                                    ? "bg-success/15 text-success ring-1 ring-success/30"
+                                    : "bg-surface-hover text-content-muted"
                             )}
                         >
                             {tag}
@@ -362,58 +362,58 @@ function ComparisonPanel({
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
-            className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-xl overflow-hidden"
+            className="bg-surface-raised border border-surface-active rounded-xl overflow-hidden"
         >
             {/* Header with gradient accent */}
             <div className="relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-[#3b82f6]/10 via-transparent to-[#2323FF]/10" />
+                <div className="absolute inset-0 bg-gradient-to-r from-brand/10 via-transparent to-ai/10" />
                 <div className="relative flex items-center justify-between px-4 py-3">
-                    <span className="text-xs font-medium text-[#737373] uppercase tracking-wider">Vibe Match</span>
+                    <span className="text-xs font-medium text-content-muted uppercase tracking-wider">Vibe Match</span>
                     <button
                         onClick={onClose}
                         className="p-1 hover:bg-white/5 rounded transition-colors"
                     >
-                        <X className="w-4 h-4 text-[#737373]" />
+                        <X className="w-4 h-4 text-content-muted" />
                     </button>
                 </div>
             </div>
 
             {/* Central similarity display */}
-            <div className="flex items-center justify-center py-6 border-b border-[#1c1c1c]">
+            <div className="flex items-center justify-center py-6 border-b border-surface-active">
                 <div className="flex items-center gap-6">
                     <CoverImage
                         coverUrl={source.coverUrl}
                         title={source.title}
                         size={56}
-                        className="rounded-md ring-2 ring-[#3b82f6]/30"
+                        className="rounded-md ring-2 ring-brand/30"
                     />
                     <SimilarityBadge similarity={similarity} size="lg" />
                     <CoverImage
                         coverUrl={match.coverUrl}
                         title={match.title}
                         size={56}
-                        className="rounded-md ring-2 ring-[#2323FF]/30"
+                        className="rounded-md ring-2 ring-ai/30"
                     />
                 </div>
             </div>
 
             {/* Track details */}
-            <div className="grid grid-cols-2 divide-x divide-[#1c1c1c] border-b border-[#1c1c1c]">
+            <div className="grid grid-cols-2 divide-x divide-surface-active border-b border-surface-active">
                 <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
-                        <div className="w-1.5 h-1.5 rounded-full bg-[#3b82f6]" />
-                        <span className="text-[10px] text-[#737373] uppercase tracking-wider">Source</span>
+                        <div className="w-1.5 h-1.5 rounded-full bg-brand" />
+                        <span className="text-[10px] text-content-muted uppercase tracking-wider">Source</span>
                     </div>
                     <p className="font-medium text-white text-sm truncate">{source.title}</p>
-                    <p className="text-xs text-[#a3a3a3] truncate">{source.artist}</p>
+                    <p className="text-xs text-content-secondary truncate">{source.artist}</p>
                     <div className="flex gap-1.5 mt-2">
                         {source.features.bpm && (
-                            <span className="text-[10px] px-1.5 py-0.5 bg-[#1a1a1a] rounded text-[#525252]">
+                            <span className="text-[10px] px-1.5 py-0.5 bg-surface-hover rounded text-content-disabled">
                                 {Math.round(source.features.bpm)} BPM
                             </span>
                         )}
                         {source.features.key && (
-                            <span className="text-[10px] px-1.5 py-0.5 bg-[#1a1a1a] rounded text-[#525252]">
+                            <span className="text-[10px] px-1.5 py-0.5 bg-surface-hover rounded text-content-disabled">
                                 {source.features.key}
                             </span>
                         )}
@@ -421,19 +421,19 @@ function ComparisonPanel({
                 </div>
                 <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
-                        <div className="w-1.5 h-1.5 rounded-full bg-[#2323FF]" />
-                        <span className="text-[10px] text-[#737373] uppercase tracking-wider">Match</span>
+                        <div className="w-1.5 h-1.5 rounded-full bg-ai" />
+                        <span className="text-[10px] text-content-muted uppercase tracking-wider">Match</span>
                     </div>
                     <p className="font-medium text-white text-sm truncate">{match.title}</p>
-                    <p className="text-xs text-[#a3a3a3] truncate">{match.artist}</p>
+                    <p className="text-xs text-content-secondary truncate">{match.artist}</p>
                     <div className="flex gap-1.5 mt-2">
                         {match.features.bpm && (
-                            <span className="text-[10px] px-1.5 py-0.5 bg-[#1a1a1a] rounded text-[#525252]">
+                            <span className="text-[10px] px-1.5 py-0.5 bg-surface-hover rounded text-content-disabled">
                                 {Math.round(match.features.bpm)} BPM
                             </span>
                         )}
                         {match.features.key && (
-                            <span className="text-[10px] px-1.5 py-0.5 bg-[#1a1a1a] rounded text-[#525252]">
+                            <span className="text-[10px] px-1.5 py-0.5 bg-surface-hover rounded text-content-disabled">
                                 {match.features.key}
                             </span>
                         )}
@@ -442,14 +442,14 @@ function ComparisonPanel({
             </div>
 
             {/* Audio features */}
-            <div className="p-4 border-b border-[#1c1c1c]">
-                <h4 className="text-[10px] font-medium text-[#737373] uppercase tracking-wider mb-4">Audio DNA</h4>
+            <div className="p-4 border-b border-surface-active">
+                <h4 className="text-[10px] font-medium text-content-muted uppercase tracking-wider mb-4">Audio DNA</h4>
                 <FeatureComparison source={source} match={match} />
             </div>
 
             {/* Mood profile */}
-            <div className="p-4 border-b border-[#1c1c1c]">
-                <h4 className="text-[10px] font-medium text-[#737373] uppercase tracking-wider mb-3">Mood Profile</h4>
+            <div className="p-4 border-b border-surface-active">
+                <h4 className="text-[10px] font-medium text-content-muted uppercase tracking-wider mb-3">Mood Profile</h4>
                 <MoodGrid source={source} match={match} />
             </div>
 
@@ -485,13 +485,13 @@ function TrackRow({
             className={cn(
                 "group grid grid-cols-[auto_1fr_auto_auto] gap-4 px-4 py-2.5 rounded-lg cursor-pointer transition-all items-center",
                 isSelected
-                    ? "bg-gradient-to-r from-[#3b82f6]/5 to-[#2323FF]/5 ring-1 ring-[#2323FF]/20"
-                    : "hover:bg-[#141414]"
+                    ? "bg-gradient-to-r from-brand/5 to-ai/5 ring-1 ring-ai/20"
+                    : "hover:bg-surface-overlay"
             )}
         >
             {/* Index / Play */}
             <div className="w-8 text-center">
-                <span className="text-sm text-[#525252] tabular-nums group-hover:hidden">
+                <span className="text-sm text-content-disabled tabular-nums group-hover:hidden">
                     {index + 1}
                 </span>
                 <button
@@ -512,20 +512,20 @@ function TrackRow({
                         className="rounded flex-shrink-0"
                     />
                     {isSelected && (
-                        <div className="absolute inset-0 rounded ring-2 ring-[#2323FF]/50" />
+                        <div className="absolute inset-0 rounded ring-2 ring-ai/50" />
                     )}
                 </div>
                 <div className="min-w-0">
                     <p className={cn(
                         "text-sm font-medium truncate transition-colors",
-                        isSelected ? "text-[#2323FF]" : "text-white"
+                        isSelected ? "text-ai" : "text-white"
                     )}>
                         {track.title}
                     </p>
                     <Link
                         href={`/artist/${track.artistId}`}
                         onClick={(e) => e.stopPropagation()}
-                        className="text-xs text-[#737373] hover:text-[#a3a3a3] hover:underline truncate block transition-colors"
+                        className="text-xs text-content-muted hover:text-content-secondary hover:underline truncate block transition-colors"
                     >
                         {track.artist}
                     </Link>
@@ -536,7 +536,7 @@ function TrackRow({
             <Link
                 href={`/album/${track.albumId}`}
                 onClick={(e) => e.stopPropagation()}
-                className="text-sm text-[#525252] hover:text-[#737373] hover:underline truncate hidden md:block max-w-[180px] transition-colors"
+                className="text-sm text-content-disabled hover:text-content-muted hover:underline truncate hidden md:block max-w-[180px] transition-colors"
             >
                 {track.album}
             </Link>
@@ -556,7 +556,7 @@ export default function VibePage() {
     if (featuresLoading) {
         return (
             <div className="flex items-center justify-center min-h-screen">
-                <Loader2 className="w-6 h-6 animate-spin text-[#525252]" />
+                <Loader2 className="w-6 h-6 animate-spin text-content-disabled" />
             </div>
         );
     }
@@ -565,9 +565,9 @@ export default function VibePage() {
         return (
             <div className="p-6">
                 <h1 className="text-xl font-semibold text-white mb-4">Vibe</h1>
-                <div className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-lg p-6">
-                    <p className="text-[#a3a3a3] mb-2">Feature not available</p>
-                    <p className="text-sm text-[#737373]">
+                <div className="bg-surface-raised border border-surface-active rounded-lg p-6">
+                    <p className="text-content-secondary mb-2">Feature not available</p>
+                    <p className="text-sm text-content-muted">
                         Vibe similarity requires the CLAP analyzer service.
                     </p>
                 </div>
@@ -916,14 +916,14 @@ function VibePageContent() {
                         opacity: selectedMatch ? 0.6 : 0.3,
                     }}
                     transition={{ duration: 1 }}
-                    className="absolute -top-40 -right-40 w-[500px] h-[500px] rounded-full bg-[#2323FF]/5 blur-[100px]"
+                    className="absolute -top-40 -right-40 w-[500px] h-[500px] rounded-full bg-ai/5 blur-[100px]"
                 />
                 <motion.div
                     animate={{
                         opacity: sourceTrack ? 0.5 : 0.2,
                     }}
                     transition={{ duration: 1 }}
-                    className="absolute -bottom-40 -left-40 w-[400px] h-[400px] rounded-full bg-[#3b82f6]/5 blur-[100px]"
+                    className="absolute -bottom-40 -left-40 w-[400px] h-[400px] rounded-full bg-brand/5 blur-[100px]"
                 />
             </div>
 
@@ -941,8 +941,8 @@ function VibePageContent() {
                                     className={cn(
                                         "flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition-colors disabled:opacity-50",
                                         sourceTrack?.id === currentTrack.id
-                                            ? "text-[#3b82f6] bg-[#3b82f6]/10"
-                                            : "text-[#737373] hover:text-white hover:bg-white/5"
+                                            ? "text-brand bg-brand/10"
+                                            : "text-content-muted hover:text-white hover:bg-white/5"
                                     )}
                                     title={`Find tracks similar to "${currentTrack.title}"`}
                                 >
@@ -953,7 +953,7 @@ function VibePageContent() {
                             <button
                                 onClick={handleRandomTrack}
                                 disabled={isLoading || libraryTracks.length === 0}
-                                className="flex items-center gap-2 px-3 py-1.5 text-sm text-[#737373] hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
+                                className="flex items-center gap-2 px-3 py-1.5 text-sm text-content-muted hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
                             >
                                 <Shuffle className="w-4 h-4" />
                                 <span className="hidden sm:inline">Random</span>
@@ -961,14 +961,14 @@ function VibePageContent() {
                             <button
                                 onClick={handleRefresh}
                                 disabled={isLoading}
-                                className="p-1.5 text-[#737373] hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
+                                className="p-1.5 text-content-muted hover:text-white hover:bg-white/5 rounded-md transition-colors disabled:opacity-50"
                             >
                                 <RefreshCw className={cn("w-4 h-4", isLoading && "animate-spin")} />
                             </button>
                         </div>
                     </div>
                     {vibeStatus && (
-                        <p className="text-sm text-[#525252]">
+                        <p className="text-sm text-content-disabled">
                             {vibeStatus.embeddedTracks.toLocaleString()} tracks with audio fingerprints
                         </p>
                     )}
@@ -986,7 +986,7 @@ function VibePageContent() {
                         </button>
                         <button
                             onClick={() => setVibeTab("map")}
-                            className="flex-1 flex items-center justify-center gap-2 py-1.5 rounded-md text-sm font-medium transition-colors text-gray-500 hover:text-gray-300"
+                            className="flex-1 flex items-center justify-center gap-2 py-1.5 rounded-md text-sm font-medium transition-colors text-gray-400 hover:text-gray-300"
                         >
                             <Map className="w-4 h-4" />
                             Map
@@ -995,16 +995,16 @@ function VibePageContent() {
 
                     {/* Search — only visible in explore tab */}
                     {vibeTab === "explore" && (<><form onSubmit={handleSearch} className="relative max-w-lg mt-5">
-                        <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[#525252]" />
+                        <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-content-disabled" />
                         <input
                             type="text"
                             placeholder="Search by vibe... try 'dark atmospheric' or 'upbeat dance'"
                             value={inputValue}
                             onChange={(e) => setInputValue(e.target.value)}
-                            className="w-full pl-10 pr-4 py-2.5 bg-[#0f0f0f] border border-[#1c1c1c] focus:border-[#333] rounded-lg text-sm text-white placeholder-[#525252] focus:outline-none transition-colors"
+                            className="w-full pl-10 pr-4 py-2.5 bg-surface-raised border border-surface-active focus:border-line-strong rounded-lg text-sm text-white placeholder-content-disabled focus:outline-none transition-colors"
                         />
                         {isSearching && (
-                            <Loader2 className="absolute right-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[#525252] animate-spin" />
+                            <Loader2 className="absolute right-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-content-disabled animate-spin" />
                         )}
                     </form>
 
@@ -1014,19 +1014,19 @@ function VibePageContent() {
                             <button
                                 key={preset.id}
                                 onClick={() => handleVibeSearch(preset.query)}
-                                className="px-3 py-1.5 text-xs text-[#737373] bg-[#0f0f0f] border border-[#1c1c1c] hover:border-[#333] hover:text-white rounded-full transition-all hover:scale-[1.02]"
+                                className="px-3 py-1.5 text-xs text-content-muted bg-surface-raised border border-surface-active hover:border-line-strong hover:text-white rounded-full transition-all hover:scale-[1.02]"
                             >
                                 {preset.name}
                             </button>
                         ))}
                         {recentSearches.length > 0 && (
                             <>
-                                <div className="w-px h-5 bg-[#1c1c1c] mx-1" />
+                                <div className="w-px h-5 bg-surface-active mx-1" />
                                 {recentSearches.slice(0, 3).map((query) => (
                                     <button
                                         key={query}
                                         onClick={() => handleVibeSearch(query)}
-                                        className="text-xs text-[#525252] hover:text-[#737373] transition-colors"
+                                        className="text-xs text-content-disabled hover:text-content-muted transition-colors"
                                     >
                                         {query}
                                     </button>
@@ -1040,9 +1040,9 @@ function VibePageContent() {
                 {vibeTab === "explore" && <>
                 {/* Error */}
                 {error && (
-                    <div className="mb-6 flex items-center gap-3 px-4 py-3 bg-[#ef4444]/5 border border-[#ef4444]/20 rounded-lg">
-                        <AlertCircle className="w-4 h-4 text-[#ef4444] flex-shrink-0" />
-                        <span className="text-sm text-[#ef4444]">{error}</span>
+                    <div className="mb-6 flex items-center gap-3 px-4 py-3 bg-error/5 border border-error/20 rounded-lg">
+                        <AlertCircle className="w-4 h-4 text-error flex-shrink-0" />
+                        <span className="text-sm text-error">{error}</span>
                     </div>
                 )}
 
@@ -1050,7 +1050,7 @@ function VibePageContent() {
                 {(isLoading || isSearching) && !error && (
                     <div className="flex items-center justify-center py-24">
                         <div className="relative">
-                            <div className="w-12 h-12 rounded-full border-2 border-[#1c1c1c] border-t-[#2323FF] animate-spin" />
+                            <div className="w-12 h-12 rounded-full border-2 border-surface-active border-t-[#2323FF] animate-spin" />
                         </div>
                     </div>
                 )}
@@ -1063,7 +1063,7 @@ function VibePageContent() {
                                 <h2 className="text-lg font-medium text-white">
                                     &ldquo;{searchQuery}&rdquo;
                                 </h2>
-                                <p className="text-sm text-[#525252]">
+                                <p className="text-sm text-content-disabled">
                                     {similarTracks.length} tracks found - double-click to explore similar
                                 </p>
                             </div>
@@ -1104,11 +1104,11 @@ function VibePageContent() {
                                             size={56}
                                             className="rounded-lg"
                                         />
-                                        <div className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-[#3b82f6] ring-2 ring-[#0a0a0a]" />
+                                        <div className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-brand ring-2 ring-surface" />
                                     </div>
                                     <div>
                                         <h2 className="font-medium text-white">Similar to</h2>
-                                        <p className="text-sm text-[#a3a3a3]">{sourceTrack.title}</p>
+                                        <p className="text-sm text-content-secondary">{sourceTrack.title}</p>
                                     </div>
                                 </div>
                                 <button
@@ -1149,12 +1149,12 @@ function VibePageContent() {
                                         <motion.div
                                             initial={{ opacity: 0 }}
                                             animate={{ opacity: 1 }}
-                                            className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-xl p-8 text-center"
+                                            className="bg-surface-raised border border-surface-active rounded-xl p-8 text-center"
                                         >
-                                            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-[#3b82f6]/10 to-[#2323FF]/10 flex items-center justify-center">
-                                                <Disc3 className="w-8 h-8 text-[#333]" />
+                                            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-brand/10 to-ai/10 flex items-center justify-center">
+                                                <Disc3 className="w-8 h-8 text-line-strong" />
                                             </div>
-                                            <p className="text-sm text-[#525252]">
+                                            <p className="text-sm text-content-disabled">
                                                 Select a track to compare audio DNA
                                             </p>
                                         </motion.div>
@@ -1168,11 +1168,11 @@ function VibePageContent() {
                 {/* Empty state - prompt user to start */}
                 {!isLoading && !isSearching && !error && !sourceTrack && similarTracks.length === 0 && viewMode === "comparison" && (
                     <div className="max-w-md mx-auto text-center py-16">
-                        <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-gradient-to-br from-[#3b82f6]/10 to-[#2323FF]/10 flex items-center justify-center">
-                            <AudioWaveform className="w-12 h-12 text-[#525252]" />
+                        <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-gradient-to-br from-brand/10 to-ai/10 flex items-center justify-center">
+                            <AudioWaveform className="w-12 h-12 text-content-disabled" />
                         </div>
                         <h2 className="text-xl font-medium text-white mb-2">Explore by Vibe</h2>
-                        <p className="text-[#737373] mb-8">
+                        <p className="text-content-muted mb-8">
                             Find tracks that sound similar to each other based on their audio characteristics.
                         </p>
 
@@ -1181,16 +1181,16 @@ function VibePageContent() {
                             {currentTrack && (
                                 <button
                                     onClick={handleUseCurrentTrack}
-                                    className="w-full flex items-center gap-4 px-4 py-3 bg-[#0f0f0f] border border-[#1c1c1c] hover:border-[#333] rounded-lg transition-all text-left group"
+                                    className="w-full flex items-center gap-4 px-4 py-3 bg-surface-raised border border-surface-active hover:border-line-strong rounded-lg transition-all text-left group"
                                 >
-                                    <div className="w-12 h-12 rounded bg-[#1a1a1a] flex items-center justify-center flex-shrink-0">
-                                        <AudioWaveform className="w-5 h-5 text-[#3b82f6]" />
+                                    <div className="w-12 h-12 rounded bg-surface-hover flex items-center justify-center flex-shrink-0">
+                                        <AudioWaveform className="w-5 h-5 text-brand" />
                                     </div>
                                     <div className="min-w-0 flex-1">
                                         <p className="text-sm font-medium text-white truncate">
                                             Find tracks like &ldquo;{currentTrack.title}&rdquo;
                                         </p>
-                                        <p className="text-xs text-[#525252]">Use the currently playing track</p>
+                                        <p className="text-xs text-content-disabled">Use the currently playing track</p>
                                     </div>
                                 </button>
                             )}
@@ -1199,22 +1199,22 @@ function VibePageContent() {
                             <button
                                 onClick={handleRandomTrack}
                                 disabled={libraryTracks.length === 0}
-                                className="w-full flex items-center gap-4 px-4 py-3 bg-[#0f0f0f] border border-[#1c1c1c] hover:border-[#333] rounded-lg transition-all text-left group disabled:opacity-50"
+                                className="w-full flex items-center gap-4 px-4 py-3 bg-surface-raised border border-surface-active hover:border-line-strong rounded-lg transition-all text-left group disabled:opacity-50"
                             >
-                                <div className="w-12 h-12 rounded bg-[#1a1a1a] flex items-center justify-center flex-shrink-0">
-                                    <Shuffle className="w-5 h-5 text-[#2323FF]" />
+                                <div className="w-12 h-12 rounded bg-surface-hover flex items-center justify-center flex-shrink-0">
+                                    <Shuffle className="w-5 h-5 text-ai" />
                                 </div>
                                 <div className="min-w-0 flex-1">
                                     <p className="text-sm font-medium text-white">Surprise me</p>
-                                    <p className="text-xs text-[#525252]">Pick a random track from your library</p>
+                                    <p className="text-xs text-content-disabled">Pick a random track from your library</p>
                                 </div>
                             </button>
 
                             {/* Divider */}
                             <div className="flex items-center gap-3 py-2">
-                                <div className="flex-1 h-px bg-[#1c1c1c]" />
-                                <span className="text-xs text-[#525252]">or search above</span>
-                                <div className="flex-1 h-px bg-[#1c1c1c]" />
+                                <div className="flex-1 h-px bg-surface-active" />
+                                <span className="text-xs text-content-disabled">or search above</span>
+                                <div className="flex-1 h-px bg-surface-active" />
                             </div>
 
                             {/* Preset chips */}
@@ -1223,7 +1223,7 @@ function VibePageContent() {
                                     <button
                                         key={preset.id}
                                         onClick={() => handleVibeSearch(preset.query)}
-                                        className="px-3 py-1.5 text-xs text-[#737373] bg-[#0f0f0f] border border-[#1c1c1c] hover:border-[#333] hover:text-white rounded-full transition-all"
+                                        className="px-3 py-1.5 text-xs text-content-muted bg-surface-raised border border-surface-active hover:border-line-strong hover:text-white rounded-full transition-all"
                                     >
                                         {preset.name}
                                     </button>
@@ -1232,7 +1232,7 @@ function VibePageContent() {
                         </div>
 
                         {vibeStatus && vibeStatus.embeddedTracks === 0 && (
-                            <p className="text-xs text-[#ef4444] mt-6">
+                            <p className="text-xs text-error mt-6">
                                 No tracks analyzed yet. Run the CLAP analyzer to enable vibe search.
                             </p>
                         )}

--- a/frontend/components/DownloadNotifications.tsx
+++ b/frontend/components/DownloadNotifications.tsx
@@ -169,7 +169,7 @@ export function DownloadNotifications() {
                 ref={containerRef}
                 className="fixed top-20 left-1/2 -translate-x-1/2 z-50 w-auto max-w-[90vw]"
             >
-                <div className="bg-[#1a1a1a]/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-2xl overflow-hidden">
+                <div className="bg-surface-hover/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-2xl overflow-hidden">
                     {/* Compact Header */}
                     <div className="flex items-center justify-between px-3 py-2 gap-3">
                         <div className="flex items-center gap-2">
@@ -254,7 +254,7 @@ export function DownloadNotifications() {
                 transition: isDragging ? "none" : "transform 0.2s ease-out",
             }}
         >
-            <div className="bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl overflow-hidden">
+            <div className="bg-surface-hover border border-white/10 rounded-lg shadow-2xl overflow-hidden">
                 {/* Header */}
                 <div
                     className={cn(
@@ -376,7 +376,7 @@ function DownloadJobItem({
         if (!job.metadata?.currentSource) return "text-white/60";
         switch (job.metadata.currentSource) {
             case "lidarr":
-                return "text-[#5b5bff]";
+                return "text-ai-hover";
             case "soulseek":
                 return "text-teal-400";
             case "tidal":
@@ -500,7 +500,7 @@ function DownloadJobItemCompact({
         if (!job.metadata?.currentSource) return "text-white/60";
         switch (job.metadata.currentSource) {
             case "lidarr":
-                return "text-[#5b5bff]";
+                return "text-ai-hover";
             case "soulseek":
                 return "text-teal-400";
             case "tidal":

--- a/frontend/components/EnrichmentFailuresModal.tsx
+++ b/frontend/components/EnrichmentFailuresModal.tsx
@@ -162,7 +162,7 @@ export function EnrichmentFailuresModal({
 
     return (
         <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
-            <div className="bg-[#1a1a1a] rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col border border-white/10">
+            <div className="bg-surface-hover rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col border border-white/10">
                 {/* Header */}
                 <div className="flex items-center justify-between p-6 border-b border-white/10">
                     <div>
@@ -230,7 +230,7 @@ export function EnrichmentFailuresModal({
                             }}
                             className={`px-5 py-2.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
                                 selectedType === tab.key
-                                    ? "bg-[#3b82f6] text-black"
+                                    ? "bg-brand text-black"
                                     : "bg-white/5 text-white/70 hover:bg-white/10"
                             }`}
                         >
@@ -406,7 +406,7 @@ export function EnrichmentFailuresModal({
             {/* Clear All Confirmation Dialog */}
             {showClearConfirm && (
                 <div className="fixed inset-0 bg-black/80 z-[60] flex items-center justify-center p-4">
-                    <div className="bg-[#1a1a1a] rounded-lg p-6 max-w-md border border-white/10">
+                    <div className="bg-surface-hover rounded-lg p-6 max-w-md border border-white/10">
                         <h3 className="text-lg font-bold text-white mb-2">
                             Clear All Failures?
                         </h3>

--- a/frontend/components/MetadataEditor.tsx
+++ b/frontend/components/MetadataEditor.tsx
@@ -265,7 +265,7 @@ export function MetadataEditor({
             {/* Modal */}
             {isOpen && (
                 <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-                    <div className="bg-[#121212] rounded-lg max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+                    <div className="bg-surface-sunken rounded-lg max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
                         {/* Header */}
                         <div className="flex items-center justify-between p-6 border-b border-white/10">
                             <h2 className="text-2xl font-bold text-white">
@@ -315,13 +315,13 @@ export function MetadataEditor({
                                             e.target.value
                                         )
                                     }
-                                    className="w-full px-4 py-2 bg-[#181818] border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
+                                    className="w-full px-4 py-2 bg-surface-elevated border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
                                 />
                                 {type === "artist" &&
                                     currentData._originalName &&
                                     currentData._originalName !==
                                         (formData.name || "") && (
-                                        <p className="mt-1 text-xs text-gray-500">
+                                        <p className="mt-1 text-xs text-gray-400">
                                             Original:{" "}
                                             {currentData._originalName}
                                         </p>
@@ -330,7 +330,7 @@ export function MetadataEditor({
                                     currentData._originalTitle &&
                                     currentData._originalTitle !==
                                         (formData.title || "") && (
-                                        <p className="mt-1 text-xs text-gray-500">
+                                        <p className="mt-1 text-xs text-gray-400">
                                             Original:{" "}
                                             {currentData._originalTitle}
                                         </p>
@@ -349,12 +349,12 @@ export function MetadataEditor({
                                             handleChange("bio", e.target.value)
                                         }
                                         rows={6}
-                                        className="w-full px-4 py-2 bg-[#181818] border border-white/10 rounded text-white focus:border-white/30 focus:outline-none resize-none"
+                                        className="w-full px-4 py-2 bg-surface-elevated border border-white/10 rounded text-white focus:border-white/30 focus:outline-none resize-none"
                                     />
                                     {currentData._originalBio &&
                                         currentData._originalBio !==
                                             (formData.bio || "") && (
-                                            <p className="mt-1 text-xs text-gray-500">
+                                            <p className="mt-1 text-xs text-gray-400">
                                                 Original:{" "}
                                                 {currentData._originalBio.substring(
                                                     0,
@@ -381,12 +381,12 @@ export function MetadataEditor({
                                                 parseInt(e.target.value)
                                             )
                                         }
-                                        className="w-full px-4 py-2 bg-[#181818] border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
+                                        className="w-full px-4 py-2 bg-surface-elevated border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
                                     />
                                     {currentData._originalYear &&
                                         currentData._originalYear !==
                                             (formData.year || null) && (
-                                            <p className="mt-1 text-xs text-gray-500">
+                                            <p className="mt-1 text-xs text-gray-400">
                                                 Original:{" "}
                                                 {currentData._originalYear}
                                             </p>
@@ -415,7 +415,7 @@ export function MetadataEditor({
                                         )
                                     }
                                     placeholder="Rock, Alternative, Indie"
-                                    className="w-full px-4 py-2 bg-[#181818] border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
+                                    className="w-full px-4 py-2 bg-surface-elevated border border-white/10 rounded text-white focus:border-white/30 focus:outline-none"
                                 />
                                 {currentData._originalGenres &&
                                     currentData._originalGenres.length > 0 &&
@@ -425,7 +425,7 @@ export function MetadataEditor({
                                         JSON.stringify(
                                             (formData.genres || []).sort()
                                         ) && (
-                                        <p className="mt-1 text-xs text-gray-500">
+                                        <p className="mt-1 text-xs text-gray-400">
                                             Original:{" "}
                                             {currentData._originalGenres.join(
                                                 ", "
@@ -452,7 +452,7 @@ export function MetadataEditor({
                                             handleChange("mbid", e.target.value)
                                         }
                                         placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                                        className={`w-full px-4 py-2 bg-[#181818] border rounded text-white focus:outline-none font-mono text-sm ${
+                                        className={`w-full px-4 py-2 bg-surface-elevated border rounded text-white focus:outline-none font-mono text-sm ${
                                             mbidFieldError
                                                 ? "border-red-500/60 focus:border-red-500"
                                                 : "border-white/10 focus:border-white/30"
@@ -517,13 +517,13 @@ export function MetadataEditor({
                                         )
                                     }
                                     placeholder="https://..."
-                                    className="w-full px-4 py-2 bg-[#181818] border border-white/10 rounded text-white focus:border-white/30 focus:outline-none text-sm"
+                                    className="w-full px-4 py-2 bg-surface-elevated border border-white/10 rounded text-white focus:border-white/30 focus:outline-none text-sm"
                                 />
                                 {type === "artist" &&
                                     currentData._originalHeroUrl &&
                                     currentData._originalHeroUrl !==
                                         (formData.heroUrl || "") && (
-                                        <p className="mt-1 text-xs text-gray-500 truncate">
+                                        <p className="mt-1 text-xs text-gray-400 truncate">
                                             Original:{" "}
                                             {currentData._originalHeroUrl}
                                         </p>
@@ -532,7 +532,7 @@ export function MetadataEditor({
                                     currentData._originalCoverUrl &&
                                     currentData._originalCoverUrl !==
                                         (formData.coverUrl || "") && (
-                                        <p className="mt-1 text-xs text-gray-500 truncate">
+                                        <p className="mt-1 text-xs text-gray-400 truncate">
                                             Original:{" "}
                                             {currentData._originalCoverUrl}
                                         </p>
@@ -589,7 +589,7 @@ export function MetadataEditor({
                             <button
                                 onClick={handleSave}
                                 disabled={isSaving}
-                                className="px-6 py-2 rounded-full bg-[#60a5fa] hover:bg-[#3b82f6] text-black font-bold transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="px-6 py-2 rounded-full bg-brand-hover hover:bg-brand text-black font-bold transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 {isSaving ? (
                                     <>

--- a/frontend/components/MixCard.tsx
+++ b/frontend/components/MixCard.tsx
@@ -32,7 +32,7 @@ const MixCard = memo(
             >
                 <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
                     {/* Mosaic cover art */}
-                    <div className="aspect-square bg-[#282828] rounded-lg mb-3 overflow-hidden relative shadow-lg">
+                    <div className="aspect-square bg-surface-highlight rounded-lg mb-3 overflow-hidden relative shadow-lg">
                         <CoverMosaic
                             coverUrls={proxiedUrls}
                             hoverScale

--- a/frontend/components/PWAInstallPrompt.tsx
+++ b/frontend/components/PWAInstallPrompt.tsx
@@ -89,7 +89,7 @@ export function PWAInstallPrompt() {
 
     return (
         <div className="fixed bottom-20 left-4 right-4 md:left-auto md:right-4 md:w-80 z-50 animate-slide-up">
-            <div className="bg-[#1a1a1a] border border-[#333] rounded-xl p-4 shadow-2xl">
+            <div className="bg-surface-hover border border-line-strong rounded-xl p-4 shadow-2xl">
                 <button
                     onClick={handleDismiss}
                     className="absolute top-2 right-2 p-1 text-white/50 hover:text-white/80 transition-colors"
@@ -99,8 +99,8 @@ export function PWAInstallPrompt() {
                 </button>
 
                 <div className="flex items-start gap-3">
-                    <div className="p-2 bg-[#3b82f6]/20 rounded-lg">
-                        <Smartphone className="w-6 h-6 text-[#3b82f6]" />
+                    <div className="p-2 bg-brand/20 rounded-lg">
+                        <Smartphone className="w-6 h-6 text-brand" />
                     </div>
                     <div className="flex-1">
                         <h3 className="text-white font-semibold text-sm mb-1">
@@ -122,7 +122,7 @@ export function PWAInstallPrompt() {
                 {!isIOS && deferredPrompt && (
                     <button
                         onClick={handleInstall}
-                        className="w-full mt-3 py-2 px-4 bg-[#3b82f6] text-black font-semibold text-sm rounded-lg hover:bg-[#93c5fd] transition-colors flex items-center justify-center gap-2"
+                        className="w-full mt-3 py-2 px-4 bg-brand text-black font-semibold text-sm rounded-lg hover:bg-brand-light transition-colors flex items-center justify-center gap-2"
                     >
                         <Download className="w-4 h-4" />
                         Install App

--- a/frontend/components/activity/ActiveDownloadsTab.tsx
+++ b/frontend/components/activity/ActiveDownloadsTab.tsx
@@ -165,7 +165,7 @@ export function ActiveDownloadsTab({
                                                     download.metadata
                                                         .currentSource ===
                                                         "lidarr"
-                                                        ? "text-[#5b5bff]"
+                                                        ? "text-ai-hover"
                                                         : download.metadata
                                                               .currentSource ===
                                                           "tidal"

--- a/frontend/components/activity/HistoryTab.tsx
+++ b/frontend/components/activity/HistoryTab.tsx
@@ -237,7 +237,7 @@ function HistoryItem({
                             title="Retry download"
                         >
                             <RotateCcw className={cn(
-                                "w-3.5 h-3.5 text-white/40 hover:text-[#3b82f6]",
+                                "w-3.5 h-3.5 text-white/40 hover:text-brand",
                                 isRetrying && "animate-spin"
                             )} />
                         </button>

--- a/frontend/components/activity/ImportsTab.tsx
+++ b/frontend/components/activity/ImportsTab.tsx
@@ -12,7 +12,7 @@ const STATUS_CONFIG: Record<string, { icon: React.ElementType; color: string; la
     cancelling: { icon: Loader2, color: "text-amber-400", label: "Cancelling" },
     completed: { icon: CheckCircle2, color: "text-emerald-400", label: "Completed" },
     failed: { icon: XCircle, color: "text-red-400", label: "Failed" },
-    cancelled: { icon: Ban, color: "text-gray-500", label: "Cancelled" },
+    cancelled: { icon: Ban, color: "text-gray-400", label: "Cancelled" },
 };
 
 function JobStatusBadge({ status }: { status: string }) {
@@ -81,7 +81,7 @@ export function ImportsTab() {
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 text-gray-500 animate-spin" />
+                <Loader2 className="w-6 h-6 text-gray-400 animate-spin" />
             </div>
         );
     }
@@ -90,7 +90,7 @@ export function ImportsTab() {
         return (
             <div className="flex flex-col items-center justify-center py-12 text-center px-4">
                 <p className="text-gray-400 text-sm">No import jobs yet</p>
-                <p className="text-gray-600 text-xs mt-1">
+                <p className="text-gray-400 text-xs mt-1">
                     Submit imports from the Import page
                 </p>
             </div>
@@ -116,7 +116,7 @@ export function ImportsTab() {
                                 <p className="text-sm text-white truncate">
                                     {job.requestedPlaylistName || job.playlistName}
                                 </p>
-                                <p className="text-xs text-gray-500 truncate mt-0.5">
+                                <p className="text-xs text-gray-400 truncate mt-0.5">
                                     {job.sourceType} &middot;{" "}
                                     {new Date(job.createdAt).toLocaleDateString()}
                                 </p>
@@ -134,7 +134,7 @@ export function ImportsTab() {
                         )}
 
                         {job.summary && job.summary.total > 0 && (
-                            <p className="text-[11px] text-gray-600 mt-1">
+                            <p className="text-[11px] text-gray-400 mt-1">
                                 {job.summary.local} local &middot;{" "}
                                 {job.summary.unresolved} unresolved &middot;{" "}
                                 {job.summary.total} total

--- a/frontend/components/activity/NotificationsTab.tsx
+++ b/frontend/components/activity/NotificationsTab.tsx
@@ -92,7 +92,7 @@ export function NotificationsTab({
                 return <AlertCircle className="w-4 h-4 text-red-400" />;
             case "playlist_ready":
             case "import_complete":
-                return <ListMusic className="w-4 h-4 text-[#3b82f6]" />;
+                return <ListMusic className="w-4 h-4 text-brand" />;
             case "system":
             default:
                 return <Bell className="w-4 h-4 text-white/60" />;
@@ -181,7 +181,7 @@ export function NotificationsTab({
                                             {notification.title}
                                         </p>
                                         {!notification.read && (
-                                            <span className="w-1.5 h-1.5 rounded-full bg-[#3b82f6] flex-shrink-0" />
+                                            <span className="w-1.5 h-1.5 rounded-full bg-brand flex-shrink-0" />
                                         )}
                                     </div>
                                     {notification.message && (
@@ -196,7 +196,7 @@ export function NotificationsTab({
                                         {link && (
                                             <Link
                                                 href={link}
-                                                className="text-[10px] text-[#3b82f6] hover:underline flex items-center gap-0.5"
+                                                className="text-[10px] text-brand hover:underline flex items-center gap-0.5"
                                             >
                                                 View{" "}
                                                 <ExternalLink className="w-2.5 h-2.5" />

--- a/frontend/components/activity/SocialTab.tsx
+++ b/frontend/components/activity/SocialTab.tsx
@@ -143,7 +143,7 @@ export function SocialTab({
                             key={user.id}
                             role="listitem"
                             tabIndex={0}
-                            className="px-3 py-3 border-b border-white/5 hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#3b82f6]/50 focus-visible:bg-white/5"
+                            className="px-3 py-3 border-b border-white/5 hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand/50 focus-visible:bg-white/5"
                         >
                             <div className="flex items-start gap-3">
                                 <div className="w-8 h-8 rounded-full bg-white/10 text-white/80 text-xs font-semibold flex items-center justify-center shrink-0 overflow-hidden">
@@ -183,7 +183,7 @@ export function SocialTab({
                                         </span>
                                         {user.isInListenTogetherGroup && (
                                             <span
-                                                className="inline-flex items-center justify-center font-bold rounded text-[9px] px-1 py-0.5 leading-none bg-[#2323FF]/20 text-[#5b5bff]"
+                                                className="inline-flex items-center justify-center font-bold rounded text-[9px] px-1 py-0.5 leading-none bg-ai/20 text-ai-hover"
                                                 title="In a Listen Together session"
                                                 aria-label="In a Listen Together session"
                                             >
@@ -199,7 +199,7 @@ export function SocialTab({
                                     )}
 
                                     {showTrack && track ? (
-                                        <p className="text-xs text-[#3b82f6] truncate mt-1 flex items-center gap-1.5">
+                                        <p className="text-xs text-brand truncate mt-1 flex items-center gap-1.5">
                                             {track.coverArt ? (
                                                 <span className="relative w-3.5 h-3.5 shrink-0 overflow-hidden rounded-[2px]">
                                                     <Image

--- a/frontend/components/layout/ActivityPanel.tsx
+++ b/frontend/components/layout/ActivityPanel.tsx
@@ -157,7 +157,7 @@ export function ActivityPanel({
 
                 {/* Panel - slides in from right */}
                 <div
-                    className="fixed inset-y-0 right-0 w-full max-w-md bg-[#0a0a0a] z-[101] flex flex-col"
+                    className="fixed inset-y-0 right-0 w-full max-w-md bg-surface z-[101] flex flex-col"
                     style={{ paddingTop: "env(safe-area-inset-top)" }}
                 >
                     {/* Header */}
@@ -190,7 +190,7 @@ export function ActivityPanel({
                                     className={cn(
                                         "flex-1 flex items-center justify-center gap-2 py-3 text-sm font-medium transition-colors relative",
                                         effectiveActiveTab === tab.id
-                                            ? "text-white border-b-2 border-[#60a5fa]"
+                                            ? "text-white border-b-2 border-brand-hover"
                                             : "text-white/50 hover:text-white/70"
                                     )}
                                 >
@@ -202,7 +202,7 @@ export function ActivityPanel({
                                                 "min-w-[18px] h-[18px] px-1 rounded-full text-xs font-bold flex items-center justify-center ml-1",
                                                 tab.id === "active"
                                                     ? "bg-blue-500 text-white"
-                                                    : "bg-[#60a5fa] text-black"
+                                                    : "bg-brand-hover text-black"
                                             )}
                                         >
                                             {badge > 99 ? "99+" : badge}
@@ -275,7 +275,7 @@ export function ActivityPanel({
                 <div
                     onClick={onToggle}
                     className={cn(
-                        "absolute left-0 top-0 bottom-0 w-12 flex items-center justify-center cursor-pointer hover:bg-[#141414] transition-colors z-10",
+                        "absolute left-0 top-0 bottom-0 w-12 flex items-center justify-center cursor-pointer hover:bg-surface-overlay transition-colors z-10",
                         isOpen && "pointer-events-none opacity-0"
                     )}
                     title="Open activity panel"
@@ -284,7 +284,7 @@ export function ActivityPanel({
 
                     {/* Activity badge */}
                     {hasActivity && (
-                        <span className="absolute top-4 right-3 w-2.5 h-2.5 rounded-full bg-[#3b82f6]" />
+                        <span className="absolute top-4 right-3 w-2.5 h-2.5 rounded-full bg-brand" />
                     )}
                 </div>
 
@@ -323,7 +323,7 @@ export function ActivityPanel({
                                 className={cn(
                                     "group flex items-center justify-center gap-2 py-3 px-3 transition-all duration-200 relative",
                                     isActive
-                                        ? "text-white border-b-2 border-[#3b82f6] flex-[2]"
+                                        ? "text-white border-b-2 border-brand flex-[2]"
                                         : "text-white/50 hover:text-white/70 hover:flex-[2] flex-1"
                                 )}
                                 title={tab.label}
@@ -345,7 +345,7 @@ export function ActivityPanel({
                                             "absolute top-1.5 right-1 min-w-[16px] h-[16px] px-0.5 rounded-full text-[10px] font-bold flex items-center justify-center",
                                             tab.id === "active"
                                                 ? "bg-blue-500 text-white"
-                                                : "bg-[#3b82f6] text-black"
+                                                : "bg-brand text-black"
                                         )}
                                     >
                                         {badge > 99 ? "99+" : badge}
@@ -425,7 +425,7 @@ export function ActivityPanelToggle({
         >
             <Bell className="w-5 h-5" />
             {hasActivity && (
-                <span className="absolute top-1.5 right-2 w-1 h-1 rounded-full bg-[#3b82f6]" />
+                <span className="absolute top-1.5 right-2 w-1 h-1 rounded-full bg-brand" />
             )}
         </button>
     );

--- a/frontend/components/layout/AuthenticatedLayout.tsx
+++ b/frontend/components/layout/AuthenticatedLayout.tsx
@@ -135,7 +135,7 @@ export function AuthenticatedLayout({ children }: { children: ReactNode }) {
                             <main
                                 id="main-content"
                                 tabIndex={-1}
-                                className="flex-1 bg-gradient-to-b from-[#1a1a1a] via-black to-black mx-2 mb-2 rounded-lg overflow-y-auto relative focus:outline-none"
+                                className="flex-1 bg-gradient-to-b from-surface-hover via-black to-black mx-2 mb-2 rounded-lg overflow-y-auto relative focus:outline-none"
                                 style={{
                                     marginTop: "calc(58px + env(safe-area-inset-top, 0px))",
                                     marginBottom:
@@ -179,7 +179,7 @@ export function AuthenticatedLayout({ children }: { children: ReactNode }) {
                         <main
                             id="main-content"
                             tabIndex={-1}
-                            className="flex-1 bg-gradient-to-b from-[#1a1a1a] via-black to-black rounded-lg overflow-y-auto relative focus:outline-none"
+                            className="flex-1 bg-gradient-to-b from-surface-hover via-black to-black rounded-lg overflow-y-auto relative focus:outline-none"
                         >
                             <GalaxyBackground />
                             {children}

--- a/frontend/components/layout/BottomNavigation.tsx
+++ b/frontend/components/layout/BottomNavigation.tsx
@@ -67,7 +67,7 @@ export function BottomNavigation() {
                                 "flex flex-col items-center justify-center flex-1 h-full py-2 transition-colors",
                                 isActive
                                     ? "text-white"
-                                    : "text-gray-500 active:text-gray-300"
+                                    : "text-gray-400 active:text-gray-300"
                             )}
                             aria-label={item.name}
                             aria-current={isActive ? "page" : undefined}

--- a/frontend/components/layout/MobileSidebar.tsx
+++ b/frontend/components/layout/MobileSidebar.tsx
@@ -99,7 +99,7 @@ export function MobileSidebar({ isOpen, onClose, hasActiveSessions }: MobileSide
 
             {/* Sidebar Drawer */}
             <div
-                className="fixed inset-y-0 left-0 w-[280px] bg-[#0a0a0a] z-50 flex flex-col overflow-hidden transform transition-transform border-r border-white/[0.06] z-100"
+                className="fixed inset-y-0 left-0 w-[280px] bg-surface z-50 flex flex-col overflow-hidden transform transition-transform border-r border-white/[0.06] z-100"
                 style={{
                     paddingTop: "env(safe-area-inset-top)",
                 }}
@@ -125,7 +125,7 @@ export function MobileSidebar({ isOpen, onClose, hasActiveSessions }: MobileSide
                     </Link>
                     <button
                         onClick={onClose}
-                        className="w-9 h-9 flex items-center justify-center text-gray-500 hover:text-white transition-colors rounded-full hover:bg-white/10"
+                        className="w-9 h-9 flex items-center justify-center text-gray-400 hover:text-white transition-colors rounded-full hover:bg-white/10"
                         aria-label="Close menu"
                     >
                         <X className="w-5 h-5" />
@@ -140,7 +140,7 @@ export function MobileSidebar({ isOpen, onClose, hasActiveSessions }: MobileSide
                 >
                     {/* Quick Links Section */}
                     <div className="px-3 mb-6">
-                        <div className="text-[10px] font-semibold text-gray-600 uppercase tracking-widest px-3 mb-2">
+                        <div className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest px-3 mb-2">
                             Quick Links
                         </div>
                         {MOBILE_QUICK_LINKS.map((link) => {
@@ -173,7 +173,7 @@ export function MobileSidebar({ isOpen, onClose, hasActiveSessions }: MobileSide
 
                     {/* Actions Section */}
                     <div className="px-3">
-                        <div className="text-[10px] font-semibold text-gray-600 uppercase tracking-widest px-3 mb-2">
+                        <div className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest px-3 mb-2">
                             Actions
                         </div>
 

--- a/frontend/components/layout/PageHeader.tsx
+++ b/frontend/components/layout/PageHeader.tsx
@@ -35,7 +35,7 @@ export function PageHeader({
                     <div className="flex items-center gap-3 mb-1">
                         <Icon
                             className={cn(
-                                "w-8 h-8 text-[#3b82f6] shrink-0",
+                                "w-8 h-8 text-brand shrink-0",
                                 iconClassName
                             )}
                         />

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -225,7 +225,7 @@ export function Sidebar() {
                                     Stream Your Way
                                 </p>
                             :   <div className="text-xs text-gray-400 truncate">
-                                    <span className="text-gray-500">
+                                    <span className="text-gray-400">
                                         Listening to:{" "}
                                     </span>
                                     <span className="text-white font-medium">
@@ -318,7 +318,7 @@ export function Sidebar() {
                                     {item.name}
                                 </span>
                                 {badge && (
-                                    <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded bg-[#3b82f6]/20 text-[#3b82f6] border border-[#3b82f6]/30">
+                                    <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded bg-brand/20 text-brand border border-brand/30">
                                         {badge}
                                     </span>
                                 )}
@@ -344,14 +344,14 @@ export function Sidebar() {
                         prefetch={false}
                         className="relative group/link"
                     >
-                        <span className="text-[10px] font-black text-gray-500 group-hover/link:text-transparent group-hover/link:bg-clip-text group-hover/link:bg-gradient-to-r group-hover/link:from-[#5b5bff] group-hover/link:to-[#00c8ff] transition-all duration-300 uppercase tracking-[0.15em]">
+                        <span className="text-[10px] font-black text-gray-400 group-hover/link:text-transparent group-hover/link:bg-clip-text group-hover/link:bg-gradient-to-r group-hover/link:from-ai-hover group-hover/link:to-[#00c8ff] transition-all duration-300 uppercase tracking-[0.15em]">
                             {playlistFilter === "others"
                                 ? "Shared playlists"
                                 : playlistFilter === "mine"
                                   ? "Your playlists"
                                   : "All playlists"}
                         </span>
-                        <div className="absolute -bottom-0.5 left-0 right-0 h-px bg-gradient-to-r from-[#2323FF]/0 via-[#2323FF]/50 to-[#2323FF]/0 opacity-0 group-hover/link:opacity-100 transition-opacity duration-300" />
+                        <div className="absolute -bottom-0.5 left-0 right-0 h-px bg-gradient-to-r from-ai/0 via-ai/50 to-ai/0 opacity-0 group-hover/link:opacity-100 transition-opacity duration-300" />
                     </Link>
                     <div className="flex items-center gap-1">
                         <div ref={sortFilterRef} className="relative">
@@ -369,8 +369,8 @@ export function Sidebar() {
                                 className={cn(
                                     "w-7 h-7 flex items-center justify-center rounded-md transition-all duration-300 border border-white/5",
                                     isFiltered
-                                        ? "bg-[#2323FF]/20 text-[#5b5bff] border-[#2323FF]/30"
-                                        : "bg-white/5 text-gray-400 hover:text-white hover:bg-gradient-to-br hover:from-[#2323FF] hover:to-[#00c8ff] hover:scale-110 shadow-lg shadow-transparent hover:shadow-[#2323FF]/30 hover:border-transparent"
+                                        ? "bg-ai/20 text-ai-hover border-ai/30"
+                                        : "bg-white/5 text-gray-400 hover:text-white hover:bg-gradient-to-br hover:from-ai hover:to-[#00c8ff] hover:scale-110 shadow-lg shadow-transparent hover:shadow-ai/30 hover:border-transparent"
                                 )}
                                 aria-label="Sort and filter playlists"
                                 title="Sort & Filter"
@@ -380,10 +380,10 @@ export function Sidebar() {
 
                             {isSortFilterOpen && sortFilterPos && (
                                 <div
-                                    className="fixed w-44 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-xl shadow-black/40 py-1 z-[10000]"
+                                    className="fixed w-44 bg-surface-hover border border-white/10 rounded-lg shadow-xl shadow-black/40 py-1 z-[10000]"
                                     style={{ top: sortFilterPos.top, left: sortFilterPos.left }}
                                 >
-                                    <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
+                                    <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
                                         Sort
                                     </div>
                                     {([
@@ -407,7 +407,7 @@ export function Sidebar() {
 
                                     <div className="mx-2 my-1 border-t border-white/10" />
 
-                                    <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
+                                    <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
                                         Show
                                     </div>
                                     {([
@@ -435,7 +435,7 @@ export function Sidebar() {
                         <Link
                             href="/playlists"
                             prefetch={false}
-                            className="w-7 h-7 flex items-center justify-center rounded-md bg-white/5 text-gray-400 hover:text-white hover:bg-gradient-to-br hover:from-[#2323FF] hover:to-[#00c8ff] hover:scale-110 transition-all duration-300 shadow-lg shadow-transparent hover:shadow-[#2323FF]/30 border border-white/5 hover:border-transparent"
+                            className="w-7 h-7 flex items-center justify-center rounded-md bg-white/5 text-gray-400 hover:text-white hover:bg-gradient-to-br hover:from-ai hover:to-[#00c8ff] hover:scale-110 transition-all duration-300 shadow-lg shadow-transparent hover:shadow-ai/30 border border-white/5 hover:border-transparent"
                             aria-label="Create playlist"
                             title="Create Playlist"
                         >
@@ -459,15 +459,15 @@ export function Sidebar() {
                                 className={cn(
                                     "block px-3 py-2.5 rounded-lg transition-all duration-300 group relative overflow-hidden",
                                     isLikedActive
-                                        ? "bg-gradient-to-r from-[#2323FF]/10 to-transparent text-white border-l-2 border-[#2323FF] shadow-md shadow-[#2323FF]/5"
-                                        : "text-gray-400 hover:text-white hover:bg-white/[0.05] border-l-2 border-transparent hover:border-l-2 hover:border-[#2323FF]/30",
+                                        ? "bg-gradient-to-r from-ai/10 to-transparent text-white border-l-2 border-ai shadow-md shadow-ai/5"
+                                        : "text-gray-400 hover:text-white hover:bg-white/[0.05] border-l-2 border-transparent hover:border-l-2 hover:border-ai/30",
                                 )}
                             >
                                 {!isLikedActive && (
-                                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-[#2323FF]/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700" />
+                                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-ai/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700" />
                                 )}
                                 <div className="flex items-center gap-1.5">
-                                    <Heart className="w-3.5 h-3.5 shrink-0 text-[#3b82f6] fill-[#3b82f6] relative z-10" />
+                                    <Heart className="w-3.5 h-3.5 shrink-0 text-brand fill-brand relative z-10" />
                                     <div
                                         className={cn(
                                             "text-sm font-medium truncate relative z-10 transition-all duration-200 flex-1",
@@ -480,7 +480,7 @@ export function Sidebar() {
                                 <div
                                     className={cn(
                                         "text-xs truncate relative z-10 mt-0.5 transition-colors duration-200",
-                                        isLikedActive ? "text-gray-400" : "text-gray-500 group-hover:text-gray-400",
+                                        isLikedActive ? "text-gray-400" : "text-gray-400 group-hover:text-gray-400",
                                     )}
                                 >
                                     Playlist &bull; {likedTotal} track{likedTotal !== 1 ? "s" : ""}
@@ -497,7 +497,7 @@ export function Sidebar() {
                                     className="px-3 py-2.5 rounded-lg relative overflow-hidden bg-white/[0.02] border-l-2 border-transparent"
                                 >
                                     <div
-                                        className="absolute inset-0 bg-gradient-to-r from-transparent via-[#2323FF]/10 to-transparent"
+                                        className="absolute inset-0 bg-gradient-to-r from-transparent via-ai/10 to-transparent"
                                         style={{
                                             animation: "shimmer 2s infinite",
                                         }}
@@ -521,13 +521,13 @@ export function Sidebar() {
                                         className={cn(
                                             "block px-3 py-2.5 rounded-lg transition-all duration-300 group relative overflow-hidden",
                                             isActive ?
-                                                "bg-gradient-to-r from-[#2323FF]/10 to-transparent text-white border-l-2 border-[#2323FF] shadow-md shadow-[#2323FF]/5"
-                                            :   "text-gray-400 hover:text-white hover:bg-white/[0.05] border-l-2 border-transparent hover:border-l-2 hover:border-[#2323FF]/30",
+                                                "bg-gradient-to-r from-ai/10 to-transparent text-white border-l-2 border-ai shadow-md shadow-ai/5"
+                                            :   "text-gray-400 hover:text-white hover:bg-white/[0.05] border-l-2 border-transparent hover:border-l-2 hover:border-ai/30",
                                         )}
                                     >
                                         {/* Hover shimmer effect */}
                                         {!isActive && (
-                                            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-[#2323FF]/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700" />
+                                            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-ai/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700" />
                                         )}
 
                                         <div className="flex items-center gap-1.5">
@@ -542,7 +542,7 @@ export function Sidebar() {
                                             </div>
                                             {isShared && (
                                                 <span
-                                                    className="shrink-0 w-1.5 h-1.5 rounded-full bg-[#2323FF]"
+                                                    className="shrink-0 w-1.5 h-1.5 rounded-full bg-ai"
                                                     title={`Shared by ${
                                                         playlist.user
                                                             ?.username ||
@@ -555,7 +555,7 @@ export function Sidebar() {
                                             className={cn(
                                                 "text-xs truncate relative z-10 mt-0.5 transition-colors duration-200",
                                                 isActive ? "text-gray-400" : (
-                                                    "text-gray-500 group-hover:text-gray-400"
+                                                    "text-gray-400 group-hover:text-gray-400"
                                                 ),
                                             )}
                                         >
@@ -574,10 +574,10 @@ export function Sidebar() {
                                 );
                             })
                     :   <div className="px-4 py-8 text-center">
-                            <div className="text-sm text-gray-500 mb-2">
+                            <div className="text-sm text-gray-400 mb-2">
                                 {isFiltered ? "No matching playlists" : "No playlists yet"}
                             </div>
-                            <div className="text-xs text-gray-600">
+                            <div className="text-xs text-gray-400">
                                 {isFiltered
                                     ? "Try changing your filter"
                                     : "Create your first playlist to get started"}
@@ -602,7 +602,7 @@ export function Sidebar() {
 
             {/* Desktop Sidebar */}
             {!isMobileOrTablet && (
-                <aside className="w-64 bg-[#0f0f0f] rounded-lg flex flex-col overflow-hidden relative z-10 border border-white/[0.03]">
+                <aside className="w-64 bg-surface-raised rounded-lg flex flex-col overflow-hidden relative z-10 border border-white/[0.03]">
                     {sidebarContent}
                 </aside>
             )}

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -128,7 +128,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                                 new CustomEvent("toggle-mobile-menu")
                             );
                         }}
-                        className="w-10 h-10 flex items-center justify-center bg-[#0f0f0f] border border-[#262626] rounded-md text-white hover:bg-[#141414] transition-colors mr-2 flex-shrink-0"
+                        className="w-10 h-10 flex items-center justify-center bg-surface-raised border border-line rounded-md text-white hover:bg-surface-overlay transition-colors mr-2 flex-shrink-0"
                         aria-label="Open menu"
                     >
                         <Menu className="w-5 h-5" />
@@ -139,7 +139,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                         {pathname !== "/" ? (
                             <button
                                 onClick={() => router.back()}
-                                className="w-10 h-10 rounded-full flex items-center justify-center transition-all bg-[#0a0a0a] text-gray-400 hover:bg-[#1a1a1a] hover:text-white"
+                                className="w-10 h-10 rounded-full flex items-center justify-center transition-all bg-surface text-gray-400 hover:bg-surface-hover hover:text-white"
                                 aria-label="Go back"
                                 title="Go back"
                             >
@@ -157,7 +157,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                             "w-10 h-10 rounded-full flex items-center justify-center transition-all flex-shrink-0 mr-1",
                             pathname === "/"
                                 ? "bg-white text-black"
-                                : "bg-[#0a0a0a] text-gray-400 hover:bg-[#1a1a1a] hover:text-white"
+                                : "bg-surface text-gray-400 hover:bg-surface-hover hover:text-white"
                         )}
                         aria-label="Home"
                         title="Home"
@@ -181,7 +181,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                                 autoCapitalize="none"
                                 autoCorrect="off"
                                 tabIndex={0}
-                                className="w-full h-10 pl-10 pr-3 bg-[#1a1a1a] hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
+                                className="w-full h-10 pl-10 pr-3 bg-surface-hover hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
                             />
                         </div>
                     </form>
@@ -231,7 +231,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                                 {pathname !== "/" && (
                                     <button
                                         onClick={() => router.back()}
-                                        className="w-12 h-12 rounded-full flex items-center justify-center transition-all flex-shrink-0 bg-[#0a0a0a] text-gray-400 hover:bg-[#1a1a1a] hover:text-white hover:scale-105"
+                                        className="w-12 h-12 rounded-full flex items-center justify-center transition-all flex-shrink-0 bg-surface text-gray-400 hover:bg-surface-hover hover:text-white hover:scale-105"
                                         aria-label="Go back"
                                         title="Go back"
                                     >
@@ -245,7 +245,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                                         "w-12 h-12 rounded-full flex items-center justify-center transition-all flex-shrink-0",
                                         pathname === "/"
                                             ? "bg-white text-black"
-                                            : "bg-[#0a0a0a] text-gray-400 hover:bg-[#1a1a1a] hover:text-white hover:scale-105"
+                                            : "bg-surface text-gray-400 hover:bg-surface-hover hover:text-white hover:scale-105"
                                     )}
                                     aria-label="Home"
                                     title="Home"
@@ -275,7 +275,7 @@ export function TopBar({ isActivityPanelOpen = false }: TopBarProps = {}) {
                                         autoCapitalize="none"
                                         autoCorrect="off"
                                         tabIndex={0}
-                                        className="w-full h-12 pl-12 pr-4 bg-[#1a1a1a] hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
+                                        className="w-full h-12 pl-12 pr-4 bg-surface-hover hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
                                     />
                                 </div>
                             </form>

--- a/frontend/components/layout/UserAvatarMenu.tsx
+++ b/frontend/components/layout/UserAvatarMenu.tsx
@@ -133,7 +133,7 @@ export function UserAvatarMenu() {
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 top-full mt-2 w-48 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-xl shadow-black/40 py-1 z-[100]">
+                <div className="absolute right-0 top-full mt-2 w-48 bg-surface-hover border border-white/10 rounded-lg shadow-xl shadow-black/40 py-1 z-[100]">
                     <div className="px-3 py-2 border-b border-white/10">
                         <p className="text-sm font-medium text-white truncate">
                             {displayName}

--- a/frontend/components/player/FullPlayer.tsx
+++ b/frontend/components/player/FullPlayer.tsx
@@ -218,7 +218,7 @@ export function FullPlayer() {
             if (result.success && result.trackCount > 0) {
                 toast.success("Vibe mode on", {
                     description: `${result.trackCount} similar tracks queued`,
-                    icon: <AudioWaveform className="w-4 h-4 text-[#60a5fa]" />,
+                    icon: <AudioWaveform className="w-4 h-4 text-brand-hover" />,
                 });
             } else {
                 toast.error("Couldn't find matching tracks");
@@ -341,7 +341,7 @@ export function FullPlayer() {
                                 className="relative w-14 h-14 flex-shrink-0 group"
                             >
                                 <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent rounded-lg blur-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                                <div className="relative w-full h-full bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
+                                <div className="relative w-full h-full bg-gradient-to-br from-[#2a2a2a] to-surface-hover rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
                                     {coverUrl ? (
                                         <Image
                                             key={coverUrl}
@@ -354,14 +354,14 @@ export function FullPlayer() {
                                             unoptimized
                                         />
                                     ) : (
-                                        <MusicIcon className="w-6 h-6 text-gray-500" />
+                                        <MusicIcon className="w-6 h-6 text-gray-400" />
                                     )}
                                 </div>
                             </Link>
                         ) : (
                             <div className="relative w-14 h-14 flex-shrink-0">
-                                <div className="relative w-full h-full bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
-                                    <MusicIcon className="w-6 h-6 text-gray-500" />
+                                <div className="relative w-full h-full bg-gradient-to-br from-[#2a2a2a] to-surface-hover rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
+                                    <MusicIcon className="w-6 h-6 text-gray-400" />
                                 </div>
                             </div>
                         )}
@@ -484,7 +484,7 @@ export function FullPlayer() {
                                         ? "bg-white text-black hover:scale-110 shadow-lg shadow-white/20 hover:shadow-white/30"
                                         : isBuffering
                                         ? "bg-white/80 text-black"
-                                        : "bg-gray-700 text-gray-500 cursor-not-allowed"
+                                        : "bg-gray-700 text-gray-400 cursor-not-allowed"
                                 )}
                                 disabled={!hasMedia || isBuffering}
                                 aria-label={
@@ -595,7 +595,7 @@ export function FullPlayer() {
                         <span
                             className={cn(
                                 "text-sm font-medium tabular-nums whitespace-nowrap",
-                                hasMedia ? "text-gray-300" : "text-gray-600"
+                                hasMedia ? "text-gray-300" : "text-gray-400"
                             )}
                         >
                             {formatTime(displayTime)}{" / "}
@@ -629,7 +629,7 @@ export function FullPlayer() {
                                     className={cn(
                                         "flex items-center justify-center w-8 h-8 transition-all duration-200 hover:scale-110 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:scale-100",
                                         vibeMode
-                                            ? "text-[#60a5fa] hover:text-[#60a5fa]"
+                                            ? "text-brand-hover hover:text-brand-hover"
                                             : "text-gray-400 hover:text-white"
                                     )}
                                     title={vibeMode ? "Turn off vibe mode" : "Match this vibe"}
@@ -683,7 +683,7 @@ export function FullPlayer() {
                                 {/* Vertical volume slider popup */}
                                 <div
                                     className={cn(
-                                        "absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-1.5 py-3 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-xl transition-all duration-200 overflow-hidden",
+                                        "absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-1.5 py-3 bg-surface-hover border border-white/10 rounded-lg shadow-xl transition-all duration-200 overflow-hidden",
                                         showVolumePopup ? "opacity-100 scale-100 pointer-events-auto" : "opacity-0 scale-95 pointer-events-none"
                                     )}
                                 >
@@ -725,7 +725,7 @@ export function FullPlayer() {
                                     "flex items-center justify-center w-8 h-8 transition-all duration-200",
                                     hasMedia
                                         ? "text-gray-400 hover:text-white hover:scale-110"
-                                        : "text-gray-600 cursor-not-allowed"
+                                        : "text-gray-400 cursor-not-allowed"
                                 )}
                                 disabled={!hasMedia}
                                 aria-label={playerMode === "overlay" ? "Close overlay player" : "Open overlay player"}

--- a/frontend/components/player/KeyboardShortcutsTooltip.tsx
+++ b/frontend/components/player/KeyboardShortcutsTooltip.tsx
@@ -34,9 +34,9 @@ export function KeyboardShortcutsTooltip() {
             </button>
 
             {isVisible && (
-                <div className="absolute bottom-full right-0 mb-2 w-64 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-4 z-50 backdrop-blur-xl">
+                <div className="absolute bottom-full right-0 mb-2 w-64 bg-surface-hover border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-4 z-50 backdrop-blur-xl">
                     {/* Pointer arrow */}
-                    <div className="absolute -bottom-1 right-3 w-2 h-2 bg-[#1a1a1a] border-r border-b border-white/10 rotate-45" />
+                    <div className="absolute -bottom-1 right-3 w-2 h-2 bg-surface-hover border-r border-b border-white/10 rotate-45" />
 
                     <h3 className="text-white font-bold text-sm mb-3 flex items-center gap-2">
                         <Info className="w-4 h-4" />
@@ -60,7 +60,7 @@ export function KeyboardShortcutsTooltip() {
                     </div>
 
                     <div className="mt-3 pt-3 border-t border-white/10">
-                        <p className="text-[10px] text-gray-500 leading-relaxed">
+                        <p className="text-[10px] text-gray-400 leading-relaxed">
                             Shortcuts work anywhere except when typing in text fields.
                         </p>
                     </div>

--- a/frontend/components/player/MiniPlayer.tsx
+++ b/frontend/components/player/MiniPlayer.tsx
@@ -91,7 +91,7 @@ export function MiniPlayer() {
             <div className="overflow-hidden border-t border-white/10 bg-black/95 backdrop-blur-sm">
                 <div className="relative h-[2px] w-full bg-white/10">
                     <div
-                        className="h-full bg-[#60a5fa] transition-all duration-150"
+                        className="h-full bg-brand-hover transition-all duration-150"
                         style={{ width: `${progress}%` }}
                     />
                 </div>

--- a/frontend/components/player/OverlayPlayer.tsx
+++ b/frontend/components/player/OverlayPlayer.tsx
@@ -990,7 +990,7 @@ export function OverlayPlayer() {
             if (result.success && result.trackCount > 0) {
                 toast.success(`Vibe mode on`, {
                     description: `${result.trackCount} similar tracks queued`,
-                    icon: <AudioWaveform className="w-4 h-4 text-[#60a5fa]" />,
+                    icon: <AudioWaveform className="w-4 h-4 text-brand-hover" />,
                 });
             } else {
                 toast.error("Couldn't find matching tracks");
@@ -1116,7 +1116,7 @@ export function OverlayPlayer() {
                     )}
                     {/* Now Playing indicator */}
                     <div className="flex items-center gap-2">
-                        <span className="text-xs text-gray-500 uppercase tracking-widest font-medium">
+                        <span className="text-xs text-gray-400 uppercase tracking-widest font-medium">
                             Now Playing
                         </span>
                         <SyncBadge compact />
@@ -1161,14 +1161,14 @@ export function OverlayPlayer() {
                                 className={cn(
                                     "absolute inset-0 rounded-2xl blur-2xl opacity-50",
                                     vibeMode
-                                        ? "bg-gradient-to-br from-brand/30 via-transparent to-[#2323FF]/30"
-                                        : "bg-gradient-to-br from-[#60a5fa]/20 via-transparent to-[#2323FF]/20"
+                                        ? "bg-gradient-to-br from-brand/30 via-transparent to-ai/30"
+                                        : "bg-gradient-to-br from-brand-hover/20 via-transparent to-ai/20"
                                 )}
                             />
                             <motion.div
                                 layoutId={artworkLayoutId}
                                 transition={{ type: "spring", stiffness: 320, damping: 34 }}
-                                className="relative h-full w-full overflow-hidden rounded-2xl bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] shadow-2xl"
+                                className="relative h-full w-full overflow-hidden rounded-2xl bg-gradient-to-br from-[#2a2a2a] to-surface-hover shadow-2xl"
                             >
                                 {coverUrl ? (
                                     <Image
@@ -1183,7 +1183,7 @@ export function OverlayPlayer() {
                                     />
                                 ) : (
                                     <div className="flex h-full w-full items-center justify-center">
-                                        <MusicIcon className="h-24 w-24 text-gray-600" />
+                                        <MusicIcon className="h-24 w-24 text-gray-400" />
                                     </div>
                                 )}
                             </motion.div>
@@ -1279,7 +1279,7 @@ export function OverlayPlayer() {
                                     showHandle={false}
                                     className="mb-2"
                                 />
-                                <div className="flex justify-between text-xs font-medium tabular-nums text-gray-500">
+                                <div className="flex justify-between text-xs font-medium tabular-nums text-gray-400">
                                     <span>{formatTime(displayTime)}</span>
                                     <span>
                                         {playbackType === "podcast" || playbackType === "audiobook"
@@ -1332,7 +1332,7 @@ export function OverlayPlayer() {
                                                 className={cn(
                                                     "flex h-11 w-11 items-center justify-center rounded-full transition-colors",
                                                     vibeMode
-                                                        ? "text-[#60a5fa] bg-white/[0.05]"
+                                                        ? "text-brand-hover bg-white/[0.05]"
                                                         : "text-gray-400 hover:text-white hover:bg-white/10"
                                                 )}
                                                 title={vibeMode ? "Turn off vibe mode" : "Match this vibe"}
@@ -1362,8 +1362,8 @@ export function OverlayPlayer() {
                                             className={cn(
                                                 "transition-colors",
                                                 isShuffle
-                                                    ? "text-[#60a5fa]"
-                                                    : "text-gray-500 hover:text-white"
+                                                    ? "text-brand-hover"
+                                                    : "text-gray-400 hover:text-white"
                                             )}
                                             title="Shuffle"
                                             aria-label="Shuffle"
@@ -1459,8 +1459,8 @@ export function OverlayPlayer() {
                                             className={cn(
                                                 "transition-colors",
                                                 repeatMode !== "off"
-                                                    ? "text-[#60a5fa]"
-                                                    : "text-gray-500 hover:text-white"
+                                                    ? "text-brand-hover"
+                                                    : "text-gray-400 hover:text-white"
                                             )}
                                             title={
                                                 repeatMode === "one"
@@ -1526,7 +1526,7 @@ export function OverlayPlayer() {
                             className={cn(
                                 "border-b pb-0.5 font-medium transition-colors",
                                 activeTab === "queue"
-                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                    ? "border-brand-hover text-brand-hover"
                                     : "border-transparent text-gray-400 hover:text-white"
                             )}
                         >
@@ -1537,7 +1537,7 @@ export function OverlayPlayer() {
                             className={cn(
                                 "border-b pb-0.5 font-medium transition-colors",
                                 activeTab === "lyrics"
-                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                    ? "border-brand-hover text-brand-hover"
                                     : "border-transparent text-gray-400 hover:text-white"
                             )}
                         >
@@ -1548,7 +1548,7 @@ export function OverlayPlayer() {
                             className={cn(
                                 "border-b pb-0.5 font-medium transition-colors",
                                 activeTab === "related"
-                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                    ? "border-brand-hover text-brand-hover"
                                     : "border-transparent text-gray-400 hover:text-white"
                             )}
                         >
@@ -1612,7 +1612,7 @@ export function OverlayPlayer() {
                                                 }
                                             }}
                                         >
-                                            <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-md bg-[#1a1a1a]">
+                                            <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-md bg-surface-hover">
                                                 {coverUrl ? (
                                                     <Image
                                                         src={coverUrl}
@@ -1624,7 +1624,7 @@ export function OverlayPlayer() {
                                                     />
                                                 ) : (
                                                     <div className="flex h-full w-full items-center justify-center">
-                                                        <MusicIcon className="h-4 w-4 text-gray-500" />
+                                                        <MusicIcon className="h-4 w-4 text-gray-400" />
                                                     </div>
                                                 )}
                                             </div>
@@ -1698,7 +1698,7 @@ export function OverlayPlayer() {
                                                 className={cn(
                                                     "border-b pb-0.5 font-medium transition-colors",
                                                     activeTab === "queue"
-                                                        ? "border-[#60a5fa] text-[#60a5fa]"
+                                                        ? "border-brand-hover text-brand-hover"
                                                         : "border-transparent text-gray-400 hover:text-white"
                                                 )}
                                             >
@@ -1709,7 +1709,7 @@ export function OverlayPlayer() {
                                                 className={cn(
                                                     "border-b pb-0.5 font-medium transition-colors",
                                                     activeTab === "lyrics"
-                                                        ? "border-[#60a5fa] text-[#60a5fa]"
+                                                        ? "border-brand-hover text-brand-hover"
                                                         : "border-transparent text-gray-400 hover:text-white"
                                                 )}
                                             >
@@ -1720,7 +1720,7 @@ export function OverlayPlayer() {
                                                 className={cn(
                                                     "border-b pb-0.5 font-medium transition-colors",
                                                     activeTab === "related"
-                                                        ? "border-[#60a5fa] text-[#60a5fa]"
+                                                        ? "border-brand-hover text-brand-hover"
                                                         : "border-transparent text-gray-400 hover:text-white"
                                                 )}
                                             >
@@ -1735,7 +1735,7 @@ export function OverlayPlayer() {
                                             className={cn(
                                                 "border-b pb-0.5 transition-colors",
                                                 activeTab === "queue"
-                                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                                    ? "border-brand-hover text-brand-hover"
                                                     : "border-transparent text-gray-400 hover:text-white"
                                             )}
                                         >
@@ -1746,7 +1746,7 @@ export function OverlayPlayer() {
                                             className={cn(
                                                 "border-b pb-0.5 transition-colors",
                                                 activeTab === "lyrics"
-                                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                                    ? "border-brand-hover text-brand-hover"
                                                     : "border-transparent text-gray-400 hover:text-white"
                                             )}
                                         >
@@ -1757,7 +1757,7 @@ export function OverlayPlayer() {
                                             className={cn(
                                                 "border-b pb-0.5 transition-colors",
                                                 activeTab === "related"
-                                                    ? "border-[#60a5fa] text-[#60a5fa]"
+                                                    ? "border-brand-hover text-brand-hover"
                                                     : "border-transparent text-gray-400 hover:text-white"
                                             )}
                                         >
@@ -1776,7 +1776,7 @@ export function OverlayPlayer() {
                                             >
                                                 <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-2">
                                                     <div className="flex items-center gap-2">
-                                                        <ListMusic className="h-4 w-4 text-[#60a5fa]" />
+                                                        <ListMusic className="h-4 w-4 text-brand-hover" />
                                                         <h2 className="text-sm font-semibold text-white">
                                                             Up Next
                                                         </h2>
@@ -1802,7 +1802,7 @@ export function OverlayPlayer() {
 
                                                 {queueTracks.length === 0 ? (
                                                     <div className="flex min-h-0 flex-1 items-center justify-center px-4">
-                                                        <p className="text-sm text-gray-500">
+                                                        <p className="text-sm text-gray-400">
                                                             No tracks in queue.
                                                         </p>
                                                     </div>
@@ -1822,7 +1822,7 @@ export function OverlayPlayer() {
                                                                         className={cn(
                                                                             "mb-1.5 flex items-center gap-2 px-2 py-2 transition-colors",
                                                                             isCurrentTrack
-                                                                                ? "rounded-md border border-[#60a5fa]/35 bg-[#60a5fa]/10"
+                                                                                ? "rounded-md border border-brand-hover/35 bg-brand-hover/10"
                                                                                 : isPlayedTrack
                                                                                   ? "rounded-md bg-white/[0.03] hover:bg-white/[0.06]"
                                                                                   : "hover:bg-white/[0.06]"
@@ -1832,8 +1832,8 @@ export function OverlayPlayer() {
                                                                             className={cn(
                                                                                 "w-5 flex-shrink-0 text-center text-[11px] tabular-nums",
                                                                                 isCurrentTrack
-                                                                                    ? "text-[#60a5fa]"
-                                                                                    : "text-gray-500"
+                                                                                    ? "text-brand-hover"
+                                                                                    : "text-gray-400"
                                                                             )}
                                                                         >
                                                                             {queueIndex + 1}
@@ -1854,7 +1854,7 @@ export function OverlayPlayer() {
                                                                                     : "Play this episode now"
                                                                             }
                                                                         >
-                                                                            <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-[#1a1a1a]">
+                                                                            <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
                                                                                 {item.coverUrl ? (
                                                                                     <Image
                                                                                         src={item.coverUrl}
@@ -1866,7 +1866,7 @@ export function OverlayPlayer() {
                                                                                     />
                                                                                 ) : (
                                                                                     <div className="flex h-full w-full items-center justify-center">
-                                                                                        <MusicIcon className="h-4 w-4 text-gray-600" />
+                                                                                        <MusicIcon className="h-4 w-4 text-gray-400" />
                                                                                     </div>
                                                                                 )}
                                                                             </div>
@@ -1875,7 +1875,7 @@ export function OverlayPlayer() {
                                                                                     className={cn(
                                                                                         "min-w-0 truncate text-sm",
                                                                                         isCurrentTrack
-                                                                                            ? "text-[#60a5fa]"
+                                                                                            ? "text-brand-hover"
                                                                                             : "text-white"
                                                                                     )}
                                                                                 >
@@ -1886,7 +1886,7 @@ export function OverlayPlayer() {
                                                                                         {item.podcastTitle || "Podcast"}
                                                                                     </p>
                                                                                     {isCurrentTrack && (
-                                                                                        <span className="inline-flex shrink-0 items-center rounded-full border border-[#60a5fa]/40 bg-[#60a5fa]/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#60a5fa]">
+                                                                                        <span className="inline-flex shrink-0 items-center rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
                                                                                             Playing
                                                                                         </span>
                                                                                     )}
@@ -1902,8 +1902,8 @@ export function OverlayPlayer() {
                                                                             className={cn(
                                                                                 "text-[11px] tabular-nums",
                                                                                 isCurrentTrack
-                                                                                    ? "text-[#60a5fa]"
-                                                                                    : "text-gray-500"
+                                                                                    ? "text-brand-hover"
+                                                                                    : "text-gray-400"
                                                                             )}
                                                                         >
                                                                             {formatTime(item.duration || 0)}
@@ -1914,7 +1914,7 @@ export function OverlayPlayer() {
                                                                                     e.stopPropagation();
                                                                                     handleRemoveFromQueue(queueIndex);
                                                                                 }}
-                                                                                className="ml-1 h-7 w-7 flex items-center justify-center rounded-full text-gray-500 hover:bg-white/10 hover:text-white transition-colors"
+                                                                                className="ml-1 h-7 w-7 flex items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
                                                                                 title="Remove from queue"
                                                                                 aria-label="Remove from queue"
                                                                             >
@@ -1936,7 +1936,7 @@ export function OverlayPlayer() {
                                                                     className={cn(
                                                                         "mb-1.5 flex items-center gap-2 px-2 py-2 transition-colors",
                                                                         isCurrentTrack
-                                                                            ? "rounded-md border border-[#60a5fa]/35 bg-[#60a5fa]/10"
+                                                                            ? "rounded-md border border-brand-hover/35 bg-brand-hover/10"
                                                                             : isPlayedTrack
                                                                               ? "rounded-md bg-white/[0.03] hover:bg-white/[0.06]"
                                                                               : "hover:bg-white/[0.06]"
@@ -1946,8 +1946,8 @@ export function OverlayPlayer() {
                                                                         className={cn(
                                                                             "w-5 flex-shrink-0 text-center text-[11px] tabular-nums",
                                                                             isCurrentTrack
-                                                                                ? "text-[#60a5fa]"
-                                                                                : "text-gray-500"
+                                                                                ? "text-brand-hover"
+                                                                                : "text-gray-400"
                                                                         )}
                                                                     >
                                                                         {queueIndex + 1}
@@ -1968,7 +1968,7 @@ export function OverlayPlayer() {
                                                                                 : "Play this track now"
                                                                         }
                                                                     >
-                                                                        <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-[#1a1a1a]">
+                                                                        <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
                                                                             {track.album?.coverArt ? (
                                                                                 <Image
                                                                                     src={api.getCoverArtUrl(
@@ -1983,7 +1983,7 @@ export function OverlayPlayer() {
                                                                                 />
                                                                             ) : (
                                                                                 <div className="flex h-full w-full items-center justify-center">
-                                                                                    <MusicIcon className="h-4 w-4 text-gray-600" />
+                                                                                    <MusicIcon className="h-4 w-4 text-gray-400" />
                                                                                 </div>
                                                                             )}
                                                                         </div>
@@ -1993,7 +1993,7 @@ export function OverlayPlayer() {
                                                                                     className={cn(
                                                                                         "min-w-0 truncate text-sm",
                                                                                         isCurrentTrack
-                                                                                            ? "text-[#60a5fa]"
+                                                                                            ? "text-brand-hover"
                                                                                             : "text-white"
                                                                                     )}
                                                                                 >
@@ -2012,11 +2012,11 @@ export function OverlayPlayer() {
                                                                                         "Unknown artist"}
                                                                                 </p>
                                                                                 {isCurrentTrack && (
-                                                                                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[#60a5fa]/40 bg-[#60a5fa]/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#60a5fa]">
+                                                                                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
                                                                                         <span className="inline-flex items-end gap-0.5">
-                                                                                            <span className="h-2 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.2s]" />
-                                                                                            <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa]" />
-                                                                                            <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.35s]" />
+                                                                                            <span className="h-2 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.2s]" />
+                                                                                            <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-brand-hover" />
+                                                                                            <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.35s]" />
                                                                                         </span>
                                                                                         Playing
                                                                                     </span>
@@ -2034,8 +2034,8 @@ export function OverlayPlayer() {
                                                                         className={cn(
                                                                             "text-[11px] tabular-nums",
                                                                             isCurrentTrack
-                                                                                ? "text-[#60a5fa]"
-                                                                                : "text-gray-500"
+                                                                                ? "text-brand-hover"
+                                                                                : "text-gray-400"
                                                                         )}
                                                                     >
                                                                         {formatTime(track.duration || 0)}
@@ -2073,7 +2073,7 @@ export function OverlayPlayer() {
                                                                                     e.stopPropagation();
                                                                                     handleRemoveFromQueue(queueIndex);
                                                                                 }}
-                                                                                className="h-7 w-7 flex items-center justify-center rounded-full text-gray-500 hover:bg-white/10 hover:text-white transition-colors"
+                                                                                className="h-7 w-7 flex items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
                                                                                 title="Remove from queue"
                                                                                 aria-label="Remove from queue"
                                                                             >
@@ -2102,7 +2102,7 @@ export function OverlayPlayer() {
                                                     </div>
                                                 ) : isLyricsError ? (
                                                     <div className="flex h-full items-center justify-center px-4">
-                                                        <p className="text-center text-sm text-gray-500">
+                                                        <p className="text-center text-sm text-gray-400">
                                                             Failed to load lyrics
                                                         </p>
                                                     </div>
@@ -2130,13 +2130,13 @@ export function OverlayPlayer() {
                                                         Similar Songs
                                                     </h3>
                                                     {isRelatedTracksLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-500">
+                                                        <div className="flex items-center gap-2 text-gray-400">
                                                             <Loader2 className="h-4 w-4 animate-spin" />
                                                             <span className="text-sm">Loading...</span>
                                                         </div>
                                                     ) : isRelatedTracksError ? (
                                                         <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-500">Failed to load similar songs.</p>
+                                                            <p className="text-sm text-gray-400">Failed to load similar songs.</p>
                                                             <button
                                                                 onClick={() => queryClient.invalidateQueries({ queryKey: ["player-related-tracks", currentTrack?.id] })}
                                                                 className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
@@ -2160,7 +2160,7 @@ export function OverlayPlayer() {
                                                                         onClick={() => playRelatedTrack(track)}
                                                                         className="group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-white/[0.06]"
                                                                     >
-                                                                    <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded bg-[#1a1a1a]">
+                                                                    <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
                                                                         {(track.album?.coverArt ||
                                                                             track.album?.coverUrl) ? (
                                                                             <Image
@@ -2177,7 +2177,7 @@ export function OverlayPlayer() {
                                                                             />
                                                                         ) : (
                                                                             <div className="flex h-full w-full items-center justify-center">
-                                                                                <MusicIcon className="h-4 w-4 text-gray-600" />
+                                                                                <MusicIcon className="h-4 w-4 text-gray-400" />
                                                                             </div>
                                                                         )}
                                                                     </div>
@@ -2185,7 +2185,7 @@ export function OverlayPlayer() {
                                                                         <p className="truncate text-sm text-gray-200 group-hover:text-white">
                                                                             {track.title}
                                                                         </p>
-                                                                        <p className="truncate text-xs text-gray-500">
+                                                                        <p className="truncate text-xs text-gray-400">
                                                                             {isInLibrary
                                                                                 ? track.album?.artist?.name ||
                                                                                   track.artist ||
@@ -2235,7 +2235,7 @@ export function OverlayPlayer() {
                                                             })}
                                                         </div>
                                                     ) : (
-                                                        <p className="text-sm text-gray-500">
+                                                        <p className="text-sm text-gray-400">
                                                             No similar songs found.
                                                         </p>
                                                     )}
@@ -2246,13 +2246,13 @@ export function OverlayPlayer() {
                                                         Similar Artists
                                                     </h3>
                                                     {isRelatedArtistsLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-500">
+                                                        <div className="flex items-center gap-2 text-gray-400">
                                                             <Loader2 className="h-4 w-4 animate-spin" />
                                                             <span className="text-sm">Loading...</span>
                                                         </div>
                                                     ) : isRelatedArtistsError ? (
                                                         <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-500">Failed to load similar artists.</p>
+                                                            <p className="text-sm text-gray-400">Failed to load similar artists.</p>
                                                             <button
                                                                 onClick={() => queryClient.invalidateQueries({ queryKey: ["player-related-artists", currentTrack?.artist?.name, currentTrack?.artist?.mbid] })}
                                                                 className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
@@ -2287,7 +2287,7 @@ export function OverlayPlayer() {
                                                                         onClick={returnToPreviousMode}
                                                                         className="group p-1.5 transition-colors hover:bg-white/[0.06]"
                                                                     >
-                                                                        <div className="mb-2 relative mx-auto h-12 w-12 overflow-hidden rounded-full bg-[#1a1a1a]">
+                                                                        <div className="mb-2 relative mx-auto h-12 w-12 overflow-hidden rounded-full bg-surface-hover">
                                                                             {artist.image ? (
                                                                                 <Image
                                                                                     src={artist.image}
@@ -2299,7 +2299,7 @@ export function OverlayPlayer() {
                                                                                 />
                                                                             ) : (
                                                                                 <div className="flex h-full w-full items-center justify-center">
-                                                                                    <MusicIcon className="h-4 w-4 text-gray-600" />
+                                                                                    <MusicIcon className="h-4 w-4 text-gray-400" />
                                                                                 </div>
                                                                             )}
                                                                         </div>
@@ -2311,7 +2311,7 @@ export function OverlayPlayer() {
                                                             })}
                                                         </div>
                                                     ) : (
-                                                        <p className="text-sm text-gray-500">
+                                                        <p className="text-sm text-gray-400">
                                                             No similar artists found.
                                                         </p>
                                                     )}
@@ -2322,13 +2322,13 @@ export function OverlayPlayer() {
                                                         More From This Artist
                                                     </h3>
                                                     {isMoreFromArtistLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-500">
+                                                        <div className="flex items-center gap-2 text-gray-400">
                                                             <Loader2 className="h-4 w-4 animate-spin" />
                                                             <span className="text-sm">Loading...</span>
                                                         </div>
                                                     ) : isMoreFromArtistError ? (
                                                         <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-500">Failed to load albums.</p>
+                                                            <p className="text-sm text-gray-400">Failed to load albums.</p>
                                                             <button
                                                                 onClick={() => queryClient.invalidateQueries({ queryKey: ["player-related-albums", currentTrack?.artist?.id] })}
                                                                 className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
@@ -2346,7 +2346,7 @@ export function OverlayPlayer() {
                                                                     onClick={returnToPreviousMode}
                                                                     className="group p-1.5 transition-colors hover:bg-white/[0.06]"
                                                                 >
-                                                                    <div className="relative mb-2 aspect-square w-full overflow-hidden rounded bg-[#1a1a1a]">
+                                                                    <div className="relative mb-2 aspect-square w-full overflow-hidden rounded bg-surface-hover">
                                                                         {album.coverArt ? (
                                                                             <Image
                                                                                 src={api.getCoverArtUrl(
@@ -2361,7 +2361,7 @@ export function OverlayPlayer() {
                                                                             />
                                                                         ) : (
                                                                             <div className="flex h-full w-full items-center justify-center">
-                                                                                <MusicIcon className="h-5 w-5 text-gray-600" />
+                                                                                <MusicIcon className="h-5 w-5 text-gray-400" />
                                                                             </div>
                                                                         )}
                                                                     </div>
@@ -2369,7 +2369,7 @@ export function OverlayPlayer() {
                                                                         {album.title}
                                                                     </p>
                                                                     {album.year && (
-                                                                        <p className="text-[11px] text-gray-500">
+                                                                        <p className="text-[11px] text-gray-400">
                                                                             {album.year}
                                                                         </p>
                                                                     )}
@@ -2377,7 +2377,7 @@ export function OverlayPlayer() {
                                                             ))}
                                                         </div>
                                                     ) : (
-                                                        <p className="text-sm text-gray-500">No albums found.</p>
+                                                        <p className="text-sm text-gray-400">No albums found.</p>
                                                     )}
                                                 </section>
                                             </motion.section>

--- a/frontend/components/player/PlaybackQualityBadgeWithStats.tsx
+++ b/frontend/components/player/PlaybackQualityBadgeWithStats.tsx
@@ -222,14 +222,14 @@ export function PlaybackQualityBadgeWithStats({
 
             {/* Stats popup */}
             <div
-                className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-3 backdrop-blur-xl z-[10002] transition-all duration-200 ${
+                className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 bg-surface-hover border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-3 backdrop-blur-xl z-[10002] transition-all duration-200 ${
                     isOpen
                         ? "opacity-100 scale-100 pointer-events-auto"
                         : "opacity-0 scale-95 pointer-events-none"
                 }`}
             >
                 {/* Pointer arrow */}
-                <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-[#1a1a1a] border-r border-b border-white/10 rotate-45" />
+                <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-surface-hover border-r border-b border-white/10 rotate-45" />
 
                 {/* Title */}
                 <div className="flex items-center justify-between mb-2">

--- a/frontend/components/player/SeekSlider.tsx
+++ b/frontend/components/player/SeekSlider.tsx
@@ -241,7 +241,7 @@ export function SeekSlider({
                     container: "h-1",
                     track: "bg-white/20",
                     progress: isActive
-                        ? "bg-gradient-to-r from-[#3b82f6] to-[#38bdf8]"
+                        ? "bg-gradient-to-r from-brand to-[#38bdf8]"
                         : "bg-white/40",
                 };
             default:

--- a/frontend/components/player/SyncBadge.tsx
+++ b/frontend/components/player/SyncBadge.tsx
@@ -90,7 +90,7 @@ const SyncBadge = memo(function SyncBadge({ compact = false }: SyncBadgeProps) {
 
     const memberCount = activeGroup.members.length;
     const accentClass = isConnected
-        ? "bg-[#2323FF]/20 text-[#5b5bff] hover:bg-[#2323FF]/30"
+        ? "bg-ai/20 text-ai-hover hover:bg-ai/30"
         : "bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30";
 
     // Compact mode: simple link, no popup
@@ -141,18 +141,18 @@ const SyncBadge = memo(function SyncBadge({ compact = false }: SyncBadgeProps) {
 
             {/* Members popup */}
             <div
-                className={`absolute bottom-full left-0 mb-2 w-64 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-3 backdrop-blur-xl z-[10002] transition-all duration-200 ${
+                className={`absolute bottom-full left-0 mb-2 w-64 bg-surface-hover border border-white/10 rounded-lg shadow-2xl shadow-black/50 p-3 backdrop-blur-xl z-[10002] transition-all duration-200 ${
                     isOpen
                         ? "opacity-100 scale-100 pointer-events-auto"
                         : "opacity-0 scale-95 pointer-events-none"
                 }`}
             >
                 {/* Pointer arrow */}
-                <div className="absolute -bottom-1 left-4 w-2 h-2 bg-[#1a1a1a] border-r border-b border-white/10 rotate-45" />
+                <div className="absolute -bottom-1 left-4 w-2 h-2 bg-surface-hover border-r border-b border-white/10 rotate-45" />
 
                 {/* Title */}
                 <div className="flex items-center justify-between mb-2">
-                    <h3 className="font-bold text-xs text-[#5b5bff]">
+                    <h3 className="font-bold text-xs text-ai-hover">
                         {activeGroup.name || "Listen Together"}
                     </h3>
                     {isMobile && (
@@ -184,7 +184,7 @@ const SyncBadge = memo(function SyncBadge({ compact = false }: SyncBadgeProps) {
                             {member.isConnected ? (
                                 <Wifi className="w-3 h-3 text-emerald-400 shrink-0" />
                             ) : (
-                                <WifiOff className="w-3 h-3 text-gray-500 shrink-0" />
+                                <WifiOff className="w-3 h-3 text-gray-400 shrink-0" />
                             )}
                         </div>
                     ))}
@@ -194,7 +194,7 @@ const SyncBadge = memo(function SyncBadge({ compact = false }: SyncBadgeProps) {
                 <Link
                     href="/listen-together"
                     prefetch={false}
-                    className="block mt-3 pt-2 border-t border-white/10 text-[11px] text-gray-400 hover:text-[#5b5bff] transition-colors text-center"
+                    className="block mt-3 pt-2 border-t border-white/10 text-[11px] text-gray-400 hover:text-ai-hover transition-colors text-center"
                 >
                     Go to Listen Together
                 </Link>

--- a/frontend/components/player/SyncedLyrics.tsx
+++ b/frontend/components/player/SyncedLyrics.tsx
@@ -156,7 +156,7 @@ export function SyncedLyrics({
         return (
             <div
                 className={cn(
-                    "flex items-center justify-center h-full text-gray-500",
+                    "flex items-center justify-center h-full text-gray-400",
                     className
                 )}
             >
@@ -222,7 +222,7 @@ export function SyncedLyrics({
                                 !isEmpty && "hover:bg-white/5",
                                 isActive &&
                                     "text-white text-lg font-semibold scale-[1.02] origin-center",
-                                isPast && !isActive && "text-gray-500 text-base",
+                                isPast && !isActive && "text-gray-400 text-base",
                                 !isPast && !isActive && "text-gray-400/60 text-base"
                             )}
                         >

--- a/frontend/components/track/TrackList.tsx
+++ b/frontend/components/track/TrackList.tsx
@@ -217,7 +217,7 @@ export function TrackList<T>({
                         aria-label={`Reorder ${rowItem.title}, use arrow keys to move`}
                         className={cn(
                             "absolute left-0 top-0 bottom-0 z-10 hidden md:flex w-4 cursor-grab touch-none",
-                            "items-center justify-center text-gray-500 hover:text-white",
+                            "items-center justify-center text-gray-400 hover:text-white",
                             "opacity-0 group-hover/reorder:opacity-100 focus:opacity-100 transition-opacity",
                             dragIndex === index && "cursor-grabbing",
                         )}

--- a/frontend/components/track/TrackListHeader.tsx
+++ b/frontend/components/track/TrackListHeader.tsx
@@ -11,7 +11,7 @@ export function TrackListHeader({ columns, className }: TrackListHeaderProps) {
     return (
         <div
             className={cn(
-                "hidden md:grid items-center text-xs text-gray-500 uppercase tracking-wider border-b border-white/10 px-3 py-2",
+                "hidden md:grid items-center text-xs text-gray-400 uppercase tracking-wider border-b border-white/10 px-3 py-2",
                 className,
             )}
         >

--- a/frontend/components/track/TrackRow.tsx
+++ b/frontend/components/track/TrackRow.tsx
@@ -64,7 +64,7 @@ export function TrackRow({
                 "grid items-center gap-2 px-1 md:gap-4 md:px-4 py-3 rounded-md hover:bg-white/5 transition-colors group cursor-pointer",
                 className,
                 isPlaying && "bg-white/5",
-                isInQueue && !isPlaying && "bg-[#3b82f6]/[0.06]",
+                isInQueue && !isPlaying && "bg-brand/[0.06]",
                 rowClassName,
             )}
         >
@@ -76,7 +76,7 @@ export function TrackRow({
                     <span
                         className={cn(
                             "text-sm group-hover:hidden",
-                            isPlaying ? "font-bold" : "text-gray-500",
+                            isPlaying ? "font-bold" : "text-gray-400",
                         )}
                         style={isPlaying ? { color: accentColor } : undefined}
                     >
@@ -96,7 +96,7 @@ export function TrackRow({
             {/* Cover art + Title/Artist */}
             <div className="flex items-center gap-3 min-w-0">
                 {showCoverArt && (
-                    <div className="relative w-10 h-10 bg-[#282828] rounded flex items-center justify-center overflow-hidden shrink-0">
+                    <div className="relative w-10 h-10 bg-surface-highlight rounded flex items-center justify-center overflow-hidden shrink-0">
                         {item.coverArtUrl ? (
                             <CachedImage
                                 src={item.coverArtUrl}
@@ -106,7 +106,7 @@ export function TrackRow({
                                 className="object-cover"
                             />
                         ) : (
-                            <Music className="w-4 h-4 text-gray-600" />
+                            <Music className="w-4 h-4 text-gray-400" />
                         )}
                     </div>
                 )}
@@ -143,7 +143,7 @@ export function TrackRow({
                 trailingActions
             ) : (
                 <div className="flex items-center gap-1">
-                    <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                    <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                         {formatTime(item.duration)}
                     </span>
                     {preferenceMode && (

--- a/frontend/components/track/badges.tsx
+++ b/frontend/components/track/badges.tsx
@@ -8,7 +8,7 @@
  */
 export function InQueueBadge() {
     return (
-        <span className="shrink-0 text-[10px] bg-[#3b82f6]/15 text-[#93c5fd] px-1.5 py-0.5 rounded border border-[#3b82f6]/30 font-medium">
+        <span className="shrink-0 text-[10px] bg-brand/15 text-brand-light px-1.5 py-0.5 rounded border border-brand/30 font-medium">
             IN QUEUE
         </span>
     );

--- a/frontend/components/ui/AudiobookCard.tsx
+++ b/frontend/components/ui/AudiobookCard.tsx
@@ -43,7 +43,7 @@ export function AudiobookCard({
             <div className="cursor-pointer group relative h-full flex flex-col">
                 {/* Book Cover Container - Fixed Aspect Ratio */}
                 <div className="relative flex-shrink-0">
-                    <div className="aspect-[2/3] rounded-sm overflow-hidden bg-gradient-to-br from-[#2a2a2a] to-[#1a1a1a] shadow-2xl relative">
+                    <div className="aspect-[2/3] rounded-sm overflow-hidden bg-gradient-to-br from-[#2a2a2a] to-surface-hover shadow-2xl relative">
                         {resolvedCoverUrl ? (
                             <CachedImage
                                 src={resolvedCoverUrl}
@@ -56,7 +56,7 @@ export function AudiobookCard({
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center">
-                                <Book className="w-16 h-16 text-gray-700" />
+                                <Book className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                         
@@ -70,7 +70,7 @@ export function AudiobookCard({
                         {progress && !progress.isFinished && (
                             <div className="absolute bottom-0 left-0 right-0 h-1 bg-black/60">
                                 <div
-                                    className="h-full bg-[#2323FF]"
+                                    className="h-full bg-ai"
                                     style={{ width: `${progress.progress}%` }}
                                 />
                             </div>
@@ -85,14 +85,14 @@ export function AudiobookCard({
 
                         {/* Series Badge (for series cards only) */}
                         {seriesBadge && (
-                            <div className="absolute top-2 right-2 bg-[#2323FF] rounded px-2 py-1 text-xs font-bold shadow-lg">
+                            <div className="absolute top-2 right-2 bg-ai rounded px-2 py-1 text-xs font-bold shadow-lg">
                                 {seriesBadge}
                             </div>
                         )}
                     </div>
                     
                     {/* Shelf Shadow */}
-                    <div className="absolute -bottom-1 left-0 right-0 h-2 bg-gradient-to-b from-[#1a1a1a]/50 to-transparent rounded-b-sm" />
+                    <div className="absolute -bottom-1 left-0 right-0 h-2 bg-gradient-to-b from-surface-hover/50 to-transparent rounded-b-sm" />
                 </div>
 
                 {/* Text Container - Fixed Height for Uniformity */}

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -12,8 +12,8 @@ const Badge = memo(forwardRef<HTMLSpanElement, BadgeProps>(
       warning: "bg-brand/10 text-brand ring-brand/20",
       error: "bg-red-500/10 text-red-500 ring-red-500/20",
       info: "bg-blue-500/10 text-blue-500 ring-blue-500/20",
-      ai: "bg-[#2323FF]/10 text-[#2323FF] ring-[#2323FF]/20",
-      default: "bg-[#1a1a1a] text-gray-400 ring-[#262626]",
+      ai: "bg-ai/10 text-ai ring-ai/20",
+      default: "bg-surface-hover text-gray-400 ring-line",
     };
 
     return (

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -20,18 +20,18 @@ const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>(
         ref
     ) => {
         const baseStyles =
-            "inline-flex items-center justify-center rounded-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2323FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a] disabled:opacity-50 disabled:cursor-not-allowed";
+            "inline-flex items-center justify-center rounded-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ai focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-50 disabled:cursor-not-allowed";
 
         // soundspan brand color: #3b82f6
         const variantStyles = {
             primary:
                 "bg-brand hover:bg-brand-hover text-black px-4 py-2 shadow-lg shadow-brand/10",
             secondary:
-                "bg-[#1a1a1a] hover:bg-[#222] text-white px-4 py-2 border border-[#262626]",
-            ghost: "text-gray-400 hover:text-white hover:bg-[#1a1a1a] px-4 py-2",
+                "bg-surface-hover hover:bg-[#222] text-white px-4 py-2 border border-line",
+            ghost: "text-gray-400 hover:text-white hover:bg-surface-hover px-4 py-2",
             danger: "text-red-500 hover:bg-red-500/10 border border-red-500/20 hover:border-red-500/40 px-4 py-2",
-            ai: "bg-[#1a1a1a] hover:bg-brand/10 text-brand border border-[#1c1c1c] hover:border-brand/30 px-4 py-2",
-            icon: "w-8 h-8 text-gray-400 hover:text-white hover:bg-[#1a1a1a]",
+            ai: "bg-surface-hover hover:bg-brand/10 text-brand border border-surface-active hover:border-brand/30 px-4 py-2",
+            icon: "w-8 h-8 text-gray-400 hover:text-white hover:bg-surface-hover",
         };
 
         return (

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -19,10 +19,10 @@ const Card = memo(forwardRef<HTMLDivElement, CardProps>(
                 hover && "hover:bg-white/5"
             ),
             ai: cn(
-                "bg-gradient-to-br from-[#121212] to-[#0f0f0f] border border-[#1c1c1c]",
+                "bg-gradient-to-br from-surface-sunken to-surface-raised border border-surface-active",
                 hover && "hover:border-yellow-500/30"
             ),
-            metric: "bg-[#0f0f0f] border border-[#1c1c1c]",
+            metric: "bg-surface-raised border border-surface-active",
         };
 
         return (

--- a/frontend/components/ui/CoverMosaic.tsx
+++ b/frontend/components/ui/CoverMosaic.tsx
@@ -74,7 +74,7 @@ function CoverMosaic({
                     className,
                 )}
             >
-                {emptyState ?? <Music className="w-10 h-10 text-gray-600" />}
+                {emptyState ?? <Music className="w-10 h-10 text-gray-400" />}
             </div>
         );
     }
@@ -116,7 +116,7 @@ function CoverMosaic({
             )}
         >
             {filledUrls.map((url, i) => (
-                <div key={`${url}-${i}`} className="relative bg-[#181818]">
+                <div key={`${url}-${i}`} className="relative bg-surface-elevated">
                     <Image
                         src={url}
                         alt=""
@@ -133,10 +133,10 @@ function CoverMosaic({
             {Array.from({ length: emptyCellCount }).map((_, i) => (
                 <div
                     key={`empty-${i}`}
-                    className="relative bg-[#282828] flex items-center justify-center"
+                    className="relative bg-surface-highlight flex items-center justify-center"
                 >
                     {showEmptyCellIcon && (
-                        <Music className="w-5 h-5 text-gray-600" />
+                        <Music className="w-5 h-5 text-gray-400" />
                     )}
                 </div>
             ))}

--- a/frontend/components/ui/EmptyState.tsx
+++ b/frontend/components/ui/EmptyState.tsx
@@ -24,11 +24,11 @@ const EmptyState = memo(function EmptyState({
 }: EmptyStateProps) {
     return (
         <div className="flex flex-col items-center justify-center py-12 md:py-16 text-center px-4">
-            <div className="mb-4 text-gray-600">{icon}</div>
+            <div className="mb-4 text-gray-400">{icon}</div>
             <h3 className="text-lg md:text-xl font-medium text-white mb-2">
                 {title}
             </h3>
-            <p className="text-sm md:text-base text-gray-500 mb-6 max-w-md">
+            <p className="text-sm md:text-base text-gray-400 mb-6 max-w-md">
                 {description}
             </p>
             {children}

--- a/frontend/components/ui/EqBars.tsx
+++ b/frontend/components/ui/EqBars.tsx
@@ -13,9 +13,9 @@ interface EqBarsProps {
 export function EqBars({ className }: EqBarsProps) {
     return (
         <div className={cn("inline-flex items-end gap-0.5 h-3", className)}>
-            <span className="h-2 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.2s] motion-reduce:animate-none" />
-            <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa] motion-reduce:animate-none" />
-            <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-[#60a5fa] [animation-delay:-0.35s] motion-reduce:animate-none" />
+            <span className="h-2 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.2s] motion-reduce:animate-none" />
+            <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-brand-hover motion-reduce:animate-none" />
+            <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.35s] motion-reduce:animate-none" />
         </div>
     );
 }

--- a/frontend/components/ui/FormElements.tsx
+++ b/frontend/components/ui/FormElements.tsx
@@ -12,11 +12,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <input
         ref={ref}
         className={cn(
-          "bg-[#0f0f0f] border text-white placeholder-gray-600 rounded-sm px-3 py-2 text-sm transition-colors",
+          "bg-surface-raised border text-white placeholder-gray-600 rounded-sm px-3 py-2 text-sm transition-colors",
           "focus:outline-none focus:ring-1",
           error
             ? "border-red-500/50 focus:border-red-500 focus:ring-red-500/20"
-            : "border-[#262626] focus:border-[#1db954]/50 focus:ring-[#2323FF]/20",
+            : "border-line focus:border-[#1db954]/50 focus:ring-ai/20",
           className
         )}
         {...props}
@@ -38,11 +38,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          "bg-[#0f0f0f] border text-white placeholder-gray-600 rounded-sm px-3 py-2 text-sm resize-none transition-colors",
+          "bg-surface-raised border text-white placeholder-gray-600 rounded-sm px-3 py-2 text-sm resize-none transition-colors",
           "focus:outline-none focus:ring-1",
           error
             ? "border-red-500/50 focus:border-red-500 focus:ring-red-500/20"
-            : "border-[#262626] focus:border-[#1db954]/50 focus:ring-[#2323FF]/20",
+            : "border-line focus:border-[#1db954]/50 focus:ring-ai/20",
           className
         )}
         {...props}
@@ -64,11 +64,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       <select
         ref={ref}
         className={cn(
-          "bg-[#0f0f0f] border text-white rounded-sm px-3 py-2 text-sm appearance-none cursor-pointer transition-colors",
+          "bg-surface-raised border text-white rounded-sm px-3 py-2 text-sm appearance-none cursor-pointer transition-colors",
           "focus:outline-none",
           error
             ? "border-red-500/50 focus:border-red-500"
-            : "border-[#262626] focus:border-[#1db954]/50",
+            : "border-line focus:border-[#1db954]/50",
           className
         )}
         {...props}

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -27,9 +27,9 @@ export function Input({
             <div className="relative">
                 <input
                     className={cn(
-                        "w-full bg-[#1a1a1a] border border-[#1c1c1c] rounded-md px-4 py-2 text-white",
-                        "placeholder:text-gray-500",
-                        "focus:outline-none focus:ring-2 focus:ring-[#2323FF]/50 focus:border-[#2323FF]",
+                        "w-full bg-surface-hover border border-surface-active rounded-md px-4 py-2 text-white",
+                        "placeholder:text-gray-400",
+                        "focus:outline-none focus:ring-2 focus:ring-ai/50 focus:border-ai",
                         "transition-all duration-200",
                         error &&
                             "border-red-500/50 focus:ring-red-500/50 focus:border-red-500",

--- a/frontend/components/ui/MediaCard.tsx
+++ b/frontend/components/ui/MediaCard.tsx
@@ -25,11 +25,11 @@ const MediaCard = memo(function MediaCard({
 }: MediaCardProps) {
     const content = (
         <div
-            className="bg-[#121212] hover:bg-[#181818] p-4 rounded-lg cursor-pointer transition-colors group"
+            className="bg-surface-sunken hover:bg-surface-elevated p-4 rounded-lg cursor-pointer transition-colors group"
             onClick={onClick}
         >
             <div
-                className={`aspect-square bg-[#181818] ${
+                className={`aspect-square bg-surface-elevated ${
                     imageShape === "circle" ? "rounded-full" : "rounded-md"
                 } mb-4 flex items-center justify-center overflow-hidden relative shadow-lg`}
                 style={{ contain: "content" }}

--- a/frontend/components/ui/Modal.tsx
+++ b/frontend/components/ui/Modal.tsx
@@ -110,12 +110,12 @@ export function Modal({
                 aria-labelledby={titleId}
                 tabIndex={-1}
                 className={cn(
-                    "bg-gradient-to-br from-[#141414] to-[#0f0f0f] border border-[#262626] rounded-sm shadow-2xl max-w-md w-full p-6",
+                    "bg-gradient-to-br from-surface-overlay to-surface-raised border border-line rounded-sm shadow-2xl max-w-md w-full p-6",
                     className
                 )}
             >
                 {/* Header */}
-                <div className="flex items-center justify-between mb-4 pb-4 border-b border-[#1c1c1c]">
+                <div className="flex items-center justify-between mb-4 pb-4 border-b border-surface-active">
                     <h2 id={titleId} className="text-lg font-medium text-white">
                         {title}
                     </h2>

--- a/frontend/components/ui/MusicBrainzLookup.tsx
+++ b/frontend/components/ui/MusicBrainzLookup.tsx
@@ -154,7 +154,7 @@ export function MusicBrainzLookup({
                         {currentValue.substring(0, 8)}...
                     </span>
                 ) : (
-                    <span className="text-xs text-gray-500">None</span>
+                    <span className="text-xs text-gray-400">None</span>
                 )}
                 {hasValidMbid && (
                     <a
@@ -177,13 +177,13 @@ export function MusicBrainzLookup({
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onKeyDown={handleKeyDown}
                         placeholder={`Enter ${type} name to search...`}
-                        className="flex-1 rounded border border-white/10 bg-[#181818] px-4 py-2 text-sm text-white focus:border-white/30 focus:outline-none"
+                        className="flex-1 rounded border border-white/10 bg-surface-elevated px-4 py-2 text-sm text-white focus:border-white/30 focus:outline-none"
                     />
                     <button
                         type="button"
                         onClick={() => void performSearch()}
                         disabled={isSearching || searchQuery.trim().length < 2}
-                        className="flex items-center gap-2 rounded border border-white/10 bg-[#282828] px-4 py-2 text-sm text-white transition-colors hover:bg-[#333] disabled:bg-[#1a1a1a] disabled:text-gray-600"
+                        className="flex items-center gap-2 rounded border border-white/10 bg-surface-highlight px-4 py-2 text-sm text-white transition-colors hover:bg-line-strong disabled:bg-surface-hover disabled:text-gray-400"
                     >
                         {isSearching ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -195,7 +195,7 @@ export function MusicBrainzLookup({
                 </div>
 
                 {hasSearched && (
-                    <div className="max-h-64 overflow-y-auto rounded-lg border border-white/10 bg-[#1a1a1a]">
+                    <div className="max-h-64 overflow-y-auto rounded-lg border border-white/10 bg-surface-hover">
                         {hasResults ? (
                             type === "artist" ? (
                                 artistResults.map((artist) => (
@@ -217,12 +217,12 @@ export function MusicBrainzLookup({
                                             </div>
                                             <div className="flex flex-shrink-0 items-center gap-2">
                                                 {artist.country && (
-                                                    <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-500">
+                                                    <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-400">
                                                         {artist.country}
                                                     </span>
                                                 )}
                                                 {artist.type && (
-                                                    <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-500">
+                                                    <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-400">
                                                         {artist.type}
                                                     </span>
                                                 )}
@@ -248,11 +248,11 @@ export function MusicBrainzLookup({
                                             </div>
                                             <div className="flex flex-shrink-0 items-center gap-2">
                                                 {album.firstReleaseDate && (
-                                                    <span className="text-xs text-gray-500">
+                                                    <span className="text-xs text-gray-400">
                                                         {album.firstReleaseDate.substring(0, 4)}
                                                     </span>
                                                 )}
-                                                <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-500">
+                                                <span className="rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-400">
                                                     {album.primaryType}
                                                 </span>
                                             </div>
@@ -285,13 +285,13 @@ export function MusicBrainzLookup({
                             value={manualMbid}
                             onChange={(e) => setManualMbid(e.target.value)}
                             placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                            className="flex-1 rounded border border-white/10 bg-[#181818] px-4 py-2 font-mono text-xs text-white focus:border-white/30 focus:outline-none"
+                            className="flex-1 rounded border border-white/10 bg-surface-elevated px-4 py-2 font-mono text-xs text-white focus:border-white/30 focus:outline-none"
                         />
                         <button
                             type="button"
                             onClick={handleManualSubmit}
                             disabled={!MBID_UUID_REGEX.test(manualMbid.trim())}
-                            className="flex items-center gap-1 rounded bg-[#3b82f6] px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-[#2563eb] disabled:cursor-not-allowed disabled:bg-gray-600"
+                            className="flex items-center gap-1 rounded bg-brand px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-brand-dark disabled:cursor-not-allowed disabled:bg-gray-600"
                         >
                             <Check className="h-4 w-4" />
                         </button>

--- a/frontend/components/ui/PlayableCard.tsx
+++ b/frontend/components/ui/PlayableCard.tsx
@@ -70,7 +70,7 @@ const PlayableCard = memo(function PlayableCard({
             <div className="relative aspect-square mb-3">
                 <div
                     className={cn(
-                        "relative w-full h-full bg-[#282828] flex items-center justify-center overflow-hidden shadow-lg",
+                        "relative w-full h-full bg-surface-highlight flex items-center justify-center overflow-hidden shadow-lg",
                         circular ? "rounded-full" : "rounded-md",
                     )}
                     style={{ contain: "content" }}
@@ -146,7 +146,7 @@ const PlayableCard = memo(function PlayableCard({
                                 className={cn(
                                     "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors",
                                     isDownloading ?
-                                        "bg-gray-500/20 border border-gray-500/30 text-gray-500 cursor-not-allowed"
+                                        "bg-gray-500/20 border border-gray-500/30 text-gray-400 cursor-not-allowed"
                                     :   "bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 hover:border-yellow-500/50 text-yellow-400 hover:text-yellow-300",
                                 )}
                                 title={
@@ -180,7 +180,7 @@ const PlayableCard = memo(function PlayableCard({
                                     className={cn(
                                         "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors",
                                         isDownloading ?
-                                            "bg-gray-500/20 border border-gray-500/30 text-gray-500 cursor-not-allowed"
+                                            "bg-gray-500/20 border border-gray-500/30 text-gray-400 cursor-not-allowed"
                                         :   "bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 hover:border-yellow-500/50 text-yellow-400 hover:text-yellow-300",
                                     )}
                                     title="Search and select release"

--- a/frontend/components/ui/PlaylistSelector.tsx
+++ b/frontend/components/ui/PlaylistSelector.tsx
@@ -153,7 +153,7 @@ export function PlaylistSelector({
             onClick={onClose}
         >
             <div
-                className="bg-linear-to-b from-[#121212] to-[#121212] rounded-xl max-w-md w-full max-h-[80vh] overflow-hidden flex flex-col border border-white/10 shadow-2xl"
+                className="bg-linear-to-b from-surface-sunken to-surface-sunken rounded-xl max-w-md w-full max-h-[80vh] overflow-hidden flex flex-col border border-white/10 shadow-2xl"
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex items-center justify-between p-6 border-b border-white/10">
@@ -188,9 +188,9 @@ export function PlaylistSelector({
                         </div>
                     ) : playlists.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-12 text-center">
-                            <Music2 className="w-12 h-12 text-gray-600 mb-3" />
+                            <Music2 className="w-12 h-12 text-gray-400 mb-3" />
                             <p className="text-gray-400">No playlists yet</p>
-                            <p className="text-gray-500 text-sm mt-1">
+                            <p className="text-gray-400 text-sm mt-1">
                                 Create one below to get started
                             </p>
                         </div>
@@ -205,7 +205,7 @@ export function PlaylistSelector({
                                     }
                                     className={`w-full text-left px-4 py-4 rounded-lg transition-all border group ${
                                         isSelected
-                                            ? "bg-[#3b82f6]/10 border-[#3b82f6]/30"
+                                            ? "bg-brand/10 border-brand/30"
                                             : "bg-white/5 hover:bg-white/10 border-white/5 hover:border-white/10"
                                     }`}
                                     disabled={isProcessing}
@@ -214,8 +214,8 @@ export function PlaylistSelector({
                                         <div className="flex-1 min-w-0">
                                             <p className={`font-semibold truncate transition-colors ${
                                                 isSelected
-                                                    ? "text-[#3b82f6]"
-                                                    : "text-white group-hover:text-[#3b82f6]"
+                                                    ? "text-brand"
+                                                    : "text-white group-hover:text-brand"
                                             }`}>
                                                 {playlist.name}
                                             </p>
@@ -227,11 +227,11 @@ export function PlaylistSelector({
                                             </p>
                                         </div>
                                         {multiSelect && isSelected ? (
-                                            <div className="w-5 h-5 rounded-full bg-[#3b82f6] flex items-center justify-center ml-2 shrink-0">
+                                            <div className="w-5 h-5 rounded-full bg-brand flex items-center justify-center ml-2 shrink-0">
                                                 <Check className="w-3 h-3 text-white" />
                                             </div>
                                         ) : (
-                                            <Plus className="w-5 h-5 text-gray-400 group-hover:text-[#3b82f6] transition-colors ml-2 shrink-0" />
+                                            <Plus className="w-5 h-5 text-gray-400 group-hover:text-brand transition-colors ml-2 shrink-0" />
                                         )}
                                     </div>
                                 </button>
@@ -245,7 +245,7 @@ export function PlaylistSelector({
                         <button
                             onClick={() => void handleConfirmMulti()}
                             disabled={isProcessing}
-                            className="w-full py-3 rounded-full font-medium bg-[#3b82f6] text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+                            className="w-full py-3 rounded-full font-medium bg-brand text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
                         >
                             {isConfirming ? (
                                 <>
@@ -259,7 +259,7 @@ export function PlaylistSelector({
                     </div>
                 )}
 
-                <div className="p-6 border-t border-white/10 bg-[#0a0a0a]/50">
+                <div className="p-6 border-t border-white/10 bg-surface/50">
                     <p className="text-sm text-gray-400 mb-3 font-medium">
                         Create New Playlist
                     </p>
@@ -272,7 +272,7 @@ export function PlaylistSelector({
                             onKeyDown={(e) =>
                                 e.key === "Enter" && handleCreatePlaylist()
                             }
-                            className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#3b82f6] focus:bg-white/10 transition-all"
+                            className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-brand focus:bg-white/10 transition-all"
                         />
                         <button
                             onClick={handleCreatePlaylist}
@@ -281,7 +281,7 @@ export function PlaylistSelector({
                                 isCreating ||
                                 isProcessing
                             }
-                            className="px-5 py-3 bg-[#60a5fa] hover:bg-[#3b82f6] disabled:bg-gray-700 disabled:cursor-not-allowed text-black font-bold rounded-lg transition-all flex items-center gap-2 disabled:text-gray-500"
+                            className="px-5 py-3 bg-brand-hover hover:bg-brand disabled:bg-gray-700 disabled:cursor-not-allowed text-black font-bold rounded-lg transition-all flex items-center gap-2 disabled:text-gray-400"
                         >
                             <Plus className="w-5 h-5" />
                             <span className="hidden sm:inline">Create</span>
@@ -295,7 +295,7 @@ export function PlaylistSelector({
                                 onChange={(e) => setIsPublic(e.target.checked)}
                                 className="sr-only peer"
                             />
-                            <div className="w-10 h-5 bg-white/10 rounded-full peer-checked:bg-[#3b82f6] transition-colors" />
+                            <div className="w-10 h-5 bg-white/10 rounded-full peer-checked:bg-brand transition-colors" />
                             <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5" />
                         </div>
                         <span className="text-sm text-gray-400 group-hover:text-gray-300 transition-colors">

--- a/frontend/components/ui/RadioStationCard.tsx
+++ b/frontend/components/ui/RadioStationCard.tsx
@@ -52,7 +52,7 @@ export function RadioStationCard({ station, onPlay, isLoading }: RadioStationCar
             className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-left w-full"
         >
             {/* Square cover art */}
-            <div className="relative aspect-square bg-[#282828] rounded-lg mb-3 overflow-hidden shadow-lg">
+            <div className="relative aspect-square bg-surface-highlight rounded-lg mb-3 overflow-hidden shadow-lg">
                 <RadioStationMosaic filter={station.filter} className="absolute inset-0" />
                 {/* Gradient tint overlay */}
                 <div
@@ -67,7 +67,7 @@ export function RadioStationCard({ station, onPlay, isLoading }: RadioStationCar
                             : "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 translate-y-2 group-hover:translate-y-0 group-focus-visible:translate-y-0"
                     )}
                 >
-                    <div className="w-10 h-10 rounded-full bg-[#60a5fa] flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
+                    <div className="w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
                         {isLoading || showSpinner ? (
                             <Loader2 className="w-4 h-4 text-black animate-spin" />
                         ) : (

--- a/frontend/components/ui/ReleaseSelectionModal.tsx
+++ b/frontend/components/ui/ReleaseSelectionModal.tsx
@@ -338,7 +338,7 @@ export function ReleaseSelectionModal({
                                 onChange={(event) =>
                                     setSortBy(event.target.value as ReleaseSortOption)
                                 }
-                                className="mt-1 w-full rounded border border-white/15 bg-[#181818] px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
+                                className="mt-1 w-full rounded border border-white/15 bg-surface-elevated px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
                             >
                                 <option value="best">Best Match</option>
                                 <option value="quality">Quality</option>
@@ -353,7 +353,7 @@ export function ReleaseSelectionModal({
                             <select
                                 value={qualityFilter}
                                 onChange={(event) => setQualityFilter(event.target.value)}
-                                className="mt-1 w-full rounded border border-white/15 bg-[#181818] px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
+                                className="mt-1 w-full rounded border border-white/15 bg-surface-elevated px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
                             >
                                 <option value="all">All</option>
                                 {qualityOptions.map((quality) => (
@@ -369,7 +369,7 @@ export function ReleaseSelectionModal({
                             <select
                                 value={indexerFilter}
                                 onChange={(event) => setIndexerFilter(event.target.value)}
-                                className="mt-1 w-full rounded border border-white/15 bg-[#181818] px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
+                                className="mt-1 w-full rounded border border-white/15 bg-surface-elevated px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
                             >
                                 <option value="all">All</option>
                                 {indexerOptions.map((indexer) => (
@@ -387,7 +387,7 @@ export function ReleaseSelectionModal({
                                 onChange={(event) =>
                                     setSeederFilter(event.target.value as "all" | "1" | "10")
                                 }
-                                className="mt-1 w-full rounded border border-white/15 bg-[#181818] px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
+                                className="mt-1 w-full rounded border border-white/15 bg-surface-elevated px-2 py-1.5 text-sm text-white focus:border-white/30 focus:outline-none"
                             >
                                 <option value="all">All</option>
                                 <option value="1">At least 1</option>

--- a/frontend/components/ui/RestartModal.tsx
+++ b/frontend/components/ui/RestartModal.tsx
@@ -39,9 +39,9 @@ export function RestartModal({
 
             {/* Modal */}
             <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                <div className="bg-[#111] border border-[#1c1c1c] rounded-lg shadow-2xl max-w-md w-full">
+                <div className="bg-[#111] border border-surface-active rounded-lg shadow-2xl max-w-md w-full">
                     {/* Header */}
-                    <div className="flex items-center justify-between p-6 border-b border-[#1c1c1c]">
+                    <div className="flex items-center justify-between p-6 border-b border-surface-active">
                         <div className="flex items-center gap-3">
                             <div className="w-10 h-10 rounded-full bg-green-500/20 flex items-center justify-center">
                                 <Check className="w-6 h-6 text-green-500" />
@@ -62,7 +62,7 @@ export function RestartModal({
                     <div className="p-6 space-y-4">
                         <p className="text-gray-300">
                             Your settings have been saved successfully and the
-                            <code className="text-[#5b5bff] bg-[#0a0a0a] px-1.5 py-0.5 rounded mx-1">
+                            <code className="text-ai-hover bg-surface px-1.5 py-0.5 rounded mx-1">
                                 .env
                             </code>
                             file has been updated.
@@ -96,12 +96,12 @@ export function RestartModal({
                                         Run this command in your terminal:
                                     </p>
                                     <div className="relative">
-                                        <div className="bg-[#0a0a0a] border border-[#1c1c1c] rounded-md px-4 py-3 pr-12 font-mono text-sm text-white">
+                                        <div className="bg-surface border border-surface-active rounded-md px-4 py-3 pr-12 font-mono text-sm text-white">
                                             {command}
                                         </div>
                                         <button
                                             onClick={handleCopy}
-                                            className="absolute right-2 top-1/2 -translate-y-1/2 p-2 hover:bg-[#1a1a1a] rounded transition-colors"
+                                            className="absolute right-2 top-1/2 -translate-y-1/2 p-2 hover:bg-surface-hover rounded transition-colors"
                                             title="Copy to clipboard"
                                         >
                                             {copied ? (
@@ -126,7 +126,7 @@ export function RestartModal({
                     </div>
 
                     {/* Footer */}
-                    <div className="flex items-center justify-end gap-3 p-6 border-t border-[#1c1c1c]">
+                    <div className="flex items-center justify-end gap-3 p-6 border-t border-surface-active">
                         {changedServices.length > 0 && (
                             <Button
                                 variant="secondary"

--- a/frontend/components/ui/ShareLinkModal.tsx
+++ b/frontend/components/ui/ShareLinkModal.tsx
@@ -189,7 +189,7 @@ export function ShareLinkModal({
                                 className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-brand/50"
                                 style={{ colorScheme: "dark" }}
                             />
-                            <p className="mt-2 text-xs text-gray-500">
+                            <p className="mt-2 text-xs text-gray-400">
                                 Leave empty to keep the link active until you revoke it.
                             </p>
                         </div>
@@ -207,9 +207,9 @@ export function ShareLinkModal({
                                 value={maxPlays}
                                 onChange={(event) => setMaxPlays(event.target.value)}
                                 placeholder="Unlimited"
-                                className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-brand/50"
+                                className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand/50"
                             />
-                            <p className="mt-2 text-xs text-gray-500">
+                            <p className="mt-2 text-xs text-gray-400">
                                 Leave empty to allow unlimited opens.
                             </p>
                         </div>

--- a/frontend/components/ui/Skeleton.tsx
+++ b/frontend/components/ui/Skeleton.tsx
@@ -12,7 +12,7 @@ interface SkeletonProps {
 export function Skeleton({ className }: SkeletonProps) {
     return (
         <div
-            className={cn("animate-pulse bg-[#1a1a1a] rounded-sm", className)}
+            className={cn("animate-pulse bg-surface-hover rounded-sm", className)}
         />
     );
 }
@@ -26,7 +26,7 @@ export function ArtistCardSkeleton({ count = 6 }: { count?: number }) {
             {Array.from({ length: count }).map((_, i) => (
                 <div
                     key={i}
-                    className="bg-gradient-to-br from-[#121212] to-[#0f0f0f] border border-[#1c1c1c] rounded-sm p-4"
+                    className="bg-gradient-to-br from-surface-sunken to-surface-raised border border-surface-active rounded-sm p-4"
                 >
                     <Skeleton className="aspect-square w-full mb-3" />
                     <Skeleton className="h-4 w-3/4 mb-2" />
@@ -46,7 +46,7 @@ export function AlbumCardSkeleton({ count = 6 }: { count?: number }) {
             {Array.from({ length: count }).map((_, i) => (
                 <div
                     key={i}
-                    className="bg-gradient-to-br from-[#121212] to-[#0f0f0f] border border-[#1c1c1c] rounded-sm p-4"
+                    className="bg-gradient-to-br from-surface-sunken to-surface-raised border border-surface-active rounded-sm p-4"
                 >
                     <Skeleton className="aspect-square w-full mb-3" />
                     <Skeleton className="h-4 w-full mb-2" />
@@ -63,7 +63,7 @@ export function AlbumCardSkeleton({ count = 6 }: { count?: number }) {
  */
 export function TrackListSkeleton({ count = 10 }: { count?: number }) {
     return (
-        <div className="bg-[#0f0f0f] border border-[#1c1c1c] rounded-sm divide-y divide-[#1c1c1c]">
+        <div className="bg-surface-raised border border-surface-active rounded-sm divide-y divide-surface-active">
             {Array.from({ length: count }).map((_, i) => (
                 <div key={i} className="flex items-center gap-4 px-4 py-3">
                     <Skeleton className="w-8 h-4" />

--- a/frontend/components/vibe/AlchemyTray.tsx
+++ b/frontend/components/vibe/AlchemyTray.tsx
@@ -84,7 +84,7 @@ function BlendResults({ view }: { view: AlchemyView }) {
     return (
         <div>
             <div className="flex items-center justify-between mb-1">
-                <p className="text-xs uppercase tracking-wide text-gray-500">Blend results</p>
+                <p className="text-xs uppercase tracking-wide text-gray-400">Blend results</p>
                 <button type="button" onClick={view.play}
                     className="inline-flex items-center gap-1 min-h-[36px] px-2 rounded-lg text-xs text-fuchsia-300 hover:text-white hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60">
                     <Play className="w-3.5 h-3.5" /> Play blend

--- a/frontend/components/vibe/FiltersPanel.tsx
+++ b/frontend/components/vibe/FiltersPanel.tsx
@@ -142,7 +142,7 @@ function DualRange({
                     className="vibe-range-input"
                 />
             </div>
-            <div className="flex items-center justify-between mt-1 text-xs text-gray-500">
+            <div className="flex items-center justify-between mt-1 text-xs text-gray-400">
                 <span>{lowLabel}</span>
                 <span>{highLabel}</span>
             </div>
@@ -214,7 +214,7 @@ function MoodFilters({ filters, moods }: { filters: FiltersSlice; moods: readonl
                     All
                 </button>
             </div>
-            <p className="mt-1.5 text-xs text-gray-500">shift-click to solo</p>
+            <p className="mt-1.5 text-xs text-gray-400">shift-click to solo</p>
         </>
     );
 }

--- a/frontend/components/vibe/JourneyPanel.tsx
+++ b/frontend/components/vibe/JourneyPanel.tsx
@@ -40,7 +40,7 @@ function DestinationPicker({ view }: { view: JourneyView }) {
     const { picking, destTrackId, destLabel, togglePick } = view;
     return (
         <>
-            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Destination</p>
+            <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Destination</p>
             <button type="button" onClick={togglePick} aria-pressed={picking}
                 className={`w-full min-h-[40px] flex items-center gap-2 px-2 py-2 mb-2 rounded-lg border text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60 ${picking ? "border-indigo-400/60 bg-indigo-500/20 text-white" : "border-white/10 text-gray-300 hover:bg-white/5"}`}>
                 <MapPin className="w-4 h-4 shrink-0" />
@@ -114,7 +114,7 @@ function JourneyRoute({ view }: { view: JourneyView }) {
     return (
         <div className="mb-3">
             <div className="flex items-center justify-between mb-1">
-                <p className="text-xs uppercase tracking-wide text-gray-500">
+                <p className="text-xs uppercase tracking-wide text-gray-400">
                     {view.targetLabel ? `Route to ${view.targetLabel}` : "Route"}
                 </p>
                 <RouteActions view={view} />
@@ -137,7 +137,7 @@ function DriftChoices({ view }: { view: JourneyView }) {
     if (choices.length === 0) return null;
     return (
         <div className="border-t border-white/10 pt-2">
-            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Drift toward…</p>
+            <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Drift toward…</p>
             <div className="flex flex-wrap gap-1.5">
                 {choices.map((m) => (
                     <button key={m.mood} type="button" onClick={() => view.drift(m.mood)}

--- a/frontend/components/vibe/MapHintChip.tsx
+++ b/frontend/components/vibe/MapHintChip.tsx
@@ -34,7 +34,7 @@ export function MapHintChip({ text, onDismiss }: MapHintChipProps) {
                     onClick={onDismiss}
                     aria-label="Hide hints"
                     title="Hide hints for this session"
-                    className="flex items-center justify-center w-7 h-7 rounded-full text-gray-500 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
+                    className="flex items-center justify-center w-7 h-7 rounded-full text-gray-400 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
                 >
                     <X className="w-3.5 h-3.5" />
                 </button>

--- a/frontend/components/vibe/QueuePanel.tsx
+++ b/frontend/components/vibe/QueuePanel.tsx
@@ -133,7 +133,7 @@ function QueueRow({ item, idx, absoluteIndex, drag, remove, disabled }: {
                     <button type="button" draggable onClick={(event) => event.stopPropagation()}
                         onDragStart={(event) => drag.start(idx, event)} onDragEnd={drag.clear}
                         aria-label={`Drag to reorder ${title}`} title="Drag to reorder"
-                        className="shrink-0 w-6 h-6 grid place-items-center rounded text-gray-500 hover:text-white cursor-grab active:cursor-grabbing">
+                        className="shrink-0 w-6 h-6 grid place-items-center rounded text-gray-400 hover:text-white cursor-grab active:cursor-grabbing">
                         <GripVertical className="w-4 h-4" />
                     </button>
                 )}
@@ -144,7 +144,7 @@ function QueueRow({ item, idx, absoluteIndex, drag, remove, disabled }: {
                 {remove && (
                     <button type="button" onClick={() => remove(absoluteIndex)}
                         aria-label={`Remove ${title} from queue`} title="Remove from queue"
-                        className="shrink-0 w-7 h-7 grid place-items-center rounded-lg text-gray-500 hover:text-red-400 hover:bg-white/10 transition-colors">
+                        className="shrink-0 w-7 h-7 grid place-items-center rounded-lg text-gray-400 hover:text-red-400 hover:bg-white/10 transition-colors">
                         <X className="w-3.5 h-3.5" />
                     </button>
                 )}

--- a/frontend/components/vibe/SpotlightSearch.tsx
+++ b/frontend/components/vibe/SpotlightSearch.tsx
@@ -259,7 +259,7 @@ function SearchForm({ query, inputRef, className, remote, rows, controller }: {
                     aria-label="Spotlight a vibe" role="combobox" aria-autocomplete="list"
                     aria-expanded={controller.show} aria-controls="spotlight-listbox"
                     aria-activedescendant={controller.show ? `spotlight-option-${controller.activeIndex}` : undefined}
-                    className="w-full h-full bg-transparent pl-9 pr-9 rounded-full text-sm text-white placeholder:text-gray-500 focus:outline-none" />
+                    className="w-full h-full bg-transparent pl-9 pr-9 rounded-full text-sm text-white placeholder:text-gray-400 focus:outline-none" />
                 {(query || remote.loading) && (
                     <button type="button" onClick={controller.clear} title="Clear (Esc)"
                         aria-label="Clear spotlight"

--- a/frontend/components/vibe/TravelPanel.tsx
+++ b/frontend/components/vibe/TravelPanel.tsx
@@ -77,7 +77,7 @@ function FeatureBar({
     const candidatePct = Math.round(candidate! * 100);
     return (
         <div className="mb-1.5 last:mb-0">
-            <div className="flex items-center justify-between text-[10px] text-gray-500 mb-0.5">
+            <div className="flex items-center justify-between text-[10px] text-gray-400 mb-0.5">
                 <span>{label}</span>
                 <span className="tabular-nums">{matchPct}% match</span>
             </div>
@@ -218,7 +218,7 @@ function TravelBreadcrumb({ items }: { items: TravelView["breadcrumbTitles"] }) 
         <div className="flex items-center flex-wrap gap-0.5 mb-2 text-xs text-gray-400">
             {items.map((item, index) => (
                 <span key={`${item.id}-${index}`} className="flex items-center">
-                    {index > 0 && <ChevronRight className="w-3 h-3 text-gray-600" />}
+                    {index > 0 && <ChevronRight className="w-3 h-3 text-gray-400" />}
                     <span className={index === items.length - 1 ? "text-indigo-300" : ""}>
                         {item.title}
                     </span>

--- a/frontend/components/vibe/VibeMapCanvasStage.tsx
+++ b/frontend/components/vibe/VibeMapCanvasStage.tsx
@@ -70,7 +70,7 @@ function ReadyMap({ model }: { model: VibeMapViewModel }) {
 function MapStatus({ model }: { model: VibeMapViewModel }) {
     if (model.data.loading) {
         return <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <Loader2 className="w-8 h-8 text-gray-500 animate-spin" />
+            <Loader2 className="w-8 h-8 text-gray-400 animate-spin" />
         </div>;
     }
     if (!model.data.error && model.data.tracks.length > 0) return null;

--- a/frontend/components/vibe/VibeMapTab.tsx
+++ b/frontend/components/vibe/VibeMapTab.tsx
@@ -27,7 +27,7 @@ export function VibeMapTab({ currentTrackPresent, onExplore }: VibeMapTabProps) 
             <Map className="w-3.5 h-3.5" />Map
         </button>
     </div>;
-    return <div className="absolute inset-0 overflow-hidden bg-[#0a0a0a]">
+    return <div className="absolute inset-0 overflow-hidden bg-surface">
         <VibeMap headerSlot={header}
             bottomInset={playerOverlapsMap ? MOBILE_PLAYER_CLEARANCE_PX : 0} />
     </div>;

--- a/frontend/components/vibe/VibeMapView.tsx
+++ b/frontend/components/vibe/VibeMapView.tsx
@@ -14,7 +14,7 @@ export function VibeMapView({ model, containerRef }: {
     containerRef: RefObject<HTMLDivElement | null>;
 }) {
     const className = model.shell.fullscreen ?
-        "fixed inset-0 z-[10005] bg-[#0a0a0a] overflow-hidden" :
+        "fixed inset-0 z-[10005] bg-surface overflow-hidden" :
         "relative w-full h-full overflow-hidden";
     const bottomInset = model.shell.fullscreen ? 0 : model.props.bottomInset ?? 0;
     return (

--- a/frontend/components/vibe/ViewControls.tsx
+++ b/frontend/components/vibe/ViewControls.tsx
@@ -133,9 +133,9 @@ export function AboutMapPopover() {
                 away. Percentages shown in panels are calibrated against random pairs
                 from your own library.
             </p>
-            <div><p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Mood colors</p><MoodLegend /></div>
-            <div><p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Lines &amp; glyphs</p><GlyphLegend /></div>
-            <div><p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Gestures</p><GestureCheatSheet /></div>
+            <div><p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Mood colors</p><MoodLegend /></div>
+            <div><p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Lines &amp; glyphs</p><GlyphLegend /></div>
+            <div><p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Gestures</p><GestureCheatSheet /></div>
         </div>
     );
 }

--- a/frontend/features/album/components/AlbumActionBar.tsx
+++ b/frontend/features/album/components/AlbumActionBar.tsx
@@ -223,7 +223,7 @@ export function AlbumActionBar({
                                     "flex items-center gap-2 px-5 py-2.5 rounded-full font-medium transition-all",
                                     isPendingDownload
                                         ? "bg-white/5 text-white/50 cursor-not-allowed"
-                                        : "bg-[#60a5fa] hover:bg-[#3b82f6] text-black hover:scale-105"
+                                        : "bg-brand-hover hover:bg-brand text-black hover:scale-105"
                                 )}
                                 title="Auto-download best release"
                             >
@@ -240,7 +240,7 @@ export function AlbumActionBar({
                                     "flex items-center gap-2 px-4 py-2.5 rounded-full font-medium transition-all",
                                     isPendingDownload
                                         ? "bg-white/5 text-white/50 cursor-not-allowed"
-                                        : "bg-[#60a5fa] hover:bg-[#3b82f6] text-black hover:scale-105"
+                                        : "bg-brand-hover hover:bg-brand text-black hover:scale-105"
                                 )}
                                 title="Search and select a specific release"
                             >
@@ -299,7 +299,7 @@ export function AlbumActionBar({
                                         isApplyingAlbumPreference ?
                                             "cursor-not-allowed text-white/35"
                                         : isAlbumLiked ?
-                                            "text-[#3b82f6] hover:bg-white/10"
+                                            "text-brand hover:bg-white/10"
                                         :   "text-white/60 hover:bg-white/10 hover:text-white"
                                     )}
                                     title={isAlbumLiked ? "Remove like from all tracks" : "Like every track on this album"}

--- a/frontend/features/album/components/AlbumHero.tsx
+++ b/frontend/features/album/components/AlbumHero.tsx
@@ -76,7 +76,7 @@ export function AlbumHero({
                                 : "linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.7) 40%, #0a0a0a 100%)",
                         }}
                     />
-                    <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0a] via-transparent to-transparent" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent" />
                 </div>
             ) : (
                 <div
@@ -93,7 +93,7 @@ export function AlbumHero({
             <div className="relative px-4 md:px-8 pt-16 pb-6">
                 <div className="flex items-end gap-6">
                     {/* Album Cover - Square */}
-                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden relative">
+                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden relative">
                         {coverUrl ? (
                             <Image
                                 src={coverUrl}
@@ -106,7 +106,7 @@ export function AlbumHero({
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center">
-                                <Disc3 className="w-16 h-16 text-gray-600" />
+                                <Disc3 className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>

--- a/frontend/features/album/components/SimilarAlbums.tsx
+++ b/frontend/features/album/components/SimilarAlbums.tsx
@@ -26,7 +26,7 @@ export function SimilarAlbums({ similarAlbums, colors, onNavigate }: SimilarAlbu
             coverArt={album.coverArt ? api.getCoverArtUrl(album.coverArt, 300) : album.coverUrl}
             title={album.title}
             subtitle={album.artist?.name}
-            placeholderIcon={<Disc3 className="w-12 h-12 text-gray-600" />}
+            placeholderIcon={<Disc3 className="w-12 h-12 text-gray-400" />}
             circular={false}
             badge={album.owned ? "owned" : undefined}
             colors={colors}

--- a/frontend/features/album/components/TrackList.tsx
+++ b/frontend/features/album/components/TrackList.tsx
@@ -94,7 +94,7 @@ export const TrackList = memo(function TrackList({
                         <span
                             className={cn(
                                 "group-hover:hidden text-sm",
-                                state.isPlaying ? "text-[#5b5bff] font-bold" : "text-gray-500",
+                                state.isPlaying ? "text-ai-hover font-bold" : "text-gray-400",
                             )}
                         >
                             {track.trackNumber || track.trackNo || track.displayTrackNo || index + 1}
@@ -118,7 +118,7 @@ export const TrackList = memo(function TrackList({
                 trailingActions: (
                     <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
                         {isPlayable && track.playCount !== undefined && track.playCount > 0 && (
-                            <div className="hidden lg:flex items-center gap-1.5 text-xs text-gray-400 bg-[#1a1a1a] px-2 py-1 rounded-full">
+                            <div className="hidden lg:flex items-center gap-1.5 text-xs text-gray-400 bg-surface-hover px-2 py-1 rounded-full">
                                 <Play className="w-3 h-3" />
                                 <span>{formatNumber(track.playCount)}</span>
                             </div>
@@ -126,13 +126,13 @@ export const TrackList = memo(function TrackList({
                         {isPreviewOnly && (
                             <button
                                 onClick={(e) => { e.stopPropagation(); onPreview(track, e); }}
-                                className="p-2 rounded-full bg-[#1a1a1a] hover:bg-[#2a2a2a] transition-colors text-white"
+                                className="p-2 rounded-full bg-surface-hover hover:bg-[#2a2a2a] transition-colors text-white"
                                 aria-label={isPreviewPlaying ? "Pause preview" : "Play preview"}
                             >
                                 {isPreviewPlaying ? <Pause className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
                             </button>
                         )}
-                        <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                        <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                             {track.duration ? formatTime(track.duration) : ""}
                         </span>
                         <TrackPreferenceButtons
@@ -158,7 +158,7 @@ export const TrackList = memo(function TrackList({
                     </div>
                 ),
                 rowClassName: cn(
-                    state.isPlaying && "bg-[#1a1a1a] border-l-2",
+                    state.isPlaying && "bg-surface-hover border-l-2",
                     isPreviewOnly && "opacity-70 hover:opacity-90",
                 ),
             };
@@ -173,8 +173,8 @@ export const TrackList = memo(function TrackList({
             const prevDisc = prevTrack ? (prevTrack.discNumber ?? prevTrack.discNo ?? 1) : 0;
             if (index === 0 || currentDisc !== prevDisc) {
                 return (
-                    <div className="flex items-center gap-2 px-3 md:px-4 py-2.5 bg-[#0d0d0d] border-b border-[#1c1c1c]">
-                        <Disc className="w-3.5 h-3.5 text-gray-500" />
+                    <div className="flex items-center gap-2 px-3 md:px-4 py-2.5 bg-[#0d0d0d] border-b border-surface-active">
+                        <Disc className="w-3.5 h-3.5 text-gray-400" />
                         <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">
                             Disc {currentDisc}
                         </span>
@@ -199,7 +199,7 @@ export const TrackList = memo(function TrackList({
                     rowClassName="grid-cols-[32px_1fr_auto] md:grid-cols-[40px_1fr_auto]"
                     accentColor={colors?.vibrant || "#5b5bff"}
                     tvSection="tracks"
-                    className="divide-y divide-[#1c1c1c]"
+                    className="divide-y divide-surface-active"
                 />
             </Card>
         </section>

--- a/frontend/features/artist/components/ArtistBio.tsx
+++ b/frontend/features/artist/components/ArtistBio.tsx
@@ -33,20 +33,20 @@ export function ArtistBio({ bio }: ArtistBioProps) {
       <div className="bg-white/5 rounded-md p-4">
         <div
           className={cn(
-            "prose prose-sm md:prose-base prose-invert max-w-none leading-relaxed [&_a]:text-[#3b82f6] [&_a]:no-underline [&_a:hover]:underline",
+            "prose prose-sm md:prose-base prose-invert max-w-none leading-relaxed [&_a]:text-brand [&_a]:no-underline [&_a:hover]:underline",
             shouldCollapse && "max-h-28 overflow-hidden"
           )}
           style={{ color: "#b3b3b3" }}
           dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(safeBio) }}
         />
         {shouldCollapse && (
-          <div className="-mt-12 h-12 bg-gradient-to-t from-[#181818] to-transparent" />
+          <div className="-mt-12 h-12 bg-gradient-to-t from-surface-elevated to-transparent" />
         )}
         {needsCollapse && !isExpanded && (
           <button
             type="button"
             onClick={() => setExpandedBio(safeBio)}
-            className="mt-2 text-sm text-[#3b82f6] hover:underline"
+            className="mt-2 text-sm text-brand hover:underline"
           >
             ...more
           </button>

--- a/frontend/features/artist/components/ArtistHero.tsx
+++ b/frontend/features/artist/components/ArtistHero.tsx
@@ -65,7 +65,7 @@ export function ArtistHero({
                                 : "linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.7) 40%, #0a0a0a 100%)",
                         }}
                     />
-                    <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0a] via-transparent to-transparent" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent" />
                 </div>
             ) : (
                 <div
@@ -82,7 +82,7 @@ export function ArtistHero({
             <div className="relative px-4 md:px-8 pt-16 pb-6">
                 <div className="flex items-end gap-6">
                     {/* Artist Image - Circular */}
-                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded-full shadow-2xl shrink-0 overflow-hidden relative">
+                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded-full shadow-2xl shrink-0 overflow-hidden relative">
                         {heroImage ? (
                             <Image
                                 src={heroImage}
@@ -95,7 +95,7 @@ export function ArtistHero({
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center">
-                                <Music className="w-16 h-16 text-gray-600" />
+                                <Music className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>
@@ -159,7 +159,7 @@ export function ArtistHero({
                                     {ownedAlbums.length > 0 && (
                                         <>
                                             <span className="mx-1">•</span>
-                                            <span className="text-[#3b82f6]">
+                                            <span className="text-brand">
                                                 {ownedAlbums.length} owned
                                             </span>
                                         </>

--- a/frontend/features/artist/components/AvailableAlbums.tsx
+++ b/frontend/features/artist/components/AvailableAlbums.tsx
@@ -144,7 +144,7 @@ function LazyAlbumCard({
                 title={album.title}
                 subtitle={subtitle}
                 placeholderIcon={
-                    <Disc3 className="w-12 h-12 text-gray-600" />
+                    <Disc3 className="w-12 h-12 text-gray-400" />
                 }
                 circular={false}
                 badge={downloadsEnabled ? "download" : null}

--- a/frontend/features/artist/components/Discography.tsx
+++ b/frontend/features/artist/components/Discography.tsx
@@ -38,7 +38,7 @@ export function Discography({
                     onChange={(e) =>
                         onSortChange(e.target.value as "year" | "dateAdded")
                     }
-                    className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-[#1a1a1a] [&>option]:text-white"
+                    className="px-3 py-1.5 bg-white/5 border border-white/10 rounded-full text-white text-xs focus:outline-none focus:border-white/20 [&>option]:bg-surface-hover [&>option]:text-white"
                 >
                     <option value="year">Year (Newest)</option>
                     <option value="dateAdded">Date Added (Recent)</option>
@@ -68,7 +68,7 @@ export function Discography({
                             title={album.title}
                             subtitle={subtitle}
                             placeholderIcon={
-                                <Disc3 className="w-12 h-12 text-gray-600" />
+                                <Disc3 className="w-12 h-12 text-gray-400" />
                             }
                             badge="owned"
                             circular={false}

--- a/frontend/features/artist/components/PopularTracks.tsx
+++ b/frontend/features/artist/components/PopularTracks.tsx
@@ -96,7 +96,7 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                 trailingActions: (
                     <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
                         {track.duration > 0 && (
-                            <span className="text-xs text-gray-500 w-10 text-right tabular-nums">
+                            <span className="text-xs text-gray-400 w-10 text-right tabular-nums">
                                 {formatTime(track.duration)}
                             </span>
                         )}
@@ -134,7 +134,7 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                     {popularHref ? (
                         <Link
                             href={popularHref}
-                            className="inline-flex items-center hover:text-[#3b82f6] transition-colors"
+                            className="inline-flex items-center hover:text-brand transition-colors"
                         >
                             Popular
                         </Link>

--- a/frontend/features/artist/components/SimilarArtists.tsx
+++ b/frontend/features/artist/components/SimilarArtists.tsx
@@ -65,7 +65,7 @@ export function SimilarArtists({
                             className="bg-transparent hover:bg-white/5 transition-all p-3 rounded-md cursor-pointer group"
                         >
                             {/* Circular Artist Image */}
-                            <div className="w-full aspect-square bg-[#282828] rounded-full mb-2.5 overflow-hidden relative shadow-lg">
+                            <div className="w-full aspect-square bg-surface-highlight rounded-full mb-2.5 overflow-hidden relative shadow-lg">
                                 {imageUrl ? (
                                     <Image
                                         src={imageUrl}
@@ -77,13 +77,13 @@ export function SimilarArtists({
                                     />
                                 ) : (
                                     <div className="w-full h-full flex items-center justify-center">
-                                        <Music className="w-12 h-12 text-gray-600" />
+                                        <Music className="w-12 h-12 text-gray-400" />
                                     </div>
                                 )}
                                 {/* Library indicator badge */}
                                 {artist.inLibrary && (
                                     <div
-                                        className="absolute bottom-1 right-1 bg-[#3b82f6] rounded-full p-1"
+                                        className="absolute bottom-1 right-1 bg-brand rounded-full p-1"
                                         title="In your library"
                                     >
                                         <Library className="w-3 h-3 text-black" />
@@ -108,7 +108,7 @@ export function SimilarArtists({
 
                             {/* Match Percentage */}
                             {matchPercentage !== null && (
-                                <p className="text-xs text-[#3b82f6] mt-1">
+                                <p className="text-xs text-brand mt-1">
                                     {matchPercentage}% match
                                 </p>
                             )}

--- a/frontend/features/audiobook/components/AudiobookActionBar.tsx
+++ b/frontend/features/audiobook/components/AudiobookActionBar.tsx
@@ -45,7 +45,7 @@ export function AudiobookActionBar({
       {onPlayPause && (
         <button
           onClick={handlePlayPauseClick}
-          className="w-14 h-14 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] hover:scale-105 transition-all flex items-center justify-center shadow-lg"
+          className="w-14 h-14 rounded-full bg-brand-hover hover:bg-brand-light hover:scale-105 transition-all flex items-center justify-center shadow-lg"
           title={showingPause ? "Pause" : (hasProgress && !isFinished ? "Resume" : "Play")}
         >
           {showSpinner ? (
@@ -70,7 +70,7 @@ export function AudiobookActionBar({
           </div>
           <div className="w-24 h-1 bg-white/10 rounded-full overflow-hidden">
             <div
-              className="h-full bg-[#3b82f6] rounded-full transition-all"
+              className="h-full bg-brand rounded-full transition-all"
               style={{
                 width: `${isThisBookPlaying ? (currentTime / audiobook.duration) * 100 : audiobook.progress.progress}%`,
               }}

--- a/frontend/features/audiobook/components/AudiobookHero.tsx
+++ b/frontend/features/audiobook/components/AudiobookHero.tsx
@@ -58,7 +58,7 @@ export function AudiobookHero({
                 : "linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.7) 40%, #0a0a0a 100%)",
             }}
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0a] via-transparent to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent" />
         </div>
       ) : (
         <div
@@ -75,7 +75,7 @@ export function AudiobookHero({
       <div className="relative px-4 md:px-8 pt-16 pb-6">
         <div className="flex items-end gap-6">
           {/* Cover Art - Square for audiobooks */}
-          <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded-lg shadow-2xl shrink-0 overflow-hidden relative">
+          <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded-lg shadow-2xl shrink-0 overflow-hidden relative">
             {heroImage ? (
               <Image
                 src={heroImage}
@@ -88,7 +88,7 @@ export function AudiobookHero({
               />
             ) : (
               <div className="w-full h-full flex items-center justify-center">
-                <Book className="w-16 h-16 text-gray-600" />
+                <Book className="w-16 h-16 text-gray-400" />
               </div>
             )}
           </div>
@@ -114,7 +114,7 @@ export function AudiobookHero({
               <span className="mx-1">•</span>
               <span>{formatTime(audiobook.duration)}</span>
               <span className="mx-1">•</span>
-              <span className={isFinished ? "text-green-400" : "text-[#3b82f6]"}>
+              <span className={isFinished ? "text-green-400" : "text-brand"}>
                 {isFinished ? "Finished" : `${Math.round(progressPercent)}% complete`}
               </span>
             </div>

--- a/frontend/features/audiobook/components/ChapterList.tsx
+++ b/frontend/features/audiobook/components/ChapterList.tsx
@@ -31,18 +31,18 @@ export function ChapterList({
             <button
               key={chapter.id}
               onClick={() => onSeekToChapter(chapter.start)}
-              className="w-full text-left p-3 rounded-md hover:bg-[#1a1a1a] transition-colors group"
+              className="w-full text-left p-3 rounded-md hover:bg-surface-hover transition-colors group"
             >
               <div className="flex items-center justify-between">
                 <div>
-                  <span className="text-sm text-gray-500 mr-2">
+                  <span className="text-sm text-gray-400 mr-2">
                     {index + 1}.
                   </span>
-                  <span className="text-sm text-white group-hover:text-[#5b5bff]">
+                  <span className="text-sm text-white group-hover:text-ai-hover">
                     {chapter.title}
                   </span>
                 </div>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-400">
                   {formatTime(chapter.start)}
                 </span>
               </div>

--- a/frontend/features/audiobook/components/PlayControls.tsx
+++ b/frontend/features/audiobook/components/PlayControls.tsx
@@ -59,9 +59,9 @@ export function PlayControls({
               )}{" "}
               / {formatTime(audiobook.duration)}
             </div>
-            <div className="w-48 h-1 bg-[#181818] rounded-full mt-2">
+            <div className="w-48 h-1 bg-surface-elevated rounded-full mt-2">
               <div
-                className="h-full bg-[#2323FF] rounded-full transition-all duration-300"
+                className="h-full bg-ai rounded-full transition-all duration-300"
                 style={{
                   width: `${
                     isThisBookPlaying

--- a/frontend/features/discover/components/DiscoverActionBar.tsx
+++ b/frontend/features/discover/components/DiscoverActionBar.tsx
@@ -73,7 +73,7 @@ export function DiscoverActionBar({
     };
 
     return (
-        <div className="bg-gradient-to-b from-[#1a1a1a]/60 to-transparent px-4 md:px-8 py-4">
+        <div className="bg-gradient-to-b from-surface-hover/60 to-transparent px-4 md:px-8 py-4">
             <div className="flex items-center gap-4">
                 {/* Play Button */}
                 {playlist && playlist.tracks.length > 0 && (
@@ -84,7 +84,7 @@ export function DiscoverActionBar({
                             "flex items-center gap-2 px-5 py-2.5 rounded-full shadow-lg transition-all border font-semibold text-sm",
                             isGenerating
                                 ? "bg-white/5 border-transparent text-white/50 cursor-not-allowed"
-                                : "bg-[#1a1acc]/20 hover:bg-[#1a1acc]/30 border-[#2323FF]/30 text-white hover:scale-105"
+                                : "bg-ai-dark/20 hover:bg-ai-dark/30 border-ai/30 text-white hover:scale-105"
                         )}
                     >
                         {showSpinner ? (

--- a/frontend/features/discover/components/DiscoverHero.tsx
+++ b/frontend/features/discover/components/DiscoverHero.tsx
@@ -31,10 +31,10 @@ export function DiscoverHero({ playlist, config }: DiscoverHeroProps) {
         : null;
 
     return (
-        <div className="relative bg-gradient-to-b from-blue-900/40 via-[#1a1a1a] to-transparent pt-16 pb-10 px-4 md:px-8">
+        <div className="relative bg-gradient-to-b from-blue-900/40 via-surface-hover to-transparent pt-16 pb-10 px-4 md:px-8">
             <div className="flex items-end gap-6">
                 {/* Cover Art */}
-                <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded shadow-2xl shrink-0 overflow-hidden relative">
+                <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded shadow-2xl shrink-0 overflow-hidden relative">
                     {coverUrl ? (
                         <CachedImage
                             src={coverUrl}
@@ -44,8 +44,8 @@ export function DiscoverHero({ playlist, config }: DiscoverHeroProps) {
                             sizes="192px"
                         />
                     ) : (
-                        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-[#1a1acc]/30 to-yellow-600/20 border border-white/10">
-                            <Music2 className="w-16 h-16 md:w-20 md:h-20 text-[#5b5bff]" />
+                        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-ai-dark/30 to-yellow-600/20 border border-white/10">
+                            <Music2 className="w-16 h-16 md:w-20 md:h-20 text-ai-hover" />
                         </div>
                     )}
                     <div className="absolute bottom-2 right-2 drop-shadow-lg">

--- a/frontend/features/discover/components/DiscoverSettings.tsx
+++ b/frontend/features/discover/components/DiscoverSettings.tsx
@@ -85,7 +85,7 @@ export function DiscoverSettings({
                             onChange={(e) =>
                                 handleConfigChange("playlistSize", parseInt(e.target.value))
                             }
-                            className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#2323FF]"
+                            className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-ai"
                         />
                         <p className="text-xs text-gray-400 mt-2">
                             Local-first recommendations. Larger playlists include more variety.
@@ -109,7 +109,7 @@ export function DiscoverSettings({
                             onChange={(e) =>
                                 handleConfigChange("exclusionMonths", parseInt(e.target.value))
                             }
-                            className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#2323FF]"
+                            className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-ai"
                         />
                         <p className="text-xs text-gray-400 mt-2">
                             How long to wait before recommending the same album again. Set to 0 to disable.

--- a/frontend/features/discover/components/HowItWorks.tsx
+++ b/frontend/features/discover/components/HowItWorks.tsx
@@ -10,40 +10,40 @@ export function HowItWorks() {
     return (
         <Card className="p-6 bg-[#111]/50  border-white/5">
             <h3 className="text-lg font-bold mb-4 flex items-center gap-2 text-white">
-                <Sparkles className="w-5 h-5 text-[#5b5bff]" />
+                <Sparkles className="w-5 h-5 text-ai-hover" />
                 How It Works
             </h3>
             <div className="space-y-3 text-sm text-gray-400">
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>
                         Builds recommendations from your listening history and local library first.
                     </p>
                 </div>
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>
                         Similarity tiers keep a mix of safe picks and exploration tracks.
                     </p>
                 </div>
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>
                         When TIDAL or YouTube Music is connected, a portion of tracks can stream via gap-fill.
                     </p>
                 </div>
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>
                         Source badges show whether each track is Local, TIDAL, or YouTube Music.
                     </p>
                 </div>
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>Albums won&apos;t repeat for 6 months</p>
                 </div>
                 <div className="flex items-start gap-3">
-                    <ChevronRight className="w-4 h-4 mt-0.5 text-[#5b5bff]/60 shrink-0" />
+                    <ChevronRight className="w-4 h-4 mt-0.5 text-ai-hover/60 shrink-0" />
                     <p>
                         No automatic downloads or library writes are performed by this flow.
                     </p>

--- a/frontend/features/discover/components/TrackList.tsx
+++ b/frontend/features/discover/components/TrackList.tsx
@@ -13,9 +13,9 @@ const tierColors: Record<string, string> = {
     high: "text-green-400",
     medium: "text-yellow-400",
     explore: "text-orange-400",
-    wildcard: "text-[#5b5bff]",
+    wildcard: "text-ai-hover",
     low: "text-orange-400",
-    wild: "text-[#5b5bff]",
+    wild: "text-ai-hover",
 };
 
 const tierLabels: Record<string, string> = {

--- a/frontend/features/discover/components/UnavailableAlbums.tsx
+++ b/frontend/features/discover/components/UnavailableAlbums.tsx
@@ -8,10 +8,10 @@ const tierColors: Record<string, string> = {
     high: "text-green-400",
     medium: "text-yellow-400",
     explore: "text-orange-400",
-    wildcard: "text-[#5b5bff]",
+    wildcard: "text-ai-hover",
     // Legacy mappings
     low: "text-orange-400",
-    wild: "text-[#5b5bff]",
+    wild: "text-ai-hover",
 };
 
 const tierLabels: Record<string, string> = {
@@ -48,7 +48,7 @@ export function UnavailableAlbums({
         <Card>
             <button
                 onClick={() => setIsExpanded(!isExpanded)}
-                className="w-full p-4 flex items-center justify-between hover:bg-[#1a1a1a] transition-colors rounded-lg"
+                className="w-full p-4 flex items-center justify-between hover:bg-surface-hover transition-colors rounded-lg"
             >
                 <div className="flex items-center gap-2">
                     <Music className="w-5 h-5 text-orange-400" />
@@ -57,9 +57,9 @@ export function UnavailableAlbums({
                     </span>
                 </div>
                 {isExpanded ? (
-                    <ChevronUp className="w-4 h-4 text-gray-500" />
+                    <ChevronUp className="w-4 h-4 text-gray-400" />
                 ) : (
-                    <ChevronDown className="w-4 h-4 text-gray-500" />
+                    <ChevronDown className="w-4 h-4 text-gray-400" />
                 )}
             </button>
             {isExpanded && (
@@ -70,7 +70,7 @@ export function UnavailableAlbums({
                             Listen to 30-second previews below!
                         </p>
                     </div>
-                    <div className="divide-y divide-[#1c1c1c]">
+                    <div className="divide-y divide-surface-active">
                 {unavailable.map((album) => {
                     const isPreviewPlaying = currentPreview === album.id;
                     const attemptLabel =
@@ -82,9 +82,9 @@ export function UnavailableAlbums({
                         <div
                             key={album.id}
                             className={cn(
-                                "flex items-center gap-4 px-4 py-3 hover:bg-[#1a1a1a] transition-colors group",
+                                "flex items-center gap-4 px-4 py-3 hover:bg-surface-hover transition-colors group",
                                 album.attemptNumber > 0 &&
-                                    "pl-12 bg-[#1a1a1a]/30"
+                                    "pl-12 bg-surface-hover/30"
                             )}
                         >
                             <div className="w-8 flex items-center justify-center">
@@ -105,12 +105,12 @@ export function UnavailableAlbums({
                                         )}
                                     </button>
                                 ) : (
-                                    <Music className="w-4 h-4 text-gray-600" />
+                                    <Music className="w-4 h-4 text-gray-400" />
                                 )}
                             </div>
 
-                            <div className="w-12 h-12 bg-[#181818] rounded flex items-center justify-center shrink-0">
-                                <Music className="w-6 h-6 text-gray-600" />
+                            <div className="w-12 h-12 bg-surface-elevated rounded flex items-center justify-center shrink-0">
+                                <Music className="w-6 h-6 text-gray-400" />
                             </div>
 
                             <div className="flex-1 min-w-0">

--- a/frontend/features/explore/components/MoodsGenresSection.tsx
+++ b/frontend/features/explore/components/MoodsGenresSection.tsx
@@ -154,7 +154,7 @@ export function MoodsGenresSection({
                                     href={`/explore/yt-playlist/${encodeURIComponent(item.playlistId)}`}
                                     className="group cursor-pointer"
                                 >
-                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-[#282828] shadow-lg">
+                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-surface-highlight shadow-lg">
                                         {item.thumbnailUrl ? (
                                             <img
                                                 src={api.getBrowseImageUrl(item.thumbnailUrl)}
@@ -163,7 +163,7 @@ export function MoodsGenresSection({
                                             />
                                         ) : (
                                             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-purple-500/30 to-purple-500/10">
-                                                <Music2 className="w-12 h-12 text-gray-600" />
+                                                <Music2 className="w-12 h-12 text-gray-400" />
                                             </div>
                                         )}
                                     </div>
@@ -182,7 +182,7 @@ export function MoodsGenresSection({
 
                     {!isLoadingMood && loadError && (
                         <div className="flex flex-col items-center justify-center py-20 text-center">
-                            <Music2 className="w-12 h-12 text-gray-500 mb-4" />
+                            <Music2 className="w-12 h-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-white mb-2">
                                 Unable to load playlists
                             </h3>
@@ -192,7 +192,7 @@ export function MoodsGenresSection({
 
                     {!isLoadingMood && !loadError && moodPlaylists.length === 0 && (
                         <div className="flex flex-col items-center justify-center py-20 text-center">
-                            <Music2 className="w-12 h-12 text-gray-500 mb-4" />
+                            <Music2 className="w-12 h-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-white mb-2">
                                 No playlists found
                             </h3>

--- a/frontend/features/explore/components/TidalMoodsGenresSection.tsx
+++ b/frontend/features/explore/components/TidalMoodsGenresSection.tsx
@@ -144,7 +144,7 @@ export function TidalMoodsGenresSection({
                                     href={`/explore/tidal-playlist/${encodeURIComponent(item.playlistId)}`}
                                     className="group cursor-pointer"
                                 >
-                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-[#282828] shadow-lg">
+                                    <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-surface-highlight shadow-lg">
                                         {item.thumbnailUrl ? (
                                             <img
                                                 src={api.getTidalBrowseImageUrl(item.thumbnailUrl)}
@@ -153,7 +153,7 @@ export function TidalMoodsGenresSection({
                                             />
                                         ) : (
                                             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-cyan-500/30 to-cyan-500/10">
-                                                <Music2 className="w-12 h-12 text-gray-600" />
+                                                <Music2 className="w-12 h-12 text-gray-400" />
                                             </div>
                                         )}
                                     </div>
@@ -172,7 +172,7 @@ export function TidalMoodsGenresSection({
 
                     {!isLoadingPlaylists && loadError && (
                         <div className="flex flex-col items-center justify-center py-20 text-center">
-                            <Music2 className="w-12 h-12 text-gray-500 mb-4" />
+                            <Music2 className="w-12 h-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-white mb-2">
                                 Unable to load playlists
                             </h3>
@@ -182,7 +182,7 @@ export function TidalMoodsGenresSection({
 
                     {!isLoadingPlaylists && !loadError && playlists.length === 0 && (
                         <div className="flex flex-col items-center justify-center py-20 text-center">
-                            <Music2 className="w-12 h-12 text-gray-500 mb-4" />
+                            <Music2 className="w-12 h-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-white mb-2">
                                 No playlists found
                             </h3>

--- a/frontend/features/home/components/ArtistsGrid.tsx
+++ b/frontend/features/home/components/ArtistsGrid.tsx
@@ -52,7 +52,7 @@ const ArtistCard = memo(
                     tabIndex={0}
                 >
                     <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
-                        <div className="aspect-square bg-[#282828] rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
+                        <div className="aspect-square bg-surface-highlight rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
                             {artist.coverArt && imageSrc ? (
                                 <Image
                                     src={imageSrc}
@@ -64,7 +64,7 @@ const ArtistCard = memo(
                                     unoptimized
                                 />
                             ) : (
-                                <Music className="w-10 h-10 text-gray-600" />
+                                <Music className="w-10 h-10 text-gray-400" />
                             )}
                         </div>
                         <h3 className="text-sm font-semibold text-white truncate">

--- a/frontend/features/home/components/AudiobooksGrid.tsx
+++ b/frontend/features/home/components/AudiobooksGrid.tsx
@@ -30,7 +30,7 @@ const AudiobookCard = memo(function AudiobookCard({
                 tabIndex={0}
             >
                 <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
-                    <div className="aspect-square bg-[#282828] rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
+                    <div className="aspect-square bg-surface-highlight rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
                         {audiobook.coverUrl ? (
                             <Image
                                 src={api.getCoverArtUrl(audiobook.coverUrl, 300)}
@@ -41,7 +41,7 @@ const AudiobookCard = memo(function AudiobookCard({
                                 unoptimized
                             />
                         ) : (
-                            <BookOpen className="w-10 h-10 text-gray-600" />
+                            <BookOpen className="w-10 h-10 text-gray-400" />
                         )}
                     </div>
                     <h3 className="text-sm font-semibold text-white truncate">

--- a/frontend/features/home/components/ContinueListening.tsx
+++ b/frontend/features/home/components/ContinueListening.tsx
@@ -97,7 +97,7 @@ const ContinueListeningCard = memo(function ContinueListeningCard({
                 tabIndex={0}
             >
                 <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors h-full flex flex-col">
-                    <div className="aspect-square bg-[#282828] rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg shrink-0">
+                    <div className="aspect-square bg-surface-highlight rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg shrink-0">
                         {imageSrc ? (
                             <Image
                                 src={imageSrc}
@@ -109,16 +109,16 @@ const ContinueListeningCard = memo(function ContinueListeningCard({
                                 unoptimized
                             />
                         ) : isPodcast ? (
-                            <Disc className="w-10 h-10 text-gray-600" />
+                            <Disc className="w-10 h-10 text-gray-400" />
                         ) : isAudiobook ? (
-                            <BookOpen className="w-10 h-10 text-gray-600" />
+                            <BookOpen className="w-10 h-10 text-gray-400" />
                         ) : (
-                            <Music className="w-10 h-10 text-gray-600" />
+                            <Music className="w-10 h-10 text-gray-400" />
                         )}
                         {hasProgress && (
                             <div className="absolute bottom-0 left-0 right-0 h-1 bg-black/50">
                                 <div
-                                    className="h-full bg-[#3b82f6]"
+                                    className="h-full bg-brand"
                                     style={{
                                         width: `${item.progress}%`,
                                     }}

--- a/frontend/features/home/components/FeaturedPlaylistsGrid.tsx
+++ b/frontend/features/home/components/FeaturedPlaylistsGrid.tsx
@@ -40,7 +40,7 @@ const PlaylistCard = memo(function PlaylistCard({
                 tabIndex={0}
                 className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors"
             >
-                <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-[#282828] shadow-lg">
+                <div className="relative aspect-square mb-3 rounded-md overflow-hidden bg-surface-highlight shadow-lg">
                     {playlist.imageUrl ? (
                         <img
                             src={playlist.imageUrl}
@@ -49,12 +49,12 @@ const PlaylistCard = memo(function PlaylistCard({
                         />
                     ) : (
                         <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-[#AD47FF]/30 to-[#AD47FF]/10">
-                            <Music2 className="w-10 h-10 text-gray-600" />
+                            <Music2 className="w-10 h-10 text-gray-400" />
                         </div>
                     )}
                     {/* Play button on hover */}
                     <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-200">
-                        <div className="w-10 h-10 rounded-full bg-[#60a5fa] flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
+                        <div className="w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
                             {showSpinner ? (
                                 <Loader2 className="w-4 h-4 text-black animate-spin" />
                             ) : (

--- a/frontend/features/home/components/HomeHero.tsx
+++ b/frontend/features/home/components/HomeHero.tsx
@@ -16,11 +16,11 @@ export function HomeHero() {
             {/* Quick gradient fade - yellow to purple */}
             <div className="absolute inset-0 pointer-events-none">
                 <div
-                    className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+                    className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
                     style={{ height: "35vh" }}
                 />
                 <div
-                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+                    className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
                     style={{ height: "25vh" }}
                 />
             </div>

--- a/frontend/features/home/components/LibraryRadioStations.tsx
+++ b/frontend/features/home/components/LibraryRadioStations.tsx
@@ -22,7 +22,7 @@ const STATIC_STATIONS: RadioStation[] = [
         id: "all",
         name: "Shuffle All",
         description: "Your entire library",
-        color: "from-[#3b82f6]/60 to-amber-600/40",
+        color: "from-brand/60 to-amber-600/40",
         filter: { type: "all" },
         minTracks: 10,
     },

--- a/frontend/features/home/components/PodcastsGrid.tsx
+++ b/frontend/features/home/components/PodcastsGrid.tsx
@@ -37,7 +37,7 @@ const PodcastCard = memo(
                     tabIndex={0}
                 >
                     <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
-                        <div className="aspect-square bg-[#282828] rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
+                        <div className="aspect-square bg-surface-highlight rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
                             {imageUrl ? (
                                 <Image
                                     src={imageUrl}
@@ -48,7 +48,7 @@ const PodcastCard = memo(
                                     unoptimized
                                 />
                             ) : (
-                                <Disc className="w-10 h-10 text-gray-600" />
+                                <Disc className="w-10 h-10 text-gray-400" />
                             )}
                         </div>
                         <h3 className="text-sm font-semibold text-white truncate">

--- a/frontend/features/home/components/PopularArtistsGrid.tsx
+++ b/frontend/features/home/components/PopularArtistsGrid.tsx
@@ -44,7 +44,7 @@ const PopularArtistCard = memo(function PopularArtistCard({
                 tabIndex={0}
             >
                 <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
-                    <div className="aspect-square bg-[#282828] rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
+                    <div className="aspect-square bg-surface-highlight rounded-full mb-3 flex items-center justify-center overflow-hidden relative shadow-lg">
                         {imageUrl ? (
                             <Image
                                 src={imageUrl}
@@ -55,7 +55,7 @@ const PopularArtistCard = memo(function PopularArtistCard({
                                 unoptimized
                             />
                         ) : (
-                            <Music className="w-10 h-10 text-gray-600" />
+                            <Music className="w-10 h-10 text-gray-400" />
                         )}
                     </div>
                     <h3 className="text-sm font-semibold text-white truncate">

--- a/frontend/features/home/components/StaticPlaylistCard.tsx
+++ b/frontend/features/home/components/StaticPlaylistCard.tsx
@@ -35,7 +35,7 @@ export const StaticPlaylistCard = memo(function StaticPlaylistCard({
     return (
         <Link href={href} data-tv-card data-tv-card-index={index} tabIndex={0}>
             <div className="p-3 rounded-md group cursor-pointer hover:bg-white/5 transition-colors">
-                <div className="aspect-square bg-[#282828] rounded-lg mb-3 overflow-hidden relative shadow-lg">
+                <div className="aspect-square bg-surface-highlight rounded-lg mb-3 overflow-hidden relative shadow-lg">
                     {coverUrl ? (
                         <CachedImage
                             src={coverUrl}

--- a/frontend/features/library/components/AlbumsGrid.tsx
+++ b/frontend/features/library/components/AlbumsGrid.tsx
@@ -72,7 +72,7 @@ const AlbumCardItem = memo(
             >
                 <div className="p-3 rounded-md cursor-pointer hover:bg-white/5 transition-colors" style={{ transform: "translateZ(0)" }}>
                     <div className="relative aspect-square mb-3">
-                        <div className="w-full h-full bg-[#282828] rounded-md flex items-center justify-center overflow-hidden" style={{ contain: "content" }}>
+                        <div className="w-full h-full bg-surface-highlight rounded-md flex items-center justify-center overflow-hidden" style={{ contain: "content" }}>
                             {coverArtUrl ? (
                                 <CachedImage
                                     src={coverArtUrl}
@@ -82,14 +82,14 @@ const AlbumCardItem = memo(
                                     sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 16vw"
                                 />
                             ) : (
-                                <Disc3 className="w-10 h-10 text-gray-600" />
+                                <Disc3 className="w-10 h-10 text-gray-400" />
                             )}
                         </div>
                         {/* Play button */}
                         {!hidePlayButtons && (
                             <button
                                 onClick={handlePlay}
-                                className="absolute bottom-1 right-1 w-10 h-10 rounded-full bg-[#60a5fa] flex items-center justify-center shadow-xl opacity-0 pointer-events-none sm:pointer-events-auto group-hover:opacity-100 transition-opacity"
+                                className="absolute bottom-1 right-1 w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl opacity-0 pointer-events-none sm:pointer-events-auto group-hover:opacity-100 transition-opacity"
                             >
                                 {showPlaySpinner ? (
                                     <Loader2 className="w-4 h-4 animate-spin text-black" />

--- a/frontend/features/library/components/ArtistsGrid.tsx
+++ b/frontend/features/library/components/ArtistsGrid.tsx
@@ -84,7 +84,7 @@ const ArtistCardItem = memo(
             >
                 <div className="p-3 rounded-md cursor-pointer hover:bg-white/5 transition-colors" style={{ transform: "translateZ(0)" }}>
                     <div className="relative aspect-square mb-3">
-                        <div className="w-full h-full bg-[#282828] rounded-full flex items-center justify-center overflow-hidden" style={{ contain: "content" }}>
+                        <div className="w-full h-full bg-surface-highlight rounded-full flex items-center justify-center overflow-hidden" style={{ contain: "content" }}>
                             {coverArtUrl ? (
                                 <CachedImage
                                     src={coverArtUrl}
@@ -94,14 +94,14 @@ const ArtistCardItem = memo(
                                     sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 16vw"
                                 />
                             ) : (
-                                <Music className="w-10 h-10 text-gray-600" />
+                                <Music className="w-10 h-10 text-gray-400" />
                             )}
                         </div>
                         {/* Play button */}
                         {!hidePlayButtons && (
                             <button
                                 onClick={handlePlay}
-                                className="absolute bottom-1 right-1 w-10 h-10 rounded-full bg-[#60a5fa] flex items-center justify-center shadow-xl opacity-0 group-hover:opacity-100 transition-opacity"
+                                className="absolute bottom-1 right-1 w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl opacity-0 group-hover:opacity-100 transition-opacity"
                             >
                                 {showPlaySpinner ? (
                                     <Loader2 className="w-4 h-4 animate-spin text-black" />

--- a/frontend/features/library/components/LibraryHeader.tsx
+++ b/frontend/features/library/components/LibraryHeader.tsx
@@ -10,11 +10,11 @@ export function LibraryHeader() {
       {/* Background gradient */}
       <div className="absolute inset-0 pointer-events-none">
         <div
-          className="absolute inset-0 bg-gradient-to-b from-[#3b82f6]/15 via-blue-900/10 to-transparent"
+          className="absolute inset-0 bg-gradient-to-b from-brand/15 via-blue-900/10 to-transparent"
           style={{ height: "35vh" }}
         />
         <div
-          className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-[#3b82f6]/8 via-transparent to-transparent"
+          className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,var(--tw-gradient-stops))] from-brand/8 via-transparent to-transparent"
           style={{ height: "25vh" }}
         />
       </div>

--- a/frontend/features/podcast/components/ContinueListening.tsx
+++ b/frontend/features/podcast/components/ContinueListening.tsx
@@ -82,7 +82,7 @@ export function ContinueListening({
 
                 {/* Current Episode - Prominent */}
                 <div
-                    className="flex items-center gap-4 p-4 rounded-lg bg-white/5 border border-[#3b82f6]/30 hover:border-[#3b82f6]/50 transition-all cursor-pointer"
+                    className="flex items-center gap-4 p-4 rounded-lg bg-white/5 border border-brand/30 hover:border-brand/50 transition-all cursor-pointer"
                     onClick={() => onPlayPause(recentEpisode)}
                 >
                     <button
@@ -90,7 +90,7 @@ export function ContinueListening({
                             e.stopPropagation();
                             handleCurrentEpisodePlayPause();
                         }}
-                        className="w-12 h-12 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] hover:scale-105 transition-all flex items-center justify-center shrink-0"
+                        className="w-12 h-12 rounded-full bg-brand-hover hover:bg-brand-light hover:scale-105 transition-all flex items-center justify-center shrink-0"
                     >
                         {showSpinner ? (
                             <Loader2 className="w-5 h-5 text-black animate-spin" />
@@ -115,13 +115,13 @@ export function ContinueListening({
                                 <div className="flex items-center gap-2">
                                     <div className="flex-1 h-1 bg-white/10 rounded-full overflow-hidden">
                                         <div
-                                            className="h-full bg-[#3b82f6] rounded-full transition-all"
+                                            className="h-full bg-brand rounded-full transition-all"
                                             style={{
                                                 width: `${recentEpisode.progress.progress}%`,
                                             }}
                                         />
                                     </div>
-                                    <span className="text-xs text-[#3b82f6]">
+                                    <span className="text-xs text-brand">
                                         {Math.floor(recentEpisode.progress.progress)}%
                                     </span>
                                 </div>

--- a/frontend/features/podcast/components/EpisodeList.tsx
+++ b/frontend/features/podcast/components/EpisodeList.tsx
@@ -70,7 +70,7 @@ export function EpisodeList({
                             {episode.progress && episode.progress.progress > 0 && (
                                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-white/5 rounded-full overflow-hidden">
                                     <div
-                                        className="h-full bg-[#3b82f6]/60 transition-all"
+                                        className="h-full bg-brand/60 transition-all"
                                         style={{
                                             width: `${episode.progress.progress}%`,
                                         }}
@@ -99,7 +99,7 @@ export function EpisodeList({
                                                         ? "hidden"
                                                         : "group-hover:hidden",
                                                     isCurrentEpisode
-                                                        ? "text-[#3b82f6] font-bold"
+                                                        ? "text-brand font-bold"
                                                         : "text-white/40"
                                                 )}
                                             >
@@ -107,7 +107,7 @@ export function EpisodeList({
                                             </span>
                                             {isCurrentEpisode && isPlaying ? (
                                                 <Pause
-                                                    className="w-4 h-4 text-[#3b82f6] cursor-pointer"
+                                                    className="w-4 h-4 text-brand cursor-pointer"
                                                     onClick={(e) => {
                                                         e.stopPropagation();
                                                         onPlayPause(episode);
@@ -118,7 +118,7 @@ export function EpisodeList({
                                                     className={cn(
                                                         "w-4 h-4 cursor-pointer",
                                                         isCurrentEpisode
-                                                            ? "text-[#3b82f6]"
+                                                            ? "text-brand"
                                                             : "text-white hidden group-hover:block"
                                                     )}
                                                     onClick={(e) => {
@@ -137,7 +137,7 @@ export function EpisodeList({
                                         className={cn(
                                             "font-medium truncate text-sm",
                                             isCurrentEpisode
-                                                ? "text-[#3b82f6]"
+                                                ? "text-brand"
                                                 : "text-white"
                                         )}
                                     >
@@ -166,7 +166,7 @@ export function EpisodeList({
                                         {isInProgress && episode.progress && (
                                             <>
                                                 <span>•</span>
-                                                <span className="text-[#3b82f6]">
+                                                <span className="text-brand">
                                                     {Math.floor(episode.progress.progress)}%
                                                 </span>
                                             </>

--- a/frontend/features/podcast/components/PodcastActionBar.tsx
+++ b/frontend/features/podcast/components/PodcastActionBar.tsx
@@ -33,7 +33,7 @@ export function PodcastActionBar({
                 <button
                     onClick={onSubscribe}
                     disabled={isSubscribing}
-                    className="h-12 px-6 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] hover:scale-105 transition-all flex items-center gap-2 font-semibold text-black disabled:opacity-50"
+                    className="h-12 px-6 rounded-full bg-brand-hover hover:bg-brand-light hover:scale-105 transition-all flex items-center gap-2 font-semibold text-black disabled:opacity-50"
                 >
                     {isSubscribing ? (
                         <>

--- a/frontend/features/podcast/components/PodcastHero.tsx
+++ b/frontend/features/podcast/components/PodcastHero.tsx
@@ -55,7 +55,7 @@ export function PodcastHero({
                                 : "linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.7) 40%, #0a0a0a 100%)",
                         }}
                     />
-                    <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0a] via-transparent to-transparent" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent" />
                 </div>
             ) : (
                 <div
@@ -72,7 +72,7 @@ export function PodcastHero({
             <div className="relative px-4 md:px-8 pt-16 pb-6">
                 <div className="flex items-end gap-6">
                     {/* Cover Art - Circular for podcasts */}
-                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-[#282828] rounded-full shadow-2xl shrink-0 overflow-hidden relative">
+                    <div className="w-[140px] h-[140px] md:w-[192px] md:h-[192px] bg-surface-highlight rounded-full shadow-2xl shrink-0 overflow-hidden relative">
                         {heroImage ? (
                             <Image
                                 src={heroImage}
@@ -85,7 +85,7 @@ export function PodcastHero({
                             />
                         ) : (
                             <div className="w-full h-full flex items-center justify-center">
-                                <Mic2 className="w-16 h-16 text-gray-600" />
+                                <Mic2 className="w-16 h-16 text-gray-400" />
                             </div>
                         )}
                     </div>
@@ -114,7 +114,7 @@ export function PodcastHero({
                             {inProgressCount > 0 && (
                                 <>
                                     <span className="mx-1">•</span>
-                                    <span className="text-[#3b82f6]">
+                                    <span className="text-brand">
                                         {inProgressCount} in progress
                                     </span>
                                 </>

--- a/frontend/features/podcast/components/PreviewEpisodes.tsx
+++ b/frontend/features/podcast/components/PreviewEpisodes.tsx
@@ -64,11 +64,11 @@ export function PreviewEpisodes({
                         </div>
 
                         {/* Blur/Fade Overlay with Subscribe CTA */}
-                        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#0a0a0a]/80 to-[#0a0a0a] flex items-end justify-center pb-8 pointer-events-none">
+                        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-surface/80 to-surface flex items-end justify-center pb-8 pointer-events-none">
                             <button
                                 onClick={onSubscribe}
                                 disabled={isSubscribing}
-                                className="flex items-center gap-2 pointer-events-auto h-12 px-6 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] hover:scale-105 transition-all font-semibold text-black disabled:opacity-50 shadow-xl"
+                                className="flex items-center gap-2 pointer-events-auto h-12 px-6 rounded-full bg-brand-hover hover:bg-brand-light hover:scale-105 transition-all font-semibold text-black disabled:opacity-50 shadow-xl"
                             >
                                 {isSubscribing ? (
                                     <>
@@ -92,7 +92,7 @@ export function PreviewEpisodes({
                         <button
                             onClick={onSubscribe}
                             disabled={isSubscribing}
-                            className="flex items-center gap-2 mx-auto h-12 px-6 rounded-full bg-[#60a5fa] hover:bg-[#93c5fd] hover:scale-105 transition-all font-semibold text-black disabled:opacity-50"
+                            className="flex items-center gap-2 mx-auto h-12 px-6 rounded-full bg-brand-hover hover:bg-brand-light hover:scale-105 transition-all font-semibold text-black disabled:opacity-50"
                         >
                             {isSubscribing ? (
                                 <>
@@ -116,7 +116,7 @@ export function PreviewEpisodes({
                     <h2 className="text-xl font-bold mb-4">About</h2>
                     <div className="bg-white/5 rounded-md p-4">
                         <div
-                            className="prose prose-invert prose-sm max-w-none text-white/70 [&_a]:text-[#3b82f6] [&_a]:no-underline [&_a:hover]:underline"
+                            className="prose prose-invert prose-sm max-w-none text-white/70 [&_a]:text-brand [&_a]:no-underline [&_a:hover]:underline"
                             dangerouslySetInnerHTML={{
                                 __html: DOMPurify.sanitize(previewData.description || ""),
                             }}

--- a/frontend/features/podcast/components/SimilarPodcasts.tsx
+++ b/frontend/features/podcast/components/SimilarPodcasts.tsx
@@ -40,7 +40,7 @@ export function SimilarPodcasts({ podcasts }: SimilarPodcastsProps) {
                                 router.push(`/podcasts/${podcast.id}`)
                             }
                         >
-                            <div className="w-full aspect-square bg-[#282828] rounded-full mb-2.5 overflow-hidden relative shadow-lg">
+                            <div className="w-full aspect-square bg-surface-highlight rounded-full mb-2.5 overflow-hidden relative shadow-lg">
                                 {imageUrl ? (
                                     <Image
                                         src={imageUrl}
@@ -52,7 +52,7 @@ export function SimilarPodcasts({ podcasts }: SimilarPodcastsProps) {
                                     />
                                 ) : (
                                     <div className="w-full h-full flex items-center justify-center">
-                                        <Mic2 className="w-10 h-10 text-gray-600" />
+                                        <Mic2 className="w-10 h-10 text-gray-400" />
                                     </div>
                                 )}
                             </div>

--- a/frontend/features/search/components/DiscoverPodcastsGrid.tsx
+++ b/frontend/features/search/components/DiscoverPodcastsGrid.tsx
@@ -40,8 +40,8 @@ export function DiscoverPodcastsGrid({
                         data-tv-card-index={index}
                         tabIndex={0}
                     >
-                        <div className="bg-[#121212] hover:bg-[#181818] transition-all p-4 rounded-lg group cursor-pointer">
-                            <div className="aspect-square bg-[#181818] rounded-md mb-4 flex items-center justify-center overflow-hidden relative">
+                        <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
+                            <div className="aspect-square bg-surface-elevated rounded-md mb-4 flex items-center justify-center overflow-hidden relative">
                                 {imageUrl ? (
                                     <Image
                                         src={imageUrl}
@@ -53,7 +53,7 @@ export function DiscoverPodcastsGrid({
                                         unoptimized
                                     />
                                 ) : (
-                                    <Music className="w-12 h-12 text-gray-600" />
+                                    <Music className="w-12 h-12 text-gray-400" />
                                 )}
                             </div>
                             <h3 className="text-base font-bold text-white line-clamp-1 mb-1">
@@ -64,7 +64,7 @@ export function DiscoverPodcastsGrid({
                             </p>
                             {typeof podcast.trackCount === "number" &&
                                 podcast.trackCount > 0 && (
-                                    <p className="text-xs text-gray-500 mt-1">
+                                    <p className="text-xs text-gray-400 mt-1">
                                         {podcast.trackCount} episodes
                                     </p>
                                 )}

--- a/frontend/features/search/components/EmptyState.tsx
+++ b/frontend/features/search/components/EmptyState.tsx
@@ -16,7 +16,7 @@ export function EmptyState({ hasSearched, isLoading }: EmptyStateProps) {
 
     return (
         <div className="flex flex-col items-center justify-center py-24 text-center">
-            <SearchIcon className="w-16 h-16 text-gray-700 mb-4" />
+            <SearchIcon className="w-16 h-16 text-gray-400 mb-4" />
             <h3 className="text-xl font-bold text-white mb-2">Search your library</h3>
             <p className="text-gray-400">Use the search bar above to find music, artists, and albums</p>
         </div>

--- a/frontend/features/search/components/LibraryAlbumsGrid.tsx
+++ b/frontend/features/search/components/LibraryAlbumsGrid.tsx
@@ -26,8 +26,8 @@ export function LibraryAlbumsGrid({ albums, limit = 6 }: LibraryAlbumsGridProps)
                     data-tv-card-index={index}
                     tabIndex={0}
                 >
-                    <div className="bg-[#121212] hover:bg-[#181818] transition-all p-4 rounded-lg group cursor-pointer">
-                        <div className="relative aspect-square bg-[#181818] rounded-md mb-4 flex items-center justify-center overflow-hidden">
+                    <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
+                        <div className="relative aspect-square bg-surface-elevated rounded-md mb-4 flex items-center justify-center overflow-hidden">
                             {album.coverUrl || album.albumId ? (
                                 <Image
                                     src={api.getCoverArtUrl(
@@ -41,7 +41,7 @@ export function LibraryAlbumsGrid({ albums, limit = 6 }: LibraryAlbumsGridProps)
                                     unoptimized
                                 />
                             ) : (
-                                <Disc3 className="w-12 h-12 text-gray-600" />
+                                <Disc3 className="w-12 h-12 text-gray-400" />
                             )}
                         </div>
                         <h3 className="text-base font-bold text-white line-clamp-1 mb-1">

--- a/frontend/features/search/components/LibraryPodcastsGrid.tsx
+++ b/frontend/features/search/components/LibraryPodcastsGrid.tsx
@@ -36,8 +36,8 @@ export function LibraryPodcastsGrid({
                         data-tv-card-index={index}
                         tabIndex={0}
                     >
-                        <div className="bg-[#121212] hover:bg-[#181818] transition-all p-4 rounded-lg group cursor-pointer">
-                            <div className="aspect-square bg-[#181818] rounded-md mb-4 flex items-center justify-center overflow-hidden relative">
+                        <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
+                            <div className="aspect-square bg-surface-elevated rounded-md mb-4 flex items-center justify-center overflow-hidden relative">
                                 {imageUrl ? (
                                     <Image
                                         src={imageUrl}
@@ -49,7 +49,7 @@ export function LibraryPodcastsGrid({
                                         unoptimized
                                     />
                                 ) : (
-                                    <Music className="w-12 h-12 text-gray-600" />
+                                    <Music className="w-12 h-12 text-gray-400" />
                                 )}
                             </div>
                             <h3 className="text-base font-bold text-white line-clamp-1 mb-1">
@@ -59,7 +59,7 @@ export function LibraryPodcastsGrid({
                                 {podcast.author || "Podcast"}
                             </p>
                             {podcast.episodeCount && podcast.episodeCount > 0 && (
-                                <p className="text-xs text-gray-500 mt-1">
+                                <p className="text-xs text-gray-400 mt-1">
                                     {podcast.episodeCount} episodes
                                 </p>
                             )}

--- a/frontend/features/search/components/LibraryTracksList.tsx
+++ b/frontend/features/search/components/LibraryTracksList.tsx
@@ -77,9 +77,9 @@ export function LibraryTracksList({ tracks, limit = 10 }: LibraryTracksListProps
                 leadingColumn: (
                     <div className="w-8 h-8 flex items-center justify-center flex-shrink-0">
                         {isPlayingThis ? (
-                            <Pause className="w-4 h-4 text-[#3b82f6]" />
+                            <Pause className="w-4 h-4 text-brand" />
                         ) : isCurrentTrack ? (
-                            <Play className="w-4 h-4 text-[#3b82f6] ml-0.5" />
+                            <Play className="w-4 h-4 text-brand ml-0.5" />
                         ) : (
                             <>
                                 <span className="text-sm text-gray-400 group-hover:hidden">

--- a/frontend/features/search/components/SearchFilters.tsx
+++ b/frontend/features/search/components/SearchFilters.tsx
@@ -82,7 +82,7 @@ export function SearchFilters({
                     onClick={() => onFilterChange("soulseek")}
                     className={cn(
                         "px-4 py-2 text-sm font-bold rounded-full transition-all flex items-center gap-2",
-                        filterTab === "soulseek" ? "bg-[#3b82f6] text-black" : "bg-[#232323] text-white hover:bg-[#2a2a2a]"
+                        filterTab === "soulseek" ? "bg-brand text-black" : "bg-[#232323] text-white hover:bg-[#2a2a2a]"
                     )}
                 >
                     <Download className="w-4 h-4" />

--- a/frontend/features/search/components/SimilarArtistsGrid.tsx
+++ b/frontend/features/search/components/SimilarArtistsGrid.tsx
@@ -63,8 +63,8 @@ export function SimilarArtistsGrid({
                             data-tv-card-index={index}
                             tabIndex={0}
                         >
-                            <div className="bg-[#121212] hover:bg-[#181818] transition-all p-4 rounded-lg group cursor-pointer">
-                                <div className="aspect-square bg-[#181818] rounded-full mb-4 flex items-center justify-center overflow-hidden relative">
+                            <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
+                                <div className="aspect-square bg-surface-elevated rounded-full mb-4 flex items-center justify-center overflow-hidden relative">
                                     {imageUrl ? (
                                         <Image
                                             src={imageUrl}
@@ -76,7 +76,7 @@ export function SimilarArtistsGrid({
                                             unoptimized
                                         />
                                     ) : (
-                                        <Music className="w-12 h-12 text-gray-600" />
+                                        <Music className="w-12 h-12 text-gray-400" />
                                     )}
                                 </div>
                                 <h3 className="text-base font-bold text-white line-clamp-1 mb-1">

--- a/frontend/features/search/components/SoulseekSongsList.tsx
+++ b/frontend/features/search/components/SoulseekSongsList.tsx
@@ -22,7 +22,7 @@ export const formatFileSize = (bytes: number): string => {
 export const getQualityBadge = (result: SoulseekResult) => {
     if (result.format === "flac") {
         return (
-            <span className="px-2 py-1 text-xs font-semibold bg-[#1a1acc]/20 text-[#5b5bff] rounded">
+            <span className="px-2 py-1 text-xs font-semibold bg-ai-dark/20 text-ai-hover rounded">
                 FLAC
             </span>
         );
@@ -102,9 +102,9 @@ export function SoulseekSongsList({
                     return (
                         <div
                             key={`${result.username}-${result.filename}-${index}`}
-                            className="flex items-center gap-4 p-3 rounded hover:bg-[#1a1a1a] group"
+                            className="flex items-center gap-4 p-3 rounded hover:bg-surface-hover group"
                         >
-                            <div className="w-10 h-10 bg-[#181818] rounded flex items-center justify-center flex-shrink-0">
+                            <div className="w-10 h-10 bg-surface-elevated rounded flex items-center justify-center flex-shrink-0">
                                 <Music className="w-5 h-5 text-gray-400" />
                             </div>
                             <div className="flex-1 min-w-0">
@@ -127,7 +127,7 @@ export function SoulseekSongsList({
                                         "px-4 py-2 rounded-full font-bold transition-all flex items-center gap-2 text-sm",
                                         isDownloading
                                             ? "bg-green-600/20 text-green-400 cursor-not-allowed"
-                                            : "bg-[#3b82f6] text-black hover:bg-[#2563eb] hover:scale-105"
+                                            : "bg-brand text-black hover:bg-brand-dark hover:scale-105"
                                     )}
                                 >
                                     {isDownloading ? (

--- a/frontend/features/search/components/TVSearchInput.tsx
+++ b/frontend/features/search/components/TVSearchInput.tsx
@@ -70,7 +70,7 @@ export function TVSearchInput({ initialQuery = "", onSearch }: TVSearchInputProp
                         tabIndex={0}
                         className={`
                             w-full h-16 pl-14 pr-6
-                            bg-[#1a1a1a]
+                            bg-surface-hover
                             rounded-lg
                             text-xl text-white
                             placeholder-gray-500
@@ -78,13 +78,13 @@ export function TVSearchInput({ initialQuery = "", onSearch }: TVSearchInputProp
                             outline-none
                             border-2
                             ${isFocused
-                                ? "border-[#3b82f6] bg-[#242424]"
+                                ? "border-brand bg-[#242424]"
                                 : "border-transparent hover:bg-[#242424]"
                             }
                         `}
                     />
                     {query && (
-                        <div className="absolute right-5 top-1/2 -translate-y-1/2 text-sm text-gray-500">
+                        <div className="absolute right-5 top-1/2 -translate-y-1/2 text-sm text-gray-400">
                             Press Enter to search
                         </div>
                     )}

--- a/frontend/features/search/components/TopResult.tsx
+++ b/frontend/features/search/components/TopResult.tsx
@@ -48,12 +48,12 @@ export function TopResult({ libraryArtist, discoveryArtist }: TopResultProps) {
             <h2 className="text-2xl font-bold text-white mb-6">Top result</h2>
             <Link
                 href={`/artist/${artistId}`}
-                className="bg-[#121212] hover:bg-[#181818] p-6 rounded-lg transition-all flex items-center gap-6 w-full sm:w-96"
+                className="bg-surface-sunken hover:bg-surface-elevated p-6 rounded-lg transition-all flex items-center gap-6 w-full sm:w-96"
                 data-tv-card
                 data-tv-card-index={0}
                 tabIndex={0}
             >
-                <div className="relative w-24 h-24 bg-[#181818] rounded-full flex items-center justify-center overflow-hidden shrink-0">
+                <div className="relative w-24 h-24 bg-surface-elevated rounded-full flex items-center justify-center overflow-hidden shrink-0">
                     {imageUrl ? (
                         <Image
                             src={api.getCoverArtUrl(imageUrl, 200)}
@@ -65,7 +65,7 @@ export function TopResult({ libraryArtist, discoveryArtist }: TopResultProps) {
                             unoptimized
                         />
                     ) : (
-                        <Music className="w-12 h-12 text-gray-600" />
+                        <Music className="w-12 h-12 text-gray-400" />
                     )}
                 </div>
                 <div className="flex-1">

--- a/frontend/features/search/components/YouTubePlaylistPreviewCard.tsx
+++ b/frontend/features/search/components/YouTubePlaylistPreviewCard.tsx
@@ -47,7 +47,7 @@ export function YouTubePlaylistPreviewCard({
         return (
             <section className="mb-8">
                 <h2 className="text-2xl font-bold text-white mb-4">YouTube</h2>
-                <div className="bg-[#121212] rounded-lg p-6 animate-pulse">
+                <div className="bg-surface-sunken rounded-lg p-6 animate-pulse">
                     <div className="space-y-3">
                         <div className="h-5 bg-white/10 rounded w-1/2" />
                         <div className="h-4 bg-white/10 rounded w-1/3" />
@@ -62,7 +62,7 @@ export function YouTubePlaylistPreviewCard({
         return (
             <section className="mb-8">
                 <h2 className="text-2xl font-bold text-white mb-4">YouTube</h2>
-                <div className="bg-[#121212] rounded-lg p-5">
+                <div className="bg-surface-sunken rounded-lg p-5">
                     <p className="text-sm text-gray-400">{error}</p>
                 </div>
             </section>
@@ -96,7 +96,7 @@ export function YouTubePlaylistPreviewCard({
     return (
         <section className="mb-8">
             <h2 className="text-2xl font-bold text-white mb-4">{heading}</h2>
-            <div className="bg-[#121212] hover:bg-[#181818] transition-colors rounded-lg p-5">
+            <div className="bg-surface-sunken hover:bg-surface-elevated transition-colors rounded-lg p-5">
                 <div className="flex items-start gap-3">
                     <ListVideo className="w-6 h-6 text-green-500 shrink-0 mt-0.5" />
                     <div className="min-w-0 flex-1">
@@ -108,10 +108,10 @@ export function YouTubePlaylistPreviewCard({
                                 {playlistInfo.uploader}
                             </p>
                         )}
-                        <p className="text-sm text-gray-500 mt-1">
+                        <p className="text-sm text-gray-400 mt-1">
                             {countLabel}
                             {playlistInfo.truncated && (
-                                <span className="text-gray-600">
+                                <span className="text-gray-400">
                                     {" "}
                                     — paste with a smaller list to get them all
                                 </span>
@@ -128,14 +128,14 @@ export function YouTubePlaylistPreviewCard({
                                 key={entry.videoId}
                                 className="flex gap-3 text-gray-300"
                             >
-                                <span className="text-gray-600 w-5 shrink-0 text-right">
+                                <span className="text-gray-400 w-5 shrink-0 text-right">
                                     {index + 1}
                                 </span>
                                 <span className="truncate">{entry.title}</span>
                             </li>
                         ))}
                         {remaining > 0 && (
-                            <li className="flex gap-3 text-gray-500">
+                            <li className="flex gap-3 text-gray-400">
                                 <span className="w-5 shrink-0" />
                                 <span>+{remaining} more</span>
                             </li>
@@ -169,7 +169,7 @@ export function YouTubePlaylistPreviewCard({
                         </button>
 
                         {showFormatMenu && !isDownloading && (
-                            <div className="absolute top-full left-0 mt-2 w-44 bg-[#282828] rounded-lg shadow-xl border border-white/10 overflow-hidden z-50">
+                            <div className="absolute top-full left-0 mt-2 w-44 bg-surface-highlight rounded-lg shadow-xl border border-white/10 overflow-hidden z-50">
                                 {FORMAT_OPTIONS.map((opt) => (
                                     <button
                                         key={opt.format}
@@ -210,7 +210,7 @@ export function YouTubePlaylistPreviewCard({
                             />
                         </div>
                         {progress.failed > 0 && (
-                            <p className="text-xs text-gray-500 mt-1.5">
+                            <p className="text-xs text-gray-400 mt-1.5">
                                 {progress.failed} unfinished (continuing in the
                                 background)
                             </p>

--- a/frontend/features/search/components/YouTubePreviewCard.tsx
+++ b/frontend/features/search/components/YouTubePreviewCard.tsx
@@ -42,7 +42,7 @@ export function YouTubePreviewCard({
         return (
             <section className="mb-8">
                 <h2 className="text-2xl font-bold text-white mb-4">YouTube</h2>
-                <div className="bg-[#121212] rounded-lg p-6 animate-pulse">
+                <div className="bg-surface-sunken rounded-lg p-6 animate-pulse">
                     <div className="flex gap-5">
                         <div className="w-64 h-36 rounded bg-white/10 shrink-0" />
                         <div className="flex-1 space-y-3 py-1">
@@ -66,7 +66,7 @@ export function YouTubePreviewCard({
     return (
         <section className="mb-8">
             <h2 className="text-2xl font-bold text-white mb-4">YouTube</h2>
-            <div className="bg-[#121212] hover:bg-[#181818] transition-colors rounded-lg p-5">
+            <div className="bg-surface-sunken hover:bg-surface-elevated transition-colors rounded-lg p-5">
                 <div className="flex flex-col sm:flex-row gap-5">
                     {/* Thumbnail */}
                     {videoInfo.thumbnail && (
@@ -90,7 +90,7 @@ export function YouTubePreviewCard({
                             <p className="text-sm text-gray-400 mt-1">
                                 {videoInfo.uploader}
                             </p>
-                            <p className="text-sm text-gray-500 mt-1">
+                            <p className="text-sm text-gray-400 mt-1">
                                 {formatTime(videoInfo.duration)}
                             </p>
                         </div>
@@ -133,7 +133,7 @@ export function YouTubePreviewCard({
                                 </button>
 
                                 {showFormatMenu && !isDownloading && (
-                                    <div className="absolute top-full left-0 mt-2 w-44 bg-[#282828] rounded-lg shadow-xl border border-white/10 overflow-hidden z-50">
+                                    <div className="absolute top-full left-0 mt-2 w-44 bg-surface-highlight rounded-lg shadow-xl border border-white/10 overflow-hidden z-50">
                                         {FORMAT_OPTIONS.map((opt) => (
                                             <button
                                                 key={opt.format}

--- a/frontend/features/settings/README.md
+++ b/frontend/features/settings/README.md
@@ -49,6 +49,7 @@ Start-here guide for `frontend/features/settings`.
 | `components/ui/SettingsSelect.tsx` | components |
 | `components/ui/SettingsSidebar.tsx` | components |
 | `components/ui/SettingsToggle.tsx` | components |
+| `components/ui/settingsFieldStyles.ts` | shared settings-field styles |
 | `hooks/settingsHydration.ts` | hooks |
 | `hooks/useAPIKeys.ts` | hooks |
 | `hooks/useSettingsData.ts` | hooks |

--- a/frontend/features/settings/components/sections/APIKeysSection.tsx
+++ b/frontend/features/settings/components/sections/APIKeysSection.tsx
@@ -152,7 +152,7 @@ export const APIKeysSection: React.FC = () => {
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
-            <tr className="border-b border-[#1c1c1c]">
+            <tr className="border-b border-surface-active">
               <th className="text-left py-3 px-4 text-sm font-medium text-gray-400">
                 Device Name
               </th>
@@ -187,7 +187,7 @@ export const APIKeysSection: React.FC = () => {
               apiKeys.map((key) => (
                 <tr
                   key={key.id}
-                  className="border-b border-[#1c1c1c] hover:bg-[#0a0a0a]"
+                  className="border-b border-surface-active hover:bg-surface"
                 >
                   <td className="py-3 px-4 text-sm text-white">
                     {key.name}
@@ -238,7 +238,7 @@ export const APIKeysSection: React.FC = () => {
                 value={newApiKeyName}
                 onChange={(e) => setNewApiKeyName(e.target.value)}
                 placeholder="e.g., My Laptop, Production Server"
-                className="w-full bg-[#0a0a0a] border border-[#1c1c1c] rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full bg-surface border border-surface-active rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 autoFocus
               />
             </div>

--- a/frontend/features/settings/components/sections/AccountSection.tsx
+++ b/frontend/features/settings/components/sections/AccountSection.tsx
@@ -325,8 +325,8 @@ export function AccountSection({ settings, onUpdate }: AccountSectionProps) {
                         
                         {twoFactorSecret && (
                             <div className="text-center">
-                                <p className="text-xs text-gray-500 mb-1">Manual entry code:</p>
-                                <code className="text-sm text-white bg-[#282828] px-3 py-1 rounded font-mono">
+                                <p className="text-xs text-gray-400 mb-1">Manual entry code:</p>
+                                <code className="text-sm text-white bg-surface-highlight px-3 py-1 rounded font-mono">
                                     {twoFactorSecret}
                                 </code>
                             </div>
@@ -419,7 +419,7 @@ export function AccountSection({ settings, onUpdate }: AccountSectionProps) {
                     </div>
                     <div className="grid grid-cols-2 gap-2">
                         {recoveryCodes.map((code, i) => (
-                            <code key={i} className="text-sm text-white bg-[#282828] px-3 py-2 rounded font-mono">
+                            <code key={i} className="text-sm text-white bg-surface-highlight px-3 py-2 rounded font-mono">
                                 {code}
                             </code>
                         ))}
@@ -427,7 +427,7 @@ export function AccountSection({ settings, onUpdate }: AccountSectionProps) {
                     <div className="flex gap-2">
                         <button
                             onClick={() => navigator.clipboard.writeText(recoveryCodes.join("\n"))}
-                            className="px-4 py-2 bg-[#333] text-white text-sm rounded-full hover:bg-[#404040]"
+                            className="px-4 py-2 bg-line-strong text-white text-sm rounded-full hover:bg-line-muted"
                         >
                             Copy
                         </button>

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -37,7 +37,7 @@ interface CacheSectionProps {
 // Progress bar component
 function ProgressBar({
     progress,
-    color = "bg-[#3b82f6]",
+    color = "bg-brand",
     showPercentage = true,
 }: {
     progress: number;
@@ -97,7 +97,7 @@ function EnrichmentStage({
                 {isComplete ? (
                     <CheckCircle className="w-4 h-4 text-green-400" />
                 ) : hasActivity ? (
-                    <Loader2 className="w-4 h-4 text-[#3b82f6] animate-spin" />
+                    <Loader2 className="w-4 h-4 text-brand animate-spin" />
                 ) : (
                     <Icon className="w-4 h-4 text-white/40" />
                 )}
@@ -121,8 +121,8 @@ function EnrichmentStage({
                             isComplete
                                 ? "bg-green-500"
                                 : isBackground
-                                ? "bg-[#2323FF]"
-                                : "bg-[#3b82f6]"
+                                ? "bg-ai"
+                                : "bg-brand"
                         }
                     />
                 </div>
@@ -131,7 +131,7 @@ function EnrichmentStage({
                         {completed} / {total}
                     </span>
                     {processing > 0 && (
-                        <span className="text-[#3b82f6]">
+                        <span className="text-brand">
                             {processing} processing
                         </span>
                     )}
@@ -619,7 +619,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             </h3>
                             {enrichmentProgress.coreComplete &&
                                 !enrichmentProgress.isFullyComplete && (
-                                    <span className="text-xs text-[#5b5bff] flex items-center gap-1">
+                                    <span className="text-xs text-ai-hover flex items-center gap-1">
                                         <Loader2 className="w-3 h-3 animate-spin" />
                                         Audio analysis running
                                     </span>
@@ -714,8 +714,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             ) : !featuresLoading ? (
                                 <div className="opacity-50 py-2">
                                     <h4 className="text-sm font-medium text-gray-300">Audio Analysis</h4>
-                                    <p className="text-sm text-gray-500">Analyzer not detected right now</p>
-                                    <p className="text-xs text-gray-600 mt-1">
+                                    <p className="text-sm text-gray-400">Analyzer not detected right now</p>
+                                    <p className="text-xs text-gray-400 mt-1">
                                         If services just started, wait about 60 seconds and refresh. In lite mode, this is expected.
                                     </p>
                                 </div>
@@ -751,8 +751,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             ) : !featuresLoading ? (
                                 <div className="opacity-50 py-2">
                                     <h4 className="text-sm font-medium text-gray-300">Vibe Similarity</h4>
-                                    <p className="text-sm text-gray-500">Analyzer not detected right now</p>
-                                    <p className="text-xs text-gray-600 mt-1">
+                                    <p className="text-sm text-gray-400">Analyzer not detected right now</p>
+                                    <p className="text-xs text-gray-400 mt-1">
                                         If services just started, wait about 60 seconds and refresh. In lite mode, this is expected.
                                     </p>
                                 </div>
@@ -845,7 +845,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                             reEnriching ||
                                             isEnrichmentActive
                                         }
-                                        className="h-3.5 w-3.5 rounded border-white/30 bg-transparent accent-[#3b82f6] disabled:opacity-50 disabled:cursor-not-allowed"
+                                        className="h-3.5 w-3.5 rounded border-white/30 bg-transparent accent-brand disabled:opacity-50 disabled:cursor-not-allowed"
                                     />
                                     Backfill mood buckets after full enrich
                                 </label>
@@ -864,7 +864,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                                 reEnriching ||
                                                 isEnrichmentActive
                                             }
-                                            className="h-3.5 w-3.5 rounded border-white/30 bg-transparent accent-[#3b82f6] disabled:opacity-50 disabled:cursor-not-allowed"
+                                            className="h-3.5 w-3.5 rounded border-white/30 bg-transparent accent-brand disabled:opacity-50 disabled:cursor-not-allowed"
                                         />
                                         Rebuild CLAP embeddings
                                     </label>
@@ -879,7 +879,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     <div className="flex items-center gap-2">
                                         {enrichmentState.status ===
                                             "running" && (
-                                            <Loader2 className="w-3 h-3 animate-spin text-[#3b82f6]" />
+                                            <Loader2 className="w-3 h-3 animate-spin text-brand" />
                                         )}
                                         {enrichmentState.status ===
                                             "paused" && (
@@ -947,7 +947,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     maxCacheSizeMb: parseInt(e.target.value),
                                 })
                             }
-                            className="w-32 h-1 bg-[#404040] rounded-lg appearance-none cursor-pointer
+                            className="w-32 h-1 bg-line-muted rounded-lg appearance-none cursor-pointer
                             [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
                             [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
                         />
@@ -974,7 +974,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     ),
                                 })
                             }
-                            className="w-32 h-1 bg-[#404040] rounded-lg appearance-none cursor-pointer
+                            className="w-32 h-1 bg-line-muted rounded-lg appearance-none cursor-pointer
                             [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
                             [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
                         />
@@ -1028,7 +1028,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     const newSpeed = parseInt(e.target.value);
                                     setConcurrencyMutation.mutate(newSpeed);
                                 }}
-                                className="w-32 h-1 bg-[#404040] rounded-lg appearance-none cursor-pointer
+                                className="w-32 h-1 bg-line-muted rounded-lg appearance-none cursor-pointer
                                 disabled:opacity-50 disabled:cursor-not-allowed
                                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
                                 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
@@ -1086,7 +1086,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         newWorkers
                                     );
                                 }}
-                                className="w-32 h-1 bg-[#404040] rounded-lg appearance-none cursor-pointer
+                                className="w-32 h-1 bg-line-muted rounded-lg appearance-none cursor-pointer
                                 disabled:opacity-50 disabled:cursor-not-allowed
                                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
                                 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
@@ -1132,7 +1132,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     const newWorkers = parseInt(e.target.value);
                                     setClapWorkersMutation.mutate(newWorkers);
                                 }}
-                                className="w-32 h-1 bg-[#404040] rounded-lg appearance-none cursor-pointer
+                                className="w-32 h-1 bg-line-muted rounded-lg appearance-none cursor-pointer
                                 disabled:opacity-50 disabled:cursor-not-allowed
                                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
                                 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"

--- a/frontend/features/settings/components/sections/LibraryHealthSection.tsx
+++ b/frontend/features/settings/components/sections/LibraryHealthSection.tsx
@@ -80,13 +80,13 @@ export function LibraryHealthSection() {
 
                 {isLoading && records.length === 0 && (
                     <div className="flex items-center justify-center py-8">
-                        <Loader2 className="w-5 h-5 text-gray-500 animate-spin" />
+                        <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
                     </div>
                 )}
 
                 {!isLoading && records.length === 0 && !error && (
                     <div className="text-center py-6">
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-400">
                             No health issues detected
                         </p>
                     </div>
@@ -112,23 +112,23 @@ export function LibraryHealthSection() {
                                                 </p>
                                             </div>
                                             {record.track?.album && (
-                                                <p className="text-xs text-gray-500 mt-0.5 ml-6 truncate">
+                                                <p className="text-xs text-gray-400 mt-0.5 ml-6 truncate">
                                                     {record.track.album.artist?.name} &middot;{" "}
                                                     {record.track.album.title}
                                                 </p>
                                             )}
-                                            <p className="text-[11px] text-gray-600 mt-1 ml-6 truncate font-mono">
+                                            <p className="text-[11px] text-gray-400 mt-1 ml-6 truncate font-mono">
                                                 {record.filePath}
                                             </p>
                                             {record.detail && (
-                                                <p className="text-[11px] text-gray-600 mt-0.5 ml-6">
+                                                <p className="text-[11px] text-gray-400 mt-0.5 ml-6">
                                                     {record.detail}
                                                 </p>
                                             )}
                                         </div>
                                         <button
                                             onClick={() => void handleDismiss(record.id)}
-                                            className="p-1.5 text-gray-600 hover:text-red-400 hover:bg-white/5 rounded transition-colors shrink-0"
+                                            className="p-1.5 text-gray-400 hover:text-red-400 hover:bg-white/5 rounded transition-colors shrink-0"
                                             title="Dismiss"
                                         >
                                             <Trash2 className="w-3.5 h-3.5" />

--- a/frontend/features/settings/components/sections/LinkDeviceSection.tsx
+++ b/frontend/features/settings/components/sections/LinkDeviceSection.tsx
@@ -8,11 +8,11 @@ export function LinkDeviceSection() {
     return (
         <div
             id="link-device"
-            className="bg-[#111] rounded-lg p-6 border border-[#1c1c1c]"
+            className="bg-[#111] rounded-lg p-6 border border-surface-active"
         >
             <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 rounded-lg bg-[#2323FF]/10">
-                    <Smartphone className="w-5 h-5 text-[#5b5bff]" />
+                <div className="p-2 rounded-lg bg-ai/10">
+                    <Smartphone className="w-5 h-5 text-ai-hover" />
                 </div>
                 <div>
                     <h3 className="font-medium text-white">Link Device</h3>
@@ -29,7 +29,7 @@ export function LinkDeviceSection() {
 
             <Link
                 href="/device"
-                className="inline-flex items-center gap-2 px-4 py-2 bg-[#2323FF]/20 hover:bg-[#2323FF]/30 text-[#5b5bff] rounded-lg transition-colors border border-[#2323FF]/30"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-ai/20 hover:bg-ai/30 text-ai-hover rounded-lg transition-colors border border-ai/30"
             >
                 <QrCode className="w-4 h-4" />
                 <span>Link a Device</span>

--- a/frontend/features/settings/components/sections/PlaybackHistorySection.tsx
+++ b/frontend/features/settings/components/sections/PlaybackHistorySection.tsx
@@ -135,7 +135,7 @@ export function PlaybackHistorySection() {
                         checked={confirmClear}
                         onChange={(e) => setConfirmClear(e.target.checked)}
                         disabled={clearing}
-                        className="mt-0.5 h-3.5 w-3.5 rounded border-white/20 bg-[#282828] text-red-500 focus:ring-red-500/40"
+                        className="mt-0.5 h-3.5 w-3.5 rounded border-white/20 bg-surface-highlight text-red-500 focus:ring-red-500/40"
                     />
                     <span>
                         I understand this will affect personalization based on my listening history.
@@ -146,7 +146,7 @@ export function PlaybackHistorySection() {
                 </label>
 
                 <div className="flex items-center gap-3">
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-gray-400">
                         {summaryLoading
                             ? "Loading history totals..."
                             : `Estimated events to remove: ${(impactedCount ?? 0).toLocaleString()}`}

--- a/frontend/features/settings/components/sections/SoulseekSection.tsx
+++ b/frontend/features/settings/components/sections/SoulseekSection.tsx
@@ -66,7 +66,7 @@ export function SoulseekCard({ settings, onUpdate, onTest, isTesting }: Soulseek
                                 href="https://www.slsknet.org/news/node/1"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1 text-[#3b82f6] hover:underline"
+                                className="inline-flex items-center gap-1 text-brand hover:underline"
                             >
                                 <ExternalLink className="w-3 h-3" />
                                 Create Account

--- a/frontend/features/settings/components/sections/SubsonicSection.tsx
+++ b/frontend/features/settings/components/sections/SubsonicSection.tsx
@@ -110,7 +110,7 @@ export function SubsonicRows() {
                         <Info className="h-3.5 w-3.5" />
                     </button>
                     {showTooltip && (
-                        <span className="absolute left-0 top-full z-30 mt-1 w-72 rounded-md border border-white/15 bg-[#141414] p-2 text-[11px] leading-relaxed text-gray-300 shadow-2xl">
+                        <span className="absolute left-0 top-full z-30 mt-1 w-72 rounded-md border border-white/15 bg-surface-overlay p-2 text-[11px] leading-relaxed text-gray-300 shadow-2xl">
                             Using an app password is recommended so you do not share your main
                             {BRAND_NAME} login with third-party clients. If a device is lost, you can
                             rotate this password without changing your main account password.
@@ -134,7 +134,7 @@ export function SubsonicRows() {
                                 type="text"
                                 value="••••••••"
                                 disabled
-                                className="w-full bg-[#333] text-white text-sm px-3 py-2 rounded-md border-0 outline-none opacity-50 cursor-not-allowed"
+                                className="w-full bg-line-strong text-white text-sm px-3 py-2 rounded-md border-0 outline-none opacity-50 cursor-not-allowed"
                             />
                         </div>
                         <button

--- a/frontend/features/settings/components/sections/TidalSection.tsx
+++ b/frontend/features/settings/components/sections/TidalSection.tsx
@@ -153,7 +153,7 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
                                     href="https://tidal.com"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1 text-[#3b82f6] hover:underline"
+                                    className="inline-flex items-center gap-1 text-brand hover:underline"
                                 >
                                     <ExternalLink className="w-3 h-3" />
                                     TIDAL
@@ -193,7 +193,7 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
                                     href={authUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="text-[#3b82f6] hover:underline break-all"
+                                    className="text-brand hover:underline break-all"
                                 >
                                     {authUrl}
                                 </a>
@@ -250,7 +250,7 @@ export function TidalCard({ settings, onUpdate, onTest, isTesting }: TidalCardPr
                                 How downloaded files are organized. Use <code className="text-xs text-white/60">/</code> to create folders.
                             </span>
                             <details className="text-xs">
-                                <summary className="cursor-pointer text-[#3b82f6] hover:underline select-none">
+                                <summary className="cursor-pointer text-brand hover:underline select-none">
                                     Show available variables
                                 </summary>
                                 <div className="mt-2 space-y-2 text-white/60">

--- a/frontend/features/settings/components/sections/UserManagementSection.tsx
+++ b/frontend/features/settings/components/sections/UserManagementSection.tsx
@@ -266,7 +266,7 @@ export function UserManagementSection() {
                 showSeparator={false}
             >
                 {/* Create User Form */}
-                <div className="py-4 px-4 bg-[#1a1a1a] rounded-lg mb-4">
+                <div className="py-4 px-4 bg-surface-hover rounded-lg mb-4">
                     <h3 className="text-sm font-medium text-white mb-3">Create New User</h3>
                     <div className="space-y-3">
                         <div className="flex gap-3">
@@ -311,7 +311,7 @@ export function UserManagementSection() {
                 </div>
 
                 {/* Invite Codes */}
-                <div className="py-4 px-4 bg-[#1a1a1a] rounded-lg mb-4">
+                <div className="py-4 px-4 bg-surface-hover rounded-lg mb-4">
                     <h3 className="text-sm font-medium text-white mb-3">Invite Codes</h3>
                     <div className="space-y-3">
                         <div className="flex gap-3 items-center flex-wrap">
@@ -382,7 +382,7 @@ export function UserManagementSection() {
                                                                 code.id
                                                             )
                                                         }
-                                                        className="p-1.5 text-gray-500 hover:text-white transition-colors"
+                                                        className="p-1.5 text-gray-400 hover:text-white transition-colors"
                                                         title="Copy invite link"
                                                     >
                                                         {copiedCodeId === code.id ? (
@@ -395,7 +395,7 @@ export function UserManagementSection() {
                                                         onClick={() =>
                                                             handleRevokeInvite(code.id)
                                                         }
-                                                        className="p-1.5 text-gray-500 hover:text-red-400 transition-colors"
+                                                        className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
                                                         title="Revoke invite code"
                                                     >
                                                         <Trash2 className="w-3.5 h-3.5" />
@@ -423,11 +423,11 @@ export function UserManagementSection() {
                     </div>
 
                     {connectedLoading ? (
-                        <div className="py-2 text-sm text-gray-500">
+                        <div className="py-2 text-sm text-gray-400">
                             Checking connected users...
                         </div>
                     ) : connectedUsers.length === 0 ? (
-                        <div className="py-2 text-sm text-gray-500">
+                        <div className="py-2 text-sm text-gray-400">
                             No active users connected
                         </div>
                     ) : (
@@ -441,12 +441,12 @@ export function UserManagementSection() {
                                         <p className="text-sm text-white truncate">
                                             {connectedUser.displayName}
                                             {currentUser?.id === connectedUser.id && (
-                                                <span className="text-xs text-gray-500 ml-2">
+                                                <span className="text-xs text-gray-400 ml-2">
                                                     (you)
                                                 </span>
                                             )}
                                         </p>
-                                        <p className="text-xs text-gray-500 truncate">
+                                        <p className="text-xs text-gray-400 truncate">
                                             @{connectedUser.username}
                                         </p>
                                     </div>
@@ -462,9 +462,9 @@ export function UserManagementSection() {
                 {/* Users List */}
                 <div className="space-y-1">
                     {loading ? (
-                        <div className="py-4 text-sm text-gray-500">Loading users...</div>
+                        <div className="py-4 text-sm text-gray-400">Loading users...</div>
                     ) : users.length === 0 ? (
-                        <div className="py-4 text-sm text-gray-500">No users found</div>
+                        <div className="py-4 text-sm text-gray-400">No users found</div>
                     ) : (
                         users.map((user) => (
                             <div
@@ -473,17 +473,17 @@ export function UserManagementSection() {
                                 onClick={() => openEditModal(user)}
                             >
                                 <div className="flex items-center gap-3">
-                                    <div className="w-8 h-8 rounded-full bg-[#333] flex items-center justify-center text-sm text-white">
+                                    <div className="w-8 h-8 rounded-full bg-line-strong flex items-center justify-center text-sm text-white">
                                         {user.username[0].toUpperCase()}
                                     </div>
                                     <div>
                                         <div className="text-sm text-white">
                                             {user.username}
                                             {currentUser?.id === user.id && (
-                                                <span className="text-xs text-gray-500 ml-2">(you)</span>
+                                                <span className="text-xs text-gray-400 ml-2">(you)</span>
                                             )}
                                         </div>
-                                        <div className="text-xs text-gray-500">
+                                        <div className="text-xs text-gray-400">
                                             {user.role === "admin" ? "Admin" : "User"}
                                             {user.email && (
                                                 <span className="ml-2">{user.email}</span>
@@ -498,7 +498,7 @@ export function UserManagementSection() {
                                             e.stopPropagation();
                                             setConfirmDelete(user.id);
                                         }}
-                                        className="p-2 text-gray-500 hover:text-red-400 transition-colors"
+                                        className="p-2 text-gray-400 hover:text-red-400 transition-colors"
                                     >
                                         <Trash2 className="w-4 h-4" />
                                     </button>

--- a/frontend/features/settings/components/sections/YouTubeMusicSection.tsx
+++ b/frontend/features/settings/components/sections/YouTubeMusicSection.tsx
@@ -62,7 +62,7 @@ export function YouTubeMusicAdminSection({ settings, onUpdate }: YouTubeMusicAdm
                         }
                         <span>Account Linking (Optional)</span>
                     </button>
-                    <p className="text-xs text-gray-500 ml-6 mb-2">
+                    <p className="text-xs text-gray-400 ml-6 mb-2">
                         Configure Google OAuth credentials to allow users to link their personal YouTube Music
                         accounts for library access. Not required for search, browse, or streaming.
                     </p>
@@ -322,7 +322,7 @@ export function YouTubeMusicCard({ settings, onUpdate }: YouTubeMusicCardProps) 
         >
             {/* Account linking hint when OAuth is available but not linked */}
             {!isConnected && canLinkAccount && status?.available && !polling && !authError && !error && !success && (
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-gray-400">
                     Link your Google account for personal library access (optional).
                 </p>
             )}

--- a/frontend/features/settings/components/ui/ConnectionCard.tsx
+++ b/frontend/features/settings/components/ui/ConnectionCard.tsx
@@ -26,10 +26,10 @@ export function ConnectionCard({
     isLoading
 }: ConnectionCardProps) {
     return (
-        <div className="flex items-center justify-between py-4 px-4 bg-[#1a1a1a] rounded-lg">
+        <div className="flex items-center justify-between py-4 px-4 bg-surface-hover rounded-lg">
             <div className="flex items-center gap-3">
                 {/* Icon */}
-                <div className="w-10 h-10 rounded-full bg-[#282828] flex items-center justify-center overflow-hidden">
+                <div className="w-10 h-10 rounded-full bg-surface-highlight flex items-center justify-center overflow-hidden">
                     {typeof icon === "string" ? (
                         <Image 
                             src={icon} 
@@ -52,7 +52,7 @@ export function ConnectionCard({
                             Connected as <span className="text-white">{connectedAs}</span>
                         </div>
                     ) : description ? (
-                        <div className="text-xs text-gray-500">{description}</div>
+                        <div className="text-xs text-gray-400">{description}</div>
                     ) : null}
                 </div>
             </div>

--- a/frontend/features/settings/components/ui/DeviceAuthLinkPanel.tsx
+++ b/frontend/features/settings/components/ui/DeviceAuthLinkPanel.tsx
@@ -54,12 +54,12 @@ function CodeStep({ userCode, copied, onCopyCode, pasteInstruction }: Pick<
             <div className="space-y-2">
                 <p className="text-sm text-gray-300">
                     {pasteInstruction}
-                    <span className="text-gray-500 text-xs ml-1">
+                    <span className="text-gray-400 text-xs ml-1">
                         (it&apos;s already on your clipboard)
                     </span>
                 </p>
                 <div className="flex items-center gap-3">
-                    <code className="px-4 py-2 text-lg font-mono font-bold tracking-wider bg-[#1a1a1a] text-white rounded-lg border border-[#444] select-all">
+                    <code className="px-4 py-2 text-lg font-mono font-bold tracking-wider bg-surface-hover text-white rounded-lg border border-[#444] select-all">
                         {userCode}
                     </code>
                     <button onClick={onCopyCode} className="p-2 text-gray-400 hover:text-white transition-colors" title="Copy code">
@@ -82,7 +82,7 @@ function WaitingRow({ timeLeftSeconds }: Pick<DeviceAuthLinkPanelProps, "timeLef
             </div>
             {timeLeftSeconds !== null && (
                 <span className={`text-xs tabular-nums ${
-                    timeLeftSeconds < 120 ? "text-amber-400/70" : "text-gray-500"
+                    timeLeftSeconds < 120 ? "text-amber-400/70" : "text-gray-400"
                 }`}>
                     Expires in {formatTime(timeLeftSeconds)}
                 </span>
@@ -94,7 +94,7 @@ function WaitingRow({ timeLeftSeconds }: Pick<DeviceAuthLinkPanelProps, "timeLef
 /** Renders reusable instructions and controls for a device-code authentication session. */
 export function DeviceAuthLinkPanel(props: DeviceAuthLinkPanelProps) {
     return (
-        <div className="p-4 bg-[#252525] rounded-lg border border-[#333] space-y-4">
+        <div className="p-4 bg-[#252525] rounded-lg border border-line-strong space-y-4">
             <div className="space-y-3">
                 <p className="text-sm text-gray-300">{props.introText}</p>
                 <CodeStep {...props} />
@@ -120,7 +120,7 @@ export function DeviceAuthLinkPanel(props: DeviceAuthLinkPanelProps) {
                 </a>
             )}
             <WaitingRow timeLeftSeconds={props.timeLeftSeconds} />
-            <button onClick={props.onCancel} className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+            <button onClick={props.onCancel} className="text-xs text-gray-400 hover:text-gray-300 transition-colors">
                 Cancel
             </button>
         </div>

--- a/frontend/features/settings/components/ui/InfoTooltip.tsx
+++ b/frontend/features/settings/components/ui/InfoTooltip.tsx
@@ -27,7 +27,7 @@ export function InfoTooltip({ text }: InfoTooltipProps) {
                 <Info className="h-3.5 w-3.5" />
             </button>
             {showTooltip && (
-                <span className="absolute left-0 top-full z-30 mt-1 w-72 rounded-md border border-white/15 bg-[#141414] p-2 text-[11px] leading-relaxed text-gray-300 shadow-2xl">
+                <span className="absolute left-0 top-full z-30 mt-1 w-72 rounded-md border border-white/15 bg-surface-overlay p-2 text-[11px] leading-relaxed text-gray-300 shadow-2xl">
                     {text}
                 </span>
             )}

--- a/frontend/features/settings/components/ui/IntegrationCard.tsx
+++ b/frontend/features/settings/components/ui/IntegrationCard.tsx
@@ -50,12 +50,12 @@ export function IntegrationCard({
     ) : statusColor === "red" ? (
         <XCircle className="w-4 h-4 text-red-400" />
     ) : (
-        <XCircle className="w-4 h-4 text-gray-500" />
+        <XCircle className="w-4 h-4 text-gray-400" />
     );
 
     return (
         <div
-            className={`rounded-lg border border-white/[0.06] bg-[#1a1a1a] overflow-hidden transition-opacity ${
+            className={`rounded-lg border border-white/[0.06] bg-surface-hover overflow-hidden transition-opacity ${
                 disabled ? "opacity-50" : ""
             }`}
         >
@@ -63,7 +63,7 @@ export function IntegrationCard({
             <div className="flex items-center justify-between px-4 py-3.5">
                 <div className="flex items-center gap-3">
                     {/* Icon */}
-                    <div className="w-9 h-9 rounded-full bg-[#282828] flex items-center justify-center shrink-0">
+                    <div className="w-9 h-9 rounded-full bg-surface-highlight flex items-center justify-center shrink-0">
                         {icon}
                     </div>
 

--- a/frontend/features/settings/components/ui/SettingsInput.tsx
+++ b/frontend/features/settings/components/ui/SettingsInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
+import { SETTINGS_FIELD_FOCUS_RING } from "./settingsFieldStyles";
 
 interface SettingsInputProps {
     id?: string;
@@ -36,13 +37,13 @@ export function SettingsInput({
                 placeholder={placeholder}
                 disabled={disabled}
                 className={`
-                    w-full bg-[#333] text-white text-sm
+                    w-full bg-line-strong text-white text-sm
                     px-3 py-2 rounded-md
                     border-0 outline-none
-                    focus:ring-2 focus:ring-white/20
-                    placeholder:text-gray-500
+                    ${SETTINGS_FIELD_FOCUS_RING}
+                    placeholder:text-gray-400
                     transition-colors
-                    hover:bg-[#404040] focus:bg-[#404040]
+                    hover:bg-line-muted focus:bg-line-muted
                     ${isPassword ? 'pr-10' : ''}
                     ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
                 `}
@@ -63,4 +64,3 @@ export function SettingsInput({
         </div>
     );
 }
-

--- a/frontend/features/settings/components/ui/SettingsLayout.tsx
+++ b/frontend/features/settings/components/ui/SettingsLayout.tsx
@@ -96,7 +96,7 @@ export function SettingsLayout({ children, sidebarItems, isAdmin, title = "Setti
     }, [sidebarItems, isAdmin]);
     
     return (
-        <div className="min-h-screen bg-[#0a0a0a] relative">
+        <div className="min-h-screen bg-surface relative">
             {/* Subtle grey gradient for systems page feel */}
             <div 
                 className="absolute inset-0 pointer-events-none"

--- a/frontend/features/settings/components/ui/SettingsRow.tsx
+++ b/frontend/features/settings/components/ui/SettingsRow.tsx
@@ -37,7 +37,7 @@ export function SettingsRow({
                     {labelExtra}
                 </div>
                 {description && (
-                    <p className="text-xs text-gray-500 mt-0.5">{description}</p>
+                    <p className="text-xs text-gray-400 mt-0.5">{description}</p>
                 )}
             </div>
             <div className="shrink-0">

--- a/frontend/features/settings/components/ui/SettingsSelect.tsx
+++ b/frontend/features/settings/components/ui/SettingsSelect.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from "lucide-react";
+import { SETTINGS_FIELD_FOCUS_RING } from "./settingsFieldStyles";
 
 interface Option {
     value: string;
@@ -26,12 +27,12 @@ export function SettingsSelect({ id, value, onChange, options, disabled }: Setti
                 onChange={(e) => onChange(e.target.value)}
                 disabled={disabled}
                 className={`
-                    appearance-none bg-[#333] text-white text-sm
+                    appearance-none bg-line-strong text-white text-sm
                     pl-3 pr-8 py-1.5 rounded-md
                     border-0 outline-none
-                    focus:ring-2 focus:ring-white/20
+                    ${SETTINGS_FIELD_FOCUS_RING}
                     cursor-pointer transition-colors
-                    hover:bg-[#404040]
+                    hover:bg-line-muted
                     ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
                 `}
             >
@@ -45,4 +46,3 @@ export function SettingsSelect({ id, value, onChange, options, disabled }: Setti
         </div>
     );
 }
-

--- a/frontend/features/settings/components/ui/SettingsSidebar.tsx
+++ b/frontend/features/settings/components/ui/SettingsSidebar.tsx
@@ -33,7 +33,7 @@ export function SettingsSidebar({ items, activeSection, onSectionClick, isAdmin 
                         className={`
                             w-full text-left px-3 py-2 rounded-md text-sm transition-colors
                             ${activeSection === item.id 
-                                ? 'text-white bg-[#282828]' 
+                                ? 'text-white bg-surface-highlight' 
                                 : 'text-gray-400 hover:text-white'
                             }
                         `}
@@ -45,7 +45,7 @@ export function SettingsSidebar({ items, activeSection, onSectionClick, isAdmin 
                 {adminItems.length > 0 && (
                     <>
                         <div className="pt-4 pb-2 px-3">
-                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                            <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
                                 Admin
                             </span>
                         </div>
@@ -56,7 +56,7 @@ export function SettingsSidebar({ items, activeSection, onSectionClick, isAdmin 
                                 className={`
                                     w-full text-left px-3 py-2 rounded-md text-sm transition-colors
                                     ${activeSection === item.id 
-                                        ? 'text-white bg-[#282828]' 
+                                        ? 'text-white bg-surface-highlight' 
                                         : 'text-gray-400 hover:text-white'
                                     }
                                 `}

--- a/frontend/features/settings/components/ui/SettingsToggle.tsx
+++ b/frontend/features/settings/components/ui/SettingsToggle.tsx
@@ -22,7 +22,7 @@ export function SettingsToggle({ id, checked, onChange, disabled }: SettingsTogg
             <div className={`
                 w-10 h-6 rounded-full transition-colors
                 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-                ${checked ? 'bg-[#1DB954]' : 'bg-[#404040]'}
+                ${checked ? 'bg-[#1DB954]' : 'bg-line-muted'}
                 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-[#1DB954]/30
                 after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                 after:bg-white after:rounded-full after:h-5 after:w-5

--- a/frontend/features/settings/components/ui/settingsFieldStyles.ts
+++ b/frontend/features/settings/components/ui/settingsFieldStyles.ts
@@ -1,0 +1,9 @@
+/**
+ * Settings focus-ring tokens provide a WCAG 1.4.11 compliant (at least 3:1)
+ * focus indicator against the focused input background.
+ */
+export const SETTINGS_FOCUS_RING_TOKEN = "brand-hover";
+
+/** Tailwind classes for the shared settings-field focus indicator. */
+export const SETTINGS_FIELD_FOCUS_RING =
+    "focus:outline-none focus:ring-2 focus:ring-brand-hover";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "start": "node server.js",
     "prelint": "tsc -p ../packages/media-metadata-contract/tsconfig.json",
     "lint": "eslint",
+    "lint:hex": "node scripts/check-hardcoded-hex.mjs",
     "typecheck": "tsc --noEmit --incremental false",
     "pretest:unit": "tsc -p ../packages/media-metadata-contract/tsconfig.json",
     "test:unit": "node --test --import tsx 'tests/unit/**/*.test.ts'",

--- a/frontend/scripts/check-hardcoded-hex.mjs
+++ b/frontend/scripts/check-hardcoded-hex.mjs
@@ -1,0 +1,79 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const BASELINE = 130;
+export const HEX_UTILITY_REGEX = /(bg|text|border|ring|ring-offset|from|via|to|shadow|fill|stroke|divide|outline|accent|caret|decoration|placeholder)-\[#[0-9a-fA-F]{3,6}\]/g;
+
+const SOURCE_DIRECTORIES = ["app", "components", "features"];
+const EXCLUDED_FILE = "components/player/AudioPlaybackOrchestrator.tsx";
+
+/** Counts arbitrary-value hex color utilities in source text. */
+export function countArbitraryHexClasses(source) {
+    if (typeof source !== "string") {
+        throw new TypeError("source must be a string");
+    }
+
+    return source.match(HEX_UTILITY_REGEX)?.length ?? 0;
+}
+
+function collectSourceFiles(rootDir) {
+    const directories = SOURCE_DIRECTORIES.map((directory) =>
+        path.join(rootDir, directory)
+    );
+    const files = [];
+
+    while (directories.length > 0) {
+        const directory = directories.pop();
+        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+            if (entry.name === "node_modules" || entry.name === ".next") {
+                continue;
+            }
+
+            const entryPath = path.join(directory, entry.name);
+            if (entry.isDirectory()) {
+                directories.push(entryPath);
+            } else if (/\.(ts|tsx)$/.test(entry.name)) {
+                files.push(entryPath);
+            }
+        }
+    }
+
+    return files;
+}
+
+/** Counts arbitrary-value hex color utilities in frontend source directories. */
+export function scanRepo(rootDir) {
+    if (typeof rootDir !== "string" || rootDir.trim() === "") {
+        throw new TypeError("rootDir must be a non-empty string");
+    }
+    if (!statSync(rootDir).isDirectory()) {
+        throw new TypeError("rootDir must identify a directory");
+    }
+
+    return collectSourceFiles(rootDir).reduce((total, filePath) => {
+        if (path.relative(rootDir, filePath) === EXCLUDED_FILE) {
+            return total;
+        }
+        return total + countArbitraryHexClasses(readFileSync(filePath, "utf8"));
+    }, 0);
+}
+
+function main() {
+    const count = scanRepo(process.cwd());
+    console.log(`hardcoded arbitrary hex utilities: ${count} (baseline ${BASELINE})`);
+
+    if (count > BASELINE) {
+        console.error(
+            "hardcoded arbitrary hex utility baseline exceeded; use a token from app/globals.css @theme instead of a new arbitrary hex"
+        );
+        process.exit(1);
+    }
+
+    process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/frontend/styles/tokens.ts
+++ b/frontend/styles/tokens.ts
@@ -1,0 +1,100 @@
+/** Custom soundspan color tokens shared by runtime checks and tests. */
+export const DESIGN_TOKENS: Record<string, string> = {
+    brand: "#3b82f6",
+    "brand-dark": "#2563eb",
+    "brand-hover": "#60a5fa",
+    "brand-light": "#93c5fd",
+    ai: "#2323ff",
+    "ai-dark": "#1a1acc",
+    "ai-hover": "#5b5bff",
+    surface: "#0a0a0a",
+    "surface-active": "#1c1c1c",
+    "surface-elevated": "#181818",
+    "surface-highlight": "#282828",
+    "surface-hover": "#1a1a1a",
+    "surface-overlay": "#141414",
+    "surface-raised": "#0f0f0f",
+    "surface-sunken": "#121212",
+    line: "#262626",
+    "line-muted": "#404040",
+    "line-strong": "#333333",
+    content: "#ffffff",
+    "content-body": "#e5e5e5",
+    "content-disabled": "#525252",
+    "content-muted": "#737373",
+    "content-secondary": "#a3a3a3",
+    error: "#ef4444",
+    success: "#22c55e",
+    warning: "#f59e0b",
+};
+
+/** WCAG AA contrast threshold for normal text. */
+export const AA_NORMAL = 4.5;
+
+/** WCAG AA contrast threshold for large text. */
+export const AA_LARGE = 3;
+
+/** WCAG contrast threshold for non-text UI components and states. */
+export const NON_TEXT = 3;
+
+type Rgb = readonly [number, number, number];
+
+function parseHex(hex: string): Rgb {
+    if (!/^#[0-9a-fA-F]{6}$/.test(hex)) {
+        throw new TypeError(`Expected a 6-digit hex color, received: ${hex}`);
+    }
+
+    return [
+        Number.parseInt(hex.slice(1, 3), 16),
+        Number.parseInt(hex.slice(3, 5), 16),
+        Number.parseInt(hex.slice(5, 7), 16),
+    ];
+}
+
+function linearizeSrgb(channel: number): number {
+    const srgb = channel / 255;
+    return srgb <= 0.04045
+        ? srgb / 12.92
+        : ((srgb + 0.055) / 1.055) ** 2.4;
+}
+
+/** Calculates WCAG relative luminance for a six-digit sRGB hex color. */
+export function relativeLuminance(hex: string): number {
+    const [red, green, blue] = parseHex(hex);
+    return (
+        0.2126 * linearizeSrgb(red) +
+        0.7152 * linearizeSrgb(green) +
+        0.0722 * linearizeSrgb(blue)
+    );
+}
+
+/** Calculates the WCAG contrast ratio between two six-digit sRGB hex colors. */
+export function contrastRatio(fgHex: string, bgHex: string): number {
+    const foreground = relativeLuminance(fgHex);
+    const background = relativeLuminance(bgHex);
+    const lighter = Math.max(foreground, background);
+    const darker = Math.min(foreground, background);
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+function channelToHex(channel: number): string {
+    return Math.round(channel).toString(16).padStart(2, "0");
+}
+
+/** Composites a six-digit foreground color over a six-digit background color. */
+export function compositeOver(
+    fgHex: string,
+    bgHex: string,
+    alpha: number
+): string {
+    const foreground = parseHex(fgHex);
+    const background = parseHex(bgHex);
+    if (!Number.isFinite(alpha) || alpha < 0 || alpha > 1) {
+        throw new RangeError(`Expected alpha between 0 and 1, received: ${alpha}`);
+    }
+
+    const channels = foreground.map(
+        (channel, index) => channel * alpha + background[index] * (1 - alpha)
+    );
+    return `#${channels.map(channelToHex).join("")}`;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,14 +7,7 @@ module.exports = {
     ],
     theme: {
         extend: {
-            colors: {
-                brand: {
-                    DEFAULT: '#3b82f6',
-                    hover: '#60a5fa',
-                    light: '#93c5fd',
-                    dark: '#2563eb'
-                }
-            },
+            // Colors live in app/globals.css @theme (Tailwind v4 CSS-first)
             screens: {
                 '3xl': '1920px',  // TV/Large Desktop
                 '4xl': '2560px',  // 4K TV/Large TV

--- a/frontend/tests/unit/designTokensContrast.test.ts
+++ b/frontend/tests/unit/designTokensContrast.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+    AA_NORMAL,
+    compositeOver,
+    contrastRatio,
+    DESIGN_TOKENS,
+    NON_TEXT,
+    relativeLuminance,
+} from "../../styles/tokens";
+import {
+    SETTINGS_FIELD_FOCUS_RING,
+    SETTINGS_FOCUS_RING_TOKEN,
+} from "../../features/settings/components/ui/settingsFieldStyles";
+
+const globalsCss = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+const themeBlock = globalsCss.match(/@theme\s*\{([^}]*)\}/)?.[1];
+
+assert.ok(themeBlock, "globals.css must contain an @theme block");
+
+const themeColors = Object.fromEntries(
+    [...themeBlock.matchAll(/--color-([\w-]+):\s*(#[0-9a-fA-F]{6});/g)].map(
+        ([, name, hex]) => [name, hex.toLowerCase()]
+    )
+);
+
+test("globals.css @theme stays synchronized with DESIGN_TOKENS", () => {
+    for (const [name, hex] of Object.entries(DESIGN_TOKENS)) {
+        assert.equal(themeColors[name], hex, `--color-${name} must equal ${hex}`);
+    }
+});
+
+test("text and brand tokens meet the normal-text contrast floor", () => {
+    for (const foreground of [
+        DESIGN_TOKENS["content-secondary"],
+        DESIGN_TOKENS["content-body"],
+        DESIGN_TOKENS.brand,
+        DESIGN_TOKENS["brand-hover"],
+        "#9ca3af",
+    ]) {
+        assert.ok(contrastRatio(foreground, DESIGN_TOKENS.surface) >= AA_NORMAL);
+    }
+});
+
+test("gray-500 and gray-600 document contrast failures on surface", () => {
+    assert.ok(contrastRatio("#6b7280", DESIGN_TOKENS.surface) < AA_NORMAL);
+    assert.ok(contrastRatio("#4b5563", DESIGN_TOKENS.surface) < AA_NORMAL);
+});
+
+test("settings focus ring token meets non-text contrast", () => {
+    assert.equal(
+        SETTINGS_FIELD_FOCUS_RING,
+        "focus:outline-none focus:ring-2 focus:ring-brand-hover"
+    );
+    assert.ok(SETTINGS_FOCUS_RING_TOKEN in DESIGN_TOKENS);
+    assert.ok(
+        contrastRatio(
+            DESIGN_TOKENS[SETTINGS_FOCUS_RING_TOKEN],
+            DESIGN_TOKENS["line-muted"]
+        ) >= NON_TEXT
+    );
+});
+
+test("old translucent white settings focus ring fails non-text contrast", () => {
+    const focusedInput = DESIGN_TOKENS["line-muted"];
+    const oldRing = compositeOver("#ffffff", focusedInput, 0.2);
+
+    assert.ok(contrastRatio(oldRing, focusedInput) < NON_TEXT);
+});
+
+test("color helpers reject malformed hex and out-of-range alpha", () => {
+    assert.throws(() => relativeLuminance("#fff"), TypeError);
+    assert.throws(() => contrastRatio("not-a-color", "#000000"), TypeError);
+    assert.throws(() => compositeOver("#ffffff", "#000000", -0.01), RangeError);
+    assert.throws(() => compositeOver("#ffffff", "#000000", 1.01), RangeError);
+});

--- a/frontend/tests/unit/hardcodedHexRatchet.test.ts
+++ b/frontend/tests/unit/hardcodedHexRatchet.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+    BASELINE,
+    countArbitraryHexClasses,
+    scanRepo,
+} from "../../scripts/check-hardcoded-hex.mjs";
+
+test("counts arbitrary-value hex color utilities", () => {
+    assert.equal(
+        countArbitraryHexClasses("a bg-[#3b82f6] text-[#fff] w-4"),
+        2
+    );
+});
+
+test("ignores token and palette color utilities", () => {
+    assert.equal(countArbitraryHexClasses("bg-brand text-gray-400"), 0);
+});
+
+test("frontend arbitrary-value hex utilities stay within the baseline", () => {
+    const frontendRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+    assert.ok(scanRepo(frontendRoot) <= BASELINE);
+});


### PR DESCRIPTION
## Summary (refactor slice P28 — design-tokens-contrast)

Centralizes the frontend color system on a single Tailwind v4 CSS-first `@theme`
palette so the brand is forkable in one place, then codemods the scattered
hardcoded palette hexes onto those tokens with **zero visual diff**. Adds the
WCAG contrast fixes flagged for the near-black theme.

## Findings addressed
- **479+ hardcoded hex literals bypass the brand token (brand unforkable).**
  Established `@theme` tokens (brand / AI / surface / line / content / status),
  removed the duplicate `brand` colors from `tailwind.config.js` (single source
  of truth), and codemodded ~900 arbitrary-value hex utilities
  (`bg-[#..]`/`text-[#..]`/`border`/`ring`/gradient/`accent`/…) across
  `app`, `components`, `features` to token utilities whose values are
  byte-identical to the originals (verified against the built CSS).
- **Low-contrast text and focus indicators on the near-black theme.**
  Raised `text-gray-500/600/700` (fail AA on `#0a0a0a`: 4.10 / 2.62) to the
  `text-gray-400` floor (7.80:1, AA). Replaced the effectively-invisible
  settings focus ring (`ring-white/20`, composited 1.81:1) with a shared
  `focus:ring-brand-hover` (4.08:1 vs the focused input bg — WCAG 1.4.11 ≥ 3:1)
  in `SettingsInput`/`SettingsSelect`.
- **Guard against regressions.** Added `frontend/scripts/check-hardcoded-hex.mjs`
  (`npm run lint:hex`), a ratchet at baseline **130** residual arbitrary hexes
  (provider brand colors + decorative gradient art), failing on any increase.

## Tests
- `tests/unit/designTokensContrast.test.ts` — @theme↔tokens sync guard, AA
  contrast floors, focus-ring non-text contrast (and proof the old white/20 ring
  failed), color-helper input validation. TDD red→green.
- `tests/unit/hardcodedHexRatchet.test.ts` — counter correctness + repo stays ≤ baseline.

## Verification
- `tsc --noEmit` exit 0
- unit tests: 9 pass / 0 fail
- `eslint .`: 244 warnings / 0 errors — **identical to origin/main** (delta 0; new files lint clean)
- `next build` exit 0; new token utilities confirmed present in built CSS with exact hex values
- `npm run lint:hex`: 130 (baseline 130) exit 0

## Scope notes / disjointness
- `AudioPlaybackOrchestrator.tsx` (concurrent slice P33) untouched (it had 0 hexes); `hooks/**` and `lib/audio-engine/**` untouched.
- Rebase conflicts in `Modal.tsx`/`ConfirmDialog.tsx` (from merged a11y-core) resolved by taking the a11y version and re-applying tokenization.
- **Minor scope extension:** added `frontend/scripts/check-hardcoded-hex.mjs` + a `lint:hex` npm script (scope listed only `app`/`components`/`features` + `tailwind.config.js`/`globals.css`) to deliver the required CI grep guard.

## Follow-ups (not in this slice)
- Wire `npm run lint:hex` into the `Frontend Quality Visibility` CI job (owned by ci-test-gates / `quality-visibility.yml`, out of this slice's scope).
- 130 residual literals remain (provider brand colors `#1db954`/`#1ed760`/`#d51007`, the `#00bfff`/`#00c8ff` accent-glow pair used ~34×, off-scale one-off grays). The accent-glow pair is a reasonable future token; provider colors should stay literal.
- `content-muted` (#737373, 4.18:1) meta/timestamp token is marginal for normal text (passes AA-large); left as the intentional design token.

## Breaking changes / UPGRADING
None. Pure styling; token values equal the previous literals. The contrast bumps are intentional visual changes (brighter secondary text, visible settings focus ring).
