### PR TITLE
fix(subsonic): stop unbounded hydration in getPlaylists and sibling count paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Subsonic getPlaylists (and the root directory/starred count paths) no longer
+  hydrate every playlist item/track/album row (or album-id/track-duration rows)
+  just to compute songCount/duration/coverArt — they now use bounded Prisma
+  aggregates; response shapes unchanged.
 - TIDAL stream proxying now handles upstream stream errors after headers are
   sent instead of crashing the entire backend via an uncaught exception; a
   mid-playback sidecar disconnect now ends only that response.

--- a/backend/src/routes/__tests__/subsonicBrowseCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicBrowseCompat.test.ts
@@ -397,13 +397,13 @@ describe("subsonic browse compatibility handlers", () => {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: "https://example.test/artist.jpg",
-                albums: [{ id: "album-1" }, { id: "album-2" }],
+                _count: { albums: 2 },
             },
             {
                 id: "artist-2",
                 name: "Artist Two",
                 heroUrl: null,
-                albums: [{ id: "album-3" }],
+                _count: { albums: 1 },
             },
         ]);
 
@@ -413,6 +413,16 @@ describe("subsonic browse compatibility handlers", () => {
             }),
             buildRes(),
         );
+
+        const artistQuery = mockArtistFindMany.mock.calls[0][0];
+        expect(artistQuery.select).toMatchObject({
+            _count: {
+                select: {
+                    albums: { where: { location: "LIBRARY" } },
+                },
+            },
+        });
+        expect(artistQuery.select).not.toHaveProperty("albums");
 
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),

--- a/backend/src/routes/__tests__/subsonicCollectionsCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicCollectionsCompat.test.ts
@@ -35,6 +35,10 @@ jest.mock("../../utils/db", () => ({
         track: {
             findFirst: jest.fn(),
             findMany: jest.fn(),
+            aggregate: jest.fn(),
+        },
+        playlistItem: {
+            findMany: jest.fn(),
         },
     },
 }));
@@ -110,6 +114,8 @@ describe("subsonic collections/core compatibility handlers", () => {
         .findMany as jest.Mock;
     const mockTrackFindMany = prisma.track.findMany as jest.Mock;
     const mockTrackFindFirst = prisma.track.findFirst as jest.Mock;
+    const mockTrackAggregate = prisma.track.aggregate as jest.Mock;
+    const mockPlaylistItemFindMany = prisma.playlistItem.findMany as jest.Mock;
     const mockSendError = sendSubsonicError as jest.Mock;
     const mockSendSuccess = sendSubsonicSuccess as jest.Mock;
 
@@ -121,6 +127,8 @@ describe("subsonic collections/core compatibility handlers", () => {
         mockPlaybackStateFindMany.mockResolvedValue([]);
         mockTrackFindMany.mockResolvedValue([]);
         mockTrackFindFirst.mockResolvedValue(null);
+        mockTrackAggregate.mockResolvedValue({ _sum: { duration: null } });
+        mockPlaylistItemFindMany.mockResolvedValue([]);
     });
 
     it("returns protocol ping payload", () => {
@@ -180,39 +188,56 @@ describe("subsonic collections/core compatibility handlers", () => {
                 _count: {
                     items: 2,
                 },
-                items: [
-                    {
-                        track: {
-                            duration: 180,
-                            album: {
-                                coverUrl: null,
-                                genres: null,
-                                userGenres: null,
-                            },
-                        },
-                    },
-                    {
-                        track: {
-                            duration: 120,
-                            album: {
-                                coverUrl: "https://example.test/covers/1.jpg",
-                                genres: null,
-                                userGenres: null,
-                            },
-                        },
-                    },
-                ],
             },
+            {
+                id: "playlist-2",
+                name: "Empty",
+                isPublic: false,
+                createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                _count: {
+                    items: 0,
+                },
+            },
+        ]);
+        mockTrackAggregate.mockResolvedValue({ _sum: { duration: 300 } });
+        mockPlaylistItemFindMany.mockResolvedValue([
+            { playlistId: "playlist-1" },
         ]);
 
         await handleGetPlaylists(buildReq({}), buildRes());
 
-        expect(mockPlaylistFindMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { userId: "user-1" },
-                orderBy: { createdAt: "desc" },
-            }),
-        );
+        const playlistQuery = mockPlaylistFindMany.mock.calls[0][0];
+        expect(playlistQuery).toMatchObject({
+            where: { userId: "user-1" },
+            orderBy: { createdAt: "desc" },
+            include: { _count: { select: { items: true } } },
+        });
+        expect(playlistQuery.include).not.toHaveProperty("items");
+        expect(mockTrackAggregate).toHaveBeenCalledTimes(1);
+        expect(mockTrackAggregate).toHaveBeenCalledWith({
+            where: {
+                playlistItems: {
+                    some: { playlistId: "playlist-1" },
+                },
+            },
+            _sum: { duration: true },
+        });
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(1);
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledWith({
+            where: {
+                playlistId: { in: ["playlist-1", "playlist-2"] },
+                track: {
+                    album: {
+                        AND: [
+                            { coverUrl: { not: null } },
+                            { coverUrl: { not: "" } },
+                        ],
+                    },
+                },
+            },
+            distinct: ["playlistId"],
+            select: { playlistId: true },
+        });
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
@@ -226,6 +251,12 @@ describe("subsonic collections/core compatibility handlers", () => {
                             duration: 300,
                             coverArt: "pl-playlist-1",
                         }),
+                        expect.objectContaining({
+                            id: "pl-playlist-2",
+                            songCount: 0,
+                            duration: 0,
+                            coverArt: undefined,
+                        }),
                     ]),
                 }),
             }),
