### PR TITLE
fix(security): encode + parameterize Helm PostgreSQL credentials (sweep #20 N15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,6 +268,8 @@ WORKDIR /app
 
 # Copy healthcheck script
 COPY healthcheck-prod.js /app/healthcheck.js
+COPY scripts/aio-postgres-credentials.sh /app/aio-postgres-credentials.sh
+RUN chmod 500 /app/aio-postgres-credentials.sh
 
 # Create supervisord config - logs to stdout/stderr for Docker visibility
 RUN cat > /etc/supervisor/conf.d/soundspan.conf << 'EOF'
@@ -479,7 +481,7 @@ else
 fi
 chmod 600 /data/secrets/postgres_password
 chown soundspan:soundspan /data/secrets/postgres_password 2>/dev/null || true
-DATABASE_URL="postgresql://soundspan:${POSTGRES_PASSWORD}@localhost:5432/soundspan"
+DATABASE_URL=$(/app/aio-postgres-credentials.sh database-url)
 
 # Clean up stale PID file if exists
 rm -f /data/postgres/postmaster.pid 2>/dev/null || true
@@ -505,9 +507,7 @@ fi
 gosu postgres $PG_BIN/pg_ctl -D /data/postgres -o "-c listen_addresses=127.0.0.1" -w start
 
 # Create the user if needed, then always synchronize its persisted password.
-gosu postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname = 'soundspan'" | grep -q 1 || \
-    gosu postgres psql -c "CREATE USER soundspan WITH PASSWORD '${POSTGRES_PASSWORD}';"
-gosu postgres psql -c "ALTER USER soundspan WITH PASSWORD '${POSTGRES_PASSWORD}';"
+/app/aio-postgres-credentials.sh sync-role
 gosu postgres psql -tc "SELECT 1 FROM pg_database WHERE datname = 'soundspan'" | grep -q 1 || \
     gosu postgres psql -c "CREATE DATABASE soundspan OWNER soundspan;"
 

--- a/charts/soundspan/templates/_helpers.tpl
+++ b/charts/soundspan/templates/_helpers.tpl
@@ -90,18 +90,51 @@ Usage: include "soundspan.image" .Values.backend.image
 {{- end }}
 
 {{/*
-PostgreSQL connection URL
+Complete external PostgreSQL connection URL
 */}}
 {{- define "soundspan.databaseUrl" -}}
-{{- if eq .Values.deploymentMode "aio" }}
-{{- printf "postgresql://soundspan:soundspan@localhost:5432/soundspan" }}
-{{- else if .Values.postgresql.external.url }}
+{{- if .Values.postgresql.external.url -}}
 {{- printf "%s" .Values.postgresql.external.url }}
-{{- else if .Values.postgresql.enabled }}
-{{- printf "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@%s-postgresql:%d/$(POSTGRES_DB)" (include "soundspan.fullname" .) (.Values.postgresql.port | int) }}
 {{- else }}
-{{- printf "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@%s:%d/$(POSTGRES_DB)" .Values.postgresql.external.host (.Values.postgresql.external.port | int) }}
+{{- fail "soundspan.databaseUrl requires a complete postgresql.external.url" }}
 {{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL component host and port used by startup-time DATABASE_URL builders.
+*/}}
+{{- define "soundspan.databaseHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" (include "soundspan.fullname" .) }}
+{{- else -}}
+{{- printf "%s" .Values.postgresql.external.host }}
+{{- end -}}
+{{- end }}
+
+{{- define "soundspan.databasePort" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.port | int }}
+{{- else -}}
+{{- .Values.postgresql.external.port | int }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Build DATABASE_URL after Kubernetes has populated Secret-backed component env.
+The final command is supplied as positional parameters and replaces the shell.
+*/}}
+{{- define "soundspan.nodeDatabaseUrlStartup" -}}
+# soundspan-database-url-start
+export DATABASE_URL="$(node -e 'const env = process.env; process.stdout.write("postgresql://" + encodeURIComponent(env.POSTGRES_USER) + ":" + encodeURIComponent(env.POSTGRES_PASSWORD) + "@" + env.SOUNDSPAN_DATABASE_HOST + ":" + env.SOUNDSPAN_DATABASE_PORT + "/" + env.POSTGRES_DB)')"
+# soundspan-database-url-end
+exec "$@"
+{{- end }}
+
+{{- define "soundspan.pythonDatabaseUrlStartup" -}}
+# soundspan-database-url-start
+export DATABASE_URL="$(python3 -c 'import os; from urllib.parse import quote; env = os.environ; print("postgresql://{}:{}@{}:{}/{}".format(quote(env["POSTGRES_USER"], safe=""), quote(env["POSTGRES_PASSWORD"], safe=""), env["SOUNDSPAN_DATABASE_HOST"], env["SOUNDSPAN_DATABASE_PORT"], env["POSTGRES_DB"]), end="")')"
+# soundspan-database-url-end
+exec "$@"
 {{- end }}
 
 {{/*

--- a/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
@@ -37,15 +37,29 @@ spec:
         - name: audio-analyzer-clap
           image: {{ include "soundspan.image" .Values.audioAnalyzerClap.image | quote }}
           imagePullPolicy: {{ .Values.audioAnalyzerClap.image.pullPolicy }}
+          {{- $audioAnalyzerClapEnv := .Values.audioAnalyzerClap.env | default (dict) }}
+          {{- $audioAnalyzerClapBuildDatabaseUrl := and (not (hasKey $audioAnalyzerClapEnv "DATABASE_URL")) (not .Values.postgresql.external.url) }}
+          {{- if $audioAnalyzerClapBuildDatabaseUrl }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |-
+              {{- include "soundspan.pythonDatabaseUrlStartup" . | nindent 14 }}
+            - soundspan-database-url
+            - python
+            - analyzer.py
+          {{- end }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          {{- $audioAnalyzerClapEnv := .Values.audioAnalyzerClap.env | default (dict) }}
           {{- $audioAnalyzerClapDefaultBackendURL := printf "http://%s-backend:%v" (include "soundspan.fullname" .) .Values.backend.port }}
-          {{- $audioAnalyzerClapHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
+          {{- $audioAnalyzerClapHasPostgresSecretEnv := not .Values.postgresql.external.url }}
           {{- $audioAnalyzerClapExplicitEnvKeys := dict
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
             "POSTGRES_DB" true
+            "SOUNDSPAN_DATABASE_HOST" true
+            "SOUNDSPAN_DATABASE_PORT" true
             "DATABASE_URL" true
             "REDIS_URL" true
             "MUSIC_PATH" true
@@ -84,10 +98,16 @@ spec:
                   name: {{ include "soundspan.secretName" . }}
                   key: POSTGRES_DB
             {{- end }}
+            {{- if $audioAnalyzerClapBuildDatabaseUrl }}
+            - name: SOUNDSPAN_DATABASE_HOST
+              value: {{ include "soundspan.databaseHost" . | quote }}
+            - name: SOUNDSPAN_DATABASE_PORT
+              value: {{ include "soundspan.databasePort" . | quote }}
+            {{- end }}
             {{- if hasKey $audioAnalyzerClapEnv "DATABASE_URL" }}
             - name: DATABASE_URL
               value: {{ index $audioAnalyzerClapEnv "DATABASE_URL" | quote }}
-            {{- else }}
+            {{- else if .Values.postgresql.external.url }}
             - name: DATABASE_URL
               value: {{ include "soundspan.databaseUrl" . | quote }}
             {{- end }}

--- a/charts/soundspan/templates/individual/audio-analyzer.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer.yaml
@@ -37,14 +37,28 @@ spec:
         - name: audio-analyzer
           image: {{ include "soundspan.image" .Values.audioAnalyzer.image | quote }}
           imagePullPolicy: {{ .Values.audioAnalyzer.image.pullPolicy }}
+          {{- $audioAnalyzerEnv := .Values.audioAnalyzer.env | default (dict) }}
+          {{- $audioAnalyzerBuildDatabaseUrl := and (not (hasKey $audioAnalyzerEnv "DATABASE_URL")) (not .Values.postgresql.external.url) }}
+          {{- if $audioAnalyzerBuildDatabaseUrl }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |-
+              {{- include "soundspan.pythonDatabaseUrlStartup" . | nindent 14 }}
+            - soundspan-database-url
+            - python3
+            - analyzer.py
+          {{- end }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          {{- $audioAnalyzerEnv := .Values.audioAnalyzer.env | default (dict) }}
-          {{- $audioAnalyzerHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
+          {{- $audioAnalyzerHasPostgresSecretEnv := not .Values.postgresql.external.url }}
           {{- $audioAnalyzerExplicitEnvKeys := dict
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
             "POSTGRES_DB" true
+            "SOUNDSPAN_DATABASE_HOST" true
+            "SOUNDSPAN_DATABASE_PORT" true
             "DATABASE_URL" true
             "REDIS_URL" true
             "MUSIC_PATH" true
@@ -81,10 +95,16 @@ spec:
                   name: {{ include "soundspan.secretName" . }}
                   key: POSTGRES_DB
             {{- end }}
+            {{- if $audioAnalyzerBuildDatabaseUrl }}
+            - name: SOUNDSPAN_DATABASE_HOST
+              value: {{ include "soundspan.databaseHost" . | quote }}
+            - name: SOUNDSPAN_DATABASE_PORT
+              value: {{ include "soundspan.databasePort" . | quote }}
+            {{- end }}
             {{- if hasKey $audioAnalyzerEnv "DATABASE_URL" }}
             - name: DATABASE_URL
               value: {{ index $audioAnalyzerEnv "DATABASE_URL" | quote }}
-            {{- else }}
+            {{- else if .Values.postgresql.external.url }}
             - name: DATABASE_URL
               value: {{ include "soundspan.databaseUrl" . | quote }}
             {{- end }}

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -41,10 +41,39 @@ spec:
         - name: backend-worker
           image: {{ include "soundspan.image" .Values.backendWorker.image | quote }}
           imagePullPolicy: {{ .Values.backendWorker.image.pullPolicy }}
+          {{- $backendWorkerEnv := .Values.backendWorker.env | default (dict) }}
+          {{- $backendWorkerBuildDatabaseUrl := and (not (hasKey $backendWorkerEnv "DATABASE_URL")) (not .Values.postgresql.external.url) }}
           ports:
             - name: health
               containerPort: {{ .Values.backendWorker.health.port }}
               protocol: TCP
+          {{- if $backendWorkerBuildDatabaseUrl }}
+          command:
+            - /usr/bin/tini
+            - --
+            - /bin/sh
+            - -c
+          args:
+            - |-
+              {{- include "soundspan.nodeDatabaseUrlStartup" . | nindent 14 }}
+            - soundspan-database-url
+            {{- with .Values.backendWorker.command }}
+            {{- toYaml . | nindent 12 }}
+            {{- with .Values.backendWorker.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- else }}
+            - node
+            - dist/worker.js
+            {{- end }}
+            {{- else }}
+            {{- with .Values.backendWorker.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- else }}
+            - node
+            - dist/worker.js
+            {{- end }}
+            {{- end }}
+          {{- else }}
           {{- with .Values.backendWorker.command }}
           command:
             {{- toYaml . | nindent 12 }}
@@ -53,10 +82,10 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          {{- $backendWorkerEnv := .Values.backendWorker.env | default (dict) }}
-          {{- $backendWorkerHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
+          {{- $backendWorkerHasPostgresSecretEnv := not .Values.postgresql.external.url }}
           {{- $backendWorkerExplicitEnvKeys := dict
             "NODE_ENV" true
             "PORT" true
@@ -72,6 +101,8 @@ spec:
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
             "POSTGRES_DB" true
+            "SOUNDSPAN_DATABASE_HOST" true
+            "SOUNDSPAN_DATABASE_PORT" true
             "DATABASE_URL" true
             "REDIS_URL" true
             "REDIS_FLUSH_ON_STARTUP" true
@@ -204,10 +235,16 @@ spec:
                   name: {{ include "soundspan.secretName" . }}
                   key: POSTGRES_DB
             {{- end }}
+            {{- if $backendWorkerBuildDatabaseUrl }}
+            - name: SOUNDSPAN_DATABASE_HOST
+              value: {{ include "soundspan.databaseHost" . | quote }}
+            - name: SOUNDSPAN_DATABASE_PORT
+              value: {{ include "soundspan.databasePort" . | quote }}
+            {{- end }}
             {{- if hasKey $backendWorkerEnv "DATABASE_URL" }}
             - name: DATABASE_URL
               value: {{ index $backendWorkerEnv "DATABASE_URL" | quote }}
-            {{- else }}
+            {{- else if .Values.postgresql.external.url }}
             - name: DATABASE_URL
               value: {{ include "soundspan.databaseUrl" . | quote }}
             {{- end }}

--- a/charts/soundspan/templates/individual/backend.yaml
+++ b/charts/soundspan/templates/individual/backend.yaml
@@ -67,6 +67,22 @@ spec:
         - name: backend
           image: {{ include "soundspan.image" .Values.backend.image | quote }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          {{- $backendEnv := .Values.backend.env | default (dict) }}
+          {{- $backendBuildDatabaseUrl := and (not (hasKey $backendEnv "DATABASE_URL")) (not .Values.postgresql.external.url) }}
+          {{- if $backendBuildDatabaseUrl }}
+          command:
+            - /usr/bin/tini
+            - --
+            - /bin/sh
+            - -c
+          args:
+            - |-
+              {{- include "soundspan.nodeDatabaseUrlStartup" . | nindent 14 }}
+            - soundspan-database-url
+            - /usr/local/bin/docker-entrypoint.sh
+            - node
+            - dist/index.js
+          {{- end }}
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           lifecycle:
@@ -80,8 +96,7 @@ spec:
             - name: http
               containerPort: {{ .Values.backend.port }}
               protocol: TCP
-          {{- $backendEnv := .Values.backend.env | default (dict) }}
-          {{- $backendHasPostgresSecretEnv := or .Values.postgresql.enabled (not .Values.postgresql.external.url) }}
+          {{- $backendHasPostgresSecretEnv := not .Values.postgresql.external.url }}
           {{- $backendExplicitEnvKeys := dict
             "NODE_ENV" true
             "PORT" true
@@ -106,6 +121,8 @@ spec:
             "POSTGRES_USER" true
             "POSTGRES_PASSWORD" true
             "POSTGRES_DB" true
+            "SOUNDSPAN_DATABASE_HOST" true
+            "SOUNDSPAN_DATABASE_PORT" true
             "DATABASE_URL" true
             "REDIS_URL" true
             "REDIS_FLUSH_ON_STARTUP" true
@@ -301,10 +318,16 @@ spec:
                   name: {{ include "soundspan.secretName" . }}
                   key: POSTGRES_DB
             {{- end }}
+            {{- if $backendBuildDatabaseUrl }}
+            - name: SOUNDSPAN_DATABASE_HOST
+              value: {{ include "soundspan.databaseHost" . | quote }}
+            - name: SOUNDSPAN_DATABASE_PORT
+              value: {{ include "soundspan.databasePort" . | quote }}
+            {{- end }}
             {{- if hasKey $backendEnv "DATABASE_URL" }}
             - name: DATABASE_URL
               value: {{ index $backendEnv "DATABASE_URL" | quote }}
-            {{- else }}
+            {{- else if .Values.postgresql.external.url }}
             - name: DATABASE_URL
               value: {{ include "soundspan.databaseUrl" . | quote }}
             {{- end }}

--- a/scripts/aio-postgres-credentials.sh
+++ b/scripts/aio-postgres-credentials.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_postgres_password() {
+    if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+        echo "ERROR: POSTGRES_PASSWORD must not be empty." >&2
+        return 1
+    fi
+}
+
+database_url() {
+    local encoded_password
+
+    require_postgres_password
+    encoded_password=$(
+        node -e 'process.stdout.write(encodeURIComponent(process.env.POSTGRES_PASSWORD))'
+    )
+    printf 'postgresql://soundspan:%s@localhost:5432/soundspan' "$encoded_password"
+}
+
+sync_role() {
+    require_postgres_password
+
+    if ! gosu postgres psql -tAc \
+        "SELECT 1 FROM pg_roles WHERE rolname = 'soundspan'" | grep -q 1; then
+        gosu postgres psql --set ON_ERROR_STOP=1 -c "CREATE USER soundspan"
+    fi
+
+    gosu postgres psql --set ON_ERROR_STOP=1 <<'SQL'
+\getenv postgres_password POSTGRES_PASSWORD
+ALTER USER soundspan WITH PASSWORD :'postgres_password';
+SQL
+}
+
+case "${1:-}" in
+    database-url)
+        database_url
+        ;;
+    sync-role)
+        sync_role
+        ;;
+    *)
+        echo "Usage: $0 {database-url|sync-role}" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/ci/__tests__/aio-postgres-credentials.test.mjs
+++ b/scripts/ci/__tests__/aio-postgres-credentials.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const credentialHelper = path.join(
+    repoRoot,
+    "scripts/aio-postgres-credentials.sh",
+);
+
+test("AIO DATABASE_URL preserves reserved PostgreSQL password characters", () => {
+    const password = "quote' slash/ query? hash# percent% at@ colon: space ";
+    const databaseUrl = execFileSync(credentialHelper, ["database-url"], {
+        encoding: "utf8",
+        env: { ...process.env, POSTGRES_PASSWORD: password },
+    });
+
+    const parsed = new URL(databaseUrl);
+    assert.equal(parsed.protocol, "postgresql:");
+    assert.equal(parsed.username, "soundspan");
+    assert.equal(decodeURIComponent(parsed.password), password);
+    assert.equal(parsed.hostname, "localhost");
+    assert.equal(parsed.port, "5432");
+    assert.equal(parsed.pathname, "/soundspan");
+});
+
+test("AIO role synchronization keeps the password out of SQL and argv", (t) => {
+    const temporaryDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "soundspan-aio-postgres-test-"),
+    );
+    t.after(() => fs.rmSync(temporaryDirectory, { recursive: true }));
+
+    const invocationLog = path.join(temporaryDirectory, "invocations.log");
+    const stdinLog = path.join(temporaryDirectory, "stdin.log");
+    const fakeGosu = path.join(temporaryDirectory, "gosu");
+    fs.writeFileSync(
+        fakeGosu,
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$INVOCATION_LOG"
+if [[ "$*" == *"SELECT 1 FROM pg_roles"* ]]; then
+    exit 0
+fi
+cat >> "$STDIN_LOG"
+`,
+        { mode: 0o700 },
+    );
+
+    const password =
+        "x'; SELECT pg_sleep(99); -- $() `command` \\ newline\nend";
+    const result = spawnSync(credentialHelper, ["sync-role"], {
+        encoding: "utf8",
+        env: {
+            ...process.env,
+            INVOCATION_LOG: invocationLog,
+            PATH: `${temporaryDirectory}:${process.env.PATH}`,
+            POSTGRES_PASSWORD: password,
+            STDIN_LOG: stdinLog,
+        },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const invocations = fs.readFileSync(invocationLog, "utf8");
+    const sql = fs.readFileSync(stdinLog, "utf8");
+    assert.doesNotMatch(invocations, /pg_sleep|command|newline/);
+    assert.doesNotMatch(sql, /pg_sleep|command|newline/);
+    assert.match(sql, /\\getenv postgres_password POSTGRES_PASSWORD/);
+    assert.match(sql, /PASSWORD :'postgres_password'/);
+});
+
+test("AIO credential operations fail closed without a password", () => {
+    const operations = ["database-url", "sync-role"];
+    for (let index = 0; index < 2; index += 1) {
+        const operation = operations[index];
+        const result = spawnSync(credentialHelper, [operation], {
+            encoding: "utf8",
+            env: { ...process.env, POSTGRES_PASSWORD: "" },
+        });
+
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /POSTGRES_PASSWORD must not be empty/);
+    }
+});

--- a/scripts/ci/__tests__/helm-database-url-check.test.mjs
+++ b/scripts/ci/__tests__/helm-database-url-check.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const checker = path.join(repoRoot, "scripts/ci/helm-database-url-check.mjs");
+const MAX_SCRIPT_LINES = 32;
+const postgresEnv = {
+    POSTGRES_DB: "soundspan",
+    POSTGRES_PASSWORD: "p@ss:w/rd",
+    POSTGRES_USER: "user@tenant",
+};
+
+function deployment(name, startupScript) {
+    const lines = startupScript.split("\n");
+    assert.ok(lines.length <= MAX_SCRIPT_LINES);
+    const indentedLines = [];
+    for (let index = 0; index < MAX_SCRIPT_LINES; index += 1) {
+        if (index >= lines.length) break;
+        indentedLines.push(`              ${lines[index]}`);
+    }
+    const indentedScript = indentedLines.join("\n");
+    return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+spec:
+  template:
+    spec:
+      containers:
+        - name: ${name}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |-
+${indentedScript}
+            - soundspan-database-url
+            - node
+            - -e
+            - process.stdout.write(process.env.DATABASE_URL)
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: soundspan
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: soundspan
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: soundspan
+                  key: POSTGRES_DB
+            - name: SOUNDSPAN_DATABASE_HOST
+              value: "soundspan-postgresql"
+            - name: SOUNDSPAN_DATABASE_PORT
+              value: "5432"
+`;
+}
+
+function writeManifest(t, contents) {
+    const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "soundspan-helm-database-url-test-"),
+    );
+    t.after(() => fs.rmSync(directory, { recursive: true }));
+    const manifest = path.join(directory, "manifest.yaml");
+    fs.writeFileSync(manifest, contents);
+    return manifest;
+}
+
+function runChecker(args, env = {}) {
+    return spawnSync(process.execPath, [checker, ...args], {
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+    });
+}
+
+test("component mode executes rendered Node and Python URL builders", (t) => {
+    const nodeScript = `# soundspan-database-url-start
+export DATABASE_URL="$(node -e 'const env = process.env; process.stdout.write("postgresql://" + encodeURIComponent(env.POSTGRES_USER) + ":" + encodeURIComponent(env.POSTGRES_PASSWORD) + "@" + env.SOUNDSPAN_DATABASE_HOST + ":" + env.SOUNDSPAN_DATABASE_PORT + "/" + env.POSTGRES_DB)')"
+# soundspan-database-url-end
+exec "$@"`;
+    const pythonScript = `# soundspan-database-url-start
+export DATABASE_URL="$(python3 -c 'import os; from urllib.parse import quote; env = os.environ; print("postgresql://{}:{}@{}:{}/{}".format(quote(env["POSTGRES_USER"], safe=""), quote(env["POSTGRES_PASSWORD"], safe=""), env["SOUNDSPAN_DATABASE_HOST"], env["SOUNDSPAN_DATABASE_PORT"], env["POSTGRES_DB"]), end="")')"
+# soundspan-database-url-end
+exec "$@"`;
+    const manifest = writeManifest(
+        t,
+        `${deployment("soundspan-backend", nodeScript)}---\n${deployment("soundspan-audio-analyzer", pythonScript)}`,
+    );
+
+    const result = runChecker(
+        [
+            "component",
+            manifest,
+            "soundspan-backend",
+            "soundspan-audio-analyzer",
+        ],
+        postgresEnv,
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+});
+
+test("component mode rejects a rendered builder that leaves reserved characters raw", (t) => {
+    const unsafeScript = `# soundspan-database-url-start
+export DATABASE_URL="postgresql://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@\${SOUNDSPAN_DATABASE_HOST}:\${SOUNDSPAN_DATABASE_PORT}/\${POSTGRES_DB}"
+# soundspan-database-url-end
+exec "$@"`;
+    const manifest = writeManifest(
+        t,
+        deployment("soundspan-backend", unsafeScript),
+    );
+
+    const result = runChecker(
+        ["component", manifest, "soundspan-backend"],
+        postgresEnv,
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /percent-encoded DATABASE_URL/);
+});
+
+test("external mode requires the supplied DATABASE_URL verbatim", (t) => {
+    const externalUrl =
+        "postgresql://external-user:literal%2Fpass@database.example.com:5432/soundspan?sslmode=require";
+    const manifest = writeManifest(
+        t,
+        `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: soundspan-backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          env:
+            - name: DATABASE_URL
+              value: "${externalUrl}"
+`,
+    );
+
+    const result = runChecker(["external", manifest, "soundspan-backend"], {
+        EXPECTED_DATABASE_URL: externalUrl,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+});
+
+test("external mode rejects a rendered startup builder", (t) => {
+    const externalUrl =
+        "postgresql://external-user:literal%2Fpass@database.example.com:5432/soundspan";
+    const rebuiltScript = `# soundspan-database-url-start
+export DATABASE_URL="postgresql://rebuilt.invalid/soundspan"
+# soundspan-database-url-end
+exec "$@"`;
+    const manifest = writeManifest(
+        t,
+        deployment("soundspan-backend", rebuiltScript),
+    );
+
+    const result = runChecker(["external", manifest, "soundspan-backend"], {
+        EXPECTED_DATABASE_URL: externalUrl,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /rebuilt the external DATABASE_URL/);
+});

--- a/scripts/ci/helm-database-url-check.mjs
+++ b/scripts/ci/helm-database-url-check.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const MAX_DOCUMENTS = 128;
+const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
+const MAX_MANIFEST_LINES = 65_536;
+const MAX_SCRIPT_LINES = 32;
+const POSTGRES_KEYS = ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"];
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readManifest(manifestFile) {
+    const manifest = readFileSync(manifestFile, "utf8");
+    if (manifest.length === 0) fail("rendered manifest is empty");
+    if (Buffer.byteLength(manifest) > MAX_MANIFEST_BYTES) {
+        fail("rendered manifest exceeds size limit");
+    }
+    return manifest;
+}
+
+function findDeployment(manifest, deploymentName) {
+    const documents = manifest.split(/^---\s*$/m);
+    if (documents.length > MAX_DOCUMENTS) fail("render has too many documents");
+    for (let index = 0; index < MAX_DOCUMENTS; index += 1) {
+        if (index >= documents.length) break;
+        const document = documents[index];
+        if (!/^kind:\s*Deployment\s*$/m.test(document)) continue;
+        const name = document.match(
+            /^metadata:\s*\n  name:\s*([^\s]+)\s*$/m,
+        )?.[1];
+        if (name === deploymentName) return document;
+    }
+    fail(`Deployment ${deploymentName} is missing`);
+}
+
+function extractEnvScalar(document, key) {
+    const escapedKey = escapeRegExp(key);
+    const match = document.match(
+        new RegExp(
+            `^\\s*- name: ${escapedKey}\\s*\\n\\s+value: ("(?:\\\\.|[^"\\\\])*")\\s*$`,
+            "m",
+        ),
+    );
+    if (match === null) fail(`${key} scalar env value is missing`);
+    return JSON.parse(match[1]);
+}
+
+function assertPostgresSecretRefs(document) {
+    for (let index = 0; index < 3; index += 1) {
+        const key = POSTGRES_KEYS[index];
+        const pattern = new RegExp(
+            `^\\s*- name: ${key}\\s*\\n\\s+valueFrom:\\s*\\n\\s+secretKeyRef:`,
+            "m",
+        );
+        if (!pattern.test(document)) fail(`${key} secretKeyRef is missing`);
+    }
+}
+
+function extractStartupScript(document) {
+    const lines = document.split("\n");
+    if (lines.length > MAX_MANIFEST_LINES)
+        fail("Deployment has too many lines");
+    let start = -1;
+    const collected = [];
+    for (let index = 0; index < MAX_MANIFEST_LINES; index += 1) {
+        if (index >= lines.length) break;
+        if (lines[index].trim() === "# soundspan-database-url-start") {
+            start = index;
+            break;
+        }
+    }
+    if (start < 0) fail("DATABASE_URL startup builder is missing");
+    const indentation = lines[start].match(/^\s*/)?.[0].length ?? 0;
+    for (let offset = 0; offset < MAX_SCRIPT_LINES; offset += 1) {
+        const line = lines[start + offset];
+        if (line === undefined) break;
+        collected.push(line.slice(indentation));
+        if (line.trim() === 'exec "$@"') return collected.join("\n");
+    }
+    fail("DATABASE_URL startup builder is incomplete or too long");
+}
+
+function expectedComponentUrl(env, host, port) {
+    for (let index = 0; index < 3; index += 1) {
+        const key = POSTGRES_KEYS[index];
+        if (env[key] === undefined || env[key] === "")
+            fail(`${key} is required`);
+    }
+    return (
+        `postgresql://${encodeURIComponent(env.POSTGRES_USER)}:` +
+        `${encodeURIComponent(env.POSTGRES_PASSWORD)}@${host}:${port}/` +
+        env.POSTGRES_DB
+    );
+}
+
+function executeStartupScript(script, env) {
+    try {
+        return execFileSync(
+            "/bin/sh",
+            [
+                "-c",
+                script,
+                "soundspan-database-url-check",
+                process.execPath,
+                "-e",
+                "process.stdout.write(process.env.DATABASE_URL)",
+            ],
+            { encoding: "utf8", env, timeout: 5_000, maxBuffer: 16_384 },
+        );
+    } catch {
+        fail("DATABASE_URL startup builder execution failed");
+    }
+}
+
+function assertComponentDeployment(manifest, deploymentName) {
+    const document = findDeployment(manifest, deploymentName);
+    assertPostgresSecretRefs(document);
+    if (/^\s*- name: DATABASE_URL\s*$/m.test(document)) {
+        fail(`${deploymentName} must construct DATABASE_URL at startup`);
+    }
+    const host = extractEnvScalar(document, "SOUNDSPAN_DATABASE_HOST");
+    const port = extractEnvScalar(document, "SOUNDSPAN_DATABASE_PORT");
+    const env = {
+        ...process.env,
+        SOUNDSPAN_DATABASE_HOST: host,
+        SOUNDSPAN_DATABASE_PORT: port,
+    };
+    const actual = executeStartupScript(extractStartupScript(document), env);
+    if (actual !== expectedComponentUrl(env, host, port)) {
+        fail(
+            `${deploymentName} did not construct a percent-encoded DATABASE_URL`,
+        );
+    }
+}
+
+function assertExternalDeployment(manifest, deploymentName, expectedUrl) {
+    const document = findDeployment(manifest, deploymentName);
+    if (/# soundspan-database-url-start/.test(document)) {
+        fail(`${deploymentName} rebuilt the external DATABASE_URL`);
+    }
+    if (/^\s*- name: POSTGRES_(?:USER|PASSWORD|DB)\s*$/m.test(document)) {
+        fail(`${deploymentName} rendered POSTGRES_* env with an external URL`);
+    }
+    if (extractEnvScalar(document, "DATABASE_URL") !== expectedUrl) {
+        fail(`${deploymentName} changed the external DATABASE_URL`);
+    }
+}
+
+function main(args) {
+    if (args.length < 3 || !["component", "external"].includes(args[0])) {
+        fail(
+            `usage: ${process.argv[1]} {component|external} <manifest> <deployment>...`,
+        );
+    }
+    const [mode, manifestFile, ...deploymentNames] = args;
+    const manifest = readManifest(manifestFile);
+    if (mode === "component") {
+        for (let index = 0; index < MAX_DOCUMENTS; index += 1) {
+            if (index >= deploymentNames.length) return;
+            assertComponentDeployment(manifest, deploymentNames[index]);
+        }
+        fail("too many component deployments");
+    }
+    const expectedUrl = process.env.EXPECTED_DATABASE_URL;
+    if (expectedUrl === undefined) fail("EXPECTED_DATABASE_URL is required");
+    for (let index = 0; index < MAX_DOCUMENTS; index += 1) {
+        if (index >= deploymentNames.length) return;
+        assertExternalDeployment(manifest, deploymentNames[index], expectedUrl);
+    }
+    fail("too many external deployments");
+}
+
+try {
+    main(process.argv.slice(2));
+} catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 255;
+}

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -34,6 +34,18 @@ assert_service_selectors_isolated() {
   fi
 }
 
