### PR TITLE
chore(release): stage 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2.0.1] - 2026-08-13
+
+### Added
+
+### Changed
+
+### Fixed
+
 - The CLAP analyzer image now ships `pgrep` so the Helm chart's default liveness and readiness probes work (#448).
 
 ## [2.0.0] - 2026-08-13

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.0.0
-appVersion: "2.0.0"
+version: 2.0.1
+appVersion: "2.0.1"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -149,7 +149,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -226,7 +226,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -281,7 +281,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -411,7 +411,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -440,7 +440,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -511,7 +511,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -569,7 +569,7 @@ audioAnalyzerClap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer-clap
-    tag: 2.0.0
+    tag: 2.0.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always

--- a/docs/release-notes/RELEASE_NOTES_2.0.1.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.1.md
@@ -1,0 +1,38 @@
+# [2.0.1] Release Notes - 2026-08-13
+
+Soundspan 2.0.1 fixes the CLAP analyzer image for Helm deployments. Under the
+2.0.0 chart's default probes, CLAP analyzer pods never became Ready because the
+image did not include `pgrep`. The 2.0.1 image includes `pgrep`, so the default
+liveness and readiness probes work.
+
+## Before you upgrade
+
+No action is required before the upgrade. If you set
+`audioAnalyzerClap.livenessProbe` or `audioAnalyzerClap.readinessProbe` to
+`null` as a workaround, you can remove those overrides after the upgrade.
+
+## Deployment and distribution
+
+- Docker images: `ghcr.io/soundspan/*:2.0.1`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.0.1
+```
+
+The chart is published only after all eight `2.0.1` image tags are available.
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
+
+## Full changelog
+
+- Compare changes: [2.0.0...2.0.1](https://github.com/soundspan/soundspan/compare/2.0.0...2.0.1)
+- Full changelog: [CHANGELOG.md](https://github.com/soundspan/soundspan/blob/2.0.1/CHANGELOG.md)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soundspan-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soundspan-frontend",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages the 2.0.1 patch release (one fix: #449 — the CLAP analyzer image ships `pgrep`, so the chart's default probes work; closes the #448 known issue).

- CHANGELOG: `[Unreleased]` fix promoted to `[2.0.1] - 2026-08-13`; fresh empty scaffold added.
- Versions: backend + frontend `package.json`/locks, `Chart.yaml` version + appVersion, all eight `values.yaml` image tags → 2.0.1 (`version-sync.mjs --check` green).
- `RELEASE_NOTES_2.0.1.md`: short STE-lite patch notes, including workaround-removal guidance for Helm users.
- Generator + validator + canon all green (independently re-run).

Staging only — the tag and GitHub release follow after merge.