### PR TITLE
fix(security): sanitize retry error leaks and widen error-canon leak ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Stopped forwarding raw download-failure text to clients from the playlist
+  pending-track retry session log and the notifications download-retry
+  response (static messages; raw detail stays in the server log), and widened
+  the route error-canon leak ratchet to also catch `.error`/`.detail`
+  property values (e.g. `result.error`, `err.response?.data?.detail`) outside
+  logger calls, freezing and documenting the pre-existing instances in the
+  baseline.
 - Pinned the remaining mutable GitHub Actions tags in
   `image-security-scanning.yml` (`actions/checkout`, `docker/login-action`,
   `github/codeql-action/upload-sarif`) and `compose-config-check.yml`

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -799,6 +799,39 @@ describe("notifications route runtime", () => {
             newJobId: "job-new-generic",
             error: null,
         });
+
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-generic-failed",
+            userId: "u1",
+            subject: "Artist - Album",
+            type: "album",
+            targetMbid: "mbid-generic-failed",
+            artistMbid: "artist-mbid",
+            metadata: { albumTitle: "Album" },
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-generic-failed",
+            metadata: {},
+        });
+        simpleDownloadManager.startDownload.mockResolvedValueOnce({
+            success: false,
+            error: "raw lidarr detail xyz",
+        });
+        const genericFailedReq = {
+            user: { id: "u1" },
+            params: { id: "job-generic-failed" },
+        } as any;
+        const genericFailedRes = createRes();
+        await retryDownload(genericFailedReq, genericFailedRes);
+        expect(genericFailedRes.statusCode).toBe(200);
+        expect(genericFailedRes.body).toEqual({
+            success: false,
+            newJobId: "job-new-generic-failed",
+            error: "Download failed (details in server log)",
+        });
+        expect(JSON.stringify(genericFailedRes.body)).not.toContain(
+            "raw lidarr detail",
+        );
     });
 
     it("handles spotify_import retry async success/fallback/catch branches", async () => {

--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -2456,7 +2456,7 @@ describe("playlists route runtime", () => {
         });
         soulseekService.downloadBestMatch.mockResolvedValueOnce({
             success: false,
-            error: "download failed",
+            error: "peer xyz123 connection reset",
         });
 
         const req = {
@@ -2473,9 +2473,19 @@ describe("playlists route runtime", () => {
                 where: { id: "job-failed-result" },
                 data: expect.objectContaining({
                     status: "failed",
-                    error: "download failed",
+                    error: "peer xyz123 connection reset",
                 }),
             }),
+        );
+        const sessionLogMock = jest.requireMock("../../utils/playlistLogger")
+            .sessionLog as jest.Mock;
+        expect(JSON.stringify(sessionLogMock.mock.calls)).not.toContain(
+            "peer xyz123",
+        );
+        expect(sessionLogMock).toHaveBeenCalledWith(
+            "PENDING-RETRY",
+            "Download failed (raw detail in server log)",
+            "WARN",
         );
     });
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -947,10 +947,18 @@ router.post(
                 false, // isDiscovery
             );
 
