### PR TITLE
fix(reliability): bound vibe semantic-search stream and podcast genre fan-out

### DIFF
--- a/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
@@ -11,6 +11,11 @@ jest.mock("../../utils/logger", () => ({
         debug: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
@@ -11,6 +11,11 @@ jest.mock("../../utils/logger", () => ({
         debug: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsDiscoverTopCompat.test.ts
+++ b/backend/src/routes/__tests__/podcastsDiscoverTopCompat.test.ts
@@ -11,6 +11,11 @@ jest.mock("../../utils/logger", () => ({
         debug: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsDiscoveryRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsDiscoveryRuntime.test.ts
@@ -11,6 +11,11 @@ jest.mock("../../utils/logger", () => ({
         debug: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -160,11 +165,7 @@ describe("podcasts discovery runtime behavior", () => {
         expect(res.body[1489]).toEqual([]);
     });
 
-    it("falls back to default search term for unknown discover genre ids", async () => {
-        mockAxiosGet.mockResolvedValueOnce({
-            data: { results: [] },
-        });
-
+    it("rejects unknown discover genre ids without outbound work", async () => {
         const req = {
             query: { genres: "9999" },
             user: { id: "user-1" },
@@ -173,19 +174,87 @@ describe("podcasts discovery runtime behavior", () => {
 
         await discoverGenresHandler(req, res);
 
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://itunes.apple.com/search",
-            expect.objectContaining({
-                params: expect.objectContaining({
-                    term: "podcast",
-                    media: "podcast",
-                    entity: "podcast",
-                    limit: 10,
-                }),
-            }),
-        );
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "genres contains an unsupported genre ID",
+        });
+        expect(mockAxiosGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects requests containing more than seven genre IDs", async () => {
+        const req = {
+            query: {
+                genres: "1303,1324,1489,1488,1321,1545,1502,1303",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await discoverGenresHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "A maximum of 7 genres may be requested",
+        });
+        expect(mockAxiosGet).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates genres before issuing outbound requests", async () => {
+        mockAxiosGet.mockResolvedValue({ data: { results: [] } });
+        const req = {
+            query: { genres: "1303,1303,1489" },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await discoverGenresHandler(req, res);
+
         expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual({ 9999: [] });
+        expect(res.body).toEqual({ 1303: [], 1489: [] });
+        expect(mockAxiosGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("limits concurrent genre discovery requests to three", async () => {
+        let activeRequests = 0;
+        let maxActiveRequests = 0;
+        const releaseRequests: Array<() => void> = [];
+        mockAxiosGet.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    activeRequests += 1;
+                    maxActiveRequests = Math.max(
+                        maxActiveRequests,
+                        activeRequests,
+                    );
+                    releaseRequests.push(() => {
+                        activeRequests -= 1;
+                        resolve({ data: { results: [] } });
+                    });
+                }),
+        );
+
+        const req = {
+            query: { genres: "1303,1324,1489,1488,1321,1545,1502" },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+        const responsePromise = discoverGenresHandler(req, res);
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(mockAxiosGet).toHaveBeenCalledTimes(3);
+        releaseRequests.splice(0).forEach((release) => release());
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(mockAxiosGet).toHaveBeenCalledTimes(6);
+        releaseRequests.splice(0).forEach((release) => release());
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(mockAxiosGet).toHaveBeenCalledTimes(7);
+        releaseRequests.splice(0).forEach((release) => release());
+        await responsePromise;
+
+        expect(res.statusCode).toBe(200);
+        expect(maxActiveRequests).toBe(3);
     });
 
     it("returns an empty object when discover genre preprocessing throws", async () => {

--- a/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
@@ -17,6 +17,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -449,6 +449,13 @@ describe("vibe search transport compatibility", () => {
                 text: "upbeat synthwave",
                 responseKey: "audio:text:embed:response:req-123",
             }),
+            {
+                TRIM: {
+                    strategy: "MAXLEN",
+                    strategyModifier: "~",
+                    threshold: 100,
+                },
+            },
         );
         expect(mockBlockingBlPop).toHaveBeenCalledWith(
             "audio:text:embed:response:req-123",
@@ -484,6 +491,13 @@ describe("vibe search transport compatibility", () => {
                 text: "melancholic piano",
                 responseKey: "audio:text:embed:response:req-123",
             }),
+            {
+                TRIM: {
+                    strategy: "MAXLEN",
+                    strategyModifier: "~",
+                    threshold: 100,
+                },
+            },
         );
         expect(mockRedisDel).toHaveBeenCalledWith(
             "audio:text:embed:response:req-123",
@@ -555,6 +569,23 @@ describe("vibe search transport compatibility", () => {
         expect(invalidEmbedRes.body).toEqual({
             error: "Failed to search tracks by vibe",
         });
+    });
+
+    it("rejects over-long search queries before admitting Redis work", async () => {
+        const req = {
+            body: { query: "q".repeat(513) },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await searchHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "Query must be at most 512 characters",
+        });
+        expect(mockRedisXAdd).not.toHaveBeenCalled();
+        expect(mockBlockingBlPop).not.toHaveBeenCalled();
     });
 
     it("expands and reranks vibe search results when vocabulary matches exist", async () => {

--- a/backend/src/routes/podcasts.ts
+++ b/backend/src/routes/podcasts.ts
@@ -16,11 +16,118 @@ import {
 } from "../services/outboundUrlSafety";
 import axios from "axios";
 import fs from "fs";
+import pLimit from "p-limit";
+import { sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
 const ITUNES_DISCOVER_TIMEOUT_MS = 10000;
 const PODCAST_PRISMA_RETRY_ATTEMPTS = 3;
 const MAX_AUDIO_REDIRECTS = 5;
+const MAX_PODCAST_DISCOVERY_GENRES = 7;
+const MAX_PODCAST_GENRES_QUERY_LENGTH = 64;
+const PODCAST_GENRE_FETCH_CONCURRENCY = 3;
+const podcastGenreDiscoveryLogger = logger.child("PodcastGenreDiscovery");
+
+const PODCAST_GENRE_SEARCH_TERMS = {
+    "1303": "comedy podcast",
+    "1324": "society culture podcast",
+    "1489": "news podcast",
+    "1488": "true crime podcast",
+    "1321": "business podcast",
+    "1545": "sports podcast",
+    "1502": "gaming hobbies podcast",
+} as const;
+
+type PodcastGenreId = keyof typeof PODCAST_GENRE_SEARCH_TERMS;
+
+type PodcastGenreIdsResult =
+    | { ok: true; genreIds: PodcastGenreId[] }
+    | { ok: false; error: string };
+
+function isPodcastGenreId(value: string): value is PodcastGenreId {
+    return Object.prototype.hasOwnProperty.call(
+        PODCAST_GENRE_SEARCH_TERMS,
+        value,
+    );
+}
+
+function parsePodcastGenreIds(genres: string): PodcastGenreIdsResult {
+    if (genres.length > MAX_PODCAST_GENRES_QUERY_LENGTH) {
+        return {
+            ok: false,
+            error: `A maximum of ${MAX_PODCAST_DISCOVERY_GENRES} genres may be requested`,
+        };
+    }
+
+    const requestedIds = genres.split(",");
+    if (requestedIds.length > MAX_PODCAST_DISCOVERY_GENRES) {
+        return {
+            ok: false,
+            error: `A maximum of ${MAX_PODCAST_DISCOVERY_GENRES} genres may be requested`,
+        };
+    }
+
+    const normalizedIds = requestedIds.map((id) => id.trim());
+    if (!normalizedIds.every(isPodcastGenreId)) {
+        return {
+            ok: false,
+            error: "genres contains an unsupported genre ID",
+        };
+    }
+
+    return { ok: true, genreIds: Array.from(new Set(normalizedIds)) };
+}
+
+function formatDiscoveredPodcast(podcast: any) {
+    return {
+        id: podcast.collectionId.toString(),
+        title: podcast.collectionName,
+        author: podcast.artistName,
+        coverUrl: podcast.artworkUrl600 || podcast.artworkUrl100,
+        feedUrl: podcast.feedUrl,
+        genres: podcast.genres || [],
+        episodeCount: podcast.trackCount || 0,
+        itunesId: podcast.collectionId,
+        isExternal: true,
+    };
+}
+
+async function fetchPodcastGenre(genreId: PodcastGenreId) {
+    const searchTerm = PODCAST_GENRE_SEARCH_TERMS[genreId];
+    podcastGenreDiscoveryLogger.debug("Searching iTunes genre", {
+        genreId,
+        searchTerm,
+    });
+
+    try {
+        const itunesResponse = await axios.get(
+            "https://itunes.apple.com/search",
+            {
+                params: {
+                    term: searchTerm,
+                    media: "podcast",
+                    entity: "podcast",
+                    limit: 10,
+                },
+                timeout: ITUNES_DISCOVER_TIMEOUT_MS,
+            },
+        );
+        const podcasts = itunesResponse.data.results.map(
+            formatDiscoveredPodcast,
+        );
+        podcastGenreDiscoveryLogger.debug("Fetched iTunes genre", {
+            genreId,
+            podcastCount: podcasts.length,
+        });
+        return { genreId, podcasts };
+    } catch (error: unknown) {
+        podcastGenreDiscoveryLogger.warn(
+            "iTunes genre search failed; returning an empty genre list",
+            { genreId, error: describeAxiosError(error) },
+        );
+        return { genreId, podcasts: [] };
+    }
+}
 
 const subscribeSchema = z
     .object({
@@ -394,12 +501,12 @@ router.get("/discover/top", requireAuthOrToken, async (req, res) => {
  *         required: true
  *         schema:
  *           type: string
- *         description: Comma-separated genre IDs (e.g. "1303,1324")
+ *         description: Up to 7 comma-separated supported genre IDs (e.g. "1303,1324")
  *     responses:
  *       200:
  *         description: Podcasts grouped by genre ID
  *       400:
- *         description: genres parameter required
+ *         description: genres parameter missing, unsupported, or over the request limit
  *       401:
  *         description: Not authenticated
  */
@@ -411,78 +518,27 @@ router.get("/discover/genres", async (req, res) => {
     try {
         const { genres } = req.query; // Comma-separated genre IDs
 
-        logger.debug(`\n[GENRE PODCASTS] Request (genres: ${genres})`);
-
         if (!genres || typeof genres !== "string") {
-            return res.status(400).json({
-                error: "genres parameter required (comma-separated genre IDs)",
-            });
+            return sendRouteError(
+                res,
+                400,
+                "genres parameter required (comma-separated genre IDs)",
+            );
         }
 
-        const genreIds = genres.split(",").map((id) => parseInt(id.trim(), 10));
+        const parsedGenreIds = parsePodcastGenreIds(genres);
+        if (!parsedGenreIds.ok) {
+            return sendRouteError(res, 400, parsedGenreIds.error);
+        }
 
-        // Map genre IDs to search terms - same approach as the working search!
-        const genreSearchTerms: { [key: number]: string } = {
-            1303: "comedy podcast", // Comedy
-            1324: "society culture podcast", // Society & Culture
-            1489: "news podcast", // News
-            1488: "true crime podcast", // True Crime
-            1321: "business podcast", // Business
-            1545: "sports podcast", // Sports
-            1502: "gaming hobbies podcast", // Leisure (Gaming & Hobbies)
-        };
-
-        // Fetch podcasts for each genre using simple iTunes search - PARALLEL execution
-        const genreFetchPromises = genreIds.map(async (genreId) => {
-            const searchTerm = genreSearchTerms[genreId] || "podcast";
-            logger.debug(`    Searching for "${searchTerm}"...`);
-
-            try {
-                // Simple iTunes search - same as the working search bar!
-                const itunesResponse = await axios.get(
-                    "https://itunes.apple.com/search",
-                    {
-                        params: {
-                            term: searchTerm,
-                            media: "podcast",
-                            entity: "podcast",
-                            limit: 10,
-                        },
-                        timeout: ITUNES_DISCOVER_TIMEOUT_MS,
-                    },
-                );
-
-                const podcasts = itunesResponse.data.results.map(
-                    (podcast: any) => ({
-                        id: podcast.collectionId.toString(),
-                        title: podcast.collectionName,
-                        author: podcast.artistName,
-                        coverUrl:
-                            podcast.artworkUrl600 || podcast.artworkUrl100,
-                        feedUrl: podcast.feedUrl,
-                        genres: podcast.genres || [],
-                        episodeCount: podcast.trackCount || 0,
-                        itunesId: podcast.collectionId,
-                        isExternal: true,
-                    }),
-                );
-
-                logger.debug(
-                    `      Found ${podcasts.length} podcasts for genre ${genreId}`,
-                );
-                return { genreId, podcasts };
-            } catch (error: unknown) {
-                logger.warn(
-                    `       iTunes search failed for "${searchTerm}", returning empty genre list. ${describeAxiosError(
-                        error,
-                    )}`,
-                );
-                return { genreId, podcasts: [] };
-            }
-        });
-
-        // Wait for all genre searches to complete in parallel
-        const genreResults = await Promise.all(genreFetchPromises);
+        // The input is capped above, and p-limit bounds active iTunes calls to
+        // three even when all supported genres are requested together.
+        const limitGenreFetch = pLimit(PODCAST_GENRE_FETCH_CONCURRENCY);
+        const genreResults = await Promise.all(
+            parsedGenreIds.genreIds.map((genreId) =>
+                limitGenreFetch(() => fetchPodcastGenre(genreId)),
+            ),
+        );
 
         // Convert array of results to object keyed by genreId
         const results: any = {};
@@ -490,15 +546,14 @@ router.get("/discover/genres", async (req, res) => {
             results[genreId] = podcasts;
         }
 
-        logger.debug(
-            `   Fetched podcasts for ${genreIds.length} genres (parallel)`,
-        );
+        podcastGenreDiscoveryLogger.debug("Completed genre discovery", {
+            genreCount: parsedGenreIds.genreIds.length,
+        });
         res.json(results);
     } catch (error: unknown) {
-        logger.warn(
-            `[GENRE PODCASTS] Failed to fetch genre discovery, returning empty result. ${describeAxiosError(
-                error,
-            )}`,
+        podcastGenreDiscoveryLogger.warn(
+            "Genre discovery failed; returning an empty result",
+            { error: describeAxiosError(error) },
         );
         res.json({});
     }

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -49,6 +49,11 @@ loadVocabulary();
 const TEXT_EMBED_REQUEST_STREAM = "audio:text:embed:requests";
 const TEXT_EMBED_RESPONSE_PREFIX = "audio:text:embed:response:";
 const TEXT_EMBED_TIMEOUT_SECONDS = 30;
+const MAX_TEXT_SEARCH_QUERY_LENGTH = 512;
+// The CLAP consumer handles one request per replica at a time and callers wait
+// at most 30 seconds. Retaining 100 entries leaves burst headroom without
+// allowing timed-out request payloads to accumulate indefinitely.
+const TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH = 100;
 
 interface TextSearchResult {
     id: string;
@@ -1107,6 +1112,7 @@ interface TextEmbedResponsePayload {
  *               query:
  *                 type: string
  *                 minLength: 2
+ *                 maxLength: 512
  *                 description: Natural language search query (e.g. "chill acoustic guitar", "aggressive punk rock")
  *               limit:
  *                 type: integer
@@ -1140,7 +1146,7 @@ interface TextEmbedResponsePayload {
  *                 debug:
  *                   type: object
  *       400:
- *         description: Query must be at least 2 characters
+ *         description: Query must contain between 2 and 512 characters
  *       401:
  *         description: Not authenticated
  *       504:
@@ -1153,11 +1159,23 @@ router.post(
         try {
             const { query, limit: requestedLimit, minSimilarity } = req.body;
 
-            if (
-                !query ||
-                typeof query !== "string" ||
-                query.trim().length < 2
-            ) {
+            if (!query || typeof query !== "string") {
+                return sendRouteError(
+                    res,
+                    400,
+                    "Query must be at least 2 characters",
+                );
+            }
+
+            if (query.length > MAX_TEXT_SEARCH_QUERY_LENGTH) {
+                return sendRouteError(
+                    res,
+                    400,
+                    `Query must be at most ${MAX_TEXT_SEARCH_QUERY_LENGTH} characters`,
+                );
+            }
+
+            if (query.trim().length < 2) {
                 return sendRouteError(
                     res,
                     400,
@@ -1184,11 +1202,22 @@ router.post(
             try {
                 // Queue text-embedding request via Redis Streams to ensure a single
                 // CLAP replica claims and processes each request.
-                await redisClient.xAdd(TEXT_EMBED_REQUEST_STREAM, "*", {
-                    requestId,
-                    text: normalizedQuery,
-                    responseKey,
-                });
+                await redisClient.xAdd(
+                    TEXT_EMBED_REQUEST_STREAM,
+                    "*",
+                    {
+                        requestId,
+                        text: normalizedQuery,
+                        responseKey,
+                    },
+                    {
+                        TRIM: {
+                            strategy: "MAXLEN",
+                            strategyModifier: "~",
+                            threshold: TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH,
+                        },
+                    },
+                );
 
                 // Wait for response from the CLAP worker.
                 const response = await blockingBlPop(


### PR DESCRIPTION
Closes **K4** and **K15** from the sweep-22 convergence review (disjoint files).

**K4** (`vibe.ts`): the semantic-search endpoint `XADD`ed to a Redis request stream with no bound. Adds a 512-char query-length limit (400) and trims the stream with `MAXLEN ~ 100` so timed-out request payloads cannot accumulate indefinitely. OpenAPI updated.

**K15** (`podcasts.ts`): genre discovery performed unbounded outbound fan-out (one iTunes request per requested genre, no cap/dedupe/concurrency). Validates genre IDs against an allowlist enum + type-guard, caps at 7 genres (64-char query), deduplicates, and runs outbound requests through a `p-limit(3)` concurrency pool (p-limit already a repo dependency).

290 vibe/podcast tests / 17 suites green, tsc clean, prettier clean, route-error canon clean.