### PR TITLE
fix(media-proxy): destroy upstream stream on client disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Playlists list endpoint no longer hydrates every track of every visible playlist: it now paginates (limit/offset, clamped) and returns a database-side track count plus a bounded cover-art preview per playlist.
+- Remote media proxy streams for Tidal, YouTube, YouTube Music, and artist
+  previews now destroy the upstream connection when the client disconnects,
+  preventing connection-pool exhaustion during seek and skip operations.
 - **Sidecar event-loop offload for OAuth onboarding and search.** The
   `tidal-downloader` (`/auth/device`, `/auth/token`, `/auth/refresh`, `/search`)
   and `ytmusic-streamer` (`/auth/device-code`, `/auth/device-code/poll`) async

--- a/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
+++ b/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
@@ -129,6 +129,7 @@ function createRes() {
             return res;
         }),
         end: jest.fn(),
+        on: jest.fn(),
     };
     return res;
 }
@@ -382,6 +383,38 @@ describe("artists preview (YT Music) routes", () => {
             );
         });
 
+        it("destroys the primary upstream stream when the client disconnects", async () => {
+            mockFindUniqueUserSettings.mockResolvedValueOnce(null);
+            const data = {
+                pipe: jest.fn(),
+                on: jest.fn(),
+                destroy: jest.fn(),
+                destroyed: false,
+            };
+            mockGetStreamProxy.mockResolvedValueOnce({
+                status: 200,
+                headers: {},
+                data,
+            });
+            const res = createRes();
+
+            await getPreviewStream(
+                buildReq("vid-primary", { userId: "user-no-oauth" }),
+                res,
+            );
+
+            const closeHandler = res.on.mock.calls.find(
+                ([event]: [string]) => event === "close",
+            )?.[1];
+            expect(closeHandler).toEqual(expect.any(Function));
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
+
+            data.destroyed = true;
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
+        });
+
         it("streams with __public__ when req.user is undefined", async () => {
             const mockStream = createMockStreamResponse();
             mockGetStreamProxy.mockResolvedValueOnce(mockStream);
@@ -479,6 +512,43 @@ describe("artists preview (YT Music) routes", () => {
                 undefined,
             );
             expect(res.statusCode).toBe(200);
+        });
+
+        it("destroys the fallback upstream stream when the client disconnects", async () => {
+            const oauthError: any = new Error("OAuth expired");
+            oauthError.response = { status: 401 };
+            mockGetStreamProxy.mockRejectedValueOnce(oauthError);
+            const data = {
+                pipe: jest.fn(),
+                on: jest.fn(),
+                destroy: jest.fn(),
+                destroyed: false,
+            };
+            mockGetStreamProxy.mockResolvedValueOnce({
+                status: 200,
+                headers: {},
+                data,
+            });
+            mockFindUniqueUserSettings.mockResolvedValueOnce({
+                ytMusicOAuthJson: '{"token":"expired"}',
+            });
+            const res = createRes();
+
+            await getPreviewStream(
+                buildReq("vid-fallback-close", { userId: "user-expired" }),
+                res,
+            );
+
+            const closeHandler = res.on.mock.calls.find(
+                ([event]: [string]) => event === "close",
+            )?.[1];
+            expect(closeHandler).toEqual(expect.any(Function));
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
+
+            data.destroyed = true;
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
         });
 
         it("returns 500 when stream proxy fails (non-401)", async () => {

--- a/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
@@ -97,6 +97,7 @@ function createRes() {
             headers[key] = value;
             return res;
         }),
+        on: jest.fn(),
     };
     return res;
 }
