### PR TITLE
fix(playlists): sanitize scanError client leak + widen error-canon ratchet to suffixed-error vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Sanitized the scan-queue failure message written to the client-readable Spotify
+  import session log, keeping raw detail in the server log only, and widened the
+  route error-canon leak ratchet to catch suffixed error identifiers
+  (`scanError.message`, etc.) and `as`-cast property access, with new frozen,
+  documented baselines for `auth.ts` (Zod validation detail) and `streaming.ts`
+  (typed `SegmentedSessionError` messages).
 - Stopped returning raw caught-error text to clients from the playlist
   pending-track retry path and podcast refresh-all: the retry handler wrote
   `error.message` into the session log (returned verbatim to any authenticated

--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -2298,6 +2298,66 @@ describe("playlists route runtime", () => {
         );
     });
 
+    it("sanitizes scan-queue enqueue errors out of the client-visible session log", async () => {
+        prisma.playlist.findUnique.mockResolvedValueOnce({
+            id: "pl-1",
+            userId: "u1",
+            isPublic: false,
+        });
+        prisma.playlistPendingTrack.findUnique.mockResolvedValueOnce({
+            id: "pt-scan-error",
+            spotifyArtist: "Artist",
+            spotifyTitle: "Title",
+            spotifyAlbum: "Album",
+            albumMbid: "rg-1",
+            artistMbid: "ar-1",
+        });
+        getSystemSettings.mockResolvedValueOnce({
+            musicPath: "/music",
+            soulseekUsername: "user",
+            soulseekPassword: "pass",
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-scan-error",
+            metadata: {},
+        });
+        soulseekService.searchTrack.mockResolvedValueOnce({
+            found: true,
+            allMatches: [{ id: "match-1" }],
+        });
+        soulseekService.downloadBestMatch.mockResolvedValueOnce({
+            success: true,
+            filePath: "/music/Artist/Album/track.flac",
+        });
+        scanQueue.add.mockRejectedValueOnce(new Error("scan blew up"));
+
+        const req = {
+            user: { id: "u1" },
+            params: { id: "pl-1", trackId: "pt-scan-error" },
+        } as any;
+        const res = createRes();
+        await retryPending(req, res);
+        await flushAsyncWork();
+
+        expect(res.statusCode).toBe(200);
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-scan-error" },
+                data: expect.objectContaining({ status: "completed" }),
+            }),
+        );
+        const sessionLogMock = jest.requireMock("../../utils/playlistLogger")
+            .sessionLog as jest.Mock;
+        expect(JSON.stringify(sessionLogMock.mock.calls)).not.toContain(
+            "scan blew up",
+        );
+        expect(sessionLogMock).toHaveBeenCalledWith(
+            "PENDING-RETRY",
+            "Failed to queue scan (raw detail in server log)",
+            "ERROR",
+        );
+    });
+
     it("marks retry download jobs failed when Soulseek returns an unsuccessful result", async () => {
         prisma.playlist.findUnique.mockResolvedValueOnce({
             id: "pl-1",

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -1664,11 +1664,10 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
                             `[Retry] Failed to queue scan:`,
                             scanError,
                         );
+                        // The session log is returned verbatim to any authenticated caller via GET /api/spotify/import/session-log, so raw error text must not be written to it.
                         sessionLog(
                             "PENDING-RETRY",
-                            `Failed to queue scan: ${
-                                (scanError as any)?.message || scanError
-                            }`,
+                            "Failed to queue scan (raw detail in server log)",
                             "ERROR",
                         );
                     }

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -109,6 +109,22 @@ test("countLeakPattern flags an intermediate const assigned from error.message",
     assert.equal(countLeakPattern(source), 1);
 });
 
+test("countLeakPattern flags suffixed-error optional message access", () => {
+    assert.equal(
+        countLeakPattern("res.json({ error: scanError?.message })"),
+        1,
+    );
+});
+
+test("countLeakPattern flags cast-wrapped suffixed-error message access", () => {
+    const source = 'sessionLog("X", `boom: ${(scanError as any)?.message}`)';
+    assert.equal(countLeakPattern(source), 1);
+});
+
+test("countLeakPattern flags a suffixed-error intermediate assignment", () => {
+    assert.equal(countLeakPattern("const detail = fetchError.message;"), 1);
+});
+
 test("countLeakPattern flags a template-literal error.stack interpolation", () => {
     assert.equal(countLeakPattern("res.send(`trace: ${error?.stack}`);"), 1);
 });
@@ -118,4 +134,12 @@ test("countLeakPattern exempts raw errors logged server-side via logger.*", () =
         "logger.error(`[CLEANUP] ${artistName}: ${error.message}`);\n" +
         "logger.error('boom', error?.message || error);";
     assert.equal(countLeakPattern(source), 0);
+});
+
+test("countLeakPattern exempts suffixed-error details logged server-side", () => {
+    assert.equal(countLeakPattern("logger.error(`x ${scanError.message}`)"), 0);
+});
+
+test("countLeakPattern ignores message access on non-error identifiers", () => {
+    assert.equal(countLeakPattern("res.json({ msg: payload.message })"), 0);
 });

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -57,15 +57,19 @@ const BASELINE = Object.freeze({
 // Raw error details can disclose internal implementation data to clients (OWASP).
 // This independent ratchet prevents new error.message/error.stack response leaks.
 const LEAK_BASELINE = Object.freeze({
+    // auth.ts remaining 2: Zod firstError.message validation detail in 400 responses (~L813 and ~L1247); code-owned schema messages, not raw errors.
+    "backend/src/routes/auth.ts": 2,
     "backend/src/routes/discover.ts": 0,
     "backend/src/routes/downloads.ts": 1,
     "backend/src/routes/listenTogether.ts": 1,
     "backend/src/routes/notifications.ts": 2,
     "backend/src/routes/playbackState.ts": 1,
-    // playlists.ts remaining 1: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904).
+    // playlists.ts remaining 1: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904); the scanError sessionLog instance was sanitized (fixed, not frozen).
     "backend/src/routes/playlists.ts": 1,
     // podcasts.ts remaining 2: Prisma-retry classification helper (~L83) and logger-only describeAxiosError (~L133); neither reaches a response body.
     "backend/src/routes/podcasts.ts": 2,
+    // streaming.ts remaining 7: segmentedError.message from toSegmentedSessionError() (~L493); typed SegmentedSessionError domain errors with static code-owned messages/status codes, not raw caught errors.
+    "backend/src/routes/streaming.ts": 7,
 });
 
 export function countPattern(source) {
@@ -97,12 +101,22 @@ export function stripLoggerCalls(source) {
 }
 
 export function countLeakPattern(source) {
-    const stripped = stripLoggerCalls(source);
-    const normalizedSource = stripped.replace(
-        /error\s*(\??)\s*\.\s*(message|stack)\b/g,
-        "error$1.$2",
+    const ERROR_ID = String.raw`(?:[A-Za-z_$][\w$]*Error|error)`;
+    const stripped = stripLoggerCalls(source).replace(
+        new RegExp(String.raw`\(\s*(${ERROR_ID})\s+as\s+[^()]*\)`, "g"),
+        "$1",
     );
-    const pattern = /(?::\s*|=\s*|\$\{[^}]*)error\??\.(?:message|stack)\b/g;
+    const normalizedSource = stripped.replace(
+        new RegExp(
+            String.raw`(${ERROR_ID})\s*(\??)\s*\.\s*(message|stack)\b`,
+            "g",
+        ),
+        "$1$2.$3",
+    );
+    const pattern = new RegExp(
+        String.raw`(?::\s*|=\s*|\$\{[^}]*?)${ERROR_ID}\??\.(?:message|stack)\b`,
+        "g",
+    );
     return normalizedSource.match(pattern)?.length ?? 0;
 }
 


### PR DESCRIPTION
## Summary

Phase-D security slice: closes a confirmed client-reachable raw-error leak that the error-canon leak ratchet was blind to, and widens the ratchet so the whole class is caught going forward.

### The leak

`backend/src/routes/playlists.ts` (retry-pending scan-queue catch) wrote

```ts
`Failed to queue scan: ${(scanError as any)?.message || scanError}`
```

into the Spotify import session log, and `GET /api/spotify/import/session-log` (requireAuthOrToken — **not** admin) returns that log **verbatim** to the caller: raw error disclosure. The ratchet missed it for two independent reasons:

1. `countLeakPattern` only matched the literal identifier `error`, not suffixed names like `scanError`;
2. the `(scanError as any)` cast broke the `identifier?.message` adjacency the regex required.

### Fix (TDD, mirrors #272/#274)

- Red-first regression test: with `scanQueue.add` rejecting with a sentinel (`"scan blew up"`), assert the raw text is absent from every `sessionLog` call and the static message is present. Confirmed failing on the pre-fix code (raw sentinel reached the session log), then green after the fix.
- `sessionLog` now writes the static `"Failed to queue scan (raw detail in server log)"`; the raw `scanError` stays in the adjacent server-side `logger.error`. No property access on the caught value remains, so non-Error throws are inherently safe.

### Ratchet widening (compounding hardening)

`scripts/ci/check-route-error-canon.mjs` `countLeakPattern` now also catches:

- suffixed-error identifiers: `[A-Za-z_$][\w$]*Error` (`scanError`, `fetchError`, `segmentedError`, `firstError`, ...) in addition to literal `error`;
- `as`-cast wrappers: `(scanError as any)?.message` / `(error as Error).message` are normalized before matching;
- template-literal + intermediate-const forms as before; the `stripLoggerCalls()` logger exemption is unchanged, so pure `logger.*` calls stay exempt.

Checker self-test gains 3 positive and 2 negative fixtures for the new patterns (19 tests total).

### Triage of newly surfaced matches

Running the widened checker across `backend/src/routes` surfaced 9 new matches beyond the fixed instance; all are non-disclosures and are **frozen** with documented baselines (checker logic not loosened):

| File | New matches | Triage |
| --- | --- | --- |
| `auth.ts` | 2 | `firstError.message` from `ZodError.issues[0]` in 400 responses (~L813, ~L1247) — code-owned schema validation text, not raw caught errors → frozen at 2 |
| `streaming.ts` | 7 | `segmentedError.message` via `toSegmentedSessionError()` — typed `SegmentedSessionError` domain errors with static code-owned messages/status codes → frozen at 7 |
| `playlists.ts` | 1 (the leak) | **Sanitized**, baseline stays at 1 (only the previously documented prefix-guarded `ensureRemoteTrack` validation detail remains) |

Scope guard note: the new-match count (9) exceeded the sanitize-in-this-slice threshold, but triage shows none of them are client-reachable raw-error leaks, so freezing them is the correct terminal state, not deferred work.

## Verification

- verify: RED jest run failed as expected (raw `"scan blew up"` in sessionLog), GREEN run after fix: playlistsRuntime suite 46/46 passed (`--maxWorkers=2`, serialized via flock)
- verify: `node scripts/ci/check-route-error-canon.mjs` exit 0 (both ratchets pass)
- verify: `node --test scripts/ci/__tests__/check-route-error-canon.test.mjs` 19 pass / 0 fail
- verify: `prettier --check` on all 5 changed files — clean
- verify: backend `tsc --noEmit` exit 0

CHANGELOG: one `[Unreleased] > Security` bullet added (no restructuring; the docs slice owns dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24
