### PR TITLE
docs(release): tune the 2.0.0 notes to STE-lite

### DIFF
--- a/docs/release-notes/RELEASE_NOTES_2.0.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.0.md
@@ -1,128 +1,125 @@
 # [2.0.0] Release Notes - 2026-08-12
 
-Soundspan 2.0.0 is a major release. It makes security and reliability better
-across the full application. It is the result of a systematic security review
-over several months. The release makes credentials, sessions, authorization,
-network boundaries, and filesystem access more strict. It also puts limits on
-more database, sidecar, and background work.
+Soundspan 2.0.0 is a major release focused on security and reliability. It is
+the result of a systematic security review over several months. It tightens
+credentials, sessions, authorization, network boundaries, and filesystem
+access, and it bounds more database, sidecar, and background work.
 
-This is a major version because you must do the steps below. Do all the steps
-before you start the new version.
+This is a major version because the upgrade needs action from you. Complete
+the steps below before you start the new version.
 
 ## Before you upgrade — required steps
 
-Do these steps in order. Each step tells you what to do and why.
+Work through these steps in order. Each step says what to do and why.
 
 ### 1. Set all required secrets
 
-`docker-compose.yml` now requires these values before startup:
+`docker-compose.yml` now requires these values at startup, and the published
+defaults are rejected:
 
 - `POSTGRES_PASSWORD`
 - `SESSION_SECRET`
 - `SETTINGS_ENCRYPTION_KEY`
 - `INTERNAL_API_SECRET`
 
-The application rejects the old published default values.
+1. Generate each new secret with `openssl rand -base64 32`.
+2. Use the same `INTERNAL_API_SECRET` on the backend and on every sidecar.
+3. Do not reuse the retired `soundspan-internal-secret-change-me` value.
 
-1. Make each new secret with `openssl rand -base64 32`.
-2. Set the same `INTERNAL_API_SECRET` on the backend and on all sidecars.
-3. Do not use the retired value `soundspan-internal-secret-change-me`.
-
-### 2. Give the database settings as components
+### 2. Provide database settings as components
 
 Compose deployments now build `DATABASE_URL` inside the application.
 
 1. Set `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`,
    and `POSTGRES_DB`.
-2. The application percent-encodes the credentials. Passwords with special URL
-   characters are now safe.
-3. If you set an explicit `DATABASE_URL`, the application uses it without
-   change. This is correct for custom deployments.
+2. Credentials are percent-encoded for you, so passwords with URL-reserved
+   characters now work.
+3. An explicit `DATABASE_URL` still wins unchanged — keep it for custom
+   deployments.
 
-### 3. Make weak custom secrets strong
+### 3. Strengthen weak custom secrets
 
-1. Make sure `SETTINGS_ENCRYPTION_KEY` and `INTERNAL_API_SECRET` have 32
-   characters or more.
-2. If you set `JWT_SECRET`, make sure it has 32 characters or more.
-3. If you do not set `JWT_SECRET`, the application uses the validated
-   `SESSION_SECRET`. No action is necessary.
+1. Make sure `SETTINGS_ENCRYPTION_KEY` and `INTERNAL_API_SECRET` are at least
+   32 characters.
+2. If you set `JWT_SECRET`, it must also be at least 32 characters.
+3. If you don't set `JWT_SECRET`, the validated `SESSION_SECRET` is used and
+   no action is needed.
 
-### 4. Replace old API keys and plan rotation
+### 4. Reissue old API keys and plan rotation
 
-API keys now expire 90 days after you create them or rotate them.
+API keys now expire 90 days after creation or rotation.
 
-1. Replace each API key that is more than 90 days old.
-2. Plan a recurring rotation for all API keys.
-3. Log in to a browser session to manage API keys, linked devices, or MFA.
-   A client with only an `X-API-Key` header cannot do these actions now.
+1. Reissue every API key older than 90 days.
+2. Plan a recurring rotation for all keys.
+3. Use a logged-in browser session to manage API keys, linked devices, or
+   MFA — an `X-API-Key` client can no longer perform those actions.
 
-The settings page shows the expiry date of each key. It also shows a flag when
-a key is expired or will expire soon.
+The settings page shows each key's expiry date and flags keys that are
+expired or expiring soon.
 
-### 5. Configure OpenSubsonic clients one time
+### 5. Reconfigure OpenSubsonic clients once
 
-Token authentication (`t` + `s`) does not use your account password now.
+Token authentication (`t` + `s`) no longer derives from your account
+password.
 
-1. Set a dedicated per-user Subsonic password with
-   `POST /api/auth/subsonic-password`. As an alternative, set the client to
-   password authentication.
-2. Note: when you change your account password, the application clears the
-   dedicated Subsonic password. Set it again after a password change.
+1. Set a dedicated per-user Subsonic password via
+   `POST /api/auth/subsonic-password`, or switch the client to password
+   authentication.
+2. Note: changing your account password clears the dedicated Subsonic
+   password. Set it again afterward.
 
 ### 6. Set the CORS policy for cross-origin frontends
 
 In production, an unset `ALLOWED_ORIGINS` now denies cross-origin browser
 requests.
 
-1. If your frontend uses the same origin as the backend proxy, no action is
-   necessary.
-2. If your frontend uses a different origin, set `ALLOWED_ORIGINS` to the list
-   of allowed frontend origins.
-3. `CORS_ALLOW_ALL=true` is a temporary escape hatch only. Do not keep it in
+1. Same-origin frontend-proxy deployments need no change.
+2. Otherwise, set `ALLOWED_ORIGINS` to your allowed frontend origins.
+3. `CORS_ALLOW_ALL=true` is a temporary escape hatch only — don't keep it in
    production.
 
-### 7. Set the Lidarr webhook secret
+### 7. Configure the Lidarr webhook secret
 
-`POST /api/webhooks/lidarr` now returns 401 when no webhook secret is set.
+`POST /api/webhooks/lidarr` now returns 401 when no webhook secret is
+configured.
 
-1. Set the webhook secret in the system settings.
-2. Set the same secret in Lidarr.
+1. Set the webhook secret in system settings.
+2. Configure the same secret in Lidarr.
 3. `LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true` is a temporary escape hatch
    only.
 
