### PR TITLE
fix(security): remove bundled 2018 FFmpeg; enforce a patched minimum version (sweep #20 N12)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@bull-board/api": "^8.6.0",
                 "@bull-board/express": "^8.6.0",
-                "@ffmpeg-installer/ffmpeg": "^1.1.0",
                 "@prisma/adapter-pg": "^7.9.1",
                 "@prisma/client": "^7.9.1",
                 "@socket.io/redis-adapter": "^8.3.0",
@@ -28,7 +27,6 @@
                 "express": "^5.2.1",
                 "express-rate-limit": "^8.6.2",
                 "express-session": "^1.17.3",
-                "ffmpeg-static": "^5.2.0",
                 "fluent-ffmpeg": "^2.1.3",
                 "fuzzball": "^2.2.6",
                 "helmet": "^8.3.0",
@@ -754,21 +752,6 @@
                 "@bull-board/api": "8.6.0"
             }
         },
-        "node_modules/@derhuerst/http-basic": {
-            "version": "8.2.4",
-            "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
-            "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
-            "license": "MIT",
-            "dependencies": {
-                "caseless": "^0.12.0",
-                "concat-stream": "^2.0.0",
-                "http-response-object": "^3.0.1",
-                "parse-cache-control": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@electric-sql/pglite": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
@@ -1273,132 +1256,6 @@
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/@ffmpeg-installer/darwin-arm64": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
-            "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
-            "cpu": [
-                "arm64"
-            ],
-            "hasInstallScript": true,
-            "license": "https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/LICENSE.md",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/darwin-x64": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
-            "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
-            "cpu": [
-                "x64"
-            ],
-            "hasInstallScript": true,
-            "license": "LGPL-2.1",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/ffmpeg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
-            "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
-            "license": "LGPL-2.1",
-            "optionalDependencies": {
-                "@ffmpeg-installer/darwin-arm64": "4.1.5",
-                "@ffmpeg-installer/darwin-x64": "4.1.0",
-                "@ffmpeg-installer/linux-arm": "4.1.3",
-                "@ffmpeg-installer/linux-arm64": "4.1.4",
-                "@ffmpeg-installer/linux-ia32": "4.1.0",
-                "@ffmpeg-installer/linux-x64": "4.1.0",
-                "@ffmpeg-installer/win32-ia32": "4.1.0",
-                "@ffmpeg-installer/win32-x64": "4.1.0"
-            }
-        },
-        "node_modules/@ffmpeg-installer/linux-arm": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
-            "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
-            "cpu": [
-                "arm"
-            ],
-            "hasInstallScript": true,
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/linux-arm64": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
-            "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
-            "cpu": [
-                "arm64"
-            ],
-            "hasInstallScript": true,
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/linux-ia32": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
-            "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "hasInstallScript": true,
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/linux-x64": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
-            "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
-            "cpu": [
-                "x64"
-            ],
-            "hasInstallScript": true,
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/win32-ia32": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
-            "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@ffmpeg-installer/win32-x64": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
-            "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "GPLv3",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
         },
         "node_modules/@img/colour": {
             "version": "1.1.0",
@@ -5274,12 +5131,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "license": "Apache-2.0"
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6213,15 +6064,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/error-ex": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -6796,22 +6638,6 @@
                 "bser": "2.1.1"
             }
         },
-        "node_modules/ffmpeg-static": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
-            "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
-            "hasInstallScript": true,
-            "license": "GPL-3.0-or-later",
-            "dependencies": {
-                "@derhuerst/http-basic": "^8.2.0",
-                "env-paths": "^2.2.0",
-                "https-proxy-agent": "^5.0.0",
-                "progress": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/file-type": {
             "version": "21.3.4",
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
@@ -7370,21 +7196,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/http-response-object": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
-            "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "^10.0.3"
-            }
-        },
-        "node_modules/http-response-object/node_modules/@types/node": {
-            "version": "10.17.60",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-            "license": "MIT"
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
@@ -9677,11 +9488,6 @@
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "license": "BlueOak-1.0.0"
         },
