### PR TITLE
fix(helm): AIO entrypoint Service no longer selects sidecar pods; render check asserts selector isolation

### DIFF
--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.selectorLabels" . | nindent 8 }}
+        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "aio") | nindent 8 }}
         {{- with .Values.global.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/soundspan/templates/aio/service.yaml
+++ b/charts/soundspan/templates/aio/service.yaml
@@ -13,5 +13,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "soundspan.selectorLabels" . | nindent 4 }}
+    {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "aio") | nindent 4 }}
 {{- end }}

--- a/scripts/ci/helm-service-selector-check.mjs
+++ b/scripts/ci/helm-service-selector-check.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const MAX_DOCUMENTS = 128;
+const MAX_LABELS = 64;
+const MAX_RESOURCES = 64;
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function parseLabels(block, indent) {
+    if (block === undefined) fail("label block is undefined");
+    if (indent !== 4 && indent !== 8) fail("label indentation is invalid");
+
+    const labels = new Map();
+    const pattern = new RegExp(
+        `^ {${indent}}([A-Za-z0-9][A-Za-z0-9_./-]*):\\s*["']?([^"'\\s]+)["']?\\s*$`,
+        "gm",
+    );
+    let reachedEnd = false;
+    for (let index = 0; index < MAX_LABELS; index += 1) {
+        const match = pattern.exec(block);
+        if (match === null) {
+            reachedEnd = true;
+            break;
+        }
+        labels.set(match[1], match[2]);
+    }
+    if (!reachedEnd && pattern.exec(block) !== null) {
+        fail(`label map exceeds ${MAX_LABELS} entries`);
+    }
+    if (labels.size === 0) fail("label map is empty");
+    return labels;
+}
+
+function selectorMatches(selector, labels) {
+    if (selector === undefined) fail("selector is undefined");
+    if (labels === undefined) fail("pod labels are undefined");
+
+    const keys = [...selector.keys()];
+    if (keys.length === 0) return false;
+    for (let index = 0; index < MAX_LABELS; index += 1) {
+        if (index >= keys.length) return true;
+        const key = keys[index];
+        if (!labels.has(key) || labels.get(key) !== selector.get(key)) {
+            return false;
+        }
+    }
+    fail(`service selector exceeds ${MAX_LABELS} entries`);
+}
+
+function parseDocument(document) {
+    if (document === undefined) fail("YAML document is undefined");
+    if (typeof document !== "string") fail("YAML document is not a scalar");
+
+    const kind = document.match(/^kind:\s*(\S+)\s*$/m)?.[1];
+    const name = document.match(
+        /^metadata:\s*\n  name:\s*["']?([^"'\s]+)["']?\s*$/m,
+    )?.[1];
+    if (kind === undefined || name === undefined) return undefined;
+    if (kind === "Service") return parseService(document, name);
+    if (!/^(?:Deployment|StatefulSet|DaemonSet)$/.test(kind)) return undefined;
+    return parseWorkload(document, kind, name);
+}
+
+function parseService(document, name) {
+    const block = document.match(
+        /^  selector:\s*\n((?:^    \S[^\n]*\n?)*)/m,
+    )?.[1];
+    if (block === undefined) return undefined;
+    return {
+        type: "service",
+        resource: { name, labels: parseLabels(block, 4) },
+    };
+}
+
+function parseWorkload(document, kind, name) {
+    const block = document.match(
+        /^  template:\s*\n    metadata:\s*\n      labels:\s*\n((?:^        \S[^\n]*\n?)*)/m,
+    )?.[1];
+    if (block === undefined)
+        fail(`${kind} ${name} is missing pod template labels`);
+    return {
+        type: "workload",
+        resource: { kind, name, labels: parseLabels(block, 8) },
+    };
+}
+
+function parseResources(yaml) {
+    if (yaml === undefined) fail("rendered YAML is undefined");
+    if (yaml.length === 0) fail("rendered YAML is empty");
+
+    const documents = yaml.split(/^---\s*$/m);
+    if (documents.length > MAX_DOCUMENTS) {
+        fail(`render exceeds ${MAX_DOCUMENTS} YAML documents`);
+    }
+    const services = [];
+    const workloads = [];
+    for (let index = 0; index < documents.length; index += 1) {
+        const parsed = parseDocument(documents[index]);
+        if (parsed?.type === "service") services.push(parsed.resource);
+        if (parsed?.type === "workload") workloads.push(parsed.resource);
+    }
+    if (services.length > MAX_RESOURCES || workloads.length > MAX_RESOURCES) {
+        fail(`render exceeds ${MAX_RESOURCES} Services or workloads`);
+    }
+    return { services, workloads };
+}
+
+function matchingTargets(service, workloads) {
+    const targets = [];
+    for (let index = 0; index < workloads.length; index += 1) {
+        const workload = workloads[index];
+        if (
+            workload.name === service.name &&
+            selectorMatches(service.labels, workload.labels)
+        ) {
+            targets.push(workload);
+        }
+    }
+    return targets;
+}
+
+function assertServiceIsolated(service, workloads) {
+    if (service === undefined) fail("service is undefined");
+    if (workloads === undefined) fail("workloads are undefined");
+
+    const targets = matchingTargets(service, workloads);
+    if (targets.length !== 1) {
+        fail(
+            `Service ${service.name} selector does not match its same-name workload`,
+        );
+    }
+    const targetComponent = componentOf(targets[0]);
+    for (let index = 0; index < workloads.length; index += 1) {
+        assertWorkloadIsolated(service, workloads[index], targetComponent);
+    }
+}
+
+function componentOf(workload) {
+    return workload.labels.get("app.kubernetes.io/component") ?? "<unlabeled>";
+}
+
+function assertWorkloadIsolated(service, workload, targetComponent) {
+    const component = componentOf(workload);
+    if (component === targetComponent) return;
+    if (!selectorMatches(service.labels, workload.labels)) return;
+    fail(
+        `Service ${service.name} selector also matches ${workload.kind} ${workload.name} ` +
+            `from component ${component} (intended component: ${targetComponent})`,
+    );
+}
+
+function readManifest(manifestFile) {
+    try {
+        return readFileSync(manifestFile, "utf8");
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        fail(`cannot open ${manifestFile}: ${detail}`);
+    }
+}
+
+function main(args) {
+    if (args.length !== 1) {
+        fail(`usage: ${process.argv[1]} <rendered-manifest>`);
+    }
+    const yaml = readManifest(args[0]);
+    const { services, workloads } = parseResources(yaml);
+    for (let index = 0; index < services.length; index += 1) {
+        assertServiceIsolated(services[index], workloads);
+    }
+}
+
+try {
+    main(process.argv.slice(2));
+} catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 255;
+}

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -23,7 +23,19 @@ else
   }
 fi
 
