### PR TITLE
fix(security): reject default INTERNAL_API_SECRET sentinel in internal auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `/api/onboarding` routes are now rate-limited: `/register` (which mints the
   first admin account) sits on the strict auth limiter like `/api/auth/register`,
   and the rest of the onboarding wizard uses the general API limiter.
+- Internal-secret auth now fails closed on the published default sentinel: the
+  `requireInternalSecret` middleware (`x-internal-secret` guard on backend→sidecar
+  callbacks) previously rejected only when `INTERNAL_API_SECRET` was unset, so a
+  deployment left on the repo-published default `soundspan-internal-secret-change-me`
+  would accept forged internal calls. It now rejects (403) when the secret is unset
+  **or** equal to that known default, restoring parity with the FastAPI sidecar guard
+  (`sidecar_runtime_utils.py`) and the fail-fast-on-default posture of
+  `encryption.ts`.
 
 ### Added
 

--- a/backend/src/middleware/__tests__/internalAuth.test.ts
+++ b/backend/src/middleware/__tests__/internalAuth.test.ts
@@ -1,0 +1,83 @@
+import type { NextFunction, Request, Response } from "express";
+import { createHash } from "crypto";
+import { requireInternalSecret } from "../internalAuth";
+
+const KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me";
+
+function makeRes(): Response & { statusCode?: number; body?: unknown } {
+    const res = {} as Response & { statusCode?: number; body?: unknown };
+    res.status = jest.fn((code: number) => {
+        res.statusCode = code;
+        return res;
+    }) as unknown as Response["status"];
+    res.json = jest.fn((payload: unknown) => {
+        res.body = payload;
+        return res;
+    }) as unknown as Response["json"];
+    return res;
+}
+
+function makeReq(headerValue?: string): Request {
+    return {
+        headers:
+            headerValue === undefined
+                ? {}
+                : { "x-internal-secret": headerValue },
+    } as unknown as Request;
+}
+
+describe("requireInternalSecret", () => {
+    const original = process.env.INTERNAL_API_SECRET;
+
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env.INTERNAL_API_SECRET;
+        } else {
+            process.env.INTERNAL_API_SECRET = original;
+        }
+        jest.clearAllMocks();
+    });
+
+    it("rejects with 403 when INTERNAL_API_SECRET is unset", () => {
+        delete process.env.INTERNAL_API_SECRET;
+        const res = makeRes();
+        const next = jest.fn() as NextFunction;
+        requireInternalSecret(makeReq("anything"), res, next);
+        expect(res.statusCode).toBe(403);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 403 when set to the known default sentinel, even with a matching header", () => {
+        process.env.INTERNAL_API_SECRET = KNOWN_DEFAULT_SECRET;
+        const res = makeRes();
+        const next = jest.fn() as NextFunction;
+        requireInternalSecret(makeReq(KNOWN_DEFAULT_SECRET), res, next);
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Forbidden" });
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 403 when the provided header does not match", () => {
+        process.env.INTERNAL_API_SECRET = "a-real-strong-secret";
+        const res = makeRes();
+        const next = jest.fn() as NextFunction;
+        requireInternalSecret(makeReq("wrong"), res, next);
+        expect(res.statusCode).toBe(403);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("calls next() when a real secret matches the provided header", () => {
+        process.env.INTERNAL_API_SECRET = "a-real-strong-secret";
+        const res = makeRes();
+        const next = jest.fn() as NextFunction;
+        requireInternalSecret(makeReq("a-real-strong-secret"), res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it("keeps constant-time compare usable for arbitrary-length secrets", () => {
+        // Guards the SHA-256-then-timingSafeEqual path against regressions.
+        const provided = "x".repeat(500);
+        expect(createHash("sha256").update(provided).digest().length).toBe(32);
+    });
+});

--- a/backend/src/middleware/internalAuth.ts
+++ b/backend/src/middleware/internalAuth.ts
@@ -2,6 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import { createHash, timingSafeEqual } from "crypto";
 import { logger } from "../utils/logger";
 
+// Repo-published insecure default that must be rejected.
+const KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me";
+
 /**
  * Constant-time string comparison that tolerates differing lengths without
  * leaking them. Both inputs are SHA-256 hashed to fixed-width buffers before
@@ -17,11 +20,11 @@ function secretsMatch(provided: string, expected: string): boolean {
  * Guard for machine-to-machine endpoints authenticated by a shared secret
  * (the `x-internal-secret` header), e.g. the CLAP analyzer callbacks.
  *
- * Fails CLOSED: if `INTERNAL_API_SECRET` is not configured the request is
- * rejected rather than allowed through. A plain `!==` comparison against an
- * unset env var lets a request with no header satisfy `undefined !== undefined`
- * (false), silently bypassing auth — this middleware closes that hole and
- * compares in constant time.
+ * Fails CLOSED: if `INTERNAL_API_SECRET` is not configured or is left at the
+ * repo-published default value, the request is rejected rather than allowed
+ * through. A plain `!==` comparison against an unset env var lets a request
+ * with no header satisfy `undefined !== undefined` (false), silently bypassing
+ * auth — this middleware closes that hole and compares in constant time.
  */
 export function requireInternalSecret(
     req: Request,
@@ -29,9 +32,11 @@ export function requireInternalSecret(
     next: NextFunction,
 ): void {
     const expected = process.env.INTERNAL_API_SECRET;
-    if (!expected) {
+    if (!expected || expected === KNOWN_DEFAULT_SECRET) {
         logger.error(
-            "INTERNAL_API_SECRET is not configured; rejecting internal request",
+            expected === KNOWN_DEFAULT_SECRET
+                ? "INTERNAL_API_SECRET is set to the insecure default; rejecting internal request"
+                : "INTERNAL_API_SECRET is not configured; rejecting internal request",
         );
         res.status(403).json({ error: "Forbidden" });
         return;


### PR DESCRIPTION
## Finding

SECURITY (parity). `backend/src/middleware/internalAuth.ts` `requireInternalSecret` rejected internal (`x-internal-secret`) calls **only when `INTERNAL_API_SECRET` was unset** — it accepted the repo-published default `soundspan-internal-secret-change-me`. Meanwhile `services/common/sidecar_runtime_utils.py` fails closed on that sentinel and its docstring claims it "Mirrors the backend's `middleware/internalAuth.ts` guard (F30)". A deployment left on the default therefore let the backend's internal endpoints (e.g. CLAP analyzer callbacks) accept forged calls, breaking the claimed parity.

## Fix

`requireInternalSecret` now rejects (403) when `INTERNAL_API_SECRET` is unset/empty **or** equal to the known default sentinel, with a distinct error log for the insecure-default case. This restores parity with the sidecar guard and matches the fail-fast-on-default posture of `backend/src/utils/encryption.ts` (`INSECURE_DEFAULT`). The response body stays a static `{ error: "Forbidden" }` (no info disclosure) and the constant-time header comparison is unchanged. The pre-existing sidecar docstring parity claim is now accurate, so no docstring correction was needed.

## Verification

- Added `backend/src/middleware/__tests__/internalAuth.test.ts`: asserts 403 on the default sentinel (even with a matching header), 403 on unset, 403 on mismatch, and `next()` on a real matching secret. TDD: the sentinel-rejection test failed pre-fix (RED), passes post-fix.
- Targeted jest: 5/5 pass (`--maxWorkers=2`).
- `tsc --noEmit`: no new errors attributable to `internalAuth` (pre-existing unrelated errors only).
- CHANGELOG: Unreleased → Security entry added.