### PR TITLE
fix(tidal): lock browse-session caches and auth state against cross-thread dict races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   override was removed so the pod inherits the chart-wide UID/GID 1000 pod
   security context, matching the realigned frontend image (`USER node`) and
   fixing `.next/cache` write failures in individual deployment mode.
+- Fixed the tidal-downloader cross-thread race where browse-session builds on
+  worker threads could mutate `_browse_sessions` during event-loop invalidation
+  iteration, aborting session refresh, restore, or logout with `RuntimeError`;
+  browse-session caches and per-user auth state are now lock-guarded like the
+  stream-URL cache.
 
 - Lidarr queue/history helper HTTP calls are now bounded. The module-level
   `cleanStuckDownloads`, `getRecentCompletedDownloads`, `getQueueCount`,

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -105,6 +105,7 @@ MUSIC_PATH = Path(os.getenv("MUSIC_PATH", "/music"))
 _user_apis: dict[str, TidalAPI] = {}
 _user_api_locks: dict[str, asyncio.Lock] = {}
 _user_auth_state: dict[str, dict[str, str]] = {}
+_user_auth_state_lock = threading.Lock()
 
 # ── Stream URL cache (per-user, keyed by (user_id, track_id, quality)) ─────
 _stream_cache: dict[tuple[str, int, str], dict] = {}
@@ -130,8 +131,10 @@ TIDALAPI_DEFAULT_QUALITY = tidalapi.Quality.high_lossless
 # ── Per-user tidalapi browse sessions ─────────────────────────────
 # Keyed by "user_id:quality" so changing quality creates a new session.
 _browse_sessions: dict[str, tidalapi.Session] = {}
+_browse_sessions_lock = threading.Lock()
 _BROWSE_SESSION_MAX = 50
 _public_browse_sessions: dict[str, tidalapi.Session] = {}
+_public_browse_sessions_lock = threading.Lock()
 _PUBLIC_BROWSE_SESSION_MAX = 8
 _BATCH_SEARCH_MAX_QUERIES = 50
 _BATCH_SEARCH_CONCURRENCY = 5
@@ -147,30 +150,33 @@ def _build_browse_session(user_id: str, quality: str | None = None) -> tidalapi.
     api_quality = TIDDL_TO_TIDALAPI_QUALITY.get(normalized or "", TIDALAPI_DEFAULT_QUALITY)
     cache_key = f"{user_id}:{api_quality.value}"
 
-    cached = _browse_sessions.get(cache_key)
+    with _browse_sessions_lock:
+        cached = _browse_sessions.get(cache_key)
     if cached is not None:
         return cached
 
-    creds = _user_auth_state.get(user_id)
-    if not creds:
+    with _user_auth_state_lock:
+        creds = _user_auth_state.get(user_id)
+        creds_snapshot = dict(creds) if creds else None
+    if not creds_snapshot:
         raise HTTPException(
             status_code=401,
             detail=f"No TIDAL session for user {user_id}. Restore credentials first.",
         )
 
-    # Evict oldest entries if cache is full
-    while len(_browse_sessions) >= _BROWSE_SESSION_MAX:
-        oldest_key = next(iter(_browse_sessions))
-        _browse_sessions.pop(oldest_key, None)
-
     session = tidalapi.Session(tidalapi.Config(quality=api_quality))
     session.load_oauth_session(
         token_type="Bearer",  # noqa: S106 -- OAuth token scheme, not a credential
-        access_token=creds["access_token"],
-        refresh_token=creds.get("refresh_token"),
+        access_token=creds_snapshot["access_token"],
+        refresh_token=creds_snapshot.get("refresh_token"),
         expiry_time=None,
     )
-    _browse_sessions[cache_key] = session
+    with _browse_sessions_lock:
+        # Evict oldest entries if cache is full
+        while len(_browse_sessions) >= _BROWSE_SESSION_MAX:
+            oldest_key = next(iter(_browse_sessions))
+            _browse_sessions.pop(oldest_key, None)
+        _browse_sessions[cache_key] = session
     return session
 
 
@@ -180,16 +186,17 @@ def _build_public_browse_session(quality: str | None = None) -> tidalapi.Session
     api_quality = TIDDL_TO_TIDALAPI_QUALITY.get(normalized or "", TIDALAPI_DEFAULT_QUALITY)
     cache_key = api_quality.value
 
-    cached = _public_browse_sessions.get(cache_key)
+    with _public_browse_sessions_lock:
+        cached = _public_browse_sessions.get(cache_key)
     if cached is not None:
         return cached
 
-    while len(_public_browse_sessions) >= _PUBLIC_BROWSE_SESSION_MAX:
-        oldest_key = next(iter(_public_browse_sessions))
-        _public_browse_sessions.pop(oldest_key, None)
-
     session = tidalapi.Session(tidalapi.Config(quality=api_quality))
