### PR TITLE
fix(security): admin-gate shared download routes; fix keep-track cross-user IDOR (sweep #19 M1/M2)

### DIFF
--- a/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
@@ -3,12 +3,9 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
-    // downloads.ts mounts requireAdmin on /clear-lidarr-queue at module
-    // scope; without this key the incomplete mock hands Router.post()
-    // undefined and the suite dies at load. Passthrough is correct here —
-    // this suite pins the interactive compat surface, not auth
-    // (downloadsRuntime.test.ts owns admin enforcement with the real
-    // middleware).
+    // downloads.ts mounts requireAdmin on shared download-control routes.
+    // Passthrough is correct here because downloadsRuntime.test.ts owns
+    // enforcement with the real middleware.
     requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
@@ -157,8 +154,8 @@ function createRes() {
 }
 
 describe("downloads interactive release compatibility", () => {
-    const releasesHandler = getRouteHandler("/releases/:albumMbid", "get");
-    const grabHandler = getRouteHandler("/grab", "post");
+    const releasesHandler = getRouteHandler("/releases/:albumMbid", "get", 1);
+    const grabHandler = getRouteHandler("/grab", "post", 1);
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
@@ -9,8 +9,8 @@ jest.mock("../../middleware/auth", () => ({
     // downloads/releases compat surface, not auth (releasesRuntime.test.ts
     // owns auth enforcement with the real middleware).
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
-    // downloads.ts likewise mounts requireAdmin on /clear-lidarr-queue at
-    // module scope (downloadsRuntime.test.ts owns admin enforcement).
+    // downloads.ts mounts requireAdmin on shared download-control routes;
+    // downloadsRuntime.test.ts owns enforcement with the real middleware.
     requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -96,7 +96,6 @@ jest.mock("../../utils/db", () => ({
             delete: jest.fn(),
         },
         discoveryTrack: {
-            findUnique: jest.fn(),
             update: jest.fn(),
         },
         album: {
@@ -123,6 +122,7 @@ const mockGetSystemSettings = getSystemSettings as jest.Mock;
 
 const mockLidarrIsEnabled = lidarrService.isEnabled as jest.Mock;
 const mockLidarrAddArtist = lidarrService.addArtist as jest.Mock;
+const mockLidarrSearchAlbum = lidarrService.searchAlbum as jest.Mock;
 const mockLidarrGrabRelease = lidarrService.grabRelease as jest.Mock;
 
 const mockSoulseekAvailable = soulseekService.isAvailable as jest.Mock;
@@ -151,7 +151,6 @@ const mockUnavailableFindMany = prisma.unavailableAlbum.findMany as jest.Mock;
 const mockUnavailableFindFirst = prisma.unavailableAlbum.findFirst as jest.Mock;
 const mockUnavailableDelete = prisma.unavailableAlbum.delete as jest.Mock;
 
-const mockDiscoveryFindUnique = prisma.discoveryTrack.findUnique as jest.Mock;
 const mockDiscoveryUpdate = prisma.discoveryTrack.update as jest.Mock;
 const mockAlbumFindFirst = prisma.album.findFirst as jest.Mock;
 const mockTransaction = prisma.$transaction as jest.Mock;
@@ -171,6 +170,22 @@ function getRouteHandler(
     }
 
     return layer.route.stack[stackIndex].handle;
+}
+
+function getFinalRouteHandler(
+    path: string,
+    method: "get" | "post" | "delete" | "patch",
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+
+    if (!layer) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+    }
+
+    return layer.route.stack[layer.route.stack.length - 1].handle;
 }
 
 function createRes() {
@@ -198,7 +213,8 @@ async function flushAsyncWork() {
 
 describe("downloads routes runtime", () => {
     const availabilityHandler = getRouteHandler("/availability", "get");
-    const createJobHandler = getRouteHandler("/", "post");
+    const createJobAdmin = getRouteHandler("/", "post");
+    const createJobHandler = getFinalRouteHandler("/", "post");
     const clearAllHandler = getRouteHandler("/clear-all", "delete");
     const clearLidarrQueueAdmin = getRouteHandler(
         "/clear-lidarr-queue",
@@ -211,15 +227,19 @@ describe("downloads routes runtime", () => {
     );
     const failedListHandler = getRouteHandler("/failed", "get");
     const failedDismissHandler = getRouteHandler("/failed/:id", "delete");
-    const grabHandler = getRouteHandler("/grab", "post");
+    const releasesAdmin = getRouteHandler("/releases/:albumMbid", "get");
+    const grabAdmin = getRouteHandler("/grab", "post");
+    const grabHandler = getFinalRouteHandler("/grab", "post");
     const getJobHandler = getRouteHandler("/:id", "get");
     const patchJobHandler = getRouteHandler("/:id", "patch");
     const deleteJobHandler = getRouteHandler("/:id", "delete");
     const listJobsHandler = getRouteHandler("/", "get");
-    const keepTrackHandler = getRouteHandler("/keep-track", "post");
+    const keepTrackAdmin = getRouteHandler("/keep-track", "post");
+    const keepTrackHandler = getFinalRouteHandler("/keep-track", "post");
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockTransaction.mockReset();
 
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
@@ -229,6 +249,7 @@ describe("downloads routes runtime", () => {
 
         mockLidarrIsEnabled.mockResolvedValue(true);
         mockLidarrAddArtist.mockResolvedValue({ id: 101 });
+        mockLidarrSearchAlbum.mockResolvedValue([]);
         mockLidarrGrabRelease.mockResolvedValue(true);
 
         mockSoulseekAvailable.mockResolvedValue(true);
@@ -264,7 +285,6 @@ describe("downloads routes runtime", () => {
         mockUnavailableFindFirst.mockResolvedValue(null);
         mockUnavailableDelete.mockResolvedValue({ id: "failed-1" });
 
-        mockDiscoveryFindUnique.mockResolvedValue(null);
         mockDiscoveryUpdate.mockResolvedValue({});
 
         mockAlbumFindFirst.mockResolvedValue(null);
@@ -318,6 +338,109 @@ describe("downloads routes runtime", () => {
             error: "Failed to check download availability",
         });
     });
+
+    it.each([
+        [
+            "ordinary session",
+            "creating a download job",
+            createJobAdmin,
+            {
+                session: { userId: "user-1" },
+                user: { id: "user-1", role: "user" },
+                body: {},
+            },
+        ],
+        [
+            "ordinary API key",
+            "creating a download job",
+            createJobAdmin,
+            {
+                headers: { "x-api-key": "ordinary-user-key" },
+                user: { id: "user-1", role: "user" },
+                body: {},
+            },
+        ],
+        [
+            "ordinary session",
+            "mutating Lidarr during release lookup",
+            releasesAdmin,
+            {
+                session: { userId: "user-1" },
+                user: { id: "user-1", role: "user" },
+                params: { albumMbid: "rg-1" },
+                query: {},
+            },
+        ],
+        [
+            "ordinary API key",
+            "mutating Lidarr during release lookup",
+            releasesAdmin,
+            {
+                headers: { "x-api-key": "ordinary-user-key" },
+                user: { id: "user-1", role: "user" },
+                params: { albumMbid: "rg-1" },
+                query: {},
+            },
+        ],
+        [
+            "ordinary session",
+            "grabbing a release",
+            grabAdmin,
+            {
+                session: { userId: "user-1" },
+                user: { id: "user-1", role: "user" },
+                body: {},
+            },
+        ],
+        [
+            "ordinary API key",
+            "grabbing a release",
+            grabAdmin,
+            {
+                headers: { "x-api-key": "ordinary-user-key" },
+                user: { id: "user-1", role: "user" },
+                body: {},
+            },
+        ],
+        [
+            "ordinary session",
+            "keeping a discovery track",
+            keepTrackAdmin,
+            {
+                session: { userId: "user-1" },
+                user: { id: "user-1", role: "user" },
+                body: { discoveryTrackId: "disc-track-1" },
+            },
+        ],
+        [
+            "ordinary API key",
+            "keeping a discovery track",
+            keepTrackAdmin,
+            {
+                headers: { "x-api-key": "ordinary-user-key" },
+                user: { id: "user-1", role: "user" },
+                body: { discoveryTrackId: "disc-track-1" },
+            },
+        ],
+    ])(
+        "rejects an %s before %s",
+        async (_credentialType, _operation, adminMiddleware, request) => {
+            const res = createRes();
+            const next = jest.fn();
+
+            await adminMiddleware(request as any, res, next);
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body).toEqual({ error: "Admin access required" });
+            expect(next).not.toHaveBeenCalled();
+            expect(mockGetSystemSettings).not.toHaveBeenCalled();
+            expect(mockLidarrIsEnabled).not.toHaveBeenCalled();
+            expect(mockLidarrSearchAlbum).not.toHaveBeenCalled();
+            expect(mockLidarrGrabRelease).not.toHaveBeenCalled();
+            expect(mockTransaction).not.toHaveBeenCalled();
+            expect(mockDownloadCreate).not.toHaveBeenCalled();
+        },
+    );
 
     it("returns 400 for missing create-job required fields", async () => {
         const req = {
@@ -1152,44 +1275,128 @@ describe("downloads routes runtime", () => {
     });
 
     it("returns 404 when keep-track target is missing", async () => {
-        mockDiscoveryFindUnique.mockResolvedValueOnce(null);
+        const txDiscoveryFindFirst = jest.fn().mockResolvedValueOnce(null);
+        const txDiscoveryUpdate = jest.fn();
+        const txDownloadCreate = jest.fn();
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                discoveryTrack: {
+                    findFirst: txDiscoveryFindFirst,
+                    update: txDiscoveryUpdate,
+                },
+                downloadJob: { create: txDownloadCreate },
+            }),
+        );
 
         const req = {
             body: { discoveryTrackId: "disc-track-1" },
-            user: { id: "user-1" },
+            user: { id: "user-1", role: "admin" },
         } as any;
         const res = createRes();
 
         await keepTrackHandler(req, res);
 
+        expect(txDiscoveryFindFirst).toHaveBeenCalledWith({
+            where: {
+                id: "disc-track-1",
+                discoveryAlbum: { userId: "user-1" },
+            },
+            include: { discoveryAlbum: true },
+        });
+        expect(txDiscoveryUpdate).not.toHaveBeenCalled();
+        expect(txDownloadCreate).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "Discovery track not found" });
+    });
+
+    it("does not mutate a discovery track owned by another user", async () => {
+        const txDiscoveryFindFirst = jest.fn().mockResolvedValueOnce(null);
+        const txDiscoveryUpdate = jest.fn();
+        const txDownloadCreate = jest.fn();
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                discoveryTrack: {
+                    findFirst: txDiscoveryFindFirst,
+                    update: txDiscoveryUpdate,
+                },
+                downloadJob: { create: txDownloadCreate },
+            }),
+        );
+
+        const req = {
+            body: { discoveryTrackId: "other-user-track" },
+            user: { id: "attacker-admin", role: "admin" },
+        } as any;
+        const res = createRes();
+
+        await keepTrackHandler(req, res);
+
+        expect(txDiscoveryFindFirst).toHaveBeenCalledWith({
+            where: {
+                id: "other-user-track",
+                discoveryAlbum: { userId: "attacker-admin" },
+            },
+            include: { discoveryAlbum: true },
+        });
+        expect(txDiscoveryUpdate).not.toHaveBeenCalled();
+        expect(txDownloadCreate).not.toHaveBeenCalled();
+        expect(mockDiscoveryUpdate).not.toHaveBeenCalled();
+        expect(mockDownloadCreate).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(404);
         expect(res.body).toEqual({ error: "Discovery track not found" });
     });
 
     it("creates follow-up album download when keeping a track and Lidarr is enabled", async () => {
-        mockDiscoveryFindUnique.mockResolvedValueOnce({
+        const discoveryTrack = {
             id: "disc-track-1",
             discoveryAlbum: {
                 albumTitle: "Discovery Album",
                 artistName: "Discovery Artist",
                 rgMbid: "rg-disc-1",
             },
-        });
+        };
+        const txDiscoveryFindFirst = jest
+            .fn()
+            .mockResolvedValueOnce(discoveryTrack);
+        const txDiscoveryUpdate = jest.fn().mockResolvedValueOnce({});
+        const txDownloadCreate = jest
+            .fn()
+            .mockResolvedValueOnce({ id: "keep-job-1" });
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                discoveryTrack: {
+                    findFirst: txDiscoveryFindFirst,
+                    update: txDiscoveryUpdate,
+                },
+                downloadJob: { create: txDownloadCreate },
+            }),
+        );
         mockLidarrIsEnabled.mockResolvedValueOnce(true);
-        mockDownloadCreate.mockResolvedValueOnce({ id: "keep-job-1" });
 
         const req = {
             body: { discoveryTrackId: "disc-track-1" },
-            user: { id: "user-1" },
+            user: { id: "user-1", role: "admin" },
         } as any;
         const res = createRes();
 
         await keepTrackHandler(req, res);
 
-        expect(mockDiscoveryUpdate).toHaveBeenCalledWith({
+        expect(mockTransaction).toHaveBeenCalledTimes(1);
+        expect(txDiscoveryUpdate).toHaveBeenCalledWith({
             where: { id: "disc-track-1" },
             data: { userKept: true },
         });
+        expect(txDownloadCreate).toHaveBeenCalledWith({
+            data: {
+                userId: "user-1",
+                subject: "Discovery Album by Discovery Artist",
+                type: "album",
+                targetMbid: "rg-disc-1",
+                status: "pending",
+            },
+        });
+        expect(mockDiscoveryUpdate).not.toHaveBeenCalled();
+        expect(mockDownloadCreate).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
             success: true,
@@ -1200,7 +1407,7 @@ describe("downloads routes runtime", () => {
     });
 
     it("returns manual follow-up message when keeping a track without Lidarr", async () => {
-        mockDiscoveryFindUnique.mockResolvedValueOnce({
+        const txDiscoveryFindFirst = jest.fn().mockResolvedValueOnce({
             id: "disc-track-2",
             discoveryAlbum: {
                 albumTitle: "Discovery Album",
@@ -1208,16 +1415,32 @@ describe("downloads routes runtime", () => {
                 rgMbid: "rg-disc-2",
             },
         });
+        const txDiscoveryUpdate = jest.fn().mockResolvedValueOnce({});
+        const txDownloadCreate = jest.fn();
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                discoveryTrack: {
+                    findFirst: txDiscoveryFindFirst,
+                    update: txDiscoveryUpdate,
+                },
+                downloadJob: { create: txDownloadCreate },
+            }),
+        );
         mockLidarrIsEnabled.mockResolvedValueOnce(false);
 
         const req = {
             body: { discoveryTrackId: "disc-track-2" },
-            user: { id: "user-1" },
+            user: { id: "user-1", role: "admin" },
         } as any;
         const res = createRes();
 
         await keepTrackHandler(req, res);
 
+        expect(txDiscoveryUpdate).toHaveBeenCalledWith({
+            where: { id: "disc-track-2" },
+            data: { userKept: true },
+        });
+        expect(txDownloadCreate).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
             success: true,
@@ -2284,7 +2507,7 @@ describe("downloads routes runtime", () => {
     });
 
     it("returns 500 when keep-track persistence fails", async () => {
-        mockDiscoveryFindUnique.mockResolvedValueOnce({
+        const txDiscoveryFindFirst = jest.fn().mockResolvedValueOnce({
             id: "disc-track-3",
             discoveryAlbum: {
                 albumTitle: "Discovery Album",
@@ -2292,11 +2515,23 @@ describe("downloads routes runtime", () => {
                 rgMbid: "rg-disc-3",
             },
         });
-        mockDiscoveryUpdate.mockRejectedValueOnce(new Error("update failed"));
+        const txDiscoveryUpdate = jest
+            .fn()
+            .mockRejectedValueOnce(new Error("update failed"));
+        const txDownloadCreate = jest.fn();
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                discoveryTrack: {
+                    findFirst: txDiscoveryFindFirst,
+                    update: txDiscoveryUpdate,
+                },
+                downloadJob: { create: txDownloadCreate },
+            }),
+        );
 
         const req = {
             body: { discoveryTrackId: "disc-track-3" },
-            user: { id: "user-1" },
+            user: { id: "user-1", role: "admin" },
         } as any;
         const res = createRes();
 
@@ -2304,5 +2539,6 @@ describe("downloads routes runtime", () => {
 
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({ error: "Failed to keep track" });
+        expect(txDownloadCreate).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -173,9 +173,11 @@ async function verifyArtistName(
  *         description: Missing required fields or no download service configured
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 // POST /downloads - Create download job
-router.post("/", async (req, res) => {
+router.post("/", requireAdmin, async (req, res) => {
     try {
         const {
             type,
@@ -1145,13 +1147,18 @@ router.delete("/failed/:id", async (req, res) => {
  *         description: Missing albumMbid or Lidarr not configured
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  *       404:
  *         description: Album not found in Lidarr
  */
 // GET /downloads/releases/:albumMbid - Get available releases for an album (interactive search)
-router.get("/releases/:albumMbid", async (req, res) => {
+router.get("/releases/:albumMbid", requireAdmin, async (req, res) => {
     try {
-        const { albumMbid } = req.params;
+        const albumMbidParam = req.params.albumMbid;
+        const albumMbid = Array.isArray(albumMbidParam)
+            ? albumMbidParam[0]
+            : albumMbidParam;
         const artistName = String(req.query.artistName || "").trim();
         const albumTitle = String(req.query.albumTitle || "").trim();
 
@@ -1297,9 +1304,11 @@ router.get("/releases/:albumMbid", async (req, res) => {
  *         description: Missing required fields or Lidarr not configured
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 // POST /downloads/grab - Grab a specific release from interactive search
-router.post("/grab", async (req, res) => {
+router.post("/grab", requireAdmin, async (req, res) => {
     try {
         const {
             guid,
@@ -1654,6 +1663,47 @@ router.get("/", async (req, res) => {
     }
 });
 
+async function keepDiscoveryTrack(
+    userId: string,
+    discoveryTrackId: string,
+    createDownloadJob: boolean,
+) {
+    return prisma.$transaction(async (tx) => {
+        const discoveryTrack = await tx.discoveryTrack.findFirst({
+            where: {
+                id: discoveryTrackId,
+                discoveryAlbum: { userId },
+            },
+            include: { discoveryAlbum: true },
+        });
+
+        if (!discoveryTrack) {
+            return { found: false } as const;
+        }
+
+        await tx.discoveryTrack.update({
+            where: { id: discoveryTrack.id },
+            data: { userKept: true },
+        });
+
+        if (!createDownloadJob) {
+            return { found: true, downloadJobId: null } as const;
+        }
+
+        const job = await tx.downloadJob.create({
+            data: {
+                userId,
+                subject: `${discoveryTrack.discoveryAlbum.albumTitle} by ${discoveryTrack.discoveryAlbum.artistName}`,
+                type: "album",
+                targetMbid: discoveryTrack.discoveryAlbum.rgMbid,
+                status: "pending",
+            },
+        });
+
+        return { found: true, downloadJobId: job.id } as const;
+    });
+}
+
 /**
  * @openapi
  * /api/downloads/keep-track:
@@ -1680,11 +1730,13 @@ router.get("/", async (req, res) => {
  *         description: Missing discoveryTrackId
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  *       404:
  *         description: Discovery track not found
  */
 // POST /downloads/keep-track - Keep a discovery track (move to permanent library)
-router.post("/keep-track", async (req, res) => {
+router.post("/keep-track", requireAdmin, async (req, res) => {
     try {
         const { discoveryTrackId } = req.body;
         const userId = req.user!.id;
@@ -1693,41 +1745,23 @@ router.post("/keep-track", async (req, res) => {
             return sendRouteError(res, 400, "Missing discoveryTrackId");
         }
 
-        const discoveryTrack = await prisma.discoveryTrack.findUnique({
-            where: { id: discoveryTrackId },
-            include: {
-                discoveryAlbum: true,
-            },
-        });
+        const lidarrEnabled = await lidarrService.isEnabled();
+        const result = await keepDiscoveryTrack(
+            userId,
+            discoveryTrackId,
+            lidarrEnabled,
+        );
 
-        if (!discoveryTrack) {
+        if (!result.found) {
             return sendRouteError(res, 404, "Discovery track not found");
         }
 
-        // Mark as kept
-        await prisma.discoveryTrack.update({
-            where: { id: discoveryTrackId },
-            data: { userKept: true },
-        });
-
-        // If Lidarr enabled, create job to download full album to permanent library
-        const lidarrEnabled = await lidarrService.isEnabled();
-        if (lidarrEnabled) {
-            const job = await prisma.downloadJob.create({
-                data: {
-                    userId,
-                    subject: `${discoveryTrack.discoveryAlbum.albumTitle} by ${discoveryTrack.discoveryAlbum.artistName}`,
-                    type: "album",
-                    targetMbid: discoveryTrack.discoveryAlbum.rgMbid,
-                    status: "pending",
-                },
-            });
-
+        if (result.downloadJobId) {
             return res.json({
                 success: true,
                 message:
                     "Track marked as kept. Full album will be downloaded to permanent library.",
-                downloadJobId: job.id,
+                downloadJobId: result.downloadJobId,
             });
         }
 


### PR DESCRIPTION
Convergence sweep #19 remediation — two confirmed release-blocking authorization defects in `backend/src/routes/downloads.ts`.

**M1 — non-admin shared-library downloads.** The router applied only `requireAuthOrToken`, so any authenticated user (or API-key holder) could `POST /api/downloads`, `POST /api/downloads/grab`, and `GET /api/downloads/releases/:albumMbid` — invoking the globally-configured Lidarr/TIDAL/Soulseek services and writing into shared storage. The frontend and YouTube-route contracts describe downloads as admin-only.

**M2 — keep-track cross-user IDOR.** `POST /api/downloads/keep-track` looked up the discovery track by `discoveryTrackId` alone, but ownership lives on `DiscoveryAlbum.userId`. Any authenticated user could mutate another user's discovery track and trigger a shared-library album download.

Fix
- `requireAdmin` on the four shared download-control routes (create, release lookup, grab, keep-track), with documented OpenAPI 403 responses. keep-track has **no frontend caller** (verified) and creates a shared-library download, so gating it introduces no UI regression and is consistent with M1.
- keep-track additionally scopes its lookup through `DiscoveryAlbum.userId` and runs the ownership check + track update + optional job creation as one Prisma transaction (defense in depth even behind the admin gate).
- Negative-authz tests: ordinary session and API-key rejection, cross-user access denial, transactional mutation coverage.

Verification: targeted jest + OpenAPI-sync 101/101; `tsc --noEmit` clean; route-error-canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).