### PR TITLE
fix(security): sanitize client-visible session-log errors; extend leak ratchet to workers/jobs/middleware

### DIFF
--- a/backend/src/services/__tests__/soulseekService.test.ts
+++ b/backend/src/services/__tests__/soulseekService.test.ts
@@ -10,6 +10,9 @@ const mockFsUnlinkSync = jest.fn();
 const mockMkdir = jest.fn();
 const mockRm = jest.fn();
 const mockStat = jest.fn();
+const mockLogInfo = jest.fn();
+const mockLogWarn = jest.fn();
+const mockLogError = jest.fn();
 
 jest.mock("slsk-client", () => ({
     __esModule: true,
@@ -24,6 +27,16 @@ jest.mock("../../utils/systemSettings", () => ({
 
 jest.mock("../../utils/playlistLogger", () => ({
     sessionLog: (...args: unknown[]) => mockSessionLog(...args),
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        child: () => ({
+            info: (...args: unknown[]) => mockLogInfo(...args),
+            warn: (...args: unknown[]) => mockLogWarn(...args),
+            error: (...args: unknown[]) => mockLogError(...args),
+        }),
+    },
 }));
 
 jest.mock("fs", () => ({
@@ -199,6 +212,24 @@ describe("soulseek service", () => {
                 "error",
                 expect.any(Function),
             );
+
+            const clientErrorHandler = clientOnSpy.mock.calls[0][1] as (
+                error: Error,
+            ) => void;
+            clientErrorHandler(new Error("socket path /srv/music/private"));
+
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "/srv/music/private",
+            );
+            expect(mockSessionLog).toHaveBeenCalledWith(
+                "SOULSEEK",
+                "Client connection error (detail in server log)",
+                "ERROR",
+            );
+            expect(mockLogError).toHaveBeenCalledWith(
+                "Soulseek client connection error",
+                expect.any(Error),
+            );
         });
 
         it("connect forwards slsk client errors", async () => {
@@ -220,6 +251,18 @@ describe("soulseek service", () => {
                 "connection refused",
             );
             expect(service.client).toBeNull();
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "connection refused",
+            );
+            expect(mockSessionLog).toHaveBeenCalledWith(
+                "SOULSEEK",
+                "Connection failed (detail in server log)",
+                "ERROR",
+            );
+            expect(mockLogError).toHaveBeenCalledWith(
+                "Soulseek connection failed",
+                expect.any(Error),
+            );
         });
 
         it("ensureConnected returns without reconnecting when already connected", async () => {
@@ -693,6 +736,16 @@ describe("soulseek service", () => {
             bestMatch: null,
             allMatches: [],
         });
+        expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+            "Timed out",
+        );
+        expect(mockLogError).toHaveBeenCalledWith(
+            "Soulseek search failed",
+            expect.objectContaining({
+                error: expect.any(Error),
+                searchId: 1,
+            }),
+        );
     });
 
     it("searchTrack handles synchronous search API failures", async () => {
@@ -712,6 +765,16 @@ describe("soulseek service", () => {
             bestMatch: null,
             allMatches: [],
         });
+        expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+            "Search API sync failure",
+        );
+        expect(mockLogError).toHaveBeenCalledWith(
+            "Soulseek search threw synchronously",
+            expect.objectContaining({
+                error: expect.any(Error),
+                searchId: 1,
+            }),
+        );
     });
 
     it("searchTrack ignores non-audio results", async () => {
@@ -1200,6 +1263,14 @@ describe("soulseek service", () => {
             success: false,
             error: "All 2 attempts failed: primary-user: timeout; fallback-user: user offline",
         });
+        expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+            "user offline",
+        );
+        expect(mockSessionLog).toHaveBeenCalledWith(
+            "SOULSEEK",
+            "Attempt 2 failed, trying next user (detail in server log)",
+            "WARN",
+        );
     });
 
     it("searchAndDownload retries secondary matches and succeeds on later attempt", async () => {
@@ -1288,7 +1359,9 @@ describe("soulseek service", () => {
                 search: jest.fn(),
                 download: jest.fn(),
             };
-            mockMkdir.mockRejectedValueOnce(new Error("EACCES"));
+            mockMkdir.mockRejectedValueOnce(
+                new Error("EACCES: denied /music/folder"),
+            );
 
             const result = await soulseekService.downloadTrack(
                 makeTrackMatch(),
@@ -1297,8 +1370,23 @@ describe("soulseek service", () => {
 
             expect(result).toEqual({
                 success: false,
-                error: "Cannot create destination directory: EACCES",
+                error: "Cannot create destination directory: EACCES: denied /music/folder",
             });
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "/music/folder",
+            );
+            expect(mockSessionLog).toHaveBeenCalledWith(
+                "SOULSEEK",
+                "Failed to create directory (detail in server log)",
+                "ERROR",
+            );
+            expect(mockLogError).toHaveBeenCalledWith(
+                "Failed to create Soulseek destination directory",
+                expect.objectContaining({
+                    destDir: "/music/folder",
+                    error: expect.any(Error),
+                }),
+            );
         });
 
         it("times out download attempts and records cleanup for partial files", async () => {
@@ -1358,6 +1446,17 @@ describe("soulseek service", () => {
             );
 
             expect(result).toEqual({ success: false, error: "user offline" });
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "user offline",
+            );
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "/music/offline.flac",
+            );
+            expect(mockSessionLog).toHaveBeenCalledWith(
+                "SOULSEEK",
+                "Download failed (detail in server log)",
+                "ERROR",
+            );
             expect(
                 (soulseekService as any).failedUsers.get("offline-user"),
             ).toEqual(expect.objectContaining({ failures: 1 }));
@@ -1384,6 +1483,14 @@ describe("soulseek service", () => {
                 success: false,
                 error: "Synchronous error: sync download failure",
             });
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "sync download failure",
+            );
+            expect(mockSessionLog).toHaveBeenCalledWith(
+                "SOULSEEK",
+                "Download failed synchronously (detail in server log)",
+                "ERROR",
+            );
         });
 
         it("returns error when downloaded file is not written to disk", async () => {

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -158,9 +158,10 @@ class SoulseekService {
                 },
                 (err: Error | null, client: SlskClient) => {
                     if (err) {
+                        log.error("Soulseek connection failed", err);
                         sessionLog(
                             "SOULSEEK",
-                            `Connection failed: ${err.message}`,
+                            "Connection failed (detail in server log)",
                             "ERROR",
                         );
                         return reject(err);
@@ -169,9 +170,13 @@ class SoulseekService {
                     // Prevent crash on unhandled socket errors
                     if ((client as any).on) {
                         (client as any).on("error", (error: Error) => {
+                            log.error(
+                                "Soulseek client connection error",
+                                error,
+                            );
                             sessionLog(
                                 "SOULSEEK",
-                                `Client connection error: ${error.message}`,
+                                "Client connection error (detail in server log)",
                                 "ERROR",
                             );
                         });
@@ -337,9 +342,13 @@ class SoulseekService {
         try {
             await this.ensureConnected();
         } catch (err: any) {
+            log.error("Soulseek search connection failed", {
+                searchId,
+                error: err,
+            });
             sessionLog(
                 "SOULSEEK",
-                `[Search #${searchId}] Connection error: ${err.message}`,
+                `[Search #${searchId}] Connection failed (detail in server log)`,
                 "ERROR",
             );
             return { found: false, bestMatch: null, allMatches: [] };
@@ -393,9 +402,14 @@ class SoulseekService {
                         );
 
                         if (err) {
+                            log.error("Soulseek search failed", {
+                                searchId,
+                                searchDuration,
+                                error: err,
+                            });
                             sessionLog(
                                 "SOULSEEK",
-                                `[Search #${searchId}] Search error after ${searchDuration}ms: ${err.message}`,
+                                `[Search #${searchId}] Search failed after ${searchDuration}ms (detail in server log)`,
                                 "ERROR",
                             );
                             this.consecutiveEmptySearches++;
@@ -555,9 +569,13 @@ class SoulseekService {
                     },
                 );
             } catch (syncError: any) {
+                log.error("Soulseek search threw synchronously", {
+                    searchId,
+                    error: syncError,
+                });
                 sessionLog(
                     "SOULSEEK",
-                    `[Search #${searchId}] Synchronous error: ${syncError.message}`,
+                    `[Search #${searchId}] Search failed synchronously (detail in server log)`,
                     "ERROR",
                 );
                 resolve({
@@ -838,9 +856,13 @@ class SoulseekService {
         try {
             await mkdir(destDir, { recursive: true });
         } catch (err: any) {
+            log.error("Failed to create Soulseek destination directory", {
+                destDir,
+                error: err,
+            });
             sessionLog(
                 "SOULSEEK",
-                `Failed to create directory ${destDir}: ${err.message}`,
+                "Failed to create directory (detail in server log)",
                 "ERROR",
             );
             this.activeDownloads--;
@@ -852,7 +874,7 @@ class SoulseekService {
 
         sessionLog(
             "SOULSEEK",
-            `Downloading from ${match.username}: ${match.filename} -> ${destPath}`,
+            `Downloading from ${match.username}: ${match.filename}`,
         );
 
         return new Promise((resolve) => {
@@ -906,9 +928,15 @@ class SoulseekService {
 
                         if (err) {
                             const errorInfo = this.categorizeError(err);
+                            log.error("Soulseek download failed", {
+                                username: match.username,
+                                filename: match.filename,
+                                errorType: errorInfo.type,
+                                error: err,
+                            });
                             sessionLog(
                                 "SOULSEEK",
-                                `Download failed (${errorInfo.type}): ${err.message}`,
+                                "Download failed (detail in server log)",
                                 "ERROR",
                             );
 
@@ -950,9 +978,14 @@ class SoulseekService {
                 clearTimeout(timeoutId); // Clear timeout to prevent double-resolve
                 resolved = true;
                 this.activeDownloads--;
+                log.error("Soulseek download threw synchronously", {
+                    username: match.username,
+                    filename: match.filename,
+                    error: syncError,
+                });
                 sessionLog(
                     "SOULSEEK",
-                    `Download synchronous error: ${syncError.message}`,
+                    "Download failed synchronously (detail in server log)",
                     "ERROR",
                 );
                 resolve({
@@ -1027,11 +1060,15 @@ class SoulseekService {
             // Log failure and try next user
             const errorMsg = downloadResult.error || "Unknown error";
             errors.push(`${match.username}: ${errorMsg}`);
+            log.warn("Soulseek download attempt failed", {
+                attempt: attempt + 1,
+                username: match.username,
+                filename: match.filename,
+                error: errorMsg,
+            });
             sessionLog(
                 "SOULSEEK",
-                `Attempt ${
-                    attempt + 1
-                } failed: ${errorMsg}, trying next user...`,
+                `Attempt ${attempt + 1} failed, trying next user (detail in server log)`,
                 "WARN",
             );
         }
@@ -1109,9 +1146,15 @@ class SoulseekService {
             // Log failure and try next user
             const errorMsg = downloadResult.error || "Unknown error";
             errors.push(`${match.username}: ${errorMsg}`);
+            log.warn("Soulseek download attempt failed", {
+                attempt: attempt + 1,
+                username: match.username,
+                filename: match.filename,
+                error: errorMsg,
+            });
             sessionLog(
                 "SOULSEEK",
-                `Attempt ${attempt + 1} failed: ${errorMsg}`,
+                `Attempt ${attempt + 1} failed (detail in server log)`,
                 "WARN",
             );
         }

--- a/backend/src/workers/__tests__/organizeSingles.test.ts
+++ b/backend/src/workers/__tests__/organizeSingles.test.ts
@@ -18,6 +18,7 @@ describe("organizeSingles worker", () => {
         const logger = {
             debug: jest.fn(),
             error: jest.fn(),
+            warn: jest.fn(),
             child: jest.fn(),
         };
         logger.child.mockReturnValue(logger);
@@ -105,8 +106,8 @@ describe("organizeSingles worker", () => {
                 module.queueOrganizeSingles(),
             ).resolves.toBeUndefined();
             expect(logger.error).toHaveBeenCalledWith(
-                "Organization failed:",
-                "MUSIC_PATH is not set. Cannot organize downloads.",
+                "Organization failed",
+                expect.any(Error),
             );
         } finally {
             process.chdir(previousCwd);
@@ -168,11 +169,18 @@ describe("organizeSingles worker", () => {
         delete process.env.MUSIC_PATH;
 
         try {
-            const { module } = loadOrganizeSingles();
+            const { module, sessionLog } = loadOrganizeSingles();
             await module.organizeSingles();
             expect(
                 fs.existsSync(path.join(musicDir, ".soulseek-migrated")),
             ).toBe(true);
+            expect(JSON.stringify(sessionLog.mock.calls)).not.toContain(
+                musicDir,
+            );
+            expect(sessionLog).toHaveBeenCalledWith(
+                "ORGANIZE",
+                "Music path configured",
+            );
         } finally {
             process.chdir(previousCwd);
         }
@@ -196,15 +204,104 @@ describe("organizeSingles worker", () => {
         );
         process.env = { ...originalEnv, MUSIC_PATH: tmpRoot };
 
-        const { module, sessionLog } = loadOrganizeSingles({
-            legacyJobsError: new Error("legacy lookup failed"),
+        const { module, logger, sessionLog } = loadOrganizeSingles({
+            legacyJobsError: new Error(
+                "legacy lookup failed at /srv/music/private",
+            ),
         });
         await module.organizeSingles();
 
         expect(sessionLog).toHaveBeenCalledWith(
             "ORGANIZE",
-            expect.stringContaining("Failed to clean up legacy jobs"),
+            "Failed to clean up legacy jobs (detail in server log)",
             "WARN",
+        );
+        expect(JSON.stringify(sessionLog.mock.calls)).not.toContain(
+            "/srv/music/private",
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Failed to clean up legacy jobs",
+            expect.any(Error),
+        );
+    });
+
+    it("keeps migration directory failures and absolute paths out of the session log", async () => {
+        const tmpRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "soundspan-org-"),
+        );
+        process.env = { ...originalEnv, MUSIC_PATH: tmpRoot };
+        const soulseekAlbum = path.join(
+            tmpRoot,
+            "Soulseek",
+            "Artist A - Album A",
+        );
+        fs.mkdirSync(soulseekAlbum, { recursive: true });
+        fs.writeFileSync(path.join(soulseekAlbum, "Track 1.mp3"), "audio");
+
+        const { module, logger, sessionLog } = loadOrganizeSingles();
+        const mkdirSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(() => {
+            throw new Error(`EACCES: denied ${tmpRoot}`);
+        });
+
+        try {
+            await module.organizeSingles();
+        } finally {
+            mkdirSpy.mockRestore();
+        }
+
+        expect(JSON.stringify(sessionLog.mock.calls)).not.toContain(tmpRoot);
+        expect(sessionLog).toHaveBeenCalledWith(
+            "ORGANIZE",
+            "Failed to create directory (detail in server log)",
+            "WARN",
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Failed to create migration destination directory",
+            expect.objectContaining({
+                destDir: expect.stringContaining("Singles"),
+                error: expect.any(Error),
+            }),
+        );
+    });
+
+    it("keeps file migration failures and source paths out of the session log", async () => {
+        const tmpRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "soundspan-org-"),
+        );
+        process.env = { ...originalEnv, MUSIC_PATH: tmpRoot };
+        const soulseekAlbum = path.join(
+            tmpRoot,
+            "Soulseek",
+            "Artist A - Album A",
+        );
+        fs.mkdirSync(soulseekAlbum, { recursive: true });
+        fs.writeFileSync(path.join(soulseekAlbum, "Track 1.mp3"), "audio");
+
+        const { module, logger, sessionLog } = loadOrganizeSingles();
+        const copySpy = jest
+            .spyOn(fs, "copyFileSync")
+            .mockImplementation(() => {
+                throw new Error(`EIO: failed ${tmpRoot}`);
+            });
+
+        try {
+            await module.organizeSingles();
+        } finally {
+            copySpy.mockRestore();
+        }
+
+        expect(JSON.stringify(sessionLog.mock.calls)).not.toContain(tmpRoot);
+        expect(sessionLog).toHaveBeenCalledWith(
+            "ORGANIZE",
+            "Failed to migrate file (detail in server log)",
+            "WARN",
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Failed to migrate Soulseek file",
+            expect.objectContaining({
+                filePath: expect.stringContaining("Track 1.mp3"),
+                error: expect.any(Error),
+            }),
         );
     });
 });

--- a/backend/src/workers/organizeSingles.ts
+++ b/backend/src/workers/organizeSingles.ts
@@ -141,9 +141,13 @@ async function migrateExistingSoulseekFiles(musicPath: string): Promise<void> {
             try {
                 fs.mkdirSync(destDir, { recursive: true });
             } catch (err: any) {
+                log.warn("Failed to create migration destination directory", {
+                    destDir,
+                    error: err,
+                });
                 sessionLog(
                     "ORGANIZE",
-                    `Failed to create directory ${destDir}: ${err.message}`,
+                    "Failed to create directory (detail in server log)",
                     "WARN",
                 );
                 continue; // Skip this file, try next
@@ -159,9 +163,13 @@ async function migrateExistingSoulseekFiles(musicPath: string): Promise<void> {
                 `Migrated: ${filename} -> Singles/${artist}/${album}/`,
             );
         } catch (err: any) {
+            log.warn("Failed to migrate Soulseek file", {
+                filePath,
+                error: err,
+            });
             sessionLog(
                 "ORGANIZE",
-                `Failed to migrate ${filePath}: ${err.message}`,
+                "Failed to migrate file (detail in server log)",
                 "WARN",
             );
         }
@@ -244,9 +252,10 @@ async function cleanupLegacySlskdJobs(): Promise<void> {
             }
         }
     } catch (err: any) {
+        log.warn("Failed to clean up legacy jobs", err);
         sessionLog(
             "ORGANIZE",
-            `Failed to clean up legacy jobs: ${err.message}`,
+            "Failed to clean up legacy jobs (detail in server log)",
             "WARN",
         );
     }
@@ -282,7 +291,7 @@ export async function organizeSingles(): Promise<void> {
         throw new Error(error);
     }
 
-    sessionLog("ORGANIZE", `Music path: ${musicPath.replace(/\\/g, "/")}`);
+    sessionLog("ORGANIZE", "Music path configured");
 
     // Run one-time migration of existing Soulseek files
     await migrateExistingSoulseekFiles(musicPath);
@@ -304,6 +313,6 @@ export async function queueOrganizeSingles(): Promise<void> {
         await organizeSingles();
         log.debug("Organization complete");
     } catch (err: any) {
-        log.error("Organization failed:", err.message);
+        log.error("Organization failed", err);
     }
 }

--- a/scripts/ci/__tests__/check-route-error-canon.test.mjs
+++ b/scripts/ci/__tests__/check-route-error-canon.test.mjs
@@ -6,11 +6,40 @@ import path from "node:path";
 
 import {
     analyzeRouteErrorCanon,
+    collectLeakCounts,
     collectCounts,
     countPattern,
     countLeakPattern,
     stripLoggerCalls,
 } from "../check-route-error-canon.mjs";
+
+test("collectLeakCounts scans every production backend root", () => {
+    const fixtureRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "route-error-canon-roots-"),
+    );
+    const sourceRoots = ["routes", "services", "workers", "jobs", "middleware"];
+
+    try {
+        for (const sourceRoot of sourceRoots) {
+            const directory = path.join(fixtureRoot, "backend/src", sourceRoot);
+            fs.mkdirSync(directory, { recursive: true });
+            fs.writeFileSync(
+                path.join(directory, `${sourceRoot}.ts`),
+                "const detail = err.message;\n",
+            );
+        }
+
+        assert.deepEqual(collectLeakCounts(fixtureRoot), {
+            "backend/src/jobs/jobs.ts": 1,
+            "backend/src/middleware/middleware.ts": 1,
+            "backend/src/routes/routes.ts": 1,
+            "backend/src/services/services.ts": 1,
+            "backend/src/workers/workers.ts": 1,
+        });
+    } finally {
+        fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+});
 
 test("collectCounts recurses into services while excluding test files", () => {
     const fixtureRoot = fs.mkdtempSync(

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -136,8 +136,8 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/services/segmented-streaming/trace.ts": 1,
     // simpleDownloadManager.ts remaining 4: download-job status objects (~L350, ~L371, ~L415, ~L436) persisted for the admin download-queue surface; frozen under the slice-E scope guard.
     "backend/src/services/simpleDownloadManager.ts": 4,
-    // soulseek.ts remaining 17: sessionLog(...) server-side log lines and { success:false, error } download-result objects consumed by the admin-only Soulseek download path; frozen under the slice-E scope guard; plus downloadResult.error consts/interpolations (~L1008, ~L1090, ~L1186) and per-peer result.error batch error strings (~L1248); frozen under the slice-J scope guard.
-    "backend/src/services/soulseek.ts": 17,
+    // soulseek.ts remaining 9: download-result error objects and downstream aggregations/passthroughs in Soulseek orchestration; the session log is client-visible and its raw error/path entries are sanitized rather than frozen.
+    "backend/src/services/soulseek.ts": 9,
     // spotify.ts +1: track-scraper error detail const consumed only by logger.debug (~L663); server-side only; frozen under the ratchet-widening (slice-B2) scope guard.
     // spotify.ts +1: the same logger-only detail's ternary-consequent error.message; frozen under the ratchet-widening (slice-X1) scope guard.
     "backend/src/services/spotify.ts": 2,
@@ -147,6 +147,26 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/services/spotifyImport.ts": 14,
     // youtubeDownload.ts remaining 1: sidecar status mapping data.error (~L329); job-state plumbing, frozen under the slice-J scope guard.
     "backend/src/services/youtubeDownload.ts": 1,
+    // queueCleaner.ts remaining 2: Prisma/retry error classification used only to decide whether the internal cleanup job retries.
+    "backend/src/jobs/queueCleaner.ts": 2,
+    // errorHandler.ts remaining 5: typed AppError fields plus development-only unknown-error detail; this is an existing transport-boundary policy exception frozen as the middleware root enters the ratchet.
+    "backend/src/middleware/errorHandler.ts": 5,
+    // dataIntegrity.ts remaining 2: Prisma/retry error classification used only by internal worker retry decisions.
+    "backend/src/workers/dataIntegrity.ts": 2,
+    // index.ts remaining 4: one scheduler retry classifier, one numeric error counter, and two worker-result details used only in scoped server logs.
+    "backend/src/workers/index.ts": 4,
+    // moodBucketWorker.ts remaining 2: internal retry classification and a scoped server-log diagnostic.
+    "backend/src/workers/moodBucketWorker.ts": 2,
+    // organizeSingles.ts is explicitly frozen at zero after sanitizing its client-visible session-log errors and absolute paths.
+    "backend/src/workers/organizeSingles.ts": 0,
+    // discoverProcessor.ts remaining 1: Redis retry classification used only by the internal worker.
+    "backend/src/workers/processors/discoverProcessor.ts": 1,
+    // imageProcessor.ts remaining 1: an existing internal queue-result error field returned to its Bull processor.
+    "backend/src/workers/processors/imageProcessor.ts": 1,
+    // umapWorker.ts remaining 2: error normalization and an internal parent-worker message.
+    "backend/src/workers/umapWorker.ts": 2,
+    // unifiedEnrichment.ts remaining 13: retry classifiers, scoped worker diagnostics, and internal failure/batch-state records.
+    "backend/src/workers/unifiedEnrichment.ts": 13,
 });
 
 export function countPattern(source) {
@@ -339,6 +359,23 @@ export function collectCounts(
     );
 }
 
+const LEAK_SCAN_DIRECTORIES = Object.freeze([
+    "backend/src/routes",
+    "backend/src/services",
+    "backend/src/workers",
+    "backend/src/jobs",
+    "backend/src/middleware",
+]);
+
+export function collectLeakCounts(repoRoot) {
+    return Object.assign(
+        {},
+        ...LEAK_SCAN_DIRECTORIES.map((relativeDirectory) =>
+            collectCounts(repoRoot, countLeakPattern, relativeDirectory),
+        ),
+    );
+}
+
 function printReport(label, result) {
     console.log(`${label}:`);
     if (result.ok) {
@@ -369,15 +406,8 @@ function runCli() {
         collectCounts(repoRoot),
         BASELINE,
     );
-    // The leak ratchet covers production route and service modules recursively.
-    const routesCounts = collectCounts(repoRoot, countLeakPattern);
-    const servicesCounts = collectCounts(
-        repoRoot,
-        countLeakPattern,
-        "backend/src/services",
-    );
     const leakResult = analyzeRouteErrorCanon(
-        { ...routesCounts, ...servicesCounts },
+        collectLeakCounts(repoRoot),
         LEAK_BASELINE,
     );
 


### PR DESCRIPTION
Convergence sweep #18 remediation (M2+M3, class-closing — the two findings share the ratchet file).

Confirmed findings
- `backend/src/services/soulseek.ts` wrote raw slsk-client error text and absolute server paths into the **client-visible** session log (`GET /api/spotify/import/session-log` returns it verbatim to any authenticated non-admin user) — the identical leak class treated as release-blocking in #274/#276. The `LEAK_BASELINE` freeze comment rationalized these as "server-side log lines," which is factually wrong.
- `backend/src/workers/organizeSingles.ts` had the same defect (raw errno text + absolute music-library paths), and could never be caught: the ratchet scanned only `backend/src/routes` and `backend/src/services`.

Fix
- Both files: `#276` pattern — full raw detail to the scoped server logger only; generic text (`... (detail in server log)`) to the session log. Whole-file sweep, not just the cited lines.
- `check-route-error-canon.mjs`: leak scan roots extended to `workers/`, `jobs/`, `middleware/`; new per-file frozen baselines each carry an accurate rationale (remaining counts are internal retry classifiers, admin-only download-result objects, and the documented errorHandler transport-boundary exception). `soulseek.ts` 17→9; `organizeSingles.ts` frozen at **0**. Any future increase fails CI.
- Gate self-test extended (53/53); behavioral leak regressions added for both sanitized files.

Verification: leak + canon ratchets pass with new baselines; soulseek jest 78/78; organizeSingles jest 9/9; `tsc --noEmit` clean; prettier clean. No CHANGELOG edit (consolidated docs PR follows, which also fixes the duplicate `### Security` heading).