### PR TITLE
fix(security): require admin for analysis + Lidarr cleanup, reject expired Subsonic keys

### DIFF
--- a/backend/src/middleware/__tests__/subsonicAuth.test.ts
+++ b/backend/src/middleware/__tests__/subsonicAuth.test.ts
@@ -471,6 +471,7 @@ describe("requireSubsonicAuth", () => {
     it("authenticates apiKey mode without password/token parameters", async () => {
         mockApiKeyFindUnique.mockResolvedValue({
             id: "key-1",
+            createdAt: new Date(),
             user: {
                 id: "u1",
                 username: "alice",
@@ -536,6 +537,7 @@ describe("requireSubsonicAuth", () => {
     it("rejects apiKey auth when provided username does not match key owner", async () => {
         mockApiKeyFindUnique.mockResolvedValue({
             id: "key-1",
+            createdAt: new Date(),
             user: {
                 id: "u1",
                 username: "alice",
@@ -567,6 +569,7 @@ describe("requireSubsonicAuth", () => {
     it("authenticates apiKey mode even when lastUsed update fails", async () => {
         mockApiKeyFindUnique.mockResolvedValue({
             id: "key-1",
+            createdAt: new Date(),
             user: {
                 id: "u1",
                 username: "alice",

--- a/backend/src/middleware/__tests__/subsonicAuthExpiry.test.ts
+++ b/backend/src/middleware/__tests__/subsonicAuthExpiry.test.ts
@@ -1,0 +1,103 @@
+process.env.SETTINGS_ENCRYPTION_KEY =
+    process.env.SETTINGS_ENCRYPTION_KEY ||
+    "subsonic-expiry-test-pepper-1234567890123456";
+
+import express from "express";
+import request from "supertest";
+
+const mockApiKeyFindUnique = jest.fn();
+const mockApiKeyUpdate = jest.fn();
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        user: {
+            findUnique: jest.fn(),
+        },
+        apiKey: {
+            findUnique: mockApiKeyFindUnique,
+            update: mockApiKeyUpdate,
+        },
+    },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import { requireSubsonicAuth } from "../subsonicAuth";
+
+const app = express();
+app.get("/rest/ping.view", requireSubsonicAuth, (_req, res) => {
+    res.json({ authenticated: true });
+});
+
+function buildApiKeyRecord(createdAt: unknown) {
+    return {
+        id: "key-1",
+        createdAt,
+        user: {
+            id: "user-1",
+            username: "alice",
+            role: "user",
+        },
+    };
+}
+
+describe("Subsonic API key expiry", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApiKeyUpdate.mockResolvedValue({});
+    });
+
+    it.each([
+        ["expired", new Date(Date.now() - 91 * 24 * 60 * 60 * 1000)],
+        ["missing", undefined],
+        ["invalid", new Date(Number.NaN)],
+    ])("rejects a %s API key at a /rest endpoint", async (_case, createdAt) => {
+        mockApiKeyFindUnique.mockResolvedValue(
+            buildApiKeyRecord(createdAt),
+        );
+
+        const response = await request(app).get("/rest/ping.view").query({
+            v: "1.16.1",
+            c: "test-client",
+            f: "json",
+            apiKey: "expired-key",
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.body["subsonic-response"]).toEqual(
+            expect.objectContaining({
+                status: "failed",
+                error: {
+                    code: 40,
+                    message: "Wrong username or password",
+                },
+            }),
+        );
+        expect(mockApiKeyUpdate).not.toHaveBeenCalled();
+    });
+
+    it("allows a fresh API key through a /rest endpoint", async () => {
+        mockApiKeyFindUnique.mockResolvedValue(
+            buildApiKeyRecord(new Date(Date.now() - 24 * 60 * 60 * 1000)),
+        );
+
+        const response = await request(app).get("/rest/ping.view").query({
+            v: "1.16.1",
+            c: "test-client",
+            f: "json",
+            apiKey: "fresh-key",
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ authenticated: true });
+        expect(mockApiKeyUpdate).toHaveBeenCalledWith({
+            where: { id: "key-1" },
+            data: { lastUsed: expect.any(Date) },
+        });
+    });
+});

--- a/backend/src/middleware/__tests__/subsonicAuthExpiry.test.ts
+++ b/backend/src/middleware/__tests__/subsonicAuthExpiry.test.ts
@@ -57,9 +57,7 @@ describe("Subsonic API key expiry", () => {
         ["missing", undefined],
         ["invalid", new Date(Number.NaN)],
     ])("rejects a %s API key at a /rest endpoint", async (_case, createdAt) => {
-        mockApiKeyFindUnique.mockResolvedValue(
-            buildApiKeyRecord(createdAt),
-        );
+        mockApiKeyFindUnique.mockResolvedValue(buildApiKeyRecord(createdAt));
 
         const response = await request(app).get("/rest/ping.view").query({
             v: "1.16.1",

--- a/backend/src/middleware/subsonicAuth.ts
+++ b/backend/src/middleware/subsonicAuth.ts
@@ -6,7 +6,7 @@ import { runDummyBcrypt } from "../utils/dummyCredential";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { prisma } from "../utils/db";
 import { decrypt } from "../utils/encryption";
-import { findApiKeyRecord } from "../utils/apiKeyHash";
+import { findApiKeyRecord, isApiKeyExpired } from "../utils/apiKeyHash";
 import { logger } from "../utils/logger";
 import {
     getResponseFormat,
@@ -133,6 +133,17 @@ export async function requireSubsonicAuth(
                 res,
                 SubsonicErrorCode.INVALID_API_KEY,
                 "Invalid API key",
+                format,
+                callback,
+            );
+            return;
+        }
+
+        if (isApiKeyExpired(apiKeyRecord.createdAt)) {
+            sendSubsonicError(
+                res,
+                SubsonicErrorCode.WRONG_CREDENTIALS,
+                "Wrong username or password",
                 format,
                 callback,
             );

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -402,12 +402,7 @@ describe("analysis routes runtime", () => {
         async (_caller, req) => {
             const res = createRes();
 
-            await invokeRouteStack(
-                "post",
-                "/analyze/:trackId",
-                req,
-                res,
-            );
+            await invokeRouteStack("post", "/analyze/:trackId", req, res);
 
             expect(res.statusCode).toBe(403);
             expect(res.body).toEqual({ error: "Admin access required" });

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -1,8 +1,22 @@
 import os from "os";
 
 jest.mock("../../middleware/auth", () => ({
-    requireAuth: (_req: any, _res: any, next: () => void) => next(),
-    requireAdmin: (_req: any, _res: any, next: () => void) => next(),
+    requireAuth: (req: any, _res: any, next: () => void) => {
+        if (req.headers?.["x-api-key"] === "non-admin-key") {
+            req.user = {
+                id: "api-key-user",
+                username: "api-key-user",
+                role: "user",
+            };
+        }
+        next();
+    },
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -111,6 +125,30 @@ function getHandler(method: "get" | "post" | "put", path: string) {
     if (!layer)
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+const MAX_ROUTE_HANDLERS = 4;
+
+async function invokeRouteStack(
+    method: "get" | "post" | "put",
+    path: string,
+    req: any,
+    res: any,
+) {
+    const layer = findRouteLayer((router as any).stack, method, path);
+    const stack = layer.route.stack;
+    if (stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${stack.length}`);
+    }
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = stack[index];
+        if (!entry) return;
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) return;
+    }
 }
 
 // The internal vibe endpoints are guarded by the per-route
@@ -339,6 +377,45 @@ describe("analysis routes runtime", () => {
             trackId: "t100",
         });
     });
+
+    it.each([
+        [
+            "authenticated user",
+            {
+                user: {
+                    id: "non-admin-user",
+                    username: "non-admin-user",
+                    role: "user",
+                },
+                params: { trackId: "track-1" },
+            },
+        ],
+        [
+            "API-key caller",
+            {
+                headers: { "x-api-key": "non-admin-key" },
+                params: { trackId: "track-1" },
+            },
+        ],
+    ])(
+        "rejects a non-admin %s before analysis queue or database effects",
+        async (_caller, req) => {
+            const res = createRes();
+
+            await invokeRouteStack(
+                "post",
+                "/analyze/:trackId",
+                req,
+                res,
+            );
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body).toEqual({ error: "Admin access required" });
+            expect(mockRedisRPush).not.toHaveBeenCalled();
+            expect(mockTrackFindUnique).not.toHaveBeenCalled();
+            expect(mockTrackUpdate).not.toHaveBeenCalled();
+        },
+    );
 
     it("returns track analysis payload or 404", async () => {
         mockTrackFindUnique.mockResolvedValueOnce(null);

--- a/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverCleanupLidarrLeak.test.ts
@@ -3,6 +3,12 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -22,9 +28,18 @@ jest.mock("../../config", () => ({
 }));
 
 const prisma = {
-    ownedAlbum: { findFirst: jest.fn(async () => null) },
-    discoveryAlbum: { findFirst: jest.fn(async () => null) },
-    downloadJob: { findMany: jest.fn(async () => []) },
+    ownedAlbum: {
+        findFirst: jest.fn(async () => null),
+        deleteMany: jest.fn(),
+    },
+    discoveryAlbum: {
+        findFirst: jest.fn(async () => null),
+        deleteMany: jest.fn(),
+    },
+    downloadJob: {
+        findMany: jest.fn(async () => []),
+        deleteMany: jest.fn(),
+    },
 };
 
 jest.mock("../../utils/db", () => ({ prisma }));
@@ -75,6 +90,30 @@ function getRouteHandler(
     return layer.route.stack[layer.route.stack.length - 1].handle;
 }
 
+const MAX_ROUTE_HANDLERS = 3;
+
+async function invokeRouteStack(req: any, res: any) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === "/cleanup-lidarr" &&
+            entry.route?.methods?.post,
+    );
+    if (!layer) throw new Error("Route not found: POST /cleanup-lidarr");
+    const stack = layer.route.stack;
+    if (stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${stack.length}`);
+    }
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = stack[index];
+        if (!entry) return;
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) return;
+    }
+}
+
 function createRes() {
     const res: any = {
         statusCode: 200,
@@ -95,6 +134,39 @@ const LEAK_MARKER =
     "connect ECONNREFUSED lidarr.internal:8686 X-Api-Key=SECRET_KEY";
 
 describe("POST /cleanup-lidarr does not disclose caught error text", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects a non-admin before Lidarr or database effects", async () => {
+        const res = createRes();
+
+        await invokeRouteStack(
+            {
+                user: {
+                    id: "user-1",
+                    username: "user-1",
+                    role: "user",
+                },
+                params: {},
+                query: {},
+                body: {},
+            },
+            res,
+        );
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(getSystemSettings).not.toHaveBeenCalled();
+        expect(axiosGet).not.toHaveBeenCalled();
+        expect(axiosDelete).not.toHaveBeenCalled();
+        expect(prisma.ownedAlbum.findFirst).not.toHaveBeenCalled();
+        expect(prisma.discoveryAlbum.findFirst).not.toHaveBeenCalled();
+        expect(prisma.ownedAlbum.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.discoveryAlbum.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.downloadJob.deleteMany).not.toHaveBeenCalled();
+    });
+
     it("returns a static per-artist message, not the raw axios error", async () => {
         axiosGet.mockResolvedValueOnce({
             data: [

--- a/backend/src/routes/__tests__/discoverErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/discoverErrorLeak.test.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/__tests__/discoverRecommendationCompat.test.ts
+++ b/backend/src/routes/__tests__/discoverRecommendationCompat.test.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/__tests__/discoverRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverRuntime.test.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../utils/logger", () => ({

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -263,6 +263,7 @@ router.post("/retry-failed", requireAuth, requireAdmin, async (req, res) => {
 router.post<{ trackId: string }>(
     "/analyze/:trackId",
     requireAuth,
+    requireAdmin,
     async (req, res) => {
         try {
             const { trackId } = req.params;

--- a/backend/src/routes/discover.ts
+++ b/backend/src/routes/discover.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { logger } from "../utils/logger";
-import { requireAuthOrToken } from "../middleware/auth";
+import { requireAdmin, requireAuthOrToken } from "../middleware/auth";
 import { prisma } from "../utils/db";
 import { lastFmService } from "../services/lastfm";
 import { startOfWeek, endOfWeek } from "date-fns";
@@ -2159,8 +2159,10 @@ router.delete("/exclusions/:id", async (req, res) => {
  *         description: Only available in legacy discovery mode
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
-router.post("/cleanup-lidarr", async (req, res) => {
+router.post("/cleanup-lidarr", requireAdmin, async (req, res) => {
     try {
         if (!isLegacyDiscoveryMode) {
             return res.status(410).json({


### PR DESCRIPTION
Closes three confirmed authorization defects found in the sweep-21 convergence review.

**M4** — `POST /analyze/:trackId` used `requireAuth` only despite its documented 403 admin contract; any authenticated user could append catalog-wide analyzer work to Redis and mutate global track analysis state. Now gated with `requireAdmin` (matching sibling `/start` and `/retry-failed`).

**M5** — `POST /cleanup-lidarr` had no admin gate under the router's `requireAuthOrToken` guard and issued Lidarr `DELETE ...deleteFiles=true` against shared-catalog artists, letting any authenticated user or API key delete external-library files. Now `requireAdmin`; OpenAPI 403 contract documented.

**M1** — OpenSubsonic `/rest` authentication accepted API keys past the 90-day expiry that #370 enforces on every other path. The API-key branch now rejects expired keys via the shared `isApiKeyExpired` helper before updating `lastUsed`.

Behavioral tests added: non-admin users and non-admin API keys receive 403 with no queue/DB/Lidarr mutation; expired Subsonic keys are rejected. Sibling discover/analysis/subsonic suites reconciled (45 suites / 722 tests green), tsc clean, route-error canon clean.