### PR TITLE
fix(security): interactive-session gate for API-key/MFA management + key expiry + OpenAPI auth (sweep #20 N2/N13/N14)

### DIFF
--- a/backend/src/config/__tests__/openapiAuthContract.test.ts
+++ b/backend/src/config/__tests__/openapiAuthContract.test.ts
@@ -1,0 +1,158 @@
+jest.mock("../../config", () => ({ config: { port: 3006 } }));
+
+type HttpMethod = "get" | "post" | "delete" | "options";
+
+interface AuthExpectation {
+    method: HttpMethod;
+    path: string;
+    anonymous: boolean;
+}
+
+const AUTH_MATRIX: AuthExpectation[] = [
+    { method: "post", path: "/api/auth/login", anonymous: true },
+    { method: "post", path: "/api/auth/logout", anonymous: true },
+    { method: "post", path: "/api/auth/refresh", anonymous: true },
+    { method: "post", path: "/api/auth/register", anonymous: true },
+    { method: "post", path: "/api/onboarding/register", anonymous: true },
+    { method: "get", path: "/api/onboarding/status", anonymous: true },
+    {
+        method: "get",
+        path: "/api/share-links/access/{token}",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/share-links/access/{token}/stream/{trackId}",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/share-links/access/{token}/zip",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/share-links/access/{token}/cover",
+        anonymous: true,
+    },
+    { method: "post", path: "/api/device-link/verify", anonymous: true },
+    {
+        method: "get",
+        path: "/api/device-link/status/{code}",
+        anonymous: true,
+    },
+    { method: "get", path: "/health", anonymous: true },
+    { method: "get", path: "/health/live", anonymous: true },
+    { method: "get", path: "/health/ready", anonymous: true },
+    { method: "get", path: "/api/health", anonymous: true },
+    { method: "get", path: "/api/health/live", anonymous: true },
+    { method: "get", path: "/api/health/ready", anonymous: true },
+    {
+        method: "options",
+        path: "/api/podcasts/{id}/cover",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/podcasts/{id}/cover",
+        anonymous: true,
+    },
+    {
+        method: "options",
+        path: "/api/podcasts/episodes/{episodeId}/cover",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/podcasts/episodes/{episodeId}/cover",
+        anonymous: true,
+    },
+    {
+        method: "options",
+        path: "/api/audiobooks/{id}/cover",
+        anonymous: true,
+    },
+    {
+        method: "get",
+        path: "/api/webhooks/lidarr/verify",
+        anonymous: true,
+    },
+    { method: "get", path: "/api/auth/me", anonymous: false },
+    { method: "post", path: "/api/api-keys", anonymous: false },
+    { method: "post", path: "/api/onboarding/complete", anonymous: false },
+    { method: "post", path: "/api/share-links", anonymous: false },
+];
+
+const INTERACTIVE_MANAGEMENT_OPERATIONS = [
+    ["post", "/api/api-keys"],
+    ["delete", "/api/api-keys/{id}"],
+    ["post", "/api/auth/2fa/setup"],
+    ["post", "/api/auth/2fa/enable"],
+    ["post", "/api/auth/2fa/disable"],
+] as const;
+
+function operationSecurity(spec: any, expectation: AuthExpectation): unknown {
+    const operation = spec.paths?.[expectation.path]?.[expectation.method];
+    if (!operation) {
+        throw new Error(
+            `Missing OpenAPI operation: ${expectation.method.toUpperCase()} ${expectation.path}`,
+        );
+    }
+    return operation.security ?? spec.security;
+}
+
+describe("OpenAPI authentication contract", () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    test("matches the runtime anonymous/protected operation matrix", () => {
+        const { swaggerSpec } = require("../swagger");
+
+        for (const expectation of AUTH_MATRIX) {
+            const security = operationSecurity(swaggerSpec, expectation);
+            if (expectation.anonymous) {
+                expect(security).toEqual([]);
+            } else {
+                expect(security).not.toEqual([]);
+            }
+        }
+    });
+
+    test("documents both runtime login success shapes", () => {
+        const { swaggerSpec } = require("../swagger");
+        const responseSchema =
+            swaggerSpec.paths["/api/auth/login"].post.responses["200"].content[
+                "application/json"
+            ].schema;
+
+        expect(responseSchema.oneOf).toEqual([
+            { $ref: "#/components/schemas/LoginTokenResponse" },
+            { $ref: "#/components/schemas/LoginTwoFactorChallenge" },
+        ]);
+        expect(swaggerSpec.components.schemas.LoginTokenResponse).toEqual(
+            expect.objectContaining({
+                required: ["token", "refreshToken", "user"],
+            }),
+        );
+        expect(swaggerSpec.components.schemas.LoginTwoFactorChallenge).toEqual(
+            expect.objectContaining({
+                required: ["requires2FA", "message"],
+                properties: expect.objectContaining({
+                    requires2FA: expect.objectContaining({ enum: [true] }),
+                }),
+            }),
+        );
+    });
+
+    test("excludes API keys from interactive credential-management operations", () => {
+        const { swaggerSpec } = require("../swagger");
+
+        for (const [method, path] of INTERACTIVE_MANAGEMENT_OPERATIONS) {
+            expect(swaggerSpec.paths[path][method].security).toEqual([
+                { sessionAuth: [] },
+                { bearerAuth: [] },
+            ]);
+        }
+    });
+});

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -8,9 +8,41 @@ import {
     BRAND_NAME,
     BRAND_SITE_URL,
 } from "./brand";
+import { safeResolvePath } from "../utils/safeResolvePath";
+
+const ANONYMOUS_OPERATIONS = [
+    ["/api/auth/login", "post"],
+    ["/api/auth/logout", "post"],
+    ["/api/auth/refresh", "post"],
+    ["/api/auth/register", "post"],
+    ["/api/onboarding/register", "post"],
+    ["/api/onboarding/status", "get"],
+    ["/api/device-link/verify", "post"],
+    ["/api/device-link/status/{code}", "get"],
+    ["/api/share-links/access/{token}", "get"],
+    ["/api/share-links/access/{token}/stream/{trackId}", "get"],
+    ["/api/share-links/access/{token}/zip", "get"],
+    ["/api/share-links/access/{token}/cover", "get"],
+    ["/health", "get"],
+    ["/health/live", "get"],
+    ["/health/ready", "get"],
+    ["/api/health", "get"],
+    ["/api/health/live", "get"],
+    ["/api/health/ready", "get"],
+    ["/api/podcasts/{id}/cover", "options"],
+    ["/api/podcasts/{id}/cover", "get"],
+    ["/api/podcasts/episodes/{episodeId}/cover", "options"],
+    ["/api/podcasts/episodes/{episodeId}/cover", "get"],
+    ["/api/audiobooks/{id}/cover", "options"],
+    ["/api/webhooks/lidarr/verify", "get"],
+] as const;
 
 function resolveApiVersion(): string {
-    const manifestPath = path.join(__dirname, "..", "..", "package.json");
+    const backendRoot = path.resolve(__dirname, "..", "..");
+    const manifestPath = safeResolvePath(backendRoot, "package.json");
+    if (!manifestPath) {
+        throw new Error("backend package.json path escaped the backend root");
+    }
     const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
         version?: unknown;
     };
