### PR TITLE
fix(listen-together): ready-gate vote persistence + server-side boundary watchdog

### DIFF
--- a/backend/src/services/__tests__/listenTogether.test.ts
+++ b/backend/src/services/__tests__/listenTogether.test.ts
@@ -1,3 +1,9 @@
+import {
+    groupManager as runtimeGroupManager,
+    type ManagerCallbacks as RuntimeManagerCallbacks,
+    type SyncQueueItem as RuntimeSyncQueueItem,
+} from "../listenTogetherManager";
+
 describe("listenTogether service", () => {
     const originalEnv = process.env;
 
@@ -1326,6 +1332,139 @@ describe("listenTogether service", () => {
                 queue: [],
                 currentTimeMs: 0,
                 isPlaying: false,
+            }),
+        );
+    });
+});
+
+describe("listenTogether playback boundary behavior", () => {
+    const track = (id: string, duration: number): RuntimeSyncQueueItem => ({
+        id,
+        title: `Track ${id}`,
+        duration,
+        artist: { id: `artist-${id}`, name: `Artist ${id}` },
+        album: { id: `album-${id}`, title: `Album ${id}`, coverArt: null },
+    });
+
+    const createCallbacks = (): jest.Mocked<RuntimeManagerCallbacks> => ({
+        onGroupState: jest.fn(),
+        onPlaybackDelta: jest.fn(),
+        onQueueDelta: jest.fn(),
+        onWaiting: jest.fn(),
+        onPlayAt: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+        onGroupEnded: jest.fn(),
+    });
+
+    function resetRuntimeManager(): void {
+        for (const groupId of runtimeGroupManager.allGroupIds()) {
+            runtimeGroupManager.remove(groupId);
+        }
+    }
+
+    function createPlayingGroup(
+        groupId: string,
+        queue: RuntimeSyncQueueItem[],
+        callbacks: RuntimeManagerCallbacks,
+    ): void {
+        runtimeGroupManager.setCallbacks(callbacks);
+        runtimeGroupManager.create(groupId, {
+            name: "Boundary Group",
+            joinCode: "BOUND1",
+            groupType: "host-follower",
+            visibility: "private",
+            hostUserId: "host",
+            hostUsername: "Host",
+            queue,
+            isPlaying: true,
+            createdAt: new Date(),
+        });
+        runtimeGroupManager.addMember(groupId, "guest", "Guest");
+        runtimeGroupManager.addSocket(groupId, "host", "host-socket");
+        runtimeGroupManager.addSocket(groupId, "guest", "guest-socket");
+    }
+
+    beforeEach(() => {
+        resetRuntimeManager();
+        jest.useFakeTimers({ now: new Date("2026-08-11T00:00:00.000Z") });
+    });
+
+    afterEach(() => {
+        resetRuntimeManager();
+        jest.useRealTimers();
+    });
+
+    it("clamps emitted positions and enters the next track ready gate after the boundary grace", async () => {
+        const callbacks = createCallbacks();
+        createPlayingGroup(
+            "g-boundary-next",
+            [track("short", 3), track("next", 30)],
+            callbacks,
+        );
+
+        await jest.advanceTimersByTimeAsync(4_000);
+        runtimeGroupManager.addMember("g-boundary-next", "host", "Host");
+        const emittedDuringGrace =
+            callbacks.onGroupState.mock.calls.at(-1)?.[1];
+        expect(emittedDuringGrace?.playback.positionMs).toBe(3_000);
+
+        await jest.advanceTimersByTimeAsync(4_001);
+
+        const afterWatchdog =
+            runtimeGroupManager.snapshotById("g-boundary-next");
+        expect(afterWatchdog?.playback.currentIndex).toBe(1);
+        expect(afterWatchdog?.syncState).toBe("waiting");
+        expect(callbacks.onWaiting).toHaveBeenCalledTimes(1);
+        expect(
+            callbacks.onGroupState.mock.calls.every(([, snapshot]) => {
+                const item =
+                    snapshot.playback.queue[snapshot.playback.currentIndex];
+                return (
+                    !item ||
+                    snapshot.playback.positionMs <= item.duration * 1_000
+                );
+            }),
+        ).toBe(true);
+    });
+
+    it("pauses and broadcasts the clamped duration when there is no next item", async () => {
+        const callbacks = createCallbacks();
+        createPlayingGroup("g-boundary-end", [track("only", 3)], callbacks);
+
+        await jest.advanceTimersByTimeAsync(8_001);
+
+        const snapshot = runtimeGroupManager.snapshotById("g-boundary-end");
+        expect(snapshot?.syncState).toBe("paused");
+        expect(snapshot?.playback.isPlaying).toBe(false);
+        expect(snapshot?.playback.positionMs).toBe(3_000);
+        expect(callbacks.onGroupState).toHaveBeenLastCalledWith(
+            "g-boundary-end",
+            expect.objectContaining({ syncState: "paused" }),
+        );
+    });
+
+    it("cancels the pending boundary action when the host advances during grace", async () => {
+        const boundaryAction = jest.fn();
+        const callbacks = {
+            ...createCallbacks(),
+            onBoundaryWatchdog: boundaryAction,
+        } as jest.Mocked<RuntimeManagerCallbacks>;
+        createPlayingGroup(
+            "g-boundary-cancel",
+            [track("short", 3), track("next", 30)],
+            callbacks,
+        );
+
+        await jest.advanceTimersByTimeAsync(4_000);
+        runtimeGroupManager.next("g-boundary-cancel", "host");
+        await jest.advanceTimersByTimeAsync(4_001);
+
+        expect(boundaryAction).not.toHaveBeenCalled();
+        expect(runtimeGroupManager.snapshotById("g-boundary-cancel")).toEqual(
+            expect.objectContaining({
+                syncState: "waiting",
+                playback: expect.objectContaining({ currentIndex: 1 }),
             }),
         );
     });

--- a/backend/src/services/__tests__/listenTogetherClusterSync.test.ts
+++ b/backend/src/services/__tests__/listenTogetherClusterSync.test.ts
@@ -1,7 +1,58 @@
+import {
+    groupManager,
+    type GroupSnapshot,
+    type ManagerCallbacks,
+    type SyncQueueItem,
+} from "../listenTogetherManager";
+
 describe("listenTogetherClusterSync", () => {
     const originalEnv = process.env;
 
+    const track = (id: string): SyncQueueItem => ({
+        id,
+        title: `Track ${id}`,
+        duration: 180,
+        artist: { id: `artist-${id}`, name: `Artist ${id}` },
+        album: { id: `album-${id}`, title: `Album ${id}`, coverArt: null },
+    });
+
+    const createCallbacks = (): jest.Mocked<ManagerCallbacks> => ({
+        onGroupState: jest.fn(),
+        onPlaybackDelta: jest.fn(),
+        onQueueDelta: jest.fn(),
+        onWaiting: jest.fn(),
+        onPlayAt: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+        onGroupEnded: jest.fn(),
+    });
+
+    function resetGroupManager(): void {
+        for (const groupId of groupManager.allGroupIds()) {
+            groupManager.remove(groupId);
+        }
+    }
+
+    function createWaitingGroup(groupId: string): GroupSnapshot {
+        groupManager.create(groupId, {
+            name: "Ready Group",
+            joinCode: "READY1",
+            groupType: "host-follower",
+            visibility: "private",
+            hostUserId: "host",
+            hostUsername: "Host",
+            queue: [track("one"), track("two")],
+            createdAt: new Date(),
+        });
+        groupManager.addMember(groupId, "guest", "Guest");
+        groupManager.addSocket(groupId, "host", "host-socket");
+        groupManager.addSocket(groupId, "guest", "guest-socket");
+        return groupManager.setTrack(groupId, "host", 1, true).snapshot;
+    }
+
     afterEach(() => {
+        jest.useRealTimers();
+        resetGroupManager();
         process.env = originalEnv;
         jest.resetModules();
         jest.clearAllMocks();
@@ -271,5 +322,78 @@ describe("listenTogetherClusterSync", () => {
 
         expect(subClient.disconnect).toHaveBeenCalledTimes(1);
         expect(pubClient.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves ready votes across the mutation-lock snapshot round trip", () => {
+        jest.useFakeTimers({ now: new Date("2026-08-11T00:00:00.000Z") });
+        const callbacks = createCallbacks();
+        groupManager.setCallbacks(callbacks);
+        createWaitingGroup("g-ready-round-trip");
+        expect(groupManager.reportReady("g-ready-round-trip", "host")).toBe(
+            false,
+        );
+        const storedSnapshot = groupManager.snapshotById("g-ready-round-trip");
+        expect(storedSnapshot?.readyUserIds).toEqual(["host"]);
+
+        groupManager.applyExternalSnapshot(storedSnapshot as GroupSnapshot);
+        expect(groupManager.reportReady("g-ready-round-trip", "guest")).toBe(
+            true,
+        );
+
+        expect(callbacks.onPlayAt).toHaveBeenCalledTimes(1);
+        expect(groupManager.snapshotById("g-ready-round-trip")?.syncState).toBe(
+            "playing",
+        );
+        expect(jest.now()).toBe(new Date("2026-08-11T00:00:00.000Z").getTime());
+    });
+
+    it("unions local ready votes when an older snapshot is rehydrated", () => {
+        jest.useFakeTimers({ now: new Date("2026-08-11T00:00:00.000Z") });
+        groupManager.setCallbacks(createCallbacks());
+        const waitingSnapshot = createWaitingGroup("g-ready-stale");
+        groupManager.reportReady("g-ready-stale", "host");
+
+        groupManager.applyExternalSnapshot({
+            ...waitingSnapshot,
+            readyUserIds: [],
+            playback: {
+                ...waitingSnapshot.playback,
+                stateVersion: waitingSnapshot.playback.stateVersion - 1,
+            },
+        });
+
+        expect(groupManager.get("g-ready-stale")?.readyUserIds).toEqual(
+            new Set(["host"]),
+        );
+        expect(
+            groupManager.get("g-ready-stale")?.members.get("host")?.isReady,
+        ).toBe(true);
+    });
+
+    it("accepts old snapshots without ready votes as an empty ready set", () => {
+        jest.useFakeTimers({ now: new Date("2026-08-11T00:00:00.000Z") });
+        groupManager.setCallbacks(createCallbacks());
+        createWaitingGroup("g-ready-old-format");
+        groupManager.reportReady("g-ready-old-format", "host");
+
+        const current = groupManager.snapshotById("g-ready-old-format");
+        expect(current).toBeDefined();
+        const oldFormatSnapshot = { ...current } as Partial<GroupSnapshot>;
+        delete oldFormatSnapshot.readyUserIds;
+        groupManager.remove("g-ready-old-format");
+
+        expect(() =>
+            groupManager.applyExternalSnapshot(
+                oldFormatSnapshot as GroupSnapshot,
+            ),
+        ).not.toThrow();
+        expect(groupManager.get("g-ready-old-format")?.readyUserIds.size).toBe(
+            0,
+        );
+        expect(
+            Array.from(
+                groupManager.get("g-ready-old-format")?.members.values() ?? [],
+            ).every((member) => !member.isReady),
+        ).toBe(true);
     });
 });

--- a/backend/src/services/__tests__/listenTogetherSocketRuntime.test.ts
+++ b/backend/src/services/__tests__/listenTogetherSocketRuntime.test.ts
@@ -23,6 +23,7 @@ describe("listen together socket runtime behavior", () => {
             warn: jest.fn(),
             error: jest.fn(),
         };
+        logger.child = jest.fn(() => logger);
         const jwtVerify: any = jest.fn(() => ({
             userId: "user-1",
             username: "User One",
@@ -111,6 +112,7 @@ describe("listen together socket runtime behavior", () => {
                 stateVersion: 1,
             })),
             reportReady: jest.fn(),
+            handleBoundaryWatchdog: jest.fn(),
         };
         const joinGroupById = jest.fn(async () => ({
             groupId: "group-1",
@@ -468,11 +470,22 @@ describe("listen together socket runtime behavior", () => {
             truncated: true,
         });
 
+        const readySnapshot = {
+            id: "group-1",
+            syncState: "waiting",
+            playback: { queue: [], stateVersion: 3 },
+            members: [],
+        };
+        mocks.groupManager.snapshotById.mockReturnValue(readySnapshot);
         const readyAck = jest.fn();
         await eventHandlers["ready"](readyAck);
         expect(mocks.groupManager.reportReady).toHaveBeenCalledWith(
             "group-1",
             "user-1",
+        );
+        expect(mocks.listenTogetherStateStore.setSnapshot).toHaveBeenCalledWith(
+            "group-1",
+            readySnapshot,
         );
         expect(readyAck).toHaveBeenCalledWith({ ok: true });
 

--- a/backend/src/services/listenTogetherManager.ts
+++ b/backend/src/services/listenTogetherManager.ts
@@ -82,6 +82,8 @@ export interface GroupState {
     readyTimeout: ReturnType<typeof setTimeout> | null;
     /** Absolute ready-gate deadline (`Date.now()` ms), if waiting. */
     readyDeadlineMs: number | null;
+    /** Timer handle for the current track's boundary watchdog. */
+    boundaryTimeout: ReturnType<typeof setTimeout> | null;
     lastActivity: number; // Date.now()
     createdAt: Date;
     /** True when in-memory state has diverged from DB and needs persisting. */
@@ -99,6 +101,8 @@ export interface GroupSnapshot {
     hostUserId: string;
     syncState: GroupSyncState;
     readyDeadlineMs?: number | null;
+    /** Ready votes are optional when reading snapshots written by older versions. */
+    readyUserIds?: string[];
     playback: {
         queue: SyncQueueItem[];
         currentIndex: number;
@@ -184,11 +188,30 @@ function truncateQueueItemsToAvailableCapacity(
     return remainingCapacity > 0 ? items.slice(0, remainingCapacity) : [];
 }
 
-/** Compute the "live" position in ms, accounting for elapsed time. */
-function computePosition(pb: GroupPlayback): number {
+function currentTrackDurationMs(pb: GroupPlayback): number | null {
+    const durationSeconds = pb.queue[pb.currentIndex]?.duration;
+    if (
+        typeof durationSeconds !== "number" ||
+        !Number.isFinite(durationSeconds) ||
+        durationSeconds < 0
+    ) {
+        return null;
+    }
+    const durationMs = durationSeconds * 1000;
+    return Number.isFinite(durationMs) ? durationMs : null;
+}
+
+function computeUnclampedPosition(pb: GroupPlayback): number {
     if (!pb.isPlaying) return pb.positionMs;
     const elapsed = Date.now() - pb.lastPositionUpdate;
     return pb.positionMs + Math.max(elapsed, 0);
+}
+
+/** Compute the "live" position in ms without running past the current track. */
+function computePosition(pb: GroupPlayback): number {
+    const positionMs = Math.max(0, computeUnclampedPosition(pb));
+    const durationMs = currentTrackDurationMs(pb);
+    return durationMs === null ? positionMs : clamp(positionMs, 0, durationMs);
 }
 
 function currentTrackId(pb: GroupPlayback): string | null {
@@ -222,6 +245,9 @@ export const MAX_QUEUE_SIZE = 500;
 
 /** Max time to wait for all members to report ready (ms). */
 const READY_GATE_TIMEOUT_MS = 8_000;
+
+/** Grace after a track boundary before the server repairs a stalled host. */
+const BOUNDARY_WATCHDOG_GRACE_MS = 5_000;
 
 /** How long before a member with no sockets is considered stale (ms). */
 const STALE_MEMBER_MS = 60_000;
@@ -260,6 +286,10 @@ export interface ManagerCallbacks {
         },
     ): void;
     onGroupEnded(groupId: string, reason: string): void;
+    onBoundaryWatchdog?(
+        groupId: string,
+        data: { currentIndex: number; stateVersion: number },
+    ): void;
 }
 
 class GroupManager {
@@ -342,6 +372,7 @@ class GroupManager {
             readyUserIds: new Set(),
             readyTimeout: null,
             readyDeadlineMs: null,
+            boundaryTimeout: null,
             lastActivity: now,
             createdAt: opts.createdAt,
             dirty: false,
@@ -417,12 +448,14 @@ class GroupManager {
             readyUserIds: new Set(),
             readyTimeout: null,
             readyDeadlineMs: null,
+            boundaryTimeout: null,
             lastActivity: now,
             createdAt: opts.createdAt,
             dirty: false,
         };
 
         this.groups.set(id, group);
+        this.syncBoundaryWatchdog(group);
         log.info(
             `Created group ${id} "${opts.name}" hosted by ${opts.hostUsername}`,
         );
@@ -440,7 +473,10 @@ class GroupManager {
     /** Remove group from memory (after DB cleanup). */
     remove(groupId: string): void {
         const group = this.groups.get(groupId);
-        if (group) this.clearReadyGateTimer(group);
+        if (group) {
+            this.clearReadyGateTimer(group);
+            this.clearBoundaryWatchdogTimer(group);
+        }
         this.groups.delete(groupId);
         log.debug(`Removed group ${groupId} from memory`);
     }
@@ -649,6 +685,7 @@ class GroupManager {
         group.syncState = "playing";
         group.lastActivity = Date.now();
         group.dirty = true;
+        this.syncBoundaryWatchdog(group);
 
         const delta = this.playbackDelta(group);
         this.callbacks?.onPlaybackDelta(groupId, delta);
@@ -662,6 +699,7 @@ class GroupManager {
         if (waitingDelta) return waitingDelta;
 
         const pb = group.playback;
+        this.clearBoundaryWatchdogTimer(group);
         // Freeze position
         pb.positionMs = computePosition(pb);
         pb.isPlaying = false;
@@ -691,6 +729,7 @@ class GroupManager {
         pb.stateVersion++;
         group.lastActivity = Date.now();
         group.dirty = true;
+        this.syncBoundaryWatchdog(group);
 
         const delta = this.playbackDelta(group);
         this.callbacks?.onPlaybackDelta(groupId, delta);
@@ -711,6 +750,7 @@ class GroupManager {
         const group = this.requireGroup(groupId);
         this.requireControl(group, userId);
         this.ensureNoPendingTrackChange(group);
+        this.clearBoundaryWatchdogTimer(group);
 
         const pb = group.playback;
         if (pb.queue.length === 0)
@@ -739,6 +779,7 @@ class GroupManager {
             } else {
                 group.syncState = "paused";
             }
+            this.syncBoundaryWatchdog(group);
             this.broadcastState(group);
             return { snapshot: this.snapshot(group), waiting: false };
         }
@@ -794,6 +835,8 @@ class GroupManager {
         if (group.syncState !== "waiting") return false;
 
         group.readyUserIds.add(userId);
+        const member = group.members.get(userId);
+        if (member) member.isReady = true;
         return this.checkReadyGate(group);
     }
 
@@ -918,6 +961,7 @@ class GroupManager {
         pb.stateVersion++;
         group.lastActivity = Date.now();
         group.dirty = true;
+        this.syncBoundaryWatchdog(group);
 
         const delta = this.queueDelta(group);
         this.callbacks?.onQueueDelta(groupId, delta);
@@ -964,6 +1008,7 @@ class GroupManager {
             syncState: group.syncState,
             readyDeadlineMs:
                 group.syncState === "waiting" ? group.readyDeadlineMs : null,
+            readyUserIds: Array.from(group.readyUserIds),
             playback: {
                 queue: pb.queue,
                 currentIndex: pb.currentIndex,
@@ -1005,6 +1050,7 @@ class GroupManager {
         if (existing) {
             // Timers close over old group objects; drop and re-arm on replacement.
             this.clearReadyGateTimer(existing);
+            this.clearBoundaryWatchdogTimer(existing);
         }
 
         const rawQueue = Array.isArray(snapshot.playback?.queue)
@@ -1041,6 +1087,21 @@ class GroupManager {
             incomingStateVersion,
             incomingServerTime,
         );
+        const readyUserIds = new Set<string>(
+            Array.isArray(snapshot.readyUserIds)
+                ? snapshot.readyUserIds.filter(
+                      (userId): userId is string => typeof userId === "string",
+                  )
+                : [],
+        );
+        if (
+            existing &&
+            incomingStateVersion <= existing.playback.stateVersion
+        ) {
+            for (const userId of existing.readyUserIds) {
+                readyUserIds.add(userId);
+            }
+        }
 
         const members = new Map<string, GroupMember>();
         for (const member of snapshot.members ?? []) {
@@ -1052,7 +1113,7 @@ class GroupManager {
                 joinedAt: new Date(member.joinedAt),
                 // Preserve local socket presence for users connected to this pod.
                 socketIds: existingMember?.socketIds ?? new Set<string>(),
-                isReady: false,
+                isReady: readyUserIds.has(member.userId),
                 unavailableIndices: new Set(),
                 lastSeen: now,
             });
@@ -1103,9 +1164,10 @@ class GroupManager {
             syncState,
             playback,
             members,
-            readyUserIds: new Set<string>(),
+            readyUserIds,
             readyTimeout: null,
             readyDeadlineMs,
+            boundaryTimeout: null,
             lastActivity: now,
             createdAt: existing?.createdAt ?? new Date(),
             dirty: false,
@@ -1117,7 +1179,46 @@ class GroupManager {
             this.rearmReadyGateFromDeadline(group, readyDeadlineMs ?? now);
         } else {
             this.clearReadyGateState(group);
+            this.syncBoundaryWatchdog(group);
         }
+    }
+
+    /** Resolve a due boundary watchdog after the socket layer acquires its lock. */
+    handleBoundaryWatchdog(
+        groupId: string,
+        expectedIndex: number,
+        expectedStateVersion: number,
+    ): boolean {
+        const group = this.groups.get(groupId);
+        if (!group) return false;
+
+        const pb = group.playback;
+        if (
+            !pb.isPlaying ||
+            pb.currentIndex !== expectedIndex ||
+            pb.stateVersion !== expectedStateVersion
+        ) {
+            return false;
+        }
+
+        const durationMs = currentTrackDurationMs(pb);
+        if (durationMs === null) return false;
+        if (
+            computeUnclampedPosition(pb) <
+            durationMs + BOUNDARY_WATCHDOG_GRACE_MS
+        ) {
+            this.syncBoundaryWatchdog(group);
+            return false;
+        }
+
+        this.clearBoundaryWatchdogTimer(group);
+        if (pb.currentIndex + 1 < pb.queue.length) {
+            this.setTrack(groupId, group.hostUserId, pb.currentIndex + 1, true);
+            return true;
+        }
+
+        this.pauseAtBoundary(group, durationMs);
+        return true;
     }
 
     // -----------------------------------------------------------------------
@@ -1189,6 +1290,7 @@ class GroupManager {
             const currentIndex = group.playback.currentIndex;
             if (member?.unavailableIndices?.has(currentIndex)) {
                 group.readyUserIds.add(uid);
+                member.isReady = true;
                 continue;
             }
             if (!group.readyUserIds.has(uid)) return false;
@@ -1213,6 +1315,60 @@ class GroupManager {
     private clearReadyGateState(group: GroupState): void {
         this.clearReadyGateTimer(group);
         group.readyUserIds.clear();
+        for (const member of group.members.values()) {
+            member.isReady = false;
+        }
+    }
+
+    private clearBoundaryWatchdogTimer(group: GroupState): void {
+        if (group.boundaryTimeout) {
+            clearTimeout(group.boundaryTimeout);
+        }
+        group.boundaryTimeout = null;
+    }
+
+    private pauseAtBoundary(group: GroupState, durationMs: number): void {
+        const now = Date.now();
+        group.playback.positionMs = durationMs;
+        group.playback.isPlaying = false;
+        group.playback.lastPositionUpdate = now;
+        group.playback.stateVersion++;
+        group.syncState = "paused";
+        group.lastActivity = now;
+        group.dirty = true;
+        this.broadcastState(group);
+    }
+
+    private syncBoundaryWatchdog(group: GroupState): void {
+        this.clearBoundaryWatchdogTimer(group);
+        if (!group.playback.isPlaying) return;
+
+        const durationMs = currentTrackDurationMs(group.playback);
+        if (durationMs === null) return;
+        const waitMs = Math.max(
+            0,
+            durationMs +
+                BOUNDARY_WATCHDOG_GRACE_MS -
+                computeUnclampedPosition(group.playback),
+        );
+        const currentIndex = group.playback.currentIndex;
+        const stateVersion = group.playback.stateVersion;
+        const boundaryTimeout = setTimeout(() => {
+            group.boundaryTimeout = null;
+            if (this.groups.get(group.id) !== group) return;
+            if (this.callbacks?.onBoundaryWatchdog) {
+                this.callbacks.onBoundaryWatchdog(group.id, {
+                    currentIndex,
+                    stateVersion,
+                });
+                return;
+            }
+            this.handleBoundaryWatchdog(group.id, currentIndex, stateVersion);
+        }, waitMs);
+        group.boundaryTimeout = boundaryTimeout;
+        if (typeof boundaryTimeout.unref === "function") {
+            boundaryTimeout.unref();
+        }
     }
 
     private ensureNoPendingTrackChange(group: GroupState): void {
@@ -1252,8 +1408,12 @@ class GroupManager {
     }
 
     private enterReadyGate(group: GroupState): void {
+        this.clearBoundaryWatchdogTimer(group);
         group.syncState = "waiting";
         group.readyUserIds.clear();
+        for (const member of group.members.values()) {
+            member.isReady = false;
+        }
         this.armReadyGateTimer(group, Date.now() + READY_GATE_TIMEOUT_MS);
     }
 
@@ -1278,6 +1438,7 @@ class GroupManager {
         pb.stateVersion++;
         group.syncState = "playing";
         group.dirty = true;
+        this.syncBoundaryWatchdog(group);
 
         this.callbacks?.onPlayAt(group.id, {
             positionMs: 0,
@@ -1291,6 +1452,7 @@ class GroupManager {
 
     private endGroupInternal(group: GroupState, reason: string): void {
         this.clearReadyGateState(group);
+        this.clearBoundaryWatchdogTimer(group);
 
         group.playback.isPlaying = false;
         group.syncState = "idle";

--- a/backend/src/services/listenTogetherSocket.ts
+++ b/backend/src/services/listenTogetherSocket.ts
@@ -40,6 +40,8 @@ import {
 import { resolveQueueForUser } from "./listenTogetherResolution";
 import { trackMappingService } from "./trackMappingService";
 
+const log = logger.child("ListenTogetherSocket");
+
 // ---------------------------------------------------------------------------
 // Auth
 // ---------------------------------------------------------------------------
@@ -727,6 +729,21 @@ export function setupListenTogetherSocket(httpServer: HttpServer): Server {
             ns.to(groupId).emit("group:ended", { reason });
             void queueEndedSnapshotSync(groupId);
         },
+        onBoundaryWatchdog(groupId: string, data) {
+            void withGroupMutationLock(
+                groupId,
+                "boundary-watchdog",
+                async () => {
+                    groupManager.handleBoundaryWatchdog(
+                        groupId,
+                        data.currentIndex,
+                        data.stateVersion,
+                    );
+                },
+            ).catch((err) => {
+                log.error(`Boundary watchdog failed for group ${groupId}`, err);
+            });
+        },
     };
 
     groupManager.setCallbacks(callbacks);
@@ -1154,7 +1171,13 @@ export function setupListenTogetherSocket(httpServer: HttpServer): Server {
                         return;
                     }
                     await withGroupMutationLock(groupId, "ready", async () => {
+                        const wasWaiting =
+                            groupManager.snapshotById(groupId)?.syncState ===
+                            "waiting";
                         groupManager.reportReady(groupId, userId);
+                        if (wasWaiting) {
+                            void queuePersistAndPublishSnapshot(groupId);
+                        }
                     });
                     sendAck(ack, { ok: true });
                 } catch (err) {


### PR DESCRIPTION
Phase G listen-together backend fixes (owner-reported S3 start-sync issues and S2 host/guest divergence).

Verified root causes addressed
1. **Ready votes erased every socket op**: all socket ops run inside `withGroupMutationLock`, which rehydrates via `listenTogetherStateStore.getSnapshot` + `applyExternalSnapshot` — and `applyExternalSnapshot` rebuilt the group with `readyUserIds: new Set()` because `GroupSnapshot` had no ready fields to round-trip. The host's vote was wiped before the guest's landed, so `checkReadyGate` could only resolve via the 8s timeout (state store defaults ON). The designed "all-ready → play immediately" path never fired; gate resolution now shrinks from a guaranteed 8s to actual buffering time, directly shrinking the restart/late-start offset window.
   - `readyUserIds` serialized in `snapshot()`; restored on rehydration with a **union** of in-memory votes when the incoming `stateVersion` is not newer; `member.isReady` kept consistent; old snapshots without the field deserialize cleanly; ready reports persist the snapshot so votes survive cross-replica round-trips.
2. **No server-side stall detection**: `computePosition` extrapolated unboundedly past track end and boundary advance was exclusively host-client-driven — a stalled host (e.g. the background-tab S1 bug) silently diverged from guests indefinitely. Now:
   - `computePosition` clamps to the current item's duration.
   - A per-group **boundary watchdog** (duration + 5s grace) fires through the group mutation lock, validates `currentIndex` + `stateVersion` (idempotent across replicas), and either advances through the **normal setTrack ready gate** (queue has a next item) or pauses-and-broadcasts at queue end. Armed/cleared on every playback transition; any host command before the grace expires cancels it; timers are `unref()`d. The host's `ended`-driven advance remains the fast path.

Tests (behavioral)
- Cluster-sync: the exact wipe sequence (setTrack with 2 members → host ready → snapshot round-trip through `applyExternalSnapshot` → guest ready) now resolves the gate from votes without advancing the 8s timer; an older-stateVersion snapshot does not clear newer votes; old-format snapshots deserialize to an empty set.
- Watchdog: playing group with a 3s item advances past duration+grace with no host command → enters the ready gate for the next index (or broadcasts paused at queue end); emitted positions never exceed item duration; a host `next` before grace expiry cancels the pending action.
- 16 suites / 154 tests pass; `tsc --noEmit` clean; prettier clean.

Pairs with the client-side slice (#340): event-driven ready reports + host play-at echo suppression.