### PR TITLE
fix(playlists): paginate list endpoint and stop full track hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Playlists list endpoint no longer hydrates every track of every visible playlist: it now paginates (limit/offset, clamped) and returns a database-side track count plus a bounded cover-art preview per playlist.
 - **Sidecar event-loop offload for OAuth onboarding and search.** The
   `tidal-downloader` (`/auth/device`, `/auth/token`, `/auth/refresh`, `/search`)
   and `ytmusic-streamer` (`/auth/device-code`, `/auth/device-code/poll`) async

--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -316,18 +316,29 @@ describe("playlists route runtime", () => {
                 userId: "u1",
                 name: "Mine",
                 user: { username: "owner" },
-                items: [{ id: "i-1" }],
+                _count: { items: 7 },
+                items: [
+                    {
+                        id: "i-1",
+                        sort: 0,
+                        track: {
+                            album: { coverUrl: "/covers/album.jpg" },
+                        },
+                    },
+                    { id: "i-2", sort: 1, track: null },
+                ],
             },
             {
                 id: "pl-2",
                 userId: "u2",
                 name: "Shared",
                 user: { username: "friend" },
+                _count: { items: 0 },
                 items: [],
             },
         ]);
 
-        const req = { user: { id: "u1" } } as any;
+        const req = { user: { id: "u1" }, query: {} } as any;
         const res = createRes();
         await listPlaylists(req, res);
 
@@ -337,7 +348,16 @@ describe("playlists route runtime", () => {
                 id: "pl-1",
                 isOwner: true,
                 isHidden: false,
-                trackCount: 1,
+                trackCount: 7,
+                items: [
+                    {
+                        id: "i-1",
+                        track: {
+                            album: { coverArt: "/covers/album.jpg" },
+                        },
+                    },
+                    { id: "i-2", track: null },
+                ],
             }),
             expect.objectContaining({
                 id: "pl-2",
@@ -346,6 +366,55 @@ describe("playlists route runtime", () => {
                 trackCount: 0,
             }),
         ]);
