### PR TITLE
chore(sidecars): enforce interpreter/lock pairing across all sidecars

### DIFF
--- a/.github/workflows/quality-visibility.yml
+++ b/.github/workflows/quality-visibility.yml
@@ -158,7 +158,9 @@ jobs:
     continue-on-error: ${{ vars.CI_NON_BLOCKING_TEST_VISIBILITY != 'false' }}
     strategy:
       fail-fast: false
-      # python-version mirrors each sidecar's Dockerfile base (tidal/ytmusic python:3.14-slim, clap python:3.12-slim); audio-analyzer's python:3.11-slim image is the exception — its tests run on 3.12.
+      # Runtime/lock targets are tidal+ytmusic 3.14, CLAP 3.12, and audio-analyzer 3.11.
+      # The analyzer stays on 3.11 because TensorFlow 2.15.x has no CPython 3.12+
+      # wheels; its dependency-light test job remains on 3.12.
       matrix:
         include:
           - service: tidal-downloader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Guarded every Python sidecar against Docker interpreter and uv lock-target
+  drift, and documented the TensorFlow 2.15 wheel ceiling that keeps the
+  Essentia analyzer on Python 3.11. (#494)
 - Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts, while navigation stays hidden when the current single-file stream proxy cannot play those seek targets. (#487)
 - Rate limits for security-sensitive endpoints are now enforced across backend
   replicas and survive backend restarts, while requests degrade open on Redis

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -1,6 +1,8 @@
 # Audio Analyzer Service - Essentia with TensorFlow (MusiCNN)
-# Runs on Python 3.11 (Debian bookworm slim), matching the repo's Python 3.11+
-# contract and the AIO image that already runs this workload on Python 3.11.
+# Python 3.11 is the runtime ceiling for the validated TensorFlow 2.15.x stack:
+# PyPI publishes its Linux wheels only through CPython 3.11. Essentia dev1389
+# has newer-interpreter wheels, but cannot move this image without TensorFlow.
+# Keep this base paired with the requirements.lock --python-version target.
 FROM python:3.11-slim@sha256:90744cff8f32887f075c47d747a173ff333e9e98801667af93c357fa9f5e28ff
 
 # Avoid interactive prompts

--- a/services/audio-analyzer/tests/test_requirements_lock.py
+++ b/services/audio-analyzer/tests/test_requirements_lock.py
@@ -1,0 +1,22 @@
+"""Runtime and lock-target synchronization tests for the audio analyzer."""
+
+import re
+from pathlib import Path
+
+
+def test_docker_python_matches_lock_target() -> None:
+    """The image interpreter must match the version used to resolve its lock."""
+    service_root = Path(__file__).resolve().parents[1]
+    dockerfile = (service_root / "Dockerfile").read_text(encoding="utf-8")
+    lock = (service_root / "requirements.lock").read_text(encoding="utf-8")
+    image_match = re.search(
+        r"^FROM python:(\d+)\.(\d+)-slim(?:@sha256:[0-9a-f]{64})?$", dockerfile, re.MULTILINE
+    )
+    target_match = re.search(r"--python-version (\d+)\.(\d+) ", lock)
+
+    assert image_match is not None
+    assert target_match is not None
+    image_version = tuple(int(part) for part in image_match.groups())
+    lock_version = tuple(int(part) for part in target_match.groups())
+    assert image_version == (3, 11)
+    assert lock_version == image_version

--- a/services/tidal-downloader/tests/test_requirements_lock.py
+++ b/services/tidal-downloader/tests/test_requirements_lock.py
@@ -4,6 +4,24 @@ import re
 from pathlib import Path
 
 
+def test_docker_python_matches_lock_target() -> None:
+    """The image interpreter must match the version used to resolve its lock."""
+    service_root = Path(__file__).resolve().parents[1]
+    dockerfile = (service_root / "Dockerfile").read_text(encoding="utf-8")
+    lock = (service_root / "requirements.lock").read_text(encoding="utf-8")
+    image_match = re.search(
+        r"^FROM python:(\d+)\.(\d+)-slim(?:@sha256:[0-9a-f]{64})?$", dockerfile, re.MULTILINE
+    )
+    target_match = re.search(r"--python-version (\d+)\.(\d+) ", lock)
+
+    assert image_match is not None
+    assert target_match is not None
+    image_version = tuple(int(part) for part in image_match.groups())
+    lock_version = tuple(int(part) for part in target_match.groups())
+    assert image_version == (3, 14)
+    assert lock_version == image_version
+
+
 def test_uvicorn_lock_satisfies_manifest_floor() -> None:
     """The image lock must ship at least the Uvicorn floor in the manifest."""
     service_root = Path(__file__).resolve().parents[1]

--- a/services/ytmusic-streamer/tests/test_requirements_lock.py
+++ b/services/ytmusic-streamer/tests/test_requirements_lock.py
@@ -4,6 +4,24 @@ import re
 from pathlib import Path
 
 
+def test_docker_python_matches_lock_target() -> None:
+    """The image interpreter must match the version used to resolve its lock."""
+    service_root = Path(__file__).resolve().parents[1]
+    dockerfile = (service_root / "Dockerfile").read_text(encoding="utf-8")
+    lock = (service_root / "requirements.lock").read_text(encoding="utf-8")
+    image_match = re.search(
+        r"^FROM python:(\d+)\.(\d+)-slim(?:@sha256:[0-9a-f]{64})?$", dockerfile, re.MULTILINE
+    )
+    target_match = re.search(r"--python-version (\d+)\.(\d+) ", lock)
+
+    assert image_match is not None
+    assert target_match is not None
+    image_version = tuple(int(part) for part in image_match.groups())
+    lock_version = tuple(int(part) for part in target_match.groups())
+    assert image_version == (3, 14)
+    assert lock_version == image_version
+
+
 def test_uvicorn_lock_satisfies_manifest_floor() -> None:
     """The image lock must ship at least the Uvicorn floor in the manifest."""
     service_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Closes #494.

## Guard coverage
| Sidecar | Guard before | Guard after |
|---|---|---|
| audio-analyzer-clap | yes (caught #461) | yes |
| audio-analyzer | **no** (why #463 passed while broken) | **yes** |
| tidal-downloader | no | yes |
| ytmusic-streamer | no | yes |

## Migration decisions (wheel-evidence-based)
- **audio-analyzer: 3.11 is the real ceiling.** essentia-tensorflow publishes cp39–cp311 wheels only with no sdist; the validated tensorflow <2.16 range agrees. Documented in the Dockerfile + CI matrix comments; the guard enforces the pair.
- **clap: stays 3.12.** torch 2.13 / torchaudio 2.11 / torchvision 0.28 / transformers 5.14.1 all publish 3.14-compatible wheels, but migration is withheld until the complete transitive set (incl. laion-clap) can be re-resolved and pytest-verified under 3.14 — no speculative bumps.
- A pre-existing requirements.txt/lock drift on essentia (dev1438 vs dev1389, from #465) was found and deliberately left for a separate change (dependency-version changes were out of scope here).

## Verification
- verify: all four guard tests pass; audio-analyzer 35/35, clap 31/31, tidal 123/123, ytmusic 196/196
- verify: ruff check + format-check clean; CI mypy lanes for tidal (16 files) and ytmusic (22 files) clean