### PR TITLE
fix(docker): AIO image user setup tolerant of missing node user + existing uid/gid 1000 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,6 +435,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AIO image builds no longer fail while removing the base image's `node` user:
+  `userdel` and `groupdel` are now conditional, and existing uid/gid 1000
+  holders are renamed and reused instead of failing `groupadd` or `useradd`.
 - OpenAPI contract sync: the generated spec (`GET /api/docs.json`, `/api/docs`)
   no longer advertises 24 phantom endpoints. The `@openapi` path keys for the
   API-key, auth (`login`/`me`), library-scan, listen-together, lyrics, mixes,

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,27 @@ RUN mkdir -p /app/backend /app/frontend /app/audio-analyzer /app/models \
     /data/postgres /data/redis /run/postgresql /var/log/supervisor \
     && chown -R postgres:postgres /data/postgres /run/postgresql
 
-# The upstream Node image reserves uid/gid 1000 for "node"; replace it with
-# the fixed runtime identity expected by the chart's fsGroup.
-RUN userdel node && groupdel node && \
-    groupadd -g 1000 soundspan && \
-    useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin -d /app soundspan
+# The chart's fsGroup expects fixed uid/gid 1000. Base Node user presence varies,
+# and on Debian userdel may also remove its same-named empty primary group.
+RUN set -eux; \
+    if getent passwd node > /dev/null; then userdel node; fi; \
+    if getent group node > /dev/null; then groupdel node; fi; \
+    existing_group="$(getent group 1000 | cut -d: -f1 || true)"; \
+    if [ -n "$existing_group" ]; then \
+        if [ "$existing_group" != soundspan ]; then groupmod -n soundspan "$existing_group"; fi; \
+    else \
+        groupadd -g 1000 soundspan; \
+    fi; \
+    existing_user="$(getent passwd 1000 | cut -d: -f1 || true)"; \
+    if [ -n "$existing_user" ]; then \
+        if [ "$existing_user" != soundspan ]; then \
+            usermod -l soundspan -g 1000 -d /app -s /usr/sbin/nologin "$existing_user"; \
+        else \
+            usermod -g 1000 -d /app -s /usr/sbin/nologin soundspan; \
+        fi; \
+    else \
+        useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin -d /app soundspan; \
+    fi
 
 # ============================================
 # AUDIO ANALYZER SETUP (Essentia AI)


### PR DESCRIPTION
## Root cause

Main's non-required "Build & Push AIO Image" job fails on `1a4085f` at Dockerfile step 4/44:

```
RUN userdel node && groupdel node && groupadd -g 1000 soundspan && useradd ...
groupdel: group 'node' does not exist  (exit code 6)
```

On `node:24-bookworm-slim` (digest `3638d9a6...`, same one CI pulled), `userdel node` succeeds **and** — Debian shadow-utils behavior — also removes the user's same-named empty primary group, so the follow-up `groupdel node` fails and aborts the build. The latent bug from the P14 aio-image-hardening slice was previously masked by the GHA layer cache; once that layer's cache invalidated, every main build failed. Mutable base tags can also legitimately ship without a `node` user, or with a different holder of uid/gid 1000.

## Fix

Replace the RUN block with a single idempotent layer: every removal is guarded by `getent`, and if uid/gid 1000 is still held after cleanup the holder is renamed/converted (`groupmod -n` / `usermod`) instead of failing `groupadd`/`useradd`. End state is unchanged from P14's hardening intent: non-root `soundspan` uid/gid 1000, home `/app`, `/usr/sbin/nologin`, no home dir created (matches the chart's fsGroup).

## Verification

- Ran the exact fixed block via `sh -c` (matching buildx's `/bin/sh`) in a throwaway `node:24-bookworm-slim` container across three base states: (1) node user present as shipped, (2) node user absent, (3) uid/gid 1000 held by a different name. All exit 0 with identical end state `soundspan:x:1000:1000::/app:/usr/sbin/nologin`.
- Scenario 1's xtrace directly reproduces the bug: after `userdel node`, `getent group node` already finds nothing.
- `docker buildx build --check .` — no warnings.
- Full AIO build not run locally (disk constraints); the real gate is the "Build & Push AIO Image" job on push to main, which I will watch post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24