### PR TITLE
docs: require coding-handbook as the standards baseline in AGENTS.md + CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,20 @@ Repository contract for soundspan.
 - Follow this file first.
 - `CLAUDE.md` and `.claude/awm-broker/**` are tool-specific companions. If they disagree with this file, this file wins.
 
+## Coding Standards & Handbook
+
+- The canonical external engineering-standards baseline for soundspan is the [coding-handbook](https://github.com/BonzTM/coding-handbook) repo (local sibling checkout at `~/git/coding-handbook` when available).
+- All contributors and AI agents — including any tools they drive (e.g. codex) — must follow the handbook's language module for the code they touch:
+  - `typescript/` for TS/JS (backend, frontend, packages)
+  - `python/` for the `services/**` sidecars
+- Precedence, so this composes with the rules below:
+  1. This AGENTS.md and its repository-specific rules win.
+  2. Then the coding-handbook language module.
+  3. Then general industry best practice.
+
+  Handbook guidance that conflicts with an explicit rule in this file defers to this file.
+- The handbook is the baseline the codebase's enterprise-standards refactor was aligned to; new work must not regress below it.
+
 ## Working Rules
 
 - **Read before edit.** Read the full relevant source before making changes. Do not guess at file contents or structure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ All development happens on the `main` branch:
 
 Please open an issue to discuss before starting work.
 
+## Coding Standards
+
+All contributions must follow the [coding-handbook](https://github.com/BonzTM/coding-handbook): the `typescript/` module for TS/JS and the `python/` module for the `services/**` sidecars. See **Coding Standards & Handbook** in [AGENTS.md](AGENTS.md) for the full policy and precedence — that section is the authority.
+
 ## Code Style
 
 ### Frontend


### PR DESCRIPTION
## Summary

Docs-only governance change: makes the [coding-handbook](https://github.com/BonzTM/coding-handbook) the required external engineering-standards baseline in the repo contract.

- **AGENTS.md** — new `## Coding Standards & Handbook` section (after Source Of Truth, before Working Rules): declares the handbook the canonical baseline, requires all contributors and AI agents (and tools they drive) to follow the `typescript/` module for TS/JS and the `python/` module for `services/**` sidecars, and states precedence explicitly (AGENTS.md repo rules > handbook language module > general industry practice). Notes the handbook is the baseline the enterprise-standards refactor was aligned to.
- **CONTRIBUTING.md** — brief `## Coding Standards` section above Code Style pointing contributors at the handbook and cross-referencing the AGENTS.md section as the authority.

No code, tests, or CHANGELOG changes (governance docs, not user-visible behavior). No other AGENTS.md rules altered — additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24