+assert_database_urls() {
+  local mode="$1"
+  local manifest_file="$2"
+  shift 2
+  local checker="${BASH_SOURCE[0]%/*}/ci/helm-database-url-check.mjs"
+
+  if ! node "$checker" "$mode" "$manifest_file" "$@"; then
+    echo "[ERROR] DATABASE_URL check failed (${mode})" >&2
+    exit 1
+  fi
+}
+
 assert_deployment_image() {
   local render_name="$1"
   local manifest_file="$2"
@@ -58,6 +70,7 @@ tmp_aio_rotated_secrets="$(mktemp)"
 tmp_aio_secret_overrides="$(mktemp)"
 tmp_aio_digests="$(mktemp)"
 tmp_individual_ha="$(mktemp)"
+tmp_individual_component_database="$(mktemp)"
 tmp_individual_external_database="$(mktemp)"
 tmp_individual_digests="$(mktemp)"
 tmp_global_env="$(mktemp)"
@@ -66,7 +79,7 @@ tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_digests" "$tmp_individual_ha" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_digests" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -182,29 +195,49 @@ if ! perl -0777 -ne 'exit((/name:\s+LISTEN_TOGETHER_STATE_STORE_ENABLED\s+value:
 fi
 assert_service_selectors_isolated "HA individual" "$tmp_individual_ha"
 
-echo "[CHECK] render analyzers with external DATABASE_URL and core-only existing Secret"
+echo "[CHECK] construct component DATABASE_URL values with percent-encoded credentials"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
   --set deploymentMode=individual \
-  --set postgresql.enabled=false \
-  --set postgresql.external.url='postgresql://external-user:external-password@database.example.com:5432/soundspan?sslmode=require' \
+  --set-string secrets.postgresUser='user@tenant' \
+  --set-string secrets.postgresPassword='p@ss:w/rd' \
+  --set backendWorker.enabled=true \
+  --set audioAnalyzer.enabled=true \
+  --set audioAnalyzerClap.enabled=true \
+  >"$tmp_individual_component_database"
+
+if ! line_match '^  POSTGRES_PASSWORD: "p@ss:w/rd"$' "$tmp_individual_component_database"; then
+  echo "[ERROR] component database render did not preserve the reserved-character Secret value" >&2
+  exit 1
+fi
+POSTGRES_USER='user@tenant' \
+  POSTGRES_PASSWORD='p@ss:w/rd' \
+  POSTGRES_DB='soundspan' \
+  assert_database_urls \
+  component \
+  "$tmp_individual_component_database" \
+  "${RELEASE_NAME}-backend" \
+  "${RELEASE_NAME}-backend-worker" \
+  "${RELEASE_NAME}-audio-analyzer" \
+  "${RELEASE_NAME}-audio-analyzer-clap"
+
+echo "[CHECK] preserve external DATABASE_URL across individual workloads"
+external_database_url='postgresql://external-user:literal%2Fpassword@database.example.com:5432/soundspan?sslmode=require'
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  --set-string postgresql.external.url="$external_database_url" \
   --set secrets.existingSecret=core-only-secret \
+  --set backendWorker.enabled=true \
   --set audioAnalyzer.enabled=true \
   --set audioAnalyzerClap.enabled=true \
   >"$tmp_individual_external_database"
 
-for analyzer in audio-analyzer audio-analyzer-clap; do
-  if ! perl -0777 -ne '
-      for my $doc (split /^---/m, $_) {
-          next unless $doc =~ /kind:\s*Deployment/;
-          next unless $doc =~ /^  name: '"$RELEASE_NAME"'-'"$analyzer"'$/m;
-          next if $doc =~ /name:\s+POSTGRES_(?:USER|PASSWORD|DB)\b/;
-          exit 0 if $doc =~ /name:\s+DATABASE_URL\s+value:\s+"postgresql:\/\/external-user:external-password\@database\.example\.com:5432\/soundspan\?sslmode=require"/s;
-      }
-      exit 1' "$tmp_individual_external_database"; then
-    echo "[ERROR] ${analyzer} must use external DATABASE_URL without POSTGRES_* secret refs" >&2
-    exit 1
-  fi
-done
+EXPECTED_DATABASE_URL="$external_database_url" assert_database_urls \
+  external \
+  "$tmp_individual_external_database" \
+  "${RELEASE_NAME}-backend" \
+  "${RELEASE_NAME}-backend-worker" \
+  "${RELEASE_NAME}-audio-analyzer" \
+  "${RELEASE_NAME}-audio-analyzer-clap"
 
 digest_aio="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 digest_backend="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"


### PR DESCRIPTION
Convergence sweep #20 remediation (N15) across `charts/soundspan/**`, `Dockerfile`, and `scripts/`.

The chart interpolated **raw** `POSTGRES_USER/PASSWORD/DB` into `DATABASE_URL` (valid special characters → invalid/misparsed URI), and AIO startup embedded `POSTGRES_PASSWORD` **directly in SQL string literals** (a quote could break or alter initialization — SQL injection).

Fix
- **AIO**: `aio-postgres-credentials.sh` percent-encodes the password for the URL and synchronizes the role via `psql \getenv` + a safely quoted `:'postgres_password'` SQL variable instead of string interpolation.
- **Individual mode**: a shared startup URL builder (Node for backend/worker, Python for analyzers) percent-encodes username+password at container start; backend, worker, audio-analyzer, and CLAP wrap their command to construct `DATABASE_URL`. An explicit workload URL or complete `postgresql.external.url` bypasses rebuilding (preserves #358).
- **Render check** (`helm-database-url-check.mjs`): reserved-character credentials (`user@tenant`, `p@ss:w/rd`) round-trip into a correctly percent-encoded `DATABASE_URL` across all four workloads; unsafe builders rejected; verbatim external URLs untouched.

Verification: `npm run verify:helm` exit 0 (lint + all render checks); `node --test` 13/13 (URL round-trip, SQL-injection resistance, missing-password failure); `bash -n` + prettier + `git diff --check` clean. No CHANGELOG edit (consolidated docs PR follows).