### PR TITLE
chore(quality): tighten canon baselines and surface API-key expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- API-key settings now show each key's expiry date with expired and
+  expiring-soon badges, while API-key, linked-device, and two-factor setup
+  actions surface interactive-session step-up failures inline.
 - Consolidated environment configuration reads into the backend config module
   for 20 more production files; the config-boundary allowlist shrank from 39
   files to 19.

--- a/frontend/app/device/page.tsx
+++ b/frontend/app/device/page.tsx
@@ -49,6 +49,7 @@ export default function DeviceLinkPage() {
     const [isLoadingDevices, setIsLoadingDevices] = useState(true);
     const [copied, setCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [deviceError, setDeviceError] = useState<string | null>(null);
 
     // Redirect if not authenticated
     useEffect(() => {
@@ -152,6 +153,7 @@ export default function DeviceLinkPage() {
 
     // Revoke a device
     const revokeDevice = async (deviceId: string) => {
+        setDeviceError(null);
         try {
             await api.request(`/device-link/devices/${deviceId}`, {
                 method: "DELETE",
@@ -159,6 +161,9 @@ export default function DeviceLinkPage() {
             setDevices((prev) => prev.filter((d) => d.id !== deviceId));
         } catch (err) {
             sharedFrontendLogger.error("Failed to revoke device:", err);
+            setDeviceError(
+                err instanceof Error ? err.message : "Failed to revoke device",
+            );
         }
     };
 
@@ -350,6 +355,13 @@ export default function DeviceLinkPage() {
                         <h2 className="text-xl font-bold text-white mb-4">
                             Linked Devices
                         </h2>
+
+                        {deviceError && (
+                            <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm flex items-center gap-2">
+                                <AlertCircle className="w-4 h-4" />
+                                {deviceError}
+                            </div>
+                        )}
 
                         {isLoadingDevices ? (
                             <div className="flex items-center justify-center py-8">

--- a/frontend/features/settings/components/sections/APIKeysSection.tsx
+++ b/frontend/features/settings/components/sections/APIKeysSection.tsx
@@ -3,7 +3,40 @@ import { useAPIKeys } from "@/features/settings/hooks/useAPIKeys";
 import { Modal } from "@/components/ui/Modal";
 import { Copy, Trash2 } from "lucide-react";
 import { InlineStatus, StatusType } from "@/components/ui/InlineStatus";
+import { Badge, type BadgeProps } from "@/components/ui/Badge";
 import { SettingsSection } from "../ui";
+
+const EXPIRING_SOON_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function getExpiryBadge(
+    expiresAt: string,
+): { label: string; variant: BadgeProps["variant"] } | null {
+    const remainingMs = Date.parse(expiresAt) - Date.now();
+    if (!Number.isFinite(remainingMs)) return null;
+    if (remainingMs <= 0) return { label: "Expired", variant: "error" };
+    if (remainingMs <= EXPIRING_SOON_WINDOW_MS) {
+        return { label: "Expires soon", variant: "warning" };
+    }
+    return null;
+}
+
+function formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+}
+
+function ApiKeyExpiry({ expiresAt }: { expiresAt: string }) {
+    const badge = getExpiryBadge(expiresAt);
+    return (
+        <div className="flex items-center gap-2 whitespace-nowrap">
+            <span>{formatDate(expiresAt)}</span>
+            {badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
+        </div>
+    );
+}
 
 export const APIKeysSection: React.FC = () => {
     const {
@@ -82,14 +115,6 @@ export const APIKeysSection: React.FC = () => {
         setCopied(false);
     };
 
-    const formatDate = (dateString: string) => {
-        return new Date(dateString).toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-        });
-    };
-
     return (
         <SettingsSection
             id="api-keys"
@@ -166,6 +191,9 @@ export const APIKeysSection: React.FC = () => {
                                 Last Used
                             </th>
                             <th className="text-left py-3 px-4 text-sm font-medium text-gray-400">
+                                Expires
+                            </th>
+                            <th className="text-left py-3 px-4 text-sm font-medium text-gray-400">
                                 Actions
                             </th>
                         </tr>
@@ -174,7 +202,7 @@ export const APIKeysSection: React.FC = () => {
                         {loadingApiKeys ? (
                             <tr>
                                 <td
-                                    colSpan={5}
+                                    colSpan={6}
                                     className="py-8 text-center text-sm text-gray-400"
                                 >
                                     Loading API keys...
@@ -183,7 +211,7 @@ export const APIKeysSection: React.FC = () => {
                         ) : apiKeys.length === 0 ? (
                             <tr>
                                 <td
-                                    colSpan={5}
+                                    colSpan={6}
                                     className="py-8 text-center text-sm text-gray-400"
                                 >
                                     No API keys yet
@@ -208,6 +236,11 @@ export const APIKeysSection: React.FC = () => {
                                         {key.lastUsedAt
                                             ? formatDate(key.lastUsedAt)
                                             : "Never"}
+                                    </td>
+                                    <td className="py-3 px-4 text-sm text-gray-400">
+                                        <ApiKeyExpiry
+                                            expiresAt={key.expiresAt}
+                                        />
                                     </td>
                                     <td className="py-3 px-4 text-sm">
                                         <button

--- a/frontend/features/settings/components/sections/AccountSection.tsx
+++ b/frontend/features/settings/components/sections/AccountSection.tsx
@@ -152,6 +152,18 @@ export function AccountSection({ settings, onUpdate }: AccountSectionProps) {
         }
     };
 
+    const handleSetup2FA = async () => {
+        setTfaStatus("loading");
+        setTfaMessage("");
+        try {
+            await setup2FA();
+            setTfaStatus("idle");
+        } catch (error: unknown) {
+            setTfaStatus("error");
+            setTfaMessage(error instanceof Error ? error.message : "Failed");
+        }
+    };
+
     // Handle 2FA disable
     const handleDisable2FA = async () => {
         setTfaStatus("loading");
@@ -316,19 +328,36 @@ export function AccountSection({ settings, onUpdate }: AccountSectionProps) {
                     {!settingUpTwoFactor &&
                         !showDisableFlow &&
                         (twoFactorEnabled ? (
-                            <button
-                                onClick={() => setShowDisableFlow(true)}
-                                className="text-sm text-red-400 hover:text-red-300"
-                            >
-                                Disable
-                            </button>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    onClick={() => setShowDisableFlow(true)}
+                                    className="text-sm text-red-400 hover:text-red-300"
+                                >
+                                    Disable
+                                </button>
+                                <InlineStatus
+                                    status={tfaStatus}
+                                    message={tfaMessage}
+                                    onClear={() => setTfaStatus("idle")}
+                                />
+                            </div>
                         ) : (
-                            <button
-                                onClick={setup2FA}
-                                className="text-sm text-white hover:underline"
-                            >
-                                Enable
-                            </button>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    onClick={handleSetup2FA}
+                                    disabled={tfaStatus === "loading"}
+                                    className="text-sm text-white hover:underline disabled:opacity-50"
+                                >
+                                    {tfaStatus === "loading"
+                                        ? "Starting..."
+                                        : "Enable"}
+                                </button>
+                                <InlineStatus
+                                    status={tfaStatus}
+                                    message={tfaMessage}
+                                    onClear={() => setTfaStatus("idle")}
+                                />
+                            </div>
                         ))}
                 </SettingsRow>
 

--- a/frontend/features/settings/types.ts
+++ b/frontend/features/settings/types.ts
@@ -81,6 +81,7 @@ export interface ApiKey {
     name: string;
     keyPreview?: string;
     createdAt: string;
+    expiresAt: string;
     lastUsed?: string | null;
     lastUsedAt?: string | null;
 }

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -182,6 +182,7 @@ export function WithAuth<TBase extends ApiClientConstructor>(Base: TBase) {
             apiKey: string;
             name: string;
             createdAt: string;
+            expiresAt: string;
             message: string;
         }> {
             return this.post("/api-keys", { deviceName });
@@ -192,6 +193,7 @@ export function WithAuth<TBase extends ApiClientConstructor>(Base: TBase) {
                 id: string;
                 name: string;
                 createdAt: string;
+                expiresAt: string;
                 lastUsed: string | null;
             }>;
         }> {

--- a/frontend/tests/component/accountStepUpErrors.component.test.ts
+++ b/frontend/tests/component/accountStepUpErrors.component.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const setup2FA = mock.fn(async () => {
+    throw new Error("Interactive session authentication required");
+});
+const enable2FA = mock.fn(async () => {
+    throw new Error("Interactive session authentication required");
+});
+const disable2FA = mock.fn(async () => {
+    throw new Error("Interactive session authentication required");
+});
+let twoFactorEnabled = false;
+let settingUpTwoFactor = false;
+
+mock.module("@/lib/auth-context", {
+    namedExports: {
+        useAuth: () => ({
+            user: {
+                username: "listener",
+                email: "listener@example.com",
+                role: "user",
+            },
+        }),
+    },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: { post: async () => ({}) },
+    },
+});
+
+mock.module("../../features/settings/hooks/useTwoFactor", {
+    namedExports: {
+        useTwoFactor: () => ({
+            twoFactorEnabled,
+            settingUpTwoFactor,
+            twoFactorQR: "",
+            twoFactorSecret: "",
+            recoveryCodes: [],
+            showRecoveryCodes: false,
+            load2FAStatus: async () => undefined,
+            setup2FA,
+            enable2FA,
+            disable2FA,
+            cancel2FASetup: () => undefined,
+            closeRecoveryCodes: () => undefined,
+        }),
+    },
+});
+
+mock.module("../../features/settings/components/sections/SubsonicSection", {
+    namedExports: { SubsonicRows: () => null },
+});
+
+mock.module("next/image", { defaultExport: () => null });
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    setup2FA.mock.resetCalls();
+    enable2FA.mock.resetCalls();
+    disable2FA.mock.resetCalls();
+    twoFactorEnabled = false;
+    settingUpTwoFactor = false;
+    document.body.replaceChildren();
+});
+
+async function mountAccountSection() {
+    const { AccountSection } =
+        await import("../../features/settings/components/sections/AccountSection");
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(AccountSection, {
+                settings: { displayName: "Listener" } as never,
+                onUpdate: () => undefined,
+            }),
+        );
+    });
+
+    return {
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function findButton(text: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.trim() === text,
+    );
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+function findInput(placeholder: string): HTMLInputElement {
+    const input = document.querySelector(`input[placeholder="${placeholder}"]`);
+    assert.ok(
+        input instanceof HTMLInputElement,
+        `Missing ${placeholder} input`,
+    );
+    return input;
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+    )?.set;
+    assert.ok(setter, "expected the input value setter");
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("shows the interactive-session message when 2FA setup is forbidden", async (t) => {
+    const harness = await mountAccountSection();
+    t.after(harness.unmount);
+    await click(findButton("Enable"));
+
+    assert.equal(setup2FA.mock.callCount(), 1);
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});
+
+test("shows the interactive-session message when 2FA enablement is forbidden", async (t) => {
+    settingUpTwoFactor = true;
+    const harness = await mountAccountSection();
+    t.after(harness.unmount);
+
+    await React.act(async () =>
+        typeInto(findInput("Enter 6-digit code"), "123456"),
+    );
+    await click(findButton("Verify"));
+
+    assert.equal(enable2FA.mock.callCount(), 1);
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});
+
+test("shows the interactive-session message when 2FA disablement is forbidden", async (t) => {
+    twoFactorEnabled = true;
+    const harness = await mountAccountSection();
+    t.after(harness.unmount);
+
+    await click(findButton("Disable"));
+    await React.act(async () => {
+        typeInto(findInput("Password"), "password");
+        typeInto(findInput("6-digit code"), "123456");
+    });
+    await click(findButton("Disable 2FA"));
+
+    assert.equal(disable2FA.mock.callCount(), 1);
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});

--- a/frontend/tests/component/apiKeysSettings.component.test.ts
+++ b/frontend/tests/component/apiKeysSettings.component.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface ListedApiKey {
+    id: string;
+    name: string;
+    createdAt: string;
+    expiresAt: string;
+    lastUsed: string | null;
+}
+
+let listedApiKeys: ListedApiKey[] = [];
+let createFailure: Error | null = null;
+let revokeFailure: Error | null = null;
+
+const listApiKeys = mock.fn(async () => ({ apiKeys: listedApiKeys }));
+const createApiKey = mock.fn(async () => {
+    if (createFailure) throw createFailure;
+    return {
+        apiKey: "generated-key",
+        name: "Test key",
+        createdAt: "2026-08-12T00:00:00.000Z",
+        expiresAt: "2026-11-10T00:00:00.000Z",
+        message: "Created",
+    };
+});
+const revokeApiKey = mock.fn(async () => {
+    if (revokeFailure) throw revokeFailure;
+    return { message: "Revoked" };
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: { listApiKeys, createApiKey, revokeApiKey },
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        createFrontendLogger: () => ({
+            error: () => undefined,
+            warn: () => undefined,
+            info: () => undefined,
+            debug: () => undefined,
+        }),
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    listedApiKeys = [];
+    createFailure = null;
+    revokeFailure = null;
+    listApiKeys.mock.resetCalls();
+    createApiKey.mock.resetCalls();
+    revokeApiKey.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+async function mountApiKeysSection() {
+    const { APIKeysSection } =
+        await import("../../features/settings/components/sections/APIKeysSection");
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(React.createElement(APIKeysSection));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    return {
+        container,
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function findButton(text: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.trim() === text,
+    );
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+function findLastButton(text: string): HTMLButtonElement {
+    const buttons = Array.from(document.querySelectorAll("button")).filter(
+        (candidate) => candidate.textContent?.trim() === text,
+    );
+    const button = buttons.at(-1);
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+    )?.set;
+    assert.ok(setter, "expected the input value setter");
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+}
+
+test("lists API-key expiry dates with expired and expiring-soon states", async (t) => {
+    t.mock.method(Date, "now", () => Date.parse("2026-08-12T00:00:00.000Z"));
+    const expiringSoon = "2026-08-15T00:00:00.000Z";
+    listedApiKeys = [
+        {
+            id: "expired-key",
+            name: "Expired key",
+            createdAt: "2025-01-01T00:00:00.000Z",
+            expiresAt: "2025-04-01T00:00:00.000Z",
+            lastUsed: null,
+        },
+        {
+            id: "soon-key",
+            name: "Soon key",
+            createdAt: "2026-08-01T00:00:00.000Z",
+            expiresAt: expiringSoon,
+            lastUsed: null,
+        },
+    ];
+
+    const harness = await mountApiKeysSection();
+    t.after(harness.unmount);
+    const text = harness.container.textContent ?? "";
+
+    assert.match(text, /Expires/);
+    assert.match(text, /Expired/);
+    assert.match(text, /Expires soon/);
+    assert.match(text, new RegExp(formatDate(expiringSoon)));
+});
+
+test("shows the interactive-session message when API-key creation is forbidden", async (t) => {
+    createFailure = new Error("Interactive session authentication required");
+    const harness = await mountApiKeysSection();
+    t.after(harness.unmount);
+
+    await click(findButton("Generate New API Key"));
+    const input = document.querySelector(
+        'input[placeholder^="e.g., My Laptop"]',
+    );
+    assert.ok(input instanceof HTMLInputElement);
+    await React.act(async () => typeInto(input, "Automation"));
+    await click(findButton("Create"));
+
+    assert.equal(createApiKey.mock.callCount(), 1);
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});
+
+test("shows the interactive-session message when API-key revocation is forbidden", async (t) => {
+    listedApiKeys = [
+        {
+            id: "api-key-1",
+            name: "Automation",
+            createdAt: "2026-08-01T00:00:00.000Z",
+            expiresAt: "2026-10-30T00:00:00.000Z",
+            lastUsed: null,
+        },
+    ];
+    revokeFailure = new Error("Interactive session authentication required");
+    const harness = await mountApiKeysSection();
+    t.after(harness.unmount);
+
+    await click(findButton("Revoke"));
+    await click(findLastButton("Revoke"));
+
+    assert.equal(revokeApiKey.mock.callCount(), 1);
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});

--- a/frontend/tests/component/deviceManagementStepUp.component.test.ts
+++ b/frontend/tests/component/deviceManagementStepUp.component.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let generateFailure: Error | null = null;
+const request = mock.fn(async (endpoint: string, options?: RequestInit) => {
+    if (endpoint === "/device-link/devices" && !options?.method) {
+        return [
+            {
+                id: "device-1",
+                name: "Living Room",
+                lastUsed: "2026-08-12T00:00:00.000Z",
+                createdAt: "2026-08-01T00:00:00.000Z",
+            },
+        ];
+    }
+    if (endpoint === "/device-link/generate" && generateFailure) {
+        throw generateFailure;
+    }
+    if (endpoint === "/device-link/devices/device-1") {
+        throw new Error("Interactive session authentication required");
+    }
+    return {};
+});
+
+mock.module("next/navigation", {
+    namedExports: { useRouter: () => ({ push: () => undefined }) },
+});
+
+mock.module("@/lib/auth-context", {
+    namedExports: {
+        useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+    },
+});
+
+mock.module("@/hooks/useVisibilityGatedInterval", {
+    namedExports: { useVisibilityGatedInterval: () => undefined },
+});
+
+mock.module("@/lib/api", { namedExports: { api: { request } } });
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: {
+            error: () => undefined,
+            warn: () => undefined,
+            info: () => undefined,
+            debug: () => undefined,
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    generateFailure = null;
+    request.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+async function mountDevicePage() {
+    const { default: DeviceLinkPage } = await import("../../app/device/page");
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(React.createElement(DeviceLinkPage));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    return {
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+function findButton(text: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) =>
+            candidate.textContent?.trim() === text || candidate.title === text,
+    );
+    assert.ok(button instanceof HTMLButtonElement, `Missing ${text} button`);
+    return button;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("shows the interactive-session message when device revocation is forbidden", async (t) => {
+    const harness = await mountDevicePage();
+    t.after(harness.unmount);
+
+    await click(findButton("Revoke device"));
+
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});
+
+test("shows the interactive-session message when link-code generation is forbidden", async (t) => {
+    generateFailure = new Error("Interactive session authentication required");
+    const harness = await mountDevicePage();
+    t.after(harness.unmount);
+
+    await click(findButton("Generate Code"));
+
+    assert.match(
+        document.body.textContent ?? "",
+        /Interactive session authentication required/,
+    );
+});

--- a/frontend/tests/unit/apiAuth401Handling.test.ts
+++ b/frontend/tests/unit/apiAuth401Handling.test.ts
@@ -112,6 +112,32 @@ test("preserves the session and response body for an unmarked upstream 401", asy
     }
 });
 
+test("preserves the interactive-session message from a 403 response", async (testContext) => {
+    const sessionExpiry = trackSessionExpiry();
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access-current", "refresh-current");
+    const fetchMock = mockFetch(testContext, () =>
+        Response.json(
+            { error: "Interactive session authentication required" },
+            { status: 403 },
+        ),
+    );
+
+    try {
+        await assert.rejects(client.post("/api-keys"), {
+            message: "Interactive session authentication required",
+            status: 403,
+            data: { error: "Interactive session authentication required" },
+        });
+        assert.equal(fetchMock.mock.callCount(), 1);
+        assert.equal(client.getToken(), "access-current");
+        assert.equal(sessionExpiry.count(), 0);
+    } finally {
+        sessionExpiry.stop();
+        client.clearToken();
+    }
+});
+
 test("keeps direct auth refresh 401 handling unchanged without the marker", async (testContext) => {
     const sessionExpiry = trackSessionExpiry();
     const client = new TestApiClient("http://soundspan.test");

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -45,14 +45,14 @@ const BASELINE = Object.freeze({
     "backend/src/routes/settings.ts": 5,
     "backend/src/routes/shareLinks.ts": 6,
     "backend/src/routes/social.ts": 3,
-    "backend/src/routes/soulseek.ts": 7,
-    "backend/src/routes/spotify.ts": 8,
+    "backend/src/routes/soulseek.ts": 6,
+    "backend/src/routes/spotify.ts": 7,
     "backend/src/routes/streaming.ts": 3,
     "backend/src/routes/system.ts": 2,
-    "backend/src/routes/systemSettings.ts": 13,
+    "backend/src/routes/systemSettings.ts": 12,
     "backend/src/routes/tidalStreaming.ts": 10,
     "backend/src/routes/trackMappings.ts": 2,
-    "backend/src/routes/webhooks.ts": 1,
+    "backend/src/routes/webhooks.ts": 0,
     "backend/src/routes/youtube.ts": 1,
     "backend/src/routes/youtubeMusic.ts": 18,
 });
@@ -107,8 +107,7 @@ const LEAK_BASELINE = Object.freeze({
     // enrichmentState.ts +1: Redis retry classification's ternary-consequent error.message (~L77); frozen under the ratchet-widening (slice-X1) scope guard.
     "backend/src/services/enrichmentState.ts": 1,
     // genericImportJobRunner.ts remaining 1: latestJob.error passthrough on user cancel (~L91); import-job state plumbing, frozen under the slice-J scope guard.
-    // genericImportJobRunner.ts +1: failed-job persistence's ternary-consequent error.message (~L99); frozen under the ratchet-widening (slice-X1) scope guard.
-    "backend/src/services/genericImportJobRunner.ts": 2,
+    "backend/src/services/genericImportJobRunner.ts": 1,
     // imageProxy.ts +1: image-fetch result's ternary-consequent lastError.message (~L248); frozen under the ratchet-widening (slice-X1) scope guard.
     "backend/src/services/imageProxy.ts": 1,
     // importJobStore.ts remaining 1: persisted input.error passthrough (~L192); job-state plumbing, frozen under the slice-J scope guard.


### PR DESCRIPTION
## Summary
Three backlog items:

- **Canon baselines tightened** (improvements locked): genericImportJobRunner 2→1, soulseek 7→6, spotify 8→7, systemSettings 13→12, webhooks 1→0 — script reports zero remaining tightening notices.
- **API-key expiry surfaced**: backend already returns `expiresAt` (verified read-only); frontend model typed + key table shows the absolute date with red **Expired** / warning **Expires soon** (≤7d) badges per existing badge patterns.
- **Interactive-session step-up UX**: 2FA setup and device revocation now surface the server's 403 message inline (matching the existing handling on API-key create/revoke and 2FA enable/disable, all now test-covered).

## Verification
Canon both ratchets clean · `tsc` clean (independent) · 8 component + 4 unit targeted tests · pinned prettier · ESLint clean (one pre-existing warning untouched)