### PR TITLE
fix(reliability): bound YouTube Music metadata extraction (deadline + socket timeout + concurrency) (sweep #19 M8)

### DIFF
--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -215,6 +215,11 @@ EXTRACT_DELAY_MIN = env_float("YTMUSIC_EXTRACT_DELAY_MIN", "0.5")
 EXTRACT_DELAY_MAX = env_float("YTMUSIC_EXTRACT_DELAY_MAX", "2.0")
 _extract_pacer = ThreadSafeRatePacer(EXTRACT_DELAY_MIN, EXTRACT_DELAY_MAX)
 EXTRACT_TIMEOUT = env_float("YTMUSIC_EXTRACT_TIMEOUT", "60")
+YTDLP_EXTRACT_CONCURRENCY = max(1, min(16, env_int("YTMUSIC_YTDLP_EXTRACT_CONCURRENCY", "4")))
+_yt_dlp_extract_executor = ThreadPoolExecutor(
+    max_workers=YTDLP_EXTRACT_CONCURRENCY,
+    thread_name_prefix="yt-dlp-extract",
+)
 # Overall deadline for public metadata browse calls.
 BROWSE_TIMEOUT = env_float("YTMUSIC_BROWSE_TIMEOUT", "30")
 YTDLP_SOCKET_TIMEOUT = env_float("YTMUSIC_YTDLP_SOCKET_TIMEOUT", "20")
@@ -912,17 +917,27 @@ def _get_stream_url_sync(user_id: str, video_id: str, quality: str = "HIGH") -> 
     )
 
 
-async def _extract_stream_info_bounded(func, *args) -> dict:
-    """Run a sync stream extraction off the event loop with an overall deadline.
+async def _extract_yt_dlp_bounded(func, *args, timeout_detail: str) -> dict:
+    """Run sync yt-dlp work in its bounded pool with an overall deadline.
 
