### PR TITLE
fix(docker): copy the database-url helper into the AIO Prisma stage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,8 @@
 name: CodeQL
 
 # Static analysis via GitHub's default-setup-style CodeQL (docs/modernization-
-# roadmap.md F45, epic #10, #59 WS2.4). Alerts surface in the Security tab
-# and are non-blocking by nature; the `continue-on-error` below is defense
-# in depth for the same day-one non-blocking posture as security-scanning.yml.
+# roadmap.md F45, epic #10, #59 WS2.4). Analysis is a blocking pull-request
+# and main-branch check, with alerts surfaced in the Security tab.
 on:
   pull_request:
     branches: [main]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The all-in-one image builds again by copying the Prisma config's database-URL
+  helper into every stage that runs the Prisma CLI, with a static CI guard
+  covering both backend Dockerfiles.
 - Compose deployments now construct `DATABASE_URL` from `POSTGRES_*`
   components in-app with percent-encoded credentials, so passwords containing
   URL-reserved characters work; explicit `DATABASE_URL` still wins.

--- a/Dockerfile
+++ b/Dockerfile
@@ -196,6 +196,7 @@ COPY backend/package*.json ./
 COPY backend/prisma ./prisma/
 # Prisma 7 CLI reads schema/migrations/datasource config from prisma.config.ts
 COPY backend/prisma.config.ts ./
+COPY backend/databaseUrl.js ./
 RUN echo "=== Migrations copied ===" && ls -la prisma/migrations/ && echo "=== End migrations ==="
 RUN npm ci && npm cache clean --force
 RUN npx prisma generate

