### PR TITLE
chore(git): merge CHANGELOG.md with the union driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Parallel PRs each append entries to the changelog; take both sides on
+# overlapping hunks instead of conflicting. Release rollovers restructure the
+# file in a single serialized PR, where union semantics are equally safe. The
+# changelog heading lint (release tooling) guards against duplicated headings.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Summary
Every parallel PR appends bullets to the same section of `CHANGELOG.md`, so each sibling merge flips the remaining PRs to conflicted (`DIRTY`) and blocks auto-merge — this has hit four PRs today alone.

`merge=union` is git's built-in driver for exactly this file shape: append-only text where both sides of an overlapping hunk are wanted. Local merges/rebases resolve automatically; GitHub's merge machinery honors checked-in `.gitattributes` for its conflict computation, so auto-merge should stop tripping as well (and if a particular case still conflicts, manual resolution stays what it was).

Release rollovers (the one operation that restructures rather than appends) happen in a single serialized PR where union semantics are equally safe, and the changelog heading lint in the release tooling guards duplicate headings.