### PR TITLE
ci(docker): pin AIO+audio-analyzer bases by digest and add to hygiene gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Digest-pinned the two remaining unpinned base images and closed the gap in the
+  Dockerfile digest-pin ratchet. The root AIO `Dockerfile` (`node:24-bookworm-slim`)
+  and `services/audio-analyzer/Dockerfile` (`python:3.11-slim`) were both unpinned
+  and excluded from `scripts/ci/dockerfile-hygiene.test.mjs`, while every sibling
+  service Dockerfile was pinned and gated. Both bases are now pinned by `@sha256:`
+  (tag kept inline for dependabot), and both paths were added to the gate's
+  `dockerfilePaths` so the ratchet enforces digest pinning across all repo
+  Dockerfiles.
 - Path containment on native audio streaming: the `GET /api/library/tracks/:id/stream`
   handler now resolves the DB-sourced `track.filePath` through `safeResolvePath`
   and returns `404 Track not available` when the resolved path escapes the

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Contains: Backend, Frontend, PostgreSQL, Redis, Audio Analyzer, Audio Analyzer CLAP
 # Usage: docker run -d -p 3030:3030 -v /path/to/music:/music ghcr.io/soundspan/soundspan-aio:latest
 
-FROM node:24-bookworm-slim
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
 
 # Add the PostgreSQL 16 repository and install runtime dependencies in one layer.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -5,8 +5,10 @@ import path from "node:path";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const dockerfilePaths = [
+    "Dockerfile",
     "backend/Dockerfile",
     "frontend/Dockerfile",
+    "services/audio-analyzer/Dockerfile",
     "services/tidal-downloader/Dockerfile",
     "services/ytmusic-streamer/Dockerfile",
     "services/audio-analyzer-clap/Dockerfile",

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -1,7 +1,7 @@
 # Audio Analyzer Service - Essentia with TensorFlow (MusiCNN)
 # Runs on Python 3.11 (Debian bookworm slim), matching the repo's Python 3.11+
 # contract and the AIO image that already runs this workload on Python 3.11.
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:90744cff8f32887f075c47d747a173ff333e9e98801667af93c357fa9f5e28ff
 
 # Avoid interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Finding (MEDIUM)

`scripts/ci/dockerfile-hygiene.test.mjs` `dockerfilePaths` listed only backend / frontend / tidal-downloader / ytmusic-streamer / audio-analyzer-clap. Two Dockerfiles were **both unpinned and excluded from the digest-pin gate**, while sibling CLAP was pinned+gated:

- Root AIO `Dockerfile` — `FROM node:24-bookworm-slim` (no `@sha256`)
- `services/audio-analyzer/Dockerfile` — `FROM python:3.11-slim` (no `@sha256`)

## Fix

- Pin `node:24-bookworm-slim` by `@sha256:3638d9a6…4fc03` (matches the digest `backend/Dockerfile` already pins — current and consistent across the repo).
- Pin `python:3.11-slim` by `@sha256:90744cff…28ff` (resolved from the live Docker registry).
- Tag kept inline before `@sha256:` so dependabot still tracks the tag (matches existing repo convention; no separate comment).
- Add `"Dockerfile"` and `"services/audio-analyzer/Dockerfile"` to `dockerfilePaths` so the digest-pin ratchet now covers **every** repo Dockerfile.

## Verification

- Digests resolved & confirmed real via `docker buildx imagetools inspect` against `docker.io/library/{node:24-bookworm-slim, python:3.11-slim}`.
- `node --test scripts/ci/dockerfile-hygiene.test.mjs` — 6/6 pass, with test #1 now enforcing pinning on the two new paths.
- `docker buildx build --check` on both Dockerfiles — "Check complete, no warnings found" for each; metadata load with the pinned digests succeeded (digests are pullable). No full build performed.
