### PR TITLE
fix(security): admin-gate Spotify session-log endpoint; drop host paths (sweep #19 M3)

### DIFF
--- a/backend/src/routes/__tests__/spotifyRuntime.test.ts
+++ b/backend/src/routes/__tests__/spotifyRuntime.test.ts
@@ -1,6 +1,14 @@
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: any, _res: any, next: () => void) => next(),
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
+
+const mockSessionLogError = jest.fn();
 
 jest.mock("../../utils/logger", () => ({
     logger: {
@@ -8,6 +16,13 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: mockSessionLogError,
+            child: jest.fn(),
+        })),
     },
 }));
 
@@ -42,11 +57,9 @@ jest.mock("../../services/deezer", () => ({
 }));
 
 const readSessionLog = jest.fn();
-const getSessionLogPath = jest.fn();
 
 jest.mock("../../utils/playlistLogger", () => ({
     readSessionLog: (...args: any[]) => readSessionLog(...args),
-    getSessionLogPath: (...args: any[]) => getSessionLogPath(...args),
 }));
 
 import router from "../spotify";
@@ -62,6 +75,42 @@ function getHandler(path: string, method: "get" | "post") {
     }
 
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+const MAX_ROUTE_HANDLERS = 3;
+
+async function invokeRouteStack(
+    path: string,
+    method: "get" | "post",
+    req: any,
+    res: any,
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+
+    if (!layer) {
+        throw new Error(`${method.toUpperCase()} route not found: ${path}`);
+    }
+    if (layer.route.stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${layer.route.stack.length}`);
+    }
+
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = layer.route.stack[index];
+        if (!entry) {
+            return;
+        }
+
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) {
+            return;
+        }
+    }
 }
 
 function createRes() {
@@ -98,7 +147,6 @@ describe("spotify route runtime", () => {
     const importsHandler = getHandler("/imports", "get");
     const refreshHandler = getHandler("/import/:jobId/refresh", "post");
     const cancelHandler = getHandler("/import/:jobId/cancel", "post");
-    const sessionLogHandler = getHandler("/import/session-log", "get");
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -145,7 +193,6 @@ describe("spotify route runtime", () => {
         });
 
         readSessionLog.mockReturnValue("session content");
-        getSessionLogPath.mockReturnValue("/tmp/session.log");
     });
 
     describe("POST /parse", () => {
@@ -847,36 +894,72 @@ describe("spotify route runtime", () => {
     });
 
     describe("GET /import/session-log", () => {
-        it("returns log path and content", async () => {
-            readSessionLog.mockReturnValueOnce("log contents");
-            getSessionLogPath.mockReturnValueOnce("/tmp/playlist-session.log");
-
-            const req = {} as any;
+        it("denies session log access to authenticated non-admin users", async () => {
+            const req = { user: { id: "u1", role: "user" } } as any;
             const res = createRes();
 
-            await sessionLogHandler(req, res);
+            await invokeRouteStack("/import/session-log", "get", req, res);
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body).toEqual({ error: "Admin access required" });
+            expect(readSessionLog).not.toHaveBeenCalled();
+        });
+
+        it("returns log content to admins without disclosing its host path", async () => {
+            readSessionLog.mockReturnValueOnce("log contents");
+
+            const req = { user: { id: "admin-1", role: "admin" } } as any;
+            const res = createRes();
+
+            await invokeRouteStack("/import/session-log", "get", req, res);
 
             expect(res.statusCode).toBe(200);
             expect(res.body).toEqual({
-                path: "/tmp/playlist-session.log",
                 content: "log contents",
             });
         });
 
-        it("returns 500 when reading session log fails", async () => {
-            readSessionLog.mockImplementationOnce(() => {
-                throw new Error("session read failed");
-            });
+        it("maps filesystem read failures to a static 500", async () => {
+            const rawError =
+                "Error reading session log: EACCES: /srv/soundspan/private/playlist-session.log";
+            readSessionLog.mockReturnValueOnce(rawError);
 
-            const req = {} as any;
+            const req = { user: { id: "admin-1", role: "admin" } } as any;
             const res = createRes();
 
-            await sessionLogHandler(req, res);
+            await invokeRouteStack("/import/session-log", "get", req, res);
 
             expect(res.statusCode).toBe(500);
             expect(res.body).toEqual({
                 error: "Failed to read session log",
             });
+            expect(JSON.stringify(res.body)).not.toContain(rawError);
+            expect(mockSessionLogError).toHaveBeenCalledWith(
+                "Session log reader reported a failure",
+                { error: rawError },
+            );
+        });
+
+        it("returns a static 500 when the session log reader throws", async () => {
+            const rawError = "Unexpected session reader failure";
+            readSessionLog.mockImplementationOnce(() => {
+                throw new Error(rawError);
+            });
+
+            const req = { user: { id: "admin-1", role: "admin" } } as any;
+            const res = createRes();
+
+            await invokeRouteStack("/import/session-log", "get", req, res);
+
+            expect(res.statusCode).toBe(500);
+            expect(res.body).toEqual({
+                error: "Failed to read session log",
+            });
+            expect(JSON.stringify(res.body)).not.toContain(rawError);
+            expect(mockSessionLogError).toHaveBeenCalledWith(
+                "Failed to read session log",
+                { error: expect.objectContaining({ message: rawError }) },
+            );
         });
     });
 });

--- a/backend/src/routes/spotify.ts
+++ b/backend/src/routes/spotify.ts
@@ -1,13 +1,20 @@
 import { Router } from "express";
 import { logger } from "../utils/logger";
-import { requireAuthOrToken } from "../middleware/auth";
+import { requireAdmin, requireAuthOrToken } from "../middleware/auth";
 import { z } from "zod";
 import { spotifyService } from "../services/spotify";
 import { spotifyImportService } from "../services/spotifyImport";
 import { deezerService } from "../services/deezer";
-import { readSessionLog, getSessionLogPath } from "../utils/playlistLogger";
+import { readSessionLog } from "../utils/playlistLogger";
+import { sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
+const sessionLogRouteLogger = logger.child("SpotifySessionLogRoute");
+const SESSION_LOG_READ_FAILURE_PREFIX = "Error reading session log:";
+
+function isSessionLogReadFailure(content: string): boolean {
+    return content.startsWith(SESSION_LOG_READ_FAILURE_PREFIX);
+}
 
 // All routes require authentication
 router.use(requireAuthOrToken);
@@ -511,35 +518,42 @@ router.post("/import/:jobId/cancel", async (req, res) => {
  * @openapi
  * /api/spotify/import/session-log:
  *   get:
- *     summary: Get the current session log for debugging import issues
+ *     summary: Get the current session log for administrative diagnostics
  *     tags: [Spotify]
  *     security:
  *       - sessionAuth: []
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Session log content and file path
+ *         description: Session log content
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 /**
  * GET /api/spotify/import/session-log
- * Get the current session log for debugging import issues
+ * Get the current session log for administrative diagnostics
  */
-router.get("/import/session-log", async (req, res) => {
+router.get("/import/session-log", requireAdmin, async (_req, res) => {
     try {
         const log = readSessionLog();
-        const logPath = getSessionLogPath();
+        if (isSessionLogReadFailure(log)) {
+            sessionLogRouteLogger.error(
+                "Session log reader reported a failure",
+                { error: log },
+            );
+            return sendInternalRouteError(res, "Failed to read session log");
+        }
 
         res.json({
-            path: logPath,
             content: log,
         });
-    } catch (error: any) {
-        logger.error("Session log error:", error);
-        res.status(500).json({
-            error: "Failed to read session log",
+    } catch (error: unknown) {
+        sessionLogRouteLogger.error("Failed to read session log", {
+            error,
         });
+        sendInternalRouteError(res, "Failed to read session log");
     }
 });
 


### PR DESCRIPTION
Convergence sweep #19 remediation (M3). `GET /api/spotify/import/session-log` applied only `requireAuthOrToken`, so any authenticated user could retrieve a **process-global** `PlaylistLogger` aggregate covering every user's import jobs — including job/media details, **absolute filesystem paths** (`getSessionLogPath()` was returned in the body), and filesystem read exceptions converted into response content.

Fix
- `requireAdmin` guards the route (documented 403 in OpenAPI); the server path is removed from the response.
- Reader-reported and thrown read failures return a static canonical 500 via `sendInternalRouteError`, detail retained only in a scoped server logger.
- Tests: non-admin denial, admin access with no host paths, sanitized failure paths.

Complements #347 (which sanitized the session-log *content*); this closes the *endpoint* access-control + path-disclosure surface. Verification: jest 39/39; `tsc --noEmit` clean; canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).