### PR TITLE
fix(player): stop the orchestrator from pausing its own queue auto-advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Queue auto-advance no longer pauses itself right after the next track starts:
+  the ready-state transition no longer erases the advance's play intent, the
+  deferred-play path re-asserts it explicitly, and load/play-intent decisions
+  are now visible in server telemetry.
 - Queue auto-advance now recovers when the browser blocks the next track's
   playback start in a background or unfocused window, using bounded automatic
   retries plus a retry on window focus, with blocked and recovery-attempt states

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -259,6 +259,8 @@ const PLAYBACK_CLIENT_SIGNAL_EVENTS = new Set<string>([
     "player.startup_timeline",
     "player.unexpected_stop",
     "player.unexpected_pause",
+    "player.load_autoplay_decision",
+    "player.autoplay_intent_conflict",
     "player.track_end_rejected",
     "player.track_end_advanced",
     "player.playback_error",
@@ -372,6 +374,7 @@ const LISTEN_TOGETHER_FOLLOWER_RECOVERY_COOLDOWN_MS = 1_500;
 const STARTUP_PLAYBACK_RECOVERY_DELAY_MS = 1400;
 const STARTUP_PLAYBACK_RECOVERY_RECHECK_DELAY_MS = 900;
 const STARTUP_PLAYBACK_RECOVERY_MAX_RECHECKS = 2;
+const AUTOPLAY_INTENT_CONFLICT_WINDOW_MS = 3_000;
 const AUTO_MATCH_VIBE_RETRY_COOLDOWN_MS = 8000;
 const SEGMENTED_HEARTBEAT_INTERVAL_MS = 15_000;
 const SEGMENTED_HANDOFF_MAX_ATTEMPTS = 4;
@@ -465,6 +468,12 @@ interface SegmentedStartupTimelineSnapshot {
     audibleAtMs: number | null;
     startupRetryCount: number;
     emitted: boolean;
+}
+
+interface DesiredLoadPlayIntent {
+    loadId: number;
+    shouldPlay: boolean;
+    decidedAtMs: number;
 }
 
 type SegmentedHandoffListenerPhase =
@@ -682,6 +691,8 @@ export const AudioPlaybackOrchestrator = memo(
             isMuted,
         });
         const loadIdRef = useRef<number>(0);
+        const desiredLoadPlayRef = useRef<DesiredLoadPlayIntent | null>(null);
+        const cancelledLoadPlayIdRef = useRef<number | null>(null);
         const cachePollingRef = useRef<NodeJS.Timeout | null>(null);
         const seekCheckTimeoutRef = useRef<NodeJS.Timeout | null>(null);
         const cacheStatusPollingRef = useRef<NodeJS.Timeout | null>(null);
@@ -2155,7 +2166,13 @@ export const AudioPlaybackOrchestrator = memo(
                     startupRecoveryTimeoutRef.current = null;
 
                     if (playbackTypeRef.current !== "track") return;
-                    if (!lastPlayingStateRef.current) return;
+                    const desiredLoadPlay = desiredLoadPlayRef.current;
+                    const hasDesiredLoadPlay = Boolean(
+                        desiredLoadPlay?.shouldPlay &&
+                        desiredLoadPlay.loadId === loadIdRef.current,
+                    );
+                    if (!lastPlayingStateRef.current && !hasDesiredLoadPlay)
+                        return;
                     if (currentTrackRef.current?.id !== trackId) return;
                     const listenTogetherSession =
                         getListenTogetherSessionSnapshot();
@@ -2219,7 +2236,13 @@ export const AudioPlaybackOrchestrator = memo(
                         startupRecoveryLoadListenerRef.current = null;
 
                         if (playbackTypeRef.current !== "track") return;
-                        if (!lastPlayingStateRef.current) return;
+                        const desiredLoadPlay = desiredLoadPlayRef.current;
+                        const hasDesiredLoadPlay = Boolean(
+                            desiredLoadPlay?.shouldPlay &&
+                            desiredLoadPlay.loadId === loadIdRef.current,
+                        );
+                        if (!lastPlayingStateRef.current && !hasDesiredLoadPlay)
+                            return;
                         if (currentTrackRef.current?.id !== trackId) return;
                         if (audioEngine.isPlaying()) return;
                         const listenTogetherSession =
@@ -4712,15 +4735,27 @@ export const AudioPlaybackOrchestrator = memo(
                 );
                 clearTransientTrackRecovery(true);
 
-                // Transition state machine - load complete
-                if (playbackStateMachine.getState() === "LOADING") {
+                const desiredLoadPlay = desiredLoadPlayRef.current;
+                const shouldPlayAfterLoad = Boolean(
+                    desiredLoadPlay?.shouldPlay &&
+                    desiredLoadPlay.loadId === loadIdRef.current,
+                );
+
+                // Autoplaying loads remain transitional until the engine's play
+                // event lands. READY deliberately means the load should stay paused.
+                if (
+                    playbackStateMachine.getState() === "LOADING" &&
+                    !shouldPlayAfterLoad
+                ) {
                     playbackStateMachine.transition("READY");
                 }
 
                 if (
                     playbackType === "track" &&
                     currentTrack?.id &&
-                    (lastPlayingStateRef.current || isPlaying)
+                    (lastPlayingStateRef.current ||
+                        isPlaying ||
+                        shouldPlayAfterLoad)
                 ) {
                     scheduleStartupPlaybackRecovery(currentTrack.id);
                 }
@@ -5847,6 +5882,8 @@ export const AudioPlaybackOrchestrator = memo(
 
             if (!currentMediaId) {
                 trackEndWatchdogRef.current?.clear();
+                desiredLoadPlayRef.current = null;
+                cancelledLoadPlayIdRef.current = null;
                 wasPlayingWhenHiddenRef.current = false;
                 markSegmentedStartupRampWindow(null, "media_cleared");
                 setStreamProfile(null);
@@ -5953,6 +5990,8 @@ export const AudioPlaybackOrchestrator = memo(
             lastTrackIdRef.current = currentMediaId;
             loadIdRef.current += 1;
             const thisLoadId = loadIdRef.current;
+            desiredLoadPlayRef.current = null;
+            cancelledLoadPlayIdRef.current = null;
             const hasAdvancePlayIntent = isAdvancePlayIntentFresh(
                 advancePlayIntentAtMsRef.current,
                 Date.now(),
@@ -6150,6 +6189,7 @@ export const AudioPlaybackOrchestrator = memo(
                     | "on_demand"
                     | null = null;
                 let forceFreshSegmentedSession = false;
+                let capturedLoadPlayIntent: DesiredLoadPlayIntent | null = null;
 
                 const resolveSourceForLoad = async (): Promise<void> => {
                     if (sourceResolved) {
@@ -6826,20 +6866,52 @@ export const AudioPlaybackOrchestrator = memo(
                         return;
                     }
 
-                    const listenTogetherSnapshotForLoad =
-                        getListenTogetherSessionSnapshot();
-                    const shouldAutoPlayOnLoad = resolveLoadAutoplayDecision({
-                        wasPlayingBeforeLoad:
+                    const deferAutoplay =
+                        typeof sourceForLoad === "string" && startTime > 0;
+                    if (!capturedLoadPlayIntent) {
+                        const listenTogetherSnapshotForLoad =
+                            getListenTogetherSessionSnapshot();
+                        const wasPlayingBeforeLoad =
                             lastPlayingStateRef.current ||
-                            wasEnginePlayingBeforeLoad,
-                        hasAdvancePlayIntent,
-                        // Followers start playback via the LT play-at/delta
-                        // resume, never from local state (audible-blip fix).
-                        isListenTogetherFollower: Boolean(
-                            listenTogetherSnapshotForLoad?.groupId &&
-                            !listenTogetherSnapshotForLoad.isHost,
-                        ),
-                    });
+                            wasEnginePlayingBeforeLoad;
+                        const resolvedShouldAutoPlay =
+                            resolveLoadAutoplayDecision({
+                                wasPlayingBeforeLoad,
+                                hasAdvancePlayIntent,
+                                // Followers start playback via the LT play-at/delta
+                                // resume, never from local state (audible-blip fix).
+                                isListenTogetherFollower: Boolean(
+                                    listenTogetherSnapshotForLoad?.groupId &&
+                                    !listenTogetherSnapshotForLoad.isHost,
+                                ),
+                            });
+                        const shouldAutoPlayOnLoad =
+                            cancelledLoadPlayIdRef.current === thisLoadId
+                                ? false
+                                : resolvedShouldAutoPlay;
+                        capturedLoadPlayIntent = {
+                            loadId: thisLoadId,
+                            shouldPlay: shouldAutoPlayOnLoad,
+                            decidedAtMs: Date.now(),
+                        };
+                        desiredLoadPlayRef.current = capturedLoadPlayIntent;
+                        logPlaybackClientMetric(
+                            "player.load_autoplay_decision",
+                            {
+                                loadId: thisLoadId,
+                                shouldAutoPlayOnLoad,
+                                deferAutoplay,
+                                hasAdvancePlayIntent,
+                                wasPlayingBeforeLoad,
+                                startTime,
+                            },
+                        );
+                    }
+                    const desiredLoadPlay = desiredLoadPlayRef.current;
+                    const shouldAutoPlayOnLoad = Boolean(
+                        desiredLoadPlay?.shouldPlay &&
+                        desiredLoadPlay.loadId === thisLoadId,
+                    );
 
                     if (typeof sourceForLoad === "string") {
                         activeSegmentedPlaybackTrackIdRef.current = null;
@@ -6849,7 +6921,6 @@ export const AudioPlaybackOrchestrator = memo(
                         // Passing autoplay=true here would cause Howler's onload to
                         // play() from position 0 before handleLoaded can seek,
                         // producing overlapping audio streams.
-                        const deferAutoplay = startTime > 0;
                         audioEngine.load(
                             sourceForLoad,
                             deferAutoplay ? false : shouldAutoPlayOnLoad,
@@ -6944,25 +7015,24 @@ export const AudioPlaybackOrchestrator = memo(
 
                         const listenTogetherSnapshotAtLoaded =
                             getListenTogetherSessionSnapshot();
-                        const shouldAutoPlay = resolveLoadAutoplayDecision({
-                            wasPlayingBeforeLoad:
-                                lastPlayingStateRef.current ||
-                                wasEnginePlayingBeforeLoad,
-                            hasAdvancePlayIntent,
+                        const desiredLoadPlay = desiredLoadPlayRef.current;
+                        const shouldAutoPlay = Boolean(
+                            desiredLoadPlay?.shouldPlay &&
+                            desiredLoadPlay.loadId === thisLoadId &&
                             // Same follower rule as the load-time decision: the
                             // deferred (seek-then-play) path must not start
                             // follower playback from local state either.
-                            isListenTogetherFollower: Boolean(
+                            !(
                                 listenTogetherSnapshotAtLoaded?.groupId &&
-                                !listenTogetherSnapshotAtLoaded.isHost,
+                                !listenTogetherSnapshotAtLoaded.isHost
                             ),
-                        });
+                        );
 
-                        if (shouldAutoPlay && !audioEngine.isPlaying()) {
-                            applyCurrentOutputState();
-                            audioEngine.play();
-                            if (!lastPlayingStateRef.current) {
-                                setIsPlaying(true);
+                        if (shouldAutoPlay) {
+                            setIsPlaying(true);
+                            if (!audioEngine.isPlaying()) {
+                                applyCurrentOutputState();
+                                audioEngine.play();
                             }
                         }
 
@@ -7453,6 +7523,25 @@ export const AudioPlaybackOrchestrator = memo(
         // Skip if a track change is in progress -- the track-change effect handles playback.
         // This prevents doubled audio when next() sets both currentTrack and isPlaying simultaneously.
         useEffect(() => {
+            if (!isPlaying) {
+                const desiredLoadPlay = desiredLoadPlayRef.current;
+                const shouldReportAutoplayConflict = Boolean(
+                    !isLoadingRef.current &&
+                    audioEngine.isPlaying() &&
+                    desiredLoadPlay?.shouldPlay &&
+                    desiredLoadPlay.loadId === loadIdRef.current &&
+                    Date.now() - desiredLoadPlay.decidedAtMs <=
+                        AUTOPLAY_INTENT_CONFLICT_WINDOW_MS,
+                );
+                if (shouldReportAutoplayConflict && desiredLoadPlay) {
+                    logPlaybackClientMetric("player.autoplay_intent_conflict", {
+                        loadId: desiredLoadPlay.loadId,
+                    });
+                }
+                desiredLoadPlayRef.current = null;
+                cancelledLoadPlayIdRef.current = loadIdRef.current;
+            }
+
             if (isLoadingRef.current) return;
 
             isUserInitiatedRef.current = true;
@@ -7990,6 +8079,8 @@ export const AudioPlaybackOrchestrator = memo(
             const segmentedPrewarmRetryTimeouts =
                 segmentedPrewarmRetryTimeoutsRef.current;
             return () => {
+                desiredLoadPlayRef.current = null;
+                cancelledLoadPlayIdRef.current = null;
                 audioEngine.stop();
 
                 if (progressSaveIntervalRef.current) {

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -483,6 +483,7 @@ let podcastCacheStatus = {
 };
 let seekToleranceOverride: boolean | null = null;
 let segmentedStartupRetryDelayOverride: number | null = null;
+let mirrorMachineIntentToPlaybackState = false;
 const segmentedStartupRetryDelayInputs: Array<{
     retryTimeoutMs: number;
     sourceKind: "segmented" | "direct";
@@ -609,6 +610,7 @@ const resetHarnessState = (): void => {
     };
     seekToleranceOverride = null;
     segmentedStartupRetryDelayOverride = null;
+    mirrorMachineIntentToPlaybackState = false;
     segmentedStartupRetryDelayInputs.length = 0;
     segmentedSessionQueue.length = 0;
     handoffSessionQueue.length = 0;
@@ -1097,6 +1099,19 @@ mock.module("@/lib/storage-migration", {
 const playbackMachine = { state: "IDLE" as string };
 const heartbeatInstances: MockHeartbeatMonitor[] = [];
 
+const transitionPlaybackMachine = (next: string): boolean => {
+    playbackMachine.state = next;
+    if (mirrorMachineIntentToPlaybackState && next === "READY") {
+        playbackState.isPlaying = false;
+        playbackCalls.setIsPlaying.push(false);
+    }
+    if (mirrorMachineIntentToPlaybackState && next === "PLAYING") {
+        playbackState.isPlaying = true;
+        playbackCalls.setIsPlaying.push(true);
+    }
+    return true;
+};
+
 class MockHeartbeatMonitor {
     public monitoring = false;
     public stalled = false;
@@ -1162,14 +1177,8 @@ class MockHeartbeatMonitor {
 mock.module("@/lib/audio", {
     exports: {
         playbackStateMachine: {
-            transition: (next: string) => {
-                playbackMachine.state = next;
-                return true;
-            },
-            forceTransition: (next: string) => {
-                playbackMachine.state = next;
-                return true;
-            },
+            transition: transitionPlaybackMachine,
+            forceTransition: transitionPlaybackMachine,
             getState: () => playbackMachine.state,
             get isPlaying() {
                 return playbackMachine.state === "PLAYING";
@@ -1681,6 +1690,203 @@ test("startup playback watchdog does not reload for a listen-together follower",
     await flushAsync();
 
     assert.equal(engine.reloadCalls, 0);
+});
+
+test("natural queue advance preserves autoplay intent across load-before-play ordering", async () => {
+    enableWindowMetrics();
+    mirrorMachineIntentToPlaybackState = true;
+    playbackState.isPlaying = true;
+    const firstTrack = makeTrack("advance-intent-1");
+    const nextTrack = makeTrack("advance-intent-2");
+    audioState.currentTrack = firstTrack;
+    audioState.queue = [firstTrack, nextTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.emit("play");
+    await flushAsync();
+    assert.equal(playbackMachine.state, "PLAYING");
+
+    engine.emit("end");
+    assert.equal(controlCalls.next, 1);
+
+    audioState.currentTrack = nextTrack;
+    audioState.currentIndex = 1;
+    rerenderOrchestrator();
+    await flushAsync();
+
+    const pauseCallsBeforeLoad = engine.pauseCalls;
+    engine.emit("load", { durationSec: 210 });
+    await flushAsync();
+    rerenderOrchestrator();
+    await flushAsync();
+
+    assert.equal(engine.pauseCalls, pauseCallsBeforeLoad);
+    assert.equal(playbackState.isPlaying, true);
+    engine.emit("play");
+    await flushAsync();
+    assert.equal(playbackMachine.state, "PLAYING");
+    const advanceDecision = getServerSignalEvents(
+        "player.load_autoplay_decision",
+    ).find(
+        (event) =>
+            (event.fields as Record<string, unknown> | undefined)?.loadId === 2,
+    );
+    const advanceDecisionFields = advanceDecision?.fields as
+        | Record<string, unknown>
+        | undefined;
+    assert.equal(advanceDecisionFields?.hasAdvancePlayIntent, true);
+    assert.equal(advanceDecisionFields?.shouldAutoPlayOnLoad, true);
+});
+
+test("manual paused load lands ready without autoplay", async () => {
+    mirrorMachineIntentToPlaybackState = true;
+    playbackState.isPlaying = false;
+    audioState.currentTrack = makeTrack("manual-paused-load");
+    audioState.queue = [audioState.currentTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+    assert.equal(engine.loadCalls[0]?.args[1], false);
+
+    engine.emit("load", { durationSec: 210 });
+    await flushAsync();
+
+    assert.equal(playbackMachine.state, "READY");
+    assert.equal(playbackState.isPlaying, false);
+    assert.equal(engine.playCalls, 0);
+});
+
+test("deferred autoplay seeks then reasserts play intent", async () => {
+    enableWindowMetrics();
+    mirrorMachineIntentToPlaybackState = true;
+    playbackState.isPlaying = true;
+    audioState.playbackType = "audiobook";
+    audioState.currentTrack = null;
+    audioState.currentAudiobook = {
+        id: "deferred-audiobook",
+        duration: 900,
+        progress: { currentTime: 37 },
+    };
+    audioState.queue = [];
+
+    renderOrchestrator();
+    await flushAsync();
+    assert.equal(engine.loadCalls[0]?.args[1], false);
+
+    engine.emit("load", { durationSec: 900 });
+    await flushAsync();
+    rerenderOrchestrator();
+    await flushAsync();
+
+    assert.ok(engine.seekCalls.includes(37));
+    assert.ok(engine.playCalls >= 1);
+    assert.ok(playbackCalls.setIsPlaying.includes(true));
+    assert.equal(playbackState.isPlaying, true);
+    assert.equal(engine.pauseCalls, 0);
+    engine.emit("play");
+    await flushAsync();
+    assert.equal(playbackMachine.state, "PLAYING");
+    const [decision] = getServerSignalEvents("player.load_autoplay_decision");
+    const decisionFields = decision?.fields as
+        | Record<string, unknown>
+        | undefined;
+    assert.equal(decisionFields?.deferAutoplay, true);
+    assert.equal(decisionFields?.shouldAutoPlayOnLoad, true);
+    assert.equal(decisionFields?.startTime, 37);
+});
+
+test("user pause during autoplay loading clears the load play intent", async () => {
+    mirrorMachineIntentToPlaybackState = true;
+    playbackState.isPlaying = true;
+    audioState.currentTrack = makeTrack("pause-during-load");
+    audioState.queue = [audioState.currentTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+    assert.equal(engine.loadCalls[0]?.args[1], true);
+
+    playbackState.isPlaying = false;
+    rerenderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    await flushAsync();
+
+    assert.equal(playbackMachine.state, "READY");
+    assert.equal(playbackState.isPlaying, false);
+    assert.equal(engine.playCalls, 0);
+});
+
+test("listen-together follower load never autoplays from local intent", async () => {
+    mirrorMachineIntentToPlaybackState = true;
+    playbackState.isPlaying = true;
+    listenTogetherSnapshot = {
+        groupId: "lt-load-follower",
+        isHost: false,
+    };
+    audioState.currentTrack = makeTrack("lt-follower-load");
+    audioState.queue = [audioState.currentTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+    assert.equal(engine.loadCalls[0]?.args[1], false);
+
+    engine.emit("load", { durationSec: 210 });
+    await flushAsync();
+
+    assert.equal(playbackMachine.state, "READY");
+    assert.equal(playbackState.isPlaying, false);
+    assert.equal(engine.playCalls, 0);
+});
+
+test("reports one server-visible autoplay decision per load", async () => {
+    enableWindowMetrics();
+    playbackState.isPlaying = true;
+    audioState.currentTrack = makeTrack("autoplay-decision");
+    audioState.queue = [audioState.currentTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+
+    const decisions = getServerSignalEvents("player.load_autoplay_decision");
+    assert.equal(decisions.length, 1);
+    assert.deepEqual(decisions[0]?.fields, {
+        engineMode: "howler",
+        activeEngine: "howler",
+        loadId: 1,
+        shouldAutoPlayOnLoad: true,
+        deferAutoplay: false,
+        hasAdvancePlayIntent: false,
+        wasPlayingBeforeLoad: true,
+        startTime: 0,
+    });
+});
+
+test("reports an autoplay intent conflict before sync-pausing a playing engine", async () => {
+    enableWindowMetrics();
+    playbackState.isPlaying = true;
+    audioState.currentTrack = makeTrack("autoplay-conflict");
+    audioState.queue = [audioState.currentTrack];
+
+    renderOrchestrator();
+    await flushAsync();
+    engine.emit("load", { durationSec: 210 });
+    engine.emit("play");
+    await flushAsync();
+
+    playbackState.isPlaying = false;
+    rerenderOrchestrator();
+    await flushAsync();
+
+    const conflicts = getServerSignalEvents("player.autoplay_intent_conflict");
+    assert.equal(conflicts.length, 1);
+    assert.deepEqual(conflicts[0]?.fields, {
+        engineMode: "howler",
+        activeEngine: "howler",
+        loadId: 1,
+    });
+    assert.equal(engine.pauseCalls, 1);
 });
 
 test("loads direct track, applies output state, and syncs play/pause transitions", async () => {


### PR DESCRIPTION
## Summary
Fourth and root fix for the queue-stall (follows #410/#413/#421, which fixed real but masking defects). Production evidence with all three deployed: `track_end_advanced` fires, the next track loads in ~350ms, **no** `playback_start_blocked`/error — yet audio stays silent until focus/manual play.

**Verified mechanism** (diagnosis citations independently checked): the native engine emits `load` **before** running its captured autoplay play call → orchestrator transitions `LOADING→READY` → the playback provider maps READY to `isPlaying=false` (`playback-intent.ts:41-46`) → `handleLoaded` calls `play()` but re-asserts intent only when `lastPlayingStateRef` is false (`:6961-6965`) — and #410's pause suppression now keeps it **true** → React commits the queued false → the UI/engine sync effect **pauses the playing engine**. A programmatic pause: zero telemetry. Pre-#410 the end pause set the ref false, so the halves masked each other — why this bug survived five fixes and didn't exist on 1.8.0.

## Fix
- Desired-play intent keyed by load id `{loadId, shouldPlay}`; recorded for both immediate-autoplay and deferred (seek-then-play) paths; replaced on new load, cleared on pause/stop/unmount.
- Autoplay loads stay `LOADING` (intent-preserving state) until the engine's `play` event lands; paused loads still transition READY.
- Load completion re-asserts `setIsPlaying(true)` unconditionally for its matching autoplay load; LT-follower rule unchanged.
- `scheduleStartupPlaybackRecovery` consults the keyed intent (no longer a no-op during advances).
- **Telemetry**: `player.load_autoplay_decision` {loadId, shouldAutoPlayOnLoad, deferAutoplay, hasAdvancePlayIntent, wasPlayingBeforeLoad, startTime} on every load; tripwire `player.autoplay_intent_conflict` fires before any sync-pause within 3s of an autoplay decision — **must never appear post-fix**.

## Tests
Seven new component tests incl. the exact regression (load-before-play ordering with a true mirror ref → no self-pause, machine reaches PLAYING), manual-paused load, deferred path, pause-during-loading, LT follower, telemetry contracts. 37/37 component + 136/136 engine unit tests (independently re-run) · `tsc --noEmit` clean · frontend-context pinned prettier clean.