### PR TITLE
fix(ytmusic): guard cross-thread module caches with locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hydrate every playlist item/track/album row (or album-id/track-duration rows)
   just to compute songCount/duration/coverArt — they now use bounded Prisma
   aggregates; response shapes unchanged.
+- YT Music sidecar: the stream-URL and search caches (plus the per-user and public YTMusic client maps) are now guarded by locks — concurrent playback/search could previously hit "dictionary changed size during iteration" on the lock-free caches shared across worker threads, surfacing as intermittent 500s on stream extraction and search.
 - TIDAL stream proxying now handles upstream stream errors after headers are
   sent instead of crashing the entire backend via an uncaught exception; a
   mid-playback sidecar disconnect now ends only that response.

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -21,6 +21,7 @@ import random
 import re
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -214,6 +215,7 @@ YTDLP_SOCKET_TIMEOUT = env_float("YTMUSIC_YTDLP_SOCKET_TIMEOUT", "20")
 
 # Search result cache (in-memory, short TTL to reduce duplicate requests)
 _search_cache: dict[str, dict] = {}
+_search_cache_lock = threading.Lock()
 SEARCH_CACHE_TTL = env_int("YTMUSIC_SEARCH_CACHE_TTL", "300")  # 5 minutes
 SEARCH_CACHE_MAX = env_int("YTMUSIC_SEARCH_CACHE_MAX", "1024")
 SEARCH_MODE = (os.getenv("YTMUSIC_SEARCH_MODE", "auto") or "auto").strip().lower()
@@ -248,6 +250,7 @@ _ALLOWED_STREAM_QUALITIES = {"LOW", "MEDIUM", "HIGH", "LOSSLESS"}
 # ── Stream URL cache (in-memory, URLs expire after ~6h) ────────────
 # Keys are "{user_id}:{video_id}" to isolate per-user sessions
 _stream_cache: dict[str, dict] = {}
+_stream_cache_lock = threading.Lock()
 STREAM_CACHE_TTL = 5 * 60 * 60  # 5 hours (YouTube URLs expire at ~6h)
 STREAM_CACHE_MAX = env_int("YTMUSIC_STREAM_CACHE_MAX", "1024")
 TV_CLIENT_NAME = "TVHTML5"
@@ -255,7 +258,7 @@ TV_CLIENT_VERSION = "7.20250101.00.00"
 
 
 def _bound_cache(cache: dict, max_size: int) -> None:
-    """Evict oldest entries until an insertion-ordered cache is bounded."""
+    """Evict oldest entries; callers must hold the owning cache's lock."""
     while len(cache) > max_size:
         cache.pop(next(iter(cache)))
 
@@ -264,11 +267,12 @@ def _bound_cache(cache: dict, max_size: int) -> None:
 # Per-user authenticated clients are used for user-private operations
 # (library, stream auth checks, browse calls).
 _ytmusic_instances: dict[str, YTMusic] = {}
-_ytmusic_lock = asyncio.Lock()
+_ytmusic_instances_lock = threading.Lock()
 _ytmusic_auto_tv_fallback_users: set[str] = set()
 # Public unauthenticated clients are used for search/matching so queries do not
 # run under a user's OAuth session.
 _public_ytmusic_instances: dict[Literal["tv", "native"], YTMusic] = {}
+_public_ytmusic_lock = threading.Lock()
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -407,20 +411,23 @@ def _get_public_ytmusic(strategy: Literal["tv", "native"]) -> YTMusic:
     """
     Get or create an unauthenticated YTMusic instance for public search.
     """
-    existing = _public_ytmusic_instances.get(strategy)
+    with _public_ytmusic_lock:
+        existing = _public_ytmusic_instances.get(strategy)
     if existing:
         return existing
 
     yt = YTMusic(language=YTMUSIC_LANGUAGE)
     if strategy == "tv":
         _apply_tv_client_context(yt)
-    _public_ytmusic_instances[strategy] = yt
+    with _public_ytmusic_lock:
+        _public_ytmusic_instances[strategy] = yt
     return yt
 
 
 def _invalidate_public_ytmusic(strategy: Literal["tv", "native"]):
     """Force re-creation of a public search client on next use."""
