### PR TITLE
chore(types): enable TypeScript strict mode for the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Frontend TypeScript now compiles under strict mode.
 - Renamed playback telemetry so log names match their emitters:
   `player.howler_startup` → `player.engine_startup`;
   `route.client.signal` / `[SegmentedStreaming.Trace]` →

--- a/frontend/app/album/[id]/page.tsx
+++ b/frontend/app/album/[id]/page.tsx
@@ -88,7 +88,7 @@ export default function AlbumPage({ params }: AlbumPageProps) {
         enrichedTracks: tidalEnrichedTracks,
         isMatching: isTidalMatching,
         isStatusResolved: isTidalStatusResolved,
-    } = useTidalGapFill(rawAlbum, source);
+    } = useTidalGapFill(rawAlbum, source ?? undefined);
     const tidalAlbum = rawAlbum
         ? { ...rawAlbum, tracks: tidalEnrichedTracks || rawAlbum.tracks }
         : rawAlbum;

--- a/frontend/app/audiobooks/page.tsx
+++ b/frontend/app/audiobooks/page.tsx
@@ -54,7 +54,7 @@ const PLAYBACK_TYPE_KEY = createMigratingStorageKey("playback_type");
 const isAudiobookshelfConfigStatus = (
     value: unknown,
 ): value is AudiobookshelfConfigStatus => {
-    return Boolean(value) && typeof value === "object" && "configured" in value;
+    return typeof value === "object" && value !== null && "configured" in value;
 };
 
 /**

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -125,14 +125,15 @@ export default function SearchPage() {
     const discoverPodcastResults = discoverResults.filter(
         (result) => result.type === "podcast",
     );
+    const libraryTracks = libraryResults?.tracks ?? [];
+    const libraryAlbums = libraryResults?.albums ?? [];
+    const libraryPodcasts = libraryResults?.podcasts ?? [];
     const hasPodcastResults =
-        (libraryResults?.podcasts?.length || 0) > 0 ||
-        discoverPodcastResults.length > 0;
+        libraryPodcasts.length > 0 || discoverPodcastResults.length > 0;
 
     // Determine if we should show the 2-column layout
     const hasTopResult = libraryResults?.artists?.[0] || topArtist;
-    const hasTracks =
-        libraryResults?.tracks?.length > 0 || soulseekResults.length > 0;
+    const hasTracks = libraryTracks.length > 0 || soulseekResults.length > 0;
     const show2ColumnLayout =
         hasSearched &&
         hasTopResult &&
@@ -351,10 +352,9 @@ export default function SearchPage() {
                                         </div>
                                     ))}
                                 </div>
-                            ) : showLibrary &&
-                              libraryResults?.tracks?.length > 0 ? (
+                            ) : showLibrary && libraryTracks.length > 0 ? (
                                 <LibraryTracksList
-                                    tracks={libraryResults.tracks}
+                                    tracks={libraryTracks}
                                     limit={isTracksView ? null : 10}
                                 />
                             ) : null}
@@ -438,7 +438,7 @@ export default function SearchPage() {
                             showLibrary &&
                             !isPodcastTab &&
                             (sectionView === null || isTracksView) &&
-                            libraryResults?.tracks?.length > 0 && (
+                            libraryTracks.length > 0 && (
                                 <section>
                                     <h2 className="text-2xl font-bold text-white mb-6">
                                         <Link
@@ -449,7 +449,7 @@ export default function SearchPage() {
                                         </Link>
                                     </h2>
                                     <LibraryTracksList
-                                        tracks={libraryResults.tracks}
+                                        tracks={libraryTracks}
                                         limit={isTracksView ? null : 10}
                                     />
                                 </section>
@@ -462,7 +462,7 @@ export default function SearchPage() {
                     showLibrary &&
                     !isPodcastTab &&
                     (sectionView === null || isAlbumsView) &&
-                    libraryResults?.albums?.length > 0 && (
+                    libraryAlbums.length > 0 && (
                         <section>
                             <h2 className="text-2xl font-bold text-white mb-6">
                                 <Link
@@ -473,7 +473,7 @@ export default function SearchPage() {
                                 </Link>
                             </h2>
                             <LibraryAlbumsGrid
-                                albums={libraryResults.albums}
+                                albums={libraryAlbums}
                                 limit={isAlbumsView ? null : 6}
                             />
                         </section>
@@ -483,13 +483,13 @@ export default function SearchPage() {
                 {hasSearched &&
                     showPodcastResults &&
                     !isSectionView &&
-                    libraryResults?.podcasts?.length > 0 && (
+                    libraryPodcasts.length > 0 && (
                         <section>
                             <h2 className="text-2xl font-bold text-white mb-6">
                                 Podcasts in Your Library
                             </h2>
                             <LibraryPodcastsGrid
-                                podcasts={libraryResults.podcasts}
+                                podcasts={libraryPodcasts}
                                 limit={isPodcastTab ? null : 6}
                             />
                         </section>

--- a/frontend/app/share/[token]/page.tsx
+++ b/frontend/app/share/[token]/page.tsx
@@ -206,7 +206,14 @@ export default function SharePage() {
     }, [data]);
 
     const playlistFilteredItems = useMemo(
-        () => playlistSortedItems.filter((item) => item.track !== null),
+        () =>
+            playlistSortedItems.filter(
+                (
+                    item,
+                ): item is PlaylistItemResource & {
+                    track: NonNullable<PlaylistItemResource["track"]>;
+                } => item.track !== null,
+            ),
         [playlistSortedItems],
     );
 

--- a/frontend/components/MetadataEditor.tsx
+++ b/frontend/components/MetadataEditor.tsx
@@ -16,13 +16,13 @@ interface MetadataEditorProps {
     currentData: {
         name?: string;
         title?: string;
-        bio?: string;
+        bio?: string | null;
         genres?: string[];
-        year?: number;
+        year?: number | null;
         mbid?: string;
         rgMbid?: string;
-        coverUrl?: string;
-        heroUrl?: string;
+        coverUrl?: string | null;
+        heroUrl?: string | null;
         // Original values for comparison (when user overrides exist)
         _originalName?: string;
         _originalBio?: string | null;
@@ -258,6 +258,7 @@ export function MetadataEditor({
         }
         setFormData((prev) => ({ ...prev, [field]: value }));
     };
+    const previewImageUrl = formData.heroUrl || formData.coverUrl;
 
     return (
         <>
@@ -554,13 +555,10 @@ export function MetadataEditor({
                                         </p>
                                     )}
                                 {/* Image Preview */}
