### PR TITLE
fix(ytmusic-streamer): offload and bound public browse calls off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Podcast background downloads now abort after 2 minutes of stream inactivity,
   preventing leaked file handles/sockets and permanently stuck "already
   downloading" episodes when a host stalls mid-transfer.
+- Offloaded the public YouTube Music album, artist, and song browse calls from
+  the ytmusic-streamer event loop and bounded them with a
+  `YTMUSIC_BROWSE_TIMEOUT` deadline (default: 30 seconds), so a slow or hung
+  upstream no longer freezes the sidecar and its health endpoint.
 - Bounded the missing-track health-record writes in the scanner and file
   validator so an unavailable music mount no longer fans out one concurrent
   upsert per track and exhausts the worker database pool (hardens the #319

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -215,6 +215,8 @@ EXTRACT_DELAY_MIN = env_float("YTMUSIC_EXTRACT_DELAY_MIN", "0.5")
 EXTRACT_DELAY_MAX = env_float("YTMUSIC_EXTRACT_DELAY_MAX", "2.0")
 _extract_pacer = ThreadSafeRatePacer(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
 EXTRACT_TIMEOUT = env_float("YTMUSIC_EXTRACT_TIMEOUT", "60")
+# Overall deadline for public metadata browse calls.
+BROWSE_TIMEOUT = env_float("YTMUSIC_BROWSE_TIMEOUT", "30")
 YTDLP_SOCKET_TIMEOUT = env_float("YTMUSIC_YTDLP_SOCKET_TIMEOUT", "20")
 
 # Search result cache (in-memory, short TTL to reduce duplicate requests)
@@ -921,6 +923,19 @@ async def _extract_stream_info_bounded(func, *args) -> dict:
         return await asyncio.wait_for(asyncio.to_thread(func, *args), timeout=EXTRACT_TIMEOUT)
     except TimeoutError as error:
         raise HTTPException(status_code=504, detail="Stream extraction timed out") from error
+
+
+async def _browse_public_bounded(func, *args):
+    """Run a sync public ytmusicapi browse call off the event loop with an overall deadline.
+
+    asyncio.wait_for cancels the awaiting request after BROWSE_TIMEOUT seconds
+    and maps it to HTTP 504. The orphaned worker thread is not force-killed,
+    but the event loop and the client are unblocked.
+    """
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(func, *args), timeout=BROWSE_TIMEOUT)
+    except TimeoutError as error:
+        raise HTTPException(status_code=504, detail="YouTube Music request timed out") from error
 
 
 def _tv_search(yt: YTMusic, query: str, filter: str | None = None, limit: int = 20) -> list[dict]:
@@ -1793,7 +1808,7 @@ async def get_album(browse_id: str, user_id: str = Query(...)):
     try:
         if user_id == "__public__":
             yt = _get_public_ytmusic("native")
-            album = yt.get_album(browse_id)
+            album = await _browse_public_bounded(yt.get_album, browse_id)
         else:
             album = await asyncio.to_thread(
                 _run_ytmusic_with_auth_retry,
@@ -1817,7 +1832,7 @@ async def get_artist(channel_id: str, user_id: str = Query(...)):
     try:
         if user_id == "__public__":
             yt = _get_public_ytmusic("native")
-            artist = yt.get_artist(channel_id)
+            artist = await _browse_public_bounded(yt.get_artist, channel_id)
         else:
             artist = await asyncio.to_thread(
                 _run_ytmusic_with_auth_retry,
@@ -1879,7 +1894,7 @@ async def get_song(video_id: str, user_id: str = Query(...)):
     try:
         if user_id == "__public__":
             yt = _get_public_ytmusic("native")
-            song = yt.get_song(video_id)
+            song = await _browse_public_bounded(yt.get_song, video_id)
         else:
             song = await asyncio.to_thread(
                 _run_ytmusic_with_auth_retry,

--- a/services/ytmusic-streamer/tests/test_blocking_offload.py
+++ b/services/ytmusic-streamer/tests/test_blocking_offload.py
@@ -65,6 +65,66 @@ async def test_charts_offloaded_to_worker_thread(client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_public_album_offloaded_to_worker_thread(client, monkeypatch):
+    """Public album work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def get_album(browse_id):
+        captured["t"] = threading.current_thread().name
+        return {"title": "t", "artists": [], "thumbnails": [], "tracks": []}
+
+    public_client = types.SimpleNamespace(get_album=get_album)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/album/x?user_id=__public__")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_public_artist_offloaded_to_worker_thread(client, monkeypatch):
+    """Public artist work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def get_artist(channel_id):
+        captured["t"] = threading.current_thread().name
+        return {"name": "a"}
+
+    public_client = types.SimpleNamespace(get_artist=get_artist)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/artist/x?user_id=__public__")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
+async def test_public_song_offloaded_to_worker_thread(client, monkeypatch):
+    """Public song work should execute in an asyncio worker thread."""
+    import app
+
+    captured = {}
+
+    def get_song(video_id):
+        captured["t"] = threading.current_thread().name
+        return {"videoDetails": {"videoId": video_id, "lengthSeconds": "1"}}
+
+    public_client = types.SimpleNamespace(get_song=get_song)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/song/dQw4w9WgXcQ?user_id=__public__")
+
+    assert response.status_code == 200
+    assert captured["t"] != "MainThread"
+
+
+@pytest.mark.anyio
 async def test_public_playlist_offloaded_to_worker_thread(client, monkeypatch):
     """Public playlist work should execute in an asyncio worker thread."""
     import app

--- a/services/ytmusic-streamer/tests/test_browse_timeout.py
+++ b/services/ytmusic-streamer/tests/test_browse_timeout.py
@@ -1,0 +1,71 @@
+"""Tests for bounded public ytmusicapi browse calls."""
+
+from __future__ import annotations
+
+import time
+import types
+
+import pytest
+
+VIDEO_ID = "dQw4w9WgXcQ"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "method_name"),
+    [
+        ("/album/x", "get_album"),
+        ("/artist/x", "get_artist"),
+        (f"/song/{VIDEO_ID}", "get_song"),
+    ],
+)
+async def test_slow_public_browse_returns_504(client, monkeypatch, path, method_name):
+    """A stalled public metadata browse should return HTTP 504."""
+    import app
+
+    def slow_browse(_identifier):
+        time.sleep(0.5)
+        return {}
+
+    public_client = types.SimpleNamespace(**{method_name: slow_browse})
+    monkeypatch.setattr(app, "BROWSE_TIMEOUT", 0.05)
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get(f"{path}?user_id=__public__")
+
+    assert response.status_code == 504
+    assert response.json()["error"] == "YouTube Music request timed out"
+
+
+@pytest.mark.anyio
+async def test_fast_public_album_browse_preserves_response_shape(client, monkeypatch):
+    """A fast public album browse should retain the existing success response."""
+    import app
+
+    public_client = types.SimpleNamespace(
+        get_album=lambda browse_id: {
+            "title": "t",
+            "artists": [],
+            "thumbnails": [],
+            "tracks": [],
+        }
+    )
+    monkeypatch.setattr(app, "_get_public_ytmusic", lambda strategy: public_client)
+
+    response = await client.get("/album/x?user_id=__public__")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "browseId": "x",
+        "title": "t",
+        "artist": "Unknown",
+        "artists": [],
+        "year": None,
+        "trackCount": None,
+        "duration": None,
+        "type": "Album",
+        "thumbnails": [],
+        "coverUrl": None,
+        "tracks": [],
+        "description": None,
+    }


### PR DESCRIPTION
## Summary
- The `__public__` branches of `/album/{browse_id}`, `/artist/{channel_id}`, and `/song/{video_id}` called synchronous ytmusicapi network methods directly on the event loop, freezing the single-process FastAPI sidecar for the full upstream round-trip (a hung upstream wedged the loop indefinitely, taking `/health` down with it). The authenticated branches were already offloaded via `asyncio.to_thread`.
- Adds a `_browse_public_bounded` helper (modeled on `_extract_stream_info_bounded`) that runs the call via `asyncio.to_thread` under an `asyncio.wait_for` deadline (`YTMUSIC_BROWSE_TIMEOUT`, default 30s) and maps timeouts to HTTP 504.
- Class-close sweep: every other public/anonymous branch (search, debug search, charts, moods, home, browse-album, playlist) already uses `to_thread`; these three were the only remaining sync-on-loop ytmusicapi call sites.

## Testing
- 3 new offload tests (worker-thread assertion) in `test_blocking_offload.py`
- New `test_browse_timeout.py`: 504 on stall for all three endpoints + fast-path response-shape regression test
- Full ytmusic-streamer suite: 190 passed
- ruff check + format clean; focused mypy on `services/ytmusic-streamer/app.py`: no issues