### PR TITLE
fix(reliability): abort share-link ZIP work when the client disconnects

### DIFF
--- a/backend/src/routes/__tests__/shareLinksCore.test.ts
+++ b/backend/src/routes/__tests__/shareLinksCore.test.ts
@@ -35,14 +35,17 @@ jest.mock("../../middleware/auth", () => ({
     requireAuth: mockRequireAuth,
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
+jest.mock("../../utils/logger", () => {
+    const loggerMock = {
         debug: jest.fn(),
         info: jest.fn(),
         warn: jest.fn(),
         error: (...args: unknown[]) => mockLoggerError(...args),
-    },
-}));
+        child: jest.fn(),
+    };
+    loggerMock.child.mockReturnValue(loggerMock);
+    return { logger: loggerMock };
+});
 
 jest.mock("../../utils/db", () => ({
     prisma: {

--- a/backend/src/routes/__tests__/shareLinksRuntime.test.ts
+++ b/backend/src/routes/__tests__/shareLinksRuntime.test.ts
@@ -1,4 +1,7 @@
 import crypto from "node:crypto";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import { PassThrough } from "node:stream";
 import type { Request, Response } from "express";
 import { prisma } from "../../utils/db";
 import router from "../shareLinks";
@@ -7,14 +10,17 @@ jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
+jest.mock("../../utils/logger", () => {
+    const mockLogger = {
         debug: jest.fn(),
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
-    },
-}));
+        child: jest.fn(),
+    };
+    mockLogger.child.mockReturnValue(mockLogger);
+    return { logger: mockLogger };
+});
 
 jest.mock("node:crypto", () => ({
     __esModule: true,
@@ -57,10 +63,12 @@ const mockGetStreamFilePath = jest.fn().mockResolvedValue({
     mimeType: "audio/flac",
 });
 const mockDestroy = jest.fn();
-const mockArchiveFile = jest.fn();
+const mockArchiveAbort = jest.fn();
+const mockArchiveAppend = jest.fn();
 const mockArchivePipe = jest.fn();
 const mockArchiveFinalize = jest.fn().mockResolvedValue(undefined);
-const mockArchiveOn = jest.fn();
+let mockArchive: EventEmitter;
+let mockArchiveDestination: MockResponse | undefined;
 
 jest.mock("../../services/audioStreaming", () => ({
     AudioStreamingService: jest.fn().mockImplementation(() => ({
@@ -72,12 +80,15 @@ jest.mock("../../services/audioStreaming", () => ({
 
 jest.mock("archiver", () => ({
     __esModule: true,
-    ZipArchive: jest.fn(() => ({
-        file: mockArchiveFile,
-        pipe: mockArchivePipe,
-        finalize: mockArchiveFinalize,
-        on: mockArchiveOn,
-    })),
+    ZipArchive: jest.fn(() => {
+        mockArchive = new EventEmitter();
+        return Object.assign(mockArchive, {
+            abort: mockArchiveAbort,
+            append: mockArchiveAppend,
+            pipe: mockArchivePipe,
+            finalize: mockArchiveFinalize,
+        });
+    }),
 }));
 
 const mockFetchExternalImage = jest.fn().mockResolvedValue({
@@ -138,10 +149,12 @@ type MockRequestInput = {
     headers?: Record<string, string>;
 };
 
-type MockResponse = {
+type MockResponse = EventEmitter & {
     statusCode: number;
     body: unknown;
     headers: Record<string, string>;
+    destroyed: boolean;
+    writableFinished: boolean;
     status: jest.MockedFunction<(code: number) => MockResponse>;
     json: jest.MockedFunction<(payload: unknown) => MockResponse>;
     setHeader: jest.MockedFunction<
@@ -169,10 +182,12 @@ function getHandler(path: string, method: "get" | "post" | "delete") {
 }
 
 function createRes() {
-    const res = {} as MockResponse;
+    const res = new EventEmitter() as MockResponse;
     res.statusCode = 200;
     res.body = undefined;
     res.headers = {};
+    res.destroyed = false;
+    res.writableFinished = false;
     res.status = jest.fn((code: number) => {
         res.statusCode = code;
         return res;
@@ -189,13 +204,40 @@ function createRes() {
         res.body = data;
         return res;
     });
-    res.destroy = jest.fn(() => res);
+    res.destroy = jest.fn(() => {
+        res.destroyed = true;
+        return res;
+    });
 
     return res;
 }
 
 function createReq(overrides: MockRequestInput): Request {
     return overrides as unknown as Request;
+}
+
+function mockSingleTrackZipShare(): void {
+    mockShareLinkFindUnique.mockResolvedValueOnce({
+        id: "share-zip",
+        token: "zip-token",
+        resourceType: "album",
+        resourceId: "album-1",
+        revoked: false,
+        expiresAt: null,
+        maxPlays: null,
+        playCount: 0,
+    });
+    mockAlbumFindUnique.mockResolvedValueOnce({
+        artist: { name: "Artist One" },
+        tracks: [
+            {
+                id: "track-1",
+                title: "Track One",
+                filePath: "artist/album/01.flac",
+                fileModified: new Date(),
+            },
+        ],
+    });
 }
 
 describe("shareLinks routes runtime", () => {
@@ -209,6 +251,30 @@ describe("shareLinks routes runtime", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
+        jest.spyOn(fs, "createReadStream").mockImplementation(
+            () => new PassThrough() as unknown as fs.ReadStream,
+        );
+
+        mockArchiveDestination = undefined;
+        mockArchiveAppend.mockReset();
+        mockArchiveFinalize.mockReset();
+        mockArchivePipe.mockReset();
+        mockArchivePipe.mockImplementation((destination: MockResponse) => {
+            mockArchiveDestination = destination;
+        });
+        mockArchiveAppend.mockImplementation(
+            (_source: NodeJS.ReadableStream, data: { name: string }) => {
+                queueMicrotask(() => mockArchive.emit("entry", data));
+                return mockArchive;
+            },
+        );
+        mockArchiveFinalize.mockImplementation(async () => {
+            if (mockArchiveDestination) {
+                mockArchiveDestination.writableFinished = true;
+                mockArchiveDestination.emit("finish");
+            }
+        });
 
         mockRandomBytes.mockReturnValue({
             toString: jest.fn(() => "a".repeat(64)),
@@ -862,8 +928,92 @@ describe("shareLinks routes runtime", () => {
             expect(res.headers["Content-Type"]).toBe("application/zip");
             expect(res.headers["Content-Disposition"]).toContain("attachment");
             expect(mockArchivePipe).toHaveBeenCalledWith(res);
-            expect(mockArchiveFile).toHaveBeenCalledTimes(2);
+            expect(mockArchiveAppend).toHaveBeenCalledTimes(2);
             expect(mockArchiveFinalize).toHaveBeenCalledTimes(1);
+        });
+
+        it("aborts once and destroys the active file stream when the client disconnects", async () => {
+            mockSingleTrackZipShare();
+
+            const fileStream = new PassThrough();
+            const destroyFileStream = jest.spyOn(fileStream, "destroy");
+            jest.mocked(fs.createReadStream).mockReturnValue(
+                fileStream as unknown as fs.ReadStream,
+            );
+            let sourceQueued: (() => void) | undefined;
+            const sourceQueuedPromise = new Promise<void>((resolve) => {
+                sourceQueued = resolve;
+            });
+            mockArchiveAppend.mockImplementationOnce(() => {
+                sourceQueued?.();
+                return mockArchive;
+            });
+
+            const req = {
+                params: { token: "zip-token" },
+            } as unknown as Request;
+            const res = createRes();
+            const routePromise = getSharedZip(req, res);
+
+            await sourceQueuedPromise;
+            res.emit("close");
+            res.emit("aborted");
+            await routePromise;
+
+            expect(mockArchiveAbort).toHaveBeenCalledTimes(1);
+            expect(destroyFileStream).toHaveBeenCalledTimes(1);
+        });
+
+        it("aborts once and releases the active file when the archive errors", async () => {
+            mockSingleTrackZipShare();
+            const fileStream = new PassThrough();
+            const destroyFileStream = jest.spyOn(fileStream, "destroy");
+            jest.mocked(fs.createReadStream).mockReturnValue(
+                fileStream as unknown as fs.ReadStream,
+            );
+            let sourceQueued: (() => void) | undefined;
+            const sourceQueuedPromise = new Promise<void>((resolve) => {
+                sourceQueued = resolve;
+            });
+            mockArchiveAppend.mockImplementationOnce(() => {
+                sourceQueued?.();
+                return mockArchive;
+            });
+
+            const req = {
+                params: { token: "zip-token" },
+            } as unknown as Request;
+            const res = createRes();
+            const routePromise = getSharedZip(req, res);
+            const archiveError = new Error("archive failed");
+
+            await sourceQueuedPromise;
+            mockArchive.emit("error", archiveError);
+            res.emit("close");
+            await routePromise;
+
+            expect(mockArchiveAbort).toHaveBeenCalledTimes(1);
+            expect(destroyFileStream).toHaveBeenCalledTimes(1);
+            expect(res.destroy).toHaveBeenCalledWith(archiveError);
+        });
+
+        it("does not abort and removes disconnect listeners after normal completion", async () => {
+            mockSingleTrackZipShare();
+
+            const req = {
+                params: { token: "zip-token" },
+            } as unknown as Request;
+            const res = createRes();
+
+            await getSharedZip(req, res);
+
+            expect(mockArchiveAbort).not.toHaveBeenCalled();
+            expect(res.listenerCount("close")).toBe(0);
+            expect(res.listenerCount("aborted")).toBe(0);
+            expect(mockArchive.listenerCount("error")).toBe(0);
+            expect(mockArchive.listenerCount("warning")).toBe(0);
+            res.emit("close");
+            expect(mockArchiveAbort).not.toHaveBeenCalled();
         });
 
         it("returns 404 when no streamable tracks exist", async () => {

--- a/backend/src/routes/shareLinks.ts
+++ b/backend/src/routes/shareLinks.ts
@@ -1,7 +1,9 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { Router } from "express";
+import { PassThrough } from "node:stream";
+import type { Archiver, ArchiverError } from "archiver";
+import { Router, type Response } from "express";
 import { z } from "zod";
 import { config } from "../config";
 import { requireAuth } from "../middleware/auth";
@@ -10,8 +12,10 @@ import { fetchExternalImage } from "../services/imageProxy";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
+import { sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
+const zipLogger = logger.child("ShareLinks.ZipArchive");
 
 const playlistItemInclude = {
     track: {
@@ -72,6 +76,214 @@ const trackStreamSelect = {
     filePath: true,
     fileModified: true,
 } as const;
+
+type ZipTrack = {
+    id: string;
+    title: string;
+    filePath: string;
+    fileModified: Date;
+    artistName: string;
+};
+
+type ZipSource = {
+    file: fs.ReadStream;
+    input: PassThrough;
+};
+
+class ZipArchiveLifecycle {
+    readonly waitForAbort: Promise<void>;
+    readonly waitForResponse: Promise<void>;
+    private readonly sources = new Set<ZipSource>();
+    private readonly abortListeners = new Set<() => void>();
+    private archiveFinalized = false;
+    private abortCalled = false;
+    private completed = false;
+    private resolveAbort: () => void = () => {};
+    private resolveResponse: () => void = () => {};
+
+    constructor(
+        private readonly archive: Archiver,
+        private readonly res: Response,
+    ) {
+        this.waitForAbort = new Promise((resolve) => {
+            this.resolveAbort = resolve;
+        });
+        this.waitForResponse = new Promise((resolve) => {
+            this.resolveResponse = resolve;
+        });
+        res.on("close", this.onDisconnect);
+        res.on("aborted", this.onDisconnect);
+        res.on("finish", this.onFinish);
+        archive.on("error", this.onArchiveError);
+        archive.on("warning", this.onArchiveWarning);
+    }
+
+    isAborted(): boolean {
+        return this.abortCalled;
+    }
+
+    markArchiveFinalized(): void {
+        this.archiveFinalized = true;
+    }
+
+    complete(): void {
+        this.completed = true;
+        this.closeSources();
+    }
+
+    abort(error?: Error): void {
+        if (this.abortCalled || this.completed) return;
+        this.abortCalled = true;
+        this.closeSources();
+        if (!this.archiveFinalized) this.archive.abort();
+        for (const listener of this.abortListeners) listener();
+        this.abortListeners.clear();
+        this.resolveAbort();
+        this.resolveResponse();
+        if (error && !this.res.destroyed) this.res.destroy(error);
+    }
+
+    appendFile(filePath: string, name: string, date: Date): Promise<boolean> {
+        const source = this.createSource(filePath);
+        return new Promise((resolve) => {
+            let settled = false;
+            const settle = (appended: boolean) => {
+                if (settled) return;
+                settled = true;
+                this.archive.off("entry", onEntry);
+                this.abortListeners.delete(onAbort);
+                if (appended) this.sources.delete(source);
+                resolve(appended);
+            };
+            const onEntry = () => settle(true);
+            const onAbort = () => settle(false);
+            this.abortListeners.add(onAbort);
+            this.archive.once("entry", onEntry);
+            this.archive.append(source.input, { name, date });
+            source.file.pipe(source.input);
+        });
+    }
+
+    cleanup(): void {
+        this.res.off("close", this.onDisconnect);
+        this.res.off("aborted", this.onDisconnect);
+        this.res.off("finish", this.onFinish);
+        this.archive.off("error", this.onArchiveError);
+        this.archive.off("warning", this.onArchiveWarning);
+        this.abortListeners.clear();
+    }
+
+    private createSource(filePath: string): ZipSource {
+        const source = {
+            file: fs.createReadStream(filePath),
+            input: new PassThrough(),
+        };
+        this.sources.add(source);
+        const onError = (error: Error) => {
+            zipLogger.error("Archive source stream failed", { error });
+            this.abort(error);
+        };
+        source.file.once("error", onError);
+        source.file.once("close", () => source.file.off("error", onError));
+        return source;
+    }
+
+    private closeSources(): void {
+        for (const source of this.sources) {
+            if (!source.file.destroyed) source.file.destroy();
+            if (!source.input.destroyed) source.input.end();
+        }
+        this.sources.clear();
+    }
+
+    private readonly onDisconnect = () => {
+        if (!this.res.writableFinished) this.abort();
+    };
+
+    private readonly onFinish = () => this.resolveResponse();
+
+    private readonly onArchiveError = (error: ArchiverError) => {
+        zipLogger.error("Archive stream failed", { error });
+        this.abort(error);
+    };
+
+    private readonly onArchiveWarning = (error: ArchiverError) => {
+        if (error.code === "ENOENT") {
+            zipLogger.warn("Archive source file was not found; skipping", {
+                error,
+            });
+            return;
+        }
+        zipLogger.error("Archive stream warning", { error });
+        this.abort(error);
+    };
+}
+
+function resolveZipSource(track: ZipTrack): {
+    filePath: string;
+    name: string;
+    date: Date;
+} | null {
+    const normalizedFilePath = track.filePath.replace(/\\/g, "/");
+    const filePath = safeResolvePath(
+        config.music.musicPath,
+        normalizedFilePath,
+    );
+    if (!filePath) return null;
+    const ext = path.extname(filePath) || ".mp3";
+    const safeName = `${track.artistName} - ${track.title}`.replace(
+        /[/\\?%*:|"<>]/g,
+        "_",
+    );
+    return { filePath, name: `${safeName}${ext}`, date: track.fileModified };
+}
+
+async function finalizeZipArchive(
+    archive: Archiver,
+    lifecycle: ZipArchiveLifecycle,
+): Promise<boolean> {
+    const finalizePromise = archive.finalize();
+    const finalized = await Promise.race([
+        finalizePromise.then(() => true),
+        lifecycle.waitForAbort.then(() => false),
+    ]);
+    if (!finalized) return false;
+    lifecycle.markArchiveFinalized();
+    await lifecycle.waitForResponse;
+    return !lifecycle.isAborted();
+}
+
+async function streamZipArchive(
+    archive: Archiver,
+    res: Response,
+    tracks: ReadonlyArray<ZipTrack>,
+): Promise<void> {
+    const lifecycle = new ZipArchiveLifecycle(archive, res);
+    archive.pipe(res);
+    try {
+        for (const track of tracks) {
+            const source = resolveZipSource(track);
+            if (!source) {
+                zipLogger.warn("Skipping track with unsafe archive path", {
+                    trackId: track.id,
+                });
+                continue;
+            }
+            const appended = await lifecycle.appendFile(
+                source.filePath,
+                source.name,
+                source.date,
+            );
+            if (!appended) return;
+        }
+        if (await finalizeZipArchive(archive, lifecycle)) lifecycle.complete();
+    } catch (error) {
+        lifecycle.abort(error instanceof Error ? error : undefined);
+        throw error;
+    } finally {
+        lifecycle.cleanup();
+    }
+}
 
 function resolveNativeCoverPath(nativePath: string): string | null {
     const trimmed = nativePath.replace(/^\/+/, "").trim();
@@ -742,46 +954,7 @@ router.get("/access/:token/zip", async (req, res) => {
             `attachment; filename="soundspan-share.zip"`,
         );
 
-        archive.on("error", (err) => {
-            logger.error("Zip archive error:", err);
-            res.destroy(err);
-        });
-
-        archive.on("warning", (err) => {
-            if (err.code === "ENOENT") {
-                logger.warn(
-                    "Zip archive: file not found, skipping:",
-                    err.message,
-                );
-            } else {
-                logger.error("Zip archive warning:", err);
-                res.destroy(err);
-            }
-        });
-
-        archive.pipe(res);
-
-        for (const track of streamableTracks) {
-            const normalizedFilePath = track.filePath.replace(/\\/g, "/");
-            const resolvedPath = safeResolvePath(
-                config.music.musicPath,
-                normalizedFilePath,
-            );
-            if (!resolvedPath) {
-                logger.warn(
-                    `Zip: skipping track with unsafe path: ${track.id}`,
-                );
-                continue;
-            }
-            const ext = path.extname(resolvedPath) || ".mp3";
-            const safeName = `${track.artistName} - ${track.title}`.replace(
-                /[/\\?%*:|"<>]/g,
-                "_",
-            );
-            archive.file(resolvedPath, { name: `${safeName}${ext}` });
-        }
-
-        await archive.finalize();
+        await streamZipArchive(archive, res, streamableTracks);
     } catch (error) {
         if (error instanceof z.ZodError) {
             return res
@@ -790,7 +963,7 @@ router.get("/access/:token/zip", async (req, res) => {
         }
         logger.error("Share zip error:", error);
         if (!res.headersSent) {
-            res.status(500).json({ error: "Failed to create zip archive" });
+            sendInternalRouteError(res, "Failed to create zip archive");
         }
     }
 });

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -40,7 +40,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/releases.ts": 4,
     "backend/src/routes/search.ts": 4,
     "backend/src/routes/settings.ts": 5,
-    "backend/src/routes/shareLinks.ts": 7,
+    "backend/src/routes/shareLinks.ts": 6,
     "backend/src/routes/social.ts": 3,
     "backend/src/routes/soulseek.ts": 7,
     "backend/src/routes/spotify.ts": 8,


### PR DESCRIPTION
Closes **M9** from the sweep-21 convergence review.

The public token ZIP route (`/access/:token/zip`) piped an Archiver stream to the response and awaited `finalize()` with no response close/aborted/error handler. Archiver exposes `abort()` but it was never called, so a client disconnect left the request blocked holding archive and file handles; repeated disconnects accumulated work.

Introduces a `ZipArchiveLifecycle` that owns the archive: it aborts **exactly once** (guarded) on client disconnect (`res` close/aborted), archive error, or per-source stream error; destroys the file/PassThrough streams; and removes all listeners on normal completion. `finalize()` races against the abort signal so a disconnect cancels promptly. The 500 path now uses `sendInternalRouteError` (route-error canon), which tightened the shareLinks raw-error baseline **7→6**.

Behavioral tests: a simulated mid-stream disconnect triggers a single `abort()` with handles released; a normal completion does not abort and removes its listeners. 67 tests / 2 suites green, tsc clean, prettier clean, route-error canon clean.