-    asyncio.wait_for cancels the awaiting request after EXTRACT_TIMEOUT
-    seconds and maps it to HTTP 504. The orphaned worker thread cannot
-    hang forever: yt-dlp's socket_timeout bounds its network reads.
+    Timed-out worker threads remain confined to the dedicated executor, and
+    yt-dlp's socket_timeout bounds their network operations.
     """
     try:
-        return await asyncio.wait_for(asyncio.to_thread(func, *args), timeout=EXTRACT_TIMEOUT)
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(_yt_dlp_extract_executor, func, *args)
+        return await asyncio.wait_for(future, timeout=EXTRACT_TIMEOUT)
     except TimeoutError as error:
-        raise HTTPException(status_code=504, detail="Stream extraction timed out") from error
+        raise HTTPException(status_code=504, detail=timeout_detail) from error
+
+
+async def _extract_stream_info_bounded(func, *args) -> dict:
+    """Run a sync stream extraction through the shared yt-dlp bounds."""
+    return await _extract_yt_dlp_bounded(
+        func,
+        *args,
+        timeout_detail="Stream extraction timed out",
+    )
 
 
 async def _browse_public_bounded(func, *args):
@@ -2178,6 +2193,7 @@ async def yt_video_info(url: str = Query(...)):
         "no_warnings": True,
         "extract_flat": False,
         "skip_download": True,
+        "socket_timeout": YTDLP_SOCKET_TIMEOUT,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -2199,7 +2215,10 @@ async def yt_video_info(url: str = Query(...)):
                     download=False,
                 )
 
-        info = await asyncio.to_thread(_extract)
+        info = await _extract_yt_dlp_bounded(
+            _extract,
+            timeout_detail="YouTube extraction timed out",
+        )
         if not info:
             raise HTTPException(status_code=404, detail="Video not found")
 
@@ -2271,6 +2290,7 @@ async def yt_playlist_info(url: str = Query(...)):
         "extract_flat": "in_playlist",
         "skip_download": True,
         "playlistend": YT_PLAYLIST_MAX_ENTRIES + 1,
+        "socket_timeout": YTDLP_SOCKET_TIMEOUT,
         "http_headers": {
             "User-Agent": _USER_AGENT,
             "Accept-Language": "en-US,en;q=0.9",
@@ -2289,7 +2309,10 @@ async def yt_playlist_info(url: str = Query(...)):
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 return ydl.extract_info(enumerate_url, download=False)
 
-        info = await asyncio.to_thread(_extract)
+        info = await _extract_yt_dlp_bounded(
+            _extract,
+            timeout_detail="YouTube extraction timed out",
+        )
         if not info:
             raise HTTPException(status_code=404, detail="Playlist or channel not found")
 
@@ -2385,8 +2408,8 @@ _yt_download_tasks: set = set()
 YT_DOWNLOAD_JOB_TTL = 6 * 60 * 60  # prune terminal jobs after 6 hours
 # Downloads run on a dedicated, size-limited executor so multi-hour yt-dlp
 # jobs cannot exhaust the event loop's shared default thread pool — used by
-# every asyncio.to_thread call (stream-URL extraction, search, /yt/info,
-# /yt/proxy) — and starve streaming for all users. Jobs beyond the limit
+# other asyncio.to_thread calls such as search and browse — and starve
+# streaming for all users. Jobs beyond the limit
 # wait in the executor's queue and stay in the "queued" state until a
 # worker picks them up.
 YT_DOWNLOAD_CONCURRENCY = max(1, env_int("YT_DOWNLOAD_CONCURRENCY", "2"))

--- a/services/ytmusic-streamer/tests/test_extraction_timeout.py
+++ b/services/ytmusic-streamer/tests/test_extraction_timeout.py
@@ -2,12 +2,82 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import threading
 import time
 
 import pytest
 
 VIDEO_ID = "dQw4w9WgXcQ"
+PLAYLIST_URL = "https://www.youtube.com/playlist?list=PL-abcDEF12345"
+METADATA_EXTRACTION_CASES = (
+    (
+        f"/yt/info?url=https://www.youtube.com/watch?v={VIDEO_ID}",
+        {"id": VIDEO_ID, "title": "video"},
+    ),
+    (
+        f"/yt/playlist-info?url={PLAYLIST_URL}",
+        {
+            "title": "playlist",
+            "entries": [{"id": VIDEO_ID, "title": "video"}],
+        },
+    ),
+)
+
+
+def _youtube_dl_returning(info, *, started=None, release=None, captured=None):
+    """Build a controllable yt-dlp fake for endpoint-level extraction tests."""
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            if captured is not None:
+                captured.append(options)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def extract_info(self, url, download=False):
+            if started is not None:
+                started.set()
+            if release is not None:
+                release.wait(timeout=1)
+            return info
+
+    return FakeYoutubeDL
+
+
+def _blocking_youtube_dl(state, state_lock, at_limit, release, concurrency_limit):
+    """Build a yt-dlp fake that records and blocks concurrent extraction."""
+
+    class BlockingYoutubeDL:
+        def __init__(self, options):
+            self.options = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def extract_info(self, url, download=False):
+            with state_lock:
+                state["active"] += 1
+                state["started"] += 1
+                state["max_active"] = max(state["max_active"], state["active"])
+                if state["active"] == concurrency_limit:
+                    at_limit.set()
+            try:
+                release.wait(timeout=2)
+                return {"id": VIDEO_ID, "title": "video"}
+            finally:
+                with state_lock:
+                    state["active"] -= 1
+
+    return BlockingYoutubeDL
 
 
 @pytest.mark.anyio
@@ -44,6 +114,36 @@ async def test_yt_proxy_slow_extraction_returns_504(client, monkeypatch):
 
     assert response.status_code == 504
     assert response.json()["error"] == "Stream extraction timed out"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "info"),
+    METADATA_EXTRACTION_CASES,
+    ids=("video-info", "playlist-info"),
+)
+async def test_slow_metadata_extraction_returns_504(client, monkeypatch, path, info):
+    """A stalled metadata extraction should return a sanitized HTTP 504."""
+    import app
+    import yt_dlp
+
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(app, "EXTRACT_TIMEOUT", 0.05)
+    monkeypatch.setattr(
+        yt_dlp,
+        "YoutubeDL",
+        _youtube_dl_returning(info, started=started, release=release),
+    )
+
+    try:
+        response = await client.get(path)
+    finally:
+        release.set()
+
+    assert started.is_set()
+    assert response.status_code == 504
+    assert response.json()["error"] == "YouTube extraction timed out"
 
 
 @pytest.mark.anyio
@@ -89,6 +189,77 @@ def test_ydl_opts_include_socket_timeout(monkeypatch):
 
     assert len(captured) == 2
     assert all(opts["socket_timeout"] == app.YTDLP_SOCKET_TIMEOUT for opts in captured)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "info"),
+    METADATA_EXTRACTION_CASES,
+    ids=("video-info", "playlist-info"),
+)
+async def test_metadata_extraction_configures_socket_timeout(client, monkeypatch, path, info):
+    """Metadata endpoints should bound each yt-dlp socket operation."""
+    import app
+    import yt_dlp
+
+    captured = []
+    monkeypatch.setattr(
+        yt_dlp,
+        "YoutubeDL",
+        _youtube_dl_returning(info, captured=captured),
+    )
+
+    response = await client.get(path)
+
+    assert response.status_code == 200
+    assert len(captured) == 1
+    assert captured[0]["socket_timeout"] == app.YTDLP_SOCKET_TIMEOUT
+
+
+@pytest.mark.anyio
+async def test_metadata_extraction_concurrency_is_bounded(client, monkeypatch):
+    """Concurrent metadata work should not exceed the configured worker bound."""
+    import app
+    import yt_dlp
+
+    at_limit = threading.Event()
+    release = threading.Event()
+    state_lock = threading.Lock()
+    state = {"active": 0, "started": 0, "max_active": 0}
+
+    monkeypatch.setattr(app, "EXTRACT_TIMEOUT", 5)
+    monkeypatch.setattr(
+        yt_dlp,
+        "YoutubeDL",
+        _blocking_youtube_dl(
+            state,
+            state_lock,
+            at_limit,
+            release,
+            app.YTDLP_EXTRACT_CONCURRENCY,
+        ),
+    )
+    request_count = app.YTDLP_EXTRACT_CONCURRENCY + 1
+    path = f"/yt/info?url=https://www.youtube.com/watch?v={VIDEO_ID}"
+    tasks = [asyncio.create_task(client.get(path)) for _ in range(request_count)]
+
+    try:
+        reached_limit = await asyncio.to_thread(at_limit.wait, 2)
+        with state_lock:
+            started_at_limit = state["started"]
+            active_at_limit = state["active"]
+        release.set()
+        responses = await asyncio.gather(*tasks)
+    finally:
+        release.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert reached_limit
+    assert started_at_limit == app.YTDLP_EXTRACT_CONCURRENCY
+    assert active_at_limit == app.YTDLP_EXTRACT_CONCURRENCY
+    assert state["max_active"] == app.YTDLP_EXTRACT_CONCURRENCY
+    assert state["started"] == request_count
+    assert all(response.status_code == 200 for response in responses)
 
 
 def test_download_sync_split():


### PR DESCRIPTION
Convergence sweep #19 remediation (M8) in `services/ytmusic-streamer/app.py`.

The authenticated `/yt/info` and `/yt/playlist-info` paths invoked yt-dlp via `asyncio.to_thread` **without** the existing `EXTRACT_TIMEOUT` wrapper or a socket timeout. A stalled extraction retained a default-executor thread indefinitely after the backend caller had already timed out — unbounded thread/resource retention.

Fix
- Both handlers now route through the shared bounded-extraction helper with an overall `EXTRACT_TIMEOUT` deadline.
- `YTDLP_SOCKET_TIMEOUT` applied so network stalls fail fast.
- Configurable bounded executor (`YTMUSIC_YTDLP_EXTRACT_CONCURRENCY`, default 4, cap 16) limits concurrent extractions.
- Timeouts still return sanitized HTTP 504s.

Verification: sidecar pytest 195 passed; ruff format + lint clean; mypy clean; route-error canon + leak ratchets green. No CHANGELOG edit (consolidated docs PR follows).