### PR TITLE
fix(security): cap external cover response bodies to prevent heap exhaustion

### DIFF
--- a/backend/src/__tests__/audiobooksCoverAuthz.test.ts
+++ b/backend/src/__tests__/audiobooksCoverAuthz.test.ts
@@ -112,8 +112,12 @@ function writeCover(filePath: string, contents: Buffer): void {
 }
 
 describe("audiobook cover authorization and path containment", () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn();
+
     beforeEach(() => {
         jest.clearAllMocks();
+        global.fetch = fetchMock;
         fs.rmSync(mockMusicPath, { recursive: true, force: true });
         fs.rmSync(path.join(mockTempRoot, "secrets"), {
             recursive: true,
@@ -126,6 +130,7 @@ describe("audiobook cover authorization and path containment", () => {
     });
 
     afterAll(() => {
+        global.fetch = originalFetch;
         fs.rmSync(mockTempRoot, { recursive: true, force: true });
     });
 
@@ -224,5 +229,65 @@ describe("audiobook cover authorization and path containment", () => {
 
         expect(response.status).toBe(404);
         expect(response.body).toEqual({ error: "Cover not found" });
+    });
+
+    it("proxies a normal small remote cover", async () => {
+        const coverBytes = Buffer.from("remote-cover-bytes");
+        mockPrisma.audiobook.findUnique.mockResolvedValue({
+            localCoverPath: null,
+            coverUrl: "items/book-1/cover",
+        });
+        mockGetSystemSettings.mockResolvedValue({
+            audiobookshelfUrl: "https://audiobooks.example",
+            audiobookshelfApiKey: "abs-key",
+        });
+        fetchMock.mockResolvedValue(
+            new Response(coverBytes, {
+                status: 200,
+                headers: { "content-type": "image/jpeg" },
+            }),
+        );
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(coverBytes);
+    });
+
+    it("cancels an oversized streamed remote cover", async () => {
+        const cancel = jest.fn();
+        const oneMiBChunk = new Uint8Array(1024 * 1024);
+        const chunks = Array.from({ length: 64 }, () => oneMiBChunk);
+        const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                const chunk = chunks.shift();
+                if (chunk) {
+                    controller.enqueue(chunk);
+                } else {
+                    controller.close();
+                }
+            },
+            cancel,
+        });
+        mockPrisma.audiobook.findUnique.mockResolvedValue({
+            localCoverPath: null,
+            coverUrl: "items/book-1/cover",
+        });
+        mockGetSystemSettings.mockResolvedValue({
+            audiobookshelfUrl: "https://audiobooks.example",
+            audiobookshelfApiKey: "abs-key",
+        });
+        fetchMock.mockResolvedValue(new Response(body, { status: 200 }));
+
+        const response = await request(buildApp())
+            .get("/api/audiobooks/book-1/cover")
+            .set("x-test-user", "yes");
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: "Cover not found" });
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(chunks.length).toBeGreaterThan(0);
     });
 });

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -346,15 +346,12 @@ describe("audiobooks advanced runtime", () => {
             })
             .mockResolvedValueOnce({ localCoverPath: null, coverUrl: null });
 
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            headers: {
-                get: jest.fn().mockReturnValue("image/png"),
-            },
-            arrayBuffer: jest
-                .fn()
-                .mockResolvedValue(Uint8Array.from([1, 2, 3]).buffer),
-        });
+        mockFetch.mockResolvedValueOnce(
+            new Response(Uint8Array.from([1, 2, 3]), {
+                status: 200,
+                headers: { "content-type": "image/png" },
+            }),
+        );
 
         const proxyRes = createRes();
         await coverHandler(

--- a/backend/src/routes/__tests__/audiobooksRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksRuntime.test.ts
@@ -339,14 +339,19 @@ describe("audiobooks route runtime", () => {
         const existsSpy = jest.spyOn(require("fs"), "existsSync");
         existsSpy.mockReturnValue(false);
         const cancel = jest.fn().mockResolvedValue(undefined);
-        const fetchMock = jest.fn().mockResolvedValue({
-            ok: true,
-            body: { cancel },
-            arrayBuffer: jest
-                .fn()
-                .mockResolvedValue(Uint8Array.from([1, 2, 3]).buffer),
-            headers: { get: jest.fn().mockReturnValue("image/jpeg") },
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(Uint8Array.from([1, 2, 3]));
+                controller.close();
+            },
+            cancel,
         });
+        const fetchMock = jest.fn().mockResolvedValue(
+            new Response(body, {
+                status: 200,
+                headers: { "content-type": "image/jpeg" },
+            }),
+        );
         (global as any).fetch = fetchMock;
         prisma.audiobook.findUnique.mockResolvedValueOnce({
             localCoverPath: null,

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -165,6 +165,7 @@ jest.mock("../../utils/colorExtractor", () => ({
 }));
 
 jest.mock("../../services/imageProxy", () => ({
+    ...jest.requireActual("../../services/imageProxy"),
     fetchExternalImage: jest.fn(),
     normalizeExternalImageUrl: (rawUrl: string) => {
         try {
@@ -205,6 +206,7 @@ import router from "../library";
 import { errorHandler } from "../../middleware/errorHandler";
 import { redisClient } from "../../utils/redis";
 import { fetchExternalImage } from "../../services/imageProxy";
+import { MAX_EXTERNAL_IMAGE_BYTES } from "../../services/imageProxy";
 import { coverArtService } from "../../services/coverArt";
 import { prisma } from "../../utils/db";
 import { deezerService } from "../../services/deezer";
@@ -1066,11 +1068,12 @@ describe("library cover-art proxy compatibility", () => {
     });
 
     it("fetches audiobook query-url cover art with auth and streams bytes", async () => {
-        const fetchMock = jest.fn().mockResolvedValue({
-            ok: true,
-            arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
-            headers: { get: jest.fn().mockReturnValue("image/jpeg") },
-        });
+        const fetchMock = jest.fn().mockResolvedValue(
+            new Response(Uint8Array.from([1, 2, 3]), {
+                status: 200,
+                headers: { "content-type": "image/jpeg" },
+            }),
+        );
         (global as any).fetch = fetchMock;
         mockGetSystemSettings.mockResolvedValueOnce({
             audiobookshelfUrl: "https://audiobooks.example",
@@ -1100,6 +1103,39 @@ describe("library cover-art proxy compatibility", () => {
         expect(res.headers["Cache-Control"]).toBe(
             "public, max-age=7776000, immutable",
         );
+    });
+
+    it("rejects a declared oversized audiobook cover and cancels its body", async () => {
+        const cancel = jest.fn();
+        const body = new ReadableStream({ cancel });
+        const fetchMock = jest.fn().mockResolvedValue(
+            new Response(body, {
+                status: 200,
+                headers: {
+                    "content-type": "image/jpeg",
+                    "content-length": String(MAX_EXTERNAL_IMAGE_BYTES + 1),
+                },
+            }),
+        );
+        (global as any).fetch = fetchMock;
+        mockGetSystemSettings.mockResolvedValueOnce({
+            audiobookshelfUrl: "https://audiobooks.example",
+            audiobookshelfApiKey: "abs-key",
+        });
+        const req = {
+            query: { url: "audiobook__items/oversized/cover" },
+            params: {},
+            headers: {},
+        } as any;
+        const res = createRes();
+
+        await coverArtHandler(req, res);
+
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({
+            error: "Audiobook cover art not found",
+        });
     });
 
     it("rejects traversal in an audiobook query cover before fetch", async () => {

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -278,6 +278,7 @@ jest.mock("../../utils/colorExtractor", () => ({
 }));
 
 jest.mock("../../services/imageProxy", () => ({
+    ...jest.requireActual("../../services/imageProxy"),
     fetchExternalImage: jest.fn(),
     normalizeExternalImageUrl: jest.fn(() => null),
 }));
@@ -4723,15 +4724,12 @@ describe("library catalog list runtime coverage", () => {
         config.allowedOrigins = ["https://app.example"];
         const fetchSpy = jest
             .spyOn(global as any, "fetch")
-            .mockResolvedValueOnce({
-                ok: true,
-                status: 200,
-                statusText: "OK",
-                headers: {
-                    get: jest.fn(() => "image/jpeg"),
-                },
-                arrayBuffer: async () => Buffer.from("audiobook-cover"),
-            } as any);
+            .mockResolvedValueOnce(
+                new Response(Buffer.from("audiobook-cover"), {
+                    status: 200,
+                    headers: { "content-type": "image/jpeg" },
+                }),
+            );
         mockGetSystemSettings.mockResolvedValueOnce({
             audiobookshelfUrl: "https://ab.example",
             audiobookshelfApiKey: "token-123",

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -7,6 +7,11 @@ import { requireAuthOrToken } from "../middleware/auth";
 import { imageLimiter, apiLimiter } from "../middleware/rateLimiter";
 import { safeResolvePath } from "../utils/safeResolvePath";
 import { buildSafeAudiobookCoverUrl } from "../services/audiobookCoverProxy";
+import {
+    MAX_EXTERNAL_IMAGE_BYTES,
+    readResponseBodyWithByteCap,
+} from "../services/imageProxy";
+import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
 
@@ -689,6 +694,18 @@ router.get<{ id: string }>(
                         });
 
                         if (response.ok) {
+                            const bodyResult =
+                                await readResponseBodyWithByteCap(
+                                    response,
+                                    MAX_EXTERNAL_IMAGE_BYTES,
+                                );
+                            if (!bodyResult.ok) {
+                                return sendRouteError(
+                                    res,
+                                    404,
+                                    "Cover not found",
+                                );
+                            }
                             res.setHeader(
                                 "Content-Type",
                                 response.headers.get("content-type") ||
@@ -702,10 +719,7 @@ router.get<{ id: string }>(
                                 "Cross-Origin-Resource-Policy",
                                 "cross-origin",
                             );
-
-                            // Stream the response body to client
-                            const buffer = await response.arrayBuffer();
-                            return res.send(Buffer.from(buffer));
+                            return res.send(bodyResult.buffer);
                         }
                         await response.body?.cancel().catch(() => {});
                     } catch (proxyError: any) {

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -37,7 +37,9 @@ import { BRAND_USER_AGENT } from "../config/brand";
 import { extractColorsFromImage } from "../utils/colorExtractor";
 import {
     fetchExternalImage,
+    MAX_EXTERNAL_IMAGE_BYTES,
     normalizeExternalImageUrl,
+    readResponseBodyWithByteCap,
 } from "../services/imageProxy";
 import { buildSafeAudiobookCoverUrl } from "../services/audiobookCoverProxy";
 import {
@@ -368,7 +370,14 @@ const sendAudiobookCover = async (
         return sendRouteError(res, 404, "Audiobook cover art not found");
     }
 
-    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+    const bodyResult = await readResponseBodyWithByteCap(
+        imageResponse,
+        MAX_EXTERNAL_IMAGE_BYTES,
+    );
+    if (!bodyResult.ok) {
+        return sendRouteError(res, 404, "Audiobook cover art not found");
+    }
+    const imageBuffer = bodyResult.buffer;
     const contentType = imageResponse.headers.get("content-type");
     if (contentType) {
         res.setHeader("Content-Type", contentType);

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -54,6 +54,7 @@ jest.mock("../../config", () => ({
 }));
 
 import { AudiobookCacheService } from "../audiobookCache";
+import { MAX_EXTERNAL_IMAGE_BYTES } from "../imageProxy";
 
 function buildBook(overrides: Record<string, any> = {}) {
     return {
@@ -110,12 +111,9 @@ describe("audiobook cache service behavior", () => {
             audiobookshelfApiKey: "api-key",
         });
 
-        fetchMock.mockResolvedValue({
-            ok: true,
-            status: 200,
-            statusText: "OK",
-            arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-        });
+        fetchMock.mockResolvedValue(
+            new Response(new Uint8Array(8), { status: 200 }),
+        );
     });
 
     it("syncs all audiobooks, parses series metadata, and tracks per-book failures", async () => {
@@ -330,12 +328,9 @@ describe("audiobook cache service behavior", () => {
         mockGetSystemSettings.mockResolvedValueOnce({
             audiobookshelfApiKey: "api-key",
         });
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            statusText: "OK",
-            arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(16)),
-        });
+        fetchMock.mockResolvedValueOnce(
+            new Response(new Uint8Array(16), { status: 200 }),
+        );
 
         const savedPath = await (service as any).downloadCover(
             "book-d",
@@ -349,6 +344,30 @@ describe("audiobook cache service behavior", () => {
             path.join("/srv/music", "cover-cache", "audiobooks", "book-d.jpg"),
             expect.any(Buffer),
         );
+    });
+
+    it("rejects a declared oversized cover and cancels its body", async () => {
+        const service = new AudiobookCacheService();
+        (service as any).coverCacheAvailable = true;
+        const cancel = jest.fn();
+        const body = new ReadableStream({ cancel });
+        fetchMock.mockResolvedValueOnce(
+            new Response(body, {
+                status: 200,
+                headers: {
+                    "content-length": String(MAX_EXTERNAL_IMAGE_BYTES + 1),
+                },
+            }),
+        );
+
+        const savedPath = await (service as any).downloadCover(
+            "book-oversized",
+            "http://abs.local/oversized.jpg",
+        );
+
+        expect(savedPath).toBeNull();
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(fsPromises.writeFile).not.toHaveBeenCalled();
     });
 
     it("returns fresh cache immediately and refreshes stale cache when needed", async () => {

--- a/backend/src/services/__tests__/imageProxy.test.ts
+++ b/backend/src/services/__tests__/imageProxy.test.ts
@@ -11,6 +11,7 @@ import {
     fetchExternalImage,
     normalizeExternalImageUrl,
     MAX_EXTERNAL_IMAGE_BYTES,
+    readResponseBodyWithByteCap,
 } from "../imageProxy";
 
 describe("imageProxy", () => {
@@ -383,6 +384,71 @@ describe("imageProxy", () => {
                 status: "fetch_error",
                 url: "https://example.com/unknown-error.jpg",
                 message: "Unknown fetch error",
+            });
+        });
+    });
+
+    describe("readResponseBodyWithByteCap", () => {
+        it("rejects a declared oversized body before reading and cancels it", async () => {
+            const cancel = jest.fn().mockResolvedValue(undefined);
+            const getReader = jest.fn();
+            const response = {
+                headers: new Headers({ "content-length": "2048" }),
+                body: { cancel, getReader },
+            } as unknown as Response;
+
+            const result = await readResponseBodyWithByteCap(response, 1024);
+
+            expect(result).toEqual({
+                ok: false,
+                error: "response_too_large",
+                message: "External image exceeds maximum size",
+            });
+            expect(getReader).not.toHaveBeenCalled();
+            expect(cancel).toHaveBeenCalledTimes(1);
+        });
+
+        it("cancels a streamed body as soon as its bytes exceed the cap", async () => {
+            const cancel = jest.fn();
+            const chunks = [
+                new Uint8Array(512),
+                new Uint8Array(512),
+                new Uint8Array(1),
+                new Uint8Array(512),
+                new Uint8Array(512),
+            ];
+            const body = new ReadableStream<Uint8Array>({
+                pull(controller) {
+                    const chunk = chunks.shift();
+                    if (chunk) {
+                        controller.enqueue(chunk);
+                    } else {
+                        controller.close();
+                    }
+                },
+                cancel,
+            });
+            const response = new Response(body, { status: 200 });
+
+            const result = await readResponseBodyWithByteCap(response, 1024);
+
+            expect(result).toEqual({
+                ok: false,
+                error: "response_too_large",
+                message: "External image exceeds maximum size",
+            });
+            expect(cancel).toHaveBeenCalledTimes(1);
+            expect(chunks).toHaveLength(1);
+        });
+
+        it("returns a normal small streamed body", async () => {
+            const response = new Response("image-bytes", { status: 200 });
+
+            const result = await readResponseBodyWithByteCap(response, 1024);
+
+            expect(result).toEqual({
+                ok: true,
+                buffer: Buffer.from("image-bytes"),
             });
         });
     });

--- a/backend/src/services/__tests__/imageStorage.test.ts
+++ b/backend/src/services/__tests__/imageStorage.test.ts
@@ -39,6 +39,17 @@ import {
     isNativePath,
 } from "../imageStorage";
 
+function createImageResponse(
+    byteLength: number,
+    contentType: string,
+    status = 200,
+): Response {
+    return new Response(new Uint8Array(byteLength), {
+        status,
+        headers: { "content-type": contentType },
+    });
+}
+
 describe("imageStorage service", () => {
     const fetchMock = jest.fn();
     const timeoutMock = jest.fn();
@@ -63,12 +74,9 @@ describe("imageStorage service", () => {
             if (target.includes("/covers/artists")) return false;
             return true;
         });
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            headers: { get: () => "image/jpeg" },
-            arrayBuffer: async () => new Uint8Array(1600).buffer,
-        });
+        fetchMock.mockResolvedValueOnce(
+            createImageResponse(1600, "image/jpeg"),
+        );
 
         const result = await downloadAndStoreImage(
             "https://img.example.com/a.jpg",
@@ -115,12 +123,9 @@ describe("imageStorage service", () => {
     });
 
     it("returns null for non-ok fetch responses", async () => {
-        fetchMock.mockResolvedValueOnce({
-            ok: false,
-            status: 404,
-            headers: { get: () => "image/jpeg" },
-            arrayBuffer: async () => new Uint8Array(2000).buffer,
-        });
+        fetchMock.mockResolvedValueOnce(
+            createImageResponse(2000, "image/jpeg", 404),
+        );
 
         const result = await downloadAndStoreImage(
             "https://img.example.com/missing.jpg",
@@ -132,12 +137,7 @@ describe("imageStorage service", () => {
     });
 
     it("returns null when content-type is not image", async () => {
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            headers: { get: () => "text/html" },
-            arrayBuffer: async () => new Uint8Array(2000).buffer,
-        });
+        fetchMock.mockResolvedValueOnce(createImageResponse(2000, "text/html"));
 
         const result = await downloadAndStoreImage(
             "https://img.example.com/not-image",
@@ -149,12 +149,7 @@ describe("imageStorage service", () => {
     });
 
     it("returns null when image is too small", async () => {
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            headers: { get: () => "image/png" },
-            arrayBuffer: async () => new Uint8Array(100).buffer,
-        });
+        fetchMock.mockResolvedValueOnce(createImageResponse(100, "image/png"));
 
         const result = await downloadAndStoreImage(
             "https://img.example.com/tiny.png",

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -6,6 +6,10 @@ import path from "path";
 import { config } from "../config";
 import { buildCachePath, isPastStaleWindow } from "./cacheHelpers";
 import { buildSafeAudiobookCoverUrl } from "./audiobookCoverProxy";
+import {
+    MAX_EXTERNAL_IMAGE_BYTES,
+    readResponseBodyWithByteCap,
+} from "./imageProxy";
 
 /**
  * Service to sync audiobooks from Audiobookshelf and cache them locally
@@ -351,11 +355,17 @@ export class AudiobookCacheService {
                 );
             }
 
-            const buffer = await response.arrayBuffer();
+            const bodyResult = await readResponseBodyWithByteCap(
+                response,
+                MAX_EXTERNAL_IMAGE_BYTES,
+            );
+            if (!bodyResult.ok) {
+                return null;
+            }
             const fileName = `${audiobookId}.jpg`;
             const filePath = path.join(this.coverCacheDir, fileName);
 
-            await fs.writeFile(filePath, Buffer.from(buffer));
+            await fs.writeFile(filePath, bodyResult.buffer);
 
             return filePath;
         } catch (error: any) {

--- a/backend/src/services/imageProxy.ts
+++ b/backend/src/services/imageProxy.ts
@@ -14,6 +14,21 @@ import {
  */
 export const MAX_EXTERNAL_IMAGE_BYTES = 15 * 1024 * 1024; // 15MB
 
+/** Result of reading a response body under the external-image byte cap. */
+export type BoundedResponseBodyResult =
+    | { ok: true; buffer: Buffer }
+    | {
+          ok: false;
+          error: "response_too_large";
+          message: "External image exceeds maximum size";
+      };
+
+const RESPONSE_TOO_LARGE_RESULT = Object.freeze({
+    ok: false,
+    error: "response_too_large",
+    message: "External image exceeds maximum size",
+} as const);
+
 /**
  * Normalizes a remote image URL with the shared outbound safety policy.
  */
@@ -91,40 +106,58 @@ async function fetchWithSafeRedirects(options: {
 }
 
 /**
- * Reads a response body while enforcing a byte cap. Returns null (after
- * cancelling the body stream) when the declared Content-Length or the bytes
- * actually read exceed `maxBytes`, so oversized images are never fully
- * buffered into memory.
+ * Reads an external-image response body as a stream under a strict byte cap.
+ * Oversized bodies return a code-owned error result after the response stream
+ * is cancelled; no upstream response details are exposed.
  */
-async function readBodyWithByteCap(
+export async function readResponseBodyWithByteCap(
     response: Response,
-    maxBytes: number,
-): Promise<Buffer | null> {
-    const declaredLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    maxBytes = MAX_EXTERNAL_IMAGE_BYTES,
+): Promise<BoundedResponseBodyResult> {
+    if (
+        !Number.isSafeInteger(maxBytes) ||
+        maxBytes < 1 ||
+        maxBytes > MAX_EXTERNAL_IMAGE_BYTES
+    ) {
+        throw new RangeError("Invalid external image byte cap");
+    }
+
+    const rawDeclaredLength = response.headers.get("content-length");
+    const declaredLength =
+        rawDeclaredLength === null ? null : Number(rawDeclaredLength);
+    if (declaredLength !== null && declaredLength > maxBytes) {
         await response.body?.cancel().catch(() => {});
-        return null;
+        return RESPONSE_TOO_LARGE_RESULT;
     }
 
     if (!response.body) {
-        const buffer = Buffer.from(await response.arrayBuffer());
-        return buffer.byteLength > maxBytes ? null : buffer;
+        return { ok: true, buffer: Buffer.alloc(0) };
     }
 
     const reader = response.body.getReader();
     const chunks: Buffer[] = [];
     let totalBytes = 0;
-    for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        totalBytes += value.byteLength;
-        if (totalBytes > maxBytes) {
-            await reader.cancel().catch(() => {});
-            return null;
+    try {
+        for (let readCount = 0; readCount <= maxBytes; readCount += 1) {
+            const { done, value } = await reader.read();
+            if (done) {
+                return {
+                    ok: true,
+                    buffer: Buffer.concat(chunks, totalBytes),
+                };
+            }
+            totalBytes += value.byteLength;
+            if (totalBytes > maxBytes) {
+                await reader.cancel().catch(() => {});
+                return RESPONSE_TOO_LARGE_RESULT;
+            }
+            chunks.push(Buffer.from(value));
         }
-        chunks.push(Buffer.from(value));
+        await reader.cancel().catch(() => {});
+        return RESPONSE_TOO_LARGE_RESULT;
+    } finally {
+        reader.releaseLock();
     }
-    return Buffer.concat(chunks);
 }
 
 /**
@@ -206,15 +239,19 @@ export async function fetchExternalImage(options: {
                 };
             }
 
-            const buffer = await readBodyWithByteCap(response, maxBytes);
-            if (buffer === null) {
+            const bodyResult = await readResponseBodyWithByteCap(
+                response,
+                maxBytes,
+            );
+            if (!bodyResult.ok) {
                 return {
                     ok: false,
                     url: finalUrl,
                     status: "fetch_error",
-                    message: `Image exceeds maximum size of ${maxBytes} bytes`,
+                    message: bodyResult.message,
                 };
             }
+            const { buffer } = bodyResult;
             const contentType = response.headers.get("content-type");
             const etag = crypto.createHash("md5").update(buffer).digest("hex");
 


### PR DESCRIPTION
Closes **M6** from the sweep-21 convergence review.

Successful external Audiobookshelf cover responses were consumed whole via `arrayBuffer()` with no byte cap. The existing 15-second deadline bounds *time*, not *bytes*, so concurrent oversized successful responses could exhaust the Node heap. This is distinct from the #330 non-success-body cancellation, which remains intact.

Adds a shared `readResponseBodyWithByteCap` helper in `imageProxy.ts` that pre-checks `Content-Length`, streams the body under the shared 15 MiB cap, and cancels the response stream on overflow. All three affected sites — `routes/library.ts`, `routes/audiobooks.ts`, `services/audiobookCache.ts` — now use it on the success path.

Behavioral tests cover declared-oversized-Content-Length rejection, chunked/streamed oversized-body abort, and normal small images, for all three paths. 354 tests / 17 suites green, tsc clean, route-error canon clean.