### PR TITLE
fix(security): canonical playlist-import links and centralized audiobook preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,6 +738,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Playlist import links now require canonical HTTP(S) URLs, and audiobook
+  preflight responses now use the central deny-by-default CORS policy.
 - Cover-image storage operations validate IDs and contain all filesystem paths
   under the type-specific covers directory.
 - Account-management, 2FA, and Subsonic-credential routes now have dedicated

--- a/backend/src/config/__tests__/openapiAuthContract.test.ts
+++ b/backend/src/config/__tests__/openapiAuthContract.test.ts
@@ -68,11 +68,6 @@ const AUTH_MATRIX: AuthExpectation[] = [
         anonymous: true,
     },
     {
-        method: "options",
-        path: "/api/audiobooks/{id}/cover",
-        anonymous: true,
-    },
-    {
         method: "get",
         path: "/api/webhooks/lidarr/verify",
         anonymous: true,

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -33,7 +33,6 @@ const ANONYMOUS_OPERATIONS = [
     ["/api/podcasts/{id}/cover", "get"],
     ["/api/podcasts/episodes/{episodeId}/cover", "options"],
     ["/api/podcasts/episodes/{episodeId}/cover", "get"],
-    ["/api/audiobooks/{id}/cover", "options"],
     ["/api/webhooks/lidarr/verify", "get"],
 ] as const;
 

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -1,4 +1,7 @@
-import type { Request, Response } from "express";
+import cors from "cors";
+import express, { type Request, type Response } from "express";
+import request from "supertest";
+import { isOriginAllowed } from "../../utils/cors";
 
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
@@ -79,10 +82,7 @@ const mockFetch = jest.fn();
 
 import router from "../audiobooks";
 
-function getHandler(
-    path: string,
-    method: "get" | "post" | "delete" | "options",
-) {
+function getHandler(path: string, method: "get" | "post" | "delete") {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -91,6 +91,23 @@ function getHandler(
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     }
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+function createAppWithCentralCors(allowedOrigins: string[]) {
+    const app = express();
+    app.use(
+        cors({
+            origin: (origin, callback) => {
+                callback(
+                    null,
+                    isOriginAllowed(origin, allowedOrigins, "production"),
+                );
+            },
+            credentials: true,
+        }),
+    );
+    app.use("/api/audiobooks", router);
+    return app;
 }
 
 function createRes() {
@@ -169,7 +186,6 @@ function createMockStream() {
 
 describe("audiobooks advanced runtime", () => {
     const debugSeriesHandler = getHandler("/debug-series", "get");
-    const coverOptionsHandler = getHandler("/:id/cover", "options");
     const coverHandler = getHandler("/:id/cover", "get");
     const detailsHandler = getHandler("/:id", "get");
     const streamHandler = getHandler("/:id/stream", "get");
@@ -271,24 +287,32 @@ describe("audiobooks advanced runtime", () => {
         expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
-    it("serves OPTIONS preflight for cover endpoint", async () => {
-        const req = {
-            params: { id: "book-1" },
-            headers: { origin: "https://app.example" },
-        } as any;
-        const res = createRes();
+    it("allows audiobook cover preflight through the central CORS allowlist", async () => {
+        const origin = "https://app.example";
+        const response = await request(createAppWithCentralCors([origin]))
+            .options("/api/audiobooks/book-1/cover")
+            .set("Origin", origin)
+            .set("Access-Control-Request-Method", "GET");
 
-        await coverOptionsHandler(req, res);
+        expect(response.status).toBe(204);
+        expect(response.headers["access-control-allow-origin"]).toBe(origin);
+        expect(response.headers["access-control-allow-credentials"]).toBe(
+            "true",
+        );
+    });
 
-        expect(res.statusCode).toBe(204);
-        expect(res.headers["Access-Control-Allow-Origin"]).toBe(
-            "https://app.example",
-        );
-        expect(res.headers["Access-Control-Allow-Credentials"]).toBe("true");
-        expect(res.headers["Access-Control-Allow-Methods"]).toBe(
-            "GET, OPTIONS",
-        );
-        expect(res.end).toHaveBeenCalled();
+    it("does not reflect a disallowed audiobook cover preflight origin", async () => {
+        const response = await request(
+            createAppWithCentralCors(["https://app.example"]),
+        )
+            .options("/api/audiobooks/book-1/cover")
+            .set("Origin", "https://evil.example")
+            .set("Access-Control-Request-Method", "GET");
+
+        expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+        expect(
+            response.headers["access-control-allow-credentials"],
+        ).toBeUndefined();
     });
 
     it("serves local cover paths and fallback disk covers", async () => {

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -541,37 +541,6 @@ router.get<{ seriesName: string }>(
 /**
  * @openapi
  * /api/audiobooks/{id}/cover:
- *   options:
- *     summary: CORS preflight for audiobook cover images
- *     tags: [Audiobooks]
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *         description: Audiobook ID
- *     responses:
- *       204:
- *         description: CORS preflight response
- */
-/**
- * OPTIONS /audiobooks/:id/cover
- * Handle CORS preflight request for cover images
- */
-router.options("/:id/cover", (req, res) => {
-    const origin = req.headers.origin || "http://localhost:3030";
-    res.setHeader("Access-Control-Allow-Origin", origin);
-    res.setHeader("Access-Control-Allow-Credentials", "true");
-    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-    res.setHeader("Access-Control-Max-Age", "86400"); // 24 hours
-    res.status(204).end();
-});
-
-/**
- * @openapi
- * /api/audiobooks/{id}/cover:
  *   get:
  *     summary: Serve audiobook cover image
  *     tags: [Audiobooks]

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -34,7 +34,11 @@ function tryParsePlaylistUrl(rawInput: string): URL | null {
         ? trimmed
         : `https://${trimmed}`;
     try {
-        return new URL(withProtocol);
+        const parsed = new URL(withProtocol);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            return null;
+        }
+        return parsed;
     } catch {
         return null;
     }
@@ -60,6 +64,9 @@ function getResolutionSubtitle(track: PlaylistImportResolvedTrack): string {
 export function isSupportedPlaylistUrl(url: string): boolean {
     const parsed = tryParsePlaylistUrl(url);
     if (!parsed) return false;
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return false;
+    }
 
     const hostname = parsed.hostname.toLowerCase();
     const path = parsed.pathname;
@@ -203,7 +210,8 @@ function ImportPageContent() {
 
     const [step, setStep] = useState<ImportStep>("input");
     const [importMode, setImportMode] = useState<ImportMode>("url");
-    const [url, setUrl] = useState("");
+    const [urlInput, setUrlInput] = useState("");
+    const [canonicalUrl, setCanonicalUrl] = useState("");
     const [playlistName, setPlaylistName] = useState("");
     const [preview, setPreview] =
         useState<PlaylistImportPreviewResponse | null>(null);
@@ -219,23 +227,26 @@ function ImportPageContent() {
 
     const fetchPreview = useCallback(
         async (nextUrl: string) => {
-            const trimmedUrl = nextUrl.trim();
-            if (!trimmedUrl) {
+            if (!nextUrl.trim()) {
                 toast.error("Please enter a playlist URL");
                 return;
             }
 
-            if (!isSupportedPlaylistUrl(trimmedUrl)) {
+            const parsedUrl = tryParsePlaylistUrl(nextUrl);
+            if (!parsedUrl || !isSupportedPlaylistUrl(parsedUrl.href)) {
                 toast.error(
                     "Supported URLs: Spotify, Deezer, YouTube Music, and TIDAL playlists",
                 );
                 return;
             }
 
+            const nextCanonicalUrl = parsedUrl.href;
             setIsPreviewLoading(true);
             try {
-                const response = await api.previewPlaylistImport(trimmedUrl);
-                setUrl(trimmedUrl);
+                const response =
+                    await api.previewPlaylistImport(nextCanonicalUrl);
+                setUrlInput(nextCanonicalUrl);
+                setCanonicalUrl(nextCanonicalUrl);
                 setPreview(response);
                 setPlaylistName(response.playlistName);
                 setStep("preview");
@@ -328,11 +339,11 @@ function ImportPageContent() {
     };
 
     const handleSubmitBackgroundJob = async () => {
-        if (!url) return;
+        if (!canonicalUrl) return;
 
         try {
             const result = await api.submitImportJob(
-                url,
+                canonicalUrl,
                 playlistName || undefined,
             );
             if (result.deduped) {
@@ -352,7 +363,8 @@ function ImportPageContent() {
 
     const resetFlow = () => {
         setStep("input");
-        setUrl("");
+        setUrlInput("");
+        setCanonicalUrl("");
         setPlaylistName("");
         setPreview(null);
         setResult(null);
@@ -438,15 +450,15 @@ function ImportPageContent() {
                                     </label>
                                     <input
                                         type="text"
-                                        value={url}
+                                        value={urlInput}
                                         onChange={(event) =>
-                                            setUrl(event.target.value)
+                                            setUrlInput(event.target.value)
                                         }
                                         placeholder="Paste a Spotify, Deezer, YouTube Music, or TIDAL playlist URL"
                                         className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand transition-colors"
                                         onKeyDown={(event) =>
                                             event.key === "Enter" &&
-                                            void fetchPreview(url)
+                                            void fetchPreview(urlInput)
                                         }
                                     />
                                     <p className="text-xs text-gray-400 mt-2">
@@ -470,8 +482,12 @@ function ImportPageContent() {
                                     </p>
                                 </div>
                                 <button
-                                    onClick={() => void fetchPreview(url)}
-                                    disabled={isPreviewLoading || !url.trim()}
+                                    onClick={() =>
+                                        void fetchPreview(urlInput)
+                                    }
+                                    disabled={
+                                        isPreviewLoading || !urlInput.trim()
+                                    }
                                     className="w-full py-3 rounded-full font-medium bg-brand text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
                                 >
                                     {isPreviewLoading ? (
@@ -573,9 +589,9 @@ function ImportPageContent() {
                                     {preview.summary.total} songs found
                                 </p>
                             </div>
-                            {url && (
+                            {canonicalUrl && (
                                 <a
-                                    href={url}
+                                    href={canonicalUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="text-gray-400 hover:text-brand transition-colors"
@@ -678,7 +694,7 @@ function ImportPageContent() {
                                 )}
                             </button>
                         </div>
-                        {url && importableCount > 0 && (
+                        {canonicalUrl && importableCount > 0 && (
                             <button
                                 onClick={() => void handleSubmitBackgroundJob()}
                                 disabled={isExecuting}

--- a/frontend/tests/component/importPage.component.test.ts
+++ b/frontend/tests/component/importPage.component.test.ts
@@ -1,13 +1,40 @@
 import assert from "node:assert/strict";
-import { beforeEach, mock, test } from "node:test";
+import { after, beforeEach, mock, test } from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const executeCalls: Array<{ previewData: any; name?: string }> = [];
+const previewCalls: string[] = [];
+const toastErrors: string[] = [];
+
+const previewResponse = {
+    playlistName: "Test Playlist",
+    resolved: [
+        {
+            index: 0,
+            artist: "Local Artist",
+            title: "Local Song",
+            source: "local" as const,
+            confidence: 100,
+            trackId: "track-1",
+        },
+    ],
+    summary: { total: 1, local: 1, youtube: 0, tidal: 0, unresolved: 0 },
+};
 
 mock.module("@/lib/api", {
     namedExports: {
         api: {
+            previewPlaylistImport: async (url: string) => {
+                previewCalls.push(url);
+                return previewResponse;
+            },
             executePlaylistImport: async (input: {
                 previewData: any;
                 name?: string;
@@ -28,6 +55,28 @@ mock.module("@/lib/api", {
     },
 });
 
+mock.module("next/navigation", {
+    namedExports: {
+        useRouter: () => ({
+            back: () => undefined,
+            push: () => undefined,
+        }),
+        useSearchParams: () => new URLSearchParams(),
+    },
+});
+
+mock.module("@/lib/toast-context", {
+    namedExports: {
+        useToast: () => ({
+            toast: {
+                error: (message: string) => toastErrors.push(message),
+                info: () => undefined,
+                success: () => undefined,
+            },
+        }),
+    },
+});
+
 mock.module("@/components/ui/TidalBadge", {
     namedExports: {
         TidalBadge: () => React.createElement("span", null, "TIDAL"),
@@ -40,9 +89,66 @@ mock.module("@/components/ui/YouTubeBadge", {
     },
 });
 
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
 beforeEach(() => {
     executeCalls.length = 0;
+    previewCalls.length = 0;
+    toastErrors.length = 0;
+    document.body.replaceChildren();
 });
+
+async function mountImportPage() {
+    const { default: ImportPage } = await import("../../app/import/page");
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(React.createElement(ImportPage));
+    });
+
+    return {
+        container,
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+    )?.set;
+    assert.ok(setter, "expected the input value setter");
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+    const button = Array.from(container.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.includes(text),
+    );
+    assert.ok(button instanceof HTMLButtonElement, `button not found: ${text}`);
+    return button;
+}
 
 test("preview list renders provider resolution badges per track", async () => {
     const { PreviewTrackResolutionList } =
@@ -132,4 +238,60 @@ test("isSupportedPlaylistUrl rejects arbitrary text containing provider host fra
         "not-a-url open.spotify.com/playlist/ definitely-not-valid";
 
     assert.equal(isSupportedPlaylistUrl(malformedValue), false);
+});
+
+test("isSupportedPlaylistUrl rejects non-HTTP executable URL schemes", async () => {
+    const { isSupportedPlaylistUrl } = await import("../../app/import/page");
+    const unsafeUrls = [
+        "javascript://open.spotify.com/playlist/playlist123",
+        "data://open.spotify.com/playlist/playlist123",
+        "vbscript://open.spotify.com/playlist/playlist123",
+    ];
+
+    for (const unsafeUrl of unsafeUrls) {
+        assert.equal(isSupportedPlaylistUrl(unsafeUrl), false, unsafeUrl);
+    }
+});
+
+test("playlist preview anchor renders only the canonical HTTP(S) URL", async () => {
+    const cases = [
+        {
+            input: "  HTTP://OPEN.SPOTIFY.COM:80/playlist/AbC123  ",
+            canonical: "http://open.spotify.com/playlist/AbC123",
+        },
+        {
+            input: "HTTPS://MUSIC.YOUTUBE.COM:443/playlist?list=PL123",
+            canonical: "https://music.youtube.com/playlist?list=PL123",
+        },
+    ];
+
+    for (const testCase of cases) {
+        const harness = await mountImportPage();
+        try {
+            const input = harness.container.querySelector(
+                'input[placeholder^="Paste a Spotify"]',
+            );
+            assert.ok(
+                input instanceof HTMLInputElement,
+                "playlist input missing",
+            );
+
+            await React.act(async () => {
+                typeInto(input, testCase.input);
+            });
+            await click(findButton(harness.container, "Preview Import"));
+
+            assert.equal(previewCalls.at(-1), testCase.canonical);
+            const anchor = harness.container.querySelector(
+                'a[target="_blank"]',
+            );
+            assert.ok(
+                anchor instanceof HTMLAnchorElement,
+                "preview anchor missing",
+            );
+            assert.equal(anchor.getAttribute("href"), testCase.canonical);
+        } finally {
+            await harness.unmount();
+        }
+    }
 });


### PR DESCRIPTION
## Summary
CodeQL remediation slice (alerts #1153 `js/xss-through-dom`, #215 `js/cors-misconfiguration-for-credentials`).

- **Playlist import page**: candidate URLs are parsed once, must be `http:`/`https:`, and the external anchor renders only the parsed **canonical** URL — `javascript:`, `data:`, `vbscript:` inputs never reach an `href`.
- **Audiobook covers**: the route-local `OPTIONS` handler reflected the request Origin with credentials; removed so the app-level deny-by-default `cors` middleware owns preflight. Cover-art GET headers audited: they serve via the shared allowlist-based helper, not arbitrary reflection.

## Tests
Component tests: hostile-scheme rejection ×3 + canonical-anchor assertions (6 pass). Backend: app-level preflight behavior for allowed/disallowed origins; audiobooks suites 58 pass (independent re-run green).

## Verification
Both `tsc --noEmit` clean · package-dir pinned prettier clean · route-error canon both ratchets · ENOSPC-interrupted first run assessed and completed by the retry with full re-verification