### PR TITLE
fix(audiobooks): validated sections model with cached navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Documentation drift sweep: corrected environment/deployment/API references across the docs tree and refreshed the route, feature, and test indexes.
+- Audiobook detail loads now serve validated sections and metadata from the local cache instead of fetching Audiobookshelf live. Sections are computed during sync when expanded Audiobookshelf data is available and backfilled lazily on first view for books synced before this change or from minified library listings. The retained `numChapters` column is superseded and no longer refreshed.
 
 ### Fixed
 
+- Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts, while navigation stays hidden when the current single-file stream proxy cannot play those seek targets. (#487)
 - Reaped dead-peer HTTP connections with TCP keepalive, made origin keep-alive
   timeouts reverse-proxy safe, and kept Node's zero idle timeout so paused or
   backpressured streams remain unaffected. (#487)

--- a/backend/prisma/migrations/20260816000000_add_audiobook_validated_sections/migration.sql
+++ b/backend/prisma/migrations/20260816000000_add_audiobook_validated_sections/migration.sql
@@ -1,0 +1,5 @@
+-- Store validated audiobook navigation produced during Audiobookshelf sync.
+-- numChapters remains for rollback compatibility but is superseded by sections
+-- and is no longer refreshed by sync code.
+
+ALTER TABLE "Audiobook" ADD COLUMN "sections" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -969,6 +969,7 @@ model Audiobook {
   duration       Float?
   numTracks      Int?
   numChapters    Int?
+  sections       Json?
   size           BigInt?
   isbn           String?
   asin           String?

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -257,11 +257,18 @@ describe("audiobooks advanced runtime", () => {
             localCoverPath: null,
             coverUrl: "federation",
             duration: 600,
+            numTracks: null,
+            sections: null,
+            publisher: null,
+            publishedYear: null,
+            isbn: null,
+            asin: null,
+            language: null,
             libraryId: null,
             series: null,
             seriesSequence: null,
             genres: [],
-            lastSyncedAt: new Date(),
+            lastSyncedAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
             federationPeer: peer,
         };
         prisma.audiobook.findMany.mockResolvedValueOnce([book]);
@@ -285,8 +292,9 @@ describe("audiobooks advanced runtime", () => {
         expect(detailRes.body).toEqual(
             expect.objectContaining({
                 id: "fed:book-1",
-                chapters: [],
-                audioFiles: [],
+                sectionKind: "none",
+                sections: [],
+                sectionsPlayable: false,
                 source: "federated",
                 peer: { id: "peer-1", name: "Peer One", online: true },
             }),
@@ -714,7 +722,56 @@ describe("audiobooks advanced runtime", () => {
         });
     });
 
-    it("serves audiobook details from cache/fallback and handles missing/error states", async () => {
+    it("returns multi-file parts but marks their seek targets non-playable", async () => {
+        prisma.audiobook.findUnique.mockResolvedValueOnce({
+            id: "book-parts",
+            title: "Parted Book",
+            author: "Author",
+            narrator: null,
+            description: null,
+            localCoverPath: null,
+            coverUrl: null,
+            duration: 1200,
+            numTracks: 2,
+            sections: {
+                kind: "parts",
+                sections: [
+                    { index: 0, title: "Part One", startSeconds: 0 },
+                    { index: 1, title: "Part Two", startSeconds: 600 },
+                ],
+            },
+            publisher: null,
+            publishedYear: null,
+            genres: [],
+            isbn: null,
+            asin: null,
+            language: null,
+            series: null,
+            seriesSequence: null,
+            libraryId: "lib-1",
+            lastSyncedAt: new Date(),
+        });
+
+        const res = createRes();
+        await detailsHandler(
+            { params: { id: "book-parts" }, user: { id: "u1" } } as any,
+            res,
+        );
+
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                sectionKind: "parts",
+                sections: [
+                    { index: 0, title: "Part One", startSeconds: 0 },
+                    { index: 1, title: "Part Two", startSeconds: 600 },
+                ],
+                sectionsPlayable: false,
+            }),
+        );
+        expect(audiobookshelfService.getAudiobook).not.toHaveBeenCalled();
+    });
+
+    it("serves fresh audiobook details only from cache and handles disabled/error states", async () => {
         getSystemSettings.mockResolvedValueOnce({
             audiobookshelfEnabled: false,
         });
@@ -736,14 +793,22 @@ describe("audiobooks advanced runtime", () => {
             localCoverPath: "/cache/book-1.jpg",
             coverUrl: null,
             duration: 200,
+            numTracks: 1,
+            sections: {
+                kind: "chapters",
+                sections: [
+                    { index: 0, title: "Opening", startSeconds: 0 },
+                    { index: 1, title: "Middle", startSeconds: 100 },
+                ],
+            },
+            publisher: "Publisher",
+            publishedYear: 2024,
+            genres: ["Fiction"],
+            isbn: "isbn-1",
+            asin: "asin-1",
+            language: "en",
             libraryId: "lib-1",
             lastSyncedAt: new Date(),
-        });
-        audiobookshelfService.getAudiobook.mockResolvedValueOnce({
-            media: {
-                chapters: [{ id: 1 }],
-                audioFiles: [{ ino: "file-1" }],
-            },
         });
         prisma.audiobookProgress.findUnique.mockResolvedValueOnce({
             currentTime: 50,
@@ -759,14 +824,25 @@ describe("audiobooks advanced runtime", () => {
         );
 
         expect(audiobookCacheService.getAudiobook).not.toHaveBeenCalled();
+        expect(audiobookshelfService.getAudiobook).not.toHaveBeenCalled();
         expect(detailRes.statusCode).toBe(200);
         expect(detailRes.body).toEqual(
             expect.objectContaining({
                 id: "book-1",
                 author: "Unknown Author",
                 coverUrl: "/audiobooks/book-1/cover",
-                chapters: [{ id: 1 }],
-                audioFiles: [{ ino: "file-1" }],
+                sectionKind: "chapters",
+                sections: [
+                    { index: 0, title: "Opening", startSeconds: 0 },
+                    { index: 1, title: "Middle", startSeconds: 100 },
+                ],
+                sectionsPlayable: true,
+                publisher: "Publisher",
+                publishedYear: 2024,
+                genres: ["Fiction"],
+                isbn: "isbn-1",
+                asin: "asin-1",
+                language: "en",
                 progress: {
                     currentTime: 50,
                     progress: 25,
@@ -775,58 +851,6 @@ describe("audiobooks advanced runtime", () => {
                 },
             }),
         );
-
-        prisma.audiobook.findUnique.mockResolvedValueOnce({
-            id: "book-2",
-            title: "Stale",
-            author: "Author",
-            narrator: null,
-            description: null,
-            localCoverPath: null,
-            coverUrl: null,
-            duration: null,
-            libraryId: "lib-2",
-            lastSyncedAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
-        });
-        audiobookCacheService.getAudiobook.mockResolvedValueOnce({
-            id: "book-2",
-            title: "Refetched",
-            author: "Author",
-            narrator: null,
-            description: null,
-            localCoverPath: null,
-            coverUrl: null,
-            duration: 0,
-            libraryId: "lib-2",
-        });
-        audiobookshelfService.getAudiobook.mockRejectedValueOnce(
-            new Error("api unavailable"),
-        );
-        prisma.audiobookProgress.findUnique.mockResolvedValueOnce(null);
-
-        const staleRes = createRes();
-        await detailsHandler(
-            { params: { id: "book-2" }, user: { id: "u1" } } as any,
-            staleRes,
-        );
-
-        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledWith(
-            "book-2",
-        );
-        expect(staleRes.statusCode).toBe(200);
-        expect(staleRes.body.chapters).toEqual([]);
-        expect(staleRes.body.audioFiles).toEqual([]);
-        expect(staleRes.body.progress).toBeNull();
-
-        prisma.audiobook.findUnique.mockResolvedValueOnce(null);
-        audiobookCacheService.getAudiobook.mockResolvedValueOnce(null);
-        const missingRes = createRes();
-        await detailsHandler(
-            { params: { id: "book-404" }, user: { id: "u1" } } as any,
-            missingRes,
-        );
-        expect(missingRes.statusCode).toBe(404);
-        expect(missingRes.body).toEqual({ error: "Audiobook not found" });
 
         prisma.audiobook.findUnique.mockRejectedValueOnce(
             new Error("details exploded"),
@@ -840,6 +864,156 @@ describe("audiobooks advanced runtime", () => {
         expect(errorRes.body).toEqual({
             error: "Failed to fetch audiobook",
         });
+    });
+
+    it("refreshes a fresh local row with unknown sections and serves the backfill", async () => {
+        prisma.audiobook.findUnique.mockResolvedValueOnce({
+            id: "book-unknown",
+            title: "Before Backfill",
+            peerId: null,
+            sections: null,
+            lastSyncedAt: new Date(),
+        });
+        audiobookCacheService.getAudiobook.mockResolvedValueOnce({
+            id: "book-unknown",
+            title: "After Backfill",
+            author: "Author",
+            narrator: null,
+            description: null,
+            localCoverPath: null,
+            coverUrl: null,
+            duration: 1200,
+            numTracks: 1,
+            sections: {
+                kind: "chapters",
+                sections: [
+                    { index: 0, title: "First", startSeconds: 0 },
+                    { index: 1, title: "Second", startSeconds: 600 },
+                ],
+            },
+            publisher: null,
+            publishedYear: null,
+            genres: [],
+            isbn: null,
+            asin: null,
+            language: null,
+            series: null,
+            seriesSequence: null,
+            libraryId: "lib-1",
+            lastSyncedAt: new Date(),
+        });
+
+        const res = createRes();
+        await detailsHandler(
+            { params: { id: "book-unknown" }, user: { id: "u1" } } as any,
+            res,
+        );
+
+        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledTimes(1);
+        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledWith(
+            "book-unknown",
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                title: "After Backfill",
+                sectionKind: "chapters",
+                sections: [
+                    { index: 0, title: "First", startSeconds: 0 },
+                    { index: 1, title: "Second", startSeconds: 600 },
+                ],
+            }),
+        );
+    });
+
+    it("refreshes stale local rows before serving details", async () => {
+        prisma.audiobook.findUnique.mockResolvedValueOnce({
+            id: "book-stale",
+            title: "Stale",
+            peerId: null,
+            sections: { kind: "none", sections: [] },
+            lastSyncedAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
+        });
+        audiobookCacheService.getAudiobook.mockResolvedValueOnce({
+            id: "book-stale",
+            title: "Refreshed",
+            author: "Author",
+            narrator: null,
+            description: null,
+            localCoverPath: null,
+            coverUrl: null,
+            duration: 1200,
+            numTracks: 1,
+            sections: { kind: "none", sections: [] },
+            publisher: null,
+            publishedYear: null,
+            genres: [],
+            isbn: null,
+            asin: null,
+            language: null,
+            series: null,
+            seriesSequence: null,
+            libraryId: "lib-1",
+            lastSyncedAt: new Date(),
+        });
+
+        const res = createRes();
+        await detailsHandler(
+            { params: { id: "book-stale" }, user: { id: "u1" } } as any,
+            res,
+        );
+
+        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBe(200);
+        expect(res.body.title).toBe("Refreshed");
+    });
+
+    it("backfills a missing local row and preserves 404 when ABS has no result", async () => {
+        prisma.audiobook.findUnique.mockResolvedValueOnce(null);
+        audiobookCacheService.getAudiobook.mockResolvedValueOnce({
+            id: "book-missing",
+            title: "Backfilled",
+            author: "Author",
+            narrator: null,
+            description: null,
+            localCoverPath: null,
+            coverUrl: null,
+            duration: 1200,
+            numTracks: 1,
+            sections: { kind: "none", sections: [] },
+            publisher: null,
+            publishedYear: null,
+            genres: [],
+            isbn: null,
+            asin: null,
+            language: null,
+            series: null,
+            seriesSequence: null,
+            libraryId: "lib-1",
+            lastSyncedAt: new Date(),
+        });
+
+        const backfilledRes = createRes();
+        await detailsHandler(
+            { params: { id: "book-missing" }, user: { id: "u1" } } as any,
+            backfilledRes,
+        );
+
+        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledTimes(1);
+        expect(backfilledRes.statusCode).toBe(200);
+        expect(backfilledRes.body.title).toBe("Backfilled");
+
+        prisma.audiobook.findUnique.mockResolvedValueOnce(null);
+        audiobookCacheService.getAudiobook.mockResolvedValueOnce(null);
+        const missingRes = createRes();
+        await detailsHandler(
+            { params: { id: "book-404" }, user: { id: "u1" } } as any,
+            missingRes,
+        );
+
+        expect(audiobookCacheService.getAudiobook).toHaveBeenCalledTimes(2);
+        expect(missingRes.statusCode).toBe(404);
+        expect(missingRes.body).toEqual({ error: "Audiobook not found" });
     });
 
     it("streams audiobook content with headers/defaults and handles failures", async () => {

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -24,6 +24,10 @@ import {
     proxyFederatedAudiobookCover,
     proxyFederatedAudiobookStream,
 } from "../services/federationAudiobookProxy";
+import {
+    parseStoredSections,
+    type AudiobookSections,
+} from "../services/audiobookSections";
 
 const router = Router();
 
@@ -111,6 +115,15 @@ function audiobookListResponse(
         progress: progressResponse(progress),
         ...federatedSource(book),
     };
+}
+
+function sectionsArePlayable(
+    book: AudiobookRow,
+    cachedSections: AudiobookSections,
+): boolean {
+    // The stream proxy currently serves only media.tracks[0]. Keep all computed
+    // multi-file parts cached, but do not expose unsafe seek navigation for them.
+    return cachedSections.kind === "chapters" && book.numTracks === 1;
 }
 
 /**
@@ -884,7 +897,41 @@ router.get<{ id: string }>(
  *         description: Audiobook ID
  *     responses:
  *       200:
- *         description: Audiobook details with chapters, audio files, and user progress
+ *         description: Cached audiobook details with validated sections and user progress
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [id, title, author, duration, sectionKind, sections, sectionsPlayable]
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                 title:
+ *                   type: string
+ *                 author:
+ *                   type: string
+ *                 duration:
+ *                   type: number
+ *                 sectionKind:
+ *                   type: string
+ *                   enum: [chapters, parts, none]
+ *                 sectionsPlayable:
+ *                   type: boolean
+ *                   description: Whether section seek targets are safe for the current stream proxy
+ *                 sections:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     required: [index, title, startSeconds]
+ *                     properties:
+ *                       index:
+ *                         type: integer
+ *                         minimum: 0
+ *                       title:
+ *                         type: string
+ *                       startSeconds:
+ *                         type: number
+ *                         minimum: 0
  *       404:
  *         description: Audiobook not found
  *       401:
@@ -892,7 +939,7 @@ router.get<{ id: string }>(
  */
 /**
  * GET /audiobooks/:id
- * Get a specific audiobook with full details (from cache, fallback to API)
+ * Get a specific audiobook with full details from the cache or ABS fallback
  */
 router.get<{ id: string }>(
     "/:id",
@@ -925,12 +972,14 @@ router.get<{ id: string }>(
             }
 
             const staleBefore = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-            const cacheStale =
+            const cacheNeedsRefresh =
                 !isFederated &&
-                (!audiobook || audiobook.lastSyncedAt < staleBefore);
-            if (cacheStale) {
+                (!audiobook ||
+                    audiobook.sections === null ||
+                    audiobook.lastSyncedAt < staleBefore);
+            if (cacheNeedsRefresh) {
                 logger.debug(
-                    `[AUDIOBOOK] Audiobook ${id} not cached or stale, fetching...`,
+                    `[AUDIOBOOK] Audiobook ${id} not cached, stale, or missing sections; syncing...`,
                 );
                 audiobook = await audiobookCacheService.getAudiobook(id);
             }
@@ -939,18 +988,7 @@ router.get<{ id: string }>(
                 return res.status(404).json({ error: "Audiobook not found" });
             }
 
-            // Get chapters and audio files from API (these change less frequently)
-            let absBook = { media: { chapters: [], audioFiles: [] } };
-            if (!isFederated) {
-                try {
-                    absBook = await audiobookshelfService.getAudiobook(id);
-                } catch (apiError: any) {
-                    logger.warn(
-                        `  Failed to fetch live data from Audiobookshelf for ${id}, using cached data only:`,
-                        apiError.message,
-                    );
-                }
-            }
+            const cachedSections = parseStoredSections(audiobook.sections);
 
             // Get user's progress
             const progress = await prisma.audiobookProgress.findUnique({
@@ -973,8 +1011,24 @@ router.get<{ id: string }>(
                         ? `/audiobooks/${audiobook.id}/cover`
                         : null,
                 duration: audiobook.duration || 0,
-                chapters: absBook.media?.chapters || [],
-                audioFiles: absBook.media?.audioFiles || [],
+                publisher: audiobook.publisher,
+                publishedYear: audiobook.publishedYear,
+                genres: audiobook.genres || [],
+                isbn: audiobook.isbn,
+                asin: audiobook.asin,
+                language: audiobook.language,
+                series: audiobook.series
+                    ? {
+                          name: audiobook.series,
+                          sequence: audiobook.seriesSequence || "1",
+                      }
+                    : null,
+                sectionKind: cachedSections.kind,
+                sections: cachedSections.sections,
+                sectionsPlayable: sectionsArePlayable(
+                    audiobook,
+                    cachedSections,
+                ),
                 libraryId: audiobook.libraryId,
                 progress: progress
                     ? {

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { Prisma } from "@prisma/client";
 
 const mockGetAllAudiobooks = jest.fn();
 const mockGetAudiobook = jest.fn();
@@ -62,8 +63,13 @@ function buildBook(overrides: Record<string, any> = {}) {
         title: "The Book",
         media: {
             duration: 3600,
-            numTracks: 10,
+            numTracks: 1,
             numChapters: 20,
+            chapters: [
+                { title: "Opening", start: 0, end: 1800 },
+                { title: "Closing", start: 1800, end: 3600 },
+            ],
+            audioFiles: [{ filename: "The Book.m4b", duration: 3600 }],
             coverPath: "items/book-1/cover",
             metadata: {
                 title: "The Book",
@@ -146,6 +152,7 @@ describe("audiobook cache service behavior", () => {
         expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(2);
 
         const firstUpsertArg = prisma.audiobook.upsert.mock.calls[0][0];
+        expect(firstUpsertArg.create).not.toHaveProperty("numChapters");
         expect(firstUpsertArg.create).toEqual(
             expect.objectContaining({
                 id: "book-1",
@@ -160,7 +167,21 @@ describe("audiobook cache service behavior", () => {
                     "audiobooks",
                     "book-1.jpg",
                 ),
+                sections: {
+                    kind: "chapters",
+                    sections: [
+                        { index: 0, title: "Opening", startSeconds: 0 },
+                        {
+                            index: 1,
+                            title: "Closing",
+                            startSeconds: 1800,
+                        },
+                    ],
+                },
             }),
+        );
+        expect(firstUpsertArg.update.sections).toEqual(
+            firstUpsertArg.create.sections,
         );
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -172,6 +193,29 @@ describe("audiobook cache service behavior", () => {
                 signal: expect.anything(),
             },
         );
+    });
+
+    it("preserves stored sections on minified updates and creates them as unknown", async () => {
+        const service = new AudiobookCacheService();
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({
+                id: "book-minified",
+                media: {
+                    duration: 3600,
+                    numTracks: 1,
+                    metadata: {
+                        title: "Minified Book",
+                        authorName: "Author A",
+                    },
+                },
+            }),
+        ]);
+
+        await service.syncAll();
+
+        const upsert = prisma.audiobook.upsert.mock.calls[0][0];
+        expect(upsert.update).not.toHaveProperty("sections");
+        expect(upsert.create.sections).toBe(Prisma.DbNull);
     });
 
     it("passes a timeout AbortSignal when downloading a cover", async () => {
@@ -401,6 +445,56 @@ describe("audiobook cache service behavior", () => {
         expect(refreshed).toEqual(
             expect.objectContaining({ title: "Refreshed" }),
         );
+    });
+
+    it("refreshes a fresh cache row whose sections are still unknown", async () => {
+        const service = new AudiobookCacheService();
+        const unknownSectionsRecord = {
+            id: "book-unknown-sections",
+            sections: null,
+            lastSyncedAt: new Date(),
+        };
+        const refreshedRecord = {
+            id: "book-unknown-sections",
+            title: "Refreshed",
+            sections: {
+                kind: "chapters",
+                sections: [
+                    { index: 0, title: "Opening", startSeconds: 0 },
+                    { index: 1, title: "Closing", startSeconds: 1800 },
+                ],
+            },
+            lastSyncedAt: new Date(),
+        };
+        prisma.audiobook.findUnique
+            .mockResolvedValueOnce(unknownSectionsRecord)
+            .mockResolvedValueOnce(refreshedRecord);
+        mockGetAudiobook.mockResolvedValueOnce(
+            buildBook({ id: "book-unknown-sections" }),
+        );
+
+        const result = await service.getAudiobook("book-unknown-sections");
+
+        expect(mockGetAudiobook).toHaveBeenCalledTimes(1);
+        expect(mockGetAudiobook).toHaveBeenCalledWith("book-unknown-sections");
+        expect(prisma.audiobook.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({
+                    sections: {
+                        kind: "chapters",
+                        sections: [
+                            { index: 0, title: "Opening", startSeconds: 0 },
+                            {
+                                index: 1,
+                                title: "Closing",
+                                startSeconds: 1800,
+                            },
+                        ],
+                    },
+                }),
+            }),
+        );
+        expect(result).toBe(refreshedRecord);
     });
 
     it("falls back to stale cache when refresh fails and throws when no cache exists", async () => {

--- a/backend/src/services/__tests__/audiobookSections.test.ts
+++ b/backend/src/services/__tests__/audiobookSections.test.ts
@@ -1,0 +1,160 @@
+import { buildSections, buildSectionsWhenPresent } from "../audiobookSections";
+
+describe("buildSections", () => {
+    it("distinguishes omitted section fields from present empty fields", () => {
+        expect(
+            buildSectionsWhenPresent({
+                durationSeconds: 1000,
+                chapters: undefined,
+                audioFiles: undefined,
+            }),
+        ).toBeNull();
+        expect(
+            buildSectionsWhenPresent({
+                durationSeconds: 1000,
+                chapters: [],
+                audioFiles: [],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+
+    it("adopts well-formed chapters that span at least 85% of the book", () => {
+        expect(
+            buildSections({
+                durationSeconds: 1000,
+                chapters: [
+                    { title: "Opening", start: 0, end: 450 },
+                    { title: "Closing", start: 450, end: 900 },
+                ],
+                audioFiles: [{ filename: "book.m4b", duration: 1000 }],
+            }),
+        ).toEqual({
+            kind: "chapters",
+            sections: [
+                { index: 0, title: "Opening", startSeconds: 0 },
+                { index: 1, title: "Closing", startSeconds: 450 },
+            ],
+        });
+    });
+
+    it("rejects sparse chapters and derives cumulative parts from multiple files", () => {
+        expect(
+            buildSections({
+                durationSeconds: 6 * 60 * 60,
+                chapters: [
+                    { title: "Marker 1", start: 0, end: 600 },
+                    { title: "Marker 2", start: 600, end: 1200 },
+                ],
+                audioFiles: [
+                    {
+                        duration: 3600,
+                        metadata: { filename: "01 - Part One.m4b" },
+                    },
+                    { duration: 7200, filename: "02_Part Two.mp3" },
+                    { duration: 10_800, filename: "003. Finale.flac" },
+                ],
+            }),
+        ).toEqual({
+            kind: "parts",
+            sections: [
+                { index: 0, title: "Part One", startSeconds: 0 },
+                { index: 1, title: "Part Two", startSeconds: 3600 },
+                { index: 2, title: "Finale", startSeconds: 10_800 },
+            ],
+        });
+    });
+
+    it.each([
+        {
+            name: "non-monotonic starts",
+            chapters: [
+                { title: "First", start: 20, end: 500 },
+                { title: "Second", start: 10, end: 900 },
+            ],
+        },
+        {
+            name: "negative timestamps",
+            chapters: [
+                { title: "First", start: -1, end: 500 },
+                { title: "Second", start: 500, end: 900 },
+            ],
+        },
+        {
+            name: "ends beyond the duration tolerance",
+            chapters: [
+                { title: "First", start: 0, end: 500 },
+                { title: "Second", start: 500, end: 1003 },
+            ],
+        },
+        {
+            name: "non-finite timestamps",
+            chapters: [
+                { title: "First", start: 0, end: 500 },
+                { title: "Second", start: Number.NaN, end: 900 },
+            ],
+        },
+    ])("rejects malformed chapters with $name", ({ chapters }) => {
+        expect(
+            buildSections({
+                durationSeconds: 1000,
+                chapters,
+                audioFiles: [{ filename: "single.m4b", duration: 1000 }],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+
+    it("does not derive parts for a single-file book", () => {
+        expect(
+            buildSections({
+                durationSeconds: 1000,
+                chapters: [],
+                audioFiles: [
+                    { filename: "01 - Complete Book.m4b", duration: 1000 },
+                ],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+
+    it("returns none when sparse chapters have no multi-file fallback", () => {
+        expect(
+            buildSections({
+                durationSeconds: 6 * 60 * 60,
+                chapters: [
+                    { title: "Marker 1", start: 0, end: 600 },
+                    { title: "Marker 2", start: 600, end: 1200 },
+                ],
+                audioFiles: [],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+
+    it("does not derive parts unless every file has a usable duration", () => {
+        expect(
+            buildSections({
+                durationSeconds: 1000,
+                chapters: [],
+                audioFiles: [
+                    { filename: "01 - First.m4b", duration: 500 },
+                    { filename: "02 - Second.m4b", duration: 0 },
+                ],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+
+    it("returns honest-empty sections for empty or malformed inputs", () => {
+        expect(
+            buildSections({
+                durationSeconds: 1000,
+                chapters: [],
+                audioFiles: [],
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+        expect(
+            buildSections({
+                durationSeconds: "unknown",
+                chapters: null,
+                audioFiles: {},
+            }),
+        ).toEqual({ kind: "none", sections: [] });
+    });
+});

--- a/backend/src/services/__tests__/audiobookshelfService.test.ts
+++ b/backend/src/services/__tests__/audiobookshelfService.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { Prisma } from "@prisma/client";
 
 const logger = {
     debug: jest.fn(),
@@ -628,6 +629,11 @@ describe("audiobookshelf service behavior", () => {
                     duration: 1200,
                     numTracks: 12,
                     numChapters: 30,
+                    chapters: [
+                        { title: "First", start: 0, end: 600 },
+                        { title: "Second", start: 600, end: 1200 },
+                    ],
+                    audioFiles: [{ filename: "Book One.m4b", duration: 1200 }],
                     size: "2048",
                     tags: ["fiction"],
                     metadata: {
@@ -672,9 +678,57 @@ describe("audiobookshelf service behavior", () => {
                     seriesSequence: "1",
                     coverUrl: "http://abs.local/cover/book-1.jpg",
                     audioUrl: "http://abs.local/api/items/book-1/play",
+                    sections: {
+                        kind: "chapters",
+                        sections: [
+                            { index: 0, title: "First", startSeconds: 0 },
+                            {
+                                index: 1,
+                                title: "Second",
+                                startSeconds: 600,
+                            },
+                        ],
+                    },
                 }),
             }),
         );
+        expect(
+            prisma.audiobook.upsert.mock.calls[0][0].create,
+        ).not.toHaveProperty("numChapters");
+        expect(
+            prisma.audiobook.upsert.mock.calls[0][0].update.sections,
+        ).toEqual(prisma.audiobook.upsert.mock.calls[0][0].create.sections);
+    });
+
+    it("preserves stored sections on minified updates and creates them as unknown", async () => {
+        const svc = audiobookshelfService as any;
+        svc.client = createClient();
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+
+        jest.spyOn(
+            audiobookshelfService,
+            "getAllAudiobooks",
+        ).mockResolvedValueOnce([
+            {
+                id: "book-minified",
+                libraryId: "lib-1",
+                media: {
+                    duration: 1200,
+                    numTracks: 1,
+                    metadata: {
+                        title: "Minified Book",
+                        authorName: "Author One",
+                    },
+                },
+            },
+        ] as any);
+
+        await audiobookshelfService.syncAudiobooksToCache();
+
+        const upsert = prisma.audiobook.upsert.mock.calls[0][0];
+        expect(upsert.update).not.toHaveProperty("sections");
+        expect(upsert.create.sections).toBe(Prisma.DbNull);
     });
 
     it("rethrows sync failures when audiobook fetch fails", async () => {

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -3,9 +3,11 @@ import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import fs from "fs/promises";
 import path from "path";
+import { Prisma } from "@prisma/client";
 import { config } from "../config";
 import { buildCachePath, isPastStaleWindow } from "./cacheHelpers";
 import { buildSafeAudiobookCoverUrl } from "./audiobookCoverProxy";
+import { buildSectionsWhenPresent } from "./audiobookSections";
 import {
     MAX_EXTERNAL_IMAGE_BYTES,
     readResponseBodyWithByteCap,
@@ -155,7 +157,11 @@ export class AudiobookCacheService {
         const tags = book.tags || [];
         const duration = book.media?.duration || null;
         const numTracks = book.media?.numTracks || null;
-        const numChapters = book.media?.numChapters || null;
+        const sections = buildSectionsWhenPresent({
+            durationSeconds: duration,
+            chapters: book.media?.chapters,
+            audioFiles: book.media?.audioFiles,
+        });
         const size = book.size ? BigInt(book.size) : null;
         const libraryId = book.libraryId || null;
 
@@ -242,7 +248,7 @@ export class AudiobookCacheService {
                 seriesSequence,
                 duration,
                 numTracks,
-                numChapters,
+                sections: sections ?? Prisma.DbNull,
                 size,
                 isbn,
                 asin,
@@ -266,7 +272,7 @@ export class AudiobookCacheService {
                 seriesSequence,
                 duration,
                 numTracks,
-                numChapters,
+                ...(sections === null ? {} : { sections }),
                 size,
                 isbn,
                 asin,
@@ -386,16 +392,17 @@ export class AudiobookCacheService {
             where: { id: audiobookId },
         });
 
-        // If not in cache or stale (> 7 days), try to sync it
+        // If not cached, stale, or missing section data, try to sync it.
         if (
             !audiobook ||
+            audiobook.sections === null ||
             isPastStaleWindow(
                 audiobook.lastSyncedAt,
                 AUDIOBOOK_CACHE_STALE_WINDOW_MS,
             )
         ) {
             logger.debug(
-                `[AUDIOBOOK] Audiobook ${audiobookId} not cached or stale, syncing...`,
+                `[AUDIOBOOK] Audiobook ${audiobookId} not cached, stale, or missing sections; syncing...`,
             );
             try {
                 const book =

--- a/backend/src/services/audiobookSections.ts
+++ b/backend/src/services/audiobookSections.ts
@@ -1,0 +1,206 @@
+import { z } from "zod";
+
+const MIN_CHAPTER_COVERAGE = 0.85;
+const CHAPTER_END_TOLERANCE_SECONDS = 2;
+const MAX_SECTION_COUNT = 10_000;
+
+const chapterPayloadSchema = z
+    .array(
+        z.looseObject({
+            title: z.string().max(1000).optional(),
+            start: z.number().finite(),
+            end: z.number().finite(),
+        }),
+    )
+    .max(MAX_SECTION_COUNT);
+
+const audioFilePayloadSchema = z
+    .array(
+        z.looseObject({
+            duration: z.number().finite().positive(),
+            filename: z.string().max(4096).optional(),
+            metadata: z
+                .looseObject({ filename: z.string().max(4096).optional() })
+                .optional(),
+        }),
+    )
+    .max(MAX_SECTION_COUNT);
+
+const sectionSchema = z.looseObject({
+    index: z.number().int().nonnegative(),
+    title: z.string().trim().min(1).max(1000),
+    startSeconds: z.number().finite().nonnegative(),
+});
+
+const storedSectionsSchema = z.discriminatedUnion("kind", [
+    z.looseObject({
+        kind: z.literal("chapters"),
+        sections: z.array(sectionSchema).min(1).max(MAX_SECTION_COUNT),
+    }),
+    z.looseObject({
+        kind: z.literal("parts"),
+        sections: z.array(sectionSchema).min(2).max(MAX_SECTION_COUNT),
+    }),
+    z.looseObject({
+        kind: z.literal("none"),
+        sections: z.array(sectionSchema).max(0),
+    }),
+]);
+
+/** The source used to construct cached audiobook navigation. */
+export type AudiobookSectionKind = "chapters" | "parts" | "none";
+
+/** A validated seek target in seconds from the start of an audiobook stream. */
+export type AudiobookSection = Readonly<{
+    index: number;
+    title: string;
+    startSeconds: number;
+}>;
+
+/** Validated, cacheable audiobook navigation derived from an ABS payload. */
+export type AudiobookSections = Readonly<{
+    kind: AudiobookSectionKind;
+    sections: ReadonlyArray<AudiobookSection>;
+}>;
+
+/** Untrusted Audiobookshelf values used to derive audiobook navigation. */
+export type BuildSectionsInput = Readonly<{
+    durationSeconds: unknown;
+    chapters: unknown;
+    audioFiles: unknown;
+}>;
+
+const EMPTY_SECTIONS: AudiobookSections = { kind: "none", sections: [] };
+
+function hasValidChapterTimeline(
+    chapters: z.infer<typeof chapterPayloadSchema>,
+    durationSeconds: number,
+): boolean {
+    let previousStart = -1;
+    let maximumEnd = 0;
+    for (const chapter of chapters) {
+        if (
+            chapter.start < 0 ||
+            chapter.end < chapter.start ||
+            chapter.start <= previousStart ||
+            chapter.end > durationSeconds + CHAPTER_END_TOLERANCE_SECONDS
+        ) {
+            return false;
+        }
+        previousStart = chapter.start;
+        maximumEnd = Math.max(maximumEnd, chapter.end);
+    }
+    return maximumEnd / durationSeconds >= MIN_CHAPTER_COVERAGE;
+}
+
+function buildChapterSections(
+    chapters: z.infer<typeof chapterPayloadSchema>,
+): AudiobookSections {
+    return {
+        kind: "chapters",
+        sections: chapters.map((chapter, index) => ({
+            index,
+            title: chapter.title?.trim() || `Chapter ${index + 1}`,
+            startSeconds: chapter.start,
+        })),
+    };
+}
+
+function cleanPartTitle(filename: string | undefined, index: number): string {
+    const basename = filename?.split(/[\\/]/).at(-1) ?? "";
+    const withoutExtension = basename.replace(/\.[A-Za-z0-9]{1,10}$/, "");
+    const withoutTrackNumber = withoutExtension.replace(
+        /^\s*\d{1,4}(?:\s*[-_.\u2013\u2014)]\s*|\s+)/,
+        "",
+    );
+    const cleaned = withoutTrackNumber
+        .replace(/^[\s._\-\u2013\u2014]+/, "")
+        .replace(/_+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    return cleaned.slice(0, 1000).trim() || `Part ${index + 1}`;
+}
+
+function buildPartSections(
+    audioFiles: z.infer<typeof audioFilePayloadSchema>,
+): AudiobookSections {
+    let startSeconds = 0;
+    return {
+        kind: "parts",
+        sections: audioFiles.map((audioFile, index) => {
+            const section = {
+                index,
+                title: cleanPartTitle(
+                    audioFile.metadata?.filename ?? audioFile.filename,
+                    index,
+                ),
+                startSeconds,
+            };
+            startSeconds += audioFile.duration;
+            return section;
+        }),
+    };
+}
+
+function hasValidStoredOrder(
+    sections: ReadonlyArray<AudiobookSection>,
+): boolean {
+    let previousStart = -1;
+    for (let index = 0; index < sections.length; index += 1) {
+        const section = sections[index];
+        if (
+            !section ||
+            section.index !== index ||
+            section.startSeconds <= previousStart
+        ) {
+            return false;
+        }
+        previousStart = section.startSeconds;
+    }
+    return true;
+}
+
+/**
+ * Build safe audiobook navigation from an untrusted expanded Audiobookshelf item.
+ * Sparse or malformed chapters are rejected before multi-file parts are considered.
+ */
+export function buildSections(input: BuildSectionsInput): AudiobookSections {
+    const duration = z
+        .number()
+        .finite()
+        .positive()
+        .safeParse(input.durationSeconds);
+    const chapters = chapterPayloadSchema.safeParse(input.chapters);
+    if (
+        duration.success &&
+        chapters.success &&
+        chapters.data.length > 0 &&
+        hasValidChapterTimeline(chapters.data, duration.data)
+    ) {
+        return buildChapterSections(chapters.data);
+    }
+
+    const audioFiles = audioFilePayloadSchema.safeParse(input.audioFiles);
+    return audioFiles.success && audioFiles.data.length > 1
+        ? buildPartSections(audioFiles.data)
+        : EMPTY_SECTIONS;
+}
+
+/** Build sections only when the Audiobookshelf payload includes section data. */
+export function buildSectionsWhenPresent(
+    input: BuildSectionsInput,
+): AudiobookSections | null {
+    if (input.chapters === undefined && input.audioFiles === undefined) {
+        return null;
+    }
+    return buildSections(input);
+}
+
+/** Parse cached section JSON, returning an honest-empty value for legacy or invalid rows. */
+export function parseStoredSections(value: unknown): AudiobookSections {
+    const parsed = storedSectionsSchema.safeParse(value);
+    if (!parsed.success || !hasValidStoredOrder(parsed.data.sections)) {
+        return EMPTY_SECTIONS;
+    }
+    return parsed.data;
+}

--- a/backend/src/services/audiobookshelf.ts
+++ b/backend/src/services/audiobookshelf.ts
@@ -1,8 +1,10 @@
 import axios, { AxiosInstance } from "axios";
+import { Prisma } from "@prisma/client";
 import { config } from "../config";
 import { logger } from "../utils/logger";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
+import { buildSectionsWhenPresent } from "./audiobookSections";
 
 const STREAM_HEADER_TIMEOUT_MS = 30_000;
 const UNSAFE_AUDIO_TRACK_URL_ERROR =
@@ -480,6 +482,11 @@ class AudiobookshelfService {
             for (const item of audiobooks) {
                 try {
                     const metadata = item.media?.metadata || {};
+                    const sections = buildSectionsWhenPresent({
+                        durationSeconds: item.media?.duration,
+                        chapters: item.media?.chapters,
+                        audioFiles: item.media?.audioFiles,
+                    });
 
                     // Extract series information (check both possible formats)
                     let series: string | null = null;
@@ -516,7 +523,7 @@ class AudiobookshelfService {
                             seriesSequence,
                             duration: item.media?.duration || null,
                             numTracks: item.media?.numTracks || null,
-                            numChapters: item.media?.numChapters || null,
+                            ...(sections === null ? {} : { sections }),
                             size: item.media?.size
                                 ? BigInt(item.media.size)
                                 : null,
@@ -550,7 +557,7 @@ class AudiobookshelfService {
                             seriesSequence,
                             duration: item.media?.duration || null,
                             numTracks: item.media?.numTracks || null,
-                            numChapters: item.media?.numChapters || null,
+                            sections: sections ?? Prisma.DbNull,
                             size: item.media?.size
                                 ? BigInt(item.media.size)
                                 : null,

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -154,6 +154,12 @@ use `FederationPodcastListing` instead of `Podcast`; matching `feedUrl` values
 drive native per-user subscription state without violating the global
 `Podcast.feedUrl` uniqueness contract.
 
+`Audiobook.sections` stores sync-time validated navigation as a discriminated
+JSON object with `kind` (`chapters`, `parts`, or `none`) and ordered
+`{ index, title, startSeconds }` entries. Legacy and federated rows may keep this
+column null; API readers map null or invalid JSON to `none`. `numChapters`
+remains temporarily for rollback compatibility but is no longer refreshed.
+
 ### User & Auth
 
 | Entity                           | Purpose                                                                                                                              |

--- a/docs/FEATURE_INDEX.json
+++ b/docs/FEATURE_INDEX.json
@@ -470,16 +470,17 @@
         {
             "id": "audiobooks",
             "name": "Audiobooks",
-            "description": "Audiobookshelf-synced and federated audiobook library with progress tracking and proxied playback",
+            "description": "Audiobookshelf-synced and federated audiobook library with validated cached section navigation, progress tracking, and proxied playback",
             "frontend": {
                 "feature_dirs": ["audiobook"],
-                "routes": ["/audiobooks/series/[name]"]
+                "routes": ["/audiobooks/[id]", "/audiobooks/series/[name]"]
             },
             "backend": {
                 "routes": ["audiobooks.ts", "listeningState.ts"],
                 "services": [
                     "audiobookshelf.ts",
                     "audiobookCache.ts",
+                    "audiobookSections.ts",
                     "federationAudiobookProxy.ts"
                 ]
             },
@@ -488,7 +489,12 @@
                     "audiobooksRuntime.test.ts",
                     "audiobooksAdvancedRuntime.test.ts"
                 ],
-                "backend_contract": []
+                "backend_contract": [
+                    "audiobookCacheService.test.ts",
+                    "audiobookSections.test.ts",
+                    "audiobookshelfService.test.ts"
+                ],
+                "frontend": ["chapterList.component.test.ts"]
             }
         },
         {

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -23,6 +23,12 @@ Connect soundspan to Lidarr to request/download new music and trigger imports.
 4. Set Lidarr API key (Lidarr → Settings → General)
 5. Test and save
 
+Audiobook detail metadata and section navigation are served from soundspan's
+local cache. Scheduled or manual Audiobookshelf sync validates chapter coverage
+and fills section data for rows created before this model was added. Multi-file
+part boundaries remain visible in the API but are not playable in the UI while
+the stream proxy serves only the first file.
+
 ### Networking note
 
 Lidarr must reach the soundspan callback URL.

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -107,6 +107,13 @@ awm health --project soundspan --include-details
 
 ### Backend Contract/Cross-Domain Tests (`backend/src/__tests__/`)
 
+Audiobook service behavior is covered by
+`src/services/__tests__/audiobookSections.test.ts`,
+`src/services/__tests__/audiobookCacheService.test.ts`, and
+`src/services/__tests__/audiobookshelfService.test.ts`. The validated section
+component contract is covered by
+`frontend/tests/component/chapterList.component.test.ts`.
+
 | Domain                   | Test Files                                                                                                                                                                                                                   |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | API Entrypoint           | `apiEntrypointRuntime.test.ts`, `apiEntrypointDbResilienceContract.test.ts`                                                                                                                                                  |

--- a/frontend/app/audiobooks/[id]/page.tsx
+++ b/frontend/app/audiobooks/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useAudiobookActions } from "@/features/audiobook/hooks/useAudiobookActi
 // Components
 import { AudiobookHero } from "@/features/audiobook/components/AudiobookHero";
 import { AudiobookActionBar } from "@/features/audiobook/components/AudiobookActionBar";
+import { ChapterList } from "@/features/audiobook/components/ChapterList";
 
 /**
  * Renders the AudiobookDetailPage component.
@@ -38,7 +39,8 @@ export default function AudiobookDetailPage() {
         handlePlayPause,
         handleMarkAsCompleted,
         handleResetProgress,
-    } = useAudiobookActions(audiobookId, audiobook, refetch);
+        seekToChapter,
+    } = useAudiobookActions(audiobookId, audiobook ?? null, refetch);
 
     // Loading state
     if (isLoading) {
@@ -103,6 +105,14 @@ export default function AudiobookDetailPage() {
                 />
 
                 <div className="relative px-4 md:px-8 py-8 space-y-6">
+                    <ChapterList
+                        kind={audiobook.sectionKind}
+                        sections={audiobook.sections}
+                        sectionsPlayable={audiobook.sectionsPlayable}
+                        onSeekToSection={seekToChapter}
+                        formatTime={formatTime}
+                    />
+
                     {/* Description / About */}
                     {showDescription && (
                         <section className="hidden md:block">

--- a/frontend/features/audiobook/README.md
+++ b/frontend/features/audiobook/README.md
@@ -4,11 +4,20 @@ Start-here guide for `frontend/features/audiobook`.
 
 ## Start Here
 
-1. Route entrypoints: `frontend/app/audiobooks/series/[name]/page.tsx`
+1. Route entrypoints: `frontend/app/audiobooks/[id]/page.tsx` and `frontend/app/audiobooks/series/[name]/page.tsx`
 2. Primary tests and route entrypoints for this domain are listed below.
 3. Targeted verification commands:
 - `npm --prefix backend test -- --runInBand src/routes/__tests__/audiobooksRuntime.test.ts src/routes/__tests__/audiobooksAdvancedRuntime.test.ts`
 - `npm --prefix backend test -- --runInBand src/services/__tests__/audiobookshelfService.test.ts`
+- `npm --prefix backend test -- --runInBand src/services/__tests__/audiobookSections.test.ts src/services/__tests__/audiobookCacheService.test.ts`
+- `npm --prefix frontend exec -- node --test --experimental-test-module-mocks --import tsx tests/component/chapterList.component.test.ts`
+
+## Section Navigation
+
+The detail page renders only validated cached sections. Sparse or malformed
+Audiobookshelf chapters are replaced by derived multi-file parts when possible.
+Navigation remains hidden for honest-empty results and for multi-file books
+until the stream proxy can serve more than the first file.
 
 ## Directory Contents
 

--- a/frontend/features/audiobook/components/ChapterList.tsx
+++ b/frontend/features/audiobook/components/ChapterList.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Card } from "@/components/ui/Card";
-import type { AudiobookChapter } from "../types";
+import type { AudiobookSection, AudiobookSectionKind } from "../types";
 
 interface ChapterListProps {
-    chapters: AudiobookChapter[];
-    onSeekToChapter: (startTime: number) => void;
+    kind: AudiobookSectionKind;
+    sections: AudiobookSection[];
+    sectionsPlayable: boolean;
+    onSeekToSection: (startTime: number) => void;
     formatTime: (seconds: number) => string;
 }
 
@@ -13,37 +15,42 @@ interface ChapterListProps {
  * Renders the ChapterList component.
  */
 export function ChapterList({
-    chapters,
-    onSeekToChapter,
+    kind,
+    sections,
+    sectionsPlayable,
+    onSeekToSection,
     formatTime,
 }: ChapterListProps) {
-    // Hide if >50 chapters (likely multi-file audiobook)
-    if (!chapters || chapters.length === 0 || chapters.length > 50) {
+    if (kind === "none" || !sectionsPlayable || sections.length === 0) {
         return null;
     }
 
+    const heading = kind === "parts" ? "Parts" : "Chapters";
+
     return (
         <section>
-            <h2 className="text-2xl md:text-3xl font-bold mb-6">Chapters</h2>
+            <h2 className="text-2xl md:text-3xl font-bold mb-6">{heading}</h2>
             <Card className="p-6">
                 <div className="space-y-2">
-                    {chapters.map((chapter, index) => (
+                    {sections.map((section) => (
                         <button
-                            key={chapter.id}
-                            onClick={() => onSeekToChapter(chapter.start)}
+                            key={section.index}
+                            onClick={() =>
+                                onSeekToSection(section.startSeconds)
+                            }
                             className="w-full text-left p-3 rounded-md hover:bg-surface-hover transition-colors group"
                         >
                             <div className="flex items-center justify-between">
                                 <div>
                                     <span className="text-sm text-gray-400 mr-2">
-                                        {index + 1}.
+                                        {section.index + 1}.
                                     </span>
                                     <span className="text-sm text-white group-hover:text-ai-hover">
-                                        {chapter.title}
+                                        {section.title}
                                     </span>
                                 </div>
                                 <span className="text-xs text-gray-400">
-                                    {formatTime(chapter.start)}
+                                    {formatTime(section.startSeconds)}
                                 </span>
                             </div>
                         </button>

--- a/frontend/features/audiobook/hooks/useAudiobookData.ts
+++ b/frontend/features/audiobook/hooks/useAudiobookData.ts
@@ -40,25 +40,13 @@ export function useAudiobookData() {
         ? api.getCoverArtUrl(audiobook.coverUrl, 300, true)
         : null;
 
-    // Extract metadata from audioFiles
+    // Shape cached metadata for the hero without depending on live ABS files.
     const getMetadata = () => {
         if (!audiobook) return null;
 
-        if (!audiobook.audioFiles?.[0]?.metaTags) {
-            return {
-                narrator: audiobook.narrator || null,
-                genre: null,
-                publishedYear: null,
-                description: audiobook.description || null,
-            };
-        }
-
-        const metaTags = audiobook.audioFiles[0].metaTags;
-
-        // Extract narrator from description or tagComment
         let narrator = audiobook.narrator;
         if (!narrator || narrator.trim() === "") {
-            const desc = audiobook.description || metaTags.tagComment || "";
+            const desc = audiobook.description || "";
             const narratorMatch = desc.match(
                 /(?:Read by|Narrated by):\s*(.+)/i,
             );
@@ -69,9 +57,9 @@ export function useAudiobookData() {
 
         return {
             narrator: narrator || null,
-            genre: metaTags.tagGenre || null,
-            publishedYear: metaTags.tagDate || null,
-            description: audiobook.description || metaTags.tagComment || null,
+            genre: audiobook.genres?.[0] || null,
+            publishedYear: audiobook.publishedYear?.toString() || null,
+            description: audiobook.description || null,
         };
     };
 

--- a/frontend/features/audiobook/types.ts
+++ b/frontend/features/audiobook/types.ts
@@ -2,14 +2,17 @@ export interface AudiobookProgress {
     currentTime: number;
     progress: number;
     isFinished: boolean;
-    lastPlayedAt: Date;
+    lastPlayedAt: Date | string;
 }
 
-export interface AudiobookChapter {
-    id: number;
+/** Source of validated audiobook navigation returned by the detail API. */
+export type AudiobookSectionKind = "chapters" | "parts" | "none";
+
+/** A seek target in seconds from the beginning of an audiobook stream. */
+export interface AudiobookSection {
+    index: number;
     title: string;
-    start: number;
-    end: number;
+    startSeconds: number;
 }
 
 export interface AudiobookSeries {
@@ -17,36 +20,26 @@ export interface AudiobookSeries {
     sequence: string;
 }
 
-export interface AudiobookMetaTags {
-    tagGenre?: string;
-    tagDate?: string;
-    tagComment?: string;
-    tagAlbum?: string;
-}
-
-export interface AudiobookAudioFile {
-    metaTags?: AudiobookMetaTags;
-}
-
 export interface Audiobook {
     id: string;
     title: string;
     author: string;
-    narrator?: string;
-    description?: string;
+    narrator?: string | null;
+    description?: string | null;
     coverUrl: string | null;
     duration: number;
-    libraryId?: string;
-    publisher?: string;
-    publishedYear?: string;
+    libraryId?: string | null;
+    publishedYear?: number | null;
+    publisher?: string | null;
     genres?: string[];
-    series?: AudiobookSeries;
-    isbn?: string;
-    asin?: string;
-    language?: string;
+    series?: AudiobookSeries | null;
+    isbn?: string | null;
+    asin?: string | null;
+    language?: string | null;
     progress?: AudiobookProgress | null;
-    chapters?: AudiobookChapter[];
-    audioFiles?: AudiobookAudioFile[];
+    sectionKind: AudiobookSectionKind;
+    sections: AudiobookSection[];
+    sectionsPlayable: boolean;
 }
 
 export interface AudiobookMetadata {

--- a/frontend/lib/api/audiobooks.ts
+++ b/frontend/lib/api/audiobooks.ts
@@ -1,4 +1,5 @@
 import { type ApiClientConstructor, type ApiData } from "./core";
+import type { Audiobook } from "@/features/audiobook/types";
 
 /** Add audiobook-domain operations to an API client base class. */
 export function WithAudiobooks<TBase extends ApiClientConstructor>(
@@ -11,7 +12,7 @@ export function WithAudiobooks<TBase extends ApiClientConstructor>(
         }
 
         async getAudiobook(id: string) {
-            return this.request<ApiData>(`/audiobooks/${id}`);
+            return this.request<Audiobook>(`/audiobooks/${id}`);
         }
 
         async getAudiobookSeries(seriesName: string) {

--- a/frontend/lib/audio-state-context.tsx
+++ b/frontend/lib/audio-state-context.tsx
@@ -144,18 +144,19 @@ export interface Track {
     } | null;
 }
 
+/** Minimal audiobook state retained by the shared playback context. */
 export interface Audiobook {
     id: string;
     title: string;
     author: string;
-    narrator?: string;
+    narrator?: string | null;
     coverUrl: string | null;
     duration: number;
     progress?: {
         currentTime: number;
         progress: number;
         isFinished: boolean;
-        lastPlayedAt: Date;
+        lastPlayedAt: Date | string;
     } | null;
 }
 
@@ -346,7 +347,7 @@ export function AudioStateProvider({ children }: { children: ReactNode }) {
                                 currentTime: number;
                                 progress: number;
                                 isFinished: boolean;
-                            };
+                            } | null;
                         }) => {
                             if (audiobook && audiobook.progress) {
                                 setCurrentAudiobook({

--- a/frontend/tests/component/chapterList.component.test.ts
+++ b/frontend/tests/component/chapterList.component.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+after(() => {
+    GlobalRegistrator.unregister();
+});
+
+mock.module("@/components/ui/Card", {
+    namedExports: {
+        Card: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement("div", null, children),
+    },
+});
+
+const sections = Array.from({ length: 51 }, (_, index) => ({
+    index,
+    title: `Section ${index + 1}`,
+    startSeconds: index * 60,
+}));
+
+async function render(props: Record<string, unknown>) {
+    const { ChapterList } =
+        await import("../../features/audiobook/components/ChapterList");
+    return renderToStaticMarkup(
+        React.createElement(ChapterList, {
+            kind: "chapters",
+            sections,
+            sectionsPlayable: true,
+            onSeekToSection: () => undefined,
+            formatTime: (seconds: number) => `${seconds}s`,
+            ...props,
+        } as never),
+    );
+}
+
+test("renders validated section navigation without a chapter-count heuristic", async () => {
+    const html = await render({});
+
+    assert.match(html, />Chapters</);
+    assert.match(html, /Section 51/);
+    assert.match(html, /3000s/);
+});
+
+test("labels file-derived navigation as parts", async () => {
+    const html = await render({
+        kind: "parts",
+        sections: sections.slice(0, 2),
+    });
+
+    assert.match(html, />Parts</);
+    assert.match(html, /Section 2/);
+});
+
+test("hides navigation for honest-empty and non-playable sections", async () => {
+    assert.equal(
+        await render({ kind: "none", sections: [], sectionsPlayable: false }),
+        "",
+    );
+    assert.equal(await render({ sectionsPlayable: false }), "");
+});
+
+test("seeks to the validated section start", async () => {
+    const { createRoot } = await import("react-dom/client");
+    const { ChapterList } =
+        await import("../../features/audiobook/components/ChapterList");
+    const seekCalls: number[] = [];
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(ChapterList, {
+                kind: "chapters",
+                sections: sections.slice(0, 2),
+                sectionsPlayable: true,
+                onSeekToSection: (seconds: number) => seekCalls.push(seconds),
+                formatTime: (seconds: number) => `${seconds}s`,
+            }),
+        );
+    });
+
+    const buttons = container.querySelectorAll("button");
+    assert.equal(buttons.length, 2);
+    await React.act(async () => buttons[1]?.click());
+    assert.deepEqual(seekCalls, [60]);
+
+    await React.act(async () => root.unmount());
+});


### PR DESCRIPTION
First #487 adoption item (see the verdict comment there); fixes broken chapter navigation on books with sparse Audiobookshelf chapter data and removes the per-detail-load ABS round-trip.

## Model
`buildSections` (new pure service, zod-validated): trust ABS chapters only when well-formed (monotonic, in-range) AND covering ≥85% of duration → `chapters`; else multi-file books derive `parts` from audio files with cleaned filename titles; else honest-empty `none`. Persisted as a nullable `sections` JSONB column at sync; `parseStoredSections` re-validates on read so legacy/invalid rows degrade to empty.

## Sync + backfill semantics (the subtle part)
ABS bulk listings are **minified** (no chapters/audioFiles), so sync must not compute from them: updates omit the column (never clobber a known value), creates store null (= unknown). The detail route refreshes via the expanded-item fetch when the row is missing, stale (7d), or has null sections — lazy one-time backfill for pre-existing rows. Cache-hit loads with known sections make **zero** ABS calls (tested by asserting no client/cache-service calls).

## Playability gate
The stream proxy currently serves only the first audio file (#495 — concatenated-proxy fix decided), so multi-file section targets are computed and cached but marked `sectionsPlayable: false`; the UI hides seek navigation for them. When #495 lands, the gate lifts without recomputing anything.

## Review history
Initial implementation was rejected in review for two blocking defects — bulk sync computing "none" for every book from minified payloads, and deletion of the route's cache-miss/stale fallback — both fixed with regression tests (minified update leaves sections untouched; null-sections row triggers exactly one expanded refresh; federated rows never backfill).

## Verification
- verify: backend tsc exit 0; frontend typecheck exit 0
- verify: 67/67 backend tests across sections/cache/ABS-service/route suites (including the socket-bound cases); 4/4 ChapterList component tests
- verify: npm run verify:gates exit 0; prisma validate + generate clean
- Migration: additive nullable column; numChapters retained for rollback. OpenAPI schema updated. Docs + CHANGELOG updated.

Refs #487