### PR TITLE
fix(routes): stop leaking raw error text to clients (discover/enrichment/library)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Route error-message disclosure hardening (OWASP): the `discover`,
+  `enrichment`, and `library` routers no longer echo raw caught-error text
+  (`error.message` / `error.stack` / a `details` field carrying it) to clients.
+  Every affected handler now returns a static, curated `{ error: "…" }` message
+  and logs the raw error server-side only. This also fixes a latent bug in
+  `enrichment.ts` where a non-object throw (e.g. `null`) made the catch block
+  dereference `error.message` and throw again, leaving the request with no
+  response. The `check-route-error-canon` CI script gains a second,
+  independent ratchet that flags raw `error.message` / `error.stack` echoed
+  into response bodies (baseline can only decrease); the three fixed routers
+  are ratcheted to zero. Remaining routers with the pattern
+  (`downloads`, `listenTogether`, `notifications`, `playbackState`,
+  `playlists`, `podcasts`) are frozen at their current counts and tracked as
+  follow-up.
 - Digest-pinned the two remaining unpinned base images and closed the gap in the
   Dockerfile digest-pin ratchet. The root AIO `Dockerfile` (`node:24-bookworm-slim`)
   and `services/audio-analyzer/Dockerfile` (`python:3.11-slim`) were both unpinned

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -44,11 +44,26 @@ Reference exemplars: `vibe.ts`, `vibeJourneyRequest.ts`, `notifications.ts`,
 `library.ts`.
 
 **Enforcement (ratchet):** `scripts/ci/check-route-error-canon.mjs`
-(`npm run check:error-canon`) freezes the current per-file count of ad-hoc
-`res.status(500).json(...)` literals and fails when a route file adds new ones.
-When you canonicalize a route, lower its baseline in that script; new route
-files start at zero. Full migration of every route file is intentionally
-incremental (per touched file), not a big-bang.
+(`npm run check:error-canon`) runs two independent per-file ratchets and fails
+if either regresses:
+
+1. **500-literal ratchet** — freezes the current per-file count of ad-hoc
+   `res.status(500).json(...)` literals and fails when a route file adds new
+   ones.
+2. **Raw-error leak ratchet** — freezes the per-file count of raw caught-error
+   text echoed into a response body (`error.message` / `error?.message` /
+   `error.stack` used as a property value, e.g. `details: error?.message` or
+   `error: error.message || "…"`). Echoing raw exception text to clients is an
+   OWASP info-disclosure risk; return a static curated message and log the raw
+   error server-side instead. `discover.ts`, `enrichment.ts`, and `library.ts`
+   are at zero. The remaining routers still carrying the pattern
+   (`downloads.ts`, `listenTogether.ts`, `notifications.ts`,
+   `playbackState.ts`, `playlists.ts`, `podcasts.ts`) are frozen at their
+   current counts and remediated as follow-up.
+
+Both baselines can only DECREASE: when you canonicalize a route, lower its
+baseline in that script; new route files start at zero. Full migration of every
+route file is intentionally incremental (per touched file), not a big-bang.
 
 ## Mounted Route Modules
 

--- a/backend/src/routes/__tests__/discoverErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverErrorLeak.test.ts
@@ -100,9 +100,7 @@ function createRes() {
     return res;
 }
 
