### PR TITLE
fix(auth): stop upstream test-connection failures from logging users out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Admin “Test connection” failures for Audiobookshelf, Fanart.tv, Last.fm,
+  Soulseek, Spotify, and TIDAL no longer log the user out: upstream credential
+  failures now return 502 instead of 401, and the web client only treats
+  explicitly marked authentication responses as session expiry.
 - Fixed the native audio engine treating the browser's spec-mandated
   end-of-stream pause as unexpected, which intermittently froze queue
   auto-advance at track boundaries, especially in hidden tabs; the Howler path

--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -293,7 +293,10 @@ describe("auth middleware", () => {
             expect(req.user).toBeUndefined();
             expect(mockApiKeyUpdate).not.toHaveBeenCalled();
             expect(res.statusCode).toBe(401);
-            expect(res.body).toEqual({ error: "Not authenticated" });
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
 
         it("authenticates via bearer token when tokenVersion matches", async () => {
@@ -337,7 +340,10 @@ describe("auth middleware", () => {
 
             expect(next).not.toHaveBeenCalled();
             expect(res.statusCode).toBe(401);
-            expect(res.body).toEqual({ error: "Not authenticated" });
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
 
         it("rejects stale bearer tokens after tokenVersion changes", async () => {
@@ -360,7 +366,10 @@ describe("auth middleware", () => {
             expect(next).not.toHaveBeenCalled();
             expect(req.user).toBeUndefined();
             expect(res.statusCode).toBe(401);
-            expect(res.body).toEqual({ error: "Not authenticated" });
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
     });
 
@@ -414,6 +423,10 @@ describe("auth middleware", () => {
             expect(req.user).toBeUndefined();
             expect(mockApiKeyUpdate).not.toHaveBeenCalled();
             expect(res.statusCode).toBe(401);
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
 
         it("accepts query param tokens for streaming routes", async () => {
@@ -478,7 +491,10 @@ describe("auth middleware", () => {
             expect(next).not.toHaveBeenCalled();
             expect(req.user).toBeUndefined();
             expect(res.statusCode).toBe(401);
-            expect(res.body).toEqual({ error: "Not authenticated" });
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
 
         it("falls back to bearer tokens when no query token is present", async () => {
@@ -545,6 +561,10 @@ describe("auth middleware", () => {
             );
             expect(next).not.toHaveBeenCalled();
             expect(res.statusCode).toBe(401);
+            expect(res.body).toEqual({
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            });
         });
     });
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -253,7 +253,9 @@ export async function requireAuth(
         req.user = user;
         return next();
     }
-    return res.status(401).json({ error: "Not authenticated" });
+    return res
+        .status(401)
+        .json({ error: "Not authenticated", code: "AUTH_REQUIRED" });
 }
 
 /** Requires an interactive session or bearer-authenticated request. */
@@ -385,5 +387,7 @@ export async function requireAuthOrToken(
         }
     }
 
-    return res.status(401).json({ error: "Not authenticated" });
+    return res
+        .status(401)
+        .json({ error: "Not authenticated", code: "AUTH_REQUIRED" });
 }

--- a/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
@@ -1084,7 +1084,8 @@ describe("systemSettings runtime routes", () => {
         const failReq = { body: { username: "u", password: "bad" } } as any;
         const failRes = createRes();
         await testSoulseekHandler(failReq, failRes);
-        expect(failRes.statusCode).toBe(401);
+        expect(failRes.statusCode).toBe(502);
+        expect(failRes.statusCode).not.toBe(401);
         expect(failRes.body.error).toBe(
             "Invalid Soulseek credentials or connection failed",
         );
@@ -1166,7 +1167,11 @@ describe("systemSettings runtime routes", () => {
         const fanartReq = { body: { fanartApiKey: "fanart-key" } } as any;
         const fanartRes = createRes();
         await testFanartHandler(fanartReq, fanartRes);
-        expect(fanartRes.statusCode).toBe(401);
+        expect(fanartRes.statusCode).toBe(502);
+        expect(fanartRes.statusCode).not.toBe(401);
+        expect(fanartRes.body).toEqual({
+            error: "Invalid Fanart.tv API key",
+        });
 
         mockAxiosGet.mockResolvedValueOnce({
             data: { artist: { name: "The Beatles" } },
@@ -1283,7 +1288,8 @@ describe("systemSettings runtime routes", () => {
         const lastfmInvalidReq = { body: { lastfmApiKey: "bad-key" } } as any;
         const lastfmInvalidRes = createRes();
         await testLastfmHandler(lastfmInvalidReq, lastfmInvalidRes);
-        expect(lastfmInvalidRes.statusCode).toBe(401);
+        expect(lastfmInvalidRes.statusCode).toBe(502);
+        expect(lastfmInvalidRes.statusCode).not.toBe(401);
         expect(lastfmInvalidRes.body).toEqual({
             error: "Invalid Last.fm API key",
         });
@@ -1311,7 +1317,8 @@ describe("systemSettings runtime routes", () => {
         } as any;
         const absInvalidRes = createRes();
         await testAudiobookshelfHandler(absInvalidReq, absInvalidRes);
-        expect(absInvalidRes.statusCode).toBe(401);
+        expect(absInvalidRes.statusCode).toBe(502);
+        expect(absInvalidRes.statusCode).not.toBe(401);
         expect(absInvalidRes.body).toEqual({
             error: "Invalid Audiobookshelf API key",
         });
@@ -1348,7 +1355,7 @@ describe("systemSettings runtime routes", () => {
         expect(lastfmRes.body.error).toBe("Unexpected response from Last.fm");
     });
 
-    it("returns 401 for invalid Spotify credentials", async () => {
+    it("returns 502 for invalid Spotify credentials", async () => {
         mockAxiosPost.mockRejectedValueOnce({
             response: { data: { error_description: "invalid_client" } },
         });
@@ -1356,7 +1363,8 @@ describe("systemSettings runtime routes", () => {
         const req = { body: { clientId: "bad", clientSecret: "bad" } } as any;
         const res = createRes();
         await testSpotifyHandler(req, res);
-        expect(res.statusCode).toBe(401);
+        expect(res.statusCode).toBe(502);
+        expect(res.statusCode).not.toBe(401);
         expect(res.body).toEqual({
             error: "Invalid Spotify credentials",
         });
@@ -1374,7 +1382,13 @@ describe("systemSettings runtime routes", () => {
         const unauthReq = { body: {} } as any;
         const unauthRes = createRes();
         await testTidalHandler(unauthReq, unauthRes);
-        expect(unauthRes.statusCode).toBe(401);
+        expect(unauthRes.statusCode).toBe(502);
+        expect(unauthRes.statusCode).not.toBe(401);
+        expect(unauthRes.body).toEqual({
+            error: "Not authenticated to TIDAL",
+            details:
+                "Use the TIDAL settings panel to authenticate via device authorization.",
+        });
 
         mockTidalService.isSidecarHealthy.mockResolvedValueOnce(true);
         const okReq = { body: {} } as any;
@@ -1457,7 +1471,7 @@ describe("systemSettings runtime routes", () => {
         });
     });
 
-    it("uses Spotify token error fallback details", async () => {
+    it("maps a Spotify token request failure to invalid credentials", async () => {
         mockAxiosPost.mockRejectedValueOnce({
             message: "rate limited",
             response: { data: {} },
@@ -1470,7 +1484,25 @@ describe("systemSettings runtime routes", () => {
 
         await testSpotifyHandler(req, res);
 
-        expect(res.statusCode).toBe(401);
+        expect(res.statusCode).toBe(502);
+        expect(res.statusCode).not.toBe(401);
+        expect(res.body).toEqual({
+            error: "Invalid Spotify credentials",
+        });
+    });
+
+    it("maps a Spotify token response without an access token to invalid credentials", async () => {
+        mockAxiosPost.mockResolvedValueOnce({ data: {} });
+
+        const req = {
+            body: { clientId: "client-id", clientSecret: "client-secret" },
+        } as any;
+        const res = createRes();
+
+        await testSpotifyHandler(req, res);
+
+        expect(res.statusCode).toBe(502);
+        expect(res.statusCode).not.toBe(401);
         expect(res.body).toEqual({
             error: "Invalid Spotify credentials",
         });

--- a/backend/src/routes/systemSettings.ts
+++ b/backend/src/routes/systemSettings.ts
@@ -819,6 +819,8 @@ router.post("/test-openai", async (req, res) => {
  *         description: Admin access required
  *       500:
  *         description: Failed to connect to Fanart.tv
+ *       502:
+ *         description: Invalid Fanart.tv API key
  */
 // Test Fanart.tv connection
 router.post("/test-fanart", async (req, res) => {
@@ -850,7 +852,7 @@ router.post("/test-fanart", async (req, res) => {
     } catch (error: any) {
         logger.error("Fanart.tv test error:", error.message);
         if (error.response?.status === 401) {
-            res.status(401).json({
+            res.status(502).json({
                 error: "Invalid Fanart.tv API key",
             });
         } else {
@@ -891,6 +893,8 @@ router.post("/test-fanart", async (req, res) => {
  *         description: Admin access required
  *       500:
  *         description: Failed to connect to Last.fm
+ *       502:
+ *         description: Invalid Last.fm API key
  */
 // Test Last.fm connection
 router.post("/test-lastfm", async (req, res) => {
@@ -933,7 +937,7 @@ router.post("/test-lastfm", async (req, res) => {
             error.response?.status === 403 ||
             error.response?.data?.error === 10
         ) {
-            res.status(401).json({
+            res.status(502).json({
                 error: "Invalid Last.fm API key",
             });
         } else {
@@ -976,6 +980,8 @@ router.post("/test-lastfm", async (req, res) => {
  *         description: Admin access required
  *       500:
  *         description: Failed to connect to Audiobookshelf
+ *       502:
+ *         description: Invalid Audiobookshelf API key
  */
 // Test Audiobookshelf connection
 router.post("/test-audiobookshelf", async (req, res) => {
@@ -1010,7 +1016,7 @@ router.post("/test-audiobookshelf", async (req, res) => {
     } catch (error: any) {
         logger.error("Audiobookshelf test error:", error.message);
         if (error.response?.status === 401 || error.response?.status === 403) {
-            res.status(401).json({
+            res.status(502).json({
                 error: "Invalid Audiobookshelf API key",
             });
         } else {
@@ -1053,6 +1059,8 @@ router.post("/test-audiobookshelf", async (req, res) => {
  *         description: Admin access required
  *       500:
  *         description: Failed to test Soulseek connection
+ *       502:
+ *         description: Invalid Soulseek credentials or connection failed
  */
 // Test Soulseek connection (direct via slsk-client)
 router.post("/test-soulseek", async (req, res) => {
@@ -1101,7 +1109,7 @@ router.post("/test-soulseek", async (req, res) => {
             });
         } catch (connectError: any) {
             logger.error(`[SOULSEEK-TEST] Error: ${connectError.message}`);
-            res.status(401).json({
+            res.status(502).json({
                 error: "Invalid Soulseek credentials or connection failed",
             });
         }
@@ -1145,6 +1153,8 @@ router.post("/test-soulseek", async (req, res) => {
  *         description: Admin access required
  *       500:
  *         description: Failed to test Spotify credentials
+ *       502:
+ *         description: Invalid Spotify credentials
  */
 // Test Spotify credentials
 router.post("/test-spotify", async (req, res) => {
@@ -1180,12 +1190,12 @@ router.post("/test-spotify", async (req, res) => {
                     message: "Spotify credentials are valid",
                 });
             } else {
-                res.status(401).json({
+                res.status(502).json({
                     error: "Invalid Spotify credentials",
                 });
             }
         } catch (tokenError: any) {
-            res.status(401).json({
+            res.status(502).json({
                 error: "Invalid Spotify credentials",
             });
         }
@@ -1210,9 +1220,11 @@ router.post("/test-spotify", async (req, res) => {
  *       200:
  *         description: TIDAL session is valid
  *       401:
- *         description: Not authenticated or no valid TIDAL session
+ *         description: Not authenticated
  *       403:
  *         description: Admin access required
+ *       502:
+ *         description: No valid TIDAL session
  *       503:
  *         description: TIDAL service is not running
  */
@@ -1241,7 +1253,7 @@ router.post("/test-tidal", async (req, res) => {
         }
 
         // No valid session — return info so the UI can trigger device auth
-        return res.status(401).json({
+        return res.status(502).json({
             error: "Not authenticated to TIDAL",
             details:
                 "Use the TIDAL settings panel to authenticate via device authorization.",

--- a/frontend/lib/api/core.ts
+++ b/frontend/lib/api/core.ts
@@ -519,9 +519,12 @@ export abstract class ApiClientCore {
                     );
                 }
 
-                // Handle 401 with token refresh (retry once)
+                const isAuthRequired =
+                    response.status === 401 && error.code === "AUTH_REQUIRED";
+
+                // Handle marked session-auth failures with token refresh (retry once)
                 if (
-                    response.status === 401 &&
+                    isAuthRequired &&
                     _retryCount === 0 &&
                     endpoint !== "/auth/refresh"
                 ) {
@@ -536,7 +539,10 @@ export abstract class ApiClientCore {
                     }
                 }
 
-                if (response.status === 401) {
+                if (
+                    isAuthRequired ||
+                    (response.status === 401 && endpoint === "/auth/refresh")
+                ) {
                     // Token is invalid and refresh failed — clear stale credentials
                     // and notify the app so the auth context can redirect to login.
                     this.clearToken();

--- a/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
+++ b/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
@@ -50,7 +50,10 @@ test("shares one token refresh across concurrent 401 responses", async () => {
                 ok: false,
                 status: 401,
                 statusText: "Unauthorized",
-                json: async () => ({ error: "unauthorized" }),
+                json: async () => ({
+                    error: "Not authenticated",
+                    code: "AUTH_REQUIRED",
+                }),
             } as Response;
         }
         if (authorization === "Bearer access-new") {

--- a/frontend/tests/unit/apiAuth401Handling.test.ts
+++ b/frontend/tests/unit/apiAuth401Handling.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test, { after, beforeEach, type TestContext } from "node:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { ApiClientCore } from "../../lib/api/core";
+
+GlobalRegistrator.register();
+
+class TestApiClient extends ApiClientCore {}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+after(() => {
+    if (originalFetch) {
+        globalThis.fetch = originalFetch;
+    } else {
+        Reflect.deleteProperty(globalThis, "fetch");
+    }
+    GlobalRegistrator.unregister();
+});
+
+function trackSessionExpiry(): { count: () => number; stop: () => void } {
+    let eventCount = 0;
+    const listener = () => {
+        eventCount += 1;
+    };
+    window.addEventListener("auth:session-expired", listener);
+    return {
+        count: () => eventCount,
+        stop: () =>
+            window.removeEventListener("auth:session-expired", listener),
+    };
+}
+
+function mockFetch(
+    testContext: TestContext,
+    responder: (url: string) => Response | Promise<Response>,
+) {
+    return testContext.mock.method(
+        globalThis,
+        "fetch",
+        async (input: string | URL | Request) => responder(String(input)),
+    );
+}
+
+test("refreshes for AUTH_REQUIRED and expires the session when refresh fails", async (testContext) => {
+    const sessionExpiry = trackSessionExpiry();
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access-old", "refresh-old");
+    const fetchMock = mockFetch(testContext, (url) => {
+        if (url.endsWith("/api/auth/refresh")) {
+            return Response.json(
+                { error: "Invalid refresh token" },
+                { status: 401 },
+            );
+        }
+        return Response.json(
+            { error: "Not authenticated", code: "AUTH_REQUIRED" },
+            { status: 401 },
+        );
+    });
+
+    try {
+        await assert.rejects(client.post("/system-settings/test-fanart"), {
+            message: "Not authenticated",
+            status: 401,
+            data: {
+                error: "Not authenticated",
+                code: "AUTH_REQUIRED",
+            },
+        });
+        assert.equal(fetchMock.mock.callCount(), 2);
+        assert.equal(client.getToken(), null);
+        assert.equal(localStorage.getItem("refresh_token"), null);
+        assert.equal(sessionExpiry.count(), 1);
+    } finally {
+        sessionExpiry.stop();
+        client.clearToken();
+    }
+});
+
+test("preserves the session and response body for an unmarked upstream 401", async (testContext) => {
+    const sessionExpiry = trackSessionExpiry();
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access-current", "refresh-current");
+    const fetchMock = mockFetch(testContext, () =>
+        Response.json(
+            { error: "Invalid Audiobookshelf API key" },
+            { status: 401 },
+        ),
+    );
+
+    try {
+        await assert.rejects(
+            client.post("/system-settings/test-audiobookshelf"),
+            {
+                message: "Invalid Audiobookshelf API key",
+                status: 401,
+                data: { error: "Invalid Audiobookshelf API key" },
+            },
+        );
+        assert.equal(fetchMock.mock.callCount(), 1);
+        assert.equal(client.getToken(), "access-current");
+        assert.equal(localStorage.getItem("refresh_token"), "refresh-current");
+        assert.equal(sessionExpiry.count(), 0);
+    } finally {
+        sessionExpiry.stop();
+        client.clearToken();
+    }
+});
+
+test("keeps direct auth refresh 401 handling unchanged without the marker", async (testContext) => {
+    const sessionExpiry = trackSessionExpiry();
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access-old", "refresh-old");
+    const fetchMock = mockFetch(testContext, () =>
+        Response.json({ error: "Invalid refresh token" }, { status: 401 }),
+    );
+
+    try {
+        await assert.rejects(client.post("/auth/refresh"), {
+            message: "Not authenticated",
+            status: 401,
+            data: { error: "Invalid refresh token" },
+        });
+        assert.equal(fetchMock.mock.callCount(), 1);
+        assert.equal(client.getToken(), null);
+        assert.equal(localStorage.getItem("refresh_token"), null);
+        assert.equal(sessionExpiry.count(), 1);
+    } finally {
+        sessionExpiry.stop();
+        client.clearToken();
+    }
+});


### PR DESCRIPTION
## Summary
Pressing **Test connection** for a media server (e.g. Audiobookshelf) with a bad/unreachable key logged the admin out instantly.

**Chain:** `systemSettings.ts` mapped upstream credential failures to our own HTTP **401** at seven test endpoints (Fanart, Last.fm, Audiobookshelf, Soulseek, Spotify ×2, Tidal) → `frontend/lib/api/core.ts` treats any 401 as session expiry (silent refresh → retry → `clearToken()` + `auth:session-expired`). Wrong current-password entries on account forms (`auth.ts` 401s) hit the same trap.

## Fix
- **Marker for real auth failures:** `requireAuth` / `requireAuthOrToken` 401s now include `code: "AUTH_REQUIRED"` (message unchanged; Subsonic `/rest` untouched).
- **Client:** refresh/retry + logout only run for marked 401s (or a 401 from `/auth/refresh` itself). All other 401s surface as normal API errors — no token clearing, no redirect. Single-flight refresh semantics preserved.
- **Server:** the seven upstream test sites return **502** with the same helpful messages; OpenAPI docs updated (our own 401 docs retained).

## Tests
- Middleware marker assertions (session + API-key paths).
- New `apiAuth401Handling.test.ts`: marked 401 → refresh+expiry path; unmarked 401 → error surfaced, no refresh/no logout; `/auth/refresh` unchanged. Existing single-flight test updated.
- Provider runtime branches updated to assert 502 (not 401) + new Spotify missing-token case.

## Verification
- Backend targeted jest (systemSettings, middleware/auth) → 109 pass (codex) + 67 independent re-run
- Frontend unit + single-flight component tests → pass
- `tsc --noEmit` backend + frontend → 0 errors
- Pinned prettier + `check-route-error-canon.mjs` → clean