### PR TITLE
fix(deploy): construct DATABASE_URL from components with percent-encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Compose deployments now construct `DATABASE_URL` from `POSTGRES_*`
+  components in-app with percent-encoded credentials, so passwords containing
+  URL-reserved characters work; explicit `DATABASE_URL` still wins.
 - Queue auto-advance no longer pauses itself right after the next track starts:
   the ready-state transition no longer erases the advance's play intent, the
   deferred-play path re-asserts it explicitly, and load/play-intent decisions

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,7 @@ COPY package*.json ./
 COPY prisma ./prisma/
 # Prisma 7 CLI reads schema/migrations/datasource config from prisma.config.ts
 COPY prisma.config.ts ./
+COPY databaseUrl.js ./
 
 # Install all deps (includes dev deps needed for tsx/prisma CLI)
 RUN npm ci && \
@@ -57,6 +58,7 @@ COPY --from=worker-deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=worker-deps --chown=node:node /app/package*.json ./
 COPY --from=worker-deps --chown=node:node /app/prisma ./prisma
 COPY --from=worker-deps --chown=node:node /app/dist ./dist
+COPY --from=worker-deps --chown=node:node /app/databaseUrl.js ./databaseUrl.js
 COPY --from=worker-deps --chown=node:node /packages/media-metadata-contract /packages/media-metadata-contract
 
 # Create writable runtime dirs and harden image
@@ -98,6 +100,7 @@ COPY --from=api-deps --chown=node:node /app/package*.json ./
 COPY --from=build --chown=node:node /app/prisma ./prisma
 COPY --from=build --chown=node:node /app/prisma.config.ts ./
 COPY --from=build --chown=node:node /app/dist ./dist
+COPY --from=build --chown=node:node /app/databaseUrl.js ./databaseUrl.js
 COPY --from=build --chown=node:node /packages/media-metadata-contract /packages/media-metadata-contract
 
 # Healthcheck + entrypoint

--- a/backend/databaseUrl.js
+++ b/backend/databaseUrl.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const POSTGRES_COMPONENT_KEYS = [
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_DB",
+];
+
+/**
+ * Resolve the PostgreSQL connection URL without changing an explicit URL.
+ *
+ * @param {Record<string, string | undefined>} environment process environment
+ * @returns {string | undefined} explicit, constructed, or absent database URL
+ */
+function resolveDatabaseUrl(environment) {
+    const explicitDatabaseUrl = environment.DATABASE_URL;
+    if (explicitDatabaseUrl) return explicitDatabaseUrl;
+
+    const hasAllComponents = POSTGRES_COMPONENT_KEYS.every(
+        (key) => environment[key],
+    );
+    if (!hasAllComponents) return explicitDatabaseUrl;
+
+    const user = encodeURIComponent(environment.POSTGRES_USER);
+    const password = encodeURIComponent(environment.POSTGRES_PASSWORD);
+    return (
+        `postgresql://${user}:${password}@${environment.POSTGRES_HOST}:` +
+        `${environment.POSTGRES_PORT}/${environment.POSTGRES_DB}`
+    );
+}
+
+module.exports = { resolveDatabaseUrl };

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,16 +1,20 @@
 import { defineConfig, env } from "prisma/config";
 
+const { resolveDatabaseUrl } = require("./databaseUrl") as {
+    resolveDatabaseUrl: (environment: NodeJS.ProcessEnv) => string | undefined;
+};
+
 // Prisma 7 moved datasource connection URLs out of schema.prisma.
 // This config is used by the Prisma CLI (generate/validate/migrate/studio);
 // the runtime client gets its connection via the pg driver adapter in
 // src/utils/db.ts. See https://pris.ly/d/config-datasource
 // env() throws at config load when the variable is unset. `prisma generate`
 // runs during Docker builds with no database available, so only wire the
