### PR TITLE
fix(security): validate AIO secrets before overwriting persisted values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -425,62 +425,105 @@ if id redis >/dev/null 2>&1; then
 fi
 
 # Resolve application secrets: operator environment, persisted file, generated.
-if [ -n "$SESSION_SECRET" ]; then
-    printf '%s' "$SESSION_SECRET" > /data/secrets/session_secret
-elif [ -f /data/secrets/session_secret ]; then
-    SESSION_SECRET=$(cat /data/secrets/session_secret)
-else
-    SESSION_SECRET=$(openssl rand -hex 32)
-    printf '%s' "$SESSION_SECRET" > /data/secrets/session_secret
-fi
-chmod 600 /data/secrets/session_secret
-chown soundspan:soundspan /data/secrets/session_secret 2>/dev/null || true
-if [ "$SESSION_SECRET" = "changeme-generate-secure-key" ] || [ "${#SESSION_SECRET}" -lt 32 ]; then
-    echo "ERROR: SESSION_SECRET must be at least 32 characters and must not use the published default." >&2
+resolve_secret_candidate() {
+    local candidate="$1"
+    local secret_file="$2"
+
+    SECRET_NEEDS_PERSIST=false
+    if [ -n "$candidate" ]; then
+        RESOLVED_SECRET="$candidate"
+        SECRET_NEEDS_PERSIST=true
+    elif [ -f "$secret_file" ]; then
+        RESOLVED_SECRET=$(cat "$secret_file")
+    else
+        RESOLVED_SECRET=$(openssl rand -hex 32)
+        SECRET_NEEDS_PERSIST=true
+    fi
+}
+
+validate_critical_secret() {
+    local secret_name="$1"
+    local secret_value="$2"
+    local published_default="$3"
+
+    if [ -z "$secret_value" ] || [ "$secret_value" = "$published_default" ] || [ "${#secret_value}" -lt 32 ]; then
+        echo "ERROR: ${secret_name} is missing, uses the published default, or is shorter than 32 characters." >&2
+        return 1
+    fi
+}
+
+persist_secret_atomically() {
+    local secret_value="$1"
+    local secret_file="$2"
+    local temporary_file
+
+    temporary_file=$(mktemp "${secret_file}.tmp.XXXXXX")
+    if ! printf '%s' "$secret_value" > "$temporary_file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+    if ! chmod 600 "$temporary_file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+    chown soundspan:soundspan "$temporary_file" 2>/dev/null || true
+    if ! mv -f -- "$temporary_file" "$secret_file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+}
+
+secure_secret_file() {
+    local secret_file="$1"
+
+    chmod 600 "$secret_file"
+    chown soundspan:soundspan "$secret_file" 2>/dev/null || true
+}
+
+resolve_secret_candidate "${SESSION_SECRET:-}" /data/secrets/session_secret
+SESSION_SECRET="$RESOLVED_SECRET"
+SESSION_SECRET_NEEDS_PERSIST="$SECRET_NEEDS_PERSIST"
+resolve_secret_candidate "${SETTINGS_ENCRYPTION_KEY:-}" /data/secrets/encryption_key
+SETTINGS_ENCRYPTION_KEY="$RESOLVED_SECRET"
+SETTINGS_ENCRYPTION_KEY_NEEDS_PERSIST="$SECRET_NEEDS_PERSIST"
+resolve_secret_candidate "${INTERNAL_API_SECRET:-}" /data/secrets/internal_api_secret
+INTERNAL_API_SECRET="$RESOLVED_SECRET"
+INTERNAL_API_SECRET_NEEDS_PERSIST="$SECRET_NEEDS_PERSIST"
+resolve_secret_candidate "${POSTGRES_PASSWORD:-}" /data/secrets/postgres_password
+POSTGRES_PASSWORD="$RESOLVED_SECRET"
+POSTGRES_PASSWORD_NEEDS_PERSIST="$SECRET_NEEDS_PERSIST"
+unset RESOLVED_SECRET SECRET_NEEDS_PERSIST
+
+# Validate every resolved candidate before changing any persisted secret.
+validate_critical_secret SESSION_SECRET "$SESSION_SECRET" "changeme-generate-secure-key"
+validate_critical_secret SETTINGS_ENCRYPTION_KEY "$SETTINGS_ENCRYPTION_KEY" "default-encryption-key-change-me"
+validate_critical_secret INTERNAL_API_SECRET "$INTERNAL_API_SECRET" "soundspan-internal-secret-change-me"
+if [ -z "$POSTGRES_PASSWORD" ]; then
+    echo "ERROR: POSTGRES_PASSWORD must not be empty." >&2
     exit 1
 fi
 
-if [ -n "$SETTINGS_ENCRYPTION_KEY" ]; then
-    printf '%s' "$SETTINGS_ENCRYPTION_KEY" > /data/secrets/encryption_key
-elif [ -f /data/secrets/encryption_key ]; then
-    SETTINGS_ENCRYPTION_KEY=$(cat /data/secrets/encryption_key)
-else
-    SETTINGS_ENCRYPTION_KEY=$(openssl rand -hex 32)
-    printf '%s' "$SETTINGS_ENCRYPTION_KEY" > /data/secrets/encryption_key
+if [ "$SESSION_SECRET_NEEDS_PERSIST" = true ]; then
+    persist_secret_atomically "$SESSION_SECRET" /data/secrets/session_secret
 fi
-chmod 600 /data/secrets/encryption_key
-chown soundspan:soundspan /data/secrets/encryption_key 2>/dev/null || true
-if [ "$SETTINGS_ENCRYPTION_KEY" = "default-encryption-key-change-me" ]; then
-    echo "ERROR: SETTINGS_ENCRYPTION_KEY must not use the published default." >&2
-    exit 1
+if [ "$SETTINGS_ENCRYPTION_KEY_NEEDS_PERSIST" = true ]; then
+    persist_secret_atomically "$SETTINGS_ENCRYPTION_KEY" /data/secrets/encryption_key
 fi
+if [ "$INTERNAL_API_SECRET_NEEDS_PERSIST" = true ]; then
+    persist_secret_atomically "$INTERNAL_API_SECRET" /data/secrets/internal_api_secret
+fi
+if [ "$POSTGRES_PASSWORD_NEEDS_PERSIST" = true ]; then
+    persist_secret_atomically "$POSTGRES_PASSWORD" /data/secrets/postgres_password
+fi
+unset SESSION_SECRET_NEEDS_PERSIST SETTINGS_ENCRYPTION_KEY_NEEDS_PERSIST
+unset INTERNAL_API_SECRET_NEEDS_PERSIST POSTGRES_PASSWORD_NEEDS_PERSIST
 
-if [ -n "$INTERNAL_API_SECRET" ]; then
-    printf '%s' "$INTERNAL_API_SECRET" > /data/secrets/internal_api_secret
-elif [ -f /data/secrets/internal_api_secret ]; then
-    INTERNAL_API_SECRET=$(cat /data/secrets/internal_api_secret)
-else
-    INTERNAL_API_SECRET=$(openssl rand -hex 32)
-    printf '%s' "$INTERNAL_API_SECRET" > /data/secrets/internal_api_secret
-fi
-chmod 600 /data/secrets/internal_api_secret
-chown soundspan:soundspan /data/secrets/internal_api_secret 2>/dev/null || true
-if [ "$INTERNAL_API_SECRET" = "soundspan-internal-secret-change-me" ]; then
-    echo "ERROR: INTERNAL_API_SECRET must not use the published default." >&2
-    exit 1
-fi
+secure_secret_file /data/secrets/session_secret
+secure_secret_file /data/secrets/encryption_key
+secure_secret_file /data/secrets/internal_api_secret
+secure_secret_file /data/secrets/postgres_password
 
-# Resolve and persist the PostgreSQL password for fresh and existing volumes.
-if [ -n "$POSTGRES_PASSWORD" ]; then
-    printf '%s' "$POSTGRES_PASSWORD" > /data/secrets/postgres_password
-elif [ -f /data/secrets/postgres_password ]; then
-    POSTGRES_PASSWORD=$(cat /data/secrets/postgres_password)
-else
-    POSTGRES_PASSWORD=$(openssl rand -hex 32)
-    printf '%s' "$POSTGRES_PASSWORD" > /data/secrets/postgres_password
-fi
-chmod 600 /data/secrets/postgres_password
-chown soundspan:soundspan /data/secrets/postgres_password 2>/dev/null || true
+# Resolve the PostgreSQL URL after its validated password is persisted.
 DATABASE_URL=$(/app/aio-postgres-credentials.sh database-url)
 
 # Clean up stale PID file if exists

--- a/tests/test_aio_image_hardening.py
+++ b/tests/test_aio_image_hardening.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import re
+import stat
+import subprocess
 from pathlib import Path
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
@@ -48,18 +52,14 @@ def _run_blocks(dockerfile: str) -> list[str]:
     return blocks
 
 
-def _assert_operator_secret_precedes_file_read(
-    start_script: str, env_name: str, secret_file: str
-) -> None:
-    """Require an operator-secret branch before the persisted secret is read."""
-    condition = re.search(
-        rf'if\s+\[\s+-n\s+"\$(?:\{{{env_name}\}}|{env_name})"\s+\]',
-        start_script,
-    )
-    file_read = re.search(rf"cat\s+[\"']?{re.escape(secret_file)}", start_script)
-    assert condition is not None, f"missing operator override check for {env_name}"
-    assert file_read is not None, f"missing persisted secret read for {env_name}"
-    assert condition.start() < file_read.start()
+def _secret_resolution_block(start_script: str, secret_directory: Path) -> str:
+    """Return the executable AIO critical-secret resolution block."""
+    start_marker = "# Resolve application secrets: operator environment, persisted file, generated."
+    end_marker = "# Resolve the PostgreSQL URL after its validated password is persisted."
+    start = start_script.index(start_marker)
+    end = start_script.index(end_marker, start)
+    block = start_script[start:end].replace("/data/secrets", str(secret_directory))
+    return f"set -euo pipefail\n{block}"
 
 
 def test_dockerfile_creates_nonroot_app_user() -> None:
@@ -92,30 +92,95 @@ def test_supervisord_runs_services_as_nonroot() -> None:
     )
 
 
