### PR TITLE
fix(audiobooks): require auth and contain cover-cache path on the cover endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   audiobooks API, and validated and contained the cover-cache fallback path,
   closing an unauthenticated arbitrary-image read and path traversal; existing
   frontend cover URLs already include `?token=`, so no client change was needed.
+  The endpoint also now uses the shared image rate limiter and defers CORS
+  headers to the app-level origin allowlist instead of reflecting the request
+  origin with credentials.
 - Stopped forwarding raw download-failure text to clients from the playlist
   pending-track retry session log and the notifications download-retry
   response (static messages; raw detail stays in the server log), and widened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Required authentication on the audiobook cover endpoint like the rest of the
+  audiobooks API, and validated and contained the cover-cache fallback path,
+  closing an unauthenticated arbitrary-image read and path traversal; existing
+  frontend cover URLs already include `?token=`, so no client change was needed.
 - Stopped forwarding raw download-failure text to clients from the playlist
   pending-track retry session log and the notifications download-retry
   response (static messages; raw detail stays in the server log), and widened

--- a/backend/src/__tests__/audiobooksCoverAuthz.test.ts
+++ b/backend/src/__tests__/audiobooksCoverAuthz.test.ts
@@ -1,0 +1,207 @@
+import express from "express";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import request from "supertest";
+
+export {};
+
+const mockTempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "soundspan-audiobook-cover-"),
+);
+const mockMusicPath = path.join(mockTempRoot, "music");
+
+const mockRequireAuthOrToken = jest.fn(
+    async (req: any, res: any, next: any) => {
+        if (req.headers["x-test-user"]) {
+            req.user = { id: "user-1", username: "tester", role: "user" };
+            return next();
+        }
+        return res.status(401).json({ error: "Not authenticated" });
+    },
+);
+
+jest.mock("../middleware/auth", () => ({
+    requireAuthOrToken: (req: any, res: any, next: any) =>
+        mockRequireAuthOrToken(req, res, next),
+}));
+
+jest.mock("../middleware/rateLimiter", () => ({
+    apiLimiter: (_req: any, _res: any, next: any) => next(),
+    imageLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const mockAudiobookshelfService = {
+    getAllAudiobooks: jest.fn(),
+    getAudiobook: jest.fn(),
+    searchAudiobooks: jest.fn(),
+    streamAudiobook: jest.fn(),
+    updateProgress: jest.fn(),
+};
+jest.mock("../services/audiobookshelf", () => ({
+    audiobookshelfService: mockAudiobookshelfService,
+}));
+
+const mockAudiobookCacheService = {
+    syncAll: jest.fn(),
+    getAudiobook: jest.fn(),
+};
+jest.mock("../services/audiobookCache", () => ({
+    audiobookCacheService: mockAudiobookCacheService,
+}));
+
+const mockNotificationService = {
+    notifySystem: jest.fn(),
+};
+jest.mock("../services/notificationService", () => ({
+    notificationService: mockNotificationService,
+}));
+
+const mockGetSystemSettings = jest.fn(async () => ({}));
+jest.mock("../utils/systemSettings", () => ({
+    getSystemSettings: mockGetSystemSettings,
+}));
+
+const mockPrisma = {
+    audiobook: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+    },
+    audiobookProgress: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+        deleteMany: jest.fn(),
+    },
+};
+jest.mock("../utils/db", () => ({
+    prisma: mockPrisma,
+}));
+
+jest.mock("../config", () => ({
+    config: {
+        music: {
+            musicPath: mockMusicPath,
+        },
+    },
+}));
+
+import audiobooksRouter from "../routes/audiobooks";
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    app.use("/api/audiobooks", audiobooksRouter);
+    return app;
+}
+
+function writeCover(filePath: string, contents: Buffer): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+}
+
+describe("audiobook cover authorization and path containment", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fs.rmSync(mockMusicPath, { recursive: true, force: true });
+        fs.rmSync(path.join(mockTempRoot, "secrets"), {
+            recursive: true,
+            force: true,
+        });
+        fs.mkdirSync(mockMusicPath, { recursive: true });
+        mockPrisma.audiobook.findUnique.mockResolvedValue(null);
+        mockPrisma.audiobook.update.mockResolvedValue({});
+        mockGetSystemSettings.mockResolvedValue({});
+    });
+
+    afterAll(() => {
+        fs.rmSync(mockTempRoot, { recursive: true, force: true });
+    });
+
+    it("rejects unauthenticated cover requests", async () => {
+        const response = await request(buildApp()).get(
+            "/api/audiobooks/book-1/cover",
+        );
+
+        expect(response.status).toBe(401);
+        expect(response.body).toEqual({ error: "Not authenticated" });
+    });
+
+    it("rejects path traversal in the audiobook ID", async () => {
+        const secretBytes = Buffer.from("known-secret-image-bytes");
+        writeCover(
+            path.join(mockTempRoot, "secrets", "secret.jpg"),
+            secretBytes,
+        );
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/%2e%2e%2f%2e%2e%2fsecrets%2fsecret/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ error: "Invalid audiobook ID" });
+        expect(
+            Buffer.isBuffer(response.body) && response.body.equals(secretBytes),
+        ).toBe(false);
+    });
+
+    it("serves and back-fills a valid fallback cover", async () => {
+        const coverBytes = Buffer.from("fallback-cover-bytes");
+        const fallbackPath = path.join(
+            mockMusicPath,
+            "cover-cache",
+            "audiobooks",
+            "book-1.jpg",
+        );
+        writeCover(fallbackPath, coverBytes);
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(coverBytes);
+        expect(mockPrisma.audiobook.update).toHaveBeenCalledWith({
+            where: { id: "book-1" },
+            data: { localCoverPath: fallbackPath },
+        });
+    });
+
+    it("serves a valid cover from the database path", async () => {
+        const coverBytes = Buffer.from("database-cover-bytes");
+        const localCoverPath = path.join(mockTempRoot, "db-cover.jpg");
+        writeCover(localCoverPath, coverBytes);
+        mockPrisma.audiobook.findUnique.mockResolvedValue({
+            localCoverPath,
+            coverUrl: null,
+        });
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(coverBytes);
+        expect(mockPrisma.audiobook.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when no cover is available", async () => {
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: "Cover not found" });
+    });
+});

