### PR TITLE
perf(mixes): bound the rediscover-mix candidate pool instead of loading the whole track table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Rediscover daily mix now builds its candidates from a bounded, indexed
+  pool (overplayed tracks excluded via a grouped play query, then a capped track
+  fetch) instead of loading and counting plays for the entire track library on
+  every cache miss.
 - The Subsonic `getPlaylists` endpoint now computes playlist durations with a
   single query over playlist items instead of one aggregate query per playlist,
   removing an unbounded N+1 fan-out that could saturate the database connection

--- a/backend/src/services/__tests__/programmaticPlaylistsBehavior.test.ts
+++ b/backend/src/services/__tests__/programmaticPlaylistsBehavior.test.ts
@@ -772,6 +772,7 @@ describe("ProgrammaticPlaylistService behavior coverage", () => {
                 }) as TrackLike & { _count: { plays: number } },
         );
 
+        (mockPrisma.play.groupBy as jest.Mock).mockResolvedValue([]);
         (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(tracks);
 
         const mix = await service.generateRediscoverMix("user-1", "2026-02-17");

--- a/backend/src/services/__tests__/programmaticPlaylistsPriorityMixes.test.ts
+++ b/backend/src/services/__tests__/programmaticPlaylistsPriorityMixes.test.ts
@@ -337,6 +337,7 @@ describe("ProgrammaticPlaylistService priority diversity generators", () => {
             },
         }));
 
