### PR TITLE
fix(library): durable-identity deployment follow-ups — worker ffmpeg, tag-key backfill, worker test graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ISRCs for durable identity matching. New and changed files populate these
   keys during scans, while a bounded resumable worker backfills existing
   libraries automatically.
+- The dedicated backend worker image now bundles ffmpeg so scans and the
+  audio-hash backfill can compute durable track identity hashes.
 - Library Health now distinguishes and counts removed tracks that are pending
   retention purge, shows the configured retention window, and explains that a
   rescan restores a track when its file returns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   libraries automatically.
 - The dedicated backend worker image now bundles ffmpeg so scans and the
   audio-hash backfill can compute durable track identity hashes.
+- The audio-hash backfill now also populates recording MBID and ISRC tag keys
+  for existing unchanged tracks.
 - Library Health now distinguishes and counts removed tracks that are pending
   retention purge, shows the configured retention window, and explains that a
   rescan restores a track when its file returns.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,9 +48,12 @@ FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba32756
 
 WORKDIR /app
 
+# ffmpeg is required by durable track identity (#457): scanner and audio-hash
+# backfill stream hashing run in the worker process.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     openssl \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy minimal runtime artifacts

--- a/backend/src/services/musicScanner.ts
+++ b/backend/src/services/musicScanner.ts
@@ -27,6 +27,7 @@ import {
 } from "./trackReplacement";
 import { cleanupOrphanedLibraryEntities } from "./libraryOrphanCleanup";
 import { config } from "../config";
+import { extractTrackIdentityTags } from "./trackIdentityTags";
 
 const scanLogger = logger.child("MusicScannerService");
 
