### PR TITLE
chore(format): apply pinned prettier to image-storage files

### DIFF
--- a/backend/src/services/__tests__/imageStorage.test.ts
+++ b/backend/src/services/__tests__/imageStorage.test.ts
@@ -260,9 +260,7 @@ describe("imageStorage service", () => {
     );
 
     it("does not delete a path outside the covers root", () => {
-        expect(
-            deleteLocalImage("native:albums/../../outside.jpg"),
-        ).toBe(false);
+        expect(deleteLocalImage("native:albums/../../outside.jpg")).toBe(false);
         expect(mockExistsSync).not.toHaveBeenCalled();
         expect(mockUnlinkSync).not.toHaveBeenCalled();
     });

--- a/backend/src/services/imageStorage.ts
+++ b/backend/src/services/imageStorage.ts
@@ -25,8 +25,7 @@ function getCoversBasePath(): string {
 }
 
 function getImageDirectory(type: ImageType): string {
-    const subdir =
-        type === "artist" ? ARTIST_IMAGES_DIR : ALBUM_IMAGES_DIR;
+    const subdir = type === "artist" ? ARTIST_IMAGES_DIR : ALBUM_IMAGES_DIR;
     return path.resolve(getCoversBasePath(), subdir);
 }
 


### PR DESCRIPTION
Formatting-only. #418's prettier verification resolved a binary outside the backend package context; the backend-context pinned 3.8.2 check flags `imageStorage.ts` + its test, so `npm run format:check` — and therefore Enforcement Gates — currently fails on main and every open PR. Fixed with the backend-context pinned run; wrap-style changes only.