### PR TITLE
refactor(frontend): route component network calls through the api layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Consolidated component network calls behind the frontend API layer and added
+  a boundary ratchet that prevents new direct `fetch()` calls in frontend app,
+  component, and feature modules.
 - Consolidated environment configuration reads into the backend config module
   for 20 more production files; the config-boundary allowlist shrank from 39
   files to 19.

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -358,7 +358,6 @@ const SEGMENTED_STARTUP_RETRY_BUDGET_MAX =
         SEGMENTED_STARTUP_STAGE_MAX_ATTEMPTS.engine_load) *
     (SEGMENTED_STARTUP_MAX_SESSION_RESETS + 1);
 const SOUNDSPAN_RUNTIME_CONFIG_KEY = "__SOUNDSPAN_RUNTIME_CONFIG__";
-const SEGMENTED_SESSION_TOKEN_QUERY_PARAM = "st";
 const SEGMENTED_STARTUP_FALLBACK_TIMEOUT_KEY =
     "SEGMENTED_STARTUP_FALLBACK_TIMEOUT_MS";
 const LISTEN_TOGETHER_SEGMENTED_PLAYBACK_ENABLED_KEY =
@@ -1706,20 +1705,12 @@ export const AudioPlaybackOrchestrator = memo(
                 ]);
 
                 try {
-                    const requestHeaders: Record<string, string> = {
-                        "x-streaming-session-token": session.sessionToken,
-                    };
-                    const authToken = api.getStreamingAuthToken();
-                    if (authToken) {
-                        requestHeaders.Authorization = `Bearer ${authToken}`;
-                    }
-
-                    const manifestResponse = await fetch(session.manifestUrl, {
-                        method: "GET",
-                        credentials: "include",
-                        headers: requestHeaders,
-                        signal: composedSignal,
-                    });
+                    const manifestResponse =
+                        await api.fetchSegmentedStreamingManifest(
+                            session.manifestUrl,
+                            session.sessionToken,
+                            composedSignal,
+                        );
                     if (!manifestResponse.ok) {
                         throw new Error(
                             `manifest_http_${manifestResponse.status}`,
@@ -1730,15 +1721,13 @@ export const AudioPlaybackOrchestrator = memo(
                     const startupChunkNames =
                         resolveStartupChunkNamesFromManifest(manifestContents);
                     for (const chunkName of startupChunkNames) {
-                        const segmentUrl =
-                            `/api/streaming/v1/sessions/${sessionId}/segments/${encodeURIComponent(chunkName)}?` +
-                            `${SEGMENTED_SESSION_TOKEN_QUERY_PARAM}=${encodeURIComponent(session.sessionToken)}`;
-                        const segmentResponse = await fetch(segmentUrl, {
-                            method: "GET",
-                            credentials: "include",
-                            headers: requestHeaders,
-                            signal: composedSignal,
-                        });
+                        const segmentResponse =
+                            await api.fetchSegmentedStreamingSegment(
+                                sessionId,
+                                session.sessionToken,
+                                chunkName,
+                                composedSignal,
+                            );
                         if (!segmentResponse.ok) {
                             throw new Error(
                                 `segment_http_${segmentResponse.status}:${chunkName}`,

--- a/frontend/lib/api/media.ts
+++ b/frontend/lib/api/media.ts
@@ -8,6 +8,8 @@ import type {
 } from "../api";
 import type { ApiClientConstructor } from "./core";
 
+const SEGMENTED_SESSION_TOKEN_QUERY_PARAM = "st";
+
 /** Add media-domain operations to an API client base class. */
 export function WithMedia<TBase extends ApiClientConstructor>(Base: TBase) {
     abstract class MediaApi extends Base {
@@ -65,6 +67,56 @@ export function WithMedia<TBase extends ApiClientConstructor>(Base: TBase) {
 
         getStreamingAuthToken(): string | null {
             return this.getCurrentToken();
+        }
+
+        /** Fetch a segmented-session manifest without altering its raw response. */
+        async fetchSegmentedStreamingManifest(
+            manifestUrl: string,
+            sessionToken: string,
+            signal: AbortSignal,
+        ): Promise<Response> {
+            return this.fetchSegmentedStreamingAsset(
+                manifestUrl,
+                sessionToken,
+                signal,
+            );
+        }
+
+        /** Fetch one segmented-session media asset without consuming its body. */
+        async fetchSegmentedStreamingSegment(
+            sessionId: string,
+            sessionToken: string,
+            segmentName: string,
+            signal: AbortSignal,
+        ): Promise<Response> {
+            const segmentUrl =
+                `/api/streaming/v1/sessions/${sessionId}/segments/${encodeURIComponent(segmentName)}?` +
+                `${SEGMENTED_SESSION_TOKEN_QUERY_PARAM}=${encodeURIComponent(sessionToken)}`;
+            return this.fetchSegmentedStreamingAsset(
+                segmentUrl,
+                sessionToken,
+                signal,
+            );
+        }
+
+        private async fetchSegmentedStreamingAsset(
+            url: string,
+            sessionToken: string,
+            signal: AbortSignal,
+        ): Promise<Response> {
+            const headers: Record<string, string> = {
+                "x-streaming-session-token": sessionToken,
+            };
+            const authToken = this.getStreamingAuthToken();
+            if (authToken) {
+                headers.Authorization = `Bearer ${authToken}`;
+            }
+            return fetch(url, {
+                method: "GET",
+                credentials: "include",
+                headers,
+                signal,
+            });
         }
 
         async heartbeatSegmentedStreamingSession(

--- a/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
+++ b/frontend/tests/component/audioPlaybackOrchestrator.component.test.ts
@@ -444,6 +444,17 @@ const controlCalls = {
 const apiCalls = {
     getStreamUrl: [] as string[],
     createSegmentedStreamingSession: [] as Array<Record<string, unknown>>,
+    fetchSegmentedStreamingManifest: [] as Array<{
+        manifestUrl: string;
+        sessionToken: string;
+        signal: AbortSignal;
+    }>,
+    fetchSegmentedStreamingSegment: [] as Array<{
+        sessionId: string;
+        sessionToken: string;
+        segmentName: string;
+        signal: AbortSignal;
+    }>,
     handoffSegmentedStreamingSession: [] as Array<{
         sessionId: string;
         sessionToken: string;
@@ -485,6 +496,13 @@ let podcastCacheStatus = {
 let seekToleranceOverride: boolean | null = null;
 let segmentedStartupRetryDelayOverride: number | null = null;
 let mirrorMachineIntentToPlaybackState = false;
+let segmentedManifestFetchOverride:
+    | ((
+          manifestUrl: string,
+          sessionToken: string,
+          signal: AbortSignal,
+      ) => Promise<Response>)
+    | null = null;
 const segmentedStartupRetryDelayInputs: Array<{
     retryTimeoutMs: number;
     sourceKind: "segmented" | "direct";
@@ -612,6 +630,7 @@ const resetHarnessState = (): void => {
     seekToleranceOverride = null;
     segmentedStartupRetryDelayOverride = null;
     mirrorMachineIntentToPlaybackState = false;
+    segmentedManifestFetchOverride = null;
     segmentedStartupRetryDelayInputs.length = 0;
     segmentedSessionQueue.length = 0;
     handoffSessionQueue.length = 0;
@@ -889,6 +908,39 @@ mock.module("@/lib/api", {
                 const next = segmentedSessionQueue.shift();
                 if (next instanceof Error) throw next;
                 return next ?? makeSegmentedSession("default-segmented");
+            },
+            fetchSegmentedStreamingManifest: async (
+                manifestUrl: string,
+                sessionToken: string,
+                signal: AbortSignal,
+            ) => {
+                apiCalls.fetchSegmentedStreamingManifest.push({
+                    manifestUrl,
+                    sessionToken,
+                    signal,
+                });
+                if (segmentedManifestFetchOverride) {
+                    return segmentedManifestFetchOverride(
+                        manifestUrl,
+                        sessionToken,
+                        signal,
+                    );
+                }
+                return new Response("<MPD />", { status: 200 });
+            },
+            fetchSegmentedStreamingSegment: async (
+                sessionId: string,
+                sessionToken: string,
+                segmentName: string,
+                signal: AbortSignal,
+            ) => {
+                apiCalls.fetchSegmentedStreamingSegment.push({
+                    sessionId,
+                    sessionToken,
+                    segmentName,
+                    signal,
+                });
+                return new Response(null, { status: 204 });
             },
             handoffSegmentedStreamingSession: async (
                 sessionId: string,
@@ -2157,15 +2209,10 @@ test("aborts in-flight segmented prewarm validation when track changes", async (
         makeSegmentedSession("prewarm-session"),
     );
 
-    const originalFetch = globalThis.fetch;
     const abortReasons: unknown[] = [];
-    (globalThis as { fetch: typeof fetch }).fetch = ((
-        _input: Parameters<typeof fetch>[0],
-        init?: Parameters<typeof fetch>[1],
-    ) => {
-        const signal = init?.signal as AbortSignal | undefined;
-        return new Promise<Response>((_resolve, reject) => {
-            signal?.addEventListener(
+    segmentedManifestFetchOverride = (_manifestUrl, _sessionToken, signal) =>
+        new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
                 "abort",
                 () => {
                     abortReasons.push(signal.reason);
@@ -2176,36 +2223,73 @@ test("aborts in-flight segmented prewarm validation when track changes", async (
                 { once: true },
             );
         });
-    }) as typeof fetch;
 
-    try {
-        renderOrchestrator();
-        await flushAsync(20);
-        assert.ok(apiCalls.createSegmentedStreamingSession.length >= 2);
+    renderOrchestrator();
+    await flushAsync(20);
+    assert.ok(apiCalls.createSegmentedStreamingSession.length >= 2);
 
-        audioState.currentTrack = makeTrack("prewarm-replacement");
-        audioState.queue = [audioState.currentTrack];
-        rerenderOrchestrator();
-        await flushAsync(20);
+    audioState.currentTrack = makeTrack("prewarm-replacement");
+    audioState.queue = [audioState.currentTrack];
+    rerenderOrchestrator();
+    await flushAsync(20);
 
-        assert.ok(abortReasons.includes("track_change"));
-        const abortedMetrics = getClientMetricEvents(
-            "session.prewarm_validation_aborted",
-        );
-        assert.ok(
-            abortedMetrics.some(
-                (metric) =>
-                    metric.reason === "track_change" &&
-                    metric.trackId === "prewarm-next",
-            ),
-        );
-    } finally {
-        if (originalFetch) {
-            (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
-        } else {
-            delete (globalThis as { fetch?: typeof fetch }).fetch;
-        }
-    }
+    assert.ok(abortReasons.includes("track_change"));
+    const abortedMetrics = getClientMetricEvents(
+        "session.prewarm_validation_aborted",
+    );
+    assert.ok(
+        abortedMetrics.some(
+            (metric) =>
+                metric.reason === "track_change" &&
+                metric.trackId === "prewarm-next",
+        ),
+    );
+});
+
+test("validates prewarmed startup chunks through the API boundary", async () => {
+    runtimeEngineMode = "videojs";
+    playbackState.isPlaying = true;
+
+    const currentTrack = makeTrack("prewarm-api-current");
+    const nextTrack = makeTrack("prewarm-api-next");
+    audioState.currentTrack = currentTrack;
+    audioState.queue = [currentTrack, nextTrack];
+    audioState.currentIndex = 0;
+    segmentedSessionQueue.push(
+        makeSegmentedSession("prewarm-api-startup"),
+        makeSegmentedSession("prewarm-api-next-session"),
+    );
+    segmentedManifestFetchOverride = async () =>
+        new Response("chunk-a.m4s chunk-a.m4s chunk-b.webm chunk-c.m4s", {
+            status: 200,
+        });
+
+    renderOrchestrator();
+    await flushAsync(24);
+
+    assert.equal(apiCalls.fetchSegmentedStreamingManifest.length, 1);
+    assert.deepEqual(
+        apiCalls.fetchSegmentedStreamingSegment.map((call) => ({
+            sessionId: call.sessionId,
+            sessionToken: call.sessionToken,
+            segmentName: call.segmentName,
+            signal: call.signal,
+        })),
+        [
+            {
+                sessionId: "prewarm-api-next-session",
+                sessionToken: "prewarm-api-next-session-token",
+                segmentName: "chunk-a.m4s",
+                signal: apiCalls.fetchSegmentedStreamingManifest[0].signal,
+            },
+            {
+                sessionId: "prewarm-api-next-session",
+                sessionToken: "prewarm-api-next-session-token",
+                segmentName: "chunk-b.webm",
+                signal: apiCalls.fetchSegmentedStreamingManifest[0].signal,
+            },
+        ],
+    );
 });
 
 test("consumes prewarmed segmented session while prewarm validation is still in-flight", async () => {
@@ -2223,41 +2307,31 @@ test("consumes prewarmed segmented session while prewarm validation is still in-
         makeSegmentedSession("inflight-prewarm"),
     );
 
-    const originalFetch = globalThis.fetch;
-    (globalThis as { fetch: typeof fetch }).fetch = (() =>
-        new Promise<Response>(() => undefined)) as typeof fetch;
+    segmentedManifestFetchOverride = async () =>
+        new Promise<Response>(() => undefined);
 
-    try {
-        renderOrchestrator();
-        await flushAsync(20);
-        assert.equal(apiCalls.createSegmentedStreamingSession.length, 2);
+    renderOrchestrator();
+    await flushAsync(20);
+    assert.equal(apiCalls.createSegmentedStreamingSession.length, 2);
 
-        audioState.currentTrack = nextTrack;
-        audioState.queue = [nextTrack];
-        audioState.currentIndex = 0;
-        rerenderOrchestrator();
-        await flushAsync(20);
+    audioState.currentTrack = nextTrack;
+    audioState.queue = [nextTrack];
+    audioState.currentIndex = 0;
+    rerenderOrchestrator();
+    await flushAsync(20);
 
-        assert.equal(apiCalls.createSegmentedStreamingSession.length, 2);
+    assert.equal(apiCalls.createSegmentedStreamingSession.length, 2);
 
-        const loadedSessionIds = engine.loadCalls
-            .map(
-                (call) =>
-                    (call.args[0] as { sessionId?: string } | undefined)
-                        ?.sessionId ?? null,
-            )
-            .filter(
-                (sessionId): sessionId is string =>
-                    typeof sessionId === "string",
-            );
-        assert.ok(loadedSessionIds.includes("inflight-prewarm"));
-    } finally {
-        if (originalFetch) {
-            (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
-        } else {
-            delete (globalThis as { fetch?: typeof fetch }).fetch;
-        }
-    }
+    const loadedSessionIds = engine.loadCalls
+        .map(
+            (call) =>
+                (call.args[0] as { sessionId?: string } | undefined)
+                    ?.sessionId ?? null,
+        )
+        .filter(
+            (sessionId): sessionId is string => typeof sessionId === "string",
+        );
+    assert.ok(loadedSessionIds.includes("inflight-prewarm"));
 });
 
 test("clears handoff listeners on track change while handoff load is pending", async () => {

--- a/frontend/tests/unit/apiClientSurface.test.ts
+++ b/frontend/tests/unit/apiClientSurface.test.ts
@@ -53,6 +53,8 @@ const EXPECTED_PUBLIC_METHODS: readonly string[] = [
     "downloadYouTube",
     "endListenGroup",
     "executePlaylistImport",
+    "fetchSegmentedStreamingManifest",
+    "fetchSegmentedStreamingSegment",
     "generateDiscoverWeekly",
     "generateMoodMix",
     "get",
@@ -291,5 +293,5 @@ test("api facade exposes every pinned public method", () => {
 });
 
 test("api facade public surface count is pinned", () => {
-    assert.equal(EXPECTED_PUBLIC_METHODS.length, 271);
+    assert.equal(EXPECTED_PUBLIC_METHODS.length, 273);
 });

--- a/frontend/tests/unit/frontendFetchBoundary.guard.test.ts
+++ b/frontend/tests/unit/frontendFetchBoundary.guard.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ALLOWLIST: readonly string[] = [];
+const FRONTEND_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const SOURCE_ROOTS = ["app", "components", "features"] as const;
+const SOURCE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx"]);
+const DIRECT_FETCH_PATTERN = /\bfetch\s*\(/;
+const MAX_ITERATIONS = 100_000;
+const MAX_DIRECTORY_ENTRIES = 100_000;
+
+function findDirectFetchOffenders(): string[] {
+    const worklist = SOURCE_ROOTS.map((root) => path.join(FRONTEND_ROOT, root));
+    const offenders: string[] = [];
+    let iterations = 0;
+
+    while (worklist.length > 0 && iterations < MAX_ITERATIONS) {
+        iterations += 1;
+        const directory = worklist.pop();
+        assert.ok(directory);
+
+        const entries = fs.readdirSync(directory, { withFileTypes: true });
+        assert.ok(entries.length <= MAX_DIRECTORY_ENTRIES);
+        for (
+            let index = 0;
+            index < entries.length && index < MAX_DIRECTORY_ENTRIES;
+            index += 1
+        ) {
+            const entry = entries[index];
+            assert.ok(entry);
+            const absolutePath = path.join(directory, entry.name);
+            if (entry.isDirectory()) {
+                worklist.push(absolutePath);
+                continue;
+            }
+            if (
+                !entry.isFile() ||
+                !SOURCE_EXTENSIONS.has(path.extname(entry.name))
+            ) {
+                continue;
+            }
+
+            const source = fs.readFileSync(absolutePath, "utf8");
+            if (DIRECT_FETCH_PATTERN.test(source)) {
+                offenders.push(
+                    path
+                        .relative(FRONTEND_ROOT, absolutePath)
+                        .split(path.sep)
+                        .join("/"),
+                );
+            }
+        }
+    }
+
+    assert.ok(iterations < MAX_ITERATIONS);
+    assert.equal(worklist.length, 0);
+    return offenders.sort();
+}
+
+test("frontend components route network calls through the API boundary", () => {
+    const offenders = findDirectFetchOffenders();
+    const unexpected = offenders.filter(
+        (offender) => !ALLOWLIST.includes(offender),
+    );
+
+    assert.deepEqual(
+        unexpected,
+        [],
+        `Unexpected direct fetch calls:\n${unexpected.join("\n")}\n` +
+            "Route these calls through frontend/lib/api.ts.",
+    );
+});
+
+test("the frontend fetch-boundary allowlist has no stale entries", () => {
+    const offenders: readonly string[] = findDirectFetchOffenders();
+    const staleEntries = ALLOWLIST.filter(
+        (entry) => !offenders.includes(entry),
+    );
+
+    assert.deepEqual(
+        staleEntries,
+        [],
+        `Stale fetch-boundary allowlist entries:\n${staleEntries.join("\n")}\n` +
+            "Remove these entries from ALLOWLIST.",
+    );
+});

--- a/frontend/tests/unit/segmentedStreamingApi.test.ts
+++ b/frontend/tests/unit/segmentedStreamingApi.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test, { after, type TestContext } from "node:test";
+
+import { api } from "../../lib/api";
+
+const originalFetch = globalThis.fetch;
+
+after(() => {
+    api.clearToken();
+    if (originalFetch) {
+        globalThis.fetch = originalFetch;
+    } else {
+        Reflect.deleteProperty(globalThis, "fetch");
+    }
+});
+
+function mockFetch(testContext: TestContext, response: Response) {
+    return testContext.mock.method(globalThis, "fetch", async () => response);
+}
+
+test("fetchSegmentedStreamingManifest preserves the raw manifest request", async (testContext) => {
+    const response = new Response("<MPD />", { status: 200 });
+    const fetchMock = mockFetch(testContext, response);
+    const controller = new AbortController();
+    api.setToken("access-token");
+
+    const result = await api.fetchSegmentedStreamingManifest(
+        "https://stream.test/session-1/manifest.mpd?st=session-token",
+        "session-token",
+        controller.signal,
+    );
+
+    assert.equal(result, response);
+    assert.deepEqual(fetchMock.mock.calls[0]?.arguments, [
+        "https://stream.test/session-1/manifest.mpd?st=session-token",
+        {
+            method: "GET",
+            credentials: "include",
+            headers: {
+                "x-streaming-session-token": "session-token",
+                Authorization: "Bearer access-token",
+            },
+            signal: controller.signal,
+        },
+    ]);
+});
+
+test("fetchSegmentedStreamingSegment preserves the relative URL and encoding", async (testContext) => {
+    const response = new Response(null, { status: 204 });
+    const fetchMock = mockFetch(testContext, response);
+    const controller = new AbortController();
+    api.setToken("access-token");
+
+    const result = await api.fetchSegmentedStreamingSegment(
+        "session-1",
+        "session token/+",
+        "chunk name/+1.m4s",
+        controller.signal,
+    );
+
+    assert.equal(result, response);
+    assert.deepEqual(fetchMock.mock.calls[0]?.arguments, [
+        "/api/streaming/v1/sessions/session-1/segments/chunk%20name%2F%2B1.m4s?st=session%20token%2F%2B",
+        {
+            method: "GET",
+            credentials: "include",
+            headers: {
+                "x-streaming-session-token": "session token/+",
+                Authorization: "Bearer access-token",
+            },
+            signal: controller.signal,
+        },
+    ]);
+});
+
+test("segmented asset methods return unmarked 401 responses without expiring auth", async (testContext) => {
+    const response = Response.json(
+        { error: "Invalid streaming session token" },
+        { status: 401 },
+    );
+    mockFetch(testContext, response);
+    api.setToken("access-current");
+
+    const result = await api.fetchSegmentedStreamingManifest(
+        "https://stream.test/session-2/manifest.mpd",
+        "expired-session-token",
+        new AbortController().signal,
+    );
+
+    assert.equal(result, response);
+    assert.equal(result.status, 401);
+    assert.equal(api.getToken(), "access-current");
+});


### PR DESCRIPTION
## Summary
Completes the AGENTS.md network boundary the reviewer flagged ("the player still performs direct component fetches").

- The only two direct calls in the component tree (orchestrator segmented manifest + segment GETs) move behind `api.fetchSegmentedStreaming*` wrappers — URLs, method, cookies, headers, raw `Response` semantics, and the composed `AbortSignal` preserved exactly.
- **Zero-allowlist ratchet**: `frontendFetchBoundary.guard.test.ts` fails on any new direct `fetch()` in `components/`, `features/`, or `app/` (stale-entry checked, mirroring the config-boundary guard).
- Orchestrator tests migrate from global-fetch mocks to API-boundary mocks, keeping abort/in-flight coverage; new request-shape/signal/unmarked-401 unit coverage for the wrappers.

## Verification
Guard + api unit tests 7/7 · orchestrator component suite 39/39 · `tsc` clean (independently re-run) · frontend-context pinned prettier · targeted ESLint clean