### PR TITLE
fix(config): inject required secrets into docker-compose backend-worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,8 @@ services:
             # Preserve Redis streams/groups across restarts unless explicitly overridden
             REDIS_FLUSH_ON_STARTUP: ${REDIS_FLUSH_ON_STARTUP:-false}
             NODE_ENV: ${NODE_ENV:-production}
+            SESSION_SECRET: "${SESSION_SECRET:?SESSION_SECRET is required - generate one with: openssl rand -base64 32}"
+            SETTINGS_ENCRYPTION_KEY: "${SETTINGS_ENCRYPTION_KEY:?SETTINGS_ENCRYPTION_KEY is required - generate one with: openssl rand -base64 32}"
             LOG_LEVEL: ${LOG_LEVEL:-warn}
             MUSIC_PATH: /music
             INTERNAL_API_SECRET: "${INTERNAL_API_SECRET:?INTERNAL_API_SECRET is required - generate one with: openssl rand -base64 32}"

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -35,7 +35,7 @@ function isExternalImage(reference) {
     return /[:@/]/.test(reference);
 }
 
-function composeConfig(postgresPassword) {
+function composeConfig(postgresPassword, { noInterpolate = false } = {}) {
     const environment = {
         ...process.env,
         INTERNAL_API_SECRET: "test-internal-secret",
@@ -48,22 +48,25 @@ function composeConfig(postgresPassword) {
         environment.POSTGRES_PASSWORD = postgresPassword;
     }
 
-    return childProcess.spawnSync(
-        "docker",
-        [
-            "compose",
-            "--env-file",
-            os.devNull,
-            "--profile",
-            "*",
-            "-f",
-            path.join(repoRoot, "docker-compose.yml"),
-            "config",
-            "--format",
-            "json",
-        ],
-        { cwd: repoRoot, encoding: "utf8", env: environment },
-    );
+    const args = [
+        "compose",
+        "--env-file",
+        os.devNull,
+        "--profile",
+        "*",
+        "-f",
+        path.join(repoRoot, "docker-compose.yml"),
+        "config",
+        ...(noInterpolate ? ["--no-interpolate"] : []),
+        "--format",
+        "json",
+    ];
+
+    return childProcess.spawnSync("docker", args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: environment,
+    });
 }
 
 function runPostgresEntrypoint(postgres, postgresPassword, executablePath) {
@@ -237,7 +240,37 @@ test("8. split-stack compose applies the configured PostgreSQL password everywhe
     );
 });
 
-test("9. split-stack PostgreSQL startup rejects the published sentinel", (t) => {
+test("9. split-stack worker requires its startup secrets", () => {
+    const result = composeConfig("test-explicit-postgres-password", {
+        noInterpolate: true,
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    const services = JSON.parse(result.stdout).services;
+    const backendEnvironment = services.backend.environment;
+    const workerEnvironment = services["backend-worker"].environment;
+    const requiredSecrets = [
+        "SESSION_SECRET",
+        "SETTINGS_ENCRYPTION_KEY",
+        "INTERNAL_API_SECRET",
+    ];
+
+    for (const secret of requiredSecrets) {
+        const workerSubstitution = workerEnvironment[secret];
+        assert.equal(
+            workerSubstitution,
+            backendEnvironment[secret],
+            `backend-worker must use backend's required substitution for ${secret}`,
+        );
+        assert.equal(typeof workerSubstitution, "string");
+        assert.ok(
+            workerSubstitution.startsWith(`\${${secret}:?`),
+            `backend-worker must fail closed when ${secret} is unset`,
+        );
+    }
+});
+
+test("10. split-stack PostgreSQL startup rejects the published sentinel", (t) => {
     const configResult = composeConfig("changeme");
     assert.equal(configResult.status, 0, configResult.stderr);
 


### PR DESCRIPTION
Closes **M10** from the sweep-21 convergence review.

The documented HA `backend-worker` Compose service supplied `INTERNAL_API_SECRET` but omitted `SESSION_SECRET` and `SETTINGS_ENCRYPTION_KEY`. `worker.ts` imports `config.ts`, which requires both (plus a valid settings-encryption key) before worker initialization, so the rendered worker exited immediately instead of registering processors and schedulers — the documented HA worker profile was non-functional.

Both secrets are now injected into `backend-worker` using the same fail-closed `${VAR:?...}` substitutions the `backend` service uses. A compose-render contract test (added to the existing dockerfile-hygiene suite, already wired into Enforcement Gates) asserts `backend-worker` carries `backend`'s required substitution for every startup secret and fails closed when any is unset.

Verified: `docker compose config` renders the worker with both secrets; the render fails when they are omitted; all 10 hygiene tests pass; prettier clean.