### PR TITLE
fix(security): contain analyzer queue paths within MUSIC_PATH

### DIFF
--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -112,6 +112,27 @@ MAX_AUDIO_DURATION = 60  # seconds
 CLAP_SAMPLE_RATE = 48000  # 48kHz for CLAP model
 
 
+def _resolve_music_path(file_path: str) -> str | None:
+    """Resolve a relative queue path beneath the configured music library."""
+    if not isinstance(file_path, str) or "\x00" in file_path:
+        return None
+
+    normalized_path = file_path.replace("\\", "/")
+    if os.path.isabs(normalized_path):
+        return None
+    if any(segment in {".", ".."} for segment in normalized_path.split("/")):
+        return None
+
+    try:
+        music_root = os.path.realpath(MUSIC_PATH)
+        resolved_path = os.path.realpath(os.path.join(music_root, normalized_path))
+        if os.path.commonpath((music_root, resolved_path)) != music_root:
+            return None
+    except (OSError, ValueError):
+        return None
+    return resolved_path
+
+
 class CLAPAnalyzer:
     """
     LAION CLAP model wrapper for generating audio and text embeddings.
@@ -450,12 +471,13 @@ class Worker:
 
         logger.info(f"Worker {self.worker_id} processing track: {track_id}")
 
+        full_path = _resolve_music_path(file_path)
+        if full_path is None:
+            logger.warning("Rejected queued CLAP path outside the configured music library")
+            return
+
         # Update track status to processing
         self._update_track_status(track_id, "processing")
-
-        # Build full path (normalize Windows-style paths)
-        normalized_path = file_path.replace("\\", "/")
-        full_path = os.path.join(MUSIC_PATH, normalized_path)
 
         # Generate embedding (pass duration to avoid file probe)
         embedding = self.analyzer.get_audio_embedding(full_path, duration)

--- a/services/audio-analyzer-clap/tests/test_music_path_containment.py
+++ b/services/audio-analyzer-clap/tests/test_music_path_containment.py
@@ -1,0 +1,155 @@
+"""Behavioral coverage for queued CLAP audio-path containment."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+import pytest
+from test_audio_analyzer_clap_env import _load_analyzer_with_recording_redis
+
+
+class SingleJobRedis:
+    """Return one queued job to the worker."""
+
+    def __init__(self, job: dict[str, Any]) -> None:
+        self.job = job
+
+    def blpop(self, queue: str, timeout: int) -> tuple[str, str]:
+        """Return the configured job without external Redis I/O."""
+        return queue, json.dumps(self.job)
+
+
+class RecordingAnalyzer:
+    """Record embedding requests without opening audio files."""
+
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+
+    def get_audio_embedding(
+        self,
+        audio_path: str,
+        duration: float | None = None,
+    ) -> np.ndarray:
+        """Record the resolved path and return a valid embedding."""
+        self.paths.append(audio_path)
+        return np.zeros(512, dtype=np.float32)
+
+
+@pytest.fixture
+def analyzer_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load the CLAP analyzer with isolated heavyweight dependencies."""
+    return _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+
+def _process_queued_path(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    music_root: Path,
+    queued_path: str,
+) -> tuple[RecordingAnalyzer, list[tuple[str, str]], list[str]]:
+    """Run one queued path through the CLAP worker boundary."""
+    analyzer = RecordingAnalyzer()
+    worker = module.Worker(1, analyzer, threading.Event())
+    worker.redis_client = SingleJobRedis(
+        {"trackId": "track-1", "filePath": queued_path, "duration": 30.0}
+    )
+    status_updates: list[tuple[str, str]] = []
+    stored_track_ids: list[str] = []
+    monkeypatch.setattr(module, "MUSIC_PATH", str(music_root))
+    monkeypatch.setattr(
+        worker,
+        "_update_track_status",
+        lambda track_id, status: status_updates.append((track_id, status)),
+    )
+
+    def store_embedding(track_id: str, _embedding: np.ndarray) -> bool:
+        stored_track_ids.append(track_id)
+        return True
+
+    monkeypatch.setattr(worker, "_store_embedding", store_embedding)
+    monkeypatch.setattr(worker, "_mark_failed", lambda _track_id, _error: None)
+    worker._process_job()
+    return analyzer, status_updates, stored_track_ids
+
+
+@pytest.mark.parametrize("attack_kind", ["absolute", "dot_segment"])
+def test_queued_traversal_path_is_rejected_without_embedding(
+    analyzer_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    attack_kind: str,
+) -> None:
+    """Reject absolute and parent-traversal queue values before audio loading."""
+    music_root = tmp_path / "music"
+    music_root.mkdir()
+    outside_file = tmp_path / "outside.flac"
+    outside_file.touch()
+    queued_path = str(outside_file) if attack_kind == "absolute" else "../outside.flac"
+
+    with caplog.at_level(logging.WARNING):
+        analyzer, _status_updates, stored_track_ids = _process_queued_path(
+            analyzer_module,
+            monkeypatch,
+            music_root,
+            queued_path,
+        )
+
+    assert analyzer.paths == []
+    assert stored_track_ids == []
+    assert "Rejected queued CLAP path" in caplog.text
+    assert str(outside_file) not in caplog.text
+    assert queued_path not in caplog.text
+
+
+def test_queued_symlink_escape_is_rejected_without_embedding(
+    analyzer_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reject an in-root symlink whose resolved target escapes the library."""
+    music_root = tmp_path / "music"
+    music_root.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "track.flac").touch()
+    (music_root / "linked").symlink_to(outside_dir, target_is_directory=True)
+
+    analyzer, _status_updates, stored_track_ids = _process_queued_path(
+        analyzer_module,
+        monkeypatch,
+        music_root,
+        "linked/track.flac",
+    )
+
+    assert analyzer.paths == []
+    assert stored_track_ids == []
+
+
+def test_queued_in_library_path_is_embedded(
+    analyzer_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Resolve and embed a valid relative path beneath the music library."""
+    music_root = tmp_path / "music"
+    track_path = music_root / "artist" / "track.flac"
+    track_path.parent.mkdir(parents=True)
+    track_path.touch()
+
+    analyzer, status_updates, stored_track_ids = _process_queued_path(
+        analyzer_module,
+        monkeypatch,
+        music_root,
+        "artist/track.flac",
+    )
+
+    assert analyzer.paths == [str(track_path.resolve())]
+    assert status_updates == [("track-1", "processing"), ("track-1", "completed")]
+    assert stored_track_ids == ["track-1"]

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -161,6 +161,27 @@ MAX_FILE_SIZE_MB = get_int_env("MAX_FILE_SIZE_MB", 500)
 BATCH_ANALYSIS_TIMEOUT_SECONDS = get_int_env("BATCH_ANALYSIS_TIMEOUT_SECONDS", 900)
 
 
+def _resolve_music_path(file_path: str) -> str | None:
+    """Resolve a relative queue path beneath the configured music library."""
+    if not isinstance(file_path, str) or "\x00" in file_path:
+        return None
+
+    normalized_path = file_path.replace("\\", "/")
+    if os.path.isabs(normalized_path):
+        return None
+    if any(segment in {".", ".."} for segment in normalized_path.split("/")):
+        return None
+
+    try:
+        music_root = os.path.realpath(MUSIC_PATH)
+        resolved_path = os.path.realpath(os.path.join(music_root, normalized_path))
+        if os.path.commonpath((music_root, resolved_path)) != music_root:
+            return None
+    except (OSError, ValueError):
+        return None
+    return resolved_path
+
+
 class DatabaseConnection:
     """PostgreSQL connection manager"""
 
@@ -1197,9 +1218,10 @@ def _analyze_track_in_process(args: tuple[str, str]) -> tuple[str, str, dict[str
         if isinstance(file_path, bytes):
             file_path = file_path.decode("utf-8", errors="replace")
 
-        # Normalize path separators (Windows paths -> Unix)
-        normalized_path = file_path.replace("\\", "/")
-        full_path = os.path.join(MUSIC_PATH, normalized_path)
+        full_path = _resolve_music_path(file_path)
+        if full_path is None:
+            logger.warning("Rejected queued audio path outside the configured music library")
+            return (track_id, "", {"_error": "Invalid audio path", "_permanent": True})
 
         # Use os.fsencode/fsdecode for filesystem-safe encoding
         try:

--- a/services/audio-analyzer/tests/test_music_path_containment.py
+++ b/services/audio-analyzer/tests/test_music_path_containment.py
@@ -1,0 +1,112 @@
+"""Behavioral coverage for queued audio-path containment."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+class RecordingAnalyzer:
+    """Record analysis requests without opening audio files."""
+
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+
+    def analyze(self, file_path: str) -> dict[str, Any]:
+        """Record the resolved path and return a successful result."""
+        self.paths.append(file_path)
+        return {"bpm": 120.0}
+
+
+def _analyze_queued_path(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    music_root: Path,
+    queued_path: str,
+) -> tuple[RecordingAnalyzer, tuple[str, str, dict[str, Any]]]:
+    """Run one queued path through the process-worker boundary."""
+    analyzer = RecordingAnalyzer()
+    monkeypatch.setattr(module, "MUSIC_PATH", str(music_root))
+    monkeypatch.setattr(module, "_process_analyzer", analyzer)
+    result = module._analyze_track_in_process(("track-1", queued_path))
+    return analyzer, result
+
+
+@pytest.mark.parametrize("attack_kind", ["absolute", "dot_segment"])
+def test_queued_traversal_path_is_rejected_without_analysis(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    attack_kind: str,
+) -> None:
+    """Reject absolute and parent-traversal queue values before analysis."""
+    music_root = tmp_path / "music"
+    music_root.mkdir()
+    outside_file = tmp_path / "outside.flac"
+    outside_file.touch()
+    queued_path = str(outside_file) if attack_kind == "absolute" else "../outside.flac"
+
+    with caplog.at_level(logging.WARNING):
+        analyzer, result = _analyze_queued_path(
+            loaded_analyzer,
+            monkeypatch,
+            music_root,
+            queued_path,
+        )
+
+    assert analyzer.paths == []
+    assert result[2] == {"_error": "Invalid audio path", "_permanent": True}
+    assert "Rejected queued audio path" in caplog.text
+    assert str(outside_file) not in caplog.text
+    assert queued_path not in caplog.text
+
+
+def test_queued_symlink_escape_is_rejected_without_analysis(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reject an in-root symlink whose resolved target escapes the library."""
+    music_root = tmp_path / "music"
+    music_root.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "track.flac").touch()
+    (music_root / "linked").symlink_to(outside_dir, target_is_directory=True)
+
+    analyzer, result = _analyze_queued_path(
+        loaded_analyzer,
+        monkeypatch,
+        music_root,
+        "linked/track.flac",
+    )
+
+    assert analyzer.paths == []
+    assert result[2] == {"_error": "Invalid audio path", "_permanent": True}
+
+
+def test_queued_in_library_path_is_analyzed(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Resolve and analyze a valid relative path beneath the music library."""
+    music_root = tmp_path / "music"
+    track_path = music_root / "artist" / "track.flac"
+    track_path.parent.mkdir(parents=True)
+    track_path.touch()
+
+    analyzer, result = _analyze_queued_path(
+        loaded_analyzer,
+        monkeypatch,
+        music_root,
+        "artist/track.flac",
+    )
+
+    assert analyzer.paths == [str(track_path.resolve())]
+    assert result == ("track-1", "artist/track.flac", {"bpm": 120.0})

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
Closes **K5** from the sweep-22 convergence review.

Both audio-analysis consumers (`audio-analyzer` and `audio-analyzer-clap`) opened queued file paths without verifying containment, so a crafted queue entry with an absolute path or `../` dot-segments could read files outside the music library (path traversal / arbitrary-file-read within the sidecar).

Adds `_resolve_music_path()` to both analyzers: reject absolute paths and any path containing `.`/`..` segments, resolve via `os.path.realpath`, and require the resolved path stays beneath the resolved `MUSIC_PATH` (`os.path.commonpath`) — symlink-safe. On violation the item is skipped with a sanitized warning (fail closed).

Traversal tests added for both services (absolute, dot-segment, and symlink-escape rejected without embedding; in-library path accepted). 8 containment tests + full service suites green (31 + 27).