### PR TITLE
fix(security): require interactive session for Subsonic credential changes

### DIFF
--- a/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
+++ b/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
@@ -1,5 +1,15 @@
+const originalJwtSecret = process.env.JWT_SECRET;
+process.env.JWT_SECRET =
+    process.env.JWT_SECRET || "auth-interactive-route-test-secret";
+
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: any, _res: any, next: () => void) => next(),
+    requireInteractiveSession: (req: any, res: any, next: () => void) =>
+        jest
+            .requireActual<
+                typeof import("../../middleware/auth")
+            >("../../middleware/auth")
+            .requireInteractiveSession(req, res, next),
     requireAdmin: (_req: any, _res: any, next: () => void) => next(),
     generateToken: jest.fn(),
     generateRefreshToken: jest.fn(),
@@ -69,12 +79,18 @@ function createRes() {
     return res;
 }
 
-async function executeRoute(path: string, req: any, res: any): Promise<void> {
+async function executeRoute(
+    path: string,
+    req: any,
+    res: any,
+    method: "post" | "delete" = "post",
+): Promise<void> {
     const layer = (router as any).stack.find(
         (entry: any) =>
-            entry.route?.path === path && entry.route?.methods?.post,
+            entry.route?.path === path && entry.route?.methods?.[method],
     );
-    if (!layer) throw new Error(`Missing POST route ${path}`);
+    if (!layer)
+        throw new Error(`Missing ${method.toUpperCase()} route ${path}`);
 
     const dispatch = async (index: number): Promise<void> => {
         const handler = layer.route.stack[index]?.handle;
@@ -90,12 +106,29 @@ async function executeRoute(path: string, req: any, res: any): Promise<void> {
 function interactiveRequest(body: Record<string, unknown>): any {
     return {
         body,
-        headers: { authorization: "Bearer access-token" },
+        headers: {},
+        session: { userId: "u1" },
         user: { id: "u1", username: "alice", role: "user" },
     };
 }
 
-describe("MFA management interactive authentication", () => {
+function apiKeyRequest(body: Record<string, unknown>): any {
+    return {
+        body,
+        headers: { "x-api-key": "stolen-key" },
+        user: { id: "u1", username: "alice", role: "user" },
+    };
+}
+
+describe("interactive authentication for sensitive credential management", () => {
+    afterAll(() => {
+        if (originalJwtSecret === undefined) {
+            delete process.env.JWT_SECRET;
+        } else {
+            process.env.JWT_SECRET = originalJwtSecret;
+        }
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockBcryptCompare.mockResolvedValue(true);
@@ -116,11 +149,9 @@ describe("MFA management interactive authentication", () => {
         ["/2fa/enable", { secret: "NEW-SECRET", token: "123456" }],
         ["/2fa/disable", { password: "secret", token: "123456" }],
     ] as const)("rejects API-key authentication on %s", async (path, body) => {
-        const req = interactiveRequest(body);
-        req.headers["x-api-key"] = "stolen-key";
         const res = createRes();
 
-        await executeRoute(path, req, res);
+        await executeRoute(path, apiKeyRequest(body), res);
 
         expect(res.statusCode).toBe(403);
         expect(res.body).toEqual({
@@ -129,6 +160,62 @@ describe("MFA management interactive authentication", () => {
         expect(prisma.user.findUnique).not.toHaveBeenCalled();
         expect(prisma.user.update).not.toHaveBeenCalled();
         expect(prisma.user.updateMany).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        ["post", { password: "my-subsonic-password" }],
+        ["delete", {}],
+    ] as const)(
+        "rejects API-key authentication on %s /subsonic-password without mutating credentials",
+        async (method, body) => {
+            const res = createRes();
+
+            await executeRoute(
+                "/subsonic-password",
+                apiKeyRequest(body),
+                res,
+                method,
+            );
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body).toEqual({
+                error: "Interactive session authentication required",
+            });
+            expect(prisma.user.update).not.toHaveBeenCalled();
+        },
+    );
+
+    it("allows an interactive session to create a Subsonic credential", async () => {
+        const res = createRes();
+
+        await executeRoute(
+            "/subsonic-password",
+            interactiveRequest({ password: "my-subsonic-password" }),
+            res,
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(prisma.user.update).toHaveBeenCalledWith({
+            where: { id: "u1" },
+            data: { subsonicPassword: "enc(my-subsonic-password)" },
+        });
+    });
+
+    it("allows an interactive session to delete a Subsonic credential", async () => {
+        const res = createRes();
+
+        await executeRoute(
+            "/subsonic-password",
+            interactiveRequest({}),
+            res,
+            "delete",
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(prisma.user.update).toHaveBeenCalledWith({
+            where: { id: "u1" },
+            data: { subsonicPassword: null },
+        });
     });
 
     it("allows setup with the existing empty payload", async () => {

--- a/backend/src/routes/__tests__/authRuntime.test.ts
+++ b/backend/src/routes/__tests__/authRuntime.test.ts
@@ -15,6 +15,9 @@ jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 const mockRequireAuth = jest.fn((_req: any, _res: any, next: () => void) =>
     next(),
 );
+const mockRequireInteractiveSession = jest.fn(
+    (_req: any, _res: any, next: () => void) => next(),
+);
 const mockRequireAdmin = jest.fn((_req: any, _res: any, next: () => void) =>
     next(),
 );
@@ -24,6 +27,7 @@ const mockVerifyAuthToken = jest.fn();
 
 jest.mock("../../middleware/auth", () => ({
     requireAuth: mockRequireAuth,
+    requireInteractiveSession: mockRequireInteractiveSession,
     requireAdmin: mockRequireAdmin,
     generateToken: mockGenerateToken,
     generateRefreshToken: mockGenerateRefreshToken,

--- a/backend/src/routes/__tests__/totpBehavior.test.ts
+++ b/backend/src/routes/__tests__/totpBehavior.test.ts
@@ -14,6 +14,9 @@ const mockRequireAuth = jest.fn((_req: any, _res: any, next: () => void) =>
 const mockRequireAdmin = jest.fn((_req: any, _res: any, next: () => void) =>
     next(),
 );
+const mockRequireInteractiveSession = jest.fn(
+    (_req: any, _res: any, next: () => void) => next(),
+);
 const mockGenerateToken = jest.fn();
 const mockGenerateRefreshToken = jest.fn();
 const mockVerifyAuthToken = jest.fn();
@@ -21,6 +24,7 @@ const mockVerifyAuthToken = jest.fn();
 jest.mock("../../middleware/auth", () => ({
     requireAuth: mockRequireAuth,
     requireAdmin: mockRequireAdmin,
+    requireInteractiveSession: mockRequireInteractiveSession,
     generateToken: mockGenerateToken,
     generateRefreshToken: mockGenerateRefreshToken,
     verifyAuthToken: mockVerifyAuthToken,

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response, Router } from "express";
+import { Router } from "express";
 import { logger } from "../utils/logger";
 import bcrypt from "bcrypt";
 import { prisma } from "../utils/db";
@@ -8,6 +8,7 @@ import QRCode from "qrcode";
 import crypto from "crypto";
 import {
     requireAuth,
+    requireInteractiveSession,
     requireAdmin,
     generateToken,
     generateRefreshToken,
@@ -17,7 +18,6 @@ import { encrypt, decrypt } from "../utils/encryption";
 import { BRAND_NAME } from "../config/brand";
 import { timingSafeCompare } from "../utils/timingSafe";
 import { runDummyBcrypt } from "../utils/dummyCredential";
-import { sendRouteError } from "./routeErrorResponse";
 
 async function verifyTotpToken(
     secret: string,
@@ -42,21 +42,6 @@ async function verifyTotpToken(
 }
 
 const router = Router();
-function requireInteractiveSession(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-) {
-    // Interactive password/current-factor step-up is a documented frontend follow-up outside this slice.
-    if (req.headers["x-api-key"] !== undefined) {
-        return sendRouteError(
-            res,
-            403,
-            "Interactive session authentication required",
-        );
-    }
-    return next();
-}
 
 const loginSchema = z.object({
     username: z.string().min(1),
@@ -1627,7 +1612,7 @@ router.get("/subsonic-password", requireAuth, async (req, res) => {
  *     tags: [Authentication]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -1649,32 +1634,39 @@ router.get("/subsonic-password", requireAuth, async (req, res) => {
  *         description: Invalid password
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Interactive session authentication required
  */
 // POST /auth/subsonic-password - Set Subsonic password
-router.post("/subsonic-password", requireAuth, async (req, res) => {
-    try {
-        const { password } = subsonicPasswordSchema.parse(req.body);
+router.post(
+    "/subsonic-password",
+    requireAuth,
+    requireInteractiveSession,
+    async (req, res) => {
+        try {
+            const { password } = subsonicPasswordSchema.parse(req.body);
 
-        await prisma.user.update({
-            where: { id: req.user!.id },
-            data: {
-                subsonicPassword: encrypt(password),
-            },
-        });
-
-        return res.json({ success: true });
-    } catch (error) {
-        if (error instanceof z.ZodError) {
-            return res.status(400).json({
-                error: "Password must be between 8 and 128 characters",
+            await prisma.user.update({
+                where: { id: req.user!.id },
+                data: {
+                    subsonicPassword: encrypt(password),
+                },
             });
+
+            return res.json({ success: true });
+        } catch (error) {
+            if (error instanceof z.ZodError) {
+                return res.status(400).json({
+                    error: "Password must be between 8 and 128 characters",
+                });
+            }
+            logger.error("Set Subsonic password error:", error);
+            return res
+                .status(500)
+                .json({ error: "Failed to set Subsonic password" });
         }
-        logger.error("Set Subsonic password error:", error);
-        return res
-            .status(500)
-            .json({ error: "Failed to set Subsonic password" });
-    }
-});
+    },
+);
 
 /**
  * @openapi
@@ -1684,30 +1676,37 @@ router.post("/subsonic-password", requireAuth, async (req, res) => {
  *     tags: [Authentication]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
+ *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: Subsonic password deleted successfully
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Interactive session authentication required
  */
 // DELETE /auth/subsonic-password - Clear Subsonic password
-router.delete("/subsonic-password", requireAuth, async (req, res) => {
-    try {
-        await prisma.user.update({
-            where: { id: req.user!.id },
-            data: {
-                subsonicPassword: null,
-            },
-        });
+router.delete(
+    "/subsonic-password",
+    requireAuth,
+    requireInteractiveSession,
+    async (req, res) => {
+        try {
+            await prisma.user.update({
+                where: { id: req.user!.id },
+                data: {
+                    subsonicPassword: null,
+                },
+            });
 
-        return res.json({ success: true });
-    } catch (error) {
-        logger.error("Delete Subsonic password error:", error);
-        return res
-            .status(500)
-            .json({ error: "Failed to delete Subsonic password" });
-    }
-});
+            return res.json({ success: true });
+        } catch (error) {
+            logger.error("Delete Subsonic password error:", error);
+            return res
+                .status(500)
+                .json({ error: "Failed to delete Subsonic password" });
+        }
+    },
+);
 
 export default router;


### PR DESCRIPTION
Closes **K1** from the sweep-22 convergence review.

`POST`/`DELETE /auth/subsonic-password` accepted `X-API-Key` callers, so a stolen API key could mint (or clear) durable Subsonic credentials that outlive the key's revocation or 90-day expiry — defeating the interactive-session restriction that already guards API-key and MFA management.

Both routes now require the shared `requireInteractiveSession` guard (rejects X-API-Key callers). This also removes `auth.ts`'s leftover local copy of that guard in favor of the shared `middleware/auth.ts` implementation (cohesion). OpenAPI documents the 403 and session/bearer security. The frontend Subsonic settings UI authenticates via the session cookie, so it is unaffected.

143 auth tests / 13 suites green, tsc clean, prettier clean, route-error canon clean.