-// datasource when DATABASE_URL is present; commands that actually need a
-// database (migrate/studio) fail fast with a missing-datasource error instead.
-const datasource = process.env.DATABASE_URL
-    ? { url: env("DATABASE_URL") }
-    : undefined;
+// datasource when an explicit URL or a complete component set resolves;
+// commands that need a database still fail fast when neither is available.
+const databaseUrl = resolveDatabaseUrl(process.env);
+if (databaseUrl) process.env.DATABASE_URL = databaseUrl;
+const datasource = databaseUrl ? { url: env("DATABASE_URL") } : undefined;
 
 export default defineConfig({
     schema: "prisma/schema.prisma",

--- a/backend/src/__tests__/config.test.ts
+++ b/backend/src/__tests__/config.test.ts
@@ -133,6 +133,37 @@ describe("config module", () => {
         ]);
     });
 
+    it("constructs DATABASE_URL from percent-encoded PostgreSQL components", async () => {
+        const { config } = await loadConfigModule({
+            DATABASE_URL: "",
+            POSTGRES_HOST: "postgres",
+            POSTGRES_PORT: "5432",
+            POSTGRES_USER: "user@:/?#% 雪",
+            POSTGRES_PASSWORD: "pass@:/?#% 雪",
+            POSTGRES_DB: "soundspan",
+        });
+
+        expect(config.databaseUrl).toBe(
+            "postgresql://user%40%3A%2F%3F%23%25%20%E9%9B%AA:" +
+                "pass%40%3A%2F%3F%23%25%20%E9%9B%AA@postgres:5432/soundspan",
+        );
+    });
+
+    it("preserves an explicit DATABASE_URL unchanged", async () => {
+        const explicitDatabaseUrl =
+            "postgresql://explicit:raw%2Fvalue@external:6432/custom?schema=tenant";
+        const { config } = await loadConfigModule({
+            DATABASE_URL: explicitDatabaseUrl,
+            POSTGRES_HOST: "postgres",
+            POSTGRES_PORT: "5432",
+            POSTGRES_USER: "component-user",
+            POSTGRES_PASSWORD: "component-password",
+            POSTGRES_DB: "soundspan",
+        });
+
+        expect(config.databaseUrl).toBe(explicitDatabaseUrl);
+    });
+
     it("retains integration secret env fallbacks by default", async () => {
         const { config } = await loadConfigModule({
             SECRETS_DB_ONLY: undefined,
@@ -660,6 +691,11 @@ describe("config module", () => {
         await expect(
             loadConfigModule({
                 DATABASE_URL: undefined,
+                POSTGRES_HOST: undefined,
+                POSTGRES_PORT: undefined,
+                POSTGRES_USER: undefined,
+                POSTGRES_PASSWORD: undefined,
+                POSTGRES_DB: undefined,
             }),
         ).rejects.toThrow("process.exit:1");
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -20,8 +20,15 @@ import {
     type CriticalSecretFailure,
 } from "./config/secretsPolicy";
 
+const { resolveDatabaseUrl } = require("../databaseUrl") as {
+    resolveDatabaseUrl: (environment: NodeJS.ProcessEnv) => string | undefined;
+};
+
 // quiet is a no-op on dotenv 16 and silences v17's per-boot injection tip line
 dotenv.config({ quiet: true });
+
+const databaseUrl = resolveDatabaseUrl(process.env);
+if (databaseUrl) process.env.DATABASE_URL = databaseUrl;
 
 const secretsDbOnly = isSecretsDbOnlyEnabled();
 
@@ -192,7 +199,7 @@ export const config = {
     port: parseEnvInt(process.env.PORT, 3006),
     nodeEnv: process.env.NODE_ENV || "development",
     // DATABASE_URL and REDIS_URL are validated by envSchema above, so they're guaranteed to exist
-    databaseUrl: process.env.DATABASE_URL!,
+    databaseUrl: databaseUrl!,
     redisUrl: process.env.REDIS_URL!,
     sessionSecret: process.env.SESSION_SECRET!,
 

--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -29,6 +29,9 @@ services:
       - SESSION_SECRET=${SESSION_SECRET:-}
       - SETTINGS_ENCRYPTION_KEY=${SETTINGS_ENCRYPTION_KEY:-}
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
+      # AIO uses fixed internal host/user/database components; its verified
+      # credential helper URL-encodes this separately supplied password.
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-}
       - BROWSE_IMAGE_CACHE_MAX_BYTES=${BROWSE_IMAGE_CACHE_MAX_BYTES:-268435456}
       - BROWSE_IMAGE_CACHE_MAX_ENTRIES=${BROWSE_IMAGE_CACHE_MAX_ENTRIES:-2048}
       # Runtime streaming-engine selector. Accepted: native | howler | videojs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,11 @@ services:
                 media-metadata-contract: ./packages/media-metadata-contract
         environment:
             # Database
-            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
+            # An explicit DATABASE_URL passes through unchanged. When empty, the
+            # app constructs it from these components and URL-encodes credentials.
+            DATABASE_URL: "${DATABASE_URL:-}"
+            POSTGRES_HOST: postgres
+            POSTGRES_PORT: "5432"
             POSTGRES_USER: ${POSTGRES_USER:-soundspan}
             POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
             POSTGRES_DB: ${POSTGRES_DB:-soundspan}
@@ -162,7 +166,11 @@ services:
                 media-metadata-contract: ./packages/media-metadata-contract
             target: worker-runtime
         environment:
-            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
+            # Keep the component path identical to the API service. The worker
+            # constructs an encoded URL unless an explicit DATABASE_URL is set.
+            DATABASE_URL: "${DATABASE_URL:-}"
+            POSTGRES_HOST: postgres
+            POSTGRES_PORT: "5432"
             POSTGRES_USER: ${POSTGRES_USER:-soundspan}
             POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
             POSTGRES_DB: ${POSTGRES_DB:-soundspan}
@@ -390,7 +398,14 @@ services:
         container_name: ${SOUNDSPAN_AUDIO_ANALYZER_CONTAINER_NAME:-soundspan_audio_analyzer}
         environment:
             REDIS_URL: redis://redis:6379
-            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
+            # Python constructs an encoded URL from components when no explicit
+            # DATABASE_URL is supplied.
+            DATABASE_URL: "${DATABASE_URL:-}"
+            POSTGRES_HOST: postgres
+            POSTGRES_PORT: "5432"
+            POSTGRES_USER: ${POSTGRES_USER:-soundspan}
+            POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
+            POSTGRES_DB: ${POSTGRES_DB:-soundspan}
             MUSIC_PATH: /music
             BATCH_SIZE: ${AUDIO_ANALYSIS_BATCH_SIZE:-10}
             SLEEP_INTERVAL: ${AUDIO_ANALYSIS_INTERVAL:-5}
@@ -450,7 +465,14 @@ services:
         container_name: ${SOUNDSPAN_CLAP_CONTAINER_NAME:-soundspan_audio_analyzer_clap}
         environment:
             REDIS_URL: redis://redis:6379
-            DATABASE_URL: "postgresql://${POSTGRES_USER:-soundspan}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}@postgres:5432/${POSTGRES_DB:-soundspan}"
+            # Python constructs an encoded URL from components when no explicit
+            # DATABASE_URL is supplied.
+            DATABASE_URL: "${DATABASE_URL:-}"
+            POSTGRES_HOST: postgres
+            POSTGRES_PORT: "5432"
+            POSTGRES_USER: ${POSTGRES_USER:-soundspan}
+            POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - generate one with: openssl rand -base64 32}"
+            POSTGRES_DB: ${POSTGRES_DB:-soundspan}
             BACKEND_URL: http://backend:3006
             MUSIC_PATH: /music
             SLEEP_INTERVAL: ${CLAP_SLEEP_INTERVAL:-5}

--- a/docs/MIGRATING_FROM_LIDIFY.md
+++ b/docs/MIGRATING_FROM_LIDIFY.md
@@ -78,10 +78,12 @@ if grep -q '^LIDIFY_CALLBACK_URL=' .env; then
   sed -i 's/^LIDIFY_CALLBACK_URL=/SOUNDSPAN_CALLBACK_URL=/' .env
 fi
 
-# Ensure legacy DB defaults are preserved if they were implicit in Lidify
+# Ensure legacy DB names are preserved if they were implicit in Lidify.
+# Services receive these components separately and URL-encode credentials, so
+# keep POSTGRES_PASSWORD raw here even when it contains URL-reserved characters.
 grep -q '^POSTGRES_USER=' .env || echo 'POSTGRES_USER=lidifydb' >> .env
 grep -q '^POSTGRES_DB=' .env || echo 'POSTGRES_DB=lidify' >> .env
-grep -q '^POSTGRES_PASSWORD=' .env || echo 'POSTGRES_PASSWORD=changeme' >> .env
+grep -q '^POSTGRES_PASSWORD=' .env || echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
 
 # AIO image repository changed to GHCR
 if grep -q '^SOUNDSPAN_AIO_IMAGE=' .env; then

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -42,6 +42,7 @@ function composeConfig(postgresPassword) {
         SESSION_SECRET: "test-session-secret",
         SETTINGS_ENCRYPTION_KEY: "test-settings-key",
     };
+    delete environment.DATABASE_URL;
     if (postgresPassword === undefined) {
         delete environment.POSTGRES_PASSWORD;
     } else {
@@ -247,36 +248,52 @@ test("7. split-stack compose refuses a missing or empty PostgreSQL password", ()
     assert.match(emptyResult.stderr, /POSTGRES_PASSWORD is required/);
 });
 
-test("8. split-stack compose applies the configured PostgreSQL password everywhere", () => {
-    const password = "test-explicit-postgres-password";
+test("8. split-stack compose passes PostgreSQL components to database consumers", () => {
+    const password = "test@:/?#% password 雪";
     const result = composeConfig(password);
 
     assert.equal(result.status, 0, result.stderr);
     const services = JSON.parse(result.stdout).services;
-    const databaseUrl = `postgresql://soundspan:${password}@postgres:5432/soundspan`;
+    const databaseConsumers = [
+        "backend",
+        "backend-worker",
+        "audio-analyzer",
+        "audio-analyzer-clap",
+    ];
 
-    assert.equal(services.backend.environment.POSTGRES_PASSWORD, password);
-    assert.equal(services.backend.environment.DATABASE_URL, databaseUrl);
-    assert.equal(
-        services["backend-worker"].environment.POSTGRES_PASSWORD,
-        password,
-    );
-    assert.equal(
-        services["backend-worker"].environment.DATABASE_URL,
-        databaseUrl,
-    );
+    for (const serviceName of databaseConsumers) {
+        const environment = services[serviceName].environment;
+        assert.equal(environment.DATABASE_URL, "");
+        assert.equal(environment.POSTGRES_HOST, "postgres");
+        assert.equal(environment.POSTGRES_PORT, "5432");
+        assert.equal(environment.POSTGRES_USER, "soundspan");
+        assert.equal(environment.POSTGRES_PASSWORD, password);
+        assert.equal(environment.POSTGRES_DB, "soundspan");
+    }
     assert.equal(services.postgres.environment.POSTGRES_PASSWORD, password);
-    assert.equal(
-        services["audio-analyzer"].environment.DATABASE_URL,
-        databaseUrl,
-    );
-    assert.equal(
-        services["audio-analyzer-clap"].environment.DATABASE_URL,
-        databaseUrl,
+});
+
+test("9. compose files never interpolate PostgreSQL components into DATABASE_URL", () => {
+    for (const relativePath of [
+        "docker-compose.yml",
+        "docker-compose.aio.yml",
+    ]) {
+        const compose = readRepoFile(relativePath);
+        assert.doesNotMatch(
+            compose,
+            /^\s*-?\s*DATABASE_URL\s*[:=][^\r\n]*\$\{POSTGRES_(?:HOST|PORT|USER|PASSWORD|DB)/m,
+            `${relativePath}: DATABASE_URL must not interpolate raw PostgreSQL components`,
+        );
+    }
+
+    assert.match(
+        readRepoFile("docker-compose.aio.yml"),
+        /^\s*- POSTGRES_PASSWORD=\$\{POSTGRES_PASSWORD:-\}\s*$/m,
+        "docker-compose.aio.yml: AIO must receive its separately supplied PostgreSQL password",
     );
 });
 
-test("9. split-stack worker requires its startup secrets", () => {
+test("10. split-stack worker requires its startup secrets", () => {
     const compose = readRepoFile("docker-compose.yml");
     const backendBlock = composeServiceBlock(compose, "backend");
     const workerBlock = composeServiceBlock(compose, "backend-worker");
@@ -305,7 +322,7 @@ test("9. split-stack worker requires its startup secrets", () => {
     }
 });
 
-test("10. split-stack PostgreSQL startup rejects the published sentinel", (t) => {
+test("11. split-stack PostgreSQL startup rejects the published sentinel", (t) => {
     const configResult = composeConfig("changeme");
     assert.equal(configResult.status, 0, configResult.stderr);
 

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -53,6 +53,7 @@ from services.common.analyzer_env import (
     get_blocking_socket_timeout,
     get_int_env,
 )
+from services.common.database_url import resolve_database_url
 from services.common.logging_utils import configure_service_logger
 
 # CPU thread limiting must be set before importing torch
@@ -80,7 +81,7 @@ logger = configure_service_logger("clap-analyzer")
 
 # Configuration from environment
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
-DATABASE_URL = os.getenv("DATABASE_URL", "")
+DATABASE_URL = resolve_database_url(os.environ)
 MUSIC_PATH = os.getenv("MUSIC_PATH", "/music")
 SLEEP_INTERVAL = get_int_env("SLEEP_INTERVAL", 5)
 REDIS_SOCKET_TIMEOUT = get_blocking_socket_timeout(

--- a/services/audio-analyzer-clap/tests/test_audio_analyzer_clap_env.py
+++ b/services/audio-analyzer-clap/tests/test_audio_analyzer_clap_env.py
@@ -178,6 +178,55 @@ def test_worker_applies_bounded_socket_timeout_to_queue_client(
     assert redis_calls == [((module.REDIS_URL,), {"socket_timeout": 23})]
 
 
+def test_clap_analyzer_builds_database_url_from_encoded_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "user@:/?#% 雪")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pass@:/?#% 雪")
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert module.DATABASE_URL == (
+        "postgresql://user%40%3A%2F%3F%23%25%20%E9%9B%AA:"
+        "pass%40%3A%2F%3F%23%25%20%E9%9B%AA@postgres:5432/soundspan"
+    )
+
+
+def test_clap_analyzer_preserves_explicit_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    explicit_database_url = "postgresql://explicit:raw@external:6432/custom?schema=tenant"
+    monkeypatch.setenv("DATABASE_URL", explicit_database_url)
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "component-user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "component-password")
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert explicit_database_url == module.DATABASE_URL
+
+
+def test_clap_analyzer_keeps_database_url_empty_without_all_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "soundspan")
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert module.DATABASE_URL == ""
+
+
 def test_configure_thread_env_without_tensorflow_sets_only_blas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -23,6 +23,7 @@ from services.common.analyzer_env import (
     get_blocking_socket_timeout,
     get_int_env,
 )
+from services.common.database_url import resolve_database_url
 from services.common.logging_utils import configure_service_logger
 
 # Get thread configuration from environment (default to 1 for safety)
@@ -115,7 +116,7 @@ TensorflowPredictMusiCNN = None  # Loaded in worker processes
 
 # Configuration from environment
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
-DATABASE_URL = os.getenv("DATABASE_URL", "")
+DATABASE_URL = resolve_database_url(os.environ)
 MUSIC_PATH = os.getenv("MUSIC_PATH", "/music")
 BATCH_SIZE = get_int_env("BATCH_SIZE", 10)
 SLEEP_INTERVAL = get_int_env("SLEEP_INTERVAL", 5)

--- a/services/audio-analyzer/tests/test_audio_analyzer_env.py
+++ b/services/audio-analyzer/tests/test_audio_analyzer_env.py
@@ -121,6 +121,55 @@ def test_audio_worker_applies_bounded_socket_timeout_to_queue_client(
     assert isinstance(worker.redis, FakeRedisClient)
 
 
+def test_audio_analyzer_builds_database_url_from_encoded_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "user@:/?#% 雪")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pass@:/?#% 雪")
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert module.DATABASE_URL == (
+        "postgresql://user%40%3A%2F%3F%23%25%20%E9%9B%AA:"
+        "pass%40%3A%2F%3F%23%25%20%E9%9B%AA@postgres:5432/soundspan"
+    )
+
+
+def test_audio_analyzer_preserves_explicit_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    explicit_database_url = "postgresql://explicit:raw@external:6432/custom?schema=tenant"
+    monkeypatch.setenv("DATABASE_URL", explicit_database_url)
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "component-user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "component-password")
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert explicit_database_url == module.DATABASE_URL
+
+
+def test_audio_analyzer_keeps_database_url_empty_without_all_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_USER", "soundspan")
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.setenv("POSTGRES_DB", "soundspan")
+
+    module = _load_analyzer_with_recording_redis(monkeypatch, [], [])
+
+    assert module.DATABASE_URL == ""
+
+
 def test_configure_thread_env_sets_tf_and_blas_vars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/common/database_url.py
+++ b/services/common/database_url.py
@@ -1,0 +1,23 @@
+"""PostgreSQL connection URL resolution shared by Python sidecars."""
+
+from collections.abc import Mapping
+from urllib.parse import quote
+
+
+def resolve_database_url(environment: Mapping[str, str]) -> str:
+    """Preserve an explicit URL or build one from complete PostgreSQL components."""
+    explicit_database_url = environment.get("DATABASE_URL", "")
+    if explicit_database_url:
+        return explicit_database_url
+
+    host = environment.get("POSTGRES_HOST")
+    port = environment.get("POSTGRES_PORT")
+    user = environment.get("POSTGRES_USER")
+    password = environment.get("POSTGRES_PASSWORD")
+    database = environment.get("POSTGRES_DB")
+    if not host or not port or not user or not password or not database:
+        return explicit_database_url
+
+    encoded_user = quote(user, safe="")
+    encoded_password = quote(password, safe="")
+    return f"postgresql://{encoded_user}:{encoded_password}@{host}:{port}/{database}"


### PR DESCRIPTION
## Summary
Closes the campaign-backlogged L-H defect via the agreed **in-app** approach (the earlier entrypoint-wrapper attempt was discarded as unverifiable without image builds).

- Shared resolvers — Node `backend/databaseUrl.js` (used by runtime config **and** Prisma migration config) and Python `services/common/database_url.py` (both analyzers): when `DATABASE_URL` is absent and all `POSTGRES_*` components are present, build the URL with percent-encoded credentials. Explicit `DATABASE_URL` always wins unchanged.
- Encoding mirrors the Helm helper exactly (`encodeURIComponent` / `quote(safe="")` — same helper family in `_helpers.tpl`).
- Compose files pass components instead of interpolating a raw URL (AIO keeps its fixed internal components, password passed separately).
- `dockerfile-hygiene.test.mjs` **strengthened**: asserts all four split services receive components and no Compose file interpolates raw PostgreSQL components into `DATABASE_URL`.
- `docs/MIGRATING_FROM_LIDIFY.md` runbook updated for the component flow.

## Tests
Reserved characters (@ : / ? # % space), Unicode, explicit-URL precedence, incomplete components — in backend config tests and both analyzers' pytest suites.

## Verification
Backend targeted jest 9 suites / 95 · hygiene 11 · analyzer pytest 34 · CLAP pytest 30 · independent re-runs green · `tsc` clean · prettier + ruff clean · canon pass — all without any image build or container run