### PR TITLE
chore(format): fix Enforcement Gates formatting on native-engine files

### DIFF
--- a/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
@@ -21,7 +21,12 @@
 
 /** Engine lifecycle status. Seeking is tracked via seek-mark fields. */
 export type NativeEngineStatus =
-    "idle" | "loading" | "playing" | "paused" | "ended" | "error";
+    | "idle"
+    | "loading"
+    | "playing"
+    | "paused"
+    | "ended"
+    | "error";
 
 /** Who caused the most recent pause: the user, or the platform/OS. */
 export type NativePauseClassification = "user" | "external" | null;

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -15,7 +15,8 @@ import {
 type ElementListener = (event: unknown) => void;
 
 type PlayBehavior =
-    { kind: "resolve" } | { kind: "reject"; name: string; message: string };
+    | { kind: "resolve" }
+    | { kind: "reject"; name: string; message: string };
 
 class FakeAudioElement implements NativeAudioElementLike {
     currentTime = 0;

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -20,7 +20,8 @@ const findEffect = <K extends NativeEnginePolicyEffect["kind"]>(
     kind: K,
 ): Extract<NativeEnginePolicyEffect, { kind: K }> | undefined =>
     effects.find((effect) => effect.kind === kind) as
-        Extract<NativeEnginePolicyEffect, { kind: K }> | undefined;
+        | Extract<NativeEnginePolicyEffect, { kind: K }>
+        | undefined;
 
 const loadedState = (
     overrides: Partial<NativeEnginePolicyState> = {},


### PR DESCRIPTION
Repairs the `Check repository formatting` failure introduced by #410: the fix branch's worktree lacked `frontend/node_modules/.bin/prettier`, so `npx prettier` silently resolved a different version whose union-type style diverges from the pinned 3.8.2. Reformatted the three files with `npx prettier@3.8.2 --write`; formatting-only, 116/116 targeted tests pass.

Process note for the backlog: worktree verify steps must use the package's pinned prettier binary (or fail loudly when it's absent) — `npx` fallback masks version skew.