### PR TITLE
docs(api): align OpenAPI playlist/play schemas with supported remote-media contracts (sweep #19 M17)

### DIFF
--- a/backend/src/config/__tests__/remoteMediaOpenapiContract.test.ts
+++ b/backend/src/config/__tests__/remoteMediaOpenapiContract.test.ts
@@ -1,0 +1,227 @@
+jest.mock("../../config", () => ({ config: { port: 3006 } }));
+
+type PropertySchema = {
+    type?: "array" | "boolean" | "integer" | "number" | "object" | "string";
+    minimum?: number;
+    minLength?: number;
+    maxLength?: number;
+    items?: PropertySchema;
+};
+
+type RequestSchema = {
+    required?: string[];
+    properties?: Record<string, PropertySchema>;
+    oneOf?: RequestSchema[];
+    anyOf?: RequestSchema[];
+    not?: { anyOf?: RequestSchema[] };
+};
+
+function hasRequiredFields(
+    schema: RequestSchema,
+    payload: Record<string, unknown>,
+): boolean {
+    return (schema.required ?? []).every(
+        (field) => payload[field] !== undefined,
+    );
+}
+
+function matchesScalarProperty(
+    schema: PropertySchema,
+    value: unknown,
+): boolean {
+    if (schema.type === "integer") {
+        return (
+            typeof value === "number" &&
+            Number.isInteger(value) &&
+            (schema.minimum === undefined || value >= schema.minimum)
+        );
+    }
+    if (schema.type === "string") {
+        return (
+            typeof value === "string" &&
+            (schema.minLength === undefined ||
+                value.length >= schema.minLength) &&
+            (schema.maxLength === undefined || value.length <= schema.maxLength)
+        );
+    }
+    if (schema.type === "boolean") return typeof value === "boolean";
+    return true;
+}
+
+function matchesProperty(schema: PropertySchema, value: unknown): boolean {
+    if (schema.type !== "array") return matchesScalarProperty(schema, value);
+    if (!Array.isArray(value)) return false;
+    return value.every((entry) =>
+        schema.items ? matchesScalarProperty(schema.items, entry) : true,
+    );
+}
+
+function matchesVariant(
+    schema: RequestSchema,
+    payload: Record<string, unknown>,
+): boolean {
+    if (!hasRequiredFields(schema, payload)) return false;
+    if (
+        schema.not?.anyOf?.some((excluded) =>
+            hasRequiredFields(excluded, payload),
+        )
+    ) {
+        return false;
+    }
+    return Object.entries(payload).every(([field, value]) => {
+        const propertySchema = schema.properties?.[field];
+        return propertySchema ? matchesProperty(propertySchema, value) : true;
+    });
+}
+
+function acceptsOneOf(
+    schema: RequestSchema,
+    payload: Record<string, unknown>,
+): boolean {
+    return (
+        schema.oneOf?.filter((variant) => matchesVariant(variant, payload))
+            .length === 1
+    );
+}
+
+function acceptsAnyOf(
+    schema: RequestSchema,
+    payload: Record<string, unknown>,
+): boolean {
+    const matchesAlternative = schema.anyOf?.some((alternative) =>
+        hasRequiredFields(alternative, payload),
+    );
+    return Boolean(matchesAlternative && matchesVariant(schema, payload));
+}
+
+function requestSchema(path: string, method: "post" | "put"): RequestSchema {
+    const { swaggerSpec } = require("../swagger");
+    const schema = swaggerSpec.paths?.[path]?.[method]?.requestBody?.content?.[
+        "application/json"
+    ]?.schema as RequestSchema | undefined;
+
+    expect(schema).toBeDefined();
+    return schema as RequestSchema;
+}
+
+function variantProperties(
+    schema: RequestSchema,
+    identifier: string,
+): string[] {
+    const variant = schema.oneOf?.find((candidate) =>
+        candidate.required?.includes(identifier),
+    );
+    expect(variant).toBeDefined();
+    return Object.keys(variant?.properties ?? {});
+}
+
+const tidalRequest = {
+    tidalTrackId: 991,
+    title: "TIDAL Song",
+    artist: "TIDAL Artist",
+    album: "TIDAL Album",
+    duration: 245,
+};
+
+const youtubeRequest = {
+    youtubeVideoId: "video-7",
+    title: "YouTube Song",
+    artist: "YouTube Artist",
+    album: "YouTube Album",
+    duration: 199,
+    thumbnailUrl: "https://img.example/video-7.jpg",
+};
+
+describe("remote-media OpenAPI request contracts", () => {
+    test("playlist add exposes every supported remote-media field", () => {
+        const schema = requestSchema("/api/playlists/{id}/items", "post");
+        const remoteFields = [
+            "title",
+            "artist",
+            "album",
+            "duration",
+            "isrc",
+            "quality",
+            "explicit",
+            "thumbnailUrl",
+        ];
+
+        expect(variantProperties(schema, "tidalTrackId")).toEqual(
+            expect.arrayContaining(["tidalTrackId", ...remoteFields]),
+        );
+        expect(variantProperties(schema, "youtubeVideoId")).toEqual(
+            expect.arrayContaining(["youtubeVideoId", ...remoteFields]),
+        );
+    });
+
+    test.each([
+        ["local", { trackId: "track-1" }, true],
+        ["TIDAL", tidalRequest, true],
+        ["YouTube", youtubeRequest, true],
+        ["missing remote metadata", { tidalTrackId: 991 }, false],
+        ["no identifier", { title: "No ID" }, false],
+        [
+            "conflicting identifiers",
+            { trackId: "track-1", ...tidalRequest },
+            false,
+        ],
+    ])("playlist add documents the %s request", (_label, payload, accepted) => {
+        const schema = requestSchema("/api/playlists/{id}/items", "post");
+
+        expect(acceptsOneOf(schema, payload)).toBe(accepted);
+    });
+
+    test.each([
+        ["local", { trackId: "track-1" }, true],
+        ["TIDAL", tidalRequest, true],
+        ["YouTube", youtubeRequest, true],
+        ["missing remote metadata", { youtubeVideoId: "video-7" }, false],
+        ["no identifier", {}, false],
+        [
+            "conflicting identifiers",
+            { youtubeVideoId: "video-7", ...tidalRequest },
+            false,
+        ],
+    ])("play logging documents the %s request", (_label, payload, accepted) => {
+        const schema = requestSchema("/api/plays", "post");
+
+        expect(acceptsOneOf(schema, payload)).toBe(accepted);
+    });
+
+    test("play logging exposes required remote metadata and thumbnails", () => {
+        const schema = requestSchema("/api/plays", "post");
+        const remoteFields = [
+            "title",
+            "artist",
+            "album",
+            "duration",
+            "thumbnailUrl",
+        ];
+
+        expect(variantProperties(schema, "tidalTrackId")).toEqual(
+            expect.arrayContaining(["tidalTrackId", ...remoteFields]),
+        );
+        expect(variantProperties(schema, "youtubeVideoId")).toEqual(
+            expect.arrayContaining(["youtubeVideoId", ...remoteFields]),
+        );
+    });
+
+    test.each([
+        ["mixed-source item IDs", { itemIds: ["item-2", "item-1"] }, true],
+        ["legacy local track IDs", { trackIds: ["track-2", "track-1"] }, true],
+        [
+            "both arrays with item IDs preferred",
+            { itemIds: ["item-2"], trackIds: ["track-2"] },
+            true,
+        ],
+        ["neither array", {}, false],
+        ["invalid item IDs", { itemIds: "item-1" }, false],
+    ])("playlist reorder documents %s", (_label, payload, accepted) => {
+        const schema = requestSchema(
+            "/api/playlists/{id}/items/reorder",
+            "put",
+        );
+
+        expect(acceptsAnyOf(schema, payload)).toBe(accepted);
+    });
+});

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -791,12 +791,90 @@ router.delete("/:id", async (req, res) => {
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             required:
- *               - trackId
- *             properties:
- *               trackId:
- *                 type: string
+ *             oneOf:
+ *               - type: object
+ *                 required: [trackId]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [tidalTrackId]
+ *                     - required: [youtubeVideoId]
+ *                 properties:
+ *                   trackId:
+ *                     type: string
+ *                     minLength: 1
+ *                     description: Local library track ID
+ *               - type: object
+ *                 required: [tidalTrackId, title, artist, album, duration]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [trackId]
+ *                     - required: [youtubeVideoId]
+ *                 properties:
+ *                   tidalTrackId:
+ *                     type: integer
+ *                     minimum: 1
+ *                   title:
+ *                     type: string
+ *                     minLength: 1
+ *                   artist:
+ *                     type: string
+ *                     minLength: 1
+ *                   album:
+ *                     type: string
+ *                     minLength: 1
+ *                   duration:
+ *                     type: integer
+ *                     minimum: 0
+ *                     description: Track duration in seconds
+ *                   isrc:
+ *                     type: string
+ *                     minLength: 1
+ *                     maxLength: 64
+ *                   quality:
+ *                     type: string
+ *                     minLength: 1
+ *                     maxLength: 64
+ *                   explicit:
+ *                     type: boolean
+ *                   thumbnailUrl:
+ *                     type: string
+ *                     minLength: 1
+ *               - type: object
+ *                 required: [youtubeVideoId, title, artist, album, duration]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [trackId]
+ *                     - required: [tidalTrackId]
+ *                 properties:
+ *                   youtubeVideoId:
+ *                     type: string
+ *                     minLength: 1
+ *                   title:
+ *                     type: string
+ *                     minLength: 1
+ *                   artist:
+ *                     type: string
+ *                     minLength: 1
+ *                   album:
+ *                     type: string
+ *                     minLength: 1
+ *                   duration:
+ *                     type: integer
+ *                     minimum: 0
+ *                     description: Track duration in seconds
+ *                   isrc:
+ *                     type: string
+ *                     minLength: 1
+ *                     maxLength: 64
+ *                   quality:
+ *                     type: string
+ *                     minLength: 1
+ *                     maxLength: 64
+ *                   explicit:
+ *                     type: boolean
+ *                   thumbnailUrl:
+ *                     type: string
+ *                     minLength: 1
  *     responses:
  *       200:
  *         description: Track added to playlist (or already exists)
@@ -1068,19 +1146,25 @@ router.delete("/:id/items/:trackId", async (req, res) => {
  *         application/json:
  *           schema:
  *             type: object
- *             required:
- *               - trackIds
  *             properties:
+ *               itemIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Playlist item IDs in the desired order. Use for remote or mixed-source playlists; preferred when both arrays are present.
  *               trackIds:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: Array of track IDs in the desired order
+ *                 description: Legacy local-library track IDs in the desired order
+ *             anyOf:
+ *               - required: [itemIds]
+ *               - required: [trackIds]
  *     responses:
  *       200:
  *         description: Playlist reordered
  *       400:
- *         description: trackIds must be an array
+ *         description: itemIds or trackIds must be an array
  *       403:
  *         description: Access denied
  *       404:

--- a/backend/src/routes/plays.ts
+++ b/backend/src/routes/plays.ts
@@ -235,12 +235,70 @@ router.delete("/history", async (req, res) => {
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             required:
- *               - trackId
- *             properties:
- *               trackId:
- *                 type: string
+ *             oneOf:
+ *               - type: object
+ *                 required: [trackId]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [tidalTrackId]
+ *                     - required: [youtubeVideoId]
+ *                 properties:
+ *                   trackId:
+ *                     type: string
+ *                     minLength: 1
+ *                     description: Local library track ID
+ *               - type: object
+ *                 required: [tidalTrackId, title, artist, album, duration]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [trackId]
+ *                     - required: [youtubeVideoId]
+ *                 properties:
+ *                   tidalTrackId:
+ *                     type: integer
+ *                     minimum: 1
+ *                   title:
+ *                     type: string
+ *                     minLength: 1
+ *                   artist:
+ *                     type: string
+ *                     minLength: 1
+ *                   album:
+ *                     type: string
+ *                     minLength: 1
+ *                   duration:
+ *                     type: integer
+ *                     minimum: 0
+ *                     description: Track duration in seconds
+ *                   thumbnailUrl:
+ *                     type: string
+ *                     minLength: 1
+ *               - type: object
+ *                 required: [youtubeVideoId, title, artist, album, duration]
+ *                 not:
+ *                   anyOf:
+ *                     - required: [trackId]
+ *                     - required: [tidalTrackId]
+ *                 properties:
+ *                   youtubeVideoId:
+ *                     type: string
+ *                     minLength: 1
+ *                   title:
+ *                     type: string
+ *                     minLength: 1
+ *                   artist:
+ *                     type: string
+ *                     minLength: 1
+ *                   album:
+ *                     type: string
+ *                     minLength: 1
+ *                   duration:
+ *                     type: integer
+ *                     minimum: 0
+ *                     description: Track duration in seconds
+ *                   thumbnailUrl:
+ *                     type: string
+ *                     minLength: 1
  *     responses:
  *       200:
  *         description: Play logged successfully


### PR DESCRIPTION
Convergence sweep #19 remediation (M17). The published OpenAPI request schemas required local `trackId`/`trackIds`, but the runtime and frontend also support TIDAL and YouTube identifiers plus mixed-source `itemIds`. Generated clients therefore couldn't add/log remote tracks or correctly reorder mixed-source playlists; `plays.ts` had the same local-only drift.

Fix (annotation + contract tests only — no request-handling logic changed)
- `playlists.ts`: local/TIDAL/YouTube `oneOf` request schemas with required remote metadata and optional remote fields; documented mixed-source `itemIds`, legacy `trackIds`, and both-array precedence.
- `plays.ts`: equivalent local/TIDAL/YouTube play-log schemas.
- Generated-spec behavioral coverage: valid, incomplete, conflicting, mixed-source requests.

The runtime-generated `swaggerSpec` now matches actual behavior. Verification: jest 98/98; `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).