### PR TITLE
test(settings): make the undecryptable-value fixture deterministic

### DIFF
--- a/backend/src/utils/__tests__/migrateSettingsToGcm.test.ts
+++ b/backend/src/utils/__tests__/migrateSettingsToGcm.test.ts
@@ -28,6 +28,19 @@ function legacyEncrypt(text: string, rawKey: string): string {
     return iv.toString("hex") + ":" + encrypted.toString("hex");
 }
 
+/** Produce one-block legacy ciphertext whose PKCS#7 padding is always invalid. */
+function legacyEncryptWithInvalidPadding(text: string, rawKey: string): string {
+    const blockBytes = 16;
+    if (Buffer.byteLength(text, "utf8") >= blockBytes) {
+        throw new Error("test fixture plaintext must fit in one CBC block");
+    }
+
+    const [ivHex, encryptedHex] = legacyEncrypt(text, rawKey).split(":");
+    const iv = Buffer.from(ivHex, "hex");
+    iv[blockBytes - 1] ^= 0xff;
+    return iv.toString("hex") + ":" + encryptedHex;
+}
+
 describe("migrate-settings-to-gcm planColumnReencryption", () => {
     it("skips empty / null / non-string values", () => {
         expect(planColumnReencryption(null)).toEqual({ action: "skip-empty" });
@@ -68,10 +81,10 @@ describe("migrate-settings-to-gcm planColumnReencryption", () => {
     });
 
     it("leaves undecryptable values UNTOUCHED (never rewrites garbage)", () => {
-        // Legacy ciphertext under a DIFFERENT key — the module cannot decrypt it.
-        const undecryptable = legacyEncrypt(
+        // Corrupt the final padding byte so decryption deterministically fails.
+        const undecryptable = legacyEncryptWithInvalidPadding(
             "lost-forever",
-            "a-totally-different-32byte-key-000000",
+            process.env.SETTINGS_ENCRYPTION_KEY as string,
         );
         const outcome = planColumnReencryption(undecryptable);
         expect(outcome.action).toBe("skip-error");
@@ -159,9 +172,9 @@ describe("migrate-settings-to-gcm migrateModelRows", () => {
     });
 
     it("skips v2 rows without updating and counts undecryptable values as skipped", async () => {
-        const undecryptable = legacyEncrypt(
+        const undecryptable = legacyEncryptWithInvalidPadding(
             "lost",
-            "a-totally-different-32byte-key-000000",
+            process.env.SETTINGS_ENCRYPTION_KEY as string,
         );
         const { delegate, updateCalls } = fakeDelegate([
             { id: "u1", subsonicPassword: "v2:aa:bb:cc:dd" },


### PR DESCRIPTION
## Summary
Root-cause deflake of `migrateSettingsToGcm` — the long-standing intermittent failure that blocked the required Backend Tests check twice on main today.

**Root cause (reproduced 1-in-30 pre-fix):** the "undecryptable" fixture encrypted with a *different key*, which is probabilistic — a random AES-CBC block decrypts to valid PKCS#7 padding with >1/256 probability (per OpenSSL's EVP docs). When the dice landed, decryption "succeeded" and the migration correctly said `reencrypt` instead of `skip-error`.

**Fix:** encrypt with the real key, then corrupt the final padding byte through the IV — decryption now fails deterministically. Assertions unchanged; test-only; no retries, no loosening.

## Verification
- Pre-fix reproduction: 29/30 pass, 1 fail with the exact CI error
- Post-fix: 30/30 (codex) + independent 10/10 loop · `tsc --noEmit` clean · pinned prettier clean