-### 8. Examine remote access to PostgreSQL and Redis
+### 8. Review remote access to PostgreSQL and Redis
 
 The Compose host ports for PostgreSQL and Redis now bind to `127.0.0.1`.
 
-1. Tools on the same host continue to work. No action is necessary.
-2. For remote tools, use the documented Compose override. A private
-   authenticated path is the better option.
+1. Tooling on the same host keeps working — no change needed.
+2. For remote tooling, use the documented Compose override, or better, a
+   private authenticated path.
 
 ### 9. Repair frontend volume ownership
 
-The production frontend image now runs as UID/GID 1000. Before this release it
-ran as 1001.
+The frontend image now runs as UID/GID 1000 (previously 1001).
 
-1. Find frontend volumes with files that UID 1001 owns. One example is
+1. Find frontend volumes with files owned by UID 1001 — usually
    `.next/cache`.
-2. Change the owner of these files to UID 1000, or create the volumes again.
-3. AIO processes also run as UID/GID 1000. Make sure bind mounts for AIO are
-   writable. The standard AIO volume paths repair themselves at boot.
+2. Re-chown those files to 1000, or recreate the volumes.
+3. AIO processes also run as UID/GID 1000 and need writable bind mounts. The
+   standard AIO volume paths repair themselves at boot.
 
-### 10. Examine Helm capacity and GPU settings
+### 10. Review Helm capacity and GPU settings
 
-1. AIO requests and limits now default to `2Gi` and `8Gi`. Make sure the
-   cluster has space for the AIO pod.
-2. Analyzer probes are now active in individual mode.
-3. The GPU flags now create a real `nvidia.com/gpu` limit. If you use these
-   flags, install the NVIDIA device plugin. Also set the runtime class if your
-   cluster requires one.
+1. AIO requests and limits now default to `2Gi`/`8Gi` — make sure the cluster
+   can place the pod.
+2. Analyzer probes are now enabled in individual mode.
+3. GPU flags now create a real `nvidia.com/gpu` limit. If you use them,
+   install the NVIDIA device plugin and set a runtime class if your cluster
+   requires one.
 
 ### 11. Update scripts for the new authorization gates
 
-These operations now require an administrator account:
+These operations now require an administrator:
 
-- Global enrichment failure operations
+- Global enrichment-failure operations
 - Shared-library download operations
 - Spotify import session logs
 - Soulseek-backed retries
@@ -134,88 +131,87 @@ These operations now require authentication:
 - Artist discovery and preview
 - Audiobook cover access
 
-Refresh tokens are only valid in the refresh exchange. They are not access
-credentials.
+Refresh tokens are accepted only by the refresh exchange — they are not
+access credentials.
 
 ### 12. Update custom sidecar clients
 
-1. TIDAL admin calls now carry credentials in headers. Legacy query
-   credentials operate temporarily.
-2. The YouTube Music sidecar strictly validates video ids and quality values.
-3. Sidecar and route errors now use the canonical `{ "error": ... }` envelope.
-4. OpenSubsonic cover sizes snap to the supported allowlist. The API does not
-   honor arbitrary dimensions now.
+1. TIDAL admin calls now carry credentials in headers; legacy query
+   credentials still work for now.
+2. YouTube Music video ids and quality values are strictly validated.
+3. Sidecar and route errors now use the canonical `{ "error": ... }`
+   envelope.
+4. OpenSubsonic cover sizes snap to the supported allowlist — arbitrary
+   dimensions are no longer honored.
 
-### 13. Make sure the music mount is correct before a scan
+### 13. Verify the music mount before you scan
 
-**Caution: a partially mounted library can cause the scan to remove track
+**Caution: a partially mounted library can cause a scan to remove the track
 records for the missing paths.**
 
-Scans now remove database tracks that are missing from disk. The "Allow
-library deletion" setting does not prevent this. A fully empty mount is
-protected.
+Scans now remove database tracks that are missing from disk, regardless of
+the "Allow library deletion" setting. A completely empty mount is protected.
 
 1. Make sure the full music library is mounted.
-2. Then start the library scan.
+2. Then run the library scan.
 
 ## Playback reliability and telemetry
 
 - Queue auto-advance is fixed across the full track-end path. The native
-  engine now accepts the end-of-stream pause from the browser. Listeners stay
-  attached while the playback state changes. A watchdog recovers a lost end
+  engine now accepts the browser's end-of-stream pause, listeners stay
+  attached through playback state changes, and a watchdog recovers a lost end
   event.
-- A browser can block the next track in a hidden or unfocused window. The
-  player now retries on a bounded timer, and again when the window gets focus
-  or becomes visible. The player also keeps the autoplay intent of each load.
-  A successful advance does not pause itself now.
-- The server now records these client telemetry events:
-  `load_autoplay_decision`, `track_end_*`, and `playback_start_blocked`.
-  Operators can set an alert on the `autoplay_intent_conflict` event. This
-  event must not occur. If it occurs, it shows a playback-intent regression.
+- If a browser blocks the next track in a hidden or unfocused window, the
+  player retries on a bounded timer and again on focus or visibility. Each
+  load's autoplay intent is preserved, so a successful advance no longer
+  pauses itself.
+- The server now records `load_autoplay_decision`, `track_end_*`, and
+  `playback_start_blocked` client telemetry. Operators can alert on
+  `autoplay_intent_conflict` — it should never fire, and if it does, it
+  signals a playback-intent regression.
 
 ## Cover art and session behavior
 
-- Cover art and segmented-streaming files are correct again for caches in a
-  dot-directory, for example `/music/.soundspan`. The server sends cover files
-  from a pinned root directory with strong containment checks.
+- Cover art and segmented-streaming assets no longer return 404 when the
+  cache lives in a dot-directory such as `/music/.soundspan`. Cover files are
+  served from a pinned root with strong containment checks.
 - A failed **Test connection** for Audiobookshelf, Fanart.tv, Last.fm,
-  Soulseek, Spotify, or TIDAL does not log you out now. Upstream credential
-  failures return 502. The web client only logs out for responses with the
-  explicit `AUTH_REQUIRED` marker. A wrong current password shows an inline
-  error.
+  Soulseek, Spotify, or TIDAL no longer logs you out. Upstream credential
+  failures return 502, and the web client logs out only for responses with
+  the explicit `AUTH_REQUIRED` marker. A wrong current password shows an
+  inline error.
 
 ## Security hardening
 
