### PR TITLE
fix(import): remove the 15s M3U preview timeout bottleneck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- M3U playlist import previews no longer fail with a 15-second timeout on
+  large libraries. The frontend now gives the M3U preview the same 60-second
+  window as URL imports. The backend now matches entries against a prebuilt
+  library index instead of re-sorting and re-normalizing every library track
+  for each playlist entry, so previews complete in a fraction of the old
+  time.
+
 ## [2.0.1] - 2026-08-13
 
 ### Added
@@ -22,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The CLAP analyzer image now ships `pgrep` so the Helm chart's default liveness and readiness probes work (#448).
 
-## [2.0.0] - 2026-08-13
+## [2.0.0] - 2026-08-12
 
 ### Added
 

--- a/backend/src/services/playlistImportService.ts
+++ b/backend/src/services/playlistImportService.ts
@@ -17,6 +17,7 @@ import { ytMusicService } from "./youtubeMusic";
 import { tidalStreamingService } from "./tidalStreaming";
 import { trackMappingService } from "./trackMappingService";
 import {
+    buildM3UMatchIndex,
     matchM3UEntryAgainstLibrary,
     matchTrackAgainstLibrary,
     type LocalTrackCandidate,
@@ -501,9 +502,10 @@ class PlaylistImportService {
     }> {
         const entries = parseM3U(content);
         const localCandidates = await this.getLocalLibraryCandidates();
+        const matchIndex = buildM3UMatchIndex(localCandidates);
 
         const resolved = entries.map((entry, index) => {
-            const match = matchM3UEntryAgainstLibrary(entry, localCandidates);
+            const match = matchM3UEntryAgainstLibrary(entry, matchIndex);
             return {
                 index,
                 artist: entry.artist || "",

--- a/backend/src/utils/__tests__/trackMatching.test.ts
+++ b/backend/src/utils/__tests__/trackMatching.test.ts
@@ -1,4 +1,5 @@
 import {
+    buildM3UMatchIndex,
     matchM3UEntryAgainstLibrary,
     matchTrackAgainstLibrary,
     normalizeAlbumForMatching,
@@ -253,8 +254,39 @@ describe("trackMatching utilities", () => {
                 }),
             ];
 
-            expect(matchM3UEntryAgainstLibrary(entry, candidates)).toEqual({
+            expect(
+                matchM3UEntryAgainstLibrary(
+                    entry,
+                    buildM3UMatchIndex(candidates),
+                ),
+            ).toEqual({
                 trackId: "path-hit",
+                matchType: "path",
+                matchConfidence: 100,
+            });
+        });
+
+        it("matches when the library path is longer than the entry path", () => {
+            const entry: M3UEntry = {
+                filePath: "Artist/Album/02 - Deep Cut.flac",
+                artist: null,
+                title: null,
+                durationSeconds: null,
+            };
+            const candidates: LocalTrackCandidate[] = [
+                makeCandidate({
+                    id: "suffix-hit",
+                    filePath: "/srv/music/Artist/Album/02 - Deep Cut.flac",
+                }),
+            ];
+
+            expect(
+                matchM3UEntryAgainstLibrary(
+                    entry,
+                    buildM3UMatchIndex(candidates),
+                ),
+            ).toEqual({
+                trackId: "suffix-hit",
                 matchType: "path",
                 matchConfidence: 100,
             });
@@ -274,11 +306,146 @@ describe("trackMatching utilities", () => {
                 }),
             ];
 
-            expect(matchM3UEntryAgainstLibrary(entry, candidates)).toEqual({
+            expect(
+                matchM3UEntryAgainstLibrary(
+                    entry,
+                    buildM3UMatchIndex(candidates),
+                ),
+            ).toEqual({
                 trackId: "filename-hit",
                 matchType: "filename",
                 matchConfidence: 98,
             });
+        });
+
+        it("resolves filename ties to the candidate first in (filePath, id) order", () => {
+            const entry: M3UEntry = {
+                filePath: "X:/Somewhere/Duplicate Song.mp3",
+                artist: null,
+                title: null,
+                durationSeconds: null,
+            };
+            const candidates: LocalTrackCandidate[] = [
+                makeCandidate({
+                    id: "later",
+                    filePath: "Library/Z Artist/Duplicate Song.mp3",
+                }),
+                makeCandidate({
+                    id: "earlier",
+                    filePath: "Library/A Artist/Duplicate Song.mp3",
+                }),
+            ];
+
+            expect(
+                matchM3UEntryAgainstLibrary(
+                    entry,
+                    buildM3UMatchIndex(candidates),
+                ),
+            ).toEqual({
+                trackId: "earlier",
+                matchType: "filename",
+                matchConfidence: 98,
+            });
+        });
+
+        it("falls back to exact metadata matching when path tiers miss", () => {
+            const entry: M3UEntry = {
+                filePath: "Missing/Path/No Match Here.flac",
+                artist: "The Metadata Band",
+                title: "Exact Song - 2011 Remastered Version",
+                durationSeconds: 200,
+            };
+            const candidates: LocalTrackCandidate[] = [
+                makeCandidate({
+                    id: "metadata-hit",
+                    filePath: "Library/The Metadata Band/Exact Song.flac",
+                    artistName: "The Metadata Band",
+                    title: "Exact Song",
+                }),
+            ];
+
+            expect(
+                matchM3UEntryAgainstLibrary(
+                    entry,
+                    buildM3UMatchIndex(candidates),
+                ),
+            ).toEqual({
+                trackId: "metadata-hit",
+                matchType: "exact",
+                matchConfidence: 100,
+            });
+        });
+
+        it("falls back to fuzzy metadata matching as the last tier", () => {
+            const entry: M3UEntry = {
+                filePath: "Missing/Path/Nowhere.flac",
+                artist: "Fuzzy Artist",
+                title: "Fuzzy Song Title Extended",
+                durationSeconds: 200,
+            };
+            const candidates: LocalTrackCandidate[] = [
+                makeCandidate({
+                    id: "fuzzy-hit",
+                    filePath: "Library/Fuzzy Artist/Fuzzy Song Title.flac",
+                    artistName: "Fuzzy Artist",
+                    title: "Fuzzy Song Title",
+                }),
+            ];
+
+            const result = matchM3UEntryAgainstLibrary(
+                entry,
+                buildM3UMatchIndex(candidates),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.trackId).toBe("fuzzy-hit");
+            expect(result?.matchType).toBe("fuzzy");
+            expect(result?.matchConfidence).toBeGreaterThanOrEqual(70);
+        });
+
+        it("returns null when the index has no candidates", () => {
+            const entry: M3UEntry = {
+                filePath: "Anything.mp3",
+                artist: "Artist",
+                title: "Title",
+                durationSeconds: null,
+            };
+
+            expect(
+                matchM3UEntryAgainstLibrary(entry, buildM3UMatchIndex([])),
+            ).toBeNull();
+        });
+
+        it("matches many entries against one prebuilt index", () => {
+            const candidates: LocalTrackCandidate[] = [
+                makeCandidate({
+                    id: "a",
+                    filePath: "Library/One/Alpha.mp3",
+                }),
+                makeCandidate({
+                    id: "b",
+                    filePath: "Library/Two/Beta.mp3",
+                }),
+            ];
+            const index = buildM3UMatchIndex(candidates);
+            const entries: M3UEntry[] = [
+                {
+                    filePath: "C:/Alpha.mp3",
+                    artist: null,
+                    title: null,
+                    durationSeconds: null,
+                },
+                {
+                    filePath: "C:/Beta.mp3",
+                    artist: null,
+                    title: null,
+                    durationSeconds: null,
+                },
+            ];
+
+            const results = entries.map((e) =>
+                matchM3UEntryAgainstLibrary(e, index),
+            );
+            expect(results.map((r) => r?.trackId)).toEqual(["a", "b"]);
         });
     });
 });

--- a/backend/src/utils/trackMatching.ts
+++ b/backend/src/utils/trackMatching.ts
@@ -75,9 +75,10 @@ export function normalizeAlbumForMatching(str: string): string {
  * Computes a 0-100 similarity score between two strings.
  */
 export function stringSimilarity(a: string, b: string): number {
-    const s1 = normalizeString(a);
-    const s2 = normalizeString(b);
+    return normalizedStringSimilarity(normalizeString(a), normalizeString(b));
+}
 
+function normalizedStringSimilarity(s1: string, s2: string): number {
     if (s1 === s2) return 100;
 
     if (s1.includes(s2) || s2.includes(s1)) {
@@ -237,84 +238,228 @@ export function matchTrackAgainstLibrary(
     return null;
 }
 
+// ── M3U match index ───────────────────────────────────────────────
+
+/**
+ * A library candidate with its match-tier normalizations precomputed.
+ */
+export interface IndexedM3UCandidate {
+    candidate: LocalTrackCandidate;
+    /** Normalized file path; empty string when the candidate has no path. */
+    normalizedPath: string;
+    /** `normalizeString` of the artist name (exact and fuzzy tiers). */
+    normalizedArtist: string;
+    /** `normalizeTrackTitle` of the track title (exact tier). */
+    normalizedExactTitle: string;
+    /** `normalizeString` of the track title (fuzzy tier). */
+    normalizedFuzzyTitle: string;
+}
+
+/**
+ * Precomputed lookup structures for matching many M3U entries against the
+ * same library snapshot. Build once per playlist with `buildM3UMatchIndex`.
+ */
+export interface M3UMatchIndex {
+    /** All candidates in deterministic (filePath, id) order. */
+    sorted: IndexedM3UCandidate[];
+    /**
+     * Path-tier buckets keyed by the final normalized path segment. Every
+     * path-tier condition (equality or `/`-boundary suffix in either
+     * direction) requires the entry and candidate to share their final path
+     * segment, so a match can only live in the entry's own bucket.
+     */
+    pathBuckets: Map<string, IndexedM3UCandidate[]>;
+    /** First sorted candidate per normalized filename stem. */
+    byFilenameStem: Map<string, LocalTrackCandidate>;
+    /** First sorted candidate per normalized `artist\u0000title` pair. */
+    byArtistTitle: Map<string, LocalTrackCandidate>;
+}
+
+function lastPathSegment(normalizedPath: string): string {
+    const separatorIndex = normalizedPath.lastIndexOf("/");
+    if (separatorIndex === -1) return normalizedPath;
+    return normalizedPath.slice(separatorIndex + 1);
+}
+
+function artistTitleKey(normalizedArtist: string, normalizedTitle: string) {
+    return `${normalizedArtist}\u0000${normalizedTitle}`;
+}
+
+/**
+ * Builds the reusable match index for `matchM3UEntryAgainstLibrary`.
+ * Sorting and normalization happen once here instead of once per entry.
+ */
+export function buildM3UMatchIndex(
+    candidates: LocalTrackCandidate[],
+): M3UMatchIndex {
+    const sorted = [...candidates]
+        .sort((a, b) => {
+            const pathCompare = (a.filePath || "").localeCompare(
+                b.filePath || "",
+            );
+            if (pathCompare !== 0) return pathCompare;
+            return a.id.localeCompare(b.id);
+        })
+        .map((candidate) => ({
+            candidate,
+            normalizedPath: candidate.filePath
+                ? normalizePathForMatching(candidate.filePath)
+                : "",
+            normalizedArtist: normalizeString(candidate.artistName),
+            normalizedExactTitle: normalizeTrackTitle(candidate.title),
+            normalizedFuzzyTitle: normalizeString(candidate.title),
+        }));
+
+    const pathBuckets = new Map<string, IndexedM3UCandidate[]>();
+    const byFilenameStem = new Map<string, LocalTrackCandidate>();
+    const byArtistTitle = new Map<string, LocalTrackCandidate>();
+
+    for (const indexed of sorted) {
+        const { candidate } = indexed;
+        if (candidate.filePath) {
+            const segment = lastPathSegment(indexed.normalizedPath);
+            const bucket = pathBuckets.get(segment);
+            if (bucket) {
+                bucket.push(indexed);
+            } else {
+                pathBuckets.set(segment, [indexed]);
+            }
+
+            const stem = normalizeTrackTitle(
+                getFilenameStem(candidate.filePath),
+            );
+            if (stem.length > 0 && !byFilenameStem.has(stem)) {
+                byFilenameStem.set(stem, candidate);
+            }
+        }
+
+        const key = artistTitleKey(
+            indexed.normalizedArtist,
+            indexed.normalizedExactTitle,
+        );
+        if (!byArtistTitle.has(key)) {
+            byArtistTitle.set(key, candidate);
+        }
+    }
+
+    return { sorted, pathBuckets, byFilenameStem, byArtistTitle };
+}
+
+function matchM3UEntryFuzzy(
+    normalizedArtist: string,
+    normalizedFuzzyTitle: string,
+    index: M3UMatchIndex,
+): TrackMatchResult | null {
+    let bestScore = 0;
+    let bestMatch: LocalTrackCandidate | null = null;
+
+    // Artist names repeat across a library, so score each distinct one once.
+    const artistScoreCache = new Map<string, number>();
+
+    for (const indexed of index.sorted) {
+        let artistScore = artistScoreCache.get(indexed.normalizedArtist);
+        if (artistScore === undefined) {
+            artistScore = normalizedStringSimilarity(
+                normalizedArtist,
+                indexed.normalizedArtist,
+            );
+            artistScoreCache.set(indexed.normalizedArtist, artistScore);
+        }
+
+        // A title score is at most 100, so this bound is exact: candidates
+        // that cannot reach the 70 threshold or beat the current best can
+        // skip the title comparison without changing the outcome.
+        const maxPossibleScore = 100 * 0.6 + artistScore * 0.4;
+        if (maxPossibleScore < 70 || maxPossibleScore <= bestScore) {
+            continue;
+        }
+
+        const titleScore = normalizedStringSimilarity(
+            normalizedFuzzyTitle,
+            indexed.normalizedFuzzyTitle,
+        );
+        // Title weighted 60%, artist 40%
+        const score = titleScore * 0.6 + artistScore * 0.4;
+
+        if (score > bestScore && score >= 70) {
+            bestScore = score;
+            bestMatch = indexed.candidate;
+        }
+    }
+
+    if (!bestMatch) return null;
+    return {
+        trackId: bestMatch.id,
+        matchType: "fuzzy",
+        matchConfidence: Math.round(bestScore),
+    };
+}
+
 /**
  * Match an M3U entry against the local library using the agreed tier order:
  * 1. Normalized file path suffix match
  * 2. Filename stem match
  * 3. Exact metadata match
  * 4. Fuzzy metadata match
+ *
+ * The album-aware strategies of `matchTrackAgainstLibrary` cannot fire on
+ * this path — M3U entries carry no album, and the exact artist+title tier
+ * has already missed by the time the fuzzy tier runs — so the fuzzy tier
+ * replicates only the fuzzy strategy over the precomputed index.
  */
 export function matchM3UEntryAgainstLibrary(
     entry: M3UEntry,
-    candidates: LocalTrackCandidate[],
+    index: M3UMatchIndex,
 ): TrackMatchResult | null {
-    if (!candidates.length) return null;
-
-    const sortedCandidates = [...candidates].sort((a, b) => {
-        const pathCompare = (a.filePath || "").localeCompare(b.filePath || "");
-        if (pathCompare !== 0) return pathCompare;
-        return a.id.localeCompare(b.id);
-    });
+    if (!index.sorted.length) return null;
 
     const entryPath = normalizePathForMatching(entry.filePath);
-
-    for (const candidate of sortedCandidates) {
-        if (!candidate.filePath) continue;
-        const candidatePath = normalizePathForMatching(candidate.filePath);
-        if (
-            candidatePath === entryPath ||
-            entryPath.endsWith(`/${candidatePath}`) ||
-            candidatePath.endsWith(`/${entryPath}`)
-        ) {
-            return {
-                trackId: candidate.id,
-                matchType: "path",
-                matchConfidence: 100,
-            };
+    const bucket = index.pathBuckets.get(lastPathSegment(entryPath));
+    if (bucket) {
+        for (const { candidate, normalizedPath } of bucket) {
+            if (
+                normalizedPath === entryPath ||
+                entryPath.endsWith(`/${normalizedPath}`) ||
+                normalizedPath.endsWith(`/${entryPath}`)
+            ) {
+                return {
+                    trackId: candidate.id,
+                    matchType: "path",
+                    matchConfidence: 100,
+                };
+            }
         }
     }
 
     const entryFilename = normalizeTrackTitle(getFilenameStem(entry.filePath));
     if (entryFilename.length > 0) {
-        for (const candidate of sortedCandidates) {
-            if (!candidate.filePath) continue;
-            const candidateFilename = normalizeTrackTitle(
-                getFilenameStem(candidate.filePath),
-            );
-            if (candidateFilename === entryFilename) {
-                return {
-                    trackId: candidate.id,
-                    matchType: "filename",
-                    matchConfidence: 98,
-                };
-            }
+        const filenameHit = index.byFilenameStem.get(entryFilename);
+        if (filenameHit) {
+            return {
+                trackId: filenameHit.id,
+                matchType: "filename",
+                matchConfidence: 98,
+            };
         }
     }
 
     if (entry.artist && entry.title) {
         const normalizedArtist = normalizeString(entry.artist);
-        const normalizedTitle = normalizeTrackTitle(entry.title);
-
-        for (const candidate of sortedCandidates) {
-            if (
-                normalizeString(candidate.artistName) === normalizedArtist &&
-                normalizeTrackTitle(candidate.title) === normalizedTitle
-            ) {
-                return {
-                    trackId: candidate.id,
-                    matchType: "exact",
-                    matchConfidence: 100,
-                };
-            }
+        const exactHit = index.byArtistTitle.get(
+            artistTitleKey(normalizedArtist, normalizeTrackTitle(entry.title)),
+        );
+        if (exactHit) {
+            return {
+                trackId: exactHit.id,
+                matchType: "exact",
+                matchConfidence: 100,
+            };
         }
 
-        return matchTrackAgainstLibrary(
-            {
-                artist: entry.artist,
-                title: entry.title,
-                duration: entry.durationSeconds ?? undefined,
-            },
-            sortedCandidates,
+        return matchM3UEntryFuzzy(
+            normalizedArtist,
+            normalizeString(entry.title),
+            index,
         );
     }
 

--- a/frontend/lib/api/imports.ts
+++ b/frontend/lib/api/imports.ts
@@ -32,6 +32,7 @@ export function WithImports<TBase extends ApiClientConstructor>(Base: TBase) {
             return this.request("/import/m3u/preview", {
                 method: "POST",
                 body: JSON.stringify({ content, name }),
+                timeoutMs: IMPORT_PREVIEW_TIMEOUT_MS,
             });
         }
 

--- a/frontend/tests/unit/importApiTimeouts.test.ts
+++ b/frontend/tests/unit/importApiTimeouts.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ApiClientCore, IMPORT_PREVIEW_TIMEOUT_MS } from "@/lib/api/core";
+import { WithImports } from "@/lib/api/imports";
+
+// Import previews resolve every playlist entry against the library before
+// responding, so they can legitimately outlive the default request timeout.
+// These tests pin the extended-timeout contract for both preview endpoints.
+
+interface RecordedCall {
+    endpoint: string;
+    timeoutMs: number | undefined;
+}
+
+class RecordingCore extends ApiClientCore {
+    public readonly calls: RecordedCall[] = [];
+
+    override async request<T>(
+        endpoint: string,
+        options: RequestInit & { timeoutMs?: number } = {},
+    ): Promise<T> {
+        this.calls.push({ endpoint, timeoutMs: options.timeoutMs });
+        return {} as T;
+    }
+}
+
+class ImportsClient extends WithImports(RecordingCore) {}
+
+test("previewM3UImport uses the extended import-preview timeout", async () => {
+    const client = new ImportsClient();
+    await client.previewM3UImport("#EXTM3U\n/music/song.mp3", "My Mix");
+
+    assert.equal(client.calls.length, 1);
+    assert.equal(client.calls[0].endpoint, "/import/m3u/preview");
+    assert.equal(client.calls[0].timeoutMs, IMPORT_PREVIEW_TIMEOUT_MS);
+});
+
+test("previewPlaylistImport uses the extended import-preview timeout", async () => {
+    const client = new ImportsClient();
+    await client.previewPlaylistImport("https://example.com/playlist/123");
+
+    assert.equal(client.calls.length, 1);
+    assert.equal(client.calls[0].endpoint, "/import/preview");
+    assert.equal(client.calls[0].timeoutMs, IMPORT_PREVIEW_TIMEOUT_MS);
+});


### PR DESCRIPTION
## Summary

Importing an M3U playlist could fail with a 15-second timeout. Two causes:

1. The frontend gave `/import/m3u/preview` the default 15-second API timeout. The URL-based preview already had a 60-second override.
2. The backend matcher re-sorted and re-normalized the entire library candidate list for every playlist entry, so large libraries could not finish inside any reasonable window.

## Changes

- `previewM3UImport` now passes `IMPORT_PREVIEW_TIMEOUT_MS` (60s), matching the URL preview.
- New `buildM3UMatchIndex` sorts and normalizes the library once per preview. The path, filename, and exact-metadata tiers resolve through hash lookups. The path tier buckets candidates by final path segment, which every path-tier condition requires to be equal.
- The fuzzy tier caches artist scores per distinct artist and skips candidates whose best possible score cannot reach the 70-point threshold. The skip bound is exact, so match results and tie-breaking are unchanged.

Benchmark (50k-track library, 1,000-entry playlist, half resolving through the path tier and half falling through to the fuzzy tier): index build 268ms, matching ~10s. The previous implementation re-sorted the library per entry and did not complete in minutes at this scale. Realistic playlists resolve mostly through the path/filename tiers, which are now constant-time per entry.

## Testing

- verify: backend `test:coverage` — 334 suites, 5,349 tests, all pass
- verify: backend `tsc --noEmit` exit 0
- verify: frontend `test:coverage`, `test:component` (545 tests), `typecheck`, `lint` — all pass
- verify: `npm run verify:gates` exit 0
- New tests: M3U tier order, suffix-path direction, filename tie-breaking determinism, exact/fuzzy fallback, empty index, index reuse; frontend timeout contract for both preview endpoints

## Changelog

Recorded under Unreleased → Fixed. No release cut.