### PR TITLE
fix(helm): AIO secret injection, conditional analyzer PG, opt-in image digest pinning (sweep #19 M11/M12/M14)

### DIFF
--- a/charts/soundspan/templates/_helpers.tpl
+++ b/charts/soundspan/templates/_helpers.tpl
@@ -74,6 +74,22 @@ Secret name
 {{- end }}
 
 {{/*
+Application image reference. A digest takes precedence over the mutable tag.
+Usage: include "soundspan.image" .Values.backend.image
+*/}}
+{{- define "soundspan.image" -}}
+{{- $digest := .digest | default "" -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) -}}
+{{- fail (printf "image.digest must use sha256:<64 lowercase hexadecimal characters>; got %q" $digest) -}}
+{{- end -}}
+{{- printf "%s@%s" .repository $digest -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 PostgreSQL connection URL
 */}}
 {{- define "soundspan.databaseUrl" -}}

--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.aio.terminationGracePeriodSeconds | default 45 }}
       containers:
         - name: soundspan
-          image: "{{ .Values.aio.image.repository }}:{{ .Values.aio.image.tag }}"
+          image: {{ include "soundspan.image" .Values.aio.image | quote }}
           imagePullPolicy: {{ .Values.aio.image.pullPolicy }}
           lifecycle:
             preStop:
@@ -59,6 +59,8 @@ spec:
             "TZ" true
             "SESSION_SECRET" true
             "SETTINGS_ENCRYPTION_KEY" true
+            "INTERNAL_API_SECRET" true
+            "POSTGRES_PASSWORD" true
             "ALLOWED_ORIGINS" true
             "LOG_LEVEL" true
             "DOCS_PUBLIC" true
@@ -103,6 +105,29 @@ spec:
                 secretKeyRef:
                   name: {{ include "soundspan.secretName" . }}
                   key: SETTINGS_ENCRYPTION_KEY
+            {{- end }}
+            {{- if hasKey $aioEnv "INTERNAL_API_SECRET" }}
+            - name: INTERNAL_API_SECRET
+              value: {{ index $aioEnv "INTERNAL_API_SECRET" | quote }}
+            {{- else }}
+            - name: INTERNAL_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "soundspan.secretName" . }}
+                  key: INTERNAL_API_SECRET
+            {{- end }}
+            {{- if hasKey $aioEnv "POSTGRES_PASSWORD" }}
+            - name: POSTGRES_PASSWORD
+              value: {{ index $aioEnv "POSTGRES_PASSWORD" | quote }}
+            {{- else }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "soundspan.secretName" . }}
+                  key: POSTGRES_PASSWORD
+                  {{- if .Values.secrets.existingSecret }}
+                  optional: true
+                  {{- end }}
             {{- end }}
             {{- if hasKey $aioEnv "ALLOWED_ORIGINS" }}
             - name: ALLOWED_ORIGINS

--- a/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
@@ -35,12 +35,13 @@ spec:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: audio-analyzer-clap
-          image: "{{ .Values.audioAnalyzerClap.image.repository }}:{{ .Values.audioAnalyzerClap.image.tag }}"
+          image: {{ include "soundspan.image" .Values.audioAnalyzerClap.image | quote }}
           imagePullPolicy: {{ .Values.audioAnalyzerClap.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- $audioAnalyzerClapEnv := .Values.audioAnalyzerClap.env | default (dict) }}
           {{- $audioAnalyzerClapDefaultBackendURL := printf "http://%s-backend:%v" (include "soundspan.fullname" .) .Values.backend.port }}
