### PR TITLE
perf(library): bound all radio candidate-pool queries and escape genre LIKE wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of leaking a reconnecting client.
 - Worker health-check interval is now captured, unref'd, and cleared during
   graceful shutdown.
+- Bounded every `/api/library/radio` candidate-pool query (discovery, favorites
+  fallback, decade, mood, workout, vibe genre/random fallbacks, and the
+  all-library default) with `ORDER BY random() LIMIT` sampling in SQL instead of
+  materializing the full matching track-id set into memory, and escaped `%`/`_`
+  LIKE wildcards in the genre-radio value so a wildcard query value can no
+  longer match the entire library.
 - Soulseek forced disconnects now destroy the underlying slsk-client, closing
   its server, listen, and peer sockets, and remove the attached error listener
   before dropping the reference. Previously each search-failure or empty-search

--- a/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
@@ -42,6 +42,7 @@ jest.mock("../../utils/db", () => ({
         dislikedEntity: {
             findMany: jest.fn(),
         },
+        $queryRaw: jest.fn(),
     },
     Prisma: {
         SortOrder: {
@@ -49,6 +50,11 @@ jest.mock("../../utils/db", () => ({
             desc: "desc",
         },
         DbNull: null,
+        sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+            strings,
+            values,
+        }),
+        join: (values: unknown[]) => values,
     },
 }));
 
@@ -189,6 +195,7 @@ const mockOwnedAlbumFindMany = prisma.ownedAlbum.findMany as jest.Mock;
 const mockSimilarArtistFindMany = prisma.similarArtist.findMany as jest.Mock;
 const mockLikedTrackFindMany = prisma.likedTrack.findMany as jest.Mock;
 const mockDislikedEntityFindMany = prisma.dislikedEntity.findMany as jest.Mock;
+const mockQueryRaw = prisma.$queryRaw as jest.Mock;
 
 function getGetHandler(path: string, stackIndex = 0) {
     const layer = (router as any).stack.find(
@@ -336,8 +343,8 @@ describe("library vibe radio reliability compatibility", () => {
         mockTrackFindMany
             .mockResolvedValueOnce([analyzedCandidate]) // analyzed comparison set
             .mockResolvedValueOnce([]) // fallback A: same artist
-            .mockResolvedValueOnce([]) // fallback D: random
             .mockResolvedValueOnce([hydratedCandidate]); // final hydrated results
+        mockQueryRaw.mockResolvedValueOnce([]); // fallback D: random
         mockOwnedAlbumFindMany.mockResolvedValue([]);
         mockSimilarArtistFindMany.mockResolvedValue([]);
 
@@ -614,11 +621,11 @@ describe("library vibe radio reliability compatibility", () => {
     });
 
     it("uses shuffled non-vibe radio ordering and tolerates tracks without artist ids", async () => {
+        mockQueryRaw.mockResolvedValueOnce([
+            { id: "all-track-1" },
+            { id: "all-track-2" },
+        ]);
         mockTrackFindMany
-            .mockResolvedValueOnce([
-                { id: "all-track-1" },
-                { id: "all-track-2" },
-            ])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 {
@@ -684,8 +691,8 @@ describe("library vibe radio reliability compatibility", () => {
                 }),
             ],
         });
-        // Pool query + diversify artist lookup (GH #46) + full track fetch.
-        expect(mockTrackFindMany).toHaveBeenCalledTimes(3);
+        // Diversify artist lookup + full track fetch; the pool is sampled in SQL.
+        expect(mockTrackFindMany).toHaveBeenCalledTimes(2);
     });
 
     it("returns 500 when radio processing throws", async () => {

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -140,6 +140,11 @@ jest.mock("../../utils/db", () => ({
             desc: "desc",
         },
         DbNull: null,
+        sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+            strings,
+            values,
+        }),
+        join: (values: unknown[]) => values,
     },
 }));
 
@@ -572,6 +577,25 @@ function createRadioTrack(id: string, overrides?: Partial<any>) {
         trackGenres: [],
         ...overrides,
     };