+assert_service_selectors_isolated() {
+  local render_name="$1"
+  local manifest_file="$2"
+  local checker="${BASH_SOURCE[0]%/*}/ci/helm-service-selector-check.mjs"
+
+  if ! node "$checker" "$manifest_file"; then
+    echo "[ERROR] Service selector isolation failed (${render_name})" >&2
+    exit 1
+  fi
+}
+
 tmp_aio="$(mktemp)"
+tmp_aio_sidecars="$(mktemp)"
 tmp_individual_ha="$(mktemp)"
 tmp_global_env="$(mktemp)"
 tmp_sidecars="$(mktemp)"
@@ -31,7 +43,7 @@ tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_individual_ha" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_individual_ha" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -46,6 +58,14 @@ if ! line_match '^  name: '"$RELEASE_NAME"'$' "$tmp_aio"; then
   echo "[ERROR] AIO render missing expected deployment name: ${RELEASE_NAME}" >&2
   exit 1
 fi
+assert_service_selectors_isolated "default AIO" "$tmp_aio"
+
+echo "[CHECK] render AIO mode with HTTP sidecars for Service selector isolation"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set tidalSidecar.enabled=true \
+  --set ytmusicStreamer.enabled=true \
+  >"$tmp_aio_sidecars"
+assert_service_selectors_isolated "AIO with HTTP sidecars" "$tmp_aio_sidecars"
 
 echo "[CHECK] render HA individual mode with worker split"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
@@ -70,6 +90,7 @@ if ! perl -0777 -ne 'exit((/name:\s+LISTEN_TOGETHER_STATE_STORE_ENABLED\s+value:
   echo "[ERROR] Individual HA render missing LISTEN_TOGETHER_STATE_STORE_ENABLED=true" >&2
   exit 1
 fi
+assert_service_selectors_isolated "HA individual" "$tmp_individual_ha"
 
 echo "[CHECK] render global.env config map + envFrom wiring"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
@@ -121,6 +142,7 @@ for sidecar in tidal ytmusic; do
     exit 1
   fi
 done
+assert_service_selectors_isolated "individual with HTTP sidecars" "$tmp_sidecars"
 
 # Secret generation (F22): the stable-lookup template must still render a
 # complete Secret on first install / dry-run (where `lookup` returns nil and the


### PR DESCRIPTION
Convergence sweep #18 remediation (M1 — verified by rendering the chart at default `deploymentMode=aio` with `tidalSidecar.enabled=true`).

Root cause: the AIO entrypoint Service (`port 3030`, named targetPort `http`) selected only `soundspan.selectorLabels` (name+instance) — a strict subset of the sidecar pods' labels (`name`, `instance`, `component: tidal`). Sidecar pods therefore joined the entrypoint Service's endpoints, and since Kubernetes resolves named targetPorts per-pod, user/ingress traffic was load-balanced between the app (3030) and the internal FastAPI sidecar (8585) — intermittent UI breakage plus exposure of the internal sidecar API through the public entrypoint.

Fix
- AIO Service selector + AIO **pod template** labels now use the existing `componentSelectorLabels` helper (`component: aio`) — the same pattern every individual-mode Service already uses (audited: no other bare-selector Services or ServiceMonitors in the chart).
- **Upgrade-safe by design**: the AIO Deployment's immutable `.spec.selector` is deliberately left unchanged (it remains a valid subset of the new pod labels), so `helm upgrade` on existing installs does not break.
- Render check (`scripts/helm-chart-render-check.sh`) now runs a dependency-free Node assertion (`scripts/ci/helm-service-selector-check.mjs`): **no rendered Service selector may match another component's workload pod labels**, checked across aio, aio+sidecar, individual-HA, and individual+sidecar renders.

Verification: `npm run verify:helm` exit 0 across all renders; reverting the service.yaml fix makes the check fail with `Service soundspan selector also matches Deployment soundspan-tidal from component tidal (intended component: aio)` (assertion proven to bite, then restored); bash -n / node --check / prettier / `git diff --check` clean. No CHANGELOG edit (consolidated docs PR follows).