### PR TITLE
fix(security): block active-content execution in share-cover proxy

### DIFF
--- a/backend/src/routes/__tests__/shareLinksCore.test.ts
+++ b/backend/src/routes/__tests__/shareLinksCore.test.ts
@@ -7,6 +7,10 @@ const ROLE_HEADER = "x-test-role";
 const TOKEN = "t".repeat(64);
 const CREATED_AT = new Date("2026-03-26T10:00:00.000Z");
 const FILE_MODIFIED = new Date("2026-03-26T09:00:00.000Z");
+const PNG_BUFFER = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const JPEG_BUFFER = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
 
 const mockRequireAuth = jest.fn(
     (req: Request, res: Response, next: NextFunction) => {
@@ -205,7 +209,7 @@ describe("share links routes integration", () => {
 
         mockFetchExternalImage.mockResolvedValue({
             ok: true,
-            buffer: Buffer.from("cover-image"),
+            buffer: PNG_BUFFER,
             contentType: "image/png",
             etag: "cover-etag",
         });
@@ -911,24 +915,87 @@ describe("share links routes integration", () => {
         },
     );
 
-    it("GET /api/share-links/access/:token/cover proxies external cover art without auth", async () => {
-        mockShareLinkFindUnique.mockResolvedValueOnce(
-            makeShareLink({ resourceType: "album", resourceId: "album-1" }),
-        );
+    it.each([
+        {
+            label: "PNG",
+            buffer: PNG_BUFFER,
+            upstreamContentType: "application/octet-stream",
+            expectedContentType: "image/png",
+        },
+        {
+            label: "JPEG",
+            buffer: JPEG_BUFFER,
+            upstreamContentType: "text/html",
+            expectedContentType: "image/jpeg",
+        },
+    ])(
+        "GET /api/share-links/access/:token/cover serves valid $label bytes with server-chosen headers",
+        async ({ buffer, upstreamContentType, expectedContentType }) => {
+            mockShareLinkFindUnique.mockResolvedValueOnce(
+                makeShareLink({
+                    resourceType: "album",
+                    resourceId: "album-1",
+                }),
+            );
+            mockFetchExternalImage.mockResolvedValueOnce({
+                ok: true,
+                buffer,
+                contentType: upstreamContentType,
+                etag: "cover-etag",
+            });
 
-        const res = await request(app)
-            .get(`/api/share-links/access/${TOKEN}/cover`)
-            .query({ url: "https://images.example.test/cover.png" });
+            const res = await request(app)
+                .get(`/api/share-links/access/${TOKEN}/cover`)
+                .query({ url: "https://images.example.test/cover" });
 
-        expect(res.status).toBe(200);
-        expect(mockFetchExternalImage).toHaveBeenCalledWith({
-            url: "https://images.example.test/cover.png",
-        });
-        expect(res.headers["content-type"]).toContain("image/png");
-        expect(res.headers["cache-control"]).toBe("public, max-age=3600");
-        expect(res.headers.etag).toBe("cover-etag");
-        expect(res.body).toEqual(Buffer.from("cover-image"));
-    });
+            expect(res.status).toBe(200);
+            expect(mockFetchExternalImage).toHaveBeenCalledWith({
+                url: "https://images.example.test/cover",
+            });
+            expect(res.headers["content-type"]).toBe(expectedContentType);
+            expect(res.headers["content-disposition"]).toBe("inline");
+            expect(res.headers["x-content-type-options"]).toBe("nosniff");
+            expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+            expect(res.headers.etag).toBe("cover-etag");
+            expect(res.body).toEqual(buffer);
+        },
+    );
+
+    it.each([
+        {
+            upstreamContentType: "text/html",
+            buffer: Buffer.from("<!doctype html><script>alert(1)</script>"),
+        },
+        {
+            upstreamContentType: "application/javascript",
+            buffer: Buffer.from("globalThis.pwned = true"),
+        },
+    ])(
+        "GET /api/share-links/access/:token/cover rejects $upstreamContentType bytes without reflecting the type",
+        async ({ upstreamContentType, buffer }) => {
+            mockShareLinkFindUnique.mockResolvedValueOnce(
+                makeShareLink({
+                    resourceType: "album",
+                    resourceId: "album-1",
+                }),
+            );
+            mockFetchExternalImage.mockResolvedValueOnce({
+                ok: true,
+                buffer,
+                contentType: upstreamContentType,
+            });
+
+            const res = await request(app)
+                .get(`/api/share-links/access/${TOKEN}/cover`)
+                .query({ url: "https://attacker.example.test/payload" });
+
+            expect(res.status).toBe(404);
+            expect(res.body).toEqual({ error: "Cover image not found" });
+            expect(res.headers["content-type"]).not.toContain(
+                upstreamContentType,
+            );
+        },
+    );
 
     it("GET /api/share-links/access/:token/cover validates the url parameter", async () => {
         mockShareLinkFindUnique.mockResolvedValueOnce(

--- a/backend/src/routes/__tests__/shareLinksRuntime.test.ts
+++ b/backend/src/routes/__tests__/shareLinksRuntime.test.ts
@@ -94,7 +94,7 @@ jest.mock("archiver", () => ({
 const mockFetchExternalImage = jest.fn().mockResolvedValue({
     ok: true,
     url: "https://example.com/cover.jpg",
-    buffer: Buffer.from("fake-image"),
+    buffer: Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
     contentType: "image/jpeg",
     etag: "abc123",
 });

--- a/backend/src/routes/shareLinks.ts
+++ b/backend/src/routes/shareLinks.ts
@@ -53,6 +53,30 @@ const shareTokenSchema = z.object({
     token: z.string().trim().min(1),
 });
 
+type AllowedImageMime = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8, 0xff]);
+const PNG_SIGNATURE = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const GIF_SIGNATURE = Buffer.from("GIF8", "ascii");
+const RIFF_SIGNATURE = Buffer.from("RIFF", "ascii");
+const WEBP_SIGNATURE = Buffer.from("WEBP", "ascii");
+
+/** Detect an allowlisted image MIME type from file-signature bytes. */
+export function detectImageMime(buffer: Buffer): AllowedImageMime | null {
+    if (buffer.subarray(0, 3).equals(JPEG_SIGNATURE)) return "image/jpeg";
+    if (buffer.subarray(0, 8).equals(PNG_SIGNATURE)) return "image/png";
+    if (buffer.subarray(0, 4).equals(GIF_SIGNATURE)) return "image/gif";
+    if (
+        buffer.subarray(0, 4).equals(RIFF_SIGNATURE) &&
+        buffer.subarray(8, 12).equals(WEBP_SIGNATURE)
+    ) {
+        return "image/webp";
+    }
+    return null;
+}
+
 function isExpired(expiresAt: Date | null): boolean {
     if (!expiresAt) return false;
     return expiresAt.getTime() <= Date.now();
@@ -1031,7 +1055,14 @@ router.get("/access/:token/cover", async (req, res) => {
             return res.status(404).json({ error: "Cover image not found" });
         }
 
-        res.setHeader("Content-Type", result.contentType || "image/jpeg");
+        const contentType = detectImageMime(result.buffer);
+        if (!contentType) {
+            return res.status(404).json({ error: "Cover image not found" });
+        }
+
+        res.setHeader("Content-Type", contentType);
+        res.setHeader("Content-Disposition", "inline");
+        res.setHeader("X-Content-Type-Options", "nosniff");
         res.setHeader("Cache-Control", "public, max-age=3600");
         if (result.etag) {
             res.setHeader("ETag", result.etag);


### PR DESCRIPTION
Closes a same-origin active-content (stored-XSS) vector from the sweep-23 review.

The public route **GET /access/:token/cover** reflected the upstream `content-type` and raw bytes with no image validation, so a share-token holder could point `url=` at attacker-controlled content served as `application/javascript`/`text/html` and have Soundspan serve it under its **own origin** — satisfying Helmet's `script-src 'self'` and executing attacker JS.

Fix (contained to shareLinks.ts; shared `imageProxy.ts` untouched):
- New pure `detectImageMime(buffer)` sniffs magic bytes for JPEG/PNG/GIF/WEBP; non-image bodies are rejected with 404.
- The response emits a **server-chosen** `Content-Type` (never the upstream one), plus `Content-Disposition: inline` and `X-Content-Type-Options: nosniff`. Byte-cap streaming and ETag/Cache-Control unchanged; the `native:` branch is unaffected.

Adds coverage: html/js bodies rejected; valid PNG/JPEG served with the sniffed type.

Verified: 75 tests (shareLink), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)