-const SECRET_ERROR = new Error(
-    "postgres://user:pw@db SECRET_LEAK_MARKER",
-);
+const SECRET_ERROR = new Error("postgres://user:pw@db SECRET_LEAK_MARKER");
 const req = {
     user: { id: "user-1" },
     params: {},

--- a/backend/src/routes/__tests__/discoverErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverErrorLeak.test.ts
@@ -1,0 +1,137 @@
+import { Request, Response } from "express";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
+        next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        discover: { mode: "recommendation" },
+        music: { musicPath: "/music" },
+    },
+}));
+
+const prisma = {
+    userDiscoverConfig: {
+        upsert: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+    },
+    discoverExclusion: {
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
+        findFirst: jest.fn(),
+        delete: jest.fn(),
+    },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+jest.mock("../../services/lastfm", () => ({
+    lastFmService: { getTopChartArtists: jest.fn() },
+}));
+
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+}));
+
+jest.mock("../../services/lidarr", () => ({ lidarrService: {} }));
+
+const discoverQueue = {
+    getJobs: jest.fn(),
+    getJob: jest.fn(),
+    add: jest.fn(),
+};
+const scanQueue = { add: jest.fn() };
+
+jest.mock("../../workers/queues", () => ({ discoverQueue, scanQueue }));
+
+const mockClearCurrentPlaylist = jest.fn();
+jest.mock("../../services/discovery", () => ({
+    discoveryRecommendationsService: {
+        getCurrentPlaylist: jest.fn(),
+        clearCurrentPlaylist: mockClearCurrentPlaylist,
+    },
+}));
+
+import router from "../discover";
+import { prisma as dbPrisma } from "../../utils/db";
+
+const mockDiscoverExclusionFindMany = dbPrisma.discoverExclusion
+    .findMany as jest.Mock;
+
+function getRouteHandler(
+    path: string,
+    method: "get" | "post" | "delete" | "patch",
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined as unknown,
+        status: jest.fn(function (code: number) {
+            res.statusCode = code;
+            return res;
+        }),
+        json: jest.fn(function (payload: unknown) {
+            res.body = payload;
+            return res;
+        }),
+    };
+    return res;
+}
+
+const SECRET_ERROR = new Error(
+    "postgres://user:pw@db SECRET_LEAK_MARKER",
+);
+const req = {
+    user: { id: "user-1" },
+    params: {},
+    query: {},
+    body: {},
+};
+
+describe("discover route errors do not disclose caught values", () => {
+    it("returns a curated exclusions error", async () => {
+        mockDiscoverExclusionFindMany.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/exclusions", "get")(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.error).toBe("Failed to get exclusions");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+
+    it("returns a curated clear-playlist error", async () => {
+        mockClearCurrentPlaylist.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/clear", "delete")(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.error).toBe("Failed to clear discovery playlist");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+});

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -893,8 +893,8 @@ describe("discover legacy-mode runtime behavior", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to clear discovery playlist",
-            details: "clear boom",
         });
+        expect(JSON.stringify(res.body)).not.toContain("clear boom");
     });
 
     it("covers lidarr-enabled legacy clear flows for moved, deleted, extra, failed, and tagged artists", async () => {
@@ -1272,10 +1272,8 @@ describe("discover legacy-mode runtime behavior", () => {
         await cleanupLidarrHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
-            error: "Failed to cleanup Lidarr",
-            details: "lidarr unavailable",
-        });
+        expect(res.body).toEqual({ error: "Failed to cleanup Lidarr" });
+        expect(JSON.stringify(res.body)).not.toContain("lidarr unavailable");
     });
 
     it("repairs mistagged discovery albums while preserving protected artists", async () => {
@@ -1358,9 +1356,9 @@ describe("discover legacy-mode runtime behavior", () => {
         await fixTaggingHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
-            error: "Failed to fix album tagging",
-            details: "discover table unavailable",
-        });
+        expect(res.body).toEqual({ error: "Failed to fix album tagging" });
+        expect(JSON.stringify(res.body)).not.toContain(
+            "discover table unavailable",
+        );
     });
 });

--- a/backend/src/routes/__tests__/discoverRecommendationCompat.test.ts
+++ b/backend/src/routes/__tests__/discoverRecommendationCompat.test.ts
@@ -446,8 +446,8 @@ describe("discover recommendation-mode compatibility", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to clear discovery playlist",
-            details: "clear failed",
         });
