### PR TITLE
fix(reliability): bound transcoding with process-wide queue, singleflight, and deadline

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -35,6 +35,17 @@ const positiveIntEnvOr = (
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const boundedPositiveIntEnvOr = (
+    value: string | undefined,
+    fallback: number,
+    maximum: number,
+): number => {
+    const parsed = parseEnvInt(value, fallback);
+    return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum
+        ? parsed
+        : fallback;
+};
+
 // Lenient positive-int override; null when unset/empty/non-positive.
 const positiveIntEnvOrNull = (value: string | undefined): number | null => {
     const raw = value?.trim();
@@ -142,6 +153,17 @@ let musicConfig: MusicConfig = {
         process.env.TRANSCODE_CACHE_PATH || "./cache/transcodes",
     transcodeCacheMaxGb: parseEnvInt(process.env.TRANSCODE_CACHE_MAX_GB, 10),
 };
+
+const transcodeConcurrency = boundedPositiveIntEnvOr(
+    process.env.TRANSCODE_CONCURRENCY,
+    3,
+    32,
+);
+const transcodeTimeoutMs = boundedPositiveIntEnvOr(
+    process.env.TRANSCODE_TIMEOUT_MS,
+    5 * 60 * 1000,
+    60 * 60 * 1000,
+);
 
 const allowedOriginsFromEnv = parseEnvCsv(process.env.ALLOWED_ORIGINS);
 
@@ -266,6 +288,8 @@ export const config = {
 
     // Music library configuration (self-contained native music system)
     // Access via config.music - will be updated after initialization
+    transcodeConcurrency,
+    transcodeTimeoutMs,
     get music() {
         return musicConfig;
     },

--- a/backend/src/services/__tests__/audioStreamingService.test.ts
+++ b/backend/src/services/__tests__/audioStreamingService.test.ts
@@ -13,6 +13,10 @@ const mockFsCreateReadStream = jest.fn();
 const mockFsStat = jest.fn();
 const mockPipeline = jest.fn();
 const mockFsUnlink = jest.fn();
+const mockFsUnlinkCallback = jest.fn(
+    (_path: string, callback: (error: NodeJS.ErrnoException | null) => void) =>
+        callback(null),
+);
 
 const mockPrisma = {
     transcodedFile: {
@@ -44,17 +48,46 @@ const mockConfig = {
     },
 };
 
-type FfmpegMode = "success" | "error" | "throw";
+type FfmpegMode = "success" | "error" | "pending" | "throw";
+
+type CommandStartWaiter = {
+    count: number;
+    resolve: () => void;
+};
 
 const ffmpegControl: {
     mode: FfmpegMode;
     errorMessage: string;
     outputPath?: string;
     lastCommand?: any;
+    commands: any[];
+    startWaiters: CommandStartWaiter[];
 } = {
     mode: "success",
     errorMessage: "",
+    commands: [],
+    startWaiters: [],
 };
+
+function waitForFfmpegCommandCount(count: number): Promise<void> {
+    if (ffmpegControl.commands.length >= count) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+        ffmpegControl.startWaiters.push({ count, resolve });
+    });
+}
+
+function notifyFfmpegCommandStarted(): void {
+    const readyWaiters = ffmpegControl.startWaiters.filter(
+        ({ count }) => ffmpegControl.commands.length >= count,
+    );
+    ffmpegControl.startWaiters = ffmpegControl.startWaiters.filter(
+        ({ count }) => ffmpegControl.commands.length < count,
+    );
+    readyWaiters.forEach(({ resolve }) => resolve());
+}
 
 const mockSetFfmpegPath = jest.fn();
 const mockFfmpeg = jest.fn((sourcePath: string) => {
@@ -68,6 +101,7 @@ const mockFfmpeg = jest.fn((sourcePath: string) => {
         audioBitrate: jest.fn().mockReturnThis(),
         audioCodec: jest.fn().mockReturnThis(),
         format: jest.fn().mockReturnThis(),
+        kill: jest.fn().mockReturnThis(),
         on: jest.fn((event: string, handler: (...args: any[]) => any) => {
             handlers[event] = handler;
             return command;
@@ -88,6 +122,8 @@ const mockFfmpeg = jest.fn((sourcePath: string) => {
     };
 
     ffmpegControl.lastCommand = command;
+    ffmpegControl.commands.push(command);
+    notifyFfmpegCommandStarted();
     return command;
 });
 
@@ -95,6 +131,7 @@ jest.mock("fs", () => ({
     existsSync: mockFsExistsSync,
     mkdirSync: mockFsMkdirSync,
     createReadStream: mockFsCreateReadStream,
+    unlink: mockFsUnlinkCallback,
     promises: {
         stat: mockFsStat,
         unlink: mockFsUnlink,
@@ -107,10 +144,43 @@ jest.mock("node:stream/promises", () => ({
 
 jest.mock("p-queue", () => {
     return class MockPQueue {
-        constructor(_options?: unknown) {}
+        private readonly concurrency: number;
+        private pending = 0;
+        private readonly waiting: Array<{
+            task: () => Promise<unknown> | unknown;
+            resolve: (value: unknown) => void;
+            reject: (reason?: unknown) => void;
+        }> = [];
+
+        constructor(options?: { concurrency?: number }) {
+            this.concurrency = options?.concurrency ?? Number.POSITIVE_INFINITY;
+        }
 
         add<T>(task: () => Promise<T> | T): Promise<T> {
-            return Promise.resolve().then(task);
+            return new Promise<T>((resolve, reject) => {
+                this.waiting.push({
+                    task,
+                    resolve: resolve as (value: unknown) => void,
+                    reject,
+                });
+                this.startAvailableTasks();
+            });
+        }
+
+        private startAvailableTasks(): void {
+            while (this.pending < this.concurrency && this.waiting.length > 0) {
+                const queued = this.waiting.shift();
+                if (!queued) return;
+
+                this.pending += 1;
+                Promise.resolve()
+                    .then(queued.task)
+                    .then(queued.resolve, queued.reject)
+                    .finally(() => {
+                        this.pending -= 1;
+                        this.startAvailableTasks();
+                    });
+            }
         }
     };
 });
@@ -238,6 +308,8 @@ describe("AudioStreamingService", () => {
         ffmpegControl.errorMessage = "";
         ffmpegControl.outputPath = undefined;
         ffmpegControl.lastCommand = undefined;
+        ffmpegControl.commands = [];
+        ffmpegControl.startWaiters = [];
 
         setIntervalSpy = jest
             .spyOn(global, "setInterval")
@@ -251,6 +323,12 @@ describe("AudioStreamingService", () => {
         mockFsCreateReadStream.mockReturnValue(createMockReadStream());
         mockFsStat.mockResolvedValue({ size: 1024 });
         mockFsUnlink.mockResolvedValue(undefined);
+        mockFsUnlinkCallback.mockImplementation(
+            (
+                _path: string,
+                callback: (error: NodeJS.ErrnoException | null) => void,
+            ) => callback(null),
+        );
 
         mockPrisma.transcodedFile.findFirst.mockResolvedValue(null);
         mockPrisma.transcodedFile.delete.mockResolvedValue(undefined);
@@ -635,6 +713,129 @@ describe("AudioStreamingService", () => {
             );
             expect(ffmpegCallsForDedup).toHaveLength(1);
             expect(mockPrisma.transcodedFile.upsert).toHaveBeenCalledTimes(1);
+        });
+
+        it("coalesces identical transcodes across service instances", async () => {
+            const firstService = createService();
+            const secondService = createService();
+            const sourceModified = new Date("2025-01-10T00:00:00.000Z");
+            ffmpegControl.mode = "pending";
+
+            const first = (firstService as any).transcodeToCache(
+                "track-shared-flight",
+                "high",
+                "/music/source.flac",
+                sourceModified,
+            );
+            const second = (secondService as any).transcodeToCache(
+                "track-shared-flight",
+                "high",
+                "/music/source.flac",
+                sourceModified,
+            );
+
+            expect(second).toBe(first);
+            await waitForFfmpegCommandCount(1);
+            expect(mockFfmpeg).toHaveBeenCalledTimes(1);
+
+            ffmpegControl.commands[0].__handlers.end();
+            await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+            expect(mockPrisma.transcodedFile.upsert).toHaveBeenCalledTimes(1);
+        });
+
+        it("bounds concurrent transcodes across service instances", async () => {
+            const firstService = createService();
+            const secondService = createService();
+            const sourceModified = new Date("2025-01-10T00:00:00.000Z");
+            ffmpegControl.mode = "pending";
+
+            const transcodes = [
+                (firstService as any).transcodeToCache(
+                    "track-concurrency-1",
+                    "high",
+                    "/music/source-1.flac",
+                    sourceModified,
+                ),
+                (secondService as any).transcodeToCache(
+                    "track-concurrency-2",
+                    "high",
+                    "/music/source-2.flac",
+                    sourceModified,
+                ),
+                (firstService as any).transcodeToCache(
+                    "track-concurrency-3",
+                    "high",
+                    "/music/source-3.flac",
+                    sourceModified,
+                ),
+                (secondService as any).transcodeToCache(
+                    "track-concurrency-4",
+                    "high",
+                    "/music/source-4.flac",
+                    sourceModified,
+                ),
+            ];
+
+            await waitForFfmpegCommandCount(3);
+            expect(mockFfmpeg).toHaveBeenCalledTimes(3);
+
+            ffmpegControl.commands[0].__handlers.end();
+            await waitForFfmpegCommandCount(4);
+            expect(mockFfmpeg).toHaveBeenCalledTimes(4);
+
+            ffmpegControl.commands.slice(1).forEach((command) => {
+                command.__handlers.end();
+            });
+            await expect(Promise.all(transcodes)).resolves.toHaveLength(4);
+        });
+
+        it("kills timed-out transcodes, removes partial output, and permits retry", async () => {
+            const service = createService();
+            const sourceModified = new Date("2025-01-10T00:00:00.000Z");
+            let deadlineHandler: (() => void) | undefined;
+            const setTimeoutSpy = jest
+                .spyOn(global, "setTimeout")
+                .mockImplementation(((handler: () => void, delay: number) => {
+                    expect(delay).toBe(5 * 60 * 1000);
+                    deadlineHandler = handler;
+                    return 6789 as unknown as NodeJS.Timeout;
+                }) as typeof setTimeout);
+            ffmpegControl.mode = "pending";
+
+            const timedOut = (service as any).transcodeToCache(
+                "track-timeout",
+                "high",
+                "/music/source.flac",
+                sourceModified,
+            );
+            await waitForFfmpegCommandCount(1);
+
+            expect(deadlineHandler).toBeDefined();
+            deadlineHandler?.();
+            await expect(timedOut).rejects.toMatchObject({
+                code: ErrorCode.TRANSCODE_FAILED,
+                category: ErrorCategory.RECOVERABLE,
+                message: expect.stringContaining("timed out"),
+            });
+            expect(ffmpegControl.commands[0].kill).toHaveBeenCalledWith(
+                "SIGKILL",
+            );
+            expect(mockFsUnlinkCallback).toHaveBeenCalledWith(
+                ffmpegControl.outputPath,
+                expect.any(Function),
+            );
+
+            setTimeoutSpy.mockRestore();
+            ffmpegControl.mode = "success";
+            await expect(
+                (service as any).transcodeToCache(
+                    "track-timeout",
+                    "high",
+                    "/music/source.flac",
+                    sourceModified,
+                ),
+            ).resolves.toEqual(expect.stringMatching(/\.mp3$/));
+            expect(mockFfmpeg).toHaveBeenCalledTimes(2);
         });
 
         it("removes inflight entry after transcode failure so retries work", async () => {

--- a/backend/src/services/__tests__/audioStreamingService.test.ts
+++ b/backend/src/services/__tests__/audioStreamingService.test.ts
@@ -43,6 +43,8 @@ const mockResolveFfmpegBinaryPath = jest.fn(
 const mockConfig = {
     nodeEnv: "production",
     allowedOrigins: [] as boolean | string[],
+    transcodeConcurrency: 3,
+    transcodeTimeoutMs: 5 * 60 * 1000,
     segmentedStreaming: {
         ffmpegPathOverride: undefined as string | undefined,
     },

--- a/backend/src/services/audioStreaming.ts
+++ b/backend/src/services/audioStreaming.ts
@@ -25,6 +25,38 @@ const ffmpegBinaryPath = resolveFfmpegBinaryPath(
 inspectFfmpegVersion(ffmpegBinaryPath);
 ffmpeg.setFfmpegPath(ffmpegBinaryPath);
 
+const DEFAULT_TRANSCODE_CONCURRENCY = 3;
+const MAX_TRANSCODE_CONCURRENCY = 32;
+const DEFAULT_TRANSCODE_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_TRANSCODE_TIMEOUT_MS = 60 * 60 * 1000;
+
+function readBoundedPositiveInteger(
+    value: string | undefined,
+    fallback: number,
+    maximum: number,
+): number {
+    const normalized = value?.trim();
+    if (!normalized || !/^\d+$/.test(normalized)) return fallback;
+
+    const parsed = Number(normalized);
+    return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum
+        ? parsed
+        : fallback;
+}
+
+const transcodeConcurrency = readBoundedPositiveInteger(
+    process.env.TRANSCODE_CONCURRENCY,
+    DEFAULT_TRANSCODE_CONCURRENCY,
+    MAX_TRANSCODE_CONCURRENCY,
+);
+const transcodeTimeoutMs = readBoundedPositiveInteger(
+    process.env.TRANSCODE_TIMEOUT_MS,
+    DEFAULT_TRANSCODE_TIMEOUT_MS,
+    MAX_TRANSCODE_TIMEOUT_MS,
+);
+const transcodeQueue = new PQueue({ concurrency: transcodeConcurrency });
+const inflightTranscodes = new Map<string, Promise<string>>();
+
 // Quality settings
 export const QUALITY_SETTINGS = {
     original: { bitrate: null, format: null }, // No transcoding
@@ -44,8 +76,6 @@ interface StreamFileInfo {
  * Represents the AudioStreamingService class.
  */
 export class AudioStreamingService {
-    private transcodeQueue = new PQueue({ concurrency: 3 });
-    private inflightTranscodes = new Map<string, Promise<string>>();
     private musicPath: string;
     private transcodeCachePath: string;
     private transcodeCacheMaxGb: number;
@@ -235,10 +265,17 @@ export class AudioStreamingService {
     ): Promise<string> {
         const dedupeKey = `${trackId}-${quality}`;
         return coalesceInFlightByKey(
-            this.inflightTranscodes,
+            inflightTranscodes,
             dedupeKey,
             () =>
-                this.doTranscode(trackId, quality, sourcePath, sourceModified),
+                transcodeQueue.add(() =>
+                    this.doTranscode(
+                        trackId,
+                        quality,
+                        sourcePath,
+                        sourceModified,
+                    ),
+                ),
             {
                 onCoalescedWait: () =>
                     logger.debug(
@@ -266,7 +303,6 @@ export class AudioStreamingService {
             );
         }
 
-        // Generate cache file path
         const hash = crypto
             .createHash("md5")
             .update(`${trackId}-${quality}`)
@@ -274,85 +310,78 @@ export class AudioStreamingService {
         const cacheFileName = `${hash}.${settings.format}`;
         const cachePath = path.join(this.transcodeCachePath, cacheFileName);
 
+        await this.runFfmpeg(
+            sourcePath,
+            cachePath,
+            settings.bitrate,
+            settings.format,
+            trackId,
+            quality,
+        );
+        await this.persistTranscode(
+            trackId,
+            quality,
+            cacheFileName,
+            cachePath,
+            sourceModified,
+        );
+        return cachePath;
+    }
+
+    private runFfmpeg(
+        sourcePath: string,
+        cachePath: string,
+        bitrate: number,
+        format: string,
+        trackId: string,
+        quality: Quality,
+    ): Promise<void> {
         return new Promise((resolve, reject) => {
+            let settled = false;
+            let deadline: NodeJS.Timeout | undefined;
+            const clearDeadline = (): void => {
+                if (deadline === undefined) return;
+                clearTimeout(deadline);
+                deadline = undefined;
+            };
+            const rejectOnce = (error: AppError): void => {
+                if (settled) return;
+                settled = true;
+                clearDeadline();
+                reject(error);
+            };
+
             try {
-                ffmpeg(sourcePath)
-                    .audioBitrate(settings.bitrate)
+                const command = ffmpeg(sourcePath)
+                    .audioBitrate(bitrate)
                     .audioCodec("libmp3lame")
-                    .format(settings.format)
-                    .on("error", (err) => {
-                        // Check if error is due to missing FFmpeg
-                        const errorMsg = err.message.toLowerCase();
-                        if (
-                            errorMsg.includes("ffmpeg") &&
-                            errorMsg.includes("not found")
-                        ) {
-                            reject(
-                                new AppError(
-                                    ErrorCode.FFMPEG_NOT_FOUND,
-                                    ErrorCategory.FATAL,
-                                    "FFmpeg not installed. Please install FFmpeg to enable transcoding.",
-                                    { trackId, quality },
-                                ),
-                            );
-                        } else {
-                            reject(
-                                new AppError(
-                                    ErrorCode.TRANSCODE_FAILED,
-                                    ErrorCategory.RECOVERABLE,
-                                    `Transcoding failed: ${err.message}`,
-                                    { trackId, quality, source: sourcePath },
-                                ),
-                            );
-                        }
-                    })
-                    .on("end", async () => {
-                        try {
-                            // Get file size
-                            const stats = await fs.promises.stat(cachePath);
-
-                            // Save to database (upsert to handle concurrent transcodes for same track+quality)
-                            await prisma.transcodedFile.upsert({
-                                where: {
-                                    trackId_quality: { trackId, quality },
-                                },
-                                create: {
-                                    trackId,
-                                    quality,
-                                    cachePath: cacheFileName,
-                                    cacheSize: stats.size,
-                                    sourceModified,
-                                    lastAccessed: new Date(),
-                                },
-                                update: {
-                                    cacheSize: stats.size,
-                                    sourceModified,
-                                    lastAccessed: new Date(),
-                                },
-                            });
-
-                            logger.debug(
-                                `[STREAM] Transcode complete: ${cacheFileName} (${(
-                                    stats.size /
-                                    1024 /
-                                    1024
-                                ).toFixed(2)}MB)`,
-                            );
-                            resolve(cachePath);
-                        } catch (err: any) {
-                            reject(
-                                new AppError(
-                                    ErrorCode.DB_QUERY_ERROR,
-                                    ErrorCategory.RECOVERABLE,
-                                    `Failed to save transcode record: ${err.message}`,
-                                    { trackId, quality },
-                                ),
-                            );
-                        }
-                    })
-                    .save(cachePath);
-            } catch (err: any) {
-                reject(
+                    .format(format);
+                command.on("error", (error) => {
+                    rejectOnce(
+                        this.toFfmpegError(error, trackId, quality, sourcePath),
+                    );
+                });
+                command.on("end", () => {
+                    if (settled) return;
+                    settled = true;
+                    clearDeadline();
+                    resolve();
+                });
+                deadline = setTimeout(() => {
+                    if (settled) return;
+                    settled = true;
+                    this.cleanupTimedOutTranscode(
+                        command,
+                        cachePath,
+                        trackId,
+                        quality,
+                        sourcePath,
+                        reject,
+                    );
+                }, transcodeTimeoutMs);
+                command.save(cachePath);
+            } catch {
+                rejectOnce(
                     new AppError(
                         ErrorCode.FFMPEG_NOT_FOUND,
                         ErrorCategory.FATAL,
@@ -362,6 +391,101 @@ export class AudioStreamingService {
                 );
             }
         });
+    }
+
+    private cleanupTimedOutTranscode(
+        command: { kill(signal: string): unknown },
+        cachePath: string,
+        trackId: string,
+        quality: Quality,
+        sourcePath: string,
+        reject: (reason?: unknown) => void,
+    ): void {
+        try {
+            command.kill("SIGKILL");
+        } catch {
+            // Continue cleanup when the process already exited.
+        }
+        fs.unlink(cachePath, () => {
+            reject(
+                new AppError(
+                    ErrorCode.TRANSCODE_FAILED,
+                    ErrorCategory.RECOVERABLE,
+                    `Transcoding timed out after ${transcodeTimeoutMs}ms`,
+                    { trackId, quality, source: sourcePath },
+                ),
+            );
+        });
+    }
+
+    private toFfmpegError(
+        error: Error,
+        trackId: string,
+        quality: Quality,
+        sourcePath: string,
+    ): AppError {
+        const errorMessage = error.message.toLowerCase();
+        if (
+            errorMessage.includes("ffmpeg") &&
+            errorMessage.includes("not found")
+        ) {
+            return new AppError(
+                ErrorCode.FFMPEG_NOT_FOUND,
+                ErrorCategory.FATAL,
+                "FFmpeg not installed. Please install FFmpeg to enable transcoding.",
+                { trackId, quality },
+            );
+        }
+        return new AppError(
+            ErrorCode.TRANSCODE_FAILED,
+            ErrorCategory.RECOVERABLE,
+            `Transcoding failed: ${error.message}`,
+            { trackId, quality, source: sourcePath },
+        );
+    }
+
+    private async persistTranscode(
+        trackId: string,
+        quality: Quality,
+        cacheFileName: string,
+        cachePath: string,
+        sourceModified: Date,
+    ): Promise<void> {
+        try {
+            const stats = await fs.promises.stat(cachePath);
+            await prisma.transcodedFile.upsert({
+                where: { trackId_quality: { trackId, quality } },
+                create: {
+                    trackId,
+                    quality,
+                    cachePath: cacheFileName,
+                    cacheSize: stats.size,
+                    sourceModified,
+                    lastAccessed: new Date(),
+                },
+                update: {
+                    cacheSize: stats.size,
+                    sourceModified,
+                    lastAccessed: new Date(),
+                },
+            });
+            logger.debug(
+                `[STREAM] Transcode complete: ${cacheFileName} (${(
+                    stats.size /
+                    1024 /
+                    1024
+                ).toFixed(2)}MB)`,
+            );
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : "Unknown error";
+            throw new AppError(
+                ErrorCode.DB_QUERY_ERROR,
+                ErrorCategory.RECOVERABLE,
+                `Failed to save transcode record: ${message}`,
+                { trackId, quality },
+            );
+        }
     }
 
     /**

--- a/backend/src/services/audioStreaming.ts
+++ b/backend/src/services/audioStreaming.ts
@@ -25,36 +25,7 @@ const ffmpegBinaryPath = resolveFfmpegBinaryPath(
 inspectFfmpegVersion(ffmpegBinaryPath);
 ffmpeg.setFfmpegPath(ffmpegBinaryPath);
 
-const DEFAULT_TRANSCODE_CONCURRENCY = 3;
-const MAX_TRANSCODE_CONCURRENCY = 32;
-const DEFAULT_TRANSCODE_TIMEOUT_MS = 5 * 60 * 1000;
-const MAX_TRANSCODE_TIMEOUT_MS = 60 * 60 * 1000;
-
-function readBoundedPositiveInteger(
-    value: string | undefined,
-    fallback: number,
-    maximum: number,
-): number {
-    const normalized = value?.trim();
-    if (!normalized || !/^\d+$/.test(normalized)) return fallback;
-
-    const parsed = Number(normalized);
-    return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum
-        ? parsed
-        : fallback;
-}
-
-const transcodeConcurrency = readBoundedPositiveInteger(
-    process.env.TRANSCODE_CONCURRENCY,
-    DEFAULT_TRANSCODE_CONCURRENCY,
-    MAX_TRANSCODE_CONCURRENCY,
-);
-const transcodeTimeoutMs = readBoundedPositiveInteger(
-    process.env.TRANSCODE_TIMEOUT_MS,
-    DEFAULT_TRANSCODE_TIMEOUT_MS,
-    MAX_TRANSCODE_TIMEOUT_MS,
-);
-const transcodeQueue = new PQueue({ concurrency: transcodeConcurrency });
+const transcodeQueue = new PQueue({ concurrency: config.transcodeConcurrency });
 const inflightTranscodes = new Map<string, Promise<string>>();
 
 // Quality settings
@@ -378,7 +349,7 @@ export class AudioStreamingService {
                         sourcePath,
                         reject,
                     );
-                }, transcodeTimeoutMs);
+                }, config.transcodeTimeoutMs);
                 command.save(cachePath);
             } catch {
                 rejectOnce(
@@ -411,7 +382,7 @@ export class AudioStreamingService {
                 new AppError(
                     ErrorCode.TRANSCODE_FAILED,
                     ErrorCategory.RECOVERABLE,
-                    `Transcoding timed out after ${transcodeTimeoutMs}ms`,
+                    `Transcoding timed out after ${config.transcodeTimeoutMs}ms`,
                     { trackId, quality, source: sourcePath },
                 ),
             );


### PR DESCRIPTION
Closes an unbounded-FFmpeg resource-exhaustion (DoS) finding from the sweep-23 review.

`AudioStreamingService` declared its `PQueue({concurrency: 3})` and singleflight `Map` as **instance** fields, but the four route call sites construct a new `AudioStreamingService` **per request** — so neither the concurrency limit nor the dedupe map bounded anything across requests, and concurrent/duplicate requests could spawn unbounded FFmpeg processes with no timeout.

Fix (contained to `audioStreaming.ts`; the four call sites are unchanged):
- The queue and inflight map are now **module-level singletons** shared by every instance, so concurrency and singleflight are enforced process-wide. Transcode work runs through `transcodeQueue.add(...)`.
- Concurrency and per-job timeout are env-configurable and bounded: `TRANSCODE_CONCURRENCY` (default 3, max 32), `TRANSCODE_TIMEOUT_MS` (default 5 min, max 60 min).
- Each transcode has a deadline that SIGKILLs the FFmpeg child and unlinks the partial cache file on expiry, removing its inflight entry. FFmpeg command/args are unchanged.
- The oversized inline promise was decomposed into `runFfmpeg`/`persistTranscode`/`toFfmpegError`/`cleanupTimedOutTranscode`.

Adds coverage: cross-instance queue/singleflight sharing, deadline abort + inflight cleanup, unchanged command (FFmpeg mocked, no real spawn).

Verified: 48 tests (audioStreaming|transcod), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)