### PR TITLE
fix(ytmusic-streamer): offload blocking ytmusicapi calls off the event loop; cap batch search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The ytmusic-streamer playlist endpoint's public-browse and auth-fallback
+  paths, and the debug search endpoint, now offload blocking ytmusicapi calls
+  to the asyncio thread pool instead of stalling the event loop, and batch
+  search now rejects requests with more than 50 queries.
 - Outbound image fetches (external image proxy and podcast cover cache) now
   cancel undici response bodies on non-success, redirect, and retry paths so
   pooled connections are released promptly instead of waiting for GC.

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -196,6 +196,10 @@ YT_PLAYLIST_MAX_ENTRIES = max(1, env_int("YT_PLAYLIST_MAX_ENTRIES", "200"))
 # keeping usage respectful and within reasonable limits.
 # Tune them via environment variables to balance speed vs. safety.
 
+# Max queries accepted in a single batch search request.
+# Oversized batches are rejected with a 422 before any work starts.
+_BATCH_SEARCH_MAX_QUERIES = 50
+
 # Max concurrent InnerTube search requests in a batch (default: 3).
 # Prevents firing 50 simultaneous requests that look bot-like.
 BATCH_CONCURRENCY = env_int("YTMUSIC_BATCH_CONCURRENCY", "3")
@@ -1677,6 +1681,11 @@ async def search_batch(req: BatchSearchRequest, user_id: str = Query(...)):
     Rate-pacing: requests are throttled via _batch_semaphore and
     inter-request delays instead of firing all N simultaneously.
     """
+    if len(req.queries) > _BATCH_SEARCH_MAX_QUERIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Batch search accepts at most {_BATCH_SEARCH_MAX_QUERIES} queries",
+        )
 
     async def _run_one(q: BatchSearchQuery) -> dict:
         """Execute and sanitize one query in the batch."""
@@ -1733,7 +1742,7 @@ async def search_debug(req: SearchRequest, user_id: str = Query(...)):
     if req.filter == "songs":
         body["params"] = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
     try:
-        raw = yt._send_request("search", body)
+        raw = await asyncio.to_thread(yt._send_request, "search", body)
         return {"raw": raw}
     except Exception as e:
         raise _sanitized_http_error("Debug search", e, 500, "Debug search failed") from e
@@ -2958,9 +2967,11 @@ async def get_playlist(
                     user_id,
                     auth_err,
                 )
-                playlist = _get_public_ytmusic("native").get_playlist(playlist_id, limit=limit)
+                yt = _get_public_ytmusic("native")
+                playlist = await asyncio.to_thread(yt.get_playlist, playlist_id, limit=limit)
         else:
-            playlist = _get_public_ytmusic("native").get_playlist(playlist_id, limit=limit)
+            yt = _get_public_ytmusic("native")
+            playlist = await asyncio.to_thread(yt.get_playlist, playlist_id, limit=limit)
 
         tracks = []
         for t in playlist.get("tracks", []):

--- a/services/ytmusic-streamer/tests/test_blocking_offload.py
+++ b/services/ytmusic-streamer/tests/test_blocking_offload.py
@@ -65,6 +65,71 @@ async def test_charts_offloaded_to_worker_thread(client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_public_playlist_offloaded_to_worker_thread(client, monkeypatch):
+    """Public playlist work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def get_playlist(playlist_id, limit):
+        captured["t"] = threading.current_thread().name
+        return {"id": playlist_id, "title": "t", "tracks": []}
+
+    public_client = types.SimpleNamespace(get_playlist=get_playlist)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/playlist/x")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_playlist_auth_fallback_offloaded_to_worker_thread(client, monkeypatch):
+    """Public playlist fallback work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def fail_authenticated_fetch(*args, **kwargs):
+        raise RuntimeError("authenticated fetch failed")
+
+    def get_playlist(playlist_id, limit):
+        captured["t"] = threading.current_thread().name
+        return {"id": playlist_id, "title": "t", "tracks": []}
+
+    public_client = types.SimpleNamespace(get_playlist=get_playlist)
+    monkeypatch.setattr(app, "_run_ytmusic_with_auth_retry", fail_authenticated_fetch)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/playlist/x?user_id=u1")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_debug_search_offloaded_to_worker_thread(client, monkeypatch):
+    """Debug-search work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def send_request(endpoint, body):
+        captured["t"] = threading.current_thread().name
+        return {}
+
+    public_client = types.SimpleNamespace(_send_request=send_request)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.post("/search/debug?user_id=u1", json={"query": "x"})
+
+    assert response.status_code == 200
+    assert response.json() == {"raw": {}}
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
 async def test_device_code_offloaded_to_worker_thread(client, monkeypatch):
     """OAuth device-code initiation should run in an asyncio worker thread."""
     import app

