### PR TITLE
chore(ci): transpile-only ts-jest (isolatedModules) for ~95% faster backend tests

### DIFF
--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>

--- a/backend/src/routes/__tests__/audiobooksRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksRuntime.test.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 const mockLookup = jest.fn();
 

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import fs from "fs";
 
 const mockLookup = jest.fn();

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import fs from "fs";
 
 const mockStreamGetStreamFilePath = jest.fn();

--- a/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
+++ b/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 const mockGetStreamFilePath = jest.fn();
 const mockStreamFileWithRangeSupport = jest.fn();

--- a/backend/src/services/discovery/index.ts
+++ b/backend/src/services/discovery/index.ts
@@ -1,19 +1,18 @@
 export {
     DiscoveryBatchLogger,
     discoveryBatchLogger,
-    BatchLogEntry,
 } from "./discoveryBatchLogger";
+export type { BatchLogEntry } from "./discoveryBatchLogger";
 export {
     DiscoveryAlbumLifecycle,
     discoveryAlbumLifecycle,
+} from "./discoveryAlbumLifecycle";
+export type {
     DiscoveryAlbumInfo,
     LidarrSettings,
 } from "./discoveryAlbumLifecycle";
-export {
-    DiscoverySeeding,
-    discoverySeeding,
-    SeedArtist,
-} from "./discoverySeeding";
+export { DiscoverySeeding, discoverySeeding } from "./discoverySeeding";
+export type { SeedArtist } from "./discoverySeeding";
 export {
     DiscoveryRecommendationsService,
     discoveryRecommendationsService,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,6 +6,7 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "strict": true,
+        "isolatedModules": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Speeds up the "Backend Tests + Coverage" job (~30 min → a few minutes).

The job ran ts-jest in full type-check mode, duplicating the separate **Backend Typecheck** job. Enabling `isolatedModules` makes ts-jest transpile per-file (no type-check during tests): a representative batch drops **~155s → ~5–8s (13–20× faster)** with identical results (508 tests / 20 suites green, incl. the type-only-import edge cases).

`isolatedModules` requires type-only imports/re-exports to be explicit, so the handful of flagged sites are converted to `import type` / `export type` (`services/discovery/index.ts` re-exports + a few Express `Response` type imports in tests). These are erased at runtime — **no behavior change**. Type safety remains fully covered by the Backend Typecheck job and `tsc --noEmit` (unchanged, green).

No CI job renamed; required-check matching unaffected.