### PR TITLE
fix(tidal): handle upstream stream errors in stream proxy instead of crashing the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TIDAL stream proxying now handles upstream stream errors after headers are
+  sent instead of crashing the entire backend via an uncaught exception; a
+  mid-playback sidecar disconnect now ends only that response.
 - Podcast cover downloads now time out after 15 seconds so an unresponsive
   image host can no longer stall the cover-sync loops.
 - Fixed the tidal-downloader stream-URL cache race where concurrent mutation

--- a/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
@@ -54,6 +54,7 @@ jest.mock("../../utils/encryption", () => ({
     decrypt: mockDecrypt,
 }));
 
+import { EventEmitter } from "node:events";
 import router from "../tidalStreaming";
 
 function getRouteLayer(
@@ -97,6 +98,7 @@ function createRes() {
             headers[key] = value;
             return res;
         }),
+        end: jest.fn(),
         on: jest.fn(),
     };
     return res;
@@ -157,6 +159,7 @@ describe("tidal streaming route runtime", () => {
                 "content-range": "bytes 0-100/200",
             },
             data: {
+                on: jest.fn(),
                 pipe: jest.fn(),
             },
         });
@@ -500,7 +503,7 @@ describe("tidal streaming route runtime", () => {
                 "content-type": "audio/aac",
                 "content-range": "bytes 0-100/200",
             },
-            data: { pipe: pipeMock },
+            data: { on: jest.fn(), pipe: pipeMock },
         });
 
         const req = {
@@ -523,6 +526,7 @@ describe("tidal streaming route runtime", () => {
 
     it("destroys the upstream stream when the client disconnects", async () => {
         const data = {
+            on: jest.fn(),
             pipe: jest.fn(),
             destroy: jest.fn(),
             destroyed: false,
@@ -552,6 +556,61 @@ describe("tidal streaming route runtime", () => {
         data.destroyed = true;
         closeHandler();
         expect(data.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("ends the response when the upstream stream errors after headers are sent", async () => {
+        const data = Object.assign(new EventEmitter(), {
+            pipe: jest.fn(),
+            destroy: jest.fn(),
+            destroyed: false,
+        });
+        tidalStreamingService.getStreamProxy.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data,
+        });
+        const req = {
+            user: { id: "u1" },
+            params: { trackId: "99" },
+            query: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+        res.headersSent = true;
+
+        await streamHandler(req, res);
+
+        expect(data.listenerCount("error")).toBeGreaterThan(0);
+        expect(() =>
+            data.emit("error", new Error("sidecar dropped")),
+        ).not.toThrow();
+        expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 502 when the upstream stream errors before headers are sent", async () => {
+        const data = Object.assign(new EventEmitter(), {
+            pipe: jest.fn(),
+            destroy: jest.fn(),
+            destroyed: false,
+        });
+        tidalStreamingService.getStreamProxy.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data,
+        });
+        const req = {
+            user: { id: "u1" },
+            params: { trackId: "99" },
+            query: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+        data.emit("error", new Error("sidecar dropped"));
+
+        expect(res.statusCode).toBe(502);
+        expect(res.body).toEqual({ error: "Upstream stream failed" });
     });
 
     it("initiates device auth and maps initiation errors", async () => {

--- a/backend/src/routes/tidalStreaming.ts
+++ b/backend/src/routes/tidalStreaming.ts
@@ -948,6 +948,16 @@ router.get(
                 res.setHeader(key, value);
             });
 
+            stream.data.on("error", (streamErr: Error) => {
+                logger.warn(
+                    `[TIDAL-STREAM] Upstream stream error for track ${trackId}: ${streamErr.message}`,
+                );
+                if (!res.headersSent) {
+                    res.status(502).json({ error: "Upstream stream failed" });
+                } else {
+                    res.end();
+                }
+            });
             // Clean up upstream stream when client disconnects
             res.on("close", () => {
                 if (


### PR DESCRIPTION
## Summary

- `GET /api/tidal/stream/:trackId` piped the axios upstream stream to the response with no `'error'` listener on the source. `Readable.pipe()` does not forward source errors, so a mid-playback TIDAL sidecar disconnect emitted an unhandled `'error'` that escalated to `uncaughtException` and tore down the entire backend via graceful shutdown.
- Attaches `stream.data.on("error", ...)` before the pipe, mirroring the established sibling pattern (youtubeMusic, youtube, podcasts, audiobooks, artists): log, 502 `{ error: "Upstream stream failed" }` before headers, `res.end()` after. The existing `res.on("close")` destroy guard is unchanged (guards on `!destroyed`, no double-teardown).
- Class-close audit of every upstream `.pipe(res)` site in `backend/src/routes/`: artists.ts (230/273), youtube.ts (222), youtubeMusic.ts (969/1434), audiobooks.ts (943), podcasts.ts (1406/1436/1571/1626/1675), shareLinks.ts (757, archiver `error` handler) all already attach upstream error handlers — tidalStreaming was the sole miss.

## Testing

- verify: `npx jest src/routes/__tests__/tidalStreamingRuntime.test.ts --maxWorkers=2` — 16 passed (2 new: post-headers error ends response without throwing; pre-headers error returns 502)
- verify: `npx tsc --noEmit` — exit 0
- verify: `npx prettier --check` on changed files — clean
- verify: `node scripts/ci/check-route-error-canon.mjs` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24