### PR TITLE
refactor(concurrency): shared keyed-singleflight helper and unified OAuth-restore coalescing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Promoted the segmented-streaming session service's identity-guarded
+  keyed-singleflight into a shared backend helper and rethreaded transcode
+  caching, vibe calibration, and both the YouTube Music and TIDAL OAuth-restore
+  paths onto it, unifying the short-TTL negative-cache policy for OAuth restores
+  and bounding the YouTube Music library limit params.
 - Replaced the three source-scraping `audioAnalyzer*Contract` Jest suites with
   behavioral pytest coverage in `services/audio-analyzer/tests/` for queue claim
   alignment, process-pool crash recovery, stale-failure resolution, and

--- a/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
@@ -230,6 +230,38 @@ describe("tidal streaming route runtime", () => {
         );
     });
 
+    it("coalesces concurrent missing-oauth lookups and preserves the unauthorized response", async () => {
+        let resolveAuthStatus!: (authenticated: boolean) => void;
+        tidalStreamingService.checkSidecarAuthStatus.mockReturnValueOnce(
+            new Promise<boolean>((resolve) => {
+                resolveAuthStatus = resolve;
+            }),
+        );
+        prisma.userSettings.findUnique.mockResolvedValueOnce(null);
+        const req = {
+            user: { id: "concurrent-no-oauth" },
+            body: { query: "hello" },
+        } as any;
+        const firstRes = createRes();
+        const secondRes = createRes();
+
+        const firstRequest = searchHandler(req, firstRes);
+        const secondRequest = searchHandler(req, secondRes);
+        await Promise.resolve();
+        expect(
+            tidalStreamingService.checkSidecarAuthStatus,
+        ).toHaveBeenCalledTimes(1);
+
+        resolveAuthStatus(false);
+        await Promise.all([firstRequest, secondRequest]);
+
+        expect(prisma.userSettings.findUnique).toHaveBeenCalledTimes(1);
+        expect(firstRes.statusCode).toBe(401);
+        expect(secondRes.statusCode).toBe(401);
+        expect(firstRes.body).toEqual({ error: "Not authenticated to TIDAL" });
+        expect(secondRes.body).toEqual(firstRes.body);
+    });
+
     it("evaluates the tidal-enabled middleware for 404, 503, and success", async () => {
         const layer = getRouteLayer("/auth/device-code", "post");
         const middleware = layer.route.stack[1].handle;

--- a/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
@@ -315,6 +315,34 @@ describe("youtube music route runtime behavior", () => {
         expect(errorRes.statusCode).toBe(500);
     });
 
+    it("coalesces concurrent missing-oauth lookups", async () => {
+        let resolveAuthStatus!: (status: { authenticated: boolean }) => void;
+        ytMusicService.getAuthStatus.mockReturnValueOnce(
+            new Promise<{ authenticated: boolean }>((resolve) => {
+                resolveAuthStatus = resolve;
+            }),
+        );
+        prisma.userSettings.findUnique.mockResolvedValueOnce(null);
+        const req = {
+            user: { id: "concurrent-no-oauth" },
+            query: {},
+        } as any;
+        const firstRes = createRes();
+        const secondRes = createRes();
+
+        const firstRequest = librarySongsHandler(req, firstRes);
+        const secondRequest = librarySongsHandler(req, secondRes);
+        await Promise.resolve();
+        expect(ytMusicService.getAuthStatus).toHaveBeenCalledTimes(1);
+
+        resolveAuthStatus({ authenticated: false });
+        await Promise.all([firstRequest, secondRequest]);
+
+        expect(prisma.userSettings.findUnique).toHaveBeenCalledTimes(1);
+        expect(firstRes.statusCode).toBe(401);
+        expect(secondRes.statusCode).toBe(401);
+    });
+
     it("validates and initiates device auth with error fallback", async () => {
         const req = { user: { id: "user-1" } } as any;
 
@@ -960,6 +988,26 @@ describe("youtube music route runtime behavior", () => {
         expect(ytMusicService.getLibraryAlbums).toHaveBeenCalledWith(
             "user-1",
             100,
+        );
+
+        const boundedSongsRes = createRes();
+        await librarySongsHandler(
+            { ...reqBase, query: { limit: "500" } } as any,
+            boundedSongsRes,
+        );
+        expect(ytMusicService.getLibrarySongs).toHaveBeenLastCalledWith(
+            "user-1",
+            100,
+        );
+
+        const boundedAlbumsRes = createRes();
+        await libraryAlbumsHandler(
+            { ...reqBase, query: { limit: "-10" } } as any,
+            boundedAlbumsRes,
+        );
+        expect(ytMusicService.getLibraryAlbums).toHaveBeenLastCalledWith(
+            "user-1",
+            1,
         );
 
         ytMusicService.getLibrarySongs.mockRejectedValueOnce({

--- a/backend/src/routes/tidalStreaming.ts
+++ b/backend/src/routes/tidalStreaming.ts
@@ -27,9 +27,12 @@ import { prisma } from "../utils/db";
 import { encrypt, decrypt } from "../utils/encryption";
 import { logger } from "../utils/logger";
 import { trackMappingService } from "../services/trackMappingService";
+import { coalesceInFlightByKey } from "../utils/singleflight";
 
 const router = Router();
 const OAUTH_CACHE_TTL_MS = process.env.NODE_ENV === "test" ? 0 : 60_000;
+const OAUTH_NEGATIVE_CACHE_TTL_MS =
+    process.env.NODE_ENV === "test" ? 0 : 15_000;
 const tidalOauthSessionCache = new Map<
     string,
     { authenticated: boolean; expiresAt: number }
@@ -40,8 +43,18 @@ const setTidalOAuthCache = (
     authenticated: boolean,
     ttlMs = OAUTH_CACHE_TTL_MS,
 ) => {
-    if (!authenticated || ttlMs <= 0) {
+    if (ttlMs <= 0) {
         tidalOauthSessionCache.delete(userId);
+        return;
+    }
+    if (!authenticated) {
+        // Cache negative results with a shorter TTL so non-linked users
+        // don't hit sidecar/DB on every browse/stream request, while still
+        // picking up new OAuth links within a reasonable window.
+        tidalOauthSessionCache.set(userId, {
+            authenticated: false,
+            expiresAt: Date.now() + OAUTH_NEGATIVE_CACHE_TTL_MS,
+        });
         return;
     }
     tidalOauthSessionCache.set(userId, {
@@ -103,56 +116,47 @@ async function ensureUserOAuth(userId: string): Promise<boolean> {
         return cached;
     }
 
-    const existingInFlight = tidalOauthRestoreInFlight.get(userId);
-    if (existingInFlight) {
-        return existingInFlight;
+    return coalesceInFlightByKey(tidalOauthRestoreInFlight, userId, () =>
+        restoreTidalUserOAuth(userId),
+    );
+}
+
+async function restoreTidalUserOAuth(userId: string): Promise<boolean> {
+    // This authenticated client carries the internal secret; a bare request
+    // would 403 and be misread as a missing sidecar session.
+    try {
+        const authenticated =
+            await tidalStreamingService.checkSidecarAuthStatus(userId);
+        if (authenticated) {
+            setTidalOAuthCache(userId, true);
+            return true;
+        }
+    } catch {
+        // Sidecar might not have the session, try to restore.
     }
 
-    const restorePromise = (async () => {
-        // Check if sidecar already has this user's session. Goes through the
-        // authenticated service client (F31) so it carries the internal secret
-        // — a bare axios.get here would 403 forever after auth landed and be
-        // misread as "sidecar has no session".
-        try {
-            const authenticated =
-                await tidalStreamingService.checkSidecarAuthStatus(userId);
-            if (authenticated) {
-                setTidalOAuthCache(userId, true);
-                return true;
-            }
-        } catch {
-            // Sidecar might not have the session, try to restore
-        }
-
-        // Load from DB and restore
-        const userSettings = await prisma.userSettings.findUnique({
-            where: { userId },
-            select: { tidalOAuthJson: true },
-        });
-        if (!userSettings?.tidalOAuthJson) {
-            setTidalOAuthCache(userId, false);
-            return false;
-        }
-
-        let oauthJson: string;
-        try {
-            oauthJson = decrypt(userSettings.tidalOAuthJson);
-        } catch {
-            oauthJson = userSettings.tidalOAuthJson;
-        }
-
-        const restored = await tidalStreamingService.restoreOAuth(
-            userId,
-            oauthJson,
-        );
-        setTidalOAuthCache(userId, restored);
-        return restored;
-    })().finally(() => {
-        tidalOauthRestoreInFlight.delete(userId);
+    const userSettings = await prisma.userSettings.findUnique({
+        where: { userId },
+        select: { tidalOAuthJson: true },
     });
+    if (!userSettings?.tidalOAuthJson) {
+        setTidalOAuthCache(userId, false);
+        return false;
+    }
 
-    tidalOauthRestoreInFlight.set(userId, restorePromise);
-    return restorePromise;
+    let oauthJson: string;
+    try {
+        oauthJson = decrypt(userSettings.tidalOAuthJson);
+    } catch {
+        oauthJson = userSettings.tidalOAuthJson;
+    }
+
+    const restored = await tidalStreamingService.restoreOAuth(
+        userId,
+        oauthJson,
+    );
+    setTidalOAuthCache(userId, restored);
+    return restored;
 }
 
 // ── Routes ─────────────────────────────────────────────────────────

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -39,6 +39,7 @@ import {
 import { fetchEmbeddingsByTrackIds } from "../services/trackEmbeddings";
 import { parseJourneyRequest } from "./vibeJourneyRequest";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
+import { coalesceInFlightByKey } from "../utils/singleflight";
 
 const router = Router();
 
@@ -1450,23 +1451,16 @@ async function getCachedOrComputeCalibration(
         });
     }
 
-    let compute = calibrationInFlight.get(cacheKey);
-    if (!compute) {
-        compute = computeCalibration()
-            .then(async (payload) => {
-                await redisClient.setEx(
-                    cacheKey,
-                    CALIBRATION_CACHE_TTL_SECONDS,
-                    JSON.stringify(payload),
-                );
-                return payload;
-            })
-            .finally(() => {
-                calibrationInFlight.delete(cacheKey);
-            });
-        calibrationInFlight.set(cacheKey, compute);
-    }
-    return compute;
+    return coalesceInFlightByKey(calibrationInFlight, cacheKey, () =>
+        computeCalibration().then(async (payload) => {
+            await redisClient.setEx(
+                cacheKey,
+                CALIBRATION_CACHE_TTL_SECONDS,
+                JSON.stringify(payload),
+            );
+            return payload;
+        }),
+    );
 }
 
 async function getCalibrationResponse() {

--- a/backend/src/routes/youtubeMusic.ts
+++ b/backend/src/routes/youtubeMusic.ts
@@ -26,6 +26,7 @@ import {
     ytMusicSearchLimiter,
     ytMusicStreamLimiter,
 } from "../middleware/rateLimiter";
+import { coalesceInFlightByKey } from "../utils/singleflight";
 
 const router = Router();
 const OAUTH_CACHE_TTL_MS = process.env.NODE_ENV === "test" ? 0 : 60_000;
@@ -111,64 +112,46 @@ async function ensureUserOAuth(userId: string): Promise<boolean> {
         return cached;
     }
 
-    const existingInFlight = ytOauthRestoreInFlight.get(userId);
-    if (existingInFlight) {
-        return existingInFlight;
-    }
+    return coalesceInFlightByKey(ytOauthRestoreInFlight, userId, () =>
+        restoreYtUserOAuth(userId),
+    );
+}
 
-    const restorePromise = (async () => {
-        try {
-            // Quick check — is the sidecar already aware of this user?
-            const status = await ytMusicService.getAuthStatus(userId);
-            if (status.authenticated) {
-                setYtOAuthCache(userId, true);
-                return true;
-            }
-
-            // Not authenticated in sidecar — try restoring from DB
-            const userSettings = await prisma.userSettings.findUnique({
-                where: { userId },
-                select: { ytMusicOAuthJson: true },
-            });
-
-            if (!userSettings?.ytMusicOAuthJson) {
-                setYtOAuthCache(userId, false);
-                return false;
-            }
-
-            const oauthJson = decrypt(userSettings.ytMusicOAuthJson);
-            if (!oauthJson) {
-                setYtOAuthCache(userId, false);
-                return false;
-            }
-
-            // Also pass client credentials so the sidecar can build OAuthCredentials
-            const systemSettings = await getSystemSettings();
-            await ytMusicService.restoreOAuthWithCredentials(
-                userId,
-                oauthJson,
-                systemSettings?.ytMusicClientId || undefined,
-                systemSettings?.ytMusicClientSecret || undefined,
-            );
-            logger.info(
-                `[YTMusic] Restored OAuth credentials for user ${userId}`,
-            );
+async function restoreYtUserOAuth(userId: string): Promise<boolean> {
+    try {
+        const status = await ytMusicService.getAuthStatus(userId);
+        if (status.authenticated) {
             setYtOAuthCache(userId, true);
             return true;
-        } catch (err) {
-            logger.debug(
-                `[YTMusic] OAuth restore failed for user ${userId}:`,
-                err,
-            );
+        }
+        const userSettings = await prisma.userSettings.findUnique({
+            where: { userId },
+            select: { ytMusicOAuthJson: true },
+        });
+        if (!userSettings?.ytMusicOAuthJson) {
             setYtOAuthCache(userId, false);
             return false;
         }
-    })().finally(() => {
-        ytOauthRestoreInFlight.delete(userId);
-    });
-
-    ytOauthRestoreInFlight.set(userId, restorePromise);
-    return restorePromise;
+        const oauthJson = decrypt(userSettings.ytMusicOAuthJson);
+        if (!oauthJson) {
+            setYtOAuthCache(userId, false);
+            return false;
+        }
+        const systemSettings = await getSystemSettings();
+        await ytMusicService.restoreOAuthWithCredentials(
+            userId,
+            oauthJson,
+            systemSettings?.ytMusicClientId || undefined,
+            systemSettings?.ytMusicClientSecret || undefined,
+        );
+        logger.info(`[YTMusic] Restored OAuth credentials for user ${userId}`);
+        setYtOAuthCache(userId, true);
+        return true;
+    } catch (err) {
+        logger.debug(`[YTMusic] OAuth restore failed for user ${userId}:`, err);
+        setYtOAuthCache(userId, false);
+        return false;
+    }
 }
 
 async function requireUserOAuth(
@@ -221,6 +204,16 @@ const getRequestedStreamQuality = (rawQuality: unknown): string | undefined => {
     }
     const trimmed = rawQuality.trim();
     return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/** Parse a query limit into a bounded integer in [1, 100]; falls back to 100. */
+const parseBoundedLimit = (raw: unknown): number => {
+    // A shared parseBoundedInt utility may supersede this route-local parser.
+    const parsed = typeof raw === "string" ? Number.parseInt(raw, 10) : NaN;
+    if (!Number.isFinite(parsed)) {
+        return 100;
+    }
+    return Math.min(100, Math.max(1, parsed));
 };
 
 async function resolveYtMusicStreamQuality(
@@ -1002,6 +995,8 @@ router.get(
  *         name: limit
  *         schema:
  *           type: integer
+ *           minimum: 1
+ *           maximum: 100
  *           default: 100
  *         description: Maximum number of songs to return
  *     responses:
@@ -1020,7 +1015,7 @@ router.get(
         try {
             const userId = req.user!.id;
             if (!(await requireUserOAuth(userId, res))) return;
-            const limit = parseInt(req.query.limit as string) || 100;
+            const limit = parseBoundedLimit(req.query.limit);
             const songs = await ytMusicService.getLibrarySongs(userId, limit);
             res.json({ songs });
         } catch (err: any) {
@@ -1047,6 +1042,8 @@ router.get(
  *         name: limit
  *         schema:
  *           type: integer
+ *           minimum: 1
+ *           maximum: 100
  *           default: 100
  *         description: Maximum number of albums to return
  *     responses:
@@ -1065,7 +1062,7 @@ router.get(
         try {
             const userId = req.user!.id;
             if (!(await requireUserOAuth(userId, res))) return;
-            const limit = parseInt(req.query.limit as string) || 100;
+            const limit = parseBoundedLimit(req.query.limit);
             const albums = await ytMusicService.getLibraryAlbums(userId, limit);
             res.json({ albums });
         } catch (err: any) {

--- a/backend/src/services/audioStreaming.ts
+++ b/backend/src/services/audioStreaming.ts
@@ -14,6 +14,7 @@ import { parseRangeHeader } from "../utils/rangeParser";
 import { parseFile } from "music-metadata";
 import { isOriginAllowed } from "../utils/cors";
 import { config } from "../config";
+import { coalesceInFlightByKey } from "../utils/singleflight";
 
 // Set FFmpeg path to bundled binary
 ffmpeg.setFfmpegPath(ffmpegPath.path);
@@ -227,25 +228,18 @@ export class AudioStreamingService {
         sourceModified: Date,
     ): Promise<string> {
         const dedupeKey = `${trackId}-${quality}`;
-        const inflight = this.inflightTranscodes.get(dedupeKey);
-        if (inflight) {
-            logger.debug(
-                `[STREAM] Joining in-flight transcode for ${dedupeKey}`,
-            );
-            return inflight;
-        }
-
-        const promise = this.doTranscode(
-            trackId,
-            quality,
-            sourcePath,
-            sourceModified,
-        ).finally(() => {
-            this.inflightTranscodes.delete(dedupeKey);
-        });
-
-        this.inflightTranscodes.set(dedupeKey, promise);
-        return promise;
+        return coalesceInFlightByKey(
+            this.inflightTranscodes,
+            dedupeKey,
+            () =>
+                this.doTranscode(trackId, quality, sourcePath, sourceModified),
+            {
+                onCoalescedWait: () =>
+                    logger.debug(
+                        `[STREAM] Joining in-flight transcode for ${dedupeKey}`,
+                    ),
+            },
+        );
     }
 
     /**

--- a/backend/src/services/segmented-streaming/sessionService.ts
+++ b/backend/src/services/segmented-streaming/sessionService.ts
@@ -6,6 +6,7 @@ import { prisma } from "../../utils/db";
 import { redisClient } from "../../utils/redis";
 import { config } from "../../config";
 import { logger } from "../../utils/logger";
+import { coalesceInFlightByKey as coalesceByKey } from "../../utils/singleflight";
 import {
     segmentedManifestService,
     type SegmentedManifestQuality,
@@ -642,25 +643,12 @@ class SegmentedSessionService {
         waitFactory: () => Promise<void>,
         traceFields: Record<string, unknown> = {},
     ): Promise<void> {
-        const existingPromise = inFlightMap.get(key);
-        if (existingPromise) {
-            logSegmentedStreamingTrace("session.readiness.coalesced_wait", {
-                ...traceFields,
-            });
-            await existingPromise;
-            return;
-        }
-
-        const inFlightPromise = Promise.resolve()
-            .then(waitFactory)
-            .finally(() => {
-                if (inFlightMap.get(key) === inFlightPromise) {
-                    inFlightMap.delete(key);
-                }
-            });
-
-        inFlightMap.set(key, inFlightPromise);
-        await inFlightPromise;
+        await coalesceByKey(inFlightMap, key, waitFactory, {
+            onCoalescedWait: () =>
+                logSegmentedStreamingTrace("session.readiness.coalesced_wait", {
+                    ...traceFields,
+                }),
+        });
     }
 
     private hasReadinessMicrocacheHit(

--- a/backend/src/utils/__tests__/singleflight.test.ts
+++ b/backend/src/utils/__tests__/singleflight.test.ts
@@ -1,0 +1,135 @@
+import { coalesceInFlightByKey } from "../singleflight";
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+}
+
+const createDeferred = <T>(): Deferred<T> => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+};
+
+describe("coalesceInFlightByKey", () => {
+    it("returns one promise and runs one factory for concurrent callers", async () => {
+        const inFlight = new Map<string, Promise<string>>();
+        const deferred = createDeferred<string>();
+        const factory = jest.fn(() => deferred.promise);
+
+        const first = coalesceInFlightByKey(inFlight, "track", factory);
+        const second = coalesceInFlightByKey(inFlight, "track", factory);
+
+        expect(second).toBe(first);
+        await Promise.resolve();
+        expect(factory).toHaveBeenCalledTimes(1);
+
+        deferred.resolve("cached-path");
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            "cached-path",
+            "cached-path",
+        ]);
+    });
+
+    it("clears a resolved flight so a later caller reruns the factory", async () => {
+        const inFlight = new Map<string, Promise<number>>();
+        const factory = jest
+            .fn<Promise<number>, []>()
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(2);
+
+        await expect(
+            coalesceInFlightByKey(inFlight, "key", factory),
+        ).resolves.toBe(1);
+        expect(inFlight.has("key")).toBe(false);
+        await expect(
+            coalesceInFlightByKey(inFlight, "key", factory),
+        ).resolves.toBe(2);
+        expect(factory).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates rejection to joiners and clears the rejected flight", async () => {
+        const inFlight = new Map<string, Promise<string>>();
+        const deferred = createDeferred<string>();
+        const error = new Error("factory failed");
+        const factory = jest
+            .fn<Promise<string>, []>()
+            .mockImplementationOnce(() => deferred.promise)
+            .mockResolvedValueOnce("recovered");
+
+        const first = coalesceInFlightByKey(inFlight, "key", factory);
+        const second = coalesceInFlightByKey(inFlight, "key", factory);
+        deferred.reject(error);
+
+        const results = await Promise.allSettled([first, second]);
+        expect(results).toEqual([
+            { status: "rejected", reason: error },
+            { status: "rejected", reason: error },
+        ]);
+        expect(inFlight.has("key")).toBe(false);
+        await expect(
+            coalesceInFlightByKey(inFlight, "key", factory),
+        ).resolves.toBe("recovered");
+        expect(factory).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not delete a replacement promise when an older flight settles", async () => {
+        const inFlight = new Map<string, Promise<string>>();
+        const deferred = createDeferred<string>();
+        const first = coalesceInFlightByKey(
+            inFlight,
+            "key",
+            () => deferred.promise,
+        );
+        const replacement = Promise.resolve("replacement");
+        inFlight.set("key", replacement);
+
+        deferred.resolve("original");
+        await expect(first).resolves.toBe("original");
+        expect(inFlight.get("key")).toBe(replacement);
+    });
+
+    it("invokes the coalesced-wait hook once per joining caller", async () => {
+        const inFlight = new Map<string, Promise<void>>();
+        const deferred = createDeferred<void>();
+        const onCoalescedWait = jest.fn();
+
+        const first = coalesceInFlightByKey(
+            inFlight,
+            "key",
+            () => deferred.promise,
+            { onCoalescedWait },
+        );
+        expect(onCoalescedWait).not.toHaveBeenCalled();
+        const second = coalesceInFlightByKey(inFlight, "key", jest.fn(), {
+            onCoalescedWait,
+        });
+        const third = coalesceInFlightByKey(inFlight, "key", jest.fn(), {
+            onCoalescedWait,
+        });
+
+        expect(onCoalescedWait).toHaveBeenCalledTimes(2);
+        deferred.resolve();
+        await Promise.all([first, second, third]);
+    });
+
+    it("runs factories independently for different keys", async () => {
+        const inFlight = new Map<string, Promise<string>>();
+        const firstFactory = jest.fn(async () => "first");
+        const secondFactory = jest.fn(async () => "second");
+
+        await expect(
+            Promise.all([
+                coalesceInFlightByKey(inFlight, "first", firstFactory),
+                coalesceInFlightByKey(inFlight, "second", secondFactory),
+            ]),
+        ).resolves.toEqual(["first", "second"]);
+        expect(firstFactory).toHaveBeenCalledTimes(1);
+        expect(secondFactory).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/utils/singleflight.ts
+++ b/backend/src/utils/singleflight.ts
@@ -1,0 +1,32 @@
+/** Options for joining keyed in-flight asynchronous work. */
+export interface SingleflightOptions {
+    /** Invoked when a caller joins an existing in-flight promise instead of starting a new one. */
+    onCoalescedWait?: () => void;
+}
+
+/**
+ * Coalesce concurrent asynchronous work by key within the provided map.
+ * The settled flight clears only its own map slot, preserving any replacement.
+ */
+export function coalesceInFlightByKey<T>(
+    inFlightMap: Map<string, Promise<T>>,
+    key: string,
+    factory: () => Promise<T>,
+    options?: SingleflightOptions,
+): Promise<T> {
+    const existingPromise = inFlightMap.get(key);
+    if (existingPromise) {
+        options?.onCoalescedWait?.();
+        return existingPromise;
+    }
+
+    const inFlightPromise = Promise.resolve()
+        .then(factory)
+        .finally(() => {
+            if (inFlightMap.get(key) === inFlightPromise) {
+                inFlightMap.delete(key);
+            }
+        });
+    inFlightMap.set(key, inFlightPromise);
+    return inFlightPromise;
+}


### PR DESCRIPTION
## Summary
- Promote the segmented-streaming session service's private identity-guarded keyed-singleflight into a shared, documented `backend/src/utils/singleflight.ts` helper (`coalesceInFlightByKey<T>` with an optional `onCoalescedWait` trace hook).
- Rethread the four hand-rolled copies onto it: `audioStreaming.transcodeToCache`, `vibe.getCachedOrComputeCalibration`, and both `ensureUserOAuth` twins (`youtubeMusic.ts`, `tidalStreaming.ts`). All slot deletes are now identity-guarded (an old flight's `finally` can no longer evict a newer in-flight slot).
- Align TIDAL's OAuth negative-result policy to YouTube Music's short-TTL negative cache (15s prod / 0 test), so non-linked users stop hitting sidecar+DB on every request.
- Bound the YouTube Music `/library/songs` and `/library/albums` `limit` query params to [1, 100] (OpenAPI schemas updated). A shared `parseBoundedInt` util can supersede the route-local parser when it lands.

## Behavior notes
- Session/streaming trace behavior is unchanged: `session.readiness.coalesced_wait` fires exactly when a caller joins an existing flight, with the same fields.
- Only intended behavior changes: tidal negative caching (policy alignment) and the bounded ytmusic limit params.

## Testing
- New behavioral suite `backend/src/utils/__tests__/singleflight.test.ts`: coalescing to one factory call, resolve/reject slot cleanup, rejection fan-out, identity guard preserving a replacement slot, per-joiner `onCoalescedWait`, key independence.
- Extended runtime suites: concurrent missing-OAuth requests coalesce to one sidecar check + one DB lookup (both ytmusic and tidal), and ytmusic limit bounding (500 → 100, -10 → 1).
- `tsc --noEmit` clean; targeted jest (`singleflight|sessionService|audioStreaming|vibe|youtubeMusic|tidal`): 23 suites, 379 tests, all passing after rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24