### PR TITLE
fix(player): background-tab playback advance hardening (autoplay rejection, breaker self-heal, refocus repair)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Playback no longer permanently stops at track boundaries in background tabs:
+  autoplay rejection is no longer treated as a fatal track error, refocusing
+  completes a missed advance, and the consecutive-error breaker self-heals on
+  return.
 - Soulseek: public disconnect() now destroys the client and removes its error listener before dropping the reference, closing a socket/listener leak on reconnect cycles (sibling of #331).
 - Dedicated Redis BLPOP connection is now closed when its initial connect fails,
   instead of leaking a reconnecting client.

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -16,6 +16,7 @@ import {
     resolveStreamingEngineMode,
 } from "@/lib/audio-engine/engineMode";
 import type {
+    AudioEngineErrorPayload,
     AudioEngineManifestStallPayload,
     AudioEngineRepresentationFailoverResult,
     AudioEngineSource,
@@ -398,6 +399,9 @@ const AUDIO_ENGINE_MANIFEST_STALL_EVENTS = [
     "manifest-stall",
 ] as const;
 const audioEngine = createRuntimeAudioEngine();
+const orchestratorLogger = sharedFrontendLogger.child(
+    "AudioPlaybackOrchestrator",
+);
 
 interface ActiveSegmentedSessionSnapshot {
     sessionId: string;
@@ -700,6 +704,7 @@ export const AudioPlaybackOrchestrator = memo(
         );
         const pendingTrackErrorSkipRef = useRef<NodeJS.Timeout | null>(null);
         const pendingTrackErrorTrackIdRef = useRef<string | null>(null);
+        const trackErrorAdvanceFromTrackIdRef = useRef<string | null>(null);
         const consecutiveErrorBreakerRef = useRef(
             createConsecutiveErrorBreaker(),
         );
@@ -718,6 +723,8 @@ export const AudioPlaybackOrchestrator = memo(
         const playbackTypeRef = useRef(playbackType);
         const lastLoggedRemotePlayKeyRef = useRef<string | null>(null);
         const activeEngineTrackIdRef = useRef<string | null>(null);
+        const activeEngineLoadIdRef = useRef<number>(-1);
+        const recoverablePlayErrorPendingRef = useRef<boolean>(false);
         const startupRecoveryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
         const startupRecoveryLoadListenerRef = useRef<(() => void) | null>(
             null,
@@ -2099,6 +2106,14 @@ export const AudioPlaybackOrchestrator = memo(
                     if (playbackTypeRef.current !== "track") return;
                     if (!lastPlayingStateRef.current) return;
                     if (currentTrackRef.current?.id !== trackId) return;
+                    const listenTogetherSession =
+                        getListenTogetherSessionSnapshot();
+                    if (
+                        listenTogetherSession?.groupId &&
+                        !listenTogetherSession.isHost
+                    ) {
+                        return;
+                    }
 
                     const startupStability =
                         segmentedStartupStabilityRef.current;
@@ -2156,6 +2171,14 @@ export const AudioPlaybackOrchestrator = memo(
                         if (!lastPlayingStateRef.current) return;
                         if (currentTrackRef.current?.id !== trackId) return;
                         if (audioEngine.isPlaying()) return;
+                        const listenTogetherSession =
+                            getListenTogetherSessionSnapshot();
+                        if (
+                            listenTogetherSession?.groupId &&
+                            !listenTogetherSession.isHost
+                        ) {
+                            return;
+                        }
 
                         audioEngine.play();
                     };
@@ -2338,6 +2361,8 @@ export const AudioPlaybackOrchestrator = memo(
 
                     lastTrackIdRef.current = null;
                     isLoadingRef.current = false;
+                    trackErrorAdvanceFromTrackIdRef.current = failedTrackId;
+                    advancePlayIntentAtMsRef.current = Date.now();
                     next();
                 }, TRACK_ERROR_SKIP_DELAY_MS);
             },
@@ -4492,8 +4517,6 @@ export const AudioPlaybackOrchestrator = memo(
 
         // Subscribe to runtime audio engine events
         useEffect(() => {
-            const effectLoadId = loadIdRef.current;
-
             const handleTimeUpdate = (data: {
                 timeSec: number;
                 time?: number;
@@ -4538,6 +4561,7 @@ export const AudioPlaybackOrchestrator = memo(
                         loadTimeoutRetryCountRef.current = 0;
                         isLoadingRef.current = false;
                         activeEngineTrackIdRef.current = liveTrackId;
+                        activeEngineLoadIdRef.current = loadIdRef.current;
                         logPlaybackClientMetric(
                             "session.startup_timeout_skip",
                             {
@@ -4649,11 +4673,23 @@ export const AudioPlaybackOrchestrator = memo(
                 );
                 if (playbackType === "track") {
                     if (isLoadingRef.current) {
+                        orchestratorLogger.warn("Rejected track end event", {
+                            reason: "engine_source_loading",
+                            currentTrackId: currentTrackRef.current?.id ?? null,
+                            activeLoadId: activeEngineLoadIdRef.current,
+                            currentLoadId: loadIdRef.current,
+                        });
                         return;
                     }
 
                     // Guard: stale end event from a previous load cycle
-                    if (effectLoadId !== loadIdRef.current) {
+                    if (activeEngineLoadIdRef.current !== loadIdRef.current) {
+                        orchestratorLogger.warn("Rejected track end event", {
+                            reason: "stale_engine_load",
+                            currentTrackId: currentTrackRef.current?.id ?? null,
+                            activeLoadId: activeEngineLoadIdRef.current,
+                            currentLoadId: loadIdRef.current,
+                        });
                         return;
                     }
                     const currentTrackId = currentTrackRef.current?.id ?? null;
@@ -4663,13 +4699,12 @@ export const AudioPlaybackOrchestrator = memo(
                         activeEngineTrackId &&
                         currentTrackId !== activeEngineTrackId
                     ) {
-                        sharedFrontendLogger.warn(
-                            "[AudioPlaybackOrchestrator] Ignoring stale Listen Together track end event",
-                            {
-                                currentTrackId,
-                                activeEngineTrackId,
-                            },
-                        );
+                        orchestratorLogger.warn("Rejected track end event", {
+                            reason: "stale_engine_track",
+                            currentTrackId,
+                            activeEngineTrackId,
+                            activeLoadId: activeEngineLoadIdRef.current,
+                        });
                         return;
                     }
 
@@ -4683,9 +4718,10 @@ export const AudioPlaybackOrchestrator = memo(
                             lastHandled.loadId === activeLoadId &&
                             now - lastHandled.handledAtMs < 1500
                         ) {
-                            sharedFrontendLogger.warn(
-                                "[AudioPlaybackOrchestrator] Ignoring duplicate track end event",
+                            orchestratorLogger.warn(
+                                "Rejected track end event",
                                 {
+                                    reason: "duplicate_end",
                                     currentTrackId,
                                     activeLoadId,
                                     sinceLastHandledMs:
@@ -4841,7 +4877,28 @@ export const AudioPlaybackOrchestrator = memo(
                 }
             };
 
-            const handleError = async (data: { error: unknown }) => {
+            const handleError = async (data: AudioEngineErrorPayload) => {
+                const isRecoverablePlayError =
+                    data.code === "NotAllowedError" ||
+                    data.recoverable === true;
+                if (isRecoverablePlayError) {
+                    orchestratorLogger.warn(
+                        "Playback deferred for browser-owned recovery",
+                        {
+                            code: data.code ?? null,
+                            recoverable: data.recoverable === true,
+                            trackId: currentTrackRef.current?.id ?? null,
+                        },
+                    );
+                    howlerLoadStartMsRef.current = 0;
+                    recoverablePlayErrorPendingRef.current = true;
+                    isUserInitiatedRef.current = false;
+                    playbackStateMachine.forceTransition("LOADING");
+                    setIsPlaying(false);
+                    setIsBuffering(true);
+                    return;
+                }
+
                 sharedFrontendLogger.error(
                     "[AudioPlaybackOrchestrator] Playback error:",
                     data.error,
@@ -4983,6 +5040,7 @@ export const AudioPlaybackOrchestrator = memo(
                 emitSegmentedStartupTimeline("playback_error", {
                     error: errorMessage,
                 });
+                recoverablePlayErrorPendingRef.current = false;
                 isUserInitiatedRef.current = false;
                 heartbeatRef.current?.stop();
                 clearTransientTrackRecovery(true);
@@ -5217,6 +5275,10 @@ export const AudioPlaybackOrchestrator = memo(
                 clearPendingTrackErrorSkip();
                 clearStartupPlaybackRecovery();
                 clearTransientTrackRecovery(true);
+                if (recoverablePlayErrorPendingRef.current) {
+                    recoverablePlayErrorPendingRef.current = false;
+                    setIsBuffering(false);
+                }
                 if (playbackTypeRef.current === "track") {
                     lastTrackTimeUpdateAtMsRef.current = Date.now();
                 }
@@ -5571,6 +5633,8 @@ export const AudioPlaybackOrchestrator = memo(
                     return;
                 }
 
+                consecutiveErrorBreakerRef.current.reset();
+
                 const decision = resolveForegroundRecoveryDecision({
                     isVisible: true,
                     wasPlayingWhenHidden: wasPlayingWhenHiddenRef.current,
@@ -5590,7 +5654,7 @@ export const AudioPlaybackOrchestrator = memo(
                 // Detect whether the track finished while backgrounded.
                 // This check runs before the throttle gate so that a
                 // completed track is never suppressed by cooldown timing.
-                if (playbackType === "track") {
+                if (playbackTypeRef.current === "track") {
                     const trackEnded =
                         typeof audioEngine.hasTrackEnded === "function"
                             ? audioEngine.hasTrackEnded()
@@ -5600,12 +5664,35 @@ export const AudioPlaybackOrchestrator = memo(
                                   return d > 0 && p >= d - 0.1;
                               })();
                     if (trackEnded) {
-                        sharedFrontendLogger.info(
-                            "[AudioPlaybackOrchestrator] Foreground recovery: track ended while backgrounded, synthesizing end event",
-                            { trackId: currentMediaId },
-                        );
-                        audioEngine.notifyTrackEnded();
-                        return;
+                        const currentLoadId = loadIdRef.current;
+                        const lastHandled = lastHandledTrackEndRef.current;
+                        const endWasAlreadyHandled =
+                            lastHandled.trackId === currentMediaId &&
+                            lastHandled.loadId === currentLoadId;
+                        const engineSourceMatchesCurrentTrack =
+                            activeEngineTrackIdRef.current === currentMediaId &&
+                            activeEngineLoadIdRef.current === currentLoadId;
+                        if (
+                            !endWasAlreadyHandled &&
+                            engineSourceMatchesCurrentTrack
+                        ) {
+                            const now = Date.now();
+                            lastHandledTrackEndRef.current = {
+                                trackId: currentMediaId,
+                                loadId: currentLoadId,
+                                handledAtMs: now,
+                            };
+                            advancePlayIntentAtMsRef.current = now;
+                            orchestratorLogger.info(
+                                "Foreground recovery advancing ended track",
+                                {
+                                    trackId: currentMediaId,
+                                    loadId: currentLoadId,
+                                },
+                            );
+                            next();
+                            return;
+                        }
                     }
                 }
 
@@ -5645,7 +5732,7 @@ export const AudioPlaybackOrchestrator = memo(
                     clearTimeout(recoveryTimeoutId);
                 }
             };
-        }, [currentAudiobook?.id, currentPodcast?.id, setIsBuffering]);
+        }, [currentAudiobook?.id, currentPodcast?.id, next, setIsBuffering]);
 
         // Load and play audio when track changes
         useEffect(() => {
@@ -5761,9 +5848,22 @@ export const AudioPlaybackOrchestrator = memo(
 
             isLoadingRef.current = true;
             activeEngineTrackIdRef.current = null;
+            activeEngineLoadIdRef.current = -1;
             lastTrackIdRef.current = currentMediaId;
             loadIdRef.current += 1;
             const thisLoadId = loadIdRef.current;
+            const hasAdvancePlayIntent = isAdvancePlayIntentFresh(
+                advancePlayIntentAtMsRef.current,
+                Date.now(),
+            );
+            advancePlayIntentAtMsRef.current = null;
+            if (
+                playbackType === "track" &&
+                previousMediaId !== null &&
+                !hasAdvancePlayIntent
+            ) {
+                consecutiveErrorBreakerRef.current.reset();
+            }
             loadTimeoutRetryCountRef.current = 0;
             segmentedStartupRetryCountRef.current = 0;
             segmentedStartupStageAttemptsRef.current =
@@ -5891,15 +5991,6 @@ export const AudioPlaybackOrchestrator = memo(
             if (streamUrl) {
                 setCurrentTime(Math.max(0, startTime));
                 const wasEnginePlayingBeforeLoad = audioEngine.isPlaying();
-                // Consume a declared auto-advance play intent (stamped by the
-                // track-end handler). Captured once so the load-time and the
-                // deferred (handleLoaded) autoplay decisions agree.
-                const hasAdvancePlayIntent = isAdvancePlayIntentFresh(
-                    advancePlayIntentAtMsRef.current,
-                    Date.now(),
-                );
-                advancePlayIntentAtMsRef.current = null;
-
                 const fallbackDuration =
                     currentTrack?.duration ||
                     currentAudiobook?.duration ||
@@ -6728,6 +6819,10 @@ export const AudioPlaybackOrchestrator = memo(
                             playbackType === "track" && currentTrack
                                 ? currentTrack.id
                                 : null;
+                        activeEngineLoadIdRef.current =
+                            playbackType === "track" && currentTrack
+                                ? thisLoadId
+                                : -1;
 
                         if (startTime > 0) {
                             audioEngine.seek(startTime);
@@ -7262,6 +7357,17 @@ export const AudioPlaybackOrchestrator = memo(
             isUserInitiatedRef.current = true;
 
             if (isPlaying) {
+                const errorAdvanceFromTrackId =
+                    trackErrorAdvanceFromTrackIdRef.current;
+                const isTrackErrorAdvance =
+                    playbackType === "track" &&
+                    errorAdvanceFromTrackId !== null &&
+                    (currentTrack?.id !== errorAdvanceFromTrackId ||
+                        repeatMode === "one");
+                trackErrorAdvanceFromTrackIdRef.current = null;
+                if (!isTrackErrorAdvance) {
+                    consecutiveErrorBreakerRef.current.reset();
+                }
                 applyCurrentOutputState();
                 audioEngine.play();
                 if (playbackType === "track" && currentTrack?.id) {
@@ -7275,6 +7381,7 @@ export const AudioPlaybackOrchestrator = memo(
             isPlaying,
             playbackType,
             currentTrack?.id,
+            repeatMode,
             applyCurrentOutputState,
             scheduleStartupPlaybackRecovery,
             clearStartupPlaybackRecovery,

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -70,11 +70,13 @@ class FakeAudioEngine {
     public pauseCalls = 0;
     public stopCalls = 0;
     public reloadCalls = 0;
+    public notifyTrackEndedCalls = 0;
 
     public currentTime = 0;
     public actualCurrentTime = 0;
     public duration = 240;
     public playing = false;
+    public trackEnded = false;
 
     private handlers = new Map<string, Set<(payload?: unknown) => void>>();
 
@@ -90,10 +92,12 @@ class FakeAudioEngine {
         this.pauseCalls = 0;
         this.stopCalls = 0;
         this.reloadCalls = 0;
+        this.notifyTrackEndedCalls = 0;
         this.currentTime = 0;
         this.actualCurrentTime = 0;
         this.duration = 240;
         this.playing = false;
+        this.trackEnded = false;
         this.handlers.clear();
     }
 
@@ -160,6 +164,14 @@ class FakeAudioEngine {
 
     isPlaying(): boolean {
         return this.playing;
+    }
+
+    hasTrackEnded(): boolean {
+        return this.trackEnded;
+    }
+
+    notifyTrackEnded(): void {
+        this.notifyTrackEndedCalls += 1;
     }
 
     // Mirrors HybridRuntimeAudioEngine.getActiveEngineDescriptor() (GH #42
@@ -484,6 +496,37 @@ const loggerCalls = {
     info: [] as Array<unknown[]>,
     warn: [] as Array<unknown[]>,
     error: [] as Array<unknown[]>,
+};
+
+class FakeVisibilityDocument {
+    public visibilityState: "hidden" | "visible" = "visible";
+    private readonly listeners = new Set<() => void>();
+
+    addEventListener(event: string, listener: () => void): void {
+        if (event === "visibilitychange") {
+            this.listeners.add(listener);
+        }
+    }
+
+    removeEventListener(event: string, listener: () => void): void {
+        if (event === "visibilitychange") {
+            this.listeners.delete(listener);
+        }
+    }
+
+    dispatchVisibility(state: "hidden" | "visible"): void {
+        this.visibilityState = state;
+        for (const listener of this.listeners) {
+            listener();
+        }
+    }
+}
+
+const installVisibilityDocument = (): FakeVisibilityDocument => {
+    const fakeDocument = new FakeVisibilityDocument();
+    (globalThis as unknown as { document: FakeVisibilityDocument }).document =
+        fakeDocument;
+    return fakeDocument;
 };
 
 const makeTrack = (id: string, overrides: Partial<Track> = {}): Track => ({
@@ -1174,17 +1217,21 @@ mock.module("sonner", {
 
 mock.module("@/lib/logger", {
     exports: {
-        frontendLogger: {
-            info: (...args: unknown[]) => {
-                loggerCalls.info.push(args);
-            },
-            warn: (...args: unknown[]) => {
-                loggerCalls.warn.push(args);
-            },
-            error: (...args: unknown[]) => {
-                loggerCalls.error.push(args);
-            },
-        },
+        frontendLogger: (() => {
+            const logger = {
+                info: (...args: unknown[]) => {
+                    loggerCalls.info.push(args);
+                },
+                warn: (...args: unknown[]) => {
+                    loggerCalls.warn.push(args);
+                },
+                error: (...args: unknown[]) => {
+                    loggerCalls.error.push(args);
+                },
+                child: () => logger,
+            };
+            return logger;
+        })(),
     },
 });
 
@@ -1225,6 +1272,7 @@ beforeEach(() => {
 afterEach(() => {
     hookRuntime.unmount();
     delete (globalThis as { window?: unknown }).window;
+    delete (globalThis as { document?: unknown }).document;
     try {
         mock.timers.reset();
     } catch {
@@ -1271,6 +1319,181 @@ const getClientMetricEvents = (
             ),
         );
 };
+
+const emitFatalLoadError = async (): Promise<void> => {
+    engine.emit("loaderror", {
+        error: new Error("fatal decode failure"),
+        code: "MEDIA_ERR_DECODE",
+        recoverable: false,
+    });
+    await flushAsync(10);
+};
+
+test("recoverable autoplay rejection preserves the track without scheduling a skip", async () => {
+    mock.timers.enable();
+    playbackState.isPlaying = true;
+    const currentTrack = makeTrack("autoplay-blocked");
+    audioState.currentTrack = currentTrack;
+    audioState.queue = [currentTrack, makeTrack("autoplay-next")];
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.playing = true;
+    engine.emit("play");
+    await flushAsync();
+
+    engine.playing = false;
+    engine.emit("playerror", {
+        error: new DOMException("Play requires a gesture", "NotAllowedError"),
+        code: "NotAllowedError",
+        recoverable: true,
+    });
+    await flushAsync(10);
+
+    assert.equal(audioState.currentTrack?.id, "autoplay-blocked");
+    assert.equal(playbackState.isPlaying, false);
+    assert.equal(playbackState.isBuffering, true);
+    assert.notEqual(playbackMachine.state, "ERROR");
+
+    mock.timers.tick(1_201);
+    await flushAsync();
+    assert.equal(controlCalls.next, 0);
+
+    engine.playing = true;
+    engine.emit("play");
+    await flushAsync();
+    assert.equal(playbackMachine.state, "PLAYING");
+    assert.equal(playbackState.isPlaying, true);
+});
+
+test("foreground visibility reset re-enables fatal-error skips after the breaker trips", async () => {
+    mock.timers.enable();
+    const visibilityDocument = installVisibilityDocument();
+    const tracks = [
+        makeTrack("breaker-1"),
+        makeTrack("breaker-2"),
+        makeTrack("breaker-3"),
+        makeTrack("breaker-4"),
+    ];
+    audioState.currentTrack = tracks[0];
+    audioState.queue = tracks;
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+
+    await emitFatalLoadError();
+    mock.timers.tick(1_201);
+    await flushAsync();
+    assert.equal(controlCalls.next, 1);
+
+    audioState.currentTrack = tracks[1];
+    audioState.currentIndex = 1;
+    rerenderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    await emitFatalLoadError();
+    mock.timers.tick(1_201);
+    await flushAsync();
+    assert.equal(controlCalls.next, 2);
+
+    audioState.currentTrack = tracks[2];
+    audioState.currentIndex = 2;
+    rerenderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    await emitFatalLoadError();
+    mock.timers.tick(1_201);
+    await flushAsync();
+    assert.equal(controlCalls.next, 2);
+
+    visibilityDocument.dispatchVisibility("hidden");
+    visibilityDocument.dispatchVisibility("visible");
+
+    await emitFatalLoadError();
+    mock.timers.tick(1_201);
+    await flushAsync();
+    assert.equal(controlCalls.next, 3);
+});
+
+test("foreground recovery directly advances an unhandled ended music track", async () => {
+    const visibilityDocument = installVisibilityDocument();
+    audioState.playbackType = null;
+    audioState.currentTrack = null;
+    audioState.queue = [];
+
+    renderOrchestrator();
+    await flushAsync();
+
+    const endedTrack = makeTrack("background-ended");
+    audioState.playbackType = "track";
+    audioState.currentTrack = endedTrack;
+    audioState.queue = [endedTrack, makeTrack("background-next")];
+    playbackState.isPlaying = true;
+    rerenderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.playing = true;
+    engine.emit("play");
+    await flushAsync();
+
+    visibilityDocument.dispatchVisibility("hidden");
+    engine.trackEnded = true;
+    engine.playing = false;
+    visibilityDocument.dispatchVisibility("visible");
+    await flushAsync();
+
+    assert.equal(controlCalls.next, 1);
+    assert.equal(engine.notifyTrackEndedCalls, 0);
+});
+
+test("newly loaded source can end immediately after an advance", async () => {
+    const tracks = [
+        makeTrack("immediate-end-1"),
+        makeTrack("immediate-end-2"),
+        makeTrack("immediate-end-3"),
+    ];
+    audioState.currentTrack = tracks[0];
+    audioState.queue = tracks;
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.emit("end");
+    assert.equal(controlCalls.next, 1);
+
+    audioState.currentTrack = tracks[1];
+    audioState.currentIndex = 1;
+    rerenderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.emit("end");
+
+    assert.equal(controlCalls.next, 2);
+});
+
+test("startup playback watchdog does not reload for a listen-together follower", async () => {
+    mock.timers.enable();
+    playbackState.isPlaying = true;
+    listenTogetherSnapshot = {
+        groupId: "lt-startup-follower",
+        isHost: false,
+    };
+    const track = makeTrack("lt-startup-track");
+    audioState.currentTrack = track;
+    audioState.queue = [track];
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    await flushAsync();
+
+    mock.timers.tick(1_500);
+    await flushAsync();
+
+    assert.equal(engine.reloadCalls, 0);
+});
 
 test("loads direct track, applies output state, and syncs play/pause transitions", async () => {
     playbackState.isPlaying = true;


### PR DESCRIPTION
Primary fix for the Phase G owner-reported bug: playback regularly stops at track boundaries when the browser window is unfocused (900+ item queues, intermittent), and refocusing never resumes it. Also removes one listen-together divergence source (S2) since a stalled host stops emitting LT advances.

Verified root causes addressed
1. **Autoplay rejection treated as fatal**: the engine classifies hidden-tab `play()` rejections (`NotAllowedError`) as `recoverable:true` and arms its own gesture/visibility retries — but `handleError` force-transitioned to ERROR and scheduled the 1.2s error skip. Each skip's next track was rejected identically, so 3 hops tripped the consecutive-error breaker → permanent silent stop. Now recoverable playerrors park as paused/buffering and defer to the engine's armed retry; nothing feeds the breaker.
2. **Breaker had no recovery path** (reset only on a successful play that could never come): now resets on hidden→visible refocus and on user-initiated play — except when that play is itself an error-advance hop (`repeat-one` handled), so genuine consecutive failures still trip it.
3. **Dead foreground recovery**: the visibilitychange effect closed over stale `playbackType` (missing dep) and its `notifyTrackEnded()` fallback is a no-op after a natural `ended`. Now reads `playbackTypeRef.current` and, when the end was never acted on (duplicate + engine-source bookkeeping guards), drives the advance directly via `next()`.
4. **Same-flush end swallow**: `handleEnd` compared a closure-captured `effectLoadId`; now compares against `activeEngineLoadIdRef` stamped when the engine source finished loading. All rejected ends are warn-logged with a reason.
5. **LT followers**: startup playback recovery (reload+play watchdog) now skips non-host listen-together members, mirroring the existing `handlePause` exclusion.

Tests (component harness, mocked engine, fake timers — behavior assertions)
- NotAllowedError playerror: track preserved, no skip at 1.2s, not ERROR, subsequent play resumes.
- Tripped breaker + refocus: next error schedules a skip again (breaker reset).
- `hasTrackEnded()` + refocus in a music session: `next()` advances the queue (regression for stale closure + dead notifyTrackEnded path).
- Advance + same-flush `end` for the new source: queue still advances (loadId guard).
- Follower LT snapshot: no `reload()` after load without play.
- 25/25 component tests pass; `tsc --noEmit` clean; prettier clean.

Complements the engine-side end re-synthesis slice (#338) — belt and braces on refocus repair.