### PR TITLE
fix(reliability): remove API-local queue-cleaner loop; use claimed worker jobs (sweep #19 M16)

### DIFF
--- a/backend/src/__tests__/lidarrWebhookFailClosed.test.ts
+++ b/backend/src/__tests__/lidarrWebhookFailClosed.test.ts
@@ -11,6 +11,7 @@
 export {};
 
 const mockScanQueueAdd = jest.fn(async () => undefined);
+const mockSchedulerQueueAdd = jest.fn(async () => undefined);
 const mockOnDownloadGrabbed = jest.fn(async () => ({ matched: false }));
 const mockOnDownloadComplete = jest.fn(async () => ({ jobId: null }));
 const mockOnImportFailed = jest.fn(async () => undefined);
@@ -24,6 +25,7 @@ const mockConfig = {
 
 jest.mock("../workers/queues", () => ({
     scanQueue: { add: mockScanQueueAdd },
+    schedulerQueue: { add: mockSchedulerQueueAdd },
 }));
 
 jest.mock("../services/simpleDownloadManager", () => ({
@@ -32,10 +34,6 @@ jest.mock("../services/simpleDownloadManager", () => ({
         onDownloadComplete: mockOnDownloadComplete,
         onImportFailed: mockOnImportFailed,
     },
-}));
-
-jest.mock("../jobs/queueCleaner", () => ({
-    queueCleaner: { start: jest.fn() },
 }));
 
 jest.mock("../utils/systemSettings", () => ({

--- a/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 
 type AuthFailureMode = "ok" | "unauthorized" | "forbidden";
 const authFailureState = { mode: "ok" as AuthFailureMode };
+const mockQueueCleanerLogError = jest.fn();
 
 const mockRequireAuth = jest.fn(
     async (_req: Request, res: Response, next: () => void) => {
@@ -33,6 +34,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: mockQueueCleanerLogError,
+        })),
     },
 }));
 
@@ -61,11 +68,19 @@ jest.mock("../../utils/systemSettings", () => ({
     invalidateSystemSettingsCache: jest.fn(),
 }));
 
-jest.mock("../../jobs/queueCleaner", () => ({
-    queueCleaner: {
-        start: jest.fn(),
-        stop: jest.fn(),
-        getStatus: jest.fn(() => ({ running: false, lastRunAt: null })),
+const mockSchedulerJobGetState = jest.fn();
+const mockSchedulerJobRemove = jest.fn();
+const mockSchedulerJob = {
+    id: "scheduler:reconciliation:on-demand",
+    getState: mockSchedulerJobGetState,
+    remove: mockSchedulerJobRemove,
+};
+const mockSchedulerQueueAdd = jest.fn();
+const mockSchedulerQueueGetJob = jest.fn();
+jest.mock("../../workers/queues", () => ({
+    schedulerQueue: {
+        add: (...args: unknown[]) => mockSchedulerQueueAdd(...args),
+        getJob: (...args: unknown[]) => mockSchedulerQueueGetJob(...args),
     },
 }));
 
@@ -135,7 +150,6 @@ import router from "../systemSettings";
 import { prisma } from "../../utils/db";
 import { writeEnvFile, EnvFileSyncSkippedError } from "../../utils/envWriter";
 import { invalidateSystemSettingsCache } from "../../utils/systemSettings";
-import { queueCleaner } from "../../jobs/queueCleaner";
 import { decrypt } from "../../utils/encryption";
 import { lastFmService } from "../../services/lastfm";
 import { tidalService } from "../../services/tidal";
@@ -156,7 +170,6 @@ const mockAxiosPut = axios.put as jest.Mock;
 const mockWriteEnvFile = writeEnvFile as jest.Mock;
 const mockInvalidateSystemSettingsCache =
     invalidateSystemSettingsCache as jest.Mock;
-const mockQueueCleaner = queueCleaner as jest.Mocked<typeof queueCleaner>;
 const mockDecrypt = decrypt as jest.Mock;
 const mockLastFmService = lastFmService as jest.Mocked<typeof lastFmService>;
 const mockTidalService = tidalService as jest.Mocked<typeof tidalService>;
@@ -266,11 +279,10 @@ describe("systemSettings runtime routes", () => {
         mockDecrypt.mockImplementation((value: string) => `dec:${value}`);
         mockLastFmService.refreshApiKey.mockResolvedValue(undefined as any);
         mockSoulseekService.disconnect.mockReturnValue(undefined as any);
-        mockQueueCleaner.start.mockResolvedValue(undefined as any);
-        mockQueueCleaner.getStatus.mockReturnValue({
-            running: true,
-            lastRunAt: "2026-02-17T00:00:00.000Z",
-        } as any);
+        mockSchedulerQueueAdd.mockResolvedValue(mockSchedulerJob);
+        mockSchedulerQueueGetJob.mockResolvedValue(null);
+        mockSchedulerJobGetState.mockResolvedValue("waiting");
+        mockSchedulerJobRemove.mockResolvedValue(undefined);
         mockTidalService.isSidecarHealthy.mockResolvedValue(true);
         mockTidalService.verifySession.mockResolvedValue({
             valid: true,
@@ -1425,24 +1437,67 @@ describe("systemSettings runtime routes", () => {
         });
     });
 
-    it("manages queue cleaner and clears cache keys while preserving sessions", async () => {
+    it("manages the cluster queue-cleaner job and clears cache keys while preserving sessions", async () => {
+        mockSchedulerQueueGetJob.mockResolvedValueOnce(mockSchedulerJob);
+        mockSchedulerJobGetState.mockResolvedValueOnce("active");
         const queueStatusReq = { user: { id: "user-1" } } as any;
         const queueStatusRes = createRes();
         await queueStatusHandler(queueStatusReq, queueStatusRes);
         expect(queueStatusRes.statusCode).toBe(200);
-        expect(queueStatusRes.body.running).toBe(true);
+        expect(queueStatusRes.body).toEqual({
+            running: true,
+            queued: false,
+            state: "active",
+            jobId: "scheduler:reconciliation:on-demand",
+            workerOwned: true,
+        });
 
         const startReq = { user: { id: "user-1" } } as any;
         const startRes = createRes();
         await queueStartHandler(startReq, startRes);
         expect(startRes.statusCode).toBe(200);
-        expect(startRes.body.success).toBe(true);
+        expect(mockSchedulerQueueAdd).toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            {
+                mode: "repeat",
+                source: "system-settings",
+            },
+            {
+                jobId: "scheduler:reconciliation:on-demand",
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
+        expect(startRes.body).toEqual({
+            success: true,
+            message: "Queue cleaner job enqueued",
+            status: {
+                running: false,
+                queued: true,
+                state: "waiting",
+                jobId: "scheduler:reconciliation:on-demand",
+                workerOwned: true,
+            },
+        });
 
+        mockSchedulerQueueGetJob.mockResolvedValueOnce(mockSchedulerJob);
+        mockSchedulerJobGetState.mockResolvedValueOnce("waiting");
         const stopReq = { user: { id: "user-1" } } as any;
         const stopRes = createRes();
         await queueStopHandler(stopReq, stopRes);
         expect(stopRes.statusCode).toBe(200);
-        expect(stopRes.body.success).toBe(true);
+        expect(mockSchedulerJobRemove).toHaveBeenCalledTimes(1);
+        expect(stopRes.body).toEqual({
+            success: true,
+            message: "Queued queue cleaner job cancelled",
+            status: {
+                running: false,
+                queued: false,
+                state: "idle",
+                jobId: null,
+                workerOwned: true,
+            },
+        });
 
         mockRedisClient.keys.mockResolvedValue([
             "sess:abc",
@@ -1462,14 +1517,68 @@ describe("systemSettings runtime routes", () => {
         );
     });
 
-    it("returns 500 when queue cleaner start fails", async () => {
-        mockQueueCleaner.start.mockRejectedValueOnce(
-            new Error("queue unavailable"),
-        );
+    it("sanitizes queue cleaner enqueue failures while logging raw detail", async () => {
+        const queueError = new Error("redis://secret@queue unavailable");
+        mockSchedulerQueueAdd.mockRejectedValueOnce(queueError);
         const req = { user: { id: "user-1" } } as any;
         const res = createRes();
         await queueStartHandler(req, res);
         expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to start queue cleaner" });
+        expect(JSON.stringify(res.body)).not.toContain("redis://secret");
+        expect(mockQueueCleanerLogError).toHaveBeenCalledWith(
+            "Failed to enqueue queue cleaner worker job",
+            queueError,
+        );
+    });
+
+    it("refuses to interrupt an active claimed queue cleaner job", async () => {
+        mockSchedulerQueueGetJob.mockResolvedValueOnce(mockSchedulerJob);
+        mockSchedulerJobGetState.mockResolvedValueOnce("active");
+        const req = { user: { id: "user-1" } } as any;
+        const res = createRes();
+
+        await queueStopHandler(req, res);
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body).toEqual({
+            error: "Queue cleaner job is already active",
+        });
+        expect(mockSchedulerJobRemove).not.toHaveBeenCalled();
+    });
+
+    it("sanitizes queue cleaner status and cancellation failures", async () => {
+        const statusError = new Error("redis://status-secret@queue");
+        mockSchedulerQueueGetJob.mockRejectedValueOnce(statusError);
+        const statusRes = createRes();
+
+        await queueStatusHandler({ user: { id: "user-1" } } as any, statusRes);
+
+        expect(statusRes.statusCode).toBe(500);
+        expect(statusRes.body).toEqual({
+            error: "Failed to get queue cleaner status",
+        });
+        expect(JSON.stringify(statusRes.body)).not.toContain("status-secret");
+        expect(mockQueueCleanerLogError).toHaveBeenCalledWith(
+            "Failed to read queue cleaner worker status",
+            statusError,
+        );
+
+        const cancellationError = new Error("redis://stop-secret@queue");
+        mockSchedulerQueueGetJob.mockResolvedValueOnce(mockSchedulerJob);
+        mockSchedulerJobGetState.mockResolvedValueOnce("waiting");
+        mockSchedulerJobRemove.mockRejectedValueOnce(cancellationError);
+        const stopRes = createRes();
+
+        await queueStopHandler({ user: { id: "user-1" } } as any, stopRes);
+
+        expect(stopRes.statusCode).toBe(500);
+        expect(stopRes.body).toEqual({ error: "Failed to stop queue cleaner" });
+        expect(JSON.stringify(stopRes.body)).not.toContain("stop-secret");
+        expect(mockQueueCleanerLogError).toHaveBeenCalledWith(
+            "Failed to cancel queued queue cleaner worker job",
+            cancellationError,
+        );
     });
 
     it("handles cache clear when no non-session keys exist", async () => {

--- a/backend/src/routes/__tests__/webhooksGrabConcurrency.test.ts
+++ b/backend/src/routes/__tests__/webhooksGrabConcurrency.test.ts
@@ -9,16 +9,13 @@
  * 2xx, not the pre-fix uncaught-P2002 500.
  */
 const mockScanQueueAdd = jest.fn();
+const mockSchedulerQueueAdd = jest.fn();
 jest.mock("../../workers/queues", () => ({
     scanQueue: {
         add: (...args: unknown[]) => mockScanQueueAdd(...args),
     },
-}));
-
-const mockQueueCleanerStart = jest.fn();
-jest.mock("../../jobs/queueCleaner", () => ({
-    queueCleaner: {
-        start: (...args: unknown[]) => mockQueueCleanerStart(...args),
+    schedulerQueue: {
+        add: (...args: unknown[]) => mockSchedulerQueueAdd(...args),
     },
 }));
 
@@ -276,6 +273,32 @@ describe("webhooks Grab route -- real simpleDownloadManager P2002 race (F23)", (
         expect(firstRes.body).toEqual({ success: true });
         expect(secondRes.statusCode).toBe(200);
         expect(secondRes.body).toEqual({ success: true });
-        expect(mockQueueCleanerStart).toHaveBeenCalledTimes(2);
+        expect(mockSchedulerQueueAdd).toHaveBeenCalledTimes(2);
+        expect(mockSchedulerQueueAdd).toHaveBeenNthCalledWith(
+            1,
+            "download-reconciliation-cycle",
+            {
+                mode: "repeat",
+                source: "lidarr-webhook",
+            },
+            {
+                jobId: "scheduler:reconciliation:on-demand",
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
+        expect(mockSchedulerQueueAdd).toHaveBeenNthCalledWith(
+            2,
+            "download-reconciliation-cycle",
+            {
+                mode: "repeat",
+                source: "lidarr-webhook",
+            },
+            {
+                jobId: "scheduler:reconciliation:on-demand",
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
     });
 });

--- a/backend/src/routes/__tests__/webhooksRuntime.test.ts
+++ b/backend/src/routes/__tests__/webhooksRuntime.test.ts
@@ -1,7 +1,11 @@
 const mockScanQueueAdd = jest.fn();
+const mockSchedulerQueueAdd = jest.fn();
 jest.mock("../../workers/queues", () => ({
     scanQueue: {
         add: (...args: unknown[]) => mockScanQueueAdd(...args),
+    },
+    schedulerQueue: {
+        add: (...args: unknown[]) => mockSchedulerQueueAdd(...args),
     },
 }));
 
@@ -15,13 +19,6 @@ jest.mock("../../services/simpleDownloadManager", () => ({
         onDownloadComplete: (...args: unknown[]) =>
             mockOnDownloadComplete(...args),
         onImportFailed: (...args: unknown[]) => mockOnImportFailed(...args),
-    },
-}));
-
-const mockQueueCleanerStart = jest.fn();
-jest.mock("../../jobs/queueCleaner", () => ({
-    queueCleaner: {
-        start: (...args: unknown[]) => mockQueueCleanerStart(...args),
     },
 }));
 
@@ -226,7 +223,7 @@ describe("webhooks routes runtime", () => {
         );
     });
 
-    it("handles Grab events, starts cleaner when matched, and ignores missing ids", async () => {
+    it("handles Grab events, enqueues claimed reconciliation when matched, and ignores missing ids", async () => {
         mockOnDownloadGrabbed.mockResolvedValueOnce({ matched: true });
 
         const req = {
@@ -255,7 +252,18 @@ describe("webhooks routes runtime", () => {
             "Artist One",
             42,
         );
-        expect(mockQueueCleanerStart).toHaveBeenCalledTimes(1);
+        expect(mockSchedulerQueueAdd).toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            {
+                mode: "repeat",
+                source: "lidarr-webhook",
+            },
+            {
+                jobId: "scheduler:reconciliation:on-demand",
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({ success: true });
 
@@ -404,9 +412,8 @@ describe("webhooks routes runtime", () => {
     });
 
     it("returns 500 on webhook processing errors", async () => {
-        mockGetSystemSettings.mockRejectedValueOnce(
-            new Error("settings unavailable"),
-        );
+        const routeError = new Error("settings unavailable");
+        mockGetSystemSettings.mockRejectedValueOnce(routeError);
 
         const req = {
             body: { eventType: "Grab", downloadId: "dl-9" },
@@ -419,8 +426,33 @@ describe("webhooks routes runtime", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({ error: "Webhook processing failed" });
         expect(mockLoggerError).toHaveBeenCalledWith(
-            "Webhook error:",
-            "settings unavailable",
+            "Webhook error",
+            routeError,
+        );
+    });
+
+    it("sanitizes scheduler enqueue failures for matched Grab events", async () => {
+        const queueError = new Error("redis://secret@queue unavailable");
+        mockOnDownloadGrabbed.mockResolvedValueOnce({ matched: true });
+        mockSchedulerQueueAdd.mockRejectedValueOnce(queueError);
+        const req = {
+            body: {
+                eventType: "Grab",
+                downloadId: "dl-queue-error",
+                albums: [{ foreignAlbumId: "mbid-queue-error" }],
+            },
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await postLidarr(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Webhook processing failed" });
+        expect(JSON.stringify(res.body)).not.toContain("redis://secret");
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Webhook error",
+            queueError,
         );
     });
 });

--- a/backend/src/routes/systemSettings.ts
+++ b/backend/src/routes/systemSettings.ts
@@ -5,7 +5,7 @@ import { prisma } from "../utils/db";
 import { z } from "zod";
 import { EnvFileSyncSkippedError, writeEnvFile } from "../utils/envWriter";
 import { invalidateSystemSettingsCache } from "../utils/systemSettings";
-import { queueCleaner } from "../jobs/queueCleaner";
+import { schedulerQueue } from "../workers/queues";
 import { encrypt, decrypt } from "../utils/encryption";
 import { ENCRYPTED_SETTINGS_COLUMNS } from "../utils/encryptedColumns";
 import { BRAND_NAME, BRAND_SLUG } from "../config/brand";
@@ -15,8 +15,69 @@ import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 const router = Router();
 const WEBHOOK_NAME_ALIASES = [BRAND_NAME];
 const WEBHOOK_URL_ALIASES = [BRAND_SLUG];
+const QUEUE_CLEANER_JOB_NAME = "download-reconciliation-cycle";
+const QUEUE_CLEANER_JOB_ID = "scheduler:reconciliation:on-demand";
+const queueCleanerLog = logger.child("SystemSettingsQueueCleaner");
 // Shared validation message for admin outbound connection-test URLs.
 const ADMIN_TEST_URL_ERROR = "URL must be a valid public HTTP(S) URL";
+
+type QueueCleanerWorkerStatus = {
+    running: boolean;
+    queued: boolean;
+    state: string;
+    jobId: string | null;
+    workerOwned: true;
+};
+
+function idleQueueCleanerWorkerStatus(): QueueCleanerWorkerStatus {
+    return {
+        running: false,
+        queued: false,
+        state: "idle",
+        jobId: null,
+        workerOwned: true,
+    };
+}
+
+async function getQueueCleanerWorkerStatus(
+    job: Awaited<ReturnType<typeof schedulerQueue.getJob>>,
+): Promise<QueueCleanerWorkerStatus> {
+    if (!job) return idleQueueCleanerWorkerStatus();
+
+    const state = await job.getState();
+    return {
+        running: state === "active",
+        queued: ["waiting", "delayed", "paused"].includes(state),
+        state,
+        jobId: String(job.id),
+        workerOwned: true,
+    };
+}
+
+async function enqueueQueueCleanerWorkerJob() {
+    return schedulerQueue.add(
+        QUEUE_CLEANER_JOB_NAME,
+        { mode: "repeat", source: "system-settings" },
+        {
+            jobId: QUEUE_CLEANER_JOB_ID,
+            removeOnComplete: true,
+            removeOnFail: 10,
+        },
+    );
+}
+
+async function cancelQueuedQueueCleanerWorkerJob(): Promise<
+    "absent" | "active" | "cancelled"
+> {
+    const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
+    if (!job) return "absent";
+
+    const status = await getQueueCleanerWorkerStatus(job);
+    if (status.running) return "active";
+
+    await job.remove();
+    return "cancelled";
+}
 
 function normalizeAdminTestUrl(url: string): string | null {
     // Deliberately the STRING check only (no DNS resolution): admin connection
@@ -1273,7 +1334,7 @@ router.post("/tidal-auth/token", async (req, res) => {
  * @openapi
  * /api/system-settings/queue-cleaner-status:
  *   get:
- *     summary: Get queue cleaner status
+ *     summary: Get cluster-wide queue cleaner worker-job status
  *     tags: [System Settings]
  *     security:
  *       - sessionAuth: []
@@ -1286,23 +1347,32 @@ router.post("/tidal-auth/token", async (req, res) => {
  *       403:
  *         description: Admin access required
  */
-// Get queue cleaner status
-router.get("/queue-cleaner-status", (req, res) => {
-    res.json(queueCleaner.getStatus());
+// Get queue cleaner worker-job status from the shared scheduler queue.
+router.get("/queue-cleaner-status", async (req, res) => {
+    try {
+        const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
+        res.json(await getQueueCleanerWorkerStatus(job));
+    } catch (error) {
+        queueCleanerLog.error(
+            "Failed to read queue cleaner worker status",
+            error,
+        );
+        sendInternalRouteError(res, "Failed to get queue cleaner status");
+    }
 });
 
 /**
  * @openapi
  * /api/system-settings/queue-cleaner/start:
  *   post:
- *     summary: Start the queue cleaner manually
+ *     summary: Enqueue a claimed queue cleaner worker job
  *     tags: [System Settings]
  *     security:
  *       - sessionAuth: []
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Queue cleaner started
+ *         description: Queue cleaner worker job enqueued
  *       401:
  *         description: Not authenticated
  *       403:
@@ -1310,19 +1380,21 @@ router.get("/queue-cleaner-status", (req, res) => {
  *       500:
  *         description: Failed to start queue cleaner
  */
-// Start queue cleaner manually
+// Request one coalesced reconciliation cycle from the worker scheduler.
 router.post("/queue-cleaner/start", async (req, res) => {
     try {
-        await queueCleaner.start();
+        const job = await enqueueQueueCleanerWorkerJob();
         res.json({
             success: true,
-            message: "Queue cleaner started",
-            status: queueCleaner.getStatus(),
+            message: "Queue cleaner job enqueued",
+            status: await getQueueCleanerWorkerStatus(job),
         });
-    } catch (error: any) {
-        res.status(500).json({
-            error: "Failed to start queue cleaner",
-        });
+    } catch (error) {
+        queueCleanerLog.error(
+            "Failed to enqueue queue cleaner worker job",
+            error,
+        );
+        sendInternalRouteError(res, "Failed to start queue cleaner");
     }
 });
 
@@ -1330,27 +1402,50 @@ router.post("/queue-cleaner/start", async (req, res) => {
  * @openapi
  * /api/system-settings/queue-cleaner/stop:
  *   post:
- *     summary: Stop the queue cleaner manually
+ *     summary: Cancel a queued queue cleaner worker job
  *     tags: [System Settings]
  *     security:
  *       - sessionAuth: []
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Queue cleaner stopped
+ *         description: Queued queue cleaner worker job cancelled or absent
  *       401:
  *         description: Not authenticated
  *       403:
  *         description: Admin access required
+ *       409:
+ *         description: Queue cleaner job is already active
+ *       500:
+ *         description: Failed to stop queue cleaner
  */
-// Stop queue cleaner manually
-router.post("/queue-cleaner/stop", (req, res) => {
-    queueCleaner.stop();
-    res.json({
-        success: true,
-        message: "Queue cleaner stopped",
-        status: queueCleaner.getStatus(),
-    });
+// Cancel a pending cluster-wide request; claimed active work is not interruptible.
+router.post("/queue-cleaner/stop", async (req, res) => {
+    try {
+        const result = await cancelQueuedQueueCleanerWorkerJob();
+        if (result === "active") {
+            return sendRouteError(
+                res,
+                409,
+                "Queue cleaner job is already active",
+            );
+        }
+
+        return res.json({
+            success: true,
+            message:
+                result === "cancelled"
+                    ? "Queued queue cleaner job cancelled"
+                    : "No queued queue cleaner job",
+            status: idleQueueCleanerWorkerStatus(),
+        });
+    } catch (error) {
+        queueCleanerLog.error(
+            "Failed to cancel queued queue cleaner worker job",
+            error,
+        );
+        return sendInternalRouteError(res, "Failed to stop queue cleaner");
+    }
 });
 
 /**

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -6,9 +6,8 @@
  */
 
 import { Router } from "express";
-import { scanQueue } from "../workers/queues";
+import { scanQueue, schedulerQueue } from "../workers/queues";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
-import { queueCleaner } from "../jobs/queueCleaner";
 import { getSystemSettings } from "../utils/systemSettings";
 import { webhookLimiter } from "../middleware/rateLimiter";
 import { prisma } from "../utils/db";
@@ -16,9 +15,24 @@ import { logger } from "../utils/logger";
 import { config } from "../config";
 import { BRAND_SLUG } from "../config/brand";
 import { timingSafeCompare } from "../utils/timingSafe";
+import { sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
 const LEGACY_SERVICE_ALIASES = [BRAND_SLUG];
+const QUEUE_CLEANER_JOB_NAME = "download-reconciliation-cycle";
+const QUEUE_CLEANER_JOB_ID = "scheduler:reconciliation:on-demand";
+
+async function enqueueQueueCleanerJob(): Promise<void> {
+    await schedulerQueue.add(
+        QUEUE_CLEANER_JOB_NAME,
+        { mode: "repeat", source: "lidarr-webhook" },
+        {
+            jobId: QUEUE_CLEANER_JOB_ID,
+            removeOnComplete: true,
+            removeOnFail: 10,
+        },
+    );
+}
 
 /**
  * @openapi
@@ -163,9 +177,9 @@ router.post("/lidarr", webhookLimiter, async (req, res) => {
         }
 
         res.json({ success: true });
-    } catch (error: any) {
-        logger.error("Webhook error:", error.message);
-        res.status(500).json({ error: "Webhook processing failed" });
+    } catch (error) {
+        logger.error("Webhook error", error);
+        sendInternalRouteError(res, "Webhook processing failed");
     }
 });
 
@@ -199,8 +213,7 @@ async function handleGrab(payload: any) {
     );
 
     if (result.matched) {
-        // Start queue cleaner to monitor this download
-        queueCleaner.start();
+        await enqueueQueueCleanerJob();
     }
 }
 


### PR DESCRIPTION
Convergence sweep #19 remediation (M16) — the final slice of the wave.

A Lidarr webhook (`backend/src/routes/webhooks.ts`) and the admin settings endpoints (`backend/src/routes/systemSettings.ts`) started `queueCleaner` **inside an API replica**, while workers already run overlapping reconciliation under scheduler claims. In split/HA deployments this creates duplicate mutators and pod-local start/stop state that doesn't reflect the cluster.

Fix
- The Lidarr webhook enqueues a **claimed scheduler-queue job** instead of `queueCleaner.start()` in-process; the `queueCleaner` import is removed from the route.
- Admin status/start/stop endpoints operate on **shared Bull job state**: queued work is cancellable, active claimed work returns `409`, and status reflects the cluster rather than one pod. Errors stay sanitized (raw detail to a scoped logger).
- No worker files touched — the claimed job uses existing queue infra, so this is disjoint from the durable-import-jobs slice (#361).

Verification: targeted jest 70/70 (matched/concurrent webhooks, status/start/stop, active-job 409, sanitized Redis failures); OpenAPI route sync 4/4; `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).