@@ -876,11 +877,7 @@ export class MusicScannerService {
         const discNo = metadata.common.disk?.no || 1;
         const duration = Math.floor(metadata.format.duration || 0);
         const mime = metadata.format.codec || "audio/mpeg";
-        const recordingMbid =
-            metadata.common.musicbrainz_recordingid?.trim() || null;
-        const rawIsrc = metadata.common.isrc as string[] | string | undefined;
-        const firstIsrc = typeof rawIsrc === "string" ? rawIsrc : rawIsrc?.[0];
-        const isrc = firstIsrc?.trim() || null;
+        const { recordingMbid, isrc } = extractTrackIdentityTags(metadata);
 
         // Artist and album info
         // IMPORTANT: Prefer albumartist over artist to keep albums grouped under the primary artist

--- a/backend/src/services/trackIdentityTags.ts
+++ b/backend/src/services/trackIdentityTags.ts
@@ -1,0 +1,20 @@
+type ParsedTrackIdentityMetadata = Readonly<{
+    common: Readonly<{
+        musicbrainz_recordingid?: string;
+        isrc?: string | readonly string[];
+    }>;
+}>;
+
+/** Extracts normalized durable track identity keys from parsed audio metadata. */
+export function extractTrackIdentityTags(
+    metadata: ParsedTrackIdentityMetadata,
+): { recordingMbid: string | null; isrc: string | null } {
+    const recordingMbid =
+        metadata.common.musicbrainz_recordingid?.trim() || null;
+    const rawIsrc = metadata.common.isrc;
+    const firstIsrc = typeof rawIsrc === "string" ? rawIsrc : rawIsrc?.[0];
+    return {
+        recordingMbid,
+        isrc: firstIsrc?.trim() || null,
+    };
+}

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -143,6 +143,9 @@ describe("workers runtime behavior", () => {
         };
 
         jest.doMock("../../utils/logger", () => ({ logger }));
+        jest.doMock("music-metadata", () => ({ parseFile: jest.fn() }), {
+            virtual: true,
+        });
         jest.doMock("../queues", () => ({
             scanQueue,
             discoverQueue,

--- a/backend/src/workers/processors/__tests__/audioHashBackfillProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/audioHashBackfillProcessor.test.ts
@@ -1,3 +1,10 @@
+type ParsedIdentityMetadata = {
+    common: {
+        musicbrainz_recordingid?: string;
+        isrc?: string | string[];
+    };
+};
+
 describe("audioHashBackfillProcessor", () => {
     afterEach(() => {
         jest.resetModules();
@@ -26,10 +33,21 @@ describe("audioHashBackfillProcessor", () => {
         const schedulerQueue = {
             add: jest.fn(async () => ({})),
         };
-        const computeAudioStreamHash = jest.fn(async (filePath: string) => {
+        const computeAudioStreamHash = jest.fn<
+            Promise<string | null>,
+            [string]
+        >(async (filePath) => {
             const suffix = filePath.length.toString(16).padStart(2, "0");
             return `sha256:${suffix.repeat(32)}`;
         });
+        const parseFile = jest.fn<Promise<ParsedIdentityMetadata>, [string]>(
+            async () => ({
+                common: {
+                    musicbrainz_recordingid: " recording-default ",
+                    isrc: [" USRC17607839 "],
+                },
+            }),
+        );
         const access = jest.fn(async (filePath: string) => {
             if (missingPaths.includes(filePath)) {
                 const error = new Error(
@@ -49,6 +67,9 @@ describe("audioHashBackfillProcessor", () => {
         jest.doMock("../../../services/audioHash", () => ({
             computeAudioStreamHash,
         }));
+        jest.doMock("music-metadata", () => ({ parseFile }), {
+            virtual: true,
+        });
         jest.doMock("../../queues", () => ({ schedulerQueue }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -59,6 +80,7 @@ describe("audioHashBackfillProcessor", () => {
             prisma,
             schedulerQueue,
             computeAudioStreamHash,
+            parseFile,
             access,
         };
     }
@@ -85,6 +107,7 @@ describe("audioHashBackfillProcessor", () => {
             prisma,
             schedulerQueue,
             computeAudioStreamHash,
+            parseFile,
         } = loadProcessor(tracks, [missingPath]);
 
         await expect(
@@ -105,12 +128,20 @@ describe("audioHashBackfillProcessor", () => {
         });
         expect(computeAudioStreamHash).toHaveBeenCalledTimes(49);
         expect(computeAudioStreamHash).not.toHaveBeenCalledWith(missingPath);
+        expect(parseFile).toHaveBeenCalledTimes(49);
+        expect(parseFile).toHaveBeenCalledWith("/music/Artist/Track-0.flac");
+        expect(parseFile).not.toHaveBeenCalledWith(
+            "/music/Artist/Track-0.flac",
+            expect.anything(),
+        );
         expect(prisma.track.updateMany).toHaveBeenCalledTimes(49);
         expect(prisma.track.updateMany).toHaveBeenCalledWith({
             where: { id: "track-000", audioHash: null },
             data: {
                 audioHash: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
                 audioHashedAt: expect.any(Date),
+                recordingMbid: "recording-default",
+                isrc: "USRC17607839",
             },
         });
         expect(schedulerQueue.add).toHaveBeenCalledWith(
@@ -177,6 +208,109 @@ describe("audioHashBackfillProcessor", () => {
                 where: { id: "track-raced", audioHash: null },
             }),
         );
+    });
+
+    it("normalizes string and array ISRC tag shapes", async () => {
+        const { module, prisma, parseFile } = loadProcessor([
+            { id: "track-array", filePath: "Artist/Array.flac" },
+            { id: "track-string", filePath: "Artist/String.flac" },
+        ]);
+        parseFile
+            .mockResolvedValueOnce({
+                common: {
+                    musicbrainz_recordingid: " recording-array ",
+                    isrc: [" ARRAY-FIRST ", "ARRAY-SECOND"],
+                },
+            })
+            .mockResolvedValueOnce({
+                common: {
+                    musicbrainz_recordingid: "recording-string",
+                    isrc: " STRING-ISRC ",
+                },
+            });
+
+        await module.processAudioHashBackfill(buildJob());
+
+        expect(prisma.track.updateMany).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    recordingMbid: "recording-array",
+                    isrc: "ARRAY-FIRST",
+                }),
+            }),
+        );
+        expect(prisma.track.updateMany).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    recordingMbid: "recording-string",
+                    isrc: "STRING-ISRC",
+                }),
+            }),
+        );
+    });
+
+    it("writes null tag keys when identity tags are absent", async () => {
+        const { module, prisma, parseFile } = loadProcessor([
+            { id: "track-untagged", filePath: "Artist/Untagged.flac" },
+        ]);
+        parseFile.mockResolvedValueOnce({ common: {} });
+
+        await module.processAudioHashBackfill(buildJob());
+
+        expect(prisma.track.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    recordingMbid: null,
+                    isrc: null,
+                }),
+            }),
+        );
+    });
+
+    it("still writes a successful hash when metadata parsing fails", async () => {
+        const { module, prisma, parseFile } = loadProcessor([
+            { id: "track-bad-tags", filePath: "Artist/Bad-Tags.flac" },
+        ]);
+        parseFile.mockRejectedValueOnce(new Error("unreadable tags"));
+
+        await expect(
+            module.processAudioHashBackfill(buildJob()),
+        ).resolves.toEqual({
+            processed: 1,
+            hashed: 1,
+            skipped: 0,
+            continued: false,
+        });
+        expect(prisma.track.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    audioHash: expect.stringMatching(/^sha256:/),
+                    recordingMbid: null,
+                    isrc: null,
+                }),
+            }),
+        );
+    });
+
+    it("writes nothing when hashing fails", async () => {
+        const { module, prisma, computeAudioStreamHash, parseFile } =
+            loadProcessor([
+                { id: "track-no-hash", filePath: "Artist/No-Hash.flac" },
+            ]);
+        computeAudioStreamHash.mockResolvedValueOnce(null);
+
+        await expect(
+            module.processAudioHashBackfill(buildJob()),
+        ).resolves.toEqual({
+            processed: 1,
+            hashed: 0,
+            skipped: 1,
+            continued: false,
+        });
+        expect(parseFile).toHaveBeenCalledWith("/music/Artist/No-Hash.flac");
+        expect(prisma.track.updateMany).not.toHaveBeenCalled();
     });
 
     it("rejects a continuation without a validated sweep token", async () => {

--- a/backend/src/workers/processors/audioHashBackfillProcessor.ts
+++ b/backend/src/workers/processors/audioHashBackfillProcessor.ts
@@ -1,9 +1,11 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { Job } from "bull";
+import { parseFile } from "music-metadata";
 import { z } from "zod";
 import { config } from "../../config";
 import { computeAudioStreamHash } from "../../services/audioHash";
+import { extractTrackIdentityTags } from "../../services/trackIdentityTags";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
 import { schedulerQueue } from "../queues";
@@ -77,6 +79,18 @@ async function fileExists(filePath: string): Promise<boolean> {
     }
 }
 
+async function readTrackIdentityTags(
+    filePath: string,
+): Promise<{ recordingMbid: string | null; isrc: string | null }> {
+    try {
+        const metadata = await parseFile(filePath);
+        return extractTrackIdentityTags(metadata);
+    } catch (error) {
+        log.warn(`Failed to read identity tags for ${filePath}`, { error });
+        return { recordingMbid: null, isrc: null };
+    }
+}
+
 async function hashTrack(track: BackfillTrack): Promise<"hashed" | "skipped"> {
     const absolutePath = path.join(config.music.musicPath, track.filePath);
     if (!(await fileExists(absolutePath))) {
@@ -84,12 +98,13 @@ async function hashTrack(track: BackfillTrack): Promise<"hashed" | "skipped"> {
         return "skipped";
     }
 
+    const identityTags = await readTrackIdentityTags(absolutePath);
     const audioHash = await computeAudioStreamHash(absolutePath);
     if (!audioHash) return "skipped";
 
     const updated = await prisma.track.updateMany({
         where: { id: track.id, audioHash: null },
-        data: { audioHash, audioHashedAt: new Date() },
+        data: { audioHash, audioHashedAt: new Date(), ...identityTags },
     });
     return updated.count === 1 ? "hashed" : "skipped";
 }

--- a/docs/designs/durable-track-identity.md
+++ b/docs/designs/durable-track-identity.md
@@ -70,7 +70,7 @@ model Track {
 
 None of these are unique: legitimate duplicates exist (same file copied twice, same recording on album + compilation). They are match keys, not primary keys. The hash string embeds its algorithm (`sha256:`) so the scheme can evolve without a second column.
 
-**Hash cost control.** The scanner never re-reads unchanged files: a hash is computed only when a file is new, or when its `fileSize`/`fileModified` differ from the stored row (the same change-detection the scanner already performs). Steady-state scans hash nothing. The initial backfill is one full-library read pass — run as a bounded, resumable background job through the existing worker/queue pattern (`backend/src/workers/`), not inline in the first scan, so the first post-upgrade scan doesn't take hours. Until a row has `audioHash`, matching simply falls through to the tag tiers below.
+**Hash cost control.** The scanner never re-reads unchanged files: a hash is computed only when a file is new, or when its `fileSize`/`fileModified` differ from the stored row (the same change-detection the scanner already performs). Steady-state scans hash nothing. The initial backfill is one full-library read pass that populates `audioHash`, `recordingMbid`, and `isrc` — run as a bounded, resumable background job through the existing worker/queue pattern (`backend/src/workers/`), not inline in the first scan, so the first post-upgrade scan doesn't take hours. Until a row has `audioHash`, matching simply falls through to the tag tiers below.
 
 ### Precedence: path first, then content
 
@@ -121,7 +121,7 @@ The existing "empty directory" guard stays: when a scan finds zero audio files (
 
 | Phase | Scope |
 | --- | --- |
-| **1. Identity columns** | Schema migration; scanner reads `recordingMbid`/`isrc` from tags in the existing metadata pass; audio-hash computation for new/changed files; backfill worker for the existing library |
+| **1. Identity columns** | Schema migration; scanner reads `recordingMbid`/`isrc` from tags in the existing metadata pass; audio-hash computation for new/changed files; backfill worker populates audio hashes and tag identity keys for the existing library |
 | **2. Soft delete + revival** | `removedAt` migration; scanner marks instead of deletes; revival tiers on scan; exclusion audit across read surfaces; purge worker + retention config; Library Health surface |
 | **3. Move detection & replacement semantics** | Same-scan and cross-scan tier matching; replacement detection (same path, hash delta) with analysis/embedding/transcode re-queue |
 | **4 (deferred). Fingerprinting** | Opt-in AcoustID/Chromaprint (`fpcalc`) as a tier above tags for untagged libraries, via the analyzer-queue pattern — only if 1–3 prove insufficient |


### PR DESCRIPTION
Post-merge follow-ups to #458 (durable track identity, #457) that landed on the feature branch after the squash-merge cutoff and were never in a PR. All three are already deployed and verified live (running as `develop-765b885`):

- **Worker image bundles ffmpeg** — the slim `worker-runtime` stage lacked it, so the audio-hash backfill skipped every track (spawn ENOENT) and scan-time hashing was inert in worker-role deployments.
- **Backfill populates tag identity keys** — unchanged files skip the scanner's metadata parse, so the existing library would never receive `recordingMbid`/`isrc`; the backfill now extracts them (shared `trackIdentityTags` helper) in the same file-read pass that computes hashes. Verified live: hashes and tag keys populating across a 49k-track library.
- **Worker test module graph** — `indexRuntime.test.ts` needed a virtual `music-metadata` mock after the processor gained a top-level import (test-only; runtime unaffected).

Cherry-picked cleanly from the feature branch (`adfba45`, `765b885`, `be70d68`).