### PR TITLE
fix(supply-chain): pin contract TypeScript and drop live pip upgrade (sweep #19 M13)

### DIFF
--- a/packages/media-metadata-contract/package-lock.json
+++ b/packages/media-metadata-contract/package-lock.json
@@ -8,7 +8,8 @@
             "name": "@soundspan/media-metadata-contract",
             "version": "1.0.0",
             "devDependencies": {
-                "prettier": "3.8.2"
+                "prettier": "3.8.2",
+                "typescript": "6.0.3"
             },
             "engines": {
                 "node": ">=24.0.0"
@@ -28,6 +29,20 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         }
     }

--- a/packages/media-metadata-contract/package.json
+++ b/packages/media-metadata-contract/package.json
@@ -11,10 +11,10 @@
         "dist"
     ],
     "scripts": {
-        "build": "npm exec --yes --package typescript -- tsc -p tsconfig.json",
+        "build": "tsc -p tsconfig.json",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
-        "typecheck": "npm exec --yes --package typescript -- tsc -p tsconfig.json --noEmit"
+        "typecheck": "tsc -p tsconfig.json --noEmit"
     },
     "exports": {
         ".": {
@@ -23,6 +23,7 @@
         }
     },
     "devDependencies": {
-        "prettier": "3.8.2"
+        "prettier": "3.8.2",
+        "typescript": "6.0.3"
     }
 }

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -26,9 +26,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip
-RUN pip3 install --upgrade pip setuptools wheel
-
 WORKDIR /app
 
 # Install ALL Python dependencies from the hash-pinned lock (roadmap F50) so a


### PR DESCRIPTION
Convergence sweep #19 remediation (M13). Two build steps let unchanged source execute different registry code:
- the `media-metadata-contract` build/typecheck invoked tsc via `npm exec --yes --package typescript`, downloading an **unversioned, unlocked** TypeScript on every build;
- the `audio-analyzer` Dockerfile ran `pip install --upgrade pip setuptools wheel` with no versions/hashes before its otherwise hash-locked install.

Fix
- TypeScript is now an exact `devDependency` (`6.0.3`) recorded with integrity in `package-lock.json`; `build`/`typecheck` call the locally-installed `tsc`.
- The live pip/setuptools/wheel upgrade is removed; the analyzer image installs only its hash-locked requirements.

Verification: offline `npm ci` + build + typecheck pass (0 audit vulns); the newly-wired dockerfile-hygiene suite (#349) passes 6/6; audio-analyzer pytest 27/27 under the CI Python env; ruff clean. No CHANGELOG edit (consolidated docs PR follows).