+}
+
+function expectBoundedRandomQuery(call: unknown[], limit: number) {
+    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+    const sql = strings.join("?");
+    expect(sql).toContain("ORDER BY random()");
+    expect(sql).toContain("LIMIT");
+    expect(values).toContain(limit);
+}
+
+function expectNoUnboundedIdPoolFetch() {
+    expect(
+        mockTrackFindMany.mock.calls.some(
+            ([args]) =>
+                args?.select?.id === true &&
+                Object.keys(args.select).length === 1 &&
+                args.take === undefined,
+        ),
+    ).toBe(false);
 }
 
 describe("library scan and organize runtime coverage", () => {
@@ -5041,8 +5065,8 @@ describe("library catalog list runtime coverage", () => {
             error: "Radio type is required",
         });
 
+        mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "u1" }, { id: "u2" }]);
         mockTrackFindMany
-            .mockResolvedValueOnce([{ id: "u1" }, { id: "u2" }])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("u1"),
@@ -5057,18 +5081,18 @@ describe("library catalog list runtime coverage", () => {
         await radioHandler(discoveryReq, discoveryRes);
         expect(discoveryRes.statusCode).toBe(200);
         expect(discoveryRes.body.tracks).toHaveLength(2);
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[0], 8);
+        expectNoUnboundedIdPoolFetch();
 
-        mockTrackFindMany
+        mockPrismaQueryRaw
             .mockResolvedValueOnce([{ id: "u3" }])
+            .mockResolvedValueOnce([{ id: "lp1" }, { id: "lp2" }]);
+        mockTrackFindMany
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("lp1"),
                 createRadioTrack("lp2"),
             ]);
-        mockPrismaQueryRaw.mockResolvedValueOnce([
-            { id: "lp1" },
-            { id: "lp2" },
-        ]);
 
         const fallbackReq = {
             query: { type: "discovery", limit: "2" },
@@ -5076,7 +5100,7 @@ describe("library catalog list runtime coverage", () => {
         } as any;
         const fallbackRes = createRes();
         await radioHandler(fallbackReq, fallbackRes);
-        expect(mockPrismaQueryRaw).toHaveBeenCalled();
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[1], 8);
         expect(fallbackRes.statusCode).toBe(200);
         expect(fallbackRes.body.tracks.map((track: any) => track.id)).toEqual([
             "lp1",
@@ -5085,9 +5109,10 @@ describe("library catalog list runtime coverage", () => {
     });
 
     it("builds workout radio using audio, genre table, and album-genre fallback sources", async () => {
-        mockTrackFindMany
+        mockPrismaQueryRaw
             .mockResolvedValueOnce([{ id: "w1" }])
-            .mockResolvedValueOnce([{ id: "w3" }])
+            .mockResolvedValueOnce([{ id: "w3" }]);
+        mockTrackFindMany
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([
                 createRadioTrack("w1"),
@@ -5114,6 +5139,9 @@ describe("library catalog list runtime coverage", () => {
             "w2",
             "w3",
         ]);
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[0], 12);
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[1], 6);
+        expectNoUnboundedIdPoolFetch();
     });
 
     it("supports artist radio validation, empty artist libraries, and mixed artist+similar queues", async () => {
@@ -5570,26 +5598,6 @@ describe("library catalog list runtime coverage", () => {
             if (Array.isArray(args.where?.album?.artistId?.in)) {
                 return [{ id: "sim-b1" }];
             }
-            if (args.where?.trackGenres?.some) {
-                return [{ id: "genre-c1" }];
-            }
-            if (
-                Array.isArray(args.where?.id?.notIn) &&
-                args.select?.id &&
-                !args.where?.album &&
-                !args.include
-            ) {
-                // Fallback D dropped `take` for sampleUniform (GH #46);
-                // return a generous pool for the sampler to draw from.
-                const fillerCount =
-                    typeof args.take === "number" ? args.take : 60;
-                return Array.from(
-                    { length: fillerCount },
-                    (_unused, index) => ({
-                        id: `rnd-d${index + 1}`,
-                    }),
-                );
-            }
             if (Array.isArray(args.where?.id?.in) && args.include?.album) {
                 return (args.where.id.in as string[]).map(
                     (id: string, index: number) =>
@@ -5610,6 +5618,13 @@ describe("library catalog list runtime coverage", () => {
         mockSimilarArtistFindMany.mockResolvedValueOnce([
             { toArtistId: "artist-sim-1", weight: 0.9 },
         ]);
+        mockPrismaQueryRaw
+            .mockResolvedValueOnce([{ id: "genre-c1" }])
+            .mockResolvedValueOnce(
+                Array.from({ length: 50 }, (_unused, index) => ({
+                    id: `rnd-d${index + 1}`,
+                })),
+            );
 
         const missingSourceReq = {
             query: { type: "vibe" },
@@ -5646,6 +5661,8 @@ describe("library catalog list runtime coverage", () => {
                 }),
             }),
         );
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[0], 55);
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[1], 50);
     });
 
     it("covers favorites, decade, genre, mood, and all radio branches", async () => {
@@ -5667,8 +5684,8 @@ describe("library catalog list runtime coverage", () => {
         ]);
 
         mockPrismaQueryRaw.mockResolvedValueOnce([]);
+        mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "rand-fav-1" }]);
         mockTrackFindMany
-            .mockResolvedValueOnce([{ id: "rand-fav-1" }])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("rand-fav-1")]);
         const fallbackFavoritesReq = {
@@ -5679,9 +5696,10 @@ describe("library catalog list runtime coverage", () => {
         await radioHandler(fallbackFavoritesReq, fallbackFavoritesRes);
         expect(fallbackFavoritesRes.statusCode).toBe(200);
         expect(fallbackFavoritesRes.body.tracks[0].id).toBe("rand-fav-1");
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[2], 4);
 
+        mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "dec-1" }]);
         mockTrackFindMany
-            .mockResolvedValueOnce([{ id: "dec-1" }])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("dec-1")]);
         const decadeReq = {
@@ -5691,8 +5709,8 @@ describe("library catalog list runtime coverage", () => {
         const decadeRes = createRes();
         await radioHandler(decadeReq, decadeRes);
         expect(decadeRes.statusCode).toBe(200);
-        expect(mockGetDecadeWhereClause).toHaveBeenCalledWith(1990);
         expect(decadeRes.body.tracks[0].id).toBe("dec-1");
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[3], 4);
 
         mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "genre-1" }]);
         mockTrackFindMany
