### PR TITLE
fix(discover): sanitize cleanup-lidarr error leak and harden leak ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Closed a `discover.ts` follow-up gap left by the route error-disclosure
+  hardening: the legacy `POST /api/discover/cleanup-lidarr` handler built a
+  per-artist failure string via a template literal
+  (`Failed to process ${name}: ${error.message}`) and returned it verbatim in
+  the response `errors[]`, leaking raw axios/Lidarr/Prisma text (connection
+  strings, hosts/ports, API-key-bearing URLs, 401 bodies) to any authenticated
+  caller since the router is `requireAuthOrToken`, not admin-only. The handler
+  now pushes a static `Failed to process <artist>` message, logs the raw detail
+  server-side only, and guards non-`Error` throws. The `check-route-error-canon`
+  leak ratchet was extended to also detect template-literal interpolations and
+  intermediate-const assignments of `error.message`/`error.stack` (previously it
+  only matched the `: error.message` object-property form), while exempting
+  raw errors written to the server-side `logger`; `discover.ts` is ratcheted to
+  zero and the newly surfaced pre-existing counts in `playlists`/`podcasts` are
+  frozen as follow-up.
 - Route error-message disclosure hardening (OWASP): the `discover`,
   `enrichment`, and `library` routers no longer echo raw caught-error text
   (`error.message` / `error.stack` / a `details` field carrying it) to clients.

