### PR TITLE
fix(reliability): dedupe and bound YouTube download watchers

### DIFF
--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -139,6 +139,7 @@ describe("api entrypoint runtime behavior", () => {
             info: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
+            child: jest.fn().mockReturnThis(),
         };
 
         const dependencyReadiness = {

--- a/backend/src/routes/__tests__/youtubeRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeRuntime.test.ts
@@ -10,6 +10,7 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn().mockReturnThis(),
     },
 }));
 
@@ -151,6 +152,10 @@ describe("youtube routes runtime", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     describe("GET /info", () => {
@@ -411,8 +416,79 @@ describe("youtube routes runtime", () => {
             expect(mockWatchJob).toHaveBeenCalledWith(
                 "job-accept",
                 expect.any(Function),
+                expect.objectContaining({ sleep: expect.any(Function) }),
             );
             expect(scanQueue.add).not.toHaveBeenCalled();
+        });
+
+        it("reuses one watcher and one timer when the same job starts twice", async () => {
+            jest.useFakeTimers({ timerLimit: 100 });
+            mockStartDownload.mockResolvedValue({
+                jobId: "job-duplicate",
+                status: "queued",
+            });
+            mockGetDownloadJobStatus.mockResolvedValue({
+                jobId: "job-duplicate",
+                status: "downloading",
+            });
+            mockWatchJob.mockImplementation(
+                async (_jobId, getStatus, options) => {
+                    await getStatus("job-duplicate");
+                    await options.sleep(5_000);
+                    return "failed";
+                },
+            );
+            const req = {
+                body: { videoId: "dQw4w9WgXcQ" },
+                user: { id: "user-1" },
+            } as any;
+
+            await downloadHandler(req, createRes());
+            await downloadHandler(req, createRes());
+            await Promise.resolve();
+
+            expect(mockWatchJob).toHaveBeenCalledTimes(1);
+            expect(jest.getTimerCount()).toBe(1);
+
+            await jest.advanceTimersByTimeAsync(5_000);
+            expect(jest.getTimerCount()).toBe(0);
+        });
+
+        it("removes a watcher when the job reaches a terminal state", async () => {
+            jest.useFakeTimers({ timerLimit: 100 });
+            mockStartDownload.mockResolvedValue({
+                jobId: "job-terminal",
+                status: "queued",
+            });
+            mockGetDownloadJobStatus.mockResolvedValue({
+                jobId: "job-terminal",
+                status: "downloading",
+            });
+            mockWatchJob.mockImplementation(
+                async (_jobId, getStatus, options) => {
+                    await getStatus("job-terminal");
+                    await options.sleep(5_000);
+                    return "failed";
+                },
+            );
+            const req = {
+                body: { videoId: "dQw4w9WgXcQ" },
+                user: { id: "user-1" },
+            } as any;
+
+            await downloadHandler(req, createRes());
+            await Promise.resolve();
+            expect(mockWatchJob).toHaveBeenCalledTimes(1);
+
+            await jest.advanceTimersByTimeAsync(5_000);
+            await downloadHandler(req, createRes());
+            await Promise.resolve();
+
+            expect(mockWatchJob).toHaveBeenCalledTimes(2);
+            expect(jest.getTimerCount()).toBe(1);
+
+            await jest.advanceTimersByTimeAsync(5_000);
+            expect(jest.getTimerCount()).toBe(0);
         });
 
         it("enqueues the scan when the server-side watcher sees completion", async () => {

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -32,6 +32,7 @@ import { logger } from "../utils/logger";
 import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
+const downloadWatcherLogger = logger.child("YouTubeDownloadWatcher");
 
 // ── Video Info ────────────────────────────────────────────────────
 
@@ -358,6 +359,16 @@ const scannedDownloadJobIds = new Set<string>();
  */
 const MAX_SCANNED_DOWNLOAD_JOB_IDS = 1000;
 
+interface ActiveDownloadWatcher {
+    sleepTimer: ReturnType<typeof setTimeout> | null;
+}
+
+/** Maximum concurrent server-side download watchers retained by this module. */
+const MAX_ACTIVE_DOWNLOAD_WATCHERS = 1000;
+
+/** Active server-side download watchers, keyed by sidecar job id. */
+const activeDownloadWatchers = new Map<string, ActiveDownloadWatcher>();
+
 /**
  * Remember `jobId` in `seen`, evicting the oldest remembered ids (Sets
  * iterate in insertion order) once `maxSize` is exceeded, so the dedupe set
@@ -531,21 +542,74 @@ async function enqueueLibraryScanForDownloadJob(
  * multi-hour downloads.
  */
 function watchDownloadJobAndQueueScan(jobId: string, userId: string): void {
-    void (async () => {
-        try {
-            const outcome = await watchYouTubeDownloadJobUntilTerminal(
-                jobId,
-                (id) => youtubeDownloadService.getDownloadJobStatus(id),
-            );
-            if (outcome === "completed") {
-                await enqueueLibraryScanForDownloadJob(jobId, userId);
-            }
-        } catch (watchErr: any) {
-            logger.warn(
-                `[YouTube Route] Download job watcher crashed for ${jobId}: ${watchErr.message}`,
-            );
+    if (activeDownloadWatchers.has(jobId)) {
+        return;
+    }
+    if (activeDownloadWatchers.size >= MAX_ACTIVE_DOWNLOAD_WATCHERS) {
+        downloadWatcherLogger.warn("Active watcher registry is full", {
+            jobId,
+            maxWatchers: MAX_ACTIVE_DOWNLOAD_WATCHERS,
+        });
+        return;
+    }
+
+    const watcher: ActiveDownloadWatcher = { sleepTimer: null };
+    activeDownloadWatchers.set(jobId, watcher);
+    void runDownloadWatcher(jobId, userId, watcher);
+}
+
+/** Run one registered watcher and always release its timer and registry slot. */
+async function runDownloadWatcher(
+    jobId: string,
+    userId: string,
+    watcher: ActiveDownloadWatcher,
+): Promise<void> {
+    try {
+        const outcome = await watchYouTubeDownloadJobUntilTerminal(
+            jobId,
+            (id) => youtubeDownloadService.getDownloadJobStatus(id),
+            { sleep: createWatcherSleep(watcher) },
+        );
+        if (outcome === "completed") {
+            await enqueueLibraryScanForDownloadJob(jobId, userId);
         }
-    })();
+    } catch (watchErr: unknown) {
+        downloadWatcherLogger.warn("Download job watcher crashed", {
+            jobId,
+            error: watchErr,
+        });
+    } finally {
+        clearWatcherSleep(watcher);
+        if (activeDownloadWatchers.get(jobId) === watcher) {
+            activeDownloadWatchers.delete(jobId);
+        }
+    }
+}
+
+/** Create a sequential polling delay owned by one registered watcher. */
+function createWatcherSleep(
+    watcher: ActiveDownloadWatcher,
+): (delayMs: number) => Promise<void> {
+    return (delayMs) =>
+        new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                if (watcher.sleepTimer === timer) {
+                    watcher.sleepTimer = null;
+                }
+                resolve();
+            }, delayMs);
+            watcher.sleepTimer = timer;
+            timer.unref?.();
+        });
+}
+
+/** Clear the pending delay, if the watcher is settling before it fires. */
+function clearWatcherSleep(watcher: ActiveDownloadWatcher): void {
+    if (watcher.sleepTimer === null) {
+        return;
+    }
+    clearTimeout(watcher.sleepTimer);
+    watcher.sleepTimer = null;
 }
 
 /**


### PR DESCRIPTION
Closes **K6** from the sweep-22 convergence review.

Each YouTube download start (including retries of the same job) spawned a new long-lived (~6-hour) polling watcher with no dedupe and no shutdown cleanup, so repeatedly starting the same job accumulated duplicate concurrent watchers and leaked timers.

Introduces a bounded jobId-keyed watcher registry: a duplicate start reuses the existing watcher instead of spawning another; each watcher's poll delay is an `unref`'d timer cleared and removed from the registry in a `finally` block on terminal state or crash; the registry is capacity-capped. The existing injectable poll `sleep` is used so the delay is cancellable.

153 youtube tests / 11 suites green, tsc clean, prettier clean, route-error canon clean.