### PR TITLE
fix(security): library-deletion path containment (sweep #20 N6)

### DIFF
--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -12,14 +12,17 @@ jest.mock("../../middleware/rateLimiter", () => ({
     apiLimiter: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
+jest.mock("../../utils/logger", () => {
+    const logger = {
         debug: jest.fn(),
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
-    },
-}));
+        child: jest.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    return { logger };
+});
 
 jest.mock("../../utils/db", () => ({
     prisma: {

--- a/backend/src/routes/__tests__/libraryErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/libraryErrorLeak.test.ts
@@ -12,14 +12,17 @@ jest.mock("../../middleware/rateLimiter", () => ({
     apiLimiter: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
+jest.mock("../../utils/logger", () => {
+    const logger = {
         debug: jest.fn(),
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
-    },
-}));
+        child: jest.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    return { logger };
+});
 
 const prisma = {
     artist: { count: jest.fn(), findMany: jest.fn() },

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -4248,8 +4248,7 @@ describe("library catalog list runtime coverage", () => {
                         { filePath: "/absolute/track.flac" },
                         { filePath: "Artist/../Other/track.flac" },
                         {
-                            filePath:
-                                "Safe Artist/Safe Album/safe-track.flac",
+                            filePath: "Safe Artist/Safe Album/safe-track.flac",
                         },
                     ],
                 },

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -4059,6 +4059,60 @@ describe("library catalog list runtime coverage", () => {
         unlinkSpy.mockRestore();
     });
 
+    it("skips absolute and dot-segment track paths while deleting their database rows", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            libraryDeletionEnabled: true,
+        });
+        mockTrackFindUnique
+            .mockResolvedValueOnce({
+                id: "track-absolute",
+                title: "Absolute Path",
+                filePath: "/outside/track.flac",
+            })
+            .mockResolvedValueOnce({
+                id: "track-windows-absolute",
+                title: "Windows Absolute Path",
+                filePath: "C:\\outside\\track.flac",
+            })
+            .mockResolvedValueOnce({
+                id: "track-dot-segment",
+                title: "Dot Segment Path",
+                filePath: "Artist/../outside.flac",
+            });
+        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+        const unlinkSpy = jest
+            .spyOn(fs, "unlinkSync")
+            .mockImplementation(() => undefined);
+
+        await deleteTrackHandler(
+            { params: { id: "track-absolute" } } as any,
+            createRes(),
+        );
+        await deleteTrackHandler(
+            { params: { id: "track-windows-absolute" } } as any,
+            createRes(),
+        );
+        await deleteTrackHandler(
+            { params: { id: "track-dot-segment" } } as any,
+            createRes(),
+        );
+
+        expect(existsSpy).not.toHaveBeenCalled();
+        expect(unlinkSpy).not.toHaveBeenCalled();
+        expect(mockTrackDelete).toHaveBeenNthCalledWith(1, {
+            where: { id: "track-absolute" },
+        });
+        expect(mockTrackDelete).toHaveBeenNthCalledWith(2, {
+            where: { id: "track-windows-absolute" },
+        });
+        expect(mockTrackDelete).toHaveBeenNthCalledWith(3, {
+            where: { id: "track-dot-segment" },
+        });
+
+        existsSpy.mockRestore();
+        unlinkSpy.mockRestore();
+    });
+
     it("continues track deletion when file removal fails", async () => {
         mockGetSystemSettings.mockResolvedValueOnce({
             libraryDeletionEnabled: true,
@@ -4172,6 +4226,62 @@ describe("library catalog list runtime coverage", () => {
             deletedFiles: 2,
             lidarrDeleted: false,
             lidarrError: null,
+        });
+
+        existsSpy.mockRestore();
+        unlinkSpy.mockRestore();
+        rmSpy.mockRestore();
+    });
+
+    it("contains artist file and recursive folder deletion for malicious persisted paths", async () => {
+        mockGetSystemSettings.mockResolvedValueOnce({
+            libraryDeletionEnabled: true,
+        });
+        mockArtistFindUnique.mockResolvedValueOnce({
+            id: "artist-containment",
+            name: "Safe Artist",
+            mbid: null,
+            albums: [
+                {
+                    tracks: [
+                        { filePath: "../outside/track.flac" },
+                        { filePath: "/absolute/track.flac" },
+                        { filePath: "Artist/../Other/track.flac" },
+                        {
+                            filePath:
+                                "Safe Artist/Safe Album/safe-track.flac",
+                        },
+                    ],
+                },
+            ],
+        });
+        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+        const unlinkSpy = jest
+            .spyOn(fs, "unlinkSync")
+            .mockImplementation(() => undefined);
+        const rmSpy = jest
+            .spyOn(fs, "rmSync")
+            .mockImplementation(() => undefined);
+
+        const res = createRes();
+        await deleteArtistHandler(
+            { params: { id: "artist-containment" } } as any,
+            res,
+        );
+
+        expect(unlinkSpy).toHaveBeenCalledTimes(1);
+        expect(unlinkSpy).toHaveBeenCalledWith(
+            "/music/Safe Artist/Safe Album/safe-track.flac",
+        );
+        expect(rmSpy).toHaveBeenCalled();
+        for (const [targetPath] of rmSpy.mock.calls) {
+            expect(targetPath).not.toBe("/music");
+            expect(targetPath).not.toBe("/");
+            expect(targetPath.toString().startsWith("/music/")).toBe(true);
+        }
+        expect(res.body.deletedFiles).toBe(1);
+        expect(mockArtistDelete).toHaveBeenCalledWith({
+            where: { id: "artist-containment" },
         });
 
         existsSpy.mockRestore();
@@ -4416,6 +4526,51 @@ describe("library catalog list runtime coverage", () => {
             message: "Album deleted successfully",
             deletedFiles: 1,
         });
+
+        existsSpy.mockRestore();
+        unlinkSpy.mockRestore();
+        readdirSpy.mockRestore();
+        rmdirSpy.mockRestore();
+    });
+
+    it("skips unsafe album track paths and out-of-root album folders", async () => {
+        mockGetSystemSettings.mockResolvedValueOnce({
+            libraryDeletionEnabled: true,
+        });
+        mockAlbumFindUnique.mockResolvedValueOnce({
+            id: "album-contained",
+            title: "..",
+            artist: { name: ".." },
+            tracks: [
+                { filePath: "../outside.flac" },
+                { filePath: "Safe Artist/Safe Album/safe.flac" },
+            ],
+        });
+        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+        const unlinkSpy = jest
+            .spyOn(fs, "unlinkSync")
+            .mockImplementation(() => undefined);
+        const readdirSpy = jest.spyOn(fs, "readdirSync").mockReturnValue([]);
+        const rmdirSpy = jest
+            .spyOn(fs, "rmdirSync")
+            .mockImplementation(() => undefined);
+
+        const res = createRes();
+        await deleteAlbumHandler(
+            { params: { id: "album-contained" } } as any,
+            res,
+        );
+
+        expect(unlinkSpy).toHaveBeenCalledTimes(1);
+        expect(unlinkSpy).toHaveBeenCalledWith(
+            "/music/Safe Artist/Safe Album/safe.flac",
+        );
+        expect(readdirSpy).not.toHaveBeenCalled();
+        expect(rmdirSpy).not.toHaveBeenCalled();
+        expect(mockAlbumDelete).toHaveBeenCalledWith({
+            where: { id: "album-contained" },
+        });
+        expect(res.body.deletedFiles).toBe(1);
 
         existsSpy.mockRestore();
         unlinkSpy.mockRestore();

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -5370,10 +5370,10 @@ router.delete<{ id: string }>(
                         });
                     }
                 } catch (err) {
-                    libraryDeletionLogger.warn(
-                        "Could not delete track file",
-                        { trackId: track.id, error: err },
-                    );
+                    libraryDeletionLogger.warn("Could not delete track file", {
+                        trackId: track.id,
+                        error: err,
+                    });
                     // Continue with database deletion even if file deletion fails
                 }
             }
@@ -5592,8 +5592,9 @@ router.delete<{ id: string }>(
             for (const album of artist.albums) {
                 for (const track of album.tracks) {
                     if (track.filePath) {
-                        const deletionPath =
-                            resolvePersistedTrackDeletionPath(track.filePath);
+                        const deletionPath = resolvePersistedTrackDeletionPath(
+                            track.filePath,
+                        );
                         if (!deletionPath) {
                             libraryDeletionLogger.warn(
                                 "Skipped unsafe persisted artist track path",
@@ -5609,7 +5610,10 @@ router.delete<{ id: string }>(
                                         deletionPath.pathParts[0].toLowerCase() ===
                                         "soulseek"
                                             ? deletionPath.pathParts.slice(0, 2)
-                                            : deletionPath.pathParts.slice(0, 1);
+                                            : deletionPath.pathParts.slice(
+                                                  0,
+                                                  1,
+                                              );
                                     const artistFolder = safeResolvePath(
                                         config.music.musicPath,
                                         artistPathParts.join("/"),

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -5281,6 +5281,49 @@ router.get<{ id: string }>(
  *       401:
  *         description: Not authenticated
  */
+interface PersistedTrackDeletionPath {
+    absolutePath: string;
+    pathParts: string[];
+}
+
+const resolvePersistedTrackDeletionPath = (
+    persistedPath: string,
+): PersistedTrackDeletionPath | null => {
+    const normalizedPath = persistedPath.replace(/\\/g, "/");
+    if (
+        path.posix.isAbsolute(normalizedPath) ||
+        path.win32.isAbsolute(persistedPath)
+    ) {
+        return null;
+    }
+
+    const pathParts = normalizedPath.split("/").filter(Boolean);
+    if (
+        pathParts.length === 0 ||
+        pathParts.some((part) => part === "." || part === "..")
+    ) {
+        return null;
+    }
+
+    const absolutePath = safeResolvePath(
+        config.music.musicPath,
+        normalizedPath,
+    );
+    return absolutePath ? { absolutePath, pathParts } : null;
+};
+
+const isSafeRecursiveDeletionTarget = (targetPath: string): boolean => {
+    const musicPath = path.resolve(config.music.musicPath);
+    const resolvedTarget = path.resolve(targetPath);
+    const relativeTarget = path.relative(musicPath, resolvedTarget);
+    return (
+        safeResolvePath(config.music.musicPath, relativeTarget) ===
+        resolvedTarget
+    );
+};
+
+const libraryDeletionLogger = logger.child("LibraryDeletion");
+
 // DELETE /library/tracks/:id
 router.delete<{ id: string }>(
     "/tracks/:id",
@@ -5310,23 +5353,29 @@ router.delete<{ id: string }>(
 
         // Delete file from filesystem if path is available
         if (track.filePath) {
-            try {
-                const normalizedRelativePath = track.filePath.replace(
-                    /\\/g,
-                    "/",
+            const deletionPath = resolvePersistedTrackDeletionPath(
+                track.filePath,
+            );
+            if (!deletionPath) {
+                libraryDeletionLogger.warn(
+                    "Skipped unsafe persisted track path",
+                    { trackId: track.id },
                 );
-                const absolutePath = path.join(
-                    config.music.musicPath,
-                    normalizedRelativePath,
-                );
-
-                if (fs.existsSync(absolutePath)) {
-                    fs.unlinkSync(absolutePath);
-                    logger.debug(`[DELETE] Deleted file: ${absolutePath}`);
+            } else {
+                try {
+                    if (fs.existsSync(deletionPath.absolutePath)) {
+                        fs.unlinkSync(deletionPath.absolutePath);
+                        libraryDeletionLogger.debug("Deleted track file", {
+                            trackId: track.id,
+                        });
+                    }
+                } catch (err) {
+                    libraryDeletionLogger.warn(
+                        "Could not delete track file",
+                        { trackId: track.id, error: err },
+                    );
+                    // Continue with database deletion even if file deletion fails
                 }
-            } catch (err) {
-                logger.warn("[DELETE] Could not delete file:", err);
-                // Continue with database deletion even if file deletion fails
             }
         }
 
@@ -5408,22 +5457,25 @@ router.delete<{ id: string }>(
         let deletedFiles = 0;
         for (const track of album.tracks) {
             if (track.filePath) {
-                try {
-                    const normalizedRelativePath = track.filePath.replace(
-                        /\\/g,
-                        "/",
+                const deletionPath = resolvePersistedTrackDeletionPath(
+                    track.filePath,
+                );
+                if (!deletionPath) {
+                    libraryDeletionLogger.warn(
+                        "Skipped unsafe persisted album track path",
                     );
-                    const absolutePath = path.join(
-                        config.music.musicPath,
-                        normalizedRelativePath,
-                    );
-
-                    if (fs.existsSync(absolutePath)) {
-                        fs.unlinkSync(absolutePath);
-                        deletedFiles++;
+                } else {
+                    try {
+                        if (fs.existsSync(deletionPath.absolutePath)) {
+                            fs.unlinkSync(deletionPath.absolutePath);
+                            deletedFiles++;
+                        }
+                    } catch (err) {
+                        libraryDeletionLogger.warn(
+                            "Could not delete album track file",
+                            { error: err },
+                        );
                     }
-                } catch (err) {
-                    logger.warn("[DELETE] Could not delete file:", err);
                 }
             }
         }
@@ -5431,13 +5483,12 @@ router.delete<{ id: string }>(
         // Try to delete album folder if empty
         try {
             const artistName = album.artist.name;
-            const albumFolder = path.join(
+            const albumFolder = safeResolvePath(
                 config.music.musicPath,
-                artistName,
-                album.title,
+                path.join(artistName, album.title),
             );
 
-            if (fs.existsSync(albumFolder)) {
+            if (albumFolder && fs.existsSync(albumFolder)) {
                 const files = fs.readdirSync(albumFolder);
                 if (files.length === 0) {
                     fs.rmdirSync(albumFolder);
@@ -5541,54 +5592,38 @@ router.delete<{ id: string }>(
             for (const album of artist.albums) {
                 for (const track of album.tracks) {
                     if (track.filePath) {
-                        try {
-                            const normalizedRelativePath =
-                                track.filePath.replace(/\\/g, "/");
-                            const absolutePath = path.join(
-                                config.music.musicPath,
-                                normalizedRelativePath,
+                        const deletionPath =
+                            resolvePersistedTrackDeletionPath(track.filePath);
+                        if (!deletionPath) {
+                            libraryDeletionLogger.warn(
+                                "Skipped unsafe persisted artist track path",
                             );
+                        } else {
+                            try {
+                                if (fs.existsSync(deletionPath.absolutePath)) {
+                                    fs.unlinkSync(deletionPath.absolutePath);
+                                    deletedFiles++;
 
-                            if (fs.existsSync(absolutePath)) {
-                                fs.unlinkSync(absolutePath);
-                                deletedFiles++;
-
-                                // Extract actual artist folder from file path
-                                // Path format: Soulseek/Artist/Album/Track.mp3 OR Artist/Album/Track.mp3
-                                const pathParts = normalizedRelativePath
-                                    .split("/")
-                                    .filter((segment) => segment.length > 0);
-                                if (pathParts.length >= 2) {
-                                    // If first part is "Soulseek", artist folder is Soulseek/Artist
-                                    // Otherwise, artist folder is just Artist
-                                    const actualArtistFolder =
-                                        pathParts[0].toLowerCase() ===
+                                    // Path format: Soulseek/Artist/Album/Track.mp3 OR Artist/Album/Track.mp3
+                                    const artistPathParts =
+                                        deletionPath.pathParts[0].toLowerCase() ===
                                         "soulseek"
-                                            ? path.join(
-                                                  config.music.musicPath,
-                                                  pathParts[0],
-                                                  pathParts[1],
-                                              )
-                                            : path.join(
-                                                  config.music.musicPath,
-                                                  pathParts[0],
-                                              );
-                                    artistFoldersToDelete.add(
-                                        actualArtistFolder,
-                                    );
-                                } else if (pathParts.length === 1) {
-                                    // Single-level path (rare case)
-                                    const actualArtistFolder = path.join(
+                                            ? deletionPath.pathParts.slice(0, 2)
+                                            : deletionPath.pathParts.slice(0, 1);
+                                    const artistFolder = safeResolvePath(
                                         config.music.musicPath,
-                                        pathParts[0],
+                                        artistPathParts.join("/"),
                                     );
-                                    artistFoldersToDelete.add(
-                                        actualArtistFolder,
-                                    );
+                                    if (artistFolder) {
+                                        artistFoldersToDelete.add(artistFolder);
+                                    }
                                 }
+                            } catch (err) {
+                                libraryDeletionLogger.warn(
+                                    "Could not delete artist track file",
+                                    { error: err },
+                                );
                             }
-                        } catch (err) {
-                            logger.warn("[DELETE] Could not delete file:", err);
                         }
                     }
                 }
@@ -5596,6 +5631,12 @@ router.delete<{ id: string }>(
 
             // Delete artist folders based on actual file paths, not database name
             for (const artistFolder of artistFoldersToDelete) {
+                if (!isSafeRecursiveDeletionTarget(artistFolder)) {
+                    libraryDeletionLogger.warn(
+                        "Skipped unsafe recursive artist folder target",
+                    );
+                    continue;
+                }
                 try {
                     if (fs.existsSync(artistFolder)) {
                         logger.debug(
@@ -5621,7 +5662,13 @@ router.delete<{ id: string }>(
                     try {
                         const files = fs.readdirSync(artistFolder);
                         for (const file of files) {
-                            const filePath = path.join(artistFolder, file);
+                            const filePath = safeResolvePath(
+                                artistFolder,
+                                file,
+                            );
+                            if (!filePath) {
+                                continue;
+                            }
                             try {
                                 const stat = fs.statSync(filePath);
                                 if (stat.isDirectory()) {
@@ -5671,6 +5718,7 @@ router.delete<{ id: string }>(
 
             for (const commonPath of commonPaths) {
                 if (
+                    isSafeRecursiveDeletionTarget(commonPath) &&
                     fs.existsSync(commonPath) &&
                     !artistFoldersToDelete.has(commonPath)
                 ) {


### PR DESCRIPTION
Convergence sweep #20 remediation (N6) in `backend/src/routes/library.ts`.

Library deletion joined persisted track paths to `MUSIC_PATH` **without containment validation**, and artist deletion derived a recursive-removal target from the first path component. A persisted `../` path could `unlink` files outside `MUSIC_PATH` and make the recursive target an **ancestor of the music directory** — arbitrary filesystem deletion via crafted DB rows.

Fix
- `resolvePersistedTrackDeletionPath` rejects absolute (POSIX **and** Windows) and dot-segment paths and resolves every persisted path through the shared `safeResolvePath` containment helper before any unlink/dir-derivation; unsafe rows are **skipped** (scoped `LibraryDeletion` warnings) while DB deletion proceeds.
- Album- and artist-folder cleanup targets are containment-checked; recursive removal of `MUSIC_PATH` or any ancestor is refused.

Verification: TDD red (3 containment tests fail pre-fix); targeted jest 129/129 (absolute, Windows, traversal, mixed safe/unsafe rows, recursive-ancestor); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).