### PR TITLE
fix(security): harden metadata escaping and remove backtracking-prone regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,6 +738,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Hardened external-metadata escaping for Deezer and Spotify, and replaced
+  backtracking-prone normalization regexes with linear forms in Soulseek,
+  search, and Lidarr.
 - Cover-image storage operations validate IDs and contain all filesystem paths
   under the type-specific covers directory.
 - Account-management, 2FA, and Subsonic-credential routes now have dedicated

--- a/backend/src/services/__tests__/deezerService.test.ts
+++ b/backend/src/services/__tests__/deezerService.test.ts
@@ -234,6 +234,20 @@ describe("deezerService", () => {
         );
     });
 
+    it.each([
+        ["backslashes", String.raw`Artist\Name`, String.raw`Artist\\Name`],
+        ["double quotes", 'Artist "Name"', String.raw`Artist \"Name\"`],
+        [
+            "backslash-quote combinations",
+            String.raw`Artist\"Name"`,
+            String.raw`Artist\\\"Name\"`,
+        ],
+    ])("escapes Deezer query phrase %s safely", (_case, input, expected) => {
+        expect((deezerService as any).escapeDeezerQueryPhrase(input)).toBe(
+            expected,
+        );
+    });
+
     it("drops empty album-title variants after descriptor stripping", () => {
         const variants = (deezerService as any).buildAlbumTitleVariants(
             " (Deluxe Edition) ",

--- a/backend/src/services/__tests__/lidarrService.test.ts
+++ b/backend/src/services/__tests__/lidarrService.test.ts
@@ -4095,6 +4095,76 @@ describe("lidarr service behavior", () => {
         waitSpy.mockRestore();
     });
 
+    it.each([
+        ["parenthetical", "("],
+        ["bracket", "["],
+    ])(
+        "addAlbum preserves exact title matching for a long unmatched %s opening delimiter",
+        async (_case, openingDelimiter) => {
+            const client = createClientMock();
+            primeServiceWithClient(client);
+            const longTitle = `Long Album ${openingDelimiter}${"x".repeat(
+                50_000,
+            )}`;
+            const artist = {
+                id: 56,
+                artistName: "Long Match Band",
+                foreignArtistId: "artist-long-match",
+                monitored: true,
+            };
+            const album = {
+                id: 903,
+                title: longTitle,
+                foreignAlbumId: "album-long-match",
+                artistId: 56,
+            };
+
+            client.get
+                .mockResolvedValueOnce({ data: [artist] })
+                .mockResolvedValueOnce({ data: [album] })
+                .mockResolvedValueOnce({
+                    data: {
+                        ...album,
+                        monitored: true,
+                        anyReleaseOk: true,
+                        releases: [{ id: 1 }],
+                    },
+                })
+                .mockResolvedValueOnce({
+                    data: {
+                        ...album,
+                        monitored: true,
+                        anyReleaseOk: true,
+                        releases: [{ id: 1 }],
+                    },
+                });
+            client.put.mockResolvedValue({
+                data: { ...album, monitored: true },
+            });
+            client.post.mockResolvedValue({ data: { id: 9103 } });
+            const waitSpy = jest
+                .spyOn(lidarrService as any, "waitForCommand")
+                .mockResolvedValue({
+                    status: "completed",
+                    message: "Search completed with 1 report",
+                });
+            const startedAt = performance.now();
+
+            await expect(
+                lidarrService.addAlbum(
+                    "different-mbid",
+                    "Long Match Band",
+                    longTitle,
+                    "/music",
+                    "artist-long-match",
+                ),
+            ).resolves.toEqual(expect.objectContaining({ id: 903 }));
+            expect(performance.now() - startedAt).toBeLessThan(500);
+
+            waitSpy.mockRestore();
+        },
+    );
+
     it("addAlbum matches album title using strict partial normalized comparison", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);

--- a/backend/src/services/__tests__/searchService.test.ts
+++ b/backend/src/services/__tests__/searchService.test.ts
@@ -64,6 +64,46 @@ describe("search service", () => {
         expect(normalizeCacheQuery("  Radio   HEAD  ")).toBe("radio head");
     });
 
+    it.each([
+        ["rock & roll", "rock:* & and:* & roll:*"],
+        ["AT&T", "AT:* & and:* & T:*"],
+        ["  one\t & \n two  ", "one:* & and:* & two:*"],
+        ["punctuation! & symbols?", "punctuation:* & and:* & symbols:*"],
+    ])("preserves tsquery output for %p", async (query, expectedTsquery) => {
+        prisma.$queryRaw.mockResolvedValueOnce([
+            {
+                id: "artist-tsquery",
+                name: "Artist",
+                mbid: "mbid-tsquery",
+                heroUrl: null,
+                rank: 1,
+            },
+        ]);
+
+        await searchService.searchArtists({ query });
+
+        expect(prisma.$queryRaw.mock.calls[0][1]).toBe(expectedTsquery);
+    });
+
+    it("normalizes long whitespace-only separators without excessive backtracking", async () => {
+        const query = `alpha${" ".repeat(50_000)}beta`;
+        prisma.$queryRaw.mockResolvedValueOnce([
+            {
+                id: "artist-long-query",
+                name: "Artist",
+                mbid: "mbid-long-query",
+                heroUrl: null,
+                rank: 1,
+            },
+        ]);
+        const startedAt = performance.now();
+
+        await searchService.searchArtists({ query });
+
+        expect(prisma.$queryRaw.mock.calls[0][1]).toBe("alpha:* & beta:*");
+        expect(performance.now() - startedAt).toBeLessThan(500);
+    });
+
     it("searches artists via fts and fallback branches", async () => {
         prisma.$queryRaw.mockResolvedValueOnce([
             {

--- a/backend/src/services/__tests__/soulseekService.test.ts
+++ b/backend/src/services/__tests__/soulseekService.test.ts
@@ -564,6 +564,26 @@ describe("soulseek service", () => {
     });
 
     it.each([
+        ["parenthetical", "(", "live "],
+        ["bracket", "[", "remaster "],
+    ])(
+        "leaves long unmatched %s descriptors unchanged without excessive backtracking",
+        (_case, openingDelimiter, descriptor) => {
+            const title = `Song ${openingDelimiter}${descriptor.repeat(
+                9_999,
+            )}${descriptor.trim()}`;
+            const startedAt = performance.now();
+
+            const normalized = (soulseekService as any).normalizeTrackTitle(
+                title,
+            );
+
+            expect(normalized).toBe(title);
+            expect(performance.now() - startedAt).toBeLessThan(500);
+        },
+    );
+
+    it.each([
         ["User not exist", "user_offline", true],
         ["Download timed out", "timeout", true],
         ["Connection refused by peer", "connection", true],

--- a/backend/src/services/__tests__/spotifyService.test.ts
+++ b/backend/src/services/__tests__/spotifyService.test.ts
@@ -198,6 +198,18 @@ describe("spotifyService", () => {
         ).toBeNull();
     });
 
+    it.each([
+        ["named", "&amp;lt;", "&lt;"],
+        ["numeric", "&#38;lt;", "&lt;"],
+    ])(
+        "decodes nested %s HTML entities exactly one level",
+        (_case, input, expected) => {
+            expect((spotifyService as any).decodeHtmlEntities(input)).toBe(
+                expected,
+            );
+        },
+    );
+
     it("rejects non-playlist URLs passed to getPlaylist", async () => {
         await expect(
             spotifyService.getPlaylist(

--- a/backend/src/services/deezer.ts
+++ b/backend/src/services/deezer.ts
@@ -114,7 +114,7 @@ class DeezerService {
     }
 
     private escapeDeezerQueryPhrase(value: string): string {
-        return value.replace(/"/g, '\\"');
+        return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     }
 
     private buildAlbumSearchQueries(

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -1032,8 +1032,8 @@ class LidarrService {
                 const normalizeTitle = (title: string) =>
                     title
                         .toLowerCase()
-                        .replace(/\(.*?\)/g, "") // Remove parenthetical content (deluxe edition, remaster, etc.)
-                        .replace(/\[.*?\]/g, "") // Remove bracketed content
+                        .replace(/\([^)]*\)/g, "") // Remove parenthetical content (deluxe edition, remaster, etc.)
+                        .replace(/\[[^\]]*\]/g, "") // Remove bracketed content
                         .replace(
                             /[-–—]\s*(deluxe|remaster|bonus|special|anniversary|expanded|limited|collector).*$/i,
                             "",

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -108,7 +108,7 @@ export class SearchService {
     private queryToTsquery(query: string): string {
         const terms = query
             .trim()
-            .replace(/\s*&\s*/g, " and ")
+            .replace(/&/g, " and ")
             .split(/\s+/)
             .map((term) => term.replace(/[^\w]/g, ""))
             .filter((term) => term.length > 0);

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -59,6 +59,8 @@ interface DownloadDestination {
 }
 
 const INVALID_DOWNLOAD_DESTINATION = "Invalid download destination";
+const TRACK_DESCRIPTOR_PATTERN =
+    /(?:live|remaster|remix|version|edit|demo|acoustic|radio|single|extended|instrumental|feat\.|ft\.|featuring)/i;
 
 class SoulseekService {
     private client: SlskClient | null = null;
@@ -116,15 +118,13 @@ class SoulseekService {
             .replace(/[–—]/g, "-") // En/em dash → hyphen
             .replace(/[×]/g, "x"); // Multiplication sign → x
 
-        // Remove content in parentheses that contains live/remaster/remix info
-        const livePatterns =
-            /\s*\([^)]*(?:live|remaster|remix|version|edit|demo|acoustic|radio|single|extended|instrumental|feat\.|ft\.|featuring)[^)]*\)\s*/gi;
-        normalized = normalized.replace(livePatterns, " ");
-
-        // Also try brackets
-        const bracketPatterns =
-            /\s*\[[^\]]*(?:live|remaster|remix|version|edit|demo|acoustic|radio|single|extended|instrumental|feat\.|ft\.|featuring)[^\]]*\]\s*/gi;
-        normalized = normalized.replace(bracketPatterns, " ");
+        // Remove delimited content only when it contains a known descriptor.
+        normalized = normalized.replace(/\(([^)]*)\)/g, (match, segment) =>
+            TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+        );
+        normalized = normalized.replace(/\[([^\]]*)\]/g, (match, segment) =>
+            TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+        );
 
         // Remove trailing dash content (often contains year or version info)
         normalized = normalized.replace(

--- a/backend/src/services/spotify.ts
+++ b/backend/src/services/spotify.ts
@@ -62,6 +62,14 @@ const SPOTIFY_ALBUM_REGEX =
     /(?:spotify\.com\/album\/|spotify:album:)([a-zA-Z0-9]+)/;
 const SPOTIFY_TRACK_REGEX =
     /(?:spotify\.com\/track\/|spotify:track:)([a-zA-Z0-9]+)/;
+const HTML_NAMED_ENTITIES: Readonly<Record<string, string>> = {
+    amp: "&",
+    quot: '"',
+    apos: "'",
+    lt: "<",
+    gt: ">",
+    nbsp: " ",
+};
 
 class SpotifyService {
     private anonymousToken: string | null = null;
@@ -719,19 +727,23 @@ class SpotifyService {
     }
 
     private decodeHtmlEntities(value: string): string {
-        return value
-            .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) =>
-                String.fromCharCode(parseInt(hex, 16)),
-            )
-            .replace(/&#(\d+);/g, (_match, dec: string) =>
-                String.fromCharCode(parseInt(dec, 10)),
-            )
-            .replace(/&amp;/g, "&")
-            .replace(/&quot;/g, '"')
-            .replace(/&apos;/g, "'")
-            .replace(/&lt;/g, "<")
-            .replace(/&gt;/g, ">")
-            .replace(/&nbsp;/g, " ");
+        return value.replace(
+            /&(?:#x([0-9a-fA-F]+)|#(\d+)|(amp|quot|apos|lt|gt|nbsp));/g,
+            (
+                match,
+                hex: string | undefined,
+                dec: string | undefined,
+                named,
+            ) => {
+                if (hex !== undefined) {
+                    return String.fromCharCode(Number.parseInt(hex, 16));
+                }
+                if (dec !== undefined) {
+                    return String.fromCharCode(Number.parseInt(dec, 10));
+                }
+                return HTML_NAMED_ENTITIES[named] ?? match;
+            },
+        );
     }
 
     private stripHtmlContent(value: string): string {


### PR DESCRIPTION
## Summary
CodeQL remediation slice (alerts #132, #131, #129, #128, #127).

- **Deezer** (`js/incomplete-sanitization`): `escapeDeezerQueryPhrase` escapes backslashes **before** quotes — a caller-supplied backslash can no longer consume the inserted quote escape.
- **Spotify** (`js/double-escaping`): ordered replacement chain → single entity-token regex + callback; `&amp;lt;` / `&#38;lt;` decode exactly one level.
- **Soulseek / search / Lidarr** (`js/polynomial-redos` ×3): lazy-dot parenthetical/bracket and `\s*&\s*` patterns → linear negated-delimiter forms; long unmatched-delimiter regression tests; tsquery output and title-matching proven identical.

## Tests
Per-service cases for each defect + output-equivalence assertions; mocked-consumer sweep re-run.

## Verification
- Targeted service suites + 45-suite mocked-consumer sweep → 1,186 tests pass
- Independent re-run (deezer/spotify/search) green · both `tsc --noEmit` clean · package-dir pinned prettier clean (3 files reformatted after the fallback-context check missed them) · route-error canon both ratchets
- ENOSPC-interrupted first run: second run assessed and completed the partial work, full verification from scratch