### PR TITLE
ci(security): SHA-pin actions in image-security-scanning + compose-config-check workflows

### DIFF
--- a/.github/workflows/compose-config-check.yml
+++ b/.github/workflows/compose-config-check.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate local compose config
         run: docker compose -f docker-compose.local.yml config --quiet

--- a/.github/workflows/image-security-scanning.yml
+++ b/.github/workflows/image-security-scanning.yml
@@ -55,10 +55,10 @@ jobs:
             image: soundspan-ytmusic-streamer
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: steps.check.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4.37.6
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-image-${{ matrix.name }}.sarif
           category: trivy-image-${{ matrix.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned the remaining mutable GitHub Actions tags in
+  `image-security-scanning.yml` (`actions/checkout`, `docker/login-action`,
+  `github/codeql-action/upload-sarif`) and `compose-config-check.yml`
+  (`actions/checkout`) to the repo-standard full commit SHAs.
 - Sanitized playback-state 500 responses and persisted download-job errors so
   raw failure details remain server-log only, and restricted
   `POST /api/downloads/clear-lidarr-queue` to administrators.


### PR DESCRIPTION
## Summary

Fixes a regressed supply-chain control: two workflows used mutable action tags while the repo standard is 40-hex SHA pins. Pins the four remaining mutable tags to the exact SHAs already used for the same actions elsewhere in this repo:

| Workflow | Action | Was | Now |
| --- | --- | --- | --- |
| `image-security-scanning.yml` | `actions/checkout` | `@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` |
| `image-security-scanning.yml` | `docker/login-action` | `@v4` | `dbcb813823bdd20940b903addbd779551569679f # v4.6.0` |
| `image-security-scanning.yml` | `github/codeql-action/upload-sarif` | `@v4.37.6` | `5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6` |
| `compose-config-check.yml` | `actions/checkout` | `@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` |

The image-scanning job runs with a GHCR-authenticated `GITHUB_TOKEN` and `security-events: write`, so a repointed mutable tag would execute attacker-controlled code with token and SARIF reach.

After this change, a repo-wide grep of `.github/workflows/` finds zero non-SHA `uses:` refs.

## Verification

- verify: both workflow files parse as valid YAML (yaml parseDocument, 0 errors)
- verify: `grep -rn 'uses:' .github/workflows/ | grep -vE '@[0-9a-f]{40}'` returns no matches
- verify: git diff contains only the 4 pin changes + one CHANGELOG entry

YAML-only change; no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24