### PR TITLE
fix(security): strip delimited segments with a linear scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -761,9 +761,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   playback-state sync routes now have route-level rate limiting; playback-state
   uses a generous dedicated tier for its high-frequency cadence, and invite
   codes use unbiased cryptographic random character selection.
-- Hardened external-metadata escaping for Deezer and Spotify, and replaced
-  backtracking-prone normalization regexes with linear forms in Soulseek,
-  search, and Lidarr.
+- Hardened external-metadata escaping for Deezer and Spotify; Soulseek and
+  Lidarr delimited-content stripping now uses a single-pass linear scanner
+  instead of regex rescans, while search normalization uses linear regex forms.
 - Cover-image storage operations validate IDs and contain all filesystem paths
   under the type-specific covers directory.
 - Account-management, 2FA, and Subsonic-credential routes now have dedicated

--- a/backend/src/services/__tests__/lidarrService.test.ts
+++ b/backend/src/services/__tests__/lidarrService.test.ts
@@ -4036,7 +4036,7 @@ describe("lidarr service behavior", () => {
 
         const album = {
             id: 901,
-            title: "Exact Match Album (Deluxe Edition)",
+            title: "Exact Match Album ((Deluxe Edition) Remainder)",
             foreignAlbumId: "album-exact",
             artistId: 55,
         };
@@ -4075,7 +4075,7 @@ describe("lidarr service behavior", () => {
             lidarrService.addAlbum(
                 "different-mbid",
                 "Exact Match Band",
-                "Exact Match Album",
+                "Exact Match Album Remainder",
                 "/music",
                 "artist-exact",
             ),
@@ -4088,7 +4088,7 @@ describe("lidarr service behavior", () => {
 
         expect(logger.debug).toHaveBeenCalledWith(
             expect.stringContaining(
-                'Matched exact normalized: "Exact Match Album (Deluxe Edition)"',
+                'Matched exact normalized: "Exact Match Album ((Deluxe Edition) Remainder)"',
             ),
         );
 
@@ -4103,9 +4103,7 @@ describe("lidarr service behavior", () => {
         async (_case, openingDelimiter) => {
             const client = createClientMock();
             primeServiceWithClient(client);
-            const longTitle = `Long Album ${openingDelimiter}${"x".repeat(
-                50_000,
-            )}`;
+            const longTitle = `Long Album ${openingDelimiter.repeat(50_000)}`;
             const artist = {
                 id: 56,
                 artistName: "Long Match Band",

--- a/backend/src/services/__tests__/soulseekService.test.ts
+++ b/backend/src/services/__tests__/soulseekService.test.ts
@@ -561,17 +561,25 @@ describe("soulseek service", () => {
 
         const fallback = (soulseekService as any).normalizeTrackTitle("(Live)");
         expect(fallback).toBe("(Live)");
+
+        const nestedDescriptor = (soulseekService as any).normalizeTrackTitle(
+            "Song ((Live) Cut)",
+        );
+        expect(nestedDescriptor).toBe("Song Cut)");
+
+        const nestedLiteral = (soulseekService as any).normalizeTrackTitle(
+            "Song ((Studio) Cut)",
+        );
+        expect(nestedLiteral).toBe("Song ((Studio) Cut)");
     });
 
     it.each([
-        ["parenthetical", "(", "live "],
-        ["bracket", "[", "remaster "],
+        ["parenthetical", "("],
+        ["bracket", "["],
     ])(
-        "leaves long unmatched %s descriptors unchanged without excessive backtracking",
-        (_case, openingDelimiter, descriptor) => {
-            const title = `Song ${openingDelimiter}${descriptor.repeat(
-                9_999,
-            )}${descriptor.trim()}`;
+        "leaves 50,000 unmatched %s openers unchanged within the regression bound",
+        (_case, openingDelimiter) => {
+            const title = `Song ${openingDelimiter.repeat(50_000)}`;
             const startedAt = performance.now();
 
             const normalized = (soulseekService as any).normalizeTrackTitle(

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -4,6 +4,7 @@ import { config } from "../config";
 import { BRAND_SLUG } from "../config/brand";
 import { getSystemSettings } from "../utils/systemSettings";
 import { stripAlbumEdition } from "../utils/artistNormalization";
+import { stripDelimitedSegments } from "../utils/stripDelimitedSegments";
 
 /**
  * Error types for music acquisition failures
@@ -1030,10 +1031,11 @@ class LidarrService {
 
                 // Normalize title for matching - remove parenthetical suffixes, edition markers, etc.
                 const normalizeTitle = (title: string) =>
-                    title
-                        .toLowerCase()
-                        .replace(/\([^)]*\)/g, "") // Remove parenthetical content (deluxe edition, remaster, etc.)
-                        .replace(/\[[^\]]*\]/g, "") // Remove bracketed content
+                    stripDelimitedSegments(
+                        stripDelimitedSegments(title.toLowerCase(), "(", ")"),
+                        "[",
+                        "]",
+                    )
                         .replace(
                             /[-–—]\s*(deluxe|remaster|bonus|special|anniversary|expanded|limited|collector).*$/i,
                             "",

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -11,6 +11,7 @@ import { getSystemSettings } from "../utils/systemSettings";
 import { sessionLog } from "../utils/playlistLogger";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
+import { stripDelimitedSegments } from "../utils/stripDelimitedSegments";
 
 const log = logger.child("Soulseek");
 
@@ -119,11 +120,19 @@ class SoulseekService {
             .replace(/[×]/g, "x"); // Multiplication sign → x
 
         // Remove delimited content only when it contains a known descriptor.
-        normalized = normalized.replace(/\(([^)]*)\)/g, (match, segment) =>
-            TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+        normalized = stripDelimitedSegments(
+            normalized,
+            "(",
+            ")",
+            (segment) => TRACK_DESCRIPTOR_PATTERN.test(segment),
+            " ",
         );
-        normalized = normalized.replace(/\[([^\]]*)\]/g, (match, segment) =>
-            TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+        normalized = stripDelimitedSegments(
+            normalized,
+            "[",
+            "]",
+            (segment) => TRACK_DESCRIPTOR_PATTERN.test(segment),
+            " ",
         );
 
         // Remove trailing dash content (often contains year or version info)

--- a/backend/src/utils/__tests__/stripDelimitedSegments.test.ts
+++ b/backend/src/utils/__tests__/stripDelimitedSegments.test.ts
@@ -1,0 +1,109 @@
+import { stripDelimitedSegments } from "../stripDelimitedSegments";
+
+const TRACK_DESCRIPTOR_PATTERN =
+    /(?:live|remaster|remix|version|edit|demo|acoustic|radio|single|extended|instrumental|feat\.|ft\.|featuring)/i;
+
+const EQUIVALENCE_CORPUS = [
+    "",
+    "plain title",
+    "()",
+    "[]",
+    "(live)",
+    "[remaster]",
+    "before (live) after",
+    "before [radio edit] after",
+    "(first)(second)",
+    "[first][second]",
+    "before ) after",
+    "before ] after",
+    "before ( after",
+    "before [ after",
+    "(((((",
+    "[[[[[",
+    "((nested) tail)",
+    "[[nested] tail]",
+    "a(b(c)d)e",
+    "a[b[c]d]e",
+    "mix (live) [deluxe] end",
+    "unicode (演奏版) café 🎵",
+    "unicode [ライブ版] naïve 🚀",
+    "descriptor (Live at 東京) [Original Mix]",
+];
+
+const DELIMITER_CASES = [
+    {
+        label: "parentheses",
+        openDelimiter: "(",
+        closeDelimiter: ")",
+        stripOracle: (input: string) => input.replace(/\([^)]*\)/g, ""),
+        filterOracle: (input: string) =>
+            input.replace(/\(([^)]*)\)/g, (match, segment) =>
+                TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+            ),
+    },
+    {
+        label: "brackets",
+        openDelimiter: "[",
+        closeDelimiter: "]",
+        stripOracle: (input: string) => input.replace(/\[[^\]]*\]/g, ""),
+        filterOracle: (input: string) =>
+            input.replace(/\[([^\]]*)\]/g, (match, segment) =>
+                TRACK_DESCRIPTOR_PATTERN.test(segment) ? " " : match,
+            ),
+    },
+];
+
+describe.each(DELIMITER_CASES)(
+    "stripDelimitedSegments with $label",
+    ({ openDelimiter, closeDelimiter, stripOracle, filterOracle }) => {
+        it.each(EQUIVALENCE_CORPUS)(
+            "matches unconditional regex semantics for corpus entry %#",
+            (input) => {
+                expect(
+                    stripDelimitedSegments(
+                        input,
+                        openDelimiter,
+                        closeDelimiter,
+                    ),
+                ).toBe(stripOracle(input));
+            },
+        );
+
+        it.each(EQUIVALENCE_CORPUS)(
+            "matches predicate-filtered regex semantics for corpus entry %#",
+            (input) => {
+                expect(
+                    stripDelimitedSegments(
+                        input,
+                        openDelimiter,
+                        closeDelimiter,
+                        (segment) => TRACK_DESCRIPTOR_PATTERN.test(segment),
+                        " ",
+                    ),
+                ).toBe(filterOracle(input));
+            },
+        );
+    },
+);
+
+it("scans 50,000 unmatched opening delimiters within the regression bound", () => {
+    const input = "(".repeat(50_000);
+    const startedAt = performance.now();
+
+    const result = stripDelimitedSegments(input, "(", ")");
+
+    expect(result).toBe(input);
+    expect(performance.now() - startedAt).toBeLessThan(200);
+});
+
+it.each([
+    ["", ")"],
+    ["(", ""],
+    ["((", ")"],
+    ["(", "))"],
+    ["(", "("],
+])("rejects invalid delimiter pairs %#", (openDelimiter, closeDelimiter) => {
+    expect(() =>
+        stripDelimitedSegments("value", openDelimiter, closeDelimiter),
+    ).toThrow(RangeError);
+});

--- a/backend/src/utils/stripDelimitedSegments.ts
+++ b/backend/src/utils/stripDelimitedSegments.ts
@@ -1,0 +1,50 @@
+type DelimitedSegmentPredicate = (segment: string) => boolean;
+
+const STRIP_EVERY_SEGMENT: DelimitedSegmentPredicate = () => true;
+
+/**
+ * Replaces complete, non-nested delimited segments in one left-to-right pass.
+ * Opening delimiters inside a segment are literal content, and unmatched
+ * delimiters are preserved. Delimiters must be distinct single code units.
+ * @throws {RangeError} When delimiters are not distinct single code units.
+ */
+export function stripDelimitedSegments(
+    input: string,
+    openDelimiter: string,
+    closeDelimiter: string,
+    shouldStrip: DelimitedSegmentPredicate = STRIP_EVERY_SEGMENT,
+    replacement: string = "",
+): string {
+    if (openDelimiter.length !== 1 || closeDelimiter.length !== 1) {
+        throw new RangeError("Delimited segment markers must be one character");
+    }
+    if (openDelimiter === closeDelimiter) {
+        throw new RangeError("Delimited segment markers must be distinct");
+    }
+
+    const outputParts: string[] = [];
+    let segmentStart = -1;
+    let copyStart = 0;
+
+    for (let index = 0; index < input.length; index += 1) {
+        const character = input[index];
+        if (segmentStart < 0) {
+            if (character === openDelimiter) segmentStart = index + 1;
+            continue;
+        }
+        if (character !== closeDelimiter) continue;
+
+        if (shouldStrip(input.slice(segmentStart, index))) {
+            outputParts.push(
+                input.slice(copyStart, segmentStart - 1),
+                replacement,
+            );
+            copyStart = index + 1;
+        }
+        segmentStart = -1;
+    }
+
+    if (outputParts.length === 0) return input;
+    outputParts.push(input.slice(copyStart));
+    return outputParts.join("");
+}


### PR DESCRIPTION
## Summary
Closes the final two CodeQL alerts (#1245, #1246 — `js/polynomial-redos` at new locations after #424): `/\([^)]*\)/g` forms are linear per match but O(n²) on strings flooded with unmatched `(` (every start position rescans to end).

- New `stripDelimitedSegments` util: single left-to-right scan, index only advances, nested openers are literal, first closer ends a segment, unmatched delimiters untouched — O(n) by construction.
- Soulseek descriptor filtering (predicate mode, exact `" "` replacement) and Lidarr title normalization (removal mode) migrated.

## Tests
- 96 equivalence-oracle comparisons (24-string corpus × 2 delimiter pairs × 2 modes) against the old regexes embedded as the oracle
- 50,000-opener input completes <200ms (regression bound)
- Service suites extended for nested/unmatched invariance

## Verification
7 targeted suites / 364 tests + 21 mock-consumer suites / 613 tests + helper suite 102 · independent re-run green · `tsc` clean · backend-context pinned prettier · canon ratchets pass