### PR TITLE
fix(reliability): bound Soulseek UI search admission + session capacity (sweep #20 N16)

### DIFF
--- a/backend/src/routes/__tests__/soulseekRuntime.test.ts
+++ b/backend/src/routes/__tests__/soulseekRuntime.test.ts
@@ -6,12 +6,17 @@ jest.mock("../../middleware/auth", () => ({
 }));
 
 jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
+    logger: (() => {
+        const mockLogger = {
+            child: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+        mockLogger.child.mockReturnValue(mockLogger);
+        return mockLogger;
+    })(),
 }));
 
 jest.mock("../../services/soulseek", () => ({
@@ -70,6 +75,7 @@ function getLastHandler(path: string, method: HttpMethod) {
 }
 
 function createRes() {
+    const headers = new Map<string, string>();
     const res: any = {
         statusCode: 200,
         body: undefined as unknown,
@@ -81,14 +87,45 @@ function createRes() {
             res.body = payload;
             return res;
         }),
+        setHeader: jest.fn(function (name: string, value: string) {
+            headers.set(name.toLowerCase(), value);
+            return res;
+        }),
+        getHeader: jest.fn((name: string) => headers.get(name.toLowerCase())),
     };
 
     return res;
 }
 
 async function flushPromises() {
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let turn = 0; turn < 8; turn += 1) {
+        await Promise.resolve();
+    }
+}
+
+const emptySearchResult = {
+    found: false,
+    bestMatch: null,
+    allMatches: [],
+};
+
+async function finishPendingSearches(
+    pending: Array<(result: typeof emptySearchResult) => void>,
+    total: number,
+) {
+    let resolved = 0;
+    for (let round = 0; round < total && resolved < total; round += 1) {
+        const available = pending.length;
+        for (
+            let pendingIndex = resolved;
+            pendingIndex < available;
+            pendingIndex += 1
+        ) {
+            pending[pendingIndex](emptySearchResult);
+        }
+        resolved = available;
+        await flushPromises();
+    }
 }
 
 describe("soulseek runtime routes", () => {
@@ -102,6 +139,7 @@ describe("soulseek runtime routes", () => {
         .stack[1].handle;
 
     beforeEach(() => {
+        jest.advanceTimersByTime(6 * 60 * 1000);
         jest.clearAllMocks();
 
         mockRandomUUID.mockReturnValue("search-default-id");
@@ -126,6 +164,10 @@ describe("soulseek runtime routes", () => {
         mockGetSystemSettings.mockResolvedValue({
             musicPath: "/music",
         });
+    });
+
+    afterEach(async () => {
+        await flushPromises();
     });
 
     afterAll(() => {
@@ -244,7 +286,10 @@ describe("soulseek runtime routes", () => {
         });
 
         mockRandomUUID.mockReturnValueOnce("search-query-id");
-        const queryReq = { body: { query: "Daft Punk" } } as any;
+        const queryReq = {
+            user: { id: "user-query" },
+            body: { query: "Daft Punk" },
+        } as any;
         const queryRes = createRes();
         await searchHandler(queryReq, queryRes);
 
@@ -256,10 +301,15 @@ describe("soulseek runtime routes", () => {
         expect(mockSoulseekService.searchTrack).toHaveBeenCalledWith(
             "Daft Punk",
             "",
+            false,
+            15000,
         );
 
         mockRandomUUID.mockReturnValueOnce("search-track-id");
-        const trackReq = { body: { artist: "Artist", title: "Track" } } as any;
+        const trackReq = {
+            user: { id: "user-track" },
+            body: { artist: "Artist", title: "Track" },
+        } as any;
         const trackRes = createRes();
         await searchHandler(trackReq, trackRes);
 
@@ -271,6 +321,8 @@ describe("soulseek runtime routes", () => {
         expect(mockSoulseekService.searchTrack).toHaveBeenCalledWith(
             "Artist Track",
             "",
+            false,
+            15000,
         );
     });
 
@@ -283,6 +335,15 @@ describe("soulseek runtime routes", () => {
         expect(res.body).toEqual({
             error: "Either 'query' or both 'artist' and 'title' are required",
         });
+    });
+
+    it("rejects a search when authenticated user context is unavailable", async () => {
+        const res = createRes();
+        await searchHandler({ body: { query: "valid query" } } as any, res);
+
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({ error: "Not authenticated" });
+        expect(mockSoulseekService.searchTrack).not.toHaveBeenCalled();
     });
 
     it("returns formatted search results and 404 when search session is missing", async () => {
@@ -304,7 +365,10 @@ describe("soulseek runtime routes", () => {
             ],
         });
 
-        const searchReq = { body: { query: "Artist Name My Song" } } as any;
+        const searchReq = {
+            user: { id: "user-results" },
+            body: { query: "Artist Name My Song" },
+        } as any;
         const searchRes = createRes();
         await searchHandler(searchReq, searchRes);
         await flushPromises();
@@ -363,7 +427,10 @@ describe("soulseek runtime routes", () => {
             ],
         } as any);
 
-        const searchReq = { body: { query: "bad file" } } as any;
+        const searchReq = {
+            user: { id: "user-bad-file" },
+            body: { query: "bad file" },
+        } as any;
         const searchRes = createRes();
         await searchHandler(searchReq, searchRes);
         await flushPromises();
@@ -387,7 +454,10 @@ describe("soulseek runtime routes", () => {
             new Error("search exploded"),
         );
 
-        const req = { body: { query: "broken query" } } as any;
+        const req = {
+            user: { id: "user-reject" },
+            body: { query: "broken query" },
+        } as any;
         const res = createRes();
         await searchHandler(req, res);
         await flushPromises();
@@ -397,9 +467,282 @@ describe("soulseek runtime routes", () => {
             searchId: "search-reject-id",
             message: "Search started",
         });
+        expect(mockLogger.error).toHaveBeenCalledWith("UI search failed", {
+            error: expect.any(Error),
+            searchId: "search-reject-id",
+            userId: "user-reject",
+        });
+    });
+
+    it("sanitizes synchronous search admission failures", async () => {
+        const failure = new Error("private admission detail");
+        mockRandomUUID.mockImplementationOnce(() => {
+            throw failure;
+        });
+        const res = createRes();
+
+        await searchHandler(
+            {
+                user: { id: "admission-failure-user" },
+                body: { query: "valid query" },
+            } as any,
+            res,
+        );
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Search failed" });
+        expect(JSON.stringify(res.body)).not.toContain(failure.message);
         expect(mockLogger.error).toHaveBeenCalledWith(
-            "[Soulseek] Search search-reject-id failed:",
-            "search exploded",
+            "UI search admission failed",
+            {
+                error: failure,
+            },
+        );
+    });
+
+    it("bounds global search concurrency and rejects work beyond the queue capacity", async () => {
+        const pending: Array<(result: typeof emptySearchResult) => void> = [];
+        mockSoulseekService.searchTrack.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    pending.push(resolve);
+                }),
+        );
+        mockRandomUUID.mockImplementation(
+            () => `global-search-${mockRandomUUID.mock.calls.length}`,
+        );
+
+        for (let index = 0; index < 24; index += 1) {
+            const res = createRes();
+            await searchHandler(
+                {
+                    user: { id: `global-user-${index}` },
+                    body: { query: `query ${index}` },
+                } as any,
+                res,
+            );
+            expect(res.statusCode).toBe(200);
+        }
+
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(4);
+
+        const overloadedRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "global-overload-user" },
+                body: { query: "overloaded query" },
+            } as any,
+            overloadedRes,
+        );
+
+        expect(overloadedRes.statusCode).toBe(503);
+        expect(overloadedRes.body).toEqual({
+            error: "Soulseek search capacity is full. Please try again later.",
+        });
+        expect(overloadedRes.getHeader("Retry-After")).toBe("15");
+
+        await finishPendingSearches(pending, 24);
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(24);
+    });
+
+    it("enforces per-user concurrency and queue fairness", async () => {
+        const pending: Array<(result: typeof emptySearchResult) => void> = [];
+        mockSoulseekService.searchTrack.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    pending.push(resolve);
+                }),
+        );
+        mockRandomUUID.mockImplementation(
+            () => `user-search-${mockRandomUUID.mock.calls.length}`,
+        );
+
+        for (let index = 0; index < 6; index += 1) {
+            const res = createRes();
+            await searchHandler(
+                {
+                    user: { id: "busy-user" },
+                    body: { query: `busy query ${index}` },
+                } as any,
+                res,
+            );
+            expect(res.statusCode).toBe(200);
+        }
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(2);
+
+        const busyUserRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "busy-user" },
+                body: { query: "one too many" },
+            } as any,
+            busyUserRes,
+        );
+        expect(busyUserRes.statusCode).toBe(503);
+
+        const otherUserRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "other-user" },
+                body: { query: "fair query" },
+            } as any,
+            otherUserRes,
+        );
+        expect(otherUserRes.statusCode).toBe(200);
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(3);
+
+        await finishPendingSearches(pending, 7);
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(7);
+    });
+
+    it("rate limits repeated searches per user and provides retry guidance", async () => {
+        mockRandomUUID.mockImplementation(
+            () => `rate-search-${mockRandomUUID.mock.calls.length}`,
+        );
+
+        for (let index = 0; index < 10; index += 1) {
+            const res = createRes();
+            await searchHandler(
+                {
+                    user: { id: "rate-user" },
+                    body: { query: `rate query ${index}` },
+                } as any,
+                res,
+            );
+            await flushPromises();
+            expect(res.statusCode).toBe(200);
+        }
+
+        const limitedRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "rate-user" },
+                body: { query: "rate query rejected" },
+            } as any,
+            limitedRes,
+        );
+
+        expect(limitedRes.statusCode).toBe(429);
+        expect(limitedRes.body).toEqual({
+            error: "Too many Soulseek searches. Please try again later.",
+        });
+        expect(limitedRes.getHeader("Retry-After")).toBe("60");
+
+        jest.advanceTimersByTime(60 * 1000);
+        const retryRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "rate-user" },
+                body: { query: "rate query accepted later" },
+            } as any,
+            retryRes,
+        );
+        expect(retryRes.statusCode).toBe(200);
+        await flushPromises();
+    });
+
+    it("rate limits aggregate searches across users", async () => {
+        mockRandomUUID.mockImplementation(
+            () => `aggregate-search-${mockRandomUUID.mock.calls.length}`,
+        );
+
+        for (let index = 0; index < 60; index += 1) {
+            const res = createRes();
+            await searchHandler(
+                {
+                    user: { id: `aggregate-user-${index}` },
+                    body: { query: `aggregate query ${index}` },
+                } as any,
+                res,
+            );
+            await flushPromises();
+            expect(res.statusCode).toBe(200);
+        }
+
+        const limitedRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "aggregate-limited-user" },
+                body: { query: "aggregate rejected" },
+            } as any,
+            limitedRes,
+        );
+        expect(limitedRes.statusCode).toBe(429);
+        expect(mockSoulseekService.searchTrack).toHaveBeenCalledTimes(60);
+    });
+
+    it("evicts the oldest retained session at the hard session cap", async () => {
+        mockRandomUUID.mockImplementation(
+            () => `retained-search-${mockRandomUUID.mock.calls.length}`,
+        );
+
+        for (let index = 0; index < 101; index += 1) {
+            if (index === 50 || index === 100) {
+                jest.advanceTimersByTime(60 * 1000);
+            }
+            const res = createRes();
+            await searchHandler(
+                {
+                    user: { id: `retained-user-${index}` },
+                    body: { query: `retained query ${index}` },
+                } as any,
+                res,
+            );
+            await flushPromises();
+            expect(res.statusCode).toBe(200);
+        }
+
+        const oldestRes = createRes();
+        await searchByIdHandler(
+            { params: { searchId: "retained-search-1" } } as any,
+            oldestRes,
+        );
+        expect(oldestRes.statusCode).toBe(404);
+
+        const newestRes = createRes();
+        await searchByIdHandler(
+            { params: { searchId: "retained-search-101" } } as any,
+            newestRes,
+        );
+        expect(newestRes.statusCode).toBe(200);
+    });
+
+    it("retains at most 100 results for a search session", async () => {
+        mockRandomUUID.mockReturnValueOnce("bounded-results-id");
+        mockSoulseekService.searchTrack.mockResolvedValueOnce({
+            found: true,
+            bestMatch: null,
+            allMatches: Array.from({ length: 101 }, (_, index) => ({
+                username: `peer-${index}`,
+                filename: `${index}.mp3`,
+                fullPath: `/library/Artist/Album/${index}.mp3`,
+                size: index,
+                bitRate: 320,
+                quality: "lossy" as const,
+                score: 1,
+            })),
+        });
+
+        const searchRes = createRes();
+        await searchHandler(
+            {
+                user: { id: "bounded-results-user" },
+                body: { query: "bounded results" },
+            } as any,
+            searchRes,
+        );
+        await flushPromises();
+
+        const resultsRes = createRes();
+        await searchByIdHandler(
+            { params: { searchId: "bounded-results-id" } } as any,
+            resultsRes,
+        );
+
+        expect(resultsRes.statusCode).toBe(200);
+        expect(resultsRes.body.count).toBe(100);
+        expect(resultsRes.body.results[99].path).toBe(
+            "/library/Artist/Album/99.mp3",
         );
     });
 

