### PR TITLE
fix(player): make engine end-of-track synthesis re-emittable on tab refocus

### DIFF
--- a/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
@@ -883,10 +883,17 @@ const handlePageRestored = (
 };
 
 const handleForceEnded = (state: State, nowMs: number): Transition => {
-    if (state.status !== "playing") {
+    const canSynthesizeEnd =
+        state.status === "playing" ||
+        state.status === "ended" ||
+        (state.status === "paused" && state.pauseClassification === "external");
+    if (!state.hasSource || !canSynthesizeEnd) {
         return noChange(state);
     }
-    return handleElementEnded(state, nowMs);
+    return {
+        state: { ...state, status: "ended", pausedAtMs: nowMs },
+        effects: [{ kind: "stopTicker" }, { kind: "emitEnd" }],
+    };
 };
 
 /**

--- a/frontend/lib/howler-engine.ts
+++ b/frontend/lib/howler-engine.ts
@@ -159,13 +159,13 @@ class HowlerEngine {
                 this.isLoading = false;
                 this.state.duration = this.howl.duration() || 0;
 
-                // Use setTimeout to emit after caller registers listeners
-                setTimeout(() => {
+                // Use a microtask to emit after caller registers listeners
+                queueMicrotask(() => {
                     this.emit("load", { duration: this.state.duration });
                     if (autoplay) {
                         this.play();
                     }
-                }, 0);
+                });
                 return;
             }
         }
@@ -692,11 +692,11 @@ class HowlerEngine {
 
     /**
      * Synthesize a track-end event. Used by foreground recovery when
-     * the track finished while the page was hidden and neither Howler's
-     * timer-polled onend nor the native fallback fired.
+     * the track finished while the page was hidden but its earlier end
+     * delivery was not handled by the orchestrator.
      */
     notifyTrackEnded(): void {
-        if (!this.state.isPlaying) return;
+        if (!this.hasTrackEnded()) return;
         this.state.isPlaying = false;
         this.stopTimeUpdates();
         this.emit("end");

--- a/frontend/tests/unit/howlerEngineEndSynthesis.test.ts
+++ b/frontend/tests/unit/howlerEngineEndSynthesis.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test, { after, before } from "node:test";
+import type { Howl, HowlOptions } from "howler";
+
+type HowlCallback = (...args: unknown[]) => void;
+
+class StubMediaElement extends EventTarget {
+    ended = false;
+    currentTime = 0;
+}
+
+class StubHowl {
+    static readonly instances: StubHowl[] = [];
+
+    readonly _sounds: Array<{ _node: StubMediaElement }>;
+    playCalls = 0;
+
+    private readonly callbacks = new Map<string, Set<HowlCallback>>();
+    private readonly options: HowlOptions;
+
+    constructor(options: HowlOptions) {
+        this.options = options;
+        this._sounds = [{ _node: new StubMediaElement() }];
+        StubHowl.instances.push(this);
+    }
+
+    finishLoad(): void {
+        this.options.onload?.(1);
+    }
+
+    duration(): number {
+        return 240;
+    }
+
+    fade(): this {
+        return this;
+    }
+
+    on(event: string, callback: HowlCallback): this {
+        const callbacks = this.callbacks.get(event) ?? new Set();
+        callbacks.add(callback);
+        this.callbacks.set(event, callbacks);
+        return this;
+    }
+
+    once(event: string, callback: HowlCallback): this {
+        return this.on(event, callback);
+    }
+
+    pause(): this {
+        return this;
+    }
+
+    play(): number {
+        this.playCalls += 1;
+        return this.playCalls;
+    }
+
+    playing(): boolean {
+        return false;
+    }
+
+    seek(): number {
+        return 0;
+    }
+
+    stop(): this {
+        return this;
+    }
+
+    unload(): null {
+        return null;
+    }
+
+    volume(): number {
+        return 1;
+    }
+}
+
+const require = createRequire(import.meta.url);
+const howlerModule = require("howler") as { Howl: typeof Howl };
+const OriginalHowl = howlerModule.Howl;
+const originalMediaElement = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "HTMLMediaElement",
+);
+
+howlerModule.Howl = StubHowl as unknown as typeof Howl;
+let HowlerEngine: (typeof import("../../lib/howler-engine"))["HowlerEngine"];
+
+before(async () => {
+    Object.defineProperty(globalThis, "HTMLMediaElement", {
+        configurable: true,
+        value: StubMediaElement,
+    });
+    ({ HowlerEngine } = await import("../../lib/howler-engine"));
+});
+
+after(() => {
+    howlerModule.Howl = OriginalHowl;
+    if (originalMediaElement) {
+        Object.defineProperty(
+            globalThis,
+            "HTMLMediaElement",
+            originalMediaElement,
+        );
+    } else {
+        Reflect.deleteProperty(globalThis, "HTMLMediaElement");
+    }
+});
+
+test("notifyTrackEnded re-emits a consumed end when the media node ended", (t) => {
+    const engine = new HowlerEngine();
+    t.after(() => engine.destroy());
+    engine.load("https://stream.example/ended.flac");
+    const howl = StubHowl.instances.at(-1);
+    assert.ok(howl);
+    howl._sounds[0]._node.ended = true;
+
+    let endEvents = 0;
+    engine.on("end", () => {
+        endEvents += 1;
+    });
+
+    assert.equal(engine.getState().isPlaying, false);
+    engine.notifyTrackEnded();
+    assert.equal(endEvents, 1);
+});
+
+test("notifyTrackEnded does not emit before the media node ends", (t) => {
+    const engine = new HowlerEngine();
+    t.after(() => engine.destroy());
+    engine.load("https://stream.example/playing.flac");
+    const howl = StubHowl.instances.at(-1);
+    assert.ok(howl);
+    howl._sounds[0]._node.ended = false;
+
+    let endEvents = 0;
+    engine.on("end", () => {
+        endEvents += 1;
+    });
+
+    engine.notifyTrackEnded();
+    assert.equal(endEvents, 0);
+});
+
+test("preloaded promotion emits load and autoplays after only a microtask flush", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const engine = new HowlerEngine();
+    t.after(() => engine.destroy());
+    const src = "https://stream.example/preloaded.flac";
+
+    engine.preload(src, "flac");
+    const preloadedHowl = StubHowl.instances.at(-1);
+    assert.ok(preloadedHowl);
+    preloadedHowl.finishLoad();
+
+    let loadEvents = 0;
+    engine.load(src, true, "flac");
+    engine.on("load", () => {
+        loadEvents += 1;
+    });
+
+    assert.equal(loadEvents, 0);
+    assert.equal(preloadedHowl.playCalls, 0);
+    await Promise.resolve();
+    assert.equal(loadEvents, 1);
+    assert.equal(preloadedHowl.playCalls, 1);
+});

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -554,7 +554,7 @@ test("native ended event emits end exactly once and stops the ticker", () => {
     assert.equal(harness.engine.hasTrackEnded(), true);
 });
 
