### PR TITLE
chore(release): stage 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2.0.2] - 2026-08-13
+
+### Added
+
+### Changed
+
+### Fixed
+
 - M3U playlist import previews no longer fail with a 15-second timeout on
   large libraries. The frontend now gives the M3U preview the same 60-second
   window as URL imports. The backend now matches entries against a prebuilt

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.0.1
-appVersion: "2.0.1"
+version: 2.0.2
+appVersion: "2.0.2"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -149,7 +149,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -226,7 +226,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -281,7 +281,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -411,7 +411,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -440,7 +440,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -511,7 +511,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -569,7 +569,7 @@ audioAnalyzerClap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer-clap
-    tag: 2.0.1
+    tag: 2.0.2
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -814,3 +814,4 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
+

--- a/docs/release-notes/RELEASE_NOTES_2.0.2.md
+++ b/docs/release-notes/RELEASE_NOTES_2.0.2.md
@@ -1,0 +1,45 @@
+# [2.0.2] Release Notes - 2026-08-13
+
+Soundspan 2.0.2 fixes M3U playlist import previews for large libraries. Under
+2.0.1, the M3U preview request used the default 15-second timeout, and the
+matcher re-sorted and re-normalized the whole library for every playlist
+entry, so large previews timed out before they finished. The 2.0.2 preview
+request allows 60 seconds, and the matcher resolves entries against a
+prebuilt library index, so previews complete in a fraction of the old time.
+Match results are unchanged.
+
+## Before you upgrade
+
+**Warning:** If you run a version earlier than 2.0.0, do not upgrade directly
+to 2.0.2. Complete the 2.0.0 breaking changes first. See
+[Upgrading from an earlier version](#upgrading-from-an-earlier-version).
+
+If you already run 2.0.0 or 2.0.1, no action is required before the upgrade.
+
+## Deployment and distribution
+
+- Docker images: `ghcr.io/soundspan/*:2.0.2`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.0.2
+```
+
+The chart is published only after all eight `2.0.2` image tags are available.
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, you must complete the
+2.0.0 upgrade before you install 2.0.2. The 2.0.0 release contains breaking
+changes that later releases depend on. Read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
+
+## Full changelog
+
+- Compare changes: [2.0.1...2.0.2](https://github.com/soundspan/soundspan/compare/2.0.1...2.0.2)
+- Full changelog: [CHANGELOG.md](https://github.com/soundspan/soundspan/blob/2.0.2/CHANGELOG.md)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soundspan-frontend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soundspan-frontend",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages the 2.0.2 patch release.

- Rolls the Unreleased M3U import preview fix into a dated `2.0.2` changelog section.
- Bumps every release version surface: backend/frontend `package.json` + lockfiles, chart `version`/`appVersion`, and all eight `values.yaml` image tags (same surfaces as the 2.0.1 staging PR #450).
- Adds `docs/release-notes/RELEASE_NOTES_2.0.2.md` in the 2.0.1 format, with an explicit warning that pre-2.0.0 deployments must complete the 2.0.0 breaking upgrade before installing 2.0.2.

Verification:

- verify: `node scripts/release/version-sync.mjs --version 2.0.2 --check` passes
- verify: `scripts/release/validate-release-version.sh 2.0.2` exit 0
- verify: `npm run check:infra-release:test` passes
- verify: release-notes script tests pass (2/2)
- verify: Prettier clean on all touched files

After merge, the `2.0.2` GitHub release will be created with the notes file as the body, which triggers the eight image builds and the chart publish.