### PR TITLE
docs(ci): sync AGENTS.md CI-gate table with quality-visibility.yml and add verify:ci

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,20 @@ npm --prefix frontend install
 
 ### Reproduce the CI gates locally (run before every PR)
 
-One command reproduces every CI gate: **`npm run verify`** (from the repo root). Per-gate equivalents:
+**`npm run verify:ci`** (from the repo root) reproduces every CI gate, including the Python gates (requires Python 3.11+ with each sidecar's `requirements-test.txt` and `services/requirements-quality.txt` installed). When you are not touching `services/**`, **`npm run verify`** runs the Node + Helm subset. Per-gate equivalents:
 
-| CI check (`quality-visibility.yml`) | Local command | Catches |
-| --- | --- | --- |
-| Backend Tests + Coverage | `npm run verify:backend` (= `npm --prefix backend run test:coverage`) | backend Jest unit/runtime tests + coverage |
-| Frontend Quality Visibility + Typecheck | `npm run verify:frontend` (= frontend `lint` + `build` + `test:coverage` + `test:component` + `typecheck`) | ESLint, Next build/type-check, targeted unit coverage, component tests, and standalone source/test TypeScript checking |
-| Python Sidecar Tests (matrix) | `npm run verify:python` (requires Python 3.11+ with each sidecar's `requirements-test.txt` installed) | pytest suites for the four `services/*` sidecars |
-| Helm Chart Visibility | `npm run verify:helm` (= `./scripts/helm-chart-render-check.sh`) | chart lint + render assertions |
+| CI job (`quality-visibility.yml`) | Blocking? | Local command | Catches |
+| --- | --- | --- | --- |
+| Backend Tests + Coverage | Visibility | `npm run verify:backend` | backend Jest unit/runtime tests + coverage |
+| Frontend Quality Visibility | Visibility | Non-typecheck part of `npm run verify:frontend`: frontend `lint` + `build` + `test:coverage` + `test:component` | ESLint, Next build, targeted unit coverage, and component tests |
+| Python Sidecar Tests (matrix) | Visibility | `npm run verify:python` | pytest suites for the four `services/*` sidecars |
+| Python Quality | Enforcement | `npm run verify:python-quality` | ruff lint, ruff format check, mypy (+ tidal-downloader standalone) |
+| Enforcement Gates | Enforcement | `npm run verify:gates` | route-error canonicalization + gate self-test, frontend hardcoded-hex baseline, OpenAPI route sync, repo-wide Prettier format check |
+| Backend Typecheck | Visibility | `npm --prefix backend exec -- tsc --noEmit` | backend TypeScript checking |
+| Frontend Typecheck | Visibility | `npm --prefix frontend run typecheck` (also part of `verify:frontend`) | complete frontend source/test TypeScript checking |
+| Helm Chart Visibility | Visibility | `npm run verify:helm` | chart lint + render assertions |
+
+Only **Enforcement Gates** and **Python Quality** block a PR on every run; the remaining jobs run as visibility (`continue-on-error`) unless the repo variable `CI_NON_BLOCKING_TEST_VISIBILITY` is set to `false`.
 
 Notes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented every CI gate in the AGENTS.md CI-gates table (adding the Python
+  Quality, Enforcement Gates, and Backend/Frontend Typecheck jobs) and added a
+  `verify:ci` npm script that reproduces all gates locally, including the Python
+  ruff/mypy and sidecar-pytest gates that `npm run verify` omits.
 - Lowered the enforced frontend ESLint warning budget from 244 to 183 and made
   timer-dependent frontend tests deterministic instead of waiting on real-time
   sleeps.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "format:python": "ruff format services",
         "format:python:check": "ruff format --check services",
         "verify": "npm run verify:backend && npm run verify:frontend && npm run verify:helm && npm run verify:gates",
+        "verify:ci": "npm run verify:backend && npm run verify:frontend && npm run verify:python && npm run verify:python-quality && npm run verify:helm && npm run verify:gates",
         "verify:backend": "npm --prefix backend run test:coverage",
         "verify:frontend": "npm --prefix frontend run lint && npm --prefix frontend run build && npm --prefix frontend run test:coverage && npm --prefix frontend run test:component && npm --prefix frontend run typecheck",
         "verify:helm": "./scripts/helm-chart-render-check.sh",


### PR DESCRIPTION
## Finding

LOW severity, cohesion-relevant. The AGENTS.md CI-gate contract was out of sync with `.github/workflows/quality-visibility.yml`:

- Root `npm run verify` = `verify:backend && verify:frontend && verify:helm && verify:gates`. It **omitted** `verify:python` (Python Sidecar Tests) and `verify:python-quality` (the **blocking** Python Quality job: ruff lint, ruff format check, mypy). So `npm run verify` did not reproduce all CI gates, contrary to the doc's claim.
- The AGENTS.md "Reproduce the CI gates locally" table listed only 4 of the 8 `quality-visibility.yml` jobs, omitting **Python Quality** (blocking), **Enforcement Gates** (blocking), and the separate **Backend/Frontend Typecheck** jobs, while asserting "One command reproduces every CI gate: `npm run verify`".

## Fix

- **package.json:** add `verify:ci` = `verify:backend && verify:frontend && verify:python && verify:python-quality && verify:helm && verify:gates` — one command that reproduces every gate (Python included). `verify` is left unchanged as the Node + Helm subset for changes that don't touch `services/**`. No new gates invented; `verify:ci` only composes existing scripts already used by CI.
- **AGENTS.md:** the CI-gates table now lists all 8 `quality-visibility.yml` jobs with a Blocking? column (Enforcement vs Visibility) and accurate per-gate local commands, plus a note that only Enforcement Gates and Python Quality block on every run (the rest are `continue-on-error` unless `CI_NON_BLOCKING_TEST_VISIBILITY=false`). Intro now points to `verify:ci` for full reproduction.
- **CHANGELOG.md:** entry under Unreleased -> Changed.

`quality-visibility.yml` is unchanged — it is the source of truth and was already accurate; AGENTS.md was brought into agreement with it.

## Verification

- `verify: JSON.parse(package.json)` valid; `.prettierrc.json` is tabWidth 4 and the new script line matches sibling indentation (prettier-clean). `**/*.md` is in `.prettierignore`, so the doc edits are not format-gated.
- `verify: npm run` lists `verify` and `verify:ci`; all six scripts referenced by `verify:ci` exist in package.json.
- `verify: git diff --check` clean (no whitespace errors).
- AGENTS.md table now matches the 8 jobs in `quality-visibility.yml` (backend-tests-coverage, frontend-quality-visibility, python-sidecar-tests, python-quality, enforcement-gates, backend-typecheck, frontend-typecheck, helm-chart-visibility), with blocking status matching each job's `continue-on-error` setting.

Docs/config-only change; no runtime behavior affected.