### PR TITLE
fix(security): validate ids and contain all image-storage filesystem paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -730,6 +730,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Cover-image storage operations validate IDs and contain all filesystem paths
+  under the type-specific covers directory.
 - Playlist pending-track operations are scoped to both the playlist and
   pending-track ids, closing a cross-user IDOR (#366).
 - API-key management and MFA setup/enable/disable now require an interactive

--- a/backend/src/services/__tests__/imageStorage.test.ts
+++ b/backend/src/services/__tests__/imageStorage.test.ts
@@ -39,6 +39,13 @@ import {
     isNativePath,
 } from "../imageStorage";
 
+const INVALID_IMAGE_PATH_CASES = [
+    ["parent traversal", "../escape", "native:albums/../escape.jpg"],
+    ["absolute path", "/tmp/escape", "native:/tmp/escape.jpg"],
+    ["null byte", "cover\0escape", "native:albums/cover\0escape.jpg"],
+    ["dotted segment", "./escape", "native:albums/./escape.jpg"],
+] as const;
+
 function createImageResponse(
     byteLength: number,
     contentType: string,
@@ -68,6 +75,23 @@ describe("imageStorage service", () => {
         expect(result).toBeNull();
         expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it.each(INVALID_IMAGE_PATH_CASES)(
+        "rejects %s ids before write or network access",
+        async (_caseName, id) => {
+            const result = await downloadAndStoreImage(
+                "https://img.example.com/a.jpg",
+                id,
+                "artist",
+            );
+
+            expect(result).toBeNull();
+            expect(mockExistsSync).not.toHaveBeenCalled();
+            expect(mockMkdirSync).not.toHaveBeenCalled();
+            expect(mockWriteFileSync).not.toHaveBeenCalled();
+            expect(fetchMock).not.toHaveBeenCalled();
+        },
+    );
 
     it("downloads and stores artist image on valid response", async () => {
         mockExistsSync.mockImplementation((target: string) => {
@@ -191,6 +215,22 @@ describe("imageStorage service", () => {
         );
     });
 
+    it.each(INVALID_IMAGE_PATH_CASES)(
+        "localImageExists rejects %s native paths before filesystem access",
+        (_caseName, _id, nativePath) => {
+            expect(localImageExists(nativePath)).toBe(false);
+            expect(mockExistsSync).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(INVALID_IMAGE_PATH_CASES)(
+        "getLocalImagePath rejects %s native paths before filesystem access",
+        (_caseName, _id, nativePath) => {
+            expect(getLocalImagePath(nativePath)).toBeNull();
+            expect(mockExistsSync).not.toHaveBeenCalled();
+        },
+    );
+
     it("deletes local image when file exists and handles failure", () => {
         mockExistsSync.mockImplementation((target: string) =>
             target.endsWith("/covers/albums/album-6.jpg"),
@@ -208,6 +248,23 @@ describe("imageStorage service", () => {
         expect(deleteLocalImage("native:albums/album-6.jpg")).toBe(false);
 
         expect(deleteLocalImage("native:albums/missing.jpg")).toBe(false);
+    });
+
+    it.each(INVALID_IMAGE_PATH_CASES)(
+        "deleteLocalImage rejects %s native paths before filesystem access",
+        (_caseName, _id, nativePath) => {
+            expect(deleteLocalImage(nativePath)).toBe(false);
+            expect(mockExistsSync).not.toHaveBeenCalled();
+            expect(mockUnlinkSync).not.toHaveBeenCalled();
+        },
+    );
+
+    it("does not delete a path outside the covers root", () => {
+        expect(
+            deleteLocalImage("native:albums/../../outside.jpg"),
+        ).toBe(false);
+        expect(mockExistsSync).not.toHaveBeenCalled();
+        expect(mockUnlinkSync).not.toHaveBeenCalled();
     });
 
     it("classifies external and native URLs", () => {

--- a/backend/src/services/imageStorage.ts
+++ b/backend/src/services/imageStorage.ts
@@ -9,10 +9,13 @@ import fs from "fs";
 import path from "path";
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import { safeResolvePath } from "../utils/safeResolvePath";
 import { fetchExternalImage } from "./imageProxy";
 
 const ARTIST_IMAGES_DIR = "artists";
 const ALBUM_IMAGES_DIR = "albums";
+const IMAGE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+type ImageType = "artist" | "album";
 
 /**
  * Get the base covers directory path
@@ -21,16 +24,38 @@ function getCoversBasePath(): string {
     return path.join(config.music.transcodeCachePath, "../covers");
 }
 
+function getImageDirectory(type: ImageType): string {
+    const subdir =
+        type === "artist" ? ARTIST_IMAGES_DIR : ALBUM_IMAGES_DIR;
+    return path.resolve(getCoversBasePath(), subdir);
+}
+
+function resolveImagePath(id: string, type: ImageType): string | null {
+    if (!IMAGE_ID_PATTERN.test(id)) return null;
+    return safeResolvePath(getImageDirectory(type), `${id}.jpg`);
+}
+
+function resolveNativeImagePath(nativePath: string): string | null {
+    const artistPrefix = `native:${ARTIST_IMAGES_DIR}/`;
+    const albumPrefix = `native:${ALBUM_IMAGES_DIR}/`;
+    const type = nativePath.startsWith(artistPrefix) ? "artist" : "album";
+    const prefix = type === "artist" ? artistPrefix : albumPrefix;
+    if (!nativePath.startsWith(prefix) || !nativePath.endsWith(".jpg")) {
+        return null;
+    }
+
+    const id = nativePath.slice(prefix.length, -".jpg".length);
+    return resolveImagePath(id, type);
+}
+
 /**
  * Ensure the covers directory exists
  */
-function ensureCoversDir(subdir: string): string {
-    const dirPath = path.join(getCoversBasePath(), subdir);
+function ensureCoversDir(dirPath: string): void {
     if (!fs.existsSync(dirPath)) {
         fs.mkdirSync(dirPath, { recursive: true });
         logger.debug(`[ImageStorage] Created directory: ${dirPath}`);
     }
-    return dirPath;
 }
 
 /**
@@ -40,14 +65,14 @@ function ensureCoversDir(subdir: string): string {
 export async function downloadAndStoreImage(
     url: string,
     id: string,
-    type: "artist" | "album",
+    type: ImageType,
 ): Promise<string | null> {
-    if (!url) return null;
+    const filePath = resolveImagePath(id, type);
+    if (!url || !filePath) return null;
 
     const subdir = type === "artist" ? ARTIST_IMAGES_DIR : ALBUM_IMAGES_DIR;
-    const dirPath = ensureCoversDir(subdir);
     const filename = `${id}.jpg`;
-    const filePath = path.join(dirPath, filename);
+    ensureCoversDir(path.dirname(filePath));
 
     try {
         logger.debug(
@@ -95,10 +120,8 @@ export async function downloadAndStoreImage(
  * Check if a local image exists
  */
 export function localImageExists(nativePath: string): boolean {
-    if (!nativePath.startsWith("native:")) return false;
-
-    const relativePath = nativePath.replace("native:", "");
-    const fullPath = path.join(getCoversBasePath(), relativePath);
+    const fullPath = resolveNativeImagePath(nativePath);
+    if (!fullPath) return false;
     return fs.existsSync(fullPath);
 }
 
@@ -106,10 +129,8 @@ export function localImageExists(nativePath: string): boolean {
  * Get the full filesystem path for a native image path
  */
 export function getLocalImagePath(nativePath: string): string | null {
-    if (!nativePath.startsWith("native:")) return null;
-
-    const relativePath = nativePath.replace("native:", "");
-    const fullPath = path.join(getCoversBasePath(), relativePath);
+    const fullPath = resolveNativeImagePath(nativePath);
+    if (!fullPath) return null;
 
     if (!fs.existsSync(fullPath)) return null;
     return fullPath;


### PR DESCRIPTION
## Summary
CodeQL remediation slice (alert #1180, `js/path-injection`): `imageStorage.ts` built filesystem paths from caller-supplied ids/native path strings without containment.

- IDs validated against the repository ID-token alphabet (`^[A-Za-z0-9_-]+$`).
- Only canonical `native:artists/<id>.jpg` / `native:albums/<id>.jpg` forms accepted; everything else fails closed.
- Every candidate resolves through the existing `safeResolvePath` beneath its type-specific covers directory before any read/write/delete — covering `downloadAndStoreImage`, `localImageExists`, `getLocalImagePath`, `deleteLocalImage`.

## Tests
Parameterized rejection tests (parent traversal, absolute paths, null bytes, dotted segments) for each public function + a delete-cannot-escape-root test; legitimate flows unchanged.

## Verification
- `npm --prefix backend test -- "imageStorage|coverArt"` → 7 suites / 151 tests (independent re-run green)
- Mocked-consumer sweep (10 suites incl. library/enrichment) → 276 tests
- `tsc --noEmit` clean · pinned prettier clean · route-error canon both ratchets pass