### PR TITLE
fix(playlists,podcasts): sanitize client-facing raw-error leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Stopped returning raw caught-error text to clients from the playlist
+  pending-track retry path and podcast refresh-all: the retry handler wrote
+  `error.message` into the session log (returned verbatim to any authenticated
+  caller via `GET /api/spotify/import/session-log`) and into the stored
+  `downloadJob.error` field (returned via `GET /api/downloads`), and
+  `refreshAllPodcastFeeds` echoed per-feed `error.message` in the
+  `POST /api/podcasts/refresh-all` response. All three now use static client
+  messages with raw detail kept in server-side logs only, and the
+  `check-route-error-canon` leak-ratchet baselines were lowered
+  (`playlists.ts` 4→1, `podcasts.ts` 3→2); the remaining counts are
+  server-side-only or code-owned validation text, documented in the checker.
 - Closed a `discover.ts` follow-up gap left by the route error-disclosure
   hardening: the legacy `POST /api/discover/cleanup-lidarr` handler built a
   per-artist failure string via a template literal

--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -2395,9 +2395,14 @@ describe("playlists route runtime", () => {
                 where: { id: "job-failed-throw" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: "socket closed",
+                    error: "Download exception",
                 }),
             }),
+        );
+        const sessionLogMock = jest.requireMock("../../utils/playlistLogger")
+            .sessionLog as jest.Mock;
+        expect(JSON.stringify(sessionLogMock.mock.calls)).not.toContain(
+            "socket closed",
         );
     });
 
@@ -2468,6 +2473,11 @@ describe("playlists route runtime", () => {
         expect(res.body).toEqual({
             error: "Failed to retry download",
         });
+        const sessionLogMock = jest.requireMock("../../utils/playlistLogger")
+            .sessionLog as jest.Mock;
+        expect(JSON.stringify(sessionLogMock.mock.calls)).not.toContain(
+            "db exploded",
+        );
     });
 
     it("handles reconcile preconditions and unexpected reconcile errors", async () => {

--- a/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
@@ -837,6 +837,10 @@ describe("podcasts branch coverage additions", () => {
             }),
         );
         expect(body.results).toHaveLength(2);
+        expect((body.results[1] as { error?: string }).error).toBe(
+            "Failed to refresh feed",
+        );
+        expect(JSON.stringify(res.body)).not.toContain("feed parse failed");
     });
 
     it("refresh-all route returns 500 when refresh-all pipeline throws", async () => {
@@ -852,7 +856,7 @@ describe("podcasts branch coverage additions", () => {
         expect(res.body).toEqual({ error: "Failed to refresh podcasts" });
     });
 
-    it("refresh-all reports 'Unknown error' for non-Error feed failures", async () => {
+    it("refresh-all reports a static error for feed failures", async () => {
         (
             prisma.podcastSubscription.findMany as jest.Mock
         ).mockResolvedValueOnce([{ podcastId: "pod-unknown-error" }]);
@@ -875,6 +879,6 @@ describe("podcasts branch coverage additions", () => {
         };
         expect(res.statusCode).toBe(200);
         expect(body.failed).toBe(1);
-        expect(body.results[0].error).toBe("Unknown error");
+        expect(body.results[0].error).toBe("Failed to refresh feed");
     });
 });

--- a/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
@@ -1552,8 +1552,11 @@ describe("podcasts core runtime behavior", () => {
             expect.objectContaining({
                 podcastId: "pod-broken",
                 success: false,
-                error: expect.stringMatching(/not found/),
+                error: "Failed to refresh feed",
             }),
+        );
+        expect(JSON.stringify(result)).not.toContain(
+            "Podcast pod-broken not found",
         );
     });
 

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -1692,9 +1692,10 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
             })
             .catch((error) => {
                 logger.error(`[Retry] Download error:`, error);
+                // The session log is returned verbatim to any authenticated caller via GET /api/spotify/import/session-log, so raw error text must not be written to it.
                 sessionLog(
                     "PENDING-RETRY",
-                    `Download exception: ${error?.message || error}`,
+                    "Download exception (raw detail in server log)",
                     "ERROR",
                 );
 
@@ -1703,7 +1704,8 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
                         where: { id: downloadJob.id },
                         data: {
                             status: "failed",
-                            error: error?.message || "Download exception",
+                            // downloadJob rows (incl. error) are returned to the owning user via GET /api/downloads
+                            error: "Download exception",
                             completedAt: new Date(),
                         },
                     })