--- a/services/ytmusic-streamer/tests/test_input_validation.py
+++ b/services/ytmusic-streamer/tests/test_input_validation.py
@@ -138,3 +138,47 @@ async def test_song_accepts_valid_video_id(client, monkeypatch):
     response = await client.get(f"/song/{VALID_ID}?user_id=__public__")
     assert response.status_code == 200
     assert response.json()["videoId"] == VALID_ID
+
+
+@pytest.mark.anyio
+async def test_batch_search_rejects_more_than_50_queries(client, monkeypatch):
+    """Batch search rejects oversized requests before search work starts."""
+    import app
+
+    calls = []
+
+    def fake_search(*args, **kwargs):
+        calls.append("called")
+        return [], "native"
+
+    monkeypatch.setattr(app, "_search_with_mode_fallback", fake_search)
+    queries = [{"query": f"query-{index}"} for index in range(51)]
+
+    response = await client.post("/search/batch?user_id=u1", json={"queries": queries})
+
+    assert response.status_code == 422
+    assert response.json() == {"error": "Batch search accepts at most 50 queries"}
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_batch_search_accepts_50_queries(client, monkeypatch):
+    """Batch search accepts requests at the configured query cap."""
+    import app
+
+    calls = []
+
+    def fake_search(*args, **kwargs):
+        calls.append("called")
+        return [], "native"
+
+    monkeypatch.setattr(app, "_search_with_mode_fallback", fake_search)
+    monkeypatch.setattr(app, "BATCH_DELAY_MIN", 0)
+    monkeypatch.setattr(app, "BATCH_DELAY_MAX", 0)
+    queries = [{"query": f"query-{index}"} for index in range(50)]
+
+    response = await client.post("/search/batch?user_id=u1", json={"queries": queries})
+
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 50
+    assert len(calls) == 50


### PR DESCRIPTION
## Summary

The ytmusic-streamer sidecar runs single-worker uvicorn, so any blocking ytmusicapi call executed directly in an `async def` handler stalls all concurrent stream/search traffic.

**Material fix** — `GET /playlist/{playlist_id}`: both the public-browse branch and the auth-failure fallback branch called `_get_public_ytmusic("native").get_playlist(...)` synchronously on the event loop, while the authenticated branch and every sibling endpoint (`get_album`, `get_home`, charts, moods) already use `await asyncio.to_thread(...)`. Both sites now offload via the same idiom.

**Class-close** (same file, same defect class):
- `POST /search/debug`: `yt._send_request("search", body)` was synchronous on the loop; now offloaded via `asyncio.to_thread`.
- `POST /search/batch`: `queries` was unbounded before `asyncio.gather`. Added `_BATCH_SEARCH_MAX_QUERIES = 50` (matching tidal-downloader's cap from #283) rejecting oversized batches with a 422 before any work starts.

No behavior change beyond non-blocking execution and the batch cap; all error handling preserved.

## Tests

- `tests/test_blocking_offload.py`: public playlist path, auth-fallback playlist path, and debug search each verified to run off the main thread (existing suite pattern).
- `tests/test_input_validation.py`: 51 queries → 422 with no search work started; 50 queries → 200 with all executed.

## Verification

- `pytest tests/test_blocking_offload.py tests/test_input_validation.py -q` — 23 passed
- `ruff check` / `ruff format --check` on touched files — clean
- `mypy` (repo config) — no issues in the touched sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24