### PR TITLE
fix(concurrency): fence OAuth logout vs lazy restore for TIDAL + YouTube Music (sweep #20 N8)

### DIFF
--- a/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/tidalStreamingRuntime.test.ts
@@ -262,6 +262,51 @@ describe("tidal streaming route runtime", () => {
         expect(secondRes.body).toEqual(firstRes.body);
     });
 
+    it("keeps logout authoritative when a lazy oauth restore finishes late", async () => {
+        let sidecarAuthenticated = false;
+        let resolveRestore!: () => void;
+        let markRestoreStarted!: () => void;
+        const restoreStarted = new Promise<void>((resolve) => {
+            markRestoreStarted = resolve;
+        });
+        const restoreGate = new Promise<void>((resolve) => {
+            resolveRestore = resolve;
+        });
+        tidalStreamingService.checkSidecarAuthStatus.mockResolvedValueOnce(
+            false,
+        );
+        tidalStreamingService.restoreOAuth.mockImplementationOnce(async () => {
+            markRestoreStarted();
+            await restoreGate;
+            sidecarAuthenticated = true;
+            return true;
+        });
+        tidalStreamingService.clearAuth.mockImplementation(async () => {
+            sidecarAuthenticated = false;
+        });
+        const userId = "logout-restore-race";
+        const searchRes = createRes();
+        const clearRes = createRes();
+
+        const searchRequest = searchHandler(
+            { user: { id: userId }, body: { query: "hello" } } as any,
+            searchRes,
+        );
+        await restoreStarted;
+        const clearRequest = clearAuthHandler(
+            { user: { id: userId } } as any,
+            clearRes,
+        );
+        resolveRestore();
+        await Promise.all([searchRequest, clearRequest]);
+
+        expect(searchRes.statusCode).toBe(401);
+        expect(searchRes.body).toEqual({ error: "Not authenticated to TIDAL" });
+        expect(clearRes.body).toEqual({ success: true });
+        expect(sidecarAuthenticated).toBe(false);
+        expect(tidalStreamingService.search).not.toHaveBeenCalled();
+    });
+
     it("evaluates the tidal-enabled middleware for 404, 503, and success", async () => {
         const layer = getRouteLayer("/auth/device-code", "post");
         const middleware = layer.route.stack[1].handle;

--- a/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
@@ -343,6 +343,51 @@ describe("youtube music route runtime behavior", () => {
         expect(secondRes.statusCode).toBe(401);
     });
 
+    it("keeps logout authoritative when a lazy oauth restore finishes late", async () => {
+        let sidecarAuthenticated = false;
+        let resolveRestore!: () => void;
+        let markRestoreStarted!: () => void;
+        const restoreStarted = new Promise<void>((resolve) => {
+            markRestoreStarted = resolve;
+        });
+        const restoreGate = new Promise<void>((resolve) => {
+            resolveRestore = resolve;
+        });
+        ytMusicService.getAuthStatus.mockResolvedValueOnce({
+            authenticated: false,
+        });
+        ytMusicService.restoreOAuthWithCredentials.mockImplementationOnce(
+            async () => {
+                markRestoreStarted();
+                await restoreGate;
+                sidecarAuthenticated = true;
+            },
+        );
+        ytMusicService.clearAuth.mockImplementation(async () => {
+            sidecarAuthenticated = false;
+        });
+        const userId = "logout-restore-race";
+        const libraryRes = createRes();
+        const clearRes = createRes();
+
+        const libraryRequest = librarySongsHandler(
+            { user: { id: userId }, query: {} } as any,
+            libraryRes,
+        );
+        await restoreStarted;
+        const clearRequest = clearAuthHandler(
+            { user: { id: userId } } as any,
+            clearRes,
+        );
+        resolveRestore();
+        await Promise.all([libraryRequest, clearRequest]);
+
+        expect(libraryRes.statusCode).toBe(401);
+        expect(clearRes.body).toEqual({ success: true });
+        expect(sidecarAuthenticated).toBe(false);
+        expect(ytMusicService.getLibrarySongs).not.toHaveBeenCalled();
+    });
+
     it("validates and initiates device auth with error fallback", async () => {
         const req = { user: { id: "user-1" } } as any;
 

--- a/backend/src/routes/tidalStreaming.ts
+++ b/backend/src/routes/tidalStreaming.ts
@@ -38,6 +38,8 @@ const tidalOauthSessionCache = new Map<
     { authenticated: boolean; expiresAt: number }
 >();
 const tidalOauthRestoreInFlight = new Map<string, Promise<boolean>>();
+const tidalOauthClearInFlight = new Map<string, Promise<void>>();
+const tidalOauthGeneration = new Map<string, number>();
 const setTidalOAuthCache = (
     userId: string,
     authenticated: boolean,
@@ -73,10 +75,20 @@ const getCachedTidalOAuth = (userId: string): boolean | null => {
     return entry.authenticated;
 };
 
-const invalidateTidalUserCaches = (userId: string) => {
+const invalidateTidalOAuthGeneration = (userId: string): number => {
+    const generation = (tidalOauthGeneration.get(userId) ?? 0) + 1;
+    tidalOauthGeneration.set(userId, generation);
     tidalOauthSessionCache.delete(userId);
-    tidalOauthRestoreInFlight.delete(userId);
+    return generation;
 };
+
+const getTidalOAuthGeneration = (userId: string): number =>
+    tidalOauthGeneration.get(userId) ?? 0;
+
+const isCurrentTidalOAuthGeneration = (
+    userId: string,
+    generation: number,
+): boolean => getTidalOAuthGeneration(userId) === generation;
 
 // ── Guard middleware ───────────────────────────────────────────────
 
@@ -111,25 +123,50 @@ async function requireTidalStreamingEnabled(
  * sidecar. Called before any per-user streaming request.
  */
 async function ensureUserOAuth(userId: string): Promise<boolean> {
+    const clearInFlight = tidalOauthClearInFlight.get(userId);
+    if (clearInFlight) {
+        await clearInFlight;
+    }
+
     const cached = getCachedTidalOAuth(userId);
     if (cached !== null) {
         return cached;
     }
 
+    const generation = getTidalOAuthGeneration(userId);
     return coalesceInFlightByKey(tidalOauthRestoreInFlight, userId, () =>
-        restoreTidalUserOAuth(userId),
+        restoreTidalUserOAuth(userId, generation),
     );
 }
 
-async function restoreTidalUserOAuth(userId: string): Promise<boolean> {
+async function finishTidalOAuthRestore(
+    userId: string,
+    generation: number,
+    authenticated: boolean,
+): Promise<boolean> {
+    if (isCurrentTidalOAuthGeneration(userId, generation)) {
+        setTidalOAuthCache(userId, authenticated);
+        return authenticated;
+    }
+
+    await tidalStreamingService.clearAuth(userId);
+    return false;
+}
+
+async function restoreTidalUserOAuth(
+    userId: string,
+    generation: number,
+): Promise<boolean> {
     // This authenticated client carries the internal secret; a bare request
     // would 403 and be misread as a missing sidecar session.
     try {
         const authenticated =
             await tidalStreamingService.checkSidecarAuthStatus(userId);
+        if (!isCurrentTidalOAuthGeneration(userId, generation)) {
+            return finishTidalOAuthRestore(userId, generation, false);
+        }
         if (authenticated) {
-            setTidalOAuthCache(userId, true);
-            return true;
+            return finishTidalOAuthRestore(userId, generation, true);
         }
     } catch {
         // Sidecar might not have the session, try to restore.
@@ -139,9 +176,11 @@ async function restoreTidalUserOAuth(userId: string): Promise<boolean> {
         where: { userId },
         select: { tidalOAuthJson: true },
     });
+    if (!isCurrentTidalOAuthGeneration(userId, generation)) {
+        return finishTidalOAuthRestore(userId, generation, false);
+    }
     if (!userSettings?.tidalOAuthJson) {
-        setTidalOAuthCache(userId, false);
-        return false;
+        return finishTidalOAuthRestore(userId, generation, false);
     }
 
     let oauthJson: string;
@@ -155,8 +194,48 @@ async function restoreTidalUserOAuth(userId: string): Promise<boolean> {
         userId,
         oauthJson,
     );
-    setTidalOAuthCache(userId, restored);
-    return restored;
+    return finishTidalOAuthRestore(userId, generation, restored);
+}
+
+async function clearTidalUserOAuth(userId: string): Promise<void> {
+    const existingClear = tidalOauthClearInFlight.get(userId);
+    if (existingClear) {
+        return existingClear;
+    }
+
+    const generation = invalidateTidalOAuthGeneration(userId);
+    const pendingRestore = tidalOauthRestoreInFlight.get(userId);
+    const clearOperation = performTidalOAuthClear(
+        userId,
+        generation,
+        pendingRestore,
+    ).finally(() => {
+        if (tidalOauthClearInFlight.get(userId) === clearOperation) {
+            tidalOauthClearInFlight.delete(userId);
+        }
+    });
+    tidalOauthClearInFlight.set(userId, clearOperation);
+    return clearOperation;
+}
+
+async function performTidalOAuthClear(
+    userId: string,
+    generation: number,
+    pendingRestore?: Promise<boolean>,
+): Promise<void> {
+    try {
+        await pendingRestore;
+    } catch {
+        // Continue: logout must still remove DB and sidecar state.
+    }
+    await prisma.userSettings.update({
+        where: { userId },
+        data: { tidalOAuthJson: null },
+    });
+    await tidalStreamingService.clearAuth(userId);
+    if (isCurrentTidalOAuthGeneration(userId, generation)) {
+        setTidalOAuthCache(userId, false);
+    }
 }
 
 // ── Routes ─────────────────────────────────────────────────────────
@@ -476,16 +555,7 @@ router.post("/auth/clear", requireAuth, async (req: Request, res: Response) => {
     const userId = req.user!.id;
 
     try {
-        // Clear from DB
-        await prisma.userSettings.update({
-            where: { userId },
-            data: { tidalOAuthJson: null },
-        });
-
-        // Clear from sidecar
-        await tidalStreamingService.clearAuth(userId);
-        invalidateTidalUserCaches(userId);
-        setTidalOAuthCache(userId, false);
+        await clearTidalUserOAuth(userId);
 
         res.json({ success: true });
     } catch (err: any) {

--- a/backend/src/routes/youtubeMusic.ts
+++ b/backend/src/routes/youtubeMusic.ts
@@ -38,6 +38,8 @@ const ytOauthSessionCache = new Map<
     { authenticated: boolean; expiresAt: number }
 >();
 const ytOauthRestoreInFlight = new Map<string, Promise<boolean>>();
+const ytOauthClearInFlight = new Map<string, Promise<void>>();
+const ytOauthGeneration = new Map<string, number>();
 
 const setYtOAuthCache = (
     userId: string,
@@ -74,10 +76,20 @@ const getCachedYtOAuth = (userId: string): boolean | null => {
     return entry.authenticated;
 };
 
-const invalidateYtOAuthCache = (userId: string) => {
+const invalidateYtOAuthGeneration = (userId: string): number => {
+    const generation = (ytOauthGeneration.get(userId) ?? 0) + 1;
+    ytOauthGeneration.set(userId, generation);
     ytOauthSessionCache.delete(userId);
-    ytOauthRestoreInFlight.delete(userId);
+    return generation;
 };
+
+const getYtOAuthGeneration = (userId: string): number =>
+    ytOauthGeneration.get(userId) ?? 0;
+
+const isCurrentYtOAuthGeneration = (
+    userId: string,
+    generation: number,
+): boolean => getYtOAuthGeneration(userId) === generation;
 
 // ── Guard middleware ───────────────────────────────────────────────
 
@@ -107,37 +119,66 @@ async function requireYtMusicEnabled(
  * if already restored.
  */
 async function ensureUserOAuth(userId: string): Promise<boolean> {
+    const clearInFlight = ytOauthClearInFlight.get(userId);
+    if (clearInFlight) {
+        await clearInFlight;
+    }
+
     const cached = getCachedYtOAuth(userId);
     if (cached !== null) {
         return cached;
     }
 
+    const generation = getYtOAuthGeneration(userId);
     return coalesceInFlightByKey(ytOauthRestoreInFlight, userId, () =>
-        restoreYtUserOAuth(userId),
+        restoreYtUserOAuth(userId, generation),
     );
 }
 
-async function restoreYtUserOAuth(userId: string): Promise<boolean> {
+async function finishYtOAuthRestore(
+    userId: string,
+    generation: number,
+    authenticated: boolean,
+): Promise<boolean> {
+    if (isCurrentYtOAuthGeneration(userId, generation)) {
+        setYtOAuthCache(userId, authenticated);
+        return authenticated;
+    }
+
+    await ytMusicService.clearAuth(userId);
+    return false;
+}
+
+async function restoreYtUserOAuth(
+    userId: string,
+    generation: number,
+): Promise<boolean> {
     try {
         const status = await ytMusicService.getAuthStatus(userId);
+        if (!isCurrentYtOAuthGeneration(userId, generation)) {
+            return finishYtOAuthRestore(userId, generation, false);
+        }
         if (status.authenticated) {
-            setYtOAuthCache(userId, true);
-            return true;
+            return finishYtOAuthRestore(userId, generation, true);
         }
         const userSettings = await prisma.userSettings.findUnique({
             where: { userId },
             select: { ytMusicOAuthJson: true },
         });
+        if (!isCurrentYtOAuthGeneration(userId, generation)) {
+            return finishYtOAuthRestore(userId, generation, false);
+        }
         if (!userSettings?.ytMusicOAuthJson) {
-            setYtOAuthCache(userId, false);
-            return false;
+            return finishYtOAuthRestore(userId, generation, false);
         }
         const oauthJson = decrypt(userSettings.ytMusicOAuthJson);
         if (!oauthJson) {
-            setYtOAuthCache(userId, false);
-            return false;
+            return finishYtOAuthRestore(userId, generation, false);
         }
         const systemSettings = await getSystemSettings();
+        if (!isCurrentYtOAuthGeneration(userId, generation)) {
+            return finishYtOAuthRestore(userId, generation, false);
+        }
         await ytMusicService.restoreOAuthWithCredentials(
             userId,
             oauthJson,
@@ -145,12 +186,55 @@ async function restoreYtUserOAuth(userId: string): Promise<boolean> {
             systemSettings?.ytMusicClientSecret || undefined,
         );
         logger.info(`[YTMusic] Restored OAuth credentials for user ${userId}`);
-        setYtOAuthCache(userId, true);
-        return true;
+        return finishYtOAuthRestore(userId, generation, true);
     } catch (err) {
         logger.debug(`[YTMusic] OAuth restore failed for user ${userId}:`, err);
-        setYtOAuthCache(userId, false);
+        if (isCurrentYtOAuthGeneration(userId, generation)) {
+            setYtOAuthCache(userId, false);
+        }
         return false;
+    }
+}
+
+async function clearYtUserOAuth(userId: string): Promise<void> {
+    const existingClear = ytOauthClearInFlight.get(userId);
+    if (existingClear) {
+        return existingClear;
+    }
+
+    const generation = invalidateYtOAuthGeneration(userId);
+    const pendingRestore = ytOauthRestoreInFlight.get(userId);
+    const clearOperation = performYtOAuthClear(
+        userId,
+        generation,
+        pendingRestore,
+    ).finally(() => {
+        if (ytOauthClearInFlight.get(userId) === clearOperation) {
+            ytOauthClearInFlight.delete(userId);
+        }
+    });
+    ytOauthClearInFlight.set(userId, clearOperation);
+    return clearOperation;
+}
+
+async function performYtOAuthClear(
+    userId: string,
+    generation: number,
+    pendingRestore?: Promise<boolean>,
+): Promise<void> {
+    try {
+        await pendingRestore;
+    } catch {
+        // Continue: logout must still remove DB and sidecar state.
+    }
+    await ytMusicService.clearAuth(userId);
+    await prisma.userSettings.upsert({
+        where: { userId },
+        create: { userId, ytMusicOAuthJson: null },
+        update: { ytMusicOAuthJson: null },
+    });
+    if (isCurrentYtOAuthGeneration(userId, generation)) {
+        setYtOAuthCache(userId, false);
     }
 }
 
@@ -545,17 +629,7 @@ router.post(
         try {
             const userId = req.user!.id;
 
-            // Clear from sidecar
-            await ytMusicService.clearAuth(userId);
-
-            // Clear from database
-            await prisma.userSettings.upsert({
-                where: { userId },
-                create: { userId, ytMusicOAuthJson: null },
-                update: { ytMusicOAuthJson: null },
-            });
-            invalidateYtOAuthCache(userId);
-            setYtOAuthCache(userId, false);
+            await clearYtUserOAuth(userId);
 
             logger.info(
                 `[YTMusic] OAuth credentials cleared for user ${userId}`,


### PR DESCRIPTION
Convergence sweep #20 remediation (N8) in `backend/src/routes/tidalStreaming.ts` + `backend/src/routes/youtubeMusic.ts`.

TIDAL and YouTube Music logout deleted their in-flight-map entries but couldn't cancel or generation-fence promises that had **already captured old credentials**. A stale lazy restore could finish after logout, recreate sidecar auth state, and overwrite the negative cache with `authenticated=true` — resurrecting a revoked session.

Fix: both routes serialize restore and clear per user with an OAuth **generation fence** — logout invalidates the generation before awaiting I/O, waits for any pending restoration, clears persisted and sidecar credentials, and blocks new restorations until complete. A stale-generation restoration returns unauthenticated and triggers sidecar cleanup.

Verification: targeted jest 64/64 (both-provider race tests); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).