### PR TITLE
fix(perf): bound playlist-detail resolution (truncate + bulk mapping load)

### DIFF
--- a/backend/src/routes/__tests__/playlistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/playlistsRuntime.test.ts
@@ -236,6 +236,7 @@ describe("playlists route runtime", () => {
             userId: "u1",
             isPublic: false,
             hiddenByUsers: [],
+            _count: { items: 0, pendingTracks: 0 },
             items: [],
             pendingTracks: [],
             user: { username: "owner" },
@@ -631,6 +632,209 @@ describe("playlists route runtime", () => {
         expect(errRes.body).toEqual({ error: "Failed to get playlist" });
     });
 
+    it("truncates oversized playlist detail with bounded bulk resolution", async () => {
+        prisma.userSettings.findUnique.mockResolvedValueOnce({
+            tidalOAuthJson: null,
+            ytMusicOAuthJson: null,
+        });
+        prisma.playlist.findUnique.mockResolvedValueOnce({
+            id: "pl-oversized",
+            userId: "u-oversized",
+            isPublic: false,
+            user: { username: "owner" },
+            hiddenByUsers: [],
+            _count: { items: 1000, pendingTracks: 1 },
+            items: Array.from({ length: 1000 }, (_, index) => ({
+                id: `pli-${index + 1}`,
+                playlistId: "pl-oversized",
+                trackId: null,
+                trackTidalId: `tt-${index + 1}`,
+                trackYtMusicId: null,
+                sort: index + 1,
+                track: null,
+                trackTidal: {
+                    id: `tt-${index + 1}`,
+                    tidalId: 1000 + index,
+                    title: `Tidal Song ${index}`,
+                    artist: "Tidal Artist",
+                    album: "Tidal Album",
+                    duration: 180,
+                },
+                trackYtMusic: null,
+            })),
+            pendingTracks: [
+                {
+                    id: "pt-first",
+                    sort: 0,
+                    spotifyArtist: "Pending Artist",
+                    spotifyTitle: "Pending Song",
+                    spotifyAlbum: "Pending Album",
+                    deezerPreviewUrl: null,
+                },
+            ],
+        });
+
+        const req = {
+            user: { id: "u-oversized" },
+            params: { id: "pl-oversized" },
+        } as any;
+        const res = createRes();
+        await getPlaylist(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.items).toHaveLength(999);
+        expect(res.body.pendingTracks).toHaveLength(1);
+        expect(res.body.mergedItems).toHaveLength(1000);
+        expect(res.body.totalItemCount).toBe(1001);
+        expect(res.body.truncated).toBe(true);
+        expect(res.body.items[998].id).toBe("pli-999");
+        expect(res.body.items).not.toContainEqual(
+            expect.objectContaining({ id: "pli-1000" }),
+        );
+        expect(res.body.mergedItems[0].id).toBe("pt-first");
+        expect(prisma.playlist.findUnique).toHaveBeenCalledWith(
+            expect.objectContaining({
+                include: expect.objectContaining({
+                    _count: {
+                        select: { items: true, pendingTracks: true },
+                    },
+                    items: expect.objectContaining({ take: 1001 }),
+                    pendingTracks: expect.objectContaining({ take: 1001 }),
+                }),
+            }),
+        );
+        expect(prisma.trackMapping.findMany).toHaveBeenCalledTimes(1);
+        const mappingQuery = prisma.trackMapping.findMany.mock.calls[0][0];
+        const tidalIds = mappingQuery.where.OR.find(
+            (clause: any) => clause.trackTidalId,
+        ).trackTidalId.in;
+        expect(tidalIds).toHaveLength(999);
+        expect(tidalIds[998]).toBe("tt-999");
+        expect(tidalIds).not.toContain("tt-1000");
+        expect(prisma.trackMapping.findFirst).not.toHaveBeenCalled();
+        expect(prisma.trackMapping.findUnique).not.toHaveBeenCalled();
+        expect(prisma.trackTidal.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("bulk-resolves cross-provider mappings and misses without per-item queries", async () => {
+        const itemCount = 50;
+        prisma.userSettings.findUnique.mockResolvedValueOnce({
+            tidalOAuthJson: null,
+            ytMusicOAuthJson: null,
+        });
+        prisma.playlist.findUnique.mockResolvedValueOnce({
+            id: "pl-bounded-resolution",
+            userId: "u-bounded-resolution",
+            isPublic: false,
+            user: { username: "owner" },
+            hiddenByUsers: [],
+            _count: { items: itemCount, pendingTracks: 0 },
+            items: Array.from({ length: itemCount }, (_, index) => ({
+                id: `pli-tidal-${index}`,
+                playlistId: "pl-bounded-resolution",
+                trackId: null,
+                trackTidalId: `tt-${index}`,
+                trackYtMusicId: null,
+                sort: index,
+                track: null,
+                trackTidal: {
+                    id: `tt-${index}`,
+                    tidalId: 1000 + index,
+                    title: `Tidal Song ${index}`,
+                    artist: "Tidal Artist",
+                    album: "Tidal Album",
+                    duration: 180,
+                },
+                trackYtMusic: null,
+            })),
+            pendingTracks: [],
+        });
+        prisma.trackMapping.findMany.mockImplementation(async (args: any) => {
+            if (args?.where?.id?.in) {
+                return [
+                    {
+                        id: "map-tt-0-yt",
+                        stale: false,
+                        confidence: 0.95,
+                        trackId: null,
+                        trackTidal: {
+                            id: "tt-0",
+                            tidalId: 1000,
+                            duration: 180,
+                        },
+                        trackYtMusic: {
+                            id: "yt-fallback",
+                            videoId: "yt-fallback-video",
+                            duration: 180,
+                        },
+                    },
+                ];
+            }
+            if (args?.select?.id) {
+                return [
+                    {
+                        id: "map-tt-0-yt",
+                        trackId: null,
+                        trackTidalId: "tt-0",
+                        trackYtMusicId: "yt-fallback",
+                        source: "import-match",
+                        confidence: 0.95,
+                        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+                    },
+                ];
+            }
+            return [
+                {
+                    trackId: null,
+                    trackTidalId: "tt-0",
+                    trackYtMusicId: "yt-fallback",
+                },
+            ];
+        });
+        prisma.trackTidal.findMany.mockResolvedValueOnce([
+            { id: "tt-0", tidalId: 1000, duration: 180 },
+        ]);
+        prisma.trackYtMusic.findMany.mockResolvedValueOnce([
+            {
+                id: "yt-fallback",
+                videoId: "yt-fallback-video",
+                title: "Fallback Song",
+                artist: "Fallback Artist",
+                album: "Fallback Album",
+                duration: 180,
+                thumbnailUrl: "https://yt/fallback.jpg",
+            },
+        ]);
+
+        const req = {
+            user: { id: "u-bounded-resolution" },
+            params: { id: "pl-bounded-resolution" },
+        } as any;
+        const res = createRes();
+        await getPlaylist(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.items).toHaveLength(itemCount);
+        expect(res.body.items[0].provider.source).toBe("youtube");
+        expect(res.body.items[0].playback.isPlayable).toBe(true);
+        expect(res.body.items[0].track.youtubeVideoId).toBe(
+            "yt-fallback-video",
+        );
+        expect(
+            res.body.items
+                .slice(1)
+                .every(
+                    (item: any) =>
+                        item.provider.source === "tidal" &&
+                        item.playback.reason === "provider_unavailable",
+                ),
+        ).toBe(true);
+        expect(prisma.trackMapping.findMany).toHaveBeenCalledTimes(3);
+        expect(prisma.trackMapping.findFirst).not.toHaveBeenCalled();
+        expect(prisma.trackMapping.findUnique).not.toHaveBeenCalled();
+        expect(prisma.trackTidal.findUnique).not.toHaveBeenCalled();
+    });
+
     it("formats playlist detail with provider/playability metadata and merged items", async () => {
         prisma.trackTidal.findMany.mockResolvedValueOnce([
             {
@@ -652,6 +856,7 @@ describe("playlists route runtime", () => {
             isPublic: false,
             user: { username: "owner" },
             hiddenByUsers: [{ id: "hidden-1" }],
+            _count: { items: 4, pendingTracks: 1 },
             items: [
                 {
                     id: "pli-1",
@@ -745,6 +950,8 @@ describe("playlists route runtime", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body.trackCount).toBe(4);
         expect(res.body.pendingCount).toBe(1);
+        expect(res.body.totalItemCount).toBe(5);
+        expect(res.body.truncated).toBe(false);
         expect(res.body.isOwner).toBe(true);
         expect(res.body.isHidden).toBe(true);
         expect(res.body.items[0].track.album.coverArt).toBe(
@@ -795,6 +1002,7 @@ describe("playlists route runtime", () => {
             isPublic: false,
             user: { username: "owner" },
             hiddenByUsers: [],
+            _count: { items: 1, pendingTracks: 0 },
             items: [
                 {
                     id: "pli-yt-1",
@@ -895,6 +1103,7 @@ describe("playlists route runtime", () => {
             isPublic: false,
             user: { username: "owner" },
             hiddenByUsers: [],
+            _count: { items: 1, pendingTracks: 0 },
             items: [
                 {
                     id: "pli-yt-conflict",
@@ -1027,6 +1236,7 @@ describe("playlists route runtime", () => {
             isPublic: false,
             user: { username: "owner" },
             hiddenByUsers: [],
+            _count: { items: 1, pendingTracks: 0 },
             items: [
                 {
                     id: "pli-tidal-1",
@@ -1082,6 +1292,7 @@ describe("playlists route runtime", () => {
             isPublic: false,
             user: { username: "owner" },
             hiddenByUsers: [],
+            _count: { items: 1, pendingTracks: 0 },
             items: [
                 {
                     id: "pli-yt-1",

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -9,7 +9,14 @@ import {
     formatUnifiedTrackItem,
     type UnifiedPlaylistItemRecord,
 } from "../services/unifiedTrackResponse";
-import { resolvePlaylistItemsForUser } from "../services/playlistTrackResolution";
+import {
+    resolvePlaylistItemsForUser,
+    type ResolvedPlaylistItem,
+} from "../services/playlistTrackResolution";
+import {
+    getUserProviderProfile,
+    type UserProviderProfile,
+} from "../services/listenTogetherResolution";
 
 const router = Router();
 
@@ -17,6 +24,8 @@ const PLAYLISTS_MAX_LIMIT = 1000;
 const PLAYLISTS_DEFAULT_LIMIT = 500;
 const PLAYLIST_PREVIEW_ITEMS = 12;
 const PLAYLIST_REORDER_MAX_ITEMS = 1000;
+const PLAYLIST_DETAIL_MAX_ITEMS = 1000;
+const PLAYLIST_DETAIL_QUERY_ITEMS = PLAYLIST_DETAIL_MAX_ITEMS + 1;
 const pendingRetryPath = "/:id/pending/:trackId/retry";
 
 type RetryRequest = Request<{ id: string; trackId: string }>;
@@ -32,6 +41,31 @@ type UnvalidatedReorderSelection =
 type ReorderPlaylistItem = {
     id: string;
     trackId: string | null;
+};
+
+type MappingAvailabilityRow = {
+    trackId: string | null;
+    trackTidalId: string | null;
+    trackYtMusicId: string | null;
+};
+
+type ResolutionPartition = {
+    delegatedItems: UnifiedPlaylistItemRecord[];
+    delegatedIndexes: number[];
+};
+
+type FallbackIds = {
+    tidalIds: string[];
+    ytIds: string[];
+};
+
+type PendingPlaylistItemRecord = {
+    id: string;
+    sort: number;
+    spotifyArtist: string;
+    spotifyTitle: string;
+    spotifyAlbum: string;
+    deezerPreviewUrl: string | null;
 };
 
 const reorderPayloadSchema = z.object({
@@ -183,6 +217,141 @@ const playlistItemInclude = {
     trackYtMusic: true,
 } as const;
 
+function getFallbackToken(
+    item: UnifiedPlaylistItemRecord,
+    profile: UserProviderProfile,
+): string | null {
+    if (item.trackTidalId && (!profile.hasTidal || !item.trackTidal)) {
+        return `t:${item.trackTidalId}`;
+    }
+    if (item.trackYtMusicId && (!profile.hasYtMusic || !item.trackYtMusic)) {
+        return `y:${item.trackYtMusicId}`;
+    }
+    return null;
+}
+
+function mappingSupportsProfile(
+    mapping: MappingAvailabilityRow,
+    profile: UserProviderProfile,
+): boolean {
+    return Boolean(
+        mapping.trackId ||
+        (mapping.trackTidalId && profile.hasTidal) ||
+        (mapping.trackYtMusicId && profile.hasYtMusic),
+    );
+}
+
+function addMappingTokens(
+    tokens: Set<string>,
+    mapping: MappingAvailabilityRow,
+): void {
+    if (mapping.trackTidalId) tokens.add(`t:${mapping.trackTidalId}`);
+    if (mapping.trackYtMusicId) tokens.add(`y:${mapping.trackYtMusicId}`);
+}
+
+function collectFallbackIds(
+    items: UnifiedPlaylistItemRecord[],
+    profile: UserProviderProfile,
+): FallbackIds {
+    const tidalIds = new Set<string>();
+    const ytIds = new Set<string>();
+    items.forEach((item) => {
+        const token = getFallbackToken(item, profile);
+        if (token?.startsWith("t:")) tidalIds.add(token.slice(2));
+        if (token?.startsWith("y:")) ytIds.add(token.slice(2));
+    });
+    return { tidalIds: Array.from(tidalIds), ytIds: Array.from(ytIds) };
+}
+
+async function loadFallbackMappings(
+    ids: FallbackIds,
+): Promise<MappingAvailabilityRow[]> {
+    if (ids.tidalIds.length === 0 && ids.ytIds.length === 0) return [];
+    return prisma.trackMapping.findMany({
+        where: {
+            stale: false,
+            OR: [
+                ...(ids.tidalIds.length > 0
+                    ? [{ trackTidalId: { in: ids.tidalIds } }]
+                    : []),
+                ...(ids.ytIds.length > 0
+                    ? [{ trackYtMusicId: { in: ids.ytIds } }]
+                    : []),
+            ],
+        },
+        select: {
+            trackId: true,
+            trackTidalId: true,
+            trackYtMusicId: true,
+        },
+    });
+}
+
+function collectUsableMappingTokens(
+    mappings: MappingAvailabilityRow[],
+    profile: UserProviderProfile,
+): Set<string> {
+    const usableTokens = new Set<string>();
+    for (const mapping of mappings) {
+        if (mappingSupportsProfile(mapping, profile)) {
+            addMappingTokens(usableTokens, mapping);
+        }
+    }
+    return usableTokens;
+}
+
+async function loadUsableFallbackTokens(
+    items: UnifiedPlaylistItemRecord[],
+    profile: UserProviderProfile,
+): Promise<Set<string>> {
+    const ids = collectFallbackIds(items, profile);
+    const mappings = await loadFallbackMappings(ids);
+    return collectUsableMappingTokens(mappings, profile);
+}
+
+function partitionResolutionItems(
+    items: UnifiedPlaylistItemRecord[],
+    profile: UserProviderProfile,
+    usableFallbackTokens: Set<string>,
+): ResolutionPartition {
+    const delegatedItems: UnifiedPlaylistItemRecord[] = [];
+    const delegatedIndexes: number[] = [];
+    items.forEach((item, index) => {
+        const fallbackToken = getFallbackToken(item, profile);
+        if (!fallbackToken || usableFallbackTokens.has(fallbackToken)) {
+            delegatedItems.push(item);
+            delegatedIndexes.push(index);
+        }
+    });
+    return { delegatedItems, delegatedIndexes };
+}
+
+async function resolvePlaylistDetailItems(
+    items: UnifiedPlaylistItemRecord[],
+    userId: string,
+): Promise<ResolvedPlaylistItem[]> {
+    if (items.length === 0) return [];
+    const profile = await getUserProviderProfile(userId);
+    const usableTokens = await loadUsableFallbackTokens(items, profile);
+    const partition = partitionResolutionItems(items, profile, usableTokens);
+    const delegated = await resolvePlaylistItemsForUser(
+        partition.delegatedItems,
+        userId,
+    );
+    const resolvedByIndex = new Map<number, ResolvedPlaylistItem>();
+    partition.delegatedIndexes.forEach((itemIndex, delegatedIndex) => {
+        resolvedByIndex.set(itemIndex, delegated[delegatedIndex]);
+    });
+    return items.map(
+        (item, index) =>
+            resolvedByIndex.get(index) ?? {
+                original: item,
+                effective: item,
+                resolution: { available: false, reason: "no-provider" },
+            },
+    );
+}
+
 const addTrackSchema = z
     .object({
         trackId: z.string().trim().min(1).optional(),
@@ -295,6 +464,92 @@ function unavailablePlaybackForReason(reason: string): {
         message:
             "Playback is unavailable because this playlist item no longer has an attached track source.",
     };
+}
+
+async function loadPlaylistDetail(playlistId: string, userId: string) {
+    return prisma.playlist.findUnique({
+        where: { id: playlistId },
+        include: {
+            user: { select: { username: true } },
+            hiddenByUsers: {
+                where: { userId },
+                select: { id: true },
+            },
+            _count: {
+                select: { items: true, pendingTracks: true },
+            },
+            items: {
+                include: playlistItemInclude,
+                orderBy: { sort: "asc" },
+                take: PLAYLIST_DETAIL_QUERY_ITEMS,
+            },
+            pendingTracks: {
+                orderBy: { sort: "asc" },
+                take: PLAYLIST_DETAIL_QUERY_ITEMS,
+            },
+        },
+    });
+}
+
+function selectBoundedPlaylistEntries<
+    TTrack extends { sort: number },
+    TPending extends { sort: number },
+>(items: TTrack[], pendingTracks: TPending[]) {
+    const entries = [
+        ...items.map((item) => ({ type: "track" as const, item })),
+        ...pendingTracks.map((item) => ({ type: "pending" as const, item })),
+    ]
+        .sort((a, b) => a.item.sort - b.item.sort)
+        .slice(0, PLAYLIST_DETAIL_MAX_ITEMS);
+    const boundedItems: TTrack[] = [];
+    const boundedPendingTracks: TPending[] = [];
+    entries.forEach((entry) => {
+        if (entry.type === "track") {
+            boundedItems.push(entry.item);
+        } else {
+            boundedPendingTracks.push(entry.item);
+        }
+    });
+    return {
+        items: boundedItems,
+        pendingTracks: boundedPendingTracks,
+    };
+}
+
+function formatResolvedPlaylistItems(resolvedItems: ResolvedPlaylistItem[]) {
+    return resolvedItems.map((resolvedItem) => {
+        const formatted = formatUnifiedTrackItem(resolvedItem.effective);
+        if (!resolvedItem.resolution.available) {
+            formatted.playback = unavailablePlaybackForReason(
+                resolvedItem.resolution.reason,
+            );
+        }
+        return formatted;
+    });
+}
+
+function formatPendingPlaylistItems(
+    pendingTracks: PendingPlaylistItemRecord[],
+) {
+    return pendingTracks.map((pending) => ({
+        id: pending.id,
+        type: "pending" as const,
+        sort: pending.sort,
+        provider: { source: "pending" as const, label: "PENDING" },
+        playback: {
+            isPlayable: false,
+            reason: "pending_import",
+            message:
+                "Playback is unavailable until this track is matched and imported.",
+        },
+        pending: {
+            id: pending.id,
+            artist: pending.spotifyArtist,
+            title: pending.spotifyTitle,
+            album: pending.spotifyAlbum,
+            previewUrl: pending.deezerPreviewUrl,
+        },
+    }));
 }
 
 /**
@@ -525,7 +780,30 @@ router.post("/", async (req, res) => {
  *         description: Playlist ID
  *     responses:
  *       200:
- *         description: Playlist details with merged items
+ *         description: Playlist details with merged items capped at 1000 combined track and pending items
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 totalItemCount:
+ *                   type: integer
+ *                   description: Total number of track and pending items in the playlist before response truncation
+ *                 truncated:
+ *                   type: boolean
+ *                   description: True when the playlist contains more than 1000 combined items and this response was capped
+ *                 items:
+ *                   type: array
+ *                   maxItems: 1000
+ *                   description: Resolved track items included in the bounded detail response
+ *                 pendingTracks:
+ *                   type: array
+ *                   maxItems: 1000
+ *                   description: Pending items included in the bounded detail response
+ *                 mergedItems:
+ *                   type: array
+ *                   maxItems: 1000
+ *                   description: The first 1000 combined track and pending items in playlist sort order
  *       403:
  *         description: Access denied
  *       404:
@@ -541,27 +819,7 @@ router.get("/:id", async (req, res) => {
         }
         const userId = req.user.id;
 
-        const playlist = await prisma.playlist.findUnique({
-            where: { id: req.params.id },
-            include: {
-                user: {
-                    select: {
-                        username: true,
-                    },
-                },
-                hiddenByUsers: {
-                    where: { userId },
-                    select: { id: true },
-                },
-                items: {
-                    include: playlistItemInclude,
-                    orderBy: { sort: "asc" },
-                },
-                pendingTracks: {
-                    orderBy: { sort: "asc" },
-                },
-            },
-        });
+        const playlist = await loadPlaylistDetail(req.params.id, userId);
 
         if (!playlist) {
             return res.status(404).json({ error: "Playlist not found" });
@@ -572,43 +830,21 @@ router.get("/:id", async (req, res) => {
             return res.status(403).json({ error: "Access denied" });
         }
 
-        const resolvedItems = await resolvePlaylistItemsForUser(
-            playlist.items as UnifiedPlaylistItemRecord[],
+        const totalItemCount =
+            playlist._count.items + playlist._count.pendingTracks;
+        const bounded = selectBoundedPlaylistEntries(
+            playlist.items,
+            playlist.pendingTracks,
+        );
+
+        const resolvedItems = await resolvePlaylistDetailItems(
+            bounded.items,
             userId,
         );
-        const formattedItems = resolvedItems.map((resolvedItem) => {
-            const formatted = formatUnifiedTrackItem(resolvedItem.effective);
-            if (!resolvedItem.resolution.available) {
-                formatted.playback = unavailablePlaybackForReason(
-                    resolvedItem.resolution.reason,
-                );
-            }
-            return formatted;
-        });
-
-        // Format pending tracks
-        const formattedPending = playlist.pendingTracks.map((pending) => ({
-            id: pending.id,
-            type: "pending" as const,
-            sort: pending.sort,
-            provider: {
-                source: "pending" as const,
-                label: "PENDING",
-            },
-            playback: {
-                isPlayable: false,
-                reason: "pending_import",
-                message:
-                    "Playback is unavailable until this track is matched and imported.",
-            },
-            pending: {
-                id: pending.id,
-                artist: pending.spotifyArtist,
-                title: pending.spotifyTitle,
-                album: pending.spotifyAlbum,
-                previewUrl: pending.deezerPreviewUrl,
-            },
-        }));
+        const formattedItems = formatResolvedPlaylistItems(resolvedItems);
+        const formattedPending = formatPendingPlaylistItems(
+            bounded.pendingTracks,
+        );
 
         // Merge and sort by position
         const mergedItems = [
@@ -616,12 +852,15 @@ router.get("/:id", async (req, res) => {
             ...formattedPending,
         ].sort((a, b) => a.sort - b.sort);
 
+        const { _count, ...playlistFields } = playlist;
         res.json({
-            ...playlist,
+            ...playlistFields,
             isOwner: playlist.userId === userId,
             isHidden: playlist.hiddenByUsers.length > 0,
-            trackCount: playlist.items.length,
-            pendingCount: playlist.pendingTracks.length,
+            trackCount: _count.items,
+            pendingCount: _count.pendingTracks,
+            totalItemCount,
+            truncated: totalItemCount > PLAYLIST_DETAIL_MAX_ITEMS,
             items: formattedItems,
             pendingTracks: formattedPending,
             mergedItems,


### PR DESCRIPTION
Closes **K14** from the sweep-22 convergence review.

The playlist-detail endpoint resolved every item with no bound and ran sequential per-item cross-provider fallback queries (N+1) — a very large playlist made it an unbounded, slow, memory-heavy request.

Detail resolution is now capped at `PLAYLIST_DETAIL_MAX_ITEMS` (1000) by slicing the item list **before** the expensive resolve, and all cross-provider mappings are bulk-loaded in a single `trackMapping.findMany({ in: ids })` instead of per-item lookups. Oversized playlists are **truncated, not rejected** — the response carries `totalItemCount` and `truncated` so the client still renders the first items and can indicate more exist (playlist size is not enforced on import, so a 422 would have made large imported playlists unviewable). Normal playlists are unchanged.

251 playlist tests / 11 suites green, tsc clean, prettier clean, route-error canon clean.