### PR TITLE
fix(tidal): cap batch search size and bound concurrency against shared session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sanitized playback-state 500 responses and persisted download-job errors so
   raw failure details remain server-log only, and restricted
   `POST /api/downloads/clear-lidarr-queue` to administrators.
+- Capped batch TIDAL search requests at 50 queries and limited concurrent
+  searches against each shared per-user TIDAL session to 5.
 
 ### Changed
 

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -133,6 +133,8 @@ _browse_sessions: dict[str, tidalapi.Session] = {}
 _BROWSE_SESSION_MAX = 50
 _public_browse_sessions: dict[str, tidalapi.Session] = {}
 _PUBLIC_BROWSE_SESSION_MAX = 8
+_BATCH_SEARCH_MAX_QUERIES = 50
+_BATCH_SEARCH_CONCURRENCY = 5
 
 
 def _build_browse_session(user_id: str, quality: str | None = None) -> tidalapi.Session:
@@ -1446,14 +1448,22 @@ async def user_search_batch(
     Batch search — run multiple search queries in one request.
     Used for gap-fill matching (find streaming versions of unowned tracks).
     """
+    if len(queries) > _BATCH_SEARCH_MAX_QUERIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Batch search accepts at most {_BATCH_SEARCH_MAX_QUERIES} queries",
+        )
+
+    semaphore = asyncio.Semaphore(_BATCH_SEARCH_CONCURRENCY)
 
     async def _run_one(q: BatchSearchQuery) -> dict:
         try:
-            results = await _run_user_api_call(
-                user_id,
-                lambda current_api: current_api.get_search(q.query),
-                operation=f"batch search '{q.query}'",
-            )
+            async with semaphore:
+                results = await _run_user_api_call(
+                    user_id,
+                    lambda current_api: current_api.get_search(q.query),
+                    operation=f"batch search '{q.query}'",
+                )
             tracks = [
                 {
                     "id": t.id,

--- a/services/tidal-downloader/tests/test_batch_search_bounds.py
+++ b/services/tidal-downloader/tests/test_batch_search_bounds.py
@@ -1,0 +1,135 @@
+"""Behavioral tests for TIDAL batch-search request and concurrency bounds."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def _search_results(query: str) -> SimpleNamespace:
+    """Build the minimal provider result shape consumed by batch search."""
+    track = SimpleNamespace(
+        id=query,
+        title=f"Result for {query}",
+        artists=[SimpleNamespace(name="Test Artist")],
+        duration=180,
+        isrc=f"ISRC-{query}",
+    )
+    return SimpleNamespace(tracks=SimpleNamespace(items=[track]))
+
+
+@pytest.mark.anyio
+async def test_batch_search_rejects_requests_above_query_cap(client, monkeypatch):
+    """Oversized batches should fail validation without invoking TIDAL."""
+    import app
+
+    calls: list[str] = []
+
+    async def fake_run_user_api_call(*_args, **_kwargs):
+        calls.append("called")
+        return _search_results("unexpected")
+
+    monkeypatch.setattr(app, "_run_user_api_call", fake_run_user_api_call)
+    sensitive_query = "must-not-appear-in-validation-detail"
+    queries = [
+        {"query": f"{sensitive_query}-{index}"}
+        for index in range(app._BATCH_SEARCH_MAX_QUERIES + 1)
+    ]
+
+    response = await client.post(
+        "/user/search/batch",
+        params={"user_id": "user-1"},
+        json=queries,
+    )
+
+    assert response.status_code == 422
+    assert calls == []
+    assert sensitive_query not in response.text
+
+
+@pytest.mark.anyio
+async def test_batch_search_bounds_concurrency_and_preserves_order(client, monkeypatch):
+    """Batch searches should limit concurrent provider calls and retain input order."""
+    import app
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fake_run_user_api_call(_user_id, func, operation):
+        assert operation.startswith("batch search")
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            api = SimpleNamespace(get_search=lambda query: _search_results(query))
+            return func(api)
+        finally:
+            in_flight -= 1
+
+    monkeypatch.setattr(app, "_run_user_api_call", fake_run_user_api_call)
+    query_values = [f"query-{index}" for index in range(20)]
+
+    response = await client.post(
+        "/user/search/batch",
+        params={"user_id": "user-1"},
+        json=[{"query": query} for query in query_values],
+    )
+
+    assert response.status_code == 200
+    assert max_in_flight <= app._BATCH_SEARCH_CONCURRENCY
+    payload_results = response.json()["results"]
+    assert [item["query"] for item in payload_results] == query_values
+    assert [item["results"][0]["id"] for item in payload_results] == query_values
+
+
+@pytest.mark.anyio
+async def test_batch_search_returns_shaped_results_in_order(client, monkeypatch):
+    """A small valid batch should retain the established response shape and order."""
+    import app
+
+    async def fake_run_user_api_call(_user_id, func, operation):
+        assert operation.startswith("batch search")
+        api = SimpleNamespace(get_search=lambda query: _search_results(query))
+        return func(api)
+
+    monkeypatch.setattr(app, "_run_user_api_call", fake_run_user_api_call)
+
+    response = await client.post(
+        "/user/search/batch",
+        params={"user_id": "user-1"},
+        json=[{"query": "first"}, {"query": "second"}],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [
+            {
+                "query": "first",
+                "results": [
+                    {
+                        "id": "first",
+                        "title": "Result for first",
+                        "artist": "Test Artist",
+                        "duration": 180,
+                        "isrc": "ISRC-first",
+                    }
+                ],
+            },
+            {
+                "query": "second",
+                "results": [
+                    {
+                        "id": "second",
+                        "title": "Result for second",
+                        "artist": "Test Artist",
+                        "duration": 180,
+                        "isrc": "ISRC-second",
+                    }
+                ],
+            },
+        ]
+    }


### PR DESCRIPTION
## Summary

`POST /user/search/batch` in the tidal-downloader sidecar accepted an unbounded `list[BatchSearchQuery]` and ran every query concurrently (`asyncio.gather` over `asyncio.to_thread`) against the same shared per-user `TidalClient` session, which is not documented thread-safe. A large batch scheduled N simultaneous thread-pool searches on one shared requests/urllib3 session — pool saturation plus interleaved request state.

- Reject batches over `_BATCH_SEARCH_MAX_QUERIES = 50` with a 422 (detail does not echo user query strings). The backend caller chunks well below this, so no caller change is needed.
- Gate each search behind a per-request `asyncio.Semaphore(_BATCH_SEARCH_CONCURRENCY = 5)`, held only around the TIDAL API call.
- Results remain complete and in request order; per-query failure still degrades to empty results.

## Testing

- New `services/tidal-downloader/tests/test_batch_search_bounds.py`: over-cap rejection without invoking the TIDAL API, max-in-flight <= 5 across a 20-query batch with order preserved, and a shaped happy-path response. Both bound tests verified failing against the unpatched handler.
- verify: `pytest services/tidal-downloader/tests -q` — 96 passed
- verify: `ruff check services/tidal-downloader` — all checks passed
- verify: `ruff format --check services/tidal-downloader` — 13 files already formatted
- verify: `MYPYPATH=services mypy services/tidal-downloader/app.py` — no issues
