### PR TITLE
chore(format): reformat contract package under prettier 3.9.6

### DIFF
--- a/packages/media-metadata-contract/src/index.ts
+++ b/packages/media-metadata-contract/src/index.ts
@@ -65,11 +65,7 @@ export interface CanonicalMediaSearchResult {
 
 /** Media types currently understood by federation v1 consumers. */
 export type FederationMediaType =
-    | "artist"
-    | "album"
-    | "track"
-    | "podcast"
-    | "audiobook";
+    "artist" | "album" | "track" | "podcast" | "audiobook";
 
 /** Source discriminator emitted by unified track response serializers. */
 export type UnifiedTrackSource = "local" | "tidal" | "youtube" | "federated";


### PR DESCRIPTION
Prettier 3.9.6 (bumped in #466) collapses short union types onto one line; `packages/media-metadata-contract/src/index.ts` was formatted under 3.8.2, so the repo-wide format check in Enforcement Gates now fails on main and on every PR rebased onto it (#467, #470, #474).

Formatting-only diff produced by the package's own `prettier --write`; no behavior change.