+        expect(JSON.stringify(res.body)).not.toContain("clear failed");
     });
 
     it("returns 410 for legacy-only mutation endpoints", async () => {

--- a/backend/src/routes/__tests__/discoverRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverRuntime.test.ts
@@ -533,10 +533,8 @@ describe("discover route runtime behavior", () => {
         await exclusionsGetHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
-            error: "Failed to get exclusions",
-            details: "db failed",
-        });
+        expect(res.body).toEqual({ error: "Failed to get exclusions" });
+        expect(JSON.stringify(res.body)).not.toContain("db failed");
     });
 
     it("clears all exclusions for current user", async () => {
@@ -637,8 +635,8 @@ describe("discover route runtime behavior", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to clear discovery playlist",
-            details: "clear boom",
         });
+        expect(JSON.stringify(res.body)).not.toContain("clear boom");
     });
 
     it("returns a 500 error when discovery config lookup fails", async () => {

--- a/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
@@ -1,0 +1,207 @@
+import { Request, Response } from "express";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/enrichment", () => ({
+    enrichmentService: {
+        getSettings: jest.fn(),
+        updateSettings: jest.fn(),
+        enrichArtist: jest.fn(),
+        applyArtistEnrichment: jest.fn(),
+        enrichAlbum: jest.fn(),
+        applyAlbumEnrichment: jest.fn(),
+    },
+}));
+
+jest.mock("../../workers/unifiedEnrichment", () => ({
+    getEnrichmentProgress: jest.fn(),
+    runFullEnrichment: jest.fn(),
+    reRunArtistsOnly: jest.fn(),
+    reRunMoodTagsOnly: jest.fn(),
+    reRunAudioAnalysisOnly: jest.fn(),
+    reRunVibeEmbeddingsOnly: jest.fn(),
+    triggerEnrichmentNow: jest.fn(),
+}));
+
+jest.mock("../../services/enrichmentState", () => ({
+    enrichmentStateService: {
+        getState: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        stop: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/enrichmentFailureService", () => ({
+    enrichmentFailureService: {
+        getFailures: jest.fn(),
+        getFailureCounts: jest.fn(),
+        resetRetryCount: jest.fn(),
+        getFailure: jest.fn(),
+        resolveFailures: jest.fn(),
+        skipFailures: jest.fn(),
+        clearAllFailures: jest.fn(),
+        deleteFailures: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/musicbrainz", () => ({
+    musicBrainzService: {
+        searchArtist: jest.fn(),
+        searchReleaseGroups: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+    invalidateSystemSettingsCache: jest.fn(),
+}));
+
+jest.mock("../../services/rateLimiter", () => ({
+    rateLimiter: {
+        updateConcurrencyMultiplier: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        del: jest.fn(),
+    },
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        features: {
+            audioAnalysis: true,
+            discovery: true,
+            autoPlaylists: true,
+        },
+    },
+}));
+
+const prisma = {
+    artist: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+    },
+    album: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+    },
+    track: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+    },
+    systemSettings: {
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+    },
+    ownedAlbum: {
+        deleteMany: jest.fn(),
+        upsert: jest.fn(),
+    },
+    user: {
+        findMany: jest.fn(async () => []),
+    },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+import router from "../enrichment";
+import { triggerEnrichmentNow } from "../../workers/unifiedEnrichment";
+import { enrichmentStateService } from "../../services/enrichmentState";
+
+const mockTriggerEnrichmentNow = triggerEnrichmentNow as jest.Mock;
+const mockPause = enrichmentStateService.pause as jest.Mock;
+
+function getRouteHandler(
+    path: string,
+    method: "get" | "post" | "put" | "delete",
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined as unknown,
+        status: jest.fn(function (code: number) {
+            res.statusCode = code;
+            return res;
+        }),
+        json: jest.fn(function (payload: unknown) {
+            res.body = payload;
+            return res;
+        }),
+    };
+    return res;
+}
+
+const SECRET_ERROR = new Error(
+    "postgres://user:pw@db SECRET_LEAK_MARKER",
+);
+const req = {
+    user: { id: "user-1" },
+    params: {},
+    query: {},
+    body: {},
+};
+
+describe("enrichment route errors do not disclose caught values", () => {
+    it("returns a curated sync error", async () => {
+        mockTriggerEnrichmentNow.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/sync", "post")(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.error).toBe("Failed to start sync");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+
+    it("returns a curated pause error", async () => {
+        mockPause.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/pause", "post")(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.error).toBe("Failed to pause enrichment");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+
+    it("responds safely when pause rejects with null", async () => {
+        mockPause.mockRejectedValueOnce(null);
+        const res = createRes();
+
+        await getRouteHandler("/pause", "post")(req, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+            error: "Failed to pause enrichment",
+        });
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+    });
+});

--- a/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
@@ -158,9 +158,7 @@ function createRes() {
     return res;
 }
 
-const SECRET_ERROR = new Error(
-    "postgres://user:pw@db SECRET_LEAK_MARKER",
-);
+const SECRET_ERROR = new Error("postgres://user:pw@db SECRET_LEAK_MARKER");
 const req = {
     user: { id: "user-1" },
     params: {},

--- a/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
@@ -214,7 +214,8 @@ describe("enrichment MusicBrainz lookup compatibility", () => {
         await searchArtistsHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "artist lookup failed" });
+        expect(res.body).toEqual({ error: "Search failed" });
+        expect(JSON.stringify(res.body)).not.toContain("artist lookup failed");
     });
 
     it("preserves non-numeric artist scores as NaN", async () => {
@@ -314,7 +315,10 @@ describe("enrichment MusicBrainz lookup compatibility", () => {
         await searchReleaseGroupsHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "release-group lookup failed" });
+        expect(res.body).toEqual({ error: "Search failed" });
+        expect(JSON.stringify(res.body)).not.toContain(
+            "release-group lookup failed",
+        );
     });
 
     it("normalizes missing artist-credit and score defaults for release-group lookup", async () => {

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -443,7 +443,8 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "musicbrainz down" });
+        expect(res.body).toEqual({ error: "Search failed" });
+        expect(JSON.stringify(res.body)).not.toContain("musicbrainz down");
     });
 
     it("validates musicbrainz release-group query length", async () => {
@@ -516,7 +517,8 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "release service down" });
+        expect(res.body).toEqual({ error: "Search failed" });
+        expect(JSON.stringify(res.body)).not.toContain("release service down");
     });
 
     it("returns enrichment progress payload", async () => {
@@ -606,7 +608,8 @@ describe("enrichment route runtime behavior", () => {
         await pauseHandler({ user: { id: "admin-1" } } as any, res);
 
         expect(res.statusCode).toBe(400);
-        expect(res.body).toEqual({ error: "already paused" });
+        expect(res.body).toEqual({ error: "Failed to pause enrichment" });
+        expect(JSON.stringify(res.body)).not.toContain("already paused");
     });
 
     it("returns 400 for resume and stop transition errors", async () => {
@@ -616,7 +619,10 @@ describe("enrichment route runtime behavior", () => {
         await resumeHandler({ user: { id: "admin-1" } } as any, resumeRes);
 
         expect(resumeRes.statusCode).toBe(400);
-        expect(resumeRes.body).toEqual({ error: "already running" });
+        expect(resumeRes.body).toEqual({
+            error: "Failed to resume enrichment",
+        });
+        expect(JSON.stringify(resumeRes.body)).not.toContain("already running");
 
         mockStop.mockRejectedValueOnce(new Error("already stopped"));
 
@@ -624,7 +630,8 @@ describe("enrichment route runtime behavior", () => {
         await stopHandler({ user: { id: "admin-1" } } as any, stopRes);
 
         expect(stopRes.statusCode).toBe(400);
-        expect(stopRes.body).toEqual({ error: "already stopped" });
+        expect(stopRes.body).toEqual({ error: "Failed to stop enrichment" });
+        expect(JSON.stringify(stopRes.body)).not.toContain("already stopped");
     });
 
     it("handles reset routes for artists, tags, audio, and vibes", async () => {
@@ -776,7 +783,8 @@ describe("enrichment route runtime behavior", () => {
         const errorRes = createRes();
         await syncHandler({ user: { id: "user-1" } } as any, errorRes);
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "queue busy" });
+        expect(errorRes.body).toEqual({ error: "Failed to start sync" });
+        expect(JSON.stringify(errorRes.body)).not.toContain("queue busy");
     });
 
     it("reads and writes per-user enrichment settings", async () => {
@@ -887,7 +895,10 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "enrichment service down" });
+        expect(res.body).toEqual({ error: "Failed to enrich artist" });
+        expect(JSON.stringify(res.body)).not.toContain(
+            "enrichment service down",
+        );
     });
 
     it("applies album enrichment only above confidence threshold", async () => {
@@ -933,7 +944,10 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "album provider timeout" });
+        expect(res.body).toEqual({ error: "Failed to enrich album" });
+        expect(JSON.stringify(res.body)).not.toContain(
+            "album provider timeout",
+        );
     });
 
     it("enforces auto-enrichment setting when starting full library run", async () => {
@@ -968,7 +982,8 @@ describe("enrichment route runtime behavior", () => {
         await startHandler({ user: { id: "admin-1" } } as any, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "db timeout" });
+        expect(res.body).toEqual({ error: "Failed to start enrichment" });
+        expect(JSON.stringify(res.body)).not.toContain("db timeout");
     });
 
     it("still returns 200 if start background task rejects", async () => {
@@ -1167,7 +1182,8 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "reset failed" });
+        expect(res.body).toEqual({ error: "Failed to retry failures" });
+        expect(JSON.stringify(res.body)).not.toContain("reset failed");
     });
 
     it("validates skip payload and skips failures by id", async () => {
@@ -1239,8 +1255,11 @@ describe("enrichment route runtime behavior", () => {
         expect(mockClearAllFailures).toHaveBeenCalledWith(undefined);
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
-            error: "clear failure store offline",
+            error: "Failed to clear failures",
         });
+        expect(JSON.stringify(res.body)).not.toContain(
+            "clear failure store offline",
+        );
     });
 
     it("deletes a single failure by id", async () => {
@@ -1280,7 +1299,8 @@ describe("enrichment route runtime behavior", () => {
             }),
         );
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "artist reset failed" });
+        expect(res.body).toEqual({ error: "Failed to reset artist metadata" });
+        expect(JSON.stringify(res.body)).not.toContain("artist reset failed");
     });
 
     it("returns 500 when deleting a failure record fails", async () => {
@@ -1294,7 +1314,8 @@ describe("enrichment route runtime behavior", () => {
 
         expect(mockDeleteFailures).toHaveBeenCalledWith(["failure-err"]);
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "delete failed" });
+        expect(res.body).toEqual({ error: "Failed to delete failure" });
+        expect(JSON.stringify(res.body)).not.toContain("delete failed");
     });
 
     it("reads concurrency settings and estimated throughput", async () => {
@@ -1453,7 +1474,8 @@ describe("enrichment route runtime behavior", () => {
             }),
         );
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "album reset failed" });
+        expect(res.body).toEqual({ error: "Failed to reset album metadata" });
+        expect(JSON.stringify(res.body)).not.toContain("album reset failed");
     });
 
     it("still returns success when artist cache invalidation fails during metadata reset", async () => {
@@ -1696,7 +1718,8 @@ describe("enrichment route runtime behavior", () => {
         );
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "track metadata failed" });
+        expect(res.body).toEqual({ error: "Failed to update track" });
+        expect(JSON.stringify(res.body)).not.toContain("track metadata failed");
     });
 
     it("returns 409 when artist metadata update hits MBID conflict", async () => {

--- a/backend/src/routes/__tests__/libraryErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/libraryErrorLeak.test.ts
@@ -201,10 +201,7 @@ const mockArtistCount = dbPrisma.artist.count as jest.Mock;
 const mockOwnedAlbumFindMany = dbPrisma.ownedAlbum.findMany as jest.Mock;
 const mockPrismaTransaction = dbPrisma.$transaction as jest.Mock;
 
-function getRouteHandler(
-    path: string,
-    method: "get" | "post" | "delete",
-) {
+function getRouteHandler(path: string, method: "get" | "post" | "delete") {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -231,9 +228,7 @@ function createRes() {
     return res;
 }
 
-const SECRET_ERROR = new Error(
-    "postgres://user:pw@db SECRET_LEAK_MARKER",
-);
+const SECRET_ERROR = new Error("postgres://user:pw@db SECRET_LEAK_MARKER");
 const req = {
     user: { id: "user-1" },
     params: {},

--- a/backend/src/routes/__tests__/libraryErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/libraryErrorLeak.test.ts
@@ -1,0 +1,269 @@
+import { Request, Response } from "express";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
+        next(),
+}));
+
+jest.mock("../../middleware/rateLimiter", () => ({
+    imageLimiter: (_req: Request, _res: Response, next: () => void) => next(),
+    apiLimiter: (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const prisma = {
+    artist: { count: jest.fn(), findMany: jest.fn() },
+    album: { findMany: jest.fn(), count: jest.fn() },
+    ownedAlbum: { findMany: jest.fn() },
+    $transaction: jest.fn(),
+};
+
+jest.mock("../../utils/db", () => ({
+    prisma,
+    Prisma: {
+        SortOrder: { asc: "asc", desc: "desc" },
+        DbNull: null,
+    },
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: { get: jest.fn(), setEx: jest.fn() },
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        audiobookshelf: undefined,
+        music: {
+            musicPath: "/music",
+            transcodeCachePath: "/tmp/soundspan-cache",
+            transcodeCacheMaxGb: 1,
+        },
+        generationDiversity: { weightAlpha: 0.5, shareCeiling: 0.3 },
+    },
+}));
+
+jest.mock("../../workers/queues", () => ({
+    scanQueue: { add: jest.fn(), getJob: jest.fn() },
+}));
+
+jest.mock("../../workers/organizeSingles", () => ({
+    organizeSingles: jest.fn(),
+}));
+
+jest.mock("../../services/lastfm", () => ({
+    lastFmService: {
+        getArtistTopTracks: jest.fn(),
+        getSimilarArtists: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/fanart", () => ({
+    fanartService: {},
+}));
+
+jest.mock("../../services/deezer", () => ({
+    deezerService: {
+        getAlbumCover: jest.fn(),
+        getArtistImage: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/imageProvider", () => ({
+    imageProviderService: {
+        getAlbumCover: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/musicbrainz", () => ({
+    musicBrainzService: {
+        searchArtist: jest.fn(),
+        getReleaseGroups: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/coverArt", () => ({
+    coverArtService: {
+        getCoverArt: jest.fn(),
+        clearNotFoundCache: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+}));
+
+jest.mock("../../services/audioStreaming", () => ({
+    AudioStreamingService: jest.fn().mockImplementation(() => ({
+        getStreamFilePath: jest.fn(),
+        streamFileWithRangeSupport: jest.fn(),
+        destroy: jest.fn(),
+    })),
+}));
+
+jest.mock("../../services/dataCache", () => ({
+    dataCacheService: {
+        getArtistImagesBatch: jest.fn(),
+        getArtistImage: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/artistCountsService", () => ({
+    backfillAllArtistCounts: jest.fn(),
+    isBackfillNeeded: jest.fn(),
+    getBackfillProgress: jest.fn(),
+    isBackfillInProgress: jest.fn(),
+}));
+
+jest.mock("../../services/imageBackfill", () => ({
+    isImageBackfillNeeded: jest.fn(),
+    getImageBackfillProgress: jest.fn(),
+    backfillAllImages: jest.fn(),
+}));
+
+jest.mock("../../utils/metadataOverrides", () => ({
+    getMergedGenres: jest.fn(() => []),
+    getArtistDisplaySummary: jest.fn(() => ""),
+}));
+
+jest.mock("../../utils/dateFilters", () => ({
+    getEffectiveYear: jest.fn(),
+    getDecadeWhereClause: jest.fn(),
+    getDecadeFromYear: jest.fn(),
+}));
+
+jest.mock("../../utils/shuffle", () => ({
+    shuffleArray: jest.fn((arr: unknown[]) => arr),
+}));
+
+jest.mock("../../utils/colorExtractor", () => ({
+    extractColorsFromImage: jest.fn(async () => ({
+        vibrant: "#000000",
+        darkVibrant: "#000000",
+        lightVibrant: "#000000",
+        muted: "#000000",
+        darkMuted: "#000000",
+        lightMuted: "#000000",
+    })),
+}));
+
+jest.mock("../../services/imageProxy", () => ({
+    fetchExternalImage: jest.fn(),
+    normalizeExternalImageUrl: jest.fn(() => null),
+}));
+
+jest.mock("../../services/imageStorage", () => ({
+    downloadAndStoreImage: jest.fn(),
+}));
+
+jest.mock("../../services/lidarr", () => ({
+    lidarrService: {
+        deleteArtist: jest.fn(),
+    },
+}));
+
+jest.mock(
+    "music-metadata",
+    () => ({
+        parseFile: jest.fn(),
+    }),
+    { virtual: true },
+);
+
+jest.mock("../../services/remoteTrackMetadataResolver", () => ({
+    resolveRemoteTrackMetadataForRequest: jest.fn(
+        async ({ metadata }: any) => ({
+            title: metadata.title ?? "Unknown",
+            artist: metadata.artist ?? "Unknown",
+            album: metadata.album ?? "Unknown",
+            duration: metadata.duration ?? 180,
+            thumbnailUrl: metadata.thumbnailUrl,
+            isrc: metadata.isrc,
+            explicit: metadata.explicit,
+            quality: metadata.quality,
+        }),
+    ),
+}));
+
+import router from "../library";
+import { prisma as dbPrisma } from "../../utils/db";
+
+const mockArtistCount = dbPrisma.artist.count as jest.Mock;
+const mockOwnedAlbumFindMany = dbPrisma.ownedAlbum.findMany as jest.Mock;
+const mockPrismaTransaction = dbPrisma.$transaction as jest.Mock;
+
+function getRouteHandler(
+    path: string,
+    method: "get" | "post" | "delete",
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined as unknown,
+        status: jest.fn(function (code: number) {
+            res.statusCode = code;
+            return res;
+        }),
+        json: jest.fn(function (payload: unknown) {
+            res.body = payload;
+            return res;
+        }),
+    };
+    return res;
+}
+
+const SECRET_ERROR = new Error(
+    "postgres://user:pw@db SECRET_LEAK_MARKER",
+);
+const req = {
+    user: { id: "user-1" },
+    params: {},
+    query: {},
+    body: {},
+};
+
+describe("library route errors do not disclose caught values", () => {
+    it("returns a curated artists error", async () => {
+        mockArtistCount.mockResolvedValueOnce(0);
+        mockPrismaTransaction.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/artists", "get")(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.error).toBe("Failed to fetch artists");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+
+    it("returns a curated albums error", async () => {
+        mockOwnedAlbumFindMany.mockRejectedValueOnce(SECRET_ERROR);
+        const res = createRes();
+
+        await getRouteHandler("/albums", "get")(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.error).toBe("Failed to fetch albums");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_LEAK_MARKER");
+        expect(res.body).not.toHaveProperty("details");
+    });
+});

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -1942,8 +1942,8 @@ describe("library catalog list runtime coverage", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to fetch artists",
-            details: "tx failed",
         });
+        expect(JSON.stringify(res.body)).not.toContain("tx failed");
     });
 
     it("hydrates artist detail with MBID resolution, discography, top tracks, and enriched similar artists", async () => {
@@ -2577,8 +2577,8 @@ describe("library catalog list runtime coverage", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to fetch albums",
-            details: "album list failed",
         });
+        expect(JSON.stringify(res.body)).not.toContain("album list failed");
     });
 
     it("handles album lookup by id, includeTracks flag, and ownership", async () => {
@@ -4290,8 +4290,8 @@ describe("library catalog list runtime coverage", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to delete artist",
-            details: "db unavailable",
         });
+        expect(JSON.stringify(res.body)).not.toContain("db unavailable");
 
         existsSpy.mockRestore();
     });

--- a/backend/src/routes/discover.ts
+++ b/backend/src/routes/discover.ts
@@ -1995,7 +1995,6 @@ router.delete("/clear", async (req, res) => {
         logger.error("Stack:", error?.stack);
         res.status(500).json({
             error: "Failed to clear discovery playlist",
-            details: error?.message || "Unknown error",
         });
     }
 });
@@ -2046,7 +2045,6 @@ router.get("/exclusions", async (req, res) => {
         logger.error("Stack:", error?.stack);
         res.status(500).json({
             error: "Failed to get exclusions",
-            details: error?.message,
         });
     }
 });
@@ -2294,7 +2292,6 @@ router.post("/cleanup-lidarr", async (req, res) => {
         );
         res.status(500).json({
             error: "Failed to cleanup Lidarr",
-            details: error?.message || "Unknown error",
         });
     }
 });
@@ -2428,7 +2425,6 @@ router.post("/fix-tagging", async (req, res) => {
         logger.error("[FIX-TAGGING] Error:", error?.message || error);
         res.status(500).json({
             error: "Failed to fix album tagging",
-            details: error?.message || "Unknown error",
         });
     }
 });

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -139,7 +139,7 @@ router.post("/pause", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Pause enrichment error:", error);
         res.status(400).json({
-            error: error.message || "Failed to pause enrichment",
+            error: "Failed to pause enrichment",
         });
     }
 });