-test("notifyTrackEnded synthesizes end only while playing (foreground recovery)", () => {
+test("notifyTrackEnded emits while playing, re-emits after end, and no-ops without a source", () => {
     const harness = createHarness();
     harness.engine.load("https://stream.example/track.flac", {
         autoplay: true,
@@ -568,7 +568,14 @@ test("notifyTrackEnded synthesizes end only while playing (foreground recovery)"
     harness.engine.notifyTrackEnded();
     assert.equal(
         harness.events.filter((event) => event.type === "end").length,
-        1,
+        2,
+    );
+
+    const unloadedHarness = createHarness();
+    unloadedHarness.engine.notifyTrackEnded();
+    assert.equal(
+        unloadedHarness.events.filter((event) => event.type === "end").length,
+        0,
     );
 });
 

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -561,19 +561,54 @@ test("ELEMENT_ENDED emits end exactly once", () => {
     assert.deepEqual(second.effects, []);
 });
 
-test("FORCE_ENDED synthesizes end only while playing", () => {
-    const playing = transitionNativeEngine(playingState(), {
-        type: "FORCE_ENDED",
+test("FORCE_ENDED re-emits a naturally consumed end", () => {
+    const naturallyEnded = transitionNativeEngine(playingState(), {
+        type: "ELEMENT_ENDED",
         nowMs: 5_000,
     });
-    assert.ok(kinds(playing.effects).includes("emitEnd"));
-    assert.equal(playing.state.status, "ended");
+    const recovered = transitionNativeEngine(naturallyEnded.state, {
+        type: "FORCE_ENDED",
+        nowMs: 5_001,
+    });
+    assert.ok(kinds(recovered.effects).includes("emitEnd"));
+    assert.equal(recovered.state.status, "ended");
+});
 
-    const paused = transitionNativeEngine(loadedState(), {
+test("FORCE_ENDED synthesizes end from an external pause", () => {
+    const externallyPaused = loadedState({ pauseClassification: "external" });
+    const recovered = transitionNativeEngine(externallyPaused, {
         type: "FORCE_ENDED",
         nowMs: 5_000,
     });
-    assert.deepEqual(paused.effects, []);
+    assert.ok(kinds(recovered.effects).includes("emitEnd"));
+    assert.equal(recovered.state.status, "ended");
+});
+
+test("FORCE_ENDED with no source is a no-op", () => {
+    const { effects } = transitionNativeEngine(
+        createInitialNativeEngineState(),
+        { type: "FORCE_ENDED", nowMs: 5_000 },
+    );
+    assert.deepEqual(effects, []);
+});
+
+test("a fresh load prevents FORCE_ENDED from re-emitting for the prior source", () => {
+    const forced = transitionNativeEngine(playingState(), {
+        type: "FORCE_ENDED",
+        nowMs: 5_000,
+    });
+    const freshLoad = transitionNativeEngine(forced.state, {
+        type: "LOAD_REQUESTED",
+        autoplay: true,
+        startTimeSec: null,
+        nowMs: 5_001,
+    });
+    const staleForce = transitionNativeEngine(freshLoad.state, {
+        type: "FORCE_ENDED",
+        nowMs: 5_002,
+    });
+    assert.equal(freshLoad.state.status, "loading");
+    assert.deepEqual(staleForce.effects, []);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of the Phase G playback-reliability fixes (owner-reported: playback stops at track boundaries in unfocused tabs and refocusing never repairs it).

Root cause (verified by diagnosis): the foreground-recovery call `audioEngine.notifyTrackEnded()` was a guaranteed no-op in BOTH engines once a natural `ended` had already fired — the native policy's `FORCE_ENDED` required `status === 'playing'` (`nativeAudioElementPolicy.ts` handleForceEnded) and Howler's `notifyTrackEnded` early-returned when `!state.isPlaying`. So a missed boundary advance could never be re-driven from a tab refocus.

Changes
- **native engine**: `FORCE_ENDED` re-emits the end from `ended` and externally-paused states when a source is loaded. `idle`/no-source still no-op; a subsequent `LOAD_REQUESTED` resets the policy so a stale force cannot re-fire for the old source (orchestrator duplicate-end/loadId guards absorb near-simultaneous doubles).
- **howler engine**: `notifyTrackEnded` now requires the underlying node's real ended state (`hasTrackEnded()`) instead of `isPlaying` before synthesizing `end`.
- **howler engine**: preloaded-track promotion emits `load`/autoplay via `queueMicrotask` instead of `setTimeout(0)` — microtasks are not subject to background-tab timer clamping, so the boundary handoff no longer stretches to ≥1s in hidden tabs. Listener-registration ordering is preserved.

Complements the orchestrator-side hardening slice (separate PR): either alone fixes refocus stickiness; together they also cover engine-swap drift.

Tests
- `nativeAudioElementPolicy.test.ts`: FORCE_ENDED from `ended` emits end; from `idle`/no-source no-ops; stale FORCE_ENDED after a fresh load no-ops.
- new `howlerEngineEndSynthesis.test.ts`: exactly one `end` when node reports ended; none otherwise; preload promotion delivers `load`+`play()` with fake timers un-advanced (microtask flush only).
- Targeted runs: 76/76 pass; prettier clean on touched files.