### PR TITLE
fix(tidal-downloader): make logout authoritative against in-flight token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TIDAL logout is now authoritative against an in-flight token refresh:
+  `/user/auth/clear` serializes with the per-user refresh lock and a refresh
+  aborts its re-insert if the session was cleared during its awaited calls, so
+  `/user/auth/status` can no longer report authenticated after an explicit logout.
 - Subsonic getPlaylists (and the root directory/starred count paths) no longer
   hydrate every playlist item/track/album row (or album-id/track-duration rows)
   just to compute songCount/duration/coverArt — they now use bounded Prisma

--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -540,11 +540,36 @@ def _is_token_expired_error(err: Exception) -> bool:
     )
 
 
+def _clear_refreshed_session_caches(user_id: str) -> None:
+    """Clear caches tied to the credentials replaced by a refresh."""
+    _clear_stream_cache(user_id)
+    with _browse_sessions_lock:
+        for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
+            _browse_sessions.pop(key, None)
+
+
+def _commit_refreshed_session(
+    user_id: str,
+    creds: dict[str, str],
+    refreshed_api: TidalAPI,
+    access_token: str,
+    tidal_user_id: str,
+    country_code: str,
+) -> TidalAPI | None:
+    """Commit a refresh only while its captured credentials remain current."""
+    with _user_auth_state_lock:
+        if _user_auth_state.get(user_id) is not creds:
+            return _user_apis.get(user_id)
+
+        creds["access_token"] = access_token
+        creds["tidal_user_id"] = tidal_user_id
+        creds["country_code"] = country_code
+        _user_apis[user_id] = refreshed_api
+        return refreshed_api
+
+
 async def _refresh_user_api(user_id: str) -> TidalAPI:
-    """
-    Refresh a user's access token using the stored refresh token and rebuild API.
-    Uses a per-user lock so concurrent requests don't stampede refresh calls.
-    """
+    """Refresh a user's token under a per-user lock to prevent stampedes."""
     lock = _get_user_lock(user_id)
 
     async with lock:
@@ -575,21 +600,6 @@ async def _refresh_user_api(user_id: str) -> TidalAPI:
 
             refreshed_api = _build_api(new_access_token, new_user_id, new_country)
             await asyncio.to_thread(refreshed_api.get_session)
-
-            _user_apis[user_id] = refreshed_api
-            with _user_auth_state_lock:
-                creds["access_token"] = new_access_token
-                creds["tidal_user_id"] = new_user_id
-                creds["country_code"] = new_country
-
-            # Stream URLs and browse sessions are tied to prior auth state; clear on refresh.
-            _clear_stream_cache(user_id)
-            with _browse_sessions_lock:
-                for key in [k for k in _browse_sessions if k.startswith(f"{user_id}:")]:
-                    _browse_sessions.pop(key, None)
-
-            log.info(f"Refreshed TIDAL session for user {user_id}")
-            return refreshed_api
         except Exception as refresh_err:
             log.error(f"TIDAL token refresh failed for user {user_id}: {refresh_err}")
             _invalidate_user_api(user_id)
@@ -597,6 +607,26 @@ async def _refresh_user_api(user_id: str) -> TidalAPI:
                 status_code=401,
                 detail="TIDAL session expired and token refresh failed",
             ) from refresh_err
