### PR TITLE
fix(reliability): coalesce global library scan/organize admission

### DIFF
--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -174,6 +174,11 @@ jest.mock("../../workers/queues", () => ({
     scanQueue: {
         add: jest.fn(),
         getJob: jest.fn(),
+        getJobs: jest.fn(),
+        client: {
+            set: jest.fn(),
+            eval: jest.fn(),
+        },
     },
 }));
 
@@ -421,9 +426,13 @@ const mockPrismaTransaction = prisma.$transaction as jest.Mock;
 const mockPrismaQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockScanQueueAdd = scanQueue.add as jest.Mock;
 const mockScanQueueGetJob = scanQueue.getJob as jest.Mock;
+const mockScanQueueGetJobs = scanQueue.getJobs as jest.Mock;
+const mockScanQueueClientSet = scanQueue.client.set as jest.Mock;
+const mockScanQueueClientEval = scanQueue.client.eval as jest.Mock;
 const mockOrganizeSingles = organizeSingles as jest.Mock;
 const mockLoggerInfo = logger.info as jest.Mock;
 const mockLoggerError = logger.error as jest.Mock;
+const mockLoggerWarn = logger.warn as jest.Mock;
 const mockLoggerDebug = logger.debug as jest.Mock;
 const mockAudioStreamingCtor = AudioStreamingService as unknown as jest.Mock;
 const mockCoverArtGetCoverArt = coverArtService.getCoverArt as jest.Mock;
@@ -613,6 +622,9 @@ describe("library scan and organize runtime coverage", () => {
         mockOrganizeSingles.mockResolvedValue(undefined);
         mockScanQueueAdd.mockResolvedValue({ id: "job-123" });
         mockScanQueueGetJob.mockResolvedValue(null);
+        mockScanQueueGetJobs.mockResolvedValue([]);
+        mockScanQueueClientSet.mockResolvedValue("OK");
+        mockScanQueueClientEval.mockResolvedValue(1);
     });
 
     it("short-circuits scan when MUSIC_PATH is missing", async () => {
@@ -647,13 +659,19 @@ describe("library scan and organize runtime coverage", () => {
             jobId: "job-123",
             musicPath: "/music",
         });
-        expect(mockScanQueueAdd).toHaveBeenCalledWith("scan", {
-            userId: "user-22",
-            musicPath: "/music",
-        });
-        expect(mockLoggerInfo).toHaveBeenCalledWith(
-            "[Scan] SLSKD organization skipped:",
-            "slskd unavailable",
+        expect(mockScanQueueAdd).toHaveBeenCalledWith(
+            "scan",
+            {
+                userId: "user-22",
+                musicPath: "/music",
+            },
+            {
+                jobId: "library-global-maintenance",
+            },
+        );
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "Download organization skipped before library scan",
+            expect.objectContaining({ message: "slskd unavailable" }),
         );
     });
 