--- a/backend/src/routes/library/radio.ts
+++ b/backend/src/routes/library/radio.ts
@@ -316,7 +316,7 @@ export async function handleGetRadio(req: Request, res: Response) {
                 const leastPlayedTracks = await prisma.$queryRaw<
                     { id: string }[]
                 >`
-                        SELECT t.id 
+                        SELECT t.id
                         FROM "Track" t
                         LEFT JOIN "Play" p ON p."trackId" = t.id
                         GROUP BY t.id

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -35,6 +35,85 @@ function isExternalImage(reference) {
     return /[:@/]/.test(reference);
 }
 
+function relativeImportFiles(configPath) {
+    const config = readRepoFile(configPath);
+    const configDirectory = path.posix.dirname(configPath);
+    const importPattern =
+        /(?:\bfrom\s+|\brequire\s*\(\s*|\bimport\s*\(\s*)["'](\.[^"']+)["']/g;
+    const imports = [...config.matchAll(importPattern)].map(
+        (match) => match[1],
+    );
+
+    return imports.map((importPath) => {
+        const unresolvedPath = path.posix.join(configDirectory, importPath);
+        const candidates = [
+            unresolvedPath,
+            `${unresolvedPath}.js`,
+            `${unresolvedPath}.ts`,
+        ];
+        const resolvedPath = candidates.find((candidate) =>
+            fs.existsSync(path.join(repoRoot, candidate)),
+        );
+        assert.ok(resolvedPath, `${configPath}: cannot resolve ${importPath}`);
+        return resolvedPath;
+    });
+}
+
+function dockerfileStages(dockerfile) {
+    return dockerfile
+        .split(/(?=^FROM )/gim)
+        .filter((stage) => /^FROM /i.test(stage))
+        .map((text, index) => {
+            const header = text.split(/\r?\n/, 1)[0];
+            const match = header.match(/^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/i);
+            assert.ok(match, `invalid Dockerfile stage header: ${header}`);
+            return {
+                base: match[1],
+                name: match[2] ?? `stage-${index + 1}`,
+                text,
+            };
+        });
+}
+
+function dockerCopySources(stage) {
+    return stage.split(/\r?\n/).flatMap((line) => {
+        const match = line.match(/^\s*COPY\s+(.+)$/i);
+        if (!match) return [];
+        const tokens = match[1].trim().split(/\s+/);
+        const operands = tokens.filter((token) => !token.startsWith("--"));
+        return operands.slice(0, -1);
+    });
+}
+
+function sourceCopiesFile(source, relativePath) {
+    const normalizedSource = path.posix.normalize(source.replaceAll('"', ""));
+    const normalizedPath = path.posix.normalize(relativePath);
+    return (
+        path.posix.basename(normalizedSource) ===
+            path.posix.basename(normalizedPath) ||
+        normalizedSource === "." ||
+        normalizedPath.startsWith(`${normalizedSource}/`)
+    );
+}
+
+function stageRunsPrisma(stage) {
+    const commands = stage
+        .split(/\r?\n/)
+        .filter((line) => !line.trimStart().startsWith("#"))
+        .join("\n");
+    return /\bnpx\s+prisma\s+(?:generate|migrate)\b/i.test(commands);
+}
+
+function effectiveStageCopies(stages) {
+    const copiesByStage = new Map();
+    return stages.map((stage) => {
+        const inheritedCopies = copiesByStage.get(stage.base) ?? [];
+        const copies = [...inheritedCopies, ...dockerCopySources(stage.text)];
+        copiesByStage.set(stage.name, copies);
+        return { ...stage, copies };
+    });
+}
+
 function composeConfig(postgresPassword) {
     const environment = {
         ...process.env,
@@ -342,4 +421,48 @@ test("11. split-stack PostgreSQL startup rejects the published sentinel", (t) =>
     assert.notEqual(sentinelResult.status, 0);
     assert.match(sentinelResult.stderr, /must not be changeme/);
     assert.equal(configuredResult.status, 0, configuredResult.stderr);
+});
+
+test("12. Prisma CLI stages copy relative prisma.config.ts imports", () => {
+    const configPath = "backend/prisma.config.ts";
+    const importedFiles = relativeImportFiles(configPath);
+    const dockerfiles = [
+        {
+            relativePath: "Dockerfile",
+            configCopyPath: configPath,
+            importedCopyPaths: importedFiles,
+        },
+        {
+            relativePath: "backend/Dockerfile",
+            configCopyPath: path.posix.basename(configPath),
+            importedCopyPaths: importedFiles.map((importedFile) =>
+                path.posix.relative("backend", importedFile),
+            ),
+        },
+    ];
+
+    for (const dockerfile of dockerfiles) {
+        const stages = effectiveStageCopies(
+            dockerfileStages(readRepoFile(dockerfile.relativePath)),
+        );
+        for (const stage of stages) {
+            const copiesConfig = stage.copies.some((source) =>
+                sourceCopiesFile(source, dockerfile.configCopyPath),
+            );
+            if (!copiesConfig && !stageRunsPrisma(stage.text)) continue;
+
+            assert.ok(
+                copiesConfig,
+                `${dockerfile.relativePath} ${stage.name}: Prisma CLI stage must copy ${dockerfile.configCopyPath}`,
+            );
+            for (const importedFile of dockerfile.importedCopyPaths) {
+                assert.ok(
+                    stage.copies.some((source) =>
+                        sourceCopiesFile(source, importedFile),
+                    ),
+                    `${dockerfile.relativePath} ${stage.name}: Prisma config import ${importedFile} must be copied into the stage`,
+                );
+            }
+        }
+    }
 });


### PR DESCRIPTION
## Summary
Fixes the reviewer's P1 build blocker. The exact-HEAD Image Builds run failed with `Cannot find module './databaseUrl'`.

- The root (AIO) Dockerfile now copies `backend/databaseUrl.js` beside `prisma.config.ts`. The single AIO stage covers both `prisma generate` at build time and `prisma migrate deploy` at startup.
- The split backend Dockerfile was audited: its three stages already have the helper (that slice missed only the root file, which CI builds only on main pushes).
- **New static PR-time guard** in `dockerfile-hygiene.test.mjs`: it parses the Prisma config's relative imports and asserts each one is copied into every Dockerfile stage that runs a Prisma CLI command — for both Dockerfiles. Demonstrated: with the fix reverted, the guard fails with the exact missing-file message; with the fix, 12/12 tests pass.
- Cleanups: SQL trailing whitespace in `library/radio.ts` removed (`git diff --check` clean); stale `codeql.yml` non-blocking header comment corrected.

## Verification
Guard catch demonstrated + 12/12 pass · `git diff --check` clean · radio suites 3/48 green · `tsc` clean · package-dir pinned prettier clean · no local image builds (the guard makes this class visible at PR time)