### PR TITLE
fix(security): audiobookshelf SSRF guard + restore #394 stream-abort

### DIFF
--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -569,15 +569,18 @@ describe("audiobooks advanced runtime", () => {
         });
 
         const successRes = createRes();
-        await streamHandler(
-            {
-                params: { id: "stream-2" },
-                headers: { range: "bytes=0-10" },
-                user: { id: "u1" },
-            } as any,
-            successRes,
-        );
+        const successReq = {
+            params: { id: "stream-2" },
+            headers: { range: "bytes=0-10" },
+            user: { id: "u1" },
+        } as any;
+        await streamHandler(successReq, successRes);
 
+        expect(audiobookshelfService.streamAudiobook).toHaveBeenCalledWith(
+            "stream-2",
+            "bytes=0-10",
+            { request: successReq, response: successRes },
+        );
         expect(successRes.statusCode).toBe(206);
         expect(successRes.headers["Content-Type"]).toBe("audio/flac");
         expect(successRes.headers["Content-Length"]).toBe("1234");

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -946,7 +946,10 @@ router.get<{ id: string }>(
             );
 
             const { stream, headers, status } =
-                await audiobookshelfService.streamAudiobook(id, rangeHeader);
+                await audiobookshelfService.streamAudiobook(id, rangeHeader, {
+                    request: req,
+                    response: res,
+                });
 
             logger.debug(
                 `[Audiobook Stream] Got stream, status: ${status}, content-type: ${headers["content-type"]}`,

--- a/backend/src/services/__tests__/audiobookshelfService.test.ts
+++ b/backend/src/services/__tests__/audiobookshelfService.test.ts
@@ -349,6 +349,7 @@ describe("audiobookshelf service behavior", () => {
         );
         expect(streamed.status).toBe(206);
         expect(client.get).toHaveBeenCalledWith("/api/items/book-1/file/123", {
+            allowAbsoluteUrls: false,
             responseType: "stream",
             timeout: 0,
             signal: expect.any(AbortSignal),
@@ -364,9 +365,66 @@ describe("audiobookshelf service behavior", () => {
         ).rejects.toThrow("No audio track found for this audiobook");
     });
 
-    it("aborts stream acquisition on an early client disconnect and detaches listeners", async () => {
+    it.each(["close", "aborted"] as const)(
+        "aborts stream acquisition when the lifecycle request emits %s",
+        async (disconnectEvent) => {
+            const client = createClient();
+            const lifecycle = createStreamLifecycle();
+            const svc = audiobookshelfService as any;
+            svc.client = client;
+            svc.baseUrl = "http://abs.local";
+            svc.initialized = true;
+
+            jest.spyOn(
+                audiobookshelfService,
+                "getAudiobook",
+            ).mockResolvedValueOnce({
+                media: {
+                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                },
+            } as any);
+            client.get.mockImplementationOnce(
+                (_url: string, options: { signal: AbortSignal }) =>
+                    new Promise((_resolve, reject) => {
+                        if (options.signal.aborted) {
+                            reject(options.signal.reason);
+                            return;
+                        }
+                        options.signal.addEventListener(
+                            "abort",
+                            () => reject(options.signal.reason),
+                            { once: true },
+                        );
+                    }),
+            );
+            const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+            const acquisition = audiobookshelfService.streamAudiobook(
+                "book-1",
+                undefined,
+                lifecycle,
+            );
+            await Promise.resolve();
+            expectStreamListeners(lifecycle, 1);
+
+            const rejectedAcquisition = expect(acquisition).rejects.toThrow(
+                "Client disconnected",
+            );
+            lifecycle.request.emit(disconnectEvent);
+
+            await rejectedAcquisition;
+            expect(abortSpy).toHaveBeenCalledTimes(1);
+            expectStreamListeners(lifecycle, 0);
+        },
+    );
+
+    it.each([
+        "https://evil.example/audio.mp3",
+        "//evil.example/audio.mp3",
+        "http://user:password@abs.local/audio.mp3",
+        "file:///etc/passwd",
+    ])("rejects an unsafe audiobook content URL: %s", async (contentUrl) => {
         const client = createClient();
-        const lifecycle = createStreamLifecycle();
         const svc = audiobookshelfService as any;
         svc.client = client;
         svc.baseUrl = "http://abs.local";
@@ -375,42 +433,49 @@ describe("audiobookshelf service behavior", () => {
         jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
             {
                 media: {
-                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                    tracks: [{ contentUrl }],
                 },
             } as any,
         );
-        client.get.mockImplementationOnce(
-            (_url: string, options: { signal: AbortSignal }) =>
-                new Promise((_resolve, reject) => {
-                    if (options.signal.aborted) {
-                        reject(options.signal.reason);
-                        return;
-                    }
-                    options.signal.addEventListener(
-                        "abort",
-                        () => reject(options.signal.reason),
-                        { once: true },
-                    );
-                }),
-        );
-        const abortSpy = jest.spyOn(AbortController.prototype, "abort");
 
-        const acquisition = audiobookshelfService.streamAudiobook(
-            "book-1",
-            undefined,
-            lifecycle,
-        );
-        await Promise.resolve();
-        expectStreamListeners(lifecycle, 1);
+        await expect(
+            audiobookshelfService.streamAudiobook("book-1"),
+        ).rejects.toThrow("Audiobookshelf returned an unsafe audio track URL");
+        expect(client.get).not.toHaveBeenCalled();
+    });
 
-        const rejectedAcquisition = expect(acquisition).rejects.toThrow(
-            "Client disconnected",
-        );
-        lifecycle.request.emit("aborted");
+    it("allows an absolute same-origin audiobook content URL", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
 
-        await rejectedAcquisition;
-        expect(abortSpy).toHaveBeenCalledTimes(1);
-        expectStreamListeners(lifecycle, 0);
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [
+                        {
+                            contentUrl:
+                                "http://abs.local/api/items/book-1/file/123?token=track",
+                        },
+                    ],
+                },
+            } as any,
+        );
+        client.get.mockResolvedValueOnce({
+            data: { pipe: jest.fn() },
+            headers: { "content-type": "audio/mpeg" },
+            status: 200,
+        });
+
+        await expect(
+            audiobookshelfService.streamAudiobook("book-1"),
+        ).resolves.toEqual(expect.objectContaining({ status: 200 }));
+        expect(client.get).toHaveBeenCalledWith(
+            "/api/items/book-1/file/123?token=track",
+            expect.objectContaining({ allowAbsoluteUrls: false }),
+        );
     });
 
     it("aborts stream acquisition when the header deadline expires", async () => {

--- a/backend/src/services/audiobookshelf.ts
+++ b/backend/src/services/audiobookshelf.ts
@@ -5,6 +5,45 @@ import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
 
 const STREAM_HEADER_TIMEOUT_MS = 30_000;
+const UNSAFE_AUDIO_TRACK_URL_ERROR =
+    "Audiobookshelf returned an unsafe audio track URL";
+
+function resolveStreamContentPath(
+    contentUrl: unknown,
+    baseUrl: string | null,
+): string {
+    if (typeof contentUrl !== "string" || !baseUrl) {
+        throw new Error(UNSAFE_AUDIO_TRACK_URL_ERROR);
+    }
+
+    let configuredBase: URL;
+    let resolvedContentUrl: URL;
+    try {
+        configuredBase = new URL(baseUrl);
+        resolvedContentUrl = new URL(
+            contentUrl,
+            `${configuredBase.href.replace(/\/$/, "")}/`,
+        );
+    } catch {
+        throw new Error(UNSAFE_AUDIO_TRACK_URL_ERROR);
+    }
+
+    const usesHttp =
+        resolvedContentUrl.protocol === "http:" ||
+        resolvedContentUrl.protocol === "https:";
+    const hasCredentials =
+        resolvedContentUrl.username !== "" ||
+        resolvedContentUrl.password !== "";
+    if (
+        !usesHttp ||
+        hasCredentials ||
+        resolvedContentUrl.origin !== configuredBase.origin
+    ) {
+        throw new Error(UNSAFE_AUDIO_TRACK_URL_ERROR);
+    }
+
+    return `${resolvedContentUrl.pathname}${resolvedContentUrl.search}`;
+}
 
 interface StreamDisconnectSource {
     readonly aborted?: boolean;
@@ -345,10 +384,15 @@ class AudiobookshelfService {
             if (!contentUrl) {
                 throw new Error("No audio track found for this audiobook");
             }
+            const contentPath = resolveStreamContentPath(
+                contentUrl,
+                this.baseUrl,
+            );
 
             const headers: Record<string, string> = {};
             if (rangeHeader) headers["Range"] = rangeHeader;
-            const response = await this.client!.get(contentUrl, {
+            const response = await this.client!.get(contentPath, {
+                allowAbsoluteUrls: false,
                 responseType: "stream",
                 timeout: 0,
                 signal: controller.signal,


### PR DESCRIPTION
Closes an authenticated SSRF and a confirmed regression from the sweep-23 review.

- **SSRF (audiobookshelf.ts):** `streamAudiobook` sent the upstream-provided `contentUrl` straight to the Axios client that carries the Audiobookshelf bearer token. A malicious/compromised upstream could return an absolute cross-origin URL and make Soundspan contact arbitrary internal/external origins **with that credential**. New `resolveStreamContentPath` resolves `contentUrl` against the configured base origin and rejects non-http(s) schemes, embedded credentials, and cross-origin targets, returning only a same-origin relative path; the request also sets `allowAbsoluteUrls: false`.
- **Regression of #394 (audiobooks.ts):** the sole production caller invoked `streamAudiobook(id, rangeHeader)` without the optional `lifecycle` arg, so `bindStreamDisconnect` never ran and a disconnected client's pending upstream requests were not aborted. The route now passes `{ request: req, response: res }`, restoring early abort.

Adds regression coverage for cross-origin/scheme-relative rejection and lifecycle abort.

Verified: 87 tests (audiobook), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)