### PR TITLE
fix(security): scope Soulseek search sessions to their owner

### DIFF
--- a/backend/src/routes/__tests__/soulseekRuntime.test.ts
+++ b/backend/src/routes/__tests__/soulseekRuntime.test.ts
@@ -346,7 +346,7 @@ describe("soulseek runtime routes", () => {
         expect(mockSoulseekService.searchTrack).not.toHaveBeenCalled();
     });
 
-    it("returns formatted search results and 404 when search session is missing", async () => {
+    it("stores the search owner, returns their results, and hides them from other users", async () => {
         mockRandomUUID.mockReturnValueOnce("search-results-id");
         mockSoulseekService.searchTrack.mockResolvedValueOnce({
             found: true,
@@ -373,7 +373,10 @@ describe("soulseek runtime routes", () => {
         await searchHandler(searchReq, searchRes);
         await flushPromises();
 
-        const resultsReq = { params: { searchId: "search-results-id" } } as any;
+        const resultsReq = {
+            user: { id: "user-results" },
+            params: { searchId: "search-results-id" },
+        } as any;
         const resultsRes = createRes();
         await searchByIdHandler(resultsReq, resultsRes);
 
@@ -394,6 +397,22 @@ describe("soulseek runtime routes", () => {
             ],
             count: 1,
         });
+
+        const otherUserReq = {
+            user: { id: "other-user" },
+            params: { searchId: "search-results-id" },
+        } as any;
+        const otherUserRes = createRes();
+        await searchByIdHandler(otherUserReq, otherUserRes);
+
+        expect(otherUserRes.statusCode).toBe(404);
+        expect(otherUserRes.body).toEqual({
+            error: "Search not found or expired",
+            results: [],
+            count: 0,
+        });
+        expect(JSON.stringify(otherUserRes.body)).not.toContain("peer-1");
+        expect(JSON.stringify(otherUserRes.body)).not.toContain("/library/");
 
         const missingReq = {
             params: { searchId: "missing-session-id" },
@@ -436,6 +455,7 @@ describe("soulseek runtime routes", () => {
         await flushPromises();
 
         const resultsReq = {
+            user: { id: "user-bad-file" },
             params: { searchId: "search-bad-file-id" },
         } as any;
         const resultsRes = createRes();
@@ -701,7 +721,10 @@ describe("soulseek runtime routes", () => {
 
         const newestRes = createRes();
         await searchByIdHandler(
-            { params: { searchId: "retained-search-101" } } as any,
+            {
+                user: { id: "retained-user-100" },
+                params: { searchId: "retained-search-101" },
+            } as any,
             newestRes,
         );
         expect(newestRes.statusCode).toBe(200);
@@ -735,7 +758,10 @@ describe("soulseek runtime routes", () => {
 
         const resultsRes = createRes();
         await searchByIdHandler(
-            { params: { searchId: "bounded-results-id" } } as any,
+            {
+                user: { id: "bounded-results-user" },
+                params: { searchId: "bounded-results-id" },
+            } as any,
             resultsRes,
         );
 

--- a/backend/src/routes/soulseek.ts
+++ b/backend/src/routes/soulseek.ts
@@ -36,6 +36,7 @@ interface SearchSession {
     query: string;
     results: SearchResult[];
     createdAt: Date;
+    userId: string;
 }
 
 interface SearchJob {
@@ -76,7 +77,11 @@ function removeOldestSearchSession(): void {
     }
 }
 
-function storeSearchSession(searchId: string, query: string): void {
+function storeSearchSession(
+    searchId: string,
+    query: string,
+    userId: string,
+): void {
     cleanupExpiredSearchSessions(Date.now());
     if (searchSessions.size >= MAX_SEARCH_SESSIONS) {
         removeOldestSearchSession();
@@ -85,6 +90,7 @@ function storeSearchSession(searchId: string, query: string): void {
         query,
         results: [],
         createdAt: new Date(),
+        userId,
     });
 }
 
@@ -466,7 +472,7 @@ router.post(
                 return sendCapacityError(res);
             }
 
-            storeSearchSession(job.searchId, searchQuery);
+            storeSearchSession(job.searchId, searchQuery, userId);
             recordRateAdmission(userId, now);
             if (!admitSearch(job)) {
                 searchSessions.delete(job.searchId);
@@ -522,6 +528,14 @@ router.get<{ searchId: string }>(
             const session = searchSessions.get(searchId);
 
             if (!session) {
+                return res.status(404).json({
+                    error: "Search not found or expired",
+                    results: [],
+                    count: 0,
+                });
+            }
+
+            if (session.userId !== req.user!.id) {
                 return res.status(404).json({
                     error: "Search not found or expired",
                     results: [],


### PR DESCRIPTION
Closes **M3** from the sweep-21 convergence review.

`GET /soulseek/search/:searchId` read the globally-keyed in-memory `SearchSession` without comparing `req.user.id` and returned peer usernames and remote file paths — any authenticated user possessing another user's search UUID could read that user's results (IDOR).

The fix persists `userId` on the `SearchSession` at creation and returns the same not-found 404 shape unless the authenticated caller owns the session (no existence disclosure, no 403). `SearchSession` is an in-memory map, not a Prisma model, so **no schema migration is required** (the original finding assumed a persisted relation; verified it is in-memory).

Two-user behavioral test: user A reads their own results; user B receives the not-found 404 with no usernames/paths. 95 tests / 2 suites green, tsc clean, prettier clean, route-error canon clean.