### PR TITLE
fix(player): window persisted queue around the current position instead of first-100 truncation

### DIFF
--- a/frontend/lib/audio-playback-context.tsx
+++ b/frontend/lib/audio-playback-context.tsx
@@ -615,11 +615,27 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
 
             // Read queue/currentIndex/isShuffle from ref for stable callback identity
             const currentAudioState = audioStateRef.current;
-            const limitedQueue = currentAudioState.queue?.slice(0, 100) || [];
-            const adjustedIndex = Math.min(
-                currentAudioState.currentIndex,
-                limitedQueue.length > 0 ? limitedQueue.length - 1 : 0,
+            const queueWindowStart = Math.max(
+                0,
+                currentAudioState.currentIndex - 10,
             );
+            const limitedQueue =
+                currentAudioState.queue?.slice(
+                    queueWindowStart,
+                    queueWindowStart + 100,
+                ) || [];
+            const adjustedIndex =
+                currentAudioState.currentIndex - queueWindowStart;
+            const hasConsistentQueuePosition =
+                invocationSnapshot.playbackType !== "track" ||
+                limitedQueue[adjustedIndex]?.id === invocationSnapshot.trackId;
+
+            const queuePositionPayload = hasConsistentQueuePosition
+                ? {
+                      queue: limitedQueue,
+                      currentIndex: adjustedIndex,
+                  }
+                : {};
 
             progressSaveInFlightRef.current = true;
             try {
@@ -629,8 +645,7 @@ export function AudioPlaybackProvider({ children }: { children: ReactNode }) {
                     trackId: invocationSnapshot.trackId ?? undefined,
                     audiobookId: invocationSnapshot.audiobookId ?? undefined,
                     podcastId: invocationSnapshot.podcastId ?? undefined,
-                    queue: limitedQueue,
-                    currentIndex: adjustedIndex,
+                    ...queuePositionPayload,
                     isShuffle: currentAudioState.isShuffle,
                     isPlaying,
                     currentTime: clampNonNegativePlaybackTime(

--- a/frontend/tests/unit/audioPlaybackPersistence.test.ts
+++ b/frontend/tests/unit/audioPlaybackPersistence.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { describe, test } from "node:test";
+import { after, describe, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { api } from "../../lib/api";
 import {
     isPlaybackSelectionMatch,
     resolveTrackPersistenceEpoch,
@@ -7,6 +10,121 @@ import {
     type ActivePlaybackSelection,
     type PlaybackPersistenceSnapshot,
 } from "../../lib/audio-playback-persistence-guards";
+import { resolveQueueAdvance } from "../../lib/audio/queue-advance-policy";
+import { normalizeQueueItems } from "../../lib/queue-item";
+import { normalizeQueueIndex } from "../../lib/playback-state-reconciliation";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type SavedPlaybackState = Parameters<typeof api.savePlaybackState>[0];
+type AudioStateApi = ReturnType<
+    (typeof import("../../lib/audio-state-context"))["useAudioState"]
+>;
+
+interface TestTrack {
+    id: string;
+    title: string;
+    artist: { name: string };
+    album: { title: string };
+    duration: number;
+    itemType: "track";
+}
+
+const savedPlaybackStates: SavedPlaybackState[] = [];
+const getPlaybackStateMock = mock.method(
+    api,
+    "getPlaybackState",
+    async () => null,
+);
+const savePlaybackStateMock = mock.method(
+    api,
+    "savePlaybackState",
+    async (state: SavedPlaybackState) => {
+        savedPlaybackStates.push(state);
+        return null;
+    },
+);
+
+after(() => {
+    getPlaybackStateMock.mock.restore();
+    savePlaybackStateMock.mock.restore();
+    GlobalRegistrator.unregister();
+});
+
+function createTrack(index: number): TestTrack {
+    return {
+        id: `track-${index}`,
+        title: `Track ${index}`,
+        artist: { name: "Artist" },
+        album: { title: "Album" },
+        duration: 180,
+        itemType: "track",
+    };
+}
+
+function createQueue(length: number): TestTrack[] {
+    return Array.from({ length }, (_, index) => createTrack(index));
+}
+
+async function persistTrackSnapshot(
+    queue: TestTrack[],
+    currentIndex: number,
+    currentTrack: TestTrack,
+): Promise<SavedPlaybackState> {
+    localStorage.clear();
+    savedPlaybackStates.length = 0;
+
+    const { createRoot } = await import("react-dom/client");
+    const { AudioStateProvider, useAudioState } =
+        await import("../../lib/audio-state-context");
+    const { AudioPlaybackProvider } =
+        await import("../../lib/audio-playback-context");
+    const stateRef = { current: null as AudioStateApi | null };
+    const Probe = () => {
+        stateRef.current = useAudioState();
+        return null;
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+        await React.act(async () => {
+            root.render(
+                React.createElement(
+                    AudioStateProvider,
+                    null,
+                    React.createElement(
+                        AudioPlaybackProvider,
+                        null,
+                        React.createElement(Probe),
+                    ),
+                ),
+            );
+        });
+        await React.act(async () => {
+            assert.ok(stateRef.current, "expected audio state to be captured");
+            stateRef.current.setQueue(queue);
+            stateRef.current.setCurrentIndex(currentIndex);
+            stateRef.current.setCurrentTrack(currentTrack);
+            stateRef.current.setPlaybackType("track");
+        });
+        await React.act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+    } finally {
+        await React.act(async () => root.unmount());
+        container.remove();
+    }
+
+    const savedState = savedPlaybackStates.at(-1);
+    assert.ok(savedState, "expected playback state to be saved");
+    return savedState;
+}
 
 describe("isPlaybackSelectionMatch", () => {
     test("returns false when playbackType differs", () => {
@@ -238,5 +356,73 @@ describe("resolveTrackPersistenceEpoch", () => {
     test("returns state epoch when state is current", () => {
         assert.equal(resolveTrackPersistenceEpoch(3, 3), 3);
         assert.equal(resolveTrackPersistenceEpoch(4, 2), 4);
+    });
+});
+
+describe("playback queue persistence", () => {
+    test("windows a large queue around the current track and retains upcoming items", async () => {
+        const queue = createQueue(900);
+
+        const payload = await persistTrackSnapshot(queue, 450, queue[450]);
+
+        const persistedQueue = payload.queue ?? [];
+        assert.ok(persistedQueue.length <= 100);
+        assert.equal(payload.currentIndex, 10);
+        assert.equal(persistedQueue[payload.currentIndex]?.id, payload.trackId);
+        assert.equal(
+            persistedQueue.filter((item) => item.id === payload.trackId).length,
+            1,
+        );
+        assert.ok(
+            persistedQueue.some((item) => item.id === "track-451"),
+            "expected the persisted window to include items ahead of the current track",
+        );
+    });
+
+    test("keeps the prefix window and live index near the start of the queue", async () => {
+        const queue = createQueue(900);
+
+        const payload = await persistTrackSnapshot(queue, 5, queue[5]);
+
+        assert.equal(payload.queue?.length, 100);
+        assert.equal(payload.queue?.[0]?.id, "track-0");
+        assert.equal(payload.currentIndex, 5);
+        assert.equal(
+            payload.queue?.[payload.currentIndex]?.id,
+            payload.trackId,
+        );
+    });
+
+    test("omits queue position when the live track does not match the rebased index", async () => {
+        const queue = createQueue(900);
+        const currentTrack = createTrack(450);
+        queue[450] = createTrack(451);
+
+        const payload = await persistTrackSnapshot(queue, 450, currentTrack);
+
+        assert.equal(payload.trackId, currentTrack.id);
+        assert.equal(Object.hasOwn(payload, "queue"), false);
+        assert.equal(Object.hasOwn(payload, "currentIndex"), false);
+    });
+
+    test("restored large-queue snapshot advances from its rebased index", async () => {
+        const queue = createQueue(900);
+        const payload = await persistTrackSnapshot(queue, 450, queue[450]);
+        const restoredQueue = normalizeQueueItems(payload.queue);
+        const restoredIndex = normalizeQueueIndex(
+            payload.currentIndex,
+            restoredQueue.length,
+        );
+
+        const advance = resolveQueueAdvance({
+            action: "next",
+            queue: restoredQueue,
+            currentIndex: restoredIndex,
+            isShuffle: false,
+            shuffleIndices: [],
+            repeatMode: "off",
+        });
+
+        assert.deepEqual(advance, { kind: "track", index: 11 });
     });
 });


### PR DESCRIPTION
Phase G playback-reliability fix (owner-reported S1, large-queue variant).

Root cause (verified): `savePlaybackProgressToServer` persisted `queue.slice(0, 100)` and clamped `currentIndex` into that prefix. At index 450 of a 900-item queue the snapshot claimed the user was at the **last slot** of a 100-item queue that didn't contain the current track's neighborhood — an adopting client (fresh session, second device, storage eviction) restored a phantom end-of-queue position from which auto-advance stopped.

Fix: persist a window `[max(0, currentIndex-10), +100)` with the index rebased into the window, guaranteeing the persisted trackId is at the persisted index; restored sessions keep advancing through the next ~90 tracks. On a trackId/index mismatch (mid-mutation race) the queue is omitted and trackId-only position persists — the restore path already supports that; a lying queue position is never persisted.

Verified no-regression claims (read, not assumed): backend re-slice/clamp at `backend/src/routes/playbackState.ts:331` is a no-op for ≤100-item windows (no backend change needed); the local-queue-authoritative reconciliation branch at `frontend/lib/playback-state-reconciliation.ts:218` is index-independent.

Tests (behavioral, 21/21 pass)
- 900-item queue @ index 450: payload ≤100 items, trackId exactly at payload index, forward items included.
- index 5: prefix window, index 5 — unchanged from today.
- forced mismatch: payload omits queue rather than clamping.
- round-trip: adoption from the saved payload yields an advance from the restored index, not a stop.
- prettier clean; tsc fails only on the fresh-worktree missing generated contract artifact (CI Frontend Typecheck covers).