### PR TITLE
fix(tidal): guard stream URL cache against concurrent mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   navigation (Arrow/Home/End to move focus between visible tracks, Enter/Space
   to explore the focused track) alongside the existing pointer interactions.
 
+### Fixed
+
+- Fixed the tidal-downloader stream-URL cache race where concurrent mutation
+  during invalidation iteration could raise `RuntimeError` and abort
+  stream/refresh requests.
+
 ### Changed
 
 - Documented every CI gate in the AGENTS.md CI-gates table (adding the Python

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -17,6 +17,7 @@ import logging
 import os
 import shutil
 import sys
+import threading
 import time
 from base64 import b64decode
 from collections.abc import Callable
@@ -107,6 +108,7 @@ _user_auth_state: dict[str, dict[str, str]] = {}
 
 # ── Stream URL cache (per-user, keyed by (user_id, track_id, quality)) ─────
 _stream_cache: dict[tuple[str, int, str], dict] = {}
+_stream_cache_lock = threading.Lock()
 STREAM_CACHE_TTL = 600  # 10 minutes
 STREAM_QUALITY_OPTIONS = {"LOW", "HIGH", "LOSSLESS", "HI_RES_LOSSLESS"}
 
@@ -478,18 +480,19 @@ def _clear_stream_cache(
 ):
     """Clear cached stream URLs for a user, optionally scoped by track/quality."""
     normalized_quality = _normalize_stream_quality(quality) if quality is not None else None
-    keys_to_remove = []
-    for cache_user_id, cache_track_id, cache_quality in _stream_cache:
-        if cache_user_id != user_id:
-            continue
-        if track_id is not None and cache_track_id != track_id:
-            continue
-        if normalized_quality is not None and cache_quality != normalized_quality:
-            continue
-        keys_to_remove.append((cache_user_id, cache_track_id, cache_quality))
+    with _stream_cache_lock:
+        keys_to_remove = []
+        for cache_user_id, cache_track_id, cache_quality in _stream_cache:
+            if cache_user_id != user_id:
+                continue
+            if track_id is not None and cache_track_id != track_id:
+                continue
+            if normalized_quality is not None and cache_quality != normalized_quality:
+                continue
+            keys_to_remove.append((cache_user_id, cache_track_id, cache_quality))
 
-    for key in keys_to_remove:
-        _stream_cache.pop(key, None)
+        for key in keys_to_remove:
+            _stream_cache.pop(key, None)
 
 
 def _invalidate_user_api(user_id: str):
@@ -684,7 +687,8 @@ def _get_stream_url_sync(user_id: str, track_id: int, quality: str = "HIGH") -> 
     """
     normalized_quality = _normalize_stream_quality(quality)
     cache_key = (user_id, track_id, normalized_quality)
-    cached = _stream_cache.get(cache_key)
+    with _stream_cache_lock:
+        cached = _stream_cache.get(cache_key)
     if cached and time.time() < cached.get("expires_at", 0):
         return cached
 
@@ -748,16 +752,18 @@ def _get_stream_url_sync(user_id: str, track_id: int, quality: str = "HIGH") -> 
         "expires_at": time.time() + STREAM_CACHE_TTL,
     }
 
-    _stream_cache[cache_key] = result
+    with _stream_cache_lock:
+        _stream_cache[cache_key] = result
     return result
 
 
 def _clean_stream_cache():
     """Remove expired entries from the stream cache."""
     now = time.time()
-    expired = [k for k, v in _stream_cache.items() if now >= v.get("expires_at", 0)]
-    for k in expired:
-        _stream_cache.pop(k, None)
+    with _stream_cache_lock:
+        expired = [k for k, v in _stream_cache.items() if now >= v.get("expires_at", 0)]
+        for k in expired:
+            _stream_cache.pop(k, None)
 
 
 # ════════════════════════════════════════════════════════════════════

--- a/services/tidal-downloader/tests/test_stream_cache_race.py
+++ b/services/tidal-downloader/tests/test_stream_cache_race.py
@@ -1,0 +1,121 @@
+"""Thread-safety regression tests for the per-user stream URL cache."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+
+def _assert_lock_held(lock: threading.Lock) -> None:
+    acquired = lock.acquire(blocking=False)
+    if acquired:
+        lock.release()
+    assert not acquired, "stream cache operation ran without mutual exclusion"
+
+
+def _assert_lock_available(lock: threading.Lock, operation: str) -> None:
+    acquired = lock.acquire(blocking=False)
+    assert acquired, f"lock held across blocking {operation}"
+    lock.release()
+
+
+class _IterationLockCheckingDict(dict):
+    def __init__(self, values, lock: threading.Lock) -> None:
+        super().__init__(values)
+        self._lock = lock
+
+    def __iter__(self):
+        _assert_lock_held(self._lock)
+        return super().__iter__()
+
+    def items(self):
+        _assert_lock_held(self._lock)
+        return super().items()
+
+
+class _AccessLockCheckingDict(dict):
+    def __init__(self, lock: threading.Lock) -> None:
+        super().__init__()
+        self._lock = lock
+
+    def get(self, key, default=None):
+        _assert_lock_held(self._lock)
+        return super().get(key, default)
+
+    def __setitem__(self, key, value) -> None:
+        _assert_lock_held(self._lock)
+        super().__setitem__(key, value)
+
+
+def test_clear_stream_cache_holds_lock_and_preserves_other_users(monkeypatch):
+    import app
+
+    lock = threading.Lock()
+    cache = _IterationLockCheckingDict(
+        {
+            ("target", 1, "HIGH"): {"expires_at": 100},
+            ("target", 2, "LOSSLESS"): {"expires_at": 100},
+            ("other", 1, "HIGH"): {"expires_at": 100},
+        },
+        lock,
+    )
+    monkeypatch.setattr(app, "_stream_cache_lock", lock, raising=False)
+    monkeypatch.setattr(app, "_stream_cache", cache)
+
+    app._clear_stream_cache("target")
+
+    assert cache == {("other", 1, "HIGH"): {"expires_at": 100}}
+
+
+def test_clean_stream_cache_holds_lock_and_removes_only_expired(monkeypatch):
+    import app
+
+    lock = threading.Lock()
+    cache = _IterationLockCheckingDict(
+        {
+            ("user", 1, "HIGH"): {"expires_at": 99},
+            ("user", 2, "HIGH"): {"expires_at": 101},
+        },
+        lock,
+    )
+    monkeypatch.setattr(app, "_stream_cache_lock", lock, raising=False)
+    monkeypatch.setattr(app, "_stream_cache", cache)
+    monkeypatch.setattr(app.time, "time", lambda: 100)
+
+    app._clean_stream_cache()
+
+    assert cache == {("user", 2, "HIGH"): {"expires_at": 101}}
+
+
+def test_stream_cache_access_lock_excludes_only_dictionary_operations(monkeypatch):
+    import app
+
+    lock = threading.Lock()
+    cache = _AccessLockCheckingDict(lock)
+
+    def assert_provider_call_is_unlocked(**_kwargs):
+        _assert_lock_available(lock, "TIDAL API call")
+        return types.SimpleNamespace(
+            manifestMimeType="application/vnd.tidal.bts",
+            audioQuality="HIGH",
+            bitDepth=None,
+            sampleRate=None,
+        )
+
+    def assert_parser_call_is_unlocked(_stream):
+        _assert_lock_available(lock, "stream parser call")
+        return ["url"], ".flac"
+
+    monkeypatch.setattr(app, "_stream_cache_lock", lock, raising=False)
+    monkeypatch.setattr(app, "_stream_cache", cache)
+    monkeypatch.setattr(
+        app,
+        "_user_apis",
+        {"user": types.SimpleNamespace(get_track_stream=assert_provider_call_is_unlocked)},
+    )
+    monkeypatch.setattr(app, "parse_track_stream", assert_parser_call_is_unlocked)
+
+    result = app._get_stream_url_sync("user", 1)
+
+    assert result["url"] == "url"
+    assert cache[("user", 1, "HIGH")] is result


### PR DESCRIPTION
## Summary

Fixes a release-blocking thread-safety race in the tidal-downloader sidecar (`services/tidal-downloader/app.py`).

The per-user stream URL cache `_stream_cache` is inserted into from `asyncio.to_thread` worker OS threads (`_get_stream_url_sync`, reached via `_run_user_api_call`), while `_clear_stream_cache` iterated the live dict on the event-loop thread (called from the `user_stream_proxy` 401 retry paths, `_refresh_user_api`, and `_invalidate_user_api`) and `_clean_stream_cache` iterated it via comprehension. With no lock, a concurrent insert during iteration raises `RuntimeError: dictionary changed size during iteration`, aborting the stream/refresh request under normal multi-user streaming.

## Fix

- Add a module-level `threading.Lock` (`_stream_cache_lock`) next to `_stream_cache`.
- Hold it around every cache operation: the `.get` read and insert in `_get_stream_url_sync`, the iterate+pop body of `_clear_stream_cache`, and the iterate+pop body of `_clean_stream_cache`.
- Critical sections are minimal: the blocking TIDAL API call (`api.get_track_stream`) and manifest parsing run outside the lock. The lock is never acquired re-entrantly (none of the guarded functions call each other).

## Tests (TDD)

New `services/tidal-downloader/tests/test_stream_cache_race.py` — three deterministic tests using instrumented dict subclasses that assert the lock is held during every iteration/read/insert, that clearing/expiry semantics are preserved (other users' entries retained; only expired entries removed), and that the lock is NOT held across the blocking provider/parser calls. Verified failing-first: 3 failed against the unfixed code, 3 pass after.

## Verification

- verify: `pytest services/tidal-downloader/tests -q` — 93 passed, exit 0
- verify: `ruff check services/` — exit 0, all checks passed
- verify: `ruff format --check services/` — exit 0, 48 files already formatted
- verify: `MYPYPATH=services mypy services/tidal-downloader/app.py` — Success, no issues, exit 0
- verify: pre-fix run of the new test file — 3 failed (TDD failing-first confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24