### PR TITLE
docs(release): refresh 2.0.0 notes, security exceptions, and deferrals

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -20,6 +20,32 @@ compile --upgrade-package`; if the resolver can select a compatible fixed
 release, remove the corresponding advisory ID in the same change. New IDs are
 never added automatically.
 
+## npm dependency audit exception
+
+The backend dependency graph currently resolves `uuid` 8.3.2 through Bull 4
+and its Bull Board integration. This is an owned, temporary exception:
+
+| Advisory | Reachability assessment | Removal condition |
+| --- | --- | --- |
+| [`GHSA-w5hq-g745-h8pq`](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (`uuid <11.1.1`) | The affected UUID v3, v5, and v6-with-caller-buffer paths are not exercised; Bull uses UUID v4 without a caller-provided buffer. | Upgrade Bull and `@bull-board/*` when their dependency graph can resolve a fixed `uuid`, then remove the exception. |
+
+`npm audit fix --force` is not an acceptable remediation: it proposes
+downgrading Bull to 1.1.3, which is a breaking queue-runtime change. Revisit
+this exception whenever Bull or Bull Board is upgraded, even if the transitive
+`uuid` range does not change.
+
+## Container-image scan stream
+
+Trivy image SARIF currently reports approximately 95 OS and package CVEs in the
+pinned analyzer and sidecar images, including findings in `keras`, `wandb`,
+`pip`, and `cryptography`. Under the repository's pinned-analyzer-stack policy,
+maintainers review these findings with a tested stack or base-image upgrade
+rather than dismissing individual alerts ad hoc.
+
+This stream is separate from dependency-lock auditing. The compatibility-owned
+Python advisories and their removal conditions remain in the
+[pip-audit exception table](#python-dependency-audit-exceptions) above.
+
 ## CodeQL alert dismissal record
 
 All open CodeQL alerts were triaged before the 2.0.0 release: 33 were fixed in

--- a/docs/modernization-roadmap.md
+++ b/docs/modernization-roadmap.md
@@ -1058,6 +1058,18 @@ One correction to the finding's framing on blast radius: session auth is NOT mer
 
 **Shape.** soundspan is a **modular monolith + Python sidecars**: a Next.js PWA (custom server proxy, one `ApiClient.request<T>()` chokepoint, AudioEngine adapter strategy) → an Express API + Bull workers in one codebase (role-split by `BACKEND_PROCESS_ROLE`, one Prisma gateway) → Postgres 16 + pgvector, Redis (queues + locks + embed streams), and four Python sidecars. The two analyzers are **`BRPOP` workers that write results straight to Postgres** (DB-as-contract), not HTTP services — a deliberate, good seam.
 
+### Deferred modernization after 2.0.0
+
+These items are deliberately deferred past the 2.0.0 release because each is
+invasive and offers little immediate consumer value compared with the release
+risk:
+
+| Area | Owned decision |
+| --- | --- |
+| Backend module format | Defer the CommonJS-to-ESM migration. Revisit it as a coordinated runtime, build, test, and dependency change rather than a pre-release conversion. |
+| Python sidecar layout | Defer a shared `src/`-layout re-architecture. Revisit it with an explicit packaging and container-entrypoint plan across all sidecars. |
+| Frontend lint debt | Keep the current 0-error/182-warning result as a tracked ratchet: no warning growth, with warning classes burned down in focused follow-ups. |
+
 ### The kernel — preserve and lean into (do not rewrite)
 
 The most important architectural fact the issue-by-issue review never states: **the codebase already has the two things that make aggressive cleanup — by a human or a future big model — safe rather than reckless.**

--- a/docs/release-notes/RELEASE_NOTES_2.0.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.0.md
@@ -14,6 +14,11 @@ the operator and client actions below; complete the checklist before rollout.
   rejected. Generate new application secrets with `openssl rand -base64 32`,
   keep the same `INTERNAL_API_SECRET` on the backend and sidecars, and do not
   reuse the retired `soundspan-internal-secret-change-me` value.
+- **Pass split-stack database settings as `POSTGRES_*` components.** Compose
+  deployments now build `DATABASE_URL` inside the application and safely
+  percent-encode credentials, including passwords with URL-reserved
+  characters. An explicit `DATABASE_URL` still takes precedence for custom
+  deployments.
 - **Strengthen weak custom secrets before starting 2.0.0.** Encryption and
   internal-auth secrets must be at least 32 characters. An operator-supplied
   `JWT_SECRET` must also be at least 32 characters; deployments that omit it
@@ -67,22 +72,56 @@ the operator and client actions below; complete the checklist before rollout.
   deletion” setting. A completely empty mount is protected, but a partially
   mounted or incomplete library can still reconcile missing paths away.
 
+## Playback reliability and telemetry
+
+- Queue auto-advance is fixed across the full track-end path. The native engine
+  now accepts the browser's end-of-stream pause, listeners remain stable while
+  playback state changes, and a one-shot watchdog recovers a lost end event.
+- If a browser blocks the next track in a hidden or unfocused window, bounded
+  retries run on a timer and again on visibility or focus. The player also
+  preserves the load's autoplay intent, so a successful advance no longer
+  pauses itself immediately after the next track starts.
+- Server-visible client telemetry now records `load_autoplay_decision`,
+  `track_end_*`, and `playback_start_blocked` events. Operators can alert on
+  the `autoplay_intent_conflict` tripwire to catch future load/play intent
+  regressions.
+
+## Cover art and session UX
+
+- Cover art and segmented-streaming assets no longer return 404 when a cache
+  lives in a dot-directory such as `/music/.soundspan`. Cover files are served
+  from an explicitly pinned root with stronger containment checks.
+- Failed media-server **Test connection** attempts for Audiobookshelf,
+  Fanart.tv, Last.fm, Soulseek, Spotify, and TIDAL no longer end the current
+  Soundspan session. Upstream credential failures return 502, while the web
+  client logs out only for responses carrying the explicit `AUTH_REQUIRED`
+  marker. Wrong current-password entries now stay inline instead of being
+  mistaken for session expiry.
+
 ## Security hardening
 
+- The pre-release CodeQL backlog is fully dispositioned: every alert was fixed
+  or recorded with an owned justification and re-evaluation condition.
 - Access-token verification is centralized, pins HS256, validates payloads,
   and rejects refresh tokens outside the refresh exchange. TOTP moved from the
   unmaintained `speakeasy` package to `otplib` while preserving existing 2FA
   enrollments.
+- Account, 2FA, Subsonic credential, admin queue-dashboard, and playback-state
+  synchronization routes now have route-specific rate limits; the playback
+  tier remains generous enough for its normal high-frequency cadence.
 - Authorization was tightened across API-key and device management, MFA,
   enrichment, shared downloads, import logs, artist discovery, audiobook
   covers, Listen Together group ending, and recovery or retry operations.
 - Client-facing failures now use curated messages across backend routes,
   segmented streaming, stored download jobs, and TIDAL/YouTube Music sidecars;
   raw paths, upstream bodies, and exception details remain in server logs.
-- Native streams, share-link streams, downloads, cache files, and analyzer or
-  repair paths enforce media-root containment. Podcast audio, remote images,
-  and Audiobookshelf cover access gained DNS-aware SSRF, redirect, namespace,
-  and input validation.
+- Native streams, share-link streams, downloads, cache files, cover-image
+  storage, and analyzer or repair paths enforce root containment. Podcast
+  audio, remote images, and Audiobookshelf cover access gained DNS-aware SSRF,
+  redirect, namespace, and input validation.
+- Playlist imports accept only canonical HTTP(S) links, text normalization and
+  delimited-content stripping now run in linear time, and audiobook preflight
+  handling uses the centralized deny-by-default CORS policy.
 - Secret-bearing `.env` writes are atomic and owner-only. YouTube Music OAuth
   files are also mode `0600`, and chart-managed workloads drop Linux
   capabilities, use `RuntimeDefault` seccomp, and do not mount service-account
@@ -91,6 +130,21 @@ the operator and client actions below; complete the checklist before rollout.
   `SECRETS_DB_ONLY=true`. Legacy decrypt fail-closed mode remains opt-in and
   should be enabled only after the secrets-status endpoint reports zero legacy
   rows.
+
+## Observability migration
+
+Update saved searches, dashboards, and alerts that use the renamed player
+signals:
+
+| Previous name | 2.0.0 name | Scope |
+| --- | --- | --- |
+| `player.howler_startup` | `player.engine_startup` | Audio-engine startup |
+| `route.client.signal` | `playback.client.signal` | Ingested client signals |
+| `[SegmentedStreaming.Trace] client.signal` | `[Playback.Trace] client.signal` | Client trace logs |
+| `[SegmentedStreaming][Metric] client.signal` | `[Playback.Metric] client.signal` | Client metric logs |
+
+Manifest, segment, session, and DASH lifecycle traces that are genuinely
+specific to segmented streaming keep their existing names.
 
 ## Reliability and performance
 
@@ -111,12 +165,22 @@ the operator and client actions below; complete the checklist before rollout.
 - Import jobs now run durably on the worker queue with recovery and
   deduplication, while queue cleaning is claimed by workers instead of repeated
   by every API replica.
-- Background playback, token refresh, polling, and Listen Together recovery
+- Token refresh, visibility-aware polling, and Listen Together recovery
   received focused fixes so long sessions, hidden tabs, large queues, and
   cross-replica ready gates recover more predictably.
-- The native audio engine no longer misreads the browser's end-of-track pause
-  as an unexpected stop, fixing queues that intermittently froze between
-  tracks instead of auto-advancing (worst in hidden tabs).
+
+## Quality and maintainability
+
+- The frontend now compiles in TypeScript strict mode. Python sidecars run
+  mypy in strict mode, with measured and documented exceptions where the
+  pinned analyzer stack requires them.
+- The large library router is decomposed into named per-resource routers and
+  typed helper modules without changing its mounted URLs or behavior.
+- Backend environment reads continue moving behind the typed configuration
+  boundary; its temporary allowlist shrank from 39 production files to 19.
+- Component network calls now go through the shared frontend API layer, with a
+  ratchet that prevents new direct `fetch()` calls in app, component, and
+  feature modules.
 
 ## Platform and deployment
 
@@ -130,9 +194,14 @@ the operator and client actions below; complete the checklist before rollout.
 - Analyzer health probes and GPU scheduling are now effective in the Helm chart,
   while PostgreSQL credentials are safely encoded and application images can be
   pinned by digest.
+- API-key settings show each key's expiry date and flag keys that are expired or
+  expiring soon, making the 90-day rotation policy visible before clients stop
+  authenticating.
 - Base images and build inputs are digest- or hash-pinned, Python quality and
   sidecar test lanes are part of CI, and the remaining mutable GitHub Actions
   and scanner image references are pinned.
+- CodeQL analysis and the release quality/enforcement gates now run as blocking
+  required checks rather than visibility-only signals.
 
 ## Also in this release
 
@@ -142,8 +211,7 @@ the operator and client actions below; complete the checklist before rollout.
   and the audio orchestrator avoid clock-driven rerenders. Visibility-aware
   polling also stops unnecessary work in hidden tabs.
 - Settings actions use consistent in-app confirmation dialogs, theme colors have
-  accessible contrast and focus guards, and API/client internals were split into
-  smaller domain modules without changing their public surfaces.
+  accessible contrast and focus guards.
 
 ## Deployment and distribution
 


### PR DESCRIPTION
## Summary
Final documentation slice of the release-closeout campaign (docs-only).

- **RELEASE_NOTES_2.0.0.md**: consumer sections for playback reliability + the telemetry contract (including the `autoplay_intent_conflict` tripwire operators can alert on), cover-art/session UX fixes, an **observability migration table** for the renamed signals, security hardening, code-quality changes, and deployment updates (component-based `DATABASE_URL`, API-key expiry badges, blocking CI gates). Upgrade checklist and known-issues preserved.
- **SECURITY.md**: owned `uuid <11.1.1`-via-bull exception (unreachable vulnerable path, breaking auto-fix, upstream revisit trigger) + Trivy container-image scan stream policy.
- **modernization-roadmap.md**: "Deferred modernization after 2.0.0" — CommonJS→ESM, Python `src/` layout, 182-warning lint ratchet.

Verification: markdown is prettier-ignored per repo config (confirmed via `--file-info`); claims cross-checked against the 2.0.0 changelog; `git diff --check` clean.