### PR TITLE
fix(infra): Helm selector-key precedence + shared release-version validation

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -45,19 +45,7 @@ jobs:
             RELEASE_TAG="${{ inputs.release_tag }}"
           fi
 
-          RELEASE_TAG="$(echo "${RELEASE_TAG}" | xargs)"
-          if [ -z "${RELEASE_TAG}" ]; then
-            echo "Release tag is required." >&2
-            exit 1
-          fi
-          if [[ "${RELEASE_TAG}" == v* ]]; then
-            echo "Release tags must be plain semantic versions without a 'v' prefix (example: 1.6.0)." >&2
-            exit 1
-          fi
-          if ! [[ "${RELEASE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Release tag must be a semantic version (example: 1.6.0 or 1.6.0-rc.1)." >&2
-            exit 1
-          fi
+          ./scripts/release/validate-release-version.sh "${RELEASE_TAG}"
 
           REPO_OWNER_LOWER="${GITHUB_REPOSITORY_OWNER,,}"
           REPO_NAME="${GITHUB_REPOSITORY#*/}"

--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -31,18 +31,7 @@ jobs:
                   fi
 
                   RELEASE_TAG="${{ github.event.release.tag_name }}"
-                  if [ -z "${RELEASE_TAG}" ]; then
-                    echo "Release tag is missing." >&2
-                    exit 1
-                  fi
-                  if [[ "${RELEASE_TAG}" == v* ]]; then
-                    echo "Release tags must be plain semantic versions without a 'v' prefix (example: 1.2.3)." >&2
-                    exit 1
-                  fi
-                  if ! [[ "${RELEASE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-                    echo "Release tag must be container-tag-compatible semantic versioning (example: 1.2.3 or 1.2.3-rc.1)." >&2
-                    exit 1
-                  fi
+                  ./scripts/release/validate-release-version.sh "${RELEASE_TAG}"
 
                   FRONTEND_VERSION="$(node -p "require('./frontend/package.json').version")"
                   if [ "${FRONTEND_VERSION}" != "${RELEASE_TAG}" ]; then

--- a/charts/soundspan/templates/_helpers.tpl
+++ b/charts/soundspan/templates/_helpers.tpl
@@ -32,15 +32,16 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "soundspan.labels" -}}
-helm.sh/chart: {{ include "soundspan.chart" . }}
-{{ include "soundspan.selectorLabels" . }}
+{{- $standardLabels := dict
+  "helm.sh/chart" (include "soundspan.chart" .)
+  "app.kubernetes.io/managed-by" .Release.Service
+-}}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- $_ := set $standardLabels "app.kubernetes.io/version" .Chart.AppVersion -}}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.global.labels }}
-{{ toYaml . }}
-{{- end }}
+{{- $globalLabels := deepCopy (.Values.global.labels | default dict) -}}
+{{- $selectorLabels := include "soundspan.selectorLabels" . | fromYaml -}}
+{{- mustMergeOverwrite $standardLabels $globalLabels $selectorLabels | toYaml }}
 {{- end }}
 
 {{/*
@@ -179,8 +180,9 @@ Component labels helper — adds a component label to the standard set
 Usage: include "soundspan.componentLabels" (dict "context" . "component" "backend")
 */}}
 {{- define "soundspan.componentLabels" -}}