@@ -177,7 +177,7 @@ router.post("/resume", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Resume enrichment error:", error);
         res.status(400).json({
-            error: error.message || "Failed to resume enrichment",
+            error: "Failed to resume enrichment",
         });
     }
 });
@@ -215,7 +215,7 @@ router.post("/stop", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Stop enrichment error:", error);
         res.status(400).json({
-            error: error.message || "Failed to stop enrichment",
+            error: "Failed to stop enrichment",
         });
     }
 });
@@ -526,7 +526,7 @@ router.post("/sync", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Trigger sync error:", error);
         res.status(500).json({
-            error: error.message || "Failed to start sync",
+            error: "Failed to start sync",
         });
     }
 });
@@ -664,7 +664,7 @@ router.post("/artist/:id", async (req, res) => {
     } catch (error: any) {
         logger.error("Enrich artist error:", error);
         res.status(500).json({
-            error: error.message || "Failed to enrich artist",
+            error: "Failed to enrich artist",
         });
     }
 });
@@ -732,7 +732,7 @@ router.post("/album/:id", async (req, res) => {
     } catch (error: any) {
         logger.error("Enrich album error:", error);
         res.status(500).json({
-            error: error.message || "Failed to enrich album",
+            error: "Failed to enrich album",
         });
     }
 });
