### PR TITLE
fix(security): require strong encryption + internal-auth secrets (sweep #19 M7)

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -20,6 +20,42 @@ if [ "$(id -u)" = "0" ]; then
   exit 1
 fi
 
+is_critical_secret_invalid() {
+  secret_value="$1"
+  insecure_default="$2"
+  [ -z "$secret_value" ] || [ "$secret_value" = "$insecure_default" ] || [ "${#secret_value}" -lt 32 ]
+}
+
+# Validate critical secrets before migrations or other external startup work.
+if is_critical_secret_invalid "${SESSION_SECRET:-}" "changeme-generate-secure-key"; then
+  cat >&2 <<'EOF'
+[ERROR] SESSION_SECRET is missing, uses the published default, or is shorter than 32 characters.
+SESSION_SECRET must be stable because it signs JWTs and is the API-key pepper fallback.
+An ephemeral value invalidates all sessions and API-key hashes on restart.
+Generate one with: openssl rand -base64 32
+EOF
+  exit 1
+fi
+
+if is_critical_secret_invalid "${SETTINGS_ENCRYPTION_KEY:-}" "default-encryption-key-change-me"; then
+  cat >&2 <<'EOF'
+[ERROR] SETTINGS_ENCRYPTION_KEY is missing, uses the published default, or is shorter than 32 characters.
+SETTINGS_ENCRYPTION_KEY encrypts API keys, passwords, and 2FA secrets and must be stable across restarts.
+Changing it makes existing encrypted data unreadable.
+Generate one with: openssl rand -base64 32
+EOF
+  exit 1
+fi
+
+if is_critical_secret_invalid "${INTERNAL_API_SECRET:-}" "soundspan-internal-secret-change-me"; then
+  cat >&2 <<'EOF'
+[ERROR] INTERNAL_API_SECRET is missing, uses the published default, or is shorter than 32 characters.
+INTERNAL_API_SECRET authenticates service-to-service requests and must match every backend sidecar.
+Generate one with: openssl rand -base64 32
+EOF
+  exit 1
+fi
+
 echo "[START] Starting soundspan Backend..."
 
 # Docker Compose health checks ensure database and Redis are ready
@@ -108,28 +144,6 @@ if [ "${REDIS_FLUSH_ON_STARTUP:-false}" = "true" ]; then
   " || echo "[REDIS] Cache clear skipped (Redis unavailable)"
 else
   echo "[REDIS] Skipping startup cache flush (REDIS_FLUSH_ON_STARTUP=false)"
-fi
-
-# Require a stable session secret.
-if [ -z "$SESSION_SECRET" ] || [ "$SESSION_SECRET" = "changeme-generate-secure-key" ] || [ "${#SESSION_SECRET}" -lt 32 ]; then
-  cat >&2 <<'EOF'
-[ERROR] SESSION_SECRET is missing, uses the published default, or is shorter than 32 characters.
-SESSION_SECRET must be stable because it signs JWTs and is the API-key pepper fallback.
-An ephemeral value invalidates all sessions and API-key hashes on restart.
-Generate one with: openssl rand -base64 32
-EOF
-  exit 1
-fi
-
-# Require a stable encryption key.
-if [ -z "$SETTINGS_ENCRYPTION_KEY" ] || [ "$SETTINGS_ENCRYPTION_KEY" = "default-encryption-key-change-me" ]; then
-  cat >&2 <<'EOF'
-[ERROR] SETTINGS_ENCRYPTION_KEY is missing or uses the published default.
-SETTINGS_ENCRYPTION_KEY encrypts API keys, passwords, and 2FA secrets and must be stable across restarts.
-Changing it makes existing encrypted data unreadable.
-Generate one with: openssl rand -base64 32
-EOF
-  exit 1
 fi
 
 echo "[START] soundspan Backend starting on port ${PORT:-3006}..."

--- a/backend/src/__tests__/config.test.ts
+++ b/backend/src/__tests__/config.test.ts
@@ -34,6 +34,8 @@ describe("config module", () => {
             DATABASE_URL: "postgresql://db/soundspan",
             REDIS_URL: "redis://127.0.0.1:6379",
             SESSION_SECRET: "12345678901234567890123456789012",
+            SETTINGS_ENCRYPTION_KEY: "23456789012345678901234567890123",
+            INTERNAL_API_SECRET: "34567890123456789012345678901234",
             MUSIC_PATH: "/music",
         };
     }
@@ -277,6 +279,123 @@ describe("config module", () => {
         const explicit = await loadConfigModule({ JWT_SECRET: jwtSecret });
 
         expect(explicit.config.jwtSecret).toBe(jwtSecret);
+        expect(mockLoggerDebug).toHaveBeenCalledWith(
+            "Environment variables validated",
+        );
+    });
+
+    it.each([
+        ["SETTINGS_ENCRYPTION_KEY", "x".repeat(31)],
+        ["INTERNAL_API_SECRET", "y".repeat(31)],
+    ])("rejects a weak %s at startup", async (name, value) => {
+        const exitSpy = jest.spyOn(process, "exit").mockImplementation(((
+            code?: number,
+        ) => {
+            throw new Error(`process.exit:${code}`);
+        }) as never);
+
+        await expect(loadConfigModule({ [name]: value })).rejects.toThrow(
+            "process.exit:1",
+        );
+        expect(
+            mockLoggerError.mock.calls.some(
+                (call) =>
+                    typeof call[0] === "string" &&
+                    call[0].includes(`${name} must be at least 32 characters`),
+            ),
+        ).toBe(true);
+        expect(JSON.stringify(mockLoggerError.mock.calls)).not.toContain(value);
+
+        exitSpy.mockRestore();
+    });
+
+    it("validates the legacy ENCRYPTION_KEY fallback with the same minimum", async () => {
+        const exitSpy = jest.spyOn(process, "exit").mockImplementation(((
+            code?: number,
+        ) => {
+            throw new Error(`process.exit:${code}`);
+        }) as never);
+
+        await expect(
+            loadConfigModule({
+                SETTINGS_ENCRYPTION_KEY: undefined,
+                ENCRYPTION_KEY: "z".repeat(31),
+            }),
+        ).rejects.toThrow("process.exit:1");
+        expect(
+            mockLoggerError.mock.calls.some(
+                (call) =>
+                    typeof call[0] === "string" &&
+                    call[0].includes(
+                        "ENCRYPTION_KEY must be at least 32 characters",
+                    ),
+            ),
+        ).toBe(true);
+
+        exitSpy.mockRestore();
+    });
+
+    it.each([
+        [
+            "SETTINGS_ENCRYPTION_KEY",
+            {
+                SETTINGS_ENCRYPTION_KEY: undefined,
+                ENCRYPTION_KEY: undefined,
+            },
+        ],
+        ["INTERNAL_API_SECRET", { INTERNAL_API_SECRET: undefined }],
+    ])("requires %s at startup", async (name, overrides) => {
+        const exitSpy = jest.spyOn(process, "exit").mockImplementation(((
+            code?: number,
+        ) => {
+            throw new Error(`process.exit:${code}`);
+        }) as never);
+
+        await expect(loadConfigModule(overrides)).rejects.toThrow(
+            "process.exit:1",
+        );
+        expect(
+            mockLoggerError.mock.calls.some(
+                (call) =>
+                    typeof call[0] === "string" &&
+                    call[0].includes(`${name} is required`),
+            ),
+        ).toBe(true);
+
+        exitSpy.mockRestore();
+    });
+
+    it.each([
+        ["SETTINGS_ENCRYPTION_KEY", "default-encryption-key-change-me"],
+        ["INTERNAL_API_SECRET", "soundspan-internal-secret-change-me"],
+    ])("rejects the published %s default at startup", async (name, value) => {
+        const exitSpy = jest.spyOn(process, "exit").mockImplementation(((
+            code?: number,
+        ) => {
+            throw new Error(`process.exit:${code}`);
+        }) as never);
+
+        await expect(loadConfigModule({ [name]: value })).rejects.toThrow(
+            "process.exit:1",
+        );
+        expect(
+            mockLoggerError.mock.calls.some(
+                (call) =>
+                    typeof call[0] === "string" &&
+                    call[0].includes(`${name} must not use the published`),
+            ),
+        ).toBe(true);
+
+        exitSpy.mockRestore();
+    });
+
+    it("accepts critical secrets at the 32-character boundary", async () => {
+        const { config } = await loadConfigModule({
+            SETTINGS_ENCRYPTION_KEY: "e".repeat(32),
+            INTERNAL_API_SECRET: "i".repeat(32),
+        });
+
+        expect(config.internalApiSecret).toBe("i".repeat(32));
         expect(mockLoggerDebug).toHaveBeenCalledWith(
             "Environment variables validated",
         );

--- a/backend/src/__tests__/dockerEntrypointSecrets.test.ts
+++ b/backend/src/__tests__/dockerEntrypointSecrets.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from "child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+const ENTRYPOINT_PATH = path.resolve(__dirname, "../../docker-entrypoint.sh");
+const STRONG_SECRET = "s".repeat(32);
+type SecretName =
+    | "SESSION_SECRET"
+    | "SETTINGS_ENCRYPTION_KEY"
+    | "INTERNAL_API_SECRET";
+
+function deleteUndefinedOverride(
+    env: NodeJS.ProcessEnv,
+    overrides: Record<string, string | undefined>,
+    name: SecretName,
+): void {
+    if (overrides[name] === undefined && name in overrides) delete env[name];
+}
+
+describe("backend Docker entrypoint secret validation", () => {
+    const commandDirectory = mkdtempSync(
+        path.join(tmpdir(), "soundspan-entrypoint-test-"),
+    );
+
+    beforeAll(() => {
+        const idPath = path.join(commandDirectory, "id");
+        const sleepPath = path.join(commandDirectory, "sleep");
+        writeFileSync(idPath, "#!/bin/sh\necho 1000\n");
+        writeFileSync(sleepPath, "#!/bin/sh\nexit 0\n");
+        chmodSync(idPath, 0o700);
+        chmodSync(sleepPath, 0o700);
+    });
+
+    afterAll(() => {
+        rmSync(commandDirectory, { recursive: true, force: true });
+    });
+
+    function runEntrypoint(
+        overrides: Record<string, string | undefined>,
+    ): ReturnType<typeof spawnSync> {
+        const env: NodeJS.ProcessEnv = {
+            ...process.env,
+            PATH: `${commandDirectory}:${process.env.PATH ?? ""}`,
+            RUN_DB_MIGRATIONS_ON_STARTUP: "false",
+            PRISMA_GENERATE_ON_STARTUP: "false",
+            REDIS_FLUSH_ON_STARTUP: "false",
+            SESSION_SECRET: STRONG_SECRET,
+            SETTINGS_ENCRYPTION_KEY: STRONG_SECRET,
+            INTERNAL_API_SECRET: STRONG_SECRET,
+            ...overrides,
+        };
+
+        deleteUndefinedOverride(env, overrides, "SESSION_SECRET");
+        deleteUndefinedOverride(env, overrides, "SETTINGS_ENCRYPTION_KEY");
+        deleteUndefinedOverride(env, overrides, "INTERNAL_API_SECRET");
+
+        return spawnSync("sh", [ENTRYPOINT_PATH, "true"], {
+            env,
+            encoding: "utf8",
+            timeout: 5_000,
+        });
+    }
+
+    it.each(["SETTINGS_ENCRYPTION_KEY", "INTERNAL_API_SECRET"])(
+        "rejects a %s shorter than 32 characters",
+        (name) => {
+            const result = runEntrypoint({ [name]: "w".repeat(31) });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain(
+                `${name} is missing, uses the published default, or is shorter than 32 characters.`,
+            );
+            expect(result.stderr).not.toContain("w".repeat(31));
+        },
+    );
+
+    it.each(["SETTINGS_ENCRYPTION_KEY", "INTERNAL_API_SECRET"])(
+        "requires %s",
+        (name) => {
+            const result = runEntrypoint({ [name]: undefined });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain(`${name} is missing`);
+        },
+    );
+
+    it.each([
+        ["SETTINGS_ENCRYPTION_KEY", "default-encryption-key-change-me"],
+        ["INTERNAL_API_SECRET", "soundspan-internal-secret-change-me"],
+    ])("rejects the published %s default", (name, value) => {
+        const result = runEntrypoint({ [name]: value });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(`${name} is missing`);
+        expect(result.stderr).not.toContain(value);
+    });
+
+    it("accepts critical secrets at the 32-character boundary", () => {
+        const result = runEntrypoint({});
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe("");
+    });
+});

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -10,7 +10,15 @@ import {
     parseEnvFloat,
     parseEnvInt,
 } from "./utils/envParsers";
-import { isSecretsDbOnlyEnabled } from "./config/secretsPolicy";
+import {
+    CRITICAL_SECRET_MIN_LENGTH,
+    getCriticalSecretFailure,
+    INSECURE_INTERNAL_API_SECRET,
+    INSECURE_SETTINGS_ENCRYPTION_KEY,
+    isSecretsDbOnlyEnabled,
+    resolveSettingsEncryptionKey,
+    type CriticalSecretFailure,
+} from "./config/secretsPolicy";
 
 // quiet is a no-op on dotenv 16 and silences v17's per-boot injection tip line
 dotenv.config({ quiet: true });
@@ -50,21 +58,66 @@ const isTraceTruthy = (value: string | undefined): boolean => {
     return normalized ? TRACE_TRUTHY_VALUES.has(normalized) : false;
 };
 
-// Validate critical environment variables on startup
-const envSchema = z.object({
-    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-    REDIS_URL: z.string().min(1, "REDIS_URL is required"),
-    SESSION_SECRET: z
-        .string()
-        .min(32, "SESSION_SECRET must be at least 32 characters"),
-    JWT_SECRET: z
-        .string()
-        .min(32, "JWT_SECRET must be at least 32 characters")
-        .optional(),
-    PORT: z.string().optional(),
-    NODE_ENV: z.enum(["development", "production", "test"]).optional(),
-    MUSIC_PATH: z.string().min(1, "MUSIC_PATH is required"),
-});
+function criticalSecretMessage(
+    name: string,
+    failure: CriticalSecretFailure,
+): string {
+    if (failure === "missing") return `${name} is required`;
+    if (failure === "published-default") {
+        return `${name} must not use the published insecure default`;
+    }
+    return `${name} must be at least ${CRITICAL_SECRET_MIN_LENGTH} characters`;
+}
+
+function addCriticalSecretIssue(
+    context: z.RefinementCtx,
+    name: string,
+    value: string | undefined,
+    publishedDefault: string,
+): void {
+    const failure = getCriticalSecretFailure(value, publishedDefault);
+    if (!failure) return;
+    context.addIssue({
+        code: "custom",
+        path: [name],
+        message: criticalSecretMessage(name, failure),
+    });
+}
+
+// Validate critical environment variables on startup.
+const envSchema = z
+    .object({
+        DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+        REDIS_URL: z.string().min(1, "REDIS_URL is required"),
+        SESSION_SECRET: z
+            .string()
+            .min(32, "SESSION_SECRET must be at least 32 characters"),
+        JWT_SECRET: z
+            .string()
+            .min(32, "JWT_SECRET must be at least 32 characters")
+            .optional(),
+        SETTINGS_ENCRYPTION_KEY: z.string().optional(),
+        ENCRYPTION_KEY: z.string().optional(),
+        INTERNAL_API_SECRET: z.string().optional(),
+        PORT: z.string().optional(),
+        NODE_ENV: z.enum(["development", "production", "test"]).optional(),
+        MUSIC_PATH: z.string().min(1, "MUSIC_PATH is required"),
+    })
+    .superRefine((env, context) => {
+        const encryptionKey = resolveSettingsEncryptionKey(env);
+        addCriticalSecretIssue(
+            context,
+            encryptionKey.name,
+            encryptionKey.value,
+            INSECURE_SETTINGS_ENCRYPTION_KEY,
+        );
+        addCriticalSecretIssue(
+            context,
+            "INTERNAL_API_SECRET",
+            env.INTERNAL_API_SECRET,
+            INSECURE_INTERNAL_API_SECRET,
+        );
+    });
 
 try {
     envSchema.parse(process.env);
@@ -337,10 +390,9 @@ export const config = {
         url: process.env.YTMUSIC_STREAMER_URL || "http://127.0.0.1:8586",
     },
 
-    // Shared secret sent as the `x-internal-secret` header on backend→sidecar
-    // calls (F31). Optional, so booting without it never fails; when unset no
-    // header is sent and the FastAPI sidecars reject the call fail-closed (403).
-    internalApiSecret: process.env.INTERNAL_API_SECRET,
+    // Validated shared secret sent as the `x-internal-secret` header on
+    // backend→sidecar calls (F31).
+    internalApiSecret: process.env.INTERNAL_API_SECRET!,
 
     // When no webhook secret is configured in system settings, the Lidarr
     // webhook rejects requests (fail closed) unless this is true; see

--- a/backend/src/config/secretsPolicy.ts
+++ b/backend/src/config/secretsPolicy.ts
@@ -1,5 +1,52 @@
 import { isEnvFlagEnabled } from "../utils/envParsers";
 
+/** Minimum accepted length for backend encryption and internal-auth secrets. */
+export const CRITICAL_SECRET_MIN_LENGTH = 32;
+
+/** Published encryption-key sentinel that must never be accepted at runtime. */
+export const INSECURE_SETTINGS_ENCRYPTION_KEY =
+    "default-encryption-key-change-me";
+
+/** Published internal-auth sentinel that must never be accepted at runtime. */
+export const INSECURE_INTERNAL_API_SECRET =
+    "soundspan-internal-secret-change-me";
+
+/** Stable reason codes returned by critical-secret validation. */
+export type CriticalSecretFailure =
+    | "missing"
+    | "published-default"
+    | "too-short";
+
+/**
+ * Resolve the primary settings-encryption key with the legacy key as fallback.
+ */
+export function resolveSettingsEncryptionKey(env: NodeJS.ProcessEnv): {
+    name: "SETTINGS_ENCRYPTION_KEY" | "ENCRYPTION_KEY";
+    value: string | undefined;
+} {
+    if (env.SETTINGS_ENCRYPTION_KEY) {
+        return {
+            name: "SETTINGS_ENCRYPTION_KEY",
+            value: env.SETTINGS_ENCRYPTION_KEY,
+        };
+    }
+    if (env.ENCRYPTION_KEY) {
+        return { name: "ENCRYPTION_KEY", value: env.ENCRYPTION_KEY };
+    }
+    return { name: "SETTINGS_ENCRYPTION_KEY", value: undefined };
+}
+
+/** Validate a required critical secret without exposing its value. */
+export function getCriticalSecretFailure(
+    value: string | undefined,
+    publishedDefault: string,
+): CriticalSecretFailure | null {
+    if (!value) return "missing";
+    if (value === publishedDefault) return "published-default";
+    if (value.length < CRITICAL_SECRET_MIN_LENGTH) return "too-short";
+    return null;
+}
+
 /**
  * Integration secret env keys excluded from fallback and env-file sync when
  * the opt-in DB-only secrets policy is enabled.

--- a/backend/src/utils/__tests__/encryption.test.ts
+++ b/backend/src/utils/__tests__/encryption.test.ts
@@ -91,6 +91,26 @@ describe("encryption utils", () => {
         ).rejects.toThrow("insecure default value");
     });
 
+    it.each([
+        ["SETTINGS_ENCRYPTION_KEY", { settingsKey: "x".repeat(31) }],
+        ["ENCRYPTION_KEY", { fallbackKey: "y".repeat(31) }],
+    ])(
+        "throws on import when %s is shorter than 32 characters",
+        async (_, keys) => {
+            await expect(loadEncryptionModule(keys)).rejects.toThrow(
+                "at least 32 characters",
+            );
+        },
+    );
+
+    it("accepts an encryption key at the 32-character boundary", async () => {
+        const { encrypt, decrypt } = await loadEncryptionModule({
+            settingsKey: "k".repeat(32),
+        });
+
+        expect(decrypt(encrypt("boundary-value"))).toBe("boundary-value");
+    });
+
     it("uses ENCRYPTION_KEY as a fallback when SETTINGS_ENCRYPTION_KEY is not set", async () => {
         const { encrypt, decrypt } = await loadEncryptionModule({
             fallbackKey: VALID_KEY,

--- a/backend/src/utils/encryption.ts
+++ b/backend/src/utils/encryption.ts
@@ -1,4 +1,10 @@
 import crypto from "crypto";
+import {
+    CRITICAL_SECRET_MIN_LENGTH,
+    getCriticalSecretFailure,
+    INSECURE_SETTINGS_ENCRYPTION_KEY,
+    resolveSettingsEncryptionKey,
+} from "../config/secretsPolicy";
 import { isEnvFlagEnabled } from "./envParsers";
 import { logger } from "./logger";
 
@@ -13,18 +19,13 @@ const GCM_IV_BYTES = 12; // 96-bit nonce, the GCM standard
 const GCM_TAG_BYTES = 16; // 128-bit authentication tag (GCM default)
 const LEGACY_IV_BYTES = 16;
 
-// Insecure default that must not be used in production
-const INSECURE_DEFAULT = "default-encryption-key-change-me";
-
 /**
  * Get and validate the raw encryption key string from the environment.
- * Throws if not set or using the insecure default. Validated on module load to
- * fail fast.
+ * Throws if missing, weak, or using the insecure default. Validated on module
+ * load to fail fast.
  */
 function getRawEncryptionKey(): string {
-    // Support both SETTINGS_ENCRYPTION_KEY (primary) and ENCRYPTION_KEY (compatibility)
-    const key =
-        process.env.SETTINGS_ENCRYPTION_KEY || process.env.ENCRYPTION_KEY;
+    const { value: key } = resolveSettingsEncryptionKey(process.env);
 
     if (!key) {
         throw new Error(
@@ -34,10 +35,21 @@ function getRawEncryptionKey(): string {
         );
     }
 
-    if (key === INSECURE_DEFAULT) {
+    const failure = getCriticalSecretFailure(
+        key,
+        INSECURE_SETTINGS_ENCRYPTION_KEY,
+    );
+    if (failure === "published-default") {
         throw new Error(
             "CRITICAL: Encryption key is set to the insecure default value.\n" +
                 "You must set a unique SETTINGS_ENCRYPTION_KEY or ENCRYPTION_KEY.\n" +
+                "Generate a secure key with: openssl rand -base64 32",
+        );
+    }
+
+    if (failure === "too-short") {
+        throw new Error(
+            `CRITICAL: Encryption key must be at least ${CRITICAL_SECRET_MIN_LENGTH} characters.\n` +
                 "Generate a secure key with: openssl rand -base64 32",
         );
     }


### PR DESCRIPTION
Convergence sweep #19 remediation (M7). `SETTINGS_ENCRYPTION_KEY` (+ legacy `ENCRYPTION_KEY`) and `INTERNAL_API_SECRET` were checked only for absence and published sentinels — a one-character encryption key stays brute-forceable despite scrypt, and a one-character internal-auth secret is guessable by in-network peers.

Fix
- `backend/src/config/secretsPolicy.ts` centralizes a **32-character minimum** and the sentinel rejection.
- Backend startup (`config.ts`) fails fast when either secret is missing/sentinel/too short, reporting variable **names only** (never values).
- `encryption.ts` rejects sub-minimum keys at import.
- The AIO/backend `docker-entrypoint.sh` validates session, encryption, and internal secrets **before** migrations or external work.

⚠️ **Breaking**: deployments configured with weak (<32-char) secrets will fail to start until strengthened. Chart-/`openssl rand`-generated secrets already exceed the minimum. Tests: missing, sentinel, 31-char, exact-32-char, legacy fallback, value-redaction.

Scope is backend + entrypoint; matching min-strength checks for the Python sidecars, Compose, and Helm are a documented follow-up. Verification: jest 69/69; `tsc --noEmit` clean; `sh -n` entrypoint clean; canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows — will carry the breaking-change note).