### PR TITLE
feat(discovery): weekly seed rotation, repeat-artist decay, shared artist caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discover Weekly now rotates play-weighted seed artists deterministically each
   user-week and decays scores for artists featured in up to three of the prior
   six weeks.
-- Subsonic `getRandomSongs` now uses artist-diversity weighted sampling before
-  shuffling its response.
+- Subsonic `getRandomSongs` now uses artist-diversity weighted sampling, then
+  tops up from remaining candidates to preserve the requested response size.
 - Score-ranked discovery and artist-radio selection now share the common artist
   cap primitive. Narrow artist-radio pools respect the hard artist-share ceiling
   and may return fewer tracks instead of using an uncapped refill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Discover Weekly now rotates play-weighted seed artists deterministically each
+  user-week and decays scores for artists featured in up to three of the prior
+  six weeks.
+- Subsonic `getRandomSongs` now uses artist-diversity weighted sampling before
+  shuffling its response.
+- Score-ranked discovery and artist-radio selection now share the common artist
+  cap primitive. Narrow artist-radio pools respect the hard artist-share ceiling
+  and may return fewer tracks instead of using an uncapped refill.
 - Federated audiobook mirror IDs now use the Node.js `randomUUID()` standard
   library API; the direct `@paralleldrive/cuid2` dependency was removed.
 