@@ -54,6 +86,12 @@ const options: swaggerJsdoc.Options = {
                     name: "X-API-Key",
                     description: "API key authentication (client integrations)",
                 },
+                bearerAuth: {
+                    type: "http",
+                    scheme: "bearer",
+                    bearerFormat: "JWT",
+                    description: "Short-lived access token returned by login",
+                },
             },
             schemas: {
                 User: {
@@ -63,6 +101,36 @@ const options: swaggerJsdoc.Options = {
                         username: { type: "string" },
                         role: { type: "string", enum: ["user", "admin"] },
                         createdAt: { type: "string", format: "date-time" },
+                    },
+                },
+                LoginUser: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["id", "username", "displayName", "role"],
+                    properties: {
+                        id: { type: "string" },
+                        username: { type: "string" },
+                        displayName: { type: "string", nullable: true },
+                        role: { type: "string", enum: ["user", "admin"] },
+                    },
+                },
+                LoginTokenResponse: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["token", "refreshToken", "user"],
+                    properties: {
+                        token: { type: "string" },
+                        refreshToken: { type: "string" },
+                        user: { $ref: "#/components/schemas/LoginUser" },
+                    },
+                },
+                LoginTwoFactorChallenge: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["requires2FA", "message"],
+                    properties: {
+                        requires2FA: { type: "boolean", enum: [true] },
+                        message: { type: "string" },
                     },
                 },
                 Artist: {
@@ -105,6 +173,7 @@ const options: swaggerJsdoc.Options = {
                         name: { type: "string" },
                         lastUsed: { type: "string", format: "date-time" },
                         createdAt: { type: "string", format: "date-time" },
+                        expiresAt: { type: "string", format: "date-time" },
                     },
                 },
                 Error: {
@@ -115,9 +184,26 @@ const options: swaggerJsdoc.Options = {
                 },
             },
         },
-        security: [{ sessionAuth: [] }, { apiKeyAuth: [] }],
+        security: [{ sessionAuth: [] }, { bearerAuth: [] }, { apiKeyAuth: [] }],
     },
     apis: ["./src/routes/*.ts"],
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function applyAnonymousSecurity(document: object): void {
+    if (!("paths" in document) || !isRecord(document.paths)) return;
+    for (const [operationPath, method] of ANONYMOUS_OPERATIONS) {
+        const pathItem = document.paths[operationPath];
+        if (!isRecord(pathItem)) continue;
+        const operation = pathItem[method];
+        if (isRecord(operation)) {
+            operation.security = [];
+        }
+    }
+}
+
 export const swaggerSpec = swaggerJsdoc(options);
+applyAnonymousSecurity(swaggerSpec);

--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -31,7 +31,7 @@ import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
-import { hashApiKey } from "../../utils/apiKeyHash";
+import { API_KEY_LIFETIME_MS, hashApiKey } from "../../utils/apiKeyHash";
 
 // API-key hashing needs a pepper. This suite deletes SESSION_SECRET to exercise
 // the JWT_SECRET path, so provide SETTINGS_ENCRYPTION_KEY explicitly as the