@@ -788,7 +788,7 @@ router.post("/start", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Start enrichment error:", error);
         res.status(500).json({
-            error: error.message || "Failed to start enrichment",
+            error: "Failed to start enrichment",
         });
     }
 });
@@ -849,7 +849,7 @@ router.get("/search/musicbrainz/artists", async (req, res) => {
     } catch (error: any) {
         logger.error("MusicBrainz artist search error:", error);
         res.status(500).json({
-            error: error?.message || "Search failed",
+            error: "Search failed",
         });
     }
 });
@@ -927,7 +927,7 @@ router.get("/search/musicbrainz/release-groups", async (req, res) => {
     } catch (error: any) {
         logger.error("MusicBrainz release-group search error:", error);
         res.status(500).json({
-            error: error?.message || "Search failed",
+            error: "Search failed",
         });
     }
 });
@@ -1177,7 +1177,7 @@ router.post("/retry", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Retry failures error:", error);
         res.status(500).json({
-            error: error.message || "Failed to retry failures",
+            error: "Failed to retry failures",
         });
     }
 });
@@ -1236,7 +1236,7 @@ router.post("/skip", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Skip failures error:", error);
         res.status(500).json({
-            error: error.message || "Failed to skip failures",
+            error: "Failed to skip failures",
         });
     }
 });
