### PR TITLE
fix(security): close SSRF class on outbound cover-art and enrichment image fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   property values (e.g. `result.error`, `err.response?.data?.detail`) outside
   logger calls, freezing and documenting the pre-existing instances in the
   baseline.
+- Closed an SSRF class on outbound image fetches: the Subsonic `getCoverArt`
+  remote fetch and the enrichment image downloader now use the shared
+  DNS-resolving outbound URL policy with per-hop redirect revalidation
+  (blocking loopback/private/link-local/metadata targets and unsafe redirects),
+  replacing a string-only host check that missed 169.254.0.0/16, most of
+  127.0.0.0/8, IPv6 link-local/ULA, and numeric IP encodings.
 - Pinned the remaining mutable GitHub Actions tags in
   `image-security-scanning.yml` (`actions/checkout`, `docker/login-action`,
   `github/codeql-action/upload-sarif`) and `compose-config-check.yml`

--- a/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
@@ -4,6 +4,11 @@ import fs from "node:fs";
 const mockGetStreamFilePath = jest.fn();
 const mockStreamFileWithRangeSupport = jest.fn();
 const mockDestroyStreamingService = jest.fn();
+const mockLookup = jest.fn();
+
+jest.mock("dns/promises", () => ({
+    lookup: (...args: unknown[]) => mockLookup(...args),
+}));
 
 jest.mock("../../middleware/subsonicAuth", () => ({
     requireSubsonicAuth: (_req: Request, _res: Response, next: () => void) =>
@@ -222,6 +227,9 @@ describe("subsonic branch coverage focused handlers", () => {
         mockGetStreamFilePath.mockReset();
         mockStreamFileWithRangeSupport.mockReset();
         mockDestroyStreamingService.mockReset();
+        // The hardened outbound path DNS-resolves cover hosts before fetching;
+        // resolve test hostnames to a public address so happy paths proceed.
+        mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
         global.fetch = jest.fn() as unknown as typeof fetch;
     });
 

--- a/backend/src/routes/__tests__/subsonicMetadataCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicMetadataCompat.test.ts
@@ -1,5 +1,11 @@
 import { Request, Response } from "express";
 
+const mockLookup = jest.fn();
+
+jest.mock("dns/promises", () => ({
+    lookup: (...args: unknown[]) => mockLookup(...args),
+}));
+
 jest.mock("../../middleware/subsonicAuth", () => ({
     requireSubsonicAuth: (_req: Request, _res: Response, next: () => void) =>
         next(),
@@ -118,6 +124,9 @@ describe("subsonic metadata compatibility handlers", () => {
             syncedLyrics: null,
             plainLyrics: null,
         });
+        // The hardened outbound path DNS-resolves cover hosts before fetching;
+        // resolve test hostnames to a public address so happy paths proceed.
+        mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     });
 
     function buildCoverArtRes(): Response {

--- a/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
+++ b/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
@@ -4,10 +4,15 @@ import { Request, Response } from "express";
 const mockGetStreamFilePath = jest.fn();
 const mockStreamFileWithRangeSupport = jest.fn();
 const mockDestroyStreamingService = jest.fn();
+const mockLookup = jest.fn();
 const mockAudioStreamingService = jest.fn().mockImplementation(() => ({
     getStreamFilePath: mockGetStreamFilePath,
     streamFileWithRangeSupport: mockStreamFileWithRangeSupport,
     destroy: mockDestroyStreamingService,
+}));
+
+jest.mock("dns/promises", () => ({
+    lookup: (...args: unknown[]) => mockLookup(...args),
 }));
 
 jest.mock("../../middleware/subsonicAuth", () => ({
@@ -140,6 +145,8 @@ beforeEach(() => {
     mockArtistFindFirst.mockReset();
     mockPlaylistFindFirst.mockReset();
     mockFetch.mockReset();
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 });
 
 afterEach(() => {
@@ -430,6 +437,79 @@ describe("handleGetCoverArt", () => {
         );
     });
 
+    it("rejects a cover host that resolves to a private address without fetching it", async () => {
+        const coverUrl = "https://covers.attacker.test/metadata.jpg";
+        mockAlbumFindFirst.mockResolvedValue({ coverUrl });
+        mockLookup.mockResolvedValue([
+            { address: "169.254.169.254", family: 4 },
+        ]);
+
+        await handleGetCoverArt(
+            buildReq({ id: "al-private-dns-cover" }),
+            buildRes(),
+        );
+
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            SubsonicErrorCode.NOT_FOUND,
+            "Cover art not found",
+            "json",
+            undefined,
+        );
+        expect(mockFetch).not.toHaveBeenCalledWith(coverUrl, expect.anything());
+    });
+
+    it("does not follow a public cover redirect to a private address", async () => {
+        const coverUrl = "https://covers.example.test/redirect.jpg";
+        const privateUrl = "http://169.254.169.254/latest";
+        mockAlbumFindFirst.mockResolvedValue({ coverUrl });
+        mockFetch.mockResolvedValueOnce(
+            new Response(null, {
+                status: 302,
+                headers: { location: privateUrl },
+            }),
+        );
+
+        await handleGetCoverArt(
+            buildReq({ id: "al-private-redirect-cover" }),
+            buildRes(),
+        );
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).not.toHaveBeenCalledWith(
+            privateUrl,
+            expect.anything(),
+        );
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            SubsonicErrorCode.NOT_FOUND,
+            "Cover art not found",
+            "json",
+            undefined,
+        );
+    });
+
+    it("serves a public-resolving remote cover with its content type", async () => {
+        const coverUrl = "https://covers.example.test/public.png";
+        mockAlbumFindFirst.mockResolvedValue({ coverUrl });
+        mockFetch.mockResolvedValueOnce(
+            new Response("public-cover-bytes", {
+                status: 200,
+                headers: { "content-type": "image/png" },
+            }),
+        );
+        const res = buildRes();
+
+        await handleGetCoverArt(buildReq({ id: "al-public-cover" }), res);
+
+        expect(mockLookup).toHaveBeenCalledWith("covers.example.test", {
+            all: true,
+        });
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(mockSendError).not.toHaveBeenCalled();
+    });
+
     it("serves artist cover art through artist lookup", async () => {
         mockArtistFindFirst.mockResolvedValue({
             heroUrl: "https://cdn.soundspan.test/covers/artist.jpg",
@@ -608,6 +688,31 @@ describe("handleGetCoverArt", () => {
         );
         expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it.each([
+        "http://169.254.169.254/x",
+        "http://127.0.0.2/x",
+        "http://[fe80::1]/x",
+    ])(
+        "rejects blocked literal cover URL %s without fetching",
+        async (coverUrl) => {
+            mockAlbumFindFirst.mockResolvedValue({ coverUrl });
+
+            await handleGetCoverArt(
+                buildReq({ id: "al-blocked-literal-cover" }),
+                buildRes(),
+            );
+
+            expect(mockSendError).toHaveBeenCalledWith(
+                expect.anything(),
+                SubsonicErrorCode.NOT_FOUND,
+                "Cover art not found",
+                "json",
+                undefined,
+            );
+            expect(mockFetch).not.toHaveBeenCalled();
+        },
+    );
 
     it("returns generic error when remote cover art fetch fails with non-404", async () => {
         mockAlbumFindFirst.mockResolvedValue({

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -29,16 +29,16 @@ import {
     snapCoverArtSize,
 } from "../services/coverArtResize";
 import { config } from "../config";
-import { BRAND_SLUG, BRAND_USER_AGENT } from "../config/brand";
+import { BRAND_SLUG } from "../config/brand";
 import { getLyrics } from "../services/lyrics";
 import { scanQueue } from "../workers/queues";
 import {
-    isPublicCoverArtUrl,
     resolveSubsonicStreamQuality,
     resolveTrackPathWithinRoot,
 } from "../utils/subsonicMedia";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
+import { fetchExternalImage } from "../services/imageProxy";
 
 const router = Router();
 const SUBSONIC_TRACE_LOGS = process.env.SUBSONIC_TRACE_LOGS === "true";
@@ -577,22 +577,22 @@ function parseSyncedLyricsLines(
 async function fetchCoverArtBuffer(
     url: string,
 ): Promise<{ buffer: Buffer; contentType: string }> {
-    const response = await fetch(url, {
-        headers: {
-            "User-Agent": BRAND_USER_AGENT,
-        },
-        signal: AbortSignal.timeout(10_000),
+    const result = await fetchExternalImage({
+        url,
+        timeoutMs: 10_000,
+        maxRetries: 1,
     });
 
-    if (!response.ok) {
-        throw new Error(`COVER_FETCH_FAILED:${response.status}`);
+    if (!result.ok) {
+        if (result.status === "not_found" || result.status === "invalid_url") {
+            throw new Error("COVER_FETCH_FAILED:404");
+        }
+        throw new Error("COVER_FETCH_FAILED");
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-    const contentType = response.headers.get("content-type") ?? "image/jpeg";
     return {
-        buffer: Buffer.from(arrayBuffer),
-        contentType,
+        buffer: result.buffer,
+        contentType: result.contentType ?? "image/jpeg",
     };
 }
 
@@ -4993,17 +4993,6 @@ export async function handleGetCoverArt(
                 contentType = "image/webp";
             }
         } else {
-            if (!isPublicCoverArtUrl(coverUrl)) {
-                sendSubsonicError(
-                    res,
-                    SubsonicErrorCode.NOT_FOUND,
-                    "Cover art not found",
-                    format,
-                    callback,
-                );
-                return;
-            }
-
             const fetched = await fetchCoverArtBuffer(coverUrl);
             imageBuffer = fetched.buffer;
             contentType = fetched.contentType;

--- a/backend/src/services/__tests__/imageStorage.test.ts
+++ b/backend/src/services/__tests__/imageStorage.test.ts
@@ -3,6 +3,11 @@ const mockMkdirSync = jest.fn();
 const mockWriteFileSync = jest.fn();
 const mockUnlinkSync = jest.fn();
 const mockLoggerDebug = jest.fn();
+const mockLookup = jest.fn();
+
+jest.mock("dns/promises", () => ({
+    lookup: (...args: unknown[]) => mockLookup(...args),
+}));
 
 jest.mock("fs", () => ({
     existsSync: (...args: unknown[]) => mockExistsSync(...args),
@@ -44,6 +49,7 @@ describe("imageStorage service", () => {
         (global as any).AbortSignal = { timeout: timeoutMock };
         timeoutMock.mockReturnValue("timeout-signal");
         mockExistsSync.mockReturnValue(true);
+        mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     });
 
     it("returns null early when URL is empty", async () => {
@@ -88,6 +94,24 @@ describe("imageStorage service", () => {
             expect.any(Buffer),
         );
         expect(result).toBe("native:artists/artist-1.jpg");
+    });
+
+    it("returns null without fetching when the image host resolves privately", async () => {
+        const targetUrl = "https://images.attacker.test/cover.jpg";
+        mockLookup.mockResolvedValue([{ address: "127.0.0.2", family: 4 }]);
+
+        const result = await downloadAndStoreImage(
+            targetUrl,
+            "artist-private",
+            "artist",
+        );
+
+        expect(result).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalledWith(
+            targetUrl,
+            expect.anything(),
+        );
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
 
     it("returns null for non-ok fetch responses", async () => {

--- a/backend/src/services/imageStorage.ts
+++ b/backend/src/services/imageStorage.ts
@@ -9,7 +9,7 @@ import fs from "fs";
 import path from "path";
 import { logger } from "../utils/logger";
 import { config } from "../config";
-import { BRAND_USER_AGENT } from "../config/brand";
+import { fetchExternalImage } from "./imageProxy";
 
 const ARTIST_IMAGES_DIR = "artists";
 const ALBUM_IMAGES_DIR = "albums";
@@ -54,27 +54,26 @@ export async function downloadAndStoreImage(
             `[ImageStorage] Downloading ${type} image: ${url.substring(0, 60)}...`,
         );
 
-        const response = await fetch(url, {
-            headers: {
-                "User-Agent": BRAND_USER_AGENT,
-            },
-            signal: AbortSignal.timeout(30000),
+        const result = await fetchExternalImage({
+            url,
+            timeoutMs: 30000,
+            maxRetries: 1,
         });
 
-        if (!response.ok) {
+        if (!result.ok) {
             logger.debug(
-                `[ImageStorage] Failed to download: ${response.status}`,
+                `[ImageStorage] Download failed: ${result.message ?? result.status}`,
             );
             return null;
         }
 
-        const contentType = response.headers.get("content-type") || "";
+        const contentType = result.contentType || "";
         if (!contentType.startsWith("image/")) {
             logger.debug(`[ImageStorage] Not an image: ${contentType}`);
             return null;
         }
 
-        const buffer = await response.arrayBuffer();
+        const buffer = result.buffer;
         if (buffer.byteLength < 1000) {
             logger.debug(
                 `[ImageStorage] Image too small (${buffer.byteLength} bytes), likely placeholder`,
@@ -82,7 +81,7 @@ export async function downloadAndStoreImage(
             return null;
         }
 
-        fs.writeFileSync(filePath, Buffer.from(buffer));
+        fs.writeFileSync(filePath, buffer);
         logger.debug(`[ImageStorage] Saved ${type} image: ${filename}`);
 
         return `native:${subdir}/${filename}`;

--- a/backend/src/utils/__tests__/subsonicMedia.test.ts
+++ b/backend/src/utils/__tests__/subsonicMedia.test.ts
@@ -1,5 +1,4 @@
 import {
-    isPublicCoverArtUrl,
     parseCoverArtSize,
     resolveSubsonicStreamQuality,
     resolveTrackPathWithinRoot,
@@ -90,40 +89,6 @@ describe("subsonicMedia", () => {
 
         it("clamps very large values", () => {
             expect(parseCoverArtSize("9999")).toBe(2048);
-        });
-    });
-
-    describe("isPublicCoverArtUrl", () => {
-        it("accepts normal public http/https urls", () => {
-            expect(isPublicCoverArtUrl("https://example.com/cover.jpg")).toBe(
-                true,
-            );
-            expect(isPublicCoverArtUrl("http://covers.example.org/a.png")).toBe(
-                true,
-            );
-        });
-
-        it("rejects localhost and private network urls", () => {
-            expect(isPublicCoverArtUrl("http://localhost:8080/cover.jpg")).toBe(
-                false,
-            );
-            expect(isPublicCoverArtUrl("http://127.0.0.1/cover.jpg")).toBe(
-                false,
-            );
-            expect(isPublicCoverArtUrl("http://10.0.0.8/cover.jpg")).toBe(
-                false,
-            );
-            expect(isPublicCoverArtUrl("http://192.168.1.2/cover.jpg")).toBe(
-                false,
-            );
-            expect(isPublicCoverArtUrl("http://172.16.1.10/cover.jpg")).toBe(
-                false,
-            );
-        });
-
-        it("rejects unsupported protocols and invalid URLs", () => {
-            expect(isPublicCoverArtUrl("file:///etc/passwd")).toBe(false);
-            expect(isPublicCoverArtUrl("not-a-url")).toBe(false);
         });
     });
 });

--- a/backend/src/utils/subsonicMedia.ts
+++ b/backend/src/utils/subsonicMedia.ts
@@ -78,34 +78,3 @@ export function parseCoverArtSize(value: unknown): number | undefined {
 
     return Math.min(parsed, MAX_COVER_ART_SIZE);
 }
-
-/**
- * Returns true when a cover-art URL is publicly reachable over HTTP(S).
- */
-export function isPublicCoverArtUrl(rawUrl: string): boolean {
-    try {
-        const parsed = new URL(rawUrl);
-        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-            return false;
-        }
-
-        const hostname = parsed.hostname.toLowerCase();
-        if (
-            hostname === "localhost" ||
-            hostname === "127.0.0.1" ||
-            hostname === "::1" ||
-            hostname === "0.0.0.0" ||
-            hostname.startsWith("10.") ||
-            hostname.startsWith("192.168.") ||
-            /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname) ||
-            hostname.endsWith(".local") ||
-            hostname.endsWith(".internal")
-        ) {
-            return false;
-        }
-
-        return true;
-    } catch {
-        return false;
-    }
-}


### PR DESCRIPTION
## Summary

Phase-D convergence slice K — class-closing SSRF remediation.

- **Subsonic `getCoverArt`** (`backend/src/routes/subsonic.ts` `fetchCoverArtBuffer`): was a raw WHATWG `fetch(url)` with default `redirect: "follow"` on a DB-stored, enrichment-sourced cover URL, guarded only by the string-only `isPublicCoverArtUrl` check (missed 169.254.0.0/16 cloud metadata, 127.0.0.0/8 beyond the literal loopback, IPv6 link-local/ULA, numeric IP encodings, and did no DNS resolution). Now routed through the shared hardened path `fetchExternalImage` (`resolveSafeOutboundUrl` DNS-resolving validation + `redirect: "manual"` loop with `resolveSafeOutboundRedirectTarget` revalidation per hop). Subsonic error contract preserved: blocked/404 → NOT_FOUND, other failures → GENERIC; content-type/JPEG-fallback behavior unchanged.
- **Enrichment image downloader** (`backend/src/services/imageStorage.ts` `downloadAndStoreImage`): same class — raw redirect-following fetch of third-party-metadata-sourced URLs; migrated to the same hardened path. Null-on-failure, image/content-type and placeholder-size checks preserved.
- The weak `isPublicCoverArtUrl` is removed entirely (subsonic.ts was its only consumer) so there is a single outbound-safety code path.

Reviewed, not migrated (rationale): Audiobookshelf fetches in `routes/library.ts`/`routes/audiobooks.ts`/`services/audiobookCache.ts` use the admin-configured trusted base URL, which is legitimately internal; `routes/artists.ts` HEAD checks hit the fixed host coverartarchive.org; `podcastCache`/`podcastDownload`/`rss-parser` already use the hardened policy.

## Tests

TDD: new behavioral tests (DNS mocked — no live lookups) assert a cover host resolving to a private/metadata address is rejected without any fetch, a 302 redirect to 169.254.169.254 is not followed, literal-blocked URLs (`169.254.169.254`, `127.0.0.2`, `[fe80::1]`) are rejected pre-fetch, and public-resolving covers still serve correctly; imageStorage gains the same private-resolution rejection test.

## Verification

- verify: targeted jest (subsonicStreamCoverArtHandlers, imageStorage, subsonicMedia, outboundUrlSafety, imageProxy) exit 0 — 5/5 suites, 81/81 tests
- verify: backend `tsc --noEmit` exit 0
- verify: prettier --check on changed files exit 0
- verify: `node scripts/ci/check-route-error-canon.mjs` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24