### PR TITLE
chore(format): apply frontend-context prettier to native-engine files

### DIFF
--- a/frontend/lib/audio-engine/nativeAudioElementEngine.ts
+++ b/frontend/lib/audio-engine/nativeAudioElementEngine.ts
@@ -715,10 +715,7 @@ export class NativeAudioElementEngine implements AudioEngine {
         this.disarmVisibilityRetry();
         let retryFired = false;
         const fireRetry = (via: "visibility" | "focus"): void => {
-            if (
-                retryFired ||
-                (via === "visibility" && this.isPageHidden())
-            ) {
+            if (retryFired || (via === "visibility" && this.isPageHidden())) {
                 return;
             }
             retryFired = true;
@@ -733,10 +730,8 @@ export class NativeAudioElementEngine implements AudioEngine {
             "visibilitychange",
             () => fireRetry("visibility"),
         );
-        const focusCleanup = this.bindGlobalListener(
-            "window",
-            "focus",
-            () => fireRetry("focus"),
+        const focusCleanup = this.bindGlobalListener("window", "focus", () =>
+            fireRetry("focus"),
         );
         this.visibilityRetryCleanup = () => {
             retryFired = true;

--- a/frontend/tests/unit/nativeAudioElementEngine.test.ts
+++ b/frontend/tests/unit/nativeAudioElementEngine.test.ts
@@ -810,9 +810,7 @@ test("NotAllowedError schedules a bounded timer retry through the normal play pa
     harness.mainElement().fireLoadedMetadata(200);
     await flushMicrotasks();
 
-    const [retry] = harness.scheduler.timers.filter(
-        (timer) => !timer.cleared,
-    );
+    const [retry] = harness.scheduler.timers.filter((timer) => !timer.cleared);
     assert.ok(retry);
     assert.equal(retry.delayMs, NATIVE_ENGINE_PLAY_RETRY_DELAYS_MS[0]);
 

--- a/frontend/tests/unit/nativeAudioElementPolicy.test.ts
+++ b/frontend/tests/unit/nativeAudioElementPolicy.test.ts
@@ -422,8 +422,8 @@ test("PAUSE_REQUESTED while playing classifies the pause as user-intended", () =
     const { state, effects } = transitionNativeEngine(
         playingState({ playStartRetriesUsed: 2 }),
         {
-        type: "PAUSE_REQUESTED",
-        nowMs: 3_000,
+            type: "PAUSE_REQUESTED",
+            nowMs: 3_000,
         },
     );
     assert.equal(state.pauseClassification, "user");


### PR DESCRIPTION
Formatting-only unblock. #421's prettier verification ran from the repo root, where the config context differs from the frontend package; the frontend-context pinned 3.8.2 check flags `nativeAudioElementEngine.ts` + two engine test files, so `npm run format:check` — and therefore Enforcement Gates — fails on main and every open PR (second incident of this class today; the slice checklist now mandates package-dir prettier runs). All four format contexts (backend, frontend, contract, scripts) verified clean on this branch.