--- a/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
@@ -97,7 +97,13 @@ const LEAK_MARKER =
 describe("POST /cleanup-lidarr does not disclose caught error text", () => {
     it("returns a static per-artist message, not the raw axios error", async () => {
         axiosGet.mockResolvedValueOnce({
-            data: [{ id: 42, foreignArtistId: "mbid-1", artistName: "Nine Inch Nails" }],
+            data: [
+                {
+                    id: 42,
+                    foreignArtistId: "mbid-1",
+                    artistName: "Nine Inch Nails",
+                },
+            ],
         });
         axiosDelete.mockRejectedValueOnce(new Error(LEAK_MARKER));
         const res = createRes();
@@ -115,7 +121,9 @@ describe("POST /cleanup-lidarr does not disclose caught error text", () => {
 
     it("survives a non-Error throw without leaking or crashing", async () => {
         axiosGet.mockResolvedValueOnce({
-            data: [{ id: 7, foreignArtistId: "mbid-2", artistName: "Aphex Twin" }],
+            data: [
+                { id: 7, foreignArtistId: "mbid-2", artistName: "Aphex Twin" },
+            ],
         });
         axiosDelete.mockRejectedValueOnce("boom-string-throw");
         const res = createRes();

--- a/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
@@ -1,0 +1,131 @@
+import { Request, Response } from "express";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
+        next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        discover: { mode: "legacy" },
+        music: { musicPath: "/music" },
+    },
+}));
+
+const prisma = {
+    ownedAlbum: { findFirst: jest.fn(async () => null) },
+    discoveryAlbum: { findFirst: jest.fn(async () => null) },
+    downloadJob: { findMany: jest.fn(async () => []) },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+jest.mock("../../services/lastfm", () => ({ lastFmService: {} }));
+
+const getSystemSettings = jest.fn(async () => ({
+    lidarrEnabled: true,
+    lidarrUrl: "http://lidarr.internal:8686",
+    lidarrApiKey: "SECRET_KEY",
+}));
+jest.mock("../../utils/systemSettings", () => ({ getSystemSettings }));
+
+const axiosGet = jest.fn();
+const axiosDelete = jest.fn();
+jest.mock("axios", () => ({
+    __esModule: true,
+    default: { get: axiosGet, delete: axiosDelete, put: jest.fn() },
+}));
+
+jest.mock("../../services/lidarr", () => ({ lidarrService: {} }));
+
+jest.mock("../../workers/queues", () => ({
+    discoverQueue: { add: jest.fn(), getJobs: jest.fn(), getJob: jest.fn() },
+    scanQueue: { add: jest.fn() },
+}));
+
+jest.mock("../../services/discovery", () => ({
+    discoveryRecommendationsService: {
+        getCurrentPlaylist: jest.fn(),
+        clearCurrentPlaylist: jest.fn(),
+    },
+}));
+
+import router from "../discover";
+
+function getRouteHandler(
+    path: string,
+    method: "get" | "post" | "delete" | "patch",
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined as unknown,
+        status: jest.fn(function (code: number) {
+            res.statusCode = code;
+            return res;
+        }),
+        json: jest.fn(function (payload: unknown) {
+            res.body = payload;
+            return res;
+        }),
+    };
+    return res;
+}
+
+const LEAK_MARKER =
+    "connect ECONNREFUSED lidarr.internal:8686 X-Api-Key=SECRET_KEY";
+
+describe("POST /cleanup-lidarr does not disclose caught error text", () => {
+    it("returns a static per-artist message, not the raw axios error", async () => {
+        axiosGet.mockResolvedValueOnce({
+            data: [{ id: 42, foreignArtistId: "mbid-1", artistName: "Nine Inch Nails" }],
+        });
+        axiosDelete.mockRejectedValueOnce(new Error(LEAK_MARKER));
+        const res = createRes();
+
+        await getRouteHandler("/cleanup-lidarr", "post")(
+            { user: { id: "user-1" }, params: {}, query: {}, body: {} },
+            res,
+        );
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.errors).toEqual(["Failed to process Nine Inch Nails"]);
+        expect(JSON.stringify(res.body)).not.toContain("ECONNREFUSED");
+        expect(JSON.stringify(res.body)).not.toContain("SECRET_KEY");
+    });
+
+    it("survives a non-Error throw without leaking or crashing", async () => {
+        axiosGet.mockResolvedValueOnce({
+            data: [{ id: 7, foreignArtistId: "mbid-2", artistName: "Aphex Twin" }],
+        });
+        axiosDelete.mockRejectedValueOnce("boom-string-throw");
+        const res = createRes();
+
+        await getRouteHandler("/cleanup-lidarr", "post")(
+            { user: { id: "user-1" }, params: {}, query: {}, body: {} },
+            res,
+        );
+
+        expect(res.body.errors).toEqual(["Failed to process Aphex Twin"]);
+        expect(JSON.stringify(res.body)).not.toContain("boom-string-throw");
+    });
+});

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -1255,7 +1255,7 @@ describe("discover legacy-mode runtime behavior", () => {
                 "Liked Artist (has native library or kept albums)",
                 "Active Artist (has active discovery)",
             ],
-            errors: ["Failed to process Error Artist: delete failed"],
+            errors: ["Failed to process Error Artist"],
             summary: {
                 removed: 1,
                 kept: 3,

--- a/backend/src/routes/discover.ts
+++ b/backend/src/routes/discover.ts
@@ -2262,10 +2262,13 @@ router.post("/cleanup-lidarr", async (req, res) => {
 
                 artistsRemoved.push(artistName);
                 logger.debug(`[CLEANUP] Removed: ${artistName}`);
-            } catch (error: any) {
-                const msg = `Failed to process ${artistName}: ${error.message}`;
-                errors.push(msg);
-                logger.error(`[CLEANUP] ${msg}`);
+            } catch (error: unknown) {
+                const detail =
+                    error instanceof Error ? error.message : String(error);
+                errors.push(`Failed to process ${artistName}`);
+                logger.error(
+                    `[CLEANUP] Failed to process ${artistName}: ${detail}`,
+                );
             }
         }
 

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -5,6 +5,7 @@ import {
     analyzeRouteErrorCanon,
     countPattern,
     countLeakPattern,
+    stripLoggerCalls,
 } from "../check-route-error-canon.mjs";
 
 test("countPattern counts occurrences and tolerates whitespace", () => {
@@ -95,4 +96,26 @@ test("analyzeRouteErrorCanon ratchets leak counts the same way", () => {
             tightenable: [],
         },
     );
+});
+
+test("countLeakPattern flags a template-literal interpolation of error.message", () => {
+    const source =
+        "const msg = `Failed to process ${artistName}: ${error.message}`;";
+    assert.equal(countLeakPattern(source), 1);
+});
+
+test("countLeakPattern flags an intermediate const assigned from error.message", () => {
+    const source = "const detail = error.message; return res.json({ detail });";
+    assert.equal(countLeakPattern(source), 1);
+});
+
+test("countLeakPattern flags a template-literal error.stack interpolation", () => {
+    assert.equal(countLeakPattern("res.send(`trace: ${error?.stack}`);"), 1);
+});
+
+test("countLeakPattern exempts raw errors logged server-side via logger.*", () => {
+    const source =
+        "logger.error(`[CLEANUP] ${artistName}: ${error.message}`);\n" +
+        "logger.error('boom', error?.message || error);";
+    assert.equal(countLeakPattern(source), 0);
 });

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -57,12 +57,13 @@ const BASELINE = Object.freeze({
 // Raw error details can disclose internal implementation data to clients (OWASP).
 // This independent ratchet prevents new error.message/error.stack response leaks.
 const LEAK_BASELINE = Object.freeze({
+    "backend/src/routes/discover.ts": 0,
     "backend/src/routes/downloads.ts": 1,
     "backend/src/routes/listenTogether.ts": 1,
     "backend/src/routes/notifications.ts": 2,
     "backend/src/routes/playbackState.ts": 1,
-    "backend/src/routes/playlists.ts": 2,
-    "backend/src/routes/podcasts.ts": 1,
+    "backend/src/routes/playlists.ts": 4,
+    "backend/src/routes/podcasts.ts": 3,
 });
 
 export function countPattern(source) {
@@ -70,12 +71,36 @@ export function countPattern(source) {
     return source.match(pattern)?.length ?? 0;
 }
 
+export function stripLoggerCalls(source) {
+    const callStart = /logger\s*\.\s*[a-zA-Z]+\s*\(/g;
+    let out = "";
+    let cursor = 0;
+    let match;
+    let guard = 0;
+    while ((match = callStart.exec(source)) !== null && guard++ < 100000) {
+        let index = match.index + match[0].length;
+        let depth = 1;
+        let innerGuard = 0;
+        while (index < source.length && depth > 0 && innerGuard++ < 1000000) {
+            const char = source[index];
+            if (char === "(") depth++;
+            else if (char === ")") depth--;
+            index++;
+        }
+        out += source.slice(cursor, match.index);
+        cursor = index;
+        callStart.lastIndex = index;
+    }
+    return out + source.slice(cursor);
+}
+
 export function countLeakPattern(source) {
-    const pattern = /:\s*error\??\.(?:message|stack)\b/g;
-    const normalizedSource = source.replace(
+    const stripped = stripLoggerCalls(source);
+    const normalizedSource = stripped.replace(
         /error\s*(\??)\s*\.\s*(message|stack)\b/g,
         "error$1.$2",
     );
+    const pattern = /(?::\s*|=\s*|\$\{[^}]*)error\??\.(?:message|stack)\b/g;
     return normalizedSource.match(pattern)?.length ?? 0;
 }
 


### PR DESCRIPTION
## Finding

SECURITY + Phase-D regression (an incomplete spot from #266). The legacy `POST /api/discover/cleanup-lidarr` handler in `backend/src/routes/discover.ts` built a per-artist failure string as:

```ts
const msg = `Failed to process ${artistName}: ${error.message}`;
errors.push(msg);
```

and returned `errors[]` verbatim via `res.json`. The `discover` router is mounted with `requireAuthOrToken` (not admin-only), so any authenticated caller received raw axios/Lidarr/Prisma text — `ECONNREFUSED host:port`, internal URLs, API-key-bearing request URLs, 401 bodies. The earlier leak ratchet only matched the `: error.message` object-property form, so this template-literal form passed silently.

## Fix

1. **discover.ts** — the catch now pushes a static `Failed to process <artist>` message (no `error.message`/`stack`), logs the raw detail server-side only, and guards non-`Error` throws (`error instanceof Error ? error.message : String(error)`). All other `error.message` uses in the file are inside `logger.*` calls (server-side) and were left unchanged.
2. **scripts/ci/check-route-error-canon.mjs** — `countLeakPattern` was extended to also flag template-literal interpolations (`${…error.message…}`) and intermediate-const assignments (`= error.message`), in addition to the existing object-property form, while a new `stripLoggerCalls` helper exempts raw errors written to the server-side `logger`. `LEAK_BASELINE` now pins `discover.ts` to `0`; the newly surfaced pre-existing counts in `playlists` (2→4) and `podcasts` (1→3) are frozen as follow-up (a later slice owns those routers).

## Verification

- `backend` jest (targeted, maxWorkers=2): new `discoverCleanupLidarrLeak.test.ts` (static message + non-Error throw), updated `discoverLegacyRuntime.test.ts`, and existing `discoverErrorLeak.test.ts` — **31 passed**.
- `node --test scripts/ci/__tests__/check-route-error-canon.test.mjs` — **14 passed** (4 new self-tests: template-literal `.message`/`.stack`, intermediate-const, and logger-exemption).
- `node scripts/ci/check-route-error-canon.mjs` — exit **0** (both ratchets pass; `discover.ts` leak count = 0).
- `prettier --check` clean on all changed files.