### PR TITLE
fix(security): rate-limit the admin queue dashboard and playback-state sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,9 +734,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Account-management, 2FA, and Subsonic-credential routes now have dedicated
-  route-level rate limiting, and invite codes use unbiased cryptographic random
-  character selection.
+- Account-management, 2FA, Subsonic-credential, admin queue-dashboard, and
+  playback-state sync routes now have route-level rate limiting; playback-state
+  uses a generous dedicated tier for its high-frequency cadence, and invite
+  codes use unbiased cryptographic random character selection.
 - Playlist pending-track operations are scoped to both the playlist and
   pending-track ids, closing a cross-user IDOR (#366).
 - API-key management and MFA setup/enable/disable now require an interactive

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -707,8 +707,12 @@ describe("api entrypoint runtime behavior", () => {
             (args: unknown[]) => args[0] === "/api/admin/queues",
         );
         expect(queuesCall).toBeDefined();
-        expect(queuesCall![1]).toBe(mocks.requireAuth);
-        expect(queuesCall![2]).toBe(mocks.requireAdmin);
+        expect(queuesCall!.slice(1)).toEqual([
+            "api-limiter",
+            mocks.requireAuth,
+            mocks.requireAdmin,
+            "bull-router",
+        ]);
     });
 
     it("mounts /api/device-link behind the stricter authLimiter", async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -256,7 +256,8 @@ app.use("/api/settings", apiLimiter, settingsRoutes);
 app.use("/api/social", apiLimiter, socialRoutes);
 app.use("/api/system-settings", apiLimiter, systemSettingsRoutes);
 app.use("/api/listening-state", apiLimiter, listeningStateRoutes);
-app.use("/api/playback-state", playbackStateRoutes); // No rate limit - syncs frequently
+// Playback-state routes use their dedicated high-volume limiter before auth.
+app.use("/api/playback-state", playbackStateRoutes);
 app.use("/api/offline", apiLimiter, offlineRoutes);
 app.use("/api/playlists", apiLimiter, playlistsRoutes);
 app.use("/api/share-links", apiLimiter, shareLinkRoutes);
@@ -607,6 +608,7 @@ httpServer.listen(config.port, "0.0.0.0", async () => {
 
         app.use(
             "/api/admin/queues",
+            apiLimiter,
             requireAuth,
             requireAdmin,
             serverAdapter.getRouter(),

--- a/backend/src/middleware/__tests__/rateLimiter.test.ts
+++ b/backend/src/middleware/__tests__/rateLimiter.test.ts
@@ -54,8 +54,9 @@ describe("rateLimiter middleware config", () => {
     it("creates each limiter with the documented window and max values", async () => {
         const mod = await loadRateLimiterModule();
 
-        expect(mockRateLimit).toHaveBeenCalledTimes(9);
+        expect(mockRateLimit).toHaveBeenCalledTimes(10);
         expect(mod.apiLimiter).toBeDefined();
+        expect(mod.playbackStateLimiter).toBeDefined();
         expect(mod.authLimiter).toBeDefined();
         expect(mod.imageLimiter).toBeDefined();
         expect(mod.downloadLimiter).toBeDefined();
@@ -67,14 +68,15 @@ describe("rateLimiter middleware config", () => {
 
         const expectedConfigs = [
             { index: 0, windowMs: 60_000, max: 5000 },
-            { index: 1, windowMs: 900_000, max: 40 },
-            { index: 2, windowMs: 60_000, max: 500 },
-            { index: 3, windowMs: 60_000, max: 100 },
-            { index: 4, windowMs: 60_000, max: 120 },
-            { index: 5, windowMs: 900_000, max: 20 },
-            { index: 6, windowMs: 60_000, max: 30 },
-            { index: 7, windowMs: 60_000, max: 20 },
-            { index: 8, windowMs: 60_000, max: 60 },
+            { index: 1, windowMs: 60_000, max: 600 },
+            { index: 2, windowMs: 900_000, max: 40 },
+            { index: 3, windowMs: 60_000, max: 500 },
+            { index: 4, windowMs: 60_000, max: 100 },
+            { index: 5, windowMs: 60_000, max: 120 },
+            { index: 6, windowMs: 900_000, max: 20 },
+            { index: 7, windowMs: 60_000, max: 30 },
+            { index: 8, windowMs: 60_000, max: 20 },
+            { index: 9, windowMs: 60_000, max: 60 },
         ];
 
         for (const config of expectedConfigs) {
@@ -86,7 +88,7 @@ describe("rateLimiter middleware config", () => {
             );
         }
 
-        expect(getOptions(1).skipSuccessfulRequests).toBe(true);
+        expect(getOptions(2).skipSuccessfulRequests).toBe(true);
     });
 
     it("uses standard headers, disables legacy headers, and disables trustProxy validation for all limiters", async () => {
@@ -167,7 +169,7 @@ describe("rateLimiter middleware config", () => {
 
     it("authLimiter handler logs the client IP and sends the configured limit response", async () => {
         await loadRateLimiterModule();
-        const handler = getOptions(1).handler as NonNullable<
+        const handler = getOptions(2).handler as NonNullable<
             RateLimitOptions["handler"]
         >;
         const res = {} as RateLimitHandlerResponse;

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -43,6 +43,17 @@ export const apiLimiter = rateLimit({
     ...trustProxyValidation,
 });
 
+// Playback-state clients persist progress every 15 seconds (4 requests/minute).
+// Allow 600 requests/minute so even 150 normally syncing devices behind one IP fit.
+export const playbackStateLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 600,
+    message: "Too many playback state requests. Please slow down.",
+    standardHeaders: true,
+    legacyHeaders: false,
+    ...trustProxyValidation,
+});
+
 // Auth limiter for login endpoints (40 attempts/15min per IP)
 // More lenient for self-hosted apps where users may have password manager issues
 export const authLimiter = rateLimit({

--- a/backend/src/routes/__tests__/playbackStateRuntime.test.ts
+++ b/backend/src/routes/__tests__/playbackStateRuntime.test.ts
@@ -1,5 +1,11 @@
+import express from "express";
+import request from "supertest";
+
 jest.mock("../../middleware/auth", () => ({
-    requireAuth: (_req: any, _res: any, next: () => void) => next(),
+    requireAuth: (req: any, _res: any, next: () => void) => {
+        req.user ??= { id: "u1" };
+        next();
+    },
 }));
 
 const mockLoggerWarn = jest.fn();
@@ -31,6 +37,8 @@ jest.mock("../../utils/db", () => ({
 }));
 
 import router from "../playbackState";
+import { requireAuth } from "../../middleware/auth";
+import { playbackStateLimiter } from "../../middleware/rateLimiter";
 import { prisma as prismaClient, Prisma as PrismaClient } from "../../utils/db";
 
 const mockFindUnique = prismaClient.playbackState.findUnique as jest.Mock;
@@ -38,6 +46,14 @@ const mockUpsert = prismaClient.playbackState.upsert as jest.Mock;
 const mockDeleteMany = prismaClient.playbackState.deleteMany as jest.Mock;
 
 function getHandler(method: "get" | "post" | "delete", path: string) {
+    const handlers = getRouteHandlers(method, path);
+    return handlers[handlers.length - 1];
+}
+
+function getRouteHandlers(
+    method: "get" | "post" | "delete",
+    path: string,
+) {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -47,7 +63,15 @@ function getHandler(method: "get" | "post" | "delete", path: string) {
         throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
     }
 
-    return layer.route.stack[layer.route.stack.length - 1].handle;
+    return layer.route.stack.map((entry: any) => entry.handle);
+}
+
+function createRuntimeApp() {
+    const app = express();
+    app.set("trust proxy", 1);
+    app.use(express.json());
+    app.use("/", router);
+    return app;
 }
 
 function createRes() {
@@ -78,6 +102,55 @@ describe("playbackState routes runtime", () => {
         mockUpsert.mockReset();
         mockDeleteMany.mockReset();
     });
+
+    it("attaches the playback-state limiter before auth on every route", () => {
+        for (const method of ["get", "post", "delete"] as const) {
+            const handlers = getRouteHandlers(method, "/");
+            expect(handlers).toHaveLength(3);
+            expect(handlers[0]).toBe(playbackStateLimiter);
+            expect(handlers[1]).toBe(requireAuth);
+        }
+    });
+
+    it("allows the normal four playback-state updates per minute", async () => {
+        mockUpsert.mockResolvedValue({ id: "state-normal-cadence" });
+        const app = createRuntimeApp();
+        const statuses: number[] = [];
+
+        for (let update = 0; update < 4; update += 1) {
+            const response = await request(app)
+                .post("/")
+                .set("X-Forwarded-For", "198.51.100.10")
+                .send({
+                    playbackType: "track",
+                    trackId: "track-1",
+                    currentTime: update * 15,
+                });
+            statuses.push(response.status);
+        }
+
+        expect(statuses).toEqual([200, 200, 200, 200]);
+        expect(mockUpsert).toHaveBeenCalledTimes(4);
+    });
+
+    it("returns 429 at the finite playback-state request boundary", async () => {
+        mockFindUnique.mockResolvedValue({ id: "state-rate-boundary" });
+        const app = createRuntimeApp();
+
+        for (let requestCount = 1; requestCount <= 600; requestCount += 1) {
+            const response = await request(app)
+                .get("/")
+                .set("X-Forwarded-For", "198.51.100.11");
+            expect(response.status).toBe(200);
+        }
+
+        const limitedResponse = await request(app)
+            .get("/")
+            .set("X-Forwarded-For", "198.51.100.11");
+
+        expect(limitedResponse.status).toBe(429);
+        expect(mockFindUnique).toHaveBeenCalledTimes(600);
+    }, 30_000);
 
     it("gets state for a device-specific record", async () => {
         mockFindUnique.mockResolvedValueOnce({

--- a/backend/src/routes/playbackState.ts
+++ b/backend/src/routes/playbackState.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { logger } from "../utils/logger";
 import { prisma, Prisma } from "../utils/db";
 import { requireAuth } from "../middleware/auth";
+import { playbackStateLimiter } from "../middleware/rateLimiter";
 import { publishSocialPresenceUpdate } from "../services/socialPresenceEvents";
 import {
     normalizeCanonicalMediaProviderIdentity,
@@ -155,7 +156,7 @@ function sanitizeTrackQueueItem(item: any): Record<string, unknown> {
  *         description: Not authenticated
  */
 // Get current playback state for the authenticated user
-router.get("/", requireAuth, async (req, res) => {
+router.get("/", playbackStateLimiter, requireAuth, async (req, res) => {
     try {
         const userId = req.user!.id;
         const deviceId = getPlaybackDeviceId(req);
@@ -280,7 +281,7 @@ router.get("/", requireAuth, async (req, res) => {
  *         description: Not authenticated
  */
 // Update current playback state for the authenticated user
-router.post("/", requireAuth, async (req, res) => {
+router.post("/", playbackStateLimiter, requireAuth, async (req, res) => {
     try {
         const userId = req.user!.id;
         const deviceId = getPlaybackDeviceId(req);
@@ -463,7 +464,7 @@ router.post("/", requireAuth, async (req, res) => {
  *         description: Not authenticated
  */
 // Clear playback state (when user stops playback completely)
-router.delete("/", requireAuth, async (req, res) => {
+router.delete("/", playbackStateLimiter, requireAuth, async (req, res) => {
     try {
         const userId = req.user!.id;
         const deviceId = getPlaybackDeviceId(req);


### PR DESCRIPTION
## Summary
CodeQL remediation slice (alerts #1174, #182, #185, #187 — `js/missing-rate-limiting`).

- **Bull Board** (`/api/admin/queues`): `apiLimiter` now precedes `requireAuth`/`requireAdmin` in the mount chain — it was the one mount with no request bound.
- **Playback-state sync** (`GET/POST/DELETE /api/playback-state`): was deliberately exempted from the global limiter ("syncs frequently"), i.e. unbounded. New dedicated `playbackStateLimiter` — 600 req/min/IP, sized for the 15-second sync cadence (~150 devices behind one IP) — attached before auth on all three routes.

No handler logic or response shapes changed.

## Tests
Mount-contract assertion for every API prefix; limiter-before-auth assertion per playback-state route; normal-cadence pass + 429 boundary behavior tests.

## Verification
- Targeted jest → 4 suites / 53 tests; middleware-mock sweep → 23 suites / 516 tests
- Independent re-run → green · `tsc --noEmit` clean · pinned prettier clean · route-error canon both ratchets