+
+        committed_api = _commit_refreshed_session(
+            user_id,
+            creds,
+            refreshed_api,
+            new_access_token,
+            new_user_id,
+            new_country,
+        )
+        if committed_api is None:
+            raise HTTPException(
+                status_code=401,
+                detail="TIDAL session was cleared during token refresh",
+            )
+        if committed_api is not refreshed_api:
+            return committed_api
+
+        _clear_refreshed_session_caches(user_id)
+        log.info(f"Refreshed TIDAL session for user {user_id}")
+        return refreshed_api
 
 
 async def _run_user_api_call(
@@ -1396,7 +1426,8 @@ async def user_auth_restore(req: UserAuthRestoreRequest, user_id: str = Query(..
 @app.post("/user/auth/clear")
 async def user_auth_clear(user_id: str = Query(...)):
     """Clear a user's TIDAL session."""
-    _invalidate_user_api(user_id)
+    async with _get_user_lock(user_id):
+        _invalidate_user_api(user_id)
     log.info(f"Cleared TIDAL session for user {user_id}")
     return {"success": True}
 

--- a/services/tidal-downloader/tests/test_auth_clear_refresh_race.py
+++ b/services/tidal-downloader/tests/test_auth_clear_refresh_race.py
@@ -1,0 +1,119 @@
+"""Regression tests for logout racing a TIDAL token refresh."""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture(autouse=True)
+def clear_user_auth_state(local_app_module):
+    """Prevent per-user auth state from leaking between race tests."""
+    import app
+
+    app._user_apis.clear()
+    app._user_api_locks.clear()
+    app._user_auth_state.clear()
+    try:
+        yield
+    finally:
+        app._user_apis.clear()
+        app._user_api_locks.clear()
+        app._user_auth_state.clear()
+
+
+def _park_refresh_in_to_thread(monkeypatch, app):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_to_thread(func, *args, **kwargs):
+        entered.set()
+        await release.wait()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(app.asyncio, "to_thread", fake_to_thread)
+    return entered, release
+
+
+def _seed_refresh(monkeypatch, app):
+    credentials = {
+        "access_token": "old-access",
+        "refresh_token": "refresh-token",
+        "tidal_user_id": "tidal-user",
+        "country_code": "US",
+    }
+    refreshed_api = types.SimpleNamespace(get_session=lambda: None)
+    auth_response = types.SimpleNamespace(
+        access_token="new-access",
+        user=types.SimpleNamespace(userId="tidal-user", countryCode="US"),
+    )
+    auth_api = types.SimpleNamespace(refresh_token=lambda _token: auth_response)
+
+    app._user_auth_state["u1"] = credentials
+    monkeypatch.setattr(app, "AuthAPI", lambda: auth_api)
+    monkeypatch.setattr(app, "_build_api", lambda *_args: refreshed_api)
+    return refreshed_api
+
+
+@pytest.mark.anyio
+async def test_auth_clear_waits_for_refresh_and_remains_authoritative(monkeypatch, client):
+    import app
+
+    refreshed_api = _seed_refresh(monkeypatch, app)
+    entered, release = _park_refresh_in_to_thread(monkeypatch, app)
+    original_get_user_lock = app._get_user_lock
+    lock_requests = 0
+    clear_requested_lock = asyncio.Event()
+
+    def observe_user_lock_request(user_id):
+        nonlocal lock_requests
+        lock_requests += 1
+        if lock_requests == 2:
+            clear_requested_lock.set()
+        return original_get_user_lock(user_id)
+
+    monkeypatch.setattr(app, "_get_user_lock", observe_user_lock_request)
+
+    refresh_task = asyncio.create_task(app._refresh_user_api("u1"))
+    await entered.wait()
+    clear_task = asyncio.create_task(client.post("/user/auth/clear?user_id=u1"))
+    async with asyncio.timeout(1):
+        await clear_requested_lock.wait()
+    await asyncio.sleep(0)
+
+    assert not clear_task.done()
+
+    release.set()
+    assert await refresh_task is refreshed_api
+    clear_response = await clear_task
+
+    assert clear_response.status_code == 200
+    assert "u1" not in app._user_apis
+    assert "u1" not in app._user_auth_state
+    status_response = await client.get("/user/auth/status?user_id=u1")
+    assert status_response.status_code == 200
+    assert status_response.json()["authenticated"] is False
+
+
+@pytest.mark.anyio
+async def test_refresh_does_not_restore_directly_cleared_session(monkeypatch):
+    import app
+
+    _seed_refresh(monkeypatch, app)
+    entered, release = _park_refresh_in_to_thread(monkeypatch, app)
+
+    refresh_task = asyncio.create_task(app._refresh_user_api("u1"))
+    await entered.wait()
+    app._invalidate_user_api("u1")
+    release.set()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_task
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "TIDAL session was cleared during token refresh"
+    assert "u1" not in app._user_apis
+    assert "u1" not in app._user_auth_state


### PR DESCRIPTION
## Summary

`POST /user/auth/clear` did not acquire the per-user refresh lock, so a logout landing during `_refresh_user_api`'s awaited calls (`refresh_token` / `get_session`) popped `_user_apis` and `_user_auth_state`, returned success, and was then undone when the refresh coroutine resumed and re-inserted `_user_apis[user_id]` while mutating the orphaned creds dict. `GET /user/auth/status` (which checks only `_user_apis` membership) then reported `authenticated: true` after an explicit logout, and streaming kept working until token expiry.

## Fix

- `user_auth_clear` now serializes with `_get_user_lock(user_id)` before invalidating, so it cannot interleave mid-refresh (lock acquired in the endpoint, not in `_invalidate_user_api`, because the refresh failure path calls the helper while already holding the non-reentrant lock).
- Defense in depth: the refresh commit is extracted into `_commit_refreshed_session` helper that, under `_user_auth_state_lock`, verifies the captured creds object is still the stored one before mutating creds and installing the API. If the session was cleared mid-refresh it aborts with 401 without re-inserting; if a concurrent restore installed fresh creds, the restored API is returned untouched. The commit/abort decision runs after the refresh try/except so the abort cannot trip the generic handler's `_invalidate_user_api`.
- No behavior change on the non-racing path; `_user_auth_state_lock` is never held across an await and lock ordering (per-user asyncio lock outer, threading state lock inner) is unchanged.

## Tests

New `services/tidal-downloader/tests/test_auth_clear_refresh_race.py` drives the interleaving deterministically by parking the refresh inside a patched `asyncio.to_thread` on asyncio Events:

- clear-via-endpoint blocks on the per-user lock during an in-flight refresh and the final state is unauthenticated (`_user_apis`/`_user_auth_state` empty, `/user/auth/status` false);
- a direct `_invalidate_user_api` during the refresh's awaits causes the refresh to abort with 401 instead of re-inserting the session.

Both tests fail on the pre-fix code.

## Verification

- `python -m pytest tests/ -q` (tidal-downloader): 112 passed
- `ruff check services/tidal-downloader/` + `ruff format --check`: clean
- `MYPYPATH=services mypy services/tidal-downloader/app.py`: no issues
