### PR TITLE
fix(security): bound offline track-completion input

### DIFF
--- a/backend/src/routes/__tests__/offlineRuntime.test.ts
+++ b/backend/src/routes/__tests__/offlineRuntime.test.ts
@@ -329,12 +329,86 @@ describe("offline routes runtime", () => {
 
         expect(res.statusCode).toBe(400);
         expect(res.body).toEqual({
-            error: "localPath, quality, and fileSizeMb required",
+            error: "Invalid request",
+            details: expect.any(Array),
         });
         expect(mockCachedTrackUpsert).not.toHaveBeenCalled();
     });
 
-    it("upserts completed cached tracks and handles errors", async () => {
+    it("rejects an out-of-allowlist completion quality", async () => {
+        const req = {
+            session: {},
+            user: { id: "u1", username: "u1", role: "user" },
+            params: { id: "t1" },
+            body: {
+                localPath: "/cache/t1.mp3",
+                quality: "ultra",
+                fileSizeMb: 15.5,
+            },
+        } as any;
+        const res = createRes();
+
+        await postTrackComplete(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "Invalid request",
+            details: expect.any(Array),
+        });
+        expect(mockCachedTrackUpsert).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["negative", -1],
+        ["NaN", "NaN"],
+        ["over the per-file maximum", 4097],
+    ])("rejects a %s completion file size", async (_label, fileSizeMb) => {
+        const req = {
+            session: {},
+            user: { id: "u1", username: "u1", role: "user" },
+            params: { id: "t1" },
+            body: {
+                localPath: "/cache/t1.mp3",
+                quality: "high",
+                fileSizeMb,
+            },
+        } as any;
+        const res = createRes();
+
+        await postTrackComplete(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "Invalid request",
+            details: expect.any(Array),
+        });
+        expect(mockCachedTrackUpsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects an overlong completion local path", async () => {
+        const req = {
+            session: {},
+            user: { id: "u1", username: "u1", role: "user" },
+            params: { id: "t1" },
+            body: {
+                localPath: "x".repeat(1025),
+                quality: "high",
+                fileSizeMb: 15.5,
+            },
+        } as any;
+        const res = createRes();
+
+        await postTrackComplete(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            error: "Invalid request",
+            details: expect.any(Array),
+        });
+        expect(mockCachedTrackUpsert).not.toHaveBeenCalled();
+    });
+
+    it("upserts completed cached tracks with a parsed numeric size", async () => {
         const req = {
             session: {},
             user: { id: "u1", username: "u1", role: "user" },
@@ -374,12 +448,26 @@ describe("offline routes runtime", () => {
         expect(res.body).toEqual(
             expect.objectContaining({ id: "cached-1", trackId: "t1" }),
         );
+    });
+
+    it("returns 500 when a completed track upsert fails", async () => {
+        const req = {
+            session: {},
+            user: { id: "u1", username: "u1", role: "user" },
+            params: { id: "t1" },
+            body: {
+                localPath: "/cache/t1.mp3",
+                quality: "high",
+                fileSizeMb: "15.5",
+            },
+        } as any;
+        const res = createRes();
 
         mockCachedTrackUpsert.mockRejectedValueOnce(new Error("write failed"));
-        const errorRes = createRes();
-        await postTrackComplete(req, errorRes);
-        expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "Failed to complete download" });
+        await postTrackComplete(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to complete download" });
     });
 
     it("returns cached albums grouped by album id", async () => {

--- a/backend/src/routes/offline.ts
+++ b/backend/src/routes/offline.ts
@@ -8,8 +8,16 @@ const router = Router();
 
 router.use(requireAuth);
 
+const qualitySchema = z.enum(["original", "high", "medium", "low"]);
+
 const downloadAlbumSchema = z.object({
-    quality: z.enum(["original", "high", "medium", "low"]).optional(),
+    quality: qualitySchema.optional(),
+});
+
+const completeTrackSchema = z.object({
+    localPath: z.string().min(1).max(1024),
+    quality: qualitySchema,
+    fileSizeMb: z.coerce.number().finite().positive().max(4096),
 });
 
 /**
@@ -178,18 +186,23 @@ router.post("/albums/:id/download", async (req, res) => {
  *             properties:
  *               localPath:
  *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 1024
  *                 description: Local file path on device
  *               quality:
  *                 type: string
+ *                 enum: [original, high, medium, low]
  *                 description: Audio quality of the cached file
  *               fileSizeMb:
  *                 type: number
+ *                 exclusiveMinimum: 0
+ *                 maximum: 4096
  *                 description: File size in megabytes
  *     responses:
  *       200:
  *         description: Cached track record created or updated
  *       400:
- *         description: Missing required fields
+ *         description: Invalid request
  *       401:
  *         description: Not authenticated
  */
@@ -198,13 +211,9 @@ router.post("/tracks/:id/complete", async (req, res) => {
     try {
         const userId = req.user!.id;
         const trackId = req.params.id;
-        const { localPath, quality, fileSizeMb } = req.body;
-
-        if (!localPath || !quality || !fileSizeMb) {
-            return res
-                .status(400)
-                .json({ error: "localPath, quality, and fileSizeMb required" });
-        }
+        const { localPath, quality, fileSizeMb } = completeTrackSchema.parse(
+            req.body,
+        );
 
         const cachedTrack = await prisma.cachedTrack.upsert({
             where: {
@@ -219,17 +228,22 @@ router.post("/tracks/:id/complete", async (req, res) => {
                 trackId,
                 localPath,
                 quality,
-                fileSizeMb: parseFloat(fileSizeMb),
+                fileSizeMb,
             },
             update: {
                 localPath,
-                fileSizeMb: parseFloat(fileSizeMb),
+                fileSizeMb,
                 lastAccessedAt: new Date(),
             },
         });
 
         res.json(cachedTrack);
     } catch (error) {
+        if (error instanceof z.ZodError) {
+            return res
+                .status(400)
+                .json({ error: "Invalid request", details: error.issues });
+        }
         logger.error("Complete track download error:", error);
         res.status(500).json({ error: "Failed to complete download" });
     }


### PR DESCRIPTION
Closes a quota-poisoning / unbounded-row finding from the sweep-23 review.

**POST /offline/tracks/:id/complete** accepted `{ localPath, quality, fileSizeMb }` with only a truthy check and stored `parseFloat(fileSizeMb)`. Because `quality` was an unvalidated free string **and part of the `userId_trackId_quality` unique key**, one user could create unlimited rows per track; `fileSizeMb` had no finite/positive check, so NaN or negative sizes poisoned the cache-size accounting.

Fix (contained to offline.ts): a bounded `completeTrackSchema` — `quality` restricted to the shared `z.enum` of allowed qualities, `fileSizeMb` = `z.coerce.number().finite().positive().max(4096)`, `localPath` = `z.string().min(1).max(1024)`. Parsed before the upsert; `ZodError` → 400 with the existing error shape. The validated numeric size is stored (no raw `parseFloat`).

Adds coverage: out-of-allowlist quality, negative/NaN/over-max size, and over-long localPath all rejected; valid body upserts.

Verified: 20 tests (offline), tsc clean, route-error canon, full prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)