### PR TITLE
fix(release): support the Accessibility changelog section in note generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The release-notes generator now supports the Accessibility changelog section.
 - The all-in-one image builds again by copying the Prisma config's database-URL
   helper into every stage that runs the Prisma CLI, with a static CI guard
   covering both backend Dockerfiles.

--- a/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
@@ -16,6 +16,10 @@
 
 {{CHANGED_ITEMS}}
 
+## Accessibility
+
+{{ACCESSIBILITY_ITEMS}}
+
 ## Admin/Operations
 
 {{ADMIN_ITEMS}}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "verify:gates": "node scripts/ci/check-route-error-canon.mjs && npm run check:error-canon:test && npm run check:infra-release:test && node --test scripts/ci/dockerfile-hygiene.test.mjs && npm --prefix frontend run lint:hex && npm --prefix backend test -- --maxWorkers=2 src/config/__tests__/openapiRouteSync.test.ts && npm run format:check",
         "check:error-canon": "node scripts/ci/check-route-error-canon.mjs",
         "check:error-canon:test": "node --test scripts/ci/__tests__/check-route-error-canon.test.mjs",
-        "check:infra-release:test": "node --test scripts/ci/__tests__/helm-service-selector-check.test.mjs scripts/ci/__tests__/release-version-validator.test.mjs",
+        "check:infra-release:test": "node --test scripts/ci/__tests__/helm-service-selector-check.test.mjs scripts/ci/__tests__/release-version-validator.test.mjs scripts/release/__tests__/generate-notes.test.mjs",
         "test:backend": "npm --prefix backend test --",
         "test:frontend": "npm --prefix frontend run test:unit"
     }

--- a/scripts/release/__tests__/generate-notes.test.mjs
+++ b/scripts/release/__tests__/generate-notes.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import {
+    copyFileSync,
+    mkdirSync,
+    mkdtempSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const generator = path.join(repoRoot, "scripts/release/generate-notes.mjs");
+const template = path.join(
+    repoRoot,
+    "docs/maintainers/RELEASE_NOTES_TEMPLATE.md",
+);
+
+function runGenerator(changelogContent) {
+    const fixtureRoot = mkdtempSync(
+        path.join(repoRoot, ".release-notes-test-"),
+    );
+    const fixtureTemplateDirectory = path.join(fixtureRoot, "docs/maintainers");
+
+    try {
+        mkdirSync(fixtureTemplateDirectory, { recursive: true });
+        writeFileSync(
+            path.join(fixtureRoot, "CHANGELOG.md"),
+            changelogContent,
+            "utf8",
+        );
+        copyFileSync(
+            template,
+            path.join(fixtureTemplateDirectory, "RELEASE_NOTES_TEMPLATE.md"),
+        );
+
+        return spawnSync(
+            process.execPath,
+            [generator, "--version", "9.9.9", "--from", "HEAD", "--to", "HEAD"],
+            { cwd: fixtureRoot, encoding: "utf8" },
+        );
+    } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+}
+
+test("generates Accessibility bullets after the Changed section", () => {
+    const result = runGenerator(`# Changelog
+
+## [9.9.9] - 2026-08-13
+
+### Accessibility
+
+- Added keyboard navigation to the release controls.
+`);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /## Changed\n\n- No behavior changes documented in this release\.\n\n## Accessibility\n\n- Added keyboard navigation to the release controls\./,
+    );
+});
+
+test("rejects a heading that is not supported", () => {
+    const result = runGenerator(`# Changelog
+
+## [9.9.9] - 2026-08-13
+
+### Experimental
+
+- Added an undocumented release category.
+`);
+
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(
+        result.stderr.trim(),
+        "CHANGELOG.md section [9.9.9] contains unsupported heading(s) with bullets: experimental.",
+    );
+});

--- a/scripts/release/generate-notes.mjs
+++ b/scripts/release/generate-notes.mjs
@@ -26,6 +26,7 @@ const RELEASE_CATEGORY_ALIASES = {
     fixed: ["Fixed", "Fixes"],
     added: ["Added", "New"],
     changed: ["Changed", "Updated"],
+    accessibility: ["Accessibility"],
     admin: ["Admin/Operations", "Admin", "Operations", "Database Migrations"],
     breaking: ["Breaking Changes", "Breaking"],
     security: ["Security"],
@@ -201,6 +202,15 @@ function buildReleaseSummary(counts, manualSummary) {
     if (counts.changed > 0) {
         parts.push(formatCount(counts.changed, "change", "changes"));
     }
+    if (counts.accessibility > 0) {
+        parts.push(
+            formatCount(
+                counts.accessibility,
+                "accessibility improvement",
+                "accessibility improvements",
+            ),
+        );
+    }
     if (counts.admin > 0) {
         parts.push(
             `${formatCount(counts.admin, "admin/operations update", "admin/operations updates")}`,
@@ -279,6 +289,10 @@ function loadReleaseItemsFromChangelog(version) {
         bulletsByHeading,
         RELEASE_CATEGORY_ALIASES.changed,
     );
+    const accessibility = pickBulletsByHeadingAliases(
+        bulletsByHeading,
+        RELEASE_CATEGORY_ALIASES.accessibility,
+    );
     const admin = pickBulletsByHeadingAliases(
         bulletsByHeading,
         RELEASE_CATEGORY_ALIASES.admin,
@@ -294,6 +308,7 @@ function loadReleaseItemsFromChangelog(version) {
         security,
         added,
         changed,
+        accessibility,
         admin,
         breaking,
     };
@@ -337,6 +352,7 @@ function main() {
         security: categorized.security.length,
         added: categorized.added.length,
         changed: categorized.changed.length,
+        accessibility: categorized.accessibility.length,
         admin: categorized.admin.length,
     };
 
@@ -367,6 +383,10 @@ function main() {
         "{{CHANGED_ITEMS}}": formatBulletBlock(
             categorized.changed,
             "No behavior changes documented in this release.",
+        ),
+        "{{ACCESSIBILITY_ITEMS}}": formatBulletBlock(
+            categorized.accessibility,
+            "No accessibility improvements documented in this release.",
         ),
         "{{ADMIN_ITEMS}}": formatBulletBlock(
             categorized.admin,


### PR DESCRIPTION
Fixes the reviewer's release-tooling blocker: `generate-notes.mjs` failed on the 2.0.0 changelog with `unsupported heading(s) with bullets: accessibility`.

- `Accessibility` category added to the alias map, rendered after **Changed** (template updated to match).
- Regression tests: an Accessibility fixture generates with its bullets; a genuinely unsupported heading still fails with the existing error. Suite wired into the root release test gate.
- Proof: generation against the real changelog exits 0 and includes the Accessibility bullets (independently re-run).
- `changelog-utils.mjs` reviewed: its list is the required scaffold, not the supported-heading set — unchanged.