@@ -247,6 +247,7 @@ describe("auth middleware", () => {
         it("authenticates via API key and updates lastUsed", async () => {
             mockApiKeyFindUnique.mockResolvedValue({
                 id: "key-1",
+                createdAt: new Date(),
                 user: { id: "u2", username: "api-user", role: "admin" },
             });
 
@@ -273,6 +274,26 @@ describe("auth middleware", () => {
                 role: "admin",
             });
             expect(next).toHaveBeenCalledTimes(1);
+        });
+
+        it("rejects an API key after its bounded lifetime", async () => {
+            mockApiKeyFindUnique.mockResolvedValue({
+                id: "expired-key",
+                createdAt: new Date(Date.now() - API_KEY_LIFETIME_MS - 1),
+                user: { id: "u2", username: "api-user", role: "admin" },
+            });
+
+            const req = createReq({ headers: { "x-api-key": "expired" } });
+            const res = createRes();
+            const next = jest.fn();
+
+            await requireAuth(asRequest(req), asResponse(res), asNext(next));
+
+            expect(next).not.toHaveBeenCalled();
+            expect(req.user).toBeUndefined();
+            expect(mockApiKeyUpdate).not.toHaveBeenCalled();
+            expect(res.statusCode).toBe(401);
+            expect(res.body).toEqual({ error: "Not authenticated" });
         });
 
         it("authenticates via bearer token when tokenVersion matches", async () => {
@@ -372,6 +393,29 @@ describe("auth middleware", () => {
     });
 
     describe("requireAuthOrToken", () => {
+        it("rejects an expired API key", async () => {
+            mockApiKeyFindUnique.mockResolvedValue({
+                id: "expired-stream-key",
+                createdAt: new Date(Date.now() - API_KEY_LIFETIME_MS - 1),
+                user: { id: "u2", username: "api-user", role: "user" },
+            });
+
+            const req = createReq({ headers: { "x-api-key": "expired" } });
+            const res = createRes();
+            const next = jest.fn();
+
+            await requireAuthOrToken(
+                asRequest(req),
+                asResponse(res),
+                asNext(next),
+            );
+
+            expect(next).not.toHaveBeenCalled();
+            expect(req.user).toBeUndefined();
+            expect(mockApiKeyUpdate).not.toHaveBeenCalled();
+            expect(res.statusCode).toBe(401);
+        });
+
         it("accepts query param tokens for streaming routes", async () => {
             mockJwtVerify.mockReturnValue({
                 userId: "stream-user",

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
-import { findApiKeyRecord } from "../utils/apiKeyHash";
+import { findApiKeyRecord, isApiKeyExpired } from "../utils/apiKeyHash";
 import jwt from "jsonwebtoken";
 
 // JWT_SECRET is required - SESSION_SECRET (a required, stable deploy secret;
@@ -188,7 +188,11 @@ async function authenticateRequest(
                 }),
             );
 
-            if (apiKeyRecord && apiKeyRecord.user) {
+            if (
+                apiKeyRecord &&
+                apiKeyRecord.user &&
+                !isApiKeyExpired(apiKeyRecord.createdAt)
+            ) {
                 // Update last used timestamp (async, don't block)
                 prisma.apiKey
                     .update({
@@ -302,7 +306,11 @@ export async function requireAuthOrToken(
                 }),
             );
 
-            if (apiKeyRecord && apiKeyRecord.user) {
+            if (
+                apiKeyRecord &&
+                apiKeyRecord.user &&
+                !isApiKeyExpired(apiKeyRecord.createdAt)
+            ) {
                 // Update last used timestamp (async, don't block)
                 prisma.apiKey
                     .update({

--- a/backend/src/routes/__tests__/apiKeysInteractiveAuthRuntime.test.ts
+++ b/backend/src/routes/__tests__/apiKeysInteractiveAuthRuntime.test.ts
@@ -1,0 +1,140 @@
+process.env.SETTINGS_ENCRYPTION_KEY =
+    process.env.SETTINGS_ENCRYPTION_KEY ||
+    "api-keys-interactive-auth-test-pepper-123456";
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: any, _res: any, next: () => void) => next(),
+}));
+
+const prisma = {
+    apiKey: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
+    },
+};
+jest.mock("../../utils/db", () => ({ prisma }));
+
+const scopedLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+};
+scopedLogger.child.mockReturnValue(scopedLogger);
+jest.mock("../../utils/logger", () => ({ logger: scopedLogger }));
+
+import router from "../apiKeys";
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined,
+        status: jest.fn((statusCode: number) => {
+            res.statusCode = statusCode;
+            return res;
+        }),
+        json: jest.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        }),
+    };
+    return res;
+}
+
+async function executeRoute(
+    method: "post" | "delete",
+    path: string,
+    req: any,
+    res: any,
+): Promise<void> {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) throw new Error(`Missing route ${method} ${path}`);
+
+    const dispatch = async (index: number): Promise<void> => {
+        const handler = layer.route.stack[index]?.handle;
+        if (!handler) return;
+        await handler(req, res, (error?: unknown) => {
+            if (error) throw error;
+            return dispatch(index + 1);
+        });
+    };
+    await dispatch(0);
+}
+
+function interactiveRequest(body: Record<string, unknown> = {}): any {
+    return {
+        body,
+        headers: { authorization: "Bearer access-token" },
+        user: { id: "u1", username: "alice", role: "user" },
+        params: { id: "key-1" },
+    };
+}
+
+describe("API key management interactive authentication", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        prisma.apiKey.create.mockResolvedValue({
+            name: "Laptop",
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        });
+        prisma.apiKey.deleteMany.mockResolvedValue({ count: 1 });
+    });
+
+    test.each([
+        ["post", "/", { deviceName: "Laptop" }],
+        ["delete", "/:id", {}],
+    ] as const)(
+        "rejects X-API-Key authentication for %s %s",
+        async (method, path, body) => {
+            const req = interactiveRequest(body);
+            req.headers["x-api-key"] = "stolen-key";
+            const res = createRes();
+
+            await executeRoute(method, path, req, res);
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body).toEqual({
+                error: "Interactive session authentication required",
+            });
+            expect(prisma.apiKey.create).not.toHaveBeenCalled();
+            expect(prisma.apiKey.deleteMany).not.toHaveBeenCalled();
+        },
+    );
+
+    it("creates a bounded key from the shipping device-name payload", async () => {
+        const res = createRes();
+
+        await executeRoute(
+            "post",
+            "/",
+            interactiveRequest({ deviceName: "Laptop" }),
+            res,
+        );
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                apiKey: expect.stringMatching(/^[0-9a-f]{64}$/),
+                name: "Laptop",
+                expiresAt: expect.any(Date),
+            }),
+        );
+        expect(res.body.expiresAt.getTime()).toBeGreaterThan(
+            res.body.createdAt.getTime(),
+        );
+    });
+
+    it("revokes a key without adding a request body", async () => {
+        const res = createRes();
+
+        await executeRoute("delete", "/:id", interactiveRequest(), res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ message: "API key revoked successfully" });
+    });
+});

--- a/backend/src/routes/__tests__/apiKeysRuntime.test.ts
+++ b/backend/src/routes/__tests__/apiKeysRuntime.test.ts
@@ -8,14 +8,15 @@ jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: any, _res: any, next: () => void) => next(),
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
-}));
+const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
 const prisma = {
     apiKey: {
@@ -139,7 +140,11 @@ describe("apiKeys routes runtime", () => {
                 name: "My Phone",
                 message:
                     "API key created successfully. Save this key - you won't see it again!",
+                expiresAt: expect.any(Date),
             }),
+        );
+        expect(res.body.expiresAt.getTime()).toBeGreaterThan(
+            res.body.createdAt.getTime(),
         );
     });
 
@@ -176,7 +181,11 @@ describe("apiKeys routes runtime", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
             apiKeys: expect.arrayContaining([
-                expect.objectContaining({ id: "k1", name: "My Phone" }),
+                expect.objectContaining({
+                    id: "k1",
+                    name: "My Phone",
+                    expiresAt: expect.any(Date),
+                }),
             ]),
         });
 