@@ -1713,7 +1715,7 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
         logger.error("Retry pending track error:", error);
         sessionLog(
             "PENDING-RETRY",
-            `Handler error: ${error?.message || error}`,
+            "Handler error (raw detail in server log)",
             "ERROR",
         );
         res.status(500).json({

--- a/backend/src/routes/podcasts.ts
+++ b/backend/src/routes/podcasts.ts
@@ -2359,7 +2359,7 @@ export async function refreshAllPodcastFeeds(
                 podcastId: sub.podcastId,
                 success: false,
                 newEpisodesCount: 0,
-                error: error.message || "Unknown error",
+                error: "Failed to refresh feed",
             });
         }
     }

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -62,8 +62,10 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/routes/listenTogether.ts": 1,
     "backend/src/routes/notifications.ts": 2,
     "backend/src/routes/playbackState.ts": 1,
-    "backend/src/routes/playlists.ts": 4,
-    "backend/src/routes/podcasts.ts": 3,
+    // playlists.ts remaining 1: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904).
+    "backend/src/routes/playlists.ts": 1,
+    // podcasts.ts remaining 2: Prisma-retry classification helper (~L83) and logger-only describeAxiosError (~L133); neither reaches a response body.
+    "backend/src/routes/podcasts.ts": 2,
 });
 
 export function countPattern(source) {


### PR DESCRIPTION
## Summary

Closes the client-facing instances the hardened raw-error leak ratchet (#272) surfaced in the frozen `playlists.ts`/`podcasts.ts` baselines (same OWASP info-disclosure class as the discover/enrichment/library fixes).

### Per-instance triage

| Instance | Triage | Action |
| --- | --- | --- |
| `playlists.ts` ~L1697 `sessionLog(\`Download exception: ${error?.message}\`)` | **Client-reachable** — session log is returned verbatim to any authenticated caller via `GET /api/spotify/import/session-log` (router is `requireAuthOrToken`, not admin-only) | Sanitized to static message; raw detail stays in adjacent server-side `logger.error` |
| `playlists.ts` ~L1706 stored `downloadJob.error = error?.message` | **Client-reachable** — `GET /api/downloads` returns `downloadJob` rows wholesale (`findMany` with no `select`), including `error` | Sanitized to static `"Download exception"` |
| `playlists.ts` ~L1716 `sessionLog(\`Handler error: ${error?.message}\`)` | **Client-reachable** (same session-log endpoint) | Sanitized to static message |
| `playlists.ts` ~L904 `details: [{ message: error.message }]` | **Not an internal-error disclosure** — prefix-guarded (`startsWith("ensureRemoteTrack requires")`) code-owned validation text in a 400 body | Left in baseline with checker comment |
| `podcasts.ts` ~L83 `const message = error.message` | **Server-side only** — Prisma-retry classification helper; message used only for `.includes()` checks | Left in baseline with checker comment |
| `podcasts.ts` ~L133 `const message = error.message` | **Server-side only** — `describeAxiosError` return value flows exclusively into `logger.warn` calls | Left in baseline with checker comment |
| `podcasts.ts` ~L2362 `error: error.message` in `refreshAllPodcastFeeds` results | **Client-reachable** — results echoed in `POST /api/podcasts/refresh-all` response body | Sanitized to static `"Failed to refresh feed"` |

### Ratchet

`LEAK_BASELINE` lowered: `playlists.ts` 4→1, `podcasts.ts` 3→2, with precise comments documenting why the remaining counts are safe. No checker-logic loosening.

### Tests

Tests asserting the old raw contract (`error: "socket closed"`, `/not found/`, `"Unknown error"`-style) were aligned to the sanitized contract, with leak-absence assertions (raw text not present in response bodies or sessionLog calls). TDD red run confirmed the new assertions fail against the old source.

### Verification

- verify: targeted jest (`playlistsRuntime`, `podcastsBranchCoverage`, `podcastsCoreRuntime`) — 3 suites, 104 tests passed, exit 0
- verify: `node scripts/ci/check-route-error-canon.mjs` exit 0 (both ratchets pass, no tightenable lines)
- verify: checker self-test (`node --test`) pass
- verify: prettier --check on all 7 changed files — clean
- verify: backend `tsc --noEmit` exit 0

One CHANGELOG Unreleased>Security entry added (no dedup — later docs slice owns that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24
