### PR TITLE
fix(tidal-downloader): offload user_auth_restore blocking calls to worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming across all users. Each blocking call is now wrapped in
   `asyncio.to_thread`, matching the existing offload pattern already used for the
   per-user refresh path.
+- **Sidecar event-loop offload for per-user session restore.** The
+  `tidal-downloader` `/user/auth/restore` handler and its `/auth/session`
+  verification path called the blocking `tiddl` `get_session()` (and, on the
+  expired-token branch, `AuthAPI().refresh_token()`) directly on the event loop,
+  stalling all concurrent onboarding and streaming while a single user's
+  credentials were restored. These calls are now wrapped in `asyncio.to_thread`,
+  completing the Phase-D offload coverage for the sidecar's auth surface.
 - Aligned the mypy type-check target (`python_version`) to Python 3.11 to match
   the repo floor (Ruff `py311` and the audio-analyzer `python:3.11-slim` pin), so
   type checks run against the oldest interpreter the sidecars use.

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -1063,7 +1063,7 @@ async def auth_session(tokens: SessionCheckPayload):
     """Verify that the stored tokens are still valid by calling /sessions."""
     try:
         api = _build_api(tokens.access_token, tokens.user_id, tokens.country_code)
-        session = api.get_session()
+        session = await asyncio.to_thread(api.get_session)
         return {
             "valid": True,
             "session_id": session.sessionId,
@@ -1289,17 +1289,18 @@ def _store_user_session(
         _browse_sessions.pop(key, None)
 
 
-def _refresh_and_restore_user(
+async def _refresh_and_restore_user(
     req: UserAuthRestoreRequest,
     soundspan_user_id: str,
 ) -> dict:
     """Refresh expired TIDAL credentials and restore the per-user session."""
-    auth_response = AuthAPI().refresh_token(req.refresh_token)
+    auth_api = AuthAPI()
+    auth_response = await asyncio.to_thread(auth_api.refresh_token, req.refresh_token)
     new_token = auth_response.access_token
     new_user_id = str(auth_response.user.userId)
     new_country = auth_response.user.countryCode
     api = _build_api(new_token, new_user_id, new_country)
-    api.get_session()
+    await asyncio.to_thread(api.get_session)
     _store_user_session(
         soundspan_user_id,
         api,
@@ -1330,7 +1331,7 @@ async def user_auth_restore(req: UserAuthRestoreRequest, user_id: str = Query(..
     """Restore a user's credentials, refreshing an expired token if needed."""
     try:
         api = _build_api(req.access_token, req.user_id, req.country_code)
-        api.get_session()
+        await asyncio.to_thread(api.get_session)
         _store_user_session(
             user_id,
             api,
@@ -1348,7 +1349,7 @@ async def user_auth_restore(req: UserAuthRestoreRequest, user_id: str = Query(..
     except ApiError as e:
         log.warning(f"TIDAL session expired for user {user_id}, attempting refresh: {e}")
         try:
-            return _refresh_and_restore_user(req, user_id)
+            return await _refresh_and_restore_user(req, user_id)
         except Exception as refresh_err:
             log.error(f"Token refresh also failed for user {user_id}: {refresh_err}")
             raise HTTPException(

--- a/services/tidal-downloader/tests/test_blocking_offload.py
+++ b/services/tidal-downloader/tests/test_blocking_offload.py
@@ -123,3 +123,109 @@ async def test_search_offloaded_to_worker_thread(client, monkeypatch):
 
     assert response.status_code == 200
     assert captured["t"] != "MainThread"
+
+
+def _session_obj() -> types.SimpleNamespace:
+    """Minimal TIDAL session object returned by get_session()."""
+    return types.SimpleNamespace(sessionId="s", userId=42, countryCode="US")
+
+
+@pytest.mark.anyio
+async def test_auth_session_offloaded_to_worker_thread(client, monkeypatch):
+    """Admin session verification should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def fake_get_session():
+        captured["t"] = threading.current_thread().name
+        return _session_obj()
+
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda *_args, **_kwargs: types.SimpleNamespace(get_session=fake_get_session),
+    )
+
+    response = await client.post(
+        "/auth/session",
+        json={"access_token": "at", "user_id": "42", "country_code": "US"},
+    )
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_user_auth_restore_session_offloaded_to_worker_thread(client, monkeypatch):
+    """Per-user session restore should verify the session off the event loop."""
+    import app
+
+    captured = {}
+
+    def fake_get_session():
+        captured["t"] = threading.current_thread().name
+        return _session_obj()
+
+    monkeypatch.setattr(
+        app,
+        "_build_api",
+        lambda *_args, **_kwargs: types.SimpleNamespace(get_session=fake_get_session),
+    )
+
+    response = await client.post(
+        "/user/auth/restore",
+        params={"user_id": "ss-user-1"},
+        json={
+            "access_token": "at",
+            "refresh_token": "rt",
+            "user_id": "42",
+            "country_code": "US",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_user_auth_restore_refresh_offloaded_to_worker_thread(client, monkeypatch):
+    """Expired-token refresh + re-verify should both run off the event loop."""
+    import app
+
+    captured = {}
+
+    class FakeAuthAPI:
+        def refresh_token(self, refresh_token):
+            captured["refresh"] = threading.current_thread().name
+            return types.SimpleNamespace(access_token="at2", user=_fake_user())
+
+    def expired_get_session():
+        raise app.ApiError("expired")
+
+    def refreshed_get_session():
+        captured["session"] = threading.current_thread().name
+        return _session_obj()
+
+    apis = [
+        types.SimpleNamespace(get_session=expired_get_session),
+        types.SimpleNamespace(get_session=refreshed_get_session),
+    ]
+
+    monkeypatch.setattr(app, "_build_api", lambda *_a, **_k: apis.pop(0))
+    monkeypatch.setattr(app, "AuthAPI", FakeAuthAPI)
+
+    response = await client.post(
+        "/user/auth/restore",
+        params={"user_id": "ss-user-2"},
+        json={
+            "access_token": "at",
+            "refresh_token": "rt",
+            "user_id": "42",
+            "country_code": "US",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["refresh"] != "MainThread"
+    assert captured["session"] != "MainThread"


### PR DESCRIPTION
## Finding

RELIABILITY (P9-class). In `services/tidal-downloader/app.py`, the async `/user/auth/restore` handler (`user_auth_restore`) called the blocking third-party `tiddl` `api.get_session()` directly on the asyncio event loop. Its `ApiError` recovery path, `_refresh_and_restore_user`, additionally ran `AuthAPI().refresh_token()` and another `api.get_session()` synchronously on the loop. The `/auth/session` verification handler had the same `get_session()` on-loop call. Because these are blocking upstream I/O, a single user's credential restore/refresh stalled all concurrent onboarding and streaming — the same class of bug fixed in the Phase-D offload of `auth_device`/`auth_token`/`auth_refresh`/`search`.

## Fix

Wrap each blocking third-party call in `asyncio.to_thread`, mirroring the existing offload pattern already used elsewhere in the file:
- `auth_session`: `get_session()` -> `await asyncio.to_thread(api.get_session)`
- `user_auth_restore`: `get_session()` -> `await asyncio.to_thread(api.get_session)`
- `_refresh_and_restore_user`: converted to `async def`; `AuthAPI().refresh_token(...)` and `get_session()` now run via `asyncio.to_thread`; caller now `await`s it.

No changes to signatures, return shapes, or error handling.

## Verification

- Extended `tests/test_blocking_offload.py` with three tests (session-restore, expired-token refresh branch, and `/auth/session`) asserting each blocking call runs off `MainThread`. Confirmed RED before the fix, GREEN after.
- Full tidal-downloader pytest suite: **90 passed** (venv).
- `ruff check` and `ruff format --check`: pass.
- CHANGELOG `### Fixed` entry added.