### PR TITLE
fix(podcasts): add 15s timeout to cover downloads so a hung host cannot stall cover sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Podcast cover downloads now time out after 15 seconds so an unresponsive
+  image host can no longer stall the cover-sync loops.
 - Fixed the tidal-downloader stream-URL cache race where concurrent mutation
   during invalidation iteration could raise `RuntimeError` and abort
   stream/refresh requests.

--- a/backend/src/services/__tests__/podcastCacheService.test.ts
+++ b/backend/src/services/__tests__/podcastCacheService.test.ts
@@ -91,6 +91,10 @@ describe("PodcastCacheService", () => {
         fetchMock.mockResolvedValue(okResponse());
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it("syncAllCovers tracks synced, skipped, and failed podcast updates", async () => {
         const service = new PodcastCacheService();
 
@@ -155,6 +159,53 @@ describe("PodcastCacheService", () => {
             },
         });
         expect(fsPromises.writeFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("syncAllCovers skips a timed-out cover and continues syncing", async () => {
+        const service = new PodcastCacheService();
+        const timeoutError = Object.assign(
+            new Error("The operation was aborted due to timeout"),
+            { name: "TimeoutError" },
+        );
+
+        prisma.podcast.findMany.mockResolvedValueOnce([
+            {
+                id: "pod-timeout",
+                title: "Timeout",
+                imageUrl: "https://img.example/timeout.jpg",
+            },
+            {
+                id: "pod-ok",
+                title: "OK",
+                imageUrl: "https://img.example/ok.jpg",
+            },
+        ]);
+        fetchMock
+            .mockRejectedValueOnce(timeoutError)
+            .mockResolvedValueOnce(okResponse());
+
+        const result = await service.syncAllCovers();
+
+        expect(result).toEqual({
+            synced: 1,
+            failed: 0,
+            skipped: 1,
+            errors: [],
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(prisma.podcast.update).toHaveBeenCalledTimes(1);
+        expect(prisma.podcast.update).toHaveBeenCalledWith({
+            where: { id: "pod-ok" },
+            data: {
+                localCoverPath: path.join(
+                    "/srv/music",
+                    "cover-cache",
+                    "podcasts",
+                    "podcast_pod-ok.jpg",
+                ),
+            },
+        });
+        expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
     });
 
     it("syncAllCovers rethrows fatal setup failures", async () => {
@@ -263,6 +314,59 @@ describe("PodcastCacheService", () => {
             "Failed to download cover for podcast pod-net:",
             "network error",
         );
+    });
+
+    it("downloadCover passes a timeout signal and handles its abort", async () => {
+        const service = new PodcastCacheService();
+        const abortController = new AbortController();
+        const timeoutSpy = jest
+            .spyOn(AbortSignal, "timeout")
+            .mockReturnValue(abortController.signal);
+        let fetchOptions: RequestInit | undefined;
+        let markFetchStarted: () => void = () => undefined;
+        const fetchStarted = new Promise<void>((resolve) => {
+            markFetchStarted = resolve;
+        });
+
+        fetchMock.mockImplementationOnce(
+            (
+                _url: string | URL | Request,
+                options?: RequestInit,
+            ): Promise<never> => {
+                fetchOptions = options;
+                markFetchStarted();
+                return new Promise((_resolve, reject) => {
+                    abortController.signal.addEventListener(
+                        "abort",
+                        () => {
+                            reject(
+                                Object.assign(
+                                    new Error(
+                                        "The operation was aborted due to timeout",
+                                    ),
+                                    { name: "TimeoutError" },
+                                ),
+                            );
+                        },
+                        { once: true },
+                    );
+                });
+            },
+        );
+
+        const download = (service as any).downloadCover(
+            "pod-timeout",
+            "https://img.example/timeout.jpg",
+            "podcast",
+        );
+        await fetchStarted;
+        abortController.abort();
+
+        await expect(download).resolves.toBeNull();
+        expect(timeoutSpy).toHaveBeenCalledWith(15000);
+        expect(fetchOptions?.signal).toBeInstanceOf(AbortSignal);
+        expect(fetchOptions?.signal).toBe(abortController.signal);
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
     });
 
     it("downloadCover rejects private/localhost URLs (SSRF protection)", async () => {

--- a/backend/src/services/podcastCache.ts
+++ b/backend/src/services/podcastCache.ts
@@ -208,7 +208,10 @@ export class PodcastCacheService {
                 return null;
             }
 
-            const response = await fetch(safeUrl, { redirect: "error" });
+            const response = await fetch(safeUrl, {
+                redirect: "error",
+                signal: AbortSignal.timeout(15000),
+            });
 
             if (!response.ok) {
                 throw new Error(


### PR DESCRIPTION
## Summary

`podcastCache.downloadCover` fetched feed-supplied cover URLs with no AbortSignal, while every sibling backend fetch site (`imageProxy.ts`, `imageStorage.ts`, `audiobookCache.ts`) uses `AbortSignal.timeout`. Because `downloadCover` runs inside the per-item `syncPodcastCovers`/`syncEpisodeCovers` loops, a slowloris host that never sends response headers hung the fetch indefinitely and stalled the whole cover-sync loop (resource exhaustion / DoS via untrusted feed content).

## Fix

- Add `signal: AbortSignal.timeout(15000)` to the cover fetch in `backend/src/services/podcastCache.ts`, matching the 15s inline convention of the direct analog `audiobookCache.downloadCover`.
- The existing try/catch already logs and returns `null` on failure, so a timed-out cover is skipped and the sync loop continues — now covered by tests.

## Tests (TDD)

- `downloadCover` passes a timeout signal to fetch (`AbortSignal.timeout` spied, called with 15000), and an abort rejection resolves to `null` without writing a file.
- `syncAllCovers` skips a timed-out cover (counted as skipped) and still syncs the remaining item.

## Verification

- verify: targeted Jest (`podcastCacheService.test.ts`, `--maxWorkers=2`) exit 0 — 12/12 passed (red run confirmed before implementation).
- verify: `tsc --noEmit` exit 0.
- verify: `prettier --check` on changed files + CHANGELOG exit 0.
- verify: `node scripts/ci/check-route-error-canon.mjs` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24
