### PR TITLE
fix(api): proactive access-token refresh so stream URLs never bake an expired JWT

### DIFF
--- a/frontend/lib/api/core.ts
+++ b/frontend/lib/api/core.ts
@@ -9,6 +9,8 @@ const AUTH_REFRESH_TIMEOUT_MS = 10_000;
 export const IMPORT_PREVIEW_TIMEOUT_MS = 60_000;
 const DEFAULT_TIMEOUT_RETRY_BACKOFF_MS = 350;
 const MAX_TIMEOUT_RETRIES = 1;
+const PROACTIVE_REFRESH_LIFETIME_RATIO = 0.8;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 interface ApiError extends Error {
     status?: number;
@@ -68,6 +70,23 @@ export abstract class ApiClientCore {
     protected tokenInitialized: boolean = false;
     private readonly inFlightGetRequests = new Map<string, Promise<unknown>>();
     private refreshPromise: Promise<boolean> | null = null;
+    private proactiveRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    private proactiveRefreshAtMs: number | null = null;
+
+    private readonly handleVisibilityChange = (): void => {
+        if (
+            typeof window === "undefined" ||
+            typeof document === "undefined" ||
+            document.visibilityState !== "visible" ||
+            this.proactiveRefreshAtMs === null ||
+            Date.now() < this.proactiveRefreshAtMs
+        ) {
+            return;
+        }
+
+        this.cancelProactiveRefreshTimer();
+        void this.refreshAccessToken();
+    };
 
     constructor(baseUrl?: string) {
         // Don't set baseUrl in constructor - determine it dynamically on each request
@@ -78,8 +97,19 @@ export abstract class ApiClientCore {
             this.token = localStorage.getItem(AUTH_TOKEN_KEY);
             if (this.token) {
                 this.tokenInitialized = true;
+                this.scheduleProactiveTokenRefresh(this.token);
             }
             // Note: Refresh token is loaded on-demand via getRefreshToken()
+        }
+
+        if (
+            typeof window !== "undefined" &&
+            typeof document !== "undefined"
+        ) {
+            document.addEventListener(
+                "visibilitychange",
+                this.handleVisibilityChange,
+            );
         }
     }
 
@@ -95,6 +125,7 @@ export abstract class ApiClientCore {
         const storedToken = localStorage.getItem(AUTH_TOKEN_KEY);
         if (storedToken) {
             this.token = storedToken;
+            this.scheduleProactiveTokenRefresh(storedToken);
         }
 
         this.tokenInitialized = true;
@@ -129,6 +160,7 @@ export abstract class ApiClientCore {
                 localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
             }
         }
+        this.scheduleProactiveTokenRefresh(token);
     }
 
     // Get refresh token from storage
@@ -142,10 +174,79 @@ export abstract class ApiClientCore {
     // Clear both JWT tokens
     clearToken() {
         this.token = null;
+        this.clearProactiveRefreshSchedule();
         if (typeof window !== "undefined") {
             localStorage.removeItem(AUTH_TOKEN_KEY);
             localStorage.removeItem(REFRESH_TOKEN_KEY);
         }
+    }
+
+    private decodeTokenExpiryMs(token: string): number | null {
+        const payloadSegment = token.split(".")[1];
+        if (!payloadSegment || typeof atob !== "function") {
+            return null;
+        }
+
+        try {
+            const base64Payload = payloadSegment
+                .replace(/-/g, "+")
+                .replace(/_/g, "/");
+            const paddedPayload = base64Payload.padEnd(
+                Math.ceil(base64Payload.length / 4) * 4,
+                "=",
+            );
+            const payload: unknown = JSON.parse(atob(paddedPayload));
+            if (!payload || typeof payload !== "object") {
+                return null;
+            }
+
+            const expiresAtSeconds = (payload as Record<string, unknown>).exp;
+            const expiresAtMs = Number(expiresAtSeconds) * 1000;
+            return typeof expiresAtSeconds === "number" &&
+                Number.isFinite(expiresAtMs) &&
+                expiresAtMs > 0
+                ? expiresAtMs
+                : null;
+        } catch {
+            return null;
+        }
+    }
+
+    private scheduleProactiveTokenRefresh(token: string): void {
+        this.clearProactiveRefreshSchedule();
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const expiresAtMs = this.decodeTokenExpiryMs(token);
+        if (expiresAtMs === null) {
+            return;
+        }
+
+        const nowMs = Date.now();
+        const remainingLifetimeMs = Math.max(0, expiresAtMs - nowMs);
+        const refreshDelayMs = Math.min(
+            Math.floor(remainingLifetimeMs * PROACTIVE_REFRESH_LIFETIME_RATIO),
+            MAX_TIMER_DELAY_MS,
+        );
+        this.proactiveRefreshAtMs = nowMs + refreshDelayMs;
+        this.proactiveRefreshTimer = setTimeout(() => {
+            this.proactiveRefreshTimer = null;
+            void this.refreshAccessToken();
+        }, refreshDelayMs);
+    }
+
+    private cancelProactiveRefreshTimer(): void {
+        if (this.proactiveRefreshTimer === null) {
+            return;
+        }
+        clearTimeout(this.proactiveRefreshTimer);
+        this.proactiveRefreshTimer = null;
+    }
+
+    private clearProactiveRefreshSchedule(): void {
+        this.cancelProactiveRefreshTimer();
+        this.proactiveRefreshAtMs = null;
     }
 
     // Get the base URL dynamically to support switching between localhost and IP
@@ -526,6 +627,7 @@ export abstract class ApiClientCore {
             if (storedToken) {
                 this.token = storedToken;
                 this.tokenInitialized = true;
+                this.scheduleProactiveTokenRefresh(storedToken);
                 return storedToken;
             }
         }

--- a/frontend/tests/unit/apiTokenProactiveRefresh.test.ts
+++ b/frontend/tests/unit/apiTokenProactiveRefresh.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test, {
+    after,
+    afterEach,
+    beforeEach,
+    type TestContext,
+} from "node:test";
+import { ApiClientCore } from "../../lib/api/core";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PROACTIVE_REFRESH_DELAY_MS = DAY_MS * 0.8;
+const START_TIME_MS = 1_800_000_000_000;
+
+class TestApiClient extends ApiClientCore {}
+
+class MemoryStorage implements Storage {
+    private readonly values = new Map<string, string>();
+
+    get length(): number {
+        return this.values.size;
+    }
+
+    clear(): void {
+        this.values.clear();
+    }
+
+    getItem(key: string): string | null {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number): string | null {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string): void {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string): void {
+        this.values.set(key, value);
+    }
+}
+
+const browserWindow = new EventTarget();
+const browserDocument = new EventTarget();
+const storage = new MemoryStorage();
+let visibilityState: DocumentVisibilityState = "visible";
+const clients: TestApiClient[] = [];
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalDocument = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "document",
+);
+const originalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+);
+
+Object.defineProperty(browserDocument, "visibilityState", {
+    configurable: true,
+    get: () => visibilityState,
+});
+Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: browserWindow,
+});
+Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: browserDocument,
+});
+Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+});
+
+function restoreGlobal(
+    key: "window" | "document" | "localStorage",
+    descriptor: PropertyDescriptor | undefined,
+): void {
+    if (descriptor) {
+        Object.defineProperty(globalThis, key, descriptor);
+        return;
+    }
+    Reflect.deleteProperty(globalThis, key);
+}
+
+function createToken(expiresAtMs: number): string {
+    const payload = Buffer.from(
+        JSON.stringify({ exp: Math.floor(expiresAtMs / 1000) }),
+    ).toString("base64url");
+    return `header.${payload}.signature`;
+}
+
+function createClient(): TestApiClient {
+    const client = new TestApiClient("http://soundspan.test");
+    clients.push(client);
+    return client;
+}
+
+function setVisibility(nextVisibility: DocumentVisibilityState): void {
+    visibilityState = nextVisibility;
+    browserDocument.dispatchEvent(new Event("visibilitychange"));
+}
+
+function mockRefreshEndpoint(testContext: TestContext) {
+    return testContext.mock.method(globalThis, "fetch", async () => {
+        const token = createToken(Date.now() + DAY_MS);
+        return Response.json({ token, refreshToken: "rotated-refresh" });
+    });
+}
+
+async function flushAsyncWork(): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        await Promise.resolve();
+    }
+}
+
+beforeEach((testContext) => {
+    storage.clear();
+    visibilityState = "visible";
+    if (!("mock" in testContext)) {
+        throw new Error("test mock context is unavailable");
+    }
+    testContext.mock.timers.enable({
+        apis: ["Date", "setTimeout"],
+        now: START_TIME_MS,
+    });
+});
+
+afterEach(() => {
+    for (const client of clients.splice(0)) {
+        client.clearToken();
+    }
+});
+
+after(() => {
+    restoreGlobal("window", originalWindow);
+    restoreGlobal("document", originalDocument);
+    restoreGlobal("localStorage", originalLocalStorage);
+});
+
+test("refreshes once at 80% of a token's remaining 24-hour lifetime", async (testContext) => {
+    const fetchMock = mockRefreshEndpoint(testContext);
+    const client = createClient();
+    const initialToken = createToken(START_TIME_MS + DAY_MS);
+
+    client.setToken(initialToken, "refresh-token");
+    testContext.mock.timers.tick(PROACTIVE_REFRESH_DELAY_MS - 1);
+    assert.equal(fetchMock.mock.callCount(), 0);
+
+    testContext.mock.timers.tick(1);
+    await flushAsyncWork();
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+    assert.notEqual(client.getToken(), initialToken);
+    assert.equal(localStorage.getItem("auth_token"), client.getToken());
+});
+
+test("re-arms proactive refresh after each successful refresh", async (testContext) => {
+    const fetchMock = mockRefreshEndpoint(testContext);
+    const client = createClient();
+
+    client.setToken(createToken(START_TIME_MS + DAY_MS), "refresh-token");
+    testContext.mock.timers.tick(PROACTIVE_REFRESH_DELAY_MS);
+    await flushAsyncWork();
+    assert.equal(fetchMock.mock.callCount(), 1);
+
+    testContext.mock.timers.tick(PROACTIVE_REFRESH_DELAY_MS);
+    await flushAsyncWork();
+    assert.equal(fetchMock.mock.callCount(), 2);
+});
+
+test("clearing tokens cancels the pending proactive refresh", async (testContext) => {
+    const fetchMock = mockRefreshEndpoint(testContext);
+    const client = createClient();
+
+    client.setToken(createToken(START_TIME_MS + DAY_MS), "refresh-token");
+    client.clearToken();
+    testContext.mock.timers.tick(PROACTIVE_REFRESH_DELAY_MS);
+    await flushAsyncWork();
+
+    assert.equal(fetchMock.mock.callCount(), 0);
+    assert.equal(client.getToken(), null);
+});
+
+test("refreshes on visibility catch-up after a hidden timer is delayed", async (testContext) => {
+    const fetchMock = mockRefreshEndpoint(testContext);
+    const client = createClient();
+
+    setVisibility("hidden");
+    client.setToken(createToken(START_TIME_MS + DAY_MS), "refresh-token");
+    testContext.mock.timers.setTime(
+        START_TIME_MS + PROACTIVE_REFRESH_DELAY_MS + 1,
+    );
+    assert.equal(fetchMock.mock.callCount(), 0);
+
+    setVisibility("visible");
+    await flushAsyncWork();
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+});
+
+test("simultaneous proactive triggers share one in-flight refresh", async (testContext) => {
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+        releaseFetch = resolve;
+    });
+    const fetchMock = testContext.mock.method(globalThis, "fetch", async () => {
+        await fetchGate;
+        return Response.json({
+            token: createToken(Date.now() + DAY_MS),
+            refreshToken: "rotated-refresh",
+        });
+    });
+    const client = createClient();
+
+    client.setToken(createToken(START_TIME_MS + DAY_MS), "refresh-token");
+    testContext.mock.timers.setTime(
+        START_TIME_MS + PROACTIVE_REFRESH_DELAY_MS + 1,
+    );
+    setVisibility("visible");
+    setVisibility("visible");
+    await Promise.resolve();
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+    assert.ok(releaseFetch);
+    releaseFetch();
+    await flushAsyncWork();
+});
+
+test("ignores malformed tokens without throwing or scheduling refresh", async (testContext) => {
+    const fetchMock = mockRefreshEndpoint(testContext);
+    const client = createClient();
+
+    assert.doesNotThrow(() => {
+        client.setToken("not-a-jwt", "refresh-token");
+    });
+    testContext.mock.timers.tick(DAY_MS * 7);
+    setVisibility("visible");
+    await flushAsyncWork();
+
+    assert.equal(fetchMock.mock.callCount(), 0);
+});


### PR DESCRIPTION
Phase G playback-reliability fix (owner-reported S1 — including the focused-window / small-queue occurrences, which are focus-independent).

Root cause (verified): token refresh was purely **reactive** (only a 401 from some API call triggered it). Long listening sessions with no other API traffic let the JWT expire; the next track load reads `getCurrentToken()` into its stream URL, fails with an auth error, and feeds the consecutive-error breaker — 3 strikes permanently halted auto-advance.

Fix (contained to `ApiClientCore`)
- On every token store, decode the `exp` claim (base64url parse, no new dependency; malformed tokens skip scheduling) and arm a **one-shot refresh at 80% of remaining lifetime**, capped at the max timer delay; re-armed after each successful refresh; cleared on logout/token-clear.
- `visibilitychange→visible` refreshes immediately when past the threshold — catching timers stretched by background-tab clamping.
- Concurrent triggers share the existing single-in-flight `refreshPromise`; the reactive 401 path stays as fallback. Engine/reload paths untouched (owned by sibling slices). No token contents logged.

Tests (fake timers + mocked refresh endpoint, 6/6 pass)
- 24h token → exactly one refresh at ~19.2h, stored token replaced; re-arms for a second 80% window.
- no timer after token clear; malformed token schedules nothing and does not throw.
- hidden-tab suppressed timer + refocus past threshold → immediate refresh.
- concurrent triggers → single fetch.
- prettier clean; tsc fails only on the fresh-worktree missing generated contract artifact (CI covers).