-                                {(formData.heroUrl || formData.coverUrl) && (
+                                {previewImageUrl && (
                                     <div className="mt-2">
                                         <Image
-                                            src={
-                                                formData.heroUrl ||
-                                                formData.coverUrl
-                                            }
+                                            src={previewImageUrl}
                                             alt="Preview"
                                             width={128}
                                             height={128}

--- a/frontend/components/activity/ActiveDownloadsTab.tsx
+++ b/frontend/components/activity/ActiveDownloadsTab.tsx
@@ -154,7 +154,7 @@ export function ActiveDownloadsTab({
                                     >
                                         {download.status}
                                     </span>
-                                    {download.metadata?.statusText && (
+                                    {Boolean(download.metadata?.statusText) && (
                                         <>
                                             <span className="text-xs text-white/30">
                                                 •
@@ -163,15 +163,15 @@ export function ActiveDownloadsTab({
                                                 className={cn(
                                                     "text-xs font-medium",
                                                     download.metadata
-                                                        .currentSource ===
+                                                        ?.currentSource ===
                                                         "lidarr"
                                                         ? "text-ai-hover"
                                                         : download.metadata
-                                                                .currentSource ===
+                                                                ?.currentSource ===
                                                             "tidal"
                                                           ? "text-cyan-400"
                                                           : download.metadata
-                                                                  .currentSource ===
+                                                                  ?.currentSource ===
                                                               "youtube"
                                                             ? "text-red-400"
                                                             : "text-teal-400",
@@ -179,7 +179,7 @@ export function ActiveDownloadsTab({
                                             >
                                                 {String(
                                                     download.metadata
-                                                        .statusText,
+                                                        ?.statusText,
                                                 )}
                                             </span>
                                         </>

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -3637,7 +3637,7 @@ export const AudioPlaybackOrchestrator = memo(
             ) {
                 activeSegmentedPlaybackTrackIdRef.current = null;
             }
-            if (!resolveSegmentedTrackContext(currentTrack)) {
+            if (!currentTrack || !resolveSegmentedTrackContext(currentTrack)) {
                 activeSegmentedSessionRef.current = null;
                 activeSegmentedPlaybackTrackIdRef.current = null;
                 segmentedHeartbeatConsecutiveFailureCountRef.current = 0;
@@ -5109,7 +5109,9 @@ export const AudioPlaybackOrchestrator = memo(
                                 null,
                             sourceType:
                                 activeSegmentedSessionRef.current?.sourceType ??
-                                resolveDirectTrackSourceType(currentTrack),
+                                (currentTrack
+                                    ? resolveDirectTrackSourceType(currentTrack)
+                                    : "unknown"),
                         });
                         playbackStateMachine.forceTransition("LOADING");
                         setIsBuffering(true);
@@ -5693,9 +5695,8 @@ export const AudioPlaybackOrchestrator = memo(
             ) => engineEventHandlersRef.current?.handleLoad(payload);
             const stableHandleEnd: AudioEngineEventHandler<"end"> = () =>
                 engineEventHandlersRef.current?.handleEnd(false);
-            const stableHandleError: AudioEngineEventHandler<"loaderror"> = (
-                payload,
-            ) => engineEventHandlersRef.current?.handleError(payload);
+            const stableHandleError = (payload: AudioEngineErrorPayload) =>
+                engineEventHandlersRef.current?.handleError(payload);
             const stableHandlePlay: AudioEngineEventHandler<"play"> = () =>
                 engineEventHandlersRef.current?.handlePlay();
             const stableHandlePause: AudioEngineEventHandler<"pause"> = () =>
@@ -5704,10 +5705,9 @@ export const AudioPlaybackOrchestrator = memo(
                 "vhsresponse"
             > = (payload) =>
                 engineEventHandlersRef.current?.handleVhsResponse(payload);
-            const stableHandleManifestStall: AudioEngineEventHandler<
-                "manifeststall"
-            > = (payload) =>
-                engineEventHandlersRef.current?.handleManifestStall(payload);
+            const stableHandleManifestStall = (
+                payload: AudioEngineManifestStallPayload,
+            ) => engineEventHandlersRef.current?.handleManifestStall(payload);
 
             audioEngine.on("timeupdate", stableHandleTimeUpdate);
             audioEngine.on("load", stableHandleLoad);

--- a/frontend/components/player/OverlayPlayer.tsx
+++ b/frontend/components/player/OverlayPlayer.tsx
@@ -393,14 +393,26 @@ export function OverlayPlayer() {
         return [...relatedTracks].sort((a, b) => {
             const scoreA =
                 (a.inLibrary ? 1000 : 0) +
-                (Number.isFinite(a.matchConfidence) ? a.matchConfidence : 0) *
+                (typeof a.matchConfidence === "number" &&
+                Number.isFinite(a.matchConfidence)
+                    ? a.matchConfidence
+                    : 0) *
                     2 +
-                (Number.isFinite(a.similarity) ? a.similarity * 100 : 0);
+                (typeof a.similarity === "number" &&
+                Number.isFinite(a.similarity)
+                    ? a.similarity * 100
+                    : 0);
             const scoreB =
                 (b.inLibrary ? 1000 : 0) +
-                (Number.isFinite(b.matchConfidence) ? b.matchConfidence : 0) *
+                (typeof b.matchConfidence === "number" &&
+                Number.isFinite(b.matchConfidence)
+                    ? b.matchConfidence
+                    : 0) *
                     2 +
-                (Number.isFinite(b.similarity) ? b.similarity * 100 : 0);
+                (typeof b.similarity === "number" &&
+                Number.isFinite(b.similarity)
+                    ? b.similarity * 100
+                    : 0);
             return scoreB - scoreA;
         });
     }, [relatedTracks]);
@@ -2496,6 +2508,13 @@ export function OverlayPlayer() {
                                                                         trackKey;
                                                                     const isInLibrary =
                                                                         !!track.inLibrary;
+                                                                    const albumCover =
+                                                                        track
+                                                                            .album
+                                                                            ?.coverArt ||
+                                                                        track
+                                                                            .album
+                                                                            ?.coverUrl;
                                                                     return (
                                                                         <button
                                                                             key={`${track.id || track.title}-${idx}`}
@@ -2508,20 +2527,10 @@ export function OverlayPlayer() {
                                                                             className="group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-white/[0.06]"
                                                                         >
                                                                             <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
-                                                                                {track
-                                                                                    .album
-                                                                                    ?.coverArt ||
-                                                                                track
-                                                                                    .album
-                                                                                    ?.coverUrl ? (
+                                                                                {albumCover ? (
                                                                                     <Image
                                                                                         src={api.getCoverArtUrl(
-                                                                                            track
-                                                                                                .album
-                                                                                                .coverArt ||
-                                                                                                track
-                                                                                                    .album
-                                                                                                    .coverUrl,
+                                                                                            albumCover,
                                                                                             100,
                                                                                         )}
                                                                                         alt={

--- a/frontend/components/ui/AudiobookCard.tsx
+++ b/frontend/components/ui/AudiobookCard.tsx
@@ -8,7 +8,7 @@ interface AudiobookCardProps {
     id: string;
     title: string;
     author: string;
-    coverUrl: string | null;
+    coverUrl?: string | null;
     progress?: {
         progress: number;
         isFinished: boolean;

--- a/frontend/features/album/types.ts
+++ b/frontend/features/album/types.ts
@@ -10,8 +10,8 @@ export interface Album {
     };
     year?: number;
     genre?: string;
-    coverArt?: string;
-    coverUrl?: string;
+    coverArt?: string | null;
+    coverUrl?: string | null;
     duration?: number;
     trackCount?: number;
     playCount?: number;
@@ -40,7 +40,7 @@ export interface Track {
     album?: {
         id?: string;
         title?: string;
-        coverArt?: string;
+        coverArt?: string | null;
     };
     // Metadata override fields
     displayTitle?: string | null;
@@ -61,8 +61,8 @@ export interface SimilarAlbum {
         id: string;
         name: string;
     };
-    coverArt?: string;
-    coverUrl?: string;
+    coverArt?: string | null;
+    coverUrl?: string | null;
     year?: number;
     owned?: boolean;
     mbid?: string;

--- a/frontend/features/artist/types.ts
+++ b/frontend/features/artist/types.ts
@@ -3,7 +3,7 @@ export type ArtistSource = "library" | "discovery";
 export interface Artist {
     id: string;
     name: string;
-    coverArt?: string;
+    coverArt?: string | null;
     image?: string;
     heroUrl?: string;
     bio?: string;
@@ -28,8 +28,8 @@ export interface Album {
     id: string;
     title: string;
     year?: number;
-    coverArt?: string;
-    coverUrl?: string;
+    coverArt?: string | null;
+    coverUrl?: string | null;
     trackCount?: number;
     songCount?: number;
     type?: string;
@@ -59,7 +59,7 @@ export interface Track {
     album?: {
         id?: string;
         title?: string;
-        coverArt?: string;
+        coverArt?: string | null;
     };
     artist?: {
         id?: string;
@@ -80,7 +80,7 @@ export interface SimilarArtist {
     id: string;
     mbid?: string;
     name: string;
-    coverArt?: string;
+    coverArt?: string | null;
     image?: string;
     albumCount?: number;
     ownedAlbumCount?: number;

--- a/frontend/features/audiobook/components/AudiobookActionBar.tsx
+++ b/frontend/features/audiobook/components/AudiobookActionBar.tsx
@@ -30,8 +30,9 @@ export function AudiobookActionBar({
     formatTime = defaultFormatTime,
 }: AudiobookActionBarProps) {
     const { showSpinner, triggerPlayFeedback } = usePlayButtonFeedback();
-    const hasProgress = audiobook.progress && audiobook.progress.progress > 0;
-    const isFinished = audiobook.progress?.isFinished;
+    const progress = audiobook.progress;
+    const hasProgress = (progress?.progress ?? 0) > 0;
+    const isFinished = progress?.isFinished;
     const showingPause = isThisBookPlaying && isPlaying;
     const handlePlayPauseClick = () => {
         if (!onPlayPause) return;
@@ -75,7 +76,7 @@ export function AudiobookActionBar({
                             {formatTime(
                                 isThisBookPlaying
                                     ? currentTime
-                                    : audiobook.progress.currentTime,
+                                    : (progress?.currentTime ?? 0),
                             )}
                         </span>
                         <span className="text-white/40 mx-1">/</span>
@@ -87,7 +88,7 @@ export function AudiobookActionBar({
                         <div
                             className="h-full bg-brand rounded-full transition-all"
                             style={{
-                                width: `${isThisBookPlaying ? (currentTime / audiobook.duration) * 100 : audiobook.progress.progress}%`,
+                                width: `${isThisBookPlaying ? (currentTime / audiobook.duration) * 100 : (progress?.progress ?? 0)}%`,
                             }}
                         />
                     </div>

--- a/frontend/features/audiobook/components/AudiobookHero.tsx
+++ b/frontend/features/audiobook/components/AudiobookHero.tsx
@@ -128,7 +128,8 @@ export function AudiobookHero({
                         </div>
 
                         {/* Series & Genre tags - compact */}
-                        {(audiobook.series || audiobook.genres?.length > 0) && (
+                        {(audiobook.series ||
+                            (audiobook.genres?.length ?? 0) > 0) && (
                             <div className="hidden md:flex flex-wrap gap-1.5 mt-3">
                                 {audiobook.series && (
                                     <span className="px-2.5 py-0.5 bg-white/10 rounded-full text-xs text-white/80">

--- a/frontend/features/audiobook/components/PlayControls.tsx
+++ b/frontend/features/audiobook/components/PlayControls.tsx
@@ -24,8 +24,9 @@ export function PlayControls({
     onPlayPause,
     formatTime,
 }: PlayControlsProps) {
-    const hasProgress = audiobook.progress && audiobook.progress.progress > 0;
-    const isFinished = audiobook.progress?.isFinished;
+    const progress = audiobook.progress;
+    const hasProgress = (progress?.progress ?? 0) > 0;
+    const isFinished = progress?.isFinished;
 
     return (
         <section>
@@ -59,7 +60,7 @@ export function PlayControls({
                             {formatTime(
                                 isThisBookPlaying
                                     ? currentTime
-                                    : audiobook.progress.currentTime,
+                                    : (progress?.currentTime ?? 0),
                             )}{" "}
                             / {formatTime(audiobook.duration)}
                         </div>
@@ -72,7 +73,7 @@ export function PlayControls({
                                             ? (currentTime /
                                                   audiobook.duration) *
                                               100
-                                            : audiobook.progress.progress
+                                            : (progress?.progress ?? 0)
                                     }%`,
                                 }}
                             />

--- a/frontend/features/discover/components/UnavailableAlbums.tsx
+++ b/frontend/features/discover/components/UnavailableAlbums.tsx
@@ -86,7 +86,7 @@ export function UnavailableAlbums({
                                     key={album.id}
                                     className={cn(
                                         "flex items-center gap-4 px-4 py-3 hover:bg-surface-hover transition-colors group",
-                                        album.attemptNumber > 0 &&
+                                        (album.attemptNumber ?? 0) > 0 &&
                                             "pl-12 bg-surface-hover/30",
                                     )}
                                 >

--- a/frontend/features/explore/components/MoodsGenresSection.tsx
+++ b/frontend/features/explore/components/MoodsGenresSection.tsx
@@ -52,7 +52,7 @@ function CategoryRow({
                         <button
                             key={item.params ?? i}
                             onClick={() => {
-                                if (item.params) {
+                                if (item.params && item.title) {
                                     onPillClick(item.params, item.title);
                                 }
                             }}

--- a/frontend/features/library/components/ArtistsGrid.tsx
+++ b/frontend/features/library/components/ArtistsGrid.tsx
@@ -18,7 +18,7 @@ interface ArtistsGridProps {
     hidePlayButtons?: boolean;
 }
 
-const getArtistImageSrc = (coverArt?: string): string | null => {
+const getArtistImageSrc = (coverArt?: string | null): string | null => {
     if (!coverArt) return null;
     return api.getCoverArtUrl(coverArt, 200);
 };

--- a/frontend/features/library/types.ts
+++ b/frontend/features/library/types.ts
@@ -4,7 +4,7 @@ export interface Artist {
     id: string;
     mbid?: string;
     name: string;
-    coverArt?: string;
+    coverArt?: string | null;
     albumCount?: number;
     trackCount?: number;
 }
@@ -12,7 +12,7 @@ export interface Artist {
 export interface Album {
     id: string;
     title: string;
-    coverArt?: string;
+    coverArt?: string | null;
     year?: number;
     artist?: {
         id: string;
@@ -29,7 +29,7 @@ export interface Track {
     album?: {
         id: string;
         title: string;
-        coverArt?: string;
+        coverArt?: string | null;
         artist?: {
             id: string;
             name: string;

--- a/frontend/features/search/components/LibraryAlbumsGrid.tsx
+++ b/frontend/features/search/components/LibraryAlbumsGrid.tsx
@@ -24,41 +24,44 @@ export function LibraryAlbumsGrid({
             className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 gap-4"
             data-tv-section="search-results-albums"
         >
-            {visibleAlbums.map((album, index) => (
-                <Link
-                    key={album.id}
-                    href={`/album/${album.id}`}
-                    data-tv-card
-                    data-tv-card-index={index}
-                    tabIndex={0}
-                >
-                    <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
-                        <div className="relative aspect-square bg-surface-elevated rounded-md mb-4 flex items-center justify-center overflow-hidden">
-                            {album.coverUrl || album.albumId ? (
-                                <Image
-                                    src={api.getCoverArtUrl(
-                                        album.coverUrl || album.albumId,
-                                        200,
-                                    )}
-                                    alt={album.title}
-                                    fill
-                                    className="object-cover"
-                                    loading="lazy"
-                                    unoptimized
-                                />
-                            ) : (
-                                <Disc3 className="w-12 h-12 text-gray-400" />
-                            )}
+            {visibleAlbums.map((album, index) => {
+                const coverArtId = album.coverUrl || album.albumId;
+                return (
+                    <Link
+                        key={album.id}
+                        href={`/album/${album.id}`}
+                        data-tv-card
+                        data-tv-card-index={index}
+                        tabIndex={0}
+                    >
+                        <div className="bg-surface-sunken hover:bg-surface-elevated transition-all p-4 rounded-lg group cursor-pointer">
+                            <div className="relative aspect-square bg-surface-elevated rounded-md mb-4 flex items-center justify-center overflow-hidden">
+                                {coverArtId ? (
+                                    <Image
+                                        src={api.getCoverArtUrl(
+                                            coverArtId,
+                                            200,
+                                        )}
+                                        alt={album.title}
+                                        fill
+                                        className="object-cover"
+                                        loading="lazy"
+                                        unoptimized
+                                    />
+                                ) : (
+                                    <Disc3 className="w-12 h-12 text-gray-400" />
+                                )}
+                            </div>
+                            <h3 className="text-base font-bold text-white line-clamp-1 mb-1">
+                                {album.title}
+                            </h3>
+                            <p className="text-sm text-[#b3b3b3] line-clamp-1">
+                                {album.artist?.name}
+                            </p>
                         </div>
-                        <h3 className="text-base font-bold text-white line-clamp-1 mb-1">
-                            {album.title}
-                        </h3>
-                        <p className="text-sm text-[#b3b3b3] line-clamp-1">
-                            {album.artist?.name}
-                        </p>
-                    </div>
-                </Link>
-            ))}
+                    </Link>
+                );
+            })}
         </div>
     );
 }

--- a/frontend/features/search/components/LibraryAudiobooksGrid.tsx
+++ b/frontend/features/search/components/LibraryAudiobooksGrid.tsx
@@ -12,7 +12,7 @@ interface LibraryAudiobooksGridProps {
 export function LibraryAudiobooksGrid({
     audiobooks,
 }: LibraryAudiobooksGridProps) {
-    const getCoverUrl = (coverUrl: string | null, size = 200) => {
+    const getCoverUrl = (coverUrl: string | null | undefined, size = 200) => {
         if (!coverUrl) return null;
         return api.getCoverArtUrl(coverUrl, size);
     };

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -211,6 +211,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
         placeholderData: keepPreviousData,
         retry: 3,
     });
+    const failedAnalysisCount = enrichmentProgress?.audioAnalysis?.failed ?? 0;
 
     // Fetch enrichment state
     const { data: enrichmentState } = useQuery({
@@ -1292,7 +1293,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             ? "Cleaning..."
                             : "Cleanup Stale Jobs"}
                     </button>
-                    {enrichmentProgress?.audioAnalysis?.failed > 0 && (
+                    {failedAnalysisCount > 0 && (
                         <button
                             onClick={handleRetryFailedAnalysis}
                             disabled={retryingFailed || isEnrichmentActive}
@@ -1301,7 +1302,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                         >
                             {retryingFailed
                                 ? "Retrying..."
-                                : `Retry Failed Analysis (${enrichmentProgress.audioAnalysis.failed})`}
+                                : `Retry Failed Analysis (${failedAnalysisCount})`}
                         </button>
                     )}
                     <button

--- a/frontend/features/settings/components/sections/playbackHistoryConfig.ts
+++ b/frontend/features/settings/components/sections/playbackHistoryConfig.ts
@@ -18,15 +18,12 @@ export const HISTORY_RANGE_OPTIONS: Array<{
     { value: "365d", label: "Past year" },
     { value: "all", label: "All time" },
 ];
-const HISTORY_RANGE_SUMMARY_KEYS: Record<
-    HistoryRange,
-    keyof PlayHistorySummary
-> = {
+const HISTORY_RANGE_SUMMARY_KEYS = {
     "7d": "last7Days",
     "30d": "last30Days",
     "365d": "last365Days",
     all: "allTime",
-};
+} satisfies Record<HistoryRange, keyof PlayHistorySummary>;
 
 /**
  * Executes getImpactedHistoryCount.

--- a/frontend/hooks/useDeviceAuthPolling.ts
+++ b/frontend/hooks/useDeviceAuthPolling.ts
@@ -202,6 +202,7 @@ function usePolling({
 }: PollingEffectArgs): void {
     useEffect(() => {
         if (phase !== "polling" || !session) return;
+        const activeSession = session;
         const runId = generationRef.current;
         const delay = Math.max(1, session.pollIntervalMs);
         const active = () => generationRef.current === runId;
@@ -221,7 +222,9 @@ function usePolling({
             if (!active()) return;
             let outcome: DeviceAuthPollOutcome;
             try {
-                outcome = await optionsRef.current.poll(session.deviceCode);
+                outcome = await optionsRef.current.poll(
+                    activeSession.deviceCode,
+                );
             } catch {
                 if (active()) schedule();
                 return;

--- a/frontend/hooks/useQueries.ts
+++ b/frontend/hooks/useQueries.ts
@@ -934,6 +934,18 @@ export function usePodcastsQuery() {
     });
 }
 
+function isPodcastNotFoundError(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) return false;
+    const status = "status" in error ? error.status : undefined;
+    const message = "message" in error ? error.message : undefined;
+    return (
+        status === 404 ||
+        (typeof message === "string" &&
+            (message.includes("not found") ||
+                message.includes("not subscribed")))
+    );
+}
+
 /**
  * Hook to fetch a single podcast
  *
@@ -952,11 +964,7 @@ export function usePodcastQuery(id: string | undefined) {
                 return await api.getPodcast(id);
             } catch (error) {
                 // If podcast not found (404), return null to allow preview mode
-                if (
-                    error?.status === 404 ||
-                    error?.message?.includes("not found") ||
-                    error?.message?.includes("not subscribed")
-                ) {
+                if (isPodcastNotFoundError(error)) {
                     return null;
                 }
                 // For other errors, throw to trigger error state

--- a/frontend/hooks/useTVNavigation.ts
+++ b/frontend/hooks/useTVNavigation.ts
@@ -10,7 +10,7 @@ interface UseTVNavigationOptions {
 }
 
 interface UseTVNavigationResult {
-    containerRef: React.RefObject<HTMLElement>;
+    containerRef: React.RefObject<HTMLElement | null>;
     focusedSectionIndex: number;
     focusedCardIndex: number;
     isContentFocused: boolean;

--- a/frontend/lib/api/discover.ts
+++ b/frontend/lib/api/discover.ts
@@ -71,6 +71,8 @@ export function WithDiscover<TBase extends ApiClientConstructor>(Base: TBase) {
                 id: string;
                 userId: string;
                 playlistSize: number;
+                exclusionMonths: number;
+                downloadRatio: number;
                 enabled: boolean;
                 lastGeneratedAt: string | null;
             }>("/discover/config");
@@ -78,12 +80,16 @@ export function WithDiscover<TBase extends ApiClientConstructor>(Base: TBase) {
 
         async updateDiscoverConfig(config: {
             playlistSize?: number;
+            exclusionMonths?: number;
+            downloadRatio?: number;
             enabled?: boolean;
         }) {
             return this.request<{
                 id: string;
                 userId: string;
                 playlistSize: number;
+                exclusionMonths: number;
+                downloadRatio: number;
                 enabled: boolean;
                 lastGeneratedAt: string | null;
             }>("/discover/config", {

--- a/frontend/lib/api/metadata.ts
+++ b/frontend/lib/api/metadata.ts
@@ -7,10 +7,10 @@ export function WithMetadata<TBase extends ApiClientConstructor>(Base: TBase) {
             artistId: string,
             data: {
                 name?: string;
-                bio?: string;
+                bio?: string | null;
                 genres?: string[];
                 mbid?: string;
-                heroUrl?: string;
+                heroUrl?: string | null;
             },
         ) {
             return this.request<ApiData>(
@@ -26,10 +26,10 @@ export function WithMetadata<TBase extends ApiClientConstructor>(Base: TBase) {
             albumId: string,
             data: {
                 title?: string;
-                year?: number;
+                year?: number | null;
                 genres?: string[];
                 rgMbid?: string;
-                coverUrl?: string;
+                coverUrl?: string | null;
             },
         ) {
             return this.request<ApiData>(

--- a/frontend/lib/api/podcasts.ts
+++ b/frontend/lib/api/podcasts.ts
@@ -1,5 +1,16 @@
 import { type ApiClientConstructor, type ApiData } from "./core";
 
+/** Podcast summary returned by the grouped genre-discovery endpoint. */
+export interface PodcastDiscoveryItem {
+    id: string;
+    title: string;
+    author?: string;
+    coverUrl?: string;
+    feedUrl?: string;
+    trackCount?: number;
+    itunesId?: number;
+}
+
 /** Add podcast-domain operations to an API client base class. */
 export function WithPodcasts<TBase extends ApiClientConstructor>(Base: TBase) {
     abstract class PodcastsApi extends Base {
@@ -109,7 +120,7 @@ export function WithPodcasts<TBase extends ApiClientConstructor>(Base: TBase) {
         }
 
         async getPodcastsByGenre(genreIds: number[]) {
-            return this.request<ApiData>(
+            return this.request<Record<string, PodcastDiscoveryItem[]>>(
                 `/podcasts/discover/genres?genres=${genreIds.join(",")}`,
             );
         }

--- a/frontend/lib/artistPlayback.ts
+++ b/frontend/lib/artistPlayback.ts
@@ -159,8 +159,8 @@ export async function loadOwnedArtistTracksNewestFirst({
             "Unknown Album";
         const resolvedAlbumId = toOptionalString(albumData.id) || seedAlbum.id;
         const resolvedCoverArt =
-            toOptionalString(albumData.coverArt) ||
-            toOptionalString(albumData.coverUrl) ||
+            toOptionalString(albumData.coverArt) ??
+            toOptionalString(albumData.coverUrl) ??
             seedAlbum.coverArt;
 
         sortedTracks.forEach((track: Record<string, unknown>) => {

--- a/frontend/lib/audio-engine/index.ts
+++ b/frontend/lib/audio-engine/index.ts
@@ -19,6 +19,10 @@ import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 
 type EngineKind = "howler" | "videojs";
 type AnyAudioEventHandler = (payload: unknown) => void;
+interface PendingLazyLoad {
+    sequence: number;
+    autoplayOverride: boolean | null;
+}
 
 /** Which concrete engine occupies the direct-playback slot. */
 export type DirectEngineDescriptor = "howler" | "native" | "tauri-native";
@@ -155,10 +159,7 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
     // of acting on the stale active engine. Non-null only while the most
     // recent load() is deferred; autoplayOverride wins over the original
     // load options when set.
-    private pendingLazyLoad: {
-        sequence: number;
-        autoplayOverride: boolean | null;
-    } | null = null;
+    private pendingLazyLoad: PendingLazyLoad | null = null;
     private isDestroyed = false;
     private outputVolume = DEFAULT_AUDIO_VOLUME;
     private outputMuted = false;
@@ -256,7 +257,7 @@ export class HybridRuntimeAudioEngine implements RuntimeAudioEngine {
             // unless a newer load superseded it in the meantime. play()/pause()
             // in the interim adjust autoplay via pendingLazyLoad rather than
             // cancelling the load (see those methods).
-            const pendingLazyLoad: NonNullable<typeof this.pendingLazyLoad> = {
+            const pendingLazyLoad: PendingLazyLoad = {
                 sequence,
                 autoplayOverride: null,
             };

--- a/frontend/lib/audio-engine/segmentedPlaybackRegressionPolicy.ts
+++ b/frontend/lib/audio-engine/segmentedPlaybackRegressionPolicy.ts
@@ -1,7 +1,7 @@
 export interface TrustedTrackPositionInput {
     fallbackPositionSec: number;
     fallbackTrackId?: string | null;
-    playbackType: string;
+    playbackType: string | null;
     currentTrackId: string | null;
     targetTrackId: string;
     isLoading: boolean;

--- a/frontend/lib/audio-engine/videoJsSegmentedEngine.ts
+++ b/frontend/lib/audio-engine/videoJsSegmentedEngine.ts
@@ -788,8 +788,9 @@ export class VideoJsSegmentedEngine implements AudioEngine {
 
     setMuted(value: boolean): void {
         this.player.muted(Boolean(value));
+        const currentVolume = this.player.volume();
         this.emit("volume", {
-            volume: this.player.volume(),
+            volume: isFiniteNumber(currentVolume) ? currentVolume : 0,
             muted: this.player.muted(),
         });
     }

--- a/frontend/lib/audio-state-context.tsx
+++ b/frontend/lib/audio-state-context.tsx
@@ -103,7 +103,7 @@ export interface Track {
     id: string;
     title: string;
     artist: { name: string; id?: string; mbid?: string };
-    album: { title: string; coverArt?: string; id?: string };
+    album: { title: string; coverArt?: string | null; id?: string };
     duration: number;
     filePath?: string;
     // Streaming source fields

--- a/frontend/lib/playback-state-reconciliation.ts
+++ b/frontend/lib/playback-state-reconciliation.ts
@@ -219,10 +219,7 @@ export function resolveServerPlaybackPollDecision(
         input.localPlaybackType === "track" && input.localMediaId
             ? input.localMediaId
             : null;
-    const hasActiveLocalTrackQueue =
-        Boolean(localActiveTrackId) && input.localQueue.length > 0;
-
-    if (hasActiveLocalTrackQueue) {
+    if (localActiveTrackId && input.localQueue.length > 0) {
         if (isServerQueueTruncatedPrefix(input.localQueue, input.serverQueue)) {
             return {
                 shouldApplyServerSnapshot: false,

--- a/frontend/tests/component/activityPanel.component.test.ts
+++ b/frontend/tests/component/activityPanel.component.test.ts
@@ -326,7 +326,7 @@ test("activity panel toggle can disable polling when panel is open", async () =>
         await import("../../components/layout/ActivityPanel");
 
     renderToStaticMarkup(
-        React.createElement(ActivityPanelToggle, {
+        React.createElement<{ pollingEnabled?: boolean }>(ActivityPanelToggle, {
             pollingEnabled: false,
         }),
     );

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -1951,12 +1951,14 @@ test("native engine startup reaches the client-signal pipeline with neutral tele
     const startupFields = startupSignals[0]?.fields as
         | Record<string, unknown>
         | undefined;
-    assert.equal(typeof startupFields?.durationMs, "number");
-    assert.ok(Number.isFinite(startupFields.durationMs));
+    assert.ok(startupFields);
+    const durationMs = startupFields.durationMs;
+    assert.equal(typeof durationMs, "number");
+    assert.ok(typeof durationMs === "number" && Number.isFinite(durationMs));
     assert.deepEqual(startupSignals[0]?.fields, {
         engineMode: "native",
         activeEngine: "native",
-        durationMs: startupFields.durationMs,
+        durationMs,
         trackId: "native-startup",
         sourceType: "local",
         playbackType: "track",

--- a/frontend/tests/component/explorePage.component.test.ts
+++ b/frontend/tests/component/explorePage.component.test.ts
@@ -72,10 +72,10 @@ mock.module("@/features/explore/hooks/useUserSettingsExplorePrefs", {
 mock.module("@/hooks/useQueries", {
     namedExports: {
         mapYtMusicChartsToFeaturedPlaylists: (
-            charts: Record<string, unknown[]>,
+            charts: Record<string, Array<{ videoId: string; title: string }>>,
         ) => {
             const entries = Object.values(charts ?? {}).flat();
-            return entries.map((e: Record<string, string>) => ({
+            return entries.map((e) => ({
                 id: e.videoId,
                 title: e.title,
             }));

--- a/frontend/tests/component/fullPlayer.component.test.ts
+++ b/frontend/tests/component/fullPlayer.component.test.ts
@@ -14,6 +14,10 @@ const state = {
         id: "track-1",
         duration: 200,
         audioFeatures: null as null | Record<string, number>,
+    } as null | {
+        id: string;
+        duration: number;
+        audioFeatures: null | Record<string, number>;
     },
     currentAudiobook: null as null | {
         id: string;

--- a/frontend/tests/component/listenTogetherSession.component.test.ts
+++ b/frontend/tests/component/listenTogetherSession.component.test.ts
@@ -16,7 +16,10 @@ import {
     setListenTogetherSessionSnapshot,
     type ListenTogetherSessionSnapshot,
 } from "../../lib/listen-together-session";
-import { listenTogetherSocket } from "../../lib/listen-together-socket";
+import {
+    listenTogetherSocket,
+    type ListenTogetherSocketCallbacks,
+} from "../../lib/listen-together-socket";
 import { api } from "@/lib/api";
 
 GlobalRegistrator.register();
@@ -106,8 +109,8 @@ async function waitFor(
 }
 
 function clearWindowStorage(): void {
-    delete globalScope.window;
-    delete globalScope.localStorage;
+    Reflect.deleteProperty(globalScope, "window");
+    Reflect.deleteProperty(globalScope, "localStorage");
 }
 
 const snapshot: ListenTogetherSessionSnapshot = {
@@ -136,13 +139,13 @@ afterEach(() => {
     setListenTogetherMembershipPending(false);
 
     if (typeof previousWindow === "undefined") {
-        delete (globalScope as any).window;
+        Reflect.deleteProperty(globalScope, "window");
     } else {
         (globalScope as any).window = previousWindow;
     }
 
     if (typeof previousLocalStorage === "undefined") {
-        delete (globalScope as any).localStorage;
+        Reflect.deleteProperty(globalScope, "localStorage");
     } else {
         (globalScope as any).localStorage = previousLocalStorage;
     }
@@ -740,33 +743,6 @@ type MockGroupSnapshot = {
     }>;
 };
 
-type ListenTogetherCallbacks = {
-    onPlaybackDelta: (delta: {
-        isPlaying: boolean;
-        positionMs: number;
-        serverTime: number;
-        stateVersion: number;
-        currentIndex: number;
-        trackId: string | null;
-    }) => void;
-    onAvailability: (data: {
-        availability: Array<{
-            queueIndex: number;
-            available: boolean;
-            source?: "local" | "tidal" | "youtube";
-            localTrackId?: string;
-        }>;
-        stateVersion: number;
-    }) => void;
-    onWaiting: (data: { trackId: string | null; currentIndex: number }) => void;
-    onPlayAt: (data: {
-        positionMs: number;
-        serverTime: number;
-        stateVersion: number;
-    }) => void;
-    onConnect: () => void;
-};
-
 const providerAuthState = {
     userId: "host-id",
 };
@@ -774,7 +750,7 @@ const providerApiState: { group: MockGroupSnapshot | null } = {
     group: null,
 };
 const providerSocketState = {
-    callbacks: null as ListenTogetherCallbacks | null,
+    callbacks: null as ListenTogetherSocketCallbacks | null,
     seekCalls: [] as number[],
     reportReadyCalls: 0,
 };
@@ -849,10 +825,28 @@ const providerControls = {
     },
 };
 
-const providerSocket = {
+type ProviderSocketStub = {
+    isConnected: boolean;
+    probeRoute: typeof listenTogetherSocket.probeRoute;
+    connect: typeof listenTogetherSocket.connect;
+    disconnect: typeof listenTogetherSocket.disconnect;
+    joinGroup: typeof listenTogetherSocket.joinGroup;
+    reportReady: typeof listenTogetherSocket.reportReady;
+    play: typeof listenTogetherSocket.play;
+    pause: typeof listenTogetherSocket.pause;
+    seek: typeof listenTogetherSocket.seek;
+    next: typeof listenTogetherSocket.next;
+    previous: typeof listenTogetherSocket.previous;
+    setTrack: typeof listenTogetherSocket.setTrack;
+    addToQueue: typeof listenTogetherSocket.addToQueue;
+    removeFromQueue: typeof listenTogetherSocket.removeFromQueue;
+    clearQueue: typeof listenTogetherSocket.clearQueue;
+};
+
+const providerSocket: ProviderSocketStub = {
     isConnected: false,
     probeRoute: async () => ({ ok: true }),
-    connect: (callbacks: ListenTogetherCallbacks) => {
+    connect: (callbacks) => {
         providerSocketState.callbacks = callbacks;
     },
     disconnect: () => {
@@ -870,7 +864,11 @@ const providerSocket = {
     next: async () => undefined,
     previous: async () => undefined,
     setTrack: async () => undefined,
-    addToQueue: async () => undefined,
+    addToQueue: async (tracks) => ({
+        acceptedCount: tracks.length,
+        skippedCount: 0,
+        truncated: false,
+    }),
     removeFromQueue: async () => undefined,
     clearQueue: async () => undefined,
 };
@@ -1243,9 +1241,11 @@ test("availability remaps update queue identity idempotently and preserve swap p
     };
     providerAudioStateCalls.currentIndex = [];
     providerAudioStateCalls.currentTrack = [];
+    const onAvailability = host.callbacks().onAvailability;
+    assert.ok(onAvailability);
 
     await host.act(() =>
-        host.callbacks().onAvailability({
+        onAvailability({
             availability: [
                 {
                     queueIndex: 0,
@@ -1265,7 +1265,7 @@ test("availability remaps update queue identity idempotently and preserve swap p
     providerEngineState.currentTime = 37.25;
     providerControlCalls.seek = [];
     await host.act(() =>
-        host.callbacks().onAvailability({
+        onAvailability({
             availability: [
                 {
                     queueIndex: 0,

--- a/frontend/tests/component/persistedPlaybackPosition.component.test.ts
+++ b/frontend/tests/component/persistedPlaybackPosition.component.test.ts
@@ -48,13 +48,13 @@ beforeEach(() => {
 
 afterEach(() => {
     if (typeof previousWindow === "undefined") {
-        delete (globalScope as any).window;
+        Reflect.deleteProperty(globalScope, "window");
     } else {
         (globalScope as any).window = previousWindow;
     }
 
     if (typeof previousLocalStorage === "undefined") {
-        delete (globalScope as any).localStorage;
+        Reflect.deleteProperty(globalScope, "localStorage");
     } else {
         (globalScope as any).localStorage = previousLocalStorage;
     }
@@ -86,8 +86,8 @@ test("ignores storage write failures", () => {
 });
 
 test("no-ops when window is unavailable", () => {
-    delete globalScope.window;
-    delete globalScope.localStorage;
+    Reflect.deleteProperty(globalScope, "window");
+    Reflect.deleteProperty(globalScope, "localStorage");
 
     assert.doesNotThrow(() => {
         resetPersistedTrackStartPosition("track-11");

--- a/frontend/tests/component/proxy.component.test.ts
+++ b/frontend/tests/component/proxy.component.test.ts
@@ -1,43 +1,20 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { NextRequest } from "next/server";
 
 type ProxyModule = {
-    proxy: (request: { url: string; nextUrl: URL }) => Response;
+    proxy: typeof import("../../proxy").proxy;
     config: { matcher: string[] };
 };
 
 async function loadProxyModule(): Promise<ProxyModule> {
     const mod = await import("../../proxy");
-    const proxy =
-        (
-            mod as {
-                proxy?: ProxyModule["proxy"];
-                default?: { proxy?: ProxyModule["proxy"] };
-            }
-        ).proxy ??
-        (mod as { default?: { proxy?: ProxyModule["proxy"] } }).default?.proxy;
-    const config =
-        (
-            mod as {
-                config?: ProxyModule["config"];
-                default?: { config?: ProxyModule["config"] };
-            }
-        ).config ??
-        (mod as { default?: { config?: ProxyModule["config"] } }).default
-            ?.config;
-
-    assert.ok(proxy, "proxy export is available");
-    assert.ok(config, "config export is available");
-
-    return { proxy, config };
+    return { proxy: mod.proxy, config: mod.config };
 }
 
 function request(pathname: string) {
     const url = `https://soundspan.test${pathname}`;
-    return {
-        url,
-        nextUrl: new URL(url),
-    };
+    return new NextRequest(url);
 }
 
 test("proxy keeps /api/* routes as passthrough responses", async () => {

--- a/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
+++ b/frontend/tests/component/runtimeAudioEngineVolumeSync.component.test.ts
@@ -162,10 +162,8 @@ test("supports an async Video.js engine factory (lazy import path)", async () =>
 test("ignores a stale DASH load that resolves after a newer direct load", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -180,7 +178,7 @@ test("ignores a stale DASH load that resolves after a newer direct load", async 
     runtimeEngine.load("https://example.test/track.mp3", {
         autoplay: false,
     });
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     assert.equal(howlerEngine.loadCalls.length, 1);
@@ -190,10 +188,8 @@ test("ignores a stale DASH load that resolves after a newer direct load", async 
 test("cancels a pending lazy DASH engine load when the user stops playback", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -206,7 +202,7 @@ test("cancels a pending lazy DASH engine load when the user stops playback", asy
         mimeType: "application/dash+xml",
     });
     runtimeEngine.stop();
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     assert.equal(videoJsEngine.loadCalls.length, 0);
@@ -215,10 +211,8 @@ test("cancels a pending lazy DASH engine load when the user stops playback", asy
 test("completes a pending lazy DASH engine load without autoplay when the user pauses", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -234,7 +228,7 @@ test("completes a pending lazy DASH engine load without autoplay when the user p
         { autoplay: true },
     );
     runtimeEngine.pause();
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     // The queued track must still finish loading (so the UI's current
@@ -247,10 +241,8 @@ test("completes a pending lazy DASH engine load without autoplay when the user p
 test("play() during a pending lazy DASH load defers to the queued track instead of restarting the stale source", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -269,7 +261,7 @@ test("play() during a pending lazy DASH load defers to the queued track instead 
         { autoplay: false },
     );
     runtimeEngine.play();
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     // play() must not restart the previous, already-halted howler source
@@ -283,10 +275,8 @@ test("play() during a pending lazy DASH load defers to the queued track instead 
 test("re-arms autoplay when the user presses play after pausing a pending lazy DASH load", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -303,7 +293,7 @@ test("re-arms autoplay when the user presses play after pausing a pending lazy D
     );
     runtimeEngine.pause();
     runtimeEngine.play();
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     assert.equal(videoJsEngine.loadCalls.length, 1);
@@ -313,10 +303,8 @@ test("re-arms autoplay when the user presses play after pausing a pending lazy D
 test("stops in-progress playback before the lazy video.js import resolves", async () => {
     const howlerEngine = new FakeAudioEngine();
     const videoJsEngine = new FakeAudioEngine();
-    let resolveEngine: ((engine: AudioEngine) => void) | null = null;
-    const enginePromise = new Promise<AudioEngine>((resolve) => {
-        resolveEngine = resolve;
-    });
+    const { promise: enginePromise, resolve: resolveEngine } =
+        Promise.withResolvers<AudioEngine>();
     const runtimeEngine = new HybridRuntimeAudioEngine({
         howlerEngine,
         createVideoJsEngine: () => enginePromise,
@@ -337,7 +325,7 @@ test("stops in-progress playback before the lazy video.js import resolves", asyn
     // not after the (potentially slow) video.js chunk download.
     assert.equal(howlerEngine.stopCalls, 1);
 
-    resolveEngine?.(videoJsEngine);
+    resolveEngine(videoJsEngine);
     await flushAsyncEngineInit();
 
     assert.equal(videoJsEngine.loadCalls.length, 1);

--- a/frontend/tests/component/trackListKeyboardReorder.component.test.ts
+++ b/frontend/tests/component/trackListKeyboardReorder.component.test.ts
@@ -77,13 +77,14 @@ async function mountTrackList(
 ) {
     const { createRoot } = await import("react-dom/client");
     const { TrackList } = await import("../../components/track");
+    const TypedTrackList = TrackList<(typeof items)[number]>;
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
 
     await React.act(async () => {
         root.render(
-            React.createElement(TrackList, {
+            React.createElement(TypedTrackList, {
                 items,
                 toRowItem,
                 onPlay: (item: (typeof items)[number]) =>

--- a/frontend/tests/e2e/predeploy/media-contract.spec.ts
+++ b/frontend/tests/e2e/predeploy/media-contract.spec.ts
@@ -54,6 +54,7 @@ test.describe("Media Contract", () => {
         baseURL,
     }) => {
         test.skip(!baseURL, "Skipping: Playwright baseURL is required");
+        if (!baseURL) return;
 
         const requestOrigin = new URL(baseURL).origin;
         const tracksResponse = await page.request.get(
@@ -68,6 +69,7 @@ test.describe("Media Contract", () => {
             !trackId,
             "Skipping: no library tracks available for media contract checks",
         );
+        if (!trackId) return;
 
         const directStreamResponse = await page.request.get(
             `/api/library/tracks/${encodeURIComponent(trackId)}/stream?quality=original`,

--- a/frontend/tests/unit/latestAsyncOperation.test.ts
+++ b/frontend/tests/unit/latestAsyncOperation.test.ts
@@ -23,10 +23,8 @@ test("keeps only the latest queued arg while in flight", async () => {
     const state = createLatestAsyncOperationState<number>();
     const executed: number[] = [];
 
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-    });
+    const { promise: firstGate, resolve: releaseFirst } =
+        Promise.withResolvers<void>();
 
     const runner = async (arg: number) => {
         executed.push(arg);
@@ -39,7 +37,7 @@ test("keeps only the latest queued arg while in flight", async () => {
     enqueueLatestAsyncOperation(state, 2, runner);
     enqueueLatestAsyncOperation(state, 3, runner);
 
-    releaseFirst?.();
+    releaseFirst();
     await waitForDrain(state);
 
     assert.deepEqual(executed, [1, 3]);
@@ -50,10 +48,8 @@ test("calls onError for queued latest operation failures", async () => {
     const executed: number[] = [];
     const failedArgs: number[] = [];
 
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-    });
+    const { promise: firstGate, resolve: releaseFirst } =
+        Promise.withResolvers<void>();
 
     const runner = async (arg: number) => {
         executed.push(arg);
@@ -75,7 +71,7 @@ test("calls onError for queued latest operation failures", async () => {
         },
     });
 
-    releaseFirst?.();
+    releaseFirst();
     await waitForDrain(state);
 
     assert.deepEqual(executed, [1, 2]);
@@ -86,10 +82,8 @@ test("LT host rapid double-next preserves both sequential intents under contenti
     const state = createLatestAsyncOperationState<"next">();
     const emitted: string[] = [];
 
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-    });
+    const { promise: firstGate, resolve: releaseFirst } =
+        Promise.withResolvers<void>();
 
     const runner = async (arg: "next") => {
         emitted.push(arg);
@@ -101,7 +95,7 @@ test("LT host rapid double-next preserves both sequential intents under contenti
     enqueueLatestAsyncOperation(state, "next", runner);
     enqueueLatestAsyncOperation(state, "next", runner);
 
-    releaseFirst?.();
+    releaseFirst();
     await waitForDrain(state);
 
     assert.deepEqual(emitted, ["next", "next"]);
@@ -112,10 +106,8 @@ test("LT host queue collapses intermediate actions to latest pending intent", as
     const state = createLatestAsyncOperationState<HostAction>();
     const emitted: HostAction[] = [];
 
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-    });
+    const { promise: firstGate, resolve: releaseFirst } =
+        Promise.withResolvers<void>();
 
     const runner = async (arg: HostAction) => {
         emitted.push(arg);
@@ -128,7 +120,7 @@ test("LT host queue collapses intermediate actions to latest pending intent", as
     enqueueLatestAsyncOperation(state, "previous", runner);
     enqueueLatestAsyncOperation(state, "set-track:7", runner);
 
-    releaseFirst?.();
+    releaseFirst();
     await waitForDrain(state);
 
     assert.deepEqual(emitted, ["next", "set-track:7"]);

--- a/frontend/tests/unit/listenTogetherClockOffset.test.ts
+++ b/frontend/tests/unit/listenTogetherClockOffset.test.ts
@@ -41,7 +41,9 @@ class FakeSocket {
         const ack = args.at(-1);
         assert.equal(typeof ack, "function");
         const serverTime = this.serverTimesMs.shift();
-        assert.notEqual(serverTime, undefined);
+        if (serverTime === undefined) {
+            throw new Error("missing test server time");
+        }
         (ack as (response: { serverTime: number }) => void)({ serverTime });
         return this;
     }
@@ -99,7 +101,9 @@ function createClockSampler(options: {
         getToken: () => "test-token",
         now: () => {
             const now = localTimesMs.shift();
-            assert.notEqual(now, undefined);
+            if (now === undefined) {
+                throw new Error("missing test local time");
+            }
             return now;
         },
         setInterval: (callback) => {
@@ -117,7 +121,9 @@ function createClockSampler(options: {
         socket,
         fakeSocket,
         sampleAgain: () => {
-            assert.ok(intervalCallback);
+            if (!intervalCallback) {
+                throw new Error("clock sample interval was not registered");
+            }
             intervalCallback();
         },
     };
@@ -228,7 +234,9 @@ function invokeResumeAndCapture(
         setListenTogetherSessionSnapshot(null);
         listenTogetherSocket.disconnect();
     }
-    assert.notEqual(targetSec, null);
+    if (targetSec === null) {
+        throw new Error("resume did not emit a seek target");
+    }
     return targetSec;
 }
 

--- a/frontend/tests/unit/mapSearch.test.ts
+++ b/frontend/tests/unit/mapSearch.test.ts
@@ -4,8 +4,9 @@ import { searchMapTracks } from "../../components/vibe/mapSearch";
 import type { MapTrack } from "../../components/vibe/types";
 
 function track(overrides: Partial<MapTrack> & { id: string }): MapTrack {
+    const { id, ...rest } = overrides;
     return {
-        id: overrides.id,
+        id,
         x: 0.5,
         y: 0.5,
         title: overrides.title ?? "Untitled",
@@ -17,7 +18,7 @@ function track(overrides: Partial<MapTrack> & { id: string }): MapTrack {
         moodScore: 0.5,
         energy: 0.5,
         valence: 0.5,
-        ...overrides,
+        ...rest,
     };
 }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
-        "strict": false,
+        "strict": true,
         "noEmit": true,
         "allowImportingTsExtensions": true,
         "esModuleInterop": true,


### PR DESCRIPTION
## Summary
Closes the reviewer's headline typing gap (frontend `"strict": false`; the handbook makes strict non-negotiable). Backend was already strict.

- `strict: true` + all **112** resulting errors fixed properly across 48 files: nullable domain/API contracts, optional-value and unknown-error guards, numeric narrowing, shared event-handler payload types, hardened fixtures/mocks.
- **Zero** `any`, zero suppression comments, zero non-null assertions added.
- Three latent null-dereference paths surfaced by the compiler, fixed defensively and flagged: recovery telemetry on a cleared track → "unknown"; video.js non-finite volume → 0; mood/genre items without a title no longer fire selection.
- Lint budget untouched: 0 errors / 182 warnings before and after (warning burn-down is a separate slice).

## Verification
- `tsc --noEmit` → 0 errors (independently re-run)
- Test batches across touched areas: 92 + 80 + 42 + 81 + 30 + 9 pass; engine unit spot re-run green
- Frontend-context pinned prettier clean · `git diff --check` clean