### PR TITLE
chore(format): apply backend-context prettier to the playback-state runtime test

### DIFF
--- a/backend/src/routes/__tests__/playbackStateRuntime.test.ts
+++ b/backend/src/routes/__tests__/playbackStateRuntime.test.ts
@@ -50,10 +50,7 @@ function getHandler(method: "get" | "post" | "delete", path: string) {
     return handlers[handlers.length - 1];
 }
 
-function getRouteHandlers(
-    method: "get" | "post" | "delete",
-    path: string,
-) {
+function getRouteHandlers(method: "get" | "post" | "delete", path: string) {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],


### PR DESCRIPTION
Formatting-only unblock: #419 merged with one file drifted from the backend-context pinned style (same class as #423/#426 — checks run outside the package directory). Backend context now fully clean on this branch. Repo-wide `format:check`/Enforcement Gates fails on main until this merges.