+        expect(res.body[0]).not.toHaveProperty("_count");
+    });
+
+    it("uses bounded playlist pages and lightweight cover previews by default", async () => {
+        const req = { user: { id: "u1" }, query: {} } as any;
+        const res = createRes();
+
+        await listPlaylists(req, res);
+
+        expect(prisma.playlist.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                take: 500,
+                skip: 0,
+                include: {
+                    user: { select: { username: true } },
+                    _count: { select: { items: true } },
+                    items: {
+                        select: {
+                            id: true,
+                            sort: true,
+                            track: {
+                                select: {
+                                    album: { select: { coverUrl: true } },
+                                },
+                            },
+                        },
+                        orderBy: { sort: "asc" },
+                        take: 12,
+                    },
+                },
+            }),
+        );
+    });
+
+    it.each([
+        ["clamps oversized limits", { limit: "99999" }, 1000, 0],
+        ["defaults invalid limits", { limit: "abc" }, 500, 0],
+        ["applies offsets", { offset: "5" }, 500, 5],
+        ["defaults zero limits", { limit: "0" }, 500, 0],
+        ["defaults negative limits", { limit: "-1" }, 500, 0],
+    ])("%s", async (_description, query, take, skip) => {
+        const req = { user: { id: "u1" }, query } as any;
+        const res = createRes();
+
+        await listPlaylists(req, res);
+
+        expect(prisma.playlist.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ take, skip }),
+        );
     });
 
     it("returns 500 when playlist listing throws", async () => {

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -13,6 +13,10 @@ import { resolvePlaylistItemsForUser } from "../services/playlistTrackResolution
 
 const router = Router();
 
+const PLAYLISTS_MAX_LIMIT = 1000;
+const PLAYLISTS_DEFAULT_LIMIT = 500;
+const PLAYLIST_PREVIEW_ITEMS = 12;
+
 router.use(requireAuthOrToken);
 
 const createPlaylistSchema = z.object({
@@ -168,15 +172,37 @@ function unavailablePlaybackForReason(reason: string): {
  *     security:
  *       - sessionAuth: []
  *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 500
+ *           maximum: 1000
+ *         description: Maximum number of playlists to return (clamped to 1000)
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         description: Number of playlists to skip
  *     responses:
  *       200:
- *         description: List of playlists with track counts and ownership info
+ *         description: List of playlists with authoritative track counts, ownership info, and bounded cover-art item previews
  *         content:
  *           application/json:
  *             schema:
  *               type: array
  *               items:
  *                 type: object
+ *                 properties:
+ *                   trackCount:
+ *                     type: integer
+ *                     description: Authoritative count of all items in the playlist
+ *                   items:
+ *                     type: array
+ *                     maxItems: 12
+ *                     description: Bounded cover-art preview; use the playlist detail endpoint for the full item list
  *       401:
  *         description: Not authenticated
  */
@@ -187,6 +213,14 @@ router.get("/", async (req, res) => {
             return res.status(401).json({ error: "Unauthorized" });
         }
         const userId = req.user.id;
+        const { limit: limitParam = "500", offset: offsetParam = "0" } =
+            req.query;
+        const parsedLimit = parseInt(limitParam as string, 10);
+        const limit = Math.min(
+            parsedLimit > 0 ? parsedLimit : PLAYLISTS_DEFAULT_LIMIT,
+            PLAYLISTS_MAX_LIMIT,
+        );
+        const offset = parseInt(offsetParam as string, 10) || 0;
 
         // Get user's hidden playlists
         const hiddenPlaylists = await prisma.hiddenPlaylist.findMany({
@@ -202,52 +236,58 @@ router.get("/", async (req, res) => {
                 OR: [{ userId }, { isPublic: true }],
             },
             orderBy: { createdAt: "desc" },
+            take: limit,
+            skip: offset,
             include: {
                 user: {
                     select: {
                         username: true,
                     },
                 },
+                _count: {
+                    select: {
+                        items: true,
+                    },
+                },
                 items: {
-                    include: {
+                    select: {
+                        id: true,
+                        sort: true,
                         track: {
-                            include: {
+                            select: {
                                 album: {
-                                    include: {
-                                        artist: {
-                                            select: {
-                                                id: true,
-                                                name: true,
-                                            },
-                                        },
+                                    select: {
+                                        coverUrl: true,
                                     },
                                 },
                             },
                         },
                     },
                     orderBy: { sort: "asc" },
+                    take: PLAYLIST_PREVIEW_ITEMS,
                 },
             },
         });
 
-        const playlistsWithCounts = playlists.map((playlist) => ({
-            ...playlist,
-            trackCount: playlist.items.length,
-            isOwner: playlist.userId === userId,
-            isHidden: hiddenPlaylistIds.has(playlist.id),
-            items: playlist.items.map((item) => ({
-                ...item,
-                track: item.track
-                    ? {
-                          ...item.track,
-                          album: {
-                              ...item.track.album,
-                              coverArt: item.track.album.coverUrl,
-                          },
-                      }
-                    : null,
-            })),
-        }));
+        const playlistsWithCounts = playlists.map((playlist) => {
+            const { _count, ...playlistFields } = playlist;
+            return {
+                ...playlistFields,
+                trackCount: _count.items,
+                isOwner: playlist.userId === userId,
+                isHidden: hiddenPlaylistIds.has(playlist.id),
+                items: playlist.items.map((item) => ({
+                    id: item.id,
+                    track: item.track
+                        ? {
+                              album: {
+                                  coverArt: item.track.album.coverUrl,
+                              },
+                          }
+                        : null,
+                })),
+            };
+        });
 
         // Debug: log shared playlists with user info
         const sharedPlaylists = playlistsWithCounts.filter((p) => !p.isOwner);


### PR DESCRIPTION
## Summary

Release blocker (Phase-D convergence slice D): `GET /api/playlists` ran an unbounded `prisma.playlist.findMany` over `{ OR: [{userId}, {isPublic:true}] }` with a deep include of ALL `items -> track -> album -> artist` and derived `trackCount` from the loaded array. One list request materialized and serialized every track of every public playlist on the instance — cost scaled with the whole library, not the page.

## Changes

- **Pagination:** `limit`/`offset` query params on the list endpoint, mirroring the `library.ts` clamp pattern. Default 500, hard-clamped to 1000, invalid/zero/negative limits fall back to the default.
- **DB-side count:** `trackCount` now comes from a Prisma `_count: { select: { items: true } }` select; the raw `_count` object is stripped from the response.
- **Bounded preview instead of full hydration:** the list query now selects only a 12-item cover-art preview per playlist (`{ id, track: { album: { coverArt } } }`, ordered by `sort`), which is exactly what the list UI's cover mosaic consumes. Full item hydration remains on the `GET /api/playlists/:id` detail endpoint.
- **OpenAPI:** list-endpoint annotation documents the new params and preview semantics.

## Frontend impact

None — verified all `getPlaylists()` consumers:
- `app/playlists/page.tsx` uses `items` only for the cover mosaic (`id` + `track.album.coverArt`); play-from-card already fetches the detail endpoint.
- `Sidebar.tsx` and `PlaylistSelector.tsx` consume `trackCount`/`name`/`id` only.

## Verification

- `jest src/routes/__tests__/playlistsRuntime.test.ts`: 52/52 passed (new tests: query-shape assertion proving no deep hydration, clamp table incl. oversized/invalid/zero/negative limits and offset, `_count`-derived trackCount with short preview, preview coverArt mapping and null-track passthrough)
- `tsc --noEmit` exit 0
- `prettier --check` clean on changed files
- `node scripts/ci/check-route-error-canon.mjs` exit 0
- `openapiRouteSync.test.ts` 4/4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24