### PR TITLE
perf(subsonic): collapse playlist-duration N+1 into a single grouped query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Subsonic `getPlaylists` endpoint now computes playlist durations with a
+  single query over playlist items instead of one aggregate query per playlist,
+  removing an unbounded N+1 fan-out that could saturate the database connection
+  pool for users with many playlists.
 - Promoted the segmented-streaming session service's identity-guarded
   keyed-singleflight into a shared backend helper and rethreaded transcode
   caching, vibe calibration, and both the YouTube Music and TIDAL OAuth-restore

--- a/backend/src/routes/__tests__/subsonicCollectionsCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicCollectionsCompat.test.ts
@@ -199,10 +199,21 @@ describe("subsonic collections/core compatibility handlers", () => {
                 },
             },
         ]);
-        mockTrackAggregate.mockResolvedValue({ _sum: { duration: 300 } });
-        mockPlaylistItemFindMany.mockResolvedValue([
-            { playlistId: "playlist-1" },
-        ]);
+        mockPlaylistItemFindMany.mockImplementation((args) => {
+            if (args.where.trackId) {
+                return Promise.resolve([
+                    {
+                        playlistId: "playlist-1",
+                        track: { duration: 120 },
+                    },
+                    {
+                        playlistId: "playlist-1",
+                        track: { duration: 180 },
+                    },
+                ]);
+            }
+            return Promise.resolve([{ playlistId: "playlist-1" }]);
+        });
 
         await handleGetPlaylists(buildReq({}), buildRes());
 
@@ -213,16 +224,18 @@ describe("subsonic collections/core compatibility handlers", () => {
             include: { _count: { select: { items: true } } },
         });
         expect(playlistQuery.include).not.toHaveProperty("items");
