### PR TITLE
fix(reliability): bound podcast auto-cache concurrent downloads

### DIFF
--- a/backend/src/services/__tests__/podcastDownloadRuntime.test.ts
+++ b/backend/src/services/__tests__/podcastDownloadRuntime.test.ts
@@ -141,6 +141,80 @@ describe("podcast download runtime behavior", () => {
         }) as typeof setTimeout);
     }
 
+    function createSuccessfulDownloadResponse(onComplete: () => void) {
+        const listeners = new Map<string, (...args: any[]) => void>();
+        return {
+            status: 200,
+            headers: { "content-length": "3" },
+            data: {
+                on: jest.fn(
+                    (event: string, callback: (...args: any[]) => void) => {
+                        listeners.set(event, callback);
+                    },
+                ),
+                pipe: jest.fn(() => {
+                    listeners.get("data")?.(Buffer.from("abc"));
+                    onComplete();
+                    listeners.get("end")?.();
+                }),
+                destroy: jest.fn(),
+            },
+        };
+    }
+
+    function mockUncachedThreeByteEpisodes(
+        mocks: ReturnType<typeof setupPodcastDownloadMocks>,
+    ): void {
+        mocks.fsPromises.access.mockRejectedValue(new Error("not found"));
+        (mocks.fsPromises.stat as jest.Mock).mockImplementation(
+            async (targetPath: string) =>
+                targetPath.endsWith(".tmp") ? { size: 3 } : { size: 1_048_576 },
+        );
+        (mocks.prisma.podcastEpisode.findUnique as jest.Mock).mockResolvedValue(
+            { fileSize: 3, podcastId: "podcast-1" },
+        );
+    }
+
+    function mockControlledSuccessfulDownloads(
+        mocks: ReturnType<typeof setupPodcastDownloadMocks>,
+    ) {
+        let active = 0;
+        let completed = 0;
+        let peak = 0;
+        let releaseDownloads = () => {};
+        const releaseGate = new Promise<void>((resolve) => {
+            releaseDownloads = resolve;
+        });
+
+        mockUncachedThreeByteEpisodes(mocks);
+        (mocks.axiosGet as jest.Mock).mockImplementation(async () => {
+            active += 1;
+            peak = Math.max(peak, active);
+            await releaseGate;
+            return createSuccessfulDownloadResponse(() => {
+                active -= 1;
+                completed += 1;
+            });
+        });
+
+        return {
+            getCompleted: () => completed,
+            getPeak: () => peak,
+            releaseDownloads,
+        };
+    }
+
+    async function waitForCount(
+        readCount: () => number,
+        expected: number,
+    ): Promise<void> {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            if (readCount() === expected) return;
+            await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+        throw new Error(`Timed out waiting for count ${expected}`);
+    }
+
     it("validates a cached podcast file and updates access metadata", async () => {
         const mocks = setupPodcastDownloadMocks();
 
@@ -332,6 +406,110 @@ describe("podcast download runtime behavior", () => {
             });
         }
         expect(mocks.axiosGet).toHaveBeenCalledTimes(1);
+    });
+
+    it("limits auto-cache download concurrency across queued episodes", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const controls = mockControlledSuccessfulDownloads(mocks);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        const { concurrency } =
+            podcastDownload.getAutoCacheDownloadQueueState();
+        const episodeCount = concurrency + 2;
+
+        for (let index = 0; index < episodeCount; index += 1) {
+            expect(
+                podcastDownload.downloadInBackground(
+                    `episode-queued-${index}`,
+                    `https://example.com/episode-queued-${index}.mp3`,
+                    "user-1",
+                ),
+            ).toBe(true);
+        }
+
+        await waitForCount(
+            () => (mocks.axiosGet as jest.Mock).mock.calls.length,
+            concurrency,
+        );
+        expect(controls.getPeak()).toBe(concurrency);
+
+        controls.releaseDownloads();
+        await podcastDownload.drainAutoCacheDownloadQueue();
+
+        expect(controls.getPeak()).toBe(concurrency);
+        expect(controls.getCompleted()).toBe(episodeCount);
+    });
+
+    it("rejects auto-cache work deterministically when queue capacity is full", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const controls = mockControlledSuccessfulDownloads(mocks);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        const initialState = podcastDownload.getAutoCacheDownloadQueueState();
+        const admittedCount = initialState.concurrency + initialState.capacity;
+
+        for (let index = 0; index < admittedCount; index += 1) {
+            expect(
+                podcastDownload.downloadInBackground(
+                    `episode-capacity-${index}`,
+                    `https://example.com/episode-capacity-${index}.mp3`,
+                    "user-1",
+                ),
+            ).toBe(true);
+        }
+        await waitForCount(
+            () => (mocks.axiosGet as jest.Mock).mock.calls.length,
+            initialState.concurrency,
+        );
+
+        expect(podcastDownload.getAutoCacheDownloadQueueState()).toEqual({
+            active: initialState.concurrency,
+            capacity: initialState.capacity,
+            concurrency: initialState.concurrency,
+            queued: initialState.capacity,
+        });
+        expect(
+            podcastDownload.downloadInBackground(
+                "episode-overflow",
+                "https://example.com/episode-overflow.mp3",
+                "user-1",
+            ),
+        ).toBe(false);
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            "Podcast auto-cache queue at capacity; rejecting download",
+            expect.objectContaining({ episodeId: "episode-overflow" }),
+        );
+
+        controls.releaseDownloads();
+        await podcastDownload.drainAutoCacheDownloadQueue();
+    });
+
+    it("downloads every episode in a normal small auto-cache feed", async () => {
+        const mocks = setupPodcastDownloadMocks();
+        const controls = mockControlledSuccessfulDownloads(mocks);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const podcastDownload = require("../podcastDownload");
+        controls.releaseDownloads();
+
+        for (let index = 0; index < 2; index += 1) {
+            expect(
+                podcastDownload.downloadInBackground(
+                    `episode-small-feed-${index}`,
+                    `https://example.com/episode-small-feed-${index}.mp3`,
+                    "user-1",
+                ),
+            ).toBe(true);
+        }
+        await podcastDownload.drainAutoCacheDownloadQueue();
+
+        expect(controls.getCompleted()).toBe(2);
+        expect(mocks.prisma.podcastDownload.upsert).toHaveBeenCalledTimes(2);
+        expect(podcastDownload.getAutoCacheDownloadQueueState()).toEqual(
+            expect.objectContaining({ active: 0, queued: 0 }),
+        );
     });
 
     it("clamps runtime progress to 100% while still downloading", async () => {

--- a/backend/src/services/podcastDownload.ts
+++ b/backend/src/services/podcastDownload.ts
@@ -5,6 +5,7 @@ import fs from "fs/promises";
 import type { WriteStream } from "node:fs";
 import path from "path";
 import axios, { type AxiosResponse } from "axios";
+import pLimit from "p-limit";
 import { BRAND_USER_AGENT } from "../config/brand";
 import {
     resolveSafeOutboundRedirectTarget,
@@ -35,9 +36,13 @@ const PODCAST_DOWNLOAD_IDLE_TIMEOUT_MS = 120_000;
 const MAX_PODCAST_DOWNLOAD_REDIRECTS = 5;
 const MAX_PODCAST_EPISODE_ID_LENGTH = 128;
 const PODCAST_EPISODE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const PODCAST_AUTO_CACHE_CONCURRENCY = 3;
+const PODCAST_AUTO_CACHE_QUEUE_CAPACITY = 32;
 /** Maximum declared or observed bytes accepted for one podcast download. */
 export const MAX_PODCAST_DOWNLOAD_BYTES = 1024 * 1024 * 1024;
 const podcastDownloadLogger = logger.child("PodcastDownload");
+const autoCacheDownloadLimit = pLimit(PODCAST_AUTO_CACHE_CONCURRENCY);
+const admittedAutoCacheDownloads = new Set<Promise<void>>();
 
 class PodcastDownloadBlockedError extends Error {
     constructor(url: string) {
@@ -357,42 +362,106 @@ export async function getCachedFilePath(
     }
 }
 
+async function performAutoCacheDownload(
+    episodeId: string,
+    audioUrl: string,
+    userId: string,
+): Promise<void> {
+    try {
+        await performDownload(episodeId, audioUrl, userId);
+    } catch (error) {
+        podcastDownloadLogger.error(
+            `Background download failed for ${episodeId}`,
+            describePodcastDownloadError(error),
+        );
+    } finally {
+        downloadingEpisodes.delete(episodeId);
+    }
+}
+
+function enqueueAutoCacheDownload(
+    episodeId: string,
+    audioUrl: string,
+    userId: string,
+): boolean {
+    downloadingEpisodes.add(episodeId);
+    const task = autoCacheDownloadLimit(() =>
+        performAutoCacheDownload(episodeId, audioUrl, userId),
+    );
+    admittedAutoCacheDownloads.add(task);
+    void task.then(
+        () => admittedAutoCacheDownloads.delete(task),
+        (error: unknown) => {
+            admittedAutoCacheDownloads.delete(task);
+            downloadingEpisodes.delete(episodeId);
+            podcastDownloadLogger.error(
+                `Auto-cache queue failed for ${episodeId}`,
+                describePodcastDownloadError(error),
+            );
+        },
+    );
+    return true;
+}
+
+function rejectAutoCacheQueueOverflow(episodeId: string): false {
+    podcastDownloadLogger.warn(
+        "Podcast auto-cache queue at capacity; rejecting download",
+        {
+            episodeId,
+            active: autoCacheDownloadLimit.activeCount,
+            capacity: PODCAST_AUTO_CACHE_QUEUE_CAPACITY,
+            queued: autoCacheDownloadLimit.pendingCount,
+        },
+    );
+    return false;
+}
+
 /**
- * Start a background download for an episode
- * Returns immediately, download happens asynchronously
+ * Start a bounded background auto-cache download for an episode.
+ * Returns whether the work was admitted; duplicate, invalid, and overflow work
+ * is rejected without starting another download.
  */
 export function downloadInBackground(
     episodeId: string,
     audioUrl: string,
     userId: string,
-): void {
+): boolean {
     if (!resolvePodcastCacheFile(episodeId, "mp3")) {
         podcastDownloadLogger.warn("Rejected invalid podcast episode ID");
-        return;
+        return false;
     }
-
-    // Skip if already downloading
     if (downloadingEpisodes.has(episodeId)) {
         podcastDownloadLogger.debug(
             `Already downloading episode ${episodeId}, skipping`,
         );
-        return;
+        return false;
     }
+    if (
+        autoCacheDownloadLimit.pendingCount >= PODCAST_AUTO_CACHE_QUEUE_CAPACITY
+    ) {
+        return rejectAutoCacheQueueOverflow(episodeId);
+    }
+    return enqueueAutoCacheDownload(episodeId, audioUrl, userId);
+}
 
-    // Mark as downloading
-    downloadingEpisodes.add(episodeId);
+/** Return the process-wide podcast auto-cache queue state. */
+export function getAutoCacheDownloadQueueState(): {
+    active: number;
+    capacity: number;
+    concurrency: number;
+    queued: number;
+} {
+    return {
+        active: autoCacheDownloadLimit.activeCount,
+        capacity: PODCAST_AUTO_CACHE_QUEUE_CAPACITY,
+        concurrency: PODCAST_AUTO_CACHE_CONCURRENCY,
+        queued: autoCacheDownloadLimit.pendingCount,
+    };
+}
 
-    // Start download in background (don't await)
-    performDownload(episodeId, audioUrl, userId)
-        .catch((error: unknown) => {
-            podcastDownloadLogger.error(
-                `Background download failed for ${episodeId}`,
-                describePodcastDownloadError(error),
-            );
-        })
-        .finally(() => {
-            downloadingEpisodes.delete(episodeId);
-        });
+/** Wait until all podcast auto-cache downloads admitted so far have settled. */
+export async function drainAutoCacheDownloadQueue(): Promise<void> {
+    await Promise.allSettled([...admittedAutoCacheDownloads]);
 }
 
 interface PodcastDownloadPaths {


### PR DESCRIPTION
Closes **K9** from the sweep-22 convergence review.

Podcast auto-cache launched unbounded concurrent background downloads (one per episode), so a large feed or many feeds could spawn hundreds of simultaneous downloads and exhaust memory/sockets/disk.

All auto-cache admission now flows through a process-wide `p-limit(3)` queue with a capacity cap (32): work beyond capacity is rejected with a warning rather than piled on, and `getAutoCacheDownloadQueueState()` exposes queue state for observability. The existing per-download idle/abort watchdog is preserved.

173 podcast tests / 8 suites green, tsc clean, prettier clean.