### PR TITLE
fix(enrichment): bound analyzer queues and retry failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,9 @@ LOG_LEVEL=debug
 # Set to 'false' to disable a subsystem; its API prefixes return 404 and its
 # background workers are not registered.
 # AUDIO_ANALYSIS_ENABLED=true   # Audio analysis queueing (Essentia + CLAP), mood buckets, /api/analysis, /api/vibe
+# AUDIO_ANALYSIS_QUEUE_MAX_DEPTH=100  # Maximum pending Redis jobs admitted for MusicCNN analysis
+# VIBE_ANALYSIS_QUEUE_MAX_DEPTH=100   # Maximum pending Redis jobs admitted for CLAP embeddings
+# ANALYSIS_QUEUE_RESERVATION_TTL_SECONDS=3600  # Self-healing per-track enqueue reservation
 # DISCOVERY_ENABLED=true        # Discover Weekly cron/processor, /api/discover, /api/recommendations
 # AUTO_PLAYLISTS_ENABLED=true   # Made For You mixes on-demand generation, /api/mixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The enrichment failures modal now provides confirmed, tab-specific “Retry
+  all” actions for Audio Analysis and Vibe Embeddings failures.
+
 ### Changed
 
 ### Fixed
+
+- Background audio-analysis and vibe-embedding producers now use bounded,
+  deduplicated Redis admission and leave queued tracks pending until an
+  analyzer claims them. Queue wait time no longer consumes the processing
+  timeout or creates false stale-processing failures during large library
+  imports.
+- Retrying all failed analyzer work now resets retry budgets and lets the
+  bounded background producer drain the backlog instead of enqueueing every
+  failed track at once. Selected vibe failures can also be retried correctly.
 
 - Backend track-mapping reconciliation now reuses a normalized local-library
   index, yields between mapping attempts, and enforces configurable per-run

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -366,6 +366,26 @@ export const config = {
         autoPlaylists: parseEnvBool(process.env.AUTO_PLAYLISTS_ENABLED, true),
     },
 
