### PR TITLE
fix(security): rate-limit all account-management auth routes and debias invite codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -723,6 +723,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Account-management, 2FA, and Subsonic-credential routes now have dedicated
+  route-level rate limiting, and invite codes use unbiased cryptographic random
+  character selection.
 - Playlist pending-track operations are scoped to both the playlist and
   pending-track ids, closing a cross-user IDOR (#366).
 - API-key management and MFA setup/enable/disable now require an interactive

--- a/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
+++ b/backend/src/routes/__tests__/authInteractiveAuthRuntime.test.ts
@@ -61,6 +61,11 @@ const scopedLogger = {
 scopedLogger.child.mockReturnValue(scopedLogger);
 jest.mock("../../utils/logger", () => ({ logger: scopedLogger }));
 
+jest.mock("../../middleware/rateLimiter", () => ({
+    authLimiter: (_req: any, _res: any, next: () => void) => next(),
+    apiLimiter: (_req: any, _res: any, next: () => void) => next(),
+}));
+
 import router from "../auth";
 
 function createRes() {

--- a/backend/src/routes/__tests__/authRuntime.test.ts
+++ b/backend/src/routes/__tests__/authRuntime.test.ts
@@ -1,4 +1,6 @@
 import crypto from "crypto";
+import express from "express";
+import request, { type Response } from "supertest";
 
 jest.mock("../../config", () => ({ config: { port: 3006 } }));
 
@@ -12,9 +14,10 @@ const mockLogger = {
 mockLogger.child.mockReturnValue(mockLogger);
 jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
-const mockRequireAuth = jest.fn((_req: any, _res: any, next: () => void) =>
-    next(),
-);
+const mockRequireAuth = jest.fn((req: any, _res: any, next: () => void) => {
+    req.user ??= { id: "u1", username: "alice", role: "admin" };
+    next();
+});
 const mockRequireInteractiveSession = jest.fn(
     (_req: any, _res: any, next: () => void) => next(),
 );
@@ -105,9 +108,12 @@ jest.mock("../../utils/encryption", () => ({
 }));
 
 import { swaggerSpec } from "../../config/swagger";
+import { apiLimiter, authLimiter } from "../../middleware/rateLimiter";
 import router from "../auth";
 
-function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
+type HttpMethod = "get" | "post" | "put" | "patch" | "delete";
+
+function getRouteLayer(path: string, method: HttpMethod) {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -115,6 +121,11 @@ function getHandler(path: string, method: "get" | "post" | "put" | "delete") {
     if (!layer) {
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     }
+    return layer;
+}
+
+function getHandler(path: string, method: HttpMethod) {
+    const layer = getRouteLayer(path, method);
     return layer.route.stack[layer.route.stack.length - 1].handle;
 }
 
@@ -164,7 +175,38 @@ function expectLoginBodyMatchesOpenApi(body: Record<string, unknown>): void {
     }
 }
 
+const AUTH_FAILED_REQUEST_LIMIT = 40;
+const AUTH_LIMIT_MESSAGE =
+    "Too many login attempts, please try again in 15 minutes.";
+
+function createRouteApp() {
+    const app = express();
+    app.set("trust proxy", 1);
+    app.use(express.json());
+    app.use(router);
+    return app;
+}
+
+async function expectFailedRequestsAreThrottled(
+    send: () => Promise<Response>,
+    expectedFailureStatus: number,
+): Promise<void> {
+    for (
+        let requestCount = 0;
+        requestCount < AUTH_FAILED_REQUEST_LIMIT;
+        requestCount++
+    ) {
+        const response = await send();
+        expect(response.status).toBe(expectedFailureStatus);
+    }
+
+    const throttledResponse = await send();
+    expect(throttledResponse.status).toBe(429);
+    expect(throttledResponse.text).toBe(AUTH_LIMIT_MESSAGE);
+}
+
 describe("auth routes runtime", () => {
+    const routeApp = createRouteApp();
     const login = getHandler("/login", "post");
     const logout = getHandler("/logout", "post");
     const refresh = getHandler("/refresh", "post");
@@ -228,6 +270,142 @@ describe("auth routes runtime", () => {
             userId: "u1",
             tokenVersion: 1,
         });
+    });
+
+    it.each([
+        ["post", "/refresh", authLimiter],
+        ["get", "/me", apiLimiter],
+        ["post", "/change-password", authLimiter],
+        ["post", "/change-email", apiLimiter],
+        ["get", "/users", apiLimiter],
+        ["post", "/create-user", authLimiter],
+        ["patch", "/users/:id", authLimiter],
+        ["delete", "/users/:id", apiLimiter],
+        ["post", "/invite-codes", apiLimiter],
+        ["get", "/invite-codes", apiLimiter],
+        ["delete", "/invite-codes/:id", apiLimiter],
+        ["post", "/2fa/setup", authLimiter],
+        ["post", "/2fa/enable", authLimiter],
+        ["post", "/2fa/disable", authLimiter],
+        ["get", "/2fa/status", apiLimiter],
+        ["get", "/subsonic-password", apiLimiter],
+        ["post", "/subsonic-password", authLimiter],
+        ["delete", "/subsonic-password", authLimiter],
+    ] as const)(
+        "attaches the prescribed limiter first on %s %s",
+        (method, path, expectedLimiter) => {
+            const layer = getRouteLayer(path, method);
+
+            expect(layer.route.stack[0].handle).toBe(expectedLimiter);
+        },
+    );
+
+    it("throttles repeated invalid refresh tokens without blocking successful rotation", async () => {
+        const success = await request(routeApp)
+            .post("/refresh")
+            .set("X-Forwarded-For", "198.51.100.10")
+            .send({ refreshToken: "valid-refresh-token" });
+        expect(success.status).toBe(200);
+        expect(success.body).toEqual({
+            token: "jwt-access",
+            refreshToken: "jwt-refresh",
+        });
+
+        mockVerifyAuthToken.mockImplementation(() => {
+            throw new Error("bad token");
+        });
+        await expectFailedRequestsAreThrottled(
+            async () =>
+                request(routeApp)
+                    .post("/refresh")
+                    .set("X-Forwarded-For", "198.51.100.10")
+                    .send({ refreshToken: "invalid-refresh-token" }),
+            401,
+        );
+    });
+
+    it("throttles repeated invalid current passwords without blocking a password change", async () => {
+        const payload = {
+            currentPassword: "current-password",
+            newPassword: "new-password",
+        };
+        const success = await request(routeApp)
+            .post("/change-password")
+            .set("X-Forwarded-For", "198.51.100.11")
+            .send(payload);
+        expect(success.status).toBe(200);
+        expect(success.body).toEqual({
+            message: "Password changed successfully",
+        });
+
+        mockBcryptCompare.mockResolvedValue(false);
+        await expectFailedRequestsAreThrottled(
+            async () =>
+                request(routeApp)
+                    .post("/change-password")
+                    .set("X-Forwarded-For", "198.51.100.11")
+                    .send(payload),
+            401,
+        );
+    });
+
+    it("throttles repeated invalid 2FA disable passwords without blocking a valid disable", async () => {
+        const payload = { password: "current-password", token: "123456" };
+        const success = await request(routeApp)
+            .post("/2fa/disable")
+            .set("X-Forwarded-For", "198.51.100.12")
+            .send(payload);
+        expect(success.status).toBe(200);
+        expect(success.body).toEqual({ message: "2FA disabled successfully" });
+
+        mockBcryptCompare.mockResolvedValue(false);
+        await expectFailedRequestsAreThrottled(
+            async () =>
+                request(routeApp)
+                    .post("/2fa/disable")
+                    .set("X-Forwarded-For", "198.51.100.12")
+                    .send(payload),
+            401,
+        );
+    });
+
+    it("throttles repeated invalid create-user requests without blocking account creation", async () => {
+        prisma.user.findUnique.mockResolvedValueOnce(null);
+        const success = await request(routeApp)
+            .post("/create-user")
+            .set("X-Forwarded-For", "198.51.100.13")
+            .send({ username: "new-user", password: "123456" });
+        expect(success.status).toBe(200);
+        expect(success.body).toEqual(
+            expect.objectContaining({ id: "u-new", username: "new-user" }),
+        );
+
+        await expectFailedRequestsAreThrottled(
+            async () =>
+                request(routeApp)
+                    .post("/create-user")
+                    .set("X-Forwarded-For", "198.51.100.13")
+                    .send({}),
+            400,
+        );
+    });
+
+    it("throttles repeated invalid Subsonic passwords without blocking a valid credential", async () => {
+        const success = await request(routeApp)
+            .post("/subsonic-password")
+            .set("X-Forwarded-For", "198.51.100.14")
+            .send({ password: "my-subsonic-password" });
+        expect(success.status).toBe(200);
+        expect(success.body).toEqual({ success: true });
+
+        await expectFailedRequestsAreThrottled(
+            async () =>
+                request(routeApp)
+                    .post("/subsonic-password")
+                    .set("X-Forwarded-For", "198.51.100.14")
+                    .send({ password: "short" }),
+            400,
+        );
     });
 
     it("validates login payload and handles invalid credentials", async () => {
@@ -1103,8 +1281,8 @@ describe("auth routes runtime", () => {
         expect(badRes.statusCode).toBe(400);
 
         const randomSpy = jest
-            .spyOn(crypto, "randomBytes")
-            .mockReturnValue(Buffer.alloc(8, 0) as any);
+            .spyOn(crypto, "randomInt")
+            .mockImplementation((_min, _max) => 0);
         (prisma as any).inviteCode.findUnique.mockResolvedValue({
             id: "existing",
         });
@@ -1118,6 +1296,8 @@ describe("auth routes runtime", () => {
         expect(exhaustedRes.body).toEqual({
             error: "Failed to generate unique code",
         });
+        expect(randomSpy).toHaveBeenCalledTimes(80);
+        expect(randomSpy).toHaveBeenCalledWith(0, 32);
         randomSpy.mockRestore();
 
         (prisma as any).inviteCode.findUnique.mockResolvedValueOnce(null);
@@ -1221,6 +1401,40 @@ describe("auth routes runtime", () => {
         expect(revokeErrRes.body).toEqual({
             error: "Failed to revoke invite code",
         });
+    });
+
+    it("generates eight-character invite codes from the unchanged alphabet with bounded randomInt calls", async () => {
+        (prisma as any).inviteCode = {
+            findUnique: jest.fn().mockResolvedValue(null),
+            create: jest.fn().mockImplementation(({ data }) => ({
+                id: "ic-1",
+                ...data,
+                createdAt: new Date("2026-03-01T00:00:00.000Z"),
+            })),
+        };
+        const randomSpy = jest
+            .spyOn(crypto, "randomInt")
+            .mockImplementation((_min, max) => randomSpy.mock.calls.length - 1);
+        const createInvite = getHandler("/invite-codes", "post");
+        const res = createRes();
+
+        await createInvite(
+            {
+                user: { id: "admin-1" },
+                body: { ttl: "never", maxUses: 1 },
+            } as any,
+            res,
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.code).toBe("ABCDEFGH");
+        expect(res.body.code).toHaveLength(8);
+        expect(res.body.code).toMatch(
+            /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/,
+        );
+        expect(randomSpy).toHaveBeenCalledTimes(8);
+        expect(randomSpy).toHaveBeenCalledWith(0, 32);
+        randomSpy.mockRestore();
     });
 
     it("covers register route branches including invite/user/email checks and transaction errors", async () => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -18,6 +18,7 @@ import { encrypt, decrypt } from "../utils/encryption";
 import { BRAND_NAME } from "../config/brand";
 import { timingSafeCompare } from "../utils/timingSafe";
 import { runDummyBcrypt } from "../utils/dummyCredential";
+import { apiLimiter, authLimiter } from "../middleware/rateLimiter";
 
 async function verifyTotpToken(
     secret: string,
@@ -78,10 +79,10 @@ const registerSchema = z
 const INVITE_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
 function generateInviteCode(): string {
-    const bytes = crypto.randomBytes(8);
     let code = "";
     for (let i = 0; i < 8; i++) {
-        code += INVITE_CODE_CHARS[bytes[i] % INVITE_CODE_CHARS.length];
+        code +=
+            INVITE_CODE_CHARS[crypto.randomInt(0, INVITE_CODE_CHARS.length)];
     }
     return code;
 }
@@ -313,7 +314,7 @@ router.post("/logout", (req, res) => {
  *         description: Invalid or expired refresh token
  */
 // POST /auth/refresh - Refresh access token using refresh token
-router.post("/refresh", async (req, res) => {
+router.post("/refresh", authLimiter, async (req, res) => {
     const { refreshToken } = req.body;
 
     if (!refreshToken) {
@@ -384,7 +385,7 @@ router.post("/refresh", async (req, res) => {
  *               $ref: '#/components/schemas/Error'
  */
 // GET /auth/me
-router.get("/me", requireAuth, async (req, res) => {
+router.get("/me", apiLimiter, requireAuth, async (req, res) => {
     const user = await prisma.user.findUnique({
         where: { id: req.user!.id },
         select: {
@@ -442,7 +443,7 @@ router.get("/me", requireAuth, async (req, res) => {
  *         description: User not found
  */
 // POST /auth/change-password
-router.post("/change-password", requireAuth, async (req, res) => {
+router.post("/change-password", authLimiter, requireAuth, async (req, res) => {
     try {
         const { currentPassword, newPassword } = req.body;
 
@@ -522,7 +523,7 @@ router.post("/change-password", requireAuth, async (req, res) => {
  *         description: Not authenticated
  */
 // POST /auth/change-email
-router.post("/change-email", requireAuth, async (req, res) => {
+router.post("/change-email", apiLimiter, requireAuth, async (req, res) => {
     try {
         const schema = z.object({ email: z.string().email() });
         const { email } = schema.parse(req.body);
@@ -566,26 +567,32 @@ router.post("/change-email", requireAuth, async (req, res) => {
  *         description: Admin access required
  */
 // GET /auth/users (Admin only)
-router.get("/users", requireAuth, requireAdmin, async (req, res) => {
-    try {
-        const users = await prisma.user.findMany({
-            select: {
-                id: true,
-                username: true,
-                email: true,
-                role: true,
-                onboardingComplete: true,
-                createdAt: true,
-            },
-            orderBy: { createdAt: "asc" },
-        });
+router.get(
+    "/users",
+    apiLimiter,
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+        try {
+            const users = await prisma.user.findMany({
+                select: {
+                    id: true,
+                    username: true,
+                    email: true,
+                    role: true,
+                    onboardingComplete: true,
+                    createdAt: true,
+                },
+                orderBy: { createdAt: "asc" },
+            });
 
-        res.json(users);
-    } catch (error) {
-        logger.error("Get users error:", error);
-        res.status(500).json({ error: "Failed to get users" });
-    }
-});
+            res.json(users);
+        } catch (error) {
+            logger.error("Get users error:", error);
+            res.status(500).json({ error: "Failed to get users" });
+        }
+    },
+);
 
 /**
  * @openapi
@@ -625,68 +632,76 @@ router.get("/users", requireAuth, requireAdmin, async (req, res) => {
  *         description: Admin access required
  */
 // POST /auth/create-user (Admin only)
-router.post("/create-user", requireAuth, requireAdmin, async (req, res) => {
-    try {
-        const { username, password, role } = req.body;
+router.post(
+    "/create-user",
+    authLimiter,
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+        try {
+            const { username, password, role } = req.body;
 
-        if (!username || !password) {
-            return res
-                .status(400)
-                .json({ error: "Username and password are required" });
+            if (!username || !password) {
+                return res
+                    .status(400)
+                    .json({ error: "Username and password are required" });
+            }
+
+            if (password.length < 6) {
+                return res
+                    .status(400)
+                    .json({ error: "Password must be at least 6 characters" });
+            }
+
+            if (role && !["user", "admin"].includes(role)) {
+                return res.status(400).json({ error: "Invalid role" });
+            }
+
+            // Check if username exists
+            const existing = await prisma.user.findUnique({
+                where: { username },
+            });
+
+            if (existing) {
+                return res
+                    .status(400)
+                    .json({ error: "Username already taken" });
+            }
+
+            // Create user
+            const passwordHash = await bcrypt.hash(password, 10);
+            const user = await prisma.user.create({
+                data: {
+                    username,
+                    passwordHash,
+                    role: role || "user",
+                    onboardingComplete: true, // Skip onboarding for created users
+                },
+            });
+
+            // Create default user settings
+            await prisma.userSettings.create({
+                data: {
+                    userId: user.id,
+                    playbackQuality: "original",
+                    wifiOnly: false,
+                    offlineEnabled: false,
+                    maxCacheSizeMb: 10240,
+                },
+            });
+
+            res.json({
+                id: user.id,
+                username: user.username,
+                role: user.role,
+                createdAt: user.createdAt,
+            });
+        } catch (error) {
+            logger.error("Create user error:", error);
+            res.status(500).json({ error: "Failed to create user" });
         }
-
-        if (password.length < 6) {
-            return res
-                .status(400)
-                .json({ error: "Password must be at least 6 characters" });
-        }
-
-        if (role && !["user", "admin"].includes(role)) {
-            return res.status(400).json({ error: "Invalid role" });
-        }
-
-        // Check if username exists
-        const existing = await prisma.user.findUnique({
-            where: { username },
-        });
-
-        if (existing) {
-            return res.status(400).json({ error: "Username already taken" });
-        }
-
-        // Create user
-        const passwordHash = await bcrypt.hash(password, 10);
-        const user = await prisma.user.create({
-            data: {
-                username,
-                passwordHash,
-                role: role || "user",
-                onboardingComplete: true, // Skip onboarding for created users
-            },
-        });
-
-        // Create default user settings
-        await prisma.userSettings.create({
-            data: {
-                userId: user.id,
-                playbackQuality: "original",
-                wifiOnly: false,
-                offlineEnabled: false,
-                maxCacheSizeMb: 10240,
-            },
-        });
-
-        res.json({
-            id: user.id,
-            username: user.username,
-            role: user.role,
-            createdAt: user.createdAt,
-        });
-    } catch (error) {
-        logger.error("Create user error:", error);
-        res.status(500).json({ error: "Failed to create user" });
-    }
-});
+    },
+);
 
 /**
  * @openapi
@@ -734,6 +749,7 @@ router.post("/create-user", requireAuth, requireAdmin, async (req, res) => {
 // PATCH /auth/users/:id (Admin only) - Edit user's username, email, or password
 router.patch<{ id: string }>(
     "/users/:id",
+    authLimiter,
     requireAuth,
     requireAdmin,
     async (req, res) => {
@@ -857,6 +873,7 @@ router.patch<{ id: string }>(
 // DELETE /auth/users/:id (Admin only)
 router.delete<{ id: string }>(
     "/users/:id",
+    apiLimiter,
     requireAuth,
     requireAdmin,
     async (req, res) => {
@@ -923,55 +940,61 @@ router.delete<{ id: string }>(
  *         description: Admin access required
  */
 // POST /auth/invite-codes - Generate a new invite code (admin only)
-router.post("/invite-codes", requireAuth, requireAdmin, async (req, res) => {
-    try {
-        const { ttl, maxUses } = inviteCodeSchema.parse(req.body);
-        const expiresAt = ttlToExpiresAt(ttl);
+router.post(
+    "/invite-codes",
+    apiLimiter,
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+        try {
+            const { ttl, maxUses } = inviteCodeSchema.parse(req.body);
+            const expiresAt = ttlToExpiresAt(ttl);
 
-        // Retry loop for uniqueness
-        let code: string;
-        let attempts = 0;
-        do {
-            code = generateInviteCode();
-            const existing = await prisma.inviteCode.findUnique({
-                where: { code },
+            // Retry loop for uniqueness
+            let code: string;
+            let attempts = 0;
+            do {
+                code = generateInviteCode();
+                const existing = await prisma.inviteCode.findUnique({
+                    where: { code },
+                });
+                if (!existing) break;
+                attempts++;
+            } while (attempts < 10);
+
+            if (attempts >= 10) {
+                return res
+                    .status(500)
+                    .json({ error: "Failed to generate unique code" });
+            }
+
+            const inviteCode = await prisma.inviteCode.create({
+                data: {
+                    code,
+                    createdBy: req.user!.id,
+                    expiresAt,
+                    maxUses,
+                },
             });
-            if (!existing) break;
-            attempts++;
-        } while (attempts < 10);
 
-        if (attempts >= 10) {
-            return res
-                .status(500)
-                .json({ error: "Failed to generate unique code" });
+            res.json({
+                id: inviteCode.id,
+                code: inviteCode.code,
+                expiresAt: inviteCode.expiresAt,
+                maxUses: inviteCode.maxUses,
+                createdAt: inviteCode.createdAt,
+            });
+        } catch (err) {
+            if (err instanceof z.ZodError) {
+                return res
+                    .status(400)
+                    .json({ error: "Invalid request", details: err.issues });
+            }
+            logger.error("Create invite code error:", err);
+            res.status(500).json({ error: "Failed to create invite code" });
         }
-
-        const inviteCode = await prisma.inviteCode.create({
-            data: {
-                code,
-                createdBy: req.user!.id,
-                expiresAt,
-                maxUses,
-            },
-        });
-
-        res.json({
-            id: inviteCode.id,
-            code: inviteCode.code,
-            expiresAt: inviteCode.expiresAt,
-            maxUses: inviteCode.maxUses,
-            createdAt: inviteCode.createdAt,
-        });
-    } catch (err) {
-        if (err instanceof z.ZodError) {
-            return res
-                .status(400)
-                .json({ error: "Invalid request", details: err.issues });
-        }
-        logger.error("Create invite code error:", err);
-        res.status(500).json({ error: "Failed to create invite code" });
-    }
-});
+    },
+);
 
 /**
  * @openapi
@@ -991,47 +1014,53 @@ router.post("/invite-codes", requireAuth, requireAdmin, async (req, res) => {
  *         description: Admin access required
  */
 // GET /auth/invite-codes - List all invite codes (admin only)
-router.get("/invite-codes", requireAuth, requireAdmin, async (_req, res) => {
-    try {
-        const codes = await prisma.inviteCode.findMany({
-            orderBy: { createdAt: "desc" },
-            include: {
-                creator: {
-                    select: { username: true },
+router.get(
+    "/invite-codes",
+    apiLimiter,
+    requireAuth,
+    requireAdmin,
+    async (_req, res) => {
+        try {
+            const codes = await prisma.inviteCode.findMany({
+                orderBy: { createdAt: "desc" },
+                include: {
+                    creator: {
+                        select: { username: true },
+                    },
                 },
-            },
-        });
+            });
 
-        const now = new Date();
-        const codesWithStatus = codes.map((c) => {
-            let status: string;
-            if (c.revoked) {
-                status = "revoked";
-            } else if (c.useCount >= c.maxUses) {
-                status = "exhausted";
-            } else if (c.expiresAt && c.expiresAt < now) {
-                status = "expired";
-            } else {
-                status = "active";
-            }
-            return {
-                id: c.id,
-                code: c.code,
-                status,
-                maxUses: c.maxUses,
-                useCount: c.useCount,
-                expiresAt: c.expiresAt,
-                createdAt: c.createdAt,
-                createdBy: c.creator.username,
-            };
-        });
+            const now = new Date();
+            const codesWithStatus = codes.map((c) => {
+                let status: string;
+                if (c.revoked) {
+                    status = "revoked";
+                } else if (c.useCount >= c.maxUses) {
+                    status = "exhausted";
+                } else if (c.expiresAt && c.expiresAt < now) {
+                    status = "expired";
+                } else {
+                    status = "active";
+                }
+                return {
+                    id: c.id,
+                    code: c.code,
+                    status,
+                    maxUses: c.maxUses,
+                    useCount: c.useCount,
+                    expiresAt: c.expiresAt,
+                    createdAt: c.createdAt,
+                    createdBy: c.creator.username,
+                };
+            });
 
-        res.json(codesWithStatus);
-    } catch (err) {
-        logger.error("List invite codes error:", err);
-        res.status(500).json({ error: "Failed to list invite codes" });
-    }
-});
+            res.json(codesWithStatus);
+        } catch (err) {
+            logger.error("List invite codes error:", err);
+            res.status(500).json({ error: "Failed to list invite codes" });
+        }
+    },
+);
 
 /**
  * @openapi
@@ -1062,6 +1091,7 @@ router.get("/invite-codes", requireAuth, requireAdmin, async (_req, res) => {
 // DELETE /auth/invite-codes/:id - Revoke an invite code (admin only)
 router.delete<{ id: string }>(
     "/invite-codes/:id",
+    apiLimiter,
     requireAuth,
     requireAdmin,
     async (req, res) => {
@@ -1287,6 +1317,7 @@ router.post("/register", async (req, res) => {
 // POST /auth/2fa/setup - Generate 2FA secret and QR code
 router.post(
     "/2fa/setup",
+    authLimiter,
     requireAuth,
     requireInteractiveSession,
     async (req, res) => {
@@ -1364,6 +1395,7 @@ router.post(
 // POST /auth/2fa/enable - Verify token and enable 2FA
 router.post(
     "/2fa/enable",
+    authLimiter,
     requireAuth,
     requireInteractiveSession,
     async (req, res) => {
@@ -1473,6 +1505,7 @@ router.post(
 // POST /auth/2fa/disable - Disable 2FA
 router.post(
     "/2fa/disable",
+    authLimiter,
     requireAuth,
     requireInteractiveSession,
     async (req, res) => {
@@ -1548,7 +1581,7 @@ router.post(
  *         description: User not found
  */
 // GET /auth/2fa/status - Check if 2FA is enabled
-router.get("/2fa/status", requireAuth, async (req, res) => {
+router.get("/2fa/status", apiLimiter, requireAuth, async (req, res) => {
     try {
         const user = await prisma.user.findUnique({
             where: { id: req.user!.id },
@@ -1584,7 +1617,7 @@ router.get("/2fa/status", requireAuth, async (req, res) => {
  *         description: User not found
  */
 // GET /auth/subsonic-password - Check if Subsonic password is configured
-router.get("/subsonic-password", requireAuth, async (req, res) => {
+router.get("/subsonic-password", apiLimiter, requireAuth, async (req, res) => {
     try {
         const user = await prisma.user.findUnique({
             where: { id: req.user!.id },
@@ -1640,6 +1673,7 @@ router.get("/subsonic-password", requireAuth, async (req, res) => {
 // POST /auth/subsonic-password - Set Subsonic password
 router.post(
     "/subsonic-password",
+    authLimiter,
     requireAuth,
     requireInteractiveSession,
     async (req, res) => {
@@ -1688,6 +1722,7 @@ router.post(
 // DELETE /auth/subsonic-password - Clear Subsonic password
 router.delete(
     "/subsonic-password",
+    authLimiter,
     requireAuth,
     requireInteractiveSession,
     async (req, res) => {


### PR DESCRIPTION
## Summary
First remediation slice of the pre-2.0.0 CodeQL triage (22 alerts on `backend/src/routes/auth.ts`).

- **Route-level rate limiting (21 alerts):** every account-management endpoint now attaches its limiter as the first middleware, ahead of `requireAuth`/`requireAdmin`/`requireInteractiveSession` — the strict failed-attempt `authLimiter` on credential-bearing paths (refresh, change-password, 2FA setup/enable/disable, Subsonic password create/delete, create-user, user PATCH) and `apiLimiter` on reads/administration (me, users, 2FA status, invite-code list/create/delete, change-email, user delete). CodeQL only recognizes route-level bounds; the sensitive routes genuinely warrant the stricter limiter.
- **Unbiased invite codes (1 alert):** `generateInviteCode` switches from `randomBytes` modulo indexing to eight bounded `crypto.randomInt` selections — same length, same alphabet, no modulo bias.

No handler logic, response shapes, or status codes changed.

## Tests
- Parameterized middleware-order assertion across all 18 routes (limiter attached first).
- Behavioral 429-boundary tests for refresh, change-password, 2FA disable, create-user, Subsonic password — each proving throttling of repeated failures without blocking the legitimate flow.
- Invite-code determinism test updated for `randomInt` (length + alphabet unchanged).

## Verification
- `npm --prefix backend test -- "auth" --maxWorkers=2` → 13 suites / 167 tests
- Mocked-consumer sweep (limiter/auth-route mocking suites incl. `totpBehavior`) → 23 suites / 511 tests
- Independent re-run of authRuntime + authInteractiveAuthRuntime → 66 pass
- `tsc --noEmit` → clean · pinned prettier → clean · `check-route-error-canon.mjs` → both ratchets pass