@@ -1293,7 +1293,7 @@ router.delete("/failures", requireAdmin, async (req, res) => {
     } catch (error: any) {
         logger.error("Clear all failures error:", error);
         res.status(500).json({
-            error: error.message || "Failed to clear failures",
+            error: "Failed to clear failures",
         });
     }
 });
@@ -1341,7 +1341,7 @@ router.delete<{ id: string }>(
         } catch (error: any) {
             logger.error("Delete failure error:", error);
             res.status(500).json({
-                error: error.message || "Failed to delete failure",
+                error: "Failed to delete failure",
             });
         }
     },
@@ -1527,7 +1527,7 @@ router.put("/artists/:id/metadata", async (req, res) => {
         }
         logger.error("Update artist metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to update artist",
+            error: "Failed to update artist",
         });
     }
 });
@@ -1721,7 +1721,7 @@ router.put("/albums/:id/metadata", async (req, res) => {
         }
         logger.error("Update album metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to update album",
+            error: "Failed to update album",
         });
     }
 });
@@ -1810,7 +1810,7 @@ router.put("/tracks/:id/metadata", async (req, res) => {
     } catch (error: any) {
         logger.error("Update track metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to update track",
+            error: "Failed to update track",
         });
     }
 });
@@ -1902,7 +1902,7 @@ router.post("/artists/:id/reset", async (req, res) => {
         }
         logger.error("Reset artist metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to reset artist metadata",
+            error: "Failed to reset artist metadata",
         });
     }
 });
