### PR TITLE
chore(release): stage 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.0.0] - 2026-08-12
+
+### Added
+
 - Added an opt-in `SECRETS_DB_ONLY` flag (default `false`). When enabled, integration secrets (Last.fm, Fanart.tv, Lidarr, OpenAI, Deezer, Audiobookshelf API keys) are read exclusively from encrypted system settings — the `.env` fallback for those keys is ignored and the settings-driven `.env` sync omits them. Startup fails fast if the settings layer is not readable before services start. Default behavior is unchanged.
 - Added repo-wide Prettier and EditorConfig conventions, applied through
   mechanical per-package formatting commits. The six formatting-only commits

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "1.9.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "1.9.0",
+            "version": "2.0.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "1.9.0",
+    "version": "2.0.0",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 1.9.0
-appVersion: "1.9.0"
+version: 2.0.0
+appVersion: "2.0.0"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -149,7 +149,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -226,7 +226,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -281,7 +281,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -411,7 +411,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -440,7 +440,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -511,7 +511,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -569,7 +569,7 @@ audioAnalyzerClap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer-clap
-    tag: 1.9.0
+    tag: 2.0.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always

--- a/docs/release-notes/RELEASE_NOTES_2.0.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.0.md
@@ -1,0 +1,172 @@
+# [2.0.0] Release Notes - 2026-08-12
+
+Soundspan 2.0.0 is a security- and reliability-hardening major release: the
+consumer-facing result of a systematic, multi-month security review. It tightens
+credentials, sessions, authorization, network boundaries, and filesystem access
+and bounds more database, sidecar, and background work. The major version reflects
+the operator and client actions below; complete the checklist before rollout.
+
+## Before you upgrade — required checklist
+
+- **Set all split-stack secrets explicitly before startup.**
+  `docker-compose.yml` now requires `POSTGRES_PASSWORD`, `SESSION_SECRET`,
+  `SETTINGS_ENCRYPTION_KEY`, and `INTERNAL_API_SECRET`; published defaults are
+  rejected. Generate new application secrets with `openssl rand -base64 32`,
+  keep the same `INTERNAL_API_SECRET` on the backend and sidecars, and do not
+  reuse the retired `soundspan-internal-secret-change-me` value.
+- **Strengthen weak custom secrets before starting 2.0.0.** Encryption and
+  internal-auth secrets must be at least 32 characters. An operator-supplied
+  `JWT_SECRET` must also be at least 32 characters; deployments that omit it
+  continue to use the validated `SESSION_SECRET`.
+- **Reissue API keys older than 90 days and plan recurring rotation.** Keys now
+  expire 90 days after creation or rotation. API-key management, linked-device
+  revocation, and MFA setup or changes require a logged-in interactive session;
+  an `X-API-Key` client can no longer perform those actions.
+- **Reconfigure OpenSubsonic token-auth clients once.** Token authentication
+  (`t` + `s`) no longer derives from a reversibly stored account password. Set a
+  dedicated per-user Subsonic password through
+  `POST /api/auth/subsonic-password`, or switch the client to password auth.
+  Changing an account password clears the dedicated Subsonic secret.
+- **Set an explicit production CORS policy for cross-origin frontends.** An
+  unset `ALLOWED_ORIGINS` now denies cross-origin browser requests in
+  production. Same-origin frontend-proxy deployments need no change; otherwise
+  set the allowed frontend origins. `CORS_ALLOW_ALL=true` is a temporary legacy
+  escape hatch.
+- **Configure the Lidarr webhook secret.** `POST /api/webhooks/lidarr` now
+  returns 401 when no webhook secret is configured. Use
+  `LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true` only as a temporary compatibility
+  escape hatch.
+- **Review remote access to Compose PostgreSQL and Redis.** Their host ports now
+  bind to `127.0.0.1` instead of all interfaces. Same-host tooling is unchanged;
+  remote tooling needs the documented Compose override or, preferably, a
+  private authenticated path.
+- **Repair frontend volume ownership when needed.** The production frontend
+  image now runs as UID/GID 1000. Re-chown existing `.next/cache` or other
+  frontend volumes owned by 1001 to 1000, or recreate them. AIO processes also
+  run as UID/GID 1000 and require writable bind mounts, although standard AIO
+  volume paths are repaired automatically at boot.
+- **Review Helm capacity and accelerator settings.** AIO requests/limits now
+  default to `2Gi`/`8Gi`; ensure the cluster can place it. Analyzer probes are
+  enabled in individual mode. GPU flags now create a real
+  `nvidia.com/gpu` limit, so clusters using them need the NVIDIA device plugin
+  and any required runtime class.
+- **Update scripts for the new authorization gates.** Global enrichment
+  failures, shared-library download operations, Spotify import session logs,
+  Soulseek-backed retries, Lidarr queue clearing, and library-wide or
+  single-item enrichment now require an administrator. Artist discovery and
+  preview plus audiobook cover access require authentication. Refresh tokens
+  are accepted only by the refresh exchange, not as access credentials.
+- **Update custom sidecar clients to the hardened request contracts.** TIDAL
+  admin calls now carry credentials in headers; legacy query credentials remain
+  temporarily supported. YouTube Music video ids and quality values are
+  strictly validated, sidecar and route errors now use the canonical
+  `{ "error": ... }` envelope, and OpenSubsonic cover sizes snap to the supported
+  allowlist instead of honoring arbitrary dimensions.
+- **Verify the music mount before running a library scan.** Scans now remove
+  database tracks that are missing from disk regardless of the “Allow library
+  deletion” setting. A completely empty mount is protected, but a partially
+  mounted or incomplete library can still reconcile missing paths away.
+
+## Security hardening
+
+- Access-token verification is centralized, pins HS256, validates payloads,
+  and rejects refresh tokens outside the refresh exchange. TOTP moved from the
+  unmaintained `speakeasy` package to `otplib` while preserving existing 2FA
+  enrollments.
+- Authorization was tightened across API-key and device management, MFA,
+  enrichment, shared downloads, import logs, artist discovery, audiobook
+  covers, Listen Together group ending, and recovery or retry operations.
+- Client-facing failures now use curated messages across backend routes,
+  segmented streaming, stored download jobs, and TIDAL/YouTube Music sidecars;
+  raw paths, upstream bodies, and exception details remain in server logs.
+- Native streams, share-link streams, downloads, cache files, and analyzer or
+  repair paths enforce media-root containment. Podcast audio, remote images,
+  and Audiobookshelf cover access gained DNS-aware SSRF, redirect, namespace,
+  and input validation.
+- Secret-bearing `.env` writes are atomic and owner-only. YouTube Music OAuth
+  files are also mode `0600`, and chart-managed workloads drop Linux
+  capabilities, use `RuntimeDefault` seccomp, and do not mount service-account
+  tokens.
+- Operators can move integration credentials fully into encrypted settings with
+  `SECRETS_DB_ONLY=true`. Legacy decrypt fail-closed mode remains opt-in and
+  should be enabled only after the secrets-status endpoint reports zero legacy
+  rows.
+
+## Reliability and performance
+
+- Rediscover uses a bounded indexed candidate pool, Subsonic playlist durations
+  use one aggregate query, playlist listings paginate with database-side counts,
+  and browse or list limits are clamped to prevent full-library work.
+- Shared keyed single-flight now coalesces transcode caching, vibe calibration,
+  and TIDAL/YouTube Music credential restores. OAuth logout is fenced against
+  in-flight restore or refresh work so cleared credentials stay cleared.
+- Sidecar network and filesystem work moves off async event loops, gains bounded
+  deadlines and cache sizes, and releases upstream connections on errors or
+  client disconnects. Stream and browse caches are lock-guarded against
+  concurrent mutation.
+- Analyzer batch timeouts preserve completed results, requeue work that never
+  started without consuming retries, and retry genuinely in-flight failures.
+  CLAP workers are supervised, resources close deterministically, and model
+  unload cannot race inference.
+- Import jobs now run durably on the worker queue with recovery and
+  deduplication, while queue cleaning is claimed by workers instead of repeated
+  by every API replica.
+- Background playback, token refresh, polling, and Listen Together recovery
+  received focused fixes so long sessions, hidden tabs, large queues, and
+  cross-replica ready gates recover more predictably.
+
+## Platform and deployment
+
+- The standalone MusiCNN analyzer moves from Ubuntu 20.04/Python 3.8 to
+  Python 3.11 with the same TensorFlow 2.15.1 and Essentia model stack as AIO.
+  The supported Essentia artifact matrix and deterministic inference baseline
+  are documented without changing model behavior.
+- AIO now persists operator-supplied master secrets, secures embedded PostgreSQL
+  on loopback with SCRAM-SHA-256, checks both frontend and backend readiness,
+  and runs application processes under the fixed `soundspan` UID/GID 1000.
+- Analyzer health probes and GPU scheduling are now effective in the Helm chart,
+  while PostgreSQL credentials are safely encoded and application images can be
+  pinned by digest.
+- Base images and build inputs are digest- or hash-pinned, Python quality and
+  sidecar test lanes are part of CI, and the remaining mutable GitHub Actions
+  and scanner image references are pinned.
+
+## Also in this release
+
+- The player seek slider, modal and confirmation flows, queue reordering, track
+  rows, and Vibe map gained stronger keyboard and screen-reader behavior.
+- Playback context and progress subscriptions were split so status-only screens
+  and the audio orchestrator avoid clock-driven rerenders. Visibility-aware
+  polling also stops unnecessary work in hidden tabs.
+- Settings actions use consistent in-app confirmation dialogs, theme colors have
+  accessible contrast and focus guards, and API/client internals were split into
+  smaller domain modules without changing their public surfaces.
+
+## Deployment and distribution
+
+- Docker images: `ghcr.io/soundspan/*:2.0.0`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.0.0
+```
+
+The chart is published only after all eight `2.0.0` image tags are available.
+
+## Known issues and compatibility notes
+
+- The TensorFlow 2.15 dependency line shared by the analyzer and AIO images
+  keeps its documented `pip-audit` exceptions (Keras 2.15.0 and protobuf
+  4.25.9); their removal conditions live in `docs/SECURITY.md`, and new
+  advisory IDs still fail CI.
+- Standard Docker and Helm upgrades preserve existing data and apply Prisma
+  migrations automatically. Custom deployments remain responsible for database
+  backups, migration ordering, and consistent sidecar secrets.
+
+## Full changelog
+
+- Compare changes: [1.9.0...2.0.0](https://github.com/soundspan/soundspan/compare/1.9.0...2.0.0)
+- Full changelog: [CHANGELOG.md](https://github.com/soundspan/soundspan/blob/2.0.0/CHANGELOG.md)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soundspan-frontend",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soundspan-frontend",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "1.9.0",
+    "version": "2.0.0",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages the 2.0.0 release in the established shape (mirrors c748d94, the 1.9.0 staging). **No tag or GitHub release is cut** — this only prepares the tree.

## Why 2.0.0

The accumulated Unreleased section contains breaking, operator-action-required changes, including: required split-stack secrets (`POSTGRES_PASSWORD`, `SESSION_SECRET`, `SETTINGS_ENCRYPTION_KEY`, `INTERNAL_API_SECRET`) with rejected published defaults; 90-day API-key expiry with interactive-session-only key/device/MFA management; OpenSubsonic token-auth reconfiguration; production CORS deny-by-default; Lidarr webhook fail-closed; Compose DB/Redis loopback binding; frontend UID 1001→1000.

## Changes

- `CHANGELOG.md` — `[Unreleased]` content moved verbatim to `[2.0.0] - 2026-08-12`; fresh empty Unreleased skeleton
- `docs/release-notes/RELEASE_NOTES_2.0.0.md` — new consumer-facing notes: required-checklist of every breaking item (each grounded in a specific changelog entry), then themed summaries (security hardening, reliability/performance, platform/deployment), known-issues/compat notes, install snippet
- `backend`/`frontend` `package.json` + lockfiles → 2.0.0 (version fields only)
- `charts/soundspan/Chart.yaml` → `version`/`appVersion` 2.0.0; `values.yaml` → all eight image tags 2.0.0

## Verification

- Prettier clean on CHANGELOG + release notes; lock diffs contain only version fields; `2.0.0 2.0.0` from both package.json files; Unreleased→2.0.0 content diff empty (moved verbatim); no stray app-version `1.9.0` references remain; file set matches the 1.9.0 staging commit exactly (8 files + notes).

After merge, cutting the release (tag + GitHub release → image/chart publish) remains a separate manual step.