### PR TITLE
fix(covers): serve cover art and streaming assets via root-pinned sendFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cover art (browse thumbnails, native library covers, podcast/audiobook covers)
+  and segmented-streaming files no longer return 404 when the configured cache
+  path contains a dot-segment directory such as `/music/.soundspan`.
 - Fixed the native audio engine treating the browser's spec-mandated
   end-of-stream pause as unexpected, which intermittently froze queue
   auto-advance at track boundaries, especially in hidden tabs; the Howler path

--- a/backend/src/__tests__/audiobooksCoverAuthz.test.ts
+++ b/backend/src/__tests__/audiobooksCoverAuthz.test.ts
@@ -206,7 +206,12 @@ describe("audiobook cover authorization and path containment", () => {
 
     it("serves a valid cover from the database path", async () => {
         const coverBytes = Buffer.from("database-cover-bytes");
-        const localCoverPath = path.join(mockTempRoot, "db-cover.jpg");
+        const localCoverPath = path.join(
+            mockMusicPath,
+            "cover-cache",
+            "audiobooks",
+            "db-cover.jpg",
+        );
         writeCover(localCoverPath, coverBytes);
         mockPrisma.audiobook.findUnique.mockResolvedValue({
             localCoverPath,

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -101,6 +101,7 @@ function createRes() {
         body: undefined as unknown,
         headers: {} as Record<string, string>,
         sentFilePath: undefined as string | undefined,
+        sentFileOptions: undefined as unknown,
         status: jest.fn(function (code: number) {
             res.statusCode = code;
             return res;
@@ -115,8 +116,9 @@ function createRes() {
             res.headersSent = true;
             return res;
         }),
-        sendFile: jest.fn(function (filePath: string) {
+        sendFile: jest.fn(function (filePath: string, options: unknown) {
             res.sentFilePath = filePath;
+            res.sentFileOptions = options;
             res.headersSent = true;
             return res;
         }),
@@ -292,14 +294,14 @@ describe("audiobooks advanced runtime", () => {
     it("serves local cover paths and fallback disk covers", async () => {
         prisma.audiobook.findUnique
             .mockResolvedValueOnce({
-                localCoverPath: "/cache/book-1.jpg",
+                localCoverPath: "/music/cover-cache/audiobooks/book-1.jpg",
                 coverUrl: null,
             })
             .mockResolvedValueOnce({ localCoverPath: null, coverUrl: null });
 
         fsExistsSync.mockImplementation(
             (targetPath: string) =>
-                targetPath === "/cache/book-1.jpg" ||
+                targetPath === "/music/cover-cache/audiobooks/book-1.jpg" ||
                 targetPath === "/music/cover-cache/audiobooks/book-2.jpg",
         );
 
@@ -312,7 +314,11 @@ describe("audiobooks advanced runtime", () => {
             localRes,
         );
         expect(localRes.statusCode).toBe(200);
-        expect(localRes.sentFilePath).toBe("/cache/book-1.jpg");
+        expect(localRes.sentFilePath).toBe("book-1.jpg");
+        expect(localRes.sentFileOptions).toEqual({
+            dotfiles: "ignore",
+            root: "/music/cover-cache/audiobooks",
+        });
         expect(localRes.headers["Cache-Control"]).toBe(
             "public, max-age=31536000, immutable",
         );
@@ -329,9 +335,7 @@ describe("audiobooks advanced runtime", () => {
                 localCoverPath: "/music/cover-cache/audiobooks/book-2.jpg",
             },
         });
-        expect(fallbackRes.sentFilePath).toBe(
-            "/music/cover-cache/audiobooks/book-2.jpg",
-        );
+        expect(fallbackRes.sentFilePath).toBe("book-2.jpg");
     });
 
     it("proxies cover from audiobookshelf and handles proxy miss/error", async () => {

--- a/backend/src/routes/__tests__/browseBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/browseBranchCoverage.test.ts
@@ -83,6 +83,7 @@ const browseImageCacheKey = jest.fn((url: string) => `cache:${url}`);
 const getBrowseImageFromCache = jest.fn();
 const fetchAndCacheBrowseImage = jest.fn();
 jest.mock("../../services/browseImageCache", () => ({
+    getBrowseImageCacheRoot: () => "/tmp",
     browseImageCacheKey,
     getBrowseImageFromCache,
     fetchAndCacheBrowseImage,

--- a/backend/src/routes/__tests__/browseRuntime.test.ts
+++ b/backend/src/routes/__tests__/browseRuntime.test.ts
@@ -42,6 +42,7 @@ jest.mock("../../services/tidalStreaming", () => ({
 }));
 
 jest.mock("../../services/browseImageCache", () => ({
+    getBrowseImageCacheRoot: () => "/tmp",
     browseImageCacheKey: jest.fn(() => "browse-image-cache-key"),
     getBrowseImageFromCache: jest.fn(() => null),
     fetchAndCacheBrowseImage: jest.fn(async () => null),

--- a/backend/src/routes/__tests__/browseTidal.test.ts
+++ b/backend/src/routes/__tests__/browseTidal.test.ts
@@ -72,6 +72,7 @@ jest.mock("../../services/tidalStreaming", () => ({
 
 // ── Browse image cache — stub to avoid disk I/O ─────────────────
 jest.mock("../../services/browseImageCache", () => ({
+    getBrowseImageCacheRoot: () => os.tmpdir(),
     browseImageCacheKey: jest.fn((url: string) => `hash:${url}`),
     getBrowseImageFromCache: jest.fn(),
     fetchAndCacheBrowseImage: jest.fn(),

--- a/backend/src/routes/__tests__/browseUrlParse.test.ts
+++ b/backend/src/routes/__tests__/browseUrlParse.test.ts
@@ -34,6 +34,7 @@ jest.mock("../../config", () => ({
 }));
 
 jest.mock("../../services/browseImageCache", () => ({
+    getBrowseImageCacheRoot: () => "/tmp",
     cacheExternalImage: jest.fn(),
     getOrCacheImage: jest.fn(),
 }));

--- a/backend/src/routes/__tests__/browseYtMusicRoutes.integration.test.ts
+++ b/backend/src/routes/__tests__/browseYtMusicRoutes.integration.test.ts
@@ -60,6 +60,7 @@ jest.mock("../../services/tidalStreaming", () => ({
 }));
 
 jest.mock("../../services/browseImageCache", () => ({
+    getBrowseImageCacheRoot: () => "/tmp",
     browseImageCacheKey: jest.fn(() => "browse-image-cache-key"),
     getBrowseImageFromCache: jest.fn(() => null),
     fetchAndCacheBrowseImage: jest.fn(async () => null),

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -1276,8 +1276,10 @@ describe("library cover-art proxy compatibility", () => {
             const queryRes = createRes();
             await coverArtHandler(queryReq, queryRes);
             expect(queryRes.sendFile).toHaveBeenCalledWith(
-                "/tmp/covers/albums/native-query.jpg",
+                "albums/native-query.jpg",
                 expect.objectContaining({
+                    dotfiles: "ignore",
+                    root: "/tmp/covers",
                     headers: expect.objectContaining({
                         "Access-Control-Allow-Origin":
                             "https://frontend.example",
@@ -1294,8 +1296,10 @@ describe("library cover-art proxy compatibility", () => {
             const idRes = createRes();
             await coverArtHandler(idReq, idRes);
             expect(idRes.sendFile).toHaveBeenCalledWith(
-                "/tmp/covers/albums/native-id.jpg",
+                "albums/native-id.jpg",
                 expect.objectContaining({
+                    dotfiles: "ignore",
+                    root: "/tmp/covers",
                     headers: expect.objectContaining({
                         "Access-Control-Allow-Origin": "*",
                     }),
@@ -1340,8 +1344,10 @@ describe("library cover-art proxy compatibility", () => {
             const allowedRes = createRes();
             await coverArtHandler(allowedReq, allowedRes);
             expect(allowedRes.sendFile).toHaveBeenCalledWith(
-                "/tmp/covers/albums/native-query.jpg",
+                "albums/native-query.jpg",
                 expect.objectContaining({
+                    dotfiles: "ignore",
+                    root: "/tmp/covers",
                     headers: expect.objectContaining({
                         "Access-Control-Allow-Origin":
                             "https://allowed.example",
@@ -1373,8 +1379,8 @@ describe("library cover-art proxy compatibility", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(queryRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/legacy-query.jpg",
-            expect.any(Object),
+            "albums/legacy-query.jpg",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "legacy-query" },
@@ -1391,8 +1397,8 @@ describe("library cover-art proxy compatibility", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(idRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/legacy-id.jpg",
-            expect.any(Object),
+            "albums/legacy-id.jpg",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "legacy-id" },
@@ -1429,12 +1435,12 @@ describe("library cover-art proxy compatibility", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(queryRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/legacy-fail-query.jpg",
-            expect.any(Object),
+            "albums/legacy-fail-query.jpg",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         expect(idRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/legacy-fail-id.jpg",
-            expect.any(Object),
+            "albums/legacy-fail-id.jpg",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         existsSpy.mockRestore();
     });
@@ -1470,12 +1476,12 @@ describe("library cover-art proxy compatibility", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(queryRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/nested",
-            expect.any(Object),
+            "albums/nested",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         expect(idRes.sendFile).toHaveBeenCalledWith(
-            "/tmp/covers/albums/nested",
-            expect.any(Object),
+            "albums/nested",
+            expect.objectContaining({ root: "/tmp/covers" }),
         );
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "nested" },

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -5109,8 +5109,10 @@ describe("library catalog list runtime coverage", () => {
 
             expect(presentRes.statusCode).toBe(200);
             expect(presentRes.body).toEqual({
-                filePath: "/tmp/covers/cover-present.jpg",
+                filePath: "cover-present.jpg",
                 options: {
+                    dotfiles: "ignore",
+                    root: "/tmp/covers",
                     headers: {
                         "Content-Type": "image/jpeg",
                         "Cache-Control": "public, max-age=7776000, immutable",

--- a/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/podcastsBranchCoverage.test.ts
@@ -112,6 +112,7 @@ jest.mock("../../services/podcastCache", () => ({
     podcastCacheService: {
         syncAllCovers: jest.fn(async () => ({ synced: 0 })),
         syncEpisodeCovers: jest.fn(async () => ({ synced: 0 })),
+        getCoverCacheRoot: () => "/cache",
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsCoreRuntime.test.ts
@@ -83,6 +83,7 @@ jest.mock("../../services/rssParser", () => ({
 const podcastCacheService = {
     syncAllCovers: jest.fn(async () => ({ synced: 0 })),
     syncEpisodeCovers: jest.fn(async () => ({ synced: 0 })),
+    getCoverCacheRoot: () => "/cache",
 };
 jest.mock("../../services/podcastCache", () => ({
     podcastCacheService,

--- a/backend/src/routes/__tests__/podcastsDiscoverTopCompat.test.ts
+++ b/backend/src/routes/__tests__/podcastsDiscoverTopCompat.test.ts
@@ -44,6 +44,7 @@ jest.mock("../../services/podcastCache", () => ({
     podcastCacheService: {
         syncAllCovers: jest.fn(async () => ({ synced: 0 })),
         syncEpisodeCovers: jest.fn(async () => ({ synced: 0 })),
+        getCoverCacheRoot: () => "/cache",
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsDiscoveryRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsDiscoveryRuntime.test.ts
@@ -58,6 +58,7 @@ jest.mock("../../services/podcastCache", () => ({
     podcastCacheService: {
         syncAllCovers: jest.fn(async () => ({ synced: 0 })),
         syncEpisodeCovers: jest.fn(async () => ({ synced: 0 })),
+        getCoverCacheRoot: () => "/cache",
     },
 }));
 

--- a/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/podcastsStreamingRuntime.test.ts
@@ -91,6 +91,7 @@ jest.mock("../../services/podcastCache", () => ({
     podcastCacheService: {
         syncAllCovers: jest.fn(async () => ({ synced: 0 })),
         syncEpisodeCovers: jest.fn(async () => ({ synced: 0 })),
+        getCoverCacheRoot: () => "/cache",
     },
 }));
 
@@ -246,8 +247,9 @@ function createRes() {
             }
             return res;
         }),
-        sendFile: jest.fn(function (filePath: string) {
+        sendFile: jest.fn(function (filePath: string, options: unknown) {
             res.sentFile = filePath;
+            res.sentFileOptions = options;
             res.headersSent = true;
             return res;
         }),
@@ -1493,7 +1495,11 @@ describe("podcasts streaming/runtime behavior", () => {
 
         const localRes = createRes();
         await coverHandler(req, localRes);
-        expect(localRes.sentFile).toBe("/cache/podcast-cover.jpg");
+        expect(localRes.sentFile).toBe("podcast-cover.jpg");
+        expect(localRes.sentFileOptions).toEqual({
+            dotfiles: "ignore",
+            root: "/cache",
+        });
 
         const redirectRes = createRes();
         await coverHandler(req, redirectRes);
@@ -1513,7 +1519,7 @@ describe("podcasts streaming/runtime behavior", () => {
 
         const epLocalRes = createRes();
         await episodeCoverHandler(req, epLocalRes);
-        expect(epLocalRes.sentFile).toBe("/cache/episode-cover.jpg");
+        expect(epLocalRes.sentFile).toBe("episode-cover.jpg");
 
         const epMissingRes = createRes();
         await episodeCoverHandler(req, epMissingRes);

--- a/backend/src/routes/__tests__/streamingRuntime.test.ts
+++ b/backend/src/routes/__tests__/streamingRuntime.test.ts
@@ -112,9 +112,10 @@ function createResponse() {
         }),
         sendFile: jest.fn(function (
             filePath: string,
+            options: unknown,
             callback?: (error?: NodeJS.ErrnoException) => void,
         ) {
-            res.body = { filePath };
+            res.body = { filePath, options };
             callback?.();
             return res;
         }),
@@ -368,7 +369,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -401,7 +402,11 @@ describe("streaming route runtime", () => {
         );
         expect(mockWaitForManifestReady).toHaveBeenCalledWith(session);
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/manifest.mpd",
+            "manifest.mpd",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
         const metricCall = findSegmentedMetricLogCall(
@@ -424,7 +429,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -497,7 +502,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -526,7 +531,11 @@ describe("streaming route runtime", () => {
         );
         expect(mockWaitForManifestReady).toHaveBeenCalledWith(session);
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/manifest.mpd",
+            "manifest.mpd",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
     });
@@ -539,7 +548,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -555,6 +564,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 const error = Object.assign(new Error("manifest missing"), {
@@ -598,7 +608,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -647,7 +657,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -843,7 +853,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -877,7 +887,11 @@ describe("streaming route runtime", () => {
             "chunk-0-00001.m4s",
         );
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/assets/chunk-0-00001.m4s",
+            "chunk-0-00001.m4s",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
         const metricCall = findSegmentedMetricLogCall(
@@ -900,7 +914,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -935,7 +949,11 @@ describe("streaming route runtime", () => {
         );
         expect(res.type).toHaveBeenCalledWith("video/iso.segment");
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/assets/chunk-1-00001.m4s",
+            "chunk-1-00001.m4s",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
     });
@@ -948,7 +966,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -967,6 +985,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 const error = Object.assign(new Error("segment missing"), {
@@ -1008,7 +1027,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1027,6 +1046,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 res.headersSent = true;
@@ -1085,6 +1105,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 res.headersSent = true;
@@ -1113,7 +1134,7 @@ describe("streaming route runtime", () => {
             trackId: "track-1",
             quality: "medium",
             sourceType: "local",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1161,7 +1182,7 @@ describe("streaming route runtime", () => {
             trackId: "track-1",
             quality: "medium",
             sourceType: "local",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1211,7 +1232,7 @@ describe("streaming route runtime", () => {
             trackId: "track-1",
             quality: "medium",
             sourceType: "local",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1261,7 +1282,7 @@ describe("streaming route runtime", () => {
             trackId: "track-1",
             quality: "medium",
             sourceType: "local",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1307,7 +1328,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1343,7 +1364,11 @@ describe("streaming route runtime", () => {
             "chunk-0-00002.m4s",
         );
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/assets/chunk-0-00002.m4s",
+            "chunk-0-00002.m4s",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
         expect(res.type).toHaveBeenCalledWith("video/iso.segment");
@@ -1357,7 +1382,7 @@ describe("streaming route runtime", () => {
             quality: "original",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1394,7 +1419,11 @@ describe("streaming route runtime", () => {
         );
         expect(res.type).toHaveBeenCalledWith("video/webm");
         expect(res.sendFile).toHaveBeenCalledWith(
-            "/tmp/assets/chunk-0-00002.webm",
+            "chunk-0-00002.webm",
+            {
+                dotfiles: "ignore",
+                root: "/tmp/assets",
+            },
             expect.any(Function),
         );
     });
@@ -1407,7 +1436,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1577,7 +1606,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1592,6 +1621,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 const error = Object.assign(new Error("manifest fs failure"), {
@@ -1625,7 +1655,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1640,6 +1670,7 @@ describe("streaming route runtime", () => {
         res.sendFile.mockImplementationOnce(
             (
                 _filePath: string,
+                _options: unknown,
                 callback?: (error?: NodeJS.ErrnoException) => void,
             ) => {
                 callback?.(
@@ -1677,7 +1708,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1737,7 +1768,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",
@@ -1861,7 +1892,7 @@ describe("streaming route runtime", () => {
             quality: "medium",
             sourceType: "local",
             cacheKey: "cache-1",
-            manifestPath: "/tmp/manifest.mpd",
+            manifestPath: "/tmp/assets/manifest.mpd",
             assetDir: "/tmp/assets",
             createdAt: "2099-01-01T00:00:00.000Z",
             expiresAt: "2099-01-01T00:05:00.000Z",

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -12,6 +12,7 @@ import {
     readResponseBodyWithByteCap,
 } from "../services/imageProxy";
 import { sendRouteError } from "./routeErrorResponse";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = Router();
 
@@ -624,15 +625,15 @@ router.get<{ id: string }>(
                 select: { localCoverPath: true, coverUrl: true },
             });
 
+            const coverDir = path.join(
+                config.music.musicPath,
+                "cover-cache",
+                "audiobooks",
+            );
             let coverPath = audiobook?.localCoverPath;
 
             // Fallback: check if cover exists on disk even if DB path is empty
             if (!coverPath) {
-                const coverDir = path.join(
-                    config.music.musicPath,
-                    "cover-cache",
-                    "audiobooks",
-                );
                 const fallbackPath = safeResolvePath(coverDir, `${id}.jpg`);
                 if (fallbackPath && fs.existsSync(fallbackPath)) {
                     coverPath = fallbackPath;
@@ -655,7 +656,7 @@ router.get<{ id: string }>(
                     "public, max-age=31536000, immutable",
                 );
                 res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
-                return res.sendFile(coverPath);
+                return sendFileFromRoot(res, coverPath, coverDir);
             }
 
             // Fallback: proxy from Audiobookshelf if coverUrl is available

--- a/backend/src/routes/browse.ts
+++ b/backend/src/routes/browse.ts
@@ -12,7 +12,9 @@ import {
     browseImageCacheKey,
     getBrowseImageFromCache,
     fetchAndCacheBrowseImage,
+    getBrowseImageCacheRoot,
 } from "../services/browseImageCache";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = Router();
 
@@ -192,7 +194,11 @@ router.get(
         if (cached) {
             res.set("Content-Type", cached.contentType);
             res.set("Cache-Control", "public, max-age=604800, immutable");
-            return res.sendFile(cached.filePath);
+            return sendFileFromRoot(
+                res,
+                cached.filePath,
+                getBrowseImageCacheRoot(),
+            );
         }
 
         // Fetch, cache, and serve
@@ -203,7 +209,7 @@ router.get(
 
         res.set("Content-Type", entry.contentType);
         res.set("Cache-Control", "public, max-age=604800, immutable");
-        return res.sendFile(entry.filePath);
+        return sendFileFromRoot(res, entry.filePath, getBrowseImageCacheRoot());
     },
 );
 
@@ -1113,7 +1119,11 @@ router.get(
         if (cached) {
             res.set("Content-Type", cached.contentType);
             res.set("Cache-Control", "public, max-age=604800, immutable");
-            return res.sendFile(cached.filePath);
+            return sendFileFromRoot(
+                res,
+                cached.filePath,
+                getBrowseImageCacheRoot(),
+            );
         }
 
         // Fetch, cache, and serve
@@ -1124,7 +1134,7 @@ router.get(
 
         res.set("Content-Type", entry.contentType);
         res.set("Cache-Control", "public, max-age=604800, immutable");
-        return res.sendFile(entry.filePath);
+        return sendFileFromRoot(res, entry.filePath, getBrowseImageCacheRoot());
     },
 );
 

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -108,7 +108,9 @@ import {
     persistHealedAlbumCover,
     resolveNativeCoverCacheHit,
     tryHealMissingNativeAlbumCover,
+    coversBaseDir,
 } from "../services/nativeCoverHealing";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = Router();
 
@@ -3874,9 +3876,12 @@ router.get<{ id?: string }>(
                     ...buildCoverArtCorsHeaders(req.headers.origin),
                 };
 
-                return res.sendFile(nativeCacheHit.cachePath, {
-                    headers,
-                });
+                return sendFileFromRoot(
+                    res,
+                    nativeCacheHit.cachePath,
+                    coversBaseDir(),
+                    { headers },
+                );
             }
 
             coverUrl = decodedUrl;
@@ -3937,9 +3942,12 @@ router.get<{ id?: string }>(
                         ...buildCoverArtCorsHeaders(req.headers.origin),
                     };
 
-                    return res.sendFile(nativeCacheHit.cachePath, {
-                        headers,
-                    });
+                    return sendFileFromRoot(
+                        res,
+                        nativeCacheHit.cachePath,
+                        coversBaseDir(),
+                        { headers },
+                    );
                 }
 
                 // Native cover file missing - try to find album and fetch from Deezer

--- a/backend/src/routes/podcasts.ts
+++ b/backend/src/routes/podcasts.ts
@@ -18,6 +18,7 @@ import axios from "axios";
 import fs from "fs";
 import pLimit from "p-limit";
 import { sendRouteError } from "./routeErrorResponse";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = Router();
 const ITUNES_DISCOVER_TIMEOUT_MS = 10000;
@@ -2162,7 +2163,11 @@ router.get("/:id/cover", async (req, res) => {
                 "public, max-age=31536000, immutable",
             );
             res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
-            return res.sendFile(podcast.localCoverPath);
+            return sendFileFromRoot(
+                res,
+                podcast.localCoverPath,
+                podcastCacheService.getCoverCacheRoot(),
+            );
         }
 
         // Fallback: redirect to original URL
@@ -2255,7 +2260,11 @@ router.get("/episodes/:episodeId/cover", async (req, res) => {
                 "public, max-age=31536000, immutable",
             );
             res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
-            return res.sendFile(episode.localCoverPath);
+            return sendFileFromRoot(
+                res,
+                episode.localCoverPath,
+                podcastCacheService.getCoverCacheRoot(),
+            );
         }
 
         // Fallback: redirect to original URL

--- a/backend/src/routes/shareLinks.ts
+++ b/backend/src/routes/shareLinks.ts
@@ -13,6 +13,7 @@ import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = Router();
 const zipLogger = logger.child("ShareLinks.ZipArchive");
@@ -360,10 +361,7 @@ function resolveNativeCoverPath(nativePath: string): string | null {
     if (trimmed.length > 0 && !trimmed.startsWith("albums/")) {
         candidates.push(`albums/${trimmed}`);
     }
-    const coversDir = path.resolve(
-        config.music.transcodeCachePath,
-        "../covers",
-    );
+    const coversDir = resolveNativeCoversDir();
     for (const candidate of candidates) {
         const resolved = safeResolvePath(coversDir, candidate);
         if (resolved && fs.existsSync(resolved)) {
@@ -371,6 +369,10 @@ function resolveNativeCoverPath(nativePath: string): string | null {
         }
     }
     return null;
+}
+
+function resolveNativeCoversDir(): string {
+    return path.resolve(config.music.transcodeCachePath, "../covers");
 }
 
 async function resolveTrackOwnership(
@@ -1047,7 +1049,7 @@ router.get("/access/:token/cover", async (req, res) => {
             }
             res.setHeader("Content-Type", "image/jpeg");
             res.setHeader("Cache-Control", "public, max-age=3600");
-            return res.sendFile(filePath);
+            return sendFileFromRoot(res, filePath, resolveNativeCoversDir());
         }
 
         const result = await fetchExternalImage({ url });

--- a/backend/src/routes/streaming.ts
+++ b/backend/src/routes/streaming.ts
@@ -14,6 +14,7 @@ import {
     buildSegmentedRouteTraceErrorFields,
     logSegmentedStreamingTrace,
 } from "../services/segmented-streaming/trace";
+import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 
 const router = express.Router();
 
@@ -683,7 +684,7 @@ const handleSegmentFetch = async (
                 ? "video/webm"
                 : "video/iso.segment",
         );
-        res.sendFile(segmentPath, (error) => {
+        sendFileFromRoot(res, segmentPath, session.assetDir, {}, (error) => {
             if (error) {
                 handleSegmentedSendFileError({
                     req,
@@ -1005,44 +1006,50 @@ router.get(
                 "private, no-cache, must-revalidate",
             );
             res.type("application/dash+xml");
-            res.sendFile(session.manifestPath, (error) => {
-                if (error) {
-                    handleSegmentedSendFileError({
-                        req,
-                        res,
-                        error,
-                        stage: "manifest",
-                        metricEvent: "manifest.fetch",
-                        startedAtMs,
-                        sessionId: session.sessionId,
-                        sourceType: session.sourceType,
-                        startupCorrelationFields,
-                        responseProfile: {
-                            notFoundError: "Manifest not found",
-                            notFoundReason: "manifest_not_found",
-                            loadFailedError: "Failed to load manifest",
-                            loadFailedReason: "manifest_load_failed",
-                        },
-                    });
-                    return;
-                }
+            sendFileFromRoot(
+                res,
+                session.manifestPath,
+                session.assetDir,
+                {},
+                (error) => {
+                    if (error) {
+                        handleSegmentedSendFileError({
+                            req,
+                            res,
+                            error,
+                            stage: "manifest",
+                            metricEvent: "manifest.fetch",
+                            startedAtMs,
+                            sessionId: session.sessionId,
+                            sourceType: session.sourceType,
+                            startupCorrelationFields,
+                            responseProfile: {
+                                notFoundError: "Manifest not found",
+                                notFoundReason: "manifest_not_found",
+                                loadFailedError: "Failed to load manifest",
+                                loadFailedReason: "manifest_load_failed",
+                            },
+                        });
+                        return;
+                    }
 
-                logSegmentedStreamingMetric("manifest.fetch", {
-                    status: "success",
-                    sessionId: session.sessionId,
-                    sourceType: session.sourceType,
-                    ...startupCorrelationFields,
-                    latencyMs: segmentedMetricDurationMs(startedAtMs),
-                });
-                logSegmentedStreamingTrace(
-                    "route.manifest.success",
-                    buildSegmentedRouteTraceFields(req, startedAtMs, {
+                    logSegmentedStreamingMetric("manifest.fetch", {
+                        status: "success",
                         sessionId: session.sessionId,
                         sourceType: session.sourceType,
                         ...startupCorrelationFields,
-                    }),
-                );
-            });
+                        latencyMs: segmentedMetricDurationMs(startedAtMs),
+                    });
+                    logSegmentedStreamingTrace(
+                        "route.manifest.success",
+                        buildSegmentedRouteTraceFields(req, startedAtMs, {
+                            sessionId: session.sessionId,
+                            sourceType: session.sourceType,
+                            ...startupCorrelationFields,
+                        }),
+                    );
+                },
+            );
             return res;
         } catch (error) {
             const errorFields = getSegmentedMetricErrorFields(error);

--- a/backend/src/services/browseImageCache.ts
+++ b/backend/src/services/browseImageCache.ts
@@ -32,14 +32,16 @@ interface DiskCacheEntry {
 }
 
 /**
- * Resolves the browse image cache directory path, creating it lazily on first call.
+ * Returns the canonical root used for server-managed browse images.
  */
+export function getBrowseImageCacheRoot(): string {
+    return path.resolve(config.music.transcodeCachePath, "../covers/browse");
+}
+
+/** Resolves the browse image cache root, creating it lazily on first call. */
 function ensureCacheDir(): Promise<string> {
     if (cacheDirPromise) return cacheDirPromise;
-    const cacheDir = path.join(
-        config.music.transcodeCachePath,
-        "../covers/browse",
-    );
+    const cacheDir = getBrowseImageCacheRoot();
     cacheDirPromise = fs
         .mkdir(cacheDir, { recursive: true })
         .then(() => cacheDir);

--- a/backend/src/services/podcastCache.ts
+++ b/backend/src/services/podcastCache.ts
@@ -86,6 +86,11 @@ export class PodcastCacheService {
         );
     }
 
+    /** Returns the canonical root used for server-managed podcast covers. */
+    getCoverCacheRoot(): string {
+        return this.coverCacheDir;
+    }
+
     /**
      * Sync cover images for all podcasts
      */

--- a/backend/src/utils/__tests__/sendFileFromRoot.test.ts
+++ b/backend/src/utils/__tests__/sendFileFromRoot.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { sendFileFromRoot } from "../sendFileFromRoot";
+
+describe("sendFileFromRoot", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "soundspan-send-file-"),
+        );
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("serves an image when the configured root contains a dotfile segment", async () => {
+        const rootDir = path.join(tempDir, ".appdata", "covers");
+        const filePath = path.join(rootDir, "browse", "thumbnail.img");
+        const imageBytes = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, imageBytes);
+
+        const app = express();
+        app.get("/image", (_req, res) => {
+            sendFileFromRoot(res, filePath, rootDir, {
+                headers: { "Content-Type": "image/jpeg" },
+            });
+        });
+
+        const response = await request(app).get("/image");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toMatch(/^image\/jpeg\b/);
+        expect(response.body).toEqual(imageBytes);
+    });
+
+    it("refuses to serve a file outside the configured root", async () => {
+        const rootDir = path.join(tempDir, ".appdata", "covers");
+        const secretPath = path.join(tempDir, "secret.txt");
+        fs.mkdirSync(rootDir, { recursive: true });
+        fs.writeFileSync(secretPath, "must-not-leak");
+
+        const app = express();
+        app.get("/escape", (_req, res) => {
+            sendFileFromRoot(res, secretPath, rootDir);
+        });
+
+        const response = await request(app).get("/escape");
+
+        expect(response.status).toBe(404);
+        expect(response.text).not.toContain("must-not-leak");
+    });
+});

--- a/backend/src/utils/sendFileFromRoot.ts
+++ b/backend/src/utils/sendFileFromRoot.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import type { Response } from "express";
+import type { Errback, SendFileOptions } from "express-serve-static-core";
+
+function isPathWithinRoot(relativePath: string): boolean {
+    return (
+        relativePath.length > 0 &&
+        relativePath !== ".." &&
+        !relativePath.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relativePath)
+    );
+}
+
+function createNotFoundError(): NodeJS.ErrnoException {
+    const error = new Error("Not Found") as NodeJS.ErrnoException;
+    error.code = "ENOENT";
+    return error;
+}
+
+/**
+ * Sends an existing server-managed file relative to its canonical storage root.
+ * Paths outside the root are rejected before Express receives the request.
+ */
+export function sendFileFromRoot(
+    res: Response,
+    filePath: string,
+    rootDir: string,
+    options: SendFileOptions = {},
+    callback?: Errback,
+): void {
+    const absoluteRoot = path.resolve(rootDir);
+    const relativePath = path.relative(absoluteRoot, path.resolve(filePath));
+    if (!isPathWithinRoot(relativePath)) {
+        if (callback) {
+            callback(createNotFoundError());
+        } else {
+            res.status(404).end();
+        }
+        return;
+    }
+
+    const rootPinnedOptions: SendFileOptions = {
+        ...options,
+        dotfiles: "ignore",
+        root: absoluteRoot,
+    };
+    if (callback) {
+        res.sendFile(relativePath, rootPinnedOptions, callback);
+    } else {
+        res.sendFile(relativePath, rootPinnedOptions);
+    }
+}


### PR DESCRIPTION
## Summary
- `res.sendFile` silently answers **404** for any absolute path containing a dot-segment directory (Express `dotfiles` default). Deployments that set `TRANSCODE_CACHE_PATH` under a dotted directory (e.g. `/music/.soundspan/transcodes` — a common convention for app data on a media share) lost **all** cover art: browse thumbnails (Tidal/YouTube Music explore), native library covers, podcast and audiobook covers, plus segmented-streaming manifests/segments. Backend logs show it as `Unhandled error: GET /api/browse/tidal/image NotFoundError: Not Found` even though the cached file exists.
- Dev/CI never hit it because the default `./cache/transcodes` has no dot segment.

## Fix
- New `sendFileFromRoot(res, filePath, rootDir, options?, callback?)`: resolves the file against its canonical storage root, **rejects any path that escapes the root** (404/ENOENT, no content leak), and calls `res.sendFile(relative, { root, dotfiles: "ignore" })` — dot segments in the root prefix stop mattering while the relative path keeps full dotfile/traversal protection.
- Migrated all 12 backend `sendFile` call sites (browse ×4, library native covers ×2, podcasts ×2, audiobooks, share links, segmented-streaming manifest+segment) with headers, cache-control, CORS, and streaming callback error profiles preserved exactly.

## Tests
- New `sendFileFromRoot.test.ts`: serves from a dotted root (regression), refuses root escape (containment).
- Existing route tests updated to assert root-pinned arguments; 1,094 targeted backend tests green.

## Verification
- `npm --prefix backend test -- "browse|coverArt|imageStorage|library|podcast|audiobook|shareLink|streaming|sendFileFromRoot" --maxWorkers=2` → 50 suites / 1,094 tests pass
- `npx --prefix backend tsc --noEmit -p backend` → clean
- `node scripts/ci/check-route-error-canon.mjs` → both ratchets pass
- Pinned prettier check on touched files → clean