### PR TITLE
fix(enrichment): require admin on library-wide enrichment routes; drop dead client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -545,6 +545,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency Review and Trivy remain non-blocking; the recommended ratchet —
   Dependency Review with `fail-on-severity: high` first, then Trivy — is
   documented in-workflow as a deliberate owner decision.
+- Require admin on `POST /api/enrichment/artist/:id` and
+  `POST /api/enrichment/album/:id` — single-item enrichment applies results
+  library-wide and makes outbound metadata API calls; removed the unused
+  `enrichArtist`/`enrichAlbum` frontend client methods.
 
 ### Changed
 

--- a/backend/src/__tests__/enrichmentRouteAuthz.test.ts
+++ b/backend/src/__tests__/enrichmentRouteAuthz.test.ts
@@ -5,6 +5,8 @@
  * admin-gated siblings (/full, /pause, /resume, /stop, resets):
  *   - POST /api/enrichment/sync  (only UI caller is the admin page)
  *   - POST /api/enrichment/start (same worker as the admin-gated /full)
+ *   - POST /api/enrichment/artist/:id and /album/:id (apply enrichment
+ *     results library-wide and make outbound API calls)
  *
  * Deliberately NOT admin-gated (user-facing by design):
  *   - GET/PUT /settings (per-user settings)
@@ -17,6 +19,10 @@ export {};
 
 const mockTriggerEnrichmentNow = jest.fn(async () => ({ triggered: true }));
 const mockRunFullEnrichment = jest.fn(async () => undefined);
+const mockEnrichArtist = jest.fn(async () => ({ confidence: 0.9 }));
+const mockEnrichAlbum = jest.fn(async () => ({ confidence: 0.9 }));
+const mockApplyArtistEnrichment = jest.fn(async () => undefined);
+const mockApplyAlbumEnrichment = jest.fn(async () => undefined);
 const mockSystemSettingsFindUnique = jest.fn(async () => ({
     autoEnrichMetadata: true,
 }));
@@ -42,6 +48,10 @@ jest.mock("../services/enrichment", () => ({
     enrichmentService: {
         getSettings: jest.fn(async () => ({ enabled: true })),
         updateSettings: jest.fn(async () => ({ enabled: true })),
+        enrichArtist: mockEnrichArtist,
+        enrichAlbum: mockEnrichAlbum,
+        applyArtistEnrichment: mockApplyArtistEnrichment,
+        applyAlbumEnrichment: mockApplyAlbumEnrichment,
     },
 }));
 
@@ -173,5 +183,43 @@ describe("enrichment router authorization", () => {
 
         expect(response.status).toBe(200);
         expect(mockRunFullEnrichment).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects non-admin users on POST /artist/:id", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/artist/artist-1")
+            .set("x-test-role", "user");
+
+        expect(response.status).toBe(403);
+        expect(mockEnrichArtist).not.toHaveBeenCalled();
+    });
+
+    it("allows admins on POST /artist/:id", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/artist/artist-1")
+            .set("x-test-role", "admin");
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(mockEnrichArtist).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects non-admin users on POST /album/:id", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/album/album-1")
+            .set("x-test-role", "user");
+
+        expect(response.status).toBe(403);
+        expect(mockEnrichAlbum).not.toHaveBeenCalled();
+    });
+
+    it("allows admins on POST /album/:id", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/album/album-1")
+            .set("x-test-role", "admin");
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(mockEnrichAlbum).toHaveBeenCalledTimes(1);
     });
 });

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -624,14 +624,17 @@ router.put("/settings", async (req, res) => {
  *         description: Enrichment is not enabled
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  *       404:
  *         description: No enrichment data found
  */
 /**
  * POST /enrichment/artist/:id
  * Enrich a single artist
+ * Admin only - applies results library-wide and makes outbound metadata API calls
  */
-router.post("/artist/:id", async (req, res) => {
+router.post<{ id: string }>("/artist/:id", requireAdmin, async (req, res) => {
     try {
         const userId = req.user!.id;
         const settings = await enrichmentService.getSettings(userId);
@@ -692,14 +695,17 @@ router.post("/artist/:id", async (req, res) => {
  *         description: Enrichment is not enabled
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  *       404:
  *         description: No enrichment data found
  */
 /**
  * POST /enrichment/album/:id
  * Enrich a single album
+ * Admin only - applies results library-wide and makes outbound metadata API calls
  */
-router.post("/album/:id", async (req, res) => {
+router.post<{ id: string }>("/album/:id", requireAdmin, async (req, res) => {
     try {
         const userId = req.user!.id;
         const settings = await enrichmentService.getSettings(userId);

--- a/frontend/lib/api/enrichment.ts
+++ b/frontend/lib/api/enrichment.ts
@@ -17,26 +17,6 @@ export function WithEnrichment<TBase extends ApiClientConstructor>(
             });
         }
 
-        async enrichArtist(artistId: string) {
-            return this.request<{
-                success: boolean;
-                confidence: number;
-                data: ApiData;
-            }>(`/enrichment/artist/${artistId}`, {
-                method: "POST",
-            });
-        }
-
-        async enrichAlbum(albumId: string) {
-            return this.request<{
-                success: boolean;
-                confidence: number;
-                data: ApiData;
-            }>(`/enrichment/album/${albumId}`, {
-                method: "POST",
-            });
-        }
-
         async startLibraryEnrichment() {
             return this.request<{ success: boolean; message: string }>(
                 "/enrichment/start",

--- a/frontend/tests/unit/apiClientSurface.test.ts
+++ b/frontend/tests/unit/apiClientSurface.test.ts
@@ -52,8 +52,6 @@ const EXPECTED_PUBLIC_METHODS: readonly string[] = [
     "downloadFromSoulseek",
     "downloadYouTube",
     "endListenGroup",
-    "enrichAlbum",
-    "enrichArtist",
     "executePlaylistImport",
     "generateDiscoverWeekly",
     "generateMoodMix",
@@ -293,5 +291,5 @@ test("api facade exposes every pinned public method", () => {
 });
 
 test("api facade public surface count is pinned", () => {
-    assert.equal(EXPECTED_PUBLIC_METHODS.length, 273);
+    assert.equal(EXPECTED_PUBLIC_METHODS.length, 271);
 });


### PR DESCRIPTION
## Summary

`POST /api/enrichment/artist/:id` and `POST /api/enrichment/album/:id` read the calling user's enrichment settings but apply results **library-wide** and make outbound metadata API calls (MusicBrainz/Last.fm) — an admin-level operation. They were reachable by any authenticated user, and the frontend has zero callers for either route.

- Add `requireAdmin` to both routes, following the exact sibling pattern (`/sync`, `/start`, `/full`, resets).
- Update both routes' OpenAPI annotations with the `403: Admin access required` response and mark the handlers admin-only.
- Delete the dead `enrichArtist`/`enrichAlbum` client methods from `frontend/lib/api/enrichment.ts` and update the pinned API-surface test (273 → 271 methods).
- Extend the existing authz contract test (`enrichmentRouteAuthz.test.ts`) with behavioral 403 (non-admin, service not invoked) and 200 (admin, success path) assertions for both routes.
- CHANGELOG bullet under the existing `[Unreleased]` → `### Security` heading.

## Verification

- `flock ... npm --prefix backend test -- src/__tests__/enrichmentRouteAuthz.test.ts --maxWorkers=2` → 9/9 passed (4 new).
- `npm --prefix frontend run typecheck` → exit 0, zero errors.
- `node --test --import tsx tests/unit/apiClientSurface.test.ts` → 2/2 passed.
- Prettier check clean on all changed files.