-    _public_browse_sessions[cache_key] = session
+    with _public_browse_sessions_lock:
+        while len(_public_browse_sessions) >= _PUBLIC_BROWSE_SESSION_MAX:
+            oldest_key = next(iter(_public_browse_sessions))
+            _public_browse_sessions.pop(oldest_key, None)
+        _public_browse_sessions[cache_key] = session
     return session
 
 
@@ -500,10 +507,12 @@ def _clear_stream_cache(
 def _invalidate_user_api(user_id: str):
     """Remove a user's API instance (e.g. on logout)."""
     _user_apis.pop(user_id, None)
-    _user_auth_state.pop(user_id, None)
+    with _user_auth_state_lock:
+        _user_auth_state.pop(user_id, None)
     # Clear all browse sessions for this user (keyed as "user_id:quality")
-    for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
-        _browse_sessions.pop(key, None)
+    with _browse_sessions_lock:
+        for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
+            _browse_sessions.pop(key, None)
     _clear_stream_cache(user_id)
 
 
@@ -539,7 +548,8 @@ async def _refresh_user_api(user_id: str) -> TidalAPI:
     lock = _get_user_lock(user_id)
 
     async with lock:
-        creds = _user_auth_state.get(user_id)
+        with _user_auth_state_lock:
+            creds = _user_auth_state.get(user_id)
         if not creds or not creds.get("refresh_token"):
             raise HTTPException(
                 status_code=401,
@@ -567,14 +577,16 @@ async def _refresh_user_api(user_id: str) -> TidalAPI:
             await asyncio.to_thread(refreshed_api.get_session)
 
             _user_apis[user_id] = refreshed_api
-            creds["access_token"] = new_access_token
-            creds["tidal_user_id"] = new_user_id
-            creds["country_code"] = new_country
+            with _user_auth_state_lock:
+                creds["access_token"] = new_access_token
+                creds["tidal_user_id"] = new_user_id
+                creds["country_code"] = new_country
 
             # Stream URLs and browse sessions are tied to prior auth state; clear on refresh.
             _clear_stream_cache(user_id)
-            for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
-                _browse_sessions.pop(key, None)
+            with _browse_sessions_lock:
+                for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
+                    _browse_sessions.pop(key, None)
 
             log.info(f"Refreshed TIDAL session for user {user_id}")
             return refreshed_api
@@ -1293,14 +1305,16 @@ def _store_user_session(
 ) -> None:
     """Store a verified per-user API and invalidate stale browse sessions."""
     _user_apis[soundspan_user_id] = api
-    _user_auth_state[soundspan_user_id] = {
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-        "tidal_user_id": tidal_user_id,
-        "country_code": country_code,
-    }
-    for key in [key for key in _browse_sessions if key.startswith(f"{soundspan_user_id}:")]:
-        _browse_sessions.pop(key, None)
+    with _user_auth_state_lock:
+        _user_auth_state[soundspan_user_id] = {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "tidal_user_id": tidal_user_id,
+            "country_code": country_code,
+        }
+    with _browse_sessions_lock:
+        for key in [key for key in _browse_sessions if key.startswith(f"{soundspan_user_id}:")]:
+            _browse_sessions.pop(key, None)
 
 
 async def _refresh_and_restore_user(

--- a/services/tidal-downloader/tests/test_browse_sessions_race.py
+++ b/services/tidal-downloader/tests/test_browse_sessions_race.py
@@ -1,0 +1,232 @@
+"""Thread-safety regression tests for TIDAL browse-session caches."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+
+def _assert_lock_held(lock: threading.Lock) -> None:
+    acquired = lock.acquire(blocking=False)
+    if acquired:
+        lock.release()
+    assert not acquired, "browse-session dictionary operation ran without mutual exclusion"
+
+
+def _assert_lock_available(lock: threading.Lock, operation: str) -> None:
+    acquired = lock.acquire(blocking=False)
+    assert acquired, f"lock held across blocking {operation}"
+    lock.release()
+
+
+class _IterationLockCheckingDict(dict):
+    def __init__(self, values, lock: threading.Lock) -> None:
+        super().__init__(values)
+        self._lock = lock
+
+    def __iter__(self):
+        _assert_lock_held(self._lock)
+        return super().__iter__()
+
+    def items(self):
+        _assert_lock_held(self._lock)
+        return super().items()
+
+    def pop(self, key, default=None):
+        _assert_lock_held(self._lock)
+        return super().pop(key, default)
+
+
+class _AccessLockCheckingDict(dict):
+    def __init__(self, values, lock: threading.Lock) -> None:
+        super().__init__(values)
+        self._lock = lock
+
+    def get(self, key, default=None):
+        _assert_lock_held(self._lock)
+        return super().get(key, default)
+
+    def __setitem__(self, key, value) -> None:
+        _assert_lock_held(self._lock)
+        super().__setitem__(key, value)
+
+    def __iter__(self):
+        _assert_lock_held(self._lock)
+        return super().__iter__()
+
+    def __len__(self) -> int:
+        _assert_lock_held(self._lock)
+        return super().__len__()
+
+    def pop(self, key, default=None):
+        _assert_lock_held(self._lock)
+        return super().pop(key, default)
+
+
+def test_invalidate_user_api_locks_auth_and_browse_state(monkeypatch):
+    import app
+
+    browse_lock = threading.Lock()
+    auth_lock = threading.Lock()
+    browse_sessions = _IterationLockCheckingDict(
+        {
+            "target:HIGH": object(),
+            "target:LOSSLESS": object(),
+            "other:HIGH": object(),
+        },
+        browse_lock,
+    )
+    auth_state = _AccessLockCheckingDict(
+        {"target": {"access_token": "target"}, "other": {"access_token": "other"}},
+        auth_lock,
+    )
+
+    monkeypatch.setattr(app, "_browse_sessions_lock", browse_lock, raising=False)
+    monkeypatch.setattr(app, "_browse_sessions", browse_sessions)
+    monkeypatch.setattr(app, "_user_auth_state_lock", auth_lock, raising=False)
+    monkeypatch.setattr(app, "_user_auth_state", auth_state)
+    monkeypatch.setattr(app, "_user_apis", {"target": object(), "other": object()})
+
+    def assert_stream_clear_is_unlocked(user_id: str) -> None:
+        assert user_id == "target"
+        _assert_lock_available(browse_lock, "stream-cache clear")
+        _assert_lock_available(auth_lock, "stream-cache clear")
+
+    monkeypatch.setattr(app, "_clear_stream_cache", assert_stream_clear_is_unlocked)
+
+    app._invalidate_user_api("target")
+
+    assert dict.copy(browse_sessions) == {"other:HIGH": browse_sessions["other:HIGH"]}
+    assert dict.copy(auth_state) == {"other": {"access_token": "other"}}
+    assert set(app._user_apis) == {"other"}
+
+
+def test_store_user_session_locks_auth_and_prunes_browse_state(monkeypatch):
+    import app
+
+    browse_lock = threading.Lock()
+    auth_lock = threading.Lock()
+    browse_sessions = _IterationLockCheckingDict(
+        {"target:HIGH": object(), "other:HIGH": object()}, browse_lock
+    )
+    auth_state = _AccessLockCheckingDict({}, auth_lock)
+    api = object()
+
+    monkeypatch.setattr(app, "_browse_sessions_lock", browse_lock, raising=False)
+    monkeypatch.setattr(app, "_browse_sessions", browse_sessions)
+    monkeypatch.setattr(app, "_user_auth_state_lock", auth_lock, raising=False)
+    monkeypatch.setattr(app, "_user_auth_state", auth_state)
+    monkeypatch.setattr(app, "_user_apis", {})
+
+    app._store_user_session("target", api, "access", "refresh", "tidal", "US")
+
+    assert app._user_apis == {"target": api}
+    assert dict.copy(auth_state) == {
+        "target": {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "tidal_user_id": "tidal",
+            "country_code": "US",
+        }
+    }
+    assert set(dict.copy(browse_sessions)) == {"other:HIGH"}
+
+
+def test_build_browse_session_locks_dict_ops_and_constructs_unlocked(monkeypatch):
+    import app
+
+    browse_lock = threading.Lock()
+    auth_lock = threading.Lock()
+    credentials = {"access_token": "old-access", "refresh_token": "old-refresh"}
+    browse_sessions = _AccessLockCheckingDict({"oldest": object()}, browse_lock)
+    auth_state = _AccessLockCheckingDict({"target": credentials}, auth_lock)
+    loaded_tokens = {}
+    session = types.SimpleNamespace()
+
+    def load_oauth_session(**kwargs) -> None:
+        _assert_lock_available(browse_lock, "OAuth session load")
+        _assert_lock_available(auth_lock, "OAuth session load")
+        loaded_tokens.update(kwargs)
+
+    def build_session(_config):
+        _assert_lock_available(browse_lock, "session construction")
+        _assert_lock_available(auth_lock, "session construction")
+        with auth_lock:
+            credentials["access_token"] = "new-access"
+            credentials["refresh_token"] = "new-refresh"
+        session.load_oauth_session = load_oauth_session
+        return session
+
+    monkeypatch.setattr(app, "_browse_sessions_lock", browse_lock, raising=False)
+    monkeypatch.setattr(app, "_browse_sessions", browse_sessions)
+    monkeypatch.setattr(app, "_user_auth_state_lock", auth_lock, raising=False)
+    monkeypatch.setattr(app, "_user_auth_state", auth_state)
+    monkeypatch.setattr(app, "_BROWSE_SESSION_MAX", 1)
+    monkeypatch.setattr(
+        app,
+        "tidalapi",
+        types.SimpleNamespace(Config=lambda **kwargs: kwargs, Session=build_session),
+    )
+
+    result = app._build_browse_session("target")
+
+    assert result is session
+    assert loaded_tokens["access_token"] == "old-access"
+    assert loaded_tokens["refresh_token"] == "old-refresh"
+    assert set(dict.copy(browse_sessions)) == {f"target:{app.TIDALAPI_DEFAULT_QUALITY.value}"}
+
+
+def test_build_public_browse_session_locks_dict_ops_and_constructs_unlocked(monkeypatch):
+    import app
+
+    lock = threading.Lock()
+    sessions = _AccessLockCheckingDict({"oldest": object()}, lock)
+    session = object()
+
+    def build_session(_config):
+        _assert_lock_available(lock, "public session construction")
+        return session
+
+    monkeypatch.setattr(app, "_public_browse_sessions_lock", lock, raising=False)
+    monkeypatch.setattr(app, "_public_browse_sessions", sessions)
+    monkeypatch.setattr(app, "_PUBLIC_BROWSE_SESSION_MAX", 1)
+    monkeypatch.setattr(
+        app,
+        "tidalapi",
+        types.SimpleNamespace(Config=lambda **kwargs: kwargs, Session=build_session),
+    )
+
+    result = app._build_public_browse_session()
+
+    assert result is session
+    assert set(dict.copy(sessions)) == {app.TIDALAPI_DEFAULT_QUALITY.value}
+
+
+def test_browse_session_eviction_preserves_size_cap_and_removes_oldest(monkeypatch):
+    import app
+
+    maximum = 3
+    sessions = {f"old-{index}": object() for index in range(maximum)}
+    monkeypatch.setattr(app, "_browse_sessions", sessions)
+    monkeypatch.setattr(app, "_BROWSE_SESSION_MAX", maximum)
+    monkeypatch.setattr(
+        app,
+        "_user_auth_state",
+        {"target": {"access_token": "access", "refresh_token": "refresh"}},
+    )
+    monkeypatch.setattr(
+        app,
+        "tidalapi",
+        types.SimpleNamespace(
+            Config=lambda **kwargs: kwargs,
+            Session=lambda _config: types.SimpleNamespace(
+                load_oauth_session=lambda **_kwargs: None
+            ),
+        ),
+    )
+
+    app._build_browse_session("target")
+
+    assert len(sessions) == maximum
+    assert "old-0" not in sessions
+    assert f"target:{app.TIDALAPI_DEFAULT_QUALITY.value}" in sessions


### PR DESCRIPTION
## Summary

- `_build_browse_session` runs on `asyncio.to_thread` worker threads (8 call sites) and inserts/evicts entries in module-global `_browse_sessions`, while the event-loop thread iterates-and-pops the same dict in `_invalidate_user_api`, `_refresh_user_api`, and `_store_user_session`. A worker mutation racing a loop-side comprehension raises `RuntimeError: dictionary changed size during iteration`, aborting session refresh/restore/logout with an unhandled 500.
- Class-closing fix mirroring the existing `_stream_cache_lock` pattern: new `_browse_sessions_lock`, `_public_browse_sessions_lock`, and `_user_auth_state_lock` (`threading.Lock`) guard every lookup, evict+insert, and iterate+pop over those structures.
- Worker-side creds reads in `_build_browse_session` now take a snapshot under the auth lock, so the in-place token mutation in `_refresh_user_api` cannot produce torn state (new access token paired with a stale refresh token).
- Critical sections cover dict operations only — no lock is held across blocking `tidalapi` construction/`load_oauth_session` or any `await`, and locks are never nested (no deadlock with the non-reentrant locks).
- Audited remaining module globals: `_user_apis` and `_user_api_locks` are mutated/read on the event-loop thread only and need no lock; `_stream_cache` was already guarded.

## Testing

- New `services/tidal-downloader/tests/test_browse_sessions_race.py` (mirrors the `test_stream_cache_race.py` lock-checking-dict pattern): asserts locks are held for every dict op, released during session construction, creds snapshot semantics, and the eviction size cap. 4 of 5 tests fail against the unguarded code.
- verify: `pytest services/tidal-downloader/tests -q` — 110 passed
- verify: `ruff check services/tidal-downloader/` — All checks passed; `ruff format --check` — 14 files already formatted
- verify: `MYPYPATH=services mypy services/tidal-downloader/app.py` — Success: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24