-def test_start_sh_honors_operator_session_secret_env() -> None:
+def test_start_sh_honors_operator_secret_env(tmp_path: Path) -> None:
     """Operator-provided secrets must take precedence over persisted values."""
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     start_script = _heredoc(dockerfile, "/app/start.sh")
+    replacements = {
+        "SESSION_SECRET": ("session_secret", "replacement-session-secret-0000000000"),
+        "SETTINGS_ENCRYPTION_KEY": (
+            "encryption_key",
+            "replacement-settings-key-00000000000",
+        ),
+        "INTERNAL_API_SECRET": (
+            "internal_api_secret",
+            "replacement-internal-secret-000000000",
+        ),
+        "POSTGRES_PASSWORD": ("postgres_password", "replacement-postgres-password"),
+    }
+    for filename, _value in replacements.values():
+        (tmp_path / filename).write_text("persisted-value", encoding="utf-8")
+    environment = {
+        **os.environ,
+        **{name: value for name, (_filename, value) in replacements.items()},
+    }
 
-    _assert_operator_secret_precedes_file_read(
-        start_script, "SESSION_SECRET", "/data/secrets/session_secret"
-    )
-    _assert_operator_secret_precedes_file_read(
-        start_script, "SETTINGS_ENCRYPTION_KEY", "/data/secrets/encryption_key"
-    )
-    _assert_operator_secret_precedes_file_read(
-        start_script, "INTERNAL_API_SECRET", "/data/secrets/internal_api_secret"
+    result = subprocess.run(
+        ["bash", "-c", _secret_resolution_block(start_script, tmp_path)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
     )
 
+    assert result.returncode == 0, result.stderr
+    for filename, value in replacements.values():
+        secret_file = tmp_path / filename
+        assert secret_file.read_text(encoding="utf-8") == value
+        assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
+        assert value not in result.stdout
+        assert value not in result.stderr
+    assert not list(tmp_path.glob("*.tmp.*"))
 
-def test_start_sh_writes_secrets_through_to_data() -> None:
-    """Operator-supplied secrets must be persisted to the data volume."""
+
+@pytest.mark.parametrize(
+    ("invalid_name", "invalid_value"),
+    [
+        ("SESSION_SECRET", "short-session-secret"),
+        ("SESSION_SECRET", "changeme-generate-secure-key"),
+        ("SETTINGS_ENCRYPTION_KEY", "short-settings-key"),
+        ("SETTINGS_ENCRYPTION_KEY", "default-encryption-key-change-me"),
+        ("INTERNAL_API_SECRET", "short-internal-secret"),
+        ("INTERNAL_API_SECRET", "soundspan-internal-secret-change-me"),
+    ],
+)
+def test_invalid_replacement_preserves_persisted_secrets(
+    tmp_path: Path, invalid_name: str, invalid_value: str
+) -> None:
+    """Invalid replacements must fail closed before any persisted secret changes."""
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     start_script = _heredoc(dockerfile, "/app/start.sh")
+    persisted = {
+        "session_secret": "persisted-session-secret-000000000000",
+        "encryption_key": "persisted-settings-key-0000000000000",
+        "internal_api_secret": "persisted-internal-secret-00000000000",
+    }
+    for filename, value in persisted.items():
+        (tmp_path / filename).write_text(value, encoding="utf-8")
 
-    assert re.search(r'>\s*"?/data/secrets/session_secret"?', start_script)
-    assert re.search(r'>\s*"?/data/secrets/encryption_key"?', start_script)
-    assert re.search(r'>\s*"?/data/secrets/internal_api_secret"?', start_script)
+    environment = {
+        **os.environ,
+        "SESSION_SECRET": "replacement-session-secret-0000000000",
+        "SETTINGS_ENCRYPTION_KEY": "replacement-settings-key-00000000000",
+        "INTERNAL_API_SECRET": "replacement-internal-secret-000000000",
+        invalid_name: invalid_value,
+    }
+    result = subprocess.run(
+        ["bash", "-c", _secret_resolution_block(start_script, tmp_path)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+
+    assert result.returncode != 0
+    assert invalid_name in result.stderr
+    assert invalid_value not in result.stdout
+    assert invalid_value not in result.stderr
+    for filename, value in persisted.items():
+        assert (tmp_path / filename).read_text(encoding="utf-8") == value
 
 
 def test_start_sh_rejects_known_default_secrets() -> None:
@@ -135,12 +200,15 @@ def test_secret_files_are_chmod_600() -> None:
     start_script = _heredoc(dockerfile, "/app/start.sh")
 
     assert re.search(r"chmod\s+700\s+/data/secrets\b", start_script)
+    assert re.search(r'chmod\s+600\s+"\$temporary_file"', start_script)
+    assert re.search(r'mv\s+-f\s+--\s+"\$temporary_file"\s+"\$secret_file"', start_script)
     for secret_file in (
         "/data/secrets/session_secret",
         "/data/secrets/encryption_key",
         "/data/secrets/internal_api_secret",
+        "/data/secrets/postgres_password",
     ):
-        assert re.search(rf"chmod\s+600\s+{re.escape(secret_file)}\b", start_script)
+        assert f"secure_secret_file {secret_file}" in start_script
     assert re.search(
         r"ENVEOF\s*\n\s*chmod\s+600\s+/app/backend/\.env\b", start_script
     )


### PR DESCRIPTION
Closes **K11** from the sweep-22 convergence review.

AIO startup overwrote persisted last-known-good critical secrets **before** validating the replacement candidates, so an invalid/empty/weak replacement would clobber the good secret — bricking the install and losing the ability to decrypt existing settings.

Reordered so every candidate (`SESSION_SECRET`, `SETTINGS_ENCRYPTION_KEY`, `INTERNAL_API_SECRET`, `POSTGRES_PASSWORD`) is validated (non-empty, not the published default, ≥32 chars) **before any persist**; on failure it exits non-zero with a sanitized message (never the secret value), leaving the persisted secret untouched. Persistence is atomic (`mktemp` + `chmod 600` + `mv` rename), so a crash mid-write cannot truncate a secret.

AIO hardening tests cover the validate-before-write ordering and fail-closed behavior (25 pass); dockerfile-hygiene 10/10.