### PR TITLE
fix(security): fail-closed .env writes + honor explicit secret clears (sweep #20 N9/N10)

### DIFF
--- a/backend/src/utils/__tests__/envWriter.test.ts
+++ b/backend/src/utils/__tests__/envWriter.test.ts
@@ -10,6 +10,14 @@ const mockLogger = {
 };
 mockLogger.child.mockReturnValue(mockLogger);
 
+function createFsError(code: string): NodeJS.ErrnoException {
+    const error = new Error(
+        `filesystem error: ${code}`,
+    ) as NodeJS.ErrnoException;
+    error.code = code;
+    return error;
+}
+
 jest.mock("fs", () => ({
     __esModule: true,
     default: {
@@ -31,7 +39,7 @@ describe("envWriter", () => {
     const originalEnv = process.env;
 
     beforeEach(() => {
-        jest.clearAllMocks();
+        jest.resetAllMocks();
         process.env = { ...originalEnv };
         delete process.env.ENABLE_ENV_FILE_SYNC;
         delete process.env.KUBERNETES_SERVICE_HOST;
@@ -93,7 +101,7 @@ describe("envWriter", () => {
             .spyOn(process, "cwd")
             .mockReturnValue("/srv/backend");
         mockReadFileSync.mockImplementation(() => {
-            throw new Error("ENOENT");
+            throw createFsError("ENOENT");
         });
 
         await writeEnvFile({ PORT: "3006" });
@@ -114,7 +122,7 @@ describe("envWriter", () => {
     it("creates a new env file when one does not exist", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         mockReadFileSync.mockImplementation(() => {
-            throw new Error("ENOENT");
+            throw createFsError("ENOENT");
         });
 
         await writeEnvFile({
@@ -191,7 +199,7 @@ describe("envWriter", () => {
     it("writes values with non-line-break special characters unchanged", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         mockReadFileSync.mockImplementation(() => {
-            throw new Error("ENOENT");
+            throw createFsError("ENOENT");
         });
         const url = "https://api.example/search?q=rock+roll&limit=10";
         const secret = "value=with equals and spaces";
@@ -209,7 +217,7 @@ describe("envWriter", () => {
     it("writes integration secret keys when DB-only mode is off", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         mockReadFileSync.mockImplementation(() => {
-            throw new Error("ENOENT");
+            throw createFsError("ENOENT");
         });
 
         await writeEnvFile({
@@ -226,7 +234,7 @@ describe("envWriter", () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         process.env.SECRETS_DB_ONLY = "true";
         mockReadFileSync.mockImplementation(() => {
-            throw new Error("ENOENT");
+            throw createFsError("ENOENT");
         });
 
         await writeEnvFile({
@@ -266,13 +274,15 @@ describe("envWriter", () => {
         expect(written).toContain("DATABASE_URL=postgresql://db/soundspan");
     });
 
-    it("parses existing values, preserves uncategorized keys, and updates non-null values", async () => {
+    it("deletes null values while preserving undefined and unrelated values", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         mockReadFileSync.mockReturnValue(
             [
                 "# Existing",
                 "DATABASE_URL=postgres://user:pass@db/app?sslmode=disable",
                 "=missing-key-value-should-be-ignored",
+                "FANART_API_KEY=clear-me",
+                "LIDARR_ENABLED=true",
                 "CUSTOM_KEY=keep-me",
                 "",
             ].join("\n"),
@@ -281,7 +291,7 @@ describe("envWriter", () => {
         await writeEnvFile({
             DATABASE_URL: "postgres://new:value@db/newdb",
             REDIS_URL: "redis://cache:6379/0",
-            CUSTOM_KEY: null,
+            FANART_API_KEY: null,
             NEW_KEY: "new-value",
             LIDARR_ENABLED: undefined,
         });
@@ -292,15 +302,43 @@ describe("envWriter", () => {
         expect(written).toContain("# Database & Redis");
         expect(written).toContain("DATABASE_URL=postgres://new:value@db/newdb");
         expect(written).toContain("REDIS_URL=redis://cache:6379/0");
+        expect(written).not.toContain("FANART_API_KEY=");
+        expect(written).toContain("LIDARR_ENABLED=true");
         expect(written).toContain("# Other Variables");
         expect(written).toContain("CUSTOM_KEY=keep-me");
         expect(written).toContain("NEW_KEY=new-value");
-        expect(written).not.toContain("LIDARR_ENABLED=");
     });
+
+    it.each(["EACCES", "EIO"])(
+        "rethrows %s read failures before replacing the env file",
+        async (code) => {
+            process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
+            const readError = createFsError(code);
+            mockReadFileSync.mockImplementation(() => {
+                throw readError;
+            });
+
+            await expect(writeEnvFile({ PORT: "3006" })).rejects.toBe(
+                readError,
+            );
+
+            expect(mockReadFileSync).toHaveBeenCalledWith(
+                "/tmp/soundspan.env",
+                "utf-8",
+            );
+            expect(mockWriteFileSync).not.toHaveBeenCalled();
+            expect(mockChmodSync).not.toHaveBeenCalled();
+            expect(mockRenameSync).not.toHaveBeenCalled();
+            expect(mockUnlinkSync).not.toHaveBeenCalled();
+        },
+    );
 
     it("cleans up the temporary file and preserves the original error when rename fails", async () => {
         process.env.ENV_FILE_PATH = "/tmp/soundspan.env";
         const renameError = new Error("rename failed");
+        mockReadFileSync.mockImplementation(() => {
+            throw createFsError("ENOENT");
+        });
         mockRenameSync.mockImplementation(() => {
             throw renameError;
         });

--- a/backend/src/utils/envWriter.ts
+++ b/backend/src/utils/envWriter.ts
@@ -21,6 +21,18 @@ const STALE_ENV_SYNC_KEYS = [
     "MULLVAD_SERVER_CITY",
 ] as const;
 
+const ENV_CATEGORIES = {
+    "Database & Redis": ["DATABASE_URL", "REDIS_URL"],
+    Server: ["PORT", "NODE_ENV", "SESSION_SECRET", "ALLOWED_ORIGINS"],
+    Lidarr: ["LIDARR_ENABLED", "LIDARR_URL", "LIDARR_API_KEY"],
+    "Last.fm": ["LASTFM_API_KEY"],
+    "Fanart.tv": ["FANART_API_KEY"],
+    OpenAI: ["OPENAI_API_KEY"],
+    Audiobookshelf: ["AUDIOBOOKSHELF_URL", "AUDIOBOOKSHELF_API_KEY"],
+    "Docker Paths": ["MUSIC_PATH", "DOWNLOAD_PATH"],
+    Security: ["SETTINGS_ENCRYPTION_KEY"],
+} as const;
+
 /**
  * Represents the EnvFileSyncSkippedError class.
  */
@@ -119,9 +131,117 @@ function atomicWriteFileSecret(targetPath: string, content: string): void {
     }
 }
 
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+    return (
+        error instanceof Error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+    );
+}
+
+function readExistingEnvVariables(envPath: string): Map<string, string> {
+    const existingVars = new Map<string, string>();
+    let existingContent: string;
+
+    try {
+        existingContent = fs.readFileSync(envPath, "utf-8");
+    } catch (error) {
+        if (!isMissingFileError(error)) {
+            throw error;
+        }
+        log.debug("No existing .env file, creating new one");
+        return existingVars;
+    }
+
+    existingContent.split("\n").forEach((line) => {
+        const trimmed = line.trim();
+        if (trimmed && !trimmed.startsWith("#")) {
+            const [key, ...valueParts] = trimmed.split("=");
+            if (key) {
+                existingVars.set(key.trim(), valueParts.join("="));
+            }
+        }
+    });
+    return existingVars;
+}
+
+function reconcileEnvVariables(
+    existingVars: Map<string, string>,
+    variables: Record<string, string | null | undefined>,
+    secretsDbOnly: boolean,
+): void {
+    STALE_ENV_SYNC_KEYS.forEach((key) => existingVars.delete(key));
+    if (secretsDbOnly) {
+        DB_ONLY_SECRET_ENV_KEYS.forEach((key) => existingVars.delete(key));
+    }
+
+    Object.entries(variables).forEach(([key, value]) => {
+        const isDbOnlySecret = DB_ONLY_SECRET_ENV_KEYS.includes(
+            key as (typeof DB_ONLY_SECRET_ENV_KEYS)[number],
+        );
+        if (secretsDbOnly && isDbOnlySecret) {
+            return;
+        }
+        if (value === null) {
+            existingVars.delete(key);
+        } else if (value !== undefined) {
+            existingVars.set(key, value);
+        }
+    });
+}
+
+function appendCategorizedVariables(
+    lines: string[],
+    existingVars: Map<string, string>,
+    writtenKeys: Set<string>,
+): void {
+    Object.entries(ENV_CATEGORIES).forEach(([category, keys]) => {
+        const categoryVars: string[] = [];
+        keys.forEach((key) => {
+            if (existingVars.has(key)) {
+                categoryVars.push(`${key}=${existingVars.get(key)}`);
+                writtenKeys.add(key);
+            }
+        });
+        if (categoryVars.length > 0) {
+            lines.push("", `# ${category}`, ...categoryVars);
+        }
+    });
+}
+
+function appendUncategorizedVariables(
+    lines: string[],
+    existingVars: Map<string, string>,
+    writtenKeys: Set<string>,
+): void {
+    const uncategorized: string[] = [];
+    existingVars.forEach((value, key) => {
+        if (!writtenKeys.has(key)) {
+            uncategorized.push(`${key}=${value}`);
+        }
+    });
+    if (uncategorized.length > 0) {
+        lines.push("", "# Other Variables", ...uncategorized);
+    }
+}
+
+function buildEnvContent(existingVars: Map<string, string>): string {
+    const lines = [
+        "# soundspan Environment Variables",
+        `# Auto-generated on ${new Date().toISOString()}`,
+        "",
+    ];
+    const writtenKeys = new Set<string>();
+
+    appendCategorizedVariables(lines, existingVars, writtenKeys);
+    appendUncategorizedVariables(lines, existingVars, writtenKeys);
+    lines.push("");
+    return lines.join("\n");
+}
+
 /**
- * Writes key-value pairs to .env file
- * Preserves existing variables not in the provided map
+ * Writes key-value pairs to the configured `.env` file atomically.
+ * `null` deletes a key, `undefined` leaves it unchanged, and omitted keys are preserved.
+ * Read failures other than a missing file are rethrown before any replacement is attempted.
  */
 export async function writeEnvFile(
     variables: Record<string, string | null | undefined>,
@@ -135,107 +255,8 @@ export async function writeEnvFile(
     }
 
     assertSafeEnvVariables(variables);
-
-    // Read existing .env
-    let existingContent = "";
-    const existingVars = new Map<string, string>();
-
-    try {
-        existingContent = fs.readFileSync(envPath, "utf-8");
-
-        // Parse existing variables
-        existingContent.split("\n").forEach((line) => {
-            const trimmed = line.trim();
-            if (trimmed && !trimmed.startsWith("#")) {
-                const [key, ...valueParts] = trimmed.split("=");
-                if (key) {
-                    existingVars.set(key.trim(), valueParts.join("="));
-                }
-            }
-        });
-    } catch (error) {
-        log.debug("No existing .env file, creating new one");
-    }
-
-    // Remove env keys that are no longer consumed at runtime.
-    STALE_ENV_SYNC_KEYS.forEach((key) => {
-        existingVars.delete(key);
-    });
-
-    if (secretsDbOnly) {
-        DB_ONLY_SECRET_ENV_KEYS.forEach((key) => {
-            existingVars.delete(key);
-        });
-    }
-
-    // Update with new values
-    Object.entries(variables).forEach(([key, value]) => {
-        if (
-            secretsDbOnly &&
-            DB_ONLY_SECRET_ENV_KEYS.includes(
-                key as (typeof DB_ONLY_SECRET_ENV_KEYS)[number],
-            )
-        ) {
-            return;
-        }
-        if (value !== null && value !== undefined) {
-            existingVars.set(key, value);
-        }
-    });
-
-    // Build new .env content
-    const lines: string[] = [
-        "# soundspan Environment Variables",
-        `# Auto-generated on ${new Date().toISOString()}`,
-        "",
-    ];
-
-    // Group variables by category
-    const categories = {
-        "Database & Redis": ["DATABASE_URL", "REDIS_URL"],
-        Server: ["PORT", "NODE_ENV", "SESSION_SECRET", "ALLOWED_ORIGINS"],
-        Lidarr: ["LIDARR_ENABLED", "LIDARR_URL", "LIDARR_API_KEY"],
-        "Last.fm": ["LASTFM_API_KEY"],
-        "Fanart.tv": ["FANART_API_KEY"],
-        OpenAI: ["OPENAI_API_KEY"],
-        Audiobookshelf: ["AUDIOBOOKSHELF_URL", "AUDIOBOOKSHELF_API_KEY"],
-        "Docker Paths": ["MUSIC_PATH", "DOWNLOAD_PATH"],
-        Security: ["SETTINGS_ENCRYPTION_KEY"],
-    };
-
-    const writtenKeys = new Set<string>();
-
-    // Write categorized variables
-    Object.entries(categories).forEach(([category, keys]) => {
-        const categoryVars: string[] = [];
-
-        keys.forEach((key) => {
-            if (existingVars.has(key)) {
-                const value = existingVars.get(key);
-                categoryVars.push(`${key}=${value}`);
-                writtenKeys.add(key);
-            }
-        });
-
-        if (categoryVars.length > 0) {
-            lines.push("", `# ${category}`, ...categoryVars);
-        }
-    });
-
-    // Write uncategorized variables
-    const uncategorized: string[] = [];
-    existingVars.forEach((value, key) => {
-        if (!writtenKeys.has(key)) {
-            uncategorized.push(`${key}=${value}`);
-        }
-    });
-
-    if (uncategorized.length > 0) {
-        lines.push("", "# Other Variables", ...uncategorized);
-    }
-
-    lines.push(""); // Trailing newline
-
-    atomicWriteFileSecret(envPath, lines.join("\n"));
+    const existingVars = readExistingEnvVariables(envPath);
+    reconcileEnvVariables(existingVars, variables, secretsDbOnly);
+    atomicWriteFileSecret(envPath, buildEnvContent(existingVars));
     log.debug(`.env file updated with ${existingVars.size} variables`);
 }


### PR DESCRIPTION
Convergence sweep #20 remediation in `backend/src/utils/envWriter.ts`.

**N9 — stale plaintext secret on explicit clear.** System Settings uses `null` as an explicit secret clear (and clears the DB value), but `writeEnvFile` ignored `null` instead of deleting the env key — with the default filesystem sync mode the revoked credential remained on disk and could be reloaded after restart. Now: `null` deletes the key, `undefined` leaves it unchanged, omitted keys preserved.

**N10 — destructive partial replacement on read error.** Every `readFileSync` failure was treated as a missing file, so `EACCES`/transient I/O caused the writer to atomically replace the original with only the integration-settings payload — erasing database, session, and encryption config. Now only `ENOENT` is absence; all other read errors are rethrown **before any rename** (fail-closed).

Verification: targeted jest 16/16 (targeted clear, unrelated-value preservation, EACCES/EIO fault injection with zero replacement ops); `tsc --noEmit` clean; prettier clean. No CHANGELOG edit (consolidated docs PR follows).