### PR TITLE
fix(reliability): durable worker-queue execution for generic import jobs (sweep #19 M15)

### DIFF
--- a/backend/src/services/__tests__/genericImportJobRunner.test.ts
+++ b/backend/src/services/__tests__/genericImportJobRunner.test.ts
@@ -1,9 +1,30 @@
 jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
+    logger: (() => {
+        const scopedLogger = {
+            child: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+        scopedLogger.child.mockReturnValue(scopedLogger);
+        return scopedLogger;
+    })(),
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        importJob: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+
+jest.mock("../../workers/queues", () => ({
+    genericImportQueue: {
+        add: jest.fn(),
+        getJob: jest.fn(),
+        isReady: jest.fn(),
     },
 }));
 
@@ -21,6 +42,9 @@ jest.mock("../playlistImportService", () => ({
     },
 }));
 
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import { genericImportQueue } from "../../workers/queues";
 import { importJobStore } from "../importJobStore";
 import { playlistImportService } from "../playlistImportService";
 import { genericImportJobRunner } from "../genericImportJobRunner";
@@ -31,9 +55,225 @@ describe("generic import job runner", () => {
     const mockPreviewImport = playlistImportService.previewImport as jest.Mock;
     const mockImportPlaylist =
         playlistImportService.importPlaylist as jest.Mock;
+    const mockQueueAdd = genericImportQueue.add as jest.Mock;
+    const mockQueueGetJob = genericImportQueue.getJob as jest.Mock;
+    const mockQueueReady = genericImportQueue.isReady as jest.Mock;
+    const mockFindMany = prisma.importJob.findMany as jest.Mock;
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockQueueAdd.mockResolvedValue({ id: "queued-job" });
+        mockQueueGetJob.mockResolvedValue(null);
+        mockQueueReady.mockResolvedValue(undefined);
+        mockFindMany.mockResolvedValue([]);
+    });
+
+    it("durably enqueues a persisted job with a stable queue identity", async () => {
+        genericImportJobRunner.enqueue("job-durable");
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "generic-import-run",
+            { jobId: "job-durable" },
+            { jobId: "job-durable" },
+        );
+    });
+
+    it("coalesces duplicate submissions onto the existing durable queue job", async () => {
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("waiting"),
+        });
+
+        genericImportJobRunner.enqueue("job-already-queued");
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(mockQueueAdd).not.toHaveBeenCalled();
+        expect(mockUpdateJob).not.toHaveBeenCalled();
+    });
+
+    it("logs queue persistence failures without leaking an unhandled rejection", async () => {
+        const queueError = new Error("redis credentials rejected");
+        mockQueueAdd.mockRejectedValueOnce(queueError);
+
+        genericImportJobRunner.enqueue("job-queue-failure");
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(logger.error).toHaveBeenCalledWith(
+            "Failed to enqueue persisted import job",
+            expect.objectContaining({
+                jobId: "job-queue-failure",
+                error: queueError,
+            }),
+        );
+    });
+
+    it("requeues a bounded batch of active persisted jobs for recovery", async () => {
+        mockFindMany.mockResolvedValueOnce([
+            { id: "pending-job" },
+            { id: "resolving-job" },
+            { id: "creating-job" },
+            { id: "cancelling-job" },
+        ]);
+
+        await expect(genericImportJobRunner.recoverActiveJobs()).resolves.toBe(
+            4,
+        );
+
+        expect(mockFindMany).toHaveBeenCalledWith({
+            where: {
+                status: {
+                    in: [
+                        "pending",
+                        "resolving",
+                        "creating_playlist",
+                        "cancelling",
+                    ],
+                },
+            },
+            orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+            select: { id: true },
+            take: 100,
+        });
+        expect(mockQueueAdd).toHaveBeenCalledTimes(4);
+        expect(mockQueueAdd).toHaveBeenNthCalledWith(
+            4,
+            "generic-import-run",
+            { jobId: "cancelling-job" },
+            { jobId: "cancelling-job" },
+        );
+    });
+
+    it("terminalizes stale persisted state when its queue retries were already exhausted", async () => {
+        mockFindMany.mockResolvedValueOnce([{ id: "exhausted-job" }]);
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("failed"),
+        });
+        mockGetJob.mockResolvedValueOnce({
+            id: "exhausted-job",
+            status: "resolving",
+        });
+
+        await expect(genericImportJobRunner.recoverActiveJobs()).resolves.toBe(
+            1,
+        );
+
+        expect(mockQueueAdd).not.toHaveBeenCalled();
+        expect(mockUpdateJob).toHaveBeenCalledWith("exhausted-job", {
+            status: "failed",
+            progress: 100,
+            error: "Generic import job failed",
+        });
+    });
+
+    it("never requeues more than the recovery batch capacity in one sweep", async () => {
+        mockFindMany.mockResolvedValueOnce(
+            Array.from({ length: 101 }, (_, index) => ({
+                id: `bounded-job-${index}`,
+            })),
+        );
+
+        await expect(genericImportJobRunner.recoverActiveJobs()).resolves.toBe(
+            100,
+        );
+
+        expect(mockQueueAdd).toHaveBeenCalledTimes(100);
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            "generic-import-run",
+            { jobId: "bounded-job-100" },
+            expect.anything(),
+        );
+    });
+
+    it("registers bounded startup and periodic recovery jobs", async () => {
+        await genericImportJobRunner.registerRecoveryJobs();
+
+        expect(mockQueueReady).toHaveBeenCalledTimes(1);
+        expect(mockQueueAdd).toHaveBeenNthCalledWith(
+            1,
+            "generic-import-recover",
+            { trigger: "startup" },
+            expect.objectContaining({
+                jobId: "generic-import-recovery:startup",
+                removeOnComplete: true,
+                removeOnFail: true,
+            }),
+        );
+        expect(mockQueueAdd).toHaveBeenNthCalledWith(
+            2,
+            "generic-import-recover",
+            { trigger: "repeat" },
+            expect.objectContaining({
+                jobId: "generic-import-recovery:repeat",
+                repeat: { every: 60_000 },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            }),
+        );
+    });
+
+    it("rethrows retryable failures without prematurely making the job terminal", async () => {
+        mockGetJob.mockResolvedValue({
+            id: "job-retry",
+            userId: "user-1",
+            sourceUrl: "https://open.spotify.com/playlist/abc",
+            requestedPlaylistName: null,
+            status: "pending",
+        });
+        const retryableError = new Error("provider temporarily unavailable");
+        mockPreviewImport.mockRejectedValueOnce(retryableError);
+
+        await expect(
+            genericImportJobRunner.runJob("job-retry", {
+                retryFailures: true,
+                finalAttempt: false,
+            }),
+        ).rejects.toBe(retryableError);
+
+        expect(mockUpdateJob).not.toHaveBeenCalledWith(
+            "job-retry",
+            expect.objectContaining({ status: "failed" }),
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Import job attempt failed; queue retry remains",
+            expect.objectContaining({
+                jobId: "job-retry",
+                error: retryableError,
+            }),
+        );
+    });
+
+    it("stores only a safe failure after queue retries are exhausted", async () => {
+        mockGetJob.mockResolvedValue({
+            id: "job-final-attempt",
+            userId: "user-1",
+            sourceUrl: "https://open.spotify.com/playlist/abc",
+            requestedPlaylistName: null,
+            status: "pending",
+        });
+        const internalError = new Error(
+            "postgresql://admin:secret@db/import failed",
+        );
+        mockPreviewImport.mockRejectedValueOnce(internalError);
+
+        await expect(
+            genericImportJobRunner.runJob("job-final-attempt", {
+                retryFailures: true,
+                finalAttempt: true,
+            }),
+        ).rejects.toBe(internalError);
+
+        expect(mockUpdateJob).toHaveBeenLastCalledWith("job-final-attempt", {
+            status: "failed",
+            progress: 100,
+            error: "Generic import job failed",
+        });
+        expect(logger.error).toHaveBeenCalledWith(
+            "Import job failed",
+            expect.objectContaining({
+                jobId: "job-final-attempt",
+                error: internalError,
+            }),
+        );
     });
 
     it("runs a pending import job through preview and playlist creation", async () => {
@@ -161,7 +401,7 @@ describe("generic import job runner", () => {
         expect(mockUpdateJob).toHaveBeenLastCalledWith("job-1", {
             status: "failed",
             progress: 100,
-            error: "preview failed",
+            error: "Generic import job failed",
         });
     });
 

--- a/backend/src/services/genericImportJobRunner.ts
+++ b/backend/src/services/genericImportJobRunner.ts
@@ -1,7 +1,34 @@
 import { Prisma } from "@prisma/client";
-import { importJobStore } from "./importJobStore";
-import { playlistImportService } from "./playlistImportService";
+import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { genericImportQueue } from "../workers/queues";
+import { importJobStore, type StoredImportJob } from "./importJobStore";
+import { playlistImportService } from "./playlistImportService";
+
+const log = logger.child("GenericImportJobRunner");
+const RUN_JOB_NAME = "generic-import-run";
+const RECOVERY_JOB_NAME = "generic-import-recover";
+const RECOVERY_BATCH_SIZE = 100;
+const RECOVERY_INTERVAL_MS = 60_000;
+const SAFE_FAILURE_MESSAGE = "Generic import job failed";
+const ACTIVE_IMPORT_JOB_STATUSES = [
+    "pending",
+    "resolving",
+    "creating_playlist",
+    "cancelling",
+] as const;
+
+type ImportPreview = Awaited<
+    ReturnType<typeof playlistImportService.previewImport>
+>;
+type ImportExecution = Awaited<
+    ReturnType<typeof playlistImportService.importPlaylist>
+>;
+
+interface RunJobOptions {
+    retryFailures?: boolean;
+    finalAttempt?: boolean;
+}
 
 class ImportJobCancelledError extends Error {}
 
@@ -12,107 +39,236 @@ function isTerminalStatus(status: string): boolean {
 }
 
 /**
- * Detached execution runner for generic import jobs.
+ * Queue-backed execution runner for persisted generic import jobs.
  */
 export class GenericImportJobRunner {
-    private readonly inFlightJobs = new Set<string>();
-
     /**
-     * Schedules an asynchronous run for the given import job id.
+     * Supervises durable queue insertion for an API-created import job.
      */
     enqueue(jobId: string): void {
-        setTimeout(() => {
-            this.runJob(jobId).catch((error) => {
-                logger.error("[ImportJobRunner] Unhandled run error:", error);
+        void this.enqueuePersistedJob(jobId).catch((error) => {
+            log.error("Failed to enqueue persisted import job", {
+                jobId,
+                error,
             });
-        }, 0);
+        });
     }
 
     /**
-     * Executes an import job with persisted progress and terminal state updates.
+     * Registers startup and periodic recovery sweeps in the durable queue.
      */
-    async runJob(jobId: string): Promise<void> {
-        if (this.inFlightJobs.has(jobId)) return;
-        this.inFlightJobs.add(jobId);
+    async registerRecoveryJobs(): Promise<void> {
+        await genericImportQueue.isReady();
+        const startupRegistration = genericImportQueue.add(
+            RECOVERY_JOB_NAME,
+            { trigger: "startup" },
+            {
+                jobId: "generic-import-recovery:startup",
+                removeOnComplete: true,
+                removeOnFail: true,
+            },
+        );
+        const repeatRegistration = genericImportQueue.add(
+            RECOVERY_JOB_NAME,
+            { trigger: "repeat" },
+            {
+                jobId: "generic-import-recovery:repeat",
+                repeat: { every: RECOVERY_INTERVAL_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
+        await Promise.all([startupRegistration, repeatRegistration]);
+    }
 
-        try {
-            const initialJob = await importJobStore.getJob(jobId);
-            if (!initialJob || isTerminalStatus(initialJob.status)) {
-                return;
+    /**
+     * Requeues one bounded batch of persisted active jobs after delivery gaps or restarts.
+     */
+    async recoverActiveJobs(): Promise<number> {
+        const jobs = await prisma.importJob.findMany({
+            where: { status: { in: [...ACTIVE_IMPORT_JOB_STATUSES] } },
+            orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+            select: { id: true },
+            take: RECOVERY_BATCH_SIZE,
+        });
+
+        let recoveredCount = 0;
+        for (
+            let index = 0;
+            index < jobs.length && index < RECOVERY_BATCH_SIZE;
+            index += 1
+        ) {
+            const job = jobs[index];
+            if (job) {
+                await this.enqueuePersistedJob(job.id);
+                recoveredCount += 1;
             }
+        }
 
-            const runnableJob = await this.ensureRunnable(jobId);
-            await importJobStore.updateJob(jobId, {
-                status: "resolving",
-                progress: 20,
+        if (recoveredCount > 0) {
+            log.info("Recovered persisted import jobs", {
+                count: recoveredCount,
             });
+        }
+        return recoveredCount;
+    }
 
-            const preview = await playlistImportService.previewImport(
-                runnableJob.userId,
-                runnableJob.sourceUrl,
-            );
-
-            await this.ensureRunnable(jobId);
-            await importJobStore.updateJob(jobId, {
-                status: "creating_playlist",
-                progress: 70,
-                summary: preview.summary,
-                resolvedTracks:
-                    preview.resolved as unknown as Prisma.InputJsonValue,
-            });
-
-            const execution = await playlistImportService.importPlaylist(
-                runnableJob.userId,
-                preview,
-                runnableJob.requestedPlaylistName ?? undefined,
-            );
-
-            const latestJob = await importJobStore.getJob(jobId);
-            const cancelledDuringImport =
-                latestJob?.status === "cancelled" ||
-                latestJob?.status === "cancelling";
-
-            await importJobStore.updateJob(jobId, {
-                status: "completed",
-                progress: 100,
-                summary: execution.summary,
-                createdPlaylistId: execution.playlistId,
-                error: cancelledDuringImport
-                    ? "Cancellation requested after playlist creation completed"
-                    : null,
-            });
+    /**
+     * Executes an import job and exposes failures to Bull while retries remain.
+     */
+    async runJob(jobId: string, options: RunJobOptions = {}): Promise<void> {
+        try {
+            await this.executeJob(jobId);
         } catch (error) {
             if (error instanceof ImportJobCancelledError) {
-                const latestJob = await importJobStore.getJob(jobId);
-                if (latestJob?.status === "cancelling") {
-                    await importJobStore.updateJob(jobId, {
-                        status: "cancelled",
-                        progress: 100,
-                        error: latestJob.error ?? "Cancelled by user",
-                    });
-                }
+                await this.finishCancellation(jobId);
                 return;
             }
 
-            const message =
-                error instanceof Error
-                    ? error.message
-                    : "Generic import job failed";
-            const latestJob = await importJobStore.getJob(jobId);
-            if (latestJob && !isTerminalStatus(latestJob.status)) {
-                await importJobStore.updateJob(jobId, {
-                    status: "failed",
-                    progress: 100,
-                    error: message,
-                });
+            await this.handleExecutionFailure(jobId, error, options);
+            if (options.retryFailures) {
+                throw error;
             }
-            logger.error(`[ImportJobRunner] Job ${jobId} failed:`, error);
-        } finally {
-            this.inFlightJobs.delete(jobId);
         }
     }
 
-    private async ensureRunnable(jobId: string) {
+    /**
+     * Marks a persisted job failed when Bull exhausts lease or processor recovery.
+     */
+    async finalizeQueueFailure(jobId: string, error: unknown): Promise<void> {
+        const latestJob = await importJobStore.getJob(jobId);
+        if (!latestJob || isTerminalStatus(latestJob.status)) {
+            return;
+        }
+
+        await this.persistSafeFailure(jobId);
+        log.error("Import queue exhausted recovery", { jobId, error });
+    }
+
+    private async enqueuePersistedJob(jobId: string): Promise<void> {
+        if (!jobId.trim()) {
+            throw new Error("Generic import job id is required");
+        }
+        const existingJob = await genericImportQueue.getJob(jobId);
+        if (existingJob) {
+            const state = await existingJob.getState();
+            if (state === "failed" || state === "completed") {
+                await this.finalizeQueueFailure(
+                    jobId,
+                    new Error(`Queue job is terminal in state ${state}`),
+                );
+            }
+            return;
+        }
+        await genericImportQueue.add(RUN_JOB_NAME, { jobId }, { jobId });
+    }
+
+    private async executeJob(jobId: string): Promise<void> {
+        const initialJob = await importJobStore.getJob(jobId);
+        if (!initialJob || isTerminalStatus(initialJob.status)) {
+            return;
+        }
+
+        const runnableJob = await this.ensureRunnable(jobId);
+        const preview = await this.resolvePreview(jobId, runnableJob);
+        const execution = await this.createPlaylist(
+            jobId,
+            runnableJob,
+            preview,
+        );
+        await this.completeJob(jobId, execution);
+    }
+
+    private async resolvePreview(
+        jobId: string,
+        job: StoredImportJob,
+    ): Promise<ImportPreview> {
+        await importJobStore.updateJob(jobId, {
+            status: "resolving",
+            progress: 20,
+        });
+        return playlistImportService.previewImport(job.userId, job.sourceUrl);
+    }
+
+    private async createPlaylist(
+        jobId: string,
+        job: StoredImportJob,
+        preview: ImportPreview,
+    ): Promise<ImportExecution> {
+        await this.ensureRunnable(jobId);
+        await importJobStore.updateJob(jobId, {
+            status: "creating_playlist",
+            progress: 70,
+            summary: preview.summary,
+            resolvedTracks:
+                preview.resolved as unknown as Prisma.InputJsonValue,
+        });
+        return playlistImportService.importPlaylist(
+            job.userId,
+            preview,
+            job.requestedPlaylistName ?? undefined,
+        );
+    }
+
+    private async completeJob(
+        jobId: string,
+        execution: ImportExecution,
+    ): Promise<void> {
+        const latestJob = await importJobStore.getJob(jobId);
+        const cancelledDuringImport =
+            latestJob?.status === "cancelled" ||
+            latestJob?.status === "cancelling";
+        await importJobStore.updateJob(jobId, {
+            status: "completed",
+            progress: 100,
+            summary: execution.summary,
+            createdPlaylistId: execution.playlistId,
+            error: cancelledDuringImport
+                ? "Cancellation requested after playlist creation completed"
+                : null,
+        });
+    }
+
+    private async handleExecutionFailure(
+        jobId: string,
+        error: unknown,
+        options: RunJobOptions,
+    ): Promise<void> {
+        if (options.retryFailures && options.finalAttempt === false) {
+            log.warn("Import job attempt failed; queue retry remains", {
+                jobId,
+                error,
+            });
+            return;
+        }
+
+        const latestJob = await importJobStore.getJob(jobId);
+        if (latestJob && !isTerminalStatus(latestJob.status)) {
+            await this.persistSafeFailure(jobId);
+        }
+        log.error("Import job failed", { jobId, error });
+    }
+
+    private async persistSafeFailure(jobId: string): Promise<void> {
+        await importJobStore.updateJob(jobId, {
+            status: "failed",
+            progress: 100,
+            error: SAFE_FAILURE_MESSAGE,
+        });
+    }
+
+    private async finishCancellation(jobId: string): Promise<void> {
+        const latestJob = await importJobStore.getJob(jobId);
+        if (latestJob?.status === "cancelling") {
+            await importJobStore.updateJob(jobId, {
+                status: "cancelled",
+                progress: 100,
+                error: latestJob.error ?? "Cancelled by user",
+            });
+        }
+    }
+
+    private async ensureRunnable(jobId: string): Promise<StoredImportJob> {
         const job = await importJobStore.getJob(jobId);
         if (!job || job.status === "cancelled" || job.status === "cancelling") {
             throw new ImportJobCancelledError("Import job is cancelled");
@@ -124,7 +280,5 @@ export class GenericImportJobRunner {
     }
 }
 
-/**
- * Shared singleton runner used by import job routes.
- */
+/** Shared queue-backed runner used by import routes and workers. */
 export const genericImportJobRunner = new GenericImportJobRunner();

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -34,6 +34,7 @@ describe("workers runtime behavior", () => {
         const imageQueue = createQueueMock();
         const validationQueue = createQueueMock();
         const schedulerQueue = createQueueMock();
+        const genericImportQueue = createQueueMock();
 
         const logger = {
             debug: jest.fn(),
@@ -51,6 +52,11 @@ describe("workers runtime behavior", () => {
         const startDiscoverWeeklyCron = jest.fn();
         const stopDiscoverWeeklyCron = jest.fn();
         const processDiscoverCronTick = jest.fn(async () => ({ ok: true }));
+        const processGenericImport = jest.fn(async () => undefined);
+        const finalizeGenericImportQueueFailure = jest.fn(
+            async () => undefined,
+        );
+        const registerRecoveryJobs = jest.fn(async () => undefined);
         const runDataIntegrityCheck = jest.fn(async () => undefined);
         const shutdownDiscoverProcessor = jest.fn(async () => undefined);
         const cleanupExpiredCache = jest.fn(async () => undefined);
@@ -135,6 +141,7 @@ describe("workers runtime behavior", () => {
             imageQueue,
             validationQueue,
             schedulerQueue,
+            genericImportQueue,
         }));
         jest.doMock("../processors/scanProcessor", () => ({
             processScan: jest.fn(async () => ({
@@ -159,6 +166,16 @@ describe("workers runtime behavior", () => {
                 tracksChecked: 0,
                 tracksRemoved: 0,
             })),
+        }));
+        jest.doMock("../processors/genericImportProcessor", () => ({
+            processGenericImport,
+            finalizeGenericImportQueueFailure,
+            GENERIC_IMPORT_WORKER_CONCURRENCY: 2,
+        }));
+        jest.doMock("../../services/genericImportJobRunner", () => ({
+            genericImportJobRunner: {
+                registerRecoveryJobs,
+            },
         }));
         jest.doMock("../unifiedEnrichment", () => ({
             startUnifiedEnrichmentWorker,
@@ -227,6 +244,7 @@ describe("workers runtime behavior", () => {
             imageQueue,
             validationQueue,
             schedulerQueue,
+            genericImportQueue,
             logger,
             startUnifiedEnrichmentWorker,
             stopUnifiedEnrichmentWorker,
@@ -234,6 +252,9 @@ describe("workers runtime behavior", () => {
             stopMoodBucketWorker,
             startDiscoverWeeklyCron,
             stopDiscoverWeeklyCron,
+            processGenericImport,
+            finalizeGenericImportQueueFailure,
+            registerRecoveryJobs,
             runDataIntegrityCheck,
             downloadQueueManager,
             simpleDownloadManager,
@@ -286,6 +307,12 @@ describe("workers runtime behavior", () => {
             "*",
             expect.any(Function),
         );
+        expect(mocks.genericImportQueue.process).toHaveBeenCalledWith(
+            "*",
+            2,
+            mocks.processGenericImport,
+        );
+        expect(mocks.registerRecoveryJobs).toHaveBeenCalledTimes(1);
         expect(mocks.startUnifiedEnrichmentWorker).toHaveBeenCalledTimes(1);
         expect(mocks.startMoodBucketWorker).toHaveBeenCalledTimes(1);
         expect(mocks.startDiscoverWeeklyCron).toHaveBeenCalledTimes(1);
@@ -407,6 +434,7 @@ describe("workers runtime behavior", () => {
         expect(workers.imageQueue).toBe(mocks.imageQueue);
         expect(workers.validationQueue).toBe(mocks.validationQueue);
         expect(workers.schedulerQueue).toBe(mocks.schedulerQueue);
+        expect(workers.genericImportQueue).toBe(mocks.genericImportQueue);
     });
 
     it("shuts down workers and queue resources cleanly", async () => {
@@ -423,7 +451,11 @@ describe("workers runtime behavior", () => {
         expect(mocks.stopMoodBucketWorker).toHaveBeenCalledTimes(1);
         expect(mocks.downloadQueueManager.shutdown).toHaveBeenCalledTimes(1);
         expect(mocks.scanQueue.removeAllListeners).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.genericImportQueue.removeAllListeners,
+        ).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.close).toHaveBeenCalledTimes(1);
+        expect(mocks.genericImportQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.enrichmentStateService.disconnect).toHaveBeenCalledTimes(
             1,
         );
@@ -1037,6 +1069,12 @@ describe("workers runtime behavior", () => {
         );
         getHandler(mocks.validationQueue, "active")(job);
 
+        getHandler(mocks.genericImportQueue, "active")(job);
+        getHandler(mocks.genericImportQueue, "completed")(job);
+        const genericImportError = new Error("import-retries-exhausted");
+        getHandler(mocks.genericImportQueue, "failed")(job, genericImportError);
+        await flushPromises();
+
         getHandler(
             mocks.schedulerQueue,
             "completed",
@@ -1060,6 +1098,10 @@ describe("workers runtime behavior", () => {
             expect.stringMatching(
                 /workerId=.* event=failed queue=worker-scheduler count=\d+/,
             ),
+        );
+        expect(mocks.finalizeGenericImportQueueFailure).toHaveBeenCalledWith(
+            job,
+            genericImportError,
         );
     });
 
@@ -1102,6 +1144,9 @@ describe("workers runtime behavior", () => {
         mocks.schedulerQueue.isReady.mockRejectedValueOnce(
             new Error("scheduler-not-ready"),
         );
+        mocks.registerRecoveryJobs.mockRejectedValueOnce(
+            new Error("generic-import-recovery-not-ready"),
+        );
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         require("../index");
@@ -1118,6 +1163,10 @@ describe("workers runtime behavior", () => {
         expect(mocks.logger.error).toHaveBeenCalledWith(
             "Failed to register scheduler queue jobs:",
             expect.any(Error),
+        );
+        expect(mocks.logger.error).toHaveBeenCalledWith(
+            "Failed to register generic import recovery jobs",
+            expect.objectContaining({ error: expect.any(Error) }),
         );
     });
 

--- a/backend/src/workers/__tests__/queues.test.ts
+++ b/backend/src/workers/__tests__/queues.test.ts
@@ -22,7 +22,9 @@ describe("workers/queues", () => {
             debug: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
+            child: jest.fn(),
         };
+        logger.child.mockReturnValue(logger);
 
         jest.doMock("bull", () => ({
             __esModule: true,
@@ -48,7 +50,7 @@ describe("workers/queues", () => {
             "rediss://user:pass@cache.example:6381/2",
         );
 
-        expect(bullCtor).toHaveBeenCalledTimes(6);
+        expect(bullCtor).toHaveBeenCalledTimes(7);
         const firstCallArgs = bullCtor.mock.calls[0];
         const firstQueueOptions = firstCallArgs[1];
 
@@ -63,7 +65,7 @@ describe("workers/queues", () => {
                 tls: {},
             }),
         );
-        expect(queuesModule.queues).toHaveLength(6);
+        expect(queuesModule.queues).toHaveLength(7);
         expect(logger.debug).toHaveBeenCalledWith(
             expect.stringContaining("Redis config resolved"),
         );
@@ -99,6 +101,29 @@ describe("workers/queues", () => {
         });
     });
 
+    it("bounds generic import retries, stalled recovery, and Redis retention", () => {
+        const { bullCtor } = loadQueues("redis://cache.example:6379/0");
+
+        const importCall = bullCtor.mock.calls.find(
+            (call: any[]) => call[0] === "generic-import",
+        );
+
+        expect(importCall).toBeDefined();
+        expect(importCall![1].settings).toEqual(
+            expect.objectContaining({
+                stalledInterval: 30_000,
+                lockDuration: 30_000,
+                maxStalledCount: 1,
+            }),
+        );
+        expect(importCall![1].defaultJobOptions).toEqual({
+            attempts: 3,
+            backoff: { type: "exponential", delay: 5_000 },
+            removeOnComplete: 100,
+            removeOnFail: 200,
+        });
+    });
+
     it("wires queue error and stalled handlers for observability", () => {
         const { bullCtor, logger } = loadQueues("redis://cache.example:6379/0");
 
@@ -115,11 +140,8 @@ describe("workers/queues", () => {
         stalledHandler({ id: "job-1", data: { payload: true } });
 
         expect(logger.error).toHaveBeenCalledWith(
-            "Bull queue error (library-scan):",
-            {
-                message: "queue exploded",
-                stack: expect.any(String),
-            },
+            "Bull queue error (library-scan)",
+            err,
         );
         expect(logger.warn).toHaveBeenCalledWith(
             "Bull job stalled (library-scan):",

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -9,6 +9,7 @@ import {
     imageQueue,
     validationQueue,
     schedulerQueue,
+    genericImportQueue,
 } from "./queues";
 import { processScan } from "./processors/scanProcessor";
 import {
@@ -17,6 +18,11 @@ import {
 } from "./processors/discoverProcessor";
 import { processImageOptimization } from "./processors/imageProcessor";
 import { processValidation } from "./processors/validationProcessor";
+import {
+    finalizeGenericImportQueueFailure,
+    GENERIC_IMPORT_WORKER_CONCURRENCY,
+    processGenericImport,
+} from "./processors/genericImportProcessor";
 import {
     startUnifiedEnrichmentWorker,
     stopUnifiedEnrichmentWorker,
@@ -43,6 +49,7 @@ import { queueCleaner } from "../jobs/queueCleaner";
 import { enrichmentStateService } from "../services/enrichmentState";
 import { createIORedisClient } from "../utils/ioredis";
 import { dataCacheService } from "../services/dataCache";
+import { genericImportJobRunner } from "../services/genericImportJobRunner";
 
 const log = logger.child("WorkerScheduler");
 const claimLog = log.child("SchedulerClaim");
@@ -889,6 +896,11 @@ if (config.features.discovery) {
 }
 imageQueue.process(processImageOptimization);
 validationQueue.process(processValidation);
+genericImportQueue.process(
+    "*",
+    GENERIC_IMPORT_WORKER_CONCURRENCY,
+    processGenericImport,
+);
 async function processSchedulerJob(job: Bull.Job<any>): Promise<void> {
     const mode = job?.data?.mode === "startup" ? "startup" : "repeat";
 
@@ -1114,6 +1126,35 @@ validationQueue.on("active", (job) => {
     );
 });
 
+genericImportQueue.on("active", (job) => {
+    recordQueueProcessorEvent("generic-import", "active", job);
+});
+
+genericImportQueue.on("completed", (job) => {
+    recordQueueProcessorEvent("generic-import", "completed", job);
+});
+
+genericImportQueue.on("failed", (job, error) => {
+    if (!job) {
+        queueProcessorLog.error("Generic import queue failure had no job", {
+            error,
+        });
+        return;
+    }
+    recordQueueProcessorEvent("generic-import", "failed", job);
+    void finalizeGenericImportQueueFailure(job, error).catch(
+        (finalizationError) => {
+            queueProcessorLog.error(
+                "Failed to finalize exhausted generic import job",
+                {
+                    jobId: job.id,
+                    error: finalizationError,
+                },
+            );
+        },
+    );
+});
+
 // The scheduler queue runs the heavy maintenance cycles (metadata refresh,
 // reconciliation, artist-count backfills) — the primary stall suspects — so
 // it MUST feed the event-loop watchdog's attribution registry.
@@ -1180,6 +1221,10 @@ registerSchedulerJobs()
         log.error("Failed to register scheduler queue jobs:", err);
     });
 
+genericImportJobRunner.registerRecoveryJobs().catch((error) => {
+    log.error("Failed to register generic import recovery jobs", { error });
+});
+
 /**
  * Gracefully shutdown all workers and cleanup resources
  */
@@ -1203,6 +1248,7 @@ export async function shutdownWorkers(): Promise<void> {
     imageQueue.removeAllListeners();
     validationQueue.removeAllListeners();
     schedulerQueue.removeAllListeners();
+    genericImportQueue.removeAllListeners();
 
     // Close all queues gracefully
     await Promise.all([
@@ -1211,6 +1257,7 @@ export async function shutdownWorkers(): Promise<void> {
         imageQueue.close(),
         validationQueue.close(),
         schedulerQueue.close(),
+        genericImportQueue.close(),
     ]);
 
     // Disconnect enrichment state service Redis connections (2 connections)
@@ -1247,4 +1294,5 @@ export {
     imageQueue,
     validationQueue,
     schedulerQueue,
+    genericImportQueue,
 };

--- a/backend/src/workers/processors/__tests__/genericImportProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/genericImportProcessor.test.ts
@@ -1,0 +1,138 @@
+const mockRunJob = jest.fn();
+const mockRecoverActiveJobs = jest.fn();
+const mockFinalizeQueueFailure = jest.fn();
+
+jest.mock("../../../services/genericImportJobRunner", () => ({
+    genericImportJobRunner: {
+        runJob: mockRunJob,
+        recoverActiveJobs: mockRecoverActiveJobs,
+        finalizeQueueFailure: mockFinalizeQueueFailure,
+    },
+}));
+
+import {
+    finalizeGenericImportQueueFailure,
+    processGenericImport,
+} from "../genericImportProcessor";
+
+describe("generic import queue processor", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRunJob.mockResolvedValue(undefined);
+        mockRecoverActiveJobs.mockResolvedValue(0);
+        mockFinalizeQueueFailure.mockResolvedValue(undefined);
+    });
+
+    it("executes a queued import and exposes whether Bull has retries left", async () => {
+        const job = {
+            id: "bull-job-1",
+            name: "generic-import-run",
+            data: { jobId: "persisted-job-1" },
+            attemptsMade: 0,
+            opts: { attempts: 3 },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processGenericImport(job);
+
+        expect(mockRunJob).toHaveBeenCalledWith("persisted-job-1", {
+            retryFailures: true,
+            finalAttempt: false,
+        });
+        expect(job.progress).toHaveBeenNthCalledWith(1, 0);
+        expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+    });
+
+    it("marks the last configured Bull attempt as final", async () => {
+        const job = {
+            id: "bull-job-final",
+            name: "generic-import-run",
+            data: { jobId: "persisted-job-final" },
+            attemptsMade: 2,
+            opts: { attempts: 3 },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processGenericImport(job);
+
+        expect(mockRunJob).toHaveBeenCalledWith("persisted-job-final", {
+            retryFailures: true,
+            finalAttempt: true,
+        });
+    });
+
+    it("rejects poison import payloads without invoking business logic", async () => {
+        const job = {
+            id: "bull-job-poison",
+            name: "generic-import-run",
+            data: { jobId: "", unexpected: "value" },
+            attemptsMade: 0,
+            opts: { attempts: 3 },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processGenericImport(job)).rejects.toThrow(
+            "Invalid generic import queue payload",
+        );
+        expect(mockRunJob).not.toHaveBeenCalled();
+    });
+
+    it("runs the bounded persisted-job recovery sweep", async () => {
+        mockRecoverActiveJobs.mockResolvedValueOnce(12);
+        const job = {
+            id: "recovery-job",
+            name: "generic-import-recover",
+            data: { trigger: "repeat" },
+            attemptsMade: 0,
+            opts: { attempts: 1 },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processGenericImport(job);
+
+        expect(mockRecoverActiveJobs).toHaveBeenCalledTimes(1);
+        expect(mockRunJob).not.toHaveBeenCalled();
+        expect(job.progress).toHaveBeenNthCalledWith(1, 0);
+        expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+    });
+
+    it("rejects unknown queue job names", async () => {
+        const job = {
+            id: "unknown-job",
+            name: "unexpected-import-operation",
+            data: {},
+            attemptsMade: 0,
+            opts: { attempts: 1 },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processGenericImport(job)).rejects.toThrow(
+            'Unsupported generic import queue job "unexpected-import-operation"',
+        );
+        expect(mockRunJob).not.toHaveBeenCalled();
+        expect(mockRecoverActiveJobs).not.toHaveBeenCalled();
+    });
+
+    it("finalizes the persisted job only after Bull exhausts queue recovery", async () => {
+        const error = new Error("job stalled more than allowable limit");
+        const failedJob = {
+            name: "generic-import-run",
+            data: { jobId: "persisted-stalled-job" },
+            getState: jest.fn().mockResolvedValue("failed"),
+        } as any;
+        const delayedJob = {
+            name: "generic-import-run",
+            data: { jobId: "persisted-retrying-job" },
+            getState: jest.fn().mockResolvedValue("delayed"),
+        } as any;
+
+        await finalizeGenericImportQueueFailure(delayedJob, error);
+        await finalizeGenericImportQueueFailure(failedJob, error);
+
+        expect(mockFinalizeQueueFailure).toHaveBeenCalledTimes(1);
+        expect(mockFinalizeQueueFailure).toHaveBeenCalledWith(
+            "persisted-stalled-job",
+            error,
+        );
+    });
+});

--- a/backend/src/workers/processors/genericImportProcessor.ts
+++ b/backend/src/workers/processors/genericImportProcessor.ts
@@ -1,0 +1,75 @@
+import type { Job } from "bull";
+import { z } from "zod";
+import { genericImportJobRunner } from "../../services/genericImportJobRunner";
+
+const RUN_JOB_NAME = "generic-import-run";
+const RECOVERY_JOB_NAME = "generic-import-recover";
+const runPayloadSchema = z
+    .object({
+        jobId: z.string().trim().min(1).max(128),
+    })
+    .strict();
+const recoveryPayloadSchema = z
+    .object({
+        trigger: z.enum(["startup", "repeat"]),
+    })
+    .strict();
+
+/** Maximum number of generic imports claimed concurrently by one worker. */
+export const GENERIC_IMPORT_WORKER_CONCURRENCY = 2;
+
+function isFinalAttempt(job: Job<unknown>): boolean {
+    const configuredAttempts = Math.max(1, job.opts.attempts ?? 1);
+    return job.attemptsMade + 1 >= configuredAttempts;
+}
+
+async function processRunJob(job: Job<unknown>): Promise<void> {
+    const parsed = runPayloadSchema.safeParse(job.data);
+    if (!parsed.success) {
+        throw new Error("Invalid generic import queue payload");
+    }
+    await genericImportJobRunner.runJob(parsed.data.jobId, {
+        retryFailures: true,
+        finalAttempt: isFinalAttempt(job),
+    });
+}
+
+async function processRecoveryJob(job: Job<unknown>): Promise<void> {
+    const parsed = recoveryPayloadSchema.safeParse(job.data);
+    if (!parsed.success) {
+        throw new Error("Invalid generic import recovery payload");
+    }
+    await genericImportJobRunner.recoverActiveJobs();
+}
+
+/**
+ * Validates and executes one generic-import queue operation.
+ */
+export async function processGenericImport(job: Job<unknown>): Promise<void> {
+    await job.progress(0);
+    if (job.name === RUN_JOB_NAME) {
+        await processRunJob(job);
+    } else if (job.name === RECOVERY_JOB_NAME) {
+        await processRecoveryJob(job);
+    } else {
+        throw new Error(`Unsupported generic import queue job "${job.name}"`);
+    }
+    await job.progress(100);
+}
+
+/**
+ * Finalizes persisted state after Bull exhausts retry and stalled-job recovery.
+ */
+export async function finalizeGenericImportQueueFailure(
+    job: Job<unknown>,
+    error: unknown,
+): Promise<void> {
+    if (job.name !== RUN_JOB_NAME) {
+        return;
+    }
+    const parsed = runPayloadSchema.safeParse(job.data);
+    if (!parsed.success || (await job.getState()) !== "failed") {
+        return;
+    }
+    await genericImportJobRunner.finalizeQueueFailure(parsed.data.jobId, error);
+}

--- a/backend/src/workers/queues.ts
+++ b/backend/src/workers/queues.ts
@@ -2,6 +2,8 @@ import Bull from "bull";
 import { logger } from "../utils/logger";
 import { config } from "../config";
 
+const log = logger.child("BullQueues");
+
 function buildBullRedisConfig(
     redisUrlString: string,
 ): Bull.QueueOptions["redis"] {
@@ -40,14 +42,14 @@ function buildBullRedisConfig(
             redisConfig.tls = {};
         }
 
-        logger.debug(
-            `[Bull] Redis config resolved (host=${redisUrl.hostname}, port=${port}, db=${redisConfig.db ?? 0}, tls=${isTls})`,
+        log.debug(
+            `Redis config resolved (host=${redisUrl.hostname}, port=${port}, db=${redisConfig.db ?? 0}, tls=${isTls})`,
         );
 
         return redisConfig as Bull.QueueOptions["redis"];
     } catch (error) {
-        logger.warn(
-            `[Bull] Failed to parse REDIS_URL for queues, falling back to ${fallback.host}:${fallback.port}`,
+        log.warn(
+            `Failed to parse REDIS_URL for queues, falling back to ${fallback.host}:${fallback.port}`,
         );
         return fallback;
     }
@@ -119,6 +121,18 @@ export const schedulerQueue = new Bull("worker-scheduler", {
     settings: defaultQueueSettings,
 });
 
+/** Durable Redis queue for persisted generic playlist-import jobs. */
+export const genericImportQueue = new Bull("generic-import", {
+    redis: redisConfig,
+    settings: defaultQueueSettings,
+    defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 5_000 },
+        removeOnComplete: 100,
+        removeOnFail: 200,
+    },
+});
+
 // Export all queues for monitoring
 export const queues = [
     scanQueue,
@@ -127,19 +141,17 @@ export const queues = [
     validationQueue,
     analysisQueue,
     schedulerQueue,
+    genericImportQueue,
 ];
 
 // Add error handlers to all queues to prevent unhandled exceptions
 queues.forEach((queue) => {
     queue.on("error", (error) => {
-        logger.error(`Bull queue error (${queue.name}):`, {
-            message: error.message,
-            stack: error.stack,
-        });
+        log.error(`Bull queue error (${queue.name})`, error);
     });
 
     queue.on("stalled", (job) => {
-        logger.warn(`Bull job stalled (${queue.name}):`, {
+        log.warn(`Bull job stalled (${queue.name}):`, {
             jobId: job.id,
             data: job.data,
         });
@@ -147,4 +159,4 @@ queues.forEach((queue) => {
 });
 
 // Log queue initialization
-logger.debug("Bull queues initialized with stability settings");
+log.debug("Bull queues initialized with stability settings");


### PR DESCRIPTION
Convergence sweep #19 remediation (M15). A persisted pending generic-import job was executed by an **API-local `setTimeout`** — no startup recovery, no distributed claim, no cross-job capacity bound. API termination permanently orphaned the job, and deduplication then returned the orphan instead of restarting it.

Fix
- Execution moves to a durable **Bull/Redis** queue with a stable job id derived from the persisted job (natural dedup/coalescing).
- **Startup + 60s recovery sweeps** re-enqueue persisted ACTIVE-status jobs, bounded to 100/sweep; recovery registrations use fixed job ids so they're idempotent.
- Three bounded retries with exponential backoff, stalled-job lease recovery, bounded queue history, worker concurrency 2.
- Strict payload validation with terminal handling when retries/lease recovery are exhausted (poison-payload safe).
- Only the sanitized failure message is persisted; raw detail stays logger-only.
- Observability, startup recovery, and graceful queue shutdown registered in the worker entrypoint.

Verification: targeted jest 108/108 (durability, dedup coalescing, recovery bounds, concurrency, retries, poison payloads, exhausted leases, registration, shutdown); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).

Note: touches `backend/src/workers/**`; the M16 slice (remove API-local queueCleaner) is sequenced after this to avoid worker-file conflicts.