### PR TITLE
fix(audiobooks): confine cover sync/download path through shared safety check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Security
+
+- Audiobook cover sync/download now routes Audiobookshelf cover paths through
+  the shared cover-path allowlist, so a traversal-bearing item id can no longer
+  pivot the admin-token fetch onto arbitrary ABS API paths.
+
 ### Added
 
 - Added repo-wide Prettier and EditorConfig conventions, applied through

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -261,6 +261,41 @@ describe("audiobook cache service behavior", () => {
         );
     });
 
+    it("rejects a traversal-bearing cover path and logs a warning", async () => {
+        const service = new AudiobookCacheService();
+
+        await expect(
+            (service as any).getFullCoverUrl("items/../../me/cover"),
+        ).resolves.toBeNull();
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("items/../../me/cover"),
+        );
+    });
+
+    it("skips cover download and caching for a traversal-bearing audiobook id", async () => {
+        const service = new AudiobookCacheService();
+        mockGetAllAudiobooks.mockResolvedValue([buildBook({ id: "../../me" })]);
+
+        const result = await service.syncAll();
+
+        expect(result).toEqual({
+            synced: 1,
+            failed: 0,
+            skipped: 0,
+            errors: [],
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
+        expect(prisma.audiobook.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({
+                    id: "../../me",
+                    localCoverPath: null,
+                }),
+            }),
+        );
+    });
+
     it("handles cover downloads for unavailable cache, HTTP failures, and success", async () => {
         const service = new AudiobookCacheService();
 

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -5,6 +5,7 @@ import fs from "fs/promises";
 import path from "path";
 import { config } from "../config";
 import { buildCachePath, isPastStaleWindow } from "./cacheHelpers";
+import { buildSafeAudiobookCoverUrl } from "./audiobookCoverProxy";
 
 /**
  * Service to sync audiobooks from Audiobookshelf and cache them locally
@@ -278,7 +279,8 @@ export class AudiobookCacheService {
     }
 
     /**
-     * Get full Audiobookshelf cover URL by prepending base URL
+     * Get the full Audiobookshelf cover URL, confining the path through the
+     * shared cover-path allowlist.
      */
     private async getFullCoverUrl(
         relativePath: string,
@@ -290,7 +292,16 @@ export class AudiobookCacheService {
 
             if (settings?.audiobookshelfUrl) {
                 const baseUrl = settings.audiobookshelfUrl.replace(/\/$/, "");
-                return `${baseUrl}/api/${relativePath}`;
+                const coverUrl = buildSafeAudiobookCoverUrl(
+                    relativePath,
+                    baseUrl,
+                );
+                if (!coverUrl) {
+                    logger.warn(
+                        `[AUDIOBOOK] Rejected unsafe cover path: ${relativePath}`,
+                    );
+                }
+                return coverUrl;
             }
 
             return null;


### PR DESCRIPTION
## Summary
- Routes the audiobook sync/download cover path through the shared `buildSafeAudiobookCoverUrl` allowlist introduced in #294, closing the remaining caller that built `${baseUrl}/api/${relativePath}` unchecked.
- A traversal-bearing Audiobookshelf item id (e.g. `../../me`) previously collapsed via URL normalization into an arbitrary ABS admin-API path fetched with the operator's admin Bearer token; `getFullCoverUrl` now returns `null` for unsafe paths and the existing caller skips the download/cache.
- Legit `items/<id>/cover` paths are unchanged.

## Tests
- New behavioral tests: traversal path rejected at `getFullCoverUrl` (null + warning) and full sync skips fetch/cache-write while still upserting metadata with `localCoverPath: null`; existing happy-path coverage retained.
- `npm --prefix backend test -- audiobookCacheService --maxWorkers=2` — 12 passed.
- `npm --prefix backend test -- audiobookCoverProxy --maxWorkers=2` — 17 passed.
- `tsc --noEmit` — clean.