### PR TITLE
fix(security): require explicit PostgreSQL password in split-stack Compose (sweep #20 N11)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
                 media-metadata-contract: ./packages/media-metadata-contract
         environment:
             # Database
-            DATABASE_URL: postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-soundspan}
+            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
             POSTGRES_USER: ${POSTGRES_USER:-soundspan}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+            POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
             POSTGRES_DB: ${POSTGRES_DB:-soundspan}
             REDIS_URL: redis://redis:6379
             # Preserve Redis streams/groups across restarts unless explicitly overridden
@@ -160,9 +160,9 @@ services:
                 media-metadata-contract: ./packages/media-metadata-contract
             target: worker-runtime
         environment:
-            DATABASE_URL: postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-soundspan}
+            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
             POSTGRES_USER: ${POSTGRES_USER:-soundspan}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+            POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
             POSTGRES_DB: ${POSTGRES_DB:-soundspan}
             REDIS_URL: redis://redis:6379
             # Preserve Redis streams/groups across restarts unless explicitly overridden
@@ -209,10 +209,20 @@ services:
 
     postgres:
         image: pgvector/pgvector:pg16@sha256:a36250871de0833b8757561c72f2477ef1ddd1101afa4e617fb552e0de514c6b
+        entrypoint:
+            - /bin/sh
+            - -ec
+            - |
+                if [ "$${POSTGRES_PASSWORD}" = "changeme" ]; then
+                    echo "POSTGRES_PASSWORD must not be changeme" >&2
+                    exit 1
+                fi
+                exec docker-entrypoint.sh "$$@"
+            - --
         container_name: ${SOUNDSPAN_DB_CONTAINER_NAME:-soundspan_db}
         environment:
             POSTGRES_USER: ${POSTGRES_USER:-soundspan}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+            POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
             POSTGRES_DB: ${POSTGRES_DB:-soundspan}
         volumes:
             - postgres_data:/var/lib/postgresql/data
@@ -376,7 +386,7 @@ services:
         container_name: ${SOUNDSPAN_AUDIO_ANALYZER_CONTAINER_NAME:-soundspan_audio_analyzer}
         environment:
             REDIS_URL: redis://redis:6379
-            DATABASE_URL: postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-soundspan}
+            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
             MUSIC_PATH: /music
             BATCH_SIZE: ${AUDIO_ANALYSIS_BATCH_SIZE:-10}
             SLEEP_INTERVAL: ${AUDIO_ANALYSIS_INTERVAL:-5}
@@ -436,7 +446,7 @@ services:
         container_name: ${SOUNDSPAN_CLAP_CONTAINER_NAME:-soundspan_audio_analyzer_clap}
         environment:
             REDIS_URL: redis://redis:6379
