### PR TITLE
ci(codeql): make analysis blocking

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,8 +24,6 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    # non-blocking day one; ratchet to blocking in 1.10.0 (#59)
-    continue-on-error: true
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Retires the day-one `continue-on-error` escape hatch on the CodeQL analyze jobs. Gate context: all 78 alerts from the pre-2.0.0 triage are dispositioned (33 fixed across #416/#418/#419/#424/#425/#433, 45 dismissed with per-alert justifications + `docs/SECURITY.md` record), and the latest main scan reports **zero open CodeQL alerts**. Test-visibility jobs were already blocking via `CI_NON_BLOCKING_TEST_VISIBILITY=false`. Next step after this merges: add CodeQL + Enforcement Gates + Python Quality + Security Scanning to the required-check list.