### PR TITLE
fix(scan): remove missing-on-disk tracks when library deletion is allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sessions could block schema migrations needing an `AccessExclusiveLock` on
   `Track`, queueing all later queries behind the migration and exhausting the
   backend connection pools during upgrades. (#224)
+- Library scans now reconcile the database with disk: whether or not the
+  admin "Allow library deletion" checkbox is enabled, a scanned track that is
+  missing from disk is removed from the database, counted in the scan's
+  removed total, and orphaned albums and artists are cleaned up. That checkbox
+  only prevents deletion of tracks-on-disk via the UI. As a safeguard, a scan
+  that finds zero audio files while the database still has tracks (for
+  example an unmounted music volume) skips removal and keeps the flag-only
+  Library Health behavior
+  ([#309](https://github.com/BonzTM/soundspan/issues/309)).
 - The ytmusic-streamer playlist endpoint's public-browse and auth-fallback
   paths, and the debug search endpoint, now offload blocking ytmusicapi calls
   to the asyncio thread pool instead of stalling the event loop, and batch

--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -515,6 +515,129 @@ describe("MusicScannerService.scanLibrary", () => {
         expect(mockParseFile).not.toHaveBeenCalled();
     });
 
+    it("removes missing tracks and cleans up orphans when library deletion is enabled", async () => {
+        const scanner = new MusicScannerService();
+
+        mockPrisma.systemSettings.findFirst.mockResolvedValue({
+            discNoBackfillDone: true,
+            libraryDeletionEnabled: true,
+        });
+        jest.spyOn(
+            MusicScannerService.prototype as any,
+            "findAudioFiles",
+        ).mockResolvedValue(["/music/Present/Track.mp3"]);
+        mockPrisma.track.findMany.mockResolvedValue([
+            {
+                id: "track-missing-1",
+                filePath: "Missing/Track.mp3",
+                fileModified: new Date("2026-01-01T00:00:00.000Z"),
+            },
+            {
+                id: "track-present-1",
+                filePath: "Present/Track.mp3",
+                fileModified: new Date("2026-02-02T00:00:00.000Z"),
+            },
+        ]);
+        mockPrisma.track.deleteMany.mockResolvedValue({ count: 1 });
+        mockPrisma.album.findMany.mockResolvedValue([
+            { id: "album-orphan-1", title: "Old Album" },
+        ]);
+        mockPrisma.artist.findMany.mockResolvedValue([
+            { id: "artist-orphan-1", name: "Old Artist" },
+        ]);
+
+        const result = await scanner.scanLibrary("/music");
+
+        expect(mockPrisma.track.deleteMany).toHaveBeenCalledWith({
+            where: { id: { in: ["track-missing-1"] } },
+        });
+        expect(result.tracksRemoved).toBe(1);
+        expect(mockPrisma.libraryHealthRecord.upsert).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({
+                    trackId: "track-missing-1",
+                    status: "MISSING_FROM_DISK",
+                }),
+            }),
+        );
+        expect(mockPrisma.album.deleteMany).toHaveBeenCalledWith({
+            where: { id: { in: ["album-orphan-1"] } },
+        });
+        expect(mockPrisma.artist.deleteMany).toHaveBeenCalledWith({
+            where: { id: { in: ["artist-orphan-1"] } },
+        });
+    });
+
+    it("removes missing tracks even when library deletion is disabled", async () => {
+        const scanner = new MusicScannerService();
+
+        mockPrisma.systemSettings.findFirst.mockResolvedValue({
+            discNoBackfillDone: true,
+            libraryDeletionEnabled: false,
+        });
+        jest.spyOn(
+            MusicScannerService.prototype as any,
+            "findAudioFiles",
+        ).mockResolvedValue(["/music/Present/Track.mp3"]);
+        mockPrisma.track.findMany.mockResolvedValue([
+            {
+                id: "track-missing-1",
+                filePath: "Missing/Track.mp3",
+                fileModified: new Date("2026-01-01T00:00:00.000Z"),
+            },
+            {
+                id: "track-present-1",
+                filePath: "Present/Track.mp3",
+                fileModified: new Date("2026-02-02T00:00:00.000Z"),
+            },
+        ]);
+        mockPrisma.track.deleteMany.mockResolvedValue({ count: 1 });
+
+        const result = await scanner.scanLibrary("/music");
+
+        expect(mockPrisma.track.deleteMany).toHaveBeenCalledWith({
+            where: { id: { in: ["track-missing-1"] } },
+        });
+        expect(result.tracksRemoved).toBe(1);
+        expect(mockPrisma.libraryHealthRecord.upsert).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({
+                    trackId: "track-missing-1",
+                    status: "MISSING_FROM_DISK",
+                }),
+            }),
+        );
+    });
+
+    it("does not delete missing tracks when no audio files are found", async () => {
+        const scanner = new MusicScannerService();
+
+        jest.spyOn(
+            MusicScannerService.prototype as any,
+            "findAudioFiles",
+        ).mockResolvedValue([]);
+        mockPrisma.track.findMany.mockResolvedValue([
+            {
+                id: "track-missing-1",
+                filePath: "Missing/Track.mp3",
+                fileModified: new Date("2026-01-01T00:00:00.000Z"),
+            },
+        ]);
+
+        const result = await scanner.scanLibrary("/music");
+
+        expect(mockPrisma.track.deleteMany).not.toHaveBeenCalled();
+        expect(mockPrisma.libraryHealthRecord.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({
+                    trackId: "track-missing-1",
+                    status: "MISSING_FROM_DISK",
+                }),
+            }),
+        );
+        expect(result.tracksRemoved).toBe(0);
+    });
+
     it("collects file processing errors and continues scan completion", async () => {
         const scanner = new MusicScannerService();
         const audioFile = "/music/Broken/Bad.flac";

--- a/backend/src/services/musicScanner.ts
+++ b/backend/src/services/musicScanner.ts
@@ -107,6 +107,42 @@ export class MusicScannerService {
         });
     }
 
