### PR TITLE
fix(reliability): cancel audiobook cover bodies on failure; consolidate the two fetch branches (sweep #19 M10)

### DIFF
--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -1178,34 +1178,50 @@ describe("library cover-art proxy compatibility", () => {
         );
     });
 
-    it("returns 404 when audiobook query-url fetch fails", async () => {
-        const cancel = jest.fn().mockResolvedValue(undefined);
-        const fetchMock = jest.fn().mockResolvedValue({
-            ok: false,
-            status: 404,
-            statusText: "Not Found",
-            body: { cancel },
-            headers: { get: jest.fn().mockReturnValue(null) },
-        });
-        (global as any).fetch = fetchMock;
-        mockGetSystemSettings.mockResolvedValueOnce({
-            audiobookshelfUrl: "https://audiobooks.example",
-            audiobookshelfApiKey: "abs-key",
-        });
-
-        const req = {
+    it.each([
+        {
+            source: "query URL",
             query: { url: "audiobook__items/missing/cover" },
             params: {},
-            headers: {},
-        } as any;
-        const res = createRes();
+        },
+        {
+            source: "ID parameter",
+            query: {},
+            params: { id: "audiobook__items/missing/cover" },
+        },
+    ])(
+        "cancels the upstream body when an audiobook $source fetch fails",
+        async ({ query, params }) => {
+            const cancel = jest.fn().mockResolvedValue(undefined);
+            const fetchMock = jest.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+                statusText: "Not Found",
+                body: { cancel },
+                headers: { get: jest.fn().mockReturnValue(null) },
+            });
+            (global as any).fetch = fetchMock;
+            mockGetSystemSettings.mockResolvedValueOnce({
+                audiobookshelfUrl: "https://audiobooks.example",
+                audiobookshelfApiKey: "abs-key",
+            });
 
-        await coverArtHandler(req, res);
+            const req = {
+                query,
+                params,
+                headers: {},
+            } as any;
+            const res = createRes();
 
-        expect(cancel).toHaveBeenCalledTimes(1);
-        expect(res.statusCode).toBe(404);
-        expect(res.body).toEqual({ error: "Audiobook cover art not found" });
-    });
+            await coverArtHandler(req, res);
+
+            expect(cancel).toHaveBeenCalledTimes(1);
+            expect(res.statusCode).toBe(404);
+            expect(res.body).toEqual({
+                error: "Audiobook cover art not found",
+            });
+        },
+    );
 
     it("serves native query and id cover files with CORS headers", async () => {
         const { config } = jest.requireMock("../../config") as {

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -318,6 +318,66 @@ const applyCoverArtCorsHeaders = (res: ExpressResponse, origin?: string) => {
     }
 };
 
+const sendAudiobookCover = async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    audiobookPath: string,
+): Promise<ExpressResponse> => {
+    const coverArtLogger = logger.child("CoverArt");
+    const settings = await getSystemSettings();
+    const audiobookshelfUrl =
+        settings?.audiobookshelfUrl || process.env.AUDIOBOOKSHELF_URL || "";
+    const audiobookshelfApiKey =
+        settings?.audiobookshelfApiKey ||
+        (config.secretsDbOnly ? "" : process.env.AUDIOBOOKSHELF_API_KEY || "");
+    const coverUrl = buildSafeAudiobookCoverUrl(
+        audiobookPath,
+        audiobookshelfUrl.replace(/\/$/, ""),
+    );
+
+    if (!coverUrl) {
+        coverArtLogger.warn("Blocked unsafe audiobook cover path", {
+            audiobookPath,
+        });
+        return sendRouteError(res, 400, "Invalid audiobook cover path");
+    }
+
+    coverArtLogger.debug("Fetching audiobook cover", { coverUrl });
+    const imageResponse = await fetch(coverUrl, {
+        headers: {
+            Authorization: `Bearer ${audiobookshelfApiKey}`,
+            "User-Agent": BRAND_USER_AGENT,
+        },
+        signal: AbortSignal.timeout(15000),
+    });
+
+    if (!imageResponse.ok) {
+        coverArtLogger.error("Failed to fetch audiobook cover", {
+            coverUrl,
+            status: imageResponse.status,
+            statusText: imageResponse.statusText,
+        });
+        try {
+            await imageResponse.body?.cancel();
+        } catch (error) {
+            coverArtLogger.warn("Failed to cancel audiobook cover body", {
+                coverUrl,
+                error,
+            });
+        }
+        return sendRouteError(res, 404, "Audiobook cover art not found");
+    }
+
+    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+    const contentType = imageResponse.headers.get("content-type");
+    if (contentType) {
+        res.setHeader("Content-Type", contentType);
+    }
+    applyCoverArtCorsHeaders(res, req.headers.origin as string | undefined);
+    res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
+    return res.send(imageBuffer);
+};
+
 const sendResizedNativeCoverResponse = (
     req: ExpressRequest,
     res: ExpressResponse,
@@ -3444,76 +3504,7 @@ router.get<{ id?: string }>(
             // Check if this is an audiobook cover (prefixed with "audiobook__")
             if (decodedUrl.startsWith("audiobook__")) {
                 const audiobookPath = decodedUrl.replace("audiobook__", "");
-
-                // Get Audiobookshelf settings
-                const settings = await getSystemSettings();
-                const audiobookshelfUrl =
-                    settings?.audiobookshelfUrl ||
-                    process.env.AUDIOBOOKSHELF_URL ||
-                    "";
-                const audiobookshelfApiKey =
-                    settings?.audiobookshelfApiKey ||
-                    (config.secretsDbOnly
-                        ? ""
-                        : process.env.AUDIOBOOKSHELF_API_KEY || "");
-                const audiobookshelfBaseUrl = audiobookshelfUrl.replace(
-                    /\/$/,
-                    "",
-                );
-
-                const safeCoverUrl = buildSafeAudiobookCoverUrl(
-                    audiobookPath,
-                    audiobookshelfBaseUrl,
-                );
-                if (!safeCoverUrl) {
-                    logger.warn(
-                        `[COVER-ART] Blocked unsafe audiobook cover path: ${audiobookPath}`,
-                    );
-                    return res
-                        .status(400)
-                        .json({ error: "Invalid audiobook cover path" });
-                }
-                coverUrl = safeCoverUrl;
-
-                // Fetch with authentication
-                logger.debug(
-                    `[COVER-ART] Fetching audiobook cover: ${coverUrl.substring(
-                        0,
-                        100,
-                    )}...`,
-                );
-                const imageResponse = await fetch(coverUrl, {
-                    headers: {
-                        Authorization: `Bearer ${audiobookshelfApiKey}`,
-                        "User-Agent": BRAND_USER_AGENT,
-                    },
-                    signal: AbortSignal.timeout(15000),
-                });
-
-                if (!imageResponse.ok) {
-                    logger.error(
-                        `[COVER-ART] Failed to fetch audiobook cover: ${coverUrl} (${imageResponse.status} ${imageResponse.statusText})`,
-                    );
-                    await imageResponse.body?.cancel().catch(() => {});
-                    return res
-                        .status(404)
-                        .json({ error: "Audiobook cover art not found" });
-                }
-
-                const buffer = await imageResponse.arrayBuffer();
-                const imageBuffer = Buffer.from(buffer);
-                const contentType = imageResponse.headers.get("content-type");
-
-                if (contentType) {
-                    res.setHeader("Content-Type", contentType);
-                }
-                applyCoverArtCorsHeaders(
-                    res,
-                    req.headers.origin as string | undefined,
-                );
-                res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
-
-                return res.send(imageBuffer);
+                return sendAudiobookCover(req, res, audiobookPath);
             }
 
             // Check if this is a native cover (prefixed with "native:")
@@ -3676,75 +3667,7 @@ router.get<{ id?: string }>(
             // Check if this is an audiobook cover (prefixed with "audiobook__")
             if (decodedId.startsWith("audiobook__")) {
                 const audiobookPath = decodedId.replace("audiobook__", "");
-
-                // Get Audiobookshelf settings
-                const settings = await getSystemSettings();
-                const audiobookshelfUrl =
-                    settings?.audiobookshelfUrl ||
-                    process.env.AUDIOBOOKSHELF_URL ||
-                    "";
-                const audiobookshelfApiKey =
-                    settings?.audiobookshelfApiKey ||
-                    (config.secretsDbOnly
-                        ? ""
-                        : process.env.AUDIOBOOKSHELF_API_KEY || "");
-                const audiobookshelfBaseUrl = audiobookshelfUrl.replace(
-                    /\/$/,
-                    "",
-                );
-
-                const safeCoverUrl = buildSafeAudiobookCoverUrl(
-                    audiobookPath,
-                    audiobookshelfBaseUrl,
-                );
-                if (!safeCoverUrl) {
-                    logger.warn(
-                        `[COVER-ART] Blocked unsafe audiobook cover path: ${audiobookPath}`,
-                    );
-                    return res
-                        .status(400)
-                        .json({ error: "Invalid audiobook cover path" });
-                }
-                coverUrl = safeCoverUrl;
-
-                // Fetch with authentication
-                logger.debug(
-                    `[COVER-ART] Fetching audiobook cover: ${coverUrl.substring(
-                        0,
-                        100,
-                    )}...`,
-                );
-                const imageResponse = await fetch(coverUrl, {
-                    headers: {
-                        Authorization: `Bearer ${audiobookshelfApiKey}`,
-                        "User-Agent": BRAND_USER_AGENT,
-                    },
-                    signal: AbortSignal.timeout(15000),
-                });
-
-                if (!imageResponse.ok) {
-                    logger.error(
-                        `[COVER-ART] Failed to fetch audiobook cover: ${coverUrl} (${imageResponse.status} ${imageResponse.statusText})`,
-                    );
-                    return res
-                        .status(404)
-                        .json({ error: "Audiobook cover art not found" });
-                }
-
-                const buffer = await imageResponse.arrayBuffer();
-                const imageBuffer = Buffer.from(buffer);
-                const contentType = imageResponse.headers.get("content-type");
-
-                if (contentType) {
-                    res.setHeader("Content-Type", contentType);
-                }
-                applyCoverArtCorsHeaders(
-                    res,
-                    req.headers.origin as string | undefined,
-                );
-                res.setHeader("Cache-Control", COVER_ART_IMAGE_CACHE_CONTROL);
-
-                return res.send(imageBuffer);
+                return sendAudiobookCover(req, res, audiobookPath);
             }
             // Check if coverId is already a full URL (from Cover Art Archive or elsewhere)
             else if (


### PR DESCRIPTION
Convergence sweep #19 remediation (M10) in `backend/src/routes/library.ts`.

The ID-parameter audiobook-cover branch returned on a non-OK Audiobookshelf fetch **without** consuming or cancelling the response body — the query branch was fixed for this in #330, but the ID branch was missed. Repeated authenticated failures could exhaust the reusable Audiobookshelf connection pool.

Fix: the duplicated query- and ID-form proxy logic is consolidated into one `sendAudiobookCover` helper (scoped logging, sanitized client errors) that cancels the upstream body on every non-OK path; both route branches use it (net −163 lines).

Verification: pre-fix regression reproduced (ID branch called `cancel` 0×); targeted jest 193/193; `tsc --noEmit` clean; canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).