### PR TITLE
fix(security): pin outbound connections to vetted IPs at connect time (close DNS-rebind TOCTOU)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema before any outbound fetch; a previously accepted malformed `feedUrl`
   or non-string `itunesId` now returns **400** instead of reaching the RSS fetch
   path.
+- Added connect-time IP re-validation to the outbound SSRF guard, closing the
+  DNS-rebinding time-of-check/time-of-use window for vetted outbound requests;
+  the shared outbound policy now also blocks RFC 6598 CGNAT/shared address space
+  (`100.64.0.0/10`) and RFC 2544 benchmarking space (`198.18.0.0/15`).
 - Confined the Audiobookshelf cover-art proxy to the ABS `items/` resource
   namespace, closing an authenticated SSRF and admin-credential-reuse class.
   The library `cover-art` handler (both the `?url=` and `:id` branches) and the

--- a/backend/src/services/__tests__/outboundUrlSafety.test.ts
+++ b/backend/src/services/__tests__/outboundUrlSafety.test.ts
@@ -1,18 +1,130 @@
+import * as dns from "dns";
+import * as http from "http";
+
 const mockLookup = jest.fn();
 jest.mock("dns/promises", () => ({
     lookup: (...args: unknown[]) => mockLookup(...args),
 }));
 
 import {
+    __testHooks,
     normalizeSafeOutboundRedirectTarget,
     normalizeSafeOutboundUrl,
     resolveSafeOutboundUrl,
     resolveSafeOutboundRedirectTarget,
 } from "../outboundUrlSafety";
 