-- All CodeQL alerts from the pre-release review are closed. Each alert is
-  fixed, or has a recorded justification and a re-evaluation condition.
-- Access-token verification is in one place. It pins HS256, validates the
-  payload, and rejects refresh tokens outside the refresh exchange. TOTP moved
-  from the unmaintained `speakeasy` package to `otplib`. Existing 2FA
-  enrollments continue to operate.
-- Account, 2FA, Subsonic credential, admin queue-dashboard, and playback-state
-  routes now have route-specific rate limits. The playback limit is large
-  enough for the normal high-frequency cadence.
-- Authorization is more strict for: API-key and device management, MFA,
+- Every CodeQL alert from the pre-release review is closed — fixed, or
+  recorded with an owned justification and a re-evaluation condition.
+- Access-token verification is centralized. It pins HS256, validates
+  payloads, and rejects refresh tokens outside the refresh exchange. TOTP
+  moved from the unmaintained `speakeasy` package to `otplib`; existing 2FA
+  enrollments keep working.
+- Account, 2FA, Subsonic-credential, admin queue-dashboard, and
+  playback-state routes now have route-specific rate limits. The playback
+  tier stays generous enough for its normal high-frequency cadence.
+- Authorization is tighter across API-key and device management, MFA,
   enrichment, shared downloads, import logs, artist discovery, audiobook
-  covers, Listen Together group ending, and recovery or retry operations.
-- Client-facing errors now use curated messages. This applies to backend
-  routes, segmented streaming, stored download jobs, and the TIDAL and YouTube
-  Music sidecars. Raw paths, upstream bodies, and exception details stay in
-  the server logs.
+  covers, Listen Together group ending, and recovery/retry operations.
+- Client-facing errors now use curated messages across backend routes,
+  segmented streaming, stored download jobs, and the TIDAL and YouTube Music
+  sidecars. Raw paths, upstream bodies, and exception details stay in server
+  logs.
 - Native streams, share-link streams, downloads, cache files, cover-image
-  storage, and analyzer or repair paths keep all file access inside their root
+  storage, and analyzer/repair paths keep all file access inside their root
   directories. Podcast audio, remote images, and Audiobookshelf cover access
-  have DNS-aware SSRF, redirect, namespace, and input validation.
-- Playlist imports accept only canonical HTTP(S) links. Text normalization and
-  delimited-content stripping run in linear time. Audiobook preflight requests
-  use the central deny-by-default CORS policy.
-- Writes to `.env` files with secrets are atomic and owner-only. YouTube Music
-  OAuth files have mode `0600`. Chart-managed workloads drop Linux
-  capabilities, use `RuntimeDefault` seccomp, and do not mount service-account
-  tokens.
+  gained DNS-aware SSRF, redirect, namespace, and input validation.
+- Playlist imports accept only canonical HTTP(S) links. Text normalization
+  and delimited-content stripping run in linear time. Audiobook preflight
+  uses the central deny-by-default CORS policy.
+- Secret-bearing `.env` writes are atomic and owner-only. YouTube Music OAuth
+  files use mode `0600`. Chart-managed workloads drop Linux capabilities, use
+  `RuntimeDefault` seccomp, and don't mount service-account tokens.
 - You can move integration credentials fully into encrypted settings with
-  `SECRETS_DB_ONLY=true`. The legacy decrypt fail-closed mode is opt-in. Turn
-  it on only after the secrets-status endpoint reports zero legacy rows.
+  `SECRETS_DB_ONLY=true`. The legacy decrypt fail-closed mode is opt-in —
+  enable it only after the secrets-status endpoint reports zero legacy rows.
 
 ## Observability migration
 
@@ -229,74 +225,74 @@ alerts that use the old names:
 | `[SegmentedStreaming.Trace] client.signal` | `[Playback.Trace] client.signal` | Client trace logs |
 | `[SegmentedStreaming][Metric] client.signal` | `[Playback.Metric] client.signal` | Client metric logs |
 
-Traces that are specific to segmented streaming keep their names. This applies
-to manifest, segment, session, and DASH lifecycle traces.
+Traces genuinely specific to segmented streaming — manifest, segment,
+session, and DASH lifecycle — keep their existing names.
 
 ## Reliability and performance
 
 - Rediscover uses a bounded, indexed candidate pool. Subsonic playlist
   durations use one aggregate query. Playlist listings paginate with
-  database-side counts. Browse and list limits have clamps that prevent
+  database-side counts, and browse/list limits are clamped to prevent
   full-library work.
-- A shared keyed single-flight now merges duplicate work for transcode
-  caching, vibe calibration, and TIDAL or YouTube Music credential restores.
-  OAuth logout is fenced against restore or refresh work that is in flight.
-  Cleared credentials stay cleared.
-- Sidecar network and filesystem work moved off the async event loops. This
-  work now has bounded deadlines and cache sizes. It releases upstream
-  connections on errors and on client disconnects. Locks guard the stream and
-  browse caches against concurrent changes.
-- Analyzer batch timeouts keep completed results. Work that never started goes
-  back to the queue without a used retry. Only work that truly failed in
-  flight uses a retry. CLAP workers have a supervisor. Resources close
-  deterministically. Model unload cannot race inference.
-- Import jobs run on the durable worker queue with recovery and deduplication.
-  Workers claim the queue-cleaning task. API replicas do not repeat it.
-- Token refresh, visibility-aware polling, and Listen Together recovery have
-  focused fixes. Long sessions, hidden tabs, large queues, and cross-replica
-  ready gates recover more predictably.
+- A shared keyed single-flight coalesces transcode caching, vibe calibration,
+  and TIDAL/YouTube Music credential restores. OAuth logout is fenced against
+  in-flight restore or refresh work, so cleared credentials stay cleared.
+- Sidecar network and filesystem work moved off the async event loops, gained
+  bounded deadlines and cache sizes, and releases upstream connections on
+  errors and client disconnects. Locks guard the stream and browse caches
+  against concurrent mutation.
+- Analyzer batch timeouts preserve completed results. Work that never started
+  is requeued without consuming a retry; only genuinely in-flight failures
+  use one. CLAP workers are supervised, resources close deterministically,
+  and model unload cannot race inference.
+- Import jobs run durably on the worker queue with recovery and
+  deduplication. Workers claim queue cleaning, so API replicas don't repeat
+  it.
+- Token refresh, visibility-aware polling, and Listen Together recovery
+  received focused fixes, so long sessions, hidden tabs, large queues, and
+  cross-replica ready gates recover more predictably.
 
 ## Quality and maintainability
 
