### PR TITLE
fix(config): preserve unrelated .env on partial settings updates

### DIFF
--- a/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
@@ -450,6 +450,27 @@ describe("systemSettings runtime routes", () => {
         );
     });
 
+    it("preserves omitted environment settings during a partial update", async () => {
+        const req = {
+            user: { id: "admin-1" },
+            body: { lidarrUrl: "http://new-lidarr:8686" },
+        } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(mockWriteEnvFile).toHaveBeenCalledWith({
+            LIDARR_ENABLED: undefined,
+            LIDARR_URL: "http://new-lidarr:8686",
+            LIDARR_API_KEY: undefined,
+            FANART_API_KEY: undefined,
+            OPENAI_API_KEY: undefined,
+            AUDIOBOOKSHELF_URL: undefined,
+            AUDIOBOOKSHELF_API_KEY: undefined,
+        });
+    });
+
     it("env sync clears secrets only on explicit null", async () => {
         mockSystemSettingsUpsert.mockResolvedValueOnce({
             id: "default",
@@ -465,9 +486,44 @@ describe("systemSettings runtime routes", () => {
         await postSettingsHandler(req, res);
 
         expect(res.statusCode).toBe(200);
-        expect(mockWriteEnvFile).toHaveBeenCalledWith(
-            expect.objectContaining({ OPENAI_API_KEY: null }),
-        );
+        expect(mockWriteEnvFile).toHaveBeenCalledWith({
+            LIDARR_ENABLED: undefined,
+            LIDARR_URL: undefined,
+            LIDARR_API_KEY: undefined,
+            FANART_API_KEY: undefined,
+            OPENAI_API_KEY: null,
+            AUDIOBOOKSHELF_URL: undefined,
+            AUDIOBOOKSHELF_API_KEY: undefined,
+        });
+    });
+
+    it("writes every environment setting supplied by a full update", async () => {
+        const req = {
+            user: { id: "admin-1" },
+            body: {
+                lidarrEnabled: false,
+                lidarrUrl: "http://lidarr:8686",
+                lidarrApiKey: "new-lidarr-key",
+                fanartApiKey: "new-fanart-key",
+                openaiApiKey: "new-openai-key",
+                audiobookshelfUrl: "http://audiobookshelf:13378",
+                audiobookshelfApiKey: "new-audiobookshelf-key",
+            },
+        } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(mockWriteEnvFile).toHaveBeenCalledWith({
+            LIDARR_ENABLED: "false",
+            LIDARR_URL: "http://lidarr:8686",
+            LIDARR_API_KEY: "new-lidarr-key",
+            FANART_API_KEY: "new-fanart-key",
+            OPENAI_API_KEY: "new-openai-key",
+            AUDIOBOOKSHELF_URL: "http://audiobookshelf:13378",
+            AUDIOBOOKSHELF_API_KEY: "new-audiobookshelf-key",
+        });
     });
 
     it("clears a stored secret only on an explicit null", async () => {

--- a/backend/src/routes/systemSettings.ts
+++ b/backend/src/routes/systemSettings.ts
@@ -179,6 +179,46 @@ const systemSettingsSchema = z.object({
     showVersion: z.boolean().optional(),
 });
 
+type SystemSettingsUpdate = z.infer<typeof systemSettingsSchema>;
+type SystemSettingsSecret =
+    (typeof ENCRYPTED_SETTINGS_COLUMNS.systemSettings)[number];
+type EffectiveSecret = (field: SystemSettingsSecret) => string | null;
+
+function buildEnvironmentUpdate(
+    data: SystemSettingsUpdate,
+    effectiveSecret: EffectiveSecret,
+): Record<string, string | null | undefined> {
+    const isSupplied = (field: keyof SystemSettingsUpdate): boolean =>
+        Object.prototype.hasOwnProperty.call(data, field) &&
+        data[field] !== undefined;
+
+    return {
+        LIDARR_ENABLED: isSupplied("lidarrEnabled")
+            ? data.lidarrEnabled
+                ? "true"
+                : "false"
+            : undefined,
+        LIDARR_URL: isSupplied("lidarrUrl")
+            ? data.lidarrUrl || null
+            : undefined,
+        LIDARR_API_KEY: isSupplied("lidarrApiKey")
+            ? effectiveSecret("lidarrApiKey")
+            : undefined,
+        FANART_API_KEY: isSupplied("fanartApiKey")
+            ? effectiveSecret("fanartApiKey")
+            : undefined,
+        OPENAI_API_KEY: isSupplied("openaiApiKey")
+            ? effectiveSecret("openaiApiKey")
+            : undefined,
+        AUDIOBOOKSHELF_URL: isSupplied("audiobookshelfUrl")
+            ? data.audiobookshelfUrl || null
+            : undefined,
+        AUDIOBOOKSHELF_API_KEY: isSupplied("audiobookshelfApiKey")
+            ? effectiveSecret("audiobookshelfApiKey")
+            : undefined,
+    };
+}
+
 /**
  * @openapi
  * /api/system-settings:
@@ -409,15 +449,7 @@ router.post("/", async (req, res) => {
 
         // Write to .env file for Docker containers
         try {
-            await writeEnvFile({
-                LIDARR_ENABLED: data.lidarrEnabled ? "true" : "false",
-                LIDARR_URL: data.lidarrUrl || null,
-                LIDARR_API_KEY: effectiveSecret("lidarrApiKey"),
-                FANART_API_KEY: effectiveSecret("fanartApiKey"),
-                OPENAI_API_KEY: effectiveSecret("openaiApiKey"),
-                AUDIOBOOKSHELF_URL: data.audiobookshelfUrl || null,
-                AUDIOBOOKSHELF_API_KEY: effectiveSecret("audiobookshelfApiKey"),
-            });
+            await writeEnvFile(buildEnvironmentUpdate(data, effectiveSecret));
             logger.debug(".env file synchronized with database settings");
         } catch (envError) {
             if (envError instanceof EnvFileSyncSkippedError) {


### PR DESCRIPTION
Closes **K10** from the sweep-22 convergence review.

A partial system-settings update built the env-write payload from **all** known keys, mapping absent request fields to empty values — so updating a single setting destructively erased other previously-configured `.env` values (URLs, secrets) that weren't included in the request.

`buildEnvironmentUpdate()` now includes only fields **explicitly present** in the request body (`hasOwnProperty` + defined), passing `undefined` for omitted fields so `envWriter` preserves them (the `undefined`=preserve / `null`=delete semantics from #373 are unchanged). Explicit clears of included fields still apply.

118 tests / 6 suites green, tsc clean, prettier clean, route-error canon clean.