@@ -664,10 +682,119 @@ describe("library scan and organize runtime coverage", () => {
         await scanHandler(req, res);
 
         expect(res.statusCode).toBe(200);
-        expect(mockScanQueueAdd).toHaveBeenCalledWith("scan", {
-            userId: "system",
+        expect(mockScanQueueAdd).toHaveBeenCalledWith(
+            "scan",
+            {
+                userId: "system",
+                musicPath: "/music",
+            },
+            {
+                jobId: "library-global-maintenance",
+            },
+        );
+    });
+
+    it("coalesces concurrent scan requests before organization starts twice", async () => {
+        let finishOrganization: (() => void) | undefined;
+        let markOrganizationStarted: (() => void) | undefined;
+        const organizationStarted = new Promise<void>((resolve) => {
+            markOrganizationStarted = resolve;
+        });
+        mockOrganizeSingles.mockImplementationOnce(() => {
+            markOrganizationStarted!();
+            return new Promise<void>((resolve) => {
+                finishOrganization = resolve;
+            });
+        });
+        mockScanQueueClientSet
+            .mockResolvedValueOnce("OK")
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce("OK");
+
+        const firstRes = createRes();
+        const secondRes = createRes();
+        const firstRequest = scanHandler(
+            { user: { id: "user-1" } } as any,
+            firstRes,
+        );
+        const secondRequest = scanHandler(
+            { user: { id: "user-1" } } as any,
+            secondRes,
+        );
+
+        await Promise.all([secondRequest, organizationStarted]);
+
+        expect(secondRes.statusCode).toBe(200);
+        expect(secondRes.body).toEqual({
+            message: "Library maintenance already running",
+            status: "processing",
+            jobId: "library-global-maintenance",
             musicPath: "/music",
         });
+        expect(mockOrganizeSingles).toHaveBeenCalledTimes(1);
+        expect(mockScanQueueAdd).not.toHaveBeenCalled();
+
+        expect(finishOrganization).toBeDefined();
+        finishOrganization!();
+        await firstRequest;
+
+        expect(firstRes.body).toEqual({
+            message: "Library scan started",
+            jobId: "job-123",
+            musicPath: "/music",
+        });
+        expect(mockScanQueueAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns already running when a scan job is active without starting duplicate work", async () => {
+        mockScanQueueGetJobs.mockResolvedValueOnce([{ id: "job-active" }]);
+
+        const res = createRes();
+        await scanHandler({ user: { id: "user-2" } } as any, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            message: "Library maintenance already running",
+            status: "processing",
+            jobId: "job-active",
+            musicPath: "/music",
+        });
+        expect(mockOrganizeSingles).not.toHaveBeenCalled();
+        expect(mockScanQueueAdd).not.toHaveBeenCalled();
+        expect(mockScanQueueClientEval).toHaveBeenCalledTimes(1);
+    });
+
+    it("reuses the maintenance identity after preserving the prior result for status polling", async () => {
+        const completedJob = {
+            id: "library-global-maintenance",
+            getState: jest.fn().mockResolvedValue("completed"),
+            remove: jest.fn().mockResolvedValue(undefined),
+        };
+        mockScanQueueGetJob.mockResolvedValueOnce(completedJob);
+
+        const res = createRes();
+        await scanHandler({ user: { id: "user-5" } } as any, res);
+
+        expect(completedJob.getState).toHaveBeenCalledTimes(1);
+        expect(completedJob.remove).toHaveBeenCalledTimes(1);
+        expect(mockScanQueueAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it("rate limits a user who started maintenance during the cooldown", async () => {
+        mockScanQueueClientSet
+            .mockResolvedValueOnce("OK")
+            .mockResolvedValueOnce(null);
+
+        const res = createRes();
+        await scanHandler({ user: { id: "user-2" } } as any, res);
+
+        expect(res.statusCode).toBe(429);
+        expect(res.body).toEqual({
+            error: "Library maintenance was started recently",
+        });
+        expect(mockOrganizeSingles).not.toHaveBeenCalled();
+        expect(mockScanQueueAdd).not.toHaveBeenCalled();
+        expect(mockScanQueueClientEval).toHaveBeenCalledTimes(1);
     });
 
     it("returns scan trigger error when queue add fails", async () => {
@@ -740,6 +867,21 @@ describe("library scan and organize runtime coverage", () => {
         expect(mockOrganizeSingles).toHaveBeenCalledTimes(1);
     });
 
+    it("does not start organization while a scan job is active", async () => {
+        mockScanQueueGetJobs.mockResolvedValueOnce([{ id: "job-active" }]);
+
+        const res = createRes();
+        await organizeHandler({ user: { id: "user-4" } } as any, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            message: "Library maintenance already running",
+            status: "processing",
+        });
+        expect(mockOrganizeSingles).not.toHaveBeenCalled();
+        expect(mockScanQueueAdd).not.toHaveBeenCalled();
+    });
+
     it("keeps organization endpoint successful when background promise rejects", async () => {
         const backgroundError = new Error("organizer worker failed");
         mockOrganizeSingles.mockReturnValueOnce(
@@ -757,7 +899,7 @@ describe("library scan and organize runtime coverage", () => {
             message: "Organization started in background",
         });
         expect(mockLoggerError).toHaveBeenCalledWith(
-            "Manual organization failed:",
+            "Manual organization failed",
             backgroundError,
         );
     });

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -141,6 +141,181 @@ const COVER_ART_IMAGE_CACHE_CONTROL = `public, max-age=${COVER_ART_IMAGE_CACHE_T
 const RELIABLE_ENHANCED_ANALYSIS_VERSION_PREFIX = "2.1b6-enhanced-v3";
 const AUDIO_INFO_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const AUDIO_INFO_CACHE_MAX_ENTRIES = 2000;
+const LIBRARY_MAINTENANCE_JOB_ID = "library-global-maintenance";
+const LIBRARY_MAINTENANCE_CLAIM_KEY =
+    "library:maintenance:admission:library-global-maintenance";
+const LIBRARY_MAINTENANCE_CLAIM_TTL_SECONDS = 6 * 60 * 60;
+const LIBRARY_MAINTENANCE_COOLDOWN_SECONDS = 30;
+const libraryMaintenanceLogger = logger.child("LibraryMaintenance");
+
+interface AdmittedLibraryMaintenance {
+    admitted: true;
+    claimToken: string;
+    cooldownKey: string;
+    cooldownToken: string;
+}
+
+interface RejectedLibraryMaintenance {
+    admitted: false;
+    reason: "active" | "cooldown";
+    jobId?: string;
+}
+
+type LibraryMaintenanceAdmission =
+    | AdmittedLibraryMaintenance
+    | RejectedLibraryMaintenance;
+
+const releaseRedisClaim = async (key: string, token: string): Promise<void> => {
+    try {
+        await scanQueue.client.eval(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+            1,
+            key,
+            token,
+        );
+    } catch (error) {
+        libraryMaintenanceLogger.warn("Failed to release admission claim", {
+            key,
+            error,
+        });
+    }
+};
+
+const findPendingLibraryMaintenanceJob = async () => {
+    const jobs = await scanQueue.getJobs(
+        ["active", "waiting", "delayed", "paused"],
+        0,
+        0,
+        true,
+    );
+    return jobs[0] ?? null;
+};
+
+const removeSettledLibraryMaintenanceJob = async (): Promise<void> => {
+    const job = await scanQueue.getJob(LIBRARY_MAINTENANCE_JOB_ID);
+    if (!job) {
+        return;
+    }
+    const state = await job.getState();
+    if (state === "completed" || state === "failed") {
+        await job.remove();
+    }
+};
+
+const admitLibraryMaintenance = async (
+    userId: string,
+): Promise<LibraryMaintenanceAdmission> => {
+    const claimToken = crypto.randomUUID();
+    const acquired = await scanQueue.client.set(
+        LIBRARY_MAINTENANCE_CLAIM_KEY,
+        claimToken,
+        "EX",
+        LIBRARY_MAINTENANCE_CLAIM_TTL_SECONDS,
+        "NX",
+    );
+    if (acquired !== "OK") {
+        return { admitted: false, reason: "active" };
+    }
+
+    try {
+        const pendingJob = await findPendingLibraryMaintenanceJob();
+        if (pendingJob) {
+            await releaseRedisClaim(LIBRARY_MAINTENANCE_CLAIM_KEY, claimToken);
+            return {
+                admitted: false,
+                reason: "active",
+                jobId: String(pendingJob.id),
+            };
+        }
+        await removeSettledLibraryMaintenanceJob();
+
+        const cooldownKey = `library:maintenance:cooldown:${userId}`;
+        const cooldownToken = crypto.randomUUID();
+        const cooldownAcquired = await scanQueue.client.set(
+            cooldownKey,
+            cooldownToken,
+            "EX",
+            LIBRARY_MAINTENANCE_COOLDOWN_SECONDS,
+            "NX",
+        );
+        if (cooldownAcquired !== "OK") {
+            await releaseRedisClaim(LIBRARY_MAINTENANCE_CLAIM_KEY, claimToken);
+            return { admitted: false, reason: "cooldown" };
+        }
+
+        return {
+            admitted: true,
+            claimToken,
+            cooldownKey,
+            cooldownToken,
+        };
+    } catch (error) {
+        await releaseRedisClaim(LIBRARY_MAINTENANCE_CLAIM_KEY, claimToken);
+        throw error;
+    }
+};
+
+const releaseLibraryMaintenanceAdmission = async (
+    admission: AdmittedLibraryMaintenance,
+    keepCooldown: boolean,
+): Promise<void> => {
+    await releaseRedisClaim(
+        LIBRARY_MAINTENANCE_CLAIM_KEY,
+        admission.claimToken,
+    );
+    if (!keepCooldown) {
+        await releaseRedisClaim(admission.cooldownKey, admission.cooldownToken);
+    }
+};
+
+const finishOrganizationInBackground = async (
+    organization: Promise<void>,
+    admission: AdmittedLibraryMaintenance,
+): Promise<void> => {
+    try {
+        await organization;
+    } catch (error) {
+        libraryMaintenanceLogger.error("Manual organization failed", error);
+    } finally {
+        await releaseLibraryMaintenanceAdmission(admission, true);
+    }
+};
+
+const organizeBeforeLibraryScan = async (): Promise<void> => {
+    try {
+        libraryMaintenanceLogger.info(
+            "Organizing downloads before library scan",
+        );
+        await organizeSingles();
+        libraryMaintenanceLogger.info("Download organization complete");
+    } catch (error) {
+        libraryMaintenanceLogger.warn(
+            "Download organization skipped before library scan",
+            error,
+        );
+    }
+};
+
+const startAdmittedLibraryScan = async (
+    userId: string,
+    admission: AdmittedLibraryMaintenance,
+) => {
+    let scanQueued = false;
+    try {
+        await organizeBeforeLibraryScan();
+        const job = await scanQueue.add(
+            "scan",
+            { userId, musicPath: config.music.musicPath },
+            {
+                jobId: LIBRARY_MAINTENANCE_JOB_ID,
+            },
+        );
+        scanQueued = true;
+        return job;
+    } finally {
+        await releaseLibraryMaintenanceAdmission(admission, scanQueued);
+    }
+};
 
 const moodPoolCondition = (moodValue: string): Prisma.Sql => {
     switch (moodValue) {
@@ -590,7 +765,7 @@ router.get(
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Library scan started successfully
+ *         description: Library scan started or global library maintenance is already running
  *         content:
  *           application/json:
  *             schema:
@@ -606,6 +781,15 @@ router.get(
  *                 musicPath:
  *                   type: string
  *                   example: "/path/to/music"
+ *                 status:
+ *                   type: string
+ *                   description: Present as "processing" when maintenance was already active
+ *       429:
+ *         description: This user started library maintenance too recently
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       500:
  *         description: Failed to start scan
  *         content:
@@ -622,28 +806,26 @@ router.post(
             });
         }
 
-        // First, organize any SLSKD downloads from Docker container to music library
-        // This ensures files are moved before the scan finds them
-        try {
-            const { organizeSingles } =
-                await import("../workers/organizeSingles");
-            logger.info("[Scan] Organizing SLSKD downloads before scan...");
-            await organizeSingles();
-            logger.info("[Scan] SLSKD organization complete");
-        } catch (err: any) {
-            // Not a fatal error - SLSKD might not be running or have no files
-            logger.info("[Scan] SLSKD organization skipped:", err.message);
+        const userId = req.user?.id || "system";
+        const admission = await admitLibraryMaintenance(userId);
+        if (!admission.admitted) {
+            if (admission.reason === "cooldown") {
+                return sendRouteError(
+                    res,
+                    429,
+                    "Library maintenance was started recently",
+                );
+            }
+            return res.json({
+                message: "Library maintenance already running",
+                status: "processing",
+                jobId: admission.jobId ?? LIBRARY_MAINTENANCE_JOB_ID,
+                musicPath: config.music.musicPath,
+            });
         }
 
-        const userId = req.user?.id || "system";
-
-        // Add scan job to queue
-        const job = await scanQueue.add("scan", {
-            userId,
-            musicPath: config.music.musicPath,
-        });
-
-        res.json({
+        const job = await startAdmittedLibraryScan(userId, admission);
+        return res.json({
             message: "Library scan started",
             jobId: job.id,
             musicPath: config.music.musicPath,
@@ -719,7 +901,7 @@ router.get(
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Organization started
+ *         description: Organization started or global library maintenance is already running
  *         content:
  *           application/json:
  *             schema:
@@ -727,6 +909,15 @@ router.get(
  *               properties:
  *                 message:
  *                   type: string
+ *                 status:
+ *                   type: string
+ *                   description: Present as "processing" when maintenance was already active
+ *       429:
+ *         description: This user started library maintenance too recently
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       401:
  *         description: Not authenticated
  */
@@ -734,10 +925,32 @@ router.get(
 router.post(
     "/organize",
     asyncHandler(async (req, res) => {
-        // Run in background
-        organizeSingles().catch((err) => {
-            logger.error("Manual organization failed:", err);
-        });
+        const admission = await admitLibraryMaintenance(
+            req.user?.id || "system",
+        );
+        if (!admission.admitted) {
+            if (admission.reason === "cooldown") {
+                return sendRouteError(
+                    res,
+                    429,
+                    "Library maintenance was started recently",
+                );
+            }
+            return res.json({
+                message: "Library maintenance already running",
+                status: "processing",
+            });
+        }
+
+        let organization: Promise<void>;
+        try {
+            organization = organizeSingles();
+        } catch (error) {
+            await releaseLibraryMaintenanceAdmission(admission, false);
+            throw error;
+        }
+
+        void finishOrganizationInBackground(organization, admission);
 
         res.json({ message: "Organization started in background" });
     }),


### PR DESCRIPTION
Closes **K3** from the sweep-22 convergence review.

The `/library/scan` and `/library/organize` routes admitted duplicate global maintenance work — any authenticated user could repeatedly trigger overlapping full-library scans/organizes, amplifying expensive global work (attacker-amplifiable unbounded work).

Both endpoints now route through a single coalesced admission: a Redis `SET NX EX` claim plus a pending-job check ensures only one global maintenance job (`library-global-maintenance`) runs at a time — an already-active request returns "already running" (200) instead of enqueuing a duplicate — with a short per-user cooldown (429). Admission claims are released atomically via a CAS Lua delete. OpenAPI documents the already-running and 429 responses.

Kept user-triggerable (coalescing + per-user cooldown) rather than admin-gating, to preserve the normal scan feature. 259 library tests / 9 suites green, tsc clean, prettier clean, route-error canon clean.