### PR TITLE
fix(security): reject newline injection in .env writes and validate URL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,6 +594,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `.env` settings sync now rejects any value containing a line break, closing
+  an env-line injection where an app admin could append arbitrary environment
+  variables to the deployment `.env`; Lidarr and Audiobookshelf URL settings
+  are now validated as URLs at the API boundary.
 - Enforced media-root containment through the shared `safeResolvePath` helper
   for segmented-streaming session creation, self-heal, and playback repair;
   library audio-info probes; file-validator checks; and artist/discovery

--- a/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
@@ -805,6 +805,58 @@ describe("systemSettings runtime routes", () => {
         expect(res.body.error).toBe("Invalid settings");
     });
 
+    it("returns 400 for an invalid Lidarr URL", async () => {
+        const req = { body: { lidarrUrl: "not a url" } } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(mockSystemSettingsUpsert).not.toHaveBeenCalled();
+        expect(mockWriteEnvFile).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for a Lidarr URL containing a newline", async () => {
+        const req = {
+            body: { lidarrUrl: "http://lidarr:8686\nEVIL=1" },
+        } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(mockSystemSettingsUpsert).not.toHaveBeenCalled();
+        expect(mockWriteEnvFile).not.toHaveBeenCalled();
+    });
+
+    it("preserves empty-string Lidarr URL clear semantics", async () => {
+        const req = { body: { lidarrUrl: "" } } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(mockSystemSettingsUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                update: expect.objectContaining({ lidarrUrl: "" }),
+            }),
+        );
+        expect(mockWriteEnvFile).toHaveBeenCalledWith(
+            expect.objectContaining({ LIDARR_URL: null }),
+        );
+    });
+
+    it("returns 400 for an invalid Audiobookshelf URL", async () => {
+        const req = { body: { audiobookshelfUrl: "not a url" } } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(mockSystemSettingsUpsert).not.toHaveBeenCalled();
+        expect(mockWriteEnvFile).not.toHaveBeenCalled();
+    });
+
     it("continues successfully when env sync is skipped", async () => {
         mockWriteEnvFile.mockRejectedValue(
             new EnvFileSyncSkippedError("containerized env"),

--- a/backend/src/routes/systemSettings.ts
+++ b/backend/src/routes/systemSettings.ts
@@ -49,7 +49,7 @@ router.use(requireAdmin);
 const systemSettingsSchema = z.object({
     // Download Services
     lidarrEnabled: z.boolean().optional(),
-    lidarrUrl: z.string().optional(),
+    lidarrUrl: z.string().url().optional().or(z.literal("")),
     lidarrApiKey: z.string().nullable().optional(),
     lidarrWebhookSecret: z.string().nullable().optional(),
 
@@ -66,7 +66,7 @@ const systemSettingsSchema = z.object({
 
     // Media Services
     audiobookshelfEnabled: z.boolean().optional(),
-    audiobookshelfUrl: z.string().optional(),
+    audiobookshelfUrl: z.string().url().optional().or(z.literal("")),
     audiobookshelfApiKey: z.string().nullable().optional(),
 
     // Soulseek (direct connection via slsk-client)

--- a/backend/src/utils/__tests__/envWriter.test.ts
+++ b/backend/src/utils/__tests__/envWriter.test.ts
@@ -135,6 +135,77 @@ describe("envWriter", () => {
         expect(written).toContain("EXTERNAL_API_URL=https://api.example");
     });
 
+    it("rejects newline injection without reading or writing the env file", async () => {
+        process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
+        const injectedValue =
+            "http://lidarr:8686\nLIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true";
+
+        const error = await writeEnvFile({
+            LIDARR_URL: injectedValue,
+        }).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error).not.toBeInstanceOf(EnvFileSyncSkippedError);
+        if (!(error instanceof Error)) {
+            throw new Error("Expected writeEnvFile to reject with an Error");
+        }
+        expect(error.message).toContain("LIDARR_URL");
+        expect(error.message).not.toContain(injectedValue);
+        expect(error.message).not.toContain(
+            "LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true",
+        );
+        expect(mockReadFileSync).not.toHaveBeenCalled();
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(mockRenameSync).not.toHaveBeenCalled();
+    });
+
+    it("rejects carriage-return injection without writing the env file", async () => {
+        process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
+
+        await expect(
+            writeEnvFile({
+                LIDARR_URL: "http://lidarr:8686\rEVIL=1",
+            }),
+        ).rejects.toThrow(
+            "Refusing to write .env: value for LIDARR_URL contains a line break",
+        );
+        expect(mockReadFileSync).not.toHaveBeenCalled();
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(mockRenameSync).not.toHaveBeenCalled();
+    });
+
+    it("asserts environment variable key syntax before filesystem access", async () => {
+        process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
+
+        await expect(writeEnvFile({ "INVALID-KEY": "value" })).rejects.toEqual(
+            expect.objectContaining({
+                name: "AssertionError",
+                message: "Invalid environment variable name",
+            }),
+        );
+        expect(mockReadFileSync).not.toHaveBeenCalled();
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(mockRenameSync).not.toHaveBeenCalled();
+    });
+
+    it("writes values with non-line-break special characters unchanged", async () => {
+        process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
+        mockReadFileSync.mockImplementation(() => {
+            throw new Error("ENOENT");
+        });
+        const url = "https://api.example/search?q=rock+roll&limit=10";
+        const secret = "value=with equals and spaces";
+
+        await writeEnvFile({
+            EXTERNAL_API_URL: url,
+            SESSION_SECRET: secret,
+        });
+
+        const written = String(mockWriteFileSync.mock.calls[0][1]);
+        expect(written).toContain(`EXTERNAL_API_URL=${url}`);
+        expect(written).toContain(`SESSION_SECRET=${secret}`);
+    });
+
     it("writes integration secret keys when DB-only mode is off", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         mockReadFileSync.mockImplementation(() => {

--- a/backend/src/utils/envWriter.ts
+++ b/backend/src/utils/envWriter.ts
@@ -9,6 +9,7 @@ import {
 } from "../config/secretsPolicy";
 
 const log = logger.child("EnvWriter");
+const ENV_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const STALE_ENV_SYNC_KEYS = [
     "SOULSEEK_USERNAME",
@@ -64,6 +65,26 @@ function shouldSkipEnvSync(envPath: string): string | null {
     return null;
 }
 
+function assertSafeEnvVariables(
+    variables: Record<string, string | null | undefined>,
+): void {
+    assert.ok(
+        variables && typeof variables === "object" && !Array.isArray(variables),
+        "variables must be an environment variable record",
+    );
+    Object.entries(variables).forEach(([key, value]) => {
+        assert.ok(
+            ENV_VARIABLE_NAME_PATTERN.test(key),
+            "Invalid environment variable name",
+        );
+        if (typeof value === "string" && /[\r\n]/.test(value)) {
+            throw new Error(
+                `Refusing to write .env: value for ${key} contains a line break`,
+            );
+        }
+    });
+}
+
 function atomicWriteFileSecret(targetPath: string, content: string): void {
     assert.strictEqual(
         typeof targetPath,
@@ -112,6 +133,8 @@ export async function writeEnvFile(
         log.debug(`Skipping .env sync: ${skipReason}`);
         throw new EnvFileSyncSkippedError(skipReason);
     }
+
+    assertSafeEnvVariables(variables);
 
     // Read existing .env
     let existingContent = "";


### PR DESCRIPTION
## Summary

Closes an env-line injection across the app-admin → deployment-config boundary.

- **Primary choke point (`backend/src/utils/envWriter.ts`)**: `writeEnvFile` now rejects any value containing `\r` or `\n` before touching the filesystem, throwing a key-only error (values — which include secrets — are never embedded in errors or logs). Env-var key names are also asserted against standard naming. Previously a value containing a newline wrote arbitrary additional `KEY=value` lines into the repo-root `.env` consumed by dotenv/docker-compose on next restart, letting an app-level admin flip fail-closed env defaults (e.g. `LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED`, `ALLOWED_ORIGINS`) or override `SESSION_SECRET`/`DATABASE_URL`.
- **Defense in depth (`backend/src/routes/systemSettings.ts`)**: `lidarrUrl` and `audiobookshelfUrl` are now validated with `z.string().url().optional().or(z.literal(""))` (the established pattern from `onboarding.ts`), preserving the existing empty-string clear semantics and Docker-internal hostnames like `http://lidarr:8686`.
- CHANGELOG updated under Unreleased → Security.

## Tests

- `envWriter.test.ts`: newline and carriage-return values reject before any read/write, error message names the key but never leaks the value, rejection is not the benign `EnvFileSyncSkippedError`, key-syntax assertion, and special-character values without line breaks still write unchanged.
- `systemSettingsRuntime.test.ts`: 400 on invalid/newline-bearing URLs (upsert and env sync never invoked), empty-string clear path still succeeds.

## Verification

- `npm --prefix backend test -- envWriter systemSettings --maxWorkers=2` — 3 suites, 76 tests passed
- `npx tsc --noEmit` (backend) — clean
- `npm run verify:gates` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24