### PR TITLE
fix(perf): bound segmented-streaming session and readiness-cache lifecycle

### DIFF
--- a/backend/src/services/segmented-streaming/__tests__/sessionService.test.ts
+++ b/backend/src/services/segmented-streaming/__tests__/sessionService.test.ts
@@ -15,7 +15,13 @@ const createBuildFailureSession = (assetType: string) => ({
     expiresAt: "2099-01-01T00:00:00.000Z",
 });
 
-const resolveSessionService = async () => {
+type ResolveSessionServiceOptions = {
+    useRealCacheService?: boolean;
+};
+
+const resolveSessionService = async (
+    options: ResolveSessionServiceOptions = {},
+) => {
     jest.resetModules();
 
     const mockTrackFindUnique = jest.fn();
@@ -29,6 +35,9 @@ const resolveSessionService = async () => {
     const mockClearSessionReference = jest.fn();
     const mockFsAccess = jest.fn();
     const mockFsReadFile = jest.fn();
+    const mockFsReaddir = jest.fn();
+    const mockFsRm = jest.fn();
+    const mockFsStat = jest.fn();
     const mockHasInFlightBuild = jest.fn();
     const mockGetBuildInFlightStatus = jest.fn(async (...args: unknown[]) => {
         const cacheKey = typeof args[0] === "string" ? args[0] : "";
@@ -48,6 +57,9 @@ const resolveSessionService = async () => {
         promises: {
             access: (...args: unknown[]) => mockFsAccess(...args),
             readFile: (...args: unknown[]) => mockFsReadFile(...args),
+            readdir: (...args: unknown[]) => mockFsReaddir(...args),
+            rm: (...args: unknown[]) => mockFsRm(...args),
+            stat: (...args: unknown[]) => mockFsStat(...args),
         },
     }));
 
@@ -79,6 +91,8 @@ const resolveSessionService = async () => {
             sessionSecret: "test-session-secret",
             music: {
                 musicPath: "/music",
+                transcodeCachePath: "/tmp/segmented",
+                transcodeCacheMaxGb: 10,
             },
         },
     }));
@@ -99,14 +113,18 @@ const resolveSessionService = async () => {
         },
     }));
 