@@ -1993,7 +1993,7 @@ router.post("/albums/:id/reset", async (req, res) => {
         }
         logger.error("Reset album metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to reset album metadata",
+            error: "Failed to reset album metadata",
         });
     }
 });
@@ -2080,7 +2080,7 @@ router.post("/tracks/:id/reset", async (req, res) => {
         }
         logger.error("Reset track metadata error:", error);
         res.status(500).json({
-            error: error.message || "Failed to reset track metadata",
+            error: "Failed to reset track metadata",
         });
     }
 });

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -1227,7 +1227,6 @@ router.get("/artists", async (req, res) => {
         logger.error("[Library] Stack:", error?.stack);
         res.status(500).json({
             error: "Failed to fetch artists",
-            details: error?.message,
         });
     }
 });
@@ -2501,7 +2500,6 @@ router.get("/albums", async (req, res) => {
         logger.error("[Library] Stack:", error?.stack);
         res.status(500).json({
             error: "Failed to fetch albums",
-            details: error?.message,
         });
     }
 });
@@ -5782,7 +5780,6 @@ router.delete<{ id: string }>(
             logger.error("Delete artist stack:", error?.stack);
             res.status(500).json({
                 error: "Failed to delete artist",
-                details: error?.message || "Unknown error",
             });
         }
     },

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
     analyzeRouteErrorCanon,
     countPattern,
+    countLeakPattern,
 } from "../check-route-error-canon.mjs";
 
 test("countPattern counts occurrences and tolerates whitespace", () => {
@@ -56,6 +57,42 @@ test("analyzeRouteErrorCanon reports a lower count as tightenable", () => {
             ok: true,
             violations: [],
             tightenable: [{ file: "route.ts", count: 1, baseline: 2 }],
+        },
+    );
+});
+
+test("countLeakPattern counts raw caught-error message/stack echoed into a body", () => {
+    const source = `
+        res.status(500).json({ error: "Failed", details: error?.message });
+        res.status(400).json({ error: error.message || "x" });
+        res.status(500).json({ error: error?.stack });
+    `;
+
+    assert.equal(countLeakPattern(source), 3);
+});
+
+test("countLeakPattern tolerates whitespace variations", () => {
+    assert.equal(countLeakPattern("details :  error ?. message"), 1);
+    assert.equal(countLeakPattern("error:error.stack"), 1);
+});
+
+test("countLeakPattern ignores static curated messages", () => {
+    const source = `
+        res.status(500).json({ error: "Failed to fetch artists" });
+        sendInternalRouteError(res, "Failed to fetch albums");
+        logger.error("boom", error);
+    `;
+
+    assert.equal(countLeakPattern(source), 0);
+});
+
+test("analyzeRouteErrorCanon ratchets leak counts the same way", () => {
+    assert.deepEqual(
+        analyzeRouteErrorCanon({ "leaky.ts": 3 }, { "leaky.ts": 2 }),
+        {
+            ok: false,
+            violations: [{ file: "leaky.ts", count: 3, baseline: 2 }],
+            tightenable: [],
         },
     );
 });

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -54,9 +54,29 @@ const BASELINE = Object.freeze({
     "backend/src/routes/youtubeMusic.ts": 18,
 });
 
