### PR TITLE
fix(library): share the LIKE-pattern escaper and apply it to the radio-builder genre fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Soulseek: public disconnect() now destroys the client and removes its error listener before dropping the reference, closing a socket/listener leak on reconnect cycles (sibling of #331).
+- Promoted the backend LIKE-pattern escaper to the shared
+  `backend/src/utils/likePattern.ts` utility and applied it to the multi-seed
+  radio builder's genre-expansion fallback, where user-editable `%` and `_`
+  characters previously acted as wildcards and could flood the radio queue; all
+  genre LIKE sites now use an explicit `ESCAPE '\'` clause.
 - Dedicated Redis BLPOP connection is now closed when its initial connect fails,
   instead of leaking a reconnecting client.
 - Worker health-check interval is now captured, unref'd, and cleared during

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -70,6 +70,7 @@ import { shuffleArray } from "../utils/shuffle";
 import { separateArtists } from "../utils/separateArtists";
 import { safeResolvePath } from "../utils/safeResolvePath";
 import { parseBoundedInt } from "../utils/queryParams";
+import { escapeLikePattern } from "../utils/likePattern";
 import {
     applyTrackPreferenceOrderBias,
     applyTrackPreferenceSimilarityBias,
@@ -138,10 +139,6 @@ const COVER_ART_IMAGE_CACHE_CONTROL = `public, max-age=${COVER_ART_IMAGE_CACHE_T
 const RELIABLE_ENHANCED_ANALYSIS_VERSION_PREFIX = "2.1b6-enhanced-v3";
 const AUDIO_INFO_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const AUDIO_INFO_CACHE_MAX_ENTRIES = 2000;
-
-/** Escape LIKE metacharacters so user input matches literally (PG default escape '\'). */
-const escapeLikePattern = (value: string): string =>
-    value.replace(/[\\%_]/g, (character) => `\\${character}`);
 
 const moodPoolCondition = (moodValue: string): Prisma.Sql => {
     switch (moodValue) {
@@ -6199,11 +6196,11 @@ router.get(
                     FROM "Track" t
                     WHERE EXISTS (
                         SELECT 1 FROM unnest(t."lastfmTags") AS tag(name)
-                        WHERE LOWER(tag.name) LIKE ${genrePattern}
+                        WHERE LOWER(tag.name) LIKE ${genrePattern} ESCAPE '\\'
                     )
                     OR EXISTS (
                         SELECT 1 FROM unnest(t."essentiaGenres") AS eg(name)
-                        WHERE LOWER(eg.name) LIKE ${genrePattern}
+                        WHERE LOWER(eg.name) LIKE ${genrePattern} ESCAPE '\\'
                     )
                     ORDER BY random()
                     LIMIT ${limitNum * 4}
@@ -6223,12 +6220,12 @@ router.get(
                         WHERE (
                             (ar.genres IS NOT NULL AND EXISTS (
                                 SELECT 1 FROM jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
-                                WHERE LOWER(g.genre) LIKE ${genrePattern}
+                                WHERE LOWER(g.genre) LIKE ${genrePattern} ESCAPE '\\'
                             ))
                             OR
                             (ar."userGenres" IS NOT NULL AND EXISTS (
                                 SELECT 1 FROM jsonb_array_elements_text(ar."userGenres"::jsonb) AS ug(genre)
-                                WHERE LOWER(ug.genre) LIKE ${genrePattern}
+                                WHERE LOWER(ug.genre) LIKE ${genrePattern} ESCAPE '\\'
                             ))
                         )
                         ORDER BY sort_key

--- a/backend/src/services/__tests__/libraryRadioBuilder.test.ts
+++ b/backend/src/services/__tests__/libraryRadioBuilder.test.ts
@@ -1,0 +1,135 @@
+const mockTrackFindMany = jest.fn();
+const mockPrismaQueryRaw = jest.fn();
+const mockComputeAggregateFeatureVector = jest.fn();
+const mockScoreTracksAgainstSeed = jest.fn();
+const mockBuildTrackPreferenceScoreMapForUser = jest.fn();
+const MAX_SQL_FRAGMENT_VALUES = 64;
+
+interface SqlFragment {
+    strings: readonly string[];
+    values: readonly unknown[];
+}
+
+const isSqlFragment = (value: unknown): value is SqlFragment =>
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as Partial<SqlFragment>).strings) &&
+    Array.isArray((value as Partial<SqlFragment>).values);
+
+const collectSql = (
+    fragment: SqlFragment,
+): { text: string; values: unknown[] } => {
+    const pending: unknown[] = [fragment];
+    const values: unknown[] = [];
+    let text = "";
+
+    for (
+        let index = 0;
+        index < pending.length && index < MAX_SQL_FRAGMENT_VALUES;
+        index += 1
+    ) {
+        const value = pending[index];
+        if (isSqlFragment(value)) {
+            text += value.strings.join("");
+            pending.push(...value.values);
+        } else if (Array.isArray(value)) {
+            pending.push(...value);
+        } else {
+            values.push(value);
+        }
+    }
+
+    if (pending.length > MAX_SQL_FRAGMENT_VALUES) {
+        throw new Error("SQL fragment exceeded the test inspection bound");
+    }
+
+    return { text, values };
+};
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: {
+            findMany: mockTrackFindMany,
+        },
+        $queryRaw: mockPrismaQueryRaw,
+    },
+    Prisma: {
+        sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+            strings: [...strings],
+            values,
+        }),
+        join: (values: unknown[]) => ({ strings: [""], values }),
+    },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../radioVibeEngine", () => ({
+    computeAggregateFeatureVector: mockComputeAggregateFeatureVector,
+    scoreTracksAgainstSeed: mockScoreTracksAgainstSeed,
+}));
+
+jest.mock("../trackPreference", () => ({
+    applyTrackPreferenceSimilarityBias: jest.fn(),
+}));
+
+jest.mock("../libraryTrackPreferences", () => ({
+    buildTrackPreferenceScoreMapForUser:
+        mockBuildTrackPreferenceScoreMapForUser,
+}));
+
+jest.mock("../../utils/shuffle", () => ({
+    shuffleArray: (values: unknown[]) => values,
+}));
+
+import { buildMultiTrackRadio } from "../libraryRadioBuilder";
+
+const createSeedTrack = (genre: string) => ({
+    id: "seed-1",
+    lastfmTags: [],
+    essentiaGenres: [],
+    album: {
+        artistId: "artist-1",
+        artist: {
+            id: "artist-1",
+            genres: [genre],
+            userGenres: [],
+        },
+    },
+});
+
+describe("buildMultiTrackRadio genre fallback", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockComputeAggregateFeatureVector.mockReturnValue({ energy: 0.5 });
+        mockScoreTracksAgainstSeed.mockReturnValue([]);
+        mockBuildTrackPreferenceScoreMapForUser.mockResolvedValue(new Map());
+        mockPrismaQueryRaw.mockResolvedValue([]);
+    });
+
+    it.each([
+        ["drum%bass", "%drum\\%bass%"],
+        ["rock", "%rock%"],
+    ])("binds genre %j as literal LIKE pattern %j", async (genre, pattern) => {
+        mockTrackFindMany
+            .mockResolvedValueOnce([createSeedTrack(genre)])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([]);
+
+        await buildMultiTrackRadio(["seed-1"], ["seed-1"], 10, "user-1");
+
+        expect(mockPrismaQueryRaw).toHaveBeenCalledTimes(1);
+        const [strings, ...values] = mockPrismaQueryRaw.mock.calls[0];
+        const query = collectSql({ strings: [...strings], values });
+        expect(query.values).toContain(pattern);
+        expect(query.text).toContain("ESCAPE '\\'");
+    });
+});

--- a/backend/src/services/libraryRadioBuilder.ts
+++ b/backend/src/services/libraryRadioBuilder.ts
@@ -8,6 +8,7 @@ import { applyTrackPreferenceSimilarityBias } from "./trackPreference";
 import { buildTrackPreferenceScoreMapForUser } from "./libraryTrackPreferences";
 import { getMergedGenres } from "../utils/metadataOverrides";
 import { shuffleArray } from "../utils/shuffle";
+import { escapeLikePattern } from "../utils/likePattern";
 
 export const getRadioArtistCapForLimit = (limit: number): number => {
     if (!Number.isFinite(limit) || limit <= 0) return 2;
@@ -272,7 +273,7 @@ export const buildMultiTrackRadio = async (
                 (g) =>
                     Prisma.sql`EXISTS (
                         SELECT 1 FROM jsonb_array_elements_text("Artist"."genres") AS g
-                        WHERE LOWER(g) LIKE ${`%${g}%`}
+                        WHERE LOWER(g) LIKE ${`%${escapeLikePattern(g)}%`} ESCAPE '\\'
                     )`,
             );
             const genreTracks = await prisma.$queryRaw<{ id: string }[]>`

--- a/backend/src/utils/__tests__/likePattern.test.ts
+++ b/backend/src/utils/__tests__/likePattern.test.ts
@@ -1,0 +1,14 @@
+import { escapeLikePattern } from "../likePattern";
+
+describe("escapeLikePattern", () => {
+    it.each([
+        ["%", "\\%"],
+        ["_", "\\_"],
+        ["\\", "\\\\"],
+        ["rock", "rock"],
+        ["50%_r\\ock", "50\\%\\_r\\\\ock"],
+        ["", ""],
+    ])("escapes %j as %j", (value, expected) => {
+        expect(escapeLikePattern(value)).toBe(expected);
+    });
+});

--- a/backend/src/utils/likePattern.ts
+++ b/backend/src/utils/likePattern.ts
@@ -1,0 +1,7 @@
+/**
+ * Escapes SQL LIKE metacharacters so user input matches literally.
+ * PostgreSQL defaults to backslash, but callers must pair the pattern with an
+ * explicit `ESCAPE '\\'` clause.
+ */
+export const escapeLikePattern = (value: string): string =>
+    value.replace(/[\\%_]/g, (character) => `\\${character}`);


### PR DESCRIPTION
## Summary

PR #334 escaped LIKE wildcards for the genre-radio route, but the escaper was file-local to `backend/src/routes/library.ts`, so a sibling site was missed: `buildMultiTrackRadio`'s genre-expansion fallback (`backend/src/services/libraryRadioBuilder.ts`) bound user-editable merged genres into `LIKE` unescaped — a genre containing `%` or `_` acted as a wildcard and flooded the radio queue with broad matches (parameterized via Prisma, so no SQL injection; match-scope only).

- Promote `escapeLikePattern` to a shared util `backend/src/utils/likePattern.ts` (escapes `\`, `%`, `_`), with JSDoc.
- Re-point `library.ts` to the shared util and delete the file-local copy.
- Apply the escaper to the radio-builder genre fallback.
- Add an explicit `ESCAPE '\'` clause at every escaped LIKE site (Postgres default is backslash; now explicit and consistent).

## LIKE-site audit

- `library.ts` genre-radio raw SQL (4 sites): already escaped via #334; now use the shared util + explicit `ESCAPE`.
- `libraryRadioBuilder.ts` Fallback B: was unescaped — fixed here.
- `library.ts` workout `LIKE '%' || g.name || '%'`: input is the hardcoded `workoutGenreNames` constant list — not user-influenced, unchanged.
- `services/search.ts` fallbacks: Prisma query-API `contains`, not raw SQL interpolation — out of scope.

## Testing

- New `backend/src/utils/__tests__/likePattern.test.ts` (unit behavior incl. `\`, `%`, `_`, combined, empty).
- New `backend/src/services/__tests__/libraryRadioBuilder.test.ts`: `drum%bass` binds as literal `%drum\%bass%` with an `ESCAPE` clause; plain `rock` unchanged.
- `npx tsc --noEmit` clean; `jest likePattern libraryRadioBuilder libraryRuntime` 134 passed; `libraryRadioVibeReliabilityCompat` 6 passed; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce1DrCV7STJUPwvZwgkD24