--- a/backend/src/routes/soulseek.ts
+++ b/backend/src/routes/soulseek.ts
@@ -5,14 +5,31 @@ import { logger } from "../utils/logger";
  * Supports both general searches (for UI) and track-specific searches (for downloads)
  */
 
-import { Router } from "express";
+import { Router, type Response } from "express";
 import { requireAdmin, requireAuth } from "../middleware/auth";
-import { soulseekService, SearchResult } from "../services/soulseek";
+import {
+    soulseekService,
+    SearchResult,
+    SearchTrackResult,
+} from "../services/soulseek";
 import { getSystemSettings } from "../utils/systemSettings";
 import { randomUUID } from "crypto";
 import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
+const searchLog = logger.child("SoulseekUiSearch");
+
+const UI_SEARCH_TIMEOUT_MS = 15_000;
+const SEARCH_RATE_WINDOW_MS = 60_000;
+const MAX_SEARCHES_PER_USER_PER_WINDOW = 10;
+const MAX_GLOBAL_SEARCHES_PER_WINDOW = 60;
+const MAX_CONCURRENT_SEARCHES = 4;
+const MAX_CONCURRENT_SEARCHES_PER_USER = 2;
+const MAX_QUEUED_SEARCHES = 20;
+const MAX_QUEUED_SEARCHES_PER_USER = 4;
+const MAX_SEARCH_SESSIONS = 100;
+const MAX_RESULTS_PER_SESSION = 100;
+const MAX_TRACKED_RATE_USERS = 256;
 
 // In-memory store for search results (with TTL cleanup)
 interface SearchSession {
@@ -21,19 +38,245 @@ interface SearchSession {
     createdAt: Date;
 }
 
+interface SearchJob {
+    searchId: string;
+    query: string;
+    userId: string;
+}
+
+interface RateWindow {
+    count: number;
+    startedAt: number;
+}
+
 const searchSessions = new Map<string, SearchSession>();
+const searchQueue: SearchJob[] = [];
+const activeSearchesByUser = new Map<string, number>();
+const queuedSearchesByUser = new Map<string, number>();
+const userRateWindows = new Map<string, RateWindow>();
+const globalRateWindow: RateWindow = { count: 0, startedAt: Date.now() };
+let activeSearches = 0;
 const SEARCH_SESSION_TTL = 5 * 60 * 1000; // 5 minutes
 
-// Cleanup old search sessions every minute
-const searchSessionCleanupTimer = setInterval(() => {
-    const now = Date.now();
+function cleanupExpiredSearchSessions(now: number): void {
+    let inspected = 0;
     for (const [searchId, session] of searchSessions.entries()) {
+        if (inspected >= MAX_SEARCH_SESSIONS) break;
+        inspected += 1;
         if (now - session.createdAt.getTime() > SEARCH_SESSION_TTL) {
             searchSessions.delete(searchId);
         }
     }
+}
+
+function removeOldestSearchSession(): void {
+    const oldestSearchId = searchSessions.keys().next().value;
+    if (typeof oldestSearchId === "string") {
+        searchSessions.delete(oldestSearchId);
+    }
+}
+
+function storeSearchSession(searchId: string, query: string): void {
+    cleanupExpiredSearchSessions(Date.now());
+    if (searchSessions.size >= MAX_SEARCH_SESSIONS) {
+        removeOldestSearchSession();
+    }
+    searchSessions.set(searchId, {
+        query,
+        results: [],
+        createdAt: new Date(),
+    });
+}
+
+// Cleanup old search sessions every minute
+const searchSessionCleanupTimer = setInterval(() => {
+    cleanupExpiredSearchSessions(Date.now());
 }, 60000);
 searchSessionCleanupTimer.unref?.();
+
+function refreshRateWindow(window: RateWindow, now: number): void {
+    if (now - window.startedAt >= SEARCH_RATE_WINDOW_MS) {
+        window.count = 0;
+        window.startedAt = now;
+    }
+}
+
+function getUserRateWindow(userId: string, now: number): RateWindow {
+    const existing = userRateWindows.get(userId);
+    if (existing) {
+        refreshRateWindow(existing, now);
+        userRateWindows.delete(userId);
+        userRateWindows.set(userId, existing);
+        return existing;
+    }
+    if (userRateWindows.size >= MAX_TRACKED_RATE_USERS) {
+        const oldestUserId = userRateWindows.keys().next().value;
+        if (typeof oldestUserId === "string")
+            userRateWindows.delete(oldestUserId);
+    }
+    const created = { count: 0, startedAt: now };
+    userRateWindows.set(userId, created);
+    return created;
+}
+
+function getRateLimitRetryAfter(userId: string, now: number): number | null {
+    refreshRateWindow(globalRateWindow, now);
+    if (globalRateWindow.count >= MAX_GLOBAL_SEARCHES_PER_WINDOW) {
+        return globalRateWindow.startedAt + SEARCH_RATE_WINDOW_MS - now;
+    }
+    const userWindow = getUserRateWindow(userId, now);
+    if (userWindow.count >= MAX_SEARCHES_PER_USER_PER_WINDOW) {
+        return userWindow.startedAt + SEARCH_RATE_WINDOW_MS - now;
+    }
+    return null;
+}
+
+function recordRateAdmission(userId: string, now: number): void {
+    refreshRateWindow(globalRateWindow, now);
+    globalRateWindow.count += 1;
+    getUserRateWindow(userId, now).count += 1;
+}
+
+function canStartSearch(userId: string): boolean {
+    return (
+        activeSearches < MAX_CONCURRENT_SEARCHES &&
+        (activeSearchesByUser.get(userId) ?? 0) <
+            MAX_CONCURRENT_SEARCHES_PER_USER
+    );
+}
+
+function canQueueSearch(userId: string): boolean {
+    return (
+        searchQueue.length < MAX_QUEUED_SEARCHES &&
+        (queuedSearchesByUser.get(userId) ?? 0) < MAX_QUEUED_SEARCHES_PER_USER
+    );
+}
+
+function changeUserCount(
+    counts: Map<string, number>,
+    userId: string,
+    delta: 1 | -1,
+): void {
+    const next = (counts.get(userId) ?? 0) + delta;
+    if (next <= 0) {
+        counts.delete(userId);
+        return;
+    }
+    counts.set(userId, next);
+}
+
+function enqueueSearch(job: SearchJob): void {
+    searchQueue.push(job);
+    changeUserCount(queuedSearchesByUser, job.userId, 1);
+}
+
+function dequeueSearch(): SearchJob | undefined {
+    const job = searchQueue.shift();
+    if (job) changeUserCount(queuedSearchesByUser, job.userId, -1);
+    return job;
+}
+
+function retainSearchResults(job: SearchJob, result: SearchTrackResult): void {
+    const session = searchSessions.get(job.searchId);
+    if (!session || !result.found || !Array.isArray(result.allMatches)) return;
+    session.results = result.allMatches
+        .slice(0, MAX_RESULTS_PER_SESSION)
+        .map((match) => ({
+            user: match.username,
+            file: match.fullPath,
+            size: match.size,
+            slots: true,
+            bitrate: match.bitRate,
+            speed: 0,
+        }));
+    searchLog.debug("UI search completed", {
+        resultCount: session.results.length,
+        searchId: job.searchId,
+        userId: job.userId,
+    });
+}
+
+async function runSearch(job: SearchJob): Promise<void> {
+    try {
+        const result = await soulseekService.searchTrack(
+            job.query,
+            "",
+            false,
+            UI_SEARCH_TIMEOUT_MS,
+        );
+        retainSearchResults(job, result);
+    } catch (error) {
+        searchLog.error("UI search failed", {
+            error,
+            searchId: job.searchId,
+            userId: job.userId,
+        });
+    } finally {
+        finishSearch(job);
+    }
+}
+
+function startSearch(job: SearchJob): void {
+    activeSearches += 1;
+    changeUserCount(activeSearchesByUser, job.userId, 1);
+    void runSearch(job).catch((error) => {
+        searchLog.error("UI search supervisor failed", {
+            error,
+            searchId: job.searchId,
+            userId: job.userId,
+        });
+    });
+}
+
+function drainSearchQueue(): void {
+    const jobsToInspect = Math.min(searchQueue.length, MAX_QUEUED_SEARCHES);
+    for (let index = 0; index < jobsToInspect; index += 1) {
+        if (activeSearches >= MAX_CONCURRENT_SEARCHES) break;
+        const job = dequeueSearch();
+        if (!job) break;
+        if (!searchSessions.has(job.searchId)) continue;
+        if (!canStartSearch(job.userId)) {
+            enqueueSearch(job);
+            continue;
+        }
+        startSearch(job);
+    }
+}
+
+function finishSearch(job: SearchJob): void {
+    activeSearches = Math.max(0, activeSearches - 1);
+    changeUserCount(activeSearchesByUser, job.userId, -1);
+    drainSearchQueue();
+}
+
+function admitSearch(job: SearchJob): boolean {
+    if (canStartSearch(job.userId)) {
+        startSearch(job);
+        return true;
+    }
+    if (!canQueueSearch(job.userId)) return false;
+    enqueueSearch(job);
+    return true;
+}
+
+function sendRateLimitError(res: Response, retryAfterMs: number): Response {
+    const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+    res.setHeader("Retry-After", String(retryAfterSeconds));
+    return sendRouteError(
+        res,
+        429,
+        "Too many Soulseek searches. Please try again later.",
+    );
+}
+
+function sendCapacityError(res: Response): Response {
+    res.setHeader("Retry-After", String(UI_SEARCH_TIMEOUT_MS / 1000));
+    return sendRouteError(
+        res,
+        503,
+        "Soulseek search capacity is full. Please try again later.",
+    );
+}
 
 // Middleware to check if Soulseek credentials are configured
 async function requireSoulseekConfigured(req: any, res: any, next: any) {
@@ -165,13 +408,17 @@ router.post(
  *                 description: Track title (used with artist for track-specific search)
  *     responses:
  *       200:
- *         description: Search started; returns searchId for polling results
+ *         description: Search accepted; returns searchId for polling results
  *       400:
  *         description: Missing query or artist/title parameters
  *       401:
  *         description: Not authenticated
  *       403:
  *         description: Soulseek credentials not configured
+ *       429:
+ *         description: Per-user or global search rate limit exceeded
+ *       503:
+ *         description: Search concurrency queue is at capacity
  */
 /**
  * POST /soulseek/search
@@ -201,62 +448,40 @@ router.post(
                 });
             }
 
-            logger.debug(
-                `[Soulseek] Starting general search: "${searchQuery}"`,
-            );
+            const userId = req.user?.id;
+            if (!userId) {
+                return sendRouteError(res, 401, "Not authenticated");
+            }
 
-            // Create search session
-            const searchId = randomUUID();
-            searchSessions.set(searchId, {
-                query: searchQuery,
-                results: [],
-                createdAt: new Date(),
-            });
+            const now = Date.now();
+            const retryAfterMs = getRateLimitRetryAfter(userId, now);
+            if (retryAfterMs !== null) {
+                searchLog.warn("UI search rate limit exceeded", { userId });
+                return sendRateLimitError(res, retryAfterMs);
+            }
 
-            // Start async search (don't await - results come in over time)
-            // Use full 45s timeout for quality results from P2P network
-            soulseekService
-                .searchTrack(searchQuery, "")
-                .then((result) => {
-                    const session = searchSessions.get(searchId);
-                    if (session && result.found && result.allMatches) {
-                        logger.debug(
-                            `[Soulseek] Search ${searchId} found ${result.allMatches.length} matches`,
-                        );
-                        // Store all matches for polling
-                        session.results = result.allMatches.map((match) => ({
-                            user: match.username,
-                            file: match.fullPath,
-                            size: match.size,
-                            slots: true, // Assume available since ranked
-                            bitrate: match.bitRate,
-                            speed: 0,
-                        }));
-                        logger.debug(
-                            `[Soulseek] Search ${searchId} session updated with ${session.results.length} results`,
-                        );
-                    } else {
-                        logger.debug(
-                            `[Soulseek] Search ${searchId} completed with no matches (found: ${result.found})`,
-                        );
-                    }
-                })
-                .catch((err) => {
-                    logger.error(
-                        `[Soulseek] Search ${searchId} failed:`,
-                        err.message,
-                    );
-                });
+            const job = { searchId: randomUUID(), query: searchQuery, userId };
+            if (!canStartSearch(userId) && !canQueueSearch(userId)) {
+                searchLog.warn("UI search capacity exhausted", { userId });
+                return sendCapacityError(res);
+            }
+
+            storeSearchSession(job.searchId, searchQuery);
+            recordRateAdmission(userId, now);
+            if (!admitSearch(job)) {
+                searchSessions.delete(job.searchId);
+                return sendCapacityError(res);
+            }
 
             res.json({
-                searchId,
+                searchId: job.searchId,
                 message: "Search started",
             });
-        } catch (error: any) {
-            logger.error("Soulseek search error:", error.message);
-            res.status(500).json({
-                error: "Search failed",
+        } catch (error) {
+            searchLog.error("UI search admission failed", {
+                error,
             });
+            return sendRouteError(res, 500, "Search failed");
         }
     },
 );


### PR DESCRIPTION
Convergence sweep #20 remediation (N16), the final slice of the wave, in `backend/src/routes/soulseek.ts`.

Every authenticated `/soulseek` search request started an independent fire-and-forget 45-second P2P search and inserted a session into an **unbounded** process-global map — no per-user/global concurrency, queue, or session bound. Thousands of simultaneous searches and retained result sets could accumulate.

Fix
- Per-user (10/min, 2 concurrent, 4 queued) and global (60/min, 4 concurrent, 20 queued) rate + concurrency limits with a bounded queue that rejects on overload (`429`) and refuses new work when saturated (`503`).
- Documented shorter **15s** UI search timeout.
- Hard caps on tracked sessions (100) and retained results per session (100); bounded rate-user table.
- Errors stay sanitized (raw detail server-log-only); OpenAPI updated for 429/503.

Verification: targeted jest 22/22 (auth, concurrency, fairness, queue overload, rate limits, timeout, retention bounds, fault sanitization); `tsc --noEmit` clean; route-error canon + leak ratchets green; prettier clean. No CHANGELOG edit (consolidated docs PR follows).