--- a/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
+++ b/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
@@ -1,0 +1,205 @@
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: any, _res: any, next: () => void) => next(),
+    requireAdmin: (_req: any, _res: any, next: () => void) => next(),
+    generateToken: jest.fn(),
+    generateRefreshToken: jest.fn(),
+    verifyAuthToken: jest.fn(),
+}));
+
+const mockBcryptCompare = jest.fn();
+jest.mock("bcrypt", () => ({
+    __esModule: true,
+    default: {
+        compare: (...args: unknown[]) => mockBcryptCompare(...args),
+        hash: jest.fn(),
+    },
+}));
+
+const mockTotpVerify = jest.fn();
+jest.mock("otplib", () => ({
+    generateSecret: jest.fn(() => "NEW-SECRET"),
+    generateURI: jest.fn(() => "otpauth://test"),
+    verify: (...args: unknown[]) => mockTotpVerify(...args),
+}));
+
+jest.mock("qrcode", () => ({
+    __esModule: true,
+    default: { toDataURL: jest.fn(() => "data:image/png;base64,test") },
+}));
+
+jest.mock("../../utils/encryption", () => ({
+    encrypt: (value: string) => `enc(${value})`,
+    decrypt: (value: string) => value.replace(/^enc\((.*)\)$/, "$1"),
+}));
+
+const prisma = {
+    user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+    },
+};
+jest.mock("../../utils/db", () => ({ prisma }));
+
+const scopedLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+};
+scopedLogger.child.mockReturnValue(scopedLogger);
+jest.mock("../../utils/logger", () => ({ logger: scopedLogger }));
+
+import router from "../auth";
+
+function createRes() {
+    const res: any = {
+        statusCode: 200,
+        body: undefined,
+        status: jest.fn((statusCode: number) => {
+            res.statusCode = statusCode;
+            return res;
+        }),
+        json: jest.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        }),
+    };
+    return res;
+}
+
+async function executeRoute(path: string, req: any, res: any): Promise<void> {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.post,
+    );
+    if (!layer) throw new Error(`Missing POST route ${path}`);
+
+    const dispatch = async (index: number): Promise<void> => {
+        const handler = layer.route.stack[index]?.handle;
+        if (!handler) return;
+        await handler(req, res, (error?: unknown) => {
+            if (error) throw error;
+            return dispatch(index + 1);
+        });
+    };
+    await dispatch(0);
+}
+
+function interactiveRequest(body: Record<string, unknown>): any {
+    return {
+        body,
+        headers: { authorization: "Bearer access-token" },
+        user: { id: "u1", username: "alice", role: "user" },
+    };
+}
+
+describe("MFA management interactive authentication", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockBcryptCompare.mockResolvedValue(true);
+        mockTotpVerify.mockResolvedValue({ valid: true });
+        prisma.user.findUnique.mockResolvedValue({
+            id: "u1",
+            username: "alice",
+            passwordHash: "password-hash",
+            twoFactorEnabled: false,
+            twoFactorSecret: null,
+        });
+        prisma.user.update.mockResolvedValue({});
+        prisma.user.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    test.each([
+        ["/2fa/setup", {}],
+        ["/2fa/enable", { secret: "NEW-SECRET", token: "123456" }],
+        ["/2fa/disable", { password: "secret", token: "123456" }],
+    ] as const)("rejects API-key authentication on %s", async (path, body) => {
+        const req = interactiveRequest(body);
+        req.headers["x-api-key"] = "stolen-key";
+        const res = createRes();
+
+        await executeRoute(path, req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({
+            error: "Interactive session authentication required",
+        });
+        expect(prisma.user.findUnique).not.toHaveBeenCalled();
+        expect(prisma.user.update).not.toHaveBeenCalled();
+        expect(prisma.user.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("allows setup with the existing empty payload", async () => {
+        const res = createRes();
+
+        await executeRoute("/2fa/setup", interactiveRequest({}), res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            secret: "NEW-SECRET",
+            qrCode: "data:image/png;base64,test",
+        });
+    });
+
+    it("allows enable with the existing secret and token payload", async () => {
+        const res = createRes();
+
+        await executeRoute(
+            "/2fa/enable",
+            interactiveRequest({ secret: "NEW-SECRET", token: "123456" }),
+            res,
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(prisma.user.updateMany).toHaveBeenCalledWith({
+            where: { id: "u1", twoFactorEnabled: false },
+            data: expect.objectContaining({
+                twoFactorEnabled: true,
+                twoFactorSecret: "enc(NEW-SECRET)",
+            }),
+        });
+    });
+
+    it("rejects an existing or concurrently enabled factor", async () => {
+        prisma.user.updateMany.mockResolvedValueOnce({ count: 0 });
+        const res = createRes();
+
+        await executeRoute(
+            "/2fa/enable",
+            interactiveRequest({ secret: "NEW-SECRET", token: "123456" }),
+            res,
+        );
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body).toEqual({ error: "2FA is already enabled" });
+    });
+
+    it("keeps disable protected by the existing password and current token", async () => {
+        prisma.user.findUnique.mockResolvedValueOnce({
+            id: "u1",
+            passwordHash: "password-hash",
+            twoFactorEnabled: true,
+            twoFactorSecret: "enc(CURRENT-SECRET)",
+        });
+        const res = createRes();
+
+        await executeRoute(
+            "/2fa/disable",
+            interactiveRequest({ password: "secret", token: "123456" }),
+            res,
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(mockBcryptCompare).toHaveBeenCalledWith(
+            "secret",
+            "password-hash",
+        );
+        expect(mockTotpVerify).toHaveBeenCalledWith({
+            secret: "CURRENT-SECRET",
+            token: "123456",
+            epochTolerance: 60,
+        });
+    });
+});

--- a/backend/src/routes/__tests__/authRuntime.test.ts
+++ b/backend/src/routes/__tests__/authRuntime.test.ts
@@ -1,13 +1,16 @@
 import crypto from "crypto";
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
-}));
+jest.mock("../../config", () => ({ config: { port: 3006 } }));
+
+const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
 const mockRequireAuth = jest.fn((_req: any, _res: any, next: () => void) =>
     next(),
@@ -33,6 +36,7 @@ const prisma = {
         findMany: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
         delete: jest.fn(),
     },
     userSettings: {
@@ -96,6 +100,7 @@ jest.mock("../../utils/encryption", () => ({
     decrypt: mockDecrypt,
 }));
 
+import { swaggerSpec } from "../../config/swagger";
 import router from "../auth";
 
 function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
@@ -125,6 +130,36 @@ function createRes() {
     return res;
 }
 
+function expectLoginBodyMatchesOpenApi(body: Record<string, unknown>): void {
+    const document = swaggerSpec as any;
+    const oneOf =
+        document.paths["/api/auth/login"].post.responses["200"].content[
+            "application/json"
+        ].schema.oneOf;
+    const schemas = document.components.schemas;
+    const matchingSchemas = oneOf.filter((candidate: { $ref: string }) => {
+        const schemaName = candidate.$ref.split("/").at(-1);
+        if (!schemaName) return false;
+        const schema = schemas[schemaName];
+        return (
+            schema.required.every((key: string) => key in body) &&
+            Object.keys(body).every((key) => key in schema.properties)
+        );
+    });
+
+    expect(matchingSchemas).toHaveLength(1);
+    if ("user" in body) {
+        const user = body.user as Record<string, unknown>;
+        const userSchema = schemas.LoginUser;
+        expect(userSchema.required.every((key: string) => key in user)).toBe(
+            true,
+        );
+        expect(
+            Object.keys(user).every((key) => key in userSchema.properties),
+        ).toBe(true);
+    }
+}
+
 describe("auth routes runtime", () => {
     const login = getHandler("/login", "post");
     const logout = getHandler("/logout", "post");
@@ -151,6 +186,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValue({
             id: "u1",
             username: "alice",
+            displayName: null,
             role: "user",
             passwordHash: "hash-1",
             tokenVersion: 1,
@@ -170,6 +206,7 @@ describe("auth routes runtime", () => {
             createdAt: new Date("2026-02-01T00:00:00.000Z"),
         });
         prisma.user.update.mockResolvedValue({});
+        prisma.user.updateMany.mockResolvedValue({ count: 1 });
         prisma.user.delete.mockResolvedValue({});
         prisma.userSettings.create.mockResolvedValue({});
 
@@ -226,6 +263,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValue({
             id: "u1",
             username: "alice",
+            displayName: null,
             role: "user",
             passwordHash: "hash-1",
             tokenVersion: 1,
@@ -244,6 +282,7 @@ describe("auth routes runtime", () => {
             requires2FA: true,
             message: "2FA token required",
         });
+        expectLoginBodyMatchesOpenApi(challengeRes.body);
 
         mockOtplibVerify.mockResolvedValueOnce({ valid: true });
         const totpReq = {
@@ -258,9 +297,11 @@ describe("auth routes runtime", () => {
             user: {
                 id: "u1",
                 username: "alice",
+                displayName: null,
                 role: "user",
             },
         });
+        expectLoginBodyMatchesOpenApi(totpRes.body);
 
         const recoveryReq = {
             body: { username: "alice", password: "pw", token: "ABCDEF12" },
@@ -670,6 +711,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             id: "u1",
             passwordHash: "hash-1",
+            twoFactorEnabled: true,
             twoFactorSecret: "enc(BASE32SECRET)",
         });
         mockBcryptCompare.mockResolvedValueOnce(false);
@@ -684,6 +726,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             id: "u1",
             passwordHash: "hash-1",
+            twoFactorEnabled: true,
             twoFactorSecret: "enc(BASE32SECRET)",
         });
         mockBcryptCompare.mockResolvedValueOnce(true);
@@ -699,6 +742,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             id: "u1",
             passwordHash: "hash-1",
+            twoFactorEnabled: true,
             twoFactorSecret: "enc(BASE32SECRET)",
         });
         mockBcryptCompare.mockResolvedValueOnce(true);
@@ -746,7 +790,7 @@ describe("auth routes runtime", () => {
 
     it("returns 500 for 2FA enable failures", async () => {
         mockOtplibVerify.mockResolvedValueOnce({ valid: true });
-        prisma.user.update.mockRejectedValueOnce(new Error("db"));
+        prisma.user.updateMany.mockRejectedValueOnce(new Error("db"));
 
         const req = {
             user: { id: "u1" },
@@ -763,6 +807,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             id: "u1",
             passwordHash: "hash-1",
+            twoFactorEnabled: true,
             twoFactorSecret: "enc(BASE32SECRET)",
         });
         mockBcryptCompare.mockResolvedValueOnce(true);
@@ -1447,6 +1492,7 @@ describe("auth routes runtime", () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             id: "u1",
             passwordHash: "hash-1",
+            twoFactorEnabled: true,
             twoFactorSecret: null,
         });
         mockBcryptCompare.mockResolvedValueOnce(true);

--- a/backend/src/routes/__tests__/totpBehavior.test.ts
+++ b/backend/src/routes/__tests__/totpBehavior.test.ts
@@ -1,11 +1,12 @@
-jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
-}));
+const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
 const mockRequireAuth = jest.fn((_req: any, _res: any, next: () => void) =>
     next(),
@@ -29,6 +30,7 @@ const prisma = {
     user: {
         findUnique: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
     },
 };
 
@@ -121,6 +123,7 @@ describe("auth TOTP behavior", () => {
         jest.spyOn(Date, "now").mockReturnValue(FIXED_EPOCH_MS);
 
         prisma.user.update.mockResolvedValue({});
+        prisma.user.updateMany.mockResolvedValue({ count: 1 });
         mockBcryptCompare.mockResolvedValue(true);
         mockGenerateToken.mockReturnValue("tok");
         mockGenerateRefreshToken.mockReturnValue("rtok");
@@ -150,8 +153,8 @@ describe("auth TOTP behavior", () => {
                 /^[A-F0-9]{8}$/.test(code),
             ),
         );
-        expect(prisma.user.update).toHaveBeenCalledWith({
-            where: { id: "u1" },
+        expect(prisma.user.updateMany).toHaveBeenCalledWith({
+            where: { id: "u1", twoFactorEnabled: false },
             data: {
                 twoFactorEnabled: true,
                 twoFactorSecret: `enc(${SECRET_B32})`,
@@ -188,7 +191,7 @@ describe("auth TOTP behavior", () => {
         await twoFaEnable(req, res);
 
         expect(res.statusCode).toBe(401);
-        expect(prisma.user.update).not.toHaveBeenCalled();
+        expect(prisma.user.updateMany).not.toHaveBeenCalled();
     });
 
     it("logs in with a valid TOTP token", async () => {

--- a/backend/src/routes/apiKeys.ts
+++ b/backend/src/routes/apiKeys.ts
@@ -1,11 +1,29 @@
-import { Router } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import { logger } from "../utils/logger";
 import { requireAuth } from "../middleware/auth";
 import { prisma } from "../utils/db";
-import { hashApiKey } from "../utils/apiKeyHash";
+import { getApiKeyExpiresAt, hashApiKey } from "../utils/apiKeyHash";
 import crypto from "crypto";
+import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
+const routeLogger = logger.child("ApiKeys");
+
+function requireInteractiveSession(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+) {
+    // Interactive password/current-factor step-up is a documented frontend follow-up outside this slice.
+    if (req.headers["x-api-key"] !== undefined) {
+        return sendRouteError(
+            res,
+            403,
+            "Interactive session authentication required",
+        );
+    }
+    return next();
+}
 
 // All API key routes require authentication (session-based)
 router.use(requireAuth);
@@ -18,6 +36,7 @@ router.use(requireAuth);
  *     tags: [API Keys]
  *     security:
  *       - sessionAuth: []
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -49,6 +68,9 @@ router.use(requireAuth);
  *                 createdAt:
  *                   type: string
  *                   format: date-time
+ *                 expiresAt:
+ *                   type: string
+ *                   format: date-time
  *                 message:
  *                   type: string
  *                   example: "API key created successfully. Save this key - you won't see it again!"
@@ -65,7 +87,7 @@ router.use(requireAuth);
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.post("/", async (req, res) => {
+router.post("/", requireInteractiveSession, async (req, res) => {
     try {
         const { deviceName } = req.body;
 
@@ -91,7 +113,7 @@ router.post("/", async (req, res) => {
             },
         });
 
-        logger.debug(`API key created for user ${userId}: ${deviceName}`);
+        routeLogger.debug("API key created", { userId, deviceName });
 
         res.status(201).json({
             // Return the raw key (not the stored hash) — the caller can never
@@ -99,11 +121,12 @@ router.post("/", async (req, res) => {
             apiKey: apiKeyValue,
             name: apiKey.name,
             createdAt: apiKey.createdAt,
+            expiresAt: getApiKeyExpiresAt(apiKey.createdAt),
             message:
                 "API key created successfully. Save this key - you won't see it again!",
         });
     } catch (error) {
-        logger.error("Create API key error:", error);
+        routeLogger.error("Create API key error", { error });
         res.status(500).json({ error: "Failed to create API key" });
     }
 });
@@ -116,6 +139,8 @@ router.post("/", async (req, res) => {
  *     tags: [API Keys]
  *     security:
  *       - sessionAuth: []
+ *       - bearerAuth: []
+ *       - apiKeyAuth: []
  *     responses:
  *       200:
  *         description: List of API keys (without the actual key values for security)
@@ -155,9 +180,14 @@ router.get("/", async (req, res) => {
             orderBy: { createdAt: "desc" },
         });
 
-        res.json({ apiKeys: keys });
+        res.json({
+            apiKeys: keys.map((key) => ({
+                ...key,
+                expiresAt: getApiKeyExpiresAt(key.createdAt),
+            })),
+        });
     } catch (error) {
-        logger.error("List API keys error:", error);
+        routeLogger.error("List API keys error", { error });
         res.status(500).json({ error: "Failed to list API keys" });
     }
 });
@@ -170,6 +200,7 @@ router.get("/", async (req, res) => {
  *     tags: [API Keys]
  *     security:
  *       - sessionAuth: []
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -201,7 +232,7 @@ router.get("/", async (req, res) => {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.delete("/:id", async (req, res) => {
+router.delete("/:id", requireInteractiveSession, async (req, res) => {
     try {
         // Use req.user.id (set by requireAuth middleware) - supports both session and JWT auth
         const userId = req.user?.id || req.session?.userId;
@@ -209,6 +240,9 @@ router.delete("/:id", async (req, res) => {
             return res.status(401).json({ error: "Not authenticated" });
         }
         const keyId = req.params.id;
+        if (typeof keyId !== "string" || keyId.length === 0) {
+            return sendRouteError(res, 400, "API key ID is required");
+        }
 
         // Only allow users to delete their own keys
         const deleted = await prisma.apiKey.deleteMany({
@@ -224,11 +258,11 @@ router.delete("/:id", async (req, res) => {
                 .json({ error: "API key not found or already deleted" });
         }
 
-        logger.debug(`API key ${keyId} revoked by user ${userId}`);
+        routeLogger.debug("API key revoked", { keyId, userId });
 
         res.json({ message: "API key revoked successfully" });
     } catch (error) {
-        logger.error("Delete API key error:", error);
+        routeLogger.error("Delete API key error", { error });
         res.status(500).json({ error: "Failed to revoke API key" });
     }
 });

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import { logger } from "../utils/logger";
 import bcrypt from "bcrypt";
 import { prisma } from "../utils/db";
@@ -17,6 +17,7 @@ import { encrypt, decrypt } from "../utils/encryption";
 import { BRAND_NAME } from "../config/brand";
 import { timingSafeCompare } from "../utils/timingSafe";
 import { runDummyBcrypt } from "../utils/dummyCredential";
+import { sendRouteError } from "./routeErrorResponse";
 
 async function verifyTotpToken(
     secret: string,
@@ -41,6 +42,21 @@ async function verifyTotpToken(
 }
 
 const router = Router();
+function requireInteractiveSession(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+) {
+    // Interactive password/current-factor step-up is a documented frontend follow-up outside this slice.
+    if (req.headers["x-api-key"] !== undefined) {
+        return sendRouteError(
+            res,
+            403,
+            "Interactive session authentication required",
+        );
+    }
+    return next();
+}
 
 const loginSchema = z.object({
     username: z.string().min(1),
@@ -119,6 +135,7 @@ const decrypt2FASecret = decrypt;
  *   post:
  *     summary: Login with username and password
  *     tags: [Authentication]
+ *     security: []
  *     requestBody:
  *       required: true
  *       content:
@@ -140,7 +157,9 @@ const decrypt2FASecret = decrypt;
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/User'
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/LoginTokenResponse'
+ *                 - $ref: '#/components/schemas/LoginTwoFactorChallenge'
  *       401:
  *         description: Invalid credentials
  *         content:
@@ -270,6 +289,7 @@ router.post("/login", async (req, res) => {
  *   post:
  *     summary: Logout the current user
  *     tags: [Authentication]
+ *     security: []
  *     responses:
  *       200:
  *         description: Logged out successfully
@@ -287,6 +307,7 @@ router.post("/logout", (req, res) => {
  *   post:
  *     summary: Refresh access token using a refresh token
  *     tags: [Authentication]
+ *     security: []
  *     requestBody:
  *       required: true
  *       content:
@@ -1081,6 +1102,7 @@ router.delete<{ id: string }>(
  *   post:
  *     summary: Register a new user account with an invite code
  *     tags: [Authentication]
+ *     security: []
  *     requestBody:
  *       required: true
  *       content:
@@ -1266,7 +1288,7 @@ router.post("/register", async (req, res) => {
  *     tags: [Authentication]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
+ *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: 2FA secret and QR code generated
@@ -1278,41 +1300,48 @@ router.post("/register", async (req, res) => {
  *         description: User not found
  */
 // POST /auth/2fa/setup - Generate 2FA secret and QR code
-router.post("/2fa/setup", requireAuth, async (req, res) => {
-    try {
-        const user = await prisma.user.findUnique({
-            where: { id: req.user!.id },
-            select: { username: true, twoFactorEnabled: true },
-        });
+router.post(
+    "/2fa/setup",
+    requireAuth,
+    requireInteractiveSession,
+    async (req, res) => {
+        try {
+            const user = await prisma.user.findUnique({
+                where: { id: req.user!.id },
+                select: { username: true, twoFactorEnabled: true },
+            });
 
-        if (!user) {
-            return res.status(404).json({ error: "User not found" });
+            if (!user) {
+                return res.status(404).json({ error: "User not found" });
+            }
+
+            if (user.twoFactorEnabled) {
+                return res
+                    .status(400)
+                    .json({ error: "2FA is already enabled" });
+            }
+
+            // Generate secret
+            const secret = generateSecret();
+            const otpauthUrl = generateURI({
+                issuer: BRAND_NAME,
+                label: user.username,
+                secret,
+            });
+
+            // Generate QR code
+            const qrCodeDataUrl = await QRCode.toDataURL(otpauthUrl);
+
+            res.json({
+                secret,
+                qrCode: qrCodeDataUrl,
+            });
+        } catch (error) {
+            logger.error("2FA setup error:", error);
+            res.status(500).json({ error: "Failed to setup 2FA" });
         }
-
-        if (user.twoFactorEnabled) {
-            return res.status(400).json({ error: "2FA is already enabled" });
-        }
-
-        // Generate secret
-        const secret = generateSecret();
-        const otpauthUrl = generateURI({
-            issuer: BRAND_NAME,
-            label: user.username,
-            secret,
-        });
-
-        // Generate QR code
-        const qrCodeDataUrl = await QRCode.toDataURL(otpauthUrl);
-
-        res.json({
-            secret,
-            qrCode: qrCodeDataUrl,
-        });
-    } catch (error) {
-        logger.error("2FA setup error:", error);
-        res.status(500).json({ error: "Failed to setup 2FA" });
-    }
-});
+    },
+);
 
 /**
  * @openapi
@@ -1322,7 +1351,7 @@ router.post("/2fa/setup", requireAuth, async (req, res) => {
  *     tags: [Authentication]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -1348,65 +1377,78 @@ router.post("/2fa/setup", requireAuth, async (req, res) => {
  *         description: Invalid token or not authenticated
  */
 // POST /auth/2fa/enable - Verify token and enable 2FA
-router.post("/2fa/enable", requireAuth, async (req, res) => {
-    try {
-        const { secret, token } = req.body;
+router.post(
+    "/2fa/enable",
+    requireAuth,
+    requireInteractiveSession,
+    async (req, res) => {
+        try {
+            const { secret, token } = req.body;
 
-        if (!secret || !token) {
-            return res
-                .status(400)
-                .json({ error: "Secret and token are required" });
-        }
+            if (!secret || !token) {
+                return res
+                    .status(400)
+                    .json({ error: "Secret and token are required" });
+            }
 
-        // Verify the token with the secret
-        const verified = await verifyTotpToken(secret, token);
+            // Verify the token with the secret
+            const verified = await verifyTotpToken(secret, token);
 
-        if (!verified) {
-            return res
-                .status(401)
-                .json({ error: "Invalid token. Please try again." });
-        }
+            if (!verified) {
+                return res
+                    .status(401)
+                    .json({ error: "Invalid token. Please try again." });
+            }
 
-        // Generate 10 recovery codes
-        const recoveryCodes: string[] = [];
-        const hashedRecoveryCodes: string[] = [];
+            // Generate 10 recovery codes
+            const recoveryCodes: string[] = [];
+            const hashedRecoveryCodes: string[] = [];
 
-        for (let i = 0; i < 10; i++) {
-            // Generate 8-character alphanumeric code
-            const code = crypto.randomBytes(4).toString("hex").toUpperCase();
-            recoveryCodes.push(code);
-            // Hash the code before storing
-            hashedRecoveryCodes.push(
-                crypto.createHash("sha256").update(code).digest("hex"),
+            for (let i = 0; i < 10; i++) {
+                // Generate 8-character alphanumeric code
+                const code = crypto
+                    .randomBytes(4)
+                    .toString("hex")
+                    .toUpperCase();
+                recoveryCodes.push(code);
+                // Hash the code before storing
+                hashedRecoveryCodes.push(
+                    crypto.createHash("sha256").update(code).digest("hex"),
+                );
+            }
+
+            // Encrypt the hashed codes for storage
+            const encryptedRecoveryCodes = encrypt2FASecret(
+                hashedRecoveryCodes.join(","),
             );
+
+            // Encrypt and save the secret
+            const encryptedSecret = encrypt2FASecret(secret);
+            const enabled = await prisma.user.updateMany({
+                where: { id: req.user!.id, twoFactorEnabled: false },
+                data: {
+                    twoFactorEnabled: true,
+                    twoFactorSecret: encryptedSecret,
+                    twoFactorRecoveryCodes: encryptedRecoveryCodes,
+                },
+            });
+            if (enabled.count !== 1) {
+                return res
+                    .status(409)
+                    .json({ error: "2FA is already enabled" });
+            }
+
+            // Return the plain recovery codes to the user (only time they'll see them)
+            res.json({
+                message: "2FA enabled successfully",
+                recoveryCodes: recoveryCodes,
+            });
+        } catch (error) {
+            logger.error("2FA enable error:", error);
+            res.status(500).json({ error: "Failed to enable 2FA" });
         }
-
-        // Encrypt the hashed codes for storage
-        const encryptedRecoveryCodes = encrypt2FASecret(
-            hashedRecoveryCodes.join(","),
-        );
-
-        // Encrypt and save the secret
-        const encryptedSecret = encrypt2FASecret(secret);
-        await prisma.user.update({
-            where: { id: req.user!.id },
-            data: {
-                twoFactorEnabled: true,
-                twoFactorSecret: encryptedSecret,
-                twoFactorRecoveryCodes: encryptedRecoveryCodes,
-            },
-        });
-
-        // Return the plain recovery codes to the user (only time they'll see them)
-        res.json({
-            message: "2FA enabled successfully",
-            recoveryCodes: recoveryCodes,
-        });
-    } catch (error) {
-        logger.error("2FA enable error:", error);
-        res.status(500).json({ error: "Failed to enable 2FA" });
-    }
-});
+    },
+);
 
 /**
  * @openapi
@@ -1416,7 +1458,7 @@ router.post("/2fa/enable", requireAuth, async (req, res) => {
  *     tags: [Authentication]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -1444,56 +1486,64 @@ router.post("/2fa/enable", requireAuth, async (req, res) => {
  *         description: User not found
  */
 // POST /auth/2fa/disable - Disable 2FA
-router.post("/2fa/disable", requireAuth, async (req, res) => {
-    try {
-        const { password, token } = req.body;
+router.post(
+    "/2fa/disable",
+    requireAuth,
+    requireInteractiveSession,
+    async (req, res) => {
+        try {
+            const { password, token } = req.body;
 
-        if (!password || !token) {
-            return res
-                .status(400)
-                .json({ error: "Password and current 2FA token are required" });
-        }
-
-        const user = await prisma.user.findUnique({
-            where: { id: req.user!.id },
-        });
-
-        if (!user) {
-            return res.status(404).json({ error: "User not found" });
-        }
-
-        // Verify password
-        const validPassword = await bcrypt.compare(password, user.passwordHash);
-        if (!validPassword) {
-            return res.status(401).json({ error: "Invalid password" });
-        }
-
-        // Verify 2FA token
-        if (user.twoFactorSecret) {
-            const secret = decrypt2FASecret(user.twoFactorSecret);
-            const verified = await verifyTotpToken(secret, token);
-
-            if (!verified) {
-                return res.status(401).json({ error: "Invalid 2FA token" });
+            if (!password || !token) {
+                return res.status(400).json({
+                    error: "Password and current 2FA token are required",
+                });
             }
+
+            const user = await prisma.user.findUnique({
+                where: { id: req.user!.id },
+            });
+
+            if (!user) {
+                return res.status(404).json({ error: "User not found" });
+            }
+
+            // Verify password
+            const validPassword = await bcrypt.compare(
+                password,
+                user.passwordHash,
+            );
+            if (!validPassword) {
+                return res.status(401).json({ error: "Invalid password" });
+            }
+
+            // Verify 2FA token
+            if (user.twoFactorSecret) {
+                const secret = decrypt2FASecret(user.twoFactorSecret);
+                const verified = await verifyTotpToken(secret, token);
+
+                if (!verified) {
+                    return res.status(401).json({ error: "Invalid 2FA token" });
+                }
+            }
+
+            // Disable 2FA
+            await prisma.user.update({
+                where: { id: req.user!.id },
+                data: {
+                    twoFactorEnabled: false,
+                    twoFactorSecret: null,
+                    twoFactorRecoveryCodes: null,
+                },
+            });
+
+            res.json({ message: "2FA disabled successfully" });
+        } catch (error) {
+            logger.error("2FA disable error:", error);
+            res.status(500).json({ error: "Failed to disable 2FA" });
         }
-
-        // Disable 2FA
-        await prisma.user.update({
-            where: { id: req.user!.id },
-            data: {
-                twoFactorEnabled: false,
-                twoFactorSecret: null,
-                twoFactorRecoveryCodes: null,
-            },
-        });
-
-        res.json({ message: "2FA disabled successfully" });
-    } catch (error) {
-        logger.error("2FA disable error:", error);
-        res.status(500).json({ error: "Failed to disable 2FA" });
-    }
-});
+    },
+);
 
 /**
  * @openapi

--- a/backend/src/utils/__tests__/apiKeyHash.test.ts
+++ b/backend/src/utils/__tests__/apiKeyHash.test.ts
@@ -10,6 +10,9 @@ import {
     planApiKeyHashing,
     getPepperSource,
     getPepperFingerprint,
+    getApiKeyExpiresAt,
+    isApiKeyExpired,
+    API_KEY_LIFETIME_MS,
     HASHED_KEY_PREFIX,
 } from "../apiKeyHash";
 
@@ -28,6 +31,20 @@ describe("apiKeyHash", () => {
 
     it("produces different hashes for different keys", () => {
         expect(hashApiKey("key-one")).not.toBe(hashApiKey("key-two"));
+    });
+
+    it("assigns and enforces a bounded API-key lifetime", () => {
+        const createdAt = new Date("2026-01-01T00:00:00.000Z");
+        const expiresAt = getApiKeyExpiresAt(createdAt);
+
+        expect(expiresAt.getTime() - createdAt.getTime()).toBe(
+            API_KEY_LIFETIME_MS,
+        );
+        expect(
+            isApiKeyExpired(createdAt, new Date(expiresAt.getTime() - 1)),
+        ).toBe(false);
+        expect(isApiKeyExpired(createdAt, expiresAt)).toBe(true);
+        expect(isApiKeyExpired("invalid-date", createdAt)).toBe(true);
     });
 
     it("isHashedApiKey distinguishes migrated values from legacy plaintext keys", () => {

--- a/backend/src/utils/apiKeyHash.ts
+++ b/backend/src/utils/apiKeyHash.ts
@@ -13,6 +13,31 @@ import { createHmac } from "crypto";
  */
 export const HASHED_KEY_PREFIX = "hmac:";
 
+/** Maximum lifetime of an API key, measured from its persisted creation time. */
+export const API_KEY_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Derive the externally visible expiry from an API key's creation time. */
+export function getApiKeyExpiresAt(createdAt: Date): Date {
+    const createdAtMs = createdAt.getTime();
+    if (!Number.isFinite(createdAtMs)) {
+        throw new TypeError("API key creation time must be a valid Date");
+    }
+    return new Date(createdAtMs + API_KEY_LIFETIME_MS);
+}
+
+/** Fail closed when an API key has reached its lifetime or has an invalid timestamp. */
+export function isApiKeyExpired(
+    createdAt: unknown,
+    now: Date = new Date(),
+): boolean {
+    if (!(createdAt instanceof Date) || !Number.isFinite(createdAt.getTime())) {
+        return true;
+    }
+    const nowMs = now.getTime();
+    if (!Number.isFinite(nowMs)) return true;
+    return getApiKeyExpiresAt(createdAt).getTime() <= nowMs;
+}
+
 /**
  * Resolve the HMAC pepper. Prefers a dedicated `API_KEY_PEPPER` (Helm-managed,
  * stabilized like the other secrets), falling back to `SETTINGS_ENCRYPTION_KEY`


### PR DESCRIPTION
Convergence sweep #20 remediation across `apiKeys.ts`, `auth.ts`, `swagger.ts`, `middleware/auth.ts`, `utils/apiKeyHash.ts`.

**N2 — privilege escalation via API-key credentials.** API-key management and `/auth/2fa/{setup,enable,disable}` used `requireAuth` (accepts `X-API-Key`), so an API-key principal could mint more persistent keys and enable/replace MFA; keys never expired.
- `requireInteractiveSession` rejects `X-API-Key` callers (403) on apiKeys create/revoke and all three 2FA routes; **session/bearer callers keep working with their existing payloads** (no new field required → UI unaffected).
- `/2fa/enable` retains the conditional update refusing to replace an already-configured factor; `/2fa/disable` retains its pre-existing password + current-TOTP requirement.
- API keys carry a **90-day expiry** (from `createdAt`), returned by create/list and enforced on both auth paths.

**N13/N14 — OpenAPI auth drift.** Intentionally anonymous operations now carry `security: []`; the login response is documented as a `oneOf` of the token-envelope and 2FA-challenge shapes.

⚠️ **Breaking**: API keys older than 90 days are now rejected and must be re-issued. Interactive password/current-factor **step-up** for these ops is deliberately deferred to a frontend-coordinated follow-up — the escalation is already closed by the `X-API-Key` rejection; adding the step-up now would break the `createApiKey({deviceName})` and 2FA-enable UI which send no such credentials.

Verification: jest 167/167 (X-API-Key rejection, session-caller success, key expiry, MFA enable-replace race, generated-spec anon/auth matrix, runtime-to-OpenAPI login contract); `tsc --noEmit` clean; route-error canon green; prettier clean. No CHANGELOG edit (consolidated docs PR follows, carrying the breaking note).