### PR TITLE
fix(lidarr): bound queue/history helper HTTP calls with explicit timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Lidarr queue/history helper HTTP calls are now bounded. The module-level
+  `cleanStuckDownloads`, `getRecentCompletedDownloads`, `getQueueCount`,
+  `getQueue`, and `isDownloadActive` helpers in `backend/src/services/lidarr.ts`
+  previously issued bare `axios` requests with no `timeout`, inheriting axios's
+  unbounded default (`0`). Because `QueueCleaner.runCleanup` only reschedules its
+  30s reconcile/clean loop after its awaits resolve, a single hung Lidarr call
+  could stall the loop indefinitely. Each call now carries an explicit
+  `timeout: 30000`, matching the class client on the same module.
 - AIO image builds no longer fail while removing the base image's `node` user:
   `userdel` and `groupdel` are now conditional, and existing uid/gid 1000
   holders are renamed and reused instead of failing `groupadd` or `useradd`.

--- a/backend/src/services/__tests__/lidarrService.test.ts
+++ b/backend/src/services/__tests__/lidarrService.test.ts
@@ -4756,3 +4756,86 @@ describe("lidarr exported queue/history helpers", () => {
         ).rejects.toThrow("history down");
     });
 });
+
+describe("lidarr exported queue/history helpers bound HTTP calls", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetSystemSettings.mockResolvedValue({
+            lidarrEnabled: true,
+            lidarrUrl: "http://lidarr:8686",
+            lidarrApiKey: "api-key",
+        });
+    });
+
+    it("cleanStuckDownloads sends an explicit timeout on queue fetch and delete", async () => {
+        mockAxiosGet.mockResolvedValueOnce({
+            data: {
+                records: [
+                    {
+                        id: 5,
+                        title: "Stuck Album",
+                        statusMessages: [],
+                        trackedDownloadStatus: "warning",
+                        trackedDownloadState: "importFailed",
+                    },
+                ],
+            },
+        });
+        mockAxiosDelete.mockResolvedValue({});
+
+        await cleanStuckDownloads("http://lidarr:8686", "api-key");
+
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+        expect(mockAxiosDelete).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+    });
+
+    it("getRecentCompletedDownloads sends an explicit timeout", async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { records: [] } });
+
+        await getRecentCompletedDownloads("http://lidarr:8686", "api-key", 5);
+
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+    });
+
+    it("getQueueCount sends an explicit timeout", async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { totalRecords: 0 } });
+
+        await getQueueCount("http://lidarr:8686", "api-key");
+
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+    });
+
+    it("getQueue sends an explicit timeout", async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { records: [] } });
+
+        await getQueue();
+
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+    });
+
+    it("isDownloadActive sends an explicit timeout", async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { records: [] } });
+
+        await isDownloadActive("dl-1");
+
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ timeout: 30000 }),
+        );
+    });
+});

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -2721,6 +2721,7 @@ export async function cleanStuckDownloads(
                     pageSize: 100,
                     includeUnknownArtistItems: true,
                 },
+                timeout: 30000,
                 headers: { "X-Api-Key": apiKey },
             },
         );
@@ -2779,6 +2780,7 @@ export async function cleanStuckDownloads(
                             blocklist: true, // Don't try this release again
                             skipRedownload: false, // DO trigger new search
                         },
+                        timeout: 30000,
                         headers: { "X-Api-Key": apiKey },
                     });
 
@@ -2829,6 +2831,7 @@ export async function getRecentCompletedDownloads(
                     sortDirection: "descending",
                     eventType: 3, // 3 = downloadFolderImported (successful import)
                 },
+                timeout: 30000,
                 headers: { "X-Api-Key": apiKey },
             },
         );
@@ -2859,6 +2862,7 @@ export async function getQueueCount(
                     page: 1,
                     pageSize: 1,
                 },
+                timeout: 30000,
                 headers: { "X-Api-Key": apiKey },
             },
         );
@@ -2892,6 +2896,7 @@ export async function getQueue(): Promise<QueueItem[]> {
                     pageSize: 100,
                     includeUnknownArtistItems: true,
                 },
+                timeout: 30000,
                 headers: { "X-Api-Key": settings.lidarrApiKey },
             },
         );
@@ -2928,6 +2933,7 @@ export async function isDownloadActive(
                     pageSize: 100,
                     includeUnknownArtistItems: true,
                 },
+                timeout: 30000,
                 headers: { "X-Api-Key": settings.lidarrApiKey },
             },
         );


### PR DESCRIPTION
## Finding (MEDIUM, bounded-work)

The module-level exported helpers in \`backend/src/services/lidarr.ts\` — \`cleanStuckDownloads\` (both the \`axios.get\` queue fetch and the \`axios.delete\`), \`getRecentCompletedDownloads\`, \`getQueueCount\`, \`getQueue\`, and \`isDownloadActive\` — issued bare \`axios\` requests passing only \`params\` + \`headers\` with **no \`timeout\`**, inheriting axios's unbounded default (\`0\`). This is unlike the class-based client on the same module (\`timeout: 30000\`) and \`simpleDownloadManager\` (\`10000\`).

\`cleanStuckDownloads\` and \`getRecentCompletedDownloads\` run inside \`QueueCleaner.runCleanup\` (\`backend/src/jobs/queueCleaner.ts\`), which self-reschedules its 30s reconcile/clean loop via \`setTimeout\` **only after its awaits resolve**. A single hung Lidarr call therefore permanently stalls the reconcile/clean loop.

## Fix

Add an explicit \`timeout: 30000\` (matching the shared class client on the same module) to each of the six bare axios call config objects in the five helper functions. No other changes; the class-based client already carries a timeout and was left untouched.

## Verification

- verify: TDD — added a \`describe("lidarr exported queue/history helpers bound HTTP calls")\` block asserting each helper's axios call carries \`timeout: 30000\`; 5 tests RED before the fix.
- verify: \`npx jest --maxWorkers=2 src/services/__tests__/lidarrService.test.ts src/jobs/__tests__/queueCleaner.test.ts\` → 2 passed, 169/169 tests.
- verify: \`npx tsc --noEmit\` (backend) exit 0, 0 errors.

Scope: \`backend/src/services/lidarr.ts\`, \`backend/src/services/__tests__/lidarrService.test.ts\`, \`CHANGELOG.md\`.