+    // Keep analyzer queues short enough that waiting work is not mistaken for
+    // active processing. Per-track reservations suppress repeated producers.
+    analysisQueues: {
+        audioMaxDepth: boundedPositiveIntEnvOr(
+            process.env.AUDIO_ANALYSIS_QUEUE_MAX_DEPTH,
+            100,
+            10_000,
+        ),
+        vibeMaxDepth: boundedPositiveIntEnvOr(
+            process.env.VIBE_ANALYSIS_QUEUE_MAX_DEPTH,
+            100,
+            10_000,
+        ),
+        reservationTtlSeconds: boundedPositiveIntEnvOr(
+            process.env.ANALYSIS_QUEUE_RESERVATION_TTL_SECONDS,
+            3600,
+            86_400,
+        ),
+    },
+
     listenTogether: {
         reconnectSloMs: positiveIntEnvOr(
             process.env.LISTEN_TOGETHER_RECONNECT_SLO_MS,

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -37,6 +37,9 @@ jest.mock("../../utils/db", () => ({
             findUnique: jest.fn(),
             update: jest.fn(),
         },
+        trackEmbedding: {
+            deleteMany: jest.fn(),
+        },
         systemSettings: {
             update: jest.fn(),
         },
@@ -81,6 +84,8 @@ const mockTrackFindMany = prisma.track.findMany as jest.Mock;
 const mockTrackUpdateMany = prisma.track.updateMany as jest.Mock;
 const mockTrackFindUnique = prisma.track.findUnique as jest.Mock;
 const mockTrackUpdate = prisma.track.update as jest.Mock;
+const mockTrackEmbeddingDeleteMany = prisma.trackEmbedding
+    .deleteMany as jest.Mock;
 const mockSystemSettingsUpdate = prisma.systemSettings.update as jest.Mock;
 const mockQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockExecuteRaw = prisma.$executeRaw as jest.Mock;
@@ -212,6 +217,7 @@ describe("analysis routes runtime", () => {
         mockTrackUpdateMany.mockResolvedValue({ count: 0 });
         mockTrackFindUnique.mockResolvedValue(null);
         mockTrackUpdate.mockResolvedValue({});
+        mockTrackEmbeddingDeleteMany.mockResolvedValue({ count: 0 });
         mockSystemSettingsUpdate.mockResolvedValue({});
         mockQueryRaw.mockResolvedValue([]);
         mockExecuteRaw.mockResolvedValue(0);
@@ -336,6 +342,16 @@ describe("analysis routes runtime", () => {
         const res = createRes();
 
         await postRetryFailed(req, res);
+
+        expect(mockTrackUpdateMany).toHaveBeenCalledWith({
+            where: { analysisStatus: "failed" },
+            data: {
+                analysisStatus: "pending",
+                analysisError: null,
+                analysisRetryCount: 0,
+                analysisStartedAt: null,
+            },
+        });
 
         expect(res.body).toEqual({
             message: "Reset 6 failed tracks to pending",
@@ -635,7 +651,7 @@ describe("analysis routes runtime", () => {
     it("queues vibe embedding jobs in force mode and clears failures", async () => {
         const pipeline = createPipeline();
         mockRedisMulti.mockReturnValue(pipeline);
-        mockQueryRaw.mockResolvedValue([
+        mockTrackFindMany.mockResolvedValue([
             { id: "t1", filePath: "/x.mp3", duration: 111, title: "T1" },
             { id: "t2", filePath: "/y.mp3", duration: 222, title: "T2" },
         ]);
@@ -645,7 +661,8 @@ describe("analysis routes runtime", () => {
 
         await postVibeStart(req, res);
 
-        expect(mockExecuteRaw).toHaveBeenCalled();
+        expect(mockTrackEmbeddingDeleteMany).toHaveBeenCalledWith();
+        expect(mockQueryRaw).not.toHaveBeenCalled();
         expect(mockTrackUpdateMany).toHaveBeenCalledWith({
             data: expect.objectContaining({
                 vibeAnalysisStatus: "pending",
@@ -666,7 +683,7 @@ describe("analysis routes runtime", () => {
     });
 
     it("returns no-op vibe start when all tracks already have embeddings", async () => {
-        mockQueryRaw.mockResolvedValue([]);
+        mockTrackFindMany.mockResolvedValue([]);
         const req = { body: {} } as any;
         const res = createRes();
         await postVibeStart(req, res);
@@ -676,43 +693,36 @@ describe("analysis routes runtime", () => {
         });
     });
 
-    it("retries vibe failures or no-ops when none exist", async () => {
-        mockGetFailures.mockResolvedValueOnce({ failures: [] });
+    it("resets all failed vibe rows without bulk queueing", async () => {
+        mockTrackUpdateMany.mockResolvedValueOnce({ count: 0 });
         const noFailuresReq = {} as any;
         const noFailuresRes = createRes();
         await postVibeRetry(noFailuresReq, noFailuresRes);
         expect(noFailuresRes.body).toEqual({
             message: "No vibe failures to retry",
-            queued: 0,
+            reset: 0,
         });
 
-        const pipeline = createPipeline();
-        mockRedisMulti.mockReturnValue(pipeline);
-        mockGetFailures.mockResolvedValueOnce({
-            failures: [{ id: "f1", entityId: "t9" }],
-        });
-        mockTrackFindMany.mockResolvedValueOnce([
-            { id: "t9", filePath: "/t9.mp3", duration: 123, title: "T9" },
-        ]);
+        mockTrackUpdateMany.mockResolvedValueOnce({ count: 1204 });
 
         const req = {} as any;
         const res = createRes();
         await postVibeRetry(req, res);
 
         expect(mockTrackUpdateMany).toHaveBeenCalledWith({
-            where: { id: { in: ["t9"] } },
+            where: { vibeAnalysisStatus: "failed" },
             data: expect.objectContaining({
                 vibeAnalysisStatus: "pending",
                 vibeAnalysisError: null,
                 vibeAnalysisStartedAt: null,
+                vibeAnalysisRetryCount: 0,
                 vibeAnalysisStatusUpdatedAt: expect.any(Date),
             }),
         });
-        expect(pipeline.rPush).toHaveBeenCalledTimes(1);
-        expect(mockResetRetryCount).toHaveBeenCalledWith(["f1"]);
+        expect(mockRedisMulti).not.toHaveBeenCalled();
         expect(res.body).toEqual({
-            message: "Queued 1 failed tracks for vibe embedding retry",
-            queued: 1,
+            message: "Reset 1204 failed tracks for vibe embedding retry",
+            reset: 1204,
         });
     });
 
@@ -875,7 +885,7 @@ describe("analysis routes runtime", () => {
     });
 
     it("returns 500 when starting vibe embedding catch branch is hit", async () => {
-        mockQueryRaw.mockRejectedValue(new Error("vibe start failed"));
+        mockTrackFindMany.mockRejectedValue(new Error("vibe start failed"));
         const req = { body: {} } as any;
         const res = createRes();
 
@@ -886,7 +896,7 @@ describe("analysis routes runtime", () => {
     });
 
     it("returns 500 when retry vibe failures catch branch is hit", async () => {
-        mockGetFailures.mockRejectedValue(new Error("vibe retry failed"));
+        mockTrackUpdateMany.mockRejectedValue(new Error("vibe retry failed"));
         const req = {} as any;
         const res = createRes();
 

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -1109,7 +1109,12 @@ describe("enrichment route runtime behavior", () => {
         expect(mockResolveFailures).toHaveBeenCalledWith(["f-track"]);
         expect(mockTrackUpdate).toHaveBeenCalledWith({
             where: { id: "track-1" },
-            data: { analysisStatus: "pending", analysisRetryCount: 0 },
+            data: {
+                analysisStatus: "pending",
+                analysisError: null,
+                analysisRetryCount: 0,
+                analysisStartedAt: null,
+            },
         });
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
@@ -1117,6 +1122,41 @@ describe("enrichment route runtime behavior", () => {
                 "Queued 2 items for retry, 1 skipped (entities no longer exist)",
             queued: 2,
             skipped: 1,
+        });
+    });
+
+    it("resets a selected vibe failure for bounded background admission", async () => {
+        mockGetFailure.mockResolvedValueOnce({
+            id: "f-vibe",
+            entityType: "vibe",
+            entityId: "track-vibe",
+        });
+        mockTrackFindUnique.mockResolvedValueOnce({ id: "track-vibe" });
+        const res = createRes();
+
+        await retryHandler(
+            {
+                body: { ids: ["f-vibe"] },
+                user: { id: "admin-1" },
+            } as any,
+            res,
+        );
+
+        expect(mockTrackUpdate).toHaveBeenCalledWith({
+            where: { id: "track-vibe" },
+            data: {
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisError: null,
+                vibeAnalysisRetryCount: 0,
+                vibeAnalysisStartedAt: null,
+                vibeAnalysisStatusUpdatedAt: expect.any(Date),
+            },
+        });
+        expect(res.body).toEqual({
+            message:
+                "Queued 1 items for retry, 0 skipped (entities no longer exist)",
+            queued: 1,
+            skipped: 0,
         });
     });
 

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -217,6 +217,8 @@ router.post("/retry-failed", requireAuth, requireAdmin, async (req, res) => {
             data: {
                 analysisStatus: "pending",
                 analysisError: null,
+                analysisRetryCount: 0,
+                analysisStartedAt: null,
             },
         });
 
@@ -773,11 +775,16 @@ router.put("/clap-workers", requireAuth, requireAdmin, async (req, res) => {
  */
 router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
     try {
-        const { limit = 500, force = false } = req.body;
+        const requestedLimit = Number(req.body.limit ?? 500);
+        const limit =
+            Number.isSafeInteger(requestedLimit) && requestedLimit > 0
+                ? Math.min(requestedLimit, 1000)
+                : 500;
+        const force = req.body.force === true;
 
         // If force mode, delete all existing embeddings first
         if (force) {
-            await prisma.$executeRaw`DELETE FROM track_embeddings`;
+            await prisma.trackEmbedding.deleteMany();
             await prisma.track.updateMany({
                 data: {
                     ...buildVibePendingReset(),
@@ -789,17 +796,19 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
         }
 
         // Find tracks without vibe embeddings (all tracks if force was used)
-        const tracks = await prisma.$queryRaw<
-            { id: string; filePath: string; duration: number; title: string }[]
-        >`
-            SELECT t.id, t."filePath", t.duration, t.title
-            FROM "Track" t
-            LEFT JOIN track_embeddings te ON t.id = te.track_id
-            WHERE te.track_id IS NULL
-            AND t."filePath" IS NOT NULL
-            ORDER BY t."fileModified" DESC
-            LIMIT ${limit}
-        `;
+        const tracks = await prisma.track.findMany({
+            where: {
+                embedding: null,
+            },
+            select: {
+                id: true,
+                filePath: true,
+                duration: true,
+                title: true,
+            },
+            orderBy: { fileModified: "desc" },
+            take: limit,
+        });
 
         if (tracks.length === 0) {
             return res.json({
@@ -854,14 +863,14 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
  * @openapi
  * /api/analysis/vibe/retry:
  *   post:
- *     summary: Retry failed vibe embeddings
+ *     summary: Reset all failed vibe embeddings for bounded retry
  *     tags: [Analysis]
  *     security:
  *       - sessionAuth: []
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Failed tracks queued for vibe embedding retry
+ *         description: Failed tracks reset to pending for bounded background retry
  *       401:
  *         description: Not authenticated
  *       403:
@@ -873,65 +882,26 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
  */
 router.post("/vibe/retry", requireAuth, requireAdmin, async (req, res) => {
     try {
-        // Get all vibe failures
-        const { failures } = await enrichmentFailureService.getFailures({
-            entityType: "vibe",
-            includeSkipped: false,
-            includeResolved: false,
+        const result = await prisma.track.updateMany({
+            where: { vibeAnalysisStatus: "failed" },
+            data: {
+                ...buildVibePendingReset(),
+                vibeAnalysisRetryCount: 0,
+            },
         });
 
-        if (failures.length === 0) {
+        if (result.count === 0) {
             return res.json({
                 message: "No vibe failures to retry",
-                queued: 0,
+                reset: 0,
             });
         }
 
-        // Get track details for failed tracks
-        const trackIds = failures.map((f) => f.entityId);
-        const tracks = await prisma.track.findMany({
-            where: { id: { in: trackIds } },
-            select: { id: true, filePath: true, duration: true, title: true },
-        });
-
-        if (tracks.length === 0) {
-            return res.json({
-                message: "No failed tracks found for vibe retry",
-                queued: 0,
-            });
-        }
-
-        // Retry should clear failed state before enqueue so queue loss does not
-        // leave tracks permanently stranded as failed.
-        await prisma.track.updateMany({
-            where: { id: { in: tracks.map((track) => track.id) } },
-            data: buildVibePendingReset(),
-        });
-
-        // Queue for retry
-        const pipeline = redisClient.multi();
-        for (const track of tracks) {
-            pipeline.rPush(
-                VIBE_QUEUE,
-                JSON.stringify({
-                    trackId: track.id,
-                    filePath: track.filePath,
-                    duration: track.duration,
-                }),
-            );
-        }
-        await pipeline.exec();
-
-        // Reset retry counts
-        await enrichmentFailureService.resetRetryCount(
-            failures.map((f) => f.id),
-        );
-
-        logger.info(`Retrying ${tracks.length} failed vibe embeddings`);
+        logger.info(`Reset ${result.count} failed vibe embeddings for retry`);
 
         res.json({
-            message: `Queued ${tracks.length} failed tracks for vibe embedding retry`,
-            queued: tracks.length,
+            message: `Reset ${result.count} failed tracks for vibe embedding retry`,
+            reset: result.count,
         });
     } catch (error: any) {
         logger.error("Retry vibe failures error:", error);

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -1203,7 +1203,34 @@ router.post("/retry", requireAdmin, async (req, res) => {
                         where: { id: failure.entityId },
                         data: {
                             analysisStatus: "pending",
+                            analysisError: null,
                             analysisRetryCount: 0,
+                            analysisStartedAt: null,
+                        },
+                    });
+                    queued++;
+                } else if (failure.entityType === "vibe") {
+                    const track = await prisma.track.findUnique({
+                        where: { id: failure.entityId },
+                        select: { id: true },
+                    });
+
+                    if (!track) {
+                        await enrichmentFailureService.resolveFailures([
+                            failure.id,
+                        ]);
+                        skipped++;
+                        continue;
+                    }
+
+                    await prisma.track.update({
+                        where: { id: failure.entityId },
+                        data: {
+                            vibeAnalysisStatus: "pending",
+                            vibeAnalysisError: null,
+                            vibeAnalysisRetryCount: 0,
+                            vibeAnalysisStartedAt: null,
+                            vibeAnalysisStatusUpdatedAt: new Date(),
                         },
                     });
                     queued++;

--- a/backend/src/workers/__tests__/enrichmentQueue.test.ts
+++ b/backend/src/workers/__tests__/enrichmentQueue.test.ts
@@ -1,0 +1,52 @@
+import {
+    enqueueReservedWork,
+    type EnrichmentQueueRedis,
+} from "../enrichmentQueue";
+
+describe("enrichment queue admission", () => {
+    it.each([
+        [1, "queued"],
+        [0, "duplicate"],
+        [-1, "full"],
+    ] as const)("maps Redis result %s to %s", async (redisResult, expected) => {
+        const client: EnrichmentQueueRedis = {
+            eval: jest.fn().mockResolvedValue(redisResult),
+        };
+
+        await expect(
+            enqueueReservedWork(client, {
+                queueKey: "audio:analysis:queue",
+                trackId: "track-1",
+                payload: "payload",
+                maxDepth: 100,
+                reservationTtlSeconds: 3600,
+            }),
+        ).resolves.toBe(expected);
+
+        expect(client.eval).toHaveBeenCalledWith(
+            expect.any(String),
+            2,
+            "audio:analysis:queue",
+            "audio:analysis:queue:reserved:track-1",
+            "100",
+            "3600",
+            "payload",
+        );
+    });
+
+    it("rejects an unexpected Redis response", async () => {
+        const client: EnrichmentQueueRedis = {
+            eval: jest.fn().mockResolvedValue("unexpected"),
+        };
+
+        await expect(
+            enqueueReservedWork(client, {
+                queueKey: "audio:analysis:queue",
+                trackId: "track-1",
+                payload: "payload",
+                maxDepth: 100,
+                reservationTtlSeconds: 3600,
+            }),
+        ).rejects.toThrow("Unexpected enrichment queue admission result");
+    });
+});

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -60,18 +60,28 @@ describe("unified enrichment runtime behavior", () => {
 
         const queueRedisPrimary = {
             llen: jest.fn(async () => 0),
-            rpush: jest.fn(async () => 1),
+            rpush: jest.fn(async (_queue?: string, _payload?: string) => 1),
+            eval: jest.fn(async () => 1),
             keys: jest.fn(async () => []),
             del: jest.fn(async () => 0),
             disconnect: jest.fn(),
         };
         const queueRedisRecovery = {
             llen: jest.fn(async () => 0),
-            rpush: jest.fn(async () => 1),
+            rpush: jest.fn(async (_queue?: string, _payload?: string) => 1),
+            eval: jest.fn(async () => 1),
             keys: jest.fn(async () => []),
             del: jest.fn(async () => 0),
             disconnect: jest.fn(),
         };
+        (queueRedisPrimary.eval as jest.Mock).mockImplementation(
+            async (...args: string[]) =>
+                queueRedisPrimary.rpush(args[2], args[6]),
+        );
+        (queueRedisRecovery.eval as jest.Mock).mockImplementation(
+            async (...args: string[]) =>
+                queueRedisRecovery.rpush(args[2], args[6]),
+        );
         const claimRedisPrimary = {
             set: jest.fn(async () => null),
             eval: jest.fn(async () => 1),
@@ -198,6 +208,11 @@ describe("unified enrichment runtime behavior", () => {
                             ? parsed
                             : 900_000;
                     },
+                },
+                analysisQueues: {
+                    audioMaxDepth: 100,
+                    vibeMaxDepth: 100,
+                    reservationTtlSeconds: 3600,
                 },
             },
         }));
@@ -592,25 +607,44 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         const queued = await enrichment.reRunAudioAnalysisOnly();
 
-        expect(queueRedisPrimary.rpush).toHaveBeenCalledTimes(2);
-        expect(prisma.track.update).toHaveBeenCalledTimes(2);
-        expect(prisma.track.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "track-a" },
-                data: expect.objectContaining({
-                    analysisStatus: "processing",
-                    analysisStartedAt: expect.any(Date),
-                }),
-            }),
-        );
+        expect(queueRedisPrimary.eval).toHaveBeenCalledTimes(2);
+        expect(prisma.track.update).not.toHaveBeenCalled();
         expect(queued).toBe(2);
+    });
+
+    it("stops audio admission when the bounded queue is full", async () => {
+        const { prisma, queueRedisPrimary } = setupUnifiedEnrichmentMocks();
+        (prisma.track.findMany as jest.Mock)
+            .mockResolvedValueOnce([{ id: "track-a" }])
+            .mockResolvedValueOnce([
+                {
+                    id: "track-a",
+                    filePath: "/music/a.flac",
+                    title: "A",
+                    duration: 120,
+                },
+                {
+                    id: "track-b",
+                    filePath: "/music/b.flac",
+                    title: "B",
+                    duration: 140,
+                },
+            ]);
+        (queueRedisPrimary.eval as jest.Mock).mockResolvedValueOnce(-1);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const enrichment = require("../unifiedEnrichment");
+        const queued = await enrichment.reRunAudioAnalysisOnly();
+
+        expect(queueRedisPrimary.eval).toHaveBeenCalledTimes(1);
+        expect(queued).toBe(0);
     });
 
     it("re-runs vibe embeddings when available and queues missing embeddings", async () => {
         const { prisma, queueRedisPrimary, getFeatures } =
             setupUnifiedEnrichmentMocks();
         getFeatures.mockResolvedValueOnce({ vibeEmbeddings: true });
-        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce([
+        (prisma.track.findMany as jest.Mock).mockResolvedValueOnce([
             {
                 id: "track-v1",
                 filePath: "/music/v1.flac",
@@ -627,11 +661,14 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         const queued = await enrichment.reRunVibeEmbeddingsOnly();
 
-        expect(prisma.track.update).toHaveBeenCalledTimes(2);
-        expect(queueRedisPrimary.rpush).toHaveBeenCalledWith(
-            "audio:clap:queue",
-            expect.any(String),
+        expect(prisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ embedding: null }),
+                take: 100,
+            }),
         );
+        expect(prisma.track.update).not.toHaveBeenCalled();
+        expect(queueRedisPrimary.eval).toHaveBeenCalledTimes(2);
         expect(queued).toBe(2);
     });
 
@@ -644,8 +681,8 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         const queued = await enrichment.reRunVibeEmbeddingsOnly();
 
-        expect(prisma.$queryRaw).not.toHaveBeenCalled();
-        expect(queueRedisPrimary.rpush).not.toHaveBeenCalled();
+        expect(prisma.track.findMany).not.toHaveBeenCalled();
+        expect(queueRedisPrimary.eval).not.toHaveBeenCalled();
         expect(queued).toBe(0);
     });
 
@@ -746,14 +783,7 @@ describe("unified enrichment runtime behavior", () => {
         expect(queueRedisPrimary.disconnect).toHaveBeenCalledTimes(1);
         expect(queueRedisPrimary.rpush).toHaveBeenCalledTimes(1);
         expect(queueRedisRecovery.rpush).toHaveBeenCalledTimes(1);
-        expect(prisma.track.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "track-enrich-1" },
-                data: expect.objectContaining({
-                    analysisStatus: "processing",
-                }),
-            }),
-        );
+        expect(prisma.track.update).not.toHaveBeenCalled();
         expect(result.audioQueued).toBeGreaterThanOrEqual(1);
     });
 
@@ -2033,7 +2063,18 @@ describe("unified enrichment runtime behavior", () => {
         (claimRedisPrimary.set as jest.Mock).mockResolvedValueOnce("OK");
         getFeatures.mockResolvedValue({ vibeEmbeddings: true });
         (prisma.artist.findMany as jest.Mock).mockResolvedValueOnce([]);
-        (prisma.track.findMany as jest.Mock).mockResolvedValue(async () => []);
+        (prisma.track.findMany as jest.Mock).mockImplementation(
+            async (query?: any) =>
+                query?.where?.embedding === null
+                    ? [
+                          {
+                              id: "track-vibe-fail",
+                              filePath: "/music/track-vibe-fail.flac",
+                              vibeAnalysisStatus: null,
+                          },
+                      ]
+                    : [],
+        );
         (prisma.track.count as jest.Mock).mockImplementation(
             async (args?: { where?: any }) => {
                 const where = args?.where;
@@ -2050,23 +2091,16 @@ describe("unified enrichment runtime behavior", () => {
         (prisma.$queryRaw as jest.Mock)
             .mockResolvedValueOnce([{ count: BigInt(0) }])
             .mockResolvedValueOnce([{ count: BigInt(0) }])
-            .mockResolvedValueOnce([
-                {
-                    id: "track-vibe-fail",
-                    filePath: "/music/track-vibe-fail.flac",
-                    vibeAnalysisStatus: null,
-                },
-            ])
             .mockResolvedValueOnce([{ count: BigInt(0) }])
             .mockResolvedValueOnce([{ count: BigInt(0) }]);
-        (prisma.track.update as jest.Mock).mockRejectedValueOnce(
-            new Error("update failed"),
+        (queueRedisPrimary.rpush as jest.Mock).mockRejectedValueOnce(
+            new Error("push failed"),
         );
         (queueRedisPrimary.llen as jest.Mock).mockResolvedValue(0);
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const enrichment = require("../unifiedEnrichment");
-        await enrichment.runFullEnrichment();
+        await enrichment.reRunVibeEmbeddingsOnly();
 
         expect(logger.error).toHaveBeenCalledWith(
             "   Failed to queue vibe embedding for track-vibe-fail:",
@@ -2078,7 +2112,7 @@ describe("unified enrichment runtime behavior", () => {
         const { prisma, getFeatures, queueRedisPrimary, logger } =
             setupUnifiedEnrichmentMocks();
         getFeatures.mockResolvedValueOnce({ vibeEmbeddings: true });
-        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce([
+        (prisma.track.findMany as jest.Mock).mockResolvedValueOnce([
             {
                 id: "track-vibe-rpush-fail",
                 filePath: "/music/track-vibe-rpush-fail.flac",
@@ -2105,7 +2139,7 @@ describe("unified enrichment runtime behavior", () => {
         const { prisma, getFeatures, queueRedisPrimary, queueRedisRecovery } =
             setupUnifiedEnrichmentMocks();
         getFeatures.mockResolvedValueOnce({ vibeEmbeddings: true });
-        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce([
+        (prisma.track.findMany as jest.Mock).mockResolvedValueOnce([
             {
                 id: "track-vibe-rpush-recovery",
                 filePath: "/music/track-vibe-rpush-recovery.flac",
@@ -2124,14 +2158,7 @@ describe("unified enrichment runtime behavior", () => {
         expect(queueRedisPrimary.disconnect).toHaveBeenCalledTimes(1);
         expect(queueRedisPrimary.rpush).toHaveBeenCalledTimes(1);
         expect(queueRedisRecovery.rpush).toHaveBeenCalledTimes(1);
-        expect(prisma.track.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "track-vibe-rpush-recovery" },
-                data: expect.objectContaining({
-                    vibeAnalysisStatus: "processing",
-                }),
-            }),
-        );
+        expect(prisma.track.update).not.toHaveBeenCalled();
     });
 
     it("logs vibe cleanup reset counts and queued embeddings", async () => {
@@ -2166,15 +2193,20 @@ describe("unified enrichment runtime behavior", () => {
         (prisma.$queryRaw as jest.Mock)
             .mockResolvedValueOnce([{ count: BigInt(0) }])
             .mockResolvedValueOnce([{ count: BigInt(0) }])
-            .mockResolvedValueOnce([
-                {
-                    id: "track-vibe-ok",
-                    filePath: "/music/track-vibe-ok.flac",
-                    vibeAnalysisStatus: null,
-                },
-            ])
             .mockResolvedValueOnce([{ count: BigInt(0) }])
             .mockResolvedValueOnce([{ count: BigInt(1) }]);
+        (prisma.track.findMany as jest.Mock).mockImplementation(
+            async (query?: any) =>
+                query?.where?.embedding === null
+                    ? [
+                          {
+                              id: "track-vibe-ok",
+                              filePath: "/music/track-vibe-ok.flac",
+                              vibeAnalysisStatus: null,
+                          },
+                      ]
+                    : [],
+        );
         (queueRedisPrimary.llen as jest.Mock).mockResolvedValue(0);
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/backend/src/workers/enrichmentQueue.ts
+++ b/backend/src/workers/enrichmentQueue.ts
@@ -1,0 +1,53 @@
+/** Minimal ioredis surface required for atomic enrichment queue admission. */
+export interface EnrichmentQueueRedis {
+    eval(
+        script: string,
+        numberOfKeys: number,
+        ...args: string[]
+    ): Promise<unknown>;
+}
+
+/** Outcome returned by atomic enrichment queue admission. */
+export type EnrichmentQueueAdmission = "queued" | "duplicate" | "full";
+
+interface EnqueueReservedWorkInput {
+    queueKey: string;
+    trackId: string;
+    payload: string;
+    maxDepth: number;
+    reservationTtlSeconds: number;
+}
+
+const ADMIT_WORK_SCRIPT = `
+local depth = redis.call("LLEN", KEYS[1])
+if depth >= tonumber(ARGV[1]) then
+    return -1
+end
+local reserved = redis.call("SET", KEYS[2], "1", "NX", "EX", ARGV[2])
+if not reserved then
+    return 0
+end
+redis.call("RPUSH", KEYS[1], ARGV[3])
+return 1
+`;
+
+/** Atomically enforce queue depth and a per-track enqueue reservation. */
+export async function enqueueReservedWork(
+    redis: EnrichmentQueueRedis,
+    input: EnqueueReservedWorkInput,
+): Promise<EnrichmentQueueAdmission> {
+    const result = await redis.eval(
+        ADMIT_WORK_SCRIPT,
+        2,
+        input.queueKey,
+        `${input.queueKey}:reserved:${input.trackId}`,
+        String(input.maxDepth),
+        String(input.reservationTtlSeconds),
+        input.payload,
+    );
+
+    if (result === 1) return "queued";
+    if (result === 0) return "duplicate";
+    if (result === -1) return "full";
+    throw new Error(`Unexpected enrichment queue admission result: ${result}`);
+}

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -28,6 +28,7 @@ import { getSystemSettings } from "../utils/systemSettings";
 import { featureDetection } from "../services/featureDetection";
 import { moodBucketService } from "../services/moodBucketService";
 import pLimit from "p-limit";
+import { enqueueReservedWork } from "./enrichmentQueue";
 
 const log = logger.child("Enrichment");
 
@@ -1331,7 +1332,7 @@ async function queueAudioAnalysis(): Promise<number> {
             title: true,
             duration: true,
         },
-        take: 10, // Match analyzer batch size to avoid stale "processing" buildup
+        take: config.analysisQueues.audioMaxDepth,
         orderBy: { fileModified: "desc" },
     });
 
@@ -1345,30 +1346,24 @@ async function queueAudioAnalysis(): Promise<number> {
 
     for (const track of tracks) {
         try {
-            // Queue for the Python audio analyzer
-            await withEnrichmentQueueRedisRetry(
-                `queueAudioAnalysis.rpush(${track.id})`,
+            const admission = await withEnrichmentQueueRedisRetry(
+                `queueAudioAnalysis.admit(${track.id})`,
                 () =>
-                    getRedis().rpush(
-                        "audio:analysis:queue",
-                        JSON.stringify({
+                    enqueueReservedWork(getRedis(), {
+                        queueKey: "audio:analysis:queue",
+                        trackId: track.id,
+                        payload: JSON.stringify({
                             trackId: track.id,
                             filePath: track.filePath,
-                            duration: track.duration, // Avoids file read in analyzer
+                            duration: track.duration,
                         }),
-                    ),
+                        maxDepth: config.analysisQueues.audioMaxDepth,
+                        reservationTtlSeconds:
+                            config.analysisQueues.reservationTtlSeconds,
+                    }),
             );
-
-            // Mark as queued (processing) with timestamp for timeout detection
-            await prisma.track.update({
-                where: { id: track.id },
-                data: {
-                    analysisStatus: "processing",
-                    analysisStartedAt: new Date(),
-                },
-            });
-
-            queued++;
+            if (admission === "full") break;
+            if (admission === "queued") queued += 1;
         } catch (error) {
             log.error(`   Failed to queue ${track.title}:`, error);
         }
@@ -1389,21 +1384,18 @@ async function queueVibeEmbeddings(): Promise<number> {
     const tracks = await withEnrichmentPrismaRetry(
         "queueVibeEmbeddings.track.select",
         () =>
-            prisma.$queryRaw<
-                {
-                    id: string;
-                    filePath: string;
-                    vibeAnalysisStatus: string | null;
-                }[]
-            >`
-          SELECT t.id, t."filePath", t."vibeAnalysisStatus"
-          FROM "Track" t
-          LEFT JOIN track_embeddings te ON t.id = te.track_id
-          WHERE te.track_id IS NULL
-            AND t."filePath" IS NOT NULL
-            AND (t."vibeAnalysisStatus" IS NULL OR t."vibeAnalysisStatus" = 'pending')
-          LIMIT 1000
-      `,
+            prisma.track.findMany({
+                where: {
+                    embedding: null,
+                    OR: [
+                        { vibeAnalysisStatus: null },
+                        { vibeAnalysisStatus: "pending" },
+                    ],
+                },
+                select: { id: true, filePath: true },
+                take: config.analysisQueues.vibeMaxDepth,
+                orderBy: { fileModified: "desc" },
+            }),
     );
 
     if (tracks.length === 0) {
@@ -1414,28 +1406,23 @@ async function queueVibeEmbeddings(): Promise<number> {
 
     for (const track of tracks) {
         try {
-            await withEnrichmentQueueRedisRetry(
-                `queueVibeEmbeddings.rpush(${track.id})`,
+            const admission = await withEnrichmentQueueRedisRetry(
+                `queueVibeEmbeddings.admit(${track.id})`,
                 () =>
-                    getRedis().rpush(
-                        "audio:clap:queue",
-                        JSON.stringify({
+                    enqueueReservedWork(getRedis(), {
+                        queueKey: "audio:clap:queue",
+                        trackId: track.id,
+                        payload: JSON.stringify({
                             trackId: track.id,
                             filePath: track.filePath,
                         }),
-                    ),
+                        maxDepth: config.analysisQueues.vibeMaxDepth,
+                        reservationTtlSeconds:
+                            config.analysisQueues.reservationTtlSeconds,
+                    }),
             );
-
-            await prisma.track.update({
-                where: { id: track.id },
-                data: {
-                    vibeAnalysisStatus: "processing",
-                    vibeAnalysisStartedAt: new Date(),
-                    vibeAnalysisStatusUpdatedAt: new Date(),
-                },
-            });
-
-            queued++;
+            if (admission === "full") break;
+            if (admission === "queued") queued += 1;
         } catch (error) {
             log.error(
                 `   Failed to queue vibe embedding for ${track.id}:`,

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -145,6 +145,9 @@ Experimental feature note:
 | --- | --- | --- | --- | --- |
 | `SOUNDSPAN_CALLBACK_URL` | `backend`, `soundspan` (AIO) | Optional | split stack: `http://backend:3006`; AIO: `http://host.docker.internal:3030` | Callback URL used for webhook/integration callbacks (for example Lidarr completion hooks). |
 | `AUDIO_ANALYSIS_ENABLED` | `backend`, `backend-worker` | Optional | `true` | Feature flag for audio analysis queueing/consumption (Essentia + CLAP vibe embeddings), the mood-bucket worker, and the `/api/analysis` + `/api/vibe` routes. Set `false` to disable; analyzer containers should then also be disabled. |
+| `AUDIO_ANALYSIS_QUEUE_MAX_DEPTH` | `backend-worker` | Optional | `100` | Maximum number of pending MusicCNN jobs admitted to Redis. Additional pending tracks remain in PostgreSQL until capacity is available. |
+| `VIBE_ANALYSIS_QUEUE_MAX_DEPTH` | `backend-worker` | Optional | `100` | Maximum number of pending CLAP jobs admitted to Redis. Additional pending tracks remain in PostgreSQL until capacity is available. |
+| `ANALYSIS_QUEUE_RESERVATION_TTL_SECONDS` | `backend-worker` | Optional | `3600` | TTL for per-track Redis admission reservations that suppress duplicate queue entries. Maximum accepted value is 86400 seconds. |
 | `DISCOVERY_ENABLED` | `backend`, `backend-worker` | Optional | `true` | Feature flag for Discover Weekly (cron + queue processors), the `/api/discover` + `/api/recommendations` routes, and the discovery auto-download lifecycle. |
 | `AUTO_PLAYLISTS_ENABLED` | `backend`, `backend-worker` | Optional | `true` | Feature flag for Made For You mixes (on-demand programmatic playlists) and the `/api/mixes` routes. |
 | `LIDARR_ENABLED` | `backend`, `backend-worker` | Optional | `false` | Enables Lidarr integration logic from env fallback paths. |

--- a/frontend/components/EnrichmentFailuresModal.tsx
+++ b/frontend/components/EnrichmentFailuresModal.tsx
@@ -10,6 +10,118 @@ interface EnrichmentFailuresModalProps {
     onClose: () => void;
 }
 
+type RetryableFailureType = "audio" | "vibe";
+
+interface RetryAllConfirmationDialogProps {
+    count: number;
+    entityType: RetryableFailureType;
+    onCancel: () => void;
+    onConfirm: () => void;
+}
+
+function RetryAllConfirmationDialog({
+    count,
+    entityType,
+    onCancel,
+    onConfirm,
+}: RetryAllConfirmationDialogProps) {
+    return (
+        <div className="fixed inset-0 bg-black/80 z-[60] flex items-center justify-center p-4">
+            <div
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="retry-all-title"
+                className="bg-surface-hover rounded-lg p-6 max-w-md border border-white/10"
+            >
+                <h3
+                    id="retry-all-title"
+                    className="text-lg font-bold text-white mb-2"
+                >
+                    Retry all failures in this tab?
+                </h3>
+                <p className="text-sm text-white/70 mb-4">
+                    This resets {count} failed{" "}
+                    {entityType === "audio"
+                        ? "audio analyses"
+                        : "vibe embeddings"}
+                    . The bounded background queue will process them gradually.
+                </p>
+                <div className="flex justify-end gap-2">
+                    <button
+                        onClick={onCancel}
+                        className="px-4 py-2 text-sm bg-white/10 text-white/70 rounded-lg hover:bg-white/20 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        onClick={onConfirm}
+                        className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                    >
+                        Retry all
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface RetryAllFailuresActionProps {
+    count: number;
+    entityType: RetryableFailureType;
+    isError: boolean;
+    isPending: boolean;
+    onRetry: () => void;
+}
+
+function RetryAllFailuresAction({
+    count,
+    entityType,
+    isError,
+    isPending,
+    onRetry,
+}: RetryAllFailuresActionProps) {
+    const [showConfirm, setShowConfirm] = useState(false);
+    if (count <= 0) return null;
+
+    return (
+        <>
+            <div className="flex items-center justify-between gap-3 px-6 py-3 bg-white/5 border-b border-white/10">
+                <div>
+                    <p className="text-sm text-white/60">
+                        Retry every failure in this tab. Work enters the
+                        analyzer queue gradually.
+                    </p>
+                    {isError && (
+                        <p role="alert" className="text-xs text-red-400 mt-1">
+                            Retry failed. Check the server logs and try again.
+                        </p>
+                    )}
+                </div>
+                <button
+                    onClick={() => setShowConfirm(true)}
+                    disabled={isPending}
+                    className="shrink-0 flex items-center gap-2 px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg
+                        hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    {isPending ? "Retrying..." : `Retry all ${count}`}
+                </button>
+            </div>
+            {showConfirm && (
+                <RetryAllConfirmationDialog
+                    count={count}
+                    entityType={entityType}
+                    onCancel={() => setShowConfirm(false)}
+                    onConfirm={() => {
+                        onRetry();
+                        setShowConfirm(false);
+                    }}
+                />
+            )}
+        </>
+    );
+}
+
 /**
  * Renders the EnrichmentFailuresModal component.
  */
@@ -114,6 +226,25 @@ export function EnrichmentFailuresModal({
         },
     });
 
+    const retryAllMutation = useMutation({
+        mutationFn: (entityType: "audio" | "vibe") =>
+            entityType === "audio"
+                ? enrichmentApi.retryFailedAudioAnalysis()
+                : enrichmentApi.retryVibeEmbeddings(),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ["enrichment-failures"],
+            });
+            queryClient.invalidateQueries({
+                queryKey: ["enrichment-failure-counts"],
+            });
+            queryClient.invalidateQueries({
+                queryKey: ["enrichment-progress"],
+            });
+            setSelectedFailures(new Set());
+        },
+    });
+
     const toggleFailureSelection = (id: string) => {
         const newSelected = new Set(selectedFailures);
         if (newSelected.has(id)) {
@@ -180,12 +311,23 @@ export function EnrichmentFailuresModal({
                         )}
                         <button
                             onClick={onClose}
+                            aria-label="Close enrichment failures"
                             className="p-2 hover:bg-white/10 rounded-lg transition-colors"
                         >
                             <X className="w-5 h-5 text-white/70" />
                         </button>
                     </div>
                 </div>
+
+                {(selectedType === "audio" || selectedType === "vibe") && (
+                    <RetryAllFailuresAction
+                        count={counts?.[selectedType] || 0}
+                        entityType={selectedType}
+                        isError={retryAllMutation.isError}
+                        isPending={retryAllMutation.isPending}
+                        onRetry={() => retryAllMutation.mutate(selectedType)}
+                    />
+                )}
 
                 {/* Filter Tabs */}
                 <div className="flex gap-3 px-6 py-4 border-b border-white/10 overflow-x-auto">
@@ -228,6 +370,7 @@ export function EnrichmentFailuresModal({
                                     ? "bg-brand text-black"
                                     : "bg-white/5 text-white/70 hover:bg-white/10"
                             }`}
+                            aria-pressed={selectedType === tab.key}
                         >
                             {tab.label} ({tab.count})
                         </button>
@@ -287,6 +430,7 @@ export function EnrichmentFailuresModal({
                             <div className="flex items-center gap-3 px-3 py-2">
                                 <input
                                     type="checkbox"
+                                    aria-label="Select all failures on this page"
                                     checked={
                                         selectedFailures.size ===
                                         failures?.failures.length
@@ -306,6 +450,7 @@ export function EnrichmentFailuresModal({
                                 >
                                     <input
                                         type="checkbox"
+                                        aria-label={`Select failure for ${failure.entityName || failure.entityId}`}
                                         checked={selectedFailures.has(
                                             failure.id,
                                         )}

--- a/frontend/lib/enrichmentApi.ts
+++ b/frontend/lib/enrichmentApi.ts
@@ -227,12 +227,20 @@ export const enrichmentApi = {
         });
     },
 
+    /** Reset every failed audio-analysis row for bounded background retry. */
+    retryFailedAudioAnalysis: async (): Promise<{
+        message: string;
+        reset: number;
+    }> => {
+        return api.post("/analysis/retry-failed", {});
+    },
+
     /**
      * Retry failed vibe embeddings
      */
     retryVibeEmbeddings: async (): Promise<{
         message: string;
-        queued: number;
+        reset: number;
     }> => {
         return api.post("/analysis/vibe/retry", {});
     },

--- a/frontend/tests/component/enrichmentFailuresModal.component.test.ts
+++ b/frontend/tests/component/enrichmentFailuresModal.component.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const retryFailedAudioAnalysis = mock.fn(async () => ({
+    message: "reset",
+    reset: 7226,
+}));
+const retryVibeEmbeddings = mock.fn(async () => ({
+    message: "reset",
+    reset: 1204,
+}));
+
+mock.module("@/lib/enrichmentApi", {
+    namedExports: {
+        enrichmentApi: {
+            getFailures: async () => ({ failures: [], total: 0 }),
+            getFailureCounts: async () => ({
+                artist: 0,
+                track: 0,
+                audio: 7226,
+                vibe: 1204,
+                total: 8430,
+            }),
+            retryFailures: async () => ({ message: "", queued: 0 }),
+            skipFailures: async () => ({ message: "", count: 0 }),
+            deleteFailure: async () => ({ message: "", count: 0 }),
+            clearAllFailures: async () => ({ message: "", count: 0 }),
+            retryFailedAudioAnalysis,
+            retryVibeEmbeddings,
+        },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    retryFailedAudioAnalysis.mock.resetCalls();
+    retryVibeEmbeddings.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+async function mountModal() {
+    const { EnrichmentFailuresModal } =
+        await import("../../components/EnrichmentFailuresModal");
+    const { createRoot } = await import("react-dom/client");
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(["enrichment-failure-counts"], {
+        artist: 0,
+        track: 0,
+        audio: 7226,
+        vibe: 1204,
+        total: 8430,
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(
+            React.createElement(
+                QueryClientProvider,
+                { client: queryClient },
+                React.createElement(EnrichmentFailuresModal, {
+                    isOpen: true,
+                    onClose: () => undefined,
+                }),
+            ),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    return {
+        container,
+        unmount: async () => React.act(async () => root.unmount()),
+    };
+}
+
+function buttonWithText(text: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) =>
+            candidate.textContent?.replace(/\s+/g, " ").trim() === text,
+    );
+    const labels = Array.from(document.querySelectorAll("button")).map(
+        (candidate) => candidate.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    assert.ok(
+        button instanceof HTMLButtonElement,
+        `Missing ${text} button; found ${labels.join(", ")}`,
+    );
+    return button;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+    await React.act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+test("retries every audio failure instead of only the visible page", async (t) => {
+    const harness = await mountModal();
+    t.after(harness.unmount);
+    await click(buttonWithText("Audio Analysis (7226)"));
+    await click(buttonWithText("Retry all 7226"));
+    assert.match(document.body.textContent ?? "", /bounded background queue/i);
+    await click(buttonWithText("Retry all"));
+    assert.equal(retryFailedAudioAnalysis.mock.callCount(), 1);
+
+    await click(buttonWithText("Vibe Embeddings (1204)"));
+    await click(buttonWithText("Retry all 1204"));
+    await click(buttonWithText("Retry all"));
+    assert.equal(retryVibeEmbeddings.mock.callCount(), 1);
+});

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -477,8 +477,11 @@ class Worker:
             logger.warning("Rejected queued CLAP path outside the configured music library")
             return
 
-        # Update track status to processing
-        self._update_track_status(track_id, "processing")
+        if not self._claim_track(track_id):
+            self._release_queue_reservation(track_id)
+            logger.info(f"Worker {self.worker_id} skipped stale queue job: {track_id}")
+            return
+        self._release_queue_reservation(track_id)
 
         # Generate embedding (pass duration to avoid file probe)
         embedding = self.analyzer.get_audio_embedding(full_path, duration)
@@ -495,6 +498,40 @@ class Worker:
             logger.info(f"Worker {self.worker_id} completed track: {track_id}")
         else:
             self._mark_failed(track_id, "Failed to store embedding")
+
+    def _claim_track(self, track_id: str) -> bool:
+        """Atomically claim one pending track for this worker."""
+        cursor = self.db.get_cursor()
+        try:
+            cursor.execute(
+                """
+                UPDATE "Track"
+                SET
+                    "vibeAnalysisStatus" = 'processing',
+                    "vibeAnalysisStartedAt" = NOW(),
+                    "vibeAnalysisStatusUpdatedAt" = NOW()
+                WHERE id = %s
+                AND ("vibeAnalysisStatus" IS NULL OR "vibeAnalysisStatus" = 'pending')
+                RETURNING id
+            """,
+                (track_id,),
+            )
+            claimed = cursor.fetchone() is not None
+            self.db.commit()
+            return claimed
+        except Exception as error:
+            logger.error(f"Failed to claim track for vibe analysis: {error}")
+            self.db.rollback()
+            return False
+        finally:
+            cursor.close()
+
+    def _release_queue_reservation(self, track_id: str) -> None:
+        """Release the producer reservation after the database claim."""
+        try:
+            self.redis_client.delete(f"{ANALYSIS_QUEUE}:reserved:{track_id}")
+        except Exception as error:
+            logger.warning(f"Failed to release vibe queue reservation: {error}")
 
     def _update_track_status(self, track_id: str, status: str):
         """Update the track's vibe analysis status (CLAP embeddings)"""

--- a/services/audio-analyzer-clap/tests/test_music_path_containment.py
+++ b/services/audio-analyzer-clap/tests/test_music_path_containment.py
@@ -19,10 +19,15 @@ class SingleJobRedis:
 
     def __init__(self, job: dict[str, Any]) -> None:
         self.job = job
+        self.deleted: list[str] = []
 
     def blpop(self, queue: str, timeout: int) -> tuple[str, str]:
         """Return the configured job without external Redis I/O."""
         return queue, json.dumps(self.job)
+
+    def delete(self, key: str) -> None:
+        """Record released queue reservations."""
+        self.deleted.append(key)
 
 
 class RecordingAnalyzer:
@@ -62,6 +67,7 @@ def _process_queued_path(
     status_updates: list[tuple[str, str]] = []
     stored_track_ids: list[str] = []
     monkeypatch.setattr(module, "MUSIC_PATH", str(music_root))
+    monkeypatch.setattr(worker, "_claim_track", lambda _track_id: True)
     monkeypatch.setattr(
         worker,
         "_update_track_status",
@@ -151,5 +157,35 @@ def test_queued_in_library_path_is_embedded(
     )
 
     assert analyzer.paths == [str(track_path.resolve())]
-    assert status_updates == [("track-1", "processing"), ("track-1", "completed")]
+    assert status_updates == [("track-1", "completed")]
     assert stored_track_ids == ["track-1"]
+
+
+def test_duplicate_queue_job_is_skipped_when_pending_claim_fails(
+    analyzer_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Do not generate a second embedding when another worker owns the track."""
+    music_root = tmp_path / "music"
+    track_path = music_root / "artist" / "track.flac"
+    track_path.parent.mkdir(parents=True)
+    track_path.touch()
+    analyzer = RecordingAnalyzer()
+    worker = analyzer_module.Worker(1, analyzer, threading.Event())
+    redis_client = SingleJobRedis(
+        {"trackId": "track-1", "filePath": "artist/track.flac", "duration": 30.0}
+    )
+    worker.redis_client = redis_client
+    monkeypatch.setattr(analyzer_module, "MUSIC_PATH", str(music_root))
+    monkeypatch.setattr(worker, "_claim_track", lambda _track_id: False)
+    monkeypatch.setattr(
+        worker,
+        "_store_embedding",
+        lambda _track_id, _embedding: pytest.fail("duplicate was stored"),
+    )
+
+    worker._process_job()
+
+    assert analyzer.paths == []
+    assert redis_client.deleted == ["audio:clap:queue:reserved:track-1"]

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -1732,8 +1732,8 @@ class AnalysisWorker:
         """
         Check database for pending tracks that may have been missed by Redis queue.
         Handles edge cases: manual DB edits, crash recovery, queue loss.
-        Marks tracks as 'processing' in DB first (prevents backend double-queuing),
-        then pushes them into the Redis queue so BRPOP picks them up.
+        Sends rows directly through the consumer claim path so queue waiting time
+        is never recorded as processing time.
 
         Returns True if pending work was found, False if nothing to do.
         """
@@ -1758,32 +1758,10 @@ class AnalysisWorker:
                 self.db.commit()
                 return False
 
-            logger.info(f"DB reconciliation found {len(tracks)} pending tracks, queuing...")
-            track_ids = [t["id"] for t in tracks]
-            cursor.execute(
-                """
-                UPDATE "Track"
-                SET "analysisStatus" = 'processing',
-                    "analysisStartedAt" = NOW(),
-                    "updatedAt" = NOW()
-                WHERE id = ANY(%s)
-                AND "analysisStatus" = 'pending'
-                RETURNING id
-            """,
-                (track_ids,),
-            )
-            marked_ids = {row["id"] for row in cursor.fetchall()}
             self.db.commit()
-            if not marked_ids:
-                return False
-            pipe = self.redis.pipeline()
-            for t in tracks:
-                if t["id"] not in marked_ids:
-                    continue
-                pipe.rpush(
-                    ANALYSIS_QUEUE, json.dumps({"trackId": t["id"], "filePath": t["filePath"]})
-                )
-            pipe.execute()
+            pending_tracks = [(track["id"], track["filePath"]) for track in tracks]
+            logger.info(f"DB reconciliation found {len(pending_tracks)} pending tracks")
+            self._process_tracks_parallel(pending_tracks)
             return True
         except Exception as e:
             logger.error(f"DB reconciliation failed: {e}")
@@ -1955,9 +1933,6 @@ class AnalysisWorker:
         tracks: list[tuple[str, str]],
     ) -> list[tuple[str, str]]:
         """Mark eligible tracks as processing and discard stale queue entries."""
-        # Queue producers may pre-claim tracks as 'processing' before enqueueing
-        # (e.g. DB reconciliation / unified enrichment). Accept both 'pending'
-        # and 'processing' rows here so freshly queued work is not dropped.
         cursor = self.db.get_cursor()
         try:
             track_ids = [t[0] for t in tracks]
@@ -1965,10 +1940,10 @@ class AnalysisWorker:
                 """
                 UPDATE "Track"
                 SET "analysisStatus" = 'processing',
-                    "analysisStartedAt" = COALESCE("analysisStartedAt", NOW()),
+                    "analysisStartedAt" = NOW(),
                     "updatedAt" = NOW()
                 WHERE id = ANY(%s)
-                AND "analysisStatus" IN ('pending', 'processing')
+                AND "analysisStatus" = 'pending'
                 RETURNING id
             """,
                 (track_ids,),
@@ -1992,6 +1967,18 @@ class AnalysisWorker:
             return []
         finally:
             cursor.close()
+
+    def _release_queue_reservations(self, tracks: list[tuple[str, str]]) -> None:
+        """Release producer reservations after the database claim completes."""
+        if not tracks:
+            return
+        try:
+            pipe = self.redis.pipeline()
+            for track_id, _ in tracks:
+                pipe.delete(f"{ANALYSIS_QUEUE}:reserved:{track_id}")
+            pipe.execute()
+        except Exception as error:
+            logger.warning(f"Failed to release audio queue reservations: {error}")
 
     def _save_completed_future(self, future) -> tuple[str, int, int, int]:
         """Persist one completed future and return its outcome counters."""
@@ -2092,11 +2079,14 @@ class AnalysisWorker:
         if not tracks:
             return
 
-        self._ensure_pool()
-        logger.info(f"Processing batch of {len(tracks)} tracks with {NUM_WORKERS} workers...")
+        queued_tracks = tracks
         tracks = self._claim_tracks_for_processing(tracks)
+        self._release_queue_reservations(queued_tracks)
         if not tracks:
             return
+
+        self._ensure_pool()
+        logger.info(f"Processing batch of {len(tracks)} tracks with {NUM_WORKERS} workers...")
 
         start_time = time.monotonic()
         finalized_track_ids: set[str] = set()

--- a/services/audio-analyzer/tests/conftest.py
+++ b/services/audio-analyzer/tests/conftest.py
@@ -94,11 +94,16 @@ class FakePipeline:
 
     def __init__(self) -> None:
         self.pushes: list[tuple[str, str]] = []
+        self.deletes: list[str] = []
         self.execute_calls = 0
 
     def rpush(self, queue: str, payload: str) -> None:
         """Record one queued payload."""
         self.pushes.append((queue, payload))
+
+    def delete(self, key: str) -> None:
+        """Record one reservation deletion."""
+        self.deletes.append(key)
 
     def execute(self) -> None:
         """Record pipeline execution."""

--- a/services/audio-analyzer/tests/test_queue_claim_alignment.py
+++ b/services/audio-analyzer/tests/test_queue_claim_alignment.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from types import ModuleType
 
 from conftest import FakeDatabaseConnection, FakeRedis
@@ -21,21 +20,23 @@ def _build_worker(
 
 
 def test_claim_tracks_keeps_only_rows_returned_by_database(loaded_analyzer: ModuleType) -> None:
-    """Keep eligible pending and pre-claimed tracks while filtering stale jobs."""
+    """Keep only tracks atomically claimed from pending state."""
     tracks = [
         ("pending-track", "/music/pending.flac"),
         ("processing-track", "/music/processing.flac"),
         ("stale-track", "/music/stale.flac"),
     ]
-    database = FakeDatabaseConnection([[{"id": "pending-track"}, {"id": "processing-track"}]])
+    database = FakeDatabaseConnection([[{"id": "pending-track"}]])
     worker = _build_worker(loaded_analyzer, database)
 
     claimed = worker._claim_tracks_for_processing(tracks)
 
-    assert claimed == tracks[:2]
+    assert claimed == tracks[:1]
     assert len(database.cursor.executions) == 1
     sql, params = database.cursor.executions[0]
-    assert "\"analysisStatus\" IN ('pending', 'processing')" in sql
+    assert "\"analysisStatus\" = 'pending'" in sql
+    assert '"analysisStartedAt" = NOW()' in sql
+    assert "COALESCE" not in sql
     assert params == ([track_id for track_id, _ in tracks],)
     assert database.commit_calls == 1
     assert database.cursor.closed is True
@@ -54,34 +55,27 @@ def test_claim_tracks_rolls_back_database_errors(loaded_analyzer: ModuleType) ->
     assert database.cursor.closed is True
 
 
-def test_reconciliation_queues_only_tracks_preclaimed_by_database(
+def test_reconciliation_processes_pending_tracks_without_redis_handoff(
     loaded_analyzer: ModuleType,
 ) -> None:
-    """Queue only pending tracks successfully transitioned to processing."""
+    """Process reconciliation rows directly so the consumer owns the claim."""
     tracks = [
         {"id": "track-a", "filePath": "/music/a.flac"},
         {"id": "track-b", "filePath": "/music/b.flac"},
     ]
-    database = FakeDatabaseConnection([tracks, [{"id": "track-b"}]])
+    database = FakeDatabaseConnection([tracks])
     redis_client = FakeRedis()
     worker = _build_worker(loaded_analyzer, database, redis_client)
+    processed: list[list[tuple[str, str]]] = []
+    worker._process_tracks_parallel = lambda batch: processed.append(batch)
 
     found_work = worker._run_db_reconciliation()
 
     assert found_work is True
-    assert len(database.cursor.executions) == 2
-    update_sql, update_params = database.cursor.executions[1]
-    assert "SET \"analysisStatus\" = 'processing'" in update_sql
-    assert "AND \"analysisStatus\" = 'pending'" in update_sql
-    assert update_params == (["track-a", "track-b"],)
+    assert len(database.cursor.executions) == 1
     assert database.commit_calls == 1
-    assert redis_client.queue_pipeline.pushes == [
-        (
-            loaded_analyzer.ANALYSIS_QUEUE,
-            json.dumps({"trackId": "track-b", "filePath": "/music/b.flac"}),
-        )
-    ]
-    assert redis_client.queue_pipeline.execute_calls == 1
+    assert processed == [[("track-a", "/music/a.flac"), ("track-b", "/music/b.flac")]]
+    assert redis_client.pipeline_calls == 0
 
 
 def test_reconciliation_closes_empty_read_transaction(loaded_analyzer: ModuleType) -> None:


### PR DESCRIPTION
## Summary

- bound and deduplicate background Redis admission for MusicCNN and CLAP work
- move `processing` transitions and timestamps to analyzer-side atomic claims
- reset failed analyzer rows for gradual retry instead of bulk-enqueueing them
- add confirmed Audio Analysis and Vibe Embeddings **Retry all** actions
- make selected vibe-failure retries functional

## Root cause

The backend worker marked tracks `processing` when it enqueued them. Large imports could wait in Redis longer than the 15-minute stale-processing threshold, so cleanup consumed retry budgets and permanently failed work that had never started. Repeated producer passes could also enqueue duplicate track jobs.

## Behavior and operations

Queued tracks now remain `pending`. The analyzer that wins the database claim sets `processing` and starts the timeout. A Lua admission operation atomically enforces a configurable queue-depth limit and a self-healing per-track reservation.

Retry-all resets failed rows and retry counters. The bounded background producer then admits the backlog as capacity becomes available. Existing file-not-found failures will still fail until their source files are restored.

New optional settings:

- `AUDIO_ANALYSIS_QUEUE_MAX_DEPTH` (default `100`)
- `VIBE_ANALYSIS_QUEUE_MAX_DEPTH` (default `100`)
- `ANALYSIS_QUEUE_RESERVATION_TTL_SECONDS` (default `3600`)

## Standards

The implementation follows the repository contract and the current local coding-handbook TypeScript and Python guidance for bounded external work, explicit settlement, idempotent consumers, focused functions, API-boundary use, and behavioral tests.

## Verification

- `npm --prefix backend test -- --runInBand src/routes/__tests__/analysisRuntime.test.ts src/routes/__tests__/enrichmentRuntime.test.ts src/workers/__tests__/enrichmentQueue.test.ts src/workers/__tests__/unifiedEnrichmentRuntime.test.ts` — 179 passed
- `npm --prefix backend exec -- tsc --noEmit` — passed
- `npm --prefix frontend run typecheck` — passed
- retry-all component test — passed
- audio-analyzer tests — 34 passed
- audio-analyzer-clap tests — 31 passed
- Ruff check and format check for changed Python files — passed
- mypy for both changed analyzers — passed
- `npm run verify:gates` — passed
- frontend lint — 0 errors; 182 existing warnings within the repository limit of 183