@@ -5707,8 +5725,8 @@ describe("library catalog list runtime coverage", () => {
         expect(genreRes.statusCode).toBe(200);
         expect(genreRes.body.tracks[0].id).toBe("genre-1");
 
+        mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "mood-1" }]);
         mockTrackFindMany
-            .mockResolvedValueOnce([{ id: "mood-1" }])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("mood-1")]);
         const moodReq = {
@@ -5719,9 +5737,10 @@ describe("library catalog list runtime coverage", () => {
         await radioHandler(moodReq, moodRes);
         expect(moodRes.statusCode).toBe(200);
         expect(moodRes.body.tracks[0].id).toBe("mood-1");
+        expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[5], 4);
 
+        mockPrismaQueryRaw.mockResolvedValueOnce([{ id: "mood-2" }]);
         mockTrackFindMany
-            .mockResolvedValueOnce([{ id: "mood-2" }])
             .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
             .mockResolvedValueOnce([createRadioTrack("mood-2")]);
         const defaultMoodReq = {
@@ -5742,8 +5761,8 @@ describe("library catalog list runtime coverage", () => {
             ["instrumental", "mood-instrumental"],
         ];
         for (const [moodValue, trackId] of additionalMoodCases) {
+            mockPrismaQueryRaw.mockResolvedValueOnce([{ id: trackId }]);
             mockTrackFindMany
-                .mockResolvedValueOnce([{ id: trackId }])
                 .mockResolvedValueOnce([]) // GH #46 diversify: pool artist lookup
                 .mockResolvedValueOnce([createRadioTrack(trackId)]);
             const req = {
@@ -5756,7 +5775,7 @@ describe("library catalog list runtime coverage", () => {
             expect(res.body.tracks[0].id).toBe(trackId);
         }
 
-        mockTrackFindMany.mockResolvedValueOnce([]);
+        mockPrismaQueryRaw.mockResolvedValueOnce([]);
         const emptyAllReq = {
             query: { type: "all", limit: "5" },
             user: { id: "user-1" },
@@ -5765,7 +5784,41 @@ describe("library catalog list runtime coverage", () => {
         await radioHandler(emptyAllReq, emptyAllRes);
         expect(emptyAllRes.statusCode).toBe(200);
         expect(emptyAllRes.body).toEqual({ tracks: [] });
+        expectBoundedRandomQuery(
+            mockPrismaQueryRaw.mock.calls[
+                mockPrismaQueryRaw.mock.calls.length - 1
+            ],
+            20,
+        );
+        expectNoUnboundedIdPoolFetch();
     });
+
+    it.each([
+        ["%", "%\\%%"],
+        ["_", "%\\_%"],
+        ["rock", "%rock%"],
+    ])(
+        "escapes genre LIKE input %s as a literal pattern",
+        async (value, pattern) => {
+            mockPrismaQueryRaw
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([]);
+
+            const req = {
+                query: { type: "genre", value, limit: "1" },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+            await radioHandler(req, res);
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual({ tracks: [] });
+            const likeValues = mockPrismaQueryRaw.mock.calls
+                .flatMap((call) => call.slice(1))
+                .filter((boundValue) => boundValue === pattern);
+            expect(likeValues).toHaveLength(4);
+        },
+    );
 
     it("returns liked radio tracks using deterministic liked-order membership", async () => {
         mockLikedTrackFindMany.mockResolvedValueOnce([
@@ -5938,7 +5991,7 @@ describe("library catalog list runtime coverage", () => {
         expect(missingTrackRes.statusCode).toBe(404);
         expect(missingTrackRes.body).toEqual({ error: "Track not found" });
 
-        mockTrackFindMany.mockRejectedValueOnce(new Error("radio explosion"));
+        mockPrismaQueryRaw.mockRejectedValueOnce(new Error("radio explosion"));
         const errorReq = {
             query: { type: "all", limit: "2" },
             user: { id: "user-1" },

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -22,10 +22,7 @@ import fs from "fs";
 import { config } from "../config";
 import { isOriginAllowed } from "../utils/cors";
 import { fanartService } from "../services/fanart";
-import {
-    allocateTracksWithArtistWeighting,
-    sampleUniform,
-} from "../services/artistSlotAllocation";
+import { allocateTracksWithArtistWeighting } from "../services/artistSlotAllocation";
 import { deezerService } from "../services/deezer";
 import { musicBrainzService } from "../services/musicbrainz";
 import { coverArtService } from "../services/coverArt";
@@ -68,11 +65,7 @@ import {
     getMergedGenres,
     getArtistDisplaySummary,
 } from "../utils/metadataOverrides";
-import {
-    getEffectiveYear,
-    getDecadeWhereClause,
-    getDecadeFromYear,
-} from "../utils/dateFilters";
+import { getEffectiveYear, getDecadeFromYear } from "../utils/dateFilters";
 import { shuffleArray } from "../utils/shuffle";
 import { separateArtists } from "../utils/separateArtists";
 import { safeResolvePath } from "../utils/safeResolvePath";
@@ -145,6 +138,32 @@ const COVER_ART_IMAGE_CACHE_CONTROL = `public, max-age=${COVER_ART_IMAGE_CACHE_T
 const RELIABLE_ENHANCED_ANALYSIS_VERSION_PREFIX = "2.1b6-enhanced-v3";
 const AUDIO_INFO_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const AUDIO_INFO_CACHE_MAX_ENTRIES = 2000;
+
+/** Escape LIKE metacharacters so user input matches literally (PG default escape '\'). */
+const escapeLikePattern = (value: string): string =>
+    value.replace(/[\\%_]/g, (character) => `\\${character}`);
+
+const moodPoolCondition = (moodValue: string): Prisma.Sql => {
+    switch (moodValue) {
+        case "high-energy":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND t.energy >= ${0.7} AND t.bpm >= ${120}`;
+        case "chill":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND (t.energy <= ${0.4} OR t.arousal <= ${0.4})`;
+        case "happy":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND t.valence >= ${0.6} AND t.energy >= ${0.5}`;
+        case "melancholy":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND (t.valence <= ${0.4} OR t."keyScale" = ${"minor"})`;
+        case "dance":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND t.danceability >= ${0.7}`;
+        case "acoustic":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND t.acousticness >= ${0.6}`;
+        case "instrumental":
+            return Prisma.sql`t."analysisStatus" = ${"completed"} AND t.instrumentalness >= ${0.7}`;
+        default:
+            return Prisma.sql`${moodValue} = ANY(t."lastfmTags")`;
+    }
+};
+
 interface AudioInfoResponsePayload {
     codec: string | null;
     bitrate: number | null;
@@ -6066,19 +6085,18 @@ router.get(
             case "discovery":
                 // Lesser-played tracks - get tracks the user hasn't played or played least
                 // First, get tracks with NO plays at all (truly undiscovered)
-                const unplayedTracks = await prisma.track.findMany({
-                    where: {
-                        plays: { none: {} }, // No plays by anyone
-                    },
-                    select: { id: true },
-                });
+                const unplayedTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id FROM "Track" t
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM "Play" p WHERE p."trackId" = t.id
+                    )
+                    ORDER BY random()
+                    LIMIT ${limitNum * 4}
+                `;
 
                 if (unplayedTracks.length >= limitNum) {
-                    // Uniform sample instead of an unordered `take` (GH #46).
-                    trackIds = sampleUniform(
-                        unplayedTracks.map((t) => t.id),
-                        limitNum * 4,
-                    );
+                    // The candidate pool is bounded and uniformly sampled in SQL.
+                    trackIds = unplayedTracks.map((t) => t.id);
                 } else {
                     // Fallback: get tracks with the fewest plays using raw count
                     const leastPlayedTracks = await prisma.$queryRaw<
@@ -6135,14 +6153,14 @@ router.get(
                     logger.debug(
                         "[Radio:favorites] No play data found, returning random tracks",
                     );
-                    const randomTracks = await prisma.track.findMany({
-                        select: { id: true },
-                    });
-                    // Uniform sample instead of an unordered `take` (GH #46).
-                    trackIds = sampleUniform(
-                        randomTracks.map((t) => t.id),
-                        limitNum * 4,
-                    );
+                    const randomTracks = await prisma.$queryRaw<
+                        { id: string }[]
+                    >`
+                        SELECT id FROM "Track"
+                        ORDER BY random()
+                        LIMIT ${limitNum * 4}
+                    `;
+                    trackIds = randomTracks.map((t) => t.id);
                 }
                 break;
 
@@ -6150,23 +6168,21 @@ router.get(
                 // Filter by decade (e.g., value = "1990" for 90s)
                 const decadeStart = parseInt(radioValue || "2000", 10) || 2000;
 
-                // Fetch all matching ids and sample uniformly — an
-                // unordered `take` returned the same artist-clustered
-                // slice on every request (GH #46).
-                const decadeTracks = await prisma.track.findMany({
-                    where: {
-                        album: getDecadeWhereClause(decadeStart),
-                    },
-                    select: { id: true },
-                });
-                trackIds = sampleUniform(
-                    decadeTracks.map((t) => t.id),
-                    limitNum * 4,
-                );
+                // The candidate pool is bounded and uniformly sampled in SQL.
+                const decadeTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id FROM "Track" t
+                    JOIN "Album" a ON a.id = t."albumId"
+                    WHERE (a."originalYear" >= ${decadeStart} AND a."originalYear" < ${decadeStart + 10})
+                       OR (a."originalYear" IS NULL AND a."year" >= ${decadeStart} AND a."year" < ${decadeStart + 10})
+                    ORDER BY random()
+                    LIMIT ${limitNum * 4}
+                `;
+                trackIds = decadeTracks.map((t) => t.id);
                 break;
 
             case "genre": {
                 const genreValue = (radioValue || "").toLowerCase();
+                const genrePattern = `%${escapeLikePattern(genreValue)}%`;
 
                 // Prefer track-level genre evidence (Last.fm track tags,
                 // Essentia genres) so the pool is matching TRACKS — the
@@ -6183,11 +6199,11 @@ router.get(
                     FROM "Track" t
                     WHERE EXISTS (
                         SELECT 1 FROM unnest(t."lastfmTags") AS tag(name)
-                        WHERE LOWER(tag.name) LIKE ${"%" + genreValue + "%"}
+                        WHERE LOWER(tag.name) LIKE ${genrePattern}
                     )
                     OR EXISTS (
                         SELECT 1 FROM unnest(t."essentiaGenres") AS eg(name)
-                        WHERE LOWER(eg.name) LIKE ${"%" + genreValue + "%"}
+                        WHERE LOWER(eg.name) LIKE ${genrePattern}
                     )
                     ORDER BY random()
                     LIMIT ${limitNum * 4}
@@ -6207,12 +6223,12 @@ router.get(
                         WHERE (
                             (ar.genres IS NOT NULL AND EXISTS (
                                 SELECT 1 FROM jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
-                                WHERE LOWER(g.genre) LIKE ${"%" + genreValue + "%"}
+                                WHERE LOWER(g.genre) LIKE ${genrePattern}
                             ))
                             OR
                             (ar."userGenres" IS NOT NULL AND EXISTS (
                                 SELECT 1 FROM jsonb_array_elements_text(ar."userGenres"::jsonb) AS ug(genre)
-                                WHERE LOWER(ug.genre) LIKE ${"%" + genreValue + "%"}
+                                WHERE LOWER(ug.genre) LIKE ${genrePattern}
                             ))
                         )
                         ORDER BY sort_key
@@ -6232,111 +6248,34 @@ router.get(
                 break;
             }
 
-            case "mood":
+            case "mood": {
                 // Mood-based filtering using audio analysis features
                 const moodValue = (radioValue || "").toLowerCase();
-                let moodWhere: any = { analysisStatus: "completed" };
-
-                switch (moodValue) {
-                    case "high-energy":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            energy: { gte: 0.7 },
-                            bpm: { gte: 120 },
-                        };
-                        break;
-                    case "chill":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            OR: [
-                                { energy: { lte: 0.4 } },
-                                { arousal: { lte: 0.4 } },
-                            ],
-                        };
-                        break;
-                    case "happy":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            valence: { gte: 0.6 },
-                            energy: { gte: 0.5 },
-                        };
-                        break;
-                    case "melancholy":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            OR: [
-                                { valence: { lte: 0.4 } },
-                                { keyScale: "minor" },
-                            ],
-                        };
-                        break;
-                    case "dance":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            danceability: { gte: 0.7 },
-                        };
-                        break;
-                    case "acoustic":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            acousticness: { gte: 0.6 },
-                        };
-                        break;
-                    case "instrumental":
-                        moodWhere = {
-                            analysisStatus: "completed",
-                            instrumentalness: { gte: 0.7 },
-                        };
-                        break;
-                    default:
-                        // Try Last.fm tags if mood not recognized
-                        moodWhere = {
-                            lastfmTags: { has: moodValue },
-                        };
-                }
-
-                // Uniform sample instead of an unordered `take` (GH #46).
-                const moodTracks = await prisma.track.findMany({
-                    where: moodWhere,
-                    select: { id: true },
-                });
-                trackIds = sampleUniform(
-                    moodTracks.map((t) => t.id),
-                    limitNum * 4,
-                );
+                const moodCondition = moodPoolCondition(moodValue);
+                const moodTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id FROM "Track" t
+                    WHERE ${moodCondition}
+                    ORDER BY random()
+                    LIMIT ${limitNum * 4}
+                `;
+                trackIds = moodTracks.map((t) => t.id);
                 break;
+            }
 
             case "workout":
                 // High-energy workout tracks - multiple strategies
                 let workoutTrackIds: string[] = [];
 
                 // Strategy 1: Audio analysis - high energy AND fast BPM
-                const energyTracks = await prisma.track.findMany({
-                    where: {
-                        analysisStatus: "completed",
-                        OR: [
-                            // High energy with fast tempo
-                            {
-                                AND: [
-                                    { energy: { gte: 0.65 } },
-                                    { bpm: { gte: 115 } },
-                                ],
-                            },
-                            // Has workout mood tag
-                            {
-                                moodTags: {
-                                    hasSome: ["workout", "energetic", "upbeat"],
-                                },
-                            },
-                        ],
-                    },
-                    select: { id: true },
-                });
-                // Uniform sample instead of an unordered `take` (GH #46).
-                workoutTrackIds = sampleUniform(
-                    energyTracks.map((t) => t.id),
-                    limitNum * 4,
-                );
+                const energyTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id FROM "Track" t
+                    WHERE t."analysisStatus" = ${"completed"}
+                      AND ((t.energy >= ${0.65} AND t.bpm >= ${115})
+                           OR t."moodTags" && ARRAY[${"workout"}, ${"energetic"}, ${"upbeat"}]::text[])
+                    ORDER BY random()
+                    LIMIT ${limitNum * 4}
+                `;
+                workoutTrackIds = energyTracks.map((t) => t.id);
                 logger.debug(
                     `[Radio:workout] Found ${workoutTrackIds.length} tracks via audio analysis`,
                 );
@@ -6394,23 +6333,19 @@ router.get(
 
                     // Also check album.genres JSON field
                     if (workoutTrackIds.length < limitNum) {
-                        const albumGenreTrackRows = await prisma.track.findMany(
-                            {
-                                where: {
-                                    album: {
-                                        OR: workoutGenreNames.map((g) => ({
-                                            genres: { string_contains: g },
-                                        })),
-                                    },
-                                },
-                                select: { id: true },
-                            },
-                        );
-                        // Uniform sample instead of an unordered `take` (GH #46).
-                        const albumGenreTracks = sampleUniform(
-                            albumGenreTrackRows,
-                            limitNum * 2,
-                        );
+                        const albumGenreTracks = await prisma.$queryRaw<
+                            { id: string }[]
+                        >`
+                            SELECT t.id FROM "Track" t
+                            JOIN "Album" a ON a.id = t."albumId"
+                            WHERE a.genres IS NOT NULL
+                              AND EXISTS (
+                                SELECT 1 FROM unnest(${workoutGenreNames}::text[]) AS g(name)
+                                WHERE (a.genres #>> '{}') LIKE '%' || g.name || '%'
+                              )
+                            ORDER BY random()
+                            LIMIT ${limitNum * 2}
+                        `;
                         workoutTrackIds = [
                             ...new Set([
                                 ...workoutTrackIds,
@@ -7307,28 +7242,29 @@ router.get(
                     vibeMatchedIds.length < limitNum &&
                     sourceGenres.length > 0
                 ) {
-                    // Search using the TrackGenre relation for better accuracy
-                    const genreTracks = await prisma.track.findMany({
-                        where: {
-                            trackGenres: {
-                                some: {
-                                    genre: {
-                                        name: {
-                                            in: sourceGenres,
-                                            mode: "insensitive",
-                                        },
-                                    },
-                                },
-                            },
-                            id: { notIn: [sourceTrackId, ...vibeMatchedIds] },
-                        },
-                        select: { id: true },
-                    });
-                    // Uniform sample instead of an unordered `take` (GH #46).
-                    const newIds = sampleUniform(
-                        genreTracks.map((t) => t.id),
-                        limitNum,
-                    );
+                    // Search using the TrackGenre relation for better accuracy.
+                    const genreTracks = await prisma.$queryRaw<
+                        { id: string }[]
+                    >`
+                        SELECT t.id FROM "Track" t
+                        WHERE EXISTS (
+                            SELECT 1 FROM "TrackGenre" tg
+                            JOIN "Genre" g ON g.id = tg."genreId"
+                            WHERE tg."trackId" = t.id
+                              AND LOWER(g.name) IN (${Prisma.join(
+                                  sourceGenres.map((genre) =>
+                                      genre.toLowerCase(),
+                                  ),
+                              )})
+                        )
+                        AND t.id NOT IN (${Prisma.join([
+                            sourceTrackId,
+                            ...vibeMatchedIds,
+                        ])})
+                        ORDER BY random()
+                        LIMIT ${limitNum}
+                    `;
+                    const newIds = genreTracks.map((t) => t.id);
                     vibeMatchedIds = [...vibeMatchedIds, ...newIds];
                     logger.debug(
                         `[Radio:vibe] Fallback C (same genre): added ${newIds.length} tracks, total: ${vibeMatchedIds.length}`,
@@ -7337,17 +7273,19 @@ router.get(
 
                 // 6. Fallback D: Random from library
                 if (vibeMatchedIds.length < limitNum) {
-                    const randomTracks = await prisma.track.findMany({
-                        where: {
-                            id: { notIn: [sourceTrackId, ...vibeMatchedIds] },
-                        },
-                        select: { id: true },
-                    });
-                    // Uniform sample instead of an unordered `take` (GH #46).
-                    const newIds = sampleUniform(
-                        randomTracks.map((t) => t.id),
-                        limitNum - vibeMatchedIds.length,
-                    );
+                    const remainingLimit = limitNum - vibeMatchedIds.length;
+                    const randomTracks = await prisma.$queryRaw<
+                        { id: string }[]
+                    >`
+                        SELECT t.id FROM "Track" t
+                        WHERE t.id NOT IN (${Prisma.join([
+                            sourceTrackId,
+                            ...vibeMatchedIds,
+                        ])})
+                        ORDER BY random()
+                        LIMIT ${remainingLimit}
+                    `;
+                    const newIds = randomTracks.map((t) => t.id);
                     vibeMatchedIds = [...vibeMatchedIds, ...newIds];
                     logger.debug(
                         `[Radio:vibe] Fallback D (random): added ${newIds.length} tracks, total: ${vibeMatchedIds.length}`,
@@ -7474,9 +7412,11 @@ router.get(
             case "all":
             default:
                 // Random selection from all tracks in library
-                const allTracks = await prisma.track.findMany({
-                    select: { id: true },
-                });
+                const allTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT id FROM "Track"
+                    ORDER BY random()
+                    LIMIT ${limitNum * 4}
+                `;
                 trackIds = allTracks.map((t) => t.id);
         }
 


### PR DESCRIPTION
## Summary

Every candidate-pool query in the GET `/api/library/radio` handler is now bounded. Previously, at least six branches materialized the entire matching track-id set into Node via `prisma.track.findMany({ select: { id: true } })` (no `take`) just to sample `limitNum * 4` ids with `sampleUniform` — on the `all`/`discovery` branches that meant the whole `Track` table on every request. Each branch now mirrors the in-file genre-branch precedent: parameterized raw SQL `ORDER BY random() LIMIT ${limitNum * 4}`, preserving each branch's WHERE semantics and the downstream shuffle/artist-diversity/preference-weighting behavior exactly.

Branches bounded:

- `discovery` (unplayed pool)
- `favorites` no-play fallback (was full-table)
- `decade`
- `mood` (all eight mood variants via a new `moodPoolCondition` `Prisma.Sql` helper)
- `workout` strategy 1 (audio analysis) and the album-genres JSON fallback
- `vibe` fallback C (same genre) and fallback D (random library fill)
- `all`/default (was full-table)

Also fixed (same switch): the genre branch bound `req.query.value` as a LIKE parameter without escaping `%`/`_`/`\`, so `?type=genre&value=%` matched the entire library. A new `escapeLikePattern` helper escapes LIKE metacharacters in all four genre LIKE patterns; values remain bound parameters (no injection before or after).

Raw SQL note: random-order sampling with `LIMIT` is not expressible in Prisma's query API; the genre branch (and the discovery/favorites play-count orderings) in this same handler are the established precedent. All queries use tagged-template `$queryRaw` with bound parameters — no `$queryRawUnsafe`.

## Tests

- Updated `libraryRuntime.test.ts` and `libraryRadioVibeReliabilityCompat.test.ts` mocks (pool fetches moved from `track.findMany` to `$queryRaw`).
- New assertions: every converted branch issues a bounded `ORDER BY random() ... LIMIT` query with the expected bound value, and no unbounded id-only `findMany` pool fetch remains; genre `value="%"` / `"_"` bind as escaped literals (`%\%%` / `%\_%`) while `"rock"` passes through unchanged; each branch still returns the expected tracks.

verify: `npm --prefix backend test -- library --maxWorkers=2` — 8 suites, 247 tests passed.
verify: `backend npx tsc --noEmit` — exit 0.
verify: `npm run verify:gates` — route-error canon, error-canon self-test, hex gate, OpenAPI route sync, and contract/backend/root Prettier all pass (frontend prettier step unrunnable locally: no frontend node_modules in this worktree; no frontend files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24