@@ -235,7 +266,16 @@ describe("subsonic collections/core compatibility handlers", () => {
     });
 
     it("returns generic error when getPlaylists query fails", async () => {
-        mockPlaylistFindMany.mockRejectedValueOnce(new Error("boom"));
+        mockPlaylistFindMany.mockResolvedValueOnce([
+            {
+                id: "playlist-1",
+                name: "Road Trip",
+                isPublic: false,
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                _count: { items: 1 },
+            },
+        ]);
+        mockTrackAggregate.mockRejectedValueOnce(new Error("boom"));
 
         await handleGetPlaylists(buildReq({}), buildRes());
 
@@ -243,6 +283,19 @@ describe("subsonic collections/core compatibility handlers", () => {
             expect.anything(),
             0,
             "Failed to fetch playlists",
+            "json",
+            undefined,
+        );
+    });
+
+    it("skips playlist aggregates when no playlists exist", async () => {
+        await handleGetPlaylists(buildReq({}), buildRes());
+
+        expect(mockTrackAggregate).not.toHaveBeenCalled();
+        expect(mockPlaylistItemFindMany).not.toHaveBeenCalled();
+        expect(mockSendSuccess).toHaveBeenCalledWith(
+            expect.anything(),
+            { playlists: { playlist: [] } },
             "json",
             undefined,
         );

--- a/backend/src/routes/__tests__/subsonicStateCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicStateCompat.test.ts
@@ -31,6 +31,7 @@ jest.mock("../../utils/db", () => ({
         track: {
             findUnique: jest.fn(),
             findMany: jest.fn(),
+            groupBy: jest.fn(),
         },
         album: {
             findMany: jest.fn(),
@@ -123,6 +124,7 @@ describe("subsonic state/admin compatibility handlers", () => {
     const mockBookmarkDeleteMany = bookmarkModel.deleteMany as jest.Mock;
     const mockTrackFindUnique = prisma.track.findUnique as jest.Mock;
     const mockTrackFindMany = prisma.track.findMany as jest.Mock;
+    const mockTrackGroupBy = prisma.track.groupBy as jest.Mock;
     const mockAlbumFindMany = prisma.album.findMany as jest.Mock;
     const mockArtistFindMany = prisma.artist.findMany as jest.Mock;
     const mockLikedTrackFindMany = prisma.likedTrack.findMany as jest.Mock;
@@ -142,6 +144,7 @@ describe("subsonic state/admin compatibility handlers", () => {
         mockBookmarkDeleteMany.mockResolvedValue({ count: 0 });
         mockTrackFindUnique.mockResolvedValue(null);
         mockTrackFindMany.mockResolvedValue([]);
+        mockTrackGroupBy.mockResolvedValue([]);
         mockAlbumFindMany.mockResolvedValue([]);
         mockArtistFindMany.mockResolvedValue([]);
         mockLikedTrackFindMany.mockResolvedValue([]);
@@ -648,7 +651,6 @@ describe("subsonic state/admin compatibility handlers", () => {
                     id: "artist-2",
                     name: "Artist Two",
                 },
-                tracks: [{ duration: 210 }],
             },
             {
                 id: "album-1",
@@ -661,7 +663,6 @@ describe("subsonic state/admin compatibility handlers", () => {
                     id: "artist-1",
                     name: "Artist One",
                 },
-                tracks: [{ duration: 180 }],
             },
         ]);
         mockArtistFindMany.mockResolvedValue([
@@ -669,17 +670,47 @@ describe("subsonic state/admin compatibility handlers", () => {
                 id: "artist-2",
                 name: "Artist Two",
                 heroUrl: null,
-                albums: [{ id: "album-2" }],
+                _count: { albums: 1 },
             },
             {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: null,
-                albums: [{ id: "album-1" }],
+                _count: { albums: 1 },
+            },
+        ]);
+        mockTrackGroupBy.mockResolvedValue([
+            {
+                albumId: "album-2",
+                _count: { _all: 2 },
+                _sum: { duration: 420 },
+            },
+            {
+                albumId: "album-1",
+                _count: { _all: 1 },
+                _sum: { duration: 180 },
             },
         ]);
 
         await handleGetStarred2(buildReq({}), buildRes());
+
+        const albumQuery = mockAlbumFindMany.mock.calls[0][0];
+        expect(albumQuery.select).not.toHaveProperty("tracks");
+        const artistQuery = mockArtistFindMany.mock.calls[0][0];
+        expect(artistQuery.select).toMatchObject({
+            _count: {
+                select: {
+                    albums: { where: { location: "LIBRARY" } },
+                },
+            },
+        });
+        expect(artistQuery.select).not.toHaveProperty("albums");
+        expect(mockTrackGroupBy).toHaveBeenCalledWith({
+            by: ["albumId"],
+            where: { albumId: { in: ["album-2", "album-1"] } },
+            _count: { _all: true },
+            _sum: { duration: true },
+        });
 
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),
@@ -696,6 +727,8 @@ describe("subsonic state/admin compatibility handlers", () => {
                     album: [
                         expect.objectContaining({
                             id: "al-album-2",
+                            songCount: 2,
+                            duration: 420,
                         }),
                         expect.objectContaining({
                             id: "al-album-1",

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -23,6 +23,8 @@ jest.mock("../../utils/db", () => ({
     prisma: {
         track: {
             findMany: jest.fn(),
+            aggregate: jest.fn(),
+            groupBy: jest.fn(),
         },
         album: {
             findMany: jest.fn(),
@@ -152,6 +154,8 @@ function buildReqWithUser(
 
 describe("subsonic Tier B handlers", () => {
     const mockTrackFindMany = prisma.track.findMany as jest.Mock;
+    const mockTrackAggregate = prisma.track.aggregate as jest.Mock;
+    const mockTrackGroupBy = prisma.track.groupBy as jest.Mock;
     const mockAlbumFindMany = prisma.album.findMany as jest.Mock;
     const mockArtistFindMany = prisma.artist.findMany as jest.Mock;
     const mockPlaylistFindMany = prisma.playlist.findMany as jest.Mock;
@@ -184,6 +188,9 @@ describe("subsonic Tier B handlers", () => {
         jest.clearAllMocks();
         resetSubsonicScanStartCooldownForTests();
         mockPlaylistFindMany.mockResolvedValue([]);
+        mockTrackAggregate.mockResolvedValue({ _sum: { duration: null } });
+        mockTrackGroupBy.mockResolvedValue([]);
+        mockPlaylistItemFindMany.mockResolvedValue([]);
         mockPlaylistDelete.mockResolvedValue({});
         mockPlaylistFindFirst.mockResolvedValue(null);
         mockUserFindUnique.mockResolvedValue(null);
@@ -672,7 +679,6 @@ describe("subsonic Tier B handlers", () => {
                     id: "artist-1",
                     name: "Artist One",
                 },
-                tracks: [{ duration: 180 }],
             },
         ]);
         mockArtistFindMany.mockResolvedValue([
@@ -680,7 +686,14 @@ describe("subsonic Tier B handlers", () => {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: "https://example.test/artist.jpg",
-                albums: [{ id: "album-1" }],
+                _count: { albums: 1 },
+            },
+        ]);
+        mockTrackGroupBy.mockResolvedValue([
+            {
+                albumId: "album-1",
+                _count: { _all: 1 },
+                _sum: { duration: 180 },
             },
         ]);
 
@@ -934,28 +947,6 @@ describe("subsonic Tier B handlers", () => {
                 _count: {
                     items: 2,
                 },
-                items: [
-                    {
-                        track: {
-                            duration: 120,
-                            album: {
-                                coverUrl: "https://example.test/cover.jpg",
-                                genres: [],
-                                userGenres: [],
-                            },
-                        },
-                    },
-                    {
-                        track: {
-                            duration: 45,
-                            album: {
-                                coverUrl: null,
-                                genres: [],
-                                userGenres: [],
-                            },
-                        },
-                    },
-                ],
             },
             {
                 id: "playlist-2",
@@ -965,21 +956,38 @@ describe("subsonic Tier B handlers", () => {
                 _count: {
                     items: 0,
                 },
-                items: [],
             },
+        ]);
+        mockTrackAggregate.mockResolvedValue({ _sum: { duration: 165 } });
+        mockPlaylistItemFindMany.mockResolvedValue([
+            { playlistId: "playlist-1" },
         ]);
 
         await handleGetPlaylists(buildReq({}), buildRes());
 
-        expect(mockPlaylistFindMany).toHaveBeenCalledWith({
-            where: {
-                userId: "user-1",
-            },
-            orderBy: {
-                createdAt: "desc",
-            },
-            include: expect.any(Object),
+        const playlistQuery = mockPlaylistFindMany.mock.calls[0][0];
+        expect(playlistQuery).toMatchObject({
+            where: { userId: "user-1" },
+            orderBy: { createdAt: "desc" },
+            include: { _count: { select: { items: true } } },
         });
+        expect(playlistQuery.include).not.toHaveProperty("items");
+        expect(mockTrackAggregate).toHaveBeenCalledTimes(1);
+        expect(mockTrackAggregate).toHaveBeenCalledWith({
+            where: {
+                playlistItems: {
+                    some: { playlistId: "playlist-1" },
+                },
+            },
+            _sum: { duration: true },
+        });
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(1);
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                distinct: ["playlistId"],
+                select: { playlistId: true },
+            }),
+        );
         const playlists = (
             mockSendSuccess.mock.calls[0][1] as {
                 playlists: { playlist: Array<Record<string, unknown>> };

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -3065,12 +3065,13 @@ async function getRootMusicDirectoryChildren(): Promise<
             id: true,
             name: true,
             heroUrl: true,
-            albums: {
-                where: {
-                    location: LIBRARY_LOCATION,
-                },
+            _count: {
                 select: {
-                    id: true,
+                    albums: {
+                        where: {
+                            location: LIBRARY_LOCATION,
+                        },
+                    },
                 },
             },
         },
@@ -3083,7 +3084,7 @@ async function getRootMusicDirectoryChildren(): Promise<
         ...formatArtistForSubsonic({
             id: artist.id,
             name: artist.name,
-            albumCount: artist.albums.length,
+            albumCount: artist._count.albums,
             heroUrl: artist.heroUrl,
         }),
         parent: SUBSONIC_MUSIC_FOLDER_ID,
@@ -5191,6 +5192,55 @@ async function resolveStarMutationTrackIds(input: {
     return Array.from(combinedIds);
 }
 
+async function getPlaylistDurations(
+    playlists: Array<{ id: string; _count: { items: number } }>,
+): Promise<Map<string, number>> {
+    const nonEmptyPlaylists = playlists.filter(
+        (playlist) => playlist._count.items > 0,
+    );
+    const durationRows = await Promise.all(
+        nonEmptyPlaylists.map(async (playlist) => ({
+            playlistId: playlist.id,
+            aggregate: await prisma.track.aggregate({
+                where: {
+                    playlistItems: { some: { playlistId: playlist.id } },
+                },
+                _sum: { duration: true },
+            }),
+        })),
+    );
+    return new Map(
+        durationRows.map(({ playlistId, aggregate }) => [
+            playlistId,
+            aggregate._sum.duration ?? 0,
+        ]),
+    );
+}
+
+async function getPlaylistCoverFlags(
+    playlistIds: string[],
+): Promise<Set<string>> {
+    if (playlistIds.length === 0) {
+        return new Set();
+    }
+    const rows = await prisma.playlistItem.findMany({
+        where: {
+            playlistId: { in: playlistIds },
+            track: {
+                album: {
+                    AND: [
+                        { coverUrl: { not: null } },
+                        { coverUrl: { not: "" } },
+                    ],
+                },
+            },
+        },
+        distinct: ["playlistId"],
+        select: { playlistId: true },
+    });
+    return new Set(rows.map((row) => row.playlistId));
+}
+
 /**
  * Executes handleGetPlaylists.
  */
@@ -5214,54 +5264,31 @@ export async function handleGetPlaylists(
                         items: true,
                     },
                 },
-                items: {
-                    orderBy: {
-                        sort: "asc",
-                    },
-                    select: {
-                        track: {
-                            select: {
-                                duration: true,
-                                album: {
-                                    select: {
-                                        coverUrl: true,
-                                        genres: true,
-                                        userGenres: true,
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
             },
         });
+        const playlistIds = playlists.map((playlist) => playlist.id);
+        const [durations, coverFlags] = await Promise.all([
+            getPlaylistDurations(playlists),
+            getPlaylistCoverFlags(playlistIds),
+        ]);
 
         sendSubsonicSuccess(
             res,
             {
                 playlists: {
-                    playlist: playlists.map((playlist) => {
-                        const duration = playlist.items.reduce(
-                            (sum, item) => sum + (item.track?.duration ?? 0),
-                            0,
-                        );
-                        const hasCover = playlist.items.some((item) =>
-                            Boolean(item.track?.album.coverUrl),
-                        );
-                        return {
-                            id: toSubsonicId("playlist", playlist.id),
-                            name: playlist.name,
-                            songCount: playlist._count.items,
-                            duration,
-                            public: playlist.isPublic,
-                            owner: req.user!.username,
-                            created: playlist.createdAt.toISOString(),
-                            changed: playlist.createdAt.toISOString(),
-                            coverArt: hasCover
-                                ? toSubsonicId("playlist", playlist.id)
-                                : undefined,
-                        };
-                    }),
+                    playlist: playlists.map((playlist) => ({
+                        id: toSubsonicId("playlist", playlist.id),
+                        name: playlist.name,
+                        songCount: playlist._count.items,
+                        duration: durations.get(playlist.id) ?? 0,
+                        public: playlist.isPublic,
+                        owner: req.user!.username,
+                        created: playlist.createdAt.toISOString(),
+                        changed: playlist.createdAt.toISOString(),
+                        coverArt: coverFlags.has(playlist.id)
+                            ? toSubsonicId("playlist", playlist.id)
+                            : undefined,
+                    })),
                 },
             },
             format,
@@ -6382,12 +6409,13 @@ async function buildStarredPayload(userId: string): Promise<{
         }
     }
 
-    const [albums, artists] = await Promise.all([
+    const albumIds = Array.from(albumStarredAt.keys());
+    const [albums, artists, albumTrackStats] = await Promise.all([
         albumStarredAt.size > 0
             ? prisma.album.findMany({
                   where: {
                       id: {
-                          in: Array.from(albumStarredAt.keys()),
+                          in: albumIds,
                       },
                       location: LIBRARY_LOCATION,
                   },
@@ -6402,11 +6430,6 @@ async function buildStarredPayload(userId: string): Promise<{
                           select: {
                               id: true,
                               name: true,
-                          },
-                      },
-                      tracks: {
-                          select: {
-                              duration: true,
                           },
                       },
                   },
@@ -6428,37 +6451,49 @@ async function buildStarredPayload(userId: string): Promise<{
                       id: true,
                       name: true,
                       heroUrl: true,
-                      albums: {
-                          where: {
-                              location: LIBRARY_LOCATION,
-                          },
+                      _count: {
                           select: {
-                              id: true,
+                              albums: {
+                                  where: {
+                                      location: LIBRARY_LOCATION,
+                                  },
+                              },
                           },
                       },
                   },
               })
             : Promise.resolve([]),
+        albumIds.length > 0
+            ? prisma.track.groupBy({
+                  by: ["albumId"],
+                  where: { albumId: { in: albumIds } },
+                  _count: { _all: true },
+                  _sum: { duration: true },
+              })
+            : Promise.resolve([]),
     ]);
+    const albumTrackStatsById = new Map(
+        albumTrackStats.map((row) => [row.albumId, row]),
+    );
 
     const albumEntries = albums
-        .map((album) => ({
-            ...formatAlbumForSubsonic({
-                id: album.id,
-                title: album.title,
-                year: album.year,
-                coverUrl: album.coverUrl,
-                genres: album.genres,
-                userGenres: album.userGenres,
-                artist: album.artist,
-                songCount: album.tracks.length,
-                duration: album.tracks.reduce(
-                    (sum, track) => sum + (track.duration ?? 0),
-                    0,
-                ),
-            }),
-            starred: albumStarredAt.get(album.id)?.toISOString(),
-        }))
+        .map((album) => {
+            const stats = albumTrackStatsById.get(album.id);
+            return {
+                ...formatAlbumForSubsonic({
+                    id: album.id,
+                    title: album.title,
+                    year: album.year,
+                    coverUrl: album.coverUrl,
+                    genres: album.genres,
+                    userGenres: album.userGenres,
+                    artist: album.artist,
+                    songCount: stats?._count._all ?? 0,
+                    duration: stats?._sum.duration ?? 0,
+                }),
+                starred: albumStarredAt.get(album.id)?.toISOString(),
+            };
+        })
         .sort((left, right) =>
             String(right.starred ?? "").localeCompare(
                 String(left.starred ?? ""),
@@ -6470,7 +6505,7 @@ async function buildStarredPayload(userId: string): Promise<{
             ...formatArtistForSubsonic({
                 id: artist.id,
                 name: artist.name,
-                albumCount: artist.albums.length,
+                albumCount: artist._count.albums,
                 heroUrl: artist.heroUrl,
             }),
             starred: artistStarredAt.get(artist.id)?.toISOString(),


### PR DESCRIPTION
## Summary

Cross-route class-close of the unbounded nested-include-to-aggregate anti-pattern removed from the native `/playlists` list endpoint in #278, now applied to the Subsonic surface (`backend/src/routes/subsonic.ts`).

`getPlaylists` is hit by Subsonic clients on nearly every library sync and hydrated every playlist `items -> track -> album` row with no `take`, only to reduce a duration sum and derive a coverArt flag — tens of thousands of joined rows into Node heap per refresh.

### Changes (all Prisma-only per AGENTS.md; no raw SQL)

- **handleGetPlaylists**: `songCount` stays on `_count.items`; duration now comes from a per-playlist `track.aggregate` `_sum` (exact: `PlaylistItem` has `@@unique([playlistId, trackId])`, and tidal/ytmusic items contributed 0 before and still do); coverArt flag from ONE bounded `playlistItem.findMany` with `distinct: ["playlistId"]`, preserving old truthiness (coverUrl not null and not empty). Empty playlists skip the aggregate; zero playlists skip both queries. Unused `genres`/`userGenres` selects dropped.
- **getRootMusicDirectoryChildren** + **buildStarredPayload (artists)**: album-id rows loaded only for `.length` replaced with a filtered relation `_count` (`albums where location = LIBRARY`).
- **buildStarredPayload (albums)**: per-album `tracks: { duration }` hydration replaced with one `track.groupBy` (`_count._all`, `_sum.duration`) over the starred album ids.

**Response shapes are byte-identical** (`songCount`, `duration`, `public`, `owner`, `created`/`changed`, `coverArt`); `docs/OPENSUBSONIC_COMPATIBILITY.md` contract unchanged.

### Tests (TDD)

Behavioral query-shape + derivation assertions across the four touched suites: playlist `findMany` include has `_count` and **no** `items` key; aggregate called once per non-empty playlist; cover-flag query called once with `distinct`; empty/zero-playlist short-circuits; starred albums derive songCount/duration from groupBy rows; error path unchanged.

### Audit result (same pattern elsewhere — reported, not touched)

- `getGenres` (subsonic.ts ~L3330): unbounded `trackGenres -> track.albumId` hydration used only for songCount + distinct albumCount. `COUNT(DISTINCT albumId)` per genre is not Prisma-expressible and raw SQL is outside the AGENTS.md allowlist — needs a contract decision or schema denormalization.
- `getTopSongs` (~L2485): loads one artist's full track rows (bounded by discography) to sort by play count and slice — rows are consumed, not aggregate-only.
- `search2/search3` + `getAlbumList` album selects: `tracks: { duration }` for songCount/duration, but bounded by clamped `take` (≤200/≤500) — lesser bounded variant.
- `getStarred` likedTracks: unbounded but rows are the response payload, not an aggregate input.
- Out of scope this wave: `library.ts` (slice R), ytmusic `app.py` (slice S).

## Verification

- Targeted jest (`subsonicCollectionsCompat`, `subsonicTierB`, `subsonicBrowseCompat`, `subsonicStateCompat`): 4 suites, 154 tests passed
- `tsc --noEmit`: clean
- `prettier --check` on changed files: clean
- `node scripts/ci/check-route-error-canon.mjs`: passed
- One CHANGELOG bullet under existing `[Unreleased] > Fixed`