-{{ include "soundspan.labels" .context }}
-app.kubernetes.io/component: {{ .component }}
+{{- $labels := include "soundspan.labels" .context | fromYaml -}}
+{{- $selectorLabels := include "soundspan.componentSelectorLabels" . | fromYaml -}}
+{{- mustMergeOverwrite $labels $selectorLabels | toYaml }}
 {{- end }}
 
 {{/*
@@ -190,6 +192,16 @@ Usage: include "soundspan.componentSelectorLabels" (dict "context" . "component"
 {{- define "soundspan.componentSelectorLabels" -}}
 {{ include "soundspan.selectorLabels" .context }}
 app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Pod labels helper — user labels are merged before immutable selector labels
+Usage: include "soundspan.componentPodLabels" (dict "context" . "component" "backend")
+*/}}
+{{- define "soundspan.componentPodLabels" -}}
+{{- $globalLabels := deepCopy (.context.Values.global.labels | default dict) -}}
+{{- $selectorLabels := include "soundspan.componentSelectorLabels" . | fromYaml -}}
+{{- mustMergeOverwrite $globalLabels $selectorLabels | toYaml }}
 {{- end }}
 
 {{/*

--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "aio") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "aio") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer-clap.yaml
@@ -13,10 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "audio-analyzer-clap") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "audio-analyzer-clap") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/audio-analyzer.yaml
+++ b/charts/soundspan/templates/individual/audio-analyzer.yaml
@@ -13,10 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "audio-analyzer") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "audio-analyzer") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -20,10 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "backend-worker") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "backend-worker") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/backend.yaml
+++ b/charts/soundspan/templates/individual/backend.yaml
@@ -45,10 +45,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "backend") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "backend") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/frontend.yaml
+++ b/charts/soundspan/templates/individual/frontend.yaml
@@ -20,10 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "frontend") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "frontend") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/postgresql.yaml
+++ b/charts/soundspan/templates/individual/postgresql.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "postgresql") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "postgresql") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/redis.yaml
+++ b/charts/soundspan/templates/individual/redis.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "redis") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "redis") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/tidal.yaml
+++ b/charts/soundspan/templates/individual/tidal.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "tidal") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "tidal") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/soundspan/templates/individual/ytmusic.yaml
+++ b/charts/soundspan/templates/individual/ytmusic.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "ytmusic") | nindent 8 }}
-        {{- with .Values.global.labels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "ytmusic") | nindent 8 }}
       {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
         "verify:helm": "./scripts/helm-chart-render-check.sh",
         "verify:python": "pytest services/tidal-downloader/tests -q && pytest services/ytmusic-streamer/tests -q && pytest services/audio-analyzer/tests -q && pytest services/audio-analyzer-clap/tests -q && pytest tests/ -q",
         "verify:python-quality": "ruff check services/ && ruff format --check services/ && mypy && MYPYPATH=services mypy services/tidal-downloader/app.py",
-        "verify:gates": "node scripts/ci/check-route-error-canon.mjs && npm run check:error-canon:test && node --test scripts/ci/dockerfile-hygiene.test.mjs && npm --prefix frontend run lint:hex && npm --prefix backend test -- --maxWorkers=2 src/config/__tests__/openapiRouteSync.test.ts && npm run format:check",
+        "verify:gates": "node scripts/ci/check-route-error-canon.mjs && npm run check:error-canon:test && npm run check:infra-release:test && node --test scripts/ci/dockerfile-hygiene.test.mjs && npm --prefix frontend run lint:hex && npm --prefix backend test -- --maxWorkers=2 src/config/__tests__/openapiRouteSync.test.ts && npm run format:check",
         "check:error-canon": "node scripts/ci/check-route-error-canon.mjs",
         "check:error-canon:test": "node --test scripts/ci/__tests__/check-route-error-canon.test.mjs",
+        "check:infra-release:test": "node --test scripts/ci/__tests__/helm-service-selector-check.test.mjs scripts/ci/__tests__/release-version-validator.test.mjs",
         "test:backend": "npm --prefix backend test --",
         "test:frontend": "npm --prefix frontend run test:unit"
     }

--- a/scripts/ci/__tests__/helm-service-selector-check.test.mjs
+++ b/scripts/ci/__tests__/helm-service-selector-check.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const checker = path.join(
+    repoRoot,
+    "scripts/ci/helm-service-selector-check.mjs",
+);
+
+function deployment(podInstance) {
+    return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: soundspan-audio-analyzer
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: soundspan
+      app.kubernetes.io/instance: soundspan
+      app.kubernetes.io/component: audio-analyzer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: soundspan
+        app.kubernetes.io/instance: ${podInstance}
+        app.kubernetes.io/component: audio-analyzer
+`;
+}
+
+function runChecker(t, manifest) {
+    const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "soundspan-helm-selector-test-"),
+    );
+    t.after(() => fs.rmSync(directory, { recursive: true }));
+    const manifestPath = path.join(directory, "manifest.yaml");
+    fs.writeFileSync(manifestPath, manifest);
+    return spawnSync(process.execPath, [checker, manifestPath], {
+        encoding: "utf8",
+    });
+}
+
+test("accepts a workload whose selector matches its pod labels", (t) => {
+    const result = runChecker(t, deployment("soundspan"));
+
+    assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects a workload whose selector does not match its pod labels", (t) => {
+    const result = runChecker(t, deployment("user-instance"));
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Deployment soundspan-audio-analyzer selector/);
+});

--- a/scripts/ci/__tests__/release-version-validator.test.mjs
+++ b/scripts/ci/__tests__/release-version-validator.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const validator = path.join(
+    repoRoot,
+    "scripts/release/validate-release-version.sh",
+);
+const acceptedVersions = [
+    "0.0.0",
+    "1.2.3",
+    "1.2.3-rc.1",
+    "10.20.30-alpha-beta.7",
+];
+const rejectedVersions = [
+    "",
+    "v1.2.3",
+    "1.2",
+    "1.2.3+build.1",
+    "1.2.3-rc.1+build.1",
+    " 1.2.3",
+    "1.2.3 ",
+    "1.2.3/release",
+];
+
+function runValidator(version) {
+    return spawnSync(validator, [version], { encoding: "utf8" });
+}
+
+test("accepts the image workflow release version forms", () => {
+    assert.equal(acceptedVersions.length, 4);
+    for (let index = 0; index < 4; index += 1) {
+        const version = acceptedVersions[index];
+        const result = runValidator(version);
+        assert.equal(result.status, 0, `${version}: ${result.stderr}`);
+    }
+});
+
+test("rejects versions the image release workflow rejects", () => {
+    assert.equal(rejectedVersions.length, 8);
+    for (let index = 0; index < 8; index += 1) {
+        const version = rejectedVersions[index];
+        const result = runValidator(version);
+        assert.notEqual(result.status, 0, `${version} was accepted`);
+    }
+});

--- a/scripts/ci/helm-service-selector-check.mjs
+++ b/scripts/ci/helm-service-selector-check.mjs
@@ -12,7 +12,7 @@ function fail(message) {
 
 function parseLabels(block, indent) {
     if (block === undefined) fail("label block is undefined");
-    if (indent !== 4 && indent !== 8) fail("label indentation is invalid");
+    if (![4, 6, 8].includes(indent)) fail("label indentation is invalid");
 
     const labels = new Map();
     const pattern = new RegExp(
@@ -77,14 +77,24 @@ function parseService(document, name) {
 }
 
 function parseWorkload(document, kind, name) {
-    const block = document.match(
+    const selectorBlock = document.match(
+        /^  selector:\s*\n    matchLabels:\s*\n((?:^      \S[^\n]*\n?)*)/m,
+    )?.[1];
+    if (selectorBlock === undefined)
+        fail(`${kind} ${name} is missing matchLabels`);
+    const podLabelBlock = document.match(
         /^  template:\s*\n    metadata:\s*\n      labels:\s*\n((?:^        \S[^\n]*\n?)*)/m,
     )?.[1];
-    if (block === undefined)
+    if (podLabelBlock === undefined)
         fail(`${kind} ${name} is missing pod template labels`);
     return {
         type: "workload",
-        resource: { kind, name, labels: parseLabels(block, 8) },
+        resource: {
+            kind,
+            name,
+            labels: parseLabels(podLabelBlock, 8),
+            selector: parseLabels(selectorBlock, 6),
+        },
     };
 }
 
@@ -139,6 +149,12 @@ function assertServiceIsolated(service, workloads) {
     }
 }
 
+function assertWorkloadSelectorMatchesPod(workload) {
+    if (workload === undefined) fail("workload is undefined");
+    if (selectorMatches(workload.selector, workload.labels)) return;
+    fail(`${workload.kind} ${workload.name} selector does not match its pods`);
+}
+
 function componentOf(workload) {
     return workload.labels.get("app.kubernetes.io/component") ?? "<unlabeled>";
 }
@@ -168,6 +184,10 @@ function main(args) {
     }
     const yaml = readManifest(args[0]);
     const { services, workloads } = parseResources(yaml);
+    for (let index = 0; index < MAX_RESOURCES; index += 1) {
+        if (index >= workloads.length) break;
+        assertWorkloadSelectorMatchesPod(workloads[index]);
+    }
     for (let index = 0; index < services.length; index += 1) {
         assertServiceIsolated(services[index], workloads);
     }

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -69,17 +69,19 @@ tmp_aio_sidecars="$(mktemp)"
 tmp_aio_rotated_secrets="$(mktemp)"
 tmp_aio_secret_overrides="$(mktemp)"
 tmp_aio_digests="$(mktemp)"
+tmp_aio_reserved_labels="$(mktemp)"
 tmp_individual_ha="$(mktemp)"
 tmp_individual_component_database="$(mktemp)"
 tmp_individual_external_database="$(mktemp)"
 tmp_individual_digests="$(mktemp)"
+tmp_individual_reserved_labels="$(mktemp)"
 tmp_global_env="$(mktemp)"
 tmp_sidecars="$(mktemp)"
 tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_digests" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_digests" "$tmp_aio_reserved_labels" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_individual_reserved_labels" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -95,6 +97,14 @@ if ! line_match '^  name: '"$RELEASE_NAME"'$' "$tmp_aio"; then
   exit 1
 fi
 assert_service_selectors_isolated "default AIO" "$tmp_aio"
+
+echo "[CHECK] reserved selector labels override global labels in AIO mode"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set-string 'global.labels.app\.kubernetes\.io/name=user-name' \
+  --set-string 'global.labels.app\.kubernetes\.io/instance=user-instance' \
+  --set-string 'global.labels.app\.kubernetes\.io/component=user-component' \
+  >"$tmp_aio_reserved_labels"
+assert_service_selectors_isolated "AIO with reserved global labels" "$tmp_aio_reserved_labels"
 
 for key in INTERNAL_API_SECRET POSTGRES_PASSWORD; do
   if ! perl -0777 -ne '
@@ -194,6 +204,20 @@ if ! perl -0777 -ne 'exit((/name:\s+LISTEN_TOGETHER_STATE_STORE_ENABLED\s+value:
   exit 1
 fi
 assert_service_selectors_isolated "HA individual" "$tmp_individual_ha"
+
+echo "[CHECK] reserved selector labels override global labels in individual mode"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  --set backendWorker.enabled=true \
+  --set tidalSidecar.enabled=true \
+  --set ytmusicStreamer.enabled=true \
+  --set audioAnalyzer.enabled=true \
+  --set audioAnalyzerClap.enabled=true \
+  --set-string 'global.labels.app\.kubernetes\.io/name=user-name' \
+  --set-string 'global.labels.app\.kubernetes\.io/instance=user-instance' \
+  --set-string 'global.labels.app\.kubernetes\.io/component=user-component' \
+  >"$tmp_individual_reserved_labels"
+assert_service_selectors_isolated "individual with reserved global labels" "$tmp_individual_reserved_labels"
 
 echo "[CHECK] construct component DATABASE_URL values with percent-encoded credentials"
 helm template "$RELEASE_NAME" "$CHART_PATH" \

--- a/scripts/release/validate-release-version.sh
+++ b/scripts/release/validate-release-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <release-version>" >&2
+  exit 1
+fi
+
+release_version="$1"
+if [ -z "$release_version" ]; then
+  echo "Release tag is missing." >&2
+  exit 1
+fi
+if [[ "$release_version" == v* ]]; then
+  echo "Release tags must be plain semantic versions without a 'v' prefix (example: 1.2.3)." >&2
+  exit 1
+fi
+if ! [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must be container-tag-compatible semantic versioning without build metadata (example: 1.2.3 or 1.2.3-rc.1)." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes **K12** and **K13** from the sweep-22 convergence review.

**K12**: user-supplied global/common labels could collide with the reserved selector keys (`app.kubernetes.io/name`, `instance`, `component`), invalidating workload selectors (a Service/Deployment could then match wrong or zero pods). The label helper now overlays the reserved `selectorLabels` **last** so they always win over user labels, applied across all workload pod templates. Existing `Deployment.spec.selector` values are unchanged (immutable — upgrade-safe). A render-check assertion fails if a global label overrides a reserved selector key.

**K13**: the chart-release and image-build workflows validated release versions with divergent logic, so a chart could be published referencing an image tag the image workflow rejects. Both workflows now call one shared `scripts/release/validate-release-version.sh`.

Node tests cover the selector-precedence check and the version validator (both wired into `verify:gates`); helm render-check passes; shared validator `bash -n` clean.