### PR TITLE
fix(reliability): bound podcast cover-art fetches (sweep #20 N4)

### DIFF
--- a/backend/src/services/__tests__/podcastCacheService.test.ts
+++ b/backend/src/services/__tests__/podcastCacheService.test.ts
@@ -3,7 +3,9 @@ import path from "path";
 const logger = {
     debug: jest.fn(),
     error: jest.fn(),
+    child: jest.fn(),
 };
+logger.child.mockReturnValue(logger);
 
 jest.mock("../../utils/logger", () => ({
     logger,
@@ -27,6 +29,7 @@ jest.mock("../../utils/db", () => ({
 const fsPromises = {
     mkdir: jest.fn(),
     writeFile: jest.fn(),
+    rename: jest.fn(),
     readdir: jest.fn(),
     unlink: jest.fn(),
 };
@@ -60,14 +63,23 @@ jest.mock("../outboundUrlSafety", () => ({
 }));
 
 import { PodcastCacheService } from "../podcastCache";
+import { MAX_EXTERNAL_IMAGE_BYTES } from "../imageProxy";
 
 function okResponse(size = 8) {
-    return {
-        ok: true,
+    return new Response(new Uint8Array(size), {
         status: 200,
-        statusText: "OK",
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(size)),
-    };
+        headers: { "content-type": "image/jpeg" },
+    });
+}
+
+function errorResponse(status: number, statusText: string) {
+    return new Response(null, { status, statusText });
+}
+
+function queuePodcastCoverSync(id: string, imageUrl: string) {
+    prisma.podcast.findMany.mockResolvedValueOnce([
+        { id, title: id, imageUrl },
+    ]);
 }
 
 describe("PodcastCacheService", () => {
@@ -80,6 +92,7 @@ describe("PodcastCacheService", () => {
 
         fsPromises.mkdir.mockResolvedValue(undefined);
         fsPromises.writeFile.mockResolvedValue(undefined);
+        fsPromises.rename.mockResolvedValue(undefined);
         fsPromises.readdir.mockResolvedValue([]);
         fsPromises.unlink.mockResolvedValue(undefined);
 
@@ -123,11 +136,7 @@ describe("PodcastCacheService", () => {
 
         fetchMock
             .mockResolvedValueOnce(okResponse())
-            .mockResolvedValueOnce({
-                ok: false,
-                status: 404,
-                statusText: "Not Found",
-            })
+            .mockResolvedValueOnce(errorResponse(404, "Not Found"))
             .mockResolvedValueOnce(okResponse(16));
 
         prisma.podcast.update
@@ -219,12 +228,12 @@ describe("PodcastCacheService", () => {
                 imageUrl: "https://img.example/error.jpg",
             },
         ]);
-        fetchMock.mockResolvedValueOnce({
-            ok: false,
-            status: 500,
-            statusText: "Server Error",
-            body: { cancel },
-        });
+        fetchMock.mockResolvedValueOnce(
+            new Response(new ReadableStream({ cancel }), {
+                status: 500,
+                statusText: "Server Error",
+            }),
+        );
 
         const result = await service.syncAllCovers();
 
@@ -287,11 +296,7 @@ describe("PodcastCacheService", () => {
 
         fetchMock
             .mockResolvedValueOnce(okResponse())
-            .mockResolvedValueOnce({
-                ok: false,
-                status: 500,
-                statusText: "Server Error",
-            })
+            .mockResolvedValueOnce(errorResponse(500, "Server Error"))
             .mockResolvedValueOnce(okResponse(24));
 
         prisma.podcastEpisode.update
@@ -444,6 +449,140 @@ describe("PodcastCacheService", () => {
         expect(mockResolveSafeOutboundUrl).toHaveBeenCalledWith(
             "https://cdn.podcast.example/cover.jpg",
         );
+    });
+
+    it("downloadCover rejects a declared oversized image and cancels its body", async () => {
+        const service = new PodcastCacheService();
+        const cancel = jest.fn();
+        const body = new ReadableStream({ cancel });
+        queuePodcastCoverSync(
+            "pod-declared-large",
+            "https://img.example/declared-large.jpg",
+        );
+        fetchMock.mockResolvedValueOnce(
+            new Response(body, {
+                status: 200,
+                headers: {
+                    "content-type": "image/jpeg",
+                    "content-length": String(MAX_EXTERNAL_IMAGE_BYTES + 1),
+                },
+            }),
+        );
+
+        const result = await service.syncAllCovers();
+
+        expect(result).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 1,
+            errors: [],
+        });
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
+        expect(prisma.podcast.update).not.toHaveBeenCalled();
+    });
+
+    it("downloadCover rejects and cancels an oversized streamed image", async () => {
+        const service = new PodcastCacheService();
+        const cancel = jest.fn();
+        queuePodcastCoverSync(
+            "pod-streamed-large",
+            "https://img.example/streamed-large.jpg",
+        );
+        const body = new ReadableStream({
+            start(controller) {
+                controller.enqueue(
+                    new Uint8Array(MAX_EXTERNAL_IMAGE_BYTES + 1),
+                );
+            },
+            cancel,
+        });
+        fetchMock.mockResolvedValueOnce(
+            new Response(body, {
+                status: 200,
+                headers: { "content-type": "image/jpeg" },
+            }),
+        );
+
+        const result = await service.syncAllCovers();
+
+        expect(result.skipped).toBe(1);
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
+        expect(prisma.podcast.update).not.toHaveBeenCalled();
+    });
+
+    it.each(["text/html", null])(
+        "syncAllCovers rejects the %s media type without writing it",
+        async (contentType) => {
+            const service = new PodcastCacheService();
+            queuePodcastCoverSync(
+                "pod-invalid-media",
+                "https://img.example/login-page",
+            );
+            const headers = contentType
+                ? { "content-type": contentType }
+                : undefined;
+            fetchMock.mockResolvedValueOnce(
+                new Response("not an image", { status: 200, headers }),
+            );
+
+            const result = await service.syncAllCovers();
+
+            expect(result.skipped).toBe(1);
+            expect(fsPromises.writeFile).not.toHaveBeenCalled();
+            expect(fsPromises.rename).not.toHaveBeenCalled();
+            expect(prisma.podcast.update).not.toHaveBeenCalled();
+        },
+    );
+
+    it("downloadCover rejects an id that would escape the cover cache", async () => {
+        const service = new PodcastCacheService();
+        queuePodcastCoverSync(
+            "../../../../outside",
+            "https://img.example/cover.jpg",
+        );
+
+        const result = await service.syncAllCovers();
+
+        expect(result.skipped).toBe(1);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
+        expect(prisma.podcast.update).not.toHaveBeenCalled();
+    });
+
+    it("downloadCover removes a partial temporary file when writing fails", async () => {
+        const service = new PodcastCacheService();
+        queuePodcastCoverSync("pod-partial", "https://img.example/cover.jpg");
+        fsPromises.writeFile.mockRejectedValueOnce(new Error("disk full"));
+
+        const result = await service.syncAllCovers();
+
+        expect(result.skipped).toBe(1);
+        expect(fsPromises.rename).not.toHaveBeenCalled();
+        expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
+        expect(fsPromises.unlink).toHaveBeenCalledWith(
+            expect.stringMatching(/podcast_pod-partial\.jpg\..+\.tmp$/),
+        );
+        expect(prisma.podcast.update).not.toHaveBeenCalled();
+    });
+
+    it("downloadCover removes the temporary file when atomic rename fails", async () => {
+        const service = new PodcastCacheService();
+        queuePodcastCoverSync(
+            "pod-rename-fail",
+            "https://img.example/cover.jpg",
+        );
+        fsPromises.rename.mockRejectedValueOnce(new Error("rename failed"));
+
+        const result = await service.syncAllCovers();
+
+        expect(result.skipped).toBe(1);
+        expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+        expect(fsPromises.unlink).toHaveBeenCalledWith(
+            expect.stringMatching(/podcast_pod-rename-fail\.jpg\..+\.tmp$/),
+        );
+        expect(prisma.podcast.update).not.toHaveBeenCalled();
     });
 
     it("downloadCover rejects hostnames that RESOLVE to private addresses", async () => {

--- a/backend/src/services/podcastCache.ts
+++ b/backend/src/services/podcastCache.ts
@@ -1,10 +1,62 @@
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { safeResolvePath } from "../utils/safeResolvePath";
+import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { config } from "../config";
 import { buildCachePath } from "./cacheHelpers";
-import { resolveSafeOutboundUrl } from "./outboundUrlSafety";
+import { fetchExternalImage, MAX_EXTERNAL_IMAGE_BYTES } from "./imageProxy";
+
+const podcastCacheLogger = logger.child("PodcastCache");
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function isImageMediaType(contentType: string | null): boolean {
+    return contentType?.trim().toLowerCase().startsWith("image/") ?? false;
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function resolveCoverPaths(
+    coverCacheDir: string,
+    id: string,
+    type: "podcast" | "episode",
+): { filePath: string; temporaryPath: string } | null {
+    const fileName = `${type}_${id}.jpg`;
+    const filePath = safeResolvePath(coverCacheDir, fileName);
+    const temporaryPath = safeResolvePath(
+        coverCacheDir,
+        `${fileName}.${randomUUID()}.tmp`,
+    );
+
+    return filePath && temporaryPath ? { filePath, temporaryPath } : null;
+}
+
+async function writeCoverAtomically(
+    filePath: string,
+    temporaryPath: string,
+    buffer: Buffer,
+): Promise<void> {
+    try {
+        await fs.writeFile(temporaryPath, buffer);
+        await fs.rename(temporaryPath, filePath);
+    } catch (error) {
+        await fs.unlink(temporaryPath).catch((cleanupError: unknown) => {
+            if (!isMissingFileError(cleanupError)) {
+                podcastCacheLogger.error(
+                    "Failed to clean up partial cover file",
+                    { error: cleanupError },
+                );
+            }
+        });
+        throw error;
+    }
+}
 
 /**
  * Service to cache podcast cover images locally
@@ -46,7 +98,7 @@ export class PodcastCacheService {
         };
 
         try {
-            logger.debug(" Starting podcast cover sync...");
+            podcastCacheLogger.debug("Starting podcast cover sync...");
 
             // Ensure cover cache directory exists
             await fs.mkdir(this.coverCacheDir, { recursive: true });
@@ -59,8 +111,8 @@ export class PodcastCacheService {
                 },
             });
 
-            logger.debug(
-                `[PODCAST] Found ${podcasts.length} podcasts needing cover sync`,
+            podcastCacheLogger.debug(
+                `Found ${podcasts.length} podcasts needing cover sync`,
             );
 
             for (const podcast of podcasts) {
@@ -78,29 +130,29 @@ export class PodcastCacheService {
                                 data: { localCoverPath: localPath },
                             });
                             result.synced++;
-                            logger.debug(
+                            podcastCacheLogger.debug(
                                 `  Synced cover for: ${podcast.title}`,
                             );
                         } else {
                             result.skipped++;
                         }
                     }
-                } catch (error: any) {
+                } catch (error: unknown) {
                     result.failed++;
-                    const errorMsg = `Failed to sync cover for ${podcast.title}: ${error.message}`;
+                    const errorMsg = `Failed to sync cover for ${podcast.title}: ${describeError(error)}`;
                     result.errors.push(errorMsg);
-                    logger.error(` ${errorMsg}`);
+                    podcastCacheLogger.error(` ${errorMsg}`);
                 }
             }
 
-            logger.debug("\nPodcast Cover Sync Summary:");
-            logger.debug(`  Synced: ${result.synced}`);
-            logger.debug(`   Failed: ${result.failed}`);
-            logger.debug(`    Skipped: ${result.skipped}`);
+            podcastCacheLogger.debug("\nPodcast Cover Sync Summary:");
+            podcastCacheLogger.debug(`  Synced: ${result.synced}`);
+            podcastCacheLogger.debug(`   Failed: ${result.failed}`);
+            podcastCacheLogger.debug(`    Skipped: ${result.skipped}`);
 
             return result;
-        } catch (error: any) {
-            logger.error(" Podcast cover sync failed:", error);
+        } catch (error: unknown) {
+            podcastCacheLogger.error(" Podcast cover sync failed:", error);
             throw error;
         }
     }
@@ -117,7 +169,7 @@ export class PodcastCacheService {
         };
 
         try {
-            logger.debug(" Starting podcast episode cover sync...");
+            podcastCacheLogger.debug("Starting podcast episode cover sync...");
 
             await fs.mkdir(this.coverCacheDir, { recursive: true });
 
@@ -141,8 +193,8 @@ export class PodcastCacheService {
                 (ep) => ep.imageUrl !== ep.podcast.imageUrl,
             );
 
-            logger.debug(
-                `[PODCAST] Found ${uniqueEpisodes.length} episodes with unique covers`,
+            podcastCacheLogger.debug(
+                `Found ${uniqueEpisodes.length} episodes with unique covers`,
             );
 
             for (const episode of uniqueEpisodes) {
@@ -160,29 +212,29 @@ export class PodcastCacheService {
                                 data: { localCoverPath: localPath },
                             });
                             result.synced++;
-                            logger.debug(
+                            podcastCacheLogger.debug(
                                 `  Synced cover for episode: ${episode.title}`,
                             );
                         } else {
                             result.skipped++;
                         }
                     }
-                } catch (error: any) {
+                } catch (error: unknown) {
                     result.failed++;
-                    const errorMsg = `Failed to sync cover for episode ${episode.title}: ${error.message}`;
+                    const errorMsg = `Failed to sync cover for episode ${episode.title}: ${describeError(error)}`;
                     result.errors.push(errorMsg);
-                    logger.error(` ${errorMsg}`);
+                    podcastCacheLogger.error(` ${errorMsg}`);
                 }
             }
 
-            logger.debug("\nEpisode Cover Sync Summary:");
-            logger.debug(`  Synced: ${result.synced}`);
-            logger.debug(`   Failed: ${result.failed}`);
-            logger.debug(`    Skipped: ${result.skipped}`);
+            podcastCacheLogger.debug("\nEpisode Cover Sync Summary:");
+            podcastCacheLogger.debug(`  Synced: ${result.synced}`);
+            podcastCacheLogger.debug(`   Failed: ${result.failed}`);
+            podcastCacheLogger.debug(`    Skipped: ${result.skipped}`);
 
             return result;
-        } catch (error: any) {
-            logger.error(" Episode cover sync failed:", error);
+        } catch (error: unknown) {
+            podcastCacheLogger.error(" Episode cover sync failed:", error);
             throw error;
         }
     }
@@ -195,42 +247,56 @@ export class PodcastCacheService {
         imageUrl: string,
         type: "podcast" | "episode",
     ): Promise<string | null> {
+        const paths = resolveCoverPaths(this.coverCacheDir, id, type);
+        if (!paths) {
+            podcastCacheLogger.error(
+                `Rejected cover path outside cache for ${type} ${id}`,
+            );
+            return null;
+        }
+
         try {
-            // DNS-resolving SSRF guard: feed-supplied cover URLs are untrusted
-            // and a public-looking hostname can resolve to an internal address.
-            // Redirects stay hard-disabled below, so one check covers the fetch.
-            const safeUrl = await resolveSafeOutboundUrl(imageUrl);
-            if (!safeUrl) {
-                logger.error(
-                    `SSRF-blocked cover download for ${type} ${id}:`,
-                    imageUrl,
+            const result = await fetchExternalImage({
+                url: imageUrl,
+                timeoutMs: 15000,
+                maxRedirects: 0,
+                maxRetries: 1,
+                maxBytes: MAX_EXTERNAL_IMAGE_BYTES,
+            });
+            if (!result.ok) {
+                if (result.status === "invalid_url") {
+                    podcastCacheLogger.error(
+                        `SSRF-blocked cover download for ${type} ${id}:`,
+                        imageUrl,
+                    );
+                } else {
+                    podcastCacheLogger.error(
+                        `Failed to download cover for ${type} ${id}:`,
+                        result.message ?? result.status,
+                    );
+                }
+                return null;
+            }
+
+            if (!isImageMediaType(result.contentType)) {
+                podcastCacheLogger.error(
+                    `Rejected non-image cover for ${type} ${id}:`,
+                    result.contentType,
                 );
                 return null;
             }
 
-            const response = await fetch(safeUrl, {
-                redirect: "error",
-                signal: AbortSignal.timeout(15000),
-            });
+            await writeCoverAtomically(
+                paths.filePath,
+                paths.temporaryPath,
+                result.buffer,
+            );
 
-            if (!response.ok) {
-                await response.body?.cancel().catch(() => {});
-                throw new Error(
-                    `HTTP ${response.status}: ${response.statusText}`,
-                );
-            }
-
-            const buffer = await response.arrayBuffer();
-            const fileName = `${type}_${id}.jpg`;
-            const filePath = path.join(this.coverCacheDir, fileName);
-
-            await fs.writeFile(filePath, Buffer.from(buffer));
-
-            return filePath;
-        } catch (error: any) {
-            logger.error(
+            return paths.filePath;
+        } catch (error: unknown) {
+            podcastCacheLogger.error(
                 `Failed to download cover for ${type} ${id}:`,
-                error.message,
+                describeError(error),
             );
             return null;
         }
@@ -264,7 +330,7 @@ export class PodcastCacheService {
             if (!validCoverPaths.has(file)) {
                 await fs.unlink(path.join(this.coverCacheDir, file));
                 deleted++;
-                logger.debug(
+                podcastCacheLogger.debug(
                     `  [DELETE] Deleted orphaned podcast cover: ${file}`,
                 );
             }


### PR DESCRIPTION
Convergence sweep #20 remediation (N4) in `backend/src/services/podcastCache.ts`.

Cover synchronization fetched feed-supplied image URLs with DNS vetting and a deadline but **fully materialized** successful bodies via `response.arrayBuffer()` with **no byte limit** — any authenticated user could trigger memory/cache-volume exhaustion via the sync route.

Fix: cover fetches now use the shared bounded `fetchExternalImage` path (`MAX_EXTERNAL_IMAGE_BYTES` cap on Content-Length and observed bytes, media-type validation, oversized-body cancellation) and clean up the temp file on failure.

Verification: targeted jest 20/20 (byte-cap, non-image type, oversized cancel, temp cleanup); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).