-            DATABASE_URL: postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-soundspan}
+            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
             BACKEND_URL: http://backend:3006
             MUSIC_PATH: /music
             SLEEP_INTERVAL: ${CLAP_SLEEP_INTERVAL:-5}

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
@@ -31,6 +33,70 @@ function fromImageReferences(dockerfile) {
 
 function isExternalImage(reference) {
     return /[:@/]/.test(reference);
+}
+
+function composeConfig(postgresPassword) {
+    const environment = {
+        ...process.env,
+        INTERNAL_API_SECRET: "test-internal-secret",
+        SESSION_SECRET: "test-session-secret",
+        SETTINGS_ENCRYPTION_KEY: "test-settings-key",
+    };
+    if (postgresPassword === undefined) {
+        delete environment.POSTGRES_PASSWORD;
+    } else {
+        environment.POSTGRES_PASSWORD = postgresPassword;
+    }
+
+    return childProcess.spawnSync(
+        "docker",
+        [
+            "compose",
+            "--env-file",
+            os.devNull,
+            "--profile",
+            "*",
+            "-f",
+            path.join(repoRoot, "docker-compose.yml"),
+            "config",
+            "--format",
+            "json",
+        ],
+        { cwd: repoRoot, encoding: "utf8", env: environment },
+    );
+}
+
+function runPostgresEntrypoint(postgres, postgresPassword, executablePath) {
+    const entrypoint = postgres.entrypoint.map((argument) =>
+        argument.replaceAll("$$", "$"),
+    );
+    return childProcess.spawnSync(
+        entrypoint[0],
+        [...entrypoint.slice(1), ...(postgres.command ?? ["postgres"])],
+        {
+            encoding: "utf8",
+            env: {
+                ...process.env,
+                PATH: `${executablePath}${path.delimiter}${process.env.PATH}`,
+                POSTGRES_PASSWORD: postgresPassword,
+            },
+        },
+    );
+}
+
+function createEntrypointFixture(t) {
+    const fixtureDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "soundspan-compose-entrypoint-"),
+    );
+    t.after(() =>
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true }),
+    );
+    fs.writeFileSync(
+        path.join(fixtureDirectory, "docker-entrypoint.sh"),
+        "#!/bin/sh\nexit 0\n",
+        { mode: 0o700 },
+    );
+    return fixtureDirectory;
 }
 
 test("1. Dockerfile external base images are pinned by digest", () => {
@@ -130,4 +196,65 @@ test("6. docker-bake.json inline infra images are pinned by digest", () => {
             `${relativePath}: inline infra FROM must contain @sha256: (${line.trim()})`,
         );
     }
+});
+
+test("7. split-stack compose refuses a missing or empty PostgreSQL password", () => {
+    const missingResult = composeConfig(undefined);
+    const emptyResult = composeConfig("");
+
+    assert.notEqual(missingResult.status, 0);
+    assert.match(missingResult.stderr, /POSTGRES_PASSWORD is required/);
+    assert.notEqual(emptyResult.status, 0);
+    assert.match(emptyResult.stderr, /POSTGRES_PASSWORD is required/);
+});
+
+test("8. split-stack compose applies the configured PostgreSQL password everywhere", () => {
+    const password = "test-explicit-postgres-password";
+    const result = composeConfig(password);
+
+    assert.equal(result.status, 0, result.stderr);
+    const services = JSON.parse(result.stdout).services;
+    const databaseUrl = `postgresql://soundspan:${password}@postgres:5432/soundspan`;
+
+    assert.equal(services.backend.environment.POSTGRES_PASSWORD, password);
+    assert.equal(services.backend.environment.DATABASE_URL, databaseUrl);
+    assert.equal(
+        services["backend-worker"].environment.POSTGRES_PASSWORD,
+        password,
+    );
+    assert.equal(
+        services["backend-worker"].environment.DATABASE_URL,
+        databaseUrl,
+    );
+    assert.equal(services.postgres.environment.POSTGRES_PASSWORD, password);
+    assert.equal(
+        services["audio-analyzer"].environment.DATABASE_URL,
+        databaseUrl,
+    );
+    assert.equal(
+        services["audio-analyzer-clap"].environment.DATABASE_URL,
+        databaseUrl,
+    );
+});
+
+test("9. split-stack PostgreSQL startup rejects the published sentinel", (t) => {
+    const configResult = composeConfig("changeme");
+    assert.equal(configResult.status, 0, configResult.stderr);
+
+    const fixtureDirectory = createEntrypointFixture(t);
+    const postgres = JSON.parse(configResult.stdout).services.postgres;
+    const sentinelResult = runPostgresEntrypoint(
+        postgres,
+        "changeme",
+        fixtureDirectory,
+    );
+    const configuredResult = runPostgresEntrypoint(
+        postgres,
+        "test-explicit-postgres-password",
+        fixtureDirectory,
+    );
+
+    assert.notEqual(sentinelResult.status, 0);
+    assert.match(sentinelResult.stderr, /must not be changeme/);
+    assert.equal(configuredResult.status, 0, configuredResult.stderr);
 });


### PR DESCRIPTION
Convergence sweep #20 remediation (N11) in `docker-compose.yml`.

The deployment-ready split stack defaulted the DB principal to `soundspan/changeme` and permitted startup with **no** `POSTGRES_PASSWORD`. Postgres is reachable on the Compose network and published on host loopback, so a **published default credential** exposed the database to any compromised peer container or local process.

Fix
- All `DATABASE_URL` / `POSTGRES_PASSWORD` interpolations use the required form `${POSTGRES_PASSWORD:?...}` — `docker compose` fails fast with a generation hint when unset/empty.
- The `postgres` service entrypoint additionally refuses to start on the literal `changeme`.

⚠️ **Breaking**: the split-stack Compose deployment now requires an explicit non-sentinel `POSTGRES_PASSWORD` (e.g. `openssl rand -base64 32`).

Verification: dockerfile-hygiene suite 9/9 (missing/empty rejected, configured password applied to every service, entrypoint rejects sentinel); `docker compose config` exit 0; prettier clean. No CHANGELOG edit (consolidated docs PR follows, carrying the breaking note).