--- a/backend/src/__tests__/audiobooksCoverAuthz.test.ts
+++ b/backend/src/__tests__/audiobooksCoverAuthz.test.ts
@@ -178,6 +178,27 @@ describe("audiobook cover authorization and path containment", () => {
         });
     });
 
+    it("does not reflect arbitrary request origins on served covers", async () => {
+        const coverBytes = Buffer.from("fallback-cover-bytes");
+        writeCover(
+            path.join(mockMusicPath, "cover-cache", "audiobooks", "book-1.jpg"),
+            coverBytes,
+        );
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes")
+            .set("Origin", "https://evil.example");
+
+        expect(response.status).toBe(200);
+        // CORS headers are owned by the app-level cors() allowlist
+        // middleware; the route handler must not reflect the origin itself.
+        expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+        expect(
+            response.headers["access-control-allow-credentials"],
+        ).toBeUndefined();
+    });
+
     it("serves a valid cover from the database path", async () => {
         const coverBytes = Buffer.from("database-cover-bytes");
         const localCoverPath = path.join(mockTempRoot, "db-cover.jpg");

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -596,11 +596,12 @@ router.options("/:id/cover", (req, res) => {
 /**
  * GET /audiobooks/:id/cover
  * Serve cached cover image from local disk, or proxy from Audiobookshelf if not cached
- * NO RATE LIMITING - These are static files served from disk with aggressive caching
+ * Uses the high-volume imageLimiter (matches library/browse image routes)
  */
 router.get<{ id: string }>(
     "/:id/cover",
     requireAuthOrToken,
+    imageLimiter,
     async (req, res) => {
         try {
             const { id } = req.params;
@@ -639,15 +640,14 @@ router.get<{ id: string }>(
                 }
             }
 
-            // If local cover exists, serve it
+            // If local cover exists, serve it. CORS headers come from the
+            // app-level cors() middleware, which enforces the origin
+            // allowlist; do not reflect the request origin here.
             if (coverPath && fs.existsSync(coverPath)) {
-                const origin = req.headers.origin || "http://localhost:3030";
                 res.setHeader(
                     "Cache-Control",
                     "public, max-age=31536000, immutable",
                 );
-                res.setHeader("Access-Control-Allow-Origin", origin);
-                res.setHeader("Access-Control-Allow-Credentials", "true");
                 res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
                 return res.sendFile(coverPath);
             }
@@ -677,8 +677,6 @@ router.get<{ id: string }>(
                         });
 
                         if (response.ok) {
-                            const origin =
-                                req.headers.origin || "http://localhost:3030";
                             res.setHeader(
                                 "Content-Type",
                                 response.headers.get("content-type") ||
@@ -688,14 +686,6 @@ router.get<{ id: string }>(
                                 "Cache-Control",
                                 "public, max-age=86400",
                             ); // 24 hours for proxied
-                            res.setHeader(
-                                "Access-Control-Allow-Origin",
-                                origin,
-                            );
-                            res.setHeader(
-                                "Access-Control-Allow-Credentials",
-                                "true",
-                            );
                             res.setHeader(
                                 "Cross-Origin-Resource-Policy",
                                 "cross-origin",

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -5,6 +5,7 @@ import { audiobookCacheService } from "../services/audiobookCache";
 import { prisma } from "../utils/db";
 import { requireAuthOrToken } from "../middleware/auth";
 import { imageLimiter, apiLimiter } from "../middleware/rateLimiter";
+import { safeResolvePath } from "../utils/safeResolvePath";
 
 const router = Router();
 
@@ -567,6 +568,9 @@ router.options("/:id/cover", (req, res) => {
  *   get:
  *     summary: Serve audiobook cover image
  *     tags: [Audiobooks]
+ *     security:
+ *       - sessionAuth: []
+ *       - apiKeyAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -582,6 +586,10 @@ router.options("/:id/cover", (req, res) => {
  *             schema:
  *               type: string
  *               format: binary
+ *       400:
+ *         description: Invalid audiobook ID
+ *       401:
+ *         description: Not authenticated
  *       404:
  *         description: Cover not found
  */
@@ -590,112 +598,132 @@ router.options("/:id/cover", (req, res) => {
  * Serve cached cover image from local disk, or proxy from Audiobookshelf if not cached
  * NO RATE LIMITING - These are static files served from disk with aggressive caching
  */
-router.get("/:id/cover", async (req, res) => {
-    try {
-        const { id } = req.params;
-        const fs = await import("fs");
-        const path = await import("path");
-        const { config } = await import("../config");
-
-        const audiobook = await prisma.audiobook.findUnique({
-            where: { id },
-            select: { localCoverPath: true, coverUrl: true },
-        });
-
-        let coverPath = audiobook?.localCoverPath;
-
-        // Fallback: check if cover exists on disk even if DB path is empty
-        if (!coverPath) {
-            const fallbackPath = path.join(
-                config.music.musicPath,
-                "cover-cache",
-                "audiobooks",
-                `${id}.jpg`,
-            );
-            if (fs.existsSync(fallbackPath)) {
-                coverPath = fallbackPath;
-                // Update database with the correct path
-                await prisma.audiobook
-                    .update({
-                        where: { id },
-                        data: { localCoverPath: fallbackPath },
-                    })
-                    .catch(() => {}); // Ignore errors if audiobook doesn't exist
+router.get<{ id: string }>(
+    "/:id/cover",
+    requireAuthOrToken,
+    async (req, res) => {
+        try {
+            const { id } = req.params;
+            if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+                return res.status(400).json({ error: "Invalid audiobook ID" });
             }
-        }
 
-        // If local cover exists, serve it
-        if (coverPath && fs.existsSync(coverPath)) {
-            const origin = req.headers.origin || "http://localhost:3030";
-            res.setHeader(
-                "Cache-Control",
-                "public, max-age=31536000, immutable",
-            );
-            res.setHeader("Access-Control-Allow-Origin", origin);
-            res.setHeader("Access-Control-Allow-Credentials", "true");
-            res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
-            return res.sendFile(coverPath);
-        }
+            const fs = await import("fs");
+            const path = await import("path");
+            const { config } = await import("../config");
 
-        // Fallback: proxy from Audiobookshelf if coverUrl is available
-        if (audiobook?.coverUrl) {
-            const { getSystemSettings } =
-                await import("../utils/systemSettings");
-            const settings = await getSystemSettings();
+            const audiobook = await prisma.audiobook.findUnique({
+                where: { id },
+                select: { localCoverPath: true, coverUrl: true },
+            });
 
-            if (settings?.audiobookshelfUrl && settings?.audiobookshelfApiKey) {
-                const baseUrl = settings.audiobookshelfUrl.replace(/\/$/, "");
-                const coverApiUrl = `${baseUrl}/api/${audiobook.coverUrl}`;
+            let coverPath = audiobook?.localCoverPath;
 
-                try {
-                    const response = await fetch(coverApiUrl, {
-                        headers: {
-                            Authorization: `Bearer ${settings.audiobookshelfApiKey}`,
-                        },
-                        signal: AbortSignal.timeout(15000),
-                    });
-
-                    if (response.ok) {
-                        const origin =
-                            req.headers.origin || "http://localhost:3030";
-                        res.setHeader(
-                            "Content-Type",
-                            response.headers.get("content-type") ||
-                                "image/jpeg",
-                        );
-                        res.setHeader("Cache-Control", "public, max-age=86400"); // 24 hours for proxied
-                        res.setHeader("Access-Control-Allow-Origin", origin);
-                        res.setHeader(
-                            "Access-Control-Allow-Credentials",
-                            "true",
-                        );
-                        res.setHeader(
-                            "Cross-Origin-Resource-Policy",
-                            "cross-origin",
-                        );
-
-                        // Stream the response body to client
-                        const buffer = await response.arrayBuffer();
-                        return res.send(Buffer.from(buffer));
-                    }
-                } catch (proxyError: any) {
-                    logger.error(
-                        `[Audiobook Cover] Proxy error for ${id}:`,
-                        proxyError.message,
-                    );
+            // Fallback: check if cover exists on disk even if DB path is empty
+            if (!coverPath) {
+                const coverDir = path.join(
+                    config.music.musicPath,
+                    "cover-cache",
+                    "audiobooks",
+                );
+                const fallbackPath = safeResolvePath(coverDir, `${id}.jpg`);
+                if (fallbackPath && fs.existsSync(fallbackPath)) {
+                    coverPath = fallbackPath;
+                    // Update database with the correct path
+                    await prisma.audiobook
+                        .update({
+                            where: { id },
+                            data: { localCoverPath: fallbackPath },
+                        })
+                        .catch(() => {}); // Ignore errors if audiobook doesn't exist
                 }
             }
-        }
 
-        // No cover available
-        return res.status(404).json({ error: "Cover not found" });
-    } catch (error: any) {
-        logger.error("Error serving cover:", error);
-        res.status(500).json({
-            error: "Failed to serve cover",
-        });
-    }
-});
+            // If local cover exists, serve it
+            if (coverPath && fs.existsSync(coverPath)) {
+                const origin = req.headers.origin || "http://localhost:3030";
+                res.setHeader(
+                    "Cache-Control",
+                    "public, max-age=31536000, immutable",
+                );
+                res.setHeader("Access-Control-Allow-Origin", origin);
+                res.setHeader("Access-Control-Allow-Credentials", "true");
+                res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+                return res.sendFile(coverPath);
+            }
+
+            // Fallback: proxy from Audiobookshelf if coverUrl is available
+            if (audiobook?.coverUrl) {
+                const { getSystemSettings } =
+                    await import("../utils/systemSettings");
+                const settings = await getSystemSettings();
+
+                if (
+                    settings?.audiobookshelfUrl &&
+                    settings?.audiobookshelfApiKey
+                ) {
+                    const baseUrl = settings.audiobookshelfUrl.replace(
+                        /\/$/,
+                        "",
+                    );
+                    const coverApiUrl = `${baseUrl}/api/${audiobook.coverUrl}`;
+
+                    try {
+                        const response = await fetch(coverApiUrl, {
+                            headers: {
+                                Authorization: `Bearer ${settings.audiobookshelfApiKey}`,
+                            },
+                            signal: AbortSignal.timeout(15000),
+                        });
+
+                        if (response.ok) {
+                            const origin =
+                                req.headers.origin || "http://localhost:3030";
+                            res.setHeader(
+                                "Content-Type",
+                                response.headers.get("content-type") ||
+                                    "image/jpeg",
+                            );
+                            res.setHeader(
+                                "Cache-Control",
+                                "public, max-age=86400",
+                            ); // 24 hours for proxied
+                            res.setHeader(
+                                "Access-Control-Allow-Origin",
+                                origin,
+                            );
+                            res.setHeader(
+                                "Access-Control-Allow-Credentials",
+                                "true",
+                            );
+                            res.setHeader(
+                                "Cross-Origin-Resource-Policy",
+                                "cross-origin",
+                            );
+
+                            // Stream the response body to client
+                            const buffer = await response.arrayBuffer();
+                            return res.send(Buffer.from(buffer));
+                        }
+                    } catch (proxyError: any) {
+                        logger.error(
+                            `[Audiobook Cover] Proxy error for ${id}:`,
+                            proxyError.message,
+                        );
+                    }
+                }
+            }
+
+            // No cover available
+            return res.status(404).json({ error: "Cover not found" });
+        } catch (error: any) {
+            logger.error("Error serving cover:", error);
+            res.status(500).json({
+                error: "Failed to serve cover",
+            });
+        }
+    },
+);
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary

Closes an unauthenticated arbitrary-image read + path traversal (CWE-306 + CWE-22) on `GET /api/audiobooks/:id/cover`:

- The route was the **only** audiobooks route without `requireAuthOrToken` (all siblings have it). It now carries the same middleware. The frontend already appends `?token=` to audiobook cover URLs (`frontend/lib/api/media.ts#getCoverArtUrl`), so no client change is needed; the OPTIONS preflight handler stays unauthenticated.
- The DB-miss fallback joined the raw url-decoded `:id` into `<musicPath>/cover-cache/audiobooks/<id>.jpg`. Express decodes `%2e%2e%2f` in the param, so an encoded-traversal id resolved outside the cover dir, and `fs.existsSync` + `res.sendFile` served it — an unauthenticated arbitrary `.jpg` read and file-existence oracle. The handler now rejects ids outside `[A-Za-z0-9_-]` with 400 (Audiobookshelf item ids — `li_...` slugs or UUIDs — all match) and resolves the fallback through the shared `safeResolvePath` utility as containment defense in depth.
- OpenAPI block updated (security stanza, 400/401 responses); one CHANGELOG entry under the existing `[Unreleased] > ### Security` heading.

## Class audit

Swept `backend/src/routes` for other file-serving handlers (`res.sendFile`/`res.download`/`fs.createReadStream`): podcasts, browse, and library are behind `router.use(requireAuthOrToken)` and serve DB/cache-owned paths; streaming uses `requireAuth` on every route; subsonic is behind `requireSubsonicAuth` and resolves within the music root; shareLinks is public by design and already uses `safeResolvePath`. This route was the only gap.

## Test plan

TDD, red first (verified against the unfixed route: exactly the unauth-401 and traversal tests failed):

- new `backend/src/__tests__/audiobooksCoverAuthz.test.ts` (supertest, repo `*RouteAuthz` pattern, real fs temp dirs): unauth request → 401; encoded-traversal id with a real out-of-dir secret file on disk → 400 and no secret bytes; valid fallback id → 200 + DB back-fill; DB-path serve → 200; nothing found → 404
- `verify:` audiobooksCoverAuthz + audiobooksRuntime + audiobooksAdvancedRuntime: 29/29 pass; apiEntrypointRuntime: 20/20 pass
- `verify:` backend `tsc --noEmit` exit 0; prettier --check clean on changed files; `check-route-error-canon.mjs` exit 0; `openapiRouteSync.test.ts` 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24