### PR TITLE
fix(helm): frontend pod inherits UID 1000, drop stale 1001 override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned the mypy type-check target (`python_version`) to Python 3.11 to match
   the repo floor (Ruff `py311` and the audio-analyzer `python:3.11-slim` pin), so
   type checks run against the oldest interpreter the sidecars use.
+- Frontend Helm pod no longer runs as the stale UID 1001; the chart frontend
+  override was removed so the pod inherits the chart-wide UID/GID 1000 pod
+  security context, matching the realigned frontend image (`USER node`) and
+  fixing `.next/cache` write failures in individual deployment mode.
 
 ### Security
 

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -278,13 +278,6 @@ frontend:
     tag: 1.9.0
     pullPolicy: Always
   replicas: 1
-  # The published frontend image's `nextjs` user is UID/GID 1001, not the
-  # chart-wide 1000. Override here so file ownership in the image matches the
-  # runtime user until the image is realigned (docker-image-hygiene slice).
-  podSecurityContext:
-    runAsUser: 1001
-    runAsGroup: 1001
-    fsGroup: 1001
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -107,10 +107,10 @@ tight resource quotas, run custom sidecars in chart pods, or have GPU nodes.
   raise it or set `aio.resources.limits.memory` back down (and disable analysis
   with `config.features.audioAnalysis: false` if you do).
 
-- **Frontend runs as UID 1001.** The chart now runs the frontend pod as
-  UID/GID `1001` to match the published image's `nextjs` user. If you mount a
-  pre-existing writable volume for the frontend (e.g. `.next/cache`), its
-  ownership may need updating; the default cache is an `emptyDir` and needs no
+- **Frontend inherits UID/GID 1000.** The frontend pod inherits the chart-wide
+  UID/GID `1000` pod security context, matching the realigned image's `node`
+  user. The earlier `1001` override was removed; see the top-of-file **frontend
+  image runtime UID changed from 1001 to 1000** breaking note for volume-ownership
   action.
 
 - **Analyzer probes.** Individual-mode audio-analyzer and CLAP Deployments now

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -30,7 +30,8 @@ tmp_sidecars="$(mktemp)"
 tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_individual_ha" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing"' EXIT
+tmp_frontend_uid="$(mktemp)"
+trap 'rm -f "$tmp_aio" "$tmp_individual_ha" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -151,6 +152,21 @@ helm template "$RELEASE_NAME" "$CHART_PATH" \
   >"$tmp_secret_existing"
 if line_match '^kind: Secret$' "$tmp_secret_existing"; then
   echo "[ERROR] existingSecret set but chart still rendered a managed Secret" >&2
+  exit 1
+fi
+
+echo "[CHECK] render individual-mode frontend inherits global UID 1000 pod security context"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  >"$tmp_frontend_uid"
+if ! perl -0777 -ne '
+    for my $doc (split /^---/m, $_) {
+        next unless $doc =~ /kind:\s*Deployment/;
+        next unless $doc =~ /^  name: '"$RELEASE_NAME"'-frontend$/m;
+        exit 0 if $doc =~ /runAsUser:\s+1000\b/s && $doc !~ /runAsUser:\s+1001\b/s;
+    }
+    exit 1' "$tmp_frontend_uid"; then
+  echo "[ERROR] individual-mode frontend pod securityContext must render runAsUser: 1000 (inherit global; stale 1001 frontend override must be removed)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Finding

HIGH cross-slice regression. P30 realigned `frontend/Dockerfile` to `USER node` (UID/GID 1000, `COPY --chown=node:node`; enforced by `scripts/ci/dockerfile-hygiene.test.mjs` test 3). But `charts/soundspan/values.yaml` `frontend.podSecurityContext` still pinned `runAsUser/runAsGroup/fsGroup: 1001` with a now-false comment. `templates/individual/frontend.yaml` merges the frontend override OVER global (`merge (frontend) (global)` — Sprig merge, override wins), so the frontend pod ran as UID 1001 against a 1000-owned filesystem tree and `.next/cache` writes failed.

## Fix

- Removed the stale `frontend.podSecurityContext` override (1001) and its false comment from `charts/soundspan/values.yaml`, so the frontend pod inherits the chart-wide `global.podSecurityContext` (UID/GID 1000).
- Added a render assertion to `scripts/helm-chart-render-check.sh` proving individual-mode frontend renders `runAsUser: 1000` (and never `1001`).
- Refreshed the now-false "Frontend runs as UID 1001" note in `docs/UPGRADING.md` and added a `### Fixed` CHANGELOG entry.

No template change was needed: the existing `merge (frontend override) (global)` correctly falls back to global once the override is empty.

## Verification

- `bash scripts/helm-chart-render-check.sh` — TDD RED before fix (new assertion failed detecting `1001`), GREEN after (`[OK] Helm render checks passed`, exit 0).
- `helm template soundspan charts/soundspan --set deploymentMode=individual` — frontend pod securityContext now renders `runAsUser/runAsGroup/fsGroup: 1000`.
- `helm lint` passes (run inside the render-check script).
- Confirmed no lingering `1001` references remain under `charts/`.