### PR TITLE
fix(ci): align mypy python_version to 3.11 repo floor

### DIFF
--- a/.github/workflows/quality-visibility.yml
+++ b/.github/workflows/quality-visibility.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          # tiddl requires Python >=3.13; mypy retains Python 3.12 semantics via pyproject.toml.
+          # tiddl requires Python >=3.13; mypy retains Python 3.11 semantics via pyproject.toml.
           python-version: "3.14"
           cache: pip
           cache-dependency-path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming across all users. Each blocking call is now wrapped in
   `asyncio.to_thread`, matching the existing offload pattern already used for the
   per-user refresh path.
+- Aligned the mypy type-check target (`python_version`) to Python 3.11 to match
+  the repo floor (Ruff `py311` and the audio-analyzer `python:3.11-slim` pin), so
+  type checks run against the oldest interpreter the sidecars use.
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,9 @@ ignore = [
 
 [tool.mypy]
 # Pragmatic initial gate; stricter checks should be enabled incrementally in follow-up ratchets.
-python_version = "3.12"
+# Python 3.11 matches the repo floor (Ruff py311 and audio-analyzer python:3.11-slim),
+# so mypy checks against the oldest interpreter the sidecars run on.
+python_version = "3.11"
 files = ["services"]
 mypy_path = ["services"]
 exclude = [


### PR DESCRIPTION
## Finding (LOW)

`pyproject.toml` `[tool.mypy] python_version` was set to `"3.12"` while:
- `[tool.ruff] target-version = "py311"` declares the repo's Python floor as 3.11, and
- the audio-analyzer sidecar is pinned to `python:3.11-slim` (`services/audio-analyzer/Dockerfile`, roadmap P29).

Result: mypy type-checked against a newer stdlib than the analyzer actually runs on, so 3.12-only stdlib usage could pass the type gate yet break at runtime on the 3.11 sidecar.

## Fix

- `pyproject.toml`: `[tool.mypy] python_version` `3.12` -> `3.11`, matching the repo floor, with an explanatory comment.
- `.github/workflows/quality-visibility.yml`: synced the Python Quality job comment from "mypy retains Python 3.12 semantics" to "3.11 semantics". The runner interpreter (`python-version: "3.14"`, required by tiddl) is unchanged — mypy's target semantics are independent of the interpreter.
- `CHANGELOG.md`: added a `### Fixed` entry under `[Unreleased]`.

Scope: config/CI comment only; no source code changed.

## Verification

In a Python 3.11 venv (3.11.15) with the repo's pinned `mypy==2.3.0`, ran mypy over `services` at both targets and compared:

- `mypy --python-version 3.12` -> `Found 15 errors in 2 files (checked 8 source files)`
- `mypy --python-version 3.11` -> `Found 15 errors in 2 files (checked 8 source files)`
- `diff` of the two outputs: **identical**.

The 15 findings are pre-existing missing-dependency import errors from the minimal quality venv (fastapi/pydantic/ytmusicapi/etc. not installed) plus two consequent unused-`type: ignore` reports — all identical across both targets. This proves the floor change is inert on the actual codebase (same baseline, no new findings). YAML change is comment-only.
