### PR TITLE
fix(player): retry browser-blocked playback starts on focus, visibility, and a bounded timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Queue auto-advance now recovers when the browser blocks the next track's
+  playback start in a background or unfocused window, using bounded automatic
+  retries plus a retry on window focus, with blocked and recovery-attempt states
+  visible in server telemetry.
 - Admin “Test connection” failures for Audiobookshelf, Fanart.tv, Last.fm,
   Soulseek, Spotify, and TIDAL no longer log the user out: upstream credential
   failures now return 502 instead of 401, and the web client only treats

--- a/frontend/lib/audio-engine/nativeAudioElementEngine.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementEngine.ts
@@ -713,19 +713,36 @@ export class NativeAudioElementEngine implements AudioEngine {
 
     private armVisibilityRetry(): void {
         this.disarmVisibilityRetry();
-        this.visibilityRetryCleanup = this.bindGlobalListener(
+        let retryFired = false;
+        const fireRetry = (via: "visibility" | "focus"): void => {
+            if (
+                retryFired ||
+                (via === "visibility" && this.isPageHidden())
+            ) {
+                return;
+            }
+            retryFired = true;
+            this.dispatch({
+                type: "VISIBILITY_RETRY_FIRED",
+                via,
+                nowMs: this.now(),
+            });
+        };
+        const visibilityCleanup = this.bindGlobalListener(
             "document",
             "visibilitychange",
-            () => {
-                if (this.isPageHidden()) {
-                    return;
-                }
-                this.dispatch({
-                    type: "VISIBILITY_RETRY_FIRED",
-                    nowMs: this.now(),
-                });
-            },
+            () => fireRetry("visibility"),
         );
+        const focusCleanup = this.bindGlobalListener(
+            "window",
+            "focus",
+            () => fireRetry("focus"),
+        );
+        this.visibilityRetryCleanup = () => {
+            retryFired = true;
+            visibilityCleanup();
+            focusCleanup();
+        };
     }
 
     private disarmVisibilityRetry(): void {

--- a/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementPolicy.ts
@@ -12,8 +12,8 @@
  * - short seek marks that suppress stale `timeupdate` positions instead
  *   of lock flags and timeout timers
  * - bounded automatic retries that exhaust into an explicit error
- * - autoplay-policy handling: `NotAllowedError` arms exactly one
- *   gesture retry and never loops
+ * - autoplay-policy handling: `NotAllowedError` arms one gesture retry,
+ *   one focus/visibility retry, and bounded timer retries
  * - media-error classification: background session reclaim (preserve
  *   media for foreground recovery), stale-source auth expiry (reload
  *   from the stored source at position), transient, and fatal
@@ -46,6 +46,11 @@ export const NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES = 3;
 /** Base delay for automatic retry backoff (multiplied by attempt). */
 export const NATIVE_ENGINE_RETRY_BASE_DELAY_MS = 500;
 
+/** Bounded delays for retrying a browser-blocked playback start. */
+export const NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS = [
+    1_000, 3_000, 7_000,
+] as const;
+
 /**
  * A pause at least this long before a media error suggests the stream
  * URL's rotating auth token expired; recover by reloading from source.
@@ -69,6 +74,8 @@ export interface NativeEnginePolicyState {
     seekTargetSec: number | null;
     /** Automatic retries consumed for the current load. */
     automaticRetriesUsed: number;
+    /** Browser-blocked playback-start retries consumed for this intent. */
+    playStartRetriesUsed: number;
     /** Whether the single autoplay gesture retry has been spent. */
     gestureRetryUsed: boolean;
     /** Classification of the most recent pause. */
@@ -132,7 +139,11 @@ export type NativeEnginePolicyEvent =
           nowMs: number;
       }
     | { type: "GESTURE_RETRY_FIRED"; nowMs: number }
-    | { type: "VISIBILITY_RETRY_FIRED"; nowMs: number }
+    | {
+          type: "VISIBILITY_RETRY_FIRED";
+          via: "visibility" | "focus";
+          nowMs: number;
+      }
     | { type: "RETRY_TIMER_FIRED"; nowMs: number }
     | { type: "RELOAD_REQUESTED"; nowMs: number }
     | {
@@ -230,6 +241,7 @@ export const createInitialNativeEngineState = (): NativeEnginePolicyState => ({
     seekMarkUntilMs: null,
     seekTargetSec: null,
     automaticRetriesUsed: 0,
+    playStartRetriesUsed: 0,
     gestureRetryUsed: false,
     pauseClassification: null,
     pausedAtMs: null,
@@ -365,6 +377,7 @@ const applyFreshLoad = (
     effects: [
         { kind: "cancelRetry" },
         { kind: "disarmGestureRetry" },
+        { kind: "disarmVisibilityRetry" },
         { kind: "stopTicker" },
         { kind: "applyLoad", autoplay: event.autoplay, isRetry: false },
     ],
@@ -434,24 +447,48 @@ const handlePlayRequested = (
         return { state: { ...state, autoplay: true }, effects: [] };
     }
     return {
-        state: { ...state, gestureRetryUsed: false },
+        state: {
+            ...state,
+            autoplay: true,
+            playStartRetriesUsed: 0,
+            gestureRetryUsed: false,
+            pauseClassification: null,
+        },
         effects: [{ kind: "callPlay" }],
     };
 };
 
 const handlePauseRequested = (state: State): Transition => {
+    if (
+        state.status !== "playing" &&
+        state.status !== "loading" &&
+        state.status !== "paused"
+    ) {
+        return noChange(state);
+    }
+    const nextState: State = {
+        ...state,
+        autoplay: false,
+        playStartRetriesUsed: 0,
+        pauseClassification: "user",
+    };
+    const cleanupEffects: NativeEnginePolicyEffect[] = [
+        { kind: "cancelRetry" },
+        { kind: "disarmGestureRetry" },
+        { kind: "disarmVisibilityRetry" },
+    ];
     if (state.status === "loading" && !state.metadataReady) {
         return {
-            state: { ...state, autoplay: false, pauseClassification: "user" },
-            effects: [],
+            state: nextState,
+            effects: cleanupEffects,
         };
     }
     if (state.status !== "playing" && state.status !== "loading") {
-        return noChange(state);
+        return { state: nextState, effects: cleanupEffects };
     }
     return {
-        state: { ...state, autoplay: false, pauseClassification: "user" },
-        effects: [{ kind: "callPause" }],
+        state: nextState,
+        effects: [...cleanupEffects, { kind: "callPause" }],
     };
 };
 
@@ -464,6 +501,7 @@ const handleStopRequested = (state: State): Transition => {
             ...state,
             status: "idle",
             autoplay: false,
+            playStartRetriesUsed: 0,
             pendingSeekSec: null,
             seekMarkUntilMs: null,
             seekTargetSec: null,
@@ -471,6 +509,8 @@ const handleStopRequested = (state: State): Transition => {
         },
         effects: [
             { kind: "cancelRetry" },
+            { kind: "disarmGestureRetry" },
+            { kind: "disarmVisibilityRetry" },
             { kind: "stopTicker" },
             { kind: "haltPlayback" },
             { kind: "emitStop" },
@@ -513,6 +553,9 @@ const handleElementPlaying = (
     event: Extract<NativeEnginePolicyEvent, { type: "ELEMENT_PLAYING" }>,
 ): Transition => {
     const effects: NativeEnginePolicyEffect[] = [
+        { kind: "cancelRetry" },
+        { kind: "disarmGestureRetry" },
+        { kind: "disarmVisibilityRetry" },
         { kind: "startTicker" },
         { kind: "emitPlay" },
         { kind: "emitBuffering", isBuffering: false },
@@ -529,6 +572,7 @@ const handleElementPlaying = (
             ...state,
             status: "playing",
             automaticRetriesUsed: 0,
+            playStartRetriesUsed: 0,
             gestureRetryUsed: false,
             pauseClassification: null,
             pausedAtMs: null,
@@ -750,9 +794,72 @@ const handleElementError = (
     };
 };
 
+type PlayPromiseRejectedEvent = Extract<
+    NativeEnginePolicyEvent,
+    { type: "PLAY_PROMISE_REJECTED" }
+>;
+
+const scheduleBlockedPlayRetry = (
+    state: State,
+    effects: NativeEnginePolicyEffect[],
+): number => {
+    const retriesUsed = state.playStartRetriesUsed;
+    if (
+        !state.autoplay ||
+        retriesUsed >= NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS.length
+    ) {
+        return retriesUsed;
+    }
+    const attempt = retriesUsed + 1;
+    effects.push({
+        kind: "scheduleRetry",
+        attempt,
+        delayMs: NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS[retriesUsed],
+    });
+    return attempt;
+};
+
+const handleBlockedPlayStart = (
+    state: State,
+    event: PlayPromiseRejectedEvent,
+): Transition => {
+    const effects: NativeEnginePolicyEffect[] = [
+        { kind: "stopTicker" },
+        {
+            kind: "emitPlayError",
+            code: "NotAllowedError",
+            message: event.errorMessage,
+            recoverable: true,
+        },
+        {
+            kind: "telemetry",
+            event: "playback_start_blocked",
+            fields: {
+                code: "NotAllowedError",
+                isPageHidden: event.isPageHidden,
+            },
+        },
+        { kind: "armVisibilityRetry" },
+    ];
+    if (!state.gestureRetryUsed) {
+        effects.push({ kind: "armGestureRetry" });
+    }
+    const playStartRetriesUsed = scheduleBlockedPlayRetry(state, effects);
+    return {
+        state: {
+            ...state,
+            status: "paused",
+            pausedAtMs: event.nowMs,
+            playStartRetriesUsed,
+            gestureRetryUsed: true,
+        },
+        effects,
+    };
+};
+
 const handlePlayPromiseRejected = (
     state: State,
-    event: Extract<NativeEnginePolicyEvent, { type: "PLAY_PROMISE_REJECTED" }>,
+    event: PlayPromiseRejectedEvent,
 ): Transition => {
     if (event.errorName === "AbortError") {
         // play() interrupted by a newer load()/pause(); the newer intent
@@ -760,35 +867,7 @@ const handlePlayPromiseRejected = (
         return noChange(state);
     }
     if (event.errorName === "NotAllowedError") {
-        const effects: NativeEnginePolicyEffect[] = [
-            { kind: "stopTicker" },
-            {
-                kind: "emitPlayError",
-                code: "NotAllowedError",
-                message: event.errorMessage,
-                recoverable: true,
-            },
-        ];
-        if (!state.gestureRetryUsed) {
-            effects.push({ kind: "armGestureRetry" });
-        }
-        // Autoplay rejected in a hidden tab (e.g. a queue auto-advance
-        // while the user is tabbed away) is not a gesture problem: the
-        // same play() is typically allowed once the page is visible.
-        // Retry once on the hidden→visible transition instead of sitting
-        // silent until the user happens to click (GH #53).
-        if (event.isPageHidden) {
-            effects.push({ kind: "armVisibilityRetry" });
-        }
-        return {
-            state: {
-                ...state,
-                status: "paused",
-                pausedAtMs: event.nowMs,
-                gestureRetryUsed: true,
-            },
-            effects,
-        };
+        return handleBlockedPlayStart(state, event);
     }
     return {
         state: { ...state, status: "error" },
@@ -813,40 +892,88 @@ const handlePlayPromiseRejected = (
 };
 
 const handleGestureRetryFired = (state: State): Transition => {
-    if (state.status !== "paused" || !state.hasSource) {
+    if (
+        state.status !== "paused" ||
+        !state.hasSource ||
+        !state.autoplay ||
+        state.pauseClassification === "user"
+    ) {
         return { state, effects: [{ kind: "disarmGestureRetry" }] };
     }
     return {
         state,
-        effects: [{ kind: "callPlay" }, { kind: "disarmGestureRetry" }],
+        effects: [
+            { kind: "callPlay" },
+            { kind: "disarmGestureRetry" },
+            {
+                kind: "telemetry",
+                event: "playback_retry_fired",
+                fields: { via: "gesture" },
+            },
+        ],
     };
 };
 
-const handleVisibilityRetryFired = (state: State): Transition => {
+const handleVisibilityRetryFired = (
+    state: State,
+    via: "visibility" | "focus",
+): Transition => {
     // One-shot: whatever happens, the arm is spent. A user pause between
-    // the rejection and the tab return must stay a pause, so only a
-    // still-externally-paused source is retried.
+    // the rejection and retry signal must stay a pause, so only a source
+    // that still carries play intent is retried.
     if (
         state.status !== "paused" ||
         !state.hasSource ||
+        !state.autoplay ||
         state.pauseClassification === "user"
     ) {
         return { state, effects: [{ kind: "disarmVisibilityRetry" }] };
     }
     return {
         state,
-        effects: [{ kind: "callPlay" }, { kind: "disarmVisibilityRetry" }],
+        effects: [
+            { kind: "callPlay" },
+            { kind: "disarmVisibilityRetry" },
+            {
+                kind: "telemetry",
+                event: "playback_retry_fired",
+                fields: { via },
+            },
+        ],
     };
 };
 
 const handleRetryTimerFired = (state: State): Transition => {
-    if (state.status !== "loading") {
+    if (state.status === "loading") {
+        return {
+            state,
+            effects: [
+                {
+                    kind: "applyLoad",
+                    autoplay: state.autoplay,
+                    isRetry: true,
+                },
+            ],
+        };
+    }
+    if (
+        state.status !== "paused" ||
+        !state.hasSource ||
+        !state.autoplay ||
+        state.pauseClassification === "user" ||
+        state.playStartRetriesUsed === 0
+    ) {
         return noChange(state);
     }
     return {
         state,
         effects: [
-            { kind: "applyLoad", autoplay: state.autoplay, isRetry: true },
+            { kind: "callPlay" },
+            {
+                kind: "telemetry",
+                event: "playback_retry_fired",
+                fields: { via: "timer" },
+            },
         ],
     };
 };
@@ -945,7 +1072,7 @@ export function transitionNativeEngine(
         case "GESTURE_RETRY_FIRED":
             return handleGestureRetryFired(state);
         case "VISIBILITY_RETRY_FIRED":
-            return handleVisibilityRetryFired(state);
+            return handleVisibilityRetryFired(state, event.via);
         case "RETRY_TIMER_FIRED":
             return handleRetryTimerFired(state);
         case "RELOAD_REQUESTED":

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -10,6 +10,7 @@ import { IosStandaloneAudioContextBridge } from "../../lib/audio-engine/iosStand
 import {
     NATIVE_ENGINE_END_PAUSE_EPSILON_SEC,
     NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES,
+    NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS,
 } from "../../lib/audio-engine/nativeAudioElementPolicy";
 
 type ElementListener = (event: unknown) => void;
@@ -796,7 +797,7 @@ test("NotAllowedError emits playerror and retries exactly once on the next gestu
     );
 });
 
-test("no automatic retry timers are scheduled for NotAllowedError", async () => {
+test("NotAllowedError schedules a bounded timer retry through the normal play path", async () => {
     const harness = createHarness();
     harness.engine.load("https://stream.example/track.flac", {
         autoplay: true,
@@ -808,9 +809,22 @@ test("no automatic retry timers are scheduled for NotAllowedError", async () => 
     };
     harness.mainElement().fireLoadedMetadata(200);
     await flushMicrotasks();
-    assert.equal(
-        harness.scheduler.timers.filter((timer) => !timer.cleared).length,
-        0,
+
+    const [retry] = harness.scheduler.timers.filter(
+        (timer) => !timer.cleared,
+    );
+    assert.ok(retry);
+    assert.equal(retry.delayMs, NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS[0]);
+
+    harness.mainElement().playBehavior = { kind: "resolve" };
+    harness.scheduler.firePendingTimer();
+    await flushMicrotasks();
+    assert.equal(harness.mainElement().playCalls, 2);
+    assert.deepEqual(
+        harness.telemetryEvents.find(
+            (entry) => entry.event === "playback_retry_fired",
+        )?.fields,
+        { via: "timer" },
     );
 });
 
@@ -996,6 +1010,13 @@ test("NotAllowedError in a hidden tab retries automatically when the page become
             !binding.removed,
     );
     assert.equal(visibilityBindings.length, 1, "visibility retry armed");
+    const focusBindings = harness.bindings.filter(
+        (binding) =>
+            binding.target === "window" &&
+            binding.type === "focus" &&
+            !binding.removed,
+    );
+    assert.equal(focusBindings.length, 1, "focus retry armed");
 
     // A visibility event while still hidden must not retry.
     visibilityBindings[0].handler({});
@@ -1010,13 +1031,25 @@ test("NotAllowedError in a hidden tab retries automatically when the page become
     assert.equal(harness.mainElement().playCalls, 2);
     assert.ok(
         harness.bindings
-            .filter((binding) => binding.type === "visibilitychange")
+            .filter(
+                (binding) =>
+                    binding.type === "visibilitychange" ||
+                    binding.type === "focus",
+            )
             .every((binding) => binding.removed),
-        "visibility retry disarmed after firing",
+        "visibility and focus retries disarmed together after firing",
+    );
+    assert.deepEqual(
+        harness.telemetryEvents.find(
+            (entry) =>
+                entry.event === "playback_retry_fired" &&
+                entry.fields.via === "visibility",
+        )?.fields,
+        { via: "visibility" },
     );
 });
 
-test("NotAllowedError in a visible tab does not arm a visibility retry", async () => {
+test("NotAllowedError in a visible unfocused window retries on focus and first event wins", async () => {
     const harness = createHarness();
     harness.engine.load("https://stream.example/track.flac", {
         autoplay: true,
@@ -1028,10 +1061,121 @@ test("NotAllowedError in a visible tab does not arm a visibility retry", async (
     };
     harness.mainElement().fireLoadedMetadata(200);
     await flushMicrotasks();
+
+    const visibilityBinding = harness.bindings.find(
+        (binding) =>
+            binding.target === "document" &&
+            binding.type === "visibilitychange" &&
+            !binding.removed,
+    );
+    const focusBinding = harness.bindings.find(
+        (binding) =>
+            binding.target === "window" &&
+            binding.type === "focus" &&
+            !binding.removed,
+    );
+    assert.ok(visibilityBinding, "visibility retry armed while visible");
+    assert.ok(focusBinding, "focus retry armed while visible");
+
+    harness.mainElement().playBehavior = { kind: "resolve" };
+    focusBinding.handler({});
+    await flushMicrotasks();
+    assert.equal(harness.mainElement().playCalls, 2, "focus retries once");
+    assert.equal(visibilityBinding.removed, true);
+    assert.equal(focusBinding.removed, true);
+
+    visibilityBinding.handler({});
+    await flushMicrotasks();
     assert.equal(
-        harness.bindings.filter(
-            (binding) => binding.type === "visibilitychange",
-        ).length,
+        harness.mainElement().playCalls,
+        2,
+        "stale second listener cannot retry again",
+    );
+    assert.deepEqual(
+        harness.telemetryEvents.find(
+            (entry) =>
+                entry.event === "playback_retry_fired" &&
+                entry.fields.via === "focus",
+        )?.fields,
+        { via: "focus" },
+    );
+});
+
+test("user pause and a new load disarm blocked-start listeners and clear timer retries", async () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/track-1.flac", {
+        autoplay: true,
+    });
+    harness.mainElement().playBehavior = {
+        kind: "reject",
+        name: "NotAllowedError",
+        message: "blocked",
+    };
+    harness.mainElement().fireLoadedMetadata(200);
+    await flushMicrotasks();
+
+    harness.engine.pause();
+    assert.ok(
+        harness.bindings
+            .filter(
+                (binding) =>
+                    binding.type === "visibilitychange" ||
+                    binding.type === "focus",
+            )
+            .every((binding) => binding.removed),
+        "pause removes focus and visibility listeners",
+    );
+    assert.equal(
+        harness.scheduler.timers.filter((timer) => !timer.cleared).length,
+        0,
+        "pause clears the retry timer",
+    );
+
+    harness.mainElement().playBehavior = {
+        kind: "reject",
+        name: "NotAllowedError",
+        message: "blocked again",
+    };
+    harness.engine.play();
+    await flushMicrotasks();
+    harness.engine.load("https://stream.example/track-2.flac", {
+        autoplay: false,
+    });
+    assert.ok(
+        harness.bindings
+            .filter(
+                (binding) =>
+                    binding.type === "visibilitychange" ||
+                    binding.type === "focus",
+            )
+            .every((binding) => binding.removed),
+        "new load removes focus and visibility listeners",
+    );
+    assert.equal(
+        harness.scheduler.timers.filter((timer) => !timer.cleared).length,
+        0,
+        "new load clears the retry timer",
+    );
+});
+
+test("destroy removes both blocked-start listeners and its retry timer", async () => {
+    const harness = createHarness();
+    harness.engine.load("https://stream.example/track.flac", {
+        autoplay: true,
+    });
+    harness.mainElement().playBehavior = {
+        kind: "reject",
+        name: "NotAllowedError",
+        message: "blocked",
+    };
+    harness.mainElement().fireLoadedMetadata(200);
+    await flushMicrotasks();
+
+    harness.engine.destroy();
+
+    assert.ok(harness.bindings.every((binding) => binding.removed));
+    assert.equal(
+        harness.scheduler.timers.filter((timer) => !timer.cleared).length,
         0,
     );
 });

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
     NATIVE_ENGINE_MAX_AUTOMATIC_RETRIES,
+    NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS,
     NATIVE_ENGINE_SEEK_MARK_MS,
     NATIVE_ENGINE_SEEK_MARK_TOLERANCE_SEC,
     NATIVE_ENGINE_STALE_SOURCE_PAUSE_MS,
@@ -59,6 +60,7 @@ test("initial state is idle with no source and no retry debt", () => {
     assert.equal(state.status, "idle");
     assert.equal(state.hasSource, false);
     assert.equal(state.automaticRetriesUsed, 0);
+    assert.equal(state.playStartRetriesUsed, 0);
     assert.equal(state.pendingSeekSec, null);
     assert.equal(state.seekMarkUntilMs, null);
 });
@@ -100,9 +102,10 @@ test("LOAD_REQUESTED with a start position queues the seek for readiness", () =>
     assert.equal(state.pendingSeekSec, 42);
 });
 
-test("LOAD_REQUESTED resets retry budget, gesture retry, and pending seeks from prior load", () => {
+test("LOAD_REQUESTED resets retry budgets, gesture retry, and pending seeks from prior load", () => {
     const prior = loadedState({
         automaticRetriesUsed: 2,
+        playStartRetriesUsed: 2,
         gestureRetryUsed: true,
         pendingSeekSec: 10,
         seekTargetSec: 10,
@@ -115,11 +118,14 @@ test("LOAD_REQUESTED resets retry budget, gesture retry, and pending seeks from 
         nowMs: 2_000,
     });
     assert.equal(state.automaticRetriesUsed, 0);
+    assert.equal(state.playStartRetriesUsed, 0);
     assert.equal(state.gestureRetryUsed, false);
     assert.equal(state.pendingSeekSec, null);
     assert.equal(state.seekTargetSec, null);
     assert.equal(state.seekMarkUntilMs, null);
     assert.ok(kinds(effects).includes("disarmGestureRetry"));
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
+    assert.ok(kinds(effects).includes("cancelRetry"));
 });
 
 test("same-source load while playing is deduped (howler parity — LT resync must not restart the track)", () => {
@@ -413,12 +419,18 @@ test("PLAY_REQUESTED in error state recovers by reloading from source at positio
 });
 
 test("PAUSE_REQUESTED while playing classifies the pause as user-intended", () => {
-    const { state, effects } = transitionNativeEngine(playingState(), {
+    const { state, effects } = transitionNativeEngine(
+        playingState({ playStartRetriesUsed: 2 }),
+        {
         type: "PAUSE_REQUESTED",
         nowMs: 3_000,
-    });
+        },
+    );
     assert.equal(state.pauseClassification, "user");
+    assert.equal(state.playStartRetriesUsed, 0);
     assert.ok(kinds(effects).includes("callPause"));
+    assert.ok(kinds(effects).includes("cancelRetry"));
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
 });
 
 test("PAUSE_REQUESTED during load cancels captured autoplay without a pause call", () => {
@@ -440,17 +452,22 @@ test("PAUSE_REQUESTED during load cancels captured autoplay without a pause call
 });
 
 test("STOP_REQUESTED halts playback, keeps the source, and emits stop", () => {
-    const { state, effects } = transitionNativeEngine(playingState(), {
-        type: "STOP_REQUESTED",
-        nowMs: 3_000,
-    });
+    const { state, effects } = transitionNativeEngine(
+        playingState({ playStartRetriesUsed: 2 }),
+        {
+            type: "STOP_REQUESTED",
+            nowMs: 3_000,
+        },
+    );
     assert.equal(state.status, "idle");
     assert.equal(state.hasSource, true);
     assert.equal(state.autoplay, false);
+    assert.equal(state.playStartRetriesUsed, 0);
     assert.ok(kinds(effects).includes("haltPlayback"));
     assert.ok(kinds(effects).includes("stopTicker"));
     assert.ok(kinds(effects).includes("emitStop"));
     assert.ok(kinds(effects).includes("cancelRetry"));
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
 });
 
 test("STOP_REQUESTED without a source is a no-op", () => {
@@ -467,15 +484,22 @@ test("STOP_REQUESTED without a source is a no-op", () => {
 
 test("ELEMENT_PLAYING enters playing, starts the ticker, resets retries, and reports start latency", () => {
     const { state, effects } = transitionNativeEngine(
-        loadedState({ autoplay: true, automaticRetriesUsed: 2 }),
+        loadedState({
+            autoplay: true,
+            automaticRetriesUsed: 2,
+            playStartRetriesUsed: 2,
+        }),
         { type: "ELEMENT_PLAYING", nowMs: 1_500 },
     );
     assert.equal(state.status, "playing");
     assert.equal(state.automaticRetriesUsed, 0);
+    assert.equal(state.playStartRetriesUsed, 0);
     assert.equal(state.gestureRetryUsed, false);
     assert.equal(state.loadRequestedAtMs, null);
     assert.ok(kinds(effects).includes("startTicker"));
     assert.ok(kinds(effects).includes("emitPlay"));
+    assert.ok(kinds(effects).includes("cancelRetry"));
+    assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
     const telemetry = findEffect(effects, "telemetry");
     assert.equal(telemetry?.event, "playback_start_latency");
     assert.equal(telemetry?.fields.latencyMs, 500);
@@ -1202,7 +1226,7 @@ test("fatal src-not-supported errors fail immediately without retries", () => {
 // Autoplay policy — play() promise rejections
 // ---------------------------------------------------------------------------
 
-test("NotAllowedError parks paused, surfaces the gesture requirement, and arms one gesture retry", () => {
+test("NotAllowedError reports the block and arms gesture, visibility, and bounded timer retries", () => {
     const { state, effects } = transitionNativeEngine(
         loadedState({ autoplay: true }),
         {
@@ -1215,10 +1239,73 @@ test("NotAllowedError parks paused, surfaces the gesture requirement, and arms o
     );
     assert.equal(state.status, "paused");
     assert.equal(state.gestureRetryUsed, true);
+    assert.equal(state.playStartRetriesUsed, 1);
     assert.ok(kinds(effects).includes("armGestureRetry"));
+    assert.ok(kinds(effects).includes("armVisibilityRetry"));
     const error = findEffect(effects, "emitPlayError");
     assert.equal(error?.code, "NotAllowedError");
-    assert.equal(kinds(effects).includes("scheduleRetry"), false);
+    const retry = findEffect(effects, "scheduleRetry");
+    assert.equal(retry?.attempt, 1);
+    assert.equal(retry?.delayMs, NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS[0]);
+    const telemetry = effects.find(
+        (effect) =>
+            effect.kind === "telemetry" &&
+            effect.event === "playback_start_blocked",
+    );
+    assert.deepEqual(
+        telemetry && "fields" in telemetry ? telemetry.fields : undefined,
+        { code: "NotAllowedError", isPageHidden: false },
+    );
+});
+
+test("NotAllowedError play-start retries stop at the fixed attempt cap", () => {
+    let state = loadedState({ autoplay: true });
+    const scheduledDelays: number[] = [];
+
+    for (
+        let rejection = 0;
+        rejection <= NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS.length;
+        rejection += 1
+    ) {
+        const transition = transitionNativeEngine(state, {
+            type: "PLAY_PROMISE_REJECTED",
+            errorName: "NotAllowedError",
+            errorMessage: "blocked",
+            isPageHidden: false,
+            nowMs: 2_000 + rejection,
+        });
+        state = transition.state;
+        const retry = findEffect(transition.effects, "scheduleRetry");
+        if (retry) {
+            scheduledDelays.push(retry.delayMs);
+        }
+    }
+
+    assert.deepEqual(scheduledDelays, [1_000, 3_000, 7_000]);
+    assert.equal(
+        state.playStartRetriesUsed,
+        NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS.length,
+    );
+});
+
+test("user pause after a blocked start clears the retry timer and retry debt", () => {
+    const blocked = transitionNativeEngine(loadedState({ autoplay: true }), {
+        type: "PLAY_PROMISE_REJECTED",
+        errorName: "NotAllowedError",
+        errorMessage: "blocked",
+        isPageHidden: false,
+        nowMs: 2_000,
+    });
+    const paused = transitionNativeEngine(blocked.state, {
+        type: "PAUSE_REQUESTED",
+        nowMs: 2_100,
+    });
+
+    assert.equal(paused.state.autoplay, false);
+    assert.equal(paused.state.playStartRetriesUsed, 0);
+    assert.ok(kinds(paused.effects).includes("cancelRetry"));
+    assert.ok(kinds(paused.effects).includes("disarmGestureRetry"));
+    assert.ok(kinds(paused.effects).includes("disarmVisibilityRetry"));
 });
 
 test("a second NotAllowedError does not re-arm the gesture retry (never loop)", () => {
@@ -1256,6 +1343,9 @@ test("GESTURE_RETRY_FIRED plays once and disarms", () => {
     });
     assert.ok(kinds(effects).includes("callPlay"));
     assert.ok(kinds(effects).includes("disarmGestureRetry"));
+    const telemetry = findEffect(effects, "telemetry");
+    assert.equal(telemetry?.event, "playback_retry_fired");
+    assert.deepEqual(telemetry?.fields, { via: "gesture" });
 });
 
 test("AbortError from an interrupted play() is ignored", () => {
@@ -1363,7 +1453,7 @@ test("NotAllowedError while hidden arms a visibility retry alongside the gesture
     assert.ok(kinds(effects).includes("armGestureRetry"));
 });
 
-test("NotAllowedError while visible does not arm a visibility retry", () => {
+test("NotAllowedError while visible arms a focus-or-visibility retry", () => {
     const { effects } = transitionNativeEngine(
         loadedState({ autoplay: true }),
         {
@@ -1374,7 +1464,7 @@ test("NotAllowedError while visible does not arm a visibility retry", () => {
             nowMs: 2_000,
         },
     );
-    assert.equal(kinds(effects).includes("armVisibilityRetry"), false);
+    assert.ok(kinds(effects).includes("armVisibilityRetry"));
 });
 
 test("VISIBILITY_RETRY_FIRED plays once and disarms", () => {
@@ -1390,10 +1480,14 @@ test("VISIBILITY_RETRY_FIRED plays once and disarms", () => {
     );
     const { effects } = transitionNativeEngine(blocked, {
         type: "VISIBILITY_RETRY_FIRED",
+        via: "visibility",
         nowMs: 3_000,
     });
     assert.ok(kinds(effects).includes("callPlay"));
     assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
+    const telemetry = findEffect(effects, "telemetry");
+    assert.equal(telemetry?.event, "playback_retry_fired");
+    assert.deepEqual(telemetry?.fields, { via: "visibility" });
 });
 
 test("VISIBILITY_RETRY_FIRED after a user pause disarms without playing", () => {
@@ -1409,7 +1503,11 @@ test("VISIBILITY_RETRY_FIRED after a user pause disarms without playing", () => 
     );
     const { effects } = transitionNativeEngine(
         { ...blocked, pauseClassification: "user" },
-        { type: "VISIBILITY_RETRY_FIRED", nowMs: 3_000 },
+        {
+            type: "VISIBILITY_RETRY_FIRED",
+            via: "focus",
+            nowMs: 3_000,
+        },
     );
     assert.equal(kinds(effects).includes("callPlay"), false);
     assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
@@ -1418,8 +1516,31 @@ test("VISIBILITY_RETRY_FIRED after a user pause disarms without playing", () => 
 test("VISIBILITY_RETRY_FIRED while already playing only disarms", () => {
     const { effects } = transitionNativeEngine(playingState(), {
         type: "VISIBILITY_RETRY_FIRED",
+        via: "focus",
         nowMs: 3_000,
     });
     assert.equal(kinds(effects).includes("callPlay"), false);
     assert.ok(kinds(effects).includes("disarmVisibilityRetry"));
+});
+
+test("RETRY_TIMER_FIRED retries a blocked play through the normal play path", () => {
+    const { state: blocked } = transitionNativeEngine(
+        loadedState({ autoplay: true }),
+        {
+            type: "PLAY_PROMISE_REJECTED",
+            errorName: "NotAllowedError",
+            errorMessage: "blocked",
+            isPageHidden: false,
+            nowMs: 2_000,
+        },
+    );
+    const { effects } = transitionNativeEngine(blocked, {
+        type: "RETRY_TIMER_FIRED",
+        nowMs: 3_000,
+    });
+
+    assert.ok(kinds(effects).includes("callPlay"));
+    const telemetry = findEffect(effects, "telemetry");
+    assert.equal(telemetry?.event, "playback_retry_fired");
+    assert.deepEqual(telemetry?.fields, { via: "timer" });
 });


### PR DESCRIPTION
## Summary
Follow-up to #413 from production validation: end handling now works (`player.track_end_advanced` fires, next track loads ~350ms later) but **audio never started until the window was focused**, with zero telemetry at the failure point.

**Gap:** the `NotAllowedError` branch of `PLAY_PROMISE_REJECTED` (browser refusing the auto-advance `play()`) had three defects:
1. No telemetry effect — the only rejection path invisible server-side.
2. `armVisibilityRetry` only when `document.hidden` — a **visible-but-unfocused** window (`hidden === false`, `visibilitychange` never fires on focus) armed nothing but a one-shot gesture retry. Exactly the reported symptom.
3. No time-based retry — one refusal permanently silenced the queue.

## Fix
- `NotAllowedError` always arms the focus/visibility retry; the engine listener now binds **both** `document.visibilitychange` and `window.focus`, one-shot, first qualifying event wins, both cleaned together.
- Bounded timer retries `NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS = [1000, 3000, 7000]` through the engine's existing retry-timer machinery while play intent is active; retry debt resets on success/new-load/user-pause/stop/destroy. No idle polling.
- Telemetry: `playback_start_blocked {code, isPageHidden}` + `playback_retry_fired {via: visibility|focus|gesture|timer}` — blocked starts and recoveries are now visible in backend logs.
- AbortError and generic-error branches unchanged; Howler path untouched.

## Tests
9 new policy/engine tests (block→arm→retry ladder, attempt cap, reset on pause/load/playing, focus-vs-visibility first-wins, destroy cleanup); 136 tests across the five engine unit files pass (independently re-run).

## Verification
`tsc --noEmit` clean (independent) · pinned `prettier@3.8.2` clean · `git diff --check` clean