-    jest.doMock("../cacheService", () => ({
-        segmentedStreamingCacheService: {
-            registerSessionReference: (...args: unknown[]) =>
-                mockRegisterSessionReference(...args),
-            clearSessionReference: (...args: unknown[]) =>
-                mockClearSessionReference(...args),
-        },
-    }));
+    if (options.useRealCacheService) {
+        jest.dontMock("../cacheService");
+    } else {
+        jest.doMock("../cacheService", () => ({
+            segmentedStreamingCacheService: {
+                registerSessionReference: (...args: unknown[]) =>
+                    mockRegisterSessionReference(...args),
+                clearSessionReference: (...args: unknown[]) =>
+                    mockClearSessionReference(...args),
+            },
+        }));
+    }
 
     jest.doMock("../segmentService", () => ({
         LOSSLESS_FILE_EXTENSION_REGEX:
@@ -126,10 +144,13 @@ const resolveSessionService = async () => {
     }));
 
     const module = await import("../sessionService");
+    const cacheModule = await import("../cacheService");
 
     return {
         segmentedStreamingSessionService:
             module.segmentedStreamingSessionService,
+        segmentedStreamingCacheService:
+            cacheModule.segmentedStreamingCacheService,
         mocks: {
             mockTrackFindUnique,
             mockUserSettingsFindUnique,
@@ -142,6 +163,9 @@ const resolveSessionService = async () => {
             mockClearSessionReference,
             mockFsAccess,
             mockFsReadFile,
+            mockFsReaddir,
+            mockFsRm,
+            mockFsStat,
             mockHasInFlightBuild,
             mockGetBuildInFlightStatus,
             mockGetBuildFailure,
@@ -151,6 +175,291 @@ const resolveSessionService = async () => {
         },
     };
 };
+
+const createLifecycleSessionRecord = (
+    sessionId: string,
+    createdAt: string,
+    expiresAt = "2099-01-01T00:00:00.000Z",
+    cacheKey = `cache-${sessionId}`,
+) => ({
+    sessionId,
+    userId: "user-1",
+    trackId: `track-${sessionId}`,
+    cacheKey,
+    quality: "medium" as const,
+    sourceType: "local" as const,
+    manifestProfile: "startup_single" as const,
+    manifestPath: `/tmp/segmented/${cacheKey}/manifest.mpd`,
+    assetDir: `/tmp/segmented/${cacheKey}`,
+    createdAt,
+    expiresAt,
+});
+
+describe("segmentedStreamingSessionService resource lifecycle", () => {
+    const segmentedEnvKeys = [
+        "SEGMENTED_STREAMING_CACHE_MAX_GB",
+        "SEGMENTED_STREAMING_CACHE_MIN_AGE_MS",
+        "SEGMENTED_STREAMING_CACHE_PRUNE_TARGET_RATIO",
+    ] as const;
+    const originalSegmentedEnv = Object.fromEntries(
+        segmentedEnvKeys.map((key) => [key, process.env[key]]),
+    );
+
+    afterEach(() => {
+        for (const key of segmentedEnvKeys) {
+            const value = originalSegmentedEnv[key];
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        jest.resetModules();
+        jest.dontMock("../../../utils/db");
+        jest.dontMock("../../../utils/redis");
+        jest.dontMock("fs");
+        jest.dontMock("../../../config");
+        jest.dontMock("../../../utils/logger");
+        jest.dontMock("../manifestService");
+        jest.dontMock("../cacheService");
+        jest.dontMock("../segmentService");
+    });
+
+    it("sweeps an abandoned expired session and makes its DASH asset prunable", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-02-23T00:00:00.000Z"),
+            timerLimit: 100,
+        });
+        process.env.SEGMENTED_STREAMING_CACHE_MAX_GB = String(
+            500 / (1024 * 1024 * 1024),
+        );
+        process.env.SEGMENTED_STREAMING_CACHE_MIN_AGE_MS = "1";
+        process.env.SEGMENTED_STREAMING_CACHE_PRUNE_TARGET_RATIO = "0.5";
+
+        const {
+            segmentedStreamingSessionService,
+            segmentedStreamingCacheService,
+            mocks,
+        } = await resolveSessionService({ useRealCacheService: true });
+        const sessionRecord = createLifecycleSessionRecord(
+            "abandoned",
+            "2026-02-22T23:55:00.000Z",
+            "2026-02-23T00:05:00.000Z",
+            "abandoned-asset",
+        );
+        const dashRoot = "/tmp/segmented/segmented-dash";
+        const outputDir = `${dashRoot}/${sessionRecord.cacheKey}`;
+        const segmentPath = `${outputDir}/chunk-0-00001.m4s`;
+
+        mocks.mockFsReaddir.mockImplementation(async (candidatePath) => {
+            if (candidatePath === dashRoot) {
+                return [
+                    {
+                        name: sessionRecord.cacheKey,
+                        isDirectory: () => true,
+                    },
+                ];
+            }
+            if (candidatePath === outputDir) {
+                return [
+                    {
+                        name: "chunk-0-00001.m4s",
+                        isDirectory: () => false,
+                    },
+                ];
+            }
+            throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        });
+        mocks.mockFsStat.mockResolvedValue({
+            size: 1_000,
+            mtimeMs: Date.now() - 60_000,
+        });
+        mocks.mockFsRm.mockResolvedValue(undefined);
+
+        await (segmentedStreamingSessionService as any).persistSession(
+            sessionRecord,
+        );
+        segmentedStreamingCacheService.registerSessionReference(
+            sessionRecord.cacheKey,
+            sessionRecord.sessionId,
+        );
+        (segmentedStreamingSessionService as any).markReadinessMicrocacheHit(
+            (segmentedStreamingSessionService as any).segmentReadyMicrocache,
+            `${sessionRecord.sessionId}:chunk-0-00001.m4s`,
+            sessionRecord.sessionId,
+        );
+
+        const protectedResult =
+            await segmentedStreamingCacheService.pruneDashCacheIfNeeded();
+        expect(protectedResult.skippedActiveEntries).toBe(1);
+        expect(mocks.mockFsRm).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        expect(
+            (segmentedStreamingSessionService as any).inMemorySessions.has(
+                sessionRecord.sessionId,
+            ),
+        ).toBe(false);
+        expect(
+            (segmentedStreamingSessionService as any).segmentReadyMicrocache
+                .size,
+        ).toBe(0);
+        expect(
+            segmentedStreamingCacheService.getSessionReferenceCount(
+                sessionRecord.cacheKey,
+            ),
+        ).toBe(0);
+
+        const prunedResult =
+            await segmentedStreamingCacheService.pruneDashCacheIfNeeded();
+        expect(prunedResult.removedEntries).toBe(1);
+        expect(mocks.mockFsRm).toHaveBeenCalledWith(outputDir, {
+            recursive: true,
+            force: true,
+        });
+        expect(mocks.mockFsStat).toHaveBeenCalledWith(segmentPath);
+
+        segmentedStreamingSessionService.dispose();
+    });
+
+    it("evicts the oldest session when the in-memory capacity is exceeded", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-02-23T00:00:00.000Z"),
+            timerLimit: 100,
+        });
+        const { segmentedStreamingSessionService, mocks } =
+            await resolveSessionService();
+        const serviceState = segmentedStreamingSessionService as any;
+        const capacity = serviceState.maxInMemorySessionEntries as number;
+
+        expect(capacity).toBe(4_096);
+        for (let index = 0; index < 4_096; index += 1) {
+            const sessionId = `session-${index.toString().padStart(5, "0")}`;
+            serviceState.inMemorySessions.set(
+                sessionId,
+                createLifecycleSessionRecord(
+                    sessionId,
+                    new Date(Date.now() + index).toISOString(),
+                ),
+            );
+        }
+
+        const newestSession = createLifecycleSessionRecord(
+            "session-newest",
+            new Date(Date.now() + capacity).toISOString(),
+        );
+        await serviceState.persistSession(newestSession);
+
+        expect(serviceState.inMemorySessions.size).toBe(capacity);
+        expect(serviceState.inMemorySessions.has("session-00000")).toBe(false);
+        expect(serviceState.inMemorySessions.has(newestSession.sessionId)).toBe(
+            true,
+        );
+        expect(mocks.mockClearSessionReference).toHaveBeenCalledWith(
+            "cache-session-00000",
+            "session-00000",
+        );
+
+        segmentedStreamingSessionService.dispose();
+    });
+
+    it("evicts the oldest readiness entry when the microcache capacity is exceeded", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-02-23T00:00:00.000Z"),
+            timerLimit: 100,
+        });
+        const { segmentedStreamingSessionService } =
+            await resolveSessionService();
+        const serviceState = segmentedStreamingSessionService as any;
+        const capacity =
+            serviceState.maxSegmentReadyMicrocacheEntries as number;
+
+        expect(capacity).toBe(8_192);
+        for (let index = 0; index < 8_192; index += 1) {
+            serviceState.markReadinessMicrocacheHit(
+                serviceState.segmentReadyMicrocache,
+                `session-${index}:chunk-0-00001.m4s`,
+                `session-${index}`,
+            );
+        }
+
+        serviceState.markReadinessMicrocacheHit(
+            serviceState.segmentReadyMicrocache,
+            "session-newest:chunk-0-00001.m4s",
+            "session-newest",
+        );
+
+        expect(serviceState.segmentReadyMicrocache.size).toBe(capacity);
+        expect(
+            serviceState.segmentReadyMicrocache.has(
+                "session-0:chunk-0-00001.m4s",
+            ),
+        ).toBe(false);
+        expect(
+            serviceState.segmentReadyMicrocache.has(
+                "session-newest:chunk-0-00001.m4s",
+            ),
+        ).toBe(true);
+
+        segmentedStreamingSessionService.dispose();
+    });
+
+    it("keeps an active non-expired session through a sweep", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-02-23T00:00:00.000Z"),
+            timerLimit: 100,
+        });
+        const { segmentedStreamingSessionService, mocks } =
+            await resolveSessionService();
+        const activeSession = createLifecycleSessionRecord(
+            "active",
+            "2026-02-23T00:00:00.000Z",
+            "2026-02-23T00:05:00.000Z",
+        );
+
+        await (segmentedStreamingSessionService as any).persistSession(
+            activeSession,
+        );
+        await jest.advanceTimersByTimeAsync(60_000);
+
+        expect(
+            (segmentedStreamingSessionService as any).inMemorySessions.get(
+                activeSession.sessionId,
+            ),
+        ).toEqual(activeSession);
+        expect(mocks.mockClearSessionReference).not.toHaveBeenCalled();
+
+        segmentedStreamingSessionService.dispose();
+    });
+
+    it("unrefs its sweep timer and clears it once on dispose", async () => {
+        jest.useFakeTimers();
+        const unref = jest.fn();
+        const timer = { unref } as unknown as NodeJS.Timeout;
+        const setIntervalSpy = jest
+            .spyOn(global, "setInterval")
+            .mockReturnValue(timer);
+        const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+        const { segmentedStreamingSessionService } =
+            await resolveSessionService();
+
+        expect(setIntervalSpy).toHaveBeenCalledWith(
+            expect.any(Function),
+            60_000,
+        );
+        expect(unref).toHaveBeenCalledTimes(1);
+
+        segmentedStreamingSessionService.dispose();
+        segmentedStreamingSessionService.dispose();
+
+        expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+        expect(clearIntervalSpy).toHaveBeenCalledWith(timer);
+    });
+});
 
 describe("segmentedStreamingSessionService local quality handling", () => {
     afterEach(() => {

--- a/backend/src/services/segmented-streaming/sessionService.ts
+++ b/backend/src/services/segmented-streaming/sessionService.ts
@@ -39,6 +39,9 @@ const ASSET_READY_POLL_MIN_REMAINING_WINDOW_SAMPLES = 6;
 const ASSET_READY_TIMEOUT_MS = 20_000;
 const ASSET_CROSS_POD_GRACE_MS = 5_000;
 const READINESS_MICROCACHE_TTL_MS = 1_500;
+const SESSION_EXPIRY_SWEEP_INTERVAL_MS = 60_000;
+const MAX_IN_MEMORY_SESSION_ENTRIES = 4_096;
+const MAX_SEGMENT_READY_MICROCACHE_ENTRIES = 8_192;
 const STARTUP_MIN_TIMELINE_SEGMENTS = 3;
 const STARTUP_SEGMENT_EXTENSIONS = ["m4s", "webm"] as const;
 const TRANSIENT_BUILD_FAILURE_PATTERNS = [
@@ -179,19 +182,48 @@ interface ReadinessPollBackoffState {
     nextBaseDelayMs: number;
 }
 
+interface ReadinessMicrocacheEntry {
+    expiresAtMs: number;
+    sessionId: string;
+}
+
 class SegmentedSessionService {
+    private readonly maxInMemorySessionEntries = MAX_IN_MEMORY_SESSION_ENTRIES;
+    private readonly maxSegmentReadyMicrocacheEntries =
+        MAX_SEGMENT_READY_MICROCACHE_ENTRIES;
     private readonly inMemorySessions = new Map<
         string,
         SegmentedSessionRecord
     >();
     private readonly manifestReadyInFlight = new Map<string, Promise<void>>();
     private readonly segmentReadyInFlight = new Map<string, Promise<void>>();
-    private readonly segmentReadyMicrocache = new Map<string, number>();
+    private readonly segmentReadyMicrocache = new Map<
+        string,
+        ReadinessMicrocacheEntry
+    >();
     private readonly playbackErrorRepairInFlight = new Map<
         string,
         Promise<void>
     >();
     private readonly playbackErrorRepairQueued = new Set<string>();
+    private expirySweepInterval: NodeJS.Timeout | null;
+
+    constructor() {
+        this.expirySweepInterval = setInterval(() => {
+            this.sweepExpiredEntries();
+        }, SESSION_EXPIRY_SWEEP_INTERVAL_MS);
+        this.expirySweepInterval.unref?.();
+    }
+
+    /** Stops the owned expiry-sweep timer. */
+    dispose(): void {
+        if (!this.expirySweepInterval) {
+            return;
+        }
+
+        clearInterval(this.expirySweepInterval);
+        this.expirySweepInterval = null;
+    }
 
     async createLocalSession(
         input: CreateLocalSegmentedSessionInput,
@@ -658,6 +690,7 @@ class SegmentedSessionService {
                 this.markReadinessMicrocacheHit(
                     this.segmentReadyMicrocache,
                     segmentReadinessKey,
+                    session.sessionId,
                 );
             },
             {
@@ -685,15 +718,15 @@ class SegmentedSessionService {
     }
 
     private hasReadinessMicrocacheHit(
-        microcache: Map<string, number>,
+        microcache: Map<string, ReadinessMicrocacheEntry>,
         key: string,
     ): boolean {
-        const expiresAtMs = microcache.get(key);
-        if (expiresAtMs === undefined) {
+        const entry = microcache.get(key);
+        if (!entry) {
             return false;
         }
 
-        if (expiresAtMs <= Date.now()) {
+        if (entry.expiresAtMs <= Date.now()) {
             microcache.delete(key);
             return false;
         }
@@ -702,17 +735,32 @@ class SegmentedSessionService {
     }
 
     private markReadinessMicrocacheHit(
-        microcache: Map<string, number>,
+        microcache: Map<string, ReadinessMicrocacheEntry>,
         key: string,
+        sessionId = key.slice(0, key.indexOf(":")),
     ): void {
-        microcache.set(key, Date.now() + READINESS_MICROCACHE_TTL_MS);
+        microcache.delete(key);
+        if (microcache.size >= this.maxSegmentReadyMicrocacheEntries) {
+            this.evictExpiredReadinessEntries(Date.now());
+        }
+        if (microcache.size >= this.maxSegmentReadyMicrocacheEntries) {
+            const oldestKey = microcache.keys().next().value;
+            if (typeof oldestKey === "string") {
+                microcache.delete(oldestKey);
+            }
+        }
+
+        microcache.set(key, {
+            expiresAtMs: Date.now() + READINESS_MICROCACHE_TTL_MS,
+            sessionId,
+        });
     }
 
     private async persistSession(
         session: SegmentedSessionRecord,
     ): Promise<void> {
         const key = this.getSessionKey(session.sessionId);
-        this.inMemorySessions.set(session.sessionId, session);
+        this.storeSessionInMemory(session);
 
         try {
             await redisClient.setEx(
@@ -738,7 +786,7 @@ class SegmentedSessionService {
             if (payload) {
                 const parsed = parseSessionRecord(payload);
                 if (parsed) {
-                    this.inMemorySessions.set(sessionId, parsed);
+                    this.storeSessionInMemory(parsed);
                     return parsed;
                 }
             }
@@ -753,19 +801,112 @@ class SegmentedSessionService {
     }
 
     private async deleteSession(sessionId: string): Promise<void> {
-        const existingSession = this.inMemorySessions.get(sessionId);
-        this.inMemorySessions.delete(sessionId);
-        if (existingSession) {
-            segmentedStreamingCacheService.clearSessionReference(
-                existingSession.cacheKey,
-                existingSession.sessionId,
-            );
-        }
+        this.evictSessionFromMemory(sessionId);
         const key = this.getSessionKey(sessionId);
         try {
             await redisClient.del(key);
         } catch {
             // Intentionally ignored: key expiry fallback still applies.
+        }
+    }
+
+    private storeSessionInMemory(session: SegmentedSessionRecord): void {
+        const isNewEntry = !this.inMemorySessions.has(session.sessionId);
+        if (
+            isNewEntry &&
+            this.inMemorySessions.size >= this.maxInMemorySessionEntries
+        ) {
+            this.evictExpiredSessions(Date.now());
+        }
+        if (
+            isNewEntry &&
+            this.inMemorySessions.size >= this.maxInMemorySessionEntries
+        ) {
+            const oldestSessionId = this.findOldestSessionId();
+            if (oldestSessionId) {
+                this.evictSessionFromMemory(oldestSessionId);
+            }
+        }
+
+        this.inMemorySessions.set(session.sessionId, session);
+    }
+
+    private findOldestSessionId(): string | null {
+        const oldestSessionId = this.inMemorySessions.keys().next().value;
+        return typeof oldestSessionId === "string" ? oldestSessionId : null;
+    }
+
+    private sweepExpiredEntries(): void {
+        const nowMs = Date.now();
+        this.evictExpiredSessions(nowMs);
+        this.evictExpiredReadinessEntries(nowMs);
+    }
+
+    private evictExpiredSessions(nowMs: number): void {
+        const evictedSessionIds = new Set<string>();
+        let inspectedEntries = 0;
+
+        for (const session of this.inMemorySessions.values()) {
+            if (inspectedEntries >= this.maxInMemorySessionEntries) {
+                break;
+            }
+            inspectedEntries += 1;
+            if (!isSessionExpired(session, nowMs)) {
+                continue;
+            }
+
+            this.evictSessionRecord(session);
+            evictedSessionIds.add(session.sessionId);
+        }
+
+        if (evictedSessionIds.size > 0) {
+            this.clearReadinessEntriesForSessions(evictedSessionIds);
+        }
+    }
+
+    private evictExpiredReadinessEntries(nowMs: number): void {
+        let inspectedEntries = 0;
+        for (const [key, entry] of this.segmentReadyMicrocache) {
+            if (inspectedEntries >= this.maxSegmentReadyMicrocacheEntries) {
+                break;
+            }
+            inspectedEntries += 1;
+            if (entry.expiresAtMs <= nowMs) {
+                this.segmentReadyMicrocache.delete(key);
+            }
+        }
+    }
+
+    private evictSessionFromMemory(sessionId: string): void {
+        const session = this.inMemorySessions.get(sessionId);
+        if (!session) {
+            return;
+        }
+
+        this.evictSessionRecord(session);
+        this.clearReadinessEntriesForSessions(new Set([sessionId]));
+    }
+
+    private evictSessionRecord(session: SegmentedSessionRecord): void {
+        this.inMemorySessions.delete(session.sessionId);
+        segmentedStreamingCacheService.clearSessionReference(
+            session.cacheKey,
+            session.sessionId,
+        );
+    }
+
+    private clearReadinessEntriesForSessions(
+        sessionIds: ReadonlySet<string>,
+    ): void {
+        let inspectedEntries = 0;
+        for (const [key, entry] of this.segmentReadyMicrocache) {
+            if (inspectedEntries >= this.maxSegmentReadyMicrocacheEntries) {
+                break;
+            }
+            inspectedEntries += 1;
+            if (sessionIds.has(entry.sessionId)) {
+                this.segmentReadyMicrocache.delete(key);
+            }
         }
     }
 
@@ -1498,6 +1639,14 @@ const normalizePositionSec = (value: unknown): number | undefined =>
 
 const normalizeIsPlaying = (value: unknown): boolean | undefined =>
     typeof value === "boolean" ? value : undefined;
+
+const isSessionExpired = (
+    session: SegmentedSessionRecord,
+    nowMs: number,
+): boolean => {
+    const expiresAtMs = Date.parse(session.expiresAt);
+    return !Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs;
+};
 
 const isSegmentedSessionTokenPayload = (
     payload: unknown,


### PR DESCRIPTION
Closes **M7** from the sweep-21 convergence review.

`inMemorySessions` and `segmentReadyMicrocache` had no capacity bound and no proactive expiry sweep — a session was deleted only when that exact expired ID was requested again. Each created session registers a cache reference, and cache pruning skips referenced assets, so abandoned sessions leaked heap state **and** could permanently exempt DASH assets from the configured disk bound.

Adds an `unref()`'d periodic expiry sweep (60s) with a `dispose()` to clear it, hard capacity caps on both maps with bounded/deterministic eviction (no recursion, all loops have fixed upper bounds), and releases each evicted session's cache reference plus its per-session microcache keys so pruning is no longer blocked.

Behavioral tests: an abandoned/expired session is evicted by the sweep without re-request; its cache reference is released so the previously-protected DASH asset becomes prunable; capacity eviction removes the oldest; active non-expired sessions survive; dispose clears the timer exactly once. 133 tests / 4 suites green, tsc clean, prettier clean.