### PR TITLE
fix(security): gate legacy device-revoke and tag-repair routes

### DIFF
--- a/backend/src/routes/__tests__/deviceLinkRuntime.test.ts
+++ b/backend/src/routes/__tests__/deviceLinkRuntime.test.ts
@@ -128,6 +128,32 @@ async function executeGenerate(req: any, res: any): Promise<void> {
     throw new Error("POST /generate exceeded the test handler limit");
 }
 
+async function executeDeleteDevice(req: any, res: any): Promise<void> {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === "/devices/:id" &&
+            entry.route?.methods?.delete,
+    );
+    if (!layer) {
+        throw new Error("Route not found: DELETE /devices/:id");
+    }
+
+    const maxRouteHandlers = 4;
+    for (let index = 0; index < maxRouteHandlers; index += 1) {
+        const handler = layer.route.stack[index]?.handle;
+        if (!handler) return;
+
+        let continued = false;
+        await handler(req, res, (error?: unknown) => {
+            if (error) throw error;
+            continued = true;
+        });
+        if (!continued) return;
+    }
+
+    throw new Error("DELETE /devices/:id exceeded the test handler limit");
+}
+
 describe("deviceLink routes runtime", () => {
     const postGenerate = getHandler("/generate", "post");
     const postVerify = getHandler("/verify", "post");
@@ -496,5 +522,44 @@ describe("deviceLink routes runtime", () => {
         await deleteDevice(req, errorRes);
         expect(errorRes.statusCode).toBe(500);
         expect(errorRes.body).toEqual({ error: "Failed to revoke device" });
+    });
+
+    it("rejects API-key device revocation while allowing an interactive session", async () => {
+        const apiKeyRes = createRes();
+        await executeDeleteDevice(
+            {
+                headers: { "x-api-key": "device-key" },
+                user: { id: "u1" },
+                params: { id: "api-key-1" },
+            },
+            apiKeyRes,
+        );
+
+        expect(apiKeyRes.statusCode).toBe(403);
+        expect(apiKeyRes.body).toEqual({
+            error: "Interactive session authentication required",
+        });
+        expect(mockApiKeyFindFirst).not.toHaveBeenCalled();
+        expect(mockApiKeyDelete).not.toHaveBeenCalled();
+
+        const sessionRes = createRes();
+        await executeDeleteDevice(
+            {
+                headers: {},
+                session: { userId: "u1" },
+                user: { id: "u1" },
+                params: { id: "api-key-1" },
+            },
+            sessionRes,
+        );
+
+        expect(sessionRes.statusCode).toBe(200);
+        expect(sessionRes.body).toEqual({ success: true });
+        expect(mockApiKeyFindFirst).toHaveBeenCalledWith({
+            where: { id: "api-key-1", userId: "u1" },
+        });
+        expect(mockApiKeyDelete).toHaveBeenCalledWith({
+            where: { id: "api-key-1" },
+        });
     });
 });

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -4,7 +4,12 @@ import fs from "fs";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
-    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAdmin: (req: any, res: any, next: () => void) => {
+        if (!req.user || req.user.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -169,6 +174,28 @@ function getRouteHandler(
         throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
     }
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+async function invokePostRouteStack(path: string, req: any, res: any) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.post,
+    );
+    if (!layer) throw new Error(`Route not found: POST ${path}`);
+
+    const maxRouteHandlers = 3;
+    for (let index = 0; index < maxRouteHandlers; index += 1) {
+        const handler = layer.route.stack[index]?.handle;
+        if (!handler) return;
+
+        let continued = false;
+        await handler(req, res, () => {
+            continued = true;
+        });
+        if (!continued) return;
+    }
+
+    throw new Error(`POST ${path} exceeded the test handler limit`);
 }
 
 function createRes() {
@@ -1345,6 +1372,57 @@ describe("discover legacy-mode runtime behavior", () => {
             ownedRecordsRemoved: 1,
             fixedArtists: ["Fix Artist"],
         });
+    });
+
+    it("allows only admins to invoke global tagging repair", async () => {
+        const nonAdminRes = createRes();
+        await invokePostRouteStack(
+            "/fix-tagging",
+            {
+                headers: {},
+                session: { userId: "user-1" },
+                user: { id: "user-1", role: "user" },
+            },
+            nonAdminRes,
+        );
+
+        expect(nonAdminRes.statusCode).toBe(403);
+        expect(nonAdminRes.body).toEqual({ error: "Admin access required" });
+        expect(prisma.discoveryAlbum.findMany).not.toHaveBeenCalled();
+
+        const apiKeyRes = createRes();
+        await invokePostRouteStack(
+            "/fix-tagging",
+            {
+                headers: { "x-api-key": "device-key" },
+                user: { id: "user-1", role: "user" },
+            },
+            apiKeyRes,
+        );
+
+        expect(apiKeyRes.statusCode).toBe(403);
+        expect(apiKeyRes.body).toEqual({ error: "Admin access required" });
+        expect(prisma.discoveryAlbum.findMany).not.toHaveBeenCalled();
+
+        const adminRes = createRes();
+        await invokePostRouteStack(
+            "/fix-tagging",
+            {
+                headers: {},
+                session: { userId: "admin-1" },
+                user: { id: "admin-1", role: "admin" },
+            },
+            adminRes,
+        );
+
+        expect(adminRes.statusCode).toBe(200);
+        expect(adminRes.body).toEqual({
+            success: true,
+            albumsFixed: 0,
+            ownedRecordsRemoved: 0,
+            fixedArtists: [],
+        });
+        expect(prisma.discoveryAlbum.findMany).toHaveBeenCalledTimes(1);
     });
 
     it("returns 500 when fix-tagging fails", async () => {

--- a/backend/src/routes/deviceLink.ts
+++ b/backend/src/routes/deviceLink.ts
@@ -320,7 +320,6 @@ router.get("/devices", requireAuthOrToken, async (req, res) => {
  *     tags: [Device Link]
  *     security:
  *       - sessionAuth: []
- *       - apiKeyAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -335,11 +334,14 @@ router.get("/devices", requireAuthOrToken, async (req, res) => {
  *         description: Device not found
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Interactive session authentication required
  */
-// DELETE /device-link/devices/:id - Revoke a device (requires auth)
+// DELETE /device-link/devices/:id - Revoke a device (requires interactive auth)
 router.delete<{ id: string }>(
     "/devices/:id",
     requireAuthOrToken,
+    requireInteractiveSession,
     async (req, res) => {
         try {
             const userId = req.user!.id;

--- a/backend/src/routes/discover.ts
+++ b/backend/src/routes/discover.ts
@@ -2320,8 +2320,10 @@ router.post("/cleanup-lidarr", requireAdmin, async (req, res) => {
  *         description: Only available in legacy discovery mode
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
  */
-router.post("/fix-tagging", async (req, res) => {
+router.post("/fix-tagging", requireAdmin, async (req, res) => {
     try {
         if (!isLegacyDiscoveryMode) {
             return res.status(410).json({


### PR DESCRIPTION
Closes two authorization-boundary gaps found in the sweep-23 convergence review.

- **DELETE /device-link/devices/:id** now requires `requireInteractiveSession` (previously `requireAuthOrToken` only), so an X-API-Key device token can no longer revoke the account's other credentials without interactive step-up. OpenAPI drops `apiKeyAuth` and documents 403. Ownership scoping (`{id, userId}`) unchanged.
- **POST /discover/fix-tagging** (legacy discovery mode) now requires `requireAdmin`; previously any authenticated user or API key could mutate `Album.location` and delete `OwnedAlbum` rows in the shared catalog. OpenAPI documents 403.

Adds regression coverage: API-key/session revocation rejection; non-admin/API-key/admin repair paths.

Verified: 319 tests (deviceLink|discover), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)