### PR TITLE
fix(security): stop cross-user disclosure in analysis and scan-status responses

### DIFF
--- a/backend/src/routes/__tests__/__snapshots__/libraryRouteTable.test.ts.snap
+++ b/backend/src/routes/__tests__/__snapshots__/libraryRouteTable.test.ts.snap
@@ -157,7 +157,9 @@ exports[`library route table matches the locked route surface 1`] = `
   },
   {
     "method": "GET",
-    "middleware": [],
+    "middleware": [
+      "requireAdmin",
+    ],
     "path": "/scan/status/:jobId",
   },
   {

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -419,18 +419,30 @@ describe("analysis routes runtime", () => {
         await getTrack(missingReq, missingRes);
         expect(missingRes.statusCode).toBe(404);
 
-        mockTrackFindUnique.mockResolvedValueOnce({
+        const storedTrack = {
             id: "t2",
             title: "Track Two",
-            analysisStatus: "completed",
-        });
+            analysisStatus: "failed",
+            analysisError:
+                "ffmpeg failed at /srv/soundspan/music/private/track.flac",
+        };
+        mockTrackFindUnique.mockImplementationOnce(async ({ select }) =>
+            Object.fromEntries(
+                Object.entries(storedTrack).filter(
+                    ([field]) => select[field] === true,
+                ),
+            ),
+        );
         const req = { params: { trackId: "t2" } } as any;
         const res = createRes();
         await getTrack(req, res);
         expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual(
-            expect.objectContaining({ id: "t2", title: "Track Two" }),
-        );
+        expect(res.body).toEqual({
+            id: "t2",
+            title: "Track Two",
+            analysisStatus: "failed",
+        });
+        expect(JSON.stringify(res.body)).not.toContain("/srv/soundspan");
     });
 
     it("returns empty features when no analyzed tracks exist", async () => {

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -13,7 +13,12 @@ jest.mock("dns/promises", () => ({
 
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
-    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+    requireAdmin: (req: Request, res: Response, next: () => void) => {
+        if (req.user?.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
 }));
@@ -484,6 +489,20 @@ function getHandler(
     return layer.route.stack[stackIndex].handle;
 }
 
+function getFinalHandler(
+    method: "get" | "post" | "delete" | "put" | "patch",
+    path: string,
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    if (!layer) {
+        throw new Error(`Route not found: [${method}] ${path}`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
 function createRes() {
     const res: any = {
         statusCode: 200,
@@ -610,7 +629,8 @@ function expectNoUnboundedIdPoolFetch() {
 
 describe("library scan and organize runtime coverage", () => {
     const scanHandler = getHandler("post", "/scan");
-    const scanStatusHandler = getHandler("get", "/scan/status/:jobId");
+    const scanStatusAccessHandler = getHandler("get", "/scan/status/:jobId");
+    const scanStatusHandler = getFinalHandler("get", "/scan/status/:jobId");
     const organizeHandler = getHandler("post", "/organize");
 
     beforeEach(() => {
@@ -820,11 +840,44 @@ describe("library scan and organize runtime coverage", () => {
         expect(res.body).toEqual({ error: "Job not found" });
     });
 
-    it("maps Bull job state, progress, and result to response payload", async () => {
+    it("rejects non-admin scan status access before reading the queue", async () => {
+        const req = {
+            params: { jobId: "job-123" },
+            user: { id: "user-1", role: "user" },
+        } as any;
+        const res = createRes();
+
+        await scanStatusAccessHandler(req, res, jest.fn());
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(mockScanQueueGetJob).not.toHaveBeenCalled();
+    });
+
+    it("maps Bull scan details to a sanitized response payload", async () => {
         const job = {
             getState: jest.fn().mockResolvedValue("completed"),
-            progress: jest.fn(() => 68),
-            returnvalue: { indexed: 241 },
+            progress: jest.fn(() => ({
+                percent: 68,
+                currentFile: "/music/private/Artist/track.flac",
+            })),
+            returnvalue: {
+                tracksAdded: 241,
+                tracksUpdated: 12,
+                tracksRemoved: 3,
+                errors: [
+                    {
+                        file: "/music/private/Artist/broken.flac",
+                        error: "decoder crashed at /usr/lib/private/codec.so",
+                    },
+                    {
+                        file: "C:\\Music\\private\\second.flac",
+                        error: "scanner exception with host diagnostics",
+                    },
+                ],
+                duration: 4321,
+                musicPath: "/music/private",
+            },
         };
         mockScanQueueGetJob.mockResolvedValueOnce(job);
 
@@ -837,8 +890,17 @@ describe("library scan and organize runtime coverage", () => {
         expect(res.body).toEqual({
             status: "completed",
             progress: 68,
-            result: { indexed: 241 },
+            result: {
+                tracksAdded: 241,
+                tracksUpdated: 12,
+                tracksRemoved: 3,
+                failedCount: 2,
+                duration: 4321,
+            },
         });
+        expect(JSON.stringify(res.body)).not.toContain("/music/private");
+        expect(JSON.stringify(res.body)).not.toContain("C:\\Music");
+        expect(JSON.stringify(res.body)).not.toContain("decoder crashed");
         expect(job.getState).toHaveBeenCalledTimes(1);
         expect(job.progress).toHaveBeenCalledTimes(1);
     });
@@ -852,6 +914,8 @@ describe("library scan and organize runtime coverage", () => {
         await invokeWithErrorHandler(scanStatusHandler, req, res);
 
         expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to get scan status" });
+        expect(JSON.stringify(res.body)).not.toContain("redis down");
     });
 
     it("starts manual organization in background", async () => {

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -356,7 +356,6 @@ router.get<{ trackId: string }>(
                     id: true,
                     title: true,
                     analysisStatus: true,
-                    analysisError: true,
                     analyzedAt: true,
                     analysisVersion: true,
                     analysisMode: true,

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -281,6 +281,52 @@ const finishOrganizationInBackground = async (
     }
 };
 
+interface SanitizedScanResult {
+    tracksAdded: number;
+    tracksUpdated: number;
+    tracksRemoved: number;
+    failedCount: number;
+    duration: number;
+}
+
+const toNonNegativeInteger = (value: unknown): number =>
+    typeof value === "number" && Number.isFinite(value) && value >= 0
+        ? Math.floor(value)
+        : 0;
+
+const sanitizeScanProgress = (value: unknown): number => {
+    let percent = value;
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        const fields = value as Record<string, unknown>;
+        if (typeof fields.percent === "number") {
+            percent = fields.percent;
+        } else if (
+            typeof fields.processed === "number" &&
+            typeof fields.total === "number" &&
+            fields.total > 0
+        ) {
+            percent = (fields.processed / fields.total) * 100;
+        }
+    }
+
+    return Math.min(100, toNonNegativeInteger(percent));
+};
+
+const sanitizeScanResult = (value: unknown): SanitizedScanResult | null => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const fields = value as Record<string, unknown>;
+    return {
+        tracksAdded: toNonNegativeInteger(fields.tracksAdded),
+        tracksUpdated: toNonNegativeInteger(fields.tracksUpdated),
+        tracksRemoved: toNonNegativeInteger(fields.tracksRemoved),
+        failedCount: Array.isArray(fields.errors) ? fields.errors.length : 0,
+        duration: toNonNegativeInteger(fields.duration),
+    };
+};
+
 const organizeBeforeLibraryScan = async (): Promise<void> => {
     try {
         libraryMaintenanceLogger.info(
@@ -860,33 +906,65 @@ router.post(
  *                 status:
  *                   type: string
  *                 progress:
- *                   type: object
+ *                   type: integer
+ *                   minimum: 0
+ *                   maximum: 100
  *                 result:
  *                   type: object
+ *                   nullable: true
+ *                   properties:
+ *                     tracksAdded:
+ *                       type: integer
+ *                       minimum: 0
+ *                     tracksUpdated:
+ *                       type: integer
+ *                       minimum: 0
+ *                     tracksRemoved:
+ *                       type: integer
+ *                       minimum: 0
+ *                     failedCount:
+ *                       type: integer
+ *                       minimum: 0
+ *                     duration:
+ *                       type: integer
+ *                       minimum: 0
  *       404:
  *         description: Job not found
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
+ *       500:
+ *         description: Failed to get scan status
  */
 // GET /library/scan/status/:jobId - Check scan job status
-router.get(
+router.get<{ jobId: string }>(
     "/scan/status/:jobId",
+    requireAdmin,
     asyncHandler(async (req, res) => {
-        const job = await scanQueue.getJob(req.params.jobId);
+        try {
+            const job = await scanQueue.getJob(req.params.jobId);
 
-        if (!job) {
-            return sendRouteError(res, 404, "Job not found");
+            if (!job) {
+                return sendRouteError(res, 404, "Job not found");
+            }
+
+            const state = await job.getState();
+            const progress = sanitizeScanProgress(job.progress());
+            const result = sanitizeScanResult(job.returnvalue);
+
+            return res.json({
+                status: state,
+                progress,
+                result,
+            });
+        } catch (error) {
+            libraryMaintenanceLogger.error("Failed to get scan status", {
+                jobId: req.params.jobId,
+                error,
+            });
+            return sendInternalRouteError(res, "Failed to get scan status");
         }
-
-        const state = await job.getState();
-        const progress = job.progress();
-        const result = job.returnvalue;
-
-        res.json({
-            status: state,
-            progress,
-            result,
-        });
     }),
 );
 


### PR DESCRIPTION
Closes two cross-user information-disclosure leaks from the sweep-23 review.

- **GET /analysis/track/:trackId** (`requireAuth`, no owner scoping) no longer selects `analysisError` into the client DTO — that field held raw analyzer exception text (dependency diagnostics, possible host paths) and crossed to users who don't own the track. Raw detail stays server-side only.
- **GET /library/scan/status/:jobId** now requires `requireAdmin` and returns a sanitized DTO: bounded integer progress (0–100) and whitelisted counts (`tracksAdded/Updated/Removed`, `failedCount`, `duration`). Previously it returned the raw Bull `job.returnvalue` — including `MUSIC_PATH`, absolute per-file paths, and raw scanner errors — to any authenticated caller. Errors now go through `sendInternalRouteError`.

Adds/updates regression coverage; route-table snapshot updated for the new admin gate.

Verified: 305 tests (analysis|library), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)