--- a/backend/src/__tests__/programmaticPlaylistArtistCap.test.ts
+++ b/backend/src/__tests__/programmaticPlaylistArtistCap.test.ts
@@ -38,6 +38,14 @@ function countByArtist(tracks: TestTrack[]): Map<string, number> {
 }
 
 describe("applyArtistCap", () => {
+    it("returns an empty selection for a non-array track input", () => {
+        expect(
+            applyArtistCap(null as unknown as TestTrack[], {
+                maxPerArtist: 1,
+            }),
+        ).toEqual([]);
+    });
+
     it("uses a custom artist identity before the album artist path", () => {
         const input = [
             { ...makeTrack("a-1", "album-a"), artistId: "artist-a" },
@@ -77,6 +85,33 @@ describe("applyArtistCap", () => {
         expect(selected.map((track) => track.id)).toEqual([
             "a-new-1",
             "b-new-1",
+        ]);
+    });
+
+    it("counts already-selected artists against relaxed fallback caps", () => {
+        const selected = applyArtistCap(
+            [
+                makeTrack("a-new-1", "artist-a"),
+                makeTrack("a-new-2", "artist-a"),
+                makeTrack("b-new-1", "artist-b"),
+                makeTrack("b-new-2", "artist-b"),
+            ],
+            {
+                maxPerArtist: 1,
+                targetCount: 4,
+                preserveInputOrder: true,
+                alreadySelected: [makeTrack("a-existing", "artist-a")],
+                fallback: {
+                    enabled: true,
+                    maxRelaxedPerArtist: 2,
+                },
+            },
+        );
+
+        expect(selected.map((track) => track.id)).toEqual([
+            "b-new-1",
+            "a-new-1",
+            "b-new-2",
         ]);
     });
 

--- a/backend/src/__tests__/programmaticPlaylistArtistCap.test.ts
+++ b/backend/src/__tests__/programmaticPlaylistArtistCap.test.ts
@@ -38,6 +38,48 @@ function countByArtist(tracks: TestTrack[]): Map<string, number> {
 }
 
 describe("applyArtistCap", () => {
+    it("uses a custom artist identity before the album artist path", () => {
+        const input = [
+            { ...makeTrack("a-1", "album-a"), artistId: "artist-a" },
+            { ...makeTrack("a-2", "album-b"), artistId: "artist-a" },
+            { ...makeTrack("u-1", "album-u"), artistId: "" },
+            { ...makeTrack("u-2", "album-u"), artistId: "" },
+        ];
+
+        const selected = applyArtistCap(input, {
+            maxPerArtist: 1,
+            preserveInputOrder: true,
+            getArtistId: (track) => track.artistId,
+        });
+
+        expect(selected.map((track) => track.id)).toEqual([
+            "a-1",
+            "u-1",
+            "u-2",
+        ]);
+    });
+
+    it("carries artist counts from tracks selected by an earlier pass", () => {
+        const selected = applyArtistCap(
+            [
+                makeTrack("a-new-1", "artist-a"),
+                makeTrack("a-new-2", "artist-a"),
+                makeTrack("b-new-1", "artist-b"),
+            ],
+            {
+                maxPerArtist: 2,
+                targetCount: 3,
+                preserveInputOrder: true,
+                alreadySelected: [makeTrack("a-existing", "artist-a")],
+            },
+        );
+
+        expect(selected.map((track) => track.id)).toEqual([
+            "a-new-1",
+            "b-new-1",
+        ]);
+    });
+
     it("enforces max-per-artist cap", () => {
         const input: TestTrack[] = [
             makeTrack("a-1", "artist-a"),

--- a/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
@@ -267,28 +267,31 @@ describe("subsonic core compatibility handlers", () => {
     });
 
     it("defaults random-song size and ignores an invalid fromYear while shuffling", async () => {
-        const candidateSongs = Array.from({ length: 20 }, (_, index) => ({
-            id: `track-${index + 1}`,
-            title: `Song ${index + 1}`,
-            trackNo: index + 1,
-            discNo: 1,
-            duration: 180,
-            fileSize: 1234,
-            mime: "audio/mpeg",
-            filePath: `Artist One/Album One/${index + 1}.mp3`,
-            album: {
-                id: "album-1",
-                title: "Album One",
-                year: 2024,
-                coverUrl: null,
-                genres: [],
-                userGenres: null,
-                artist: {
-                    id: "artist-1",
-                    name: "Artist One",
+        const candidateSongs = Array.from({ length: 20 }, (_, index) => {
+            const artistNumber = Math.floor(index / 4) + 1;
+            return {
+                id: `track-${index + 1}`,
+                title: `Song ${index + 1}`,
+                trackNo: index + 1,
+                discNo: 1,
+                duration: 180,
+                fileSize: 1234,
+                mime: "audio/mpeg",
+                filePath: `Artist ${artistNumber}/Album/${index + 1}.mp3`,
+                album: {
+                    id: `album-${artistNumber}`,
+                    title: `Album ${artistNumber}`,
+                    year: 2024,
+                    coverUrl: null,
+                    genres: [],
+                    userGenres: null,
+                    artist: {
+                        id: `artist-${artistNumber}`,
+                        name: `Artist ${artistNumber}`,
+                    },
                 },
-            },
-        }));
+            };
+        });
         mockTrackFindMany.mockResolvedValue(candidateSongs);
         const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.6);
 
@@ -317,6 +320,52 @@ describe("subsonic core compatibility handlers", () => {
                 take: 5000,
             }),
         );
+        randomSpy.mockRestore();
+    });
+
+    it("weights random songs by artist before returning a flat shuffle", async () => {
+        const makeSong = (artistId: string, index: number) => ({
+            id: `${artistId}-track-${index}`,
+            title: `${artistId} Song ${index}`,
+            trackNo: index,
+            discNo: 1,
+            duration: 180,
+            fileSize: 1234,
+            mime: "audio/mpeg",
+            filePath: `${artistId}/Album/${index}.mp3`,
+            album: {
+                id: `${artistId}-album-${index}`,
+                title: `${artistId} Album`,
+                year: 2024,
+                coverUrl: null,
+                genres: [],
+                userGenres: null,
+                artist: {
+                    id: artistId,
+                    name: artistId,
+                },
+            },
+        });
+        const dominant = Array.from({ length: 20 }, (_, index) =>
+            makeSong("artist-a", index + 1),
+        );
+        const tail = ["artist-b", "artist-c", "artist-d", "artist-e"].flatMap(
+            (artistId) => [makeSong(artistId, 1), makeSong(artistId, 2)],
+        );
+        mockTrackFindMany.mockResolvedValue([...dominant, ...tail]);
+        const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.999);
+
+        await handleGetRandomSongs(buildReq({ size: "10" }), buildRes());
+
+        const payload = mockSendSuccess.mock.calls[0][1] as {
+            randomSongs: { song: Array<{ artist: string }> };
+        };
+        const artistACount = payload.randomSongs.song.filter(
+            (song) => song.artist === "artist-a",
+        ).length;
+        expect(payload.randomSongs.song).toHaveLength(10);
+        expect(artistACount).toBeLessThanOrEqual(3);
+        expect(randomSpy).toHaveBeenCalled();
         randomSpy.mockRestore();
     });
 

--- a/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
@@ -323,6 +323,41 @@ describe("subsonic core compatibility handlers", () => {
         randomSpy.mockRestore();
     });
 
+    it("tops up random songs to the requested size for a single-artist pool", async () => {
+        const candidateSongs = Array.from({ length: 50 }, (_, index) => ({
+            id: `track-${index + 1}`,
+            title: `Song ${index + 1}`,
+            trackNo: index + 1,
+            discNo: 1,
+            duration: 180,
+            fileSize: 1234,
+            mime: "audio/mpeg",
+            filePath: `Artist One/Album/${index + 1}.mp3`,
+            album: {
+                id: "album-1",
+                title: "Album One",
+                year: 2024,
+                coverUrl: null,
+                genres: [],
+                userGenres: null,
+                artist: {
+                    id: "artist-1",
+                    name: "Artist One",
+                },
+            },
+        }));
+        mockTrackFindMany.mockResolvedValue(candidateSongs);
+        const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+        await handleGetRandomSongs(buildReq({ size: "10" }), buildRes());
+
+        const payload = mockSendSuccess.mock.calls[0][1] as {
+            randomSongs: { song: Array<unknown> };
+        };
+        expect(payload.randomSongs.song).toHaveLength(10);
+        randomSpy.mockRestore();
+    });
+
     it("weights random songs by artist before returning a flat shuffle", async () => {
         const makeSong = (artistId: string, index: number) => ({
             id: `${artistId}-track-${index}`,

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -7,7 +7,10 @@ import {
     subsonicRateLimiter,
 } from "../middleware/subsonicAuth";
 import { prisma } from "../utils/db";
-import { seededShuffle } from "../services/artistSlotAllocation";
+import {
+    allocateTracksWithArtistWeighting,
+    seededShuffle,
+} from "../services/artistSlotAllocation";
 import {
     getResponseFormat,
     sendSubsonicError,
@@ -3557,7 +3560,7 @@ export async function handleGetSongsByGenre(
 }
 
 /**
- * Executes handleGetRandomSongs.
+ * Return a flat shuffled Subsonic song sample with weighted artist diversity.
  */
 export async function handleGetRandomSongs(
     req: Request,
@@ -3655,8 +3658,13 @@ export async function handleGetRandomSongs(
             take: 5000,
         });
 
-        shuffleInPlace(candidates);
-        const songs = candidates.slice(0, size).map((track) =>
+        const selectedCandidates = allocateTracksWithArtistWeighting(
+            candidates,
+            (track) => track.album.artist.id,
+            { targetCount: size },
+        );
+        shuffleInPlace(selectedCandidates);
+        const songs = selectedCandidates.map((track) =>
             formatSongForSubsonic({
                 ...track,
                 genre: genre || undefined,

--- a/backend/src/routes/subsonic.ts
+++ b/backend/src/routes/subsonic.ts
@@ -3663,6 +3663,21 @@ export async function handleGetRandomSongs(
             (track) => track.album.artist.id,
             { targetCount: size },
         );
+        if (selectedCandidates.length < size) {
+            const selectedTrackIds = new Set(
+                selectedCandidates.map((track) => track.id),
+            );
+            const remainingCandidates = candidates.filter(
+                (track) => !selectedTrackIds.has(track.id),
+            );
+            shuffleInPlace(remainingCandidates);
+            selectedCandidates.push(
+                ...remainingCandidates.slice(
+                    0,
+                    size - selectedCandidates.length,
+                ),
+            );
+        }
         shuffleInPlace(selectedCandidates);
         const songs = selectedCandidates.map((track) =>
             formatSongForSubsonic({

--- a/backend/src/services/__tests__/libraryRadioBuilder.test.ts
+++ b/backend/src/services/__tests__/libraryRadioBuilder.test.ts
@@ -109,6 +109,22 @@ const createSeedTrack = (genre: string) => ({
 });
 
 describe("selectTracksWithArtistDiversity", () => {
+    it("returns an empty selection for invalid tracks or target counts", () => {
+        const tracks = [{ id: "a-1", artistId: "artist-a" }];
+
+        expect(
+            selectTracksWithArtistDiversity(tracks, Number.NaN, 1, 2),
+        ).toEqual([]);
+        expect(
+            selectTracksWithArtistDiversity(
+                null as unknown as typeof tracks,
+                1,
+                1,
+                2,
+            ),
+        ).toEqual([]);
+    });
+
     it("returns a shorter result instead of unbounded narrow-pool refill", () => {
         const tracks = [
             { id: "a-1", artistId: "artist-a" },

--- a/backend/src/services/__tests__/libraryRadioBuilder.test.ts
+++ b/backend/src/services/__tests__/libraryRadioBuilder.test.ts
@@ -89,7 +89,10 @@ jest.mock("../../utils/shuffle", () => ({
     shuffleArray: (values: unknown[]) => values,
 }));
 
-import { buildMultiTrackRadio } from "../libraryRadioBuilder";
+import {
+    buildMultiTrackRadio,
+    selectTracksWithArtistDiversity,
+} from "../libraryRadioBuilder";
 
 const createSeedTrack = (genre: string) => ({
     id: "seed-1",
@@ -103,6 +106,27 @@ const createSeedTrack = (genre: string) => ({
             userGenres: [],
         },
     },
+});
+
+describe("selectTracksWithArtistDiversity", () => {
+    it("returns a shorter result instead of unbounded narrow-pool refill", () => {
+        const tracks = [
+            { id: "a-1", artistId: "artist-a" },
+            { id: "a-2", artistId: "artist-a" },
+            { id: "a-3", artistId: "artist-a" },
+            { id: "a-4", artistId: "artist-a" },
+            { id: "a-5", artistId: "artist-a" },
+            { id: "b-1", artistId: "artist-b" },
+        ];
+
+        const selected = selectTracksWithArtistDiversity(tracks, 6, 1, 2);
+
+        expect(selected.map((track) => track.id)).toEqual([
+            "a-1",
+            "b-1",
+            "a-2",
+        ]);
+    });
 });
 
 describe("buildMultiTrackRadio genre fallback", () => {

--- a/backend/src/services/artistSlotAllocation.ts
+++ b/backend/src/services/artistSlotAllocation.ts
@@ -1,21 +1,16 @@
 /**
- * Shared artist-diversity selection for generated queues (GH #46).
+ * Shared primitives for the two artist-diversity selection problems (GH #46).
  *
- * Every queue/mix generation surface (library radio, programmatic
- * mixes, mood buckets, Subsonic samplers) selects tracks through this
- * module instead of carrying its own shuffle/cap logic — four
- * independent selection implementations is how artist-dominance bugs
- * replicated per surface.
+ * `allocateTracksWithArtistWeighting` handles unranked sampled pools: generated
+ * library-radio modes routed through `routes/library/radio.ts`, programmatic
+ * playlists, and Subsonic `getRandomSongs`. It allocates damped proportional
+ * artist slots under a hard share ceiling, then samples within each artist.
  *
- * Model: damped proportional slot allocation. Each artist's weight is
- * `n^alpha` (n = matching tracks). `alpha = 0` degenerates to
- * one-share-each (the flat cap), `alpha = 1` is fully proportional and
- * reproduces the dominance bug; the useful range is between. Slots are
- * distributed by largest-remainder rounding under a hard per-artist
- * ceiling (a share of the target size), so no artist can be a majority
- * regardless of discography size. Tracks within an artist are sampled
- * without replacement using the caller's RNG, so seeded generators stay
- * deterministic per seed.
+ * Score-ranked pools instead preserve ranking through
+ * `programmaticPlaylistArtistCap.applyArtistCap`: mood buckets, Discover Weekly,
+ * and artist-radio similar tracks selected by `libraryRadioBuilder`. Ordered
+ * vibe, liked, playlist, and tracks-radio queues intentionally skip artist
+ * diversification so their source order remains intact.
  */
 
 export interface ArtistAllocationOptions {

--- a/backend/src/services/discovery/__tests__/discoveryRecommendationsService.test.ts
+++ b/backend/src/services/discovery/__tests__/discoveryRecommendationsService.test.ts
@@ -240,6 +240,34 @@ describe("DiscoveryRecommendationsService", () => {
             expect(result).toEqual([]);
             expect(mockPrisma.artist.findMany).not.toHaveBeenCalled();
         });
+
+        it("deduplicates seed names case-insensitively while preserving first casing", async () => {
+            (
+                mockDiscoverySeeding.getSeedArtists as jest.Mock
+            ).mockResolvedValue([
+                { name: "Shared Artist" },
+                { name: "shared artist" },
+                { name: "SHARED ARTIST" },
+            ]);
+            (mockPrisma.artist.findMany as jest.Mock).mockResolvedValue([]);
+
+            await (service as any).resolveSeedArtistIds("user-1");
+
+            expect(mockPrisma.artist.findMany).toHaveBeenCalledWith({
+                where: {
+                    OR: [
+                        {
+                            name: {
+                                equals: "Shared Artist",
+                                mode: "insensitive",
+                            },
+                        },
+                    ],
+                },
+                select: { id: true },
+                take: 30,
+            });
+        });
     });
 
     describe("buildArtistScoreMap", () => {
@@ -411,6 +439,7 @@ describe("DiscoveryRecommendationsService", () => {
                     artistName: true,
                     weekStartDate: true,
                 },
+                take: 600,
             });
             expect(mockPrisma.artist.findMany).toHaveBeenCalledWith({
                 where: {
@@ -423,12 +452,6 @@ describe("DiscoveryRecommendationsService", () => {
                         {
                             name: {
                                 equals: "Repeat Artist",
-                                mode: "insensitive",
-                            },
-                        },
-                        {
-                            name: {
-                                equals: "repeat artist",
                                 mode: "insensitive",
                             },
                         },
@@ -447,6 +470,39 @@ describe("DiscoveryRecommendationsService", () => {
             );
             expect(result.get("fresh-artist")).toBe(0.8);
             expect(result.has("not-in-score-map")).toBe(false);
+        });
+
+        it("does not decay a same-named artist with a different MBID", async () => {
+            (mockPrisma.discoveryAlbum.findMany as jest.Mock).mockResolvedValue(
+                [
+                    {
+                        artistMbid: "featured-mbid",
+                        artistName: "Shared Artist",
+                        weekStartDate: new Date("2025-03-10T00:00:00.000Z"),
+                    },
+                ],
+            );
+            (mockPrisma.artist.findMany as jest.Mock).mockResolvedValue([
+                {
+                    id: "featured-artist",
+                    mbid: "featured-mbid",
+                    name: "Shared Artist",
+                },
+                {
+                    id: "different-artist",
+                    mbid: "different-mbid",
+                    name: "Shared Artist",
+                },
+            ]);
+            const scores = new Map([
+                ["featured-artist", 1],
+                ["different-artist", 1],
+            ]);
+
+            await (service as any).applyRecentArtistDecay("user-1", scores);
+
+            expect(scores.get("featured-artist")).toBeCloseTo(0.6);
+            expect(scores.get("different-artist")).toBe(1);
         });
     });
 

--- a/backend/src/services/discovery/__tests__/discoveryRecommendationsService.test.ts
+++ b/backend/src/services/discovery/__tests__/discoveryRecommendationsService.test.ts
@@ -1,4 +1,4 @@
-import { addMonths, endOfWeek, startOfWeek, subDays } from "date-fns";
+import { addMonths, endOfWeek, startOfWeek, subDays, subWeeks } from "date-fns";
 import { DiscoveryRecommendationsService } from "../discoveryRecommendations";
 import { discoverySeeding } from "../discoverySeeding";
 import { prisma } from "../../../utils/db";
@@ -12,6 +12,7 @@ jest.mock("date-fns", () => {
         endOfWeek: jest.fn(),
         startOfWeek: jest.fn(),
         subDays: jest.fn(),
+        subWeeks: jest.fn(),
     };
 });
 
@@ -79,6 +80,7 @@ const WEEK_START = new Date("2025-03-17T00:00:00.000Z");
 const WEEK_END = new Date("2025-03-23T23:59:59.999Z");
 const SUB_120 = new Date("2024-11-19T12:00:00.000Z");
 const SUB_14 = new Date("2025-03-05T12:00:00.000Z");
+const SUB_6_WEEKS = new Date("2025-02-03T00:00:00.000Z");
 const EXPIRES_AT = new Date("2025-09-19T12:00:00.000Z");
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
@@ -90,6 +92,7 @@ const mockAddMonths = addMonths as jest.MockedFunction<typeof addMonths>;
 const mockEndOfWeek = endOfWeek as jest.MockedFunction<typeof endOfWeek>;
 const mockStartOfWeek = startOfWeek as jest.MockedFunction<typeof startOfWeek>;
 const mockSubDays = subDays as jest.MockedFunction<typeof subDays>;
+const mockSubWeeks = subWeeks as jest.MockedFunction<typeof subWeeks>;
 
 describe("DiscoveryRecommendationsService", () => {
     let service: DiscoveryRecommendationsService;
@@ -106,11 +109,13 @@ describe("DiscoveryRecommendationsService", () => {
             (_date: Parameters<typeof subDays>[0], amount: number) =>
                 amount === 120 ? SUB_120 : SUB_14,
         );
+        mockSubWeeks.mockReturnValue(SUB_6_WEEKS);
         mockAddMonths.mockReturnValue(EXPIRES_AT);
 
         mathRandomSpy = jest.spyOn(Math, "random").mockReturnValue(0);
         (mockPrisma.likedTrack.findMany as jest.Mock).mockResolvedValue([]);
         (mockPrisma.dislikedEntity.findMany as jest.Mock).mockResolvedValue([]);
+        (mockPrisma.discoveryAlbum.findMany as jest.Mock).mockResolvedValue([]);
 
         service = new DiscoveryRecommendationsService();
     });
@@ -338,6 +343,110 @@ describe("DiscoveryRecommendationsService", () => {
             });
             expect(result.get("fallback-1")).toBe(0.4);
             expect(result.get("fallback-2")).toBe(0.4);
+        });
+
+        it("decays existing scores by distinct recently featured weeks without adding artists", async () => {
+            jest.spyOn(
+                service as any,
+                "resolveSeedArtistIds",
+            ).mockResolvedValue(["seed-artist"]);
+            (mockPrisma.similarArtist.findMany as jest.Mock).mockResolvedValue([
+                { toArtistId: "repeat-artist", weight: 0.9 },
+                { toArtistId: "fresh-artist", weight: 0.8 },
+            ]);
+            (mockPrisma.discoveryAlbum.findMany as jest.Mock).mockResolvedValue(
+                [
+                    {
+                        artistMbid: "repeat-mbid",
+                        artistName: "Repeat Artist",
+                        weekStartDate: new Date("2025-03-10T00:00:00.000Z"),
+                    },
+                    {
+                        artistMbid: "repeat-mbid",
+                        artistName: "Repeat Artist",
+                        weekStartDate: new Date("2025-03-10T00:00:00.000Z"),
+                    },
+                    {
+                        artistMbid: null,
+                        artistName: "repeat artist",
+                        weekStartDate: new Date("2025-03-03T00:00:00.000Z"),
+                    },
+                    {
+                        artistMbid: "repeat-mbid",
+                        artistName: "Repeat Artist",
+                        weekStartDate: new Date("2025-02-24T00:00:00.000Z"),
+                    },
+                    {
+                        artistMbid: "missing-mbid",
+                        artistName: "Missing Artist",
+                        weekStartDate: new Date("2025-03-10T00:00:00.000Z"),
+                    },
+                ],
+            );
+            (mockPrisma.artist.findMany as jest.Mock).mockResolvedValue([
+                {
+                    id: "repeat-artist",
+                    mbid: "repeat-mbid",
+                    name: "Repeat Artist",
+                },
+                {
+                    id: "not-in-score-map",
+                    mbid: "missing-mbid",
+                    name: "Missing Artist",
+                },
+            ]);
+
+            const result = await (service as any).buildArtistScoreMap("user-1");
+
+            expect(mockPrisma.discoveryAlbum.findMany).toHaveBeenCalledWith({
+                where: {
+                    userId: "user-1",
+                    weekStartDate: {
+                        lt: WEEK_START,
+                        gte: SUB_6_WEEKS,
+                    },
+                },
+                select: {
+                    artistMbid: true,
+                    artistName: true,
+                    weekStartDate: true,
+                },
+            });
+            expect(mockPrisma.artist.findMany).toHaveBeenCalledWith({
+                where: {
+                    OR: [
+                        {
+                            mbid: {
+                                in: ["repeat-mbid", "missing-mbid"],
+                            },
+                        },
+                        {
+                            name: {
+                                equals: "Repeat Artist",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            name: {
+                                equals: "repeat artist",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            name: {
+                                equals: "Missing Artist",
+                                mode: "insensitive",
+                            },
+                        },
+                    ],
+                },
+                select: { id: true, mbid: true, name: true },
+            });
+            expect(result.get("repeat-artist")).toBeCloseTo(
+                0.9 * Math.pow(0.6, 3),
+            );
+            expect(result.get("fresh-artist")).toBe(0.8);
+            expect(result.has("not-in-score-map")).toBe(false);
         });
     });
 

--- a/backend/src/services/discovery/__tests__/discoverySeeding.test.ts
+++ b/backend/src/services/discovery/__tests__/discoverySeeding.test.ts
@@ -462,6 +462,39 @@ describe("DiscoverySeeding", () => {
             ]);
         });
 
+        it("samples tied play counts deterministically across database row orders", async () => {
+            const recentPlays = Array.from({ length: 8 }, (_, index) => ({
+                trackId: `track-${index + 1}`,
+                _count: { id: 5 },
+            }));
+            const tracks = recentPlays.map((play, index) => ({
+                id: play.trackId,
+                album: {
+                    artistId: `artist-${index + 1}`,
+                    artist: {
+                        id: `artist-${index + 1}`,
+                        name: `Artist ${index + 1}`,
+                        mbid: `mbid-${index + 1}`,
+                    },
+                },
+            }));
+
+            (mockPrisma.play.groupBy as jest.Mock)
+                .mockResolvedValueOnce(recentPlays)
+                .mockResolvedValueOnce([...recentPlays].reverse());
+            (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(tracks);
+
+            const first = await seeding.getSeedArtists(userId, 3);
+            const reordered = await seeding.getSeedArtists(userId, 3);
+
+            expect(reordered).toEqual(first);
+            expect(mockPrisma.play.groupBy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    orderBy: [{ _count: { id: "desc" } }, { trackId: "asc" }],
+                }),
+            );
+        });
+
         it("should deduplicate artists from multiple tracks", async () => {
             // Need at least 5 plays to not trigger fallback
             const recentPlays = [

--- a/backend/src/services/discovery/__tests__/discoverySeeding.test.ts
+++ b/backend/src/services/discovery/__tests__/discoverySeeding.test.ts
@@ -43,8 +43,14 @@ describe("DiscoverySeeding", () => {
     let seeding: DiscoverySeeding;
 
     beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date("2026-08-12T12:00:00.000Z"));
         jest.clearAllMocks();
         seeding = new DiscoverySeeding();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     describe("getSeedArtists", () => {
@@ -126,14 +132,18 @@ describe("DiscoverySeeding", () => {
             const result = await seeding.getSeedArtists(userId);
 
             expect(result).toHaveLength(5);
-            expect(result[0]).toEqual({
-                name: "Artist One",
-                mbid: "valid-mbid-1",
-            });
-            expect(result[1]).toEqual({
-                name: "Artist Two",
-                mbid: "valid-mbid-2",
-            });
+            expect(result).toEqual(
+                expect.arrayContaining([
+                    {
+                        name: "Artist One",
+                        mbid: "valid-mbid-1",
+                    },
+                    {
+                        name: "Artist Two",
+                        mbid: "valid-mbid-2",
+                    },
+                ]),
+            );
         });
 
         it("should filter out artists with temp- MBIDs", async () => {
@@ -214,7 +224,7 @@ describe("DiscoverySeeding", () => {
             // Should have 4 valid artists (artist-1 has temp- MBID)
             expect(result).toHaveLength(4);
             expect(result.find((a) => a.mbid === "temp-12345")).toBeUndefined();
-            expect(result[0]).toEqual({
+            expect(result).toContainEqual({
                 name: "Artist Two",
                 mbid: "valid-mbid-2",
             });
@@ -298,7 +308,7 @@ describe("DiscoverySeeding", () => {
             // Should have 4 valid artists (artist-1 has null MBID)
             expect(result).toHaveLength(4);
             expect(result.find((a) => a.mbid === null)).toBeUndefined();
-            expect(result[0]).toEqual({
+            expect(result).toContainEqual({
                 name: "Artist Two",
                 mbid: "valid-mbid-2",
             });
@@ -403,6 +413,55 @@ describe("DiscoverySeeding", () => {
             expect(result.length).toBeLessThanOrEqual(5);
         });
 
+        it("dampens aggregated artist plays and rotates the deterministic sample across weeks", async () => {
+            const recentPlays = [
+                { trackId: "a-1", _count: { id: 64 } },
+                { trackId: "a-2", _count: { id: 36 } },
+                { trackId: "b-1", _count: { id: 36 } },
+                { trackId: "c-1", _count: { id: 25 } },
+                { trackId: "d-1", _count: { id: 16 } },
+                { trackId: "e-1", _count: { id: 9 } },
+                { trackId: "f-1", _count: { id: 4 } },
+            ];
+            const tracks = recentPlays.map((play) => {
+                const artistId = play.trackId.slice(0, 1);
+                return {
+                    id: play.trackId,
+                    album: {
+                        artistId,
+                        artist: {
+                            id: artistId,
+                            name: `Artist ${artistId.toUpperCase()}`,
+                            mbid: `mbid-${artistId}`,
+                        },
+                    },
+                };
+            });
+
+            (mockPrisma.play.groupBy as jest.Mock).mockResolvedValue(
+                recentPlays,
+            );
+            (mockPrisma.track.findMany as jest.Mock).mockResolvedValue(tracks);
+
+            const first = await seeding.getSeedArtists(userId, 3);
+            const repeated = await seeding.getSeedArtists(userId, 3);
+
+            jest.setSystemTime(new Date("2026-08-19T12:00:00.000Z"));
+            const followingWeek = await seeding.getSeedArtists(userId, 3);
+
+            expect(first.map((artist) => artist.mbid)).toEqual([
+                "mbid-a",
+                "mbid-c",
+                "mbid-e",
+            ]);
+            expect(repeated).toEqual(first);
+            expect(followingWeek.map((artist) => artist.mbid)).toEqual([
+                "mbid-b",
+                "mbid-a",
+                "mbid-c",
+            ]);
+        });
+
         it("should deduplicate artists from multiple tracks", async () => {
             // Need at least 5 plays to not trigger fallback
             const recentPlays = [
@@ -480,11 +539,13 @@ describe("DiscoverySeeding", () => {
 
             // Should have 3 unique artists despite 5 tracks (artist-1 appears 3 times)
             expect(result).toHaveLength(3);
-            expect(result.map((a) => a.name)).toEqual([
-                "Same Artist",
-                "Different Artist",
-                "Third Artist",
-            ]);
+            expect(result.map((a) => a.name)).toEqual(
+                expect.arrayContaining([
+                    "Same Artist",
+                    "Different Artist",
+                    "Third Artist",
+                ]),
+            );
         });
     });
 

--- a/backend/src/services/discovery/discoveryRecommendations.ts
+++ b/backend/src/services/discovery/discoveryRecommendations.ts
@@ -1,4 +1,4 @@
-import { addMonths, endOfWeek, startOfWeek, subDays } from "date-fns";
+import { addMonths, endOfWeek, startOfWeek, subDays, subWeeks } from "date-fns";
 import { prisma } from "../../utils/db";
 import {
     TRACK_BROWSE_WHERE,
@@ -12,6 +12,19 @@ import {
     TRACK_DISLIKE_ENTITY_TYPE,
 } from "../trackPreference";
 import { separateArtists } from "../../utils/separateArtists";
+import { applyArtistCap } from "../programmaticPlaylistArtistCap";
+
+/**
+ * Weekly score multiplier for recently featured artists so fresh candidates
+ * outrank repeats without removing repeat artists from the candidate pool.
+ */
+const RECENT_FEATURE_DECAY = 0.6;
+
+/**
+ * Cap the six-week repeat penalty at three featured weeks; 3+ appearances
+ * receive about 0.22x, below the generic candidate score of 0.35.
+ */
+const RECENT_FEATURE_DECAY_MAX_WEEKS = 3;
 
 type RecommendationTier = "high" | "medium" | "explore" | "wildcard";
 
@@ -61,6 +74,195 @@ interface CurrentPlaylistResponse {
     unavailable: never[];
     totalCount: number;
     unavailableCount: number;
+}
+
+type ArtistIdentity = {
+    mbid?: string | null;
+    name?: string | null;
+};
+
+type ResolvedArtistIdentity = {
+    id: string;
+    mbid: string;
+    name: string;
+};
+
+type RecentFeaturedArtist = {
+    artistMbid: string | null;
+    artistName: string;
+    weekStartDate: Date;
+};
+
+type SelectableDiscoveryTrack = {
+    id: string;
+    title: string;
+    duration: number;
+    filePath: string | null;
+    albumId: string;
+    album: {
+        artistId: string;
+        title: string;
+        rgMbid: string;
+        coverUrl: string | null;
+        artist: {
+            id: string;
+            name: string;
+            mbid: string;
+        };
+    };
+};
+
+type ScoredDiscoveryTrack = SelectableDiscoveryTrack & {
+    score: number;
+    tier: RecommendationTier;
+};
+
+/** Build the MBID/name OR clauses used to resolve library artists. */
+function buildArtistIdentityClauses(
+    identities: ArtistIdentity[],
+): Array<Record<string, unknown>> {
+    const mbids = Array.from(
+        new Set(
+            identities
+                .map((identity) => identity.mbid)
+                .filter((mbid): mbid is string => Boolean(mbid)),
+        ),
+    );
+    const names = Array.from(
+        new Set(
+            identities
+                .map((identity) => identity.name)
+                .filter((name): name is string => Boolean(name)),
+        ),
+    );
+    const clauses: Array<Record<string, unknown>> = [];
+    if (mbids.length > 0) clauses.push({ mbid: { in: mbids } });
+    for (const name of names) {
+        clauses.push({
+            name: { equals: name, mode: "insensitive" as const },
+        });
+    }
+    return clauses;
+}
+
+/** Return whether a stored feature row identifies a resolved artist. */
+function featureMatchesArtist(
+    feature: RecentFeaturedArtist,
+    artist: ResolvedArtistIdentity,
+): boolean {
+    if (feature.artistMbid && feature.artistMbid === artist.mbid) return true;
+    return (
+        feature.artistName.localeCompare(artist.name, undefined, {
+            sensitivity: "accent",
+        }) === 0
+    );
+}
+
+/** Count distinct featured weeks for a resolved artist. */
+function countFeaturedWeeks(
+    features: RecentFeaturedArtist[],
+    artist: ResolvedArtistIdentity,
+): number {
+    const weeks = new Set<number>();
+    for (const feature of features) {
+        if (featureMatchesArtist(feature, artist)) {
+            weeks.add(feature.weekStartDate.getTime());
+        }
+    }
+    return weeks.size;
+}
+
+/** Keep the first, highest-ranked track for each album. */
+function dedupeTracksByAlbum<T extends { albumId: string }>(tracks: T[]): T[] {
+    const seenAlbumIds = new Set<string>();
+    const deduped: T[] = [];
+    for (const track of tracks) {
+        if (seenAlbumIds.has(track.albumId)) continue;
+        seenAlbumIds.add(track.albumId);
+        deduped.push(track);
+    }
+    return deduped;
+}
+
+/** Map a selected library track into the persisted Discover Weekly shape. */
+function toSelectedTrack(
+    track: SelectableDiscoveryTrack,
+    similarity: number,
+    tier: RecommendationTier,
+): SelectedTrack {
+    return {
+        trackId: track.id,
+        title: track.title,
+        duration: track.duration,
+        filePath: track.filePath ?? "",
+        albumId: track.albumId,
+        albumTitle: track.album.title,
+        albumMbid: track.album.rgMbid,
+        artistId: track.album.artist.id,
+        artistName: track.album.artist.name,
+        artistMbid: track.album.artist.mbid,
+        coverUrl: track.album.coverUrl,
+        similarity,
+        tier,
+    };
+}
+
+/** Score candidate tracks while preserving all fields needed for selection. */
+function scoreDiscoveryCandidates(
+    tracks: SelectableDiscoveryTrack[],
+    artistScores: Map<string, number>,
+    preferenceScores: Map<string, number>,
+): ScoredDiscoveryTrack[] {
+    return tracks
+        .map((track) => {
+            const artistScore = artistScores.get(track.album.artistId) ?? 0.35;
+            const baseScore = clampSimilarity(artistScore + randomJitter(0.14));
+            const score = clampSimilarity(
+                applyTrackPreferenceSimilarityBias(
+                    baseScore,
+                    preferenceScores.get(track.id) ?? 0,
+                ),
+            );
+            return { ...track, score, tier: similarityToTier(score) };
+        })
+        .sort((left, right) => right.score - left.score);
+}
+
+/** Apply the shared strict/relaxed cap to a ranked discovery pass. */
+function capRankedDiscoveryTracks<T extends SelectableDiscoveryTrack>(
+    tracks: T[],
+    targetCount: number,
+    strictArtistCap: number,
+    relaxedArtistCap: number,
+    alreadySelected?: T[],
+): T[] {
+    return applyArtistCap(dedupeTracksByAlbum(tracks), {
+        preserveInputOrder: true,
+        targetCount,
+        maxPerArtist: strictArtistCap,
+        ...(alreadySelected ? { alreadySelected } : {}),
+        fallback: {
+            enabled: true,
+            relaxationStep: Math.max(1, relaxedArtistCap - strictArtistCap),
+            maxRelaxedPerArtist: relaxedArtistCap,
+        },
+    });
+}
+
+/** Score and map fallback tracks after rank-preserving artist selection. */
+function mapFallbackSelections(
+    tracks: SelectableDiscoveryTrack[],
+    preferenceScores: Map<string, number>,
+): SelectedTrack[] {
+    return tracks.map((track) => {
+        const similarity = clampSimilarity(
+            applyTrackPreferenceSimilarityBias(
+                0.34 + randomJitter(0.15),
+                preferenceScores.get(track.id) ?? 0,
+            ),
+        );
+        return toSelectedTrack(track, similarity, similarityToTier(similarity));
+    });
 }
 
 function clampSimilarity(value: number): number {
@@ -116,26 +318,7 @@ export class DiscoveryRecommendationsService {
 
     private async resolveSeedArtistIds(userId: string): Promise<string[]> {
         const seeds = await discoverySeeding.getSeedArtists(userId);
-
-        const mbids = seeds
-            .map((seed) => seed.mbid)
-            .filter(Boolean) as string[];
-        const names = seeds.map((seed) => seed.name).filter(Boolean);
-
-        const whereClauses: Array<Record<string, unknown>> = [];
-        if (mbids.length > 0) {
-            whereClauses.push({ mbid: { in: mbids } });
-        }
-        if (names.length > 0) {
-            whereClauses.push(
-                ...names.map((name) => ({
-                    name: {
-                        equals: name,
-                        mode: "insensitive" as const,
-                    },
-                })),
-            );
-        }
+        const whereClauses = buildArtistIdentityClauses(seeds);
 
         if (whereClauses.length === 0) {
             return [];
@@ -152,95 +335,143 @@ export class DiscoveryRecommendationsService {
         return artists.map((artist) => artist.id);
     }
 
-    private async buildArtistScoreMap(
+    private async applyRecentArtistDecay(
         userId: string,
-    ): Promise<Map<string, number>> {
-        const scoreMap = new Map<string, number>();
+        scoreMap: Map<string, number>,
+    ): Promise<void> {
+        const currentWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+        const recentFeatures = await prisma.discoveryAlbum.findMany({
+            where: {
+                userId,
+                weekStartDate: {
+                    lt: currentWeekStart,
+                    gte: subWeeks(currentWeekStart, 6),
+                },
+            },
+            select: {
+                artistMbid: true,
+                artistName: true,
+                weekStartDate: true,
+            },
+        });
+        if (recentFeatures.length === 0) return;
 
+        const whereClauses = buildArtistIdentityClauses(
+            recentFeatures.map((feature) => ({
+                mbid: feature.artistMbid,
+                name: feature.artistName,
+            })),
+        );
+        if (whereClauses.length === 0) return;
+
+        const artists = await prisma.artist.findMany({
+            where: { OR: whereClauses },
+            select: { id: true, mbid: true, name: true },
+        });
+        for (const artist of artists) {
+            const score = scoreMap.get(artist.id);
+            if (score === undefined) continue;
+            const weeks = Math.min(
+                countFeaturedWeeks(recentFeatures, artist),
+                RECENT_FEATURE_DECAY_MAX_WEEKS,
+            );
+            if (weeks === 0) continue;
+            scoreMap.set(
+                artist.id,
+                score * Math.pow(RECENT_FEATURE_DECAY, weeks),
+            );
+        }
+    }
+
+    private async addSeedArtistScores(
+        userId: string,
+        scoreMap: Map<string, number>,
+    ): Promise<void> {
         const seedArtistIds = await this.resolveSeedArtistIds(userId);
         for (const artistId of seedArtistIds) {
             scoreMap.set(artistId, 0.62 + randomJitter(0.08));
         }
+        if (seedArtistIds.length === 0) return;
 
-        if (seedArtistIds.length > 0) {
-            const similarEdges = await prisma.similarArtist.findMany({
-                where: {
-                    fromArtistId: { in: seedArtistIds },
-                },
-                orderBy: { weight: "desc" },
-                select: {
-                    toArtistId: true,
-                    weight: true,
-                },
-                take: 800,
-            });
-
-            for (const edge of similarEdges) {
-                const weighted = clampSimilarity(edge.weight || 0.35);
-                const existing = scoreMap.get(edge.toArtistId) || 0;
-                if (weighted > existing) {
-                    scoreMap.set(edge.toArtistId, weighted);
-                }
+        const similarEdges = await prisma.similarArtist.findMany({
+            where: { fromArtistId: { in: seedArtistIds } },
+            orderBy: { weight: "desc" },
+            select: { toArtistId: true, weight: true },
+            take: 800,
+        });
+        for (const edge of similarEdges) {
+            const weighted = clampSimilarity(edge.weight || 0.35);
+            const existing = scoreMap.get(edge.toArtistId) || 0;
+            if (weighted > existing) {
+                scoreMap.set(edge.toArtistId, weighted);
             }
         }
+    }
 
-        if (scoreMap.size === 0) {
-            // Fallback: derive seeds from recent plays when metadata seeding is unavailable.
-            const recentPlays = await prisma.play.findMany({
-                where: {
-                    userId,
-                    playedAt: { gte: subDays(new Date(), 120) },
-                    track: {
-                        ...TRACK_VISIBLE_WHERE,
-                        ...TRACK_BROWSE_WHERE,
+    private async addRecentPlayArtistScores(
+        userId: string,
+        scoreMap: Map<string, number>,
+    ): Promise<void> {
+        if (scoreMap.size > 0) return;
+
+        const recentPlays = await prisma.play.findMany({
+            where: {
+                userId,
+                playedAt: { gte: subDays(new Date(), 120) },
+                track: {
+                    ...TRACK_VISIBLE_WHERE,
+                    ...TRACK_BROWSE_WHERE,
+                },
+            },
+            select: {
+                track: {
+                    select: {
+                        album: { select: { artistId: true } },
                     },
                 },
-                select: {
-                    track: {
-                        select: {
-                            album: {
-                                select: {
-                                    artistId: true,
-                                },
-                            },
-                        },
-                    },
-                },
-                take: 600,
-                orderBy: { playedAt: "desc" },
-            });
-
-            for (const play of recentPlays) {
-                const artistId = play.track?.album?.artistId;
-                if (!artistId) continue;
-                if (!scoreMap.has(artistId)) {
-                    scoreMap.set(artistId, 0.5 + randomJitter(0.08));
-                }
+            },
+            take: 600,
+            orderBy: { playedAt: "desc" },
+        });
+        for (const play of recentPlays) {
+            const artistId = play.track?.album?.artistId;
+            if (artistId && !scoreMap.has(artistId)) {
+                scoreMap.set(artistId, 0.5 + randomJitter(0.08));
             }
         }
+    }
 
-        if (scoreMap.size === 0) {
-            // Last resort fallback for very fresh libraries.
-            const fallbackArtists = await prisma.artist.findMany({
-                where: {
-                    albums: {
-                        some: {
-                            tracks: {
-                                some: {},
-                            },
-                        },
+    private async addCatalogArtistScores(
+        scoreMap: Map<string, number>,
+    ): Promise<void> {
+        if (scoreMap.size > 0) return;
+
+        const fallbackArtists = await prisma.artist.findMany({
+            where: {
+                albums: {
+                    some: {
+                        tracks: { some: {} },
                     },
                 },
-                select: { id: true },
-                take: 100,
-                orderBy: { countsLastUpdated: "desc" },
-            });
-
-            for (const artist of fallbackArtists) {
-                scoreMap.set(artist.id, 0.4 + randomJitter(0.08));
-            }
+            },
+            select: { id: true },
+            take: 100,
+            orderBy: { countsLastUpdated: "desc" },
+        });
+        for (const artist of fallbackArtists) {
+            scoreMap.set(artist.id, 0.4 + randomJitter(0.08));
         }
+    }
 
+    private async buildArtistScoreMap(
+        userId: string,
+    ): Promise<Map<string, number>> {
+        const scoreMap = new Map<string, number>();
+        await this.addSeedArtistScores(userId, scoreMap);
+        await this.addRecentPlayArtistScores(userId, scoreMap);
+        await this.addCatalogArtistScores(scoreMap);
+
+        await this.applyRecentArtistDecay(userId, scoreMap);
         return scoreMap;
     }
 
@@ -302,15 +533,10 @@ export class DiscoveryRecommendationsService {
         return scoreMap;
     }
 
-    private async selectTracks(
-        userId: string,
-        targetCount: number,
-    ): Promise<SelectedTrack[]> {
-        const strictArtistCap = getArtistCapForTarget(targetCount);
-        const relaxedArtistCap = getRelaxedArtistCapForTarget(targetCount);
-        const artistScores = await this.buildArtistScoreMap(userId);
-        const prioritizedArtistIds = Array.from(artistScores.keys());
-
+    private async getSelectionFilters(userId: string): Promise<{
+        recentTrackIds: string[];
+        excludedAlbumMbids: string[];
+    }> {
         const recentPlays = await prisma.play.findMany({
             where: {
                 userId,
@@ -324,19 +550,25 @@ export class DiscoveryRecommendationsService {
             .filter(
                 (trackId): trackId is string => typeof trackId === "string",
             );
-
         const activeExclusions = await prisma.discoverExclusion.findMany({
-            where: {
-                userId,
-                expiresAt: { gt: new Date() },
-            },
+            where: { userId, expiresAt: { gt: new Date() } },
             select: { albumMbid: true },
         });
-        const excludedAlbumMbids = activeExclusions.map(
-            (entry) => entry.albumMbid,
-        );
+        return {
+            recentTrackIds,
+            excludedAlbumMbids: activeExclusions.map(
+                (entry) => entry.albumMbid,
+            ),
+        };
+    }
 
-        const candidateTracks = await prisma.track.findMany({
+    private async findPrimaryCandidateTracks(
+        targetCount: number,
+        prioritizedArtistIds: string[],
+        recentTrackIds: string[],
+        excludedAlbumMbids: string[],
+    ): Promise<SelectableDiscoveryTrack[]> {
+        return prisma.track.findMany({
             where: {
                 ...TRACK_VISIBLE_WHERE,
                 ...TRACK_BROWSE_WHERE,
@@ -358,11 +590,7 @@ export class DiscoveryRecommendationsService {
                 album: {
                     include: {
                         artist: {
-                            select: {
-                                id: true,
-                                name: true,
-                                mbid: true,
-                            },
+                            select: { id: true, name: true, mbid: true },
                         },
                     },
                 },
@@ -370,235 +598,121 @@ export class DiscoveryRecommendationsService {
             take: Math.max(targetCount * 20, 220),
             orderBy: [{ updatedAt: "desc" }],
         });
-        const candidatePreferenceScores = await this.getTrackPreferenceScoreMap(
-            userId,
-            candidateTracks.map((track) => track.id),
-        );
+    }
 
-        const scoredCandidates = candidateTracks
-            .map((track) => {
-                const artistScore =
-                    artistScores.get(track.album.artistId) ?? 0.35;
-                const baseScore = clampSimilarity(
-                    artistScore + randomJitter(0.14),
-                );
-                const score = clampSimilarity(
-                    applyTrackPreferenceSimilarityBias(
-                        baseScore,
-                        candidatePreferenceScores.get(track.id) ?? 0,
-                    ),
-                );
-                return {
-                    track,
-                    score,
-                    tier: similarityToTier(score),
-                };
-            })
-            .sort((left, right) => right.score - left.score);
-
-        const selected: SelectedTrack[] = [];
-        const selectedAlbumIds = new Set<string>();
-        const selectedTrackIds = new Set<string>();
-        const selectedArtistCounts = new Map<string, number>();
-
-        const canSelectArtist = (artistId: string, cap: number): boolean =>
-            (selectedArtistCounts.get(artistId) ?? 0) < cap;
-
-        const recordSelectedArtist = (artistId: string): void => {
-            selectedArtistCounts.set(
-                artistId,
-                (selectedArtistCounts.get(artistId) ?? 0) + 1,
-            );
-        };
-
-        const deferredPrimaryCandidates: typeof scoredCandidates = [];
-
-        for (const candidate of scoredCandidates) {
-            if (selected.length >= targetCount) break;
-            if (selectedTrackIds.has(candidate.track.id)) continue;
-            if (selectedAlbumIds.has(candidate.track.albumId)) continue;
-            if (
-                !canSelectArtist(
-                    candidate.track.album.artist.id,
-                    strictArtistCap,
-                )
-            ) {
-                deferredPrimaryCandidates.push(candidate);
-                continue;
-            }
-
-            selectedTrackIds.add(candidate.track.id);
-            selectedAlbumIds.add(candidate.track.albumId);
-            recordSelectedArtist(candidate.track.album.artist.id);
-
-            selected.push({
-                trackId: candidate.track.id,
-                title: candidate.track.title,
-                duration: candidate.track.duration,
-                filePath: candidate.track.filePath ?? "",
-                albumId: candidate.track.albumId,
-                albumTitle: candidate.track.album.title,
-                albumMbid: candidate.track.album.rgMbid,
-                artistId: candidate.track.album.artist.id,
-                artistName: candidate.track.album.artist.name,
-                artistMbid: candidate.track.album.artist.mbid,
-                coverUrl: candidate.track.album.coverUrl,
-                similarity: candidate.score,
-                tier: candidate.tier,
-            });
-        }
-
-        if (selected.length < targetCount) {
-            for (const candidate of deferredPrimaryCandidates) {
-                if (selected.length >= targetCount) break;
-                if (selectedTrackIds.has(candidate.track.id)) continue;
-                if (selectedAlbumIds.has(candidate.track.albumId)) continue;
-                if (
-                    !canSelectArtist(
-                        candidate.track.album.artist.id,
-                        relaxedArtistCap,
-                    )
-                ) {
-                    continue;
-                }
-
-                selectedTrackIds.add(candidate.track.id);
-                selectedAlbumIds.add(candidate.track.albumId);
-                recordSelectedArtist(candidate.track.album.artist.id);
-
-                selected.push({
-                    trackId: candidate.track.id,
-                    title: candidate.track.title,
-                    duration: candidate.track.duration,
-                    filePath: candidate.track.filePath ?? "",
-                    albumId: candidate.track.albumId,
-                    albumTitle: candidate.track.album.title,
-                    albumMbid: candidate.track.album.rgMbid,
-                    artistId: candidate.track.album.artist.id,
-                    artistName: candidate.track.album.artist.name,
-                    artistMbid: candidate.track.album.artist.mbid,
-                    coverUrl: candidate.track.album.coverUrl,
-                    similarity: candidate.score,
-                    tier: candidate.tier,
-                });
-            }
-        }
-
-        if (selected.length < targetCount) {
-            const fallbackTracks = await prisma.track.findMany({
-                where: {
-                    ...TRACK_VISIBLE_WHERE,
-                    ...TRACK_BROWSE_WHERE,
-                    duration: { gt: 0 },
-                    id: { notIn: Array.from(selectedTrackIds) },
-                    album: {
-                        location: { in: ["LIBRARY", "FEDERATED"] },
-                        ...(excludedAlbumMbids.length > 0
-                            ? { rgMbid: { notIn: excludedAlbumMbids } }
-                            : {}),
-                    },
+    private async findFallbackCandidateTracks(
+        targetCount: number,
+        selectedTrackIds: string[],
+        excludedAlbumMbids: string[],
+    ): Promise<SelectableDiscoveryTrack[]> {
+        return prisma.track.findMany({
+            where: {
+                ...TRACK_VISIBLE_WHERE,
+                ...TRACK_BROWSE_WHERE,
+                duration: { gt: 0 },
+                id: { notIn: selectedTrackIds },
+                album: {
+                    location: { in: ["LIBRARY", "FEDERATED"] },
+                    ...(excludedAlbumMbids.length > 0
+                        ? { rgMbid: { notIn: excludedAlbumMbids } }
+                        : {}),
                 },
-                include: {
-                    album: {
-                        include: {
-                            artist: {
-                                select: {
-                                    id: true,
-                                    name: true,
-                                    mbid: true,
-                                },
-                            },
+            },
+            include: {
+                album: {
+                    include: {
+                        artist: {
+                            select: { id: true, name: true, mbid: true },
                         },
                     },
                 },
-                take: Math.max(targetCount * 10, 180),
-                orderBy: [{ updatedAt: "desc" }],
-            });
-            const fallbackPreferenceScores =
-                await this.getTrackPreferenceScoreMap(
-                    userId,
-                    fallbackTracks.map((track) => track.id),
-                );
+            },
+            take: Math.max(targetCount * 10, 180),
+            orderBy: [{ updatedAt: "desc" }],
+        });
+    }
 
-            const deferredFallbackTracks: typeof fallbackTracks = [];
+    private async selectFallbackTracks(
+        userId: string,
+        targetCount: number,
+        strictArtistCap: number,
+        relaxedArtistCap: number,
+        primaryTracks: ScoredDiscoveryTrack[],
+        excludedAlbumMbids: string[],
+    ): Promise<SelectedTrack[]> {
+        const selectedTrackIds = primaryTracks.map((track) => track.id);
+        const selectedAlbumIds = new Set(
+            primaryTracks.map((track) => track.albumId),
+        );
+        const fallbackTracks = await this.findFallbackCandidateTracks(
+            targetCount,
+            selectedTrackIds,
+            excludedAlbumMbids,
+        );
+        const preferenceScores = await this.getTrackPreferenceScoreMap(
+            userId,
+            fallbackTracks.map((track) => track.id),
+        );
+        const eligibleTracks = fallbackTracks.filter(
+            (track) =>
+                !selectedTrackIds.includes(track.id) &&
+                !selectedAlbumIds.has(track.albumId),
+        );
+        const selections = capRankedDiscoveryTracks(
+            eligibleTracks,
+            targetCount - primaryTracks.length,
+            strictArtistCap,
+            relaxedArtistCap,
+            primaryTracks,
+        );
+        return mapFallbackSelections(selections, preferenceScores);
+    }
 
-            for (const track of fallbackTracks) {
-                if (selected.length >= targetCount) break;
-                if (selectedTrackIds.has(track.id)) continue;
-                if (selectedAlbumIds.has(track.albumId)) continue;
-                if (!canSelectArtist(track.album.artist.id, strictArtistCap)) {
-                    deferredFallbackTracks.push(track);
-                    continue;
-                }
+    private async selectTracks(
+        userId: string,
+        targetCount: number,
+    ): Promise<SelectedTrack[]> {
+        const strictArtistCap = getArtistCapForTarget(targetCount);
+        const relaxedArtistCap = getRelaxedArtistCapForTarget(targetCount);
+        const artistScores = await this.buildArtistScoreMap(userId);
+        const prioritizedArtistIds = Array.from(artistScores.keys());
+        const { recentTrackIds, excludedAlbumMbids } =
+            await this.getSelectionFilters(userId);
+        const candidateTracks = await this.findPrimaryCandidateTracks(
+            targetCount,
+            prioritizedArtistIds,
+            recentTrackIds,
+            excludedAlbumMbids,
+        );
+        const preferenceScores = await this.getTrackPreferenceScoreMap(
+            userId,
+            candidateTracks.map((track) => track.id),
+        );
+        const scoredCandidates = scoreDiscoveryCandidates(
+            candidateTracks,
+            artistScores,
+            preferenceScores,
+        );
+        const primaryTracks = capRankedDiscoveryTracks(
+            scoredCandidates,
+            targetCount,
+            strictArtistCap,
+            relaxedArtistCap,
+        );
+        const selected = primaryTracks.map((track) =>
+            toSelectedTrack(track, track.score, track.tier),
+        );
 
-                selectedTrackIds.add(track.id);
-                selectedAlbumIds.add(track.albumId);
-                recordSelectedArtist(track.album.artist.id);
-
-                const fallbackSimilarity = clampSimilarity(
-                    applyTrackPreferenceSimilarityBias(
-                        0.34 + randomJitter(0.15),
-                        fallbackPreferenceScores.get(track.id) ?? 0,
-                    ),
-                );
-                selected.push({
-                    trackId: track.id,
-                    title: track.title,
-                    duration: track.duration,
-                    filePath: track.filePath ?? "",
-                    albumId: track.albumId,
-                    albumTitle: track.album.title,
-                    albumMbid: track.album.rgMbid,
-                    artistId: track.album.artist.id,
-                    artistName: track.album.artist.name,
-                    artistMbid: track.album.artist.mbid,
-                    coverUrl: track.album.coverUrl,
-                    similarity: fallbackSimilarity,
-                    tier: similarityToTier(fallbackSimilarity),
-                });
-            }
-
-            if (selected.length < targetCount) {
-                for (const track of deferredFallbackTracks) {
-                    if (selected.length >= targetCount) break;
-                    if (selectedTrackIds.has(track.id)) continue;
-                    if (selectedAlbumIds.has(track.albumId)) continue;
-                    if (
-                        !canSelectArtist(
-                            track.album.artist.id,
-                            relaxedArtistCap,
-                        )
-                    ) {
-                        continue;
-                    }
-
-                    selectedTrackIds.add(track.id);
-                    selectedAlbumIds.add(track.albumId);
-                    recordSelectedArtist(track.album.artist.id);
-
-                    const fallbackSimilarity = clampSimilarity(
-                        applyTrackPreferenceSimilarityBias(
-                            0.34 + randomJitter(0.15),
-                            fallbackPreferenceScores.get(track.id) ?? 0,
-                        ),
-                    );
-                    selected.push({
-                        trackId: track.id,
-                        title: track.title,
-                        duration: track.duration,
-                        filePath: track.filePath ?? "",
-                        albumId: track.albumId,
-                        albumTitle: track.album.title,
-                        albumMbid: track.album.rgMbid,
-                        artistId: track.album.artist.id,
-                        artistName: track.album.artist.name,
-                        artistMbid: track.album.artist.mbid,
-                        coverUrl: track.album.coverUrl,
-                        similarity: fallbackSimilarity,
-                        tier: similarityToTier(fallbackSimilarity),
-                    });
-                }
-            }
+        if (selected.length < targetCount) {
+            const fallbackSelections = await this.selectFallbackTracks(
+                userId,
+                targetCount,
+                strictArtistCap,
+                relaxedArtistCap,
+                primaryTracks,
+                excludedAlbumMbids,
+            );
+            selected.push(...fallbackSelections);
         }
 
         return separateArtists(

--- a/backend/src/services/discovery/discoveryRecommendations.ts
+++ b/backend/src/services/discovery/discoveryRecommendations.ts
@@ -128,13 +128,15 @@ function buildArtistIdentityClauses(
                 .filter((mbid): mbid is string => Boolean(mbid)),
         ),
     );
-    const names = Array.from(
-        new Set(
-            identities
-                .map((identity) => identity.name)
-                .filter((name): name is string => Boolean(name)),
-        ),
-    );
+    const namesByLowercase = new Map<string, string>();
+    for (const identity of identities) {
+        if (!identity.name) continue;
+        const lowercaseName = identity.name.toLowerCase();
+        if (!namesByLowercase.has(lowercaseName)) {
+            namesByLowercase.set(lowercaseName, identity.name);
+        }
+    }
+    const names = Array.from(namesByLowercase.values());
     const clauses: Array<Record<string, unknown>> = [];
     if (mbids.length > 0) clauses.push({ mbid: { in: mbids } });
     for (const name of names) {
@@ -150,7 +152,9 @@ function featureMatchesArtist(
     feature: RecentFeaturedArtist,
     artist: ResolvedArtistIdentity,
 ): boolean {
-    if (feature.artistMbid && feature.artistMbid === artist.mbid) return true;
+    if (feature.artistMbid && artist.mbid) {
+        return feature.artistMbid === artist.mbid;
+    }
     return (
         feature.artistName.localeCompare(artist.name, undefined, {
             sensitivity: "accent",
@@ -353,6 +357,8 @@ export class DiscoveryRecommendationsService {
                 artistName: true,
                 weekStartDate: true,
             },
+            // Bounds six weeks x 50 tracks x both discovery pipelines.
+            take: 600,
         });
         if (recentFeatures.length === 0) return;
 
@@ -641,6 +647,7 @@ export class DiscoveryRecommendationsService {
         excludedAlbumMbids: string[],
     ): Promise<SelectedTrack[]> {
         const selectedTrackIds = primaryTracks.map((track) => track.id);
+        const selectedTrackIdSet = new Set(selectedTrackIds);
         const selectedAlbumIds = new Set(
             primaryTracks.map((track) => track.albumId),
         );
@@ -655,7 +662,7 @@ export class DiscoveryRecommendationsService {
         );
         const eligibleTracks = fallbackTracks.filter(
             (track) =>
-                !selectedTrackIds.includes(track.id) &&
+                !selectedTrackIdSet.has(track.id) &&
                 !selectedAlbumIds.has(track.albumId),
         );
         const selections = capRankedDiscoveryTracks(

--- a/backend/src/services/discovery/discoverySeeding.ts
+++ b/backend/src/services/discovery/discoverySeeding.ts
@@ -14,11 +14,94 @@ import {
 } from "../../utils/librarySorting";
 import { logger } from "../../utils/logger";
 import { lidarrService } from "../lidarr";
-import { subWeeks } from "date-fns";
+import {
+    createSeededRng,
+    DEFAULT_ARTIST_WEIGHT_ALPHA,
+    getSeededRandom,
+} from "../artistSlotAllocation";
+import { format, startOfWeek, subWeeks } from "date-fns";
 
+/** Artist identity returned for Discover Weekly metadata seeding. */
 export interface SeedArtist {
     name: string;
     mbid?: string;
+}
+
+type RecentPlayCount = {
+    trackId: string | null;
+    _count: { id: number };
+};
+
+type SeedTrack = {
+    id: string;
+    album: {
+        artistId: string;
+        artist: {
+            name: string;
+            mbid: string | null;
+        };
+    };
+};
+
+type WeightedSeedArtist = {
+    artist: SeedArtist;
+    playCount: number;
+    firstSeenIndex: number;
+};
+
+/** Aggregate track play counts into valid artist-level seed weights. */
+function aggregateArtistPlayCounts(
+    recentPlays: RecentPlayCount[],
+    tracks: SeedTrack[],
+    isValidMbid: (mbid: string | null | undefined) => mbid is string,
+): WeightedSeedArtist[] {
+    const trackById = new Map(tracks.map((track) => [track.id, track]));
+    const artistWeights = new Map<string, WeightedSeedArtist>();
+    for (let index = 0; index < recentPlays.length; index += 1) {
+        const play = recentPlays[index];
+        const track = play.trackId ? trackById.get(play.trackId) : undefined;
+        if (!track || !isValidMbid(track.album.artist.mbid)) continue;
+
+        const existing = artistWeights.get(track.album.artistId);
+        if (existing) {
+            existing.playCount += play._count.id;
+            continue;
+        }
+        artistWeights.set(track.album.artistId, {
+            artist: {
+                name: track.album.artist.name,
+                mbid: track.album.artist.mbid,
+            },
+            playCount: play._count.id,
+            firstSeenIndex: index,
+        });
+    }
+    return Array.from(artistWeights.values());
+}
+
+/**
+ * Weighted-sample artists without replacement using Efraimidis-Spirakis keys.
+ */
+function sampleSeedArtists(
+    artists: WeightedSeedArtist[],
+    limit: number,
+    rng: () => number,
+): SeedArtist[] {
+    return artists
+        .map((entry) => ({
+            ...entry,
+            key: Math.pow(
+                rng(),
+                1 / Math.pow(entry.playCount, DEFAULT_ARTIST_WEIGHT_ALPHA),
+            ),
+        }))
+        .sort(
+            (left, right) =>
+                right.key - left.key ||
+                left.firstSeenIndex - right.firstSeenIndex,
+        )
+        .slice(0, limit)
+        .map((entry) => entry.artist);
 }
 
 /**
@@ -75,20 +158,17 @@ export class DiscoverySeeding {
             include: { album: { include: { artist: true } } },
         });
 
-        const artistMap = new Map<string, SeedArtist>();
-        for (const track of tracks) {
-            const artist = track.album.artist;
-            if (!artistMap.has(track.album.artistId)) {
-                if (this.isValidMbid(artist.mbid)) {
-                    artistMap.set(track.album.artistId, {
-                        name: artist.name,
-                        mbid: artist.mbid,
-                    });
-                }
-            }
-        }
-
-        const artists = Array.from(artistMap.values()).slice(0, limit);
+        const weightedArtists = aggregateArtistPlayCounts(
+            recentPlays,
+            tracks,
+            (mbid): mbid is string => this.isValidMbid(mbid),
+        );
+        const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+        const weekKey = format(weekStart, "yyyy-MM-dd");
+        const rng = createSeededRng(
+            getSeededRandom(`discover-seeds-${userId}-${weekKey}`),
+        );
+        const artists = sampleSeedArtists(weightedArtists, limit, rng);
         logger.debug(
             `[DiscoverySeeding] Found ${artists.length} seed artists from play history`,
         );

--- a/backend/src/services/discovery/discoverySeeding.ts
+++ b/backend/src/services/discovery/discoverySeeding.ts
@@ -87,7 +87,13 @@ function sampleSeedArtists(
     limit: number,
     rng: () => number,
 ): SeedArtist[] {
-    return artists
+    return [...artists]
+        .sort(
+            (left, right) =>
+                (left.artist.mbid ?? "").localeCompare(
+                    right.artist.mbid ?? "",
+                ) || left.artist.name.localeCompare(right.artist.name),
+        )
         .map((entry) => ({
             ...entry,
             key: Math.pow(
@@ -131,7 +137,7 @@ export class DiscoverySeeding {
                 source: { in: ["LIBRARY", "DISCOVERY_KEPT"] },
             },
             _count: { id: true },
-            orderBy: { _count: { id: "desc" } },
+            orderBy: [{ _count: { id: "desc" } }, { trackId: "asc" }],
             take: this.RECENT_PLAYS_LIMIT,
         });
 

--- a/backend/src/services/libraryRadioBuilder.ts
+++ b/backend/src/services/libraryRadioBuilder.ts
@@ -38,6 +38,13 @@ export const selectTracksWithArtistDiversity = <
     strictCap: number,
     relaxedCap: number,
 ): T[] => {
+    if (
+        !Array.isArray(tracks) ||
+        !Number.isFinite(targetCount) ||
+        targetCount <= 0
+    ) {
+        return [];
+    }
     return applyArtistCap(tracks, {
         preserveInputOrder: true,
         targetCount,

--- a/backend/src/services/libraryRadioBuilder.ts
+++ b/backend/src/services/libraryRadioBuilder.ts
@@ -10,17 +10,26 @@ import { getMergedGenres } from "../utils/metadataOverrides";
 import { shuffleArray } from "../utils/shuffle";
 import { escapeLikePattern } from "../utils/likePattern";
 import { TRACK_VISIBLE_WHERE } from "../utils/librarySorting";
+import { applyArtistCap } from "./programmaticPlaylistArtistCap";
 
+/** Return the strict per-artist cap for a requested radio queue length. */
 export const getRadioArtistCapForLimit = (limit: number): number => {
     if (!Number.isFinite(limit) || limit <= 0) return 2;
     return Math.max(2, Math.floor(limit / 12));
 };
 
+/** Return the bounded relaxed per-artist cap for a radio queue length. */
 export const getRelaxedRadioArtistCapForLimit = (limit: number): number => {
     const strictCap = getRadioArtistCapForLimit(limit);
     return Math.max(strictCap + 1, Math.ceil(limit / 6));
 };
 
+/**
+ * Select ranked radio tracks under strict and relaxed artist caps.
+ *
+ * The final refill remains bounded by the shared 30%-share ceiling, so a
+ * narrow one- or two-artist pool may return fewer tracks than requested.
+ */
 export const selectTracksWithArtistDiversity = <
     T extends { id: string; artistId: string },
 >(
@@ -29,52 +38,18 @@ export const selectTracksWithArtistDiversity = <
     strictCap: number,
     relaxedCap: number,
 ): T[] => {
-    if (!Array.isArray(tracks) || targetCount <= 0) {
-        return [];
-    }
-
-    const selected: T[] = [];
-    const deferred: T[] = [];
-    const artistCounts = new Map<string, number>();
-
-    const trySelect = (track: T, cap: number): boolean => {
-        const artistKey =
-            typeof track.artistId === "string" && track.artistId.length > 0
-                ? track.artistId
-                : `unknown:${track.id}`;
-        const count = artistCounts.get(artistKey) ?? 0;
-
-        if (count >= cap) {
-            return false;
-        }
-
-        artistCounts.set(artistKey, count + 1);
-        selected.push(track);
-        return true;
-    };
-
-    for (const track of tracks) {
-        if (selected.length >= targetCount) break;
-        if (!trySelect(track, strictCap)) {
-            deferred.push(track);
-        }
-    }
-
-    if (selected.length < targetCount) {
-        for (const track of deferred) {
-            if (selected.length >= targetCount) break;
-            trySelect(track, relaxedCap);
-        }
-    }
-
-    if (selected.length < targetCount) {
-        for (const track of deferred) {
-            if (selected.length >= targetCount) break;
-            selected.push(track);
-        }
-    }
-
-    return selected.slice(0, targetCount);
+    return applyArtistCap(tracks, {
+        preserveInputOrder: true,
+        targetCount,
+        maxPerArtist: strictCap,
+        getArtistId: (track) => track.artistId,
+        fallback: {
+            enabled: true,
+            relaxationStep: Math.max(1, relaxedCap - strictCap),
+            maxRelaxedPerArtist: relaxedCap,
+            refillFromExcludedAfterMaxRelaxation: true,
+        },
+    });
 };
 
 /**

--- a/backend/src/services/programmaticPlaylistArtistCap.ts
+++ b/backend/src/services/programmaticPlaylistArtistCap.ts
@@ -185,6 +185,8 @@ export function applyArtistCap<T extends ArtistCapTrack>(
     tracks: T[],
     options: ApplyArtistCapOptions<T> = {},
 ): T[] {
+    if (!Array.isArray(tracks)) return [];
+
     const maxPerArtist = options.maxPerArtist ?? DEFAULT_MAX_PER_ARTIST;
     if (
         !Number.isFinite(maxPerArtist) ||

--- a/backend/src/services/programmaticPlaylistArtistCap.ts
+++ b/backend/src/services/programmaticPlaylistArtistCap.ts
@@ -1,3 +1,4 @@
+/** Minimal track shape supported by the default album-artist resolver. */
 export type ArtistCapTrack = {
     id?: string;
     album?: {
@@ -7,18 +8,40 @@ export type ArtistCapTrack = {
     };
 };
 
-export type ApplyArtistCapOptions = {
+/** Options for rank-preserving per-artist track selection. */
+export type ApplyArtistCapOptions<T extends ArtistCapTrack = ArtistCapTrack> = {
+    /** Strict maximum number of tracks per resolved artist. */
     maxPerArtist?: number;
+    /** RNG used when input ranking is not preserved. */
     rng?: () => number;
+    /** Number of tracks to select in this call. */
     targetCount?: number;
+    /** Keep candidates in their supplied ranked order. */
     preserveInputOrder?: boolean;
+    /** Optional bounded cap-relaxation behavior. */
     fallback?: ArtistCapFallbackOptions;
+    /**
+     * Resolve artist identity from a caller-specific track shape. When set,
+     * this takes precedence over `album.artist.id`; empty values use the
+     * deterministic unknown-track fallback.
+     */
+    getArtistId?: (track: T) => string | null | undefined;
+    /**
+     * Tracks chosen by an earlier pass whose artist counts must consume this
+     * pass's caps. `targetCount` still counts only newly selected tracks.
+     */
+    alreadySelected?: T[];
 };
 
+/** Controlled cap-relaxation behavior for {@link applyArtistCap}. */
 export type ArtistCapFallbackOptions = {
+    /** Enable bounded passes above the strict artist cap. */
     enabled?: boolean;
+    /** Amount added to the cap for each relaxation pass. */
     relaxationStep?: number;
+    /** Highest absolute per-artist cap allowed during relaxation. */
     maxRelaxedPerArtist?: number;
+    /** Run one final refill under the hard artist-share ceiling. */
     refillFromExcludedAfterMaxRelaxation?: boolean;
 };
 
@@ -45,15 +68,111 @@ function shuffleWithRng<T>(items: T[], rng: () => number): T[] {
     return shuffled;
 }
 
-function getArtistBucketKey(
-    track: ArtistCapTrack,
+function getArtistBucketKey<T extends ArtistCapTrack>(
+    track: T,
     unknownFallbackKey: string,
+    getArtistId?: (track: T) => string | null | undefined,
 ): string {
-    const artistId = track.album?.artist?.id;
+    const artistId = getArtistId ? getArtistId(track) : track.album?.artist?.id;
     if (typeof artistId === "string" && artistId.trim().length > 0) {
         return `artist:${artistId}`;
     }
     return `unknown:${unknownFallbackKey}`;
+}
+
+type IndexedTrack<T> = {
+    track: T;
+    unknownFallbackKey: string;
+};
+
+type ArtistCapSelectionState<T> = {
+    candidates: IndexedTrack<T>[];
+    artistCounts: Map<string, number>;
+    selected: T[];
+    selectedByIndex: boolean[];
+    targetCount: number;
+    getArtistId?: (track: T) => string | null | undefined;
+};
+
+function buildArtistCounts<T extends ArtistCapTrack>(
+    tracks: T[],
+    getArtistId?: (track: T) => string | null | undefined,
+): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (let index = 0; index < tracks.length; index += 1) {
+        const track = tracks[index];
+        const fallbackKey = track.id ?? `already:${index}`;
+        const bucketKey = getArtistBucketKey(track, fallbackKey, getArtistId);
+        counts.set(bucketKey, (counts.get(bucketKey) ?? 0) + 1);
+    }
+    return counts;
+}
+
+function selectUpToCap<T extends ArtistCapTrack>(
+    state: ArtistCapSelectionState<T>,
+    cap: number,
+): void {
+    for (let index = 0; index < state.candidates.length; index += 1) {
+        if (state.selectedByIndex[index]) continue;
+        const entry = state.candidates[index];
+        const bucketKey = getArtistBucketKey(
+            entry.track,
+            entry.unknownFallbackKey,
+            state.getArtistId,
+        );
+        const count = state.artistCounts.get(bucketKey) ?? 0;
+        if (count >= cap) continue;
+
+        state.artistCounts.set(bucketKey, count + 1);
+        state.selectedByIndex[index] = true;
+        state.selected.push(entry.track);
+        if (state.selected.length >= state.targetCount) return;
+    }
+}
+
+function relaxArtistCap<T extends ArtistCapTrack>(
+    state: ArtistCapSelectionState<T>,
+    initialCap: number,
+    options: ApplyArtistCapOptions<T>,
+): void {
+    const relaxationStep = Math.max(
+        1,
+        Math.floor(options.fallback?.relaxationStep ?? DEFAULT_RELAXATION_STEP),
+    );
+    const maximumUsefulCap =
+        (options.alreadySelected?.length ?? 0) + state.targetCount;
+    const maxRelaxedPerArtist = Math.min(
+        maximumUsefulCap,
+        Math.max(
+            initialCap,
+            Math.floor(
+                options.fallback?.maxRelaxedPerArtist ??
+                    initialCap + DEFAULT_RELAXED_CAP_DELTA,
+            ),
+        ),
+    );
+
+    for (
+        let cap = initialCap + relaxationStep;
+        cap <= maxRelaxedPerArtist && state.selected.length < state.targetCount;
+        cap += relaxationStep
+    ) {
+        selectUpToCap(state, cap);
+    }
+
+    if (
+        state.selected.length >= state.targetCount ||
+        !options.fallback?.refillFromExcludedAfterMaxRelaxation
+    ) {
+        return;
+    }
+
+    const refillCeiling = Math.max(
+        maxRelaxedPerArtist,
+        Math.floor(state.targetCount * REFILL_HARD_CEILING_SHARE),
+        1,
+    );
+    selectUpToCap(state, refillCeiling);
 }
 
 /**
@@ -64,7 +183,7 @@ function getArtistBucketKey(
  */
 export function applyArtistCap<T extends ArtistCapTrack>(
     tracks: T[],
-    options: ApplyArtistCapOptions = {},
+    options: ApplyArtistCapOptions<T> = {},
 ): T[] {
     const maxPerArtist = options.maxPerArtist ?? DEFAULT_MAX_PER_ARTIST;
     if (
@@ -78,7 +197,6 @@ export function applyArtistCap<T extends ArtistCapTrack>(
     const integerCap = Math.floor(maxPerArtist);
     const rng = options.rng ?? Math.random;
     const preserveInputOrder = options.preserveInputOrder ?? false;
-    const fallbackEnabled = options.fallback?.enabled ?? false;
     const hasTargetCount = Number.isFinite(options.targetCount);
     const targetCount = hasTargetCount
         ? Math.max(
@@ -95,85 +213,32 @@ export function applyArtistCap<T extends ArtistCapTrack>(
 
     const indexedTracks = tracks.map((track, index) => ({
         track,
-        unknownFallbackKey: track.id ?? `index:${index}`,
+        unknownFallbackKey: track.id ?? `candidate:${index}`,
     }));
 
     const candidates = preserveInputOrder
         ? indexedTracks
         : shuffleWithRng(indexedTracks, rng);
-    const artistCounts = new Map<string, number>();
-    const selected: T[] = [];
-    const selectedByIndex = new Array(candidates.length).fill(false);
-
-    const trySelectUpToCap = (cap: number): void => {
-        for (let i = 0; i < candidates.length; i += 1) {
-            if (selectedByIndex[i]) continue;
-
-            const entry = candidates[i];
-            const bucketKey = getArtistBucketKey(
-                entry.track,
-                entry.unknownFallbackKey,
-            );
-            const count = artistCounts.get(bucketKey) ?? 0;
-            if (count >= cap) {
-                continue;
-            }
-
-            artistCounts.set(bucketKey, count + 1);
-            selectedByIndex[i] = true;
-            selected.push(entry.track);
-            if (selected.length >= targetCount) {
-                return;
-            }
-        }
+    const state: ArtistCapSelectionState<T> = {
+        candidates,
+        artistCounts: buildArtistCounts(
+            options.alreadySelected ?? [],
+            options.getArtistId,
+        ),
+        selected: [],
+        selectedByIndex: new Array(candidates.length).fill(false),
+        targetCount,
+        getArtistId: options.getArtistId,
     };
 
-    trySelectUpToCap(integerCap);
-    if (selected.length >= targetCount) {
-        return selected;
-    }
-
-    if (!fallbackEnabled) {
-        return selected;
-    }
-
-    const relaxationStep = Math.max(
-        1,
-        Math.floor(options.fallback?.relaxationStep ?? DEFAULT_RELAXATION_STEP),
-    );
-    const maxRelaxedPerArtist = Math.max(
-        integerCap,
-        Math.floor(
-            options.fallback?.maxRelaxedPerArtist ??
-                integerCap + DEFAULT_RELAXED_CAP_DELTA,
-        ),
-    );
-    const refillFromExcluded =
-        options.fallback?.refillFromExcludedAfterMaxRelaxation ?? false;
-
-    for (
-        let relaxedCap = integerCap + relaxationStep;
-        relaxedCap <= maxRelaxedPerArtist && selected.length < targetCount;
-        relaxedCap += relaxationStep
+    selectUpToCap(state, integerCap);
+    if (
+        state.selected.length >= targetCount ||
+        !(options.fallback?.enabled ?? false)
     ) {
-        trySelectUpToCap(relaxedCap);
+        return state.selected;
     }
 
-    if (selected.length >= targetCount || !refillFromExcluded) {
-        return selected;
-    }
-
-    // The refill previously ignored the artist cap entirely, so a narrow
-    // pool was GUARANTEED to end up dominated by 1-2 artists (GH #46).
-    // Refill now respects a hard ceiling (share of the target size);
-    // when the pool is genuinely too narrow, a shorter diverse playlist
-    // beats a full-length dominated one.
-    const refillCeiling = Math.max(
-        maxRelaxedPerArtist,
-        Math.floor(targetCount * REFILL_HARD_CEILING_SHARE),
-        1,
-    );
-    trySelectUpToCap(refillCeiling);
-
-    return selected;
+    relaxArtistCap(state, integerCap, options);
+    return state.selected;
 }

--- a/docs/OPENSUBSONIC_COMPATIBILITY.md
+++ b/docs/OPENSUBSONIC_COMPATIBILITY.md
@@ -201,6 +201,7 @@ Promote a deferred gap to in-scope when at least one of these is true:
 - `search`/`search2`/`search3` now honor `musicFolderId` filtering, normalize quoted-empty full-sync queries (`query=\"\"`), and treat zero counts as bounded full-sync requests.
 - `search`/`search2`/`search3` now pass through large offset values without a hard `10000` clamp so client pagination can complete on very large libraries.
 - Song/album protocol payloads now project `genre` from library metadata (prefer `userGenres`, then `genres`), and genre-filtered song responses (`getSongsByGenre`, `getRandomSongs` with `genre`) force explicit `genre` values in each returned song item.
+- `getRandomSongs` now uses artist-diversity weighted sampling before returning its flat shuffled song list.
 - `getTopSongs` now deterministically falls back to case-insensitive artist-name lookup when ID-path lookup misses, including artist names containing hyphens.
 - `getSimilarSongs` uses artist-to-similar-artist graph data; `getSimilarSongs2` merges similar-artist tracks with genre and same-artist fallback sources to avoid empty responses when similarity metadata is sparse.
 - `getLyrics` currently resolves by best-match library track (artist/title query), then returns plain lyrics or synced lyrics flattened to plain text lines.

--- a/docs/OPENSUBSONIC_COMPATIBILITY.md
+++ b/docs/OPENSUBSONIC_COMPATIBILITY.md
@@ -201,7 +201,7 @@ Promote a deferred gap to in-scope when at least one of these is true:
 - `search`/`search2`/`search3` now honor `musicFolderId` filtering, normalize quoted-empty full-sync queries (`query=\"\"`), and treat zero counts as bounded full-sync requests.
 - `search`/`search2`/`search3` now pass through large offset values without a hard `10000` clamp so client pagination can complete on very large libraries.
 - Song/album protocol payloads now project `genre` from library metadata (prefer `userGenres`, then `genres`), and genre-filtered song responses (`getSongsByGenre`, `getRandomSongs` with `genre`) force explicit `genre` values in each returned song item.
-- `getRandomSongs` now uses artist-diversity weighted sampling before returning its flat shuffled song list.
+- `getRandomSongs` uses artist-diversity weighted sampling with a top-up to the requested size before returning its flat shuffled song list.
 - `getTopSongs` now deterministically falls back to case-insensitive artist-name lookup when ID-path lookup misses, including artist names containing hyphens.
 - `getSimilarSongs` uses artist-to-similar-artist graph data; `getSimilarSongs2` merges similar-artist tracks with genre and same-artist fallback sources to avoid empty responses when similarity metadata is sparse.
 - `getLyrics` currently resolves by best-match library track (artist/title query), then returns plain lyrics or synced lyrics flattened to plain text lines.


### PR DESCRIPTION
## Summary

Fixes Discover Weekly surfacing the same artists week after week, and unifies the repo's artist-diversity selection onto two shared primitives.

### Discover Weekly repeat-artist fix
- **Seed rotation** (`discoverySeeding.ts`): seed artists are now play-weighted (`count^0.5`, reusing `DEFAULT_ARTIST_WEIGHT_ALPHA`) and sampled without replacement via Efraimidis–Spirakis keys under a seeded RNG keyed to user + ISO week. Deterministic within a week, rotates across weeks, and damping keeps heavy-rotation artists from always crowding out the tail.
- **Cross-week artist decay** (`discoveryRecommendations.ts`): artists featured in the prior six weeks of Discover playlists have their candidate scores multiplied by `0.6^distinctFeaturedWeeks` (capped at 3 weeks, ~0.22x), sinking repeats below the 0.35 generic-candidate default without excluding them. The existing album-level `exclusionMonths` machinery is unchanged.

### Consolidation
- `applyArtistCap` gains two additive options: `getArtistId` (caller-specific artist resolution) and `alreadySelected` (carries per-artist counts across multi-pass selection).
- The duplicate strict/relaxed cap loops in `libraryRadioBuilder.selectTracksWithArtistDiversity` and both Discover Weekly selection passes now delegate to `applyArtistCap`. Album dedupe is preserved via best-track-per-album pre-dedupe (equivalent, since artist identity is album-scoped).
- `artistSlotAllocation.ts` module header rewritten to document the two primitives (weighted allocation for unranked pools, rank-preserving caps for score-ranked pools) and their actual consumers.

### Subsonic
- `getRandomSongs` now routes through `allocateTracksWithArtistWeighting` before its flat shuffle, so large discographies no longer dominate proportionally. `getSongsByGenre`'s day-stable seeded pagination is intentionally untouched. Documented in `OPENSUBSONIC_COMPATIBILITY.md`.

## Behavior change to note
Artist-radio similar-track selection previously had an **uncapped third-pass refill**: a narrow pool was guaranteed full length but could be dominated by 1–2 artists (the original GH #46 bug shape). It now respects the hard 30% artist-share ceiling and may return a shorter, more diverse queue instead. This is deliberate and documented on the function.

## Verification
- verify: discovery seeding + recommendations tests — 2 suites, 37 passed
- verify: programmaticPlaylistArtistCap + libraryRadioBuilder + artistSlotAllocation + moodBucketService — 4 suites, 48 passed
- verify: discoverWeeklyPrefilterParity + discoverWeeklyRuntime + subsonicCoreCompat + subsonicBranchCoverage — 4 suites, 164 passed
- verify: backend `tsc --noEmit` exit 0
- verify: `npm run verify:gates` exit 0