+// Raw error details can disclose internal implementation data to clients (OWASP).
+// This independent ratchet prevents new error.message/error.stack response leaks.
+const LEAK_BASELINE = Object.freeze({
+    "backend/src/routes/downloads.ts": 1,
+    "backend/src/routes/listenTogether.ts": 1,
+    "backend/src/routes/notifications.ts": 2,
+    "backend/src/routes/playbackState.ts": 1,
+    "backend/src/routes/playlists.ts": 2,
+    "backend/src/routes/podcasts.ts": 1,
+});
+
 export function countPattern(source) {
     const pattern = /res\s*\.\s*status\s*\(\s*500\s*\)\s*\.\s*json\s*\(/g;
     return source.match(pattern)?.length ?? 0;
+}
+
+export function countLeakPattern(source) {
+    const pattern = /:\s*error\??\.(?:message|stack)\b/g;
+    const normalizedSource = source.replace(
+        /error\s*(\??)\s*\.\s*(message|stack)\b/g,
+        "error$1.$2",
+    );
+    return normalizedSource.match(pattern)?.length ?? 0;
 }
 
 export function analyzeRouteErrorCanon(counts, baseline) {
@@ -84,7 +104,7 @@ function routeFiles(directory) {
         .map((entry) => path.join(directory, entry.name));
 }
 
-function collectCounts(repoRoot) {
+function collectCounts(repoRoot, counter = countPattern) {
     const routesDirectory = path.join(repoRoot, "backend/src/routes");
     return Object.fromEntries(
         routeFiles(routesDirectory)
@@ -96,13 +116,14 @@ function collectCounts(repoRoot) {
                     .join("/");
                 return [
                     relativePath,
-                    countPattern(fs.readFileSync(filePath, "utf8")),
+                    counter(fs.readFileSync(filePath, "utf8")),
                 ];
             }),
     );
 }
 
-function printReport(result) {
+function printReport(label, result) {
+    console.log(`${label}:`);
     if (result.ok) {
         console.log("Route error canonicalization ratchet passed.");
     } else {
@@ -122,18 +143,26 @@ function printReport(result) {
             );
         }
     }
-
-    console.log(
-        "Use sendInternalRouteError/AppError instead; see backend/src/routes/README.md.",
-    );
 }
 
 function runCli() {
     const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
     const repoRoot = path.resolve(scriptDirectory, "../..");
-    const result = analyzeRouteErrorCanon(collectCounts(repoRoot), BASELINE);
-    printReport(result);
-    process.exit(result.ok ? 0 : 1);
+    const canonicalResult = analyzeRouteErrorCanon(
+        collectCounts(repoRoot),
+        BASELINE,
+    );
+    const leakResult = analyzeRouteErrorCanon(
+        collectCounts(repoRoot, countLeakPattern),
+        LEAK_BASELINE,
+    );
+
+    printReport("500-literal ratchet", canonicalResult);
+    printReport("Raw-error leak ratchet", leakResult);
+    console.log(
+        "Use sendInternalRouteError/AppError instead; see backend/src/routes/README.md.",
+    );
+    process.exit(canonicalResult.ok && leakResult.ok ? 0 : 1);
 }
 
 if (


### PR DESCRIPTION
## Finding

MEDIUM — OWASP information disclosure. ~37 route responses returned raw `error.message` / `error.stack` (or a `details` field carrying it) to clients: `discover.ts` (`details: error?.message` at 4 sites), `enrichment.ts` (19× `error: error.message`), `library.ts`, and others. These **pass** the existing `{error}`-key canon, which only checks key presence, not value safety, so raw DB / axios / Lidarr / stack text reached clients. Additionally, `enrichment.ts`'s non-optional `error.message` variants would throw *inside* the catch on a non-object throw (e.g. `null`), leaving the request with **no response**.

## Fix (scoped to the 3 named high-traffic routers + the checker)

- **discover.ts / enrichment.ts / library.ts**: return static, curated `{ error: "…" }` messages; the raw error is logged server-side only. Removes 19 enrichment, 4 discover, and 3 library leak sites. Status codes and existing server-side logging preserved.
- **Non-object-throw guard**: eliminating the response-body `error.message` dereference also fixes the "no response" bug; no unguarded `error.message`/`error.stack` deref remains in the touched catch blocks.
- **scripts/ci/check-route-error-canon.mjs**: adds a second, independent ratchet (`countLeakPattern`) that flags raw `error.message`/`error.stack` echoed into response bodies. Baseline can only decrease; `discover`/`enrichment`/`library` are ratcheted to **zero**. Remaining routers still carrying the pattern (`downloads`, `listenTogether`, `notifications`, `playbackState`, `playlists`, `podcasts`) are frozen at current counts and noted as **follow-up** in `backend/src/routes/README.md`.
- Docs: `CHANGELOG.md` (Security) and routes `README.md` enforcement note updated.

## Tests (TDD, error-path)

New colocated suites assert that when a mocked dependency throws an error whose message contains a secret marker, the handler responds with the static curated message and `JSON.stringify(res.body)` does **not** contain the marker and has no `details` key. Includes an enrichment non-object-throw (`null` rejection) test proving a response is still sent.

- `backend/src/routes/__tests__/enrichmentErrorLeak.test.ts`
- `backend/src/routes/__tests__/discoverErrorLeak.test.ts`
- `backend/src/routes/__tests__/libraryErrorLeak.test.ts`
- extended `scripts/ci/__tests__/check-route-error-canon.test.mjs`

## Verification

- `verify:` targeted jest (`--maxWorkers=2`) — 3 route suites, 7 tests, all pass.
- `verify:` `node --test scripts/ci/__tests__/check-route-error-canon.test.mjs` — 10 pass.
- `verify:` `node scripts/ci/check-route-error-canon.mjs` — both ratchets pass, exit 0.
- `verify:` `prettier --check` on all changed files — clean.
- `verify:` post-fix leak grep on the 3 routers — 0 remaining `: error?.message`/`.stack` in response bodies.