-- The frontend compiles in TypeScript strict mode. The Python sidecars run
-  mypy in strict mode. The exceptions for the pinned analyzer stack are
-  measured and documented.
+- The frontend compiles in TypeScript strict mode, and the Python sidecars
+  run mypy in strict mode with measured, documented exceptions for the pinned
+  analyzer stack.
 - The large library router is now a set of named per-resource routers with
-  typed helper modules. The mounted URLs and the behavior did not change.
-- Backend environment reads continue to move behind the typed configuration
-  boundary. The temporary allowlist went from 39 production files to 19.
-- Component network calls go through the shared frontend API layer. A ratchet
-  test prevents new direct `fetch()` calls in app, component, and feature
-  modules.
+  typed helper modules. Mounted URLs and behavior are unchanged.
+- Backend environment reads keep moving behind the typed configuration
+  boundary; the temporary allowlist shrank from 39 production files to 19.
+- Component network calls go through the shared frontend API layer, with a
+  ratchet test that blocks new direct `fetch()` calls in app, component, and
+  feature modules.
 
 ## Platform and deployment
 
-- The standalone MusiCNN analyzer moved from Ubuntu 20.04 with Python 3.8 to
-  Python 3.11. It uses the same TensorFlow 2.15.1 and Essentia model stack as
-  AIO. The supported Essentia artifact matrix and the deterministic inference
-  baseline are documented. Model behavior did not change.
-- AIO now keeps operator-supplied master secrets. It secures embedded
-  PostgreSQL on loopback with SCRAM-SHA-256. It checks frontend and backend
-  readiness. It runs application processes under the fixed `soundspan`
+- The standalone MusiCNN analyzer moved from Ubuntu 20.04/Python 3.8 to
+  Python 3.11, with the same TensorFlow 2.15.1 and Essentia model stack as
+  AIO. The supported Essentia artifact matrix and deterministic inference
+  baseline are documented; model behavior is unchanged.
+- AIO now persists operator-supplied master secrets, secures embedded
+  PostgreSQL on loopback with SCRAM-SHA-256, checks frontend and backend
+  readiness, and runs application processes under the fixed `soundspan`
   UID/GID 1000.
-- Analyzer health probes and GPU scheduling now operate in the Helm chart.
-  PostgreSQL credentials are safely encoded. You can pin application images by
-  digest.
-- Base images and build inputs are pinned by digest or hash. Python quality
-  and sidecar test lanes are part of CI. The remaining mutable GitHub Actions
+- Analyzer health probes and GPU scheduling now work in the Helm chart.
+  PostgreSQL credentials are safely encoded, and application images can be
+  pinned by digest.
+- Base images and build inputs are digest- or hash-pinned. Python quality and
+  sidecar test lanes are part of CI, and the remaining mutable GitHub Actions
   and scanner image references are pinned.
-- CodeQL analysis and the quality and enforcement gates are now blocking
-  required checks. They are not visibility-only signals now.
+- CodeQL analysis and the quality/enforcement gates now run as blocking
+  required checks, not visibility-only signals.
 
 ## Also in this release
 
-- The seek slider, modal and confirmation flows, queue reordering, track rows,
-  and the Vibe map have better keyboard and screen-reader behavior.
-- The playback context and the progress subscriptions are now separate.
-  Status-only screens and the audio orchestrator avoid clock-driven
+- The seek slider, modal and confirmation flows, queue reordering, track
+  rows, and the Vibe map gained stronger keyboard and screen-reader behavior.
+- Playback context and progress subscriptions are now separate, so
+  status-only screens and the audio orchestrator avoid clock-driven
   re-renders. Visibility-aware polling stops unnecessary work in hidden tabs.
-- Settings actions use consistent in-app confirmation dialogs. Theme colors
-  have accessible contrast and focus guards.
+- Settings actions use consistent in-app confirmation dialogs, and theme
+  colors have accessible contrast and focus guards.
 
 ## Deployment and distribution
 
@@ -314,13 +310,13 @@ The chart is published only after all eight `2.0.0` image tags are available.
 
 ## Known issues and compatibility notes
 
-- The TensorFlow 2.15 dependency line for the analyzer and AIO images keeps
-  its documented `pip-audit` exceptions. These are Keras 2.15.0 and protobuf
-  4.25.9. The removal conditions are in `docs/SECURITY.md`. New advisory IDs
-  continue to fail CI.
-- Standard Docker and Helm upgrades keep existing data. They apply Prisma
-  migrations automatically. For custom deployments, you are responsible for
-  database backups, migration order, and consistent sidecar secrets.
+- The TensorFlow 2.15 dependency line shared by the analyzer and AIO images
+  keeps its documented `pip-audit` exceptions (Keras 2.15.0 and protobuf
+  4.25.9). Their removal conditions live in `docs/SECURITY.md`, and new
+  advisory IDs still fail CI.
+- Standard Docker and Helm upgrades preserve existing data and apply Prisma
+  migrations automatically. Custom deployments remain responsible for
+  database backups, migration ordering, and consistent sidecar secrets.
 
 ## Full changelog
 

--- a/docs/release-notes/RELEASE_NOTES_2.0.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.0.md
@@ -1,140 +1,226 @@
 # [2.0.0] Release Notes - 2026-08-12
 
-Soundspan 2.0.0 is a security- and reliability-hardening major release: the
-consumer-facing result of a systematic, multi-month security review. It tightens
-credentials, sessions, authorization, network boundaries, and filesystem access
-and bounds more database, sidecar, and background work. The major version reflects
-the operator and client actions below; complete the checklist before rollout.
+Soundspan 2.0.0 is a major release. It makes security and reliability better
+across the full application. It is the result of a systematic security review
+over several months. The release makes credentials, sessions, authorization,
+network boundaries, and filesystem access more strict. It also puts limits on
+more database, sidecar, and background work.
 