+            if (!result.success) {
+                logger.warn(
+                    `[Retry] Download failed for job ${newJobRecord.id}: ${result.error}`,
+                );
+            }
             res.json({
                 success: result.success,
                 newJobId: newJobRecord.id,
-                error: result.error,
+                // startDownload result.error carries raw downstream error text; return a static message (raw detail in server log).
+                error: result.success
+                    ? null
+                    : "Download failed (details in server log)",
             });
         } catch (error: any) {
             logger.error("Error retrying download:", error);

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -1713,9 +1713,10 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
                     }
                 } else {
                     logger.debug(`[Retry] Download failed: ${result.error}`);
+                    // The session log is returned verbatim to any authenticated caller via GET /api/spotify/import/session-log, so raw error text must not be written to it.
                     sessionLog(
                         "PENDING-RETRY",
-                        `Download failed: ${result.error || "unknown error"}`,
+                        "Download failed (raw detail in server log)",
                         "WARN",
                     );
 

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -165,3 +165,50 @@ test("countLeakPattern ignores identifiers ending in e", () => {
     assert.equal(countLeakPattern("res.json({ detail: response.message })"), 0);
     assert.equal(countLeakPattern("res.send(`${resource.message}`);"), 0);
 });
+
+test("countLeakPattern flags result.error forwarded in a response body", () => {
+    assert.equal(
+        countLeakPattern(
+            "res.json({ success: result.success, error: result.error });",
+        ),
+        1,
+    );
+});
+
+test("countLeakPattern flags result.error interpolated into a session log push", () => {
+    const source =
+        'sessionLog("PENDING-RETRY", `Download failed: ${result.error || "unknown error"}`, "WARN");';
+    assert.equal(countLeakPattern(source), 1);
+});
+
+test("countLeakPattern flags chained optional sidecar detail in a response", () => {
+    assert.equal(
+        countLeakPattern(
+            'res.status(502).json({ error: err.response?.data?.detail || "Download failed" });',
+        ),
+        1,
+    );
+});
+
+test("countLeakPattern exempts result.error inside logger calls", () => {
+    const source =
+        'logger.warn("retry failed:", result.error);\n' +
+        "logger.debug(`[Retry] Download failed: ${result.error}`);";
+    assert.equal(countLeakPattern(source), 0);
+});
+
+test("countLeakPattern ignores derived access on .error", () => {
+    const source =
+        "res.status(400).json({ details: parsedBody.error.issues });\n" +
+        "res.status(400).json({ details: parsedBody.error.flatten() });";
+    assert.equal(countLeakPattern(source), 0);
+});
+
+test("countLeakPattern flags an intermediate const assigned from a result error", () => {
+    assert.equal(
+        countLeakPattern(
+            'const errorMsg = downloadResult.error || "Unknown error";',
+        ),
+        1,
+    );
+});

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -55,7 +55,8 @@ const BASELINE = Object.freeze({
 });
 
 // Raw error details can disclose internal implementation data to clients (OWASP).
-// This independent ratchet prevents new error.message/error.stack response leaks.
+// This independent ratchet prevents new error.message/error.stack response leaks
+// and terminal .error/.detail property values assigned or interpolated outside logger calls.
 const LEAK_BASELINE = Object.freeze({
     // auth.ts remaining 2: Zod firstError.message validation detail in 400 responses (~L813 and ~L1247); code-owned schema messages, not raw errors.
     "backend/src/routes/auth.ts": 2,
@@ -64,26 +65,37 @@ const LEAK_BASELINE = Object.freeze({
     // library.ts remaining 1: admin-only Lidarr connection-test diagnostics (~L5740 lidarrError = err?.message) returned in an admin settings probe response, not a general-user 500 leak.
     "backend/src/routes/library.ts": 1,
     "backend/src/routes/listenTogether.ts": 1,
-    "backend/src/routes/notifications.ts": 0,
+    // notifications.ts remaining 2: stored downloadJob.error strings from the soulseek retry result (~L702) and Lidarr fallback (~L864); stored-then-returned to the owning user via GET /api/downloads — client-reachable, flagged for follow-up sanitization under the slice-J scope guard (the POST retry response leak itself was sanitized).
+    "backend/src/routes/notifications.ts": 2,
     "backend/src/routes/playbackState.ts": 0,
     // playlistImport.ts remaining 2: substring-guarded 400 echoes of playlistImportService's own thrown validation messages (~L434 preview, ~L516 "Invalid track reference" execute); code-owned text, not raw transport errors.
     "backend/src/routes/playlistImport.ts": 2,
-    // playlists.ts remaining 1: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904); the scanError sessionLog instance was sanitized (fixed, not frozen).
-    "backend/src/routes/playlists.ts": 1,
+    // playlists.ts remaining 2: prefix-guarded ensureRemoteTrack validation message (code-owned 400 detail, ~L904); plus stored downloadJob.error from the soulseek retry result (~L1725), stored-then-returned to the owning user via GET /api/downloads — flagged for follow-up sanitization under the slice-J scope guard (the sessionLog WARN leak was sanitized).
+    "backend/src/routes/playlists.ts": 2,
     // podcasts.ts remaining 2: Prisma-retry classification helper (~L83) and logger-only describeAxiosError (~L133); neither reaches a response body.
     "backend/src/routes/podcasts.ts": 2,
     // settings.ts remaining 1: multer MulterError.message in a 400 upload-validation response (~L307), behind an instanceof MulterError guard; library-owned validation text.
     "backend/src/routes/settings.ts": 1,
+    // soulseek.ts remaining 1: direct-download 404 response error: result.error (~L454) on the requireAdmin-gated download route (#216); admin-only surface, frozen under the slice-J scope guard.
+    "backend/src/routes/soulseek.ts": 1,
     // streaming.ts remaining 7: segmentedError.message from toSegmentedSessionError() (~L493); typed SegmentedSessionError domain errors with static code-owned messages/status codes, not raw caught errors.
     "backend/src/routes/streaming.ts": 7,
-    // acquisitionService.ts remaining 3: { success:false, error } acquisition result objects (~L482, ~L678, ~L767) consumed by the download orchestration/admin surface, not raw route 500 bodies; frozen under the slice-E scope guard.
-    "backend/src/services/acquisitionService.ts": 3,
+    // youtube.ts remaining 4: yt-dlp sidecar err.response?.data?.detail echoed in error responses (L68, L126, L335, L341); known backlog item, frozen under the slice-J scope guard.
+    "backend/src/routes/youtube.ts": 4,
+    // youtubeMusic.ts remaining 11: ytmusic sidecar err.response?.data?.detail echoes (10x) plus one result.error response (~L434); same sidecar-detail class as youtube.ts, frozen under the slice-J scope guard, flagged for follow-up.
+    "backend/src/routes/youtubeMusic.ts": 11,
+    // acquisitionService.ts remaining 4: { success:false, error } acquisition result objects (~L482, ~L678, ~L767) consumed by the download orchestration/admin surface, not raw route 500 bodies; frozen under the slice-E scope guard; plus a result.error passthrough in a { success:false, error } result object (~L748); frozen under the slice-J scope guard.
+    "backend/src/services/acquisitionService.ts": 4,
     // audioStreaming.ts remaining 3: internal ffmpeg-error classification (~L285) plus transcode-failure AppError messages (~L303, ~L347); frozen under the slice-E scope guard — AppError messages are echoed by errorHandler, flagged for follow-up sanitization.
     "backend/src/services/audioStreaming.ts": 3,
     // audiobookCache.ts remaining 2: sync-failure detail string recorded server-side (~L104) and an internal thrown sync-error message (~L398); frozen under the slice-E scope guard.
     "backend/src/services/audiobookCache.ts": 2,
-    // discoverWeekly.ts remaining 3: error-classification const (~L51), discoveryLogger line (~L564), and internal transaction-failure message (~L1484); server-side generation pipeline, frozen under the slice-E scope guard.
-    "backend/src/services/discoverWeekly.ts": 3,
+    // discoverWeekly.ts remaining 6: error-classification const (~L51), discoveryLogger line (~L564), and internal transaction-failure message (~L1484); server-side generation pipeline, frozen under the slice-E scope guard; plus discoveryLogger/discoveryBatchLogger interpolations (~L481, ~L496) and a stored job error field (~L489) in the server-side generation pipeline; frozen under the slice-J scope guard.
+    "backend/src/services/discoverWeekly.ts": 6,
+    // genericImportJobRunner.ts remaining 1: latestJob.error passthrough on user cancel (~L91); import-job state plumbing, frozen under the slice-J scope guard.
+    "backend/src/services/genericImportJobRunner.ts": 1,
+    // importJobStore.ts remaining 1: persisted input.error passthrough (~L192); job-state plumbing, frozen under the slice-J scope guard.
+    "backend/src/services/importJobStore.ts": 1,
     // lidarr.ts remaining 3: { success, message } Lidarr client results (~L1651, ~L1732, ~L2152) consumed by admin Lidarr management flows; frozen under the slice-E scope guard.
     "backend/src/services/lidarr.ts": 3,
     // moodBucketService.ts remaining 1: error-classification const (~L185), never a response body; frozen under the slice-E scope guard.
@@ -96,10 +108,12 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/services/podcastDownload.ts": 1,
     // simpleDownloadManager.ts remaining 4: download-job status objects (~L350, ~L371, ~L415, ~L436) persisted for the admin download-queue surface; frozen under the slice-E scope guard.
     "backend/src/services/simpleDownloadManager.ts": 4,
-    // soulseek.ts remaining 13: sessionLog(...) server-side log lines and { success:false, error } download-result objects consumed by the admin-only Soulseek download path; frozen under the slice-E scope guard.
-    "backend/src/services/soulseek.ts": 13,
-    // spotifyImport.ts remaining 4: error-classification const (~L48), import-job error fields (~L1521, ~L1768), and a non-logger import log line (~L1723); admin-visible import-job state, frozen under the slice-E scope guard.
-    "backend/src/services/spotifyImport.ts": 4,
+    // soulseek.ts remaining 17: sessionLog(...) server-side log lines and { success:false, error } download-result objects consumed by the admin-only Soulseek download path; frozen under the slice-E scope guard; plus downloadResult.error consts/interpolations (~L1008, ~L1090, ~L1186) and per-peer result.error batch error strings (~L1248); frozen under the slice-J scope guard.
+    "backend/src/services/soulseek.ts": 17,
+    // spotifyImport.ts remaining 9: error-classification const (~L48), import-job error fields (~L1521, ~L1768), and a non-logger import log line (~L1723); admin-visible import-job state, frozen under the slice-E scope guard; plus job.error/dbJob.error status-object passthroughs (~L289, ~L298, ~L364, ~L2655) and an errorMsg assigned from result.error (~L1694); frozen under the slice-J scope guard.
+    "backend/src/services/spotifyImport.ts": 9,
+    // youtubeDownload.ts remaining 1: sidecar status mapping data.error (~L329); job-state plumbing, frozen under the slice-J scope guard.
+    "backend/src/services/youtubeDownload.ts": 1,
 });
 
 export function countPattern(source) {
@@ -147,7 +161,25 @@ export function countLeakPattern(source) {
         String.raw`(?::\s*|=\s*|\$\{[^}]*?)${ERROR_ID}\??\.(?:message|stack)\b`,
         "g",
     );
-    return normalizedSource.match(pattern)?.length ?? 0;
+    const messageCount = normalizedSource.match(pattern)?.length ?? 0;
+    return messageCount + countErrorPropertyLeaks(stripped);
+}
+
+// Widened leak class: `.error` / `.detail` property values on any object chain
+// (result.error, err.response?.data?.detail, ...) assigned or interpolated
+// outside logger.* calls. Derived access (parsedBody.error.issues,
+// .error.flatten(), .error[...]) is excluded — only terminal values leak.
+function countErrorPropertyLeaks(strippedSource) {
+    const CHAIN = String.raw`(?<![\w$.])[A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*`;
+    const normalized = strippedSource.replace(
+        new RegExp(String.raw`(${CHAIN})\s*(\??)\s*\.\s*(error|detail)\b`, "g"),
+        "$1$2.$3",
+    );
+    const pattern = new RegExp(
+        String.raw`(?::\s*|=\s*|\$\{[^}]*?)${CHAIN}\??\.(?:error|detail)\b(?!\s*[.(\[])`,
+        "g",
+    );
+    return normalized.match(pattern)?.length ?? 0;
 }
 
 export function analyzeRouteErrorCanon(counts, baseline) {


### PR DESCRIPTION
## Summary

Phase-D convergence slice J — class-closing error-leak remediation.

**Two confirmed client-reachable leaks sanitized (TDD, red-first):**
- `backend/src/routes/playlists.ts` pending-track retry: the `sessionLog("PENDING-RETRY", ...)` WARN branch interpolated raw `result.error` (soulseek/node error text + peer usernames) into the shared session log, which `GET /api/spotify/import/session-log` returns verbatim to any authenticated user. Now a static message; raw detail stays in the existing `logger.debug` line.
- `backend/src/routes/notifications.ts` `POST /api/notifications/downloads/:id/retry` (requireAuth, no admin) forwarded `result.error` from `simpleDownloadManager.startDownload` (raw `error.message`) in the response body. Now a static message on failure (`error: null` on success, preserving the response shape); raw detail goes to `logger.warn`.

**Class-close — ratchet widening:**
`scripts/ci/check-route-error-canon.mjs` `countLeakPattern` now also counts terminal `.error`/`.detail` property values on any object chain (`result.error`, `lidarrResult.error`, `err.response?.data?.detail`) assigned or template-interpolated outside `logger.*` calls. Derived access (`parsedBody.error.issues`, `.error.flatten()`) is excluded, so Zod validation responses don't count. Self-test extended with positive/negative fixtures (response vs logger, derived access).

**Triage of the 37 pre-existing matches the widening surfaced:** the slice scope guard (>8 new matches) applies, so all are FROZEN in `LEAK_BASELINE` with per-instance comments rather than sanitized. Flagged for follow-up (client-reachable):
- stored-then-returned `downloadJob.error` fields visible to the owning user via `GET /api/downloads` (notifications.ts ~L702/~L864, playlists.ts ~L1725)
- yt-dlp/ytmusic sidecar `err.response?.data?.detail` echoes in youtube.ts (4) and youtubeMusic.ts (11)

Admin-only / server-side plumbing frozen with comments: routes/soulseek.ts (admin download route), services acquisitionService, discoverWeekly, genericImportJobRunner, importJobStore, soulseek, spotifyImport, youtubeDownload.

## Verification

- verify: red-first — new self-test fixtures return 0 on the old checker; both new jest leak-absence assertions fail against the original routes (session log contained "peer xyz123 connection reset"; response body leaked raw error)
- verify: `node --test scripts/ci/__tests__/check-route-error-canon.test.mjs` — 29 pass, 0 fail
- verify: `node scripts/ci/check-route-error-canon.mjs` — exit 0, both ratchets pass, no tightenable slack in touched baselines
- verify: jest `playlistsRuntime` + `notificationsRuntime` + `apiEntrypointRuntime` — 3 suites, 83 tests pass (`--maxWorkers=2`)
- verify: backend `tsc --noEmit` — exit 0
- verify: `prettier --check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24