+type LookupResult = dns.LookupAddress | dns.LookupAddress[];
+
+function createBaseLookup(
+    resolveAddress: (hostname: string) => dns.LookupAddress[],
+): typeof dns.lookup {
+    return ((
+        hostname: string,
+        optionsOrCallback: dns.LookupOptions | number | Function,
+        possibleCallback?: Function,
+    ) => {
+        const callback =
+            typeof optionsOrCallback === "function"
+                ? optionsOrCallback
+                : possibleCallback;
+        const all =
+            typeof optionsOrCallback === "object" &&
+            optionsOrCallback.all === true;
+        const addresses = resolveAddress(hostname);
+        if (all) {
+            callback?.(null, addresses);
+            return;
+        }
+        callback?.(null, addresses[0].address, addresses[0].family);
+    }) as unknown as typeof dns.lookup;
+}
+
+function lookupAll(hostname: string): Promise<dns.LookupAddress[]> {
+    return new Promise((resolve, reject) => {
+        dns.lookup(hostname, { all: true }, (error, addresses) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(addresses);
+        });
+    });
+}
+
+function lookupOne(
+    hostname: string,
+    family?: number,
+): Promise<LookupResult> {
+    return new Promise((resolve, reject) => {
+        const callback = (
+            error: NodeJS.ErrnoException | null,
+            address: string,
+            resultFamily: number,
+        ) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve({ address, family: resultFamily });
+        };
+        if (family === undefined) {
+            dns.lookup(hostname, callback);
+            return;
+        }
+        dns.lookup(hostname, family, callback);
+    });
+}
+
+async function startLocalServer(): Promise<http.Server> {
+    const server = http.createServer((_request, response) => {
+        response.end("local response");
+    });
+    await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    return server;
+}
+
+function serverPort(server: http.Server): number {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Expected local TCP server address");
+    }
+    return address.port;
+}
+
+async function closeServer(server: http.Server | null): Promise<void> {
+    if (!server) {
+        return;
+    }
+    await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
 describe("outboundUrlSafety", () => {
+    let localServer: http.Server | null = null;
+
     beforeEach(() => {
         mockLookup.mockReset();
+        __testHooks.uninstall();
+        __testHooks.resetRegistry();
+        jest.useRealTimers();
+    });
+
+    afterEach(async () => {
+        __testHooks.uninstall();
+        __testHooks.resetRegistry();
+        jest.useRealTimers();
+        await closeServer(localServer);
+        localServer = null;
     });
 
     describe("resolveSafeOutboundUrl (DNS-resolving guard)", () => {
@@ -31,6 +143,16 @@ describe("outboundUrlSafety", () => {
                 await resolveSafeOutboundUrl("https://internal.example.com"),
             ).toBeNull();
         });
+
+        it.each(["100.64.1.2", "198.18.5.5"])(
+            "rejects a host that resolves to reserved address %s",
+            async (address) => {
+                mockLookup.mockResolvedValue([{ address, family: 4 }]);
+                expect(
+                    await resolveSafeOutboundUrl("https://reserved.example.com"),
+                ).toBeNull();
+            },
+        );
 
         it("rejects when ANY resolved address is private (DNS multi-record)", async () => {
             mockLookup.mockResolvedValue([
@@ -99,6 +221,102 @@ describe("outboundUrlSafety", () => {
                 "http://110.1.2.3/",
             );
         });
+
+        it("blocks a private address returned by connect-time DNS rebinding", async () => {
+            localServer = await startLocalServer();
+            mockLookup.mockResolvedValue([
+                { address: "93.184.216.34", family: 4 },
+            ]);
+            __testHooks.setBaseLookup(
+                createBaseLookup(() => [
+                    { address: "127.0.0.1", family: 4 },
+                ]),
+            );
+            const vettedUrl = await resolveSafeOutboundUrl(
+                `http://rebind.test:${serverPort(localServer)}/`,
+            );
+
+            expect(vettedUrl).not.toBeNull();
+            await expect(fetch(vettedUrl!)).rejects.toMatchObject({
+                cause: { code: "EOUTBOUNDBLOCKED" },
+            });
+        });
+
+        it("passes public connect-time addresses through unchanged", async () => {
+            const publicAddress = { address: "93.184.216.34", family: 4 };
+            mockLookup.mockResolvedValue([publicAddress]);
+            __testHooks.setBaseLookup(
+                createBaseLookup(() => [publicAddress]),
+            );
+            await resolveSafeOutboundUrl("https://public.test/");
+
+            await expect(lookupAll("public.test")).resolves.toEqual([
+                publicAddress,
+            ]);
+            await expect(lookupOne("public.test")).resolves.toEqual(
+                publicAddress,
+            );
+            await expect(lookupOne("public.test", 4)).resolves.toEqual(
+                publicAddress,
+            );
+        });
+
+        it("leaves unregistered private-host traffic untouched", async () => {
+            localServer = await startLocalServer();
+            mockLookup.mockResolvedValue([
+                { address: "93.184.216.34", family: 4 },
+            ]);
+            __testHooks.setBaseLookup(
+                createBaseLookup(() => [
+                    { address: "127.0.0.1", family: 4 },
+                ]),
+            );
+            await resolveSafeOutboundUrl("https://vetted.test/");
+
+            const response = await fetch(
+                `http://internal-service.test:${serverPort(localServer)}/`,
+            );
+            expect(response.status).toBe(200);
+            await expect(response.text()).resolves.toBe("local response");
+        });
+
+        it("fails open after the vetted-host TTL expires", async () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date("2026-08-10T00:00:00Z"));
+            mockLookup.mockResolvedValue([
+                { address: "93.184.216.34", family: 4 },
+            ]);
+            __testHooks.setBaseLookup(
+                createBaseLookup(() => [
+                    { address: "127.0.0.1", family: 4 },
+                ]),
+            );
+            await resolveSafeOutboundUrl("https://expiring.test/");
+
+            jest.advanceTimersByTime(30_001);
+
+            await expect(lookupOne("expiring.test")).resolves.toEqual({
+                address: "127.0.0.1",
+                family: 4,
+            });
+        });
+
+        it("blocks when any connect-time address is private", async () => {
+            mockLookup.mockResolvedValue([
+                { address: "93.184.216.34", family: 4 },
+            ]);
+            __testHooks.setBaseLookup(
+                createBaseLookup(() => [
+                    { address: "93.184.216.34", family: 4 },
+                    { address: "10.0.0.5", family: 4 },
+                ]),
+            );
+            await resolveSafeOutboundUrl("https://mixed.test/");
+
+            await expect(lookupAll("mixed.test")).rejects.toMatchObject({
+                code: "EOUTBOUNDBLOCKED",
+            });
+        });
     });
 
     describe("resolveSafeOutboundRedirectTarget", () => {
@@ -138,6 +356,37 @@ describe("outboundUrlSafety", () => {
             ).toBeNull();
             expect(
                 normalizeSafeOutboundUrl("http://192.168.1.9/feed"),
+            ).toBeNull();
+        });
+
+        it.each([
+            "http://100.64.1.2/x",
+            "http://100.127.255.255/",
+            "http://198.18.0.1/",
+            "http://198.19.255.254/",
+        ])("rejects reserved ipv4 destination %s", (url) => {
+            expect(normalizeSafeOutboundUrl(url)).toBeNull();
+        });
+
+        it.each([
+            "http://100.63.255.255/",
+            "http://100.128.0.0/",
+            "http://198.17.255.255/",
+            "http://198.20.0.1/",
+        ])("allows public address outside reserved boundaries %s", (url) => {
+            expect(normalizeSafeOutboundUrl(url)).toBe(url);
+        });
+
+        it.each([
+            "http://100.64.1.2.example/",
+            "http://198.18.example/",
+        ])("does not parse malformed dotted-quad hostname %s", (url) => {
+            expect(normalizeSafeOutboundUrl(url)).toBe(url);
+        });
+
+        it("rejects an ipv4-mapped ipv6 reserved destination", () => {
+            expect(
+                normalizeSafeOutboundUrl("http://[::ffff:100.64.1.2]/"),
             ).toBeNull();
         });
 

--- a/backend/src/services/outboundUrlSafety.ts
+++ b/backend/src/services/outboundUrlSafety.ts
@@ -1,7 +1,14 @@
+import dns = require("dns");
 import { lookup } from "dns/promises";
 
 const IPV4_PRIVATE_172_RE = /^172\.(1[6-9]|2[0-9]|3[0-1])\./;
+const IPV4_DOTTED_QUAD_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
 const IPV6_LINK_LOCAL_RE = /^fe[89ab]/i;
+const VETTED_HOSTNAME_TTL_MS = 30_000;
+const MAX_VETTED_HOSTNAMES = 256;
+const vettedHostnames = new Map<string, number>();
+let originalLookup: typeof dns.lookup | null = null;
+let baseLookupOverride: typeof dns.lookup | null = null;
 
 function stripIpv6Brackets(hostname: string): string {
     if (hostname.startsWith("[") && hostname.endsWith("]")) {
@@ -9,6 +16,35 @@ function stripIpv6Brackets(hostname: string): string {
     }
 
     return hostname;
+}
+
+function parseIpv4Octets(
+    hostname: string,
+): [number, number, number, number] | null {
+    const match = IPV4_DOTTED_QUAD_RE.exec(hostname);
+    if (!match) {
+        return null;
+    }
+    const first = Number(match[1]);
+    const second = Number(match[2]);
+    const third = Number(match[3]);
+    const fourth = Number(match[4]);
+    if (first > 255 || second > 255 || third > 255 || fourth > 255) {
+        return null;
+    }
+    return [first, second, third, fourth];
+}
+
+function isBlockedReservedIpv4Hostname(hostname: string): boolean {
+    const octets = parseIpv4Octets(hostname);
+    if (!octets) {
+        return false;
+    }
+    const [first, second] = octets;
+    return (
+        (first === 100 && second >= 64 && second <= 127) ||
+        (first === 198 && second >= 18 && second <= 19)
+    );
 }
 
 function isBlockedIpv4Hostname(hostname: string): boolean {
@@ -23,8 +59,19 @@ function isBlockedIpv4Hostname(hostname: string): boolean {
         hostname.startsWith("10.") ||
         hostname.startsWith("192.168.") ||
         hostname.startsWith("169.254.") ||
-        IPV4_PRIVATE_172_RE.test(hostname)
+        IPV4_PRIVATE_172_RE.test(hostname) ||
+        isBlockedReservedIpv4Hostname(hostname)
     );
+}
+
+function decodeMappedIpv4Hostname(hostname: string): string {
+    const match = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(hostname);
+    if (!match) {
+        return hostname;
+    }
+    const high = Number.parseInt(match[1], 16);
+    const low = Number.parseInt(match[2], 16);
+    return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
 }
 
 function isBlockedIpv6Hostname(hostname: string): boolean {
@@ -35,13 +82,25 @@ function isBlockedIpv6Hostname(hostname: string): boolean {
     }
 
     if (normalized.startsWith("::ffff:")) {
-        return isBlockedIpv4Hostname(normalized.slice("::ffff:".length));
+        const mappedHostname = normalized.slice("::ffff:".length);
+        return isBlockedIpv4Hostname(
+            decodeMappedIpv4Hostname(mappedHostname),
+        );
     }
 
     return (
         IPV6_LINK_LOCAL_RE.test(normalized) ||
         normalized.startsWith("fc") ||
         normalized.startsWith("fd")
+    );
+}
+
+/**
+ * Returns whether an IP address is denied by the shared outbound SSRF policy.
+ */
+export function isBlockedAddress(address: string): boolean {
+    return (
+        isBlockedIpv4Hostname(address) || isBlockedIpv6Hostname(address)
     );
 }
 
@@ -103,11 +162,9 @@ export function normalizeSafeOutboundRedirectTarget(
  * (decimal `2130706433`, hex `0x7f000001`, octal, `127.1`) and by DNS names that
  * point at an internal address; resolving via getaddrinfo normalizes those
  * encodings and exposes the real target IPs, which are then range-checked.
- * Returns true only if every resolved address is public.
- *
- * Note: this checks at resolve time; a DNS-rebinding attacker could in theory
- * return a different address to the subsequent fetch. Pinning the resolved IP
- * into the request agent would close that and is a larger follow-up.
+ * Returns true only if every resolved address is public. Successful validation
+ * also enables a short-lived connect-time lookup check using this same policy,
+ * closing the DNS-rebinding gap while the vetted-hostname entry remains live.
  */
 async function hasOnlyPublicResolvedAddresses(
     hostname: string,
@@ -118,15 +175,107 @@ async function hasOnlyPublicResolvedAddresses(
         if (addresses.length === 0) {
             return false;
         }
-        return addresses.every(
-            ({ address }) =>
-                !isBlockedIpv4Hostname(address) &&
-                !isBlockedIpv6Hostname(address),
-        );
+        return addresses.every(({ address }) => !isBlockedAddress(address));
     } catch {
         return false;
     }
 }
+
+function normalizeHostname(hostname: string): string {
+    return stripIpv6Brackets(hostname).toLowerCase();
+}
+
+function registerVettedHostname(hostname: string): void {
+    const normalized = normalizeHostname(hostname);
+    vettedHostnames.delete(normalized);
+    if (vettedHostnames.size >= MAX_VETTED_HOSTNAMES) {
+        const oldest = vettedHostnames.keys().next().value;
+        if (oldest !== undefined) {
+            vettedHostnames.delete(oldest);
+        }
+    }
+    vettedHostnames.set(normalized, Date.now() + VETTED_HOSTNAME_TTL_MS);
+}
+
+function isVettedHostname(hostname: string): boolean {
+    const normalized = normalizeHostname(hostname);
+    const expiry = vettedHostnames.get(normalized);
+    if (expiry === undefined) {
+        return false;
+    }
+    if (expiry <= Date.now()) {
+        // Expiry and eviction intentionally fail open to pre-pinning behavior.
+        vettedHostnames.delete(normalized);
+        return false;
+    }
+    return true;
+}
+
+function createBlockedLookupError(hostname: string): NodeJS.ErrnoException {
+    const error = new Error(
+        `Outbound request blocked: connect-time DNS for ${hostname} returned a private, loopback, or link-local address`,
+    ) as NodeJS.ErrnoException;
+    error.code = "EOUTBOUNDBLOCKED";
+    return error;
+}
+
+function hasBlockedLookupResult(result: unknown): boolean {
+    if (Array.isArray(result)) {
+        return result.some(
+            (entry: dns.LookupAddress) => isBlockedAddress(entry.address),
+        );
+    }
+    return typeof result === "string" && isBlockedAddress(result);
+}
+
+function guardedLookup(hostname: string, ...args: unknown[]): void {
+    const delegate = baseLookupOverride ?? originalLookup;
+    if (!delegate) {
+        throw new Error("Outbound DNS lookup guard is not installed");
+    }
+    const callback = args.at(-1);
+    if (!isVettedHostname(hostname) || typeof callback !== "function") {
+        Reflect.apply(delegate, dns, [hostname, ...args]);
+        return;
+    }
+    const guardedCallback = (...callbackArgs: unknown[]) => {
+        if (!callbackArgs[0] && hasBlockedLookupResult(callbackArgs[1])) {
+            callback(createBlockedLookupError(hostname));
+            return;
+        }
+        callback(...callbackArgs);
+    };
+    Reflect.apply(delegate, dns, [hostname, ...args.slice(0, -1), guardedCallback]);
+}
+
+function installLookupGuard(): void {
+    if (originalLookup) {
+        return;
+    }
+    originalLookup = dns.lookup;
+    (dns as { lookup: typeof dns.lookup }).lookup =
+        guardedLookup as unknown as typeof dns.lookup;
+}
+
+/**
+ * Test-only controls for resetting global guard state and supplying deterministic
+ * callback-style DNS lookup behavior without using the host network.
+ */
+export const __testHooks = {
+    resetRegistry(): void {
+        vettedHostnames.clear();
+    },
+    setBaseLookup(baseLookup: typeof dns.lookup): void {
+        baseLookupOverride = baseLookup;
+    },
+    uninstall(): void {
+        if (originalLookup) {
+            (dns as { lookup: typeof dns.lookup }).lookup = originalLookup;
+        }
+        originalLookup = null;
+        baseLookupOverride = null;
+    },
+};
 
 /**
  * Like `normalizeSafeOutboundUrl`, but additionally resolves the hostname via
@@ -142,7 +291,12 @@ export async function resolveSafeOutboundUrl(
         return null;
     }
     const { hostname } = new URL(normalized);
-    return (await hasOnlyPublicResolvedAddresses(hostname)) ? normalized : null;
+    if (!(await hasOnlyPublicResolvedAddresses(hostname))) {
+        return null;
+    }
+    installLookupGuard();
+    registerVettedHostname(hostname);
+    return normalized;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the DNS-rebinding time-of-check/time-of-use window in the shared outbound SSRF guard (`backend/src/services/outboundUrlSafety.ts`).

Previously, `resolveSafeOutboundUrl` vetted a hostname's resolved addresses at validation time, but the actual socket connect performed a second, independent DNS lookup. A rebinding attacker could answer the validation lookup with a public IP and the connect-time lookup with a private/loopback IP, slipping an internal address past the guard. The module's own doc comment flagged this as a known follow-up.

## Approach

- The guard now enforces the SAME address policy at connect time: on successful vetting, the hostname enters a bounded (256-entry, 30s TTL) registry, and a lazily installed, idempotent wrapper around the `dns.lookup` module method re-applies the existing blocked-address policy to every address resolved for a vetted hostname at socket connect. Any blocked address fails the lookup (`EOUTBOUNDBLOCKED`), so the connection never reaches an internal IP.
- Both egress clients are covered with zero caller edits: Node's built-in `fetch` (bundled undici connector) and axios (http adapter -> `net.connect`) both resolve through the `dns.lookup` module method at call time (verified on Node 26).
- Strictly additive: hostnames never vetted by the guard (internal services on private IPs) pass through untouched, and registry expiry/eviction falls back to today's resolve-time-only behavior — never weaker than the status quo, no divergent second allowlist.

## Also: two missing reserved IPv4 ranges

`isBlockedIpv4Hostname` now also blocks RFC 6598 CGNAT/shared address space (`100.64.0.0/10`) and RFC 2544 benchmarking space (`198.18.0.0/15`), which were previously treated as public. The /10 boundary uses a strict numeric dotted-quad range check (prefix matching cannot express the 64-127 second-octet boundary); malformed strings fall through to existing behavior. Because this is the single shared predicate, URL literals, DNS-resolved addresses, IPv4-mapped IPv6 (including hex-form `::ffff:6440:102`), and the connect-time guard are all covered automatically.

## Tests

- Behavioral rebind test: a URL that passes validation (public IP at resolve time) but rebinds to 127.0.0.1 at connect time is blocked on a real connection attempt against a live local server.
- Public hosts resolve unchanged (both `all: true` and single-address callback shapes).
- Unvetted hostnames pass through untouched (real request to a local server succeeds).
- TTL expiry fails open to status-quo behavior; any-blocked multi-record semantics enforced.
- CGNAT/benchmark ranges: literal and DNS-resolved blocking, exact /10 and /15 boundary cases (blocked and not-blocked neighbors), IPv4-mapped IPv6 forms, malformed-hostname fall-through.

## Verification

- verify: `npm --prefix backend test -- outboundUrlSafety --maxWorkers=2` — 34/34 passed.
- verify: `npx tsc --noEmit` (backend) — exit 0.
- verify: `npx prettier --check` on the three touched files — clean.