-## Before you upgrade — required checklist
+This is a major version because you must do the steps below. Do all the steps
+before you start the new version.
 
-- **Set all split-stack secrets explicitly before startup.**
-  `docker-compose.yml` now requires `POSTGRES_PASSWORD`, `SESSION_SECRET`,
-  `SETTINGS_ENCRYPTION_KEY`, and `INTERNAL_API_SECRET`; published defaults are
-  rejected. Generate new application secrets with `openssl rand -base64 32`,
-  keep the same `INTERNAL_API_SECRET` on the backend and sidecars, and do not
-  reuse the retired `soundspan-internal-secret-change-me` value.
-- **Pass split-stack database settings as `POSTGRES_*` components.** Compose
-  deployments now build `DATABASE_URL` inside the application and safely
-  percent-encode credentials, including passwords with URL-reserved
-  characters. An explicit `DATABASE_URL` still takes precedence for custom
-  deployments.
-- **Strengthen weak custom secrets before starting 2.0.0.** Encryption and
-  internal-auth secrets must be at least 32 characters. An operator-supplied
-  `JWT_SECRET` must also be at least 32 characters; deployments that omit it
-  continue to use the validated `SESSION_SECRET`.
-- **Reissue API keys older than 90 days and plan recurring rotation.** Keys now
-  expire 90 days after creation or rotation. API-key management, linked-device
-  revocation, and MFA setup or changes require a logged-in interactive session;
-  an `X-API-Key` client can no longer perform those actions.
-- **Reconfigure OpenSubsonic token-auth clients once.** Token authentication
-  (`t` + `s`) no longer derives from a reversibly stored account password. Set a
-  dedicated per-user Subsonic password through
-  `POST /api/auth/subsonic-password`, or switch the client to password auth.
-  Changing an account password clears the dedicated Subsonic secret.
-- **Set an explicit production CORS policy for cross-origin frontends.** An
-  unset `ALLOWED_ORIGINS` now denies cross-origin browser requests in
-  production. Same-origin frontend-proxy deployments need no change; otherwise
-  set the allowed frontend origins. `CORS_ALLOW_ALL=true` is a temporary legacy
-  escape hatch.
-- **Configure the Lidarr webhook secret.** `POST /api/webhooks/lidarr` now
-  returns 401 when no webhook secret is configured. Use
-  `LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true` only as a temporary compatibility
-  escape hatch.
-- **Review remote access to Compose PostgreSQL and Redis.** Their host ports now
-  bind to `127.0.0.1` instead of all interfaces. Same-host tooling is unchanged;
-  remote tooling needs the documented Compose override or, preferably, a
-  private authenticated path.
-- **Repair frontend volume ownership when needed.** The production frontend
-  image now runs as UID/GID 1000. Re-chown existing `.next/cache` or other
-  frontend volumes owned by 1001 to 1000, or recreate them. AIO processes also
-  run as UID/GID 1000 and require writable bind mounts, although standard AIO
-  volume paths are repaired automatically at boot.
-- **Review Helm capacity and accelerator settings.** AIO requests/limits now
-  default to `2Gi`/`8Gi`; ensure the cluster can place it. Analyzer probes are
-  enabled in individual mode. GPU flags now create a real
-  `nvidia.com/gpu` limit, so clusters using them need the NVIDIA device plugin
-  and any required runtime class.
-- **Update scripts for the new authorization gates.** Global enrichment
-  failures, shared-library download operations, Spotify import session logs,
-  Soulseek-backed retries, Lidarr queue clearing, and library-wide or
-  single-item enrichment now require an administrator. Artist discovery and
-  preview plus audiobook cover access require authentication. Refresh tokens
-  are accepted only by the refresh exchange, not as access credentials.
-- **Update custom sidecar clients to the hardened request contracts.** TIDAL
-  admin calls now carry credentials in headers; legacy query credentials remain
-  temporarily supported. YouTube Music video ids and quality values are
-  strictly validated, sidecar and route errors now use the canonical
-  `{ "error": ... }` envelope, and OpenSubsonic cover sizes snap to the supported
-  allowlist instead of honoring arbitrary dimensions.
-- **Verify the music mount before running a library scan.** Scans now remove
-  database tracks that are missing from disk regardless of the “Allow library
-  deletion” setting. A completely empty mount is protected, but a partially
-  mounted or incomplete library can still reconcile missing paths away.
+## Before you upgrade — required steps
+
+Do these steps in order. Each step tells you what to do and why.
+
+### 1. Set all required secrets
+
+`docker-compose.yml` now requires these values before startup:
+
+- `POSTGRES_PASSWORD`
+- `SESSION_SECRET`
+- `SETTINGS_ENCRYPTION_KEY`
+- `INTERNAL_API_SECRET`
+
+The application rejects the old published default values.
+
+1. Make each new secret with `openssl rand -base64 32`.
+2. Set the same `INTERNAL_API_SECRET` on the backend and on all sidecars.
+3. Do not use the retired value `soundspan-internal-secret-change-me`.
+
+### 2. Give the database settings as components
+
+Compose deployments now build `DATABASE_URL` inside the application.
+
+1. Set `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+   and `POSTGRES_DB`.
+2. The application percent-encodes the credentials. Passwords with special URL
+   characters are now safe.
+3. If you set an explicit `DATABASE_URL`, the application uses it without
+   change. This is correct for custom deployments.
+
+### 3. Make weak custom secrets strong
+
+1. Make sure `SETTINGS_ENCRYPTION_KEY` and `INTERNAL_API_SECRET` have 32
+   characters or more.
+2. If you set `JWT_SECRET`, make sure it has 32 characters or more.
+3. If you do not set `JWT_SECRET`, the application uses the validated
+   `SESSION_SECRET`. No action is necessary.
+
+### 4. Replace old API keys and plan rotation
+
+API keys now expire 90 days after you create them or rotate them.
+
+1. Replace each API key that is more than 90 days old.
+2. Plan a recurring rotation for all API keys.
+3. Log in to a browser session to manage API keys, linked devices, or MFA.
+   A client with only an `X-API-Key` header cannot do these actions now.
+
+The settings page shows the expiry date of each key. It also shows a flag when
+a key is expired or will expire soon.
+
+### 5. Configure OpenSubsonic clients one time
+
+Token authentication (`t` + `s`) does not use your account password now.
+
+1. Set a dedicated per-user Subsonic password with
+   `POST /api/auth/subsonic-password`. As an alternative, set the client to
+   password authentication.
+2. Note: when you change your account password, the application clears the
+   dedicated Subsonic password. Set it again after a password change.
+
+### 6. Set the CORS policy for cross-origin frontends
+
+In production, an unset `ALLOWED_ORIGINS` now denies cross-origin browser
+requests.
+
+1. If your frontend uses the same origin as the backend proxy, no action is
+   necessary.
+2. If your frontend uses a different origin, set `ALLOWED_ORIGINS` to the list
+   of allowed frontend origins.
+3. `CORS_ALLOW_ALL=true` is a temporary escape hatch only. Do not keep it in
+   production.
+
+### 7. Set the Lidarr webhook secret
+
+`POST /api/webhooks/lidarr` now returns 401 when no webhook secret is set.
+
+1. Set the webhook secret in the system settings.
+2. Set the same secret in Lidarr.
+3. `LIDARR_WEBHOOK_ALLOW_UNAUTHENTICATED=true` is a temporary escape hatch
+   only.
+
+### 8. Examine remote access to PostgreSQL and Redis
+
+The Compose host ports for PostgreSQL and Redis now bind to `127.0.0.1`.
+
+1. Tools on the same host continue to work. No action is necessary.
+2. For remote tools, use the documented Compose override. A private
+   authenticated path is the better option.
+
+### 9. Repair frontend volume ownership
+
+The production frontend image now runs as UID/GID 1000. Before this release it
+ran as 1001.
+
+1. Find frontend volumes with files that UID 1001 owns. One example is
+   `.next/cache`.
+2. Change the owner of these files to UID 1000, or create the volumes again.
+3. AIO processes also run as UID/GID 1000. Make sure bind mounts for AIO are
+   writable. The standard AIO volume paths repair themselves at boot.
+
+### 10. Examine Helm capacity and GPU settings
+
+1. AIO requests and limits now default to `2Gi` and `8Gi`. Make sure the
+   cluster has space for the AIO pod.
+2. Analyzer probes are now active in individual mode.
+3. The GPU flags now create a real `nvidia.com/gpu` limit. If you use these
+   flags, install the NVIDIA device plugin. Also set the runtime class if your
+   cluster requires one.
+
+### 11. Update scripts for the new authorization gates
+
+These operations now require an administrator account:
+
+- Global enrichment failure operations
+- Shared-library download operations
+- Spotify import session logs
+- Soulseek-backed retries
+- Lidarr queue clearing
+- Library-wide or single-item enrichment
+
+These operations now require authentication:
+
+- Artist discovery and preview
+- Audiobook cover access
+
+Refresh tokens are only valid in the refresh exchange. They are not access
+credentials.
+
+### 12. Update custom sidecar clients
+
+1. TIDAL admin calls now carry credentials in headers. Legacy query
+   credentials operate temporarily.
+2. The YouTube Music sidecar strictly validates video ids and quality values.
+3. Sidecar and route errors now use the canonical `{ "error": ... }` envelope.
+4. OpenSubsonic cover sizes snap to the supported allowlist. The API does not
+   honor arbitrary dimensions now.
+
+### 13. Make sure the music mount is correct before a scan
+
+**Caution: a partially mounted library can cause the scan to remove track
+records for the missing paths.**
+
+Scans now remove database tracks that are missing from disk. The "Allow
+library deletion" setting does not prevent this. A fully empty mount is
+protected.
+
+1. Make sure the full music library is mounted.
+2. Then start the library scan.
 
 ## Playback reliability and telemetry
 
-- Queue auto-advance is fixed across the full track-end path. The native engine
-  now accepts the browser's end-of-stream pause, listeners remain stable while
-  playback state changes, and a one-shot watchdog recovers a lost end event.
-- If a browser blocks the next track in a hidden or unfocused window, bounded
-  retries run on a timer and again on visibility or focus. The player also
-  preserves the load's autoplay intent, so a successful advance no longer
-  pauses itself immediately after the next track starts.
-- Server-visible client telemetry now records `load_autoplay_decision`,
-  `track_end_*`, and `playback_start_blocked` events. Operators can alert on
-  the `autoplay_intent_conflict` tripwire to catch future load/play intent
-  regressions.
+- Queue auto-advance is fixed across the full track-end path. The native
+  engine now accepts the end-of-stream pause from the browser. Listeners stay
+  attached while the playback state changes. A watchdog recovers a lost end
+  event.
+- A browser can block the next track in a hidden or unfocused window. The
+  player now retries on a bounded timer, and again when the window gets focus
+  or becomes visible. The player also keeps the autoplay intent of each load.
+  A successful advance does not pause itself now.
+- The server now records these client telemetry events:
+  `load_autoplay_decision`, `track_end_*`, and `playback_start_blocked`.
+  Operators can set an alert on the `autoplay_intent_conflict` event. This
+  event must not occur. If it occurs, it shows a playback-intent regression.
 
-## Cover art and session UX
+## Cover art and session behavior
 
-- Cover art and segmented-streaming assets no longer return 404 when a cache
-  lives in a dot-directory such as `/music/.soundspan`. Cover files are served
-  from an explicitly pinned root with stronger containment checks.
-- Failed media-server **Test connection** attempts for Audiobookshelf,
-  Fanart.tv, Last.fm, Soulseek, Spotify, and TIDAL no longer end the current
-  Soundspan session. Upstream credential failures return 502, while the web
-  client logs out only for responses carrying the explicit `AUTH_REQUIRED`
-  marker. Wrong current-password entries now stay inline instead of being
-  mistaken for session expiry.
+- Cover art and segmented-streaming files are correct again for caches in a
+  dot-directory, for example `/music/.soundspan`. The server sends cover files
+  from a pinned root directory with strong containment checks.
+- A failed **Test connection** for Audiobookshelf, Fanart.tv, Last.fm,
+  Soulseek, Spotify, or TIDAL does not log you out now. Upstream credential
+  failures return 502. The web client only logs out for responses with the
+  explicit `AUTH_REQUIRED` marker. A wrong current password shows an inline
+  error.
 
 ## Security hardening
 
-- The pre-release CodeQL backlog is fully dispositioned: every alert was fixed
-  or recorded with an owned justification and re-evaluation condition.
-- Access-token verification is centralized, pins HS256, validates payloads,
-  and rejects refresh tokens outside the refresh exchange. TOTP moved from the
-  unmaintained `speakeasy` package to `otplib` while preserving existing 2FA
-  enrollments.
+- All CodeQL alerts from the pre-release review are closed. Each alert is
+  fixed, or has a recorded justification and a re-evaluation condition.
+- Access-token verification is in one place. It pins HS256, validates the
+  payload, and rejects refresh tokens outside the refresh exchange. TOTP moved
+  from the unmaintained `speakeasy` package to `otplib`. Existing 2FA
+  enrollments continue to operate.
 - Account, 2FA, Subsonic credential, admin queue-dashboard, and playback-state
-  synchronization routes now have route-specific rate limits; the playback
-  tier remains generous enough for its normal high-frequency cadence.
-- Authorization was tightened across API-key and device management, MFA,
+  routes now have route-specific rate limits. The playback limit is large
+  enough for the normal high-frequency cadence.
+- Authorization is more strict for: API-key and device management, MFA,
   enrichment, shared downloads, import logs, artist discovery, audiobook
   covers, Listen Together group ending, and recovery or retry operations.
-- Client-facing failures now use curated messages across backend routes,
-  segmented streaming, stored download jobs, and TIDAL/YouTube Music sidecars;
-  raw paths, upstream bodies, and exception details remain in server logs.
+- Client-facing errors now use curated messages. This applies to backend
+  routes, segmented streaming, stored download jobs, and the TIDAL and YouTube
+  Music sidecars. Raw paths, upstream bodies, and exception details stay in
+  the server logs.
 - Native streams, share-link streams, downloads, cache files, cover-image
-  storage, and analyzer or repair paths enforce root containment. Podcast
-  audio, remote images, and Audiobookshelf cover access gained DNS-aware SSRF,
-  redirect, namespace, and input validation.
-- Playlist imports accept only canonical HTTP(S) links, text normalization and
-  delimited-content stripping now run in linear time, and audiobook preflight
-  handling uses the centralized deny-by-default CORS policy.
-- Secret-bearing `.env` writes are atomic and owner-only. YouTube Music OAuth
-  files are also mode `0600`, and chart-managed workloads drop Linux
+  storage, and analyzer or repair paths keep all file access inside their root
+  directories. Podcast audio, remote images, and Audiobookshelf cover access
+  have DNS-aware SSRF, redirect, namespace, and input validation.
+- Playlist imports accept only canonical HTTP(S) links. Text normalization and
+  delimited-content stripping run in linear time. Audiobook preflight requests
+  use the central deny-by-default CORS policy.
+- Writes to `.env` files with secrets are atomic and owner-only. YouTube Music
+  OAuth files have mode `0600`. Chart-managed workloads drop Linux
   capabilities, use `RuntimeDefault` seccomp, and do not mount service-account
   tokens.
-- Operators can move integration credentials fully into encrypted settings with
-  `SECRETS_DB_ONLY=true`. Legacy decrypt fail-closed mode remains opt-in and
-  should be enabled only after the secrets-status endpoint reports zero legacy
-  rows.
+- You can move integration credentials fully into encrypted settings with
+  `SECRETS_DB_ONLY=true`. The legacy decrypt fail-closed mode is opt-in. Turn
+  it on only after the secrets-status endpoint reports zero legacy rows.
 
 ## Observability migration
 
-Update saved searches, dashboards, and alerts that use the renamed player
-signals:
+Some player signals have new names. Update saved searches, dashboards, and
+alerts that use the old names:
 
 | Previous name | 2.0.0 name | Scope |
 | --- | --- | --- |
@@ -143,75 +229,74 @@ signals:
 | `[SegmentedStreaming.Trace] client.signal` | `[Playback.Trace] client.signal` | Client trace logs |
 | `[SegmentedStreaming][Metric] client.signal` | `[Playback.Metric] client.signal` | Client metric logs |
 
-Manifest, segment, session, and DASH lifecycle traces that are genuinely
-specific to segmented streaming keep their existing names.
+Traces that are specific to segmented streaming keep their names. This applies
+to manifest, segment, session, and DASH lifecycle traces.
 
 ## Reliability and performance
 
-- Rediscover uses a bounded indexed candidate pool, Subsonic playlist durations
-  use one aggregate query, playlist listings paginate with database-side counts,
-  and browse or list limits are clamped to prevent full-library work.
-- Shared keyed single-flight now coalesces transcode caching, vibe calibration,
-  and TIDAL/YouTube Music credential restores. OAuth logout is fenced against
-  in-flight restore or refresh work so cleared credentials stay cleared.
-- Sidecar network and filesystem work moves off async event loops, gains bounded
-  deadlines and cache sizes, and releases upstream connections on errors or
-  client disconnects. Stream and browse caches are lock-guarded against
-  concurrent mutation.
-- Analyzer batch timeouts preserve completed results, requeue work that never
-  started without consuming retries, and retry genuinely in-flight failures.
-  CLAP workers are supervised, resources close deterministically, and model
-  unload cannot race inference.
-- Import jobs now run durably on the worker queue with recovery and
-  deduplication, while queue cleaning is claimed by workers instead of repeated
-  by every API replica.
-- Token refresh, visibility-aware polling, and Listen Together recovery
-  received focused fixes so long sessions, hidden tabs, large queues, and
-  cross-replica ready gates recover more predictably.
+- Rediscover uses a bounded, indexed candidate pool. Subsonic playlist
+  durations use one aggregate query. Playlist listings paginate with
+  database-side counts. Browse and list limits have clamps that prevent
+  full-library work.
+- A shared keyed single-flight now merges duplicate work for transcode
+  caching, vibe calibration, and TIDAL or YouTube Music credential restores.
+  OAuth logout is fenced against restore or refresh work that is in flight.
+  Cleared credentials stay cleared.
+- Sidecar network and filesystem work moved off the async event loops. This
+  work now has bounded deadlines and cache sizes. It releases upstream
+  connections on errors and on client disconnects. Locks guard the stream and
+  browse caches against concurrent changes.
+- Analyzer batch timeouts keep completed results. Work that never started goes
+  back to the queue without a used retry. Only work that truly failed in
+  flight uses a retry. CLAP workers have a supervisor. Resources close
+  deterministically. Model unload cannot race inference.
+- Import jobs run on the durable worker queue with recovery and deduplication.
+  Workers claim the queue-cleaning task. API replicas do not repeat it.
+- Token refresh, visibility-aware polling, and Listen Together recovery have
+  focused fixes. Long sessions, hidden tabs, large queues, and cross-replica
+  ready gates recover more predictably.
 
 ## Quality and maintainability
 
-- The frontend now compiles in TypeScript strict mode. Python sidecars run
-  mypy in strict mode, with measured and documented exceptions where the
-  pinned analyzer stack requires them.
-- The large library router is decomposed into named per-resource routers and
-  typed helper modules without changing its mounted URLs or behavior.
-- Backend environment reads continue moving behind the typed configuration
-  boundary; its temporary allowlist shrank from 39 production files to 19.
-- Component network calls now go through the shared frontend API layer, with a
-  ratchet that prevents new direct `fetch()` calls in app, component, and
-  feature modules.
+- The frontend compiles in TypeScript strict mode. The Python sidecars run
+  mypy in strict mode. The exceptions for the pinned analyzer stack are
+  measured and documented.
+- The large library router is now a set of named per-resource routers with
+  typed helper modules. The mounted URLs and the behavior did not change.
+- Backend environment reads continue to move behind the typed configuration
+  boundary. The temporary allowlist went from 39 production files to 19.
+- Component network calls go through the shared frontend API layer. A ratchet
+  test prevents new direct `fetch()` calls in app, component, and feature
+  modules.
 
 ## Platform and deployment
 
-- The standalone MusiCNN analyzer moves from Ubuntu 20.04/Python 3.8 to
-  Python 3.11 with the same TensorFlow 2.15.1 and Essentia model stack as AIO.
-  The supported Essentia artifact matrix and deterministic inference baseline
-  are documented without changing model behavior.
-- AIO now persists operator-supplied master secrets, secures embedded PostgreSQL
-  on loopback with SCRAM-SHA-256, checks both frontend and backend readiness,
-  and runs application processes under the fixed `soundspan` UID/GID 1000.
-- Analyzer health probes and GPU scheduling are now effective in the Helm chart,
-  while PostgreSQL credentials are safely encoded and application images can be
-  pinned by digest.
-- API-key settings show each key's expiry date and flag keys that are expired or
-  expiring soon, making the 90-day rotation policy visible before clients stop
-  authenticating.
-- Base images and build inputs are digest- or hash-pinned, Python quality and
-  sidecar test lanes are part of CI, and the remaining mutable GitHub Actions
+- The standalone MusiCNN analyzer moved from Ubuntu 20.04 with Python 3.8 to
+  Python 3.11. It uses the same TensorFlow 2.15.1 and Essentia model stack as
+  AIO. The supported Essentia artifact matrix and the deterministic inference
+  baseline are documented. Model behavior did not change.
+- AIO now keeps operator-supplied master secrets. It secures embedded
+  PostgreSQL on loopback with SCRAM-SHA-256. It checks frontend and backend
+  readiness. It runs application processes under the fixed `soundspan`
+  UID/GID 1000.
+- Analyzer health probes and GPU scheduling now operate in the Helm chart.
+  PostgreSQL credentials are safely encoded. You can pin application images by
+  digest.
+- Base images and build inputs are pinned by digest or hash. Python quality
+  and sidecar test lanes are part of CI. The remaining mutable GitHub Actions
   and scanner image references are pinned.
-- CodeQL analysis and the release quality/enforcement gates now run as blocking
-  required checks rather than visibility-only signals.
+- CodeQL analysis and the quality and enforcement gates are now blocking
+  required checks. They are not visibility-only signals now.
 
 ## Also in this release
 
-- The player seek slider, modal and confirmation flows, queue reordering, track
-  rows, and Vibe map gained stronger keyboard and screen-reader behavior.
-- Playback context and progress subscriptions were split so status-only screens
-  and the audio orchestrator avoid clock-driven rerenders. Visibility-aware
-  polling also stops unnecessary work in hidden tabs.
-- Settings actions use consistent in-app confirmation dialogs, theme colors have
-  accessible contrast and focus guards.
+- The seek slider, modal and confirmation flows, queue reordering, track rows,
+  and the Vibe map have better keyboard and screen-reader behavior.
+- The playback context and the progress subscriptions are now separate.
+  Status-only screens and the audio orchestrator avoid clock-driven
+  re-renders. Visibility-aware polling stops unnecessary work in hidden tabs.
+- Settings actions use consistent in-app confirmation dialogs. Theme colors
+  have accessible contrast and focus guards.
 
 ## Deployment and distribution
 
@@ -229,13 +314,13 @@ The chart is published only after all eight `2.0.0` image tags are available.
 
 ## Known issues and compatibility notes
 
-- The TensorFlow 2.15 dependency line shared by the analyzer and AIO images
-  keeps its documented `pip-audit` exceptions (Keras 2.15.0 and protobuf
-  4.25.9); their removal conditions live in `docs/SECURITY.md`, and new
-  advisory IDs still fail CI.
-- Standard Docker and Helm upgrades preserve existing data and apply Prisma
-  migrations automatically. Custom deployments remain responsible for database
-  backups, migration ordering, and consistent sidecar secrets.
+- The TensorFlow 2.15 dependency line for the analyzer and AIO images keeps
+  its documented `pip-audit` exceptions. These are Keras 2.15.0 and protobuf
+  4.25.9. The removal conditions are in `docs/SECURITY.md`. New advisory IDs
+  continue to fail CI.
+- Standard Docker and Helm upgrades keep existing data. They apply Prisma
+  migrations automatically. For custom deployments, you are responsible for
+  database backups, migration order, and consistent sidecar secrets.
 
 ## Full changelog
 


### PR DESCRIPTION
Follow-up to #443, per the owner's style decision: keep the STE structure — the numbered 13-step upgrade procedure, short active sentences, one instruction per step, caution before instruction — but drop the controlled-dictionary phrasing for natural technical vocabulary ("reissue" instead of "replace... one time", "still work for now" instead of "operate temporarily", contractions where natural). All technical facts unchanged. Docs-only.