### PR TITLE
docs(security): record CodeQL dismissal classes for the 2.0.0 triage

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -19,3 +19,26 @@ affected releases are safe. Lock regeneration is performed with `uv pip
 compile --upgrade-package`; if the resolver can select a compatible fixed
 release, remove the corresponding advisory ID in the same change. New IDs are
 never added automatically.
+
+## CodeQL alert dismissal record
+
+All open CodeQL alerts were triaged before the 2.0.0 release: 33 were fixed in
+code and 45 were dismissed with per-alert justifications recorded on each alert
+in the GitHub code-scanning UI (2026-08-12). Dismissals fall into the classes
+below; re-evaluate them whenever the cited guard modules change materially.
+
+| Reason | Rule | Alerts | Class justification |
+| --- | --- | --- | --- |
+| false positive | `js/bad-tag-filter` | #1173 | Release-notes tag filter only classifies repository-owned changelog content during release staging; no untrusted HTML is processed. |
+| false positive | `js/incomplete-multi-character-sanitization` | #1172 | Transformed description is rendered as a React text child (no dangerouslySetInnerHTML); React escaping applies. |
+| false positive | `js/incomplete-url-substring-sanitization` | #138, #139, #145, #1170 | Substring check is a fail-closed exclusion or non-authorizing classification helper; accepted inputs are reduced to allowlisted IDs or validated URLs. |
+| false positive | `js/insufficient-password-hash` | #213 | SHA-256 over high-entropy random API keys; a password KDF is unnecessary for non-memorable secrets. |
+| false positive | `js/missing-token-validation` | #134 | Session cookies are HttpOnly and SameSite=Lax, and API-key/bearer authentication requires explicit headers; state-changing routes are not cookie-only reachable cross-site. |
+| false positive | `js/request-forgery` | #190, #191, #196, #197, #204, #205, #206, #207, #208, #209, #210, #1156, #1158, #1159, #1163, #1230, #1243, #1244 | Outbound URL reaches a fixed-baseURL internal sidecar client or passes the outbound URL-safety guard before the request; destination host is not attacker-controllable. |
+| false positive | `py/incomplete-url-substring-sanitization` | #109 | Fail-closed exclusion; accepted inputs reduced to allowlisted IDs and reconstructed onto literal youtube.com URLs. |
+| false positive | `py/path-injection` | #116, #117, #118, #1154, #1155 | Paths are resolved and contained under the service storage root before filesystem access. |
+| used in tests | `js/incomplete-url-substring-sanitization` | #140, #141, #142, #143, #144 | Pattern appears in test fixtures/mocks only; no attacker-controlled destination is requested. |
+| used in tests | `js/shell-command-injection-from-environment` | #1237 | CI assertion intentionally executes a bounded startup script extracted from a rendered, repository-owned Helm manifest; no external input reaches the shell. |
+| won't fix | `js/insufficient-password-hash` | #1171 | Subsonic protocol token derivation (dedicated password), or SHA-256 over high-entropy random API keys where a KDF is unnecessary. |
+| won't fix | `js/sensitive-get-query` | #1168, #1169, #1238, #1239, #1240 | OpenSubsonic protocol mandates GET token authentication; mitigated by the documented dedicated-password posture. |
+| won't fix | `js/weak-cryptographic-algorithm` | #1167 | OpenSubsonic mandates MD5(password+salt) token auth; dedicated password documented. |


### PR DESCRIPTION
## Summary
Companion record for the pre-2.0.0 CodeQL triage: all 78 open alerts dispositioned — 33 queued as code fixes (first slice: #—auth throttling PR), 45 dismissed with per-alert justifications in the code-scanning UI.

This adds the class-level dismissal record to `docs/SECURITY.md` (reason × rule × alert numbers × standing rationale) so the exceptions remain owned and re-evaluable when the cited guard modules change.

No code changes.