### PR TITLE
fix(security): require admin on Soulseek-download retry paths (close #216 bypass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -620,6 +620,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Retry endpoints for Soulseek-backed downloads (playlist pending-track retry
+  and download-job retry) are now admin-only, closing the authorization bypass
+  around the #216 direct-download admin boundary.
 - YouTube Music browse home, mood-playlists, and mixes 4xx responses no longer
   echo raw sidecar error details to clients; they return static messages while
   retaining status and detail in server logs. The route-error leak ratchet now

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -1,5 +1,11 @@
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: any, _res: any, next: () => void) => next(),
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -71,8 +77,12 @@ jest.mock("../../services/simpleDownloadManager", () => ({
 }));
 
 import router from "../notifications";
+import { requireAdmin } from "../../middleware/auth";
 
-function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
+type HttpMethod = "get" | "post" | "put" | "delete";
+const MAX_ROUTE_HANDLERS = 4;
+
+function getRouteLayer(path: string, method: HttpMethod) {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -80,7 +90,37 @@ function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
     if (!layer) {
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     }
+    return layer;
+}
+
+function getHandler(path: string, method: HttpMethod) {
+    const layer = getRouteLayer(path, method);
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+async function invokeRouteStack(
+    path: string,
+    method: HttpMethod,
+    req: any,
+    res: any,
+) {
+    const { stack } = getRouteLayer(path, method).route;
+    if (stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${stack.length}`);
+    }
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = stack[index];
+        if (!entry) {
+            return;
+        }
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) {
+            return;
+        }
+    }
 }
 
 function createRes() {
@@ -173,6 +213,72 @@ describe("notifications route runtime", () => {
             success: true,
             error: null,
         });
+    });
+
+    it("requires admin authorization for download retries", () => {
+        const middlewares = getRouteLayer(
+            "/downloads/:id/retry",
+            "post",
+        ).route.stack.map((entry: { handle: unknown }) => entry.handle);
+
+        expect(middlewares).toContain(requireAdmin);
+    });
+
+    it("rejects non-admin download retries before downloads or writes", async () => {
+        const req = {
+            user: { id: "u1", role: "user" },
+            params: { id: "job-1" },
+        } as any;
+        const res = createRes();
+
+        await invokeRouteStack("/downloads/:id/retry", "post", req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(soulseekService.downloadBestMatch).not.toHaveBeenCalled();
+        expect(soulseekService.searchAndDownloadBatch).not.toHaveBeenCalled();
+        expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.updateMany).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.update).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.create).not.toHaveBeenCalled();
+    });
+
+    it("allows admin download retries through the route stack", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-generic",
+            userId: "u1",
+            subject: "Artist - Album",
+            type: "album",
+            targetMbid: "album-mbid",
+            artistMbid: "artist-mbid",
+            metadata: {},
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-generic",
+            metadata: {},
+        });
+        const req = {
+            user: { id: "u1", role: "admin" },
+            params: { id: "job-generic" },
+        } as any;
+        const res = createRes();
+
+        await invokeRouteStack("/downloads/:id/retry", "post", req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-generic",
+            error: null,
+        });
+        expect(simpleDownloadManager.startDownload).toHaveBeenCalledWith(
+            "job-new-generic",
+            "Artist",
+            "Album",
+            "album-mbid",
+            "u1",
+            false,
+        );
     });
 
     it("handles notification listing/read/clear endpoints", async () => {

--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -1,5 +1,11 @@
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: any, _res: any, next: () => void) => next(),
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 const childLogger = {
@@ -127,8 +133,12 @@ jest.mock("../../utils/playlistLogger", () => ({
 
 import { z } from "zod";
 import router from "../playlists";
+import { requireAdmin } from "../../middleware/auth";
 
-function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
+type HttpMethod = "get" | "post" | "put" | "delete";
+const MAX_ROUTE_HANDLERS = 4;
+
+function getRouteLayer(path: string, method: HttpMethod) {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -136,7 +146,37 @@ function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
     if (!layer) {
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     }
+    return layer;
+}
+
+function getHandler(path: string, method: HttpMethod) {
+    const layer = getRouteLayer(path, method);
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+async function invokeRouteStack(
+    path: string,
+    method: HttpMethod,
+    req: any,
+    res: any,
+) {
+    const { stack } = getRouteLayer(path, method).route;
+    if (stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${stack.length}`);
+    }
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = stack[index];
+        if (!entry) {
+            return;
+        }
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) {
+            return;
+        }
+    }
 }
 
 function createRes() {
@@ -294,6 +334,81 @@ describe("playlists route runtime", () => {
             soulseekPassword: null,
         });
         scanQueue.add.mockResolvedValue({ id: "scan-1" });
+    });
+
+    it("requires admin authorization for pending-track retries", () => {
+        const middlewares = getRouteLayer(
+            "/:id/pending/:trackId/retry",
+            "post",
+        ).route.stack.map((entry: { handle: unknown }) => entry.handle);
+
+        expect(middlewares).toContain(requireAdmin);
+    });
+
+    it("rejects non-admin pending-track retries before downloads or writes", async () => {
+        const req = {
+            user: { id: "u1", role: "user" },
+            params: { id: "pl-1", trackId: "pt-1" },
+        } as any;
+        const res = createRes();
+
+        await invokeRouteStack("/:id/pending/:trackId/retry", "post", req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(soulseekService.downloadBestMatch).not.toHaveBeenCalled();
+        expect(prisma.hiddenPlaylist.upsert).not.toHaveBeenCalled();
+        expect(prisma.hiddenPlaylist.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.playlist.create).not.toHaveBeenCalled();
+        expect(prisma.playlist.update).not.toHaveBeenCalled();
+        expect(prisma.playlist.delete).not.toHaveBeenCalled();
+        expect(prisma.playlistItem.create).not.toHaveBeenCalled();
+        expect(prisma.playlistItem.delete).not.toHaveBeenCalled();
+        expect(prisma.playlistItem.update).not.toHaveBeenCalled();
+        expect(prisma.playlistPendingTrack.update).not.toHaveBeenCalled();
+        expect(prisma.playlistPendingTrack.delete).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.create).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.update).not.toHaveBeenCalled();
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("allows admin pending-track retries through the route stack", async () => {
+        prisma.playlist.findUnique.mockResolvedValueOnce({
+            id: "pl-1",
+            userId: "u1",
+            isPublic: false,
+        });
+        prisma.playlistPendingTrack.findUnique.mockResolvedValueOnce({
+            id: "pt-1",
+            spotifyArtist: "Artist",
+            spotifyTitle: "Title",
+            spotifyAlbum: "Album",
+            albumMbid: null,
+            artistMbid: null,
+        });
+        getSystemSettings.mockResolvedValueOnce({
+            musicPath: "/music",
+            soulseekUsername: "user",
+            soulseekPassword: "pass",
+        });
+        const req = {
+            user: { id: "u1", role: "admin" },
+            params: { id: "pl-1", trackId: "pt-1" },
+        } as any;
+        const res = createRes();
+
+        await invokeRouteStack("/:id/pending/:trackId/retry", "post", req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: false,
+            message: "Track not found on Soulseek",
+            error: "No matching files found",
+        });
+        expect(soulseekService.searchTrack).toHaveBeenCalledWith(
+            "Artist",
+            "Title",
+        );
     });
 
     it("rejects unauthenticated listing", async () => {

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import { logger } from "../utils/logger";
 import { notificationService } from "../services/notificationService";
-import { requireAuth } from "../middleware/auth";
+import { requireAdmin, requireAuth } from "../middleware/auth";
 import { asyncHandler } from "../middleware/asyncHandler";
 import { prisma } from "../utils/db";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
@@ -452,7 +452,7 @@ router.post(
  * @openapi
  * /api/notifications/downloads/{id}/retry:
  *   post:
- *     summary: Retry a failed download
+ *     summary: Retry a failed download (admin only)
  *     description: Retries a failed or exhausted download job. Supports pending-track-retry (Soulseek), spotify_import (Soulseek then Lidarr fallback), and generic album retry via Lidarr.
  *     tags: [Notifications]
  *     security:
@@ -487,10 +487,13 @@ router.post(
  *         description: Download not found or not in failed state
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 router.post(
     "/downloads/:id/retry",
     requireAuth,
+    requireAdmin,
     asyncHandler(async (req: Request<{ id: string }>, res: Response) => {
         try {
             // Get the failed download

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -1,7 +1,7 @@
-import { Router } from "express";
+import { Request, Router } from "express";
 import { logger } from "../utils/logger";
 import { z } from "zod";
-import { requireAuthOrToken } from "../middleware/auth";
+import { requireAdmin, requireAuthOrToken } from "../middleware/auth";
 import { prisma } from "../utils/db";
 import { sessionLog } from "../utils/playlistLogger";
 import { trackMappingService } from "../services/trackMappingService";
@@ -16,6 +16,9 @@ const router = Router();
 const PLAYLISTS_MAX_LIMIT = 1000;
 const PLAYLISTS_DEFAULT_LIMIT = 500;
 const PLAYLIST_PREVIEW_ITEMS = 12;
+const pendingRetryPath = "/:id/pending/:trackId/retry";
+
+type RetryRequest = Request<{ id: string; trackId: string }>;
 
 router.use(requireAuthOrToken);
 
@@ -1420,7 +1423,7 @@ router.get("/:id/pending/:trackId/preview", async (req, res) => {
  * @openapi
  * /api/playlists/{id}/pending/{trackId}/retry:
  *   post:
- *     summary: Retry downloading a pending track from Soulseek
+ *     summary: Retry downloading a pending track from Soulseek (admin only)
  *     description: Returns immediately and downloads in background. Triggers a library scan after download.
  *     tags: [Playlists]
  *     security:
@@ -1456,13 +1459,13 @@ router.get("/:id/pending/:trackId/preview", async (req, res) => {
  *       400:
  *         description: Music path or Soulseek credentials not configured
  *       403:
- *         description: Access denied
+ *         description: Authenticated but not an admin, or access denied
  *       404:
  *         description: Playlist or pending track not found
  *       401:
  *         description: Not authenticated
  */
-router.post("/:id/pending/:trackId/retry", async (req, res) => {
+router.post(pendingRetryPath, requireAdmin, async (req: RetryRequest, res) => {
     try {
         const userId = req.user!.id;
         const { id: playlistId, trackId: pendingTrackId } = req.params;


### PR DESCRIPTION
Extends the #216 admin boundary (direct Soulseek downloads are admin-only) to the retry endpoints that reach the same library-writing capability.

**Intentional UX change:** non-admins can no longer retry their own failed Soulseek/import downloads — this is the owner-approved, #216-consistent behavior.

## Gated routes

- `POST /api/playlists/:id/pending/:trackId/retry` (backend/src/routes/playlists.ts) — previously only `requireAuthOrToken` + playlist ownership; calls `soulseekService.searchTrack` + `downloadBestMatch(..., musicPath)`. Now `requireAdmin` at the route level.
- `POST /api/notifications/downloads/:id/retry` (backend/src/routes/notifications.ts) — previously only `requireAuth`; all three branches trigger library-writing downloads (pending-track-retry via `downloadBestMatch`, spotify_import via `searchAndDownloadBatch` with Lidarr fallback, generic album retry via Lidarr). Now `requireAuth, requireAdmin`.

## Class-close audit (all route-level soulseekService download callers)

Multiline-aware grep (`rg -nU 'soulseekService\s*\n?\s*\.(downloadBestMatch|searchAndDownloadBatch|searchAndDownload)\b' backend/src/routes`) — the single-line variant misses the calls split across lines:

| Caller | Route | Gate |
|---|---|---|
| soulseek.ts:440 `searchAndDownload` | POST /api/soulseek/download | requireAuth + requireAdmin (#216, unchanged) |
| playlists.ts:1646 `downloadBestMatch` | POST /api/playlists/:id/pending/:trackId/retry | requireAdmin (this PR) |
| notifications.ts:654 `downloadBestMatch` | POST /api/notifications/downloads/:id/retry | requireAuth + requireAdmin (this PR) |
| notifications.ts:802 `searchAndDownloadBatch` | POST /api/notifications/downloads/:id/retry | requireAuth + requireAdmin (this PR) |

Non-route callers (`acquisitionService.ts:446/604`, used by discoverWeekly/spotifyImport services) are service-layer acquisition flows, out of scope here.

## Tests

Follows the #216 exemplar (`soulseekRuntime.test.ts`): structural assertion that the route stack contains `requireAdmin`, plus behavioral full-route-stack tests — non-admin → 403 `{ error: "Admin access required" }` with no soulseek call and no prisma writes; admin → proceeds past the gate to the existing handler path. Both runtime suites' partial `middleware/auth` mocks gained a `requireAdmin` implementation mirroring the real middleware.

verify: `jest playlistsRuntime notificationsRuntime soulseekRuntime --maxWorkers=2` → 3 suites, 83/83 pass; `tsc --noEmit` exit 0; route-error canon ratchet pass; `openapiRouteSync` 4/4 pass; Prettier check clean.