@@ -487,6 +488,39 @@ describe("tidal streaming route runtime", () => {
             "bytes 0-100/200",
         );
         expect(pipeMock).toHaveBeenCalledWith(res);
+    });
+
+    it("destroys the upstream stream when the client disconnects", async () => {
+        const data = {
+            pipe: jest.fn(),
+            destroy: jest.fn(),
+            destroyed: false,
+        };
+        tidalStreamingService.getStreamProxy.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data,
+        });
+        const req = {
+            user: { id: "u1" },
+            params: { trackId: "99" },
+            query: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        const closeHandler = res.on.mock.calls.find(
+            ([event]: [string]) => event === "close",
+        )?.[1];
+        expect(closeHandler).toEqual(expect.any(Function));
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
+
+        data.destroyed = true;
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
     });
 
     it("initiates device auth and maps initiation errors", async () => {

--- a/backend/src/routes/__tests__/youtubeMusicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/youtubeMusicBranchCoverage.test.ts
@@ -352,6 +352,8 @@ describe("youtubeMusic routes branch coverage", () => {
             pipe: () => {
                 earlyOnError?.(new Error("upstream dropped"));
             },
+            destroy: jest.fn(),
+            destroyed: false,
         };
         ytMusicService.getStreamProxy.mockResolvedValueOnce({
             status: 200,
@@ -374,6 +376,8 @@ describe("youtubeMusic routes branch coverage", () => {
                 res.write("x");
                 onError?.(new Error("late upstream error"));
             },
+            destroy: jest.fn(),
+            destroyed: false,
         };
         ytMusicService.getStreamProxy.mockResolvedValueOnce({
             status: 200,
@@ -384,6 +388,11 @@ describe("youtubeMusic routes branch coverage", () => {
             "/api/ytmusic/stream-public/video-2",
         );
         expect(headersSentRes.status).toBe(200);
+
+        // The route's close-handler destroys the upstream once the client
+        // response closes.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(syntheticStream.destroy).toHaveBeenCalled();
 
         ytMusicService.getStreamProxy.mockRejectedValueOnce({
             response: { status: 404 },

--- a/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
@@ -136,6 +136,7 @@ function createRes() {
             res.headersSent = true;
             return res;
         }),
+        on: jest.fn(),
     };
     return res;
 }
@@ -155,6 +156,10 @@ describe("youtube music route runtime behavior", () => {
     const songHandler = getLastHandler("/song/:videoId", "get");
     const streamInfoHandler = getLastHandler("/stream-info/:videoId", "get");
     const streamHandler = getLastHandler("/stream/:videoId", "get");
+    const publicStreamHandler = getLastHandler(
+        "/stream-public/:videoId",
+        "get",
+    );
     const librarySongsHandler = getLastHandler("/library/songs", "get");
     const libraryAlbumsHandler = getLastHandler("/library/albums", "get");
     const matchHandler = getLastHandler("/match", "post");
@@ -865,6 +870,73 @@ describe("youtube music route runtime behavior", () => {
         await streamHandler(reqBase, errorRes);
         expect(errorRes.statusCode).toBe(500);
         expect(errorRes.body).toEqual({ error: "Failed to stream audio" });
+    });
+
+    it("destroys the authenticated upstream stream when the client disconnects", async () => {
+        const data = {
+            pipe: jest.fn(),
+            on: jest.fn(),
+            destroy: jest.fn(),
+            destroyed: false,
+        };
+        ytMusicService.getStreamProxy.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data,
+        });
+        const req = {
+            user: { id: "user-1" },
+            params: { videoId: "vid-close" },
+            query: { quality: "high" },
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        const closeHandler = res.on.mock.calls.find(
+            ([event]: [string]) => event === "close",
+        )?.[1];
+        expect(closeHandler).toEqual(expect.any(Function));
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
+
+        data.destroyed = true;
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys the public upstream stream when the client disconnects", async () => {
+        const data = {
+            pipe: jest.fn(),
+            on: jest.fn(),
+            destroy: jest.fn(),
+            destroyed: false,
+        };
+        ytMusicService.getStreamProxy.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data,
+        });
+        const req = {
+            params: { videoId: "vid-public-close" },
+            query: { quality: "high" },
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await publicStreamHandler(req, res);
+
+        const closeHandler = res.on.mock.calls.find(
+            ([event]: [string]) => event === "close",
+        )?.[1];
+        expect(closeHandler).toEqual(expect.any(Function));
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
+
+        data.destroyed = true;
+        closeHandler();
+        expect(data.destroy).toHaveBeenCalledTimes(1);
     });
 
     it("handles library songs and albums retrieval with fallback errors", async () => {

--- a/backend/src/routes/__tests__/youtubeRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeRuntime.test.ts
@@ -42,6 +42,7 @@ import {
 
 const mockGetVideoInfo = youtubeDownloadService.getVideoInfo as jest.Mock;
 const mockGetPlaylistInfo = youtubeDownloadService.getPlaylistInfo as jest.Mock;
+const mockGetStreamProxy = youtubeDownloadService.getStreamProxy as jest.Mock;
 const mockStartDownload = youtubeDownloadService.startDownload as jest.Mock;
 const mockGetDownloadJobStatus =
     youtubeDownloadService.getDownloadJobStatus as jest.Mock;
@@ -109,9 +110,12 @@ function getHandler(path: string, method: "get" | "post" | "delete") {
 }
 
 function createRes() {
+    const headers: Record<string, string> = {};
     const res: any = {
         statusCode: 200,
         body: undefined as unknown,
+        headersSent: false,
+        headers,
         status: jest.fn(function (code: number) {
             res.statusCode = code;
             return res;
@@ -120,6 +124,12 @@ function createRes() {
             res.body = payload;
             return res;
         }),
+        setHeader: jest.fn(function (key: string, value: string) {
+            headers[key] = value;
+            return res;
+        }),
+        end: jest.fn(),
+        on: jest.fn(),
     };
     return res;
 }
@@ -133,6 +143,7 @@ function sidecarError(status: number, detail?: string) {
 describe("youtube routes runtime", () => {
     const infoHandler = getHandler("/info", "get");
     const playlistInfoHandler = getHandler("/playlist-info", "get");
+    const streamHandler = getHandler("/stream/:videoId", "get");
     const downloadHandler = getHandler("/download", "post");
     const statusHandler = getHandler("/download/:jobId", "get");
     const downloadsListHandler = getHandler("/downloads", "get");
@@ -311,6 +322,41 @@ describe("youtube routes runtime", () => {
             expect(res.body).toEqual({
                 error: "Failed to enumerate playlist or channel",
             });
+        });
+    });
+
+    describe("GET /stream/:videoId", () => {
+        it("destroys the upstream stream when the client disconnects", async () => {
+            const data = {
+                pipe: jest.fn(),
+                on: jest.fn(),
+                destroy: jest.fn(),
+                destroyed: false,
+            };
+            mockGetStreamProxy.mockResolvedValueOnce({
+                status: 200,
+                headers: {},
+                data,
+            });
+            const req = {
+                params: { videoId: "video-1" },
+                query: {},
+                headers: {},
+            } as any;
+            const res = createRes();
+
+            await streamHandler(req, res);
+
+            const closeHandler = res.on.mock.calls.find(
+                ([event]: [string]) => event === "close",
+            )?.[1];
+            expect(closeHandler).toEqual(expect.any(Function));
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
+
+            data.destroyed = true;
+            closeHandler();
+            expect(data.destroy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -217,6 +217,16 @@ router.get(
                     res.end();
                 }
             });
+            // Clean up upstream stream when client disconnects
+            res.on("close", () => {
+                if (
+                    proxyRes.data &&
+                    typeof proxyRes.data.destroy === "function" &&
+                    !proxyRes.data.destroyed
+                ) {
+                    proxyRes.data.destroy();
+                }
+            });
             proxyRes.data.pipe(res);
         } catch (error: any) {
             // If user's OAuth failed, retry with public
@@ -248,6 +258,16 @@ router.get(
                             });
                         } else {
                             res.end();
+                        }
+                    });
+                    // Clean up upstream stream when client disconnects
+                    res.on("close", () => {
+                        if (
+                            proxyRes.data &&
+                            typeof proxyRes.data.destroy === "function" &&
+                            !proxyRes.data.destroyed
+                        ) {
+                            proxyRes.data.destroy();
                         }
                     });
                     proxyRes.data.pipe(res);

--- a/backend/src/routes/tidalStreaming.ts
+++ b/backend/src/routes/tidalStreaming.ts
@@ -945,6 +945,16 @@ router.get(
                 res.setHeader(key, value);
             });
 
+            // Clean up upstream stream when client disconnects
+            res.on("close", () => {
+                if (
+                    stream.data &&
+                    typeof stream.data.destroy === "function" &&
+                    !stream.data.destroyed
+                ) {
+                    stream.data.destroy();
+                }
+            });
             stream.data.pipe(res);
         } catch (err: any) {
             if (err?.response?.status === 401) {

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -209,6 +209,16 @@ router.get(
                     res.end();
                 }
             });
+            // Clean up upstream stream when client disconnects
+            res.on("close", () => {
+                if (
+                    proxyRes.data &&
+                    typeof proxyRes.data.destroy === "function" &&
+                    !proxyRes.data.destroyed
+                ) {
+                    proxyRes.data.destroy();
+                }
+            });
             proxyRes.data.pipe(res);
         } catch (err: any) {
             if (err.response?.status === 404) {

--- a/backend/src/routes/youtubeMusic.ts
+++ b/backend/src/routes/youtubeMusic.ts
@@ -956,6 +956,16 @@ router.get(
                     res.end();
                 }
             });
+            // Clean up upstream stream when client disconnects
+            res.on("close", () => {
+                if (
+                    proxyRes.data &&
+                    typeof proxyRes.data.destroy === "function" &&
+                    !proxyRes.data.destroyed
+                ) {
+                    proxyRes.data.destroy();
+                }
+            });
             proxyRes.data.pipe(res);
         } catch (err: any) {
             if (err.response?.status === 404) {
@@ -1409,6 +1419,16 @@ router.get(
                     res.status(502).json({ error: "Upstream stream failed" });
                 } else {
                     res.end();
+                }
+            });
+            // Clean up upstream stream when client disconnects
+            res.on("close", () => {
+                if (
+                    proxyRes.data &&
+                    typeof proxyRes.data.destroy === "function" &&
+                    !proxyRes.data.destroyed
+                ) {
+                    proxyRes.data.destroy();
                 }
             });
             proxyRes.data.pipe(res);


### PR DESCRIPTION
## Summary

Six remote media-proxy routes piped an axios `responseType:"stream"` upstream to the client response with a bare `.pipe(res)` and no close-event cleanup. Node's `pipe()` unpipes when the destination closes but never destroys the source, so every client seek/skip left the upstream sidecar/YouTube socket open and buffering until its 300000ms timeout — exhausting the connection pool under normal use. Release-blocking resource leak.

## Sites fixed (all with the guarded `res.on("close")` destroy pattern already used by the podcasts proxy)

- `backend/src/routes/tidalStreaming.ts` — Tidal stream proxy
- `backend/src/routes/youtube.ts` — YouTube stream proxy
- `backend/src/routes/youtubeMusic.ts` — authenticated `/stream/:videoId` and public `/stream-public/:videoId`
- `backend/src/routes/artists.ts` — preview stream primary path and 401 public-fallback path

## Tests

One focused runtime test per site (6 total) asserting the captured `close` handler destroys the upstream stream exactly once and respects the `destroyed` guard (no double-destroy). Verified each test fails against the unfixed source.

## Verification

- Targeted jest (4 touched suites): 91/91 passed
- `tsc --noEmit`: clean
- `prettier --check` on all changed files: clean
- `node scripts/ci/check-route-error-canon.mjs`: both ratchets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24