### PR TITLE
fix(security): enforce share-link play limits at every media entry point

### DIFF
--- a/backend/src/routes/__tests__/shareLinksCore.test.ts
+++ b/backend/src/routes/__tests__/shareLinksCore.test.ts
@@ -139,6 +139,7 @@ function makeShareLink(overrides: Record<string, unknown> = {}) {
         expiresAt: null,
         maxPlays: null,
         playCount: 0,
+        lastStreamedAt: null,
         revoked: false,
         createdAt: CREATED_AT,
         ...overrides,
@@ -592,11 +593,12 @@ describe("share links routes integration", () => {
             );
 
             expect(res.status).toBe(200);
-            expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-            expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-                where: { id: "share-1" },
-                data: { lastStreamedAt: expect.any(Date) },
-            });
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: { lastStreamedAt: expect.any(Date) },
+                }),
+            );
+            expect(mockShareLinkUpdate).not.toHaveBeenCalled();
         });
 
         it("returns 404 when maxPlays is exhausted before page load", async () => {
@@ -756,7 +758,7 @@ describe("share links routes integration", () => {
         },
     );
 
-    it("GET /api/share-links/access/:token/stream/:trackId on a new session only updates lastStreamedAt", async () => {
+    it("GET /api/share-links/access/:token/stream/:trackId consumes a new play session", async () => {
         mockShareLinkFindUnique.mockResolvedValueOnce(
             makeShareLink({
                 resourceType: "track",
@@ -770,14 +772,18 @@ describe("share links routes integration", () => {
             `/api/share-links/access/${TOKEN}/stream/track-1`,
         );
 
-        expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-        expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-            where: { id: "share-1" },
-            data: { lastStreamedAt: expect.any(Date) },
-        });
+        expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: {
+                    playCount: { increment: 1 },
+                    lastStreamedAt: expect.any(Date),
+                },
+            }),
+        );
+        expect(mockShareLinkUpdate).not.toHaveBeenCalled();
     });
 
-    it("GET /api/share-links/access/:token/stream/:trackId on an existing session only updates lastStreamedAt", async () => {
+    it("GET /api/share-links/access/:token/stream/:trackId only refreshes an existing session", async () => {
         const recentStream = new Date(Date.now() - 5 * 60 * 1000);
         mockShareLinkFindUnique.mockResolvedValueOnce(
             makeShareLink({
@@ -792,14 +798,15 @@ describe("share links routes integration", () => {
             `/api/share-links/access/${TOKEN}/stream/track-1`,
         );
 
-        expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-        expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-            where: { id: "share-1" },
-            data: { lastStreamedAt: expect.any(Date) },
-        });
+        expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: { lastStreamedAt: expect.any(Date) },
+            }),
+        );
+        expect(mockShareLinkUpdate).not.toHaveBeenCalled();
     });
 
-    it("GET /api/share-links/access/:token/stream/:trackId after the session window still only updates lastStreamedAt", async () => {
+    it("GET /api/share-links/access/:token/stream/:trackId consumes a new play after the session window", async () => {
         const oldStream = new Date(Date.now() - 2 * 60 * 60 * 1000);
         mockShareLinkFindUnique.mockResolvedValueOnce(
             makeShareLink({
@@ -814,11 +821,15 @@ describe("share links routes integration", () => {
             `/api/share-links/access/${TOKEN}/stream/track-1`,
         );
 
-        expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-        expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-            where: { id: "share-1" },
-            data: { lastStreamedAt: expect.any(Date) },
-        });
+        expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: {
+                    playCount: { increment: 1 },
+                    lastStreamedAt: expect.any(Date),
+                },
+            }),
+        );
+        expect(mockShareLinkUpdate).not.toHaveBeenCalled();
     });
 
     it("GET /api/share-links/access/:token/stream/:trackId rejects when maxPlays is reached", async () => {

--- a/backend/src/routes/__tests__/shareLinksRuntime.test.ts
+++ b/backend/src/routes/__tests__/shareLinksRuntime.test.ts
@@ -536,6 +536,17 @@ describe("shareLinks routes runtime", () => {
         expect(res.statusCode).toBe(200);
     });
 
+    it("access endpoint rejects when its atomic session consume loses a race", async () => {
+        mockShareLinkUpdateMany.mockResolvedValueOnce({ count: 0 });
+        const req = createReq({ params: { token: "a".repeat(64) } });
+        const res = createRes();
+
+        await getSharedResource(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "Share link not found" });
+    });
+
     it("access endpoint only updates lastStreamedAt within the session window", async () => {
         mockShareLinkFindUnique.mockResolvedValueOnce({
             id: "share-3",
@@ -565,11 +576,12 @@ describe("shareLinks routes runtime", () => {
 
         await getSharedResource(req, res);
 
-        expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-        expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-            where: { id: "share-3" },
-            data: { lastStreamedAt: expect.any(Date) },
-        });
+        expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: { lastStreamedAt: expect.any(Date) },
+            }),
+        );
+        expect(mockShareLinkUpdate).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(200);
     });
 
@@ -582,8 +594,9 @@ describe("shareLinks routes runtime", () => {
                 resourceId: "track-1",
                 revoked: false,
                 expiresAt: null,
-                maxPlays: null,
+                maxPlays: 2,
                 playCount: 0,
+                lastStreamedAt: null,
             });
             mockTrackFindUnique.mockResolvedValueOnce({
                 id: "track-1",
@@ -600,8 +613,118 @@ describe("shareLinks routes runtime", () => {
             const res = createRes();
             await getSharedStream(req, res);
 
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: {
+                        playCount: { increment: 1 },
+                        lastStreamedAt: expect.any(Date),
+                    },
+                }),
+            );
             expect(mockStreamFileWithRangeSupport).toHaveBeenCalled();
             expect(mockDestroy).toHaveBeenCalled();
+        });
+
+        it("allows only one of two concurrent new sessions when one play remains", async () => {
+            const shareLink = {
+                id: "share-1",
+                token: "valid-token",
+                resourceType: "track",
+                resourceId: "track-1",
+                revoked: false,
+                expiresAt: null,
+                maxPlays: 1,
+                playCount: 0,
+                lastStreamedAt: null,
+            };
+            mockShareLinkFindUnique
+                .mockResolvedValueOnce(shareLink)
+                .mockResolvedValueOnce(shareLink);
+            mockTrackFindUnique.mockResolvedValue({
+                id: "track-1",
+                title: "Track",
+                filePath: "a/b/track.flac",
+                fileModified: new Date(),
+            });
+            mockShareLinkUpdateMany
+                .mockResolvedValueOnce({ count: 1 })
+                .mockResolvedValueOnce({ count: 0 });
+
+            const firstResponse = createRes();
+            const secondResponse = createRes();
+            await Promise.all([
+                getSharedStream(
+                    createReq({
+                        params: {
+                            token: "valid-token",
+                            trackId: "track-1",
+                        },
+                        query: {},
+                        headers: {},
+                    }),
+                    firstResponse,
+                ),
+                getSharedStream(
+                    createReq({
+                        params: {
+                            token: "valid-token",
+                            trackId: "track-1",
+                        },
+                        query: {},
+                        headers: {},
+                    }),
+                    secondResponse,
+                ),
+            ]);
+
+            expect(
+                [firstResponse.statusCode, secondResponse.statusCode].sort(),
+            ).toEqual([200, 404]);
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledTimes(2);
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        AND: expect.arrayContaining([{ playCount: { lt: 1 } }]),
+                    }),
+                }),
+            );
+            expect(mockStreamFileWithRangeSupport).toHaveBeenCalledTimes(1);
+        });
+
+        it("streams an already-counted active session without another play", async () => {
+            mockShareLinkFindUnique.mockResolvedValueOnce({
+                id: "share-1",
+                token: "valid-token",
+                resourceType: "track",
+                resourceId: "track-1",
+                revoked: false,
+                expiresAt: null,
+                maxPlays: 1,
+                playCount: 1,
+                lastStreamedAt: new Date(Date.now() - 5 * 60 * 1000),
+            });
+            mockTrackFindUnique.mockResolvedValueOnce({
+                id: "track-1",
+                title: "Track",
+                filePath: "a/b/track.flac",
+                fileModified: new Date(),
+            });
+
+            const req = createReq({
+                params: { token: "valid-token", trackId: "track-1" },
+                query: {},
+                headers: {},
+            });
+            const res = createRes();
+            await getSharedStream(req, res);
+
+            expect(res.statusCode).toBe(200);
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: { lastStreamedAt: expect.any(Date) },
+                }),
+            );
+            expect(mockStreamFileWithRangeSupport).toHaveBeenCalledTimes(1);
         });
 
         it("streams track belonging to shared album", async () => {
@@ -804,7 +927,7 @@ describe("shareLinks routes runtime", () => {
             );
         });
 
-        it("only updates lastStreamedAt for a new stream session", async () => {
+        it("consumes a play for a new stream session", async () => {
             mockShareLinkFindUnique.mockResolvedValueOnce({
                 id: "share-1",
                 token: "valid-token",
@@ -831,14 +954,18 @@ describe("shareLinks routes runtime", () => {
             const res = createRes();
             await getSharedStream(req, res);
 
-            expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-            expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-                where: { id: "share-1" },
-                data: { lastStreamedAt: expect.any(Date) },
-            });
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: {
+                        playCount: { increment: 1 },
+                        lastStreamedAt: expect.any(Date),
+                    },
+                }),
+            );
+            expect(mockShareLinkUpdate).not.toHaveBeenCalled();
         });
 
-        it("only updates lastStreamedAt for an existing stream session", async () => {
+        it("only refreshes lastStreamedAt for an existing stream session", async () => {
             mockShareLinkFindUnique.mockResolvedValueOnce({
                 id: "share-1",
                 token: "valid-token",
@@ -865,11 +992,12 @@ describe("shareLinks routes runtime", () => {
             const res = createRes();
             await getSharedStream(req, res);
 
-            expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
-            expect(mockShareLinkUpdate).toHaveBeenCalledWith({
-                where: { id: "share-1" },
-                data: { lastStreamedAt: expect.any(Date) },
-            });
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: { lastStreamedAt: expect.any(Date) },
+                }),
+            );
+            expect(mockShareLinkUpdate).not.toHaveBeenCalled();
         });
     });
 
@@ -886,6 +1014,47 @@ describe("shareLinks routes runtime", () => {
 
             expect(res.statusCode).toBe(404);
             expect(res.body).toEqual({ error: "Share link not found" });
+        });
+
+        it("returns 404 when the share play limit is exhausted", async () => {
+            mockShareLinkFindUnique.mockResolvedValueOnce({
+                id: "share-zip",
+                token: "zip-token",
+                resourceType: "album",
+                resourceId: "album-1",
+                revoked: false,
+                expiresAt: null,
+                maxPlays: 1,
+                playCount: 1,
+                lastStreamedAt: null,
+            });
+
+            const req = {
+                params: { token: "zip-token" },
+            } as unknown as Request;
+            const res = createRes();
+
+            await getSharedZip(req, res);
+
+            expect(res.statusCode).toBe(404);
+            expect(res.body).toEqual({ error: "Share link not found" });
+            expect(mockAlbumFindUnique).not.toHaveBeenCalled();
+            expect(mockArchivePipe).not.toHaveBeenCalled();
+        });
+
+        it("returns 404 when its atomic session consume loses a race", async () => {
+            mockSingleTrackZipShare();
+            mockShareLinkUpdateMany.mockResolvedValueOnce({ count: 0 });
+            const req = {
+                params: { token: "zip-token" },
+            } as unknown as Request;
+            const res = createRes();
+
+            await getSharedZip(req, res);
+
+            expect(res.statusCode).toBe(404);
+            expect(res.body).toEqual({ error: "Share link not found" });
+            expect(mockArchivePipe).not.toHaveBeenCalled();
         });
 
         it("streams a zip for a valid album share", async () => {
@@ -1057,7 +1226,7 @@ describe("shareLinks routes runtime", () => {
             expect(mockArchiveFinalize).not.toHaveBeenCalled();
         });
 
-        it("does not mutate play counts during zip download", async () => {
+        it("consumes a new play session before starting a zip download", async () => {
             mockShareLinkFindUnique.mockResolvedValueOnce({
                 id: "share-zip",
                 token: "zip-token",
@@ -1065,8 +1234,9 @@ describe("shareLinks routes runtime", () => {
                 resourceId: "album-1",
                 revoked: false,
                 expiresAt: null,
-                maxPlays: null,
+                maxPlays: 2,
                 playCount: 0,
+                lastStreamedAt: null,
             });
             mockAlbumFindUnique.mockResolvedValueOnce({
                 artist: { name: "Artist One" },
@@ -1094,7 +1264,15 @@ describe("shareLinks routes runtime", () => {
             await getSharedZip(req, res);
 
             expect(mockShareLinkUpdate).not.toHaveBeenCalled();
-            expect(mockShareLinkUpdateMany).not.toHaveBeenCalled();
+            expect(mockShareLinkUpdateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: {
+                        playCount: { increment: 1 },
+                        lastStreamedAt: expect.any(Date),
+                    },
+                }),
+            );
+            expect(mockArchivePipe).toHaveBeenCalledWith(res);
         });
     });
 

--- a/backend/src/routes/shareLinks.ts
+++ b/backend/src/routes/shareLinks.ts
@@ -12,10 +12,11 @@ import { fetchExternalImage } from "../services/imageProxy";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
-import { sendInternalRouteError } from "./routeErrorResponse";
+import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
 const zipLogger = logger.child("ShareLinks.ZipArchive");
+const SHARE_SESSION_WINDOW_MS = 60 * 60 * 1000;
 
 const playlistItemInclude = {
     track: {
@@ -57,6 +58,11 @@ function isExpired(expiresAt: Date | null): boolean {
     return expiresAt.getTime() <= Date.now();
 }
 
+function isActiveSession(lastStreamedAt: Date | null, now: Date): boolean {
+    if (!lastStreamedAt) return false;
+    return lastStreamedAt.getTime() >= now.getTime() - SHARE_SESSION_WINDOW_MS;
+}
+
 async function validateShareLink(token: string) {
     const shareLink = await prisma.shareLink.findUnique({ where: { token } });
     if (!shareLink) return null;
@@ -64,10 +70,49 @@ async function validateShareLink(token: string) {
     if (isExpired(shareLink.expiresAt)) return null;
     if (
         shareLink.maxPlays !== null &&
-        shareLink.playCount >= shareLink.maxPlays
+        shareLink.playCount >= shareLink.maxPlays &&
+        !isActiveSession(shareLink.lastStreamedAt, new Date())
     )
         return null;
     return shareLink;
+}
+
+async function consumeShareSession(shareLink: {
+    id: string;
+    maxPlays: number | null;
+    lastStreamedAt: Date | null;
+}): Promise<boolean> {
+    const now = new Date();
+    const windowStart = new Date(now.getTime() - SHARE_SESSION_WINDOW_MS);
+    const activeSession = isActiveSession(shareLink.lastStreamedAt, now);
+    const sessionCondition = activeSession
+        ? { lastStreamedAt: { gte: windowStart } }
+        : {
+              OR: [
+                  { lastStreamedAt: null },
+                  { lastStreamedAt: { lt: windowStart } },
+              ],
+          };
+    const result = await prisma.shareLink.updateMany({
+        where: {
+            id: shareLink.id,
+            revoked: false,
+            AND: [
+                { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
+                sessionCondition,
+                ...(!activeSession && shareLink.maxPlays !== null
+                    ? [{ playCount: { lt: shareLink.maxPlays } }]
+                    : []),
+            ],
+        },
+        data: activeSession
+            ? { lastStreamedAt: now }
+            : {
+                  playCount: { increment: 1 },
+                  lastStreamedAt: now,
+              },
+    });
+    return result.count === 1;
 }
 
 const trackStreamSelect = {
@@ -646,46 +691,8 @@ router.get("/access/:token", async (req, res) => {
             return res.status(404).json({ error: "Share link not found" });
         }
 
-        const sessionWindowMs = 60 * 60 * 1000;
-        const now = new Date();
-        const windowStart = new Date(now.getTime() - sessionWindowMs);
-        const isNewSession =
-            shareLink.lastStreamedAt === null ||
-            shareLink.lastStreamedAt < windowStart;
-
-        if (isNewSession) {
-            await prisma.shareLink.updateMany({
-                where: {
-                    id: shareLink.id,
-                    revoked: false,
-                    AND: [
-                        {
-                            OR: [
-                                { expiresAt: null },
-                                { expiresAt: { gt: now } },
-                            ],
-                        },
-                        {
-                            OR: [
-                                { lastStreamedAt: null },
-                                { lastStreamedAt: { lt: windowStart } },
-                            ],
-                        },
-                        ...(shareLink.maxPlays !== null
-                            ? [{ playCount: { lt: shareLink.maxPlays } }]
-                            : []),
-                    ],
-                },
-                data: {
-                    playCount: { increment: 1 },
-                    lastStreamedAt: now,
-                },
-            });
-        } else {
-            await prisma.shareLink.update({
-                where: { id: shareLink.id },
-                data: { lastStreamedAt: now },
-            });
+        if (!(await consumeShareSession(shareLink))) {
+            return sendRouteError(res, 404, "Share link not found");
         }
 
         res.json({
@@ -751,11 +758,6 @@ router.get("/access/:token/stream/:trackId", async (req, res) => {
                 .json({ error: "Track not available for streaming" });
         }
 
-        await prisma.shareLink.update({
-            where: { id: shareLink.id },
-            data: { lastStreamedAt: new Date() },
-        });
-
         const normalizedFilePath = track.filePath.replace(/\\/g, "/");
         const absolutePath = safeResolvePath(
             config.music.musicPath,
@@ -765,6 +767,10 @@ router.get("/access/:token/stream/:trackId", async (req, res) => {
             return res
                 .status(404)
                 .json({ error: "Track not available for streaming" });
+        }
+
+        if (!(await consumeShareSession(shareLink))) {
+            return sendRouteError(res, 404, "Share link not found");
         }
 
         const streamingService = new AudioStreamingService(
@@ -942,6 +948,10 @@ router.get("/access/:token/zip", async (req, res) => {
             return res
                 .status(404)
                 .json({ error: "No streamable tracks found" });
+        }
+
+        if (!(await consumeShareSession(shareLink))) {
+            return sendRouteError(res, 404, "Share link not found");
         }
 
         // archiver v8 is ESM-only with named class exports; node 24 loads it via require(esm)


### PR DESCRIPTION
Closes **K2** from the sweep-22 convergence review.

Share-link play/session limits were enforced only on `/access/:token`; the direct per-track stream (`/access/:token/stream/:trackId`) and ZIP (`/access/:token/zip`) endpoints did not consume the limit, so a client could bypass max-plays by hitting those URLs directly.

Extracts an atomic `consumeShareSession()` that validates-and-consumes in a single conditional `updateMany` (guarded by revoked/expiry/session-window/playCount, gated on `count === 1`) and applies it at all three media entry points, preserving the existing 60-minute session-window semantics so concurrent requests cannot over-consume. Exhausted/expired links now 404 at every entry point.

72 shareLinks tests / 2 suites green, tsc clean, prettier clean, route-error canon clean.