### PR TITLE
fix(a11y): keyboard + AT support for the vibe map canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clickable track rows expose button semantics with Enter/Space activation,
   queue icon controls have accessible labels, and scoped jsx-a11y lint guards
   protect the hardened accessibility components.
+- The vibe map canvas now exposes an application role, an accessible name and a
+  live text summary of its node count and focused track, and supports keyboard
+  navigation (Arrow/Home/End to move focus between visible tracks, Enter/Space
+  to explore the focused track) alongside the existing pointer interactions.
 
 ### Changed
 

--- a/frontend/components/vibe/MapCanvas.tsx
+++ b/frontend/components/vibe/MapCanvas.tsx
@@ -2,11 +2,12 @@
 
 /** Canvas renderer for the vibe map's filtered, highlighted dot sample. */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { resolveMapKeyNav } from "./mapKeyboardNav";
 import type { Viewport } from "./mapViewport";
 import { computeDotRadius, fitViewport } from "./mapViewport";
 import type { MapTrack } from "./types";
-import { getMoodColor } from "./types";
+import { getMoodColor, VIBE_ACCENTS } from "./types";
 
 export interface MapCanvasProps {
     tracks: readonly MapTrack[];
@@ -19,6 +20,10 @@ export interface MapCanvasProps {
     dimUnhighlighted?: boolean;
     hoveredId?: string | null;
     className?: string;
+    onSelectTrack?: (
+        id: string,
+        mods: { ctrlOrMeta: boolean; shift: boolean },
+    ) => void;
     onPointerDown?: (event: React.PointerEvent<HTMLCanvasElement>) => void;
     onPointerMove?: (event: React.PointerEvent<HTMLCanvasElement>) => void;
     onPointerUp?: (event: React.PointerEvent<HTMLCanvasElement>) => void;
@@ -34,6 +39,19 @@ const HOVER_BOOST = 2.5;
 const GLOW_BOOST = 2.5;
 const GLOW_RING_EXTRA = 3.5;
 const CULL_MARGIN = 12;
+
+type MapCanvasDrawProps = Pick<
+    MapCanvasProps,
+    | "tracks"
+    | "viewport"
+    | "width"
+    | "height"
+    | "mask"
+    | "positions"
+    | "highlightIds"
+    | "dimUnhighlighted"
+    | "hoveredId"
+> & { focusedId: string | null };
 
 function prepareCanvas(
     canvas: HTMLCanvasElement,
@@ -53,9 +71,23 @@ function prepareCanvas(
     return context;
 }
 
+function paintFocusRing(
+    context: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    radius: number,
+): void {
+    context.beginPath();
+    context.arc(x, y, radius + GLOW_RING_EXTRA, 0, TAU);
+    context.strokeStyle = VIBE_ACCENTS.trail;
+    context.lineWidth = 2;
+    context.globalAlpha = 1;
+    context.stroke();
+}
+
 function paintDots(
     context: CanvasRenderingContext2D,
-    props: MapCanvasProps,
+    props: MapCanvasDrawProps,
 ): void {
     const { tracks, viewport, width, height, mask, positions } = props;
     const highlights = props.highlightIds;
@@ -106,23 +138,51 @@ function paintDots(
         context.fillStyle = color;
         context.globalAlpha = alpha;
         context.fill();
+        if (visible && props.focusedId === track.id)
+            paintFocusRing(context, sx, sy, dotRadius);
     }
     context.globalAlpha = 1;
 }
 
 function drawCanvas(
     canvas: HTMLCanvasElement | null,
-    props: MapCanvasProps,
+    props: MapCanvasDrawProps,
 ): void {
     if (!canvas || props.width <= 0 || props.height <= 0) return;
     const context = prepareCanvas(canvas, props.width, props.height);
     if (context) paintDots(context, props);
 }
 
-export function MapCanvas(props: MapCanvasProps) {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
+function navigableOrder(tracks: readonly MapTrack[], mask: Uint8Array) {
+    return tracks.flatMap((_, index) => (mask[index] !== 0 ? [index] : []));
+}
+
+function handleCanvasKeyDown(
+    event: React.KeyboardEvent<HTMLCanvasElement>,
+    props: MapCanvasProps,
+    order: readonly number[],
+    focusedIndex: number | null,
+    setFocusedIndex: React.Dispatch<React.SetStateAction<number | null>>,
+): void {
+    const result = resolveMapKeyNav(event.key, { order, focusedIndex });
+    if (result.type === "none") return;
+    event.preventDefault();
+    if (result.type === "move") {
+        setFocusedIndex(result.index);
+        return;
+    }
+    props.onSelectTrack?.(props.tracks[result.index].id, {
+        ctrlOrMeta: event.ctrlKey || event.metaKey,
+        shift: event.shiftKey,
+    });
+}
+
+function useCanvasDrawing(
+    canvasRef: React.RefObject<HTMLCanvasElement | null>,
+    props: MapCanvasDrawProps,
+): void {
     const { tracks, viewport, width, height, mask, positions } = props;
-    const { highlightIds, dimUnhighlighted, hoveredId } = props;
+    const { highlightIds, dimUnhighlighted, hoveredId, focusedId } = props;
     useEffect(() => {
         drawCanvas(canvasRef.current, {
             tracks,
@@ -134,8 +194,10 @@ export function MapCanvas(props: MapCanvasProps) {
             highlightIds,
             dimUnhighlighted,
             hoveredId,
+            focusedId,
         });
     }, [
+        canvasRef,
         tracks,
         viewport,
         width,
@@ -145,16 +207,57 @@ export function MapCanvas(props: MapCanvasProps) {
         highlightIds,
         dimUnhighlighted,
         hoveredId,
+        focusedId,
     ]);
+}
+
+export function MapCanvas(props: MapCanvasProps) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const baseId = useId();
+    const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+    const { tracks, viewport, width, height, mask, positions } = props;
+    const { highlightIds, dimUnhighlighted, hoveredId } = props;
+    const order = useMemo(() => navigableOrder(tracks, mask), [tracks, mask]);
+    const focusedId = tracks[focusedIndex ?? -1]?.id ?? null;
+    const summaryId = `${baseId}-summary`;
+    const summary = `Vibe map, ${tracks.length} tracks, ${order.length} shown. Use arrow keys to move between tracks and Enter to explore.`;
+    const focusedTrack = tracks[focusedIndex ?? -1];
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLCanvasElement>) =>
+        handleCanvasKeyDown(event, props, order, focusedIndex, setFocusedIndex);
+    useCanvasDrawing(canvasRef, {
+        tracks,
+        viewport,
+        width,
+        height,
+        mask,
+        positions,
+        highlightIds,
+        dimUnhighlighted,
+        hoveredId,
+        focusedId,
+    });
     return (
-        <canvas
-            ref={canvasRef}
-            className={props.className ?? "absolute inset-0 touch-none"}
-            onPointerDown={props.onPointerDown}
-            onPointerMove={props.onPointerMove}
-            onPointerUp={props.onPointerUp}
-            onPointerCancel={props.onPointerCancel}
-            onPointerLeave={props.onPointerLeave}
-        />
+        <>
+            <canvas
+                ref={canvasRef}
+                className={props.className ?? "absolute inset-0 touch-none"}
+                role="application"
+                aria-roledescription="Vibe map"
+                aria-label={summary}
+                aria-describedby={summaryId}
+                tabIndex={0}
+                onKeyDown={handleKeyDown}
+                onPointerDown={props.onPointerDown}
+                onPointerMove={props.onPointerMove}
+                onPointerUp={props.onPointerUp}
+                onPointerCancel={props.onPointerCancel}
+                onPointerLeave={props.onPointerLeave}
+            />
+            <span id={summaryId} className="sr-only" aria-live="polite">
+                {focusedTrack
+                    ? `Focused: ${focusedTrack.title} by ${focusedTrack.artist}.`
+                    : summary}
+            </span>
+        </>
     );
 }

--- a/frontend/components/vibe/VibeMapCanvasStage.tsx
+++ b/frontend/components/vibe/VibeMapCanvasStage.tsx
@@ -87,6 +87,7 @@ function ReadyMap({ model }: { model: VibeMapViewModel }) {
                 highlightIds={model.presentation.effectiveHighlightIds}
                 dimUnhighlighted={model.presentation.effectiveDim}
                 hoveredId={model.gestures.hoveredId}
+                onSelectTrack={model.vibe.onDotClick}
                 onPointerDown={model.gestures.handlePointerDown}
                 onPointerMove={model.gestures.handlePointerMove}
                 onPointerUp={model.gestures.handlePointerUp}

--- a/frontend/components/vibe/mapKeyboardNav.ts
+++ b/frontend/components/vibe/mapKeyboardNav.ts
@@ -1,0 +1,39 @@
+/** A keyboard navigation outcome for the vibe map. */
+export type MapKeyNavResult =
+    | { type: "move"; index: number }
+    | { type: "select"; index: number }
+    | { type: "none" };
+
+/** The visible track order and current track focus. */
+export interface MapKeyNavContext {
+    order: readonly number[];
+    focusedIndex: number | null;
+}
+
+/** Resolve a keyboard input without depending on React or the DOM. */
+export function resolveMapKeyNav(
+    key: string,
+    ctx: MapKeyNavContext,
+): MapKeyNavResult {
+    if (ctx.order.length === 0) return { type: "none" };
+    const position =
+        ctx.focusedIndex === null ? -1 : ctx.order.indexOf(ctx.focusedIndex);
+    if (key === "ArrowRight" || key === "ArrowDown") {
+        const next =
+            position < 0 ? 0 : Math.min(position + 1, ctx.order.length - 1);
+        return { type: "move", index: ctx.order[next] };
+    }
+    if (key === "ArrowLeft" || key === "ArrowUp") {
+        const previous = position < 0 ? 0 : Math.max(position - 1, 0);
+        return { type: "move", index: ctx.order[previous] };
+    }
+    if (key === "Home") return { type: "move", index: ctx.order[0] };
+    if (key === "End") {
+        return { type: "move", index: ctx.order[ctx.order.length - 1] };
+    }
+    if (key === "Enter" || key === " " || key === "Spacebar") {
+        if (position < 0 || ctx.focusedIndex === null) return { type: "none" };
+        return { type: "select", index: ctx.focusedIndex };
+    }
+    return { type: "none" };
+}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -46,6 +46,7 @@ const eslintConfig = defineConfig([
     {
         files: [
             "components/player/SeekSlider.tsx",
+            "components/vibe/MapCanvas.tsx",
             "components/ui/Modal.tsx",
             "components/ui/ConfirmDialog.tsx",
             "components/track/TrackRow.tsx",

--- a/frontend/tests/component/mapCanvasA11y.component.test.ts
+++ b/frontend/tests/component/mapCanvasA11y.component.test.ts
@@ -63,7 +63,10 @@ async function mountCanvas(
     return { container, root };
 }
 
-async function unmount(mounted: { container: HTMLElement; root: { unmount: () => void } }) {
+async function unmount(mounted: {
+    container: HTMLElement;
+    root: { unmount: () => void };
+}) {
     await React.act(async () => {
         mounted.root.unmount();
     });
@@ -76,7 +79,11 @@ function canvasOf(container: HTMLElement): HTMLCanvasElement {
     return canvas as HTMLCanvasElement;
 }
 
-async function press(canvas: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+async function press(
+    canvas: HTMLElement,
+    key: string,
+    init: KeyboardEventInit = {},
+) {
     await React.act(async () => {
         canvas.dispatchEvent(
             new KeyboardEvent("keydown", { key, bubbles: true, ...init }),

--- a/frontend/tests/component/mapCanvasA11y.component.test.ts
+++ b/frontend/tests/component/mapCanvasA11y.component.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+type Mods = { ctrlOrMeta: boolean; shift: boolean };
+type SelectCall = { id: string; mods: Mods };
+
+const baseTrack = {
+    x: 0.5,
+    y: 0.5,
+    title: "",
+    artist: "",
+    artistId: "a",
+    albumId: "al",
+    coverUrl: null,
+    dominantMood: "moodHappy",
+    moodScore: 0.5,
+    energy: 0.5,
+    valence: 0.5,
+};
+
+const tracks = [
+    { ...baseTrack, id: "t1", title: "First Song", artist: "Artist One" },
+    { ...baseTrack, id: "t2", title: "Second Song", artist: "Artist Two" },
+    { ...baseTrack, id: "t3", title: "Third Song", artist: "Artist Three" },
+];
+
+async function mountCanvas(
+    mask: number[],
+    onSelectTrack: (id: string, mods: Mods) => void,
+) {
+    const { createRoot } = await import("react-dom/client");
+    const { MapCanvas } = await import("../../components/vibe/MapCanvas");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(
+            React.createElement(MapCanvas, {
+                tracks,
+                viewport: { scale: 100, tx: 0, ty: 0 },
+                width: 400,
+                height: 300,
+                mask: Uint8Array.from(mask),
+                onSelectTrack,
+            }),
+        );
+    });
+    return { container, root };
+}
+
+async function unmount(mounted: { container: HTMLElement; root: { unmount: () => void } }) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+function canvasOf(container: HTMLElement): HTMLCanvasElement {
+    const canvas = container.querySelector("canvas");
+    assert.ok(canvas, "expected a canvas element");
+    return canvas as HTMLCanvasElement;
+}
+
+async function press(canvas: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+    await React.act(async () => {
+        canvas.dispatchEvent(
+            new KeyboardEvent("keydown", { key, bubbles: true, ...init }),
+        );
+    });
+}
+
+test("canvas exposes an application role, accessible name and node count", async () => {
+    const mounted = await mountCanvas([1, 1, 1], () => undefined);
+    const canvas = canvasOf(mounted.container);
+
+    assert.equal(canvas.getAttribute("role"), "application");
+    assert.equal((canvas as HTMLElement).tabIndex, 0);
+
+    const name = canvas.getAttribute("aria-label") ?? "";
+    assert.match(name, /vibe map/i, "aria-label should name the map");
+    assert.match(name, /3/, "aria-label should mention the node count");
+
+    // A text alternative (aria-describedby) summarises the map for AT.
+    const describedBy = canvas.getAttribute("aria-describedby");
+    assert.ok(describedBy, "expected aria-describedby");
+    const summary = mounted.container.querySelector(`#${describedBy}`);
+    assert.ok(summary, "expected the described-by summary element in the DOM");
+
+    await unmount(mounted);
+});
+
+test("arrow keys move focus between visible nodes and Enter selects", async () => {
+    const calls: SelectCall[] = [];
+    const mounted = await mountCanvas([1, 1, 1], (id, mods) =>
+        calls.push({ id, mods }),
+    );
+    const canvas = canvasOf(mounted.container);
+    canvas.focus();
+
+    await press(canvas, "ArrowRight"); // focus first
+    await press(canvas, "Enter");
+    assert.deepEqual(calls.at(-1), {
+        id: "t1",
+        mods: { ctrlOrMeta: false, shift: false },
+    });
+
+    await press(canvas, "ArrowRight"); // advance to second
+    await press(canvas, "Enter");
+    assert.equal(calls.at(-1)?.id, "t2");
+
+    await unmount(mounted);
+});
+
+test("Enter forwards ctrl/shift modifiers to selection", async () => {
+    const calls: SelectCall[] = [];
+    const mounted = await mountCanvas([1, 1, 1], (id, mods) =>
+        calls.push({ id, mods }),
+    );
+    const canvas = canvasOf(mounted.container);
+    canvas.focus();
+
+    await press(canvas, "ArrowRight");
+    await press(canvas, "Enter", { shiftKey: true, metaKey: true });
+    assert.deepEqual(calls.at(-1), {
+        id: "t1",
+        mods: { ctrlOrMeta: true, shift: true },
+    });
+
+    await unmount(mounted);
+});
+
+test("keyboard navigation skips filtered-out (masked) nodes", async () => {
+    const calls: SelectCall[] = [];
+    // Only the middle track is visible.
+    const mounted = await mountCanvas([0, 1, 0], (id, mods) =>
+        calls.push({ id, mods }),
+    );
+    const canvas = canvasOf(mounted.container);
+    canvas.focus();
+
+    await press(canvas, "ArrowRight");
+    await press(canvas, "ArrowRight"); // cannot advance past the only visible node
+    await press(canvas, "Enter");
+    assert.equal(calls.at(-1)?.id, "t2");
+    assert.equal(calls.length, 1);
+
+    await unmount(mounted);
+});

--- a/frontend/tests/unit/mapKeyboardNav.test.ts
+++ b/frontend/tests/unit/mapKeyboardNav.test.ts
@@ -14,7 +14,10 @@ test("returns none when there is nothing navigable", () => {
 
 test("first arrow focuses the first navigable node when nothing is focused", () => {
     assert.deepEqual(
-        resolveMapKeyNav("ArrowRight", { order: [2, 5, 9], focusedIndex: null }),
+        resolveMapKeyNav("ArrowRight", {
+            order: [2, 5, 9],
+            focusedIndex: null,
+        }),
         { type: "move", index: 2 },
     );
     assert.deepEqual(

--- a/frontend/tests/unit/mapKeyboardNav.test.ts
+++ b/frontend/tests/unit/mapKeyboardNav.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveMapKeyNav } from "../../components/vibe/mapKeyboardNav";
+
+// `order` is the list of navigable track indices (e.g. the visible dots) in
+// traversal order; `focusedIndex` is the currently focused track index.
+
+test("returns none when there is nothing navigable", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowRight", { order: [], focusedIndex: null }),
+        { type: "none" },
+    );
+});
+
+test("first arrow focuses the first navigable node when nothing is focused", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowRight", { order: [2, 5, 9], focusedIndex: null }),
+        { type: "move", index: 2 },
+    );
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowLeft", { order: [2, 5, 9], focusedIndex: null }),
+        { type: "move", index: 2 },
+    );
+});
+
+test("forward keys advance and clamp at the last node", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowRight", { order: [2, 5, 9], focusedIndex: 2 }),
+        { type: "move", index: 5 },
+    );
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowDown", { order: [2, 5, 9], focusedIndex: 9 }),
+        { type: "move", index: 9 },
+    );
+});
+
+test("backward keys retreat and clamp at the first node", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowLeft", { order: [2, 5, 9], focusedIndex: 5 }),
+        { type: "move", index: 2 },
+    );
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowUp", { order: [2, 5, 9], focusedIndex: 2 }),
+        { type: "move", index: 2 },
+    );
+});
+
+test("Home and End jump to the ends of the navigable list", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("Home", { order: [2, 5, 9], focusedIndex: 9 }),
+        { type: "move", index: 2 },
+    );
+    assert.deepEqual(
+        resolveMapKeyNav("End", { order: [2, 5, 9], focusedIndex: 2 }),
+        { type: "move", index: 9 },
+    );
+});
+
+test("Enter and Space select the focused node", () => {
+    for (const key of ["Enter", " ", "Spacebar"]) {
+        assert.deepEqual(
+            resolveMapKeyNav(key, { order: [2, 5, 9], focusedIndex: 5 }),
+            { type: "select", index: 5 },
+        );
+    }
+});
+
+test("selection keys do nothing without a focused node", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("Enter", { order: [2, 5, 9], focusedIndex: null }),
+        { type: "none" },
+    );
+});
+
+test("a focused index that is no longer navigable is treated as unfocused", () => {
+    // index 7 is not in `order`; a forward key should focus the first node.
+    assert.deepEqual(
+        resolveMapKeyNav("ArrowRight", { order: [2, 5, 9], focusedIndex: 7 }),
+        { type: "move", index: 2 },
+    );
+    assert.deepEqual(
+        resolveMapKeyNav("Enter", { order: [2, 5, 9], focusedIndex: 7 }),
+        { type: "none" },
+    );
+});
+
+test("unrelated keys yield none", () => {
+    assert.deepEqual(
+        resolveMapKeyNav("Tab", { order: [2, 5, 9], focusedIndex: 5 }),
+        { type: "none" },
+    );
+});


### PR DESCRIPTION
## Finding

The new vibe-map code (flag-gated off behind `vibeEmbeddings`, fix before the flip) renders a bare `<canvas>` in `frontend/components/vibe/MapCanvas.tsx` wired only to pointer handlers — no `role`, `aria-label`, or text alternative, and the only keyboard support in the map chain is a global Escape. The map is unreachable for keyboard and assistive-technology users.

## Fix

- **Accessible name + role + text alternative:** the canvas now has `role="application"`, `aria-roledescription="Vibe map"`, an `aria-label` that names the map and includes the node count, and an `aria-live` (`aria-describedby`) summary announcing the node count and the currently focused track.
- **Keyboard path:** Arrow/Home/End move focus between visible (unmasked) tracks; Enter/Space explore the focused track, forwarding ctrl/meta/shift modifiers to the existing `onDotClick` routing. A focus ring is painted on the focused dot. The pure `resolveMapKeyNav` module holds the navigation logic (fully unit-tested).
- Wired `onSelectTrack={model.vibe.onDotClick}` at the render site (`VibeMapCanvasStage`).
- Scoped the jsx-a11y error-level guards to `MapCanvas.tsx`, mirroring the P26 a11y-core enforcement set.

Behavior remains behind the existing `vibeEmbeddings` gate (the map only renders when the flag is on). Pointer interactions are unchanged.

## Verification

- `verify:` new unit test `tests/unit/mapKeyboardNav.test.ts` — 9/9 pass (written failing first, TDD).
- `verify:` new component test `tests/component/mapCanvasA11y.component.test.ts` (happy-dom) asserts application role + accessible name + node count + keyboard focus/selection incl. masked-node skipping and modifier forwarding — 4/4 pass.
- `verify:` existing `tests/component/vibeMap.component.test.ts` still passes (no regression).
- `verify:` `tsc --noEmit` exit 0.
- `verify:` `eslint .` = 183 problems (0 errors, 183 warnings) — at the ≤183 budget, no regression; changed files lint clean.