+        (mockPrisma.play.groupBy as jest.Mock).mockResolvedValue([]);
         (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(
             rediscoverTracks,
         );
@@ -354,6 +355,78 @@ describe("ProgrammaticPlaylistService priority diversity generators", () => {
         expect(
             countMaxPerArtist(mix!.trackIds, tracksById),
         ).toBeLessThanOrEqual(2);
+    });
+
+    it("generateRediscoverMix bounds the candidate pool and never loads the whole track table", async () => {
+        const rediscoverTracks = Array.from({ length: 40 }, (_, i) => ({
+            id: `bounded-rediscover-track-${i + 1}`,
+            _count: { plays: i % 3 },
+            album: {
+                coverUrl: `bounded-rediscover-cover-${i + 1}.jpg`,
+                artist: { id: `bounded-rediscover-artist-${i + 1}` },
+            },
+        }));
+
+        (mockPrisma.play.groupBy as jest.Mock).mockResolvedValue([
+            { trackId: "overplayed-1", _count: { trackId: 5 } },
+            { trackId: null, _count: { trackId: 4 } },
+            { trackId: "overplayed-2", _count: { trackId: 9 } },
+        ]);
+        (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(
+            rediscoverTracks,
+        );
+
+        const mix = await service.generateRediscoverMix("user-1", "2026-02-13");
+
+        expect(mockPrisma.play.groupBy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                by: ["trackId"],
+                where: expect.objectContaining({ userId: "user-1" }),
+                having: expect.anything(),
+            }),
+        );
+        expect(mockPrisma.track.findMany).toHaveBeenCalledTimes(1);
+        expect(mockPrisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    id: { notIn: ["overplayed-1", "overplayed-2"] },
+                },
+                orderBy: { id: "asc" },
+                take: 1000,
+            }),
+        );
+        expect(mix).not.toBeNull();
+        expect(mix!.trackIds).toHaveLength(20);
+        expect(mix!.trackIds).not.toContain("overplayed-1");
+        expect(mix!.trackIds).not.toContain("overplayed-2");
+    });
+
+    it("generateRediscoverMix omits the notIn filter when the user has no overplayed tracks", async () => {
+        const rediscoverTracks = Array.from({ length: 40 }, (_, i) => ({
+            id: `unplayed-rediscover-track-${i + 1}`,
+            _count: { plays: i % 3 },
+            album: {
+                coverUrl: `unplayed-rediscover-cover-${i + 1}.jpg`,
+                artist: { id: `unplayed-rediscover-artist-${i + 1}` },
+            },
+        }));
+
+        (mockPrisma.play.groupBy as jest.Mock).mockResolvedValue([]);
+        (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(
+            rediscoverTracks,
+        );
+
+        const mix = await service.generateRediscoverMix("user-1", "2026-02-13");
+
+        expect(mockPrisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: undefined,
+                orderBy: { id: "asc" },
+                take: 1000,
+            }),
+        );
+        expect(mix).not.toBeNull();
+        expect(mix!.trackIds).toHaveLength(20);
     });
 
     it("generatePartyMix applies artist diversity and returns target size", async () => {

--- a/backend/src/services/programmaticPlaylists.ts
+++ b/backend/src/services/programmaticPlaylists.ts
@@ -1121,14 +1121,29 @@ export class ProgrammaticPlaylistService {
     }
 
     /**
-     * Generate "Rediscover" mix with daily rotation
+     * Generate "Rediscover" mix with daily rotation from a bounded candidate pool
      */
     async generateRediscoverMix(
         userId: string,
         today: string,
     ): Promise<ProgrammaticMix | null> {
-        // Get tracks with low play count (0-2 plays)
-        const allTracks = await prisma.track.findMany({
+        const overplayed = await prisma.play.groupBy({
+            by: ["trackId"],
+            where: { userId, trackId: { not: null } },
+            _count: { trackId: true },
+            having: { trackId: { _count: { gt: 2 } } },
+        });
+        const overplayedIds = overplayed
+            .map((row) => row.trackId)
+            .filter(
+                (trackId): trackId is string => typeof trackId === "string",
+            );
+
+        const candidateTracks = await prisma.track.findMany({
+            where:
+                overplayedIds.length > 0
+                    ? { id: { notIn: overplayedIds } }
+                    : undefined,
             include: {
                 _count: {
                     select: {
@@ -1142,9 +1157,13 @@ export class ProgrammaticPlaylistService {
                     },
                 },
             },
+            orderBy: { id: "asc" },
+            take: this.TRACK_LIMIT * 50,
         });
 
-        const underplayedTracks = allTracks.filter((t) => t._count.plays <= 2);
+        const underplayedTracks = candidateTracks.filter(
+            (t) => t._count.plays <= 2,
+        );
 
         if (underplayedTracks.length < 5) return null;
 


### PR DESCRIPTION
## Summary

`generateRediscoverMix()` was the sole mix generator with an unbounded pool: it ran `prisma.track.findMany` with **no `where` and no `take`**, hydrating every Track row (plus a correlated per-user play `_count` and album/artist join) into heap, then filtered `plays <= 2` in JS just to pick 20 tracks. On a large library, a GET `/api/mixes` Redis cache miss with Rediscover selected could spike the DB and OOM the host.

## Fix (Prisma-only, per AGENTS.md — no raw SQL)

Two bounded steps, mirroring the sibling generators' capped-pool pattern:

1. `play.groupBy` on `trackId` (`where: { userId }`, `having: _count > 2`) — ids only, served by the existing `(userId, playedAt)` index — to find the user's overplayed tracks.
2. `track.findMany` excluding those ids with `orderBy: { id: "asc" }, take: TRACK_LIMIT * 50` (1000) — same `include` shape as before, so `diversifyTracks`, the `< 5 → null` threshold, and all downstream selection/shuffle are untouched.

The `plays <= 2` JS filter is retained as a cheap invariant guard (plays landing between the two queries). Rediscover semantics are preserved: 20 low-play-count tracks with the same daily-rotation seed.

## Tests

- New behavioral tests assert the candidate query is bounded (`take: 1000`, `orderBy`), overplayed ids are excluded from the query and the result, null `trackId` groupBy rows are dropped, and the `notIn` filter is omitted when the user has no overplayed tracks.
- Existing rediscover tests (target size/artist cap, below-threshold null) updated with the `play.groupBy` mock and pass unchanged.

## Verification

- verify: `npm --prefix backend test -- programmaticPlaylists --maxWorkers=2` — 4 suites, 80 tests, all passed.
- verify: `npx tsc --noEmit` (backend) — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24