-        expect(mockTrackAggregate).toHaveBeenCalledTimes(1);
-        expect(mockTrackAggregate).toHaveBeenCalledWith({
+        expect(mockTrackAggregate).not.toHaveBeenCalled();
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(2);
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledWith({
             where: {
-                playlistItems: {
-                    some: { playlistId: "playlist-1" },
-                },
+                playlistId: { in: ["playlist-1"] },
+                trackId: { not: null },
             },
-            _sum: { duration: true },
+            select: {
+                playlistId: true,
+                track: { select: { duration: true } },
+            },
         });
-        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(1);
         expect(mockPlaylistItemFindMany).toHaveBeenCalledWith({
             where: {
                 playlistId: { in: ["playlist-1", "playlist-2"] },
@@ -265,6 +278,68 @@ describe("subsonic collections/core compatibility handlers", () => {
         );
     });
 
+    it("loads all playlist durations with one query", async () => {
+        mockPlaylistFindMany.mockResolvedValue([
+            {
+                id: "playlist-a",
+                name: "Playlist A",
+                isPublic: false,
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                _count: { items: 2 },
+            },
+            {
+                id: "playlist-b",
+                name: "Playlist B",
+                isPublic: false,
+                createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                _count: { items: 1 },
+            },
+            {
+                id: "playlist-c",
+                name: "Playlist C",
+                isPublic: false,
+                createdAt: new Date("2026-01-03T00:00:00.000Z"),
+                _count: { items: 0 },
+            },
+        ]);
+        mockPlaylistItemFindMany.mockImplementation((args) => {
+            if (args.where.trackId) {
+                return Promise.resolve([
+                    { playlistId: "playlist-a", track: { duration: 100 } },
+                    { playlistId: "playlist-a", track: { duration: 150 } },
+                    { playlistId: "playlist-b", track: { duration: 40 } },
+                    { playlistId: "playlist-b", track: null },
+                ]);
+            }
+            return Promise.resolve([]);
+        });
+
+        await handleGetPlaylists(buildReq({}), buildRes());
+
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(2);
+        expect(mockTrackAggregate).not.toHaveBeenCalled();
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledWith({
+            where: {
+                playlistId: { in: ["playlist-a", "playlist-b"] },
+                trackId: { not: null },
+            },
+            select: {
+                playlistId: true,
+                track: { select: { duration: true } },
+            },
+        });
+        const playlists = (
+            mockSendSuccess.mock.calls[0][1] as {
+                playlists: { playlist: Array<Record<string, unknown>> };
+            }
+        ).playlists.playlist;
+        expect(playlists).toEqual([
+            expect.objectContaining({ id: "pl-playlist-a", duration: 250 }),
+            expect.objectContaining({ id: "pl-playlist-b", duration: 40 }),
+            expect.objectContaining({ id: "pl-playlist-c", duration: 0 }),
+        ]);
+    });
+
     it("returns generic error when getPlaylists query fails", async () => {
         mockPlaylistFindMany.mockResolvedValueOnce([
             {
@@ -275,7 +350,12 @@ describe("subsonic collections/core compatibility handlers", () => {
                 _count: { items: 1 },
             },
         ]);
-        mockTrackAggregate.mockRejectedValueOnce(new Error("boom"));
+        mockPlaylistItemFindMany.mockImplementation((args) => {
+            if (args.where.trackId) {
+                return Promise.reject(new Error("boom"));
+            }
+            return Promise.resolve([]);
+        });
 
         await handleGetPlaylists(buildReq({}), buildRes());
 

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -958,10 +958,21 @@ describe("subsonic Tier B handlers", () => {
                 },
             },
         ]);
-        mockTrackAggregate.mockResolvedValue({ _sum: { duration: 165 } });
-        mockPlaylistItemFindMany.mockResolvedValue([
-            { playlistId: "playlist-1" },
-        ]);
+        mockPlaylistItemFindMany.mockImplementation((args) => {
+            if (args.where.trackId) {
+                return Promise.resolve([
+                    {
+                        playlistId: "playlist-1",
+                        track: { duration: 100 },
+                    },
+                    {
+                        playlistId: "playlist-1",
+                        track: { duration: 65 },
+                    },
+                ]);
+            }
+            return Promise.resolve([{ playlistId: "playlist-1" }]);
+        });
 
         await handleGetPlaylists(buildReq({}), buildRes());
 
@@ -972,16 +983,18 @@ describe("subsonic Tier B handlers", () => {
             include: { _count: { select: { items: true } } },
         });
         expect(playlistQuery.include).not.toHaveProperty("items");
-        expect(mockTrackAggregate).toHaveBeenCalledTimes(1);
-        expect(mockTrackAggregate).toHaveBeenCalledWith({
+        expect(mockTrackAggregate).not.toHaveBeenCalled();
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(2);
+        expect(mockPlaylistItemFindMany).toHaveBeenCalledWith({
             where: {
-                playlistItems: {
-                    some: { playlistId: "playlist-1" },
-                },
+                playlistId: { in: ["playlist-1"] },
+                trackId: { not: null },
             },
-            _sum: { duration: true },
+            select: {
+                playlistId: true,
+                track: { select: { duration: true } },
+            },
         });
-        expect(mockPlaylistItemFindMany).toHaveBeenCalledTimes(1);
         expect(mockPlaylistItemFindMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 distinct: ["playlistId"],

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -5195,26 +5195,30 @@ async function resolveStarMutationTrackIds(input: {
 async function getPlaylistDurations(
     playlists: Array<{ id: string; _count: { items: number } }>,
 ): Promise<Map<string, number>> {
-    const nonEmptyPlaylists = playlists.filter(
-        (playlist) => playlist._count.items > 0,
-    );
-    const durationRows = await Promise.all(
-        nonEmptyPlaylists.map(async (playlist) => ({
-            playlistId: playlist.id,
-            aggregate: await prisma.track.aggregate({
-                where: {
-                    playlistItems: { some: { playlistId: playlist.id } },
-                },
-                _sum: { duration: true },
-            }),
-        })),
-    );
-    return new Map(
-        durationRows.map(({ playlistId, aggregate }) => [
-            playlistId,
-            aggregate._sum.duration ?? 0,
-        ]),
-    );
+    const nonEmptyIds = playlists
+        .filter((playlist) => playlist._count.items > 0)
+        .map((playlist) => playlist.id);
+    if (nonEmptyIds.length === 0) {
+        return new Map();
+    }
+    const rows = await prisma.playlistItem.findMany({
+        where: {
+            playlistId: { in: nonEmptyIds },
+            trackId: { not: null },
+        },
+        select: {
+            playlistId: true,
+            track: { select: { duration: true } },
+        },
+    });
+    const durations = new Map<string, number>();
+    for (const row of rows) {
+        durations.set(
+            row.playlistId,
+            (durations.get(row.playlistId) ?? 0) + (row.track?.duration ?? 0),
+        );
+    }
+    return durations;
 }
 
 async function getPlaylistCoverFlags(


### PR DESCRIPTION
## Summary
- `getPlaylistDurations` in `backend/src/routes/subsonic.ts` issued one `prisma.track.aggregate` per non-empty playlist via `Promise.all`, and `handleGetPlaylists` fetches all of a user's playlists with no `take` — so query concurrency scaled linearly with playlist count, saturating the Prisma pool when Subsonic clients (Symfonium/DSub) poll `getPlaylists`.
- Replaced the fan-out with a single `prisma.playlistItem.findMany` filtered to the non-empty playlist ids (`trackId: { not: null }`), selecting `playlistId` + `track.duration`, summed per playlist in JS — mirroring the single-query pattern already used by the adjacent `getPlaylistCoverFlags`.
- Semantics preserved exactly: `@@unique([playlistId, trackId])` makes the per-item sum equivalent to the old distinct-track aggregate; tidal/ytmusic-only items remain excluded; empty playlists still render `duration: 0`; errors still propagate to the generic Subsonic error path. Prisma `groupBy` cannot sum a relation field, and AGENTS.md mandates Prisma over raw SQL for anything Prisma can express, hence findMany + in-process sum.

## Testing
- Updated the two suites that asserted the old per-playlist aggregate shape and added a behavioral test proving exactly one durations query regardless of playlist count (2 non-empty + 1 empty playlist, correct per-playlist sums, zero `track.aggregate` calls, defensive `track: null` row).
- `jest subsonic --maxWorkers=2`: 19 suites, 350 tests passed.
- `tsc --noEmit` (backend): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24