### PR TITLE
fix(security): TIDAL template path containment + bounded stream-manifest cache (sweep #19 M6/M9)

### DIFF
--- a/services/tidal-downloader/app.py
+++ b/services/tidal-downloader/app.py
@@ -21,6 +21,7 @@ import threading
 import time
 from base64 import b64decode
 from collections.abc import Callable
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
 from xml.etree.ElementTree import fromstring as xml_fromstring
@@ -83,10 +84,35 @@ class _ThrottlePoolFullWarning(logging.Filter):
 
 logging.getLogger("urllib3.connectionpool").addFilter(_ThrottlePoolFullWarning())
 
+
+async def _run_stream_cache_cleanup() -> None:
+    """Remove expired stream manifests at a fixed interval until shutdown."""
+    # A service-lifetime loop is intentionally shutdown-bounded by _app_lifespan.
+    while True:
+        await asyncio.sleep(_STREAM_CACHE_CLEANUP_INTERVAL_SECONDS)
+        _clean_stream_cache()
+
+
+@asynccontextmanager
+async def _app_lifespan(_app: FastAPI):
+    """Own and stop the stream-cache maintenance task with the application."""
+    cleanup_task = asyncio.create_task(
+        _run_stream_cache_cleanup(),
+        name="tidal-stream-cache-cleanup",
+    )
+    try:
+        yield
+    finally:
+        cleanup_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await cleanup_task
+
+
 # ── FastAPI app ─────────────────────────────────────────────────────
 app = FastAPI(
     title="soundspan TIDAL Downloader & Streamer",
     version="2.0.0",
+    lifespan=_app_lifespan,
     dependencies=[Depends(require_internal_secret)],
     # The docs/openapi routes are registered via add_route(), which app-level
     # dependencies do NOT cover — left on they'd disclose the full API schema
@@ -111,6 +137,8 @@ _user_auth_state_lock = threading.Lock()
 _stream_cache: dict[tuple[str, int, str], dict] = {}
 _stream_cache_lock = threading.Lock()
 STREAM_CACHE_TTL = 600  # 10 minutes
+_STREAM_CACHE_MAX_ENTRIES = 1000
+_STREAM_CACHE_CLEANUP_INTERVAL_SECONDS = 60
 STREAM_QUALITY_OPTIONS = {"LOW", "HIGH", "LOSSLESS", "HI_RES_LOSSLESS"}
 
 # ── tidalapi ↔ tiddl quality mapping ──────────────────────────────
@@ -345,6 +373,46 @@ def _sanitize_path_component(name: str) -> str:
     return name.strip(". ")
 
 
+def _sanitize_download_relative_path(rendered_path: str) -> Path:
+    """Validate and sanitize every rendered download-path component."""
+    sanitized_parts = []
+    for component in rendered_path.split("/"):
+        sanitized = _sanitize_path_component(component)
+        if not sanitized or sanitized in {".", ".."} or Path(sanitized).is_absolute():
+            raise ValueError("Invalid output template path component")
+        sanitized_parts.append(sanitized)
+    return Path(*sanitized_parts)
+
+
+def _require_contained_download_path(path: Path, destination_root: Path) -> Path:
+    """Resolve a download path and reject targets outside the destination root."""
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(destination_root)
+    except ValueError:
+        raise ValueError("Download path resolves outside MUSIC_PATH") from None
+    return resolved_path
+
+
+def _build_download_file_path(
+    relative_stem: Path,
+    file_extension: str,
+    dest_base: Path,
+) -> tuple[Path, Path, Path]:
+    """Build contained final and temporary paths from a rendered template."""
+    relative_file = relative_stem.parent / f"{relative_stem.name}{file_extension}"
+    destination_root = dest_base.resolve()
+    file_path = _require_contained_download_path(
+        destination_root / relative_file,
+        destination_root,
+    )
+    tmp_path = _require_contained_download_path(
+        file_path.with_suffix(file_path.suffix + ".tmp"),
+        destination_root,
+    )
+    return relative_file, file_path, tmp_path
+
+
 def _is_playlist_not_found_error(error: Exception) -> bool:
     """Return True when an upstream exception clearly indicates missing playlist."""
     if isinstance(error, HTTPException):
@@ -391,14 +459,17 @@ def _download_track_sync(
         album=album,
         with_asterisk_ext=False,
     )
-    # Sanitize each path component
-    parts = relative_path.split("/")
-    parts = [_sanitize_path_component(p) for p in parts if p]
-    relative_path = "/".join(parts)
+    relative_stem = _sanitize_download_relative_path(relative_path)
 
     # 3. Get stream data
     stream = api.get_track_stream(track_id=track_id, quality=quality)
     urls, file_extension = parse_track_stream(stream)
+
+    relative_file, file_path, tmp_path = _build_download_file_path(
+        relative_stem,
+        file_extension,
+        dest_base,
+    )
 
     # Download raw bytes
     from tiddl.core.utils.download import download as download_bytes
@@ -406,11 +477,9 @@ def _download_track_sync(
     stream_data = download_bytes(urls)
 
     # 4. Write to disk
-    file_path = dest_base / f"{relative_path}{file_extension}"
     file_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write to temp file first, then move (atomic-ish)
-    tmp_path = file_path.with_suffix(file_path.suffix + ".tmp")
     tmp_path.write_bytes(stream_data)
 
     # 5. If FLAC, ffmpeg extraction may be needed
@@ -450,7 +519,7 @@ def _download_track_sync(
         "album": album.title,
         "quality": stream.audioQuality,
         "file_path": str(file_path),
-        "relative_path": f"{relative_path}{file_extension}",
+        "relative_path": relative_file.as_posix(),
         "file_size": file_path.stat().st_size,
     }
 
@@ -731,9 +800,14 @@ def _get_stream_url_sync(user_id: str, track_id: int, quality: str = "HIGH") -> 
     """
     normalized_quality = _normalize_stream_quality(quality)
     cache_key = (user_id, track_id, normalized_quality)
+    now = time.time()
     with _stream_cache_lock:
+        _remove_expired_stream_cache_entries(now)
         cached = _stream_cache.get(cache_key)
-    if cached and time.time() < cached.get("expires_at", 0):
+        if cached is not None:
+            _stream_cache.pop(cache_key, None)
+            _stream_cache[cache_key] = cached
+    if cached is not None:
         return cached
 
     api = _get_user_api(user_id)
@@ -797,17 +871,26 @@ def _get_stream_url_sync(user_id: str, track_id: int, quality: str = "HIGH") -> 
     }
 
     with _stream_cache_lock:
+        _remove_expired_stream_cache_entries(time.time())
+        _stream_cache.pop(cache_key, None)
         _stream_cache[cache_key] = result
+        if len(_stream_cache) > _STREAM_CACHE_MAX_ENTRIES:
+            oldest_key = next(iter(_stream_cache))
+            _stream_cache.pop(oldest_key, None)
     return result
 
 
-def _clean_stream_cache():
+def _remove_expired_stream_cache_entries(now: float) -> None:
+    """Remove expired entries while the caller holds the stream-cache lock."""
+    expired = [key for key, value in _stream_cache.items() if now >= value.get("expires_at", 0)]
+    for key in expired:
+        _stream_cache.pop(key, None)
+
+
+def _clean_stream_cache() -> None:
     """Remove expired entries from the stream cache."""
-    now = time.time()
     with _stream_cache_lock:
-        expired = [k for k, v in _stream_cache.items() if now >= v.get("expires_at", 0)]
-        for k in expired:
-            _stream_cache.pop(k, None)
+        _remove_expired_stream_cache_entries(time.time())
 
 
 # ════════════════════════════════════════════════════════════════════

--- a/services/tidal-downloader/tests/test_download_path_safety.py
+++ b/services/tidal-downloader/tests/test_download_path_safety.py
@@ -1,0 +1,124 @@
+"""Behavioral coverage for TIDAL download destination containment."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+class _FakeDownloadApi:
+    """Provide the minimal provider behavior needed for a track download."""
+
+    def get_track(self, track_id: int):
+        return types.SimpleNamespace(
+            id=track_id,
+            title="Track",
+            album=types.SimpleNamespace(id=22),
+            artists=[types.SimpleNamespace(name="Artist")],
+        )
+
+    def get_album(self, _album_id: int):
+        return types.SimpleNamespace(title="Album", cover=None, releaseDate=None)
+
+    def get_track_stream(self, *, track_id: int, quality: str):
+        return types.SimpleNamespace(audioQuality=quality)
+
+
+def _configure_download(monkeypatch, app, rendered_path: str, payload: bytes = b"audio") -> None:
+    """Stub provider helpers while preserving real filesystem writes."""
+    download_module = types.ModuleType("tiddl.core.utils.download")
+    download_module.download = lambda _urls: payload
+    monkeypatch.setitem(sys.modules, "tiddl.core.utils.download", download_module)
+    monkeypatch.setattr(app, "format_template", lambda **_kwargs: rendered_path)
+    monkeypatch.setattr(app, "parse_track_stream", lambda _stream: (["url"], ".m4a"))
+    monkeypatch.setattr(app, "add_track_metadata", lambda **_kwargs: None)
+
+
+def test_download_rejects_absolute_rendered_template(tmp_path, monkeypatch):
+    import app
+
+    destination = tmp_path / "music"
+    outside_stem = tmp_path / "outside" / "track"
+    _configure_download(monkeypatch, app, outside_stem.as_posix())
+
+    with pytest.raises(ValueError, match="output template path"):
+        app._download_track_sync(_FakeDownloadApi(), 1, "HIGH", "ignored", destination)
+
+    assert not outside_stem.with_suffix(".m4a").exists()
+
+
+def test_download_rejects_symlink_escape(tmp_path, monkeypatch):
+    import app
+
+    destination = tmp_path / "music"
+    outside = tmp_path / "outside"
+    destination.mkdir()
+    outside.mkdir()
+    (destination / "linked").symlink_to(outside, target_is_directory=True)
+    _configure_download(monkeypatch, app, "linked/track")
+
+    with pytest.raises(ValueError, match="outside MUSIC_PATH"):
+        app._download_track_sync(_FakeDownloadApi(), 1, "HIGH", "ignored", destination)
+
+    assert not (outside / "track.m4a").exists()
+
+
+def test_download_rejects_temporary_file_symlink_escape(tmp_path, monkeypatch):
+    import app
+
+    destination = tmp_path / "music"
+    target_parent = destination / "Artist" / "Album"
+    outside_file = tmp_path / "outside.m4a.tmp"
+    target_parent.mkdir(parents=True)
+    outside_file.write_bytes(b"unchanged")
+    (target_parent / "01. Track.m4a.tmp").symlink_to(outside_file)
+    _configure_download(monkeypatch, app, "Artist/Album/01. Track", b"replacement")
+
+    with pytest.raises(ValueError, match="outside MUSIC_PATH"):
+        app._download_track_sync(_FakeDownloadApi(), 1, "HIGH", "ignored", destination)
+
+    assert outside_file.read_bytes() == b"unchanged"
+
+
+def test_download_writes_valid_rendered_template_beneath_destination(tmp_path, monkeypatch):
+    import app
+
+    destination = tmp_path / "music"
+    _configure_download(monkeypatch, app, "Artist/Album/01. Track")
+
+    result = app._download_track_sync(_FakeDownloadApi(), 1, "HIGH", "ignored", destination)
+
+    expected = destination / "Artist" / "Album" / "01. Track.m4a"
+    assert expected.read_bytes() == b"audio"
+    assert Path(result["file_path"]) == expected
+    assert result["relative_path"] == "Artist/Album/01. Track.m4a"
+
+
+@pytest.mark.anyio
+async def test_download_route_sanitizes_component_that_becomes_empty(
+    client,
+    tmp_path,
+    monkeypatch,
+):
+    import app
+
+    destination = tmp_path / "music"
+    outside_stem = tmp_path / "outside" / "escaped"
+    rendered_path = f"..{outside_stem.as_posix()}"
+    _configure_download(monkeypatch, app, rendered_path)
+    monkeypatch.setattr(app, "MUSIC_PATH", destination)
+    monkeypatch.setattr(app, "_build_api", lambda *_args: _FakeDownloadApi())
+
+    response = await client.post(
+        "/download/track",
+        headers={"Authorization": "Bearer token"},
+        json={"track_id": 1, "output_template": "malicious"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["error"] == "Download failed"
+    assert str(outside_stem) not in response.text
+    assert not outside_stem.with_suffix(".m4a").exists()

--- a/services/tidal-downloader/tests/test_stream_cache_race.py
+++ b/services/tidal-downloader/tests/test_stream_cache_race.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import types
+
+import pytest
 
 
 def _assert_lock_held(lock: threading.Lock) -> None:
@@ -119,3 +122,119 @@ def test_stream_cache_access_lock_excludes_only_dictionary_operations(monkeypatc
 
     assert result["url"] == "url"
     assert cache[("user", 1, "HIGH")] is result
+
+
+def _stream_api(url_by_track: dict[int, str]):
+    """Build a provider double that returns a distinct URL per track."""
+
+    def get_track_stream(*, track_id: int, quality: str):
+        return types.SimpleNamespace(
+            manifestMimeType="application/vnd.tidal.bts",
+            audioQuality=quality,
+            bitDepth=None,
+            sampleRate=None,
+            url=url_by_track[track_id],
+        )
+
+    return types.SimpleNamespace(get_track_stream=get_track_stream)
+
+
+def _configure_stream_loading(monkeypatch, app, cache, urls: dict[int, str]) -> None:
+    """Install deterministic cache and provider state for stream lookups."""
+    monkeypatch.setattr(app, "_stream_cache", cache)
+    monkeypatch.setattr(app, "_user_apis", {"user": _stream_api(urls)})
+    monkeypatch.setattr(app, "parse_track_stream", lambda stream: ([stream.url], ".flac"))
+
+
+def test_stream_lookup_removes_expired_entries(monkeypatch):
+    import app
+
+    cache = {
+        ("expired-user", 9, "HIGH"): {"expires_at": 99},
+        ("user", 2, "HIGH"): {"url": "fresh", "expires_at": 101},
+    }
+    _configure_stream_loading(monkeypatch, app, cache, {1: "loaded"})
+    monkeypatch.setattr(app.time, "time", lambda: 100)
+
+    result = app._get_stream_url_sync("user", 1)
+
+    assert result["url"] == "loaded"
+    assert ("expired-user", 9, "HIGH") not in cache
+    assert ("user", 2, "HIGH") in cache
+
+
+def test_stream_cache_is_bounded_and_evicts_least_recently_used(monkeypatch):
+    import app
+
+    cache = {
+        ("user", 1, "HIGH"): {"url": "one", "expires_at": 200},
+        ("user", 2, "HIGH"): {"url": "two", "expires_at": 200},
+    }
+    _configure_stream_loading(monkeypatch, app, cache, {3: "three"})
+    monkeypatch.setattr(app, "_STREAM_CACHE_MAX_ENTRIES", 2, raising=False)
+    monkeypatch.setattr(app.time, "time", lambda: 100)
+
+    assert app._get_stream_url_sync("user", 1)["url"] == "one"
+    assert app._get_stream_url_sync("user", 3)["url"] == "three"
+
+    assert list(cache) == [("user", 1, "HIGH"), ("user", 3, "HIGH")]
+
+
+def test_stream_insertion_prefers_expired_eviction(monkeypatch):
+    import app
+
+    cache = {
+        ("user", 1, "HIGH"): {"url": "fresh", "expires_at": 200},
+        ("other", 2, "HIGH"): {"url": "expired", "expires_at": 99},
+    }
+    _configure_stream_loading(monkeypatch, app, cache, {3: "three"})
+    monkeypatch.setattr(app, "_STREAM_CACHE_MAX_ENTRIES", 2, raising=False)
+    monkeypatch.setattr(app.time, "time", lambda: 100)
+
+    app._get_stream_url_sync("user", 3)
+
+    assert list(cache) == [("user", 1, "HIGH"), ("user", 3, "HIGH")]
+
+
+@pytest.mark.anyio
+async def test_stream_cache_cleanup_loop_runs_periodically(monkeypatch):
+    import app
+
+    cleanup_calls = []
+    sleep_calls = []
+
+    async def one_interval_then_cancel(delay: float) -> None:
+        sleep_calls.append(delay)
+        if len(sleep_calls) > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(app.asyncio, "sleep", one_interval_then_cancel)
+    monkeypatch.setattr(app, "_clean_stream_cache", lambda: cleanup_calls.append(True))
+
+    with pytest.raises(asyncio.CancelledError):
+        await app._run_stream_cache_cleanup()
+
+    assert sleep_calls == [app._STREAM_CACHE_CLEANUP_INTERVAL_SECONDS] * 2
+    assert cleanup_calls == [True]
+
+
+@pytest.mark.anyio
+async def test_app_lifespan_owns_stream_cache_cleanup_task(monkeypatch):
+    import app
+
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def cleanup_until_cancelled() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            stopped.set()
+
+    monkeypatch.setattr(app, "_run_stream_cache_cleanup", cleanup_until_cancelled)
+
+    async with app._app_lifespan(app.app):
+        await started.wait()
+
+    assert stopped.is_set()


### PR DESCRIPTION
Convergence sweep #19 remediation in `services/tidal-downloader/app.py`.

**M6 — path traversal outside MUSIC_PATH.** Output-template components were filtered *before* sanitization, so `..` sanitized to empty and could make the rejoined path absolute; path composition then discarded `dest_base` with no final containment check — writes outside `MUSIC_PATH`. Now each rendered component is rejected if it sanitizes to empty/`.`/`..`/absolute, and the resolved final and temp paths must `resolve()` beneath the destination root (symlink escapes covered) or the download is rejected.

**M9 — unbounded stream-manifest cache.** Expired entries were ignored but never evicted, and every unique user/track/quality result was inserted, growing memory monotonically with `_clean_stream_cache` having no runtime caller. Lookups/inserts now evict expired entries, the cache is a 1,000-entry LRU, and a 60s lifespan-owned cleanup task (cancelled on shutdown) reclaims stale entries.

Verification: TIDAL sidecar pytest 122 passed (+13 async-debug warnings-as-errors); ruff format + lint clean; mypy clean; route-error canon + leak ratchets green. No CHANGELOG edit (consolidated docs PR follows).