### PR TITLE
fix(security): sanitize playback-state/download-job error leaks; admin-gate clear-lidarr-queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   during invalidation iteration could raise `RuntimeError` and abort
   stream/refresh requests.
 
+### Security
+
+- Sanitized playback-state 500 responses and persisted download-job errors so
+  raw failure details remain server-log only, and restricted
+  `POST /api/downloads/clear-lidarr-queue` to administrators.
+
 ### Changed
 
 - Documented every CI gate in the AGENTS.md CI-gates table (adding the Python

--- a/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
@@ -3,6 +3,13 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    // downloads.ts mounts requireAdmin on /clear-lidarr-queue at module
+    // scope; without this key the incomplete mock hands Router.post()
+    // undefined and the suite dies at load. Passthrough is correct here —
+    // this suite pins the interactive compat surface, not auth
+    // (downloadsRuntime.test.ts owns admin enforcement with the real
+    // middleware).
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
@@ -9,6 +9,9 @@ jest.mock("../../middleware/auth", () => ({
     // downloads/releases compat surface, not auth (releasesRuntime.test.ts
     // owns auth enforcement with the real middleware).
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
+    // downloads.ts likewise mounts requireAdmin on /clear-lidarr-queue at
+    // module scope (downloadsRuntime.test.ts owns admin enforcement).
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -1,8 +1,11 @@
 import { Request, Response } from "express";
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret";
+
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: jest.requireActual("../../middleware/auth").requireAdmin,
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -195,9 +198,14 @@ describe("downloads routes runtime", () => {
     const availabilityHandler = getRouteHandler("/availability", "get");
     const createJobHandler = getRouteHandler("/", "post");
     const clearAllHandler = getRouteHandler("/clear-all", "delete");
+    const clearLidarrQueueAdmin = getRouteHandler(
+        "/clear-lidarr-queue",
+        "post",
+    );
     const clearLidarrQueueHandler = getRouteHandler(
         "/clear-lidarr-queue",
         "post",
+        1,
     );
     const failedListHandler = getRouteHandler("/failed", "get");
     const failedDismissHandler = getRouteHandler("/failed/:id", "delete");
@@ -725,12 +733,28 @@ describe("downloads routes runtime", () => {
         expect(res.body).toEqual({ error: "Failed to clear downloads" });
     });
 
-    it("clears Lidarr queue entries", async () => {
+    it("rejects non-admin users before clearing Lidarr queue entries", async () => {
+        const req = { user: { id: "user-1", role: "user" } } as any;
+        const res = createRes();
+        const next = jest.fn();
+
+        await clearLidarrQueueAdmin(req, res, next);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(next).not.toHaveBeenCalled();
+        expect(mockClearLidarrQueue).not.toHaveBeenCalled();
+    });
+
+    it("allows admins to clear Lidarr queue entries", async () => {
         mockClearLidarrQueue.mockResolvedValueOnce({ removed: 4, errors: 1 });
 
-        const req = {} as any;
+        const req = { user: { id: "admin-1", role: "admin" } } as any;
         const res = createRes();
+        const next = jest.fn();
 
+        await clearLidarrQueueAdmin(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
         await clearLidarrQueueHandler(req, res);
 
         expect(res.statusCode).toBe(200);
@@ -742,7 +766,7 @@ describe("downloads routes runtime", () => {
             new Error("lidarr queue timeout"),
         );
 
-        const req = {} as any;
+        const req = { user: { id: "admin-1", role: "admin" } } as any;
         const res = createRes();
 
         await clearLidarrQueueHandler(req, res);
@@ -1858,6 +1882,75 @@ describe("downloads routes runtime", () => {
         );
     });
 
+    it("persists a sanitized error when a tidal download throws", async () => {
+        const rawError =
+            "ECONNREFUSED http://tidal-internal:9999 token=secret123";
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "tidal",
+            primaryFailureFallback: "none",
+        });
+        mockTidalAvailable.mockResolvedValue(true);
+        mockTidalFindAlbum.mockResolvedValueOnce({
+            albumId: 321,
+            title: "Album",
+            artist: "Artist",
+            numberOfTracks: 10,
+        });
+        mockTidalDownloadAlbum.mockRejectedValueOnce(new Error(rawError));
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                $queryRaw: jest.fn().mockResolvedValue([]),
+                downloadJob: {
+                    create: jest.fn().mockResolvedValue({
+                        id: "job-tidal-error",
+                        status: "pending",
+                    }),
+                },
+            }),
+        );
+        let findUniqueCall = 0;
+        mockDownloadFindUnique.mockImplementation(async () => {
+            findUniqueCall += 1;
+            if (findUniqueCall === 1) {
+                return {
+                    id: "job-tidal-error",
+                    userId: "user-1",
+                    metadata: {},
+                };
+            }
+            return { metadata: { albumMbid: "rg-tidal-error" } };
+        });
+
+        const req = {
+            body: {
+                type: "album",
+                mbid: "rg-tidal-error",
+                subject: "Artist - Album",
+                artistName: "Artist",
+                albumTitle: "Album",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await createJobHandler(req, res);
+        await flushAsyncWork();
+
+        const failedUpdate = mockDownloadUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "failed",
+        )?.[0];
+        expect(failedUpdate).toEqual(
+            expect.objectContaining({
+                where: { id: "job-tidal-error" },
+                data: expect.objectContaining({
+                    error: "TIDAL download failed",
+                }),
+            }),
+        );
+        expect(JSON.stringify(failedUpdate)).not.toContain(rawError);
+    });
+
     it("falls back when tidal cannot find album and reports fallback failures", async () => {
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
@@ -1985,9 +2078,12 @@ describe("downloads routes runtime", () => {
                 where: { id: "job-tidal-fail" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: expect.stringContaining("Album not found on TIDAL"),
+                    error: "TIDAL download failed",
                 }),
             }),
+        );
+        expect(JSON.stringify(mockDownloadUpdate.mock.calls)).not.toContain(
+            "Album not found on TIDAL",
         );
     });
 
@@ -2057,9 +2153,12 @@ describe("downloads routes runtime", () => {
                 where: { id: "job-tidal-zero" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: "All 8 tracks failed to download",
+                    error: "TIDAL download failed",
                 }),
             }),
+        );
+        expect(JSON.stringify(mockDownloadUpdate.mock.calls)).not.toContain(
+            "All 8 tracks failed to download",
         );
     });
 

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -679,8 +679,10 @@ describe("notifications route runtime", () => {
             found: true,
             allMatches: [{ id: "m1" }],
         });
+        const pendingRawError =
+            "ECONNRESET soulseek-internal token=pending-secret";
         soulseekService.downloadBestMatch.mockRejectedValueOnce(
-            new Error("socket closed"),
+            new Error(pendingRawError),
         );
 
         const throwReq = {
@@ -696,10 +698,13 @@ describe("notifications route runtime", () => {
                 where: { id: "job-new-throw" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: "socket closed",
+                    error: "Download exception",
                 }),
             }),
         );