-        "node_modules/parse-cache-control": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-            "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-        },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10094,15 +9900,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
-        },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
         },
         "node_modules/proper-lockfile": {
             "version": "4.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,6 @@
     "dependencies": {
         "@bull-board/api": "^8.6.0",
         "@bull-board/express": "^8.6.0",
-        "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@prisma/adapter-pg": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "@socket.io/redis-adapter": "^8.3.0",
@@ -54,7 +53,6 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.6.2",
         "express-session": "^1.17.3",
-        "ffmpeg-static": "^5.2.0",
         "fluent-ffmpeg": "^2.1.3",
         "fuzzball": "^2.2.6",
         "helmet": "^8.3.0",

--- a/backend/src/services/__tests__/audioStreamingService.test.ts
+++ b/backend/src/services/__tests__/audioStreamingService.test.ts
@@ -27,12 +27,21 @@ const mockPrisma = {
 
 const mockParseFile = jest.fn();
 const mockParseRangeHeader = jest.fn();
+const mockInspectFfmpegVersion = jest.fn(
+    (_binaryPath: string) => "ffmpeg version 7.0",
+);
+const mockResolveFfmpegBinaryPath = jest.fn(
+    (_configuredPath?: string) => "/usr/bin/ffmpeg",
+);
 
 // Mutable config mock so individual tests can exercise the ALLOWED_ORIGINS
 // allowlist semantics ([] = empty → deny cross-origin in production).
 const mockConfig = {
     nodeEnv: "production",
     allowedOrigins: [] as boolean | string[],
+    segmentedStreaming: {
+        ffmpegPathOverride: undefined as string | undefined,
+    },
 };
 
 type FfmpegMode = "success" | "error" | "throw";
@@ -130,11 +139,9 @@ jest.mock("../../config", () => ({
     config: mockConfig,
 }));
 
-jest.mock("@ffmpeg-installer/ffmpeg", () => ({
-    __esModule: true,
-    default: {
-        path: "/mock/bin/ffmpeg",
-    },
+jest.mock("../../utils/configValidator", () => ({
+    inspectFfmpegVersion: mockInspectFfmpegVersion,
+    resolveFfmpegBinaryPath: mockResolveFfmpegBinaryPath,
 }));
 
 jest.mock("fluent-ffmpeg", () => ({
@@ -146,6 +153,9 @@ jest.mock("fluent-ffmpeg", () => ({
 
 import { AudioStreamingService, QUALITY_SETTINGS } from "../audioStreaming";
 import { AppError, ErrorCategory, ErrorCode } from "../../utils/errors";
+
+const configuredFfmpegPath = mockSetFfmpegPath.mock.calls[0]?.[0];
+const inspectedFfmpegPath = mockInspectFfmpegVersion.mock.calls[0]?.[0];
 
 type MockReadStream = {
     on: jest.Mock;
@@ -215,6 +225,11 @@ describe("AudioStreamingService", () => {
         createdServices.push(service);
         return service;
     }
+
+    it("selects the validated system ffmpeg binary", () => {
+        expect(inspectedFfmpegPath).toBe("/usr/bin/ffmpeg");
+        expect(configuredFfmpegPath).toBe("/usr/bin/ffmpeg");
+    });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/backend/src/services/audioStreaming.ts
+++ b/backend/src/services/audioStreaming.ts
@@ -7,7 +7,6 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { prisma } from "../utils/db";
 import ffmpeg from "fluent-ffmpeg";
-import ffmpegPath from "@ffmpeg-installer/ffmpeg";
 import PQueue from "p-queue";
 import { AppError, ErrorCode, ErrorCategory } from "../utils/errors";
 import { parseRangeHeader } from "../utils/rangeParser";
@@ -15,9 +14,16 @@ import { parseFile } from "music-metadata";
 import { isOriginAllowed } from "../utils/cors";
 import { config } from "../config";
 import { coalesceInFlightByKey } from "../utils/singleflight";
+import {
+    inspectFfmpegVersion,
+    resolveFfmpegBinaryPath,
+} from "../utils/configValidator";
 
-// Set FFmpeg path to bundled binary
-ffmpeg.setFfmpegPath(ffmpegPath.path);
+const ffmpegBinaryPath = resolveFfmpegBinaryPath(
+    config.segmentedStreaming.ffmpegPathOverride,
+);
+inspectFfmpegVersion(ffmpegBinaryPath);
+ffmpeg.setFfmpegPath(ffmpegBinaryPath);
 
 // Quality settings
 export const QUALITY_SETTINGS = {

--- a/backend/src/services/segmented-streaming/__tests__/segmentService.test.ts
+++ b/backend/src/services/segmented-streaming/__tests__/segmentService.test.ts
@@ -43,6 +43,9 @@ const resolveSegmentService = async () => {
     const mockListDashSegments = jest.fn();
     const mockScheduleDashCachePrune = jest.fn();
     const mockSpawn = jest.fn();
+    const mockInspectFfmpegVersion = jest.fn(
+        (_binaryPath: string) => "ffmpeg version 7.0",
+    );
     const heldBuildLocks = new Map<string, string>();
     const mockBuildLockSet = jest.fn(
         async (
@@ -85,11 +88,16 @@ const resolveSegmentService = async () => {
             mockBuildLockEval(...args),
     }));
 
-    jest.doMock("@ffmpeg-installer/ffmpeg", () => ({
-        __esModule: true,
-        default: {
-            path: "/tmp/mock-ffmpeg",
+    jest.doMock("../../../config", () => ({
+        config: {
+            segmentedStreaming: {
+                ffmpegPathOverride: undefined,
+            },
         },
+    }));
+    jest.doMock("../../../utils/configValidator", () => ({
+        inspectFfmpegVersion: mockInspectFfmpegVersion,
+        resolveFfmpegBinaryPath: jest.fn(() => "/tmp/system-ffmpeg"),
     }));
 
     jest.doMock("child_process", () => ({
@@ -133,6 +141,7 @@ const resolveSegmentService = async () => {
             mockListDashSegments,
             mockScheduleDashCachePrune,
             mockSpawn,
+            mockInspectFfmpegVersion,
             mockBuildLockSet,
             mockBuildLockExists,
             mockBuildLockEval,
@@ -153,7 +162,8 @@ describe("segmentedSegmentService", () => {
                 originalLocalSegmentDurationSec;
         }
         jest.resetModules();
-        jest.dontMock("@ffmpeg-installer/ffmpeg");
+        jest.dontMock("../../../config");
+        jest.dontMock("../../../utils/configValidator");
         jest.dontMock("child_process");
         jest.dontMock("../cacheService");
         jest.dontMock("../../../utils/ioredis");
@@ -204,6 +214,14 @@ describe("segmentedSegmentService", () => {
         });
         expect(mocks.mockScheduleDashCachePrune).toHaveBeenCalledTimes(1);
         expect(mocks.mockSpawn).toHaveBeenCalledTimes(1);
+        expect(mocks.mockInspectFfmpegVersion).toHaveBeenCalledWith(
+            "/tmp/system-ffmpeg",
+        );
+        expect(mocks.mockSpawn).toHaveBeenCalledWith(
+            "/tmp/system-ffmpeg",
+            expect.any(Array),
+            expect.any(Object),
+        );
 
         ffmpegProcess.emit("close", 0);
         await wait(0);

--- a/backend/src/services/segmented-streaming/segmentService.ts
+++ b/backend/src/services/segmented-streaming/segmentService.ts
@@ -1,8 +1,12 @@
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import fs, { promises as fsPromises } from "fs";
-import ffmpegPath from "@ffmpeg-installer/ffmpeg";
 import { logger } from "../../utils/logger";
+import { config } from "../../config";
+import {
+    inspectFfmpegVersion,
+    resolveFfmpegBinaryPath,
+} from "../../utils/configValidator";
 import { createIORedisClient } from "../../utils/ioredis";
 import {
     segmentedStreamingCacheService,
@@ -20,7 +24,6 @@ const REMOTE_INPUT_CAPABILITY_PROBE_TIMEOUT_MS = 4_000;
 const BUILD_FAILURE_RETENTION_MS = 60_000;
 const STARTUP_CACHE_VALIDATION_SUCCESS_TTL_MS = 5_000;
 const FULL_CACHE_VALIDATION_SUCCESS_TTL_MS = 60_000;
-const SYSTEM_FFMPEG_PATH = "/usr/bin/ffmpeg";
 const SEGMENTED_STREAMING_DASH_BUILD_LOCK_ENABLED =
     process.env.SEGMENTED_STREAMING_DASH_BUILD_LOCK_ENABLED !== "false";
 const DEFAULT_SEGMENTED_STREAMING_DASH_BUILD_LOCK_TTL_MS =
@@ -174,17 +177,10 @@ type DashBuildLockAcquireResult =
     | { acquired: false; unavailable: true }
     | { acquired: false; unavailable: false };
 
-const resolveSegmentedFfmpegBinaryPath = (): string => {
-    const configuredPath = process.env.FFMPEG_PATH?.trim();
-    if (configuredPath) {
-        return configuredPath;
-    }
-    if (fs.existsSync(SYSTEM_FFMPEG_PATH)) {
-        return SYSTEM_FFMPEG_PATH;
-    }
-    return ffmpegPath.path;
-};
-const SEGMENTED_FFMPEG_BINARY_PATH = resolveSegmentedFfmpegBinaryPath();
+const SEGMENTED_FFMPEG_BINARY_PATH = resolveFfmpegBinaryPath(
+    config.segmentedStreaming.ffmpegPathOverride,
+);
+inspectFfmpegVersion(SEGMENTED_FFMPEG_BINARY_PATH);
 
 interface DashEncodingPlan {
     targetRepresentation: DashAudioRepresentation;

--- a/backend/src/utils/__tests__/configValidator.test.ts
+++ b/backend/src/utils/__tests__/configValidator.test.ts
@@ -15,7 +15,7 @@ type LoadOptions = {
     mkdirError?: string;
     execOutput?: string;
     execError?: string;
-    ffmpegPath?: string;
+    execErrorCode?: string;
 };
 
 type ValidatorModule = {
@@ -49,7 +49,8 @@ describe("validateMusicConfig", () => {
             ...options.env,
         };
 
-        const ffmpegPath = options.ffmpegPath ?? "/bin/ffmpeg";
+        const ffmpegPath =
+            options.env?.FFMPEG_PATH?.trim() || "/usr/bin/ffmpeg";
         const existingPaths = new Set<string>([
             "/music",
             "/cache/transcodes",
@@ -83,9 +84,11 @@ describe("validateMusicConfig", () => {
             }
             createdPaths.add(String(candidate));
         });
-        const execSync = jest.fn(() => {
+        const execFileSync = jest.fn(() => {
             if (options.execError) {
-                throw new Error(options.execError);
+                throw Object.assign(new Error(options.execError), {
+                    code: options.execErrorCode,
+                });
             }
             return options.execOutput ?? "ffmpeg version 7.0";
         });
@@ -97,7 +100,9 @@ describe("validateMusicConfig", () => {
             info: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
+            child: jest.fn(),
         };
+        logger.child.mockReturnValue(logger);
 
         jest.doMock("fs", () => ({
             existsSync,
@@ -106,11 +111,7 @@ describe("validateMusicConfig", () => {
             constants: { R_OK: 4, W_OK: 2 },
         }));
         jest.doMock("child_process", () => ({
-            execSync,
-        }));
-        jest.doMock("@ffmpeg-installer/ffmpeg", () => ({
-            __esModule: true,
-            default: { path: ffmpegPath },
+            execFileSync,
         }));
         jest.doMock("../systemSettings", () => ({
             getSystemSettings,
@@ -128,7 +129,7 @@ describe("validateMusicConfig", () => {
             existsSync,
             accessSync,
             mkdirSync,
-            execSync,
+            execFileSync,
             getSystemSettings,
             logger,
             ffmpegPath,
@@ -300,44 +301,93 @@ describe("validateMusicConfig", () => {
         );
     });
 
-    it("logs warning and continues when bundled ffmpeg is missing", async () => {
-        const { validateMusicConfig, execSync, logger, ffmpegPath } =
+    it("logs warning and continues when system ffmpeg is missing", async () => {
+        const { validateMusicConfig, execFileSync, logger, ffmpegPath } =
             loadValidator({
                 env: { MUSIC_PATH: "/env/music" },
                 existingPaths: ["/env/music"],
-                missingPaths: ["/bin/ffmpeg"],
+                execError: "spawn /usr/bin/ffmpeg ENOENT",
+                execErrorCode: "ENOENT",
             });
 
         const result = await validateMusicConfig();
 
         expect(result.musicPath).toBe("/env/music");
-        expect(execSync).not.toHaveBeenCalled();
-        expect(logger.warn).toHaveBeenCalledWith(
-            "  Bundled FFmpeg not available. Transcoding will not be available.",
+        expect(execFileSync).toHaveBeenCalledWith(
+            "/usr/bin/ffmpeg",
+            ["-version"],
+            {
+                encoding: "utf8",
+                maxBuffer: 65536,
+                timeout: 5000,
+            },
         );
         expect(logger.warn).toHaveBeenCalledWith(
-            `   Error: Bundled FFmpeg not found at: ${ffmpegPath}`,
+            "System FFmpeg is not available; transcoding is disabled",
+            { ffmpegPath },
         );
     });
 
-    it("logs warning and continues when ffmpeg output is invalid", async () => {
-        const { validateMusicConfig, execSync, logger } = loadValidator({
+    it("fails startup when ffmpeg reports an affected version", async () => {
+        const { validateMusicConfig } = loadValidator({
+            env: { MUSIC_PATH: "/env/music" },
+            existingPaths: ["/env/music"],
+            execOutput: "ffmpeg version 4.3.6-0+deb11u1\nconfiguration",
+        });
+
+        await expect(validateMusicConfig()).rejects.toThrow(
+            "FFmpeg 4.3 is unsupported; version 4.4 or newer is required",
+        );
+    });
+
+    it("fails startup when ffmpeg version output cannot be verified", async () => {
+        const { validateMusicConfig } = loadValidator({
             env: { MUSIC_PATH: "/env/music" },
             existingPaths: ["/env/music"],
             execOutput: "not-ffmpeg",
         });
 
-        const result = await validateMusicConfig();
-
-        expect(result.musicPath).toBe("/env/music");
-        expect(execSync).toHaveBeenCalledWith('"/bin/ffmpeg" -version', {
-            encoding: "utf8",
-        });
-        expect(logger.warn).toHaveBeenCalledWith(
-            "  Bundled FFmpeg not available. Transcoding will not be available.",
+        await expect(validateMusicConfig()).rejects.toThrow(
+            "Unable to determine FFmpeg version",
         );
-        expect(logger.warn).toHaveBeenCalledWith(
-            "   Error: Invalid ffmpeg output",
+    });
+
+    it("fails startup when the configured ffmpeg cannot execute", async () => {
+        const { validateMusicConfig } = loadValidator({
+            env: { MUSIC_PATH: "/env/music" },
+            existingPaths: ["/env/music"],
+            execError: "spawn EACCES",
+            execErrorCode: "EACCES",
+        });
+
+        await expect(validateMusicConfig()).rejects.toThrow(
+            "Unable to execute FFmpeg at /usr/bin/ffmpeg",
+        );
+    });
+
+    it("uses a configured system ffmpeg path without shell interpolation", async () => {
+        const configuredPath = "/opt/soundspan/bin/ffmpeg";
+        const { validateMusicConfig, execFileSync } = loadValidator({
+            env: {
+                MUSIC_PATH: "/env/music",
+                FFMPEG_PATH: ` ${configuredPath} `,
+            },
+            existingPaths: ["/env/music"],
+            execOutput: "ffmpeg version 4.4.0\nconfiguration",
+        });
+
+        await expect(validateMusicConfig()).resolves.toEqual(
+            expect.objectContaining({ musicPath: "/env/music" }),
+        );
+
+        expect(execFileSync).toHaveBeenCalledWith(
+            configuredPath,
+            ["-version"],
+            {
+                encoding: "utf8",
+                maxBuffer: 65536,
+                timeout: 5000,
+            },
         );
     });
 

--- a/backend/src/utils/configValidator.ts
+++ b/backend/src/utils/configValidator.ts
@@ -1,11 +1,67 @@
 import * as fs from "fs";
 import { logger } from "./logger";
 import * as path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { AppError, ErrorCode, ErrorCategory } from "./errors";
-import ffmpegPath from "@ffmpeg-installer/ffmpeg";
 import { getSystemSettings } from "./systemSettings";
 import { parseEnvInt } from "./envParsers";
+
+const ffmpegLogger = logger.child("FFmpeg");
+const SYSTEM_FFMPEG_PATH = "/usr/bin/ffmpeg";
+const MINIMUM_FFMPEG_MAJOR = 4;
+const MINIMUM_FFMPEG_MINOR = 4;
+const FFMPEG_VERSION_TIMEOUT_MS = 5_000;
+const FFMPEG_VERSION_MAX_BUFFER_BYTES = 64 * 1024;
+const FFMPEG_VERSION_PATTERN =
+    /^ffmpeg version (?:n)?(\d+)\.(\d+)(?:[.\s-]|$)/i;
+
+/** Resolves the configured FFmpeg executable, defaulting to the image system binary. */
+export function resolveFfmpegBinaryPath(configuredPath?: string): string {
+    return configuredPath?.trim() || SYSTEM_FFMPEG_PATH;
+}
+
+/** Verifies that an available FFmpeg executable meets the supported version floor. */
+export function inspectFfmpegVersion(binaryPath: string): string | null {
+    let output: string;
+    try {
+        output = execFileSync(binaryPath, ["-version"], {
+            encoding: "utf8",
+            maxBuffer: FFMPEG_VERSION_MAX_BUFFER_BYTES,
+            timeout: FFMPEG_VERSION_TIMEOUT_MS,
+        });
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+        ) {
+            return null;
+        }
+        throw new Error(`Unable to execute FFmpeg at ${binaryPath}`, {
+            cause: error,
+        });
+    }
+
+    const versionLine = output.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    const versionMatch = FFMPEG_VERSION_PATTERN.exec(versionLine);
+    if (!versionMatch) {
+        throw new Error(`Unable to determine FFmpeg version at ${binaryPath}`);
+    }
+
+    const major = Number.parseInt(versionMatch[1], 10);
+    const minor = Number.parseInt(versionMatch[2], 10);
+    const isSupported =
+        major > MINIMUM_FFMPEG_MAJOR ||
+        (major === MINIMUM_FFMPEG_MAJOR && minor >= MINIMUM_FFMPEG_MINOR);
+    if (!isSupported) {
+        throw new Error(
+            `FFmpeg ${major}.${minor} is unsupported; version 4.4 or newer is required`,
+        );
+    }
+
+    return versionLine;
+}
 
 export interface MusicConfig {
     musicPath: string;
@@ -118,30 +174,18 @@ export async function validateMusicConfig(): Promise<MusicConfig> {
         );
     }
 
-    // VALIDATE BUNDLED FFMPEG (from @ffmpeg-installer/ffmpeg)
-    try {
-        // Check if bundled FFmpeg binary exists
-        if (!fs.existsSync(ffmpegPath.path)) {
-            throw new Error(`Bundled FFmpeg not found at: ${ffmpegPath.path}`);
-        }
-
-        // Verify it's executable by running version check
-        const result = execSync(`"${ffmpegPath.path}" -version`, {
-            encoding: "utf8",
+    const ffmpegPath = resolveFfmpegBinaryPath(process.env.FFMPEG_PATH);
+    const ffmpegVersion = inspectFfmpegVersion(ffmpegPath);
+    if (ffmpegVersion) {
+        ffmpegLogger.debug("System FFmpeg validated", {
+            ffmpegPath,
+            version: ffmpegVersion,
         });
-        if (!result.includes("ffmpeg version")) {
-            throw new Error("Invalid ffmpeg output");
-        }
-
-        logger.debug(`FFmpeg detected (bundled): ${result.split("\n")[0]}`);
-        logger.debug(`   FFmpeg path: ${ffmpegPath.path}`);
-    } catch (err: any) {
-        logger.warn(
-            "  Bundled FFmpeg not available. Transcoding will not be available.",
+    } else {
+        ffmpegLogger.warn(
+            "System FFmpeg is not available; transcoding is disabled",
+            { ffmpegPath },
         );
-        logger.warn(`   Error: ${err.message}`);
-        logger.warn("   Original quality streaming will still work.");
-        // Don't throw - allow server to start without FFmpeg
     }
 
     logger.debug("Music configuration validated successfully");


### PR DESCRIPTION
Convergence sweep #20 remediation (N12).

The backend production lockfile shipped `@ffmpeg-installer/linux-x64 4.1.0` and `audioStreaming.ts` explicitly selected that **bundled 2018** executable instead of the patched system FFmpeg installed in the image. FFmpeg through 4.3 is affected by crafted-media buffer-overflow **CVE-2021-30123**, and the backend transcodes untrusted uploaded/streamed media.

Fix
- Removed the `@ffmpeg-installer` packages from `package.json` and the lockfile.
- `audioStreaming.ts` and the segmented-streaming segment service select the patched system/configured FFmpeg binary.
- `configValidator` enforces a minimum FFmpeg version at startup and rejects a vulnerable or unparseable build.

Verification: targeted jest 97/97 (vulnerable-version rejection, malformed output, exec failure, missing binary, configured-path, core/segmented selection); `tsc --noEmit` clean; route-error canon + leak ratchets green; `npm audit` no longer lists the removed packages; prettier clean. No CHANGELOG edit (consolidated docs PR follows).