### PR TITLE
fix(enrichment): clamp GET /failures limit via shared bounded-int parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Clamp `GET /api/enrichment/failures` `limit`/`offset` through the shared bounded-int parser so oversized or non-numeric values can no longer trigger whole-table loads or Prisma 500s.
 - Bounded the missing-track health-record writes in the scanner and file
   validator so an unavailable music mount no longer fans out one concurrent
   upsert per track and exhausts the worker database pool (hardens the #319

--- a/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
@@ -1,0 +1,184 @@
+import express, { Request, Response } from "express";
+import request from "supertest";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/enrichment", () => ({
+    enrichmentService: {
+        getSettings: jest.fn(),
+        updateSettings: jest.fn(),
+        enrichArtist: jest.fn(),
+        applyArtistEnrichment: jest.fn(),
+        enrichAlbum: jest.fn(),
+        applyAlbumEnrichment: jest.fn(),
+    },
+}));
+
+jest.mock("../../workers/unifiedEnrichment", () => ({
+    getEnrichmentProgress: jest.fn(),
+    runFullEnrichment: jest.fn(),
+    reRunArtistsOnly: jest.fn(),
+    reRunMoodTagsOnly: jest.fn(),
+    reRunAudioAnalysisOnly: jest.fn(),
+    reRunVibeEmbeddingsOnly: jest.fn(),
+    triggerEnrichmentNow: jest.fn(),
+}));
+
+jest.mock("../../services/enrichmentState", () => ({
+    enrichmentStateService: {
+        getState: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        stop: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/enrichmentFailureService", () => ({
+    enrichmentFailureService: {
+        getFailures: jest.fn(),
+        getFailureCounts: jest.fn(),
+        resetRetryCount: jest.fn(),
+        getFailure: jest.fn(),
+        resolveFailures: jest.fn(),
+        skipFailures: jest.fn(),
+        clearAllFailures: jest.fn(),
+        deleteFailures: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/musicbrainz", () => ({
+    musicBrainzService: {
+        searchArtist: jest.fn(),
+        searchReleaseGroups: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+    invalidateSystemSettingsCache: jest.fn(),
+}));
+
+jest.mock("../../services/rateLimiter", () => ({
+    rateLimiter: {
+        updateConcurrencyMultiplier: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        del: jest.fn(),
+    },
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        features: {
+            audioAnalysis: true,
+            discovery: true,
+            autoPlaylists: true,
+        },
+    },
+}));
+
+const prisma = {
+    artist: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+    },
+    album: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+    },
+    track: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+    },
+    systemSettings: {
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+    },
+    ownedAlbum: {
+        deleteMany: jest.fn(),
+        upsert: jest.fn(),
+    },
+    user: {
+        findMany: jest.fn(async () => []),
+    },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+import router from "../enrichment";
+import { enrichmentFailureService } from "../../services/enrichmentFailureService";
+
+const mockGetFailures = enrichmentFailureService.getFailures as jest.Mock;
+const app = express();
+app.use("/api/enrichment", router);
+
+describe("GET /api/enrichment/failures bounded query parameters", () => {
+    beforeEach(() => {
+        mockGetFailures.mockResolvedValue({ failures: [], total: 0 });
+    });
+
+    it("uses the default limit for a non-numeric value", async () => {
+        const response = await request(app).get(
+            "/api/enrichment/failures?limit=abc",
+        );
+
+        expect(response.status).toBe(200);
+        expect(mockGetFailures).toHaveBeenCalledWith({
+            limit: 100,
+            offset: 0,
+        });
+    });
+
+    it("clamps an oversized limit", async () => {
+        await request(app).get("/api/enrichment/failures?limit=100000000");
+
+        expect(mockGetFailures).toHaveBeenCalledWith({
+            limit: 100,
+            offset: 0,
+        });
+    });
+
+    it("preserves valid limit and offset values", async () => {
+        await request(app).get("/api/enrichment/failures?limit=25&offset=50");
+
+        expect(mockGetFailures).toHaveBeenCalledWith({
+            limit: 25,
+            offset: 50,
+        });
+    });
+
+    it("uses service-compatible defaults when parameters are omitted", async () => {
+        await request(app).get("/api/enrichment/failures");
+
+        expect(mockGetFailures).toHaveBeenCalledWith({
+            limit: 100,
+            offset: 0,
+        });
+    });
+
+    it("clamps a negative offset to zero", async () => {
+        await request(app).get("/api/enrichment/failures?offset=-5");
+
+        expect(mockGetFailures).toHaveBeenCalledWith({
+            limit: 100,
+            offset: 0,
+        });
+    });
+});

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -27,6 +27,7 @@ import { redisClient } from "../utils/redis";
 import { prisma } from "../utils/db";
 import { config } from "../config";
 import { sendFeatureDisabled } from "../utils/featureGate";
+import { parseBoundedInt } from "../utils/queryParams";
 import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
@@ -971,10 +972,16 @@ router.get("/search/musicbrainz/release-groups", async (req, res) => {
  *         name: limit
  *         schema:
  *           type: integer
+ *           default: 100
+ *           minimum: 1
+ *           maximum: 100
  *       - in: query
  *         name: offset
  *         schema:
  *           type: integer
+ *           default: 0
+ *           minimum: 0
+ *           maximum: 1000000
  *     responses:
  *       200:
  *         description: List of enrichment failures
@@ -994,8 +1001,8 @@ router.get("/failures", async (req, res) => {
         if (entityType) options.entityType = entityType as string;
         if (includeSkipped === "true") options.includeSkipped = true;
         if (includeResolved === "true") options.includeResolved = true;
-        if (limit) options.limit = parseInt(limit as string);
-        if (offset) options.offset = parseInt(offset as string);
+        options.limit = parseBoundedInt(req.query.limit, 100, 1, 100);
+        options.offset = parseBoundedInt(req.query.offset, 0, 0, 1_000_000);
 
         const result = await enrichmentFailureService.getFailures(options);
         res.json(result);


### PR DESCRIPTION
## Summary
- `GET /api/enrichment/failures` was the one list endpoint missed by the #300/#313/#321 bounded-int sweep: `limit`/`offset` went through bare `parseInt` with no clamp, reaching Prisma verbatim as `take`/`skip`. `?limit=100000000` loaded the whole table (memory DoS); `?limit=abc` produced `take: NaN` and a Prisma 500.
- Route both params through the shared `parseBoundedInt` helper (`backend/src/utils/queryParams.ts`), matching the sibling-route idiom: `limit` defaults to 100, clamped 1..100 (service default preserved); `offset` defaults to 0, clamped 0..1,000,000.
- Documented the bounds in the OpenAPI block and added five behavioral supertest cases (`non-numeric → default`, `oversized → clamped`, `valid passthrough`, `omitted → defaults`, `negative offset → 0`).

## Testing
- verify: `npm --prefix backend test -- enrichment --maxWorkers=2` — 17 suites / 245 tests passed
- verify: `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24