### PR TITLE
fix(player): native engine end-of-stream pause no longer freezes queue auto-advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the native audio engine treating the browser's spec-mandated
+  end-of-stream pause as unexpected, which intermittently froze queue
+  auto-advance at track boundaries, especially in hidden tabs; the Howler path
+  is unaffected.
 - Podcast cover-art fetches are size-bounded to prevent resource exhaustion
   (#369).
 - Playlist reorder rejects duplicate-amplified database transactions (#366).

--- a/docs/release-notes/RELEASE_NOTES_2.0.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.0.md
@@ -114,6 +114,9 @@ the operator and client actions below; complete the checklist before rollout.
 - Background playback, token refresh, polling, and Listen Together recovery
   received focused fixes so long sessions, hidden tabs, large queues, and
   cross-replica ready gates recover more predictably.
+- The native audio engine no longer misreads the browser's end-of-track pause
+  as an unexpected stop, fixing queues that intermittently froze between
+  tracks instead of auto-advancing (worst in hidden tabs).
 
 ## Platform and deployment
 

--- a/frontend/lib/audio-engine/nativeAudioElementEngine.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementEngine.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/audio-engine/types";
 import {
     createInitialNativeEngineState,
+    NATIVE_ENGINE_END_PAUSE_EPSILON_SEC,
     transitionNativeEngine,
     type NativeEnginePolicyEffect,
     type NativeEnginePolicyEvent,
@@ -168,6 +169,13 @@ const toFiniteDuration = (value: number): number =>
     typeof value === "number" && Number.isFinite(value) && value > 0
         ? value
         : 0;
+
+const isAtEndOfStream = (element: NativeAudioElementLike): boolean =>
+    element.ended ||
+    (Number.isFinite(element.duration) &&
+        element.duration > 0 &&
+        element.currentTime >=
+            element.duration - NATIVE_ENGINE_END_PAUSE_EPSILON_SEC);
 
 /**
  * AudioEngine implementation backed by a single native `<audio>` element.
@@ -814,7 +822,11 @@ export class NativeAudioElementEngine implements AudioEngine {
             case "playing":
                 return this.dispatch({ type: "ELEMENT_PLAYING", nowMs });
             case "pause":
-                return this.dispatch({ type: "ELEMENT_PAUSED", nowMs });
+                return this.dispatch({
+                    type: "ELEMENT_PAUSED",
+                    atEndOfStream: isAtEndOfStream(element),
+                    nowMs,
+                });
             case "ended":
                 return this.dispatch({ type: "ELEMENT_ENDED", nowMs });
             case "seeked":

--- a/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
@@ -21,12 +21,7 @@
 
 /** Engine lifecycle status. Seeking is tracked via seek-mark fields. */
 export type NativeEngineStatus =
-    | "idle"
-    | "loading"
-    | "playing"
-    | "paused"
-    | "ended"
-    | "error";
+    "idle" | "loading" | "playing" | "paused" | "ended" | "error";
 
 /** Who caused the most recent pause: the user, or the platform/OS. */
 export type NativePauseClassification = "user" | "external" | null;
@@ -36,6 +31,9 @@ export const NATIVE_ENGINE_SEEK_MARK_MS = 300;
 
 /** Positions within this many seconds of the seek target are current. */
 export const NATIVE_ENGINE_SEEK_MARK_TOLERANCE_SEC = 2;
+
+/** Unclassified end-adjacent pauses within this many seconds await `ended`. */
+export const NATIVE_ENGINE_END_PAUSE_EPSILON_SEC = 0.5;
 
 /** Automatic (non-gesture) retry budget per load before exhausting. */
 export const NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES = 3;
@@ -104,7 +102,12 @@ export type NativeEnginePolicyEvent =
     | { type: "STOP_REQUESTED"; nowMs: number }
     | { type: "SEEK_REQUESTED"; timeSec: number; nowMs: number }
     | { type: "ELEMENT_PLAYING"; nowMs: number }
-    | { type: "ELEMENT_PAUSED"; nowMs: number }
+    | {
+          type: "ELEMENT_PAUSED";
+          /** Whether the element was ended or within the end epsilon. */
+          atEndOfStream: boolean;
+          nowMs: number;
+      }
     | { type: "ELEMENT_ENDED"; nowMs: number }
     | { type: "ELEMENT_SEEKED"; timeSec: number; nowMs: number }
     | { type: "ELEMENT_TIME_UPDATE"; timeSec: number; nowMs: number }
@@ -534,6 +537,9 @@ const handleElementPaused = (
     state: State,
     event: Extract<NativeEnginePolicyEvent, { type: "ELEMENT_PAUSED" }>,
 ): Transition => {
+    if (event.atEndOfStream && state.pauseClassification !== "user") {
+        return noChange(state);
+    }
     // Pauses land from "playing" and from the post-metadata startup
     // window (status still "loading" after a quick user pause interrupts
     // the autoplay play() call). Pre-metadata pause noise from source

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -7,13 +7,15 @@ import {
     type NativeEngineScheduler,
 } from "../../lib/audio-engine/nativeAudioElementEngine";
 import { IosStandaloneAudioContextBridge } from "../../lib/audio-engine/iosStandalonePwaBridge";
-import { NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES } from "../../lib/audio-engine/nativeAudioElementPolicy";
+import {
+    NATIVE_ENGINE_END_PAUSE_EPSILON_SEC,
+    NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES,
+} from "../../lib/audio-engine/nativeAudioElementPolicy";
 
 type ElementListener = (event: unknown) => void;
 
 type PlayBehavior =
-    | { kind: "resolve" }
-    | { kind: "reject"; name: string; message: string };
+    { kind: "resolve" } | { kind: "reject"; name: string; message: string };
 
 class FakeAudioElement implements NativeAudioElementLike {
     currentTime = 0;
@@ -534,6 +536,62 @@ test("stale timeupdate positions are suppressed during the seek mark, then flow 
 // ---------------------------------------------------------------------------
 // End detection — native ended only
 // ---------------------------------------------------------------------------
+
+test("end-adjacent pause with the ended flag waits for ended without emitting pause", () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/track.flac", {
+        autoplay: true,
+    });
+    const element = harness.mainElement();
+    element.fireLoadedMetadata(200);
+    harness.events.length = 0;
+
+    element.paused = true;
+    element.ended = true;
+    element.fire("pause");
+    assert.equal(eventTypes(harness).includes("pause"), false);
+
+    element.fire("ended");
+    assert.equal(
+        harness.events.filter((event) => event.type === "end").length,
+        1,
+    );
+});
+
+test("pause within the end-of-stream epsilon does not emit pause", () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/track.flac", {
+        autoplay: true,
+    });
+    const element = harness.mainElement();
+    element.fireLoadedMetadata(200);
+    harness.events.length = 0;
+
+    element.paused = true;
+    element.currentTime = 200 - NATIVE_ENGINE_END_PAUSE_EPSILON_SEC / 2;
+    element.fire("pause");
+
+    assert.equal(eventTypes(harness).includes("pause"), false);
+});
+
+test("pause with an infinite duration still emits pause", () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/live.flac", {
+        autoplay: true,
+    });
+    const element = harness.mainElement();
+    element.fireLoadedMetadata(Number.POSITIVE_INFINITY);
+    harness.events.length = 0;
+
+    element.paused = true;
+    element.currentTime = 3_600;
+    element.fire("pause");
+
+    assert.equal(
+        harness.events.filter((event) => event.type === "pause").length,
+        1,
+    );
+});
 
 test("native ended event emits end exactly once and stops the ticker", () => {
     const harness = createHarness();

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -20,8 +20,7 @@ const findEffect = <K extends NativeEnginePolicyEffect["kind"]>(
     kind: K,
 ): Extract<NativeEnginePolicyEffect, { kind: K }> | undefined =>
     effects.find((effect) => effect.kind === kind) as
-        | Extract<NativeEnginePolicyEffect, { kind: K }>
-        | undefined;
+        Extract<NativeEnginePolicyEffect, { kind: K }> | undefined;
 
 const loadedState = (
     overrides: Partial<NativeEnginePolicyState> = {},
@@ -484,6 +483,7 @@ test("ELEMENT_PLAYING enters playing, starts the ticker, resets retries, and rep
 test("ELEMENT_PAUSED while playing without a user request classifies as external", () => {
     const { state, effects } = transitionNativeEngine(playingState(), {
         type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
         nowMs: 4_000,
     });
     assert.equal(state.status, "paused");
@@ -493,6 +493,66 @@ test("ELEMENT_PAUSED while playing without a user request classifies as external
     assert.ok(kinds(effects).includes("emitPause"));
 });
 
+test("ELEMENT_PAUSED at end of stream is suppressed until ELEMENT_ENDED emits end", () => {
+    const playing = playingState();
+    const paused = transitionNativeEngine(playing, {
+        type: "ELEMENT_PAUSED",
+        atEndOfStream: true,
+        nowMs: 4_000,
+    });
+    assert.equal(paused.state.status, "playing");
+    assert.equal(kinds(paused.effects).includes("emitPause"), false);
+
+    const ended = transitionNativeEngine(paused.state, {
+        type: "ELEMENT_ENDED",
+        nowMs: 4_001,
+    });
+    assert.equal(ended.state.status, "ended");
+    assert.equal(
+        ended.effects.filter((effect) => effect.kind === "emitEnd").length,
+        1,
+    );
+});
+
+test("ELEMENT_PAUSED at end of stream after a user pause emits pause", () => {
+    const { state: pauseRequested } = transitionNativeEngine(playingState(), {
+        type: "PAUSE_REQUESTED",
+        nowMs: 3_900,
+    });
+    const { state, effects } = transitionNativeEngine(pauseRequested, {
+        type: "ELEMENT_PAUSED",
+        atEndOfStream: true,
+        nowMs: 4_000,
+    });
+    assert.equal(state.status, "paused");
+    assert.ok(kinds(effects).includes("emitPause"));
+});
+
+test("ELEMENT_PAUSED mid-track still emits pause exactly once", () => {
+    const { state, effects } = transitionNativeEngine(playingState(), {
+        type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
+        nowMs: 4_000,
+    });
+    assert.equal(state.status, "paused");
+    assert.equal(
+        effects.filter((effect) => effect.kind === "emitPause").length,
+        1,
+    );
+});
+
+test("ELEMENT_PAUSED with an unknown-duration boundary result still emits pause", () => {
+    const { effects } = transitionNativeEngine(playingState(), {
+        type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
+        nowMs: 4_000,
+    });
+    assert.equal(
+        effects.filter((effect) => effect.kind === "emitPause").length,
+        1,
+    );
+});
+
 test("ELEMENT_PAUSED after a user pause request keeps the user classification", () => {
     const { state: pauseRequested } = transitionNativeEngine(playingState(), {
         type: "PAUSE_REQUESTED",
@@ -500,6 +560,7 @@ test("ELEMENT_PAUSED after a user pause request keeps the user classification", 
     });
     const { state } = transitionNativeEngine(pauseRequested, {
         type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
         nowMs: 4_000,
     });
     assert.equal(state.pauseClassification, "user");
@@ -529,6 +590,7 @@ test("quick pause during autoplay startup (post-metadata window) reaches paused 
     // …the native pause event must land in paused, not stay stuck loading.
     const { state, effects } = transitionNativeEngine(pauseRequested, {
         type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
         nowMs: 1_070,
     });
     assert.equal(state.status, "paused");
@@ -540,6 +602,7 @@ test("ELEMENT_PAUSED after ended is ignored", () => {
     const ended = playingState({ status: "ended" });
     const { effects } = transitionNativeEngine(ended, {
         type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
         nowMs: 4_000,
     });
     assert.deepEqual(effects, []);
@@ -879,6 +942,7 @@ test("stale source after a long pause reloads from source at the current positio
     const paused = playingState();
     const { state: afterPause } = transitionNativeEngine(paused, {
         type: "ELEMENT_PAUSED",
+        atEndOfStream: false,
         nowMs: longPausedAt,
     });
     const resumeAt = longPausedAt + NATIVE_ENGINE_STALE_SOURCE_PAUSE_MS + 1;


### PR DESCRIPTION
## Problem

Queues intermittently stop after each track on the native audio engine (`STREAMING_ENGINE_MODE=native`), requiring a manual play; tab-return sometimes recovers it. Confirmed in production telemetry: every natural track end logs `player.unexpected_pause` with `reason: 'pause_near_track_end'`, followed by a raced or lost auto-advance.

## Root cause

Per the WHATWG spec, a media element reaching end-of-resource fires `pause` **then** `ended`. Howler swallows the end-adjacent pause; the native engine forwarded it as a real external pause. The orchestrator then classified it `pause_near_track_end`, transitioned to READY, and called `setIsPlaying(false)` — re-running the listener-binding effect (`isPlaying` is in its deps) and detaching/reattaching all engine listeners at the exact moment `end` arrived. The advance was intermittently lost or rejected by `handleEnd` guards (console-only warnings), freezing the queue. Timing-dependent, worse under hidden-tab throttling — which is why prior guard-level fixes never fully resolved it.

## Fix (native engine only)

- Engine computes `atEndOfStream` at the element boundary: `element.ended`, or `currentTime` within `NATIVE_ENGINE_END_PAUSE_EPSILON_SEC` (0.5s) of a finite duration.
- Policy suppresses the pause emission for **unclassified** end-adjacent pauses (`atEndOfStream && pauseClassification !== "user"`), deferring to the `ended` event that follows.
- User-classified pauses still emit inside the epsilon window, so a manual pause in the final half-second cannot wedge the state machine (PAUSE_REQUESTED relies on the element echo to reach "paused").
- Unknown/Infinity durations fail open to current behavior. Howler path untouched.

## Tests

6 new policy/engine tests: end-of-stream suppression until `ended` emits `end`; user pause inside the epsilon still emits pause; mid-track pause regression guard; unknown/Infinity-duration fail-open; engine-boundary `atEndOfStream` computation. 128/128 targeted tests pass (policy, engine, hybrid integration, howler end-synthesis); frontend `tsc --noEmit` 0 errors; prettier clean.

## Release placement

Changelog entry recorded under **[2.0.0] ### Fixed** (release is staged, not cut) with a matching line in `RELEASE_NOTES_2.0.0.md`.