### PR TITLE
fix(security): admin-gate global enrichment-failure API + redact response (sweep #20 N3)

### DIFF
--- a/backend/src/__tests__/enrichmentRouteAuthz.test.ts
+++ b/backend/src/__tests__/enrichmentRouteAuthz.test.ts
@@ -7,6 +7,8 @@
  *   - POST /api/enrichment/start (same worker as the admin-gated /full)
  *   - POST /api/enrichment/artist/:id and /album/:id (apply enrichment
  *     results library-wide and make outbound API calls)
+ *   - GET /api/enrichment/failures and /failures/counts (global operational
+ *     failure data has no user ownership scope)
  *
  * Deliberately NOT admin-gated (user-facing by design):
  *   - GET/PUT /settings (per-user settings)
@@ -23,6 +25,14 @@ const mockEnrichArtist = jest.fn(async () => ({ confidence: 0.9 }));
 const mockEnrichAlbum = jest.fn(async () => ({ confidence: 0.9 }));
 const mockApplyArtistEnrichment = jest.fn(async () => undefined);
 const mockApplyAlbumEnrichment = jest.fn(async () => undefined);
+const mockGetFailures = jest.fn(async () => ({ failures: [], total: 0 }));
+const mockGetFailureCounts = jest.fn(async () => ({
+    artist: 0,
+    track: 0,
+    audio: 0,
+    vibe: 0,
+    total: 0,
+}));
 const mockSystemSettingsFindUnique = jest.fn(async () => ({
     autoEnrichMetadata: true,
 }));
@@ -70,7 +80,10 @@ jest.mock("../services/enrichmentState", () => ({
 }));
 
 jest.mock("../services/enrichmentFailureService", () => ({
-    enrichmentFailureService: {},
+    enrichmentFailureService: {
+        getFailures: mockGetFailures,
+        getFailureCounts: mockGetFailureCounts,
+    },
 }));
 
 jest.mock("../services/musicbrainz", () => ({
@@ -221,5 +234,51 @@ describe("enrichment router authorization", () => {
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
         expect(mockEnrichAlbum).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects non-admin users on GET /failures", async () => {
+        const response = await request(buildApp())
+            .get("/api/enrichment/failures")
+            .set("x-test-role", "user");
+
+        expect(response.status).toBe(403);
+        expect(response.body).toEqual({ error: "Admin access required" });
+        expect(mockGetFailures).not.toHaveBeenCalled();
+    });
+
+    it("allows admins on GET /failures", async () => {
+        const response = await request(buildApp())
+            .get("/api/enrichment/failures")
+            .set("x-test-role", "admin");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ failures: [], total: 0 });
+        expect(mockGetFailures).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects non-admin users on GET /failures/counts", async () => {
+        const response = await request(buildApp())
+            .get("/api/enrichment/failures/counts")
+            .set("x-test-role", "user");
+
+        expect(response.status).toBe(403);
+        expect(response.body).toEqual({ error: "Admin access required" });
+        expect(mockGetFailureCounts).not.toHaveBeenCalled();
+    });
+
+    it("allows admins on GET /failures/counts", async () => {
+        const response = await request(buildApp())
+            .get("/api/enrichment/failures/counts")
+            .set("x-test-role", "admin");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            artist: 0,
+            track: 0,
+            audio: 0,
+            vibe: 0,
+            total: 0,
+        });
+        expect(mockGetFailureCounts).toHaveBeenCalledTimes(1);
     });
 });

--- a/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
@@ -181,4 +181,58 @@ describe("GET /api/enrichment/failures bounded query parameters", () => {
             offset: 0,
         });
     });
