### PR TITLE
fix(security): Soulseek download destination containment (sweep #20 N7)

### DIFF
--- a/backend/src/services/__tests__/soulseekService.test.ts
+++ b/backend/src/services/__tests__/soulseekService.test.ts
@@ -8,6 +8,7 @@ const mockFsExistsSync = jest.fn();
 const mockFsStatSync = jest.fn();
 const mockFsUnlinkSync = jest.fn();
 const mockMkdir = jest.fn();
+const mockRename = jest.fn();
 const mockRm = jest.fn();
 const mockStat = jest.fn();
 const mockLogInfo = jest.fn();
@@ -53,6 +54,7 @@ jest.mock("fs", () => ({
 
 jest.mock("fs/promises", () => ({
     mkdir: (...args: unknown[]) => mockMkdir(...args),
+    rename: (...args: unknown[]) => mockRename(...args),
     rm: (...args: unknown[]) => mockRm(...args),
     stat: (...args: unknown[]) => mockStat(...args),
 }));
@@ -100,6 +102,16 @@ function makeTrackMatch(overrides: Partial<TrackMatch> = {}): TrackMatch {
     };
 }
 
+function expectedDownloadDestination(
+    musicPath: string,
+    artist: string,
+    album: string,
+    filename: string,
+): { finalPath: string; tempPath: string } {
+    const finalPath = path.join(musicPath, "Singles", artist, album, filename);
+    return { finalPath, tempPath: `${finalPath}.part` };
+}
+
 function resetServiceState(): void {
     const service = soulseekService as any;
     service.client = null;
@@ -137,6 +149,7 @@ describe("soulseek service", () => {
             soulseekPassword: "test-pass",
         });
         mockMkdir.mockResolvedValue(undefined);
+        mockRename.mockResolvedValue(undefined);
         mockFsExistsSync.mockReturnValue(true);
         mockFsStatSync.mockReturnValue({ size: 2048 });
         mockFsUnlinkSync.mockImplementation(() => undefined);
@@ -984,39 +997,37 @@ describe("soulseek service", () => {
             [first, second],
             "/library",
         );
+        const firstDestination = expectedDownloadDestination(
+            "/library",
+            "Artist_One",
+            "Album_One",
+            "Bad_.mp3",
+        );
+        const secondDestination = expectedDownloadDestination(
+            "/library",
+            "Artist_One",
+            "Album_One",
+            "Good_.flac",
+        );
 
         expect(downloadTrackSpy).toHaveBeenCalledTimes(2);
         expect(downloadTrackSpy).toHaveBeenNthCalledWith(
             1,
             first,
-            path.join(
-                "/library",
-                "Singles",
-                "Artist_One",
-                "Album_One",
-                "Bad_.mp3",
-            ),
+            firstDestination.finalPath,
+            0,
+            firstDestination.tempPath,
         );
         expect(downloadTrackSpy).toHaveBeenNthCalledWith(
             2,
             second,
-            path.join(
-                "/library",
-                "Singles",
-                "Artist_One",
-                "Album_One",
-                "Good_.flac",
-            ),
+            secondDestination.finalPath,
+            0,
+            secondDestination.tempPath,
         );
         expect(result).toEqual({
             success: true,
-            filePath: path.join(
-                "/library",
-                "Singles",
-                "Artist_One",
-                "Album_One",
-                "Good_.flac",
-            ),
+            filePath: secondDestination.finalPath,
         });
     });
 
@@ -1034,6 +1045,37 @@ describe("soulseek service", () => {
             error: "No matches provided",
         });
     });
+
+    it.each([
+        ["empty artist", "   ", "Album", "Track.mp3"],
+        ["empty album", "Artist", "", "Track.mp3"],
+        ["empty filename", "Artist", "Album", "   "],
+        ["dot artist", "..", "Album", "Track.mp3"],
+        ["dot album", "Artist", ".", "Track.mp3"],
+        ["dot filename", "Artist", "Album", ".."],
+    ])(
+        "downloadBestMatch rejects an %s destination component",
+        async (_description, artist, album, filename) => {
+            const downloadTrackSpy = jest.spyOn(
+                soulseekService,
+                "downloadTrack",
+            );
+
+            await expect(
+                soulseekService.downloadBestMatch(
+                    artist,
+                    "Track",
+                    album,
+                    [makeTrackMatch({ filename })],
+                    "/library",
+                ),
+            ).resolves.toEqual({
+                success: false,
+                error: "Invalid download destination",
+            });
+            expect(downloadTrackSpy).not.toHaveBeenCalled();
+        },
+    );
 
     it("searchAndDownloadBatch retries per-track and returns mixed outcomes", async () => {
         const first = makeTrackMatch({
@@ -1095,23 +1137,39 @@ describe("soulseek service", () => {
             "/music",
             1,
         );
+        const firstDestination = expectedDownloadDestination(
+            "/music",
+            "Artist_One",
+            "Album_One",
+            "Retry_.flac",
+        );
+        const secondDestination = expectedDownloadDestination(
+            "/music",
+            "Artist_One",
+            "Album_One",
+            "Recovered_.flac",
+        );
 
         expect(searchTrackSpy).toHaveBeenCalledTimes(2);
         expect(downloadTrackSpy).toHaveBeenCalledTimes(2);
-        expect(downloadTrackSpy.mock.calls[0][2]).toBe(0);
-        expect(downloadTrackSpy.mock.calls[1][2]).toBe(1);
+        expect(downloadTrackSpy).toHaveBeenNthCalledWith(
+            1,
+            first,
+            firstDestination.finalPath,
+            0,
+            firstDestination.tempPath,
+        );
+        expect(downloadTrackSpy).toHaveBeenNthCalledWith(
+            2,
+            second,
+            secondDestination.finalPath,
+            1,
+            secondDestination.tempPath,
+        );
         expect(result).toEqual({
             successful: 1,
             failed: 1,
-            files: [
-                path.join(
-                    "/music",
-                    "Singles",
-                    "Artist_One",
-                    "Album_One",
-                    "Recovered_.flac",
-                ),
-            ],
+            files: [secondDestination.finalPath],
             errors: ["Artist Two - Missing Track: No match found on Soulseek"],
         });
     });
@@ -1154,6 +1212,30 @@ describe("soulseek service", () => {
                 "Artist - Track: batch-primary: timeout; batch-fallback: user offline",
             ],
         });
+    });
+
+    it("searchAndDownloadBatch rejects invalid destination components without downloading", async () => {
+        const match = makeTrackMatch({ filename: "Track.mp3" });
+        jest.spyOn(soulseekService, "searchTrack").mockResolvedValue({
+            found: true,
+            bestMatch: match,
+            allMatches: [match],
+        });
+        const downloadTrackSpy = jest.spyOn(soulseekService, "downloadTrack");
+
+        await expect(
+            soulseekService.searchAndDownloadBatch(
+                [{ artist: "Artist", title: "Track", album: ".." }],
+                "/music",
+                1,
+            ),
+        ).resolves.toEqual({
+            successful: 0,
+            failed: 1,
+            files: [],
+            errors: ["Artist - Track: Invalid download destination"],
+        });
+        expect(downloadTrackSpy).not.toHaveBeenCalled();
     });
 
     it("searchAndDownloadBatch counts no-match failures and download failures together", async () => {
@@ -1227,6 +1309,24 @@ describe("soulseek service", () => {
             success: false,
             error: "No suitable match found",
         });
+    });
+
+    it("searchAndDownload rejects invalid destination components without downloading", async () => {
+        const match = makeTrackMatch({ filename: "Track.mp3" });
+        jest.spyOn(soulseekService, "searchTrack").mockResolvedValue({
+            found: true,
+            bestMatch: match,
+            allMatches: [match],
+        });
+        const downloadTrackSpy = jest.spyOn(soulseekService, "downloadTrack");
+
+        await expect(
+            soulseekService.searchAndDownload("..", "Track", "Album", "/music"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Invalid download destination",
+        });
+        expect(downloadTrackSpy).not.toHaveBeenCalled();
     });
 
     it("searchAndDownload aggregates all failed attempt errors", async () => {
@@ -1303,17 +1403,37 @@ describe("soulseek service", () => {
             "Album:One",
             "/music",
         );
+        const firstDestination = expectedDownloadDestination(
+            "/music",
+            "Artist_One",
+            "Album_One",
+            "Retry_.flac",
+        );
+        const secondDestination = expectedDownloadDestination(
+            "/music",
+            "Artist_One",
+            "Album_One",
+            "Recovered_.flac",
+        );
 
         expect(downloadTrackSpy).toHaveBeenCalledTimes(2);
+        expect(downloadTrackSpy).toHaveBeenNthCalledWith(
+            1,
+            first,
+            firstDestination.finalPath,
+            0,
+            firstDestination.tempPath,
+        );
+        expect(downloadTrackSpy).toHaveBeenNthCalledWith(
+            2,
+            second,
+            secondDestination.finalPath,
+            0,
+            secondDestination.tempPath,
+        );
         expect(result).toEqual({
             success: true,
-            filePath: path.join(
-                "/music",
-                "Singles",
-                "Artist_One",
-                "Album_One",
-                "Recovered_.flac",
-            ),
+            filePath: secondDestination.finalPath,
         });
     });
 
@@ -1413,7 +1533,7 @@ describe("soulseek service", () => {
                 success: false,
                 error: "Download timed out",
             });
-            expect(mockRm).toHaveBeenCalledWith("/music/timeout.flac", {
+            expect(mockRm).toHaveBeenCalledWith("/music/timeout.flac.part", {
                 force: true,
             });
             expect(
@@ -1498,7 +1618,7 @@ describe("soulseek service", () => {
                 soulseekService as any,
                 "ensureConnected",
             ).mockResolvedValueOnce(undefined);
-            // The post-download check is `await stat(destPath)`, which REJECTS
+            // The post-download check is `await stat(tempPath)`, which REJECTS
             // when the file is missing — that is the real "not written" path.
             // (Previously this test only set existsSync=false and left mockStat
             // returning undefined, so it passed for the wrong reason: reading
@@ -1529,7 +1649,7 @@ describe("soulseek service", () => {
 
             // The error comes from stat() rejecting on the missing file, not
             // from an incidental TypeError — assert the verification ran.
-            expect(mockStat).toHaveBeenCalledWith("/music/missing.flac");
+            expect(mockStat).toHaveBeenCalledWith("/music/missing.flac.part");
             expect(result).toEqual({
                 success: false,
                 error: "File not written",
@@ -1537,6 +1657,40 @@ describe("soulseek service", () => {
         });
 
         it("returns success when callback completes and file exists", async () => {
+            jest.spyOn(
+                soulseekService as any,
+                "ensureConnected",
+            ).mockResolvedValueOnce(undefined);
+            const download = jest.fn(
+                (
+                    _opts: unknown,
+                    cb: (err: Error | null, data?: { buffer: Buffer }) => void,
+                ) => cb(null, { buffer: Buffer.from("ok") }),
+            );
+            (soulseekService as any).client = {
+                search: jest.fn(),
+                download,
+            };
+            mockStat.mockResolvedValue({ size: 4096 });
+
+            const result = await soulseekService.downloadTrack(
+                makeTrackMatch(),
+                "/music/success.flac",
+            );
+
+            expect(result).toEqual({ success: true });
+            expect(download).toHaveBeenCalledWith(
+                expect.objectContaining({ path: "/music/success.flac.part" }),
+                expect.any(Function),
+            );
+            expect(mockStat).toHaveBeenCalledWith("/music/success.flac.part");
+            expect(mockRename).toHaveBeenCalledWith(
+                "/music/success.flac.part",
+                "/music/success.flac",
+            );
+        });
+
+        it("cleans the temporary file when finalization fails", async () => {
             jest.spyOn(
                 soulseekService as any,
                 "ensureConnected",
@@ -1554,13 +1708,28 @@ describe("soulseek service", () => {
                 ),
             };
             mockStat.mockResolvedValue({ size: 4096 });
+            mockRename.mockRejectedValueOnce(new Error("EACCES"));
+            mockRm.mockResolvedValue(undefined);
 
-            const result = await soulseekService.downloadTrack(
-                makeTrackMatch(),
-                "/music/success.flac",
+            await expect(
+                soulseekService.downloadTrack(
+                    makeTrackMatch(),
+                    "/music/finalize.flac",
+                ),
+            ).resolves.toEqual({
+                success: false,
+                error: "File not written",
+            });
+            expect(mockRm).toHaveBeenCalledWith("/music/finalize.flac.part", {
+                force: true,
+            });
+            expect(JSON.stringify(mockSessionLog.mock.calls)).not.toContain(
+                "EACCES",
             );
-
-            expect(result).toEqual({ success: true });
+            expect(mockLogError).toHaveBeenCalledWith(
+                "Failed to finalize Soulseek download",
+                expect.objectContaining({ error: expect.any(Error) }),
+            );
         });
     });
 

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -5,11 +5,12 @@
 
 import slsk from "slsk-client";
 import path from "path";
-import { mkdir, rm, stat } from "fs/promises";
+import { mkdir, rename, rm, stat } from "fs/promises";
 import PQueue from "p-queue";
 import { getSystemSettings } from "../utils/systemSettings";
 import { sessionLog } from "../utils/playlistLogger";
 import { logger } from "../utils/logger";
+import { safeResolvePath } from "../utils/safeResolvePath";
 
 const log = logger.child("Soulseek");
 
@@ -51,6 +52,13 @@ export interface SearchTrackResult {
     bestMatch: TrackMatch | null;
     allMatches: TrackMatch[]; // All ranked matches for retry
 }
+
+interface DownloadDestination {
+    finalPath: string;
+    tempPath: string;
+}
+
+const INVALID_DOWNLOAD_DESTINATION = "Invalid download destination";
 
 class SoulseekService {
     private client: SlskClient | null = null;
@@ -687,6 +695,37 @@ class SoulseekService {
         return { type: "unknown", skipUser: false };
     }
 
+    private sanitizeDownloadComponent(name: string): string | null {
+        const sanitized = name.replace(/[<>:"/\\|?*]/g, "_").trim();
+        if (!sanitized || sanitized === "." || sanitized === "..") {
+            return null;
+        }
+        return sanitized;
+    }
+
+    private resolveDownloadDestination(
+        musicPath: string,
+        artistName: string,
+        albumName: string,
+        filename: string,
+    ): DownloadDestination | null {
+        const artist = this.sanitizeDownloadComponent(artistName);
+        const album = this.sanitizeDownloadComponent(albumName);
+        const file = this.sanitizeDownloadComponent(filename);
+        if (!artist || !album || !file) {
+            return null;
+        }
+
+        const relativePath = path.join(artist, album, file);
+        const singlesRoot = path.resolve(musicPath, "Singles");
+        const finalPath = safeResolvePath(singlesRoot, relativePath);
+        const tempPath = safeResolvePath(singlesRoot, `${relativePath}.part`);
+        if (!finalPath || !tempPath) {
+            return null;
+        }
+        return { finalPath, tempPath };
+    }
+
     /**
      * Rank all search results and return sorted matches (best first)
      * Filters out matches below minimum score threshold and blocked users
@@ -818,12 +857,17 @@ class SoulseekService {
     }
 
     /**
-     * Download a track directly to the music library with timeout
+     * Download a track to a temporary file and atomically finalize it.
+     * @param match - Remote Soulseek match to download.
+     * @param destPath - Final destination path.
+     * @param attemptNumber - Zero-based retry number used for timeout selection.
+     * @param tempPath - Prevalidated temporary path for the incomplete file.
      */
     async downloadTrack(
         match: TrackMatch,
         destPath: string,
         attemptNumber: number = 0,
+        tempPath: string = `${destPath}.part`,
     ): Promise<{ success: boolean; error?: string }> {
         // Track active downloads for concurrency monitoring
         this.activeDownloads++;
@@ -897,7 +941,7 @@ class SoulseekService {
                     // Clean up the partial file without blocking the event
                     // loop; force:true ignores ENOENT so no existence check is
                     // needed and cleanup errors are swallowed.
-                    void rm(destPath, { force: true }).catch(() => {
+                    void rm(tempPath, { force: true }).catch(() => {
                         // Ignore cleanup errors
                     });
                     resolve({ success: false, error: "Download timed out" });
@@ -918,7 +962,7 @@ class SoulseekService {
                 this.client!.download(
                     {
                         file: downloadFile,
-                        path: destPath,
+                        path: tempPath,
                     },
                     async (err) => {
                         if (resolved) return; // Already timed out
@@ -953,7 +997,8 @@ class SoulseekService {
 
                         // Verify file was written (stat throws if missing).
                         try {
-                            const stats = await stat(destPath);
+                            const stats = await stat(tempPath);
+                            await rename(tempPath, destPath);
                             sessionLog(
                                 "SOULSEEK",
                                 `✓ Downloaded: ${match.filename} (${Math.round(
@@ -961,7 +1006,15 @@ class SoulseekService {
                                 )}KB)`,
                             );
                             resolve({ success: true });
-                        } catch {
+                        } catch (finalizeError) {
+                            await rm(tempPath, { force: true }).catch(() => {
+                                // Ignore cleanup errors
+                            });
+                            log.error("Failed to finalize Soulseek download", {
+                                destPath,
+                                tempPath,
+                                error: finalizeError,
+                            });
                             sessionLog(
                                 "SOULSEEK",
                                 "File not found after download",
@@ -1013,8 +1066,6 @@ class SoulseekService {
             return { success: false, error: "No suitable match found" };
         }
 
-        const sanitize = (name: string) =>
-            name.replace(/[<>:"/\\|?*]/g, "_").trim();
         const errors: string[] = [];
 
         // Try up to MAX_DOWNLOAD_RETRIES different users
@@ -1033,17 +1084,23 @@ class SoulseekService {
                 } for ${match.filename}`,
             );
 
-            // Build destination path: Singles/Artist/Album/filename
-            const destPath = path.join(
+            const destination = this.resolveDownloadDestination(
                 musicPath,
-                "Singles",
-                sanitize(artistName),
-                sanitize(albumName),
-                sanitize(match.filename),
+                artistName,
+                albumName,
+                match.filename,
             );
+            if (!destination) {
+                return { success: false, error: INVALID_DOWNLOAD_DESTINATION };
+            }
 
             // Download with timeout
-            const downloadResult = await this.downloadTrack(match, destPath);
+            const downloadResult = await this.downloadTrack(
+                match,
+                destination.finalPath,
+                0,
+                destination.tempPath,
+            );
 
             if (downloadResult.success) {
                 if (attempt > 0) {
@@ -1054,7 +1111,7 @@ class SoulseekService {
                         })`,
                     );
                 }
-                return { success: true, filePath: destPath };
+                return { success: true, filePath: destination.finalPath };
             }
 
             // Log failure and try next user
@@ -1102,8 +1159,6 @@ class SoulseekService {
             return { success: false, error: "No matches provided" };
         }
 
-        const sanitize = (name: string) =>
-            name.replace(/[<>:"/\\|?*]/g, "_").trim();
         const errors: string[] = [];
 
         // Try up to MAX_DOWNLOAD_RETRIES different users
@@ -1119,17 +1174,23 @@ class SoulseekService {
                 }: Trying ${match.username}`,
             );
 
-            // Build destination path: Singles/Artist/Album/filename
-            const destPath = path.join(
+            const destination = this.resolveDownloadDestination(
                 musicPath,
-                "Singles",
-                sanitize(artistName),
-                sanitize(albumName),
-                sanitize(match.filename),
+                artistName,
+                albumName,
+                match.filename,
             );
+            if (!destination) {
+                return { success: false, error: INVALID_DOWNLOAD_DESTINATION };
+            }
 
             // Download with timeout
-            const downloadResult = await this.downloadTrack(match, destPath);
+            const downloadResult = await this.downloadTrack(
+                match,
+                destination.finalPath,
+                0,
+                destination.tempPath,
+            );
 
             if (downloadResult.success) {
                 if (attempt > 0) {
@@ -1140,7 +1201,7 @@ class SoulseekService {
                         })`,
                     );
                 }
-                return { success: true, filePath: destPath };
+                return { success: true, filePath: destination.finalPath };
             }
 
             // Log failure and try next user
@@ -1273,8 +1334,6 @@ class SoulseekService {
         allMatches: TrackMatch[],
         musicPath: string,
     ): Promise<{ success: boolean; filePath?: string; error?: string }> {
-        const sanitize = (name: string) =>
-            name.replace(/[<>:"/\\|?*]/g, "_").trim();
         const errors: string[] = [];
         const matchesToTry = allMatches.slice(0, this.MAX_DOWNLOAD_RETRIES);
 
@@ -1288,15 +1347,22 @@ class SoulseekService {
                 }: Trying ${match.username}`,
             );
 
-            const destPath = path.join(
+            const destination = this.resolveDownloadDestination(
                 musicPath,
-                "Singles",
-                sanitize(artistName),
-                sanitize(albumName),
-                sanitize(match.filename),
+                artistName,
+                albumName,
+                match.filename,
             );
+            if (!destination) {
+                return { success: false, error: INVALID_DOWNLOAD_DESTINATION };
+            }
 
-            const result = await this.downloadTrack(match, destPath, attempt);
+            const result = await this.downloadTrack(
+                match,
+                destination.finalPath,
+                attempt,
+                destination.tempPath,
+            );
             if (result.success) {
                 if (attempt > 0) {
                     sessionLog(
@@ -1306,7 +1372,7 @@ class SoulseekService {
                         }`,
                     );
                 }
-                return { success: true, filePath: destPath };
+                return { success: true, filePath: destination.finalPath };
             }
             errors.push(`${match.username}: ${result.error}`);
         }


### PR DESCRIPTION
Convergence sweep #20 remediation (N7) in `backend/src/services/soulseek.ts`.

Three Soulseek download paths replaced reserved characters but **preserved `.`/`..` components**, and joined artist/album/file values beneath `MUSIC_PATH/Singles` with **no final containment check** — dot segments could move the destination outside the music root (write-outside-MUSIC_PATH).

Fix
- Shared `sanitizeDownloadComponent` rejects empty/`.`/`..` components; all three flows use it.
- Final and temporary (`.part`) paths are resolved through the shared `safeResolvePath` containment helper beneath `MUSIC_PATH/Singles` and rejected on escape.
- Downloads write to the temp path and atomically rename after validation; timeout/finalization failures clean up the temp file, raw errors stay server-log-only.

Verification: targeted jest 73/73 (invalid components, all three flows, contained paths, timeout cleanup, finalization, rename-failure without leakage); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).