+          {{- $audioAnalyzerClapHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
           {{- $audioAnalyzerClapExplicitEnvKeys := dict
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
@@ -56,7 +57,7 @@ spec:
             {{- if hasKey $audioAnalyzerClapEnv "POSTGRES_USER" }}
             - name: POSTGRES_USER
               value: {{ index $audioAnalyzerClapEnv "POSTGRES_USER" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerClapHasPostgresSecretEnv }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -66,7 +67,7 @@ spec:
             {{- if hasKey $audioAnalyzerClapEnv "POSTGRES_PASSWORD" }}
             - name: POSTGRES_PASSWORD
               value: {{ index $audioAnalyzerClapEnv "POSTGRES_PASSWORD" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerClapHasPostgresSecretEnv }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -76,7 +77,7 @@ spec:
             {{- if hasKey $audioAnalyzerClapEnv "POSTGRES_DB" }}
             - name: POSTGRES_DB
               value: {{ index $audioAnalyzerClapEnv "POSTGRES_DB" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerClapHasPostgresSecretEnv }}
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:

--- a/charts/soundspan/templates/individual/audio-analyzer.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer.yaml
@@ -35,11 +35,12 @@ spec:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: audio-analyzer
-          image: "{{ .Values.audioAnalyzer.image.repository }}:{{ .Values.audioAnalyzer.image.tag }}"
+          image: {{ include "soundspan.image" .Values.audioAnalyzer.image | quote }}
           imagePullPolicy: {{ .Values.audioAnalyzer.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- $audioAnalyzerEnv := .Values.audioAnalyzer.env | default (dict) }}
+          {{- $audioAnalyzerHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
           {{- $audioAnalyzerExplicitEnvKeys := dict
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
@@ -53,7 +54,7 @@ spec:
             {{- if hasKey $audioAnalyzerEnv "POSTGRES_USER" }}
             - name: POSTGRES_USER
               value: {{ index $audioAnalyzerEnv "POSTGRES_USER" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerHasPostgresSecretEnv }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -63,7 +64,7 @@ spec:
             {{- if hasKey $audioAnalyzerEnv "POSTGRES_PASSWORD" }}
             - name: POSTGRES_PASSWORD
               value: {{ index $audioAnalyzerEnv "POSTGRES_PASSWORD" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerHasPostgresSecretEnv }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -73,7 +74,7 @@ spec:
             {{- if hasKey $audioAnalyzerEnv "POSTGRES_DB" }}
             - name: POSTGRES_DB
               value: {{ index $audioAnalyzerEnv "POSTGRES_DB" | quote }}
-            {{- else }}
+            {{- else if $audioAnalyzerHasPostgresSecretEnv }}
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: backend-worker
-          image: "{{ .Values.backendWorker.image.repository }}:{{ .Values.backendWorker.image.tag }}"
+          image: {{ include "soundspan.image" .Values.backendWorker.image | quote }}
           imagePullPolicy: {{ .Values.backendWorker.image.pullPolicy }}
           ports:
             - name: health

--- a/charts/soundspan/templates/individual/backend.yaml
+++ b/charts/soundspan/templates/individual/backend.yaml
@@ -65,7 +65,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds | default 45 }}
       containers:
         - name: backend
-          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          image: {{ include "soundspan.image" .Values.backend.image | quote }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}

--- a/charts/soundspan/templates/individual/frontend.yaml
+++ b/charts/soundspan/templates/individual/frontend.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds | default 30 }}
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          image: {{ include "soundspan.image" .Values.frontend.image | quote }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}

--- a/charts/soundspan/templates/individual/tidal.yaml
+++ b/charts/soundspan/templates/individual/tidal.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: tidal
-          image: "{{ .Values.tidalSidecar.image.repository }}:{{ .Values.tidalSidecar.image.tag }}"
+          image: {{ include "soundspan.image" .Values.tidalSidecar.image | quote }}
           imagePullPolicy: {{ .Values.tidalSidecar.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}

--- a/charts/soundspan/templates/individual/ytmusic.yaml
+++ b/charts/soundspan/templates/individual/ytmusic.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: ytmusic
-          image: "{{ .Values.ytmusicStreamer.image.repository }}:{{ .Values.ytmusicStreamer.image.tag }}"
+          image: {{ include "soundspan.image" .Values.ytmusicStreamer.image | quote }}
           imagePullPolicy: {{ .Values.ytmusicStreamer.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -90,6 +90,8 @@ aio:
   image:
     repository: ghcr.io/soundspan/soundspan
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: IfNotPresent
   # Grace window + preStop sleep to drain requests before pod shutdown.
   terminationGracePeriodSeconds: 45
@@ -148,6 +150,8 @@ backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   # -- Backend process role. Leave empty for auto:
   #    - "all" when backendWorker is disabled
@@ -223,6 +227,8 @@ backendWorker:
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   # -- Worker process role override. Defaults to "worker".
   processRole: ""
@@ -276,6 +282,8 @@ frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   replicas: 1
   strategy:
@@ -404,6 +412,8 @@ tidalSidecar:
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   port: 8585
   resources:
@@ -431,6 +441,8 @@ ytmusicStreamer:
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   port: 8586
   resources:
@@ -500,6 +512,8 @@ audioAnalyzer:
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   resources:
     requests:
@@ -556,6 +570,8 @@ audioAnalyzerClap:
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer-clap
     tag: 1.9.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
     pullPolicy: Always
   resources:
     requests:
@@ -798,12 +814,3 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
-
-
-
-
-
-
-
-
-

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -34,16 +34,39 @@ assert_service_selectors_isolated() {
   fi
 }
 
+assert_deployment_image() {
+  local render_name="$1"
+  local manifest_file="$2"
+  local deployment_name="$3"
+  local expected_image="$4"
+
+  if ! DEPLOYMENT_NAME="$deployment_name" EXPECTED_IMAGE="$expected_image" perl -0777 -ne '
+      for my $doc (split /^---/m, $_) {
+          next unless $doc =~ /kind:\s*Deployment/;
+          next unless $doc =~ /^  name: \Q$ENV{DEPLOYMENT_NAME}\E$/m;
+          exit 0 if $doc =~ /^          image: "\Q$ENV{EXPECTED_IMAGE}\E"$/m;
+      }
+      exit 1' "$manifest_file"; then
+    echo "[ERROR] ${render_name} missing digest-bound image ${expected_image}" >&2
+    exit 1
+  fi
+}
+
 tmp_aio="$(mktemp)"
 tmp_aio_sidecars="$(mktemp)"
+tmp_aio_rotated_secrets="$(mktemp)"
+tmp_aio_secret_overrides="$(mktemp)"
+tmp_aio_digests="$(mktemp)"
 tmp_individual_ha="$(mktemp)"
+tmp_individual_external_database="$(mktemp)"
+tmp_individual_digests="$(mktemp)"
 tmp_global_env="$(mktemp)"
 tmp_sidecars="$(mktemp)"
 tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_individual_ha" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_digests" "$tmp_individual_ha" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -59,6 +82,73 @@ if ! line_match '^  name: '"$RELEASE_NAME"'$' "$tmp_aio"; then
   exit 1
 fi
 assert_service_selectors_isolated "default AIO" "$tmp_aio"
+
+for key in INTERNAL_API_SECRET POSTGRES_PASSWORD; do
+  if ! perl -0777 -ne '
+      for my $doc (split /^---/m, $_) {
+          next unless $doc =~ /kind:\s*Deployment/;
+          next unless $doc =~ /^  name: '"$RELEASE_NAME"'$/m;
+          exit 0 if $doc =~ /name:\s+'"$key"'\s+valueFrom:\s+secretKeyRef:\s+name:\s+'"$RELEASE_NAME"'\s+key:\s+'"$key"'/s;
+      }
+      exit 1' "$tmp_aio"; then
+    echo "[ERROR] AIO Deployment missing ${key} secretKeyRef" >&2
+    exit 1
+  fi
+done
+
+echo "[CHECK] render AIO secret rotations with optional HTTP sidecars"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set secrets.internalApiSecret=rotated-internal-secret \
+  --set secrets.postgresPassword=rotated-postgres-password \
+  --set tidalSidecar.enabled=true \
+  --set ytmusicStreamer.enabled=true \
+  >"$tmp_aio_rotated_secrets"
+
+for expected_secret in \
+  'INTERNAL_API_SECRET: "rotated-internal-secret"' \
+  'POSTGRES_PASSWORD: "rotated-postgres-password"'; do
+  if ! line_match "^  ${expected_secret}$" "$tmp_aio_rotated_secrets"; then
+    echo "[ERROR] explicit Secret rotation missing ${expected_secret}" >&2
+    exit 1
+  fi
+done
+for deployment in "$RELEASE_NAME" "${RELEASE_NAME}-tidal" "${RELEASE_NAME}-ytmusic"; do
+  if ! DEPLOYMENT_NAME="$deployment" SECRET_NAME="$RELEASE_NAME" perl -0777 -ne '
+      for my $doc (split /^---/m, $_) {
+          next unless $doc =~ /kind:\s*Deployment/;
+          next unless $doc =~ /^  name: \Q$ENV{DEPLOYMENT_NAME}\E$/m;
+          exit 0 if $doc =~ /name:\s+INTERNAL_API_SECRET\s+valueFrom:\s+secretKeyRef:\s+name:\s+\Q$ENV{SECRET_NAME}\E\s+key:\s+INTERNAL_API_SECRET/s;
+      }
+      exit 1' "$tmp_aio_rotated_secrets"; then
+    echo "[ERROR] ${deployment} does not consume the rotated chart INTERNAL_API_SECRET" >&2
+    exit 1
+  fi
+done
+
+echo "[CHECK] render explicit AIO secret env overrides"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set aio.env.INTERNAL_API_SECRET=aio-internal-override \
+  --set aio.env.POSTGRES_PASSWORD=aio-postgres-override \
+  >"$tmp_aio_secret_overrides"
+
+for expected_override in \
+  'INTERNAL_API_SECRET\s+value:\s+"aio-internal-override"' \
+  'POSTGRES_PASSWORD\s+value:\s+"aio-postgres-override"'; do
+  if ! perl -0777 -ne 'exit(/name:\s+'"$expected_override"'/s ? 0 : 1)' "$tmp_aio_secret_overrides"; then
+    echo "[ERROR] AIO explicit env override missing for ${expected_override%%\\*}" >&2
+    exit 1
+  fi
+done
+if ! perl -0777 -ne '
+    for my $doc (split /^---/m, $_) {
+        next unless $doc =~ /kind:\s*Deployment/;
+        next unless $doc =~ /^  name: '"$RELEASE_NAME"'$/m;
+        exit 0 if $doc !~ /name:\s+(?:INTERNAL_API_SECRET|POSTGRES_PASSWORD)\s+valueFrom:/s;
+    }
+    exit 1' "$tmp_aio_secret_overrides"; then
+  echo "[ERROR] AIO explicit secret env overrides rendered duplicate secretKeyRefs" >&2
+  exit 1
+fi
 
 echo "[CHECK] render AIO mode with HTTP sidecars for Service selector isolation"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
@@ -91,6 +181,80 @@ if ! perl -0777 -ne 'exit((/name:\s+LISTEN_TOGETHER_STATE_STORE_ENABLED\s+value:
   exit 1
 fi
 assert_service_selectors_isolated "HA individual" "$tmp_individual_ha"
+
+echo "[CHECK] render analyzers with external DATABASE_URL and core-only existing Secret"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  --set postgresql.enabled=false \
+  --set postgresql.external.url='postgresql://external-user:external-password@database.example.com:5432/soundspan?sslmode=require' \
+  --set secrets.existingSecret=core-only-secret \
+  --set audioAnalyzer.enabled=true \
+  --set audioAnalyzerClap.enabled=true \
+  >"$tmp_individual_external_database"
+
+for analyzer in audio-analyzer audio-analyzer-clap; do
+  if ! perl -0777 -ne '
+      for my $doc (split /^---/m, $_) {
+          next unless $doc =~ /kind:\s*Deployment/;
+          next unless $doc =~ /^  name: '"$RELEASE_NAME"'-'"$analyzer"'$/m;
+          next if $doc =~ /name:\s+POSTGRES_(?:USER|PASSWORD|DB)\b/;
+          exit 0 if $doc =~ /name:\s+DATABASE_URL\s+value:\s+"postgresql:\/\/external-user:external-password\@database\.example\.com:5432\/soundspan\?sslmode=require"/s;
+      }
+      exit 1' "$tmp_individual_external_database"; then
+    echo "[ERROR] ${analyzer} must use external DATABASE_URL without POSTGRES_* secret refs" >&2
+    exit 1
+  fi
+done
+
+digest_aio="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+digest_backend="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+digest_worker="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+digest_frontend="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+digest_tidal="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+digest_ytmusic="sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+digest_analyzer="sha256:1111111111111111111111111111111111111111111111111111111111111111"
+digest_clap="sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+echo "[CHECK] render AIO application image by digest"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set aio.image.digest="$digest_aio" \
+  >"$tmp_aio_digests"
+assert_deployment_image \
+  "AIO Deployment" \
+  "$tmp_aio_digests" \
+  "$RELEASE_NAME" \
+  "ghcr.io/soundspan/soundspan@${digest_aio}"
+
+echo "[CHECK] render every individual application image by digest"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  --set backendWorker.enabled=true \
+  --set tidalSidecar.enabled=true \
+  --set ytmusicStreamer.enabled=true \
+  --set audioAnalyzer.enabled=true \
+  --set audioAnalyzerClap.enabled=true \
+  --set backend.image.digest="$digest_backend" \
+  --set backendWorker.image.digest="$digest_worker" \
+  --set frontend.image.digest="$digest_frontend" \
+  --set tidalSidecar.image.digest="$digest_tidal" \
+  --set ytmusicStreamer.image.digest="$digest_ytmusic" \
+  --set audioAnalyzer.image.digest="$digest_analyzer" \
+  --set audioAnalyzerClap.image.digest="$digest_clap" \
+  >"$tmp_individual_digests"
+
+assert_deployment_image "backend Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-backend" "ghcr.io/soundspan/soundspan-backend@${digest_backend}"
+assert_deployment_image "backend-worker Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-backend-worker" "ghcr.io/soundspan/soundspan-backend-worker@${digest_worker}"
+assert_deployment_image "frontend Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-frontend" "ghcr.io/soundspan/soundspan-frontend@${digest_frontend}"
+assert_deployment_image "TIDAL Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-tidal" "ghcr.io/soundspan/soundspan-tidal-downloader@${digest_tidal}"
+assert_deployment_image "YT Music Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-ytmusic" "ghcr.io/soundspan/soundspan-ytmusic-streamer@${digest_ytmusic}"
+assert_deployment_image "audio analyzer Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-audio-analyzer" "ghcr.io/soundspan/soundspan-audio-analyzer@${digest_analyzer}"
+assert_deployment_image "CLAP analyzer Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-audio-analyzer-clap" "ghcr.io/soundspan/soundspan-audio-analyzer-clap@${digest_clap}"
+
+echo "[CHECK] reject malformed application image digests"
+if helm template "$RELEASE_NAME" "$CHART_PATH" --set aio.image.digest=sha256:not-a-digest >/dev/null 2>&1; then
+  echo "[ERROR] malformed application image digest was accepted" >&2
+  exit 1
+fi
 
 echo "[CHECK] render global.env config map + envFrom wiring"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
@@ -174,6 +338,16 @@ helm template "$RELEASE_NAME" "$CHART_PATH" \
   >"$tmp_secret_existing"
 if line_match '^kind: Secret$' "$tmp_secret_existing"; then
   echo "[ERROR] existingSecret set but chart still rendered a managed Secret" >&2
+  exit 1
+fi
+if ! perl -0777 -ne '
+    for my $doc (split /^---/m, $_) {
+        next unless $doc =~ /kind:\s*Deployment/;
+        next unless $doc =~ /^  name: '"$RELEASE_NAME"'$/m;
+        exit 0 if $doc =~ /name:\s+POSTGRES_PASSWORD\s+valueFrom:\s+secretKeyRef:\s+name:\s+external-secret\s+key:\s+POSTGRES_PASSWORD\s+optional:\s+true/s;
+    }
+    exit 1' "$tmp_secret_existing"; then
+  echo "[ERROR] AIO existingSecret POSTGRES_PASSWORD reference must remain optional" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Convergence sweep #19 remediation across `charts/soundspan/**`.

**M11 — AIO missing chart-managed secrets.** The chart creates `INTERNAL_API_SECRET` and `POSTGRES_PASSWORD`, but the AIO pod received neither: AIO generated volume-local values while optional TIDAL/YouTube sidecars used the *chart* secret and were rejected by the backend, and configured Postgres password rotations were silently ignored. AIO now consumes both chart-managed secrets, honors `aio.env` overrides, and keeps Postgres optional for documented core-only external Secrets.

**M12 — analyzer PG keys required under external DATABASE_URL.** Both analyzer templates referenced `POSTGRES_USER/PASSWORD/DB` unconditionally even with a complete `postgresql.external.url`, leaving pods in `CreateContainerConfigError` when the `existingSecret` held only core keys. They now use the backend's conditional Postgres-secret logic.

**M14 — no digest binding for application images.** Application workloads rendered `repository:tag` only, so a moved tag could deploy bytes different from the reviewed release despite digest-pinned base images. Added optional per-workload `sha256` digest values and a shared `soundspan.image` renderer — `repository@sha256:…` when a digest is set, else `repository:tag` — across AIO, backend, worker, frontend, TIDAL, YouTube Music, and both analyzers; malformed digests fail rendering. **Opt-in** (`digest: ""` default preserves current behavior), so existing installs are unaffected.

Verification: `npm run verify:helm` exit 0 (lint + all render assertions, including rotation, sidecar secret sharing, overrides, external-URL analyzers, all 8 digest-bound images, malformed-digest rejection, core-only Secrets); `bash -n` + prettier + `git diff --check` clean. No CHANGELOG edit (consolidated docs PR follows).