### PR TITLE
fix(listen-together): client-server clock-offset estimation for synchronized starts

### DIFF
--- a/frontend/lib/audio-controls-context.tsx
+++ b/frontend/lib/audio-controls-context.tsx
@@ -20,6 +20,7 @@ import { useAudioPlayback } from "./audio-playback-context";
 import { api } from "@/lib/api";
 import { audioSeekEmitter } from "./audio-seek-emitter";
 import {
+    getServerClockOffsetMs,
     listenTogetherSocket,
     type QueueTrackInput,
 } from "./listen-together-socket";
@@ -967,7 +968,12 @@ export function AudioControlsProvider({ children }: { children: ReactNode }) {
                     ltSession.playback.serverTime;
 
                 const elapsedMs = syncIsPlaying
-                    ? Math.max(0, Date.now() - syncServerTimeMs)
+                    ? Math.max(
+                          0,
+                          Date.now() -
+                              getServerClockOffsetMs() -
+                              syncServerTimeMs,
+                      )
                     : 0;
                 const targetSec = (syncPositionMs + elapsedMs) / 1000;
                 const mediaDuration =

--- a/frontend/lib/listen-together-socket.ts
+++ b/frontend/lib/listen-together-socket.ts
@@ -187,6 +187,9 @@ const LISTEN_TOGETHER_ALLOW_POLLING =
     process.env.NEXT_PUBLIC_LISTEN_TOGETHER_ALLOW_POLLING === "true";
 const LISTEN_TOGETHER_SOCKET_TRANSPORTS: Array<"websocket" | "polling"> =
     LISTEN_TOGETHER_ALLOW_POLLING ? ["websocket", "polling"] : ["websocket"];
+const CLOCK_OFFSET_SAMPLE_INTERVAL_MS = 60_000;
+const CLOCK_OFFSET_SAMPLE_LIMIT = 5;
+const MAX_ABSOLUTE_CLOCK_OFFSET_MS = 5 * 60_000;
 const TRANSIENT_CONFLICT_MAX_RETRIES = 3;
 const TRANSIENT_CONFLICT_BASE_DELAY_MS = 60;
 const TRANSIENT_CONFLICT_MAX_DELAY_MS = 300;
@@ -218,6 +221,60 @@ const TRANSIENT_CONFLICT_RETRY_POLICY: EmitRetryPolicy = {
     jitterFactor: TRANSIENT_CONFLICT_JITTER_FACTOR,
 };
 
+interface ListenTogetherSocketDependencies {
+    createSocket: typeof io;
+    getToken: () => string | null;
+    now: () => number;
+    setInterval: (
+        callback: () => void,
+        intervalMs: number,
+    ) => ReturnType<typeof setInterval>;
+    clearInterval: (handle: ReturnType<typeof setInterval>) => void;
+}
+
+const DEFAULT_SOCKET_DEPENDENCIES: ListenTogetherSocketDependencies = {
+    createSocket: io,
+    getToken: () => api.getToken(),
+    now: () => Date.now(),
+    setInterval: (callback, intervalMs) =>
+        globalThis.setInterval(callback, intervalMs),
+    clearInterval: (handle) => globalThis.clearInterval(handle),
+};
+
+let serverClockOffsetSamplesMs: number[] = [];
+let serverClockOffsetMs = 0;
+
+function resetServerClockOffset(): void {
+    serverClockOffsetSamplesMs = [];
+    serverClockOffsetMs = 0;
+}
+
+function recordServerClockOffsetSample(serverMinusClientMs: number): void {
+    if (!Number.isFinite(serverMinusClientMs)) return;
+    const clientMinusServerMs = -serverMinusClientMs;
+    const boundedSampleMs = Math.max(
+        -MAX_ABSOLUTE_CLOCK_OFFSET_MS,
+        Math.min(MAX_ABSOLUTE_CLOCK_OFFSET_MS, clientMinusServerMs),
+    );
+    serverClockOffsetSamplesMs = [
+        ...serverClockOffsetSamplesMs,
+        boundedSampleMs,
+    ].slice(-CLOCK_OFFSET_SAMPLE_LIMIT);
+    const sortedSamples = [...serverClockOffsetSamplesMs].sort(
+        (left, right) => left - right,
+    );
+    const middleIndex = Math.floor(sortedSamples.length / 2);
+    serverClockOffsetMs =
+        sortedSamples.length % 2 === 0
+            ? (sortedSamples[middleIndex - 1] + sortedSamples[middleIndex]) / 2
+            : sortedSamples[middleIndex];
+}
+
+/** Return how far the client wall clock is ahead of the server clock. */
+export function getServerClockOffsetMs(): number {
+    return serverClockOffsetMs;
+}
+
 /**
  * Represents the ListenTogetherSocket class.
  */
@@ -230,6 +287,17 @@ export class ListenTogetherSocket {
         result: SocketRouteProbeResult;
     } | null = null;
     private routeProbeInFlight: Promise<SocketRouteProbeResult> | null = null;
+    private clockOffsetInterval: ReturnType<typeof setInterval> | null = null;
+    private clockOffsetSamplingGeneration = 0;
+    private clockOffsetSampleInFlightGeneration: number | null = null;
+    private readonly dependencies: ListenTogetherSocketDependencies;
+
+    constructor(dependencies: Partial<ListenTogetherSocketDependencies> = {}) {
+        this.dependencies = {
+            ...DEFAULT_SOCKET_DEPENDENCIES,
+            ...dependencies,
+        };
+    }
 
     async probeRoute(force: boolean = false): Promise<SocketRouteProbeResult> {
         if (typeof window === "undefined") return { ok: true };
@@ -256,7 +324,7 @@ export class ListenTogetherSocket {
 
     connect(callbacks: ListenTogetherSocketCallbacks): void {
         this.callbacks = callbacks;
-        const token = api.getToken();
+        const token = this.dependencies.getToken();
         if (!token) {
             callbacks.onError(new Error("No auth token available"));
             return;
@@ -274,7 +342,7 @@ export class ListenTogetherSocket {
 
         const url = getSocketUrl();
 
-        this.socket = io(`${url}/listen-together`, {
+        this.socket = this.dependencies.createSocket(`${url}/listen-together`, {
             path: "/socket.io/listen-together",
             auth: { token },
             transports: LISTEN_TOGETHER_SOCKET_TRANSPORTS,
@@ -287,6 +355,7 @@ export class ListenTogetherSocket {
         });
 
         this.socket.on("connect", () => {
+            this.restartClockOffsetSampling();
             this.callbacks?.onConnect();
             // Re-join group on reconnect
             if (this.currentGroupId) {
@@ -295,6 +364,7 @@ export class ListenTogetherSocket {
         });
 
         this.socket.on("disconnect", (reason) => {
+            this.stopClockOffsetSampling();
             this.callbacks?.onDisconnect(reason);
         });
 
@@ -510,6 +580,8 @@ export class ListenTogetherSocket {
 
     disconnect(): void {
         this.currentGroupId = null;
+        this.stopClockOffsetSampling();
+        resetServerClockOffset();
         if (this.socket) {
             this.socket.removeAllListeners();
             this.socket.disconnect();
@@ -643,7 +715,14 @@ export class ListenTogetherSocket {
                 "lt-ping",
                 (res: { serverTime?: number; error?: string }) => {
                     if (res?.error) reject(new Error(res.error));
-                    else resolve(res?.serverTime ?? Date.now());
+                    else if (
+                        typeof res?.serverTime === "number" &&
+                        Number.isFinite(res.serverTime)
+                    ) {
+                        resolve(res.serverTime);
+                    } else {
+                        reject(new Error("Invalid Listen Together ping ack"));
+                    }
                 },
             );
         });
@@ -652,6 +731,49 @@ export class ListenTogetherSocket {
     // -----------------------------------------------------------------------
     // Internal
     // -----------------------------------------------------------------------
+
+    private restartClockOffsetSampling(): void {
+        this.stopClockOffsetSampling();
+        resetServerClockOffset();
+        const generation = this.clockOffsetSamplingGeneration;
+        void this.sampleServerClockOffset(generation);
+        this.clockOffsetInterval = this.dependencies.setInterval(() => {
+            void this.sampleServerClockOffset(generation);
+        }, CLOCK_OFFSET_SAMPLE_INTERVAL_MS);
+    }
+
+    private stopClockOffsetSampling(): void {
+        this.clockOffsetSamplingGeneration += 1;
+        this.clockOffsetSampleInFlightGeneration = null;
+        if (this.clockOffsetInterval === null) return;
+        this.dependencies.clearInterval(this.clockOffsetInterval);
+        this.clockOffsetInterval = null;
+    }
+
+    private async sampleServerClockOffset(generation: number): Promise<void> {
+        if (this.clockOffsetSampleInFlightGeneration === generation) return;
+        this.clockOffsetSampleInFlightGeneration = generation;
+        const sendTimeMs = this.dependencies.now();
+        try {
+            const serverTimeMs = await this.ping();
+            const receiveTimeMs = this.dependencies.now();
+            if (
+                generation !== this.clockOffsetSamplingGeneration ||
+                receiveTimeMs < sendTimeMs
+            ) {
+                return;
+            }
+            const clientMidpointMs =
+                sendTimeMs + (receiveTimeMs - sendTimeMs) / 2;
+            recordServerClockOffsetSample(serverTimeMs - clientMidpointMs);
+        } catch {
+            // The next periodic sample or reconnect will retry.
+        } finally {
+            if (this.clockOffsetSampleInFlightGeneration === generation) {
+                this.clockOffsetSampleInFlightGeneration = null;
+            }
+        }
+    }
 
     private async emit(
         event: string,

--- a/frontend/tests/unit/listenTogetherClockOffset.test.ts
+++ b/frontend/tests/unit/listenTogetherClockOffset.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+    AudioControlsProvider,
+    useAudioControls,
+} from "../../lib/audio-controls-context";
+import { AudioPlaybackProvider } from "../../lib/audio-playback-context";
+import { audioSeekEmitter } from "../../lib/audio-seek-emitter";
+import { AudioStateProvider } from "../../lib/audio-state-context";
+import {
+    getServerClockOffsetMs,
+    ListenTogetherSocket,
+    listenTogetherSocket,
+    type ListenTogetherSocketCallbacks,
+} from "../../lib/listen-together-socket";
+import { setListenTogetherSessionSnapshot } from "../../lib/listen-together-session";
+
+type SocketHandler = (...args: unknown[]) => void;
+type SocketDependencies = NonNullable<
+    ConstructorParameters<typeof ListenTogetherSocket>[0]
+>;
+const MAX_TEST_CLOCK_SAMPLES = 5;
+
+class FakeSocket {
+    connected = true;
+    auth: Record<string, unknown> = {};
+    readonly io = { on: () => undefined };
+    private readonly handlers = new Map<string, SocketHandler>();
+
+    constructor(private readonly serverTimesMs: number[]) {}
+
+    on(event: string, handler: SocketHandler): this {
+        this.handlers.set(event, handler);
+        return this;
+    }
+
+    emit(event: string, ...args: unknown[]): this {
+        if (event !== "lt-ping") return this;
+        const ack = args.at(-1);
+        assert.equal(typeof ack, "function");
+        const serverTime = this.serverTimesMs.shift();
+        assert.notEqual(serverTime, undefined);
+        (ack as (response: { serverTime: number }) => void)({ serverTime });
+        return this;
+    }
+
+    trigger(event: string, ...args: unknown[]): void {
+        const handler = this.handlers.get(event);
+        assert.ok(handler, `missing ${event} handler`);
+        handler(...args);
+    }
+
+    connect(): this {
+        this.connected = true;
+        return this;
+    }
+
+    disconnect(): this {
+        this.connected = false;
+        return this;
+    }
+
+    removeAllListeners(): this {
+        this.handlers.clear();
+        return this;
+    }
+}
+
+const callbacks: ListenTogetherSocketCallbacks = {
+    onGroupState: () => undefined,
+    onPlaybackDelta: () => undefined,
+    onQueueDelta: () => undefined,
+    onWaiting: () => undefined,
+    onPlayAt: () => undefined,
+    onMemberJoined: () => undefined,
+    onMemberLeft: () => undefined,
+    onGroupEnded: () => undefined,
+    onConnect: () => undefined,
+    onDisconnect: () => undefined,
+    onError: () => undefined,
+};
+
+function createClockSampler(options: {
+    localTimesMs: number[];
+    serverTimesMs: number[];
+}): {
+    socket: ListenTogetherSocket;
+    fakeSocket: FakeSocket;
+    sampleAgain: () => void;
+} {
+    const localTimesMs = [...options.localTimesMs];
+    const fakeSocket = new FakeSocket([...options.serverTimesMs]);
+    let intervalCallback: (() => void) | null = null;
+    const dependencies: SocketDependencies = {
+        createSocket: (() =>
+            fakeSocket) as unknown as SocketDependencies["createSocket"],
+        getToken: () => "test-token",
+        now: () => {
+            const now = localTimesMs.shift();
+            assert.notEqual(now, undefined);
+            return now;
+        },
+        setInterval: (callback) => {
+            intervalCallback = callback;
+            return 1 as unknown as ReturnType<typeof setInterval>;
+        },
+        clearInterval: () => {
+            intervalCallback = null;
+        },
+    };
+    const socket = new ListenTogetherSocket(dependencies);
+    socket.connect(callbacks);
+    fakeSocket.trigger("connect");
+    return {
+        socket,
+        fakeSocket,
+        sampleAgain: () => {
+            assert.ok(intervalCallback);
+            intervalCallback();
+        },
+    };
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+async function sampleClockOffset(options: {
+    clientOffsetMs: number;
+    sampleCount?: number;
+}): Promise<{ socket: ListenTogetherSocket; fakeSocket: FakeSocket }> {
+    const sampleCount = options.sampleCount ?? 1;
+    assert.ok(sampleCount > 0 && sampleCount <= MAX_TEST_CLOCK_SAMPLES);
+    const localTimesMs: number[] = [];
+    const serverTimesMs: number[] = [];
+    for (let sample = 0; sample < MAX_TEST_CLOCK_SAMPLES; sample += 1) {
+        if (sample >= sampleCount) break;
+        const serverSendTimeMs = 10_000 + sample * 1_000;
+        localTimesMs.push(
+            serverSendTimeMs + options.clientOffsetMs,
+            serverSendTimeMs + 100 + options.clientOffsetMs,
+        );
+        serverTimesMs.push(serverSendTimeMs + 50);
+    }
+
+    const sampler = createClockSampler({ localTimesMs, serverTimesMs });
+    await flushPromises();
+    for (let sample = 1; sample < MAX_TEST_CLOCK_SAMPLES; sample += 1) {
+        if (sample >= sampleCount) break;
+        sampler.sampleAgain();
+        await flushPromises();
+    }
+    return sampler;
+}
+
+async function captureResumeTarget(options: {
+    clientNowMs: number;
+    serverTimeMs: number;
+}): Promise<number> {
+    await prepareFollowerSession(options.serverTimeMs);
+    const controls = renderAudioControls();
+    return invokeResumeAndCapture(controls, options);
+}
+
+async function prepareFollowerSession(serverTimeMs: number): Promise<void> {
+    await listenTogetherSocket.joinGroup("group-clock-test").catch(() => {});
+    setListenTogetherSessionSnapshot({
+        groupId: "group-clock-test",
+        isHost: false,
+        playback: {
+            isPlaying: true,
+            positionMs: 2_000,
+            serverTime: serverTimeMs,
+            currentIndex: 0,
+        },
+    });
+}
+
+function renderAudioControls(): ReturnType<typeof useAudioControls> {
+    let controls: ReturnType<typeof useAudioControls> | null = null;
+    const Probe = () => {
+        controls = useAudioControls();
+        return React.createElement("div", null, "controls-ready");
+    };
+    const html = renderToStaticMarkup(
+        React.createElement(
+            AudioStateProvider,
+            null,
+            React.createElement(
+                AudioPlaybackProvider,
+                null,
+                React.createElement(
+                    AudioControlsProvider,
+                    null,
+                    React.createElement(Probe),
+                ),
+            ),
+        ),
+    );
+    assert.ok(html.includes("controls-ready"));
+    assert.ok(controls);
+    return controls;
+}
+
+function invokeResumeAndCapture(
+    controls: ReturnType<typeof useAudioControls>,
+    options: { clientNowMs: number; serverTimeMs: number },
+): number {
+    let targetSec: number | null = null;
+    const unsubscribe = audioSeekEmitter.subscribe((time) => {
+        targetSec = time;
+    });
+    const originalDateNow = Date.now;
+    Date.now = () => options.clientNowMs;
+    try {
+        controls.resume({
+            suppressListenTogetherBroadcast: true,
+            listenTogetherForceIsPlaying: true,
+            listenTogetherPositionMs: 2_000,
+            listenTogetherServerTimeMs: options.serverTimeMs,
+        });
+    } finally {
+        Date.now = originalDateNow;
+        unsubscribe();
+        setListenTogetherSessionSnapshot(null);
+        listenTogetherSocket.disconnect();
+    }
+    assert.notEqual(targetSec, null);
+    return targetSec;
+}
+
+test("clock samples converge on a client clock that is 3000ms ahead", async () => {
+    const { socket } = await sampleClockOffset({
+        clientOffsetMs: 3_000,
+        sampleCount: 3,
+    });
+
+    assert.ok(Math.abs(getServerClockOffsetMs() - 3_000) <= 1);
+    socket.disconnect();
+});
+
+test("follower resume removes fast-client skew from the seek target", async () => {
+    const { socket } = await sampleClockOffset({ clientOffsetMs: 3_000 });
+
+    const targetSec = await captureResumeTarget({
+        clientNowMs: 13_000,
+        serverTimeMs: 9_000,
+    });
+
+    assert.ok(Math.abs(targetSec - 3) <= 0.001);
+    socket.disconnect();
+});
+
+test("follower resume preserves zero-skew timing", async () => {
+    const { socket } = await sampleClockOffset({ clientOffsetMs: 0 });
+
+    const targetSec = await captureResumeTarget({
+        clientNowMs: 10_000,
+        serverTimeMs: 9_000,
+    });
+
+    assert.ok(Math.abs(targetSec - 3) <= 0.001);
+    socket.disconnect();
+});
+
+test("reconnect discards clock samples from the previous connection", async () => {
+    const sampler = createClockSampler({
+        localTimesMs: [13_000, 13_100, 9_000, 9_100],
+        serverTimesMs: [10_050, 10_050],
+    });
+    await flushPromises();
+    assert.ok(Math.abs(getServerClockOffsetMs() - 3_000) <= 1);
+
+    sampler.fakeSocket.trigger("disconnect", "transport close");
+    sampler.fakeSocket.trigger("connect");
+    await flushPromises();
+
+    assert.ok(Math.abs(getServerClockOffsetMs() + 1_000) <= 1);
+    sampler.socket.disconnect();
+});


### PR DESCRIPTION
Phase G listen-together fix (owner-reported S3, late-start variant: guests start 1-4s into the track, clipping intros). Final slice of the playback-reliability series.

Root cause (verified): all sync math treated `Date.now() - serverWallClock` as pure network latency with no clock-offset estimation (`resume()` in `audio-controls-context.tsx` ~969: `elapsedMs = Math.max(0, Date.now() - syncServerTimeMs)`, capped at 5000ms — exactly the reported 1-4s window). A client clock ahead of the server clipped that skew off every synchronized start; clocks behind clamped to 0.

Fix
- `listen-together-socket.ts`: samples the **existing `lt-ping` ack** (no new server messages) on connect and every 60s; `offset = serverTime - (sendTime + rtt/2)`; bounded five-sample **median**, |offset| capped at 5 min, reset on connect/disconnect, generation-guarded against stale in-flight acks; exported as `getServerClockOffsetMs()`. The ping ack now rejects when the server timestamp is missing instead of silently substituting the client clock.
- `audio-controls-context.tsx` `resume()`: elapsed = `(Date.now() - getServerClockOffsetMs()) - syncServerTimeMs`, preserving the existing clamp/cap semantics. Zero skew ⇒ identical behavior to today.
- `listen-together-context.tsx` deliberately untouched (owned by #340); its apply-site adoption of the helper is a small follow-up if residual skew shows after both merge — `resume()` is the path that positions followers on synchronized starts.

Tests (4/4 pass): +3000ms skew converges to ~+3000 offset; skew-corrected resume seek equals true elapsed within tolerance; zero-skew unchanged; samples reset on reconnect. Prettier clean; tsc fails only on the fresh-worktree missing generated artifact (CI covers).