-    _public_ytmusic_instances.pop(strategy, None)
+    with _public_ytmusic_lock:
+        _public_ytmusic_instances.pop(strategy, None)
 
 
 def _parse_duration_text_value(value: Any) -> int:
@@ -542,8 +549,10 @@ def _native_search(
 
 def _get_ytmusic(user_id: str) -> YTMusic:
     """Get or create an authenticated YTMusic instance for a specific user."""
-    if user_id in _ytmusic_instances:
-        return _ytmusic_instances[user_id]
+    with _ytmusic_instances_lock:
+        existing = _ytmusic_instances.get(user_id)
+    if existing:
+        return existing
 
     oauth_path = _oauth_file(user_id)
     if oauth_path.exists():
@@ -584,7 +593,8 @@ def _get_ytmusic(user_id: str) -> YTMusic:
                 _apply_tv_client_context(yt)
                 # ── WORKAROUND(#813) END ────────────────────────────────
 
-            _ytmusic_instances[user_id] = yt
+            with _ytmusic_instances_lock:
+                _ytmusic_instances[user_id] = yt
             log.info(
                 "Loaded YTMusic for user %s (search_strategy=%s, configured_mode=%s)",
                 user_id,
@@ -607,7 +617,8 @@ def _get_ytmusic(user_id: str) -> YTMusic:
 
 def _invalidate_ytmusic(user_id: str):
     """Force re-creation of a user's YTMusic instance on next use."""
-    _ytmusic_instances.pop(user_id, None)
+    with _ytmusic_instances_lock:
+        _ytmusic_instances.pop(user_id, None)
 
 
 def _is_oauth_auth_error(err: Exception) -> bool:
@@ -791,7 +802,8 @@ def _extract_stream_info(
     """
     import yt_dlp
 
-    cached = _stream_cache.get(cache_key)
+    with _stream_cache_lock:
+        cached = _stream_cache.get(cache_key)
     if cached and cached.get("expires_at", 0) > time.time():
         log.debug(f"Stream URL cache hit for {cache_key}")
         return cached
@@ -814,9 +826,12 @@ def _extract_stream_info(
                 "abr": info.get("abr", 0),
                 "acodec": info.get("acodec", ""),
             }
-            _stream_cache[cache_key] = result
-            _clean_stream_cache()
-            _bound_cache(_stream_cache, STREAM_CACHE_MAX)
+            with _stream_cache_lock:
+                _stream_cache[cache_key] = result
+                expired_count = _clean_stream_cache_locked()
+                _bound_cache(_stream_cache, STREAM_CACHE_MAX)
+            if expired_count:
+                log.debug(f"Cleaned {expired_count} expired stream cache entries")
             log.debug(
                 "Extracted stream URL for %s: %s @ %skbps",
                 cache_key,
@@ -1181,14 +1196,21 @@ def _tv_search(yt: YTMusic, query: str, filter: str | None = None, limit: int = 
     return normalized[:limit]
 
 
-def _clean_stream_cache():
-    """Remove expired entries from stream cache."""
+def _clean_stream_cache_locked() -> int:
+    """Remove expired stream entries while the owning lock is held."""
     now = time.time()
     expired = [k for k, v in _stream_cache.items() if v.get("expires_at", 0) <= now]
     for k in expired:
         del _stream_cache[k]
-    if expired:
-        log.debug(f"Cleaned {len(expired)} expired stream cache entries")
+    return len(expired)
+
+
+def _clean_stream_cache():
+    """Remove expired entries from stream cache."""
+    with _stream_cache_lock:
+        expired_count = _clean_stream_cache_locked()
+    if expired_count:
+        log.debug(f"Cleaned {expired_count} expired stream cache entries")
 
 
 def _search_cache_key(
@@ -1211,12 +1233,14 @@ def _get_cached_search(
 ) -> list | None:
     """Return cached search results if still valid, else None."""
     key = _search_cache_key(user_id, query, filter_, limit, strategy)
-    entry = _search_cache.get(key)
+    with _search_cache_lock:
+        entry = _search_cache.get(key)
+        if entry and entry.get("expires_at", 0) <= time.time():
+            del _search_cache[key]
+            entry = None
     if entry and entry.get("expires_at", 0) > time.time():
         log.debug(f"Search cache hit: {key}")
         return entry["results"]
-    if entry:
-        del _search_cache[key]
     return None
 
 
@@ -1230,12 +1254,15 @@ def _set_cached_search(
 ):
     """Store search results in cache with TTL."""
     key = _search_cache_key(user_id, query, filter_, limit, strategy)
-    _search_cache[key] = {
-        "results": results,
-        "expires_at": time.time() + SEARCH_CACHE_TTL,
-    }
-    _clean_search_cache()
-    _bound_cache(_search_cache, SEARCH_CACHE_MAX)
+    with _search_cache_lock:
+        _search_cache[key] = {
+            "results": results,
+            "expires_at": time.time() + SEARCH_CACHE_TTL,
+        }
+        expired_count = _clean_search_cache_locked()
+        _bound_cache(_search_cache, SEARCH_CACHE_MAX)
+    if expired_count:
+        log.debug(f"Cleaned {expired_count} expired search cache entries")
 
 
 def _search_once(
@@ -1360,14 +1387,21 @@ def _search_with_mode_fallback(
         )
 
 
-def _clean_search_cache():
-    """Remove expired entries from search cache."""
+def _clean_search_cache_locked() -> int:
+    """Remove expired search entries while the owning lock is held."""
     now = time.time()
     expired = [k for k, v in _search_cache.items() if v.get("expires_at", 0) <= now]
     for k in expired:
         del _search_cache[k]
-    if expired:
-        log.debug(f"Cleaned {len(expired)} expired search cache entries")
+    return len(expired)
+
+
+def _clean_search_cache():
+    """Remove expired entries from search cache."""
+    with _search_cache_lock:
+        expired_count = _clean_search_cache_locked()
+    if expired_count:
+        log.debug(f"Cleaned {expired_count} expired search cache entries")
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -3050,7 +3084,8 @@ def _parse_duration(duration_str: str) -> int:
 async def shutdown():
     _clean_stream_cache()
     _clean_search_cache()
-    _ytmusic_instances.clear()
+    with _ytmusic_instances_lock:
+        _ytmusic_instances.clear()
     log.info("YouTube Music Streamer shutting down")
 
 

--- a/services/ytmusic-streamer/tests/test_cache_thread_safety.py
+++ b/services/ytmusic-streamer/tests/test_cache_thread_safety.py
@@ -1,0 +1,102 @@
+"""Thread-safety regressions for ytmusic-streamer module caches."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+def test_cross_thread_cache_locks_exist():
+    import app
+
+    lock_type = type(threading.Lock())
+    locks = (
+        app._stream_cache_lock,
+        app._search_cache_lock,
+        app._public_ytmusic_lock,
+        app._ytmusic_instances_lock,
+    )
+
+    assert all(isinstance(lock, lock_type) for lock in locks)
+    assert not hasattr(app, "_ytmusic_lock")
+
+
+@pytest.mark.parametrize(
+    ("cache_name", "lock_name", "cleaner_name"),
+    (
+        ("_stream_cache", "_stream_cache_lock", "_clean_stream_cache"),
+        ("_search_cache", "_search_cache_lock", "_clean_search_cache"),
+    ),
+)
+def test_cache_cleanup_waits_for_owning_lock(cache_name, lock_name, cleaner_name):
+    import app
+
+    cache = getattr(app, cache_name)
+    lock = getattr(app, lock_name)
+    cleaner = getattr(app, cleaner_name)
+    expired_key = "expired"
+    with lock:
+        cache.clear()
+        cache[expired_key] = {"expires_at": time.time() - 1}
+        worker = threading.Thread(target=cleaner)
+        worker.start()
+        worker.join(timeout=0.5)
+        assert worker.is_alive()
+        assert expired_key in cache
+
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert expired_key not in cache
+
+
+def test_search_cache_concurrent_access_is_safe():
+    import app
+
+    def exercise_cache(worker_id: int) -> None:
+        for iteration in range(200):
+            query = f"query-{worker_id}-{iteration}"
+            app._set_cached_search(str(worker_id), query, None, 5, "native", [query])
+            assert app._get_cached_search(str(worker_id), query, None, 5, "native") == [query]
+            with app._search_cache_lock:
+                app._search_cache[f"expired-{worker_id}-{iteration}"] = {
+                    "expires_at": time.time() - 1,
+                    "results": [],
+                }
+            app._clean_search_cache()
+
+    with app._search_cache_lock:
+        app._search_cache.clear()
+    try:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(exercise_cache, worker_id) for worker_id in range(4)]
+            for future in futures:
+                future.result(timeout=30)
+    finally:
+        with app._search_cache_lock:
+            app._search_cache.clear()
+
+
+def test_stream_cache_concurrent_access_is_safe():
+    import app
+
+    def exercise_cache(worker_id: int) -> None:
+        for iteration in range(200):
+            expires_at = time.time() + 60 if iteration % 2 else time.time() - 1
+            with app._stream_cache_lock:
+                app._stream_cache[f"stream-{worker_id}-{iteration}"] = {"expires_at": expires_at}
+                app._bound_cache(app._stream_cache, app.STREAM_CACHE_MAX)
+            app._clean_stream_cache()
+
+    with app._stream_cache_lock:
+        app._stream_cache.clear()
+    try:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(exercise_cache, worker_id) for worker_id in range(4)]
+            for future in futures:
+                future.result(timeout=30)
+    finally:
+        with app._stream_cache_lock:
+            app._stream_cache.clear()


### PR DESCRIPTION
## Summary

Cross-service class-close of the lock-free cross-thread cache bug already fixed in the tidal sidecar (#279, #290) but never applied to the ytmusic sidecar.

Four module-global dicts in `services/ytmusic-streamer/app.py` were mutated and iterated across `asyncio.to_thread` workers (shared default executor) and the event loop with no synchronization:

- `_stream_cache` — written + cleaned (list-comp over `.items()`) + bounded inside `_extract_stream_info`, which runs on worker threads. Thread A iterating while thread B inserts/deletes raises `RuntimeError: dictionary changed size during iteration` → intermittent 500s on stream extraction under concurrent playback.
- `_search_cache` — same pattern inside `_search_once` (worker threads) → intermittent search failures.
- `_public_ytmusic_instances` — get-or-create mutated both on the event loop and inside `to_thread` lambdas (same class as tidal #290's `_browse_sessions`).
- `_ytmusic_instances` — get/set/pop from `_run_ytmusic_with_auth_retry` on worker threads and directly on the event loop. Its existing `_ytmusic_lock = asyncio.Lock()` was dead (never acquired) and the wrong primitive for worker threads; removed.

## Fix

Mirrors the tidal sidecar pattern exactly: one `threading.Lock` per structure, held around every read/write/del/iteration/eviction. Critical sections stay minimal — yt-dlp extraction, `YTMusic()` construction, OAuth file I/O, and logging all happen outside the locks. Cleanup helpers are split into `_locked` variants (called from already-locked write paths) and lock-acquiring public wrappers (shutdown), so the non-reentrant locks are never double-acquired. `_bound_cache` documents that callers must hold the owning cache's lock.

Audited-safe (left untouched): `_ytmusic_auto_tv_fallback_users` (set, atomic ops only, never iterated), `_yt_download_jobs`/`_yt_download_tasks` (containers mutated only on the event loop).

## Tests

New `tests/test_cache_thread_safety.py`: lock existence + dead-lock removal, deterministic mutual-exclusion (cleaner blocks until the owning lock is released, bounded joins), and bounded 4-thread × 200-iteration concurrency hammers for both caches.

## Verification

- `pytest services/ytmusic-streamer/tests -q` — 175 passed (170 baseline + 5 new)
- `ruff check services/` — clean; `ruff format --check services/` — clean
- `mypy` (repo root config) — Success: no issues found in 8 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24