+    private async markMissingTracks(
+        tracks: Array<{ id: string; filePath: string }>,
+    ): Promise<void> {
+        await Promise.all(
+            tracks.map((track) =>
+                this.markTrackHealthIssue(
+                    track.id,
+                    "MISSING_FROM_DISK",
+                    track.filePath,
+                ),
+            ),
+        );
+        logger.debug(
+            `Recorded ${tracks.length} missing tracks in library health`,
+        );
+    }
+
+    private async handleMissingTracks(
+        tracks: Array<{ id: string; filePath: string }>,
+        audioFileCount: number,
+    ): Promise<number> {
+        if (audioFileCount === 0) {
+            await this.markMissingTracks(tracks);
+            logger.warn(
+                "Skipped removing missing tracks because no audio files were found; the music directory may be unavailable",
+            );
+            return 0;
+        }
+
+        const deleted = await prisma.track.deleteMany({
+            where: { id: { in: tracks.map((track) => track.id) } },
+        });
+        logger.info(`Removed ${deleted.count} missing tracks from the library`);
+        return deleted.count;
+    }
+
     /**
      * Scan the music directory and update the database
      */
@@ -223,7 +259,7 @@ export class MusicScannerService {
 
         await this.scanQueue.onIdle();
 
-        // Step 4: Record health issues for tracked files that no longer exist
+        // Step 4: Handle tracked files that no longer exist
         const scannedPaths = new Set(
             audioFiles.map((f) => path.relative(musicPath, f)),
         );
@@ -232,19 +268,14 @@ export class MusicScannerService {
         );
 
         if (tracksToRemove.length > 0) {
-            await Promise.all(
-                tracksToRemove.map((track) =>
-                    this.markTrackHealthIssue(
-                        track.id,
-                        "MISSING_FROM_DISK",
-                        track.filePath,
-                    ),
-                ),
-            );
-            logger.debug(
-                `Recorded ${tracksToRemove.length} missing tracks in library health`,
+            result.tracksRemoved = await this.handleMissingTracks(
+                tracksToRemove,
+                audioFiles.length,
             );
         }
+
+        const shouldCleanOrphans =
+            tracksToRemove.length === 0 || result.tracksRemoved > 0;
 
         // Step 5: Clean up orphaned albums (albums with no tracks)
         const orphanedAlbums = await prisma.album.findMany({
@@ -254,7 +285,7 @@ export class MusicScannerService {
             select: { id: true, title: true },
         });
 
-        if (tracksToRemove.length === 0 && orphanedAlbums.length > 0) {
+        if (shouldCleanOrphans && orphanedAlbums.length > 0) {
             logger.debug(
                 `Removing ${orphanedAlbums.length} orphaned albums...`,
             );
@@ -273,7 +304,7 @@ export class MusicScannerService {
             select: { id: true, name: true },
         });
 
-        if (tracksToRemove.length === 0 && orphanedArtists.length > 0) {
+        if (shouldCleanOrphans && orphanedArtists.length > 0) {
             logger.debug(
                 `Removing ${
                     orphanedArtists.length


### PR DESCRIPTION
Root cause: `MusicScannerService.scanLibrary` Step 4 computed the set of DB tracks whose files no longer exist on disk but only upserted `MISSING_FROM_DISK` Library Health records — it never deleted the `Track` rows and never incremented `tracksRemoved`, so scans always reported "removed 0" and out-of-band file deletions were never reconciled.

Contract (owner-confirmed): "The library protection/deletion flag in the admin UI is only there to prevent deletion of tracks-on-disk via the UI. Whether that checkbox is enabled or not, the deletion policy is the same when a scanned track is missing from disk: it is removed from the database."

Fix: library scans now reconcile the database with disk by default. Missing-on-disk tracks are removed via `prisma.track.deleteMany` (schema-level cascades clean up health records, playlist memberships, etc., matching the in-app delete path), counted in the scan's "removed N" total, and albums/artists emptied by the removal are cleaned up. The only guard is catastrophic: a scan that finds zero audio files while the DB still has tracks (e.g. an unmounted music volume) skips removal and keeps the flag-only Library Health behavior. The "Allow library deletion" setting continues to gate only the in-app UI file-deletion routes, which are untouched.

Tests: removal asserted with the admin flag both enabled and disabled (plus orphan cleanup), and the zero-audio-files guard case; the pre-existing flag-only zero-files test still passes via the guard.

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24