### PR TITLE
fix(reliability): cancel readiness probe ops on deadline; abort audiobookshelf stream on disconnect

### DIFF
--- a/backend/src/services/__tests__/audiobookshelfService.test.ts
+++ b/backend/src/services/__tests__/audiobookshelfService.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 const logger = {
     debug: jest.fn(),
     warn: jest.fn(),
@@ -49,10 +51,29 @@ function createClient() {
     };
 }
 
+function createStreamLifecycle() {
+    return {
+        request: new EventEmitter(),
+        response: new EventEmitter(),
+    };
+}
+
+function expectStreamListeners(
+    lifecycle: ReturnType<typeof createStreamLifecycle>,
+    count: number,
+) {
+    expect(lifecycle.request.listenerCount("close")).toBe(count);
+    expect(lifecycle.request.listenerCount("aborted")).toBe(count);
+    expect(lifecycle.response.listenerCount("close")).toBe(count);
+    expect(lifecycle.response.listenerCount("aborted")).toBe(count);
+}
+
 describe("audiobookshelf service behavior", () => {
     const originalEnv = process.env;
 
     beforeEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
         jest.clearAllMocks();
         process.env = { ...originalEnv };
         delete process.env.AUDIOBOOKSHELF_URL;
@@ -330,6 +351,7 @@ describe("audiobookshelf service behavior", () => {
         expect(client.get).toHaveBeenCalledWith("/api/items/book-1/file/123", {
             responseType: "stream",
             timeout: 0,
+            signal: expect.any(AbortSignal),
             headers: {
                 Range: "bytes=0-99",
             },
@@ -340,6 +362,141 @@ describe("audiobookshelf service behavior", () => {
         await expect(
             audiobookshelfService.streamAudiobook("book-2"),
         ).rejects.toThrow("No audio track found for this audiobook");
+    });
+
+    it("aborts stream acquisition on an early client disconnect and detaches listeners", async () => {
+        const client = createClient();
+        const lifecycle = createStreamLifecycle();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                },
+            } as any,
+        );
+        client.get.mockImplementationOnce(
+            (_url: string, options: { signal: AbortSignal }) =>
+                new Promise((_resolve, reject) => {
+                    if (options.signal.aborted) {
+                        reject(options.signal.reason);
+                        return;
+                    }
+                    options.signal.addEventListener(
+                        "abort",
+                        () => reject(options.signal.reason),
+                        { once: true },
+                    );
+                }),
+        );
+        const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+        const acquisition = audiobookshelfService.streamAudiobook(
+            "book-1",
+            undefined,
+            lifecycle,
+        );
+        await Promise.resolve();
+        expectStreamListeners(lifecycle, 1);
+
+        const rejectedAcquisition = expect(acquisition).rejects.toThrow(
+            "Client disconnected",
+        );
+        lifecycle.request.emit("aborted");
+
+        await rejectedAcquisition;
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expectStreamListeners(lifecycle, 0);
+    });
+
+    it("aborts stream acquisition when the header deadline expires", async () => {
+        jest.useFakeTimers();
+        const client = createClient();
+        const lifecycle = createStreamLifecycle();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                },
+            } as any,
+        );
+        client.get.mockImplementationOnce(
+            (_url: string, options: { signal: AbortSignal }) =>
+                new Promise((_resolve, reject) => {
+                    if (options.signal.aborted) {
+                        reject(options.signal.reason);
+                        return;
+                    }
+                    options.signal.addEventListener(
+                        "abort",
+                        () => reject(options.signal.reason),
+                        { once: true },
+                    );
+                }),
+        );
+        const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+        const acquisition = audiobookshelfService.streamAudiobook(
+            "book-1",
+            undefined,
+            lifecycle,
+        );
+        await Promise.resolve();
+        const rejectedAcquisition = expect(acquisition).rejects.toThrow(
+            "Audiobookshelf stream headers timed out after 30000ms",
+        );
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await rejectedAcquisition;
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expectStreamListeners(lifecycle, 0);
+    });
+
+    it("hands off a connected stream and detaches acquisition listeners", async () => {
+        const client = createClient();
+        const lifecycle = createStreamLifecycle();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                },
+            } as any,
+        );
+        const stream = { pipe: jest.fn() };
+        client.get.mockResolvedValueOnce({
+            data: stream,
+            headers: { "content-type": "audio/mpeg" },
+            status: 200,
+        });
+        const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+        const result = await audiobookshelfService.streamAudiobook(
+            "book-1",
+            undefined,
+            lifecycle,
+        );
+
+        expect(result).toEqual({
+            stream,
+            headers: { "content-type": "audio/mpeg" },
+            status: 200,
+        });
+        expect(abortSpy).not.toHaveBeenCalled();
+        expectStreamListeners(lifecycle, 0);
     });
 
     it("streams podcast episodes and handles missing episodes/files", async () => {

--- a/backend/src/services/audiobookshelf.ts
+++ b/backend/src/services/audiobookshelf.ts
@@ -4,6 +4,53 @@ import { logger } from "../utils/logger";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
 
+const STREAM_HEADER_TIMEOUT_MS = 30_000;
+
+interface StreamDisconnectSource {
+    readonly aborted?: boolean;
+    readonly destroyed?: boolean;
+    once(event: "close" | "aborted", listener: () => void): unknown;
+    off(event: "close" | "aborted", listener: () => void): unknown;
+}
+
+interface StreamAcquisitionLifecycle {
+    request: StreamDisconnectSource;
+    response: StreamDisconnectSource;
+}
+
+function bindStreamDisconnect(
+    lifecycle: StreamAcquisitionLifecycle,
+    controller: AbortController,
+): () => void {
+    const onDisconnect = () => {
+        if (!controller.signal.aborted) {
+            controller.abort(
+                new Error("Client disconnected during stream acquisition"),
+            );
+        }
+    };
+
+    lifecycle.request.once("close", onDisconnect);
+    lifecycle.request.once("aborted", onDisconnect);
+    lifecycle.response.once("close", onDisconnect);
+    lifecycle.response.once("aborted", onDisconnect);
+
+    if (
+        lifecycle.request.aborted ||
+        lifecycle.request.destroyed ||
+        lifecycle.response.destroyed
+    ) {
+        onDisconnect();
+    }
+
+    return () => {
+        lifecycle.request.off("close", onDisconnect);
+        lifecycle.request.off("aborted", onDisconnect);
+        lifecycle.response.off("close", onDisconnect);
+        lifecycle.response.off("aborted", onDisconnect);
+    };
+}
+
 /**
  * Audiobookshelf API Service
  * Handles all interactions with the Audiobookshelf server
@@ -212,11 +259,12 @@ class AudiobookshelfService {
     /**
      * Get a specific audiobook by ID
      */
-    async getAudiobook(audiobookId: string) {
+    async getAudiobook(audiobookId: string, signal?: AbortSignal) {
         await this.ensureInitialized();
-        const response = await this.client!.get(
-            `/api/items/${audiobookId}?expanded=1`,
-        );
+        const path = `/api/items/${audiobookId}?expanded=1`;
+        const response = signal
+            ? await this.client!.get(path, { signal })
+            : await this.client!.get(path);
         return response.data;
     }
 
@@ -271,38 +319,54 @@ class AudiobookshelfService {
      * Stream an audiobook with authentication
      * Returns a readable stream that can be piped to the response
      */
-    async streamAudiobook(audiobookId: string, rangeHeader?: string) {
-        await this.ensureInitialized();
+    async streamAudiobook(
+        audiobookId: string,
+        rangeHeader?: string,
+        lifecycle?: StreamAcquisitionLifecycle,
+    ) {
+        const controller = new AbortController();
+        const detachDisconnect = lifecycle
+            ? bindStreamDisconnect(lifecycle, controller)
+            : () => undefined;
+        const timeoutError = new Error(
+            `Audiobookshelf stream headers timed out after ${STREAM_HEADER_TIMEOUT_MS}ms`,
+        );
+        const timeoutId = setTimeout(() => {
+            if (!controller.signal.aborted) controller.abort(timeoutError);
+        }, STREAM_HEADER_TIMEOUT_MS);
 
-        // First, get the audiobook to find the track file
-        const audiobook = await this.getAudiobook(audiobookId);
+        try {
+            await this.ensureInitialized();
+            const audiobook = await this.getAudiobook(
+                audiobookId,
+                controller.signal,
+            );
+            const contentUrl = audiobook.media?.tracks?.[0]?.contentUrl;
+            if (!contentUrl) {
+                throw new Error("No audio track found for this audiobook");
+            }
 
-        // Get the first track's content URL
-        const firstTrack = audiobook.media?.tracks?.[0];
-        if (!firstTrack || !firstTrack.contentUrl) {
-            throw new Error("No audio track found for this audiobook");
+            const headers: Record<string, string> = {};
+            if (rangeHeader) headers["Range"] = rangeHeader;
+            const response = await this.client!.get(contentUrl, {
+                responseType: "stream",
+                timeout: 0,
+                signal: controller.signal,
+                headers,
+                validateStatus: (status) => status >= 200 && status < 300,
+            });
+            return {
+                stream: response.data,
+                headers: response.headers,
+                status: response.status,
+            };
+        } catch (error) {
+            if (controller.signal.aborted) throw controller.signal.reason;
+            throw error;
+        } finally {
+            clearTimeout(timeoutId);
+            detachDisconnect();
         }
-
-        // Build request headers
-        const headers: Record<string, string> = {};
-        if (rangeHeader) {
-            headers["Range"] = rangeHeader;
-        }
-
-        // The contentUrl format is: /api/items/{id}/file/{ino}
-        const response = await this.client!.get(firstTrack.contentUrl, {
-            responseType: "stream",
-            timeout: 0, // No timeout for streaming
-            headers,
-            // Don't throw on 206 Partial Content
-            validateStatus: (status) => status >= 200 && status < 300,
-        });
-
-        return {
-            stream: response.data,
-            headers: response.headers,
-            status: response.status,
-        };
     }
 
     /**

--- a/backend/src/utils/__tests__/dependencyReadinessBehavior.test.ts
+++ b/backend/src/utils/__tests__/dependencyReadinessBehavior.test.ts
@@ -2,6 +2,7 @@ describe("dependency readiness tracker behavior", () => {
     const originalEnv = process.env;
 
     afterEach(() => {
+        jest.useRealTimers();
         process.env = originalEnv;
         jest.resetModules();
         jest.clearAllMocks();
@@ -34,30 +35,92 @@ describe("dependency readiness tracker behavior", () => {
             redisReject: options?.redisReject,
         };
 
+        let activePostgresOperations = 0;
+        let activeRedisOperations = 0;
+        let rejectPostgresOperation: ((error: Error) => void) | undefined;
+        const postgresCancel = jest.fn(() => {
+            rejectPostgresOperation?.(
+                new Error("postgres transaction timed out"),
+            );
+        });
+        const redisCancel = jest.fn();
+
         const queryRaw = jest.fn().mockImplementation(() => {
             if (options?.postgresHang) {
-                return new Promise(() => undefined);
+                activePostgresOperations += 1;
+                return new Promise((_resolve, reject) => {
+                    rejectPostgresOperation = (error: Error) => {
+                        activePostgresOperations -= 1;
+                        reject(error);
+                    };
+                });
             }
             if (state.postgresReject) {
                 return Promise.reject(new Error(state.postgresReject));
             }
             return Promise.resolve(1);
         });
-        const ping = jest.fn().mockImplementation(() => {
+        const transaction = jest
+            .fn()
+            .mockImplementation(
+                async (
+                    operation:
+                        | Array<Promise<unknown>>
+                        | ((client: {
+                              $queryRaw: typeof queryRaw;
+                          }) => Promise<unknown>),
+                    deadline: { timeout: number },
+                ) => {
+                    const operationPromise = Array.isArray(operation)
+                        ? Promise.all(operation)
+                        : operation({ $queryRaw: queryRaw });
+                    if (!options?.postgresHang) {
+                        return await operationPromise;
+                    }
+
+                    const timeoutId = setTimeout(
+                        postgresCancel,
+                        deadline.timeout,
+                    );
+                    try {
+                        return await operationPromise;
+                    } finally {
+                        clearTimeout(timeoutId);
+                    }
+                },
+            );
+        const ping = jest.fn().mockImplementation((signal?: AbortSignal) => {
             if (options?.redisHang) {
-                return new Promise(() => undefined);
+                activeRedisOperations += 1;
+                return new Promise((_resolve, reject) => {
+                    signal?.addEventListener(
+                        "abort",
+                        () => {
+                            redisCancel();
+                            activeRedisOperations -= 1;
+                            reject(signal.reason);
+                        },
+                        { once: true },
+                    );
+                });
             }
             if (state.redisReject) {
                 return Promise.reject(new Error(state.redisReject));
             }
             return Promise.resolve("PONG");
         });
+        const withCommandOptions = jest.fn(
+            ({ abortSignal }: { abortSignal: AbortSignal }) => ({
+                ping: () => ping(abortSignal),
+            }),
+        );
 
         const redisClient = {
             get isReady() {
                 return state.redisReady;
             },
             ping,
+            withCommandOptions,
         };
 
         const logger = {
@@ -72,6 +135,7 @@ describe("dependency readiness tracker behavior", () => {
         jest.doMock("../db", () => ({
             prisma: {
                 $queryRaw: queryRaw,
+                $transaction: transaction,
             },
         }));
         jest.doMock("../redis", () => ({ redisClient }));
@@ -85,8 +149,18 @@ describe("dependency readiness tracker behavior", () => {
         return {
             tracker,
             queryRaw,
+            transaction,
             ping,
+            withCommandOptions,
             logger,
+            postgresCancel,
+            redisCancel,
+            getActiveOperations() {
+                return {
+                    postgres: activePostgresOperations,
+                    redis: activeRedisOperations,
+                };
+            },
             setRedisReady(value: boolean) {
                 state.redisReady = value;
             },
@@ -98,6 +172,39 @@ describe("dependency readiness tracker behavior", () => {
             },
         };
     }
+
+    it("cancels and awaits timed-out dependency work before completing the probe", async () => {
+        jest.useFakeTimers();
+        const {
+            tracker,
+            transaction,
+            withCommandOptions,
+            postgresCancel,
+            redisCancel,
+            getActiveOperations,
+        } = loadTracker({
+            required: true,
+            postgresHang: true,
+            redisHang: true,
+            timeoutMs: "10",
+        });
+
+        const probePromise = tracker.probe(true);
+        await jest.advanceTimersByTimeAsync(10);
+        const snapshot = await probePromise;
+
+        expect(snapshot.overallHealthy).toBe(false);
+        expect(transaction).toHaveBeenCalledWith(expect.any(Array), {
+            maxWait: expect.any(Number),
+            timeout: expect.any(Number),
+        });
+        expect(withCommandOptions).toHaveBeenCalledWith({
+            abortSignal: expect.any(AbortSignal),
+        });
+        expect(postgresCancel).toHaveBeenCalledTimes(1);
+        expect(redisCancel).toHaveBeenCalledTimes(1);
+        expect(getActiveOperations()).toEqual({ postgres: 0, redis: 0 });
+    });
 
     it("reports healthy without probing dependencies when dependency checks are disabled", async () => {
         const { tracker, queryRaw, ping } = loadTracker({ required: false });

--- a/backend/src/utils/__tests__/dependencyReadinessLatency.test.ts
+++ b/backend/src/utils/__tests__/dependencyReadinessLatency.test.ts
@@ -31,6 +31,9 @@ describe("dependency readiness tracker latency", () => {
             }
             return Promise.resolve(1);
         });
+        const transaction = jest.fn((operations: Array<Promise<unknown>>) =>
+            Promise.all(operations),
+        );
 
         const ping = jest.fn().mockImplementation(() => {
             if (state.redisReject) {
@@ -44,7 +47,9 @@ describe("dependency readiness tracker latency", () => {
                 return state.redisReady;
             },
             ping,
+            withCommandOptions: jest.fn(),
         };
+        redisClient.withCommandOptions.mockReturnValue(redisClient);
 
         const logger = {
             info: jest.fn(),
@@ -58,6 +63,7 @@ describe("dependency readiness tracker latency", () => {
         jest.doMock("../db", () => ({
             prisma: {
                 $queryRaw: queryRaw,
+                $transaction: transaction,
             },
         }));
         jest.doMock("../redis", () => ({ redisClient }));

--- a/backend/src/utils/dependencyReadiness.ts
+++ b/backend/src/utils/dependencyReadiness.ts
@@ -64,31 +64,38 @@ function initialSnapshot(): DependencyReadinessSnapshot {
     };
 }
 
-async function withTimeout<T>(
-    promise: Promise<T>,
+async function withAbortDeadline<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
     timeoutMs: number,
 ): Promise<T> {
-    return await new Promise<T>((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-            reject(new Error(`timed out after ${timeoutMs}ms`));
-        }, timeoutMs);
+    const controller = new AbortController();
+    const timeoutError = new Error(`timed out after ${timeoutMs}ms`);
+    const timeoutId = setTimeout(
+        () => controller.abort(timeoutError),
+        timeoutMs,
+    );
 
-        promise
-            .then((value) => {
-                clearTimeout(timeoutId);
-                resolve(value);
-            })
-            .catch((error) => {
-                clearTimeout(timeoutId);
-                reject(error);
-            });
-    });
+    try {
+        return await operation(controller.signal);
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw timeoutError;
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeoutId);
+    }
 }
 
 async function probePostgres(timeoutMs: number): Promise<DependencyStatus> {
     const startedAt = Date.now();
+    const maxWait = Math.max(1, Math.floor(timeoutMs / 2));
+    const timeout = Math.max(1, timeoutMs - maxWait);
     try {
-        await withTimeout(prisma.$queryRaw`SELECT 1`, timeoutMs);
+        await prisma.$transaction([prisma.$queryRaw`SELECT 1`], {
+            maxWait,
+            timeout,
+        });
         return {
             ok: true,
             error: null,
@@ -114,7 +121,13 @@ async function probeRedis(timeoutMs: number): Promise<DependencyStatus> {
 
     const startedAt = Date.now();
     try {
-        await withTimeout(redisClient.ping(), timeoutMs);
+        await withAbortDeadline(
+            async (signal) =>
+                await redisClient
+                    .withCommandOptions({ abortSignal: signal })
+                    .ping(),
+            timeoutMs,
+        );
         return {
             ok: true,
             error: null,


### PR DESCRIPTION
Closes **K7** and **K8** from the sweep-22 convergence review (disjoint files).

**K7** (`dependencyReadiness.ts`): probes raced a timeout and abandoned the live PostgreSQL/Redis operation on timeout. Postgres now runs under a bounded `$transaction` (maxWait + timeout) so the query is cancelled server-side; Redis runs under an `AbortController`-backed command deadline (`withCommandOptions({ abortSignal })`) via a `withAbortDeadline` helper that clears its timer and only surfaces after the operation settles or is aborted — no abandoned in-flight work.

**K8** (`audiobookshelf.ts`): stream acquisition had no deadline and missed early client disconnects. An `AbortController` is now bound to request/response `close`/`aborted` before acquisition (early disconnect aborts the upstream fetch), a bounded header-acquisition deadline is enforced, and listeners are detached after handoff or failure.

27 tests / 5 suites green (incl. sibling latency test mock reconciled to the new API surface), tsc clean, prettier clean.