+        expect(
+            JSON.stringify(prisma.downloadJob.update.mock.calls),
+        ).not.toContain(pendingRawError);
     });
 
     it("validates spotify_import retries and generic retries", async () => {
@@ -953,8 +958,10 @@ describe("notifications route runtime", () => {
             metadata: {},
         });
         getSystemSettings.mockResolvedValueOnce({ musicPath: "/music" });
+        const spotifyRawError =
+            "ECONNREFUSED soulseek-internal token=spotify-secret";
         soulseekService.searchAndDownloadBatch.mockRejectedValueOnce(
-            new Error("soulseek crashed"),
+            new Error(spotifyRawError),
         );
 
         const catchReq = {
@@ -970,10 +977,13 @@ describe("notifications route runtime", () => {
                 where: { id: "job-new-spotify-catch" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: "soulseek crashed",
+                    error: "Soulseek error",
                 }),
             }),
         );
+        expect(
+            JSON.stringify(prisma.downloadJob.update.mock.calls),
+        ).not.toContain(spotifyRawError);
     });
 
     it("returns 500 when retry handler throws unexpectedly", async () => {

--- a/backend/src/routes/__tests__/playbackStateRuntime.test.ts
+++ b/backend/src/routes/__tests__/playbackStateRuntime.test.ts
@@ -520,7 +520,7 @@ describe("playbackState routes runtime", () => {
         expect(res.statusCode).toBe(200);
     });
 
-    it("returns 500 with details when save fails", async () => {
+    it("returns a sanitized 500 when save fails", async () => {
         mockUpsert.mockRejectedValueOnce(new Error("write failed"));
 
         const req = {
@@ -533,10 +533,8 @@ describe("playbackState routes runtime", () => {
         await postState(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
-            error: "Internal server error",
-            details: "write failed",
-        });
+        expect(res.body).toEqual({ error: "Failed to save playback state" });
+        expect(JSON.stringify(res.body)).not.toContain("write failed");
     });
 
     it("deletes state for the current device and handles failures", async () => {

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { logger } from "../utils/logger";
-import { requireAuthOrToken } from "../middleware/auth";
+import { requireAdmin, requireAuthOrToken } from "../middleware/auth";
 import { prisma } from "../utils/db";
 import { config } from "../config";
 import { getSystemSettings } from "../utils/systemSettings";
@@ -924,17 +924,18 @@ async function processTidalDownload(
         logger.debug(
             `[TIDAL] Scan queued for: ${result.artist} - ${result.album_title}`,
         );
-    } catch (error: any) {
+    } catch (error: unknown) {
         logger.error(
             `[TIDAL] Download failed for job ${jobId}:`,
-            error.message,
+            error instanceof Error ? error.message : error,
         );
 
         await prisma.downloadJob.update({
             where: { id: jobId },
             data: {
                 status: "failed",
-                error: error.message,
+                // downloadJob rows (incl. error) are returned to the owning user via GET /api/downloads
+                error: "TIDAL download failed",
                 completedAt: new Date(),
                 metadata: {
                     ...existingMetadata,
@@ -1006,9 +1007,11 @@ router.delete("/clear-all", async (req, res) => {
  *         description: Number of removed items and any errors
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 // POST /downloads/clear-lidarr-queue - Clear stuck/failed items from Lidarr's queue
-router.post("/clear-lidarr-queue", async (req, res) => {
+router.post("/clear-lidarr-queue", requireAdmin, async (req, res) => {
     try {
         const result = await simpleDownloadManager.clearLidarrQueue();
         res.json({

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -706,11 +706,13 @@ router.post(
                         }
                     })
                     .catch(async (error) => {
+                        logger.error(`[Retry] Download error:`, error);
                         await prisma.downloadJob.update({
                             where: { id: newJobRecord.id },
                             data: {
                                 status: "failed",
-                                error: error?.message || "Download exception",
+                                // downloadJob rows (incl. error) are returned to the owning user via GET /api/downloads
+                                error: "Download exception",
                                 completedAt: new Date(),
                             },
                         });
@@ -883,7 +885,8 @@ router.post(
                             where: { id: newJobRecord.id },
                             data: {
                                 status: "failed",
-                                error: error?.message || "Soulseek error",
+                                // downloadJob rows (incl. error) are returned to the owning user via GET /api/downloads
+                                error: "Soulseek error",
                                 completedAt: new Date(),
                             },
                         });

--- a/backend/src/routes/playbackState.ts
+++ b/backend/src/routes/playbackState.ts
@@ -436,11 +436,8 @@ router.post("/", requireAuth, async (req, res) => {
         if (error?.meta) {
             logger.error("[PlaybackState] Prisma meta:", error.meta);
         }
-        // Return more specific error for debugging
-        res.status(500).json({
-            error: "Internal server error",
-            details: error?.message || "Unknown error",
-        });
+        // Raw failure detail is available only in the server logs above.
+        res.status(500).json({ error: "Failed to save playback state" });
     }
 });
 

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -60,10 +60,10 @@ const LEAK_BASELINE = Object.freeze({
     // auth.ts remaining 2: Zod firstError.message validation detail in 400 responses (~L813 and ~L1247); code-owned schema messages, not raw errors.
     "backend/src/routes/auth.ts": 2,
     "backend/src/routes/discover.ts": 0,
-    "backend/src/routes/downloads.ts": 1,
+    "backend/src/routes/downloads.ts": 0,
     "backend/src/routes/listenTogether.ts": 1,
-    "backend/src/routes/notifications.ts": 2,
-    "backend/src/routes/playbackState.ts": 1,
+    "backend/src/routes/notifications.ts": 0,
+    "backend/src/routes/playbackState.ts": 0,
     // playlists.ts remaining 1: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904); the scanError sessionLog instance was sanitized (fixed, not frozen).
     "backend/src/routes/playlists.ts": 1,
     // podcasts.ts remaining 2: Prisma-retry classification helper (~L83) and logger-only describeAxiosError (~L133); neither reaches a response body.


### PR DESCRIPTION
## Summary

Fixes three adversarially-confirmed release-blocking security findings (Phase-D convergence slice A):

1. **playbackState.ts info disclosure** — the `POST /api/playback-state` catch returned `details: error?.message` to any authenticated caller, leaking Prisma/schema detail. Now returns a static `{ error: "Failed to save playback state" }`; raw detail remains server-log only (mirrors the #274 playlists sanitization pattern).
2. **downloadJob.error raw-text persistence** — three sites (`downloads.ts` TIDAL `processDownload` catch, `notifications.ts` retry catches at the pending-retry and spotify_import paths) persisted raw `error.message` into `downloadJob.error`, which `GET /api/downloads/:id` returns verbatim to the owner — leaking tokens and internal host:port strings. All three now store static status strings ("TIDAL download failed", "Download exception", "Soulseek error"); raw errors go to `logger.error` only.
3. **Missing admin gate** — `POST /api/downloads/clear-lidarr-queue` had only router-level `requireAuthOrToken`, but `clearLidarrQueue` flushes every user's queue. Now gated by `requireAdmin` (matches the #216 soulseek direct-download precedent), with a 403 documented in the OpenAPI block.

Ratchet: `LEAK_BASELINE` lowered to 0 for `downloads.ts` (1→0), `notifications.ts` (2→0), `playbackState.ts` (1→0) in `scripts/ci/check-route-error-canon.mjs`.

## Tests

TDD: assertions updated/added first (red), then implemented.

- playbackStateRuntime: 500 body is static and does not contain raw error text
- downloadsRuntime: TIDAL failure path persists sanitized `error` (negative assertion on a distinctive raw message); non-admin → 403 without invoking `clearLidarrQueue`, admin → 200 (real `requireAdmin` via `jest.requireActual`)
- notificationsRuntime: both retry catch paths persist static strings; negative assertions on raw messages

## Verification

- verify: targeted jest (playbackState + downloads + notifications suites) — 3 suites, 87 tests passed, exit 0
- verify: `node scripts/ci/check-route-error-canon.mjs` — both ratchets passed, exit 0
- verify: `npm run check:error-canon:test` — 19 pass, 0 fail
- verify: `npx tsc --noEmit` (backend) — exit 0
- verify: `prettier --check` on all 8 changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24
