### PR TITLE
fix(sidecars): offload blocking OAuth/search calls to worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `error` string and HTTP status are unchanged; the frontend reads only `error`,
   so no client action is required.
 
+### Fixed
+
+- **Sidecar event-loop offload for OAuth onboarding and search.** The
+  `tidal-downloader` (`/auth/device`, `/auth/token`, `/auth/refresh`, `/search`)
+  and `ytmusic-streamer` (`/auth/device-code`, `/auth/device-code/poll`) async
+  handlers called blocking third-party `tiddl`/`ytmusicapi` methods directly on
+  the event loop. During device-code onboarding the poll endpoint runs every few
+  seconds, so a blocking call there serialized concurrent onboarding and
+  streaming across all users. Each blocking call is now wrapped in
+  `asyncio.to_thread`, matching the existing offload pattern already used for the
+  per-user refresh path.
+
 ### Security
 
 - Path containment on native audio streaming: the `GET /api/library/tracks/:id/stream`

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -981,7 +981,7 @@ async def auth_device():
     """Step 1: Initiate device-code OAuth flow. Returns a verification URL."""
     try:
         auth_api = AuthAPI()
-        device_auth = auth_api.get_device_auth()
+        device_auth = await asyncio.to_thread(auth_api.get_device_auth)
         return {
             "device_code": device_auth.deviceCode,
             "user_code": device_auth.userCode,
@@ -1004,7 +1004,7 @@ async def auth_token(req: AuthTokenRequest):
     """Step 2: Poll for token after user has authorised the device code."""
     try:
         auth_api = AuthAPI()
-        auth_response = auth_api.get_auth(req.device_code)
+        auth_response = await asyncio.to_thread(auth_api.get_auth, req.device_code)
         return {
             "access_token": auth_response.access_token,
             "refresh_token": auth_response.refresh_token,
@@ -1035,7 +1035,7 @@ async def auth_refresh(req: RefreshRequest):
     """Refresh an expired access token."""
     try:
         auth_api = AuthAPI()
-        auth_response = auth_api.refresh_token(req.refresh_token)
+        auth_response = await asyncio.to_thread(auth_api.refresh_token, req.refresh_token)
         return {
             "access_token": auth_response.access_token,
             "token_type": auth_response.token_type,
@@ -1091,7 +1091,7 @@ async def search(
     """Search using bearer-header auth or the one-release query fallback."""
     api = _build_api(creds.access_token, creds.user_id, creds.country_code)
     try:
-        results = api.get_search(req.query)
+        results = await asyncio.to_thread(api.get_search, req.query)
         return {
             "tracks": [
                 {

--- a/services/tidal-downloader/tests/test_blocking_offload.py
+++ b/services/tidal-downloader/tests/test_blocking_offload.py
@@ -1,0 +1,125 @@
+"""Tests that blocking TIDAL auth/search calls run off the event-loop thread."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+
+def _fake_user() -> types.SimpleNamespace:
+    """Minimal TIDAL user object returned by auth responses."""
+    return types.SimpleNamespace(userId=42, countryCode="US", username="tester")
+
+
+@pytest.mark.anyio
+async def test_device_auth_offloaded_to_worker_thread(client, monkeypatch):
+    """Device-auth initiation should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeAuthAPI:
+        def get_device_auth(self):
+            captured["t"] = threading.current_thread().name
+            return types.SimpleNamespace(
+                deviceCode="dc",
+                userCode="uc",
+                verificationUri="https://example.test/verify",
+                verificationUriComplete="https://example.test/verify?uc",
+                expiresIn=300,
+                interval=5,
+            )
+
+    monkeypatch.setattr(app, "AuthAPI", FakeAuthAPI)
+
+    response = await client.post("/auth/device")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_token_exchange_offloaded_to_worker_thread(client, monkeypatch):
+    """Token exchange should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeAuthAPI:
+        def get_auth(self, device_code):
+            captured["t"] = threading.current_thread().name
+            return types.SimpleNamespace(
+                access_token="at",
+                refresh_token="rt",
+                token_type="Bearer",
+                expires_in=3600,
+                user=_fake_user(),
+            )
+
+    monkeypatch.setattr(app, "AuthAPI", FakeAuthAPI)
+
+    response = await client.post("/auth/token", json={"device_code": "dc"})
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_token_refresh_offloaded_to_worker_thread(client, monkeypatch):
+    """Token refresh should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeAuthAPI:
+        def refresh_token(self, refresh_token):
+            captured["t"] = threading.current_thread().name
+            return types.SimpleNamespace(
+                access_token="at2",
+                token_type="Bearer",
+                expires_in=3600,
+                user=_fake_user(),
+            )
+
+    monkeypatch.setattr(app, "AuthAPI", FakeAuthAPI)
+
+    response = await client.post("/auth/refresh", json={"refresh_token": "rt"})
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_search_offloaded_to_worker_thread(client, monkeypatch):
+    """Admin search should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def _empty_results():
+        return types.SimpleNamespace(
+            tracks=types.SimpleNamespace(items=[]),
+            albums=types.SimpleNamespace(items=[]),
+            artists=types.SimpleNamespace(items=[]),
+        )
+
+    def fake_get_search(query):
+        captured["t"] = threading.current_thread().name
+        return _empty_results()
+
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda *_args, **_kwargs: types.SimpleNamespace(get_search=fake_get_search),
+    )
+
+    response = await client.post(
+        "/search",
+        json={"query": "q"},
+        headers={"Authorization": "Bearer tok-header", "x-tidal-user-id": "u1"},
+    )
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -1485,7 +1485,7 @@ async def auth_device_code(req: DeviceCodeRequest):
             client_id=req.client_id,
             client_secret=req.client_secret,
         )
-        code = oauth_creds.get_code()
+        code = await asyncio.to_thread(oauth_creds.get_code)
         log.info(f"Device code flow initiated, user_code: {code.get('user_code')}")
         return {
             "device_code": code["device_code"],
@@ -1523,7 +1523,9 @@ async def auth_device_code_poll(req: DeviceCodePollRequest, user_id: str = Query
             client_id=req.client_id,
             client_secret=req.client_secret,
         )
-        token = cast(dict[str, Any], oauth_creds.token_from_code(req.device_code))
+        token = cast(
+            dict[str, Any], await asyncio.to_thread(oauth_creds.token_from_code, req.device_code)
+        )
 
         # Check if we got an error (authorization_pending, slow_down, etc.)
         if "error" in token:

--- a/services/ytmusic-streamer/tests/test_blocking_offload.py
+++ b/services/ytmusic-streamer/tests/test_blocking_offload.py
@@ -62,3 +62,63 @@ async def test_charts_offloaded_to_worker_thread(client, monkeypatch):
 
     assert response.status_code == 200
     assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_device_code_offloaded_to_worker_thread(client, monkeypatch):
+    """OAuth device-code initiation should run in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeOAuthCredentials:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_code(self):
+            captured["t"] = threading.current_thread().name
+            return {
+                "device_code": "dc",
+                "user_code": "uc",
+                "verification_url": "https://example.test/verify",
+                "expires_in": 1800,
+                "interval": 5,
+            }
+
+    monkeypatch.setattr(app, "OAuthCredentials", FakeOAuthCredentials)
+
+    response = await client.post(
+        "/auth/device-code",
+        json={"client_id": "cid", "client_secret": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_device_code_poll_offloaded_to_worker_thread(client, monkeypatch):
+    """OAuth device-code polling should run in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeOAuthCredentials:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def token_from_code(self, device_code):
+            captured["t"] = threading.current_thread().name
+            # Pending short-circuits before any file writes.
+            return {"error": "authorization_pending"}
+
+    monkeypatch.setattr(app, "OAuthCredentials", FakeOAuthCredentials)
+
+    response = await client.post(
+        "/auth/device-code/poll?user_id=u1",
+        json={"client_id": "cid", "client_secret": "secret", "device_code": "dc"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending", "error": "authorization_pending"}
+    assert captured["t"] != "MainThread"


### PR DESCRIPTION
## Finding

MEDIUM P9 gap (12-dim review sweep, verified against origin/main). Several FastAPI **async** handlers in the Python sidecars called blocking third-party `tiddl`/`ytmusicapi` methods **directly on the event loop**:

- `services/tidal-downloader/app.py`: `auth_device` → `get_device_auth()`, `auth_token` → `get_auth()`, `auth_refresh` → `refresh_token()`, `search` → `get_search()`
- `services/ytmusic-streamer/app.py`: `auth_device_code` → `get_code()`, `auth_device_code_poll` → `token_from_code()`

The device-code poll endpoint is hit every few seconds during onboarding, so a blocking call there **serializes concurrent onboarding and streaming** across all users. The per-user refresh path (`_refresh_user_api`, ~line 555) was already `asyncio.to_thread`-wrapped; these onboarding/search paths were not.

## Fix

Wrap each blocking third-party call in `asyncio.to_thread(...)`, mirroring the existing offload pattern. Exception handling and response shaping are unchanged. The one line that grew past the 100-char ruff limit (`token_from_code` in the poll handler) was reflowed to the formatter's layout.

## Verification

- `verify:` tidal targeted pytest — `test_blocking_offload.py` (new, 4 tests) + `test_admin_token_headers.py` + `test_error_sanitization.py` + `test_error_shape.py` → **19 passed**. Offload tests confirmed RED (asserted `MainThread`) before the fix, GREEN after.
- `verify:` ytmusic targeted pytest — `test_blocking_offload.py` (extended, +2 device-code tests) + `test_error_sanitization.py` + `test_error_shape.py` → **13 passed**. Device-code offload tests confirmed RED before, GREEN after.
- `verify:` `ruff check` (from repo root, per-file-ignores applied) → **All checks passed**; `ruff format --check` → **2 files already formatted**.

Tests assert each blocking call executes off `MainThread` by capturing `threading.current_thread().name` inside monkeypatched provider stubs.