### PR TITLE
fix(security): resolve pre-existing CodeQL alerts — format string, MBID path injection, CSRF

### DIFF
--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -326,6 +326,7 @@ describe("api entrypoint runtime behavior", () => {
             shutdownWorkers,
             compressionMiddleware,
             compressionFilter,
+            sessionMiddleware,
         };
     }
 
@@ -434,6 +435,34 @@ describe("api entrypoint runtime behavior", () => {
         );
         expect(processOnSpy).toHaveBeenCalled();
         expect(setIntervalSpy).toHaveBeenCalled();
+    });
+
+    it("configures the session cookie with explicit SameSite=Lax protection", async () => {
+        process.env = {
+            ...originalEnv,
+            BACKEND_PROCESS_ROLE: "api",
+        };
+
+        jest.spyOn(process, "on").mockImplementation(() => process as any);
+        jest.spyOn(global, "setInterval").mockImplementation(
+            () => 1 as unknown as NodeJS.Timeout,
+        );
+        process.exit = jest.fn() as any;
+
+        const mocks = setupApiEntrypointMocks();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        expect(mocks.sessionMiddleware).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cookie: expect.objectContaining({
+                    httpOnly: true,
+                    sameSite: "lax",
+                }),
+            }),
+        );
     });
 
     it("mounts FEATURE_DISABLED 404 handlers for gated prefixes when flags are off", async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -210,6 +210,7 @@ app.use((req, res, next) => {
 // client can't spoof X-Forwarded-For to evade per-IP rate limits.
 app.set("trust proxy", config.trustProxy);
 
+// codeql[js/missing-token-validation] Session cookies are SameSite=Lax, while API-key and bearer alternatives require explicit headers, blocking classic cross-site unsafe requests.
 app.use(
     session({
         store: new RedisStore({

--- a/backend/src/services/__tests__/musicbrainzService.test.ts
+++ b/backend/src/services/__tests__/musicbrainzService.test.ts
@@ -41,6 +41,9 @@ const mockRedisKeys = redisClient.keys as jest.Mock;
 const mockRateLimiterExecute = rateLimiter.execute as jest.Mock;
 const mockLoggerWarn = logger.warn as jest.Mock;
 const mockLoggerError = logger.error as jest.Mock;
+const VALID_ARTIST_MBID = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3";
+const VALID_RELEASE_GROUP_MBID = "6b9a9e04-abd7-4666-86ba-bb220ef4c3b2";
+const VALID_RELEASE_MBID = "189002e7-3285-4e2e-92a3-7f6c30d407a2";
 
 describe("musicBrainzService", () => {
     let mockHttpGet: jest.Mock;
@@ -102,6 +105,21 @@ describe("musicBrainzService", () => {
             2592000,
             JSON.stringify(artists),
         );
+    });
+
+    it("keeps free-text searches in Axios query params instead of the request path", async () => {
+        const query = "../artist?fmt=xml & alias";
+        mockHttpGet.mockResolvedValueOnce({ data: { artists: [] } });
+
+        await musicBrainzService.searchArtist(query, 5);
+
+        expect(mockHttpGet).toHaveBeenCalledWith("/artist", {
+            params: {
+                query,
+                limit: 5,
+                fmt: "json",
+            },
+        });
     });
 
     it("returns fallback [] on non-404 artist lookup failures and short-caches fallback", async () => {
@@ -185,11 +203,11 @@ describe("musicBrainzService", () => {
     it("caches successful null responses with 1-hour TTL", async () => {
         mockHttpGet.mockResolvedValueOnce({ data: null });
 
-        const result = await musicBrainzService.getArtist("artist-null");
+        const result = await musicBrainzService.getArtist(VALID_ARTIST_MBID);
 
         expect(result).toBeNull();
         expect(mockRedisSetEx).toHaveBeenCalledWith(
-            "mb:artist:artist-null:url-rels,tags",
+            `mb:artist:${VALID_ARTIST_MBID}:url-rels,tags`,
             3600,
             "null",
         );
@@ -198,11 +216,11 @@ describe("musicBrainzService", () => {
     it("returns fallback null for non-404 getArtist errors and short-caches fallback", async () => {
         mockRateLimiterExecute.mockRejectedValueOnce(new Error("network down"));
 
-        const result = await musicBrainzService.getArtist("artist-broken");
+        const result = await musicBrainzService.getArtist(VALID_ARTIST_MBID);
 
         expect(result).toBeNull();
         expect(mockRedisSetEx).toHaveBeenCalledWith(
-            "mb:artist:artist-broken:url-rels,tags",
+            `mb:artist:${VALID_ARTIST_MBID}:url-rels,tags`,
             120,
             "null",
         );
@@ -214,9 +232,9 @@ describe("musicBrainzService", () => {
         });
         mockRateLimiterExecute.mockRejectedValueOnce(notFoundError);
 
-        await expect(musicBrainzService.getArtist("artist-404")).rejects.toBe(
-            notFoundError,
-        );
+        await expect(
+            musicBrainzService.getArtist(VALID_ARTIST_MBID),
+        ).rejects.toBe(notFoundError);
         expect(mockRedisSetEx).not.toHaveBeenCalled();
     });
 
@@ -267,13 +285,17 @@ describe("musicBrainzService", () => {
             .mockResolvedValueOnce({ data: { id: "release-detail" } });
 
         const groups = await musicBrainzService.getReleaseGroups(
-            "artist-mbid",
+            VALID_ARTIST_MBID,
             ["album", "single"],
             25,
         );
-        const group = await musicBrainzService.getReleaseGroup("rg-1");
-        const details = await musicBrainzService.getReleaseGroupDetails("rg-1");
-        const release = await musicBrainzService.getRelease("rel-1");
+        const group = await musicBrainzService.getReleaseGroup(
+            VALID_RELEASE_GROUP_MBID,
+        );
+        const details = await musicBrainzService.getReleaseGroupDetails(
+            VALID_RELEASE_GROUP_MBID,
+        );
+        const release = await musicBrainzService.getRelease(VALID_RELEASE_MBID);
 
         expect(groups).toEqual([{ id: "rg-a" }]);
         expect(group).toEqual({ id: "rg-detail" });
@@ -281,30 +303,82 @@ describe("musicBrainzService", () => {
         expect(release).toEqual({ id: "release-detail" });
         expect(mockHttpGet).toHaveBeenNthCalledWith(1, "/release-group", {
             params: {
-                artist: "artist-mbid",
+                artist: VALID_ARTIST_MBID,
                 type: "album|single",
                 limit: 25,
                 fmt: "json",
             },
         });
-        expect(mockHttpGet).toHaveBeenNthCalledWith(2, "/release-group/rg-1", {
-            params: {
-                inc: "artist-credits+releases",
-                fmt: "json",
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+            2,
+            `/release-group/${VALID_RELEASE_GROUP_MBID}`,
+            {
+                params: {
+                    inc: "artist-credits+releases",
+                    fmt: "json",
+                },
             },
-        });
-        expect(mockHttpGet).toHaveBeenNthCalledWith(3, "/release-group/rg-1", {
-            params: {
-                inc: "artist-credits+releases+labels",
-                fmt: "json",
+        );
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+            3,
+            `/release-group/${VALID_RELEASE_GROUP_MBID}`,
+            {
+                params: {
+                    inc: "artist-credits+releases+labels",
+                    fmt: "json",
+                },
             },
-        });
-        expect(mockHttpGet).toHaveBeenNthCalledWith(4, "/release/rel-1", {
-            params: {
-                inc: "recordings+artist-credits+labels",
-                fmt: "json",
+        );
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+            4,
+            `/release/${VALID_RELEASE_MBID}`,
+            {
+                params: {
+                    inc: "recordings+artist-credits+labels",
+                    fmt: "json",
+                },
             },
-        });
+        );
+    });
+
+    it.each([
+        ["artist", () => musicBrainzService.getArtist("../artist")],
+        [
+            "artist browse",
+            () => musicBrainzService.getReleaseGroups("artist?limit=100"),
+        ],
+        [
+            "release group",
+            () => musicBrainzService.getReleaseGroup("group?fmt=json"),
+        ],
+        [
+            "release group details",
+            () => musicBrainzService.getReleaseGroupDetails("../group"),
+        ],
+        ["release", () => musicBrainzService.getRelease("../release")],
+        [
+            "album tracks",
+            () => musicBrainzService.getAlbumTracks("group?inc=releases"),
+        ],
+    ])(
+        "rejects a malformed %s MBID before outbound work",
+        async (_name, run) => {
+            await expect(run()).rejects.toThrow(/Invalid .* MBID/);
+            expect(mockRateLimiterExecute).not.toHaveBeenCalled();
+            expect(mockHttpGet).not.toHaveBeenCalled();
+        },
+    );
+
+    it("allows a valid UUID MBID through to the fixed MusicBrainz origin", async () => {
+        mockHttpGet.mockResolvedValueOnce({ data: { id: VALID_ARTIST_MBID } });
+
+        await expect(
+            musicBrainzService.getArtist(VALID_ARTIST_MBID),
+        ).resolves.toEqual({ id: VALID_ARTIST_MBID });
+        expect(mockHttpGet).toHaveBeenCalledWith(
+            `/artist/${VALID_ARTIST_MBID}`,
+            expect.any(Object),
+        );
     });
 
     it("returns first-hit result from searchAlbum strategy 1", async () => {
@@ -878,7 +952,7 @@ describe("musicBrainzService", () => {
                 data: {
                     releases: [
                         { id: "bootleg-1", status: "Bootleg" },
-                        { id: "official-1", status: "Official" },
+                        { id: VALID_RELEASE_MBID, status: "Official" },
                     ],
                 },
             })
@@ -905,7 +979,9 @@ describe("musicBrainzService", () => {
                 },
             });
 
-        const result = await musicBrainzService.getAlbumTracks("rg-tracks");
+        const result = await musicBrainzService.getAlbumTracks(
+            VALID_RELEASE_GROUP_MBID,
+        );
 
         expect(result).toEqual([
             { title: "Track 1", position: 1, duration: 180000 },
@@ -913,7 +989,7 @@ describe("musicBrainzService", () => {
         ]);
         expect(mockHttpGet).toHaveBeenNthCalledWith(
             1,
-            "/release-group/rg-tracks",
+            `/release-group/${VALID_RELEASE_GROUP_MBID}`,
             {
                 params: {
                     inc: "releases",
@@ -921,23 +997,30 @@ describe("musicBrainzService", () => {
                 },
             },
         );
-        expect(mockHttpGet).toHaveBeenNthCalledWith(2, "/release/official-1", {
-            params: {
-                inc: "recordings",
-                fmt: "json",
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+            2,
+            `/release/${VALID_RELEASE_MBID}`,
+            {
+                params: {
+                    inc: "recordings",
+                    fmt: "json",
+                },
             },
-        });
+        );
     });
 
     it("returns [] for albums with no releases and on getAlbumTracks errors", async () => {
         mockHttpGet.mockResolvedValueOnce({ data: { releases: [] } });
 
-        const noReleaseTracks =
-            await musicBrainzService.getAlbumTracks("rg-empty");
+        const noReleaseTracks = await musicBrainzService.getAlbumTracks(
+            VALID_RELEASE_GROUP_MBID,
+        );
         expect(noReleaseTracks).toEqual([]);
 
         mockHttpGet.mockRejectedValueOnce(new Error("album tracks failed"));
-        const errorTracks = await musicBrainzService.getAlbumTracks("rg-error");
+        const errorTracks = await musicBrainzService.getAlbumTracks(
+            VALID_RELEASE_GROUP_MBID,
+        );
         expect(errorTracks).toEqual([]);
         expect(mockLoggerError).toHaveBeenCalledWith(
             "MusicBrainz getAlbumTracks error: album tracks failed",

--- a/backend/src/services/musicbrainz.ts
+++ b/backend/src/services/musicbrainz.ts
@@ -8,6 +8,23 @@ import {
 } from "../utils/stringNormalization";
 import { BRAND_USER_AGENT } from "../config/brand";
 
+const MBID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type MbidEntity = "artist" | "release group" | "release";
+
+function validateMbid(value: unknown, entity: MbidEntity): string {
+    if (typeof value !== "string" || !MBID_PATTERN.test(value)) {
+        throw new TypeError(`Invalid ${entity} MBID`);
+    }
+
+    return value;
+}
+
+function encodeMbidPathSegment(value: unknown, entity: MbidEntity): string {
+    return encodeURIComponent(validateMbid(value, entity));
+}
+
 class MusicBrainzService {
     private client: AxiosInstance;
 
@@ -130,17 +147,21 @@ class MusicBrainzService {
     }
 
     async getArtist(mbid: string, includes: string[] = ["url-rels", "tags"]) {
-        const cacheKey = `mb:artist:${mbid}:${includes.join(",")}`;
+        const artistMbid = encodeMbidPathSegment(mbid, "artist");
+        const cacheKey = `mb:artist:${artistMbid}:${includes.join(",")}`;
 
         return this.cachedRequest(
             cacheKey,
             async () => {
-                const response = await this.client.get(`/artist/${mbid}`, {
-                    params: {
-                        inc: includes.join("+"),
-                        fmt: "json",
+                const response = await this.client.get(
+                    `/artist/${artistMbid}`,
+                    {
+                        params: {
+                            inc: includes.join("+"),
+                            fmt: "json",
+                        },
                     },
-                });
+                );
                 return response.data;
             },
             2592000,
@@ -153,14 +174,15 @@ class MusicBrainzService {
         types: string[] = ["album", "ep"],
         limit = 100,
     ) {
-        const cacheKey = `mb:rg:${artistMbid}:${types.join(",")}:${limit}`;
+        const validatedArtistMbid = validateMbid(artistMbid, "artist");
+        const cacheKey = `mb:rg:${validatedArtistMbid}:${types.join(",")}:${limit}`;
 
         return this.cachedRequest(
             cacheKey,
             async () => {
                 const response = await this.client.get("/release-group", {
                     params: {
-                        artist: artistMbid,
+                        artist: validatedArtistMbid,
                         type: types.join("|"),
                         limit,
                         fmt: "json",
@@ -174,13 +196,14 @@ class MusicBrainzService {
     }
 
     async getReleaseGroup(rgMbid: string) {
-        const cacheKey = `mb:rg:${rgMbid}`;
+        const releaseGroupMbid = encodeMbidPathSegment(rgMbid, "release group");
+        const cacheKey = `mb:rg:${releaseGroupMbid}`;
 
         return this.cachedRequest(
             cacheKey,
             async () => {
                 const response = await this.client.get(
-                    `/release-group/${rgMbid}`,
+                    `/release-group/${releaseGroupMbid}`,
                     {
                         params: {
                             inc: "artist-credits+releases",
@@ -196,13 +219,14 @@ class MusicBrainzService {
     }
 
     async getReleaseGroupDetails(rgMbid: string) {
-        const cacheKey = `mb:rg:details:${rgMbid}`;
+        const releaseGroupMbid = encodeMbidPathSegment(rgMbid, "release group");
+        const cacheKey = `mb:rg:details:${releaseGroupMbid}`;
 
         return this.cachedRequest(
             cacheKey,
             async () => {
                 const response = await this.client.get(
-                    `/release-group/${rgMbid}`,
+                    `/release-group/${releaseGroupMbid}`,
                     {
                         params: {
                             inc: "artist-credits+releases+labels",
@@ -218,13 +242,17 @@ class MusicBrainzService {
     }
 
     async getRelease(releaseMbid: string) {
-        const cacheKey = `mb:release:${releaseMbid}`;
+        const validatedReleaseMbid = encodeMbidPathSegment(
+            releaseMbid,
+            "release",
+        );
+        const cacheKey = `mb:release:${validatedReleaseMbid}`;
 
         return this.cachedRequest(
             cacheKey,
             async () => {
                 const response = await this.client.get(
-                    `/release/${releaseMbid}`,
+                    `/release/${validatedReleaseMbid}`,
                     {
                         params: {
                             inc: "recordings+artist-credits+labels",
@@ -804,13 +832,14 @@ class MusicBrainzService {
     async getAlbumTracks(
         rgMbid: string,
     ): Promise<Array<{ title: string; position?: number; duration?: number }>> {
-        const cacheKey = `mb:albumtracks:${rgMbid}`;
+        const releaseGroupMbid = encodeMbidPathSegment(rgMbid, "release group");
+        const cacheKey = `mb:albumtracks:${releaseGroupMbid}`;
 
         return this.cachedRequest(cacheKey, async () => {
             try {
                 // Step 1: Get releases from the release group
                 const rgResponse = await this.client.get(
-                    `/release-group/${rgMbid}`,
+                    `/release-group/${releaseGroupMbid}`,
                     {
                         params: {
                             inc: "releases",
@@ -822,7 +851,7 @@ class MusicBrainzService {
                 const releases = rgResponse.data?.releases || [];
                 if (releases.length === 0) {
                     logger.debug(
-                        `[MusicBrainz] No releases found for release group ${rgMbid}`,
+                        `[MusicBrainz] No releases found for release group ${releaseGroupMbid}`,
                     );
                     return [];
                 }
@@ -831,10 +860,14 @@ class MusicBrainzService {
                 const release =
                     releases.find((r: any) => r.status === "Official") ||
                     releases[0];
+                const releaseMbid = encodeMbidPathSegment(
+                    release.id,
+                    "release",
+                );
 
                 // Step 2: Get full release details with recordings
                 const releaseResponse = await this.client.get(
-                    `/release/${release.id}`,
+                    `/release/${releaseMbid}`,
                     {
                         params: {
                             inc: "recordings",
@@ -861,7 +894,7 @@ class MusicBrainzService {
                 }
 
                 logger.debug(
-                    `[MusicBrainz] Found ${tracks.length} tracks for release group ${rgMbid}`,
+                    `[MusicBrainz] Found ${tracks.length} tracks for release group ${releaseGroupMbid}`,
                 );
                 return tracks;
             } catch (error: any) {

--- a/backend/src/utils/__tests__/logger.test.ts
+++ b/backend/src/utils/__tests__/logger.test.ts
@@ -1,3 +1,5 @@
+import { format } from "node:util";
+
 const originalEnv = { ...process.env };
 
 describe("logger", () => {
@@ -134,8 +136,8 @@ describe("logger", () => {
 
         expect(consoleDebug).not.toHaveBeenCalled();
         expect(consoleInfo).not.toHaveBeenCalled();
-        expect(consoleWarn).toHaveBeenCalledWith("[WARN] warn call");
-        expect(consoleError).toHaveBeenCalledWith("[ERROR] error call");
+        expect(consoleWarn).toHaveBeenCalledWith("%s", "[WARN] warn call");
+        expect(consoleError).toHaveBeenCalledWith("%s", "[ERROR] error call");
     });
 
     it("uses development defaults when LOG_LEVEL is unset and NODE_ENV is not production", () => {
@@ -147,10 +149,10 @@ describe("logger", () => {
         logger.warn("warn call");
         logger.error("error call");
 
-        expect(consoleDebug).toHaveBeenCalledWith("[DEBUG] debug call");
-        expect(consoleInfo).toHaveBeenCalledWith("[INFO] info call");
-        expect(consoleWarn).toHaveBeenCalledWith("[WARN] warn call");
-        expect(consoleError).toHaveBeenCalledWith("[ERROR] error call");
+        expect(consoleDebug).toHaveBeenCalledWith("%s", "[DEBUG] debug call");
+        expect(consoleInfo).toHaveBeenCalledWith("%s", "[INFO] info call");
+        expect(consoleWarn).toHaveBeenCalledWith("%s", "[WARN] warn call");
+        expect(consoleError).toHaveBeenCalledWith("%s", "[ERROR] error call");
     });
 
     it("uses the environment default and warns once when LOG_LEVEL is unknown", () => {
@@ -196,8 +198,14 @@ describe("logger", () => {
                 scenario.expected.info ? 1 : 0,
             );
             expect(consoleWarn).toHaveBeenCalledTimes(2);
-            expect(consoleWarn).toHaveBeenLastCalledWith("[WARN] warn call");
-            expect(consoleError).toHaveBeenCalledWith("[ERROR] error call");
+            expect(consoleWarn).toHaveBeenLastCalledWith(
+                "%s",
+                "[WARN] warn call",
+            );
+            expect(consoleError).toHaveBeenCalledWith(
+                "%s",
+                "[ERROR] error call",
+            );
         }
     });
 
@@ -214,22 +222,42 @@ describe("logger", () => {
         logger.error("failed", new Error("nope"));
 
         expect(consoleDebug).toHaveBeenCalledWith(
+            "%s",
             "[DEBUG] starting",
             context,
             payload,
         );
         expect(consoleInfo).toHaveBeenCalledWith(
+            "%s",
             "[INFO] running",
             1,
             "two",
             context,
         );
-        expect(consoleWarn).toHaveBeenCalledWith("[WARN] almost", payload);
-        expect(consoleError).toHaveBeenCalledWith("[ERROR] failed", {
+        expect(consoleWarn).toHaveBeenCalledWith(
+            "%s",
+            "[WARN] almost",
+            payload,
+        );
+        expect(consoleError).toHaveBeenCalledWith("%s", "[ERROR] failed", {
             name: "Error",
             message: "nope",
             stack: expect.any(String),
         });
+    });
+
+    it("logs percent placeholders literally without consuming following arguments", () => {
+        const { logger, consoleInfo } = loadLoggerModule({ logLevel: "info" });
+        const rendered: string[] = [];
+        consoleInfo.mockImplementation((...args: unknown[]) => {
+            rendered.push(format(...args));
+        });
+
+        logger.info("requested %s track", "following-argument");
+
+        expect(rendered).toEqual([
+            "[INFO] requested %s track following-argument",
+        ]);
     });
 
     it("creates scoped child loggers with dotted scope names", () => {
@@ -243,6 +271,7 @@ describe("logger", () => {
         child.info("started", { jobId: "42" });
 
         expect(consoleInfo).toHaveBeenCalledWith(
+            "%s",
             "[INFO] [Worker.Scan] started",
             { jobId: "42" },
         );
@@ -262,17 +291,19 @@ describe("logger", () => {
 
         expect(result).toBe("ok");
         expect(consoleDebug).toHaveBeenCalledTimes(2);
-        expect(consoleDebug.mock.calls[0][0]).toBe(
+        expect(consoleDebug.mock.calls[0][0]).toBe("%s");
+        expect(consoleDebug.mock.calls[0][1]).toBe(
             "[DEBUG] refresh-cache started",
         );
-        expect(consoleDebug.mock.calls[0][1]).toEqual({ cacheKey: "abc" });
-        expect(consoleDebug.mock.calls[1][0]).toBe(
+        expect(consoleDebug.mock.calls[0][2]).toEqual({ cacheKey: "abc" });
+        expect(consoleDebug.mock.calls[1][0]).toBe("%s");
+        expect(consoleDebug.mock.calls[1][1]).toBe(
             "[DEBUG] refresh-cache completed",
         );
-        expect(consoleDebug.mock.calls[1][1]).toMatchObject({
+        expect(consoleDebug.mock.calls[1][2]).toMatchObject({
             cacheKey: "abc",
         });
-        expect(typeof consoleDebug.mock.calls[1][1].durationMs).toBe("number");
+        expect(typeof consoleDebug.mock.calls[1][2].durationMs).toBe("number");
     });
 
     it("withLogTiming records failure context and rethrows", async () => {
@@ -292,13 +323,14 @@ describe("logger", () => {
         ).rejects.toThrow("boom");
 
         expect(consoleError).toHaveBeenCalledTimes(1);
-        expect(consoleError.mock.calls[0][0]).toBe(
+        expect(consoleError.mock.calls[0][0]).toBe("%s");
+        expect(consoleError.mock.calls[0][1]).toBe(
             "[ERROR] refresh-cache failed",
         );
-        expect(consoleError.mock.calls[0][1]).toMatchObject({
+        expect(consoleError.mock.calls[0][2]).toMatchObject({
             cacheKey: "abc",
         });
-        expect(consoleError.mock.calls[0][1].error).toMatchObject({
+        expect(consoleError.mock.calls[0][2].error).toMatchObject({
             message: "boom",
             name: "Error",
         });
@@ -313,7 +345,7 @@ describe("logger", () => {
             jobId: "job-1",
         });
 
-        expect(consoleError).toHaveBeenCalledWith("[ERROR] job failed", {
+        expect(consoleError).toHaveBeenCalledWith("%s", "[ERROR] job failed", {
             jobId: "job-1",
             error: expect.objectContaining({
                 message: "nope",

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -119,11 +119,11 @@ function emit(
                 : console.error;
 
     if (context) {
-        method(prefix, context, ...passthrough);
+        method("%s", prefix, context, ...passthrough);
         return;
     }
 
-    method(prefix, ...passthrough);
+    method("%s", prefix, ...passthrough);
 }
 
 /**


### PR DESCRIPTION
Code-scanning cleanup surfaced during sweep #19 (CodeQL is advisory/non-required, so these never blocked the wave — this closes them so `main` is clean on code-scanning per the zero-warnings standard). All pre-existing; none introduced by the sweep-19 slices.

- **logger.ts — externally-controlled format string.** Scoped prefixes were `console.*`'s first argument (a printf format), so a `%s`/`%d` in a prefix could mis-format or consume a following argument. Prefixes are now data args to a constant `"%s"` format. Test: a `%s` prefix logs literally without consuming the next arg.
- **musicbrainz.ts — SSRF / path injection.** Request builders interpolated user ids into the path. The client has a fixed base URL (no host control), but an unvalidated id could inject path segments/query. Every MBID is now validated as a canonical 8-4-4-4-12 UUID and path-encoded before the call; free text stays in query params. Tests: traversal/query payloads rejected before any outbound work; valid UUID passes.
- **index.ts — missing CSRF middleware.** The session cookie already sets `SameSite=Lax` (mitigating classic cross-site unsafe requests for a design that also requires header/token credentials on mutations); added a narrowly-scoped, documented `codeql[js/missing-token-validation]` suppression. Test asserts the SameSite config. (A full CSRF-token scheme, if later desired, is noted as a follow-up.)

Verification: jest 109/109; `tsc --noEmit` clean; route-error canon green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).