### PR TITLE
fix(tidal): offload blocking album metadata and browse-session calls off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TIDAL stream proxying now handles upstream stream errors after headers are
   sent instead of crashing the entire backend via an uncaught exception; a
   mid-playback sidecar disconnect now ends only that response.
+- TIDAL sidecar: album downloads and browse endpoints no longer block the event
+  loop — album metadata/pagination and browse-session creation now run in worker
+  threads, keeping streaming, search, and health responsive during large operations.
 - Podcast cover downloads now time out after 15 seconds so an unresponsive
   image host can no longer stall the cover-sync loops.
 - Fixed the tidal-downloader stream-URL cache race where concurrent mutation

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -1168,6 +1168,13 @@ def _get_album_tracks(api: TidalAPI, album_id: int) -> list[Any]:
     return tracks
 
 
+def _get_album_with_tracks(api: TidalAPI, album_id: int) -> tuple[Any, list[Any]]:
+    """Fetch album metadata and its paginated tracks synchronously."""
+    album = api.get_album(album_id)
+    tracks = _get_album_tracks(api, album_id)
+    return album, tracks
+
+
 async def _download_album_tracks(
     api: TidalAPI,
     tracks: list[Any],
@@ -1246,8 +1253,7 @@ async def download_album(
     """Download using bearer-header auth or the one-release query fallback."""
     api = _build_api(creds.access_token, creds.user_id, creds.country_code)
     try:
-        album = api.get_album(req.album_id)
-        tracks = _get_album_tracks(api, req.album_id)
+        album, tracks = await asyncio.to_thread(_get_album_with_tracks, api, req.album_id)
         results, errors = await _download_album_tracks(api, tracks, req)
         return {
             "album_id": req.album_id,
@@ -1818,7 +1824,7 @@ async def user_browse_home(
 ):
     """Get personalized TIDAL home page shelves."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(session.home)
         shelves = _serialize_page(page)
         return {"shelves": shelves[:limit]}
@@ -1839,7 +1845,7 @@ async def user_browse_explore(
 ):
     """Get TIDAL editorial/new releases shelves."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(session.explore)
         shelves = _serialize_page(page)
         return {"shelves": shelves[:limit]}
@@ -1858,7 +1864,7 @@ async def user_browse_explore(
 async def user_browse_genres(user_id: str = Query(...), quality: str | None = Query(None)):
     """Get TIDAL genre categories."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(session.genres)
         genres = _extract_page_links(page)
         return {"genres": genres}
@@ -1877,7 +1883,7 @@ async def user_browse_genres(user_id: str = Query(...), quality: str | None = Qu
 async def user_browse_moods(user_id: str = Query(...), quality: str | None = Query(None)):
     """Get TIDAL mood categories."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(session.moods)
         moods = _extract_page_links(page)
         return {"moods": moods}
@@ -1896,7 +1902,7 @@ async def user_browse_moods(user_id: str = Query(...), quality: str | None = Que
 async def user_browse_mixes(user_id: str = Query(...), quality: str | None = Query(None)):
     """Get personal TIDAL mixes (daily discovery, etc.)."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(session.mixes)
         mixes = []
         for cat in page.categories or []:
@@ -1927,7 +1933,7 @@ async def user_browse_genre_playlists(
     if not re.match(r"^[a-zA-Z0-9_\-/]+$", path) or ".." in path:
         raise HTTPException(status_code=400, detail="Invalid genre path")
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         page = await asyncio.to_thread(lambda: session.page.get(f"pages/{path}"))
         shelves = _serialize_page(page)
         # Flatten all shelf contents into a single playlist list
@@ -1987,7 +1993,7 @@ async def user_browse_playlist(
 ):
     """Get TIDAL playlist details with tracks."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         playlist = await asyncio.to_thread(session.playlist, playlist_uuid)
         result = await asyncio.to_thread(_serialize_playlist_detail, playlist)
         if limit and len(result.get("tracks", [])) > limit:
@@ -2010,7 +2016,7 @@ async def user_browse_mix(
 ):
     """Get TIDAL mix details with tracks."""
     try:
-        session = _build_browse_session(user_id, quality)
+        session = await asyncio.to_thread(_build_browse_session, user_id, quality)
         mix = await asyncio.to_thread(session.mix, mix_id)
         tracks = await asyncio.to_thread(mix.items)
         return {

--- a/services/tidal-downloader/tests/test_blocking_offload.py
+++ b/services/tidal-downloader/tests/test_blocking_offload.py
@@ -125,6 +125,94 @@ async def test_search_offloaded_to_worker_thread(client, monkeypatch):
     assert captured["t"] != "MainThread"
 
 
+@pytest.mark.anyio
+async def test_download_album_metadata_offloaded_to_worker_thread(client, monkeypatch):
+    """Album metadata and pagination should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    class FakeAPI:
+        def get_album(self, album_id):
+            captured["album"] = threading.current_thread().name
+            return types.SimpleNamespace(
+                title="A",
+                artist=types.SimpleNamespace(name="X"),
+            )
+
+        def get_album_items(self, album_id, limit=100, offset=0):
+            captured["items"] = threading.current_thread().name
+            return types.SimpleNamespace(items=[], totalNumberOfItems=0)
+
+    monkeypatch.setattr(app, "_build_api", lambda *_args, **_kwargs: FakeAPI())
+
+    response = await client.post(
+        "/download/album",
+        json={"album_id": 1},
+        headers={"Authorization": "Bearer tok-header", "x-tidal-user-id": "u1"},
+    )
+
+    assert response.status_code == 200
+    assert captured["album"] != "MainThread"
+    assert captured["items"] != "MainThread"
+
+
+def _fake_browse_session(endpoint: str) -> types.SimpleNamespace:
+    """Build the minimal fake session required by one browse endpoint."""
+    empty_page = types.SimpleNamespace(categories=[])
+    if endpoint.endswith("/home"):
+        return types.SimpleNamespace(home=lambda: empty_page)
+    if endpoint.endswith("/explore"):
+        return types.SimpleNamespace(explore=lambda: empty_page)
+    if endpoint.endswith("/genres"):
+        return types.SimpleNamespace(genres=lambda: empty_page)
+    if endpoint.endswith("/moods"):
+        return types.SimpleNamespace(moods=lambda: empty_page)
+    if endpoint.endswith("/mixes"):
+        return types.SimpleNamespace(mixes=lambda: empty_page)
+    if endpoint.endswith("/genre-playlists"):
+        return types.SimpleNamespace(page=types.SimpleNamespace(get=lambda _path: empty_page))
+    if "/playlist/" in endpoint:
+        playlist = types.SimpleNamespace(id="p1", name="P", num_tracks=0, tracks=list)
+        return types.SimpleNamespace(playlist=lambda _uuid: playlist)
+    mix = types.SimpleNamespace(id="m1", title="M", sub_title="", items=list)
+    return types.SimpleNamespace(mix=lambda _mix_id: mix)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("endpoint", "params"),
+    [
+        ("/user/browse/home", {}),
+        ("/user/browse/explore", {}),
+        ("/user/browse/genres", {}),
+        ("/user/browse/moods", {}),
+        ("/user/browse/mixes", {}),
+        ("/user/browse/genre-playlists", {"path": "Pop"}),
+        ("/user/browse/playlist/p1", {}),
+        ("/user/browse/mix/m1", {}),
+    ],
+)
+async def test_browse_session_build_offloaded_to_worker_thread(
+    client, monkeypatch, endpoint, params
+):
+    """Each authenticated browse endpoint should build its session in a worker thread."""
+    import app
+
+    captured = {}
+
+    def fake_build_browse_session(user_id, quality):
+        captured["t"] = threading.current_thread().name
+        return _fake_browse_session(endpoint)
+
+    monkeypatch.setattr(app, "_build_browse_session", fake_build_browse_session)
+
+    response = await client.get(endpoint, params={"user_id": "u1", **params})
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
 def _session_obj() -> types.SimpleNamespace:
     """Minimal TIDAL session object returned by get_session()."""
     return types.SimpleNamespace(sessionId="s", userId=42, countryCode="US")


### PR DESCRIPTION
## Summary
Phase-D convergence slice L — class-closing event-loop-blocking remediation in the TIDAL python sidecar.

The async `download_album` handler called the synchronous tiddl client inline on the event loop: `api.get_album(...)` plus `_get_album_tracks(...)` (up to 1000 sequential blocking `get_album_items` pages). Separately, all eight authenticated browse handlers called `_build_browse_session(...)` inline — tidalapi 0.8.11's `Session.load_oauth_session` issues a synchronous `GET sessions` request on every cache miss. Both classes froze the worker's single event loop (stream-proxy byte pumping, `/user/search`, `/health`) for the full duration of the blocking work.

## Changes
- `download_album`: album metadata + pagination now fetched via a small sync helper (`_get_album_with_tracks`) wrapped in `asyncio.to_thread`, matching the `download_track` / #270 convention.
- Eight browse handlers (`home`, `explore`, `genres`, `moods`, `mixes`, `genre-playlists`, `user_browse_playlist`, `user_browse_mix`): `_build_browse_session` now runs via `asyncio.to_thread`.
- Audited every remaining `async def` in `app.py`: `_run_user_api_call` paths, auth handlers (#270), and the httpx stream proxy are already offloaded/async; `_build_api` and `_build_public_browse_session` are network-free constructors; serializers are local attribute access — no other blocking sites.

## Tests
- New behavioral thread-recorder tests in `test_blocking_offload.py` covering all nine call sites (album metadata + 8 parametrized browse endpoints). All 9 fail against the unfixed handler code and pass with the fix.
- `pytest services/tidal-downloader/tests -q`: 105 passed
- `ruff check` + `ruff format --check`: clean
- `MYPYPATH=services mypy services/tidal-downloader/app.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24