### PR TITLE
docs(changelog) + style(format): Phase G changelog bullets and prettier realignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Audio engines can now re-synthesize a missed end-of-track on tab refocus,
+  and Howler's preloaded-track promotion no longer depends on
+  background-throttled timers. (#338)
+- Listen Together hosts no longer snap back to the start when their own
+  ready-gate `play-at` broadcast arrives, cross-resolved queue items preserve
+  mid-track position, and event-driven ready reports let backgrounded hosts
+  pass the gate promptly. (#340)
+- Listen Together ready-gate votes now survive cross-replica snapshot
+  rehydration (track changes start when everyone is buffered instead of always
+  waiting out the 8s timeout), and the server clamps virtual position to track
+  duration with a boundary watchdog so a stalled host can no longer silently
+  diverge from guests. (#341)
+- Persisted playback snapshots now window the queue around the current position
+  instead of truncating to the first 100 items, so restored sessions with large
+  queues resume at the real track and keep auto-advancing. (#342)
+- Access tokens now refresh proactively before expiry (with a refocus
+  catch-up), so long listening sessions no longer bake expired credentials into
+  stream URLs and stall at the next track load. (#343)
+- The playback error breaker now half-opens after a 60s cooldown, probing one
+  advance instead of halting playback permanently until reload. (#344)
+- Listen Together followers now estimate client-server clock offset and
+  skew-correct their synchronized start positions, so a fast client clock no
+  longer clips track intros. (#345)
 - Playback no longer permanently stops at track boundaries in background tabs:
   autoplay rejection is no longer treated as a fatal track error, refocusing
   completes a missed advance, and the consecutive-error breaker self-heals on

--- a/frontend/lib/api/core.ts
+++ b/frontend/lib/api/core.ts
@@ -102,10 +102,7 @@ export abstract class ApiClientCore {
             // Note: Refresh token is loaded on-demand via getRefreshToken()
         }
 
-        if (
-            typeof window !== "undefined" &&
-            typeof document !== "undefined"
-        ) {
+        if (typeof window !== "undefined" && typeof document !== "undefined") {
             document.addEventListener(
                 "visibilitychange",
                 this.handleVisibilityChange,

--- a/frontend/lib/listen-together-context.tsx
+++ b/frontend/lib/listen-together-context.tsx
@@ -488,196 +488,207 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
     // Player manipulation helpers (defined before the callbacks that use them)
     // -----------------------------------------------------------------------
 
-    const applyPlaybackToPlayer = useCallback((snapshot: GroupSnapshot) => {
-        const pb = snapshot.playback;
-        if (!pb || !Array.isArray(pb.queue)) return;
-        const availabilityForState =
-            trackAvailabilityStateVersionRef.current === pb.stateVersion
-                ? trackAvailabilityRef.current
-                : null;
-        const mappedQueue = pb.queue.map((item, index) =>
-            toLocalTrack(item, availabilityForState?.get(index)),
-        );
-        const safeIndex =
-            mappedQueue.length > 0
-                ? Math.min(Math.max(pb.currentIndex, 0), mappedQueue.length - 1)
-                : 0;
-        const targetTrack = mappedQueue[safeIndex] ?? null;
-
-        const state = audioStateRef.current;
-        const ctrl = controlsRef.current;
-
-        if (
-            pendingHostTrackIndexRef.current !== null &&
-            pendingHostTrackIndexRef.current !== safeIndex
-        ) {
-            pendingHostTrackIndexRef.current = null;
-        }
-        clearObsoleteReadyReportLoadListener(
-            safeIndex,
-            pb.queue[safeIndex]?.id ?? null,
-        );
-        isApplyingRemoteRef.current = true;
-
-        // Pause before switching tracks to prevent buffered audio from
-        // the old track replaying during the async transition.
-        if (
-            state.currentTrack?.id !== targetTrack?.id &&
-            playbackEngine.isPlaying()
-        ) {
-            ctrl.pause({ suppressListenTogetherBroadcast: true });
-        }
-
-        // Set queue + track
-        state.setPlaybackType("track");
-        state.setQueue(mappedQueue);
-        state.setCurrentIndex(safeIndex);
-        state.setCurrentTrack(targetTrack);
-        state.setCurrentAudiobook(null);
-        state.setCurrentPodcast(null);
-        state.setIsShuffle(false); // Sync groups don't use shuffle
-        state.setVibeMode(false);
-
-        // Compute target position (compensate for network latency)
-        let targetMs = Math.max(0, pb.positionMs);
-        if (pb.isPlaying && pb.serverTime) {
-            const age = Date.now() - pb.serverTime;
-            targetMs += Math.min(Math.max(age, 0), 5000); // Cap compensation at 5s
-        }
-        if (targetTrack?.duration) {
-            targetMs = Math.min(targetMs, targetTrack.duration * 1000);
-        }
-
-        // Convert to seconds for the player
-        const targetSec = targetMs / 1000;
-
-        // Seek if needed
-        const drift = Math.abs(playbackEngine.getCurrentTime() - targetSec);
-        if (drift > 1.5 || state.currentTrack?.id !== targetTrack?.id) {
-            ctrl.seek(targetSec, {
-                allowListenTogetherFollower: true,
-                suppressListenTogetherBroadcast: true,
-            });
-        }
-
-        // Play/pause — skip resume when a reconnect audio recovery is pending,
-        // because recoverAudioAfterReconnect will reload the stream and resume
-        // after the reload completes. Resuming here would race with the reload
-        // and cause overlapping audio. Pause must still be applied so that a
-        // paused host state is respected (recoverAudioAfterReconnect exits
-        // early when !pb.isPlaying).
-        if (pendingReconnectAudioRecoveryRef.current && pb.isPlaying) {
-            // Let recoverAudioAfterReconnect handle resume after reload
-        } else if (pb.isPlaying) {
-            ctrl.resume({
-                suppressListenTogetherBroadcast: true,
-                listenTogetherForceIsPlaying: true,
-                listenTogetherPositionMs: pb.positionMs,
-                listenTogetherServerTimeMs: pb.serverTime,
-            });
-        } else {
-            ctrl.pause({ suppressListenTogetherBroadcast: true });
-        }
-
-        queueMicrotask(() => {
-            isApplyingRemoteRef.current = false;
-        });
-    }, [clearObsoleteReadyReportLoadListener]);
-
-    const applyDeltaToPlayer = useCallback((delta: PlaybackDelta) => {
-        // Ignore deltas while a reconnect audio recovery is in progress.
-        // recoverAudioAfterReconnect owns the reload+resume lifecycle;
-        // applying a delta here would race with that reload.
-        if (pendingReconnectAudioRecoveryRef.current) return;
-
-        const state = audioStateRef.current;
-        const ctrl = controlsRef.current;
-
-        isApplyingRemoteRef.current = true;
-
-        // Handle track change if currentIndex changed
-        const currentQueue = state.queue;
-        let trackChanged = false;
-        if (currentQueue.length > 0) {
-            const safeIdx = Math.min(
-                Math.max(delta.currentIndex, 0),
-                currentQueue.length - 1,
+    const applyPlaybackToPlayer = useCallback(
+        (snapshot: GroupSnapshot) => {
+            const pb = snapshot.playback;
+            if (!pb || !Array.isArray(pb.queue)) return;
+            const availabilityForState =
+                trackAvailabilityStateVersionRef.current === pb.stateVersion
+                    ? trackAvailabilityRef.current
+                    : null;
+            const mappedQueue = pb.queue.map((item, index) =>
+                toLocalTrack(item, availabilityForState?.get(index)),
             );
-            const queueItem = currentQueue[safeIdx] ?? null;
-            // Listen Together queues are music-only; ignore episode entries.
-            const effectiveTrack =
-                queueItem && !isEpisodeQueueItem(queueItem) ? queueItem : null;
-            trackChanged = effectiveTrack?.id !== state.currentTrack?.id;
+            const safeIndex =
+                mappedQueue.length > 0
+                    ? Math.min(
+                          Math.max(pb.currentIndex, 0),
+                          mappedQueue.length - 1,
+                      )
+                    : 0;
+            const targetTrack = mappedQueue[safeIndex] ?? null;
+
+            const state = audioStateRef.current;
+            const ctrl = controlsRef.current;
+
             if (
                 pendingHostTrackIndexRef.current !== null &&
-                pendingHostTrackIndexRef.current !== safeIdx
+                pendingHostTrackIndexRef.current !== safeIndex
             ) {
                 pendingHostTrackIndexRef.current = null;
             }
             clearObsoleteReadyReportLoadListener(
-                safeIdx,
-                delta.trackId,
+                safeIndex,
+                pb.queue[safeIndex]?.id ?? null,
             );
-            if (trackChanged) {
-                // Pause before switching to prevent buffered audio from the old
-                // track replaying during the async transition.
-                if (playbackEngine.isPlaying()) {
-                    ctrl.pause({ suppressListenTogetherBroadcast: true });
-                }
-                state.setCurrentIndex(safeIdx);
-                state.setCurrentTrack(effectiveTrack);
-            } else if (safeIdx !== state.currentIndex) {
-                state.setCurrentIndex(safeIdx);
+            isApplyingRemoteRef.current = true;
+
+            // Pause before switching tracks to prevent buffered audio from
+            // the old track replaying during the async transition.
+            if (
+                state.currentTrack?.id !== targetTrack?.id &&
+                playbackEngine.isPlaying()
+            ) {
+                ctrl.pause({ suppressListenTogetherBroadcast: true });
             }
-        }
 
-        // Compute target position
-        let targetMs = Math.max(0, delta.positionMs);
-        if (delta.isPlaying && delta.serverTime) {
-            const age = Date.now() - delta.serverTime;
-            targetMs += Math.min(Math.max(age, 0), 5000);
-        }
-        const safeTrackIdx =
-            currentQueue.length > 0
-                ? Math.min(
-                      Math.max(delta.currentIndex, 0),
-                      currentQueue.length - 1,
-                  )
-                : -1;
-        const track =
-            safeTrackIdx >= 0 ? currentQueue[safeTrackIdx] : undefined;
-        if (track?.duration) {
-            targetMs = Math.min(targetMs, track.duration * 1000);
-        }
+            // Set queue + track
+            state.setPlaybackType("track");
+            state.setQueue(mappedQueue);
+            state.setCurrentIndex(safeIndex);
+            state.setCurrentTrack(targetTrack);
+            state.setCurrentAudiobook(null);
+            state.setCurrentPodcast(null);
+            state.setIsShuffle(false); // Sync groups don't use shuffle
+            state.setVibeMode(false);
 
-        const targetSec = targetMs / 1000;
-        const drift = Math.abs(playbackEngine.getCurrentTime() - targetSec);
+            // Compute target position (compensate for network latency)
+            let targetMs = Math.max(0, pb.positionMs);
+            if (pb.isPlaying && pb.serverTime) {
+                const age = Date.now() - pb.serverTime;
+                targetMs += Math.min(Math.max(age, 0), 5000); // Cap compensation at 5s
+            }
+            if (targetTrack?.duration) {
+                targetMs = Math.min(targetMs, targetTrack.duration * 1000);
+            }
 
-        // Seek if drift is significant
-        if (drift > 1.5) {
-            ctrl.seek(targetSec, {
-                allowListenTogetherFollower: true,
-                suppressListenTogetherBroadcast: true,
+            // Convert to seconds for the player
+            const targetSec = targetMs / 1000;
+
+            // Seek if needed
+            const drift = Math.abs(playbackEngine.getCurrentTime() - targetSec);
+            if (drift > 1.5 || state.currentTrack?.id !== targetTrack?.id) {
+                ctrl.seek(targetSec, {
+                    allowListenTogetherFollower: true,
+                    suppressListenTogetherBroadcast: true,
+                });
+            }
+
+            // Play/pause — skip resume when a reconnect audio recovery is pending,
+            // because recoverAudioAfterReconnect will reload the stream and resume
+            // after the reload completes. Resuming here would race with the reload
+            // and cause overlapping audio. Pause must still be applied so that a
+            // paused host state is respected (recoverAudioAfterReconnect exits
+            // early when !pb.isPlaying).
+            if (pendingReconnectAudioRecoveryRef.current && pb.isPlaying) {
+                // Let recoverAudioAfterReconnect handle resume after reload
+            } else if (pb.isPlaying) {
+                ctrl.resume({
+                    suppressListenTogetherBroadcast: true,
+                    listenTogetherForceIsPlaying: true,
+                    listenTogetherPositionMs: pb.positionMs,
+                    listenTogetherServerTimeMs: pb.serverTime,
+                });
+            } else {
+                ctrl.pause({ suppressListenTogetherBroadcast: true });
+            }
+
+            queueMicrotask(() => {
+                isApplyingRemoteRef.current = false;
             });
-        }
+        },
+        [clearObsoleteReadyReportLoadListener],
+    );
 
-        // Play/pause — after a track change, always call resume if delta says
-        // playing, because the pre-switch pause may have cleared isPlaying state.
-        if (delta.isPlaying && (trackChanged || !playbackEngine.isPlaying())) {
-            ctrl.resume({
-                suppressListenTogetherBroadcast: true,
-                listenTogetherForceIsPlaying: true,
-                listenTogetherPositionMs: delta.positionMs,
-                listenTogetherServerTimeMs: delta.serverTime,
+    const applyDeltaToPlayer = useCallback(
+        (delta: PlaybackDelta) => {
+            // Ignore deltas while a reconnect audio recovery is in progress.
+            // recoverAudioAfterReconnect owns the reload+resume lifecycle;
+            // applying a delta here would race with that reload.
+            if (pendingReconnectAudioRecoveryRef.current) return;
+
+            const state = audioStateRef.current;
+            const ctrl = controlsRef.current;
+
+            isApplyingRemoteRef.current = true;
+
+            // Handle track change if currentIndex changed
+            const currentQueue = state.queue;
+            let trackChanged = false;
+            if (currentQueue.length > 0) {
+                const safeIdx = Math.min(
+                    Math.max(delta.currentIndex, 0),
+                    currentQueue.length - 1,
+                );
+                const queueItem = currentQueue[safeIdx] ?? null;
+                // Listen Together queues are music-only; ignore episode entries.
+                const effectiveTrack =
+                    queueItem && !isEpisodeQueueItem(queueItem)
+                        ? queueItem
+                        : null;
+                trackChanged = effectiveTrack?.id !== state.currentTrack?.id;
+                if (
+                    pendingHostTrackIndexRef.current !== null &&
+                    pendingHostTrackIndexRef.current !== safeIdx
+                ) {
+                    pendingHostTrackIndexRef.current = null;
+                }
+                clearObsoleteReadyReportLoadListener(safeIdx, delta.trackId);
+                if (trackChanged) {
+                    // Pause before switching to prevent buffered audio from the old
+                    // track replaying during the async transition.
+                    if (playbackEngine.isPlaying()) {
+                        ctrl.pause({ suppressListenTogetherBroadcast: true });
+                    }
+                    state.setCurrentIndex(safeIdx);
+                    state.setCurrentTrack(effectiveTrack);
+                } else if (safeIdx !== state.currentIndex) {
+                    state.setCurrentIndex(safeIdx);
+                }
+            }
+
+            // Compute target position
+            let targetMs = Math.max(0, delta.positionMs);
+            if (delta.isPlaying && delta.serverTime) {
+                const age = Date.now() - delta.serverTime;
+                targetMs += Math.min(Math.max(age, 0), 5000);
+            }
+            const safeTrackIdx =
+                currentQueue.length > 0
+                    ? Math.min(
+                          Math.max(delta.currentIndex, 0),
+                          currentQueue.length - 1,
+                      )
+                    : -1;
+            const track =
+                safeTrackIdx >= 0 ? currentQueue[safeTrackIdx] : undefined;
+            if (track?.duration) {
+                targetMs = Math.min(targetMs, track.duration * 1000);
+            }
+
+            const targetSec = targetMs / 1000;
+            const drift = Math.abs(playbackEngine.getCurrentTime() - targetSec);
+
+            // Seek if drift is significant
+            if (drift > 1.5) {
+                ctrl.seek(targetSec, {
+                    allowListenTogetherFollower: true,
+                    suppressListenTogetherBroadcast: true,
+                });
+            }
+
+            // Play/pause — after a track change, always call resume if delta says
+            // playing, because the pre-switch pause may have cleared isPlaying state.
+            if (
+                delta.isPlaying &&
+                (trackChanged || !playbackEngine.isPlaying())
+            ) {
+                ctrl.resume({
+                    suppressListenTogetherBroadcast: true,
+                    listenTogetherForceIsPlaying: true,
+                    listenTogetherPositionMs: delta.positionMs,
+                    listenTogetherServerTimeMs: delta.serverTime,
+                });
+            } else if (!delta.isPlaying && playbackEngine.isPlaying()) {
+                ctrl.pause({ suppressListenTogetherBroadcast: true });
+            }
+
+            queueMicrotask(() => {
+                isApplyingRemoteRef.current = false;
             });
-        } else if (!delta.isPlaying && playbackEngine.isPlaying()) {
-            ctrl.pause({ suppressListenTogetherBroadcast: true });
-        }
-
-        queueMicrotask(() => {
-            isApplyingRemoteRef.current = false;
-        });
-    }, [clearObsoleteReadyReportLoadListener]);
+        },
+        [clearObsoleteReadyReportLoadListener],
+    );
 
     const recoverAudioAfterReconnect = useCallback(
         (snapshot: GroupSnapshot) => {
@@ -837,69 +848,72 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
     /**
      * Apply a queue delta — queue changed server-side.
      */
-    const applyQueueDelta = useCallback((delta: QueueDelta) => {
-        // Ignore stale/equal versions so late queue packets cannot rewind visuals.
-        if (delta.stateVersion <= lastAppliedVersionRef.current) return;
-        lastAppliedVersionRef.current = delta.stateVersion;
+    const applyQueueDelta = useCallback(
+        (delta: QueueDelta) => {
+            // Ignore stale/equal versions so late queue packets cannot rewind visuals.
+            if (delta.stateVersion <= lastAppliedVersionRef.current) return;
+            lastAppliedVersionRef.current = delta.stateVersion;
 
-        setActiveGroup((prev) => {
-            if (!prev) return prev;
-            const next = {
-                ...prev,
-                playback: {
-                    ...prev.playback,
-                    queue: delta.queue,
-                    currentIndex: delta.currentIndex,
-                    trackId: delta.trackId,
-                    stateVersion: delta.stateVersion,
-                },
-            };
-            activeGroupRef.current = next;
-            return next;
-        });
+            setActiveGroup((prev) => {
+                if (!prev) return prev;
+                const next = {
+                    ...prev,
+                    playback: {
+                        ...prev.playback,
+                        queue: delta.queue,
+                        currentIndex: delta.currentIndex,
+                        trackId: delta.trackId,
+                        stateVersion: delta.stateVersion,
+                    },
+                };
+                activeGroupRef.current = next;
+                return next;
+            });
 
-        // Rebuild local queue from sync queue
-        if (!Array.isArray(delta.queue)) return;
-        const availabilityForState =
-            trackAvailabilityStateVersionRef.current === delta.stateVersion
-                ? trackAvailabilityRef.current
-                : null;
-        const mappedQueue = delta.queue.map((item, index) =>
-            toLocalTrack(item, availabilityForState?.get(index)),
-        );
-        const safeIndex =
-            mappedQueue.length > 0
-                ? Math.min(
-                      Math.max(delta.currentIndex, 0),
-                      mappedQueue.length - 1,
-                  )
-                : 0;
+            // Rebuild local queue from sync queue
+            if (!Array.isArray(delta.queue)) return;
+            const availabilityForState =
+                trackAvailabilityStateVersionRef.current === delta.stateVersion
+                    ? trackAvailabilityRef.current
+                    : null;
+            const mappedQueue = delta.queue.map((item, index) =>
+                toLocalTrack(item, availabilityForState?.get(index)),
+            );
+            const safeIndex =
+                mappedQueue.length > 0
+                    ? Math.min(
+                          Math.max(delta.currentIndex, 0),
+                          mappedQueue.length - 1,
+                      )
+                    : 0;
 
-        if (
-            pendingHostTrackIndexRef.current !== null &&
-            pendingHostTrackIndexRef.current !== safeIndex
-        ) {
-            pendingHostTrackIndexRef.current = null;
-        }
-        clearObsoleteReadyReportLoadListener(safeIndex, delta.trackId);
-        isApplyingRemoteRef.current = true;
-        const aState = audioStateRef.current;
+            if (
+                pendingHostTrackIndexRef.current !== null &&
+                pendingHostTrackIndexRef.current !== safeIndex
+            ) {
+                pendingHostTrackIndexRef.current = null;
+            }
+            clearObsoleteReadyReportLoadListener(safeIndex, delta.trackId);
+            isApplyingRemoteRef.current = true;
+            const aState = audioStateRef.current;
 
-        startTransition(() => {
-            aState.setPlaybackType("track");
-            aState.setQueue(mappedQueue);
-            aState.setCurrentIndex(safeIndex);
-            aState.setCurrentTrack(mappedQueue[safeIndex] ?? null);
-            aState.setCurrentAudiobook(null);
-            aState.setCurrentPodcast(null);
-            aState.setVibeMode(false);
-        });
+            startTransition(() => {
+                aState.setPlaybackType("track");
+                aState.setQueue(mappedQueue);
+                aState.setCurrentIndex(safeIndex);
+                aState.setCurrentTrack(mappedQueue[safeIndex] ?? null);
+                aState.setCurrentAudiobook(null);
+                aState.setCurrentPodcast(null);
+                aState.setVibeMode(false);
+            });
 
-        // Allow time for the deferred startTransition to commit before clearing
-        setTimeout(() => {
-            isApplyingRemoteRef.current = false;
-        }, 100);
-    }, [clearObsoleteReadyReportLoadListener]);
+            // Allow time for the deferred startTransition to commit before clearing
+            setTimeout(() => {
+                isApplyingRemoteRef.current = false;
+            }, 100);
+        },
+        [clearObsoleteReadyReportLoadListener],
+    );
 
     // -----------------------------------------------------------------------
     // Socket.IO lifecycle
@@ -1617,10 +1631,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             // Listen Together queues are music-only; ignore episode entries.
             if (!targetTrack || isEpisodeQueueItem(targetTrack)) return false;
             pendingHostTrackIndexRef.current = safeIndex;
-            clearObsoleteReadyReportLoadListener(
-                safeIndex,
-                targetTrack.id,
-            );
+            clearObsoleteReadyReportLoadListener(safeIndex, targetTrack.id);
             const optimisticSelectionPolicy =
                 getListenTogetherOptimisticTrackSelectionPolicy();
             if (optimisticSelectionPolicy.guardRemoteApply) {

--- a/frontend/tests/component/listenTogetherSession.component.test.ts
+++ b/frontend/tests/component/listenTogetherSession.component.test.ts
@@ -758,10 +758,7 @@ type ListenTogetherCallbacks = {
         }>;
         stateVersion: number;
     }) => void;
-    onWaiting: (data: {
-        trackId: string | null;
-        currentIndex: number;
-    }) => void;
+    onWaiting: (data: { trackId: string | null; currentIndex: number }) => void;
     onPlayAt: (data: {
         positionMs: number;
         serverTime: number;
@@ -923,10 +920,8 @@ const originalProviderSocketMethods = {
     removeFromQueue: listenTogetherSocket.removeFromQueue,
     clearQueue: listenTogetherSocket.clearQueue,
 };
-const originalProviderSocketConnectedDescriptor = Object.getOwnPropertyDescriptor(
-    listenTogetherSocket,
-    "isConnected",
-);
+const originalProviderSocketConnectedDescriptor =
+    Object.getOwnPropertyDescriptor(listenTogetherSocket, "isConnected");
 const providerApi = api as unknown as {
     getMyListenGroup: () => Promise<MockGroupSnapshot | null>;
 };
@@ -961,42 +956,33 @@ function installProviderBoundaryStubs(): void {
 after(() => {
     if (!providerBoundaryStubsInstalled) return;
     const socket = listenTogetherSocket as unknown as typeof providerSocket;
-    socket.probeRoute = originalProviderSocketMethods.probeRoute.bind(
-        listenTogetherSocket,
-    );
-    socket.connect = originalProviderSocketMethods.connect.bind(
-        listenTogetherSocket,
-    );
-    socket.disconnect = originalProviderSocketMethods.disconnect.bind(
-        listenTogetherSocket,
-    );
-    socket.joinGroup = originalProviderSocketMethods.joinGroup.bind(
-        listenTogetherSocket,
-    );
-    socket.reportReady = originalProviderSocketMethods.reportReady.bind(
-        listenTogetherSocket,
-    );
+    socket.probeRoute =
+        originalProviderSocketMethods.probeRoute.bind(listenTogetherSocket);
+    socket.connect =
+        originalProviderSocketMethods.connect.bind(listenTogetherSocket);
+    socket.disconnect =
+        originalProviderSocketMethods.disconnect.bind(listenTogetherSocket);
+    socket.joinGroup =
+        originalProviderSocketMethods.joinGroup.bind(listenTogetherSocket);
+    socket.reportReady =
+        originalProviderSocketMethods.reportReady.bind(listenTogetherSocket);
     socket.play = originalProviderSocketMethods.play.bind(listenTogetherSocket);
-    socket.pause = originalProviderSocketMethods.pause.bind(
-        listenTogetherSocket,
-    );
+    socket.pause =
+        originalProviderSocketMethods.pause.bind(listenTogetherSocket);
     socket.seek = originalProviderSocketMethods.seek.bind(listenTogetherSocket);
     socket.next = originalProviderSocketMethods.next.bind(listenTogetherSocket);
-    socket.previous = originalProviderSocketMethods.previous.bind(
-        listenTogetherSocket,
-    );
-    socket.setTrack = originalProviderSocketMethods.setTrack.bind(
-        listenTogetherSocket,
-    );
-    socket.addToQueue = originalProviderSocketMethods.addToQueue.bind(
-        listenTogetherSocket,
-    );
-    socket.removeFromQueue = originalProviderSocketMethods.removeFromQueue.bind(
-        listenTogetherSocket,
-    );
-    socket.clearQueue = originalProviderSocketMethods.clearQueue.bind(
-        listenTogetherSocket,
-    );
+    socket.previous =
+        originalProviderSocketMethods.previous.bind(listenTogetherSocket);
+    socket.setTrack =
+        originalProviderSocketMethods.setTrack.bind(listenTogetherSocket);
+    socket.addToQueue =
+        originalProviderSocketMethods.addToQueue.bind(listenTogetherSocket);
+    socket.removeFromQueue =
+        originalProviderSocketMethods.removeFromQueue.bind(
+            listenTogetherSocket,
+        );
+    socket.clearQueue =
+        originalProviderSocketMethods.clearQueue.bind(listenTogetherSocket);
     if (originalProviderSocketConnectedDescriptor) {
         Object.defineProperty(
             listenTogetherSocket,
@@ -1088,7 +1074,8 @@ function resetProviderHarness(isHost: boolean, currentIndex: number): void {
     providerControlCalls.pause = 0;
     providerAudioState.queue = group.playback.queue;
     providerAudioState.currentIndex = currentIndex;
-    providerAudioState.currentTrack = group.playback.queue[currentIndex] ?? null;
+    providerAudioState.currentTrack =
+        group.playback.queue[currentIndex] ?? null;
     providerAudioState.playbackType = "track";
     providerAudioStateCalls.currentIndex = [];
     providerAudioStateCalls.currentTrack = [];
@@ -1154,11 +1141,17 @@ async function mountListenTogetherProvider(
 
     return {
         latest: () => {
-            assert.ok(latestRef.current, "listen-together context did not render");
+            assert.ok(
+                latestRef.current,
+                "listen-together context did not render",
+            );
             return latestRef.current;
         },
         callbacks: () => {
-            assert.ok(providerSocketState.callbacks, "socket callbacks missing");
+            assert.ok(
+                providerSocketState.callbacks,
+                "socket callbacks missing",
+            );
             return providerSocketState.callbacks;
         },
         act: async (action: () => void | Promise<void>) => {


### PR DESCRIPTION
Two mechanical follow-ups closing out the Phase G merge train:

1. **CHANGELOG**: adds the `[Unreleased] > ### Fixed` bullets for the seven playback-reliability PRs whose CHANGELOG hunks were deliberately stripped so the file-disjoint fixes could merge in parallel (#338, #340, #341, #342, #343, #344, #345). #339's bullet landed with its own PR.
2. **Formatting**: Enforcement Gates' repository-formatting check (not a required check, so it did not block the train) flagged three files formatted with a drifted prettier during implementation — `frontend/lib/api/core.ts`, `frontend/lib/listen-together-context.tsx`, `frontend/tests/component/listenTogetherSession.component.test.ts`. Reformatted with the repo-pinned frontend prettier; `git diff -w` confirms whitespace-only (no semantic changes).

Restores main to a fully green Enforcement Gates before the convergence re-sweep.