+
+    it("returns a client-safe DTO without worker errors or filesystem metadata", async () => {
+        mockGetFailures.mockResolvedValueOnce({
+            failures: [
+                {
+                    id: "failure-1",
+                    entityType: "audio",
+                    entityId: "track-1",
+                    entityName: "Example Track",
+                    errorMessage: "SECRET_LEAK_MARKER: decoder crashed",
+                    errorCode: "WORKER_SECRET_CODE",
+                    retryCount: 2,
+                    maxRetries: 3,
+                    firstFailedAt: new Date("2026-08-10T12:00:00.000Z"),
+                    lastFailedAt: new Date("2026-08-11T12:00:00.000Z"),
+                    skipped: false,
+                    skippedAt: null,
+                    resolved: false,
+                    resolvedAt: null,
+                    metadata: {
+                        track: { filePath: "/srv/music/private/track.flac" },
+                    },
+                },
+            ],
+            total: 1,
+        });
+
+        const response = await request(app).get("/api/enrichment/failures");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            failures: [
+                {
+                    id: "failure-1",
+                    entityType: "audio",
+                    entityId: "track-1",
+                    entityName: "Example Track",
+                    retryCount: 2,
+                    maxRetries: 3,
+                    firstFailedAt: "2026-08-10T12:00:00.000Z",
+                    lastFailedAt: "2026-08-11T12:00:00.000Z",
+                    skipped: false,
+                    skippedAt: null,
+                    resolved: false,
+                    resolvedAt: null,
+                },
+            ],
+            total: 1,
+        });
+        expect(JSON.stringify(response.body)).not.toContain(
+            "SECRET_LEAK_MARKER",
+        );
+        expect(JSON.stringify(response.body)).not.toContain("/srv/music");
+    });
 });

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -342,7 +342,7 @@ describe("enrichment route runtime behavior", () => {
         mockSystemSettingsFindUnique.mockResolvedValue({
             autoEnrichMetadata: true,
         });
-        mockGetFailures.mockResolvedValue({ items: [], total: 0 });
+        mockGetFailures.mockResolvedValue({ failures: [], total: 0 });
         mockGetFailureCounts.mockResolvedValue({
             artist: 1,
             track: 2,
@@ -1022,7 +1022,7 @@ describe("enrichment route runtime behavior", () => {
             offset: 10,
         });
         expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual({ items: [], total: 0 });
+        expect(res.body).toEqual({ failures: [], total: 0 });
 
         mockGetFailures.mockRejectedValueOnce(new Error("bad query"));
         const errorRes = createRes();

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -15,7 +15,10 @@ import {
     enrichmentStateService,
     type EnrichmentState,
 } from "../services/enrichmentState";
-import { enrichmentFailureService } from "../services/enrichmentFailureService";
+import {
+    enrichmentFailureService,
+    type EnrichmentFailure,
+} from "../services/enrichmentFailureService";
 import { musicBrainzService } from "../services/musicbrainz";
 import { coverArtService } from "../services/coverArt";
 import {
@@ -40,6 +43,30 @@ const MBID_UUID_REGEX =
 
 function isValidMusicBrainzId(value: string): boolean {
     return MBID_UUID_REGEX.test(value);
+}
+
+type ClientSafeEnrichmentFailure = Omit<
+    EnrichmentFailure,
+    "errorMessage" | "errorCode" | "metadata"
+>;
+
+function toClientSafeEnrichmentFailure(
+    failure: EnrichmentFailure,
+): ClientSafeEnrichmentFailure {
+    return {
+        id: failure.id,
+        entityType: failure.entityType,
+        entityId: failure.entityId,
+        entityName: failure.entityName,
+        retryCount: failure.retryCount,
+        maxRetries: failure.maxRetries,
+        firstFailedAt: failure.firstFailedAt,
+        lastFailedAt: failure.lastFailedAt,
+        skipped: failure.skipped,
+        skippedAt: failure.skippedAt,
+        resolved: failure.resolved,
+        resolvedAt: failure.resolvedAt,
+    };
 }
 
 /**
@@ -944,7 +971,7 @@ router.get("/search/musicbrainz/release-groups", async (req, res) => {
  * @openapi
  * /api/enrichment/failures:
  *   get:
- *     summary: Get all enrichment failures with filtering
+ *     summary: Get all enrichment failures with filtering (admin only)
  *     tags: [Enrichment]
  *     security:
  *       - sessionAuth: []
@@ -987,12 +1014,14 @@ router.get("/search/musicbrainz/release-groups", async (req, res) => {
  *         description: List of enrichment failures
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 /**
  * GET /enrichment/failures
- * Get all enrichment failures with filtering
+ * Get all enrichment failures with filtering (admin only)
  */
-router.get("/failures", async (req, res) => {
+router.get("/failures", requireAdmin, async (req, res) => {
     try {
         const { entityType, includeSkipped, includeResolved, limit, offset } =
             req.query;
@@ -1005,7 +1034,10 @@ router.get("/failures", async (req, res) => {
         options.offset = parseBoundedInt(req.query.offset, 0, 0, 1_000_000);
 
         const result = await enrichmentFailureService.getFailures(options);
-        res.json(result);
+        res.json({
+            failures: result.failures.map(toClientSafeEnrichmentFailure),
+            total: result.total,
+        });
     } catch (error) {
         logger.error("Get failures error:", error);
         res.status(500).json({ error: "Failed to get failures" });
@@ -1016,7 +1048,7 @@ router.get("/failures", async (req, res) => {
  * @openapi
  * /api/enrichment/failures/counts:
  *   get:
- *     summary: Get enrichment failure counts by type
+ *     summary: Get enrichment failure counts by type (admin only)
  *     tags: [Enrichment]
  *     security:
  *       - sessionAuth: []
@@ -1026,12 +1058,14 @@ router.get("/failures", async (req, res) => {
  *         description: Failure counts grouped by entity type
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
 /**
  * GET /enrichment/failures/counts
- * Get failure counts by type
+ * Get failure counts by type (admin only)
  */
-router.get("/failures/counts", async (req, res) => {
+router.get("/failures/counts", requireAdmin, async (req, res) => {
     try {
         const counts = await enrichmentFailureService.getFailureCounts();
         res.json(counts);


### PR DESCRIPTION
Convergence sweep #20 remediation (N3) in `backend/src/routes/enrichment.ts`.

Any authenticated user could retrieve **unscoped** `EnrichmentFailure` rows via the global `/enrichment/failures` and `/failures/counts` endpoints. The records have no ownership field and included raw worker exception text plus `metadata` containing `track.filePath`. This is **not** the accepted owner-scoped job-error backlog — it's a global operational surface leaking filesystem paths to any user.

Fix
- `requireAdmin` guards both global failure endpoints.
- Responses use an explicit allowlist DTO omitting `errorMessage`, `errorCode`, and all `metadata` (including nested `track.filePath`).

Verification: targeted jest 26/26 (admin/non-admin authz + exact redaction); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).