### PR TITLE
fix(player): half-open cooldown for the consecutive-error breaker

### DIFF
--- a/frontend/lib/audio-engine/consecutiveErrorBreaker.ts
+++ b/frontend/lib/audio-engine/consecutiveErrorBreaker.ts
@@ -3,13 +3,16 @@
  *
  * Tracks consecutive playback errors across track transitions.
  * When the threshold is reached, auto-advance should be halted
- * to prevent infinite rapid error loops.
+ * to prevent infinite rapid error loops. After a cooldown, one
+ * half-open probe is allowed so transient failures can recover.
  *
  * Counter resets on any successful playback.
  */
 
 /** Default number of consecutive errors before the breaker trips. */
 export const DEFAULT_CONSECUTIVE_ERROR_THRESHOLD = 3;
+
+const DEFAULT_HALF_OPEN_COOLDOWN_MS = 60_000;
 
 export interface ConsecutiveErrorBreakerState {
     consecutiveErrors: number;
@@ -31,30 +34,63 @@ export interface ConsecutiveErrorBreaker {
 
 /**
  * Creates a consecutive error circuit breaker.
+ *
+ * @param threshold Consecutive errors required to trip the breaker.
+ * @param cooldownMs Time before one half-open probe is allowed.
+ * @param now Clock returning epoch milliseconds.
  */
 export function createConsecutiveErrorBreaker(
     threshold: number = DEFAULT_CONSECUTIVE_ERROR_THRESHOLD,
+    cooldownMs: number = DEFAULT_HALF_OPEN_COOLDOWN_MS,
+    now: () => number = Date.now,
 ): ConsecutiveErrorBreaker {
     let consecutiveErrors = 0;
     let tripped = false;
+    let trippedAtMs: number | null = null;
+    let halfOpenProbeInFlight = false;
+
+    const trip = (): void => {
+        tripped = true;
+        trippedAtMs = now();
+        halfOpenProbeInFlight = false;
+    };
+
+    const clear = (): void => {
+        consecutiveErrors = 0;
+        tripped = false;
+        trippedAtMs = null;
+        halfOpenProbeInFlight = false;
+    };
 
     return {
         recordError(): boolean {
             consecutiveErrors += 1;
-            if (consecutiveErrors >= threshold && !tripped) {
-                tripped = true;
+            if (
+                halfOpenProbeInFlight ||
+                (consecutiveErrors >= threshold && !tripped)
+            ) {
+                trip();
                 return true;
             }
             return false;
         },
 
         recordSuccess(): void {
-            consecutiveErrors = 0;
-            tripped = false;
+            clear();
         },
 
         isTripped(): boolean {
-            return tripped;
+            if (!tripped) {
+                return false;
+            }
+            if (halfOpenProbeInFlight || trippedAtMs === null) {
+                return true;
+            }
+            if (now() - trippedAtMs < cooldownMs) {
+                return true;
+            }
+            halfOpenProbeInFlight = true;
+            return false;
         },
 
         getErrorCount(): number {
@@ -62,8 +98,7 @@ export function createConsecutiveErrorBreaker(
         },
 
         reset(): void {
-            consecutiveErrors = 0;
-            tripped = false;
+            clear();
         },
     };
 }

--- a/frontend/tests/unit/consecutiveErrorBreaker.test.ts
+++ b/frontend/tests/unit/consecutiveErrorBreaker.test.ts
@@ -5,6 +5,16 @@ import {
     DEFAULT_CONSECUTIVE_ERROR_THRESHOLD,
 } from "../../lib/audio-engine/consecutiveErrorBreaker";
 
+function createBreakerHarness(cooldownMs: number = 60_000) {
+    let nowMs = 0;
+    return {
+        breaker: createConsecutiveErrorBreaker(3, cooldownMs, () => nowMs),
+        advanceBy(ms: number): void {
+            nowMs += ms;
+        },
+    };
+}
+
 test("default threshold is 3", () => {
     assert.equal(DEFAULT_CONSECUTIVE_ERROR_THRESHOLD, 3);
 });
@@ -98,4 +108,60 @@ test("success between errors prevents tripping", () => {
     breaker.recordError(); // 2 again
     assert.equal(breaker.isTripped(), false);
     assert.equal(breaker.getErrorCount(), 2);
+});
+
+test("half-opens for one probe after the cooldown elapses", () => {
+    const harness = createBreakerHarness();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+
+    assert.equal(harness.breaker.isTripped(), true);
+    harness.advanceBy(59_000);
+    assert.equal(harness.breaker.isTripped(), true);
+    harness.advanceBy(1_001);
+    assert.equal(harness.breaker.isTripped(), false);
+    assert.equal(harness.breaker.isTripped(), true);
+});
+
+test("one error during the half-open probe immediately re-trips", () => {
+    const harness = createBreakerHarness();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.advanceBy(60_000);
+    assert.equal(harness.breaker.isTripped(), false);
+
+    assert.equal(harness.breaker.recordError(), true);
+    assert.equal(harness.breaker.isTripped(), true);
+});
+
+test("success during the half-open probe fully resets the breaker", () => {
+    const harness = createBreakerHarness();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.advanceBy(60_000);
+    assert.equal(harness.breaker.isTripped(), false);
+
+    harness.breaker.recordSuccess();
+    assert.equal(harness.breaker.getErrorCount(), 0);
+    assert.equal(harness.breaker.recordError(), false);
+    assert.equal(harness.breaker.recordError(), false);
+    assert.equal(harness.breaker.isTripped(), false);
+});
+
+test("error count remains consecutive across the half-open transition", () => {
+    const harness = createBreakerHarness();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    harness.breaker.recordError();
+    assert.equal(harness.breaker.getErrorCount(), 3);
+
+    harness.advanceBy(60_000);
+    assert.equal(harness.breaker.isTripped(), false);
+    assert.equal(harness.breaker.getErrorCount(), 3);
+
+    harness.breaker.recordError();
+    assert.equal(harness.breaker.getErrorCount(), 4);
 });


### PR DESCRIPTION
Phase G playback-reliability fix — the slice that matters most for the owner-reported **focused-window / small-queue** stops.

Root cause (verified): the consecutive-error breaker (trip at 3) reset only via `recordSuccess()` — a successful `play` event that can never arrive once the breaker itself has halted auto-advance. Any transient 3-in-a-row (expired stream URLs, autoplay rejection, backend blips) became a permanent silent stop until page reload; the only signal was a 6-second toast.

Fix: standard circuit-breaker half-open semantics, self-healing by construction:
- `trippedAtMs` recorded on trip; after a 60s cooldown (threshold/cooldown/clock injectable for tests) `isTripped()` returns false exactly once, allowing **one probe advance**;
- a `recordError()` during the probe re-trips **immediately** (no fresh 3-count) and restarts the cooldown — the rapid error loop the breaker exists to prevent cannot recur;
- `recordSuccess()`/`reset()` fully clear as before; `getErrorCount()` stays continuous across the half-open transition.

Turns "playback dead until reload" into "one probe per minute," which recovers on its own when the failure was transient (token refreshed by #343, tab visible again, backend recovered). Composes with #339's event-driven resets — file-disjoint, defense in depth.

Tests (injected clock, 14/14 pass): tripped at 59s, half-open past 60s, single probe, immediate re-trip on probe failure, full reset on success (2 subsequent errors don't trip), count consistency. Prettier clean; tsc fails only on the fresh-worktree missing generated artifact (CI covers).