### PR TITLE
fix(audiobooks): stream multi-file books through a concatenated Range-mapped proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drift, and documented the TensorFlow 2.15 wheel ceiling that keeps the
   Essentia analyzer on Python 3.11. (#494)
 - Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts, while navigation stays hidden when the current single-file stream proxy cannot play those seek targets. (#487)
+- Fixed multi-file audiobooks so playback continues past the first file and seeking works across file boundaries. (#495)
+- Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts. (#487)
 - Rate limits for security-sensitive endpoints are now enforced across backend
   replicas and survive backend restarts, while requests degrade open on Redis
   outages instead of failing or hanging. (#489)

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -722,7 +722,7 @@ describe("audiobooks advanced runtime", () => {
         });
     });
 
-    it("returns multi-file parts but marks their seek targets non-playable", async () => {
+    it("returns playable seek targets for multi-file parts", async () => {
         prisma.audiobook.findUnique.mockResolvedValueOnce({
             id: "book-parts",
             title: "Parted Book",
@@ -765,7 +765,7 @@ describe("audiobooks advanced runtime", () => {
                     { index: 0, title: "Part One", startSeconds: 0 },
                     { index: 1, title: "Part Two", startSeconds: 600 },
                 ],
-                sectionsPlayable: false,
+                sectionsPlayable: true,
             }),
         );
         expect(audiobookshelfService.getAudiobook).not.toHaveBeenCalled();
@@ -1067,6 +1067,31 @@ describe("audiobooks advanced runtime", () => {
 
         successRes.emit("close");
         expect(stream.destroy).toHaveBeenCalled();
+
+        const unsatisfiableStream = createMockStream();
+        audiobookshelfService.streamAudiobook.mockResolvedValueOnce({
+            stream: unsatisfiableStream,
+            headers: {
+                "accept-ranges": "bytes",
+                "content-length": "0",
+                "content-range": "bytes */100",
+            },
+            status: 416,
+        });
+        const unsatisfiableRes = createRes();
+        await streamHandler(
+            {
+                params: { id: "stream-416" },
+                headers: { range: "bytes=100-" },
+                user: { id: "u1" },
+            } as any,
+            unsatisfiableRes,
+        );
+        expect(unsatisfiableRes.statusCode).toBe(416);
+        expect(unsatisfiableRes.headers["Content-Type"]).toBeUndefined();
+        expect(unsatisfiableRes.headers["Content-Length"]).toBe("0");
+        expect(unsatisfiableRes.headers["Accept-Ranges"]).toBe("bytes");
+        expect(unsatisfiableRes.headers["Content-Range"]).toBe("bytes */100");
 
         const defaultStream = createMockStream();
         audiobookshelfService.streamAudiobook.mockResolvedValueOnce({

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -117,13 +117,8 @@ function audiobookListResponse(
     };
 }
 
-function sectionsArePlayable(
-    book: AudiobookRow,
-    cachedSections: AudiobookSections,
-): boolean {
-    // The stream proxy currently serves only media.tracks[0]. Keep all computed
-    // multi-file parts cached, but do not expose unsafe seek navigation for them.
-    return cachedSections.kind === "chapters" && book.numTracks === 1;
+function sectionsArePlayable(cachedSections: AudiobookSections): boolean {
+    return cachedSections.kind !== "none";
 }
 
 /**
@@ -1017,10 +1012,7 @@ router.get<{ id: string }>(
                     : null,
                 sectionKind: cachedSections.kind,
                 sections: cachedSections.sections,
-                sectionsPlayable: sectionsArePlayable(
-                    audiobook,
-                    cachedSections,
-                ),
+                sectionsPlayable: sectionsArePlayable(cachedSections),
                 libraryId: audiobook.libraryId,
                 progress: progress
                     ? {
@@ -1070,14 +1062,33 @@ router.get<{ id: string }>(
  *         description: HTTP range header for partial content
  *     responses:
  *       200:
- *         description: Full audio stream
+ *         description: Full concatenated audio stream
+ *         headers:
+ *           Accept-Ranges:
+ *             schema: { type: string, example: bytes }
+ *           Content-Length:
+ *             schema: { type: integer, format: int64 }
  *         content:
  *           audio/mpeg:
  *             schema:
  *               type: string
  *               format: binary
  *       206:
- *         description: Partial audio stream
+ *         description: Partial concatenated audio stream
+ *         headers:
+ *           Accept-Ranges:
+ *             schema: { type: string, example: bytes }
+ *           Content-Length:
+ *             schema: { type: integer, format: int64 }
+ *           Content-Range:
+ *             schema: { type: string, example: "bytes 100-199/1000" }
+ *       416:
+ *         description: Requested byte range is outside the concatenated audiobook
+ *         headers:
+ *           Accept-Ranges:
+ *             schema: { type: string, example: bytes }
+ *           Content-Range:
+ *             schema: { type: string }
  *       401:
  *         description: Not authenticated
  *       503:
@@ -1189,8 +1200,12 @@ router.get<{ id: string }>(
 
             // Set content type - ensure it's audio
             // axios >=1.18 types indexed header access as a union; coerce to string.
-            const contentType = String(headers["content-type"] || "audio/mpeg");
-            res.setHeader("Content-Type", contentType);
+            if (responseStatus !== 416) {
+                const contentType = String(
+                    headers["content-type"] || "audio/mpeg",
+                );
+                res.setHeader("Content-Type", contentType);
+            }
 
             // Set other headers
             if (headers["content-length"]) {

--- a/backend/src/services/__tests__/audiobookStreamMap.test.ts
+++ b/backend/src/services/__tests__/audiobookStreamMap.test.ts
@@ -1,0 +1,88 @@
+import {
+    buildAudiobookStreamMap,
+    resolveAudiobookRange,
+} from "../audiobookStreamMap";
+
+describe("audiobook stream map", () => {
+    const map = buildAudiobookStreamMap([
+        { index: 0, byteLength: 5 },
+        { index: 1, byteLength: 10 },
+        { index: 2, byteLength: 15 },
+    ]);
+
+    it("maps the full three-file byte range", () => {
+        expect(map.totalBytes()).toBe(30);
+        expect(map.resolveRange(0, 29)).toEqual([
+            { fileIndex: 0, fileStartByte: 0, fileEndByte: 4 },
+            { fileIndex: 1, fileStartByte: 0, fileEndByte: 9 },
+            { fileIndex: 2, fileStartByte: 0, fileEndByte: 14 },
+        ]);
+    });
+
+    it("maps a range entirely inside the second file", () => {
+        expect(map.resolveRange(7, 11)).toEqual([
+            { fileIndex: 1, fileStartByte: 2, fileEndByte: 6 },
+        ]);
+    });
+
+    it("maps a range spanning the first through third files", () => {
+        expect(map.resolveRange(3, 20)).toEqual([
+            { fileIndex: 0, fileStartByte: 3, fileEndByte: 4 },
+            { fileIndex: 1, fileStartByte: 0, fileEndByte: 9 },
+            { fileIndex: 2, fileStartByte: 0, fileEndByte: 5 },
+        ]);
+    });
+
+    it("resolves a suffix range", () => {
+        expect(resolveAudiobookRange("bytes=-6", map)).toEqual({
+            kind: "partial",
+            startByte: 24,
+            endByte: 29,
+            slices: [{ fileIndex: 2, fileStartByte: 9, fileEndByte: 14 }],
+        });
+    });
+
+    it("resolves an open-ended range", () => {
+        expect(resolveAudiobookRange("bytes=12-", map)).toEqual({
+            kind: "partial",
+            startByte: 12,
+            endByte: 29,
+            slices: [
+                { fileIndex: 1, fileStartByte: 7, fileEndByte: 9 },
+                { fileIndex: 2, fileStartByte: 0, fileEndByte: 14 },
+            ],
+        });
+    });
+
+    it("rejects an out-of-range request", () => {
+        expect(resolveAudiobookRange("bytes=30-", map)).toEqual({
+            kind: "unsatisfiable",
+            totalBytes: 30,
+        });
+    });
+
+    it("preserves the single-file degenerate case", () => {
+        const singleFileMap = buildAudiobookStreamMap([
+            { index: 7, byteLength: 10 },
+        ]);
+
+        expect(singleFileMap.totalBytes()).toBe(10);
+        expect(singleFileMap.resolveRange(2, 5)).toEqual([
+            { fileIndex: 7, fileStartByte: 2, fileEndByte: 5 },
+        ]);
+    });
+
+    it("skips zero-length files without shifting later file indexes", () => {
+        const zeroLengthMap = buildAudiobookStreamMap([
+            { index: 0, byteLength: 5 },
+            { index: 1, byteLength: 0 },
+            { index: 2, byteLength: 5 },
+        ]);
+
+        expect(zeroLengthMap.totalBytes()).toBe(10);
+        expect(zeroLengthMap.resolveRange(3, 7)).toEqual([
+            { fileIndex: 0, fileStartByte: 3, fileEndByte: 4 },
+            { fileIndex: 2, fileStartByte: 0, fileEndByte: 2 },
+        ]);
+    });
+});

--- a/backend/src/services/__tests__/audiobookshelfService.test.ts
+++ b/backend/src/services/__tests__/audiobookshelfService.test.ts
@@ -1,11 +1,14 @@
 import { EventEmitter } from "events";
+import { PassThrough, Readable } from "stream";
 import { Prisma } from "@prisma/client";
 
 const logger = {
     debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    child: jest.fn(),
 };
+logger.child.mockReturnValue(logger);
 jest.mock("../../utils/logger", () => ({
     logger,
 }));
@@ -48,8 +51,17 @@ import { audiobookshelfService } from "../audiobookshelf";
 function createClient() {
     return {
         get: jest.fn(),
+        head: jest.fn(),
         patch: jest.fn(),
     };
+}
+
+async function readStream(stream: Readable): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
 }
 
 function createStreamLifecycle() {
@@ -86,6 +98,7 @@ describe("audiobookshelf service behavior", () => {
         svc.apiKey = null;
         svc.initialized = false;
         svc.podcastCache = null;
+        svc.audiobookStreamMapCache?.clear();
 
         mockGetSystemSettings.mockResolvedValue(null);
         prisma.audiobook.upsert.mockResolvedValue({});
@@ -334,12 +347,14 @@ describe("audiobookshelf service behavior", () => {
                 tracks: [
                     {
                         contentUrl: "/api/items/book-1/file/123",
+                        mimeType: "audio/mpeg",
+                        metadata: { size: 1000 },
                     },
                 ],
             },
         } as any);
         client.get.mockResolvedValueOnce({
-            data: { pipe: jest.fn() },
+            data: Readable.from([Buffer.alloc(100)]),
             headers: { "content-type": "audio/mpeg" },
             status: 206,
         });
@@ -352,7 +367,7 @@ describe("audiobookshelf service behavior", () => {
         expect(client.get).toHaveBeenCalledWith("/api/items/book-1/file/123", {
             allowAbsoluteUrls: false,
             responseType: "stream",
-            timeout: 0,
+            timeout: 30000,
             signal: expect.any(AbortSignal),
             headers: {
                 Range: "bytes=0-99",
@@ -364,6 +379,309 @@ describe("audiobookshelf service behavior", () => {
         await expect(
             audiobookshelfService.streamAudiobook("book-2"),
         ).rejects.toThrow("No audio track found for this audiobook");
+    });
+
+    it("streams every audiobook file in order with exact full-response headers", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book/file/1",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 5 },
+                        },
+                        {
+                            contentUrl: "/api/items/book/file/2",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 4 },
+                        },
+                        {
+                            contentUrl: "/api/items/book/file/3",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 5 },
+                        },
+                    ],
+                },
+            } as any,
+        );
+        const bodies = new Map([
+            ["/api/items/book/file/1", "alpha"],
+            ["/api/items/book/file/2", "beta"],
+            ["/api/items/book/file/3", "gamma"],
+        ]);
+        client.get.mockImplementation(async (path: string) => ({
+            data: Readable.from([Buffer.from(bodies.get(path) ?? "")]),
+            headers: { "content-type": "audio/mpeg" },
+            status: 200,
+        }));
+
+        const result = await audiobookshelfService.streamAudiobook("book-1");
+
+        await expect(readStream(result.stream)).resolves.toEqual(
+            Buffer.from("alphabetagamma"),
+        );
+        expect(result).toEqual(
+            expect.objectContaining({
+                status: 200,
+                headers: expect.objectContaining({
+                    "content-type": "audio/mpeg",
+                    "content-length": "14",
+                    "accept-ranges": "bytes",
+                }),
+            }),
+        );
+        expect(client.head).not.toHaveBeenCalled();
+        expect(client.get).toHaveBeenCalledTimes(3);
+    });
+
+    it("streams a cross-file range byte-exact with concatenated range headers", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: ["abcde", "fghij", "klmno"].map((_, index) => ({
+                        contentUrl: `/api/items/book/file/${index + 1}`,
+                        mimeType: "audio/mpeg",
+                        metadata: { size: 5 },
+                    })),
+                },
+            } as any,
+        );
+        const bodies = ["abcde", "fghij", "klmno"];
+        client.get.mockImplementation(
+            async (
+                path: string,
+                options: { headers?: Record<string, string> },
+            ) => {
+                const fileIndex = Number(path.at(-1)) - 1;
+                const body = bodies[fileIndex] ?? "";
+                const range = options.headers?.Range;
+                const match = range ? /^bytes=(\d+)-(\d+)$/.exec(range) : null;
+                const selected = match
+                    ? body.slice(Number(match[1]), Number(match[2]) + 1)
+                    : body;
+                return {
+                    data: Readable.from([Buffer.from(selected)]),
+                    headers: { "content-type": "audio/mpeg" },
+                    status: range ? 206 : 200,
+                };
+            },
+        );
+
+        const result = await audiobookshelfService.streamAudiobook(
+            "book-1",
+            "bytes=3-11",
+        );
+
+        await expect(readStream(result.stream)).resolves.toEqual(
+            Buffer.from("defghijkl"),
+        );
+        expect(result.status).toBe(206);
+        expect(result.headers).toEqual(
+            expect.objectContaining({
+                "content-range": "bytes 3-11/15",
+                "content-length": "9",
+                "accept-ranges": "bytes",
+            }),
+        );
+        expect(
+            client.get.mock.calls.map(([, options]) => options.headers),
+        ).toEqual([{ Range: "bytes=3-4" }, {}, { Range: "bytes=0-1" }]);
+    });
+
+    it("keeps the first file content type and warns about a mixed container", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: ["audio/mpeg", "audio/flac"].map(
+                        (mimeType, index) => ({
+                            contentUrl: `/api/items/book/file/${index + 1}`,
+                            mimeType,
+                            metadata: { size: 1 },
+                        }),
+                    ),
+                },
+            } as any,
+        );
+        client.get.mockImplementation(async (path: string) => ({
+            data: Readable.from([Buffer.from("x")]),
+            headers: {
+                "content-type": path.endsWith("/1")
+                    ? "audio/mpeg"
+                    : "audio/flac",
+            },
+            status: 200,
+        }));
+
+        const result = await audiobookshelfService.streamAudiobook("book-1");
+        await readStream(result.stream);
+
+        expect(result.headers["content-type"]).toBe("audio/mpeg");
+        expect(logger.child).toHaveBeenCalledWith("AudiobookStream");
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Audiobook track content type differs from the first file",
+            expect.objectContaining({
+                firstContentType: "audio/mpeg",
+                trackContentType: "audio/flac",
+                fileIndex: 1,
+            }),
+        );
+    });
+
+    it("returns 416 without opening a file when a range is out of bounds", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book/file/1",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 5 },
+                        },
+                    ],
+                },
+            } as any,
+        );
+
+        const result = await audiobookshelfService.streamAudiobook(
+            "book-1",
+            "bytes=5-",
+        );
+
+        await expect(readStream(result.stream)).resolves.toEqual(
+            Buffer.alloc(0),
+        );
+        expect(result.status).toBe(416);
+        expect(result.headers).toEqual(
+            expect.objectContaining({
+                "content-range": "bytes */5",
+                "content-length": "0",
+                "accept-ranges": "bytes",
+            }),
+        );
+        expect(client.get).not.toHaveBeenCalled();
+    });
+
+    it("aborts the active upstream file when the client disconnects", async () => {
+        const client = createClient();
+        const lifecycle = createStreamLifecycle();
+        const upstream = new PassThrough();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
+            {
+                media: {
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book/file/1",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 5 },
+                        },
+                    ],
+                },
+            } as any,
+        );
+        let upstreamSignal: AbortSignal | undefined;
+        client.get.mockImplementationOnce(
+            async (_path: string, options: { signal: AbortSignal }) => {
+                upstreamSignal = options.signal;
+                return {
+                    data: upstream,
+                    headers: { "content-type": "audio/mpeg" },
+                    status: 200,
+                };
+            },
+        );
+        const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+        const result = await audiobookshelfService.streamAudiobook(
+            "book-1",
+            undefined,
+            lifecycle,
+        );
+        const reading = readStream(result.stream).catch(() => Buffer.alloc(0));
+        lifecycle.response.emit("close");
+        await reading;
+
+        expect(upstreamSignal?.aborted).toBe(true);
+        expect(abortSpy).toHaveBeenCalled();
+        expect(upstream.destroyed).toBe(true);
+    });
+
+    it("caches HEAD-derived track sizes per book and invalidates on file-list change", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        const firstPayload = {
+            media: {
+                tracks: [1, 2].map((index) => ({
+                    contentUrl: `/api/items/book/file/${index}`,
+                    mimeType: "audio/mpeg",
+                })),
+            },
+        };
+        jest.spyOn(audiobookshelfService, "getAudiobook")
+            .mockResolvedValueOnce(firstPayload as any)
+            .mockResolvedValueOnce(firstPayload as any)
+            .mockResolvedValueOnce({
+                media: {
+                    tracks: [
+                        ...firstPayload.media.tracks,
+                        {
+                            contentUrl: "/api/items/book/file/3",
+                            mimeType: "audio/mpeg",
+                        },
+                    ],
+                },
+            } as any);
+        client.head.mockResolvedValue({
+            headers: {
+                "content-length": "5",
+                "content-type": "audio/mpeg",
+            },
+        });
+        client.get.mockImplementation(async () => ({
+            data: Readable.from([Buffer.from("12345")]),
+            headers: { "content-type": "audio/mpeg" },
+            status: 200,
+        }));
+
+        await readStream(
+            (await audiobookshelfService.streamAudiobook("book-1")).stream,
+        );
+        await readStream(
+            (await audiobookshelfService.streamAudiobook("book-1")).stream,
+        );
+        expect(client.head).toHaveBeenCalledTimes(2);
+
+        await readStream(
+            (await audiobookshelfService.streamAudiobook("book-1")).stream,
+        );
+        expect(client.head).toHaveBeenCalledTimes(5);
     });
 
     it.each(["close", "aborted"] as const)(
@@ -381,7 +699,13 @@ describe("audiobookshelf service behavior", () => {
                 "getAudiobook",
             ).mockResolvedValueOnce({
                 media: {
-                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book-1/file/123",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 100 },
+                        },
+                    ],
                 },
             } as any);
             client.get.mockImplementationOnce(
@@ -414,7 +738,7 @@ describe("audiobookshelf service behavior", () => {
             lifecycle.request.emit(disconnectEvent);
 
             await rejectedAcquisition;
-            expect(abortSpy).toHaveBeenCalledTimes(1);
+            expect(abortSpy).toHaveBeenCalled();
             expectStreamListeners(lifecycle, 0);
         },
     );
@@ -434,7 +758,13 @@ describe("audiobookshelf service behavior", () => {
         jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
             {
                 media: {
-                    tracks: [{ contentUrl }],
+                    tracks: [
+                        {
+                            contentUrl,
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 100 },
+                        },
+                    ],
                 },
             } as any,
         );
@@ -459,13 +789,15 @@ describe("audiobookshelf service behavior", () => {
                         {
                             contentUrl:
                                 "http://abs.local/api/items/book-1/file/123?token=track",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 100 },
                         },
                     ],
                 },
             } as any,
         );
         client.get.mockResolvedValueOnce({
-            data: { pipe: jest.fn() },
+            data: Readable.from([Buffer.alloc(100)]),
             headers: { "content-type": "audio/mpeg" },
             status: 200,
         });
@@ -491,7 +823,13 @@ describe("audiobookshelf service behavior", () => {
         jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
             {
                 media: {
-                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book-1/file/123",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 100 },
+                        },
+                    ],
                 },
             } as any,
         );
@@ -527,7 +865,7 @@ describe("audiobookshelf service behavior", () => {
         expectStreamListeners(lifecycle, 0);
     });
 
-    it("hands off a connected stream and detaches acquisition listeners", async () => {
+    it("keeps disconnect listeners until the connected stream finishes", async () => {
         const client = createClient();
         const lifecycle = createStreamLifecycle();
         const svc = audiobookshelfService as any;
@@ -538,13 +876,19 @@ describe("audiobookshelf service behavior", () => {
         jest.spyOn(audiobookshelfService, "getAudiobook").mockResolvedValueOnce(
             {
                 media: {
-                    tracks: [{ contentUrl: "/api/items/book-1/file/123" }],
+                    tracks: [
+                        {
+                            contentUrl: "/api/items/book-1/file/123",
+                            mimeType: "audio/mpeg",
+                            metadata: { size: 4 },
+                        },
+                    ],
                 },
             } as any,
         );
-        const stream = { pipe: jest.fn() };
+        const upstream = Readable.from([Buffer.from("book")]);
         client.get.mockResolvedValueOnce({
-            data: stream,
+            data: upstream,
             headers: { "content-type": "audio/mpeg" },
             status: 200,
         });
@@ -556,11 +900,11 @@ describe("audiobookshelf service behavior", () => {
             lifecycle,
         );
 
-        expect(result).toEqual({
-            stream,
-            headers: { "content-type": "audio/mpeg" },
-            status: 200,
-        });
+        expect(result.status).toBe(200);
+        expectStreamListeners(lifecycle, 1);
+        await expect(readStream(result.stream)).resolves.toEqual(
+            Buffer.from("book"),
+        );
         expect(abortSpy).not.toHaveBeenCalled();
         expectStreamListeners(lifecycle, 0);
     });

--- a/backend/src/services/audiobookStreamMap.ts
+++ b/backend/src/services/audiobookStreamMap.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+
+const MAX_AUDIOBOOK_FILES = 10_000;
+const byteFileSchema = z.strictObject({
+    index: z.number().int().nonnegative(),
+    byteLength: z.number().int().nonnegative().safe(),
+});
+const byteFilesSchema = z.array(byteFileSchema).max(MAX_AUDIOBOOK_FILES);
+
+/** One byte interval to request from an Audiobookshelf track. */
+export type AudiobookFileSlice = Readonly<{
+    fileIndex: number;
+    fileStartByte: number;
+    fileEndByte: number;
+}>;
+
+type StreamMapEntry = Readonly<{
+    fileIndex: number;
+    streamStartByte: number;
+    streamEndByte: number;
+}>;
+
+/** A validated translation table from concatenated bytes to track-local bytes. */
+export type AudiobookStreamMap = Readonly<{
+    totalBytes(): number;
+    resolveRange(startByte: number, endByte: number): AudiobookFileSlice[];
+}>;
+
+/** The result of parsing and resolving one HTTP byte range. */
+export type AudiobookRangeResolution =
+    | Readonly<{
+          kind: "partial";
+          startByte: number;
+          endByte: number;
+          slices: AudiobookFileSlice[];
+      }>
+    | Readonly<{ kind: "unsatisfiable"; totalBytes: number }>;
+
+function buildEntries(
+    files: z.infer<typeof byteFilesSchema>,
+): StreamMapEntry[] {
+    const entries: StreamMapEntry[] = [];
+    let streamStartByte = 0;
+    for (const file of files) {
+        if (file.byteLength === 0) continue;
+        const streamEndByte = streamStartByte + file.byteLength - 1;
+        if (!Number.isSafeInteger(streamEndByte)) {
+            throw new RangeError(
+                "Audiobook byte length exceeds safe integer range",
+            );
+        }
+        entries.push({
+            fileIndex: file.index,
+            streamStartByte,
+            streamEndByte,
+        });
+        streamStartByte = streamEndByte + 1;
+    }
+    return entries;
+}
+
+function assertResolvableRange(
+    startByte: number,
+    endByte: number,
+    totalBytes: number,
+): void {
+    const valid =
+        Number.isSafeInteger(startByte) &&
+        Number.isSafeInteger(endByte) &&
+        startByte >= 0 &&
+        endByte >= startByte &&
+        endByte < totalBytes;
+    if (!valid) throw new RangeError("Audiobook byte range is not satisfiable");
+}
+
+function resolveEntries(
+    entries: ReadonlyArray<StreamMapEntry>,
+    startByte: number,
+    endByte: number,
+): AudiobookFileSlice[] {
+    return entries.flatMap((entry) => {
+        if (
+            endByte < entry.streamStartByte ||
+            startByte > entry.streamEndByte
+        ) {
+            return [];
+        }
+        return [
+            {
+                fileIndex: entry.fileIndex,
+                fileStartByte:
+                    Math.max(startByte, entry.streamStartByte) -
+                    entry.streamStartByte,
+                fileEndByte:
+                    Math.min(endByte, entry.streamEndByte) -
+                    entry.streamStartByte,
+            },
+        ];
+    });
+}
+
+/** Build a deterministic byte-to-track translation table in payload order. */
+export function buildAudiobookStreamMap(input: unknown): AudiobookStreamMap {
+    const entries = buildEntries(byteFilesSchema.parse(input));
+    const total = entries.at(-1)?.streamEndByte ?? -1;
+    const totalByteLength = total + 1;
+    return {
+        totalBytes: () => totalByteLength,
+        resolveRange: (startByte, endByte) => {
+            assertResolvableRange(startByte, endByte, totalByteLength);
+            return resolveEntries(entries, startByte, endByte);
+        },
+    };
+}
+
+function parseRangeNumber(value: string): number | null {
+    if (!/^\d+$/.test(value)) return null;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function unsatisfiable(totalBytes: number): AudiobookRangeResolution {
+    return { kind: "unsatisfiable", totalBytes };
+}
+
+/** Parse and resolve a single HTTP bytes range against an audiobook map. */
+export function resolveAudiobookRange(
+    rangeHeader: string,
+    map: AudiobookStreamMap,
+): AudiobookRangeResolution {
+    const totalBytes = map.totalBytes();
+    const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+    if (!match || totalBytes === 0) return unsatisfiable(totalBytes);
+    const [, rawStart = "", rawEnd = ""] = match;
+    const startValue = rawStart === "" ? null : parseRangeNumber(rawStart);
+    const endValue = rawEnd === "" ? null : parseRangeNumber(rawEnd);
+    if (
+        (rawStart !== "" && startValue === null) ||
+        (rawEnd !== "" && endValue === null)
+    ) {
+        return unsatisfiable(totalBytes);
+    }
+
+    const startByte = startValue ?? Math.max(totalBytes - (endValue ?? 0), 0);
+    const endByte =
+        startValue === null
+            ? totalBytes - 1
+            : Math.min(endValue ?? totalBytes - 1, totalBytes - 1);
+    if (startByte >= totalBytes || endByte < startByte) {
+        return unsatisfiable(totalBytes);
+    }
+    return {
+        kind: "partial",
+        startByte,
+        endByte,
+        slices: map.resolveRange(startByte, endByte),
+    };
+}

--- a/backend/src/services/audiobookshelf.ts
+++ b/backend/src/services/audiobookshelf.ts
@@ -1,14 +1,107 @@
 import axios, { AxiosInstance } from "axios";
 import { Prisma } from "@prisma/client";
+import { Readable } from "stream";
+import { z } from "zod";
 import { config } from "../config";
 import { logger } from "../utils/logger";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
 import { buildSectionsWhenPresent } from "./audiobookSections";
+import {
+    buildAudiobookStreamMap,
+    resolveAudiobookRange,
+    type AudiobookFileSlice,
+    type AudiobookStreamMap,
+} from "./audiobookStreamMap";
 
 const STREAM_HEADER_TIMEOUT_MS = 30_000;
+const AUDIOBOOK_STREAM_MAP_CACHE_TTL_MS = 15 * 60 * 1000;
+const AUDIOBOOK_STREAM_MAP_CACHE_MAX_ITEMS = 256;
+const MAX_AUDIOBOOK_TRACKS = 10_000;
 const UNSAFE_AUDIO_TRACK_URL_ERROR =
     "Audiobookshelf returned an unsafe audio track URL";
+
+const audiobookTrackSchema = z.looseObject({
+    contentUrl: z.string().min(1).max(8192),
+    mimeType: z.string().min(1).max(255).nullish(),
+    metadata: z
+        .looseObject({
+            size: z.number().int().nonnegative().safe().nullish(),
+        })
+        .nullish(),
+});
+const audiobookTracksSchema = z
+    .array(audiobookTrackSchema)
+    .min(1)
+    .max(MAX_AUDIOBOOK_TRACKS);
+const contentLengthSchema = z.union([
+    z.number().int().nonnegative().safe(),
+    z
+        .string()
+        .regex(/^\d+$/)
+        .transform(Number)
+        .pipe(z.number().int().nonnegative().safe()),
+]);
+
+type AudiobookTrack = Readonly<{
+    contentPath: string;
+    byteLength?: number;
+    mimeType?: string;
+}>;
+
+type CachedAudiobookStreamMap = Readonly<{
+    fingerprint: string;
+    byteLengths: ReadonlyArray<number>;
+    contentType?: string;
+    expiresAt: number;
+}>;
+
+type OpenTrackStream = Readonly<{
+    stream: Readable;
+    contentType?: string;
+    close(): void;
+}>;
+
+type RequestController = Readonly<{
+    controller: AbortController;
+    headersReceived(): void;
+    dispose(): void;
+}>;
+
+type AudiobookStreamResult = Readonly<{
+    stream: Readable;
+    headers: Record<string, string>;
+    status: number;
+}>;
+
+type ResolvedTrackMetadata = Readonly<{
+    byteLengths: number[];
+    contentType?: string;
+}>;
+
+type AudiobookStreamPlan = Readonly<{
+    status: 200 | 206 | 416;
+    totalBytes: number;
+    contentLength: number;
+    contentRange?: string;
+    slices: ReadonlyArray<AudiobookFileSlice>;
+}>;
+
+type PreparedAudiobookStream = Readonly<{
+    tracks: ReadonlyArray<AudiobookTrack>;
+    metadata: ResolvedTrackMetadata;
+    plan: AudiobookStreamPlan;
+}>;
+
+type StreamSlicesInput = Readonly<{
+    tracks: ReadonlyArray<AudiobookTrack>;
+    byteLengths: ReadonlyArray<number>;
+    slices: ReadonlyArray<AudiobookFileSlice>;
+    firstOpen: OpenTrackStream;
+    contentType: string;
+    signal: AbortSignal;
+    detachDisconnect(): void;
+}>;
 
 function resolveStreamContentPath(
     contentUrl: unknown,
@@ -45,6 +138,148 @@ function resolveStreamContentPath(
     }
 
     return `${resolvedContentUrl.pathname}${resolvedContentUrl.search}`;
+}
+
+function parseAudiobookTracks(
+    payload: unknown,
+    baseUrl: string | null,
+): AudiobookTrack[] {
+    const tracksValue =
+        typeof payload === "object" && payload !== null && "media" in payload
+            ? (payload as { media?: { tracks?: unknown } }).media?.tracks
+            : undefined;
+    if (Array.isArray(tracksValue) && tracksValue.length === 0) {
+        throw new Error("No audio track found for this audiobook");
+    }
+    const tracks = audiobookTracksSchema.parse(tracksValue);
+    return tracks.map((track) => ({
+        contentPath: resolveStreamContentPath(track.contentUrl, baseUrl),
+        ...(track.metadata?.size === null || track.metadata?.size === undefined
+            ? {}
+            : { byteLength: track.metadata.size }),
+        ...(track.mimeType ? { mimeType: track.mimeType } : {}),
+    }));
+}
+
+function streamMapFingerprint(tracks: ReadonlyArray<AudiobookTrack>): string {
+    return tracks.map((track) => track.contentPath).join("\u0000");
+}
+
+function normalizedContentType(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim() !== ""
+        ? value.split(";", 1)[0]?.trim().toLowerCase()
+        : undefined;
+}
+
+function sliceByteLength(slice: AudiobookFileSlice): number {
+    return slice.fileEndByte - slice.fileStartByte + 1;
+}
+
+function resolveStreamPlan(
+    map: AudiobookStreamMap,
+    rangeHeader?: string,
+): AudiobookStreamPlan {
+    const totalBytes = map.totalBytes();
+    const range = rangeHeader
+        ? resolveAudiobookRange(rangeHeader, map)
+        : undefined;
+    if (range?.kind === "unsatisfiable") {
+        return {
+            status: 416,
+            totalBytes,
+            contentLength: 0,
+            contentRange: `bytes */${totalBytes}`,
+            slices: [],
+        };
+    }
+    if (range?.kind === "partial") {
+        return {
+            status: 206,
+            totalBytes,
+            contentLength: range.endByte - range.startByte + 1,
+            contentRange: `bytes ${range.startByte}-${range.endByte}/${totalBytes}`,
+            slices: range.slices,
+        };
+    }
+    return {
+        status: 200,
+        totalBytes,
+        contentLength: totalBytes,
+        slices: totalBytes === 0 ? [] : map.resolveRange(0, totalBytes - 1),
+    };
+}
+
+function streamHeaders(
+    plan: AudiobookStreamPlan,
+    contentType?: string,
+): Record<string, string> {
+    return {
+        ...(plan.status === 416
+            ? {}
+            : { "content-type": contentType ?? "audio/mpeg" }),
+        "accept-ranges": "bytes",
+        "content-length": String(plan.contentLength),
+        ...(plan.contentRange ? { "content-range": plan.contentRange } : {}),
+    };
+}
+
+function abortOnEarlyClose(
+    stream: Readable,
+    controller: AbortController,
+): void {
+    stream.once("close", () => {
+        if (!stream.readableEnded && !controller.signal.aborted) {
+            controller.abort(
+                new Error("Audiobook response stream closed early"),
+            );
+        }
+    });
+}
+
+function warnOnContentTypeMismatch(
+    expectedContentType: string,
+    actualContentType: string | undefined,
+    fileIndex: number,
+): void {
+    if (!actualContentType || actualContentType === expectedContentType) return;
+    logger
+        .child("AudiobookStream")
+        .warn("Audiobook track content type differs from the first file", {
+            firstContentType: expectedContentType,
+            trackContentType: actualContentType,
+            fileIndex,
+        });
+}
+
+function asStreamChunk(value: unknown): Buffer {
+    if (Buffer.isBuffer(value)) return value;
+    if (typeof value === "string" || value instanceof Uint8Array) {
+        return Buffer.from(value);
+    }
+    throw new Error("Audiobookshelf returned a non-byte stream chunk");
+}
+
+async function* readExactStream(
+    stream: Readable,
+    expectedBytes: number,
+): AsyncGenerator<Buffer> {
+    let emittedBytes = 0;
+    // The byte count bounds this transport-driven loop even though chunking is upstream-owned.
+    for await (const value of stream) {
+        const chunk = asStreamChunk(value);
+        if (emittedBytes + chunk.byteLength > expectedBytes) {
+            throw new Error(
+                "Audiobookshelf track exceeded its declared byte range",
+            );
+        }
+        emittedBytes += chunk.byteLength;
+        yield chunk;
+    }
+    if (emittedBytes !== expectedBytes) {
+        throw new Error(
+            "Audiobookshelf track ended before its declared byte range",
+        );
+    }
 }
 
 interface StreamDisconnectSource {
@@ -103,6 +338,10 @@ class AudiobookshelfService {
     private initialized = false;
     private podcastCache: { items: any[]; expiresAt: number } | null = null;
     private readonly PODCAST_CACHE_TTL_MS = 5 * 60 * 1000;
+    private readonly audiobookStreamMapCache = new Map<
+        string,
+        CachedAudiobookStreamMap
+    >();
 
     private async ensureInitialized() {
         if (this.initialized && this.client) return;
@@ -356,62 +595,343 @@ class AudiobookshelfService {
         return `${this.baseUrl}/api/items/${audiobookId}/play`;
     }
 
-    /**
-     * Stream an audiobook with authentication
-     * Returns a readable stream that can be piped to the response
-     */
+    private createRequestController(
+        parentSignal: AbortSignal,
+    ): RequestController {
+        const controller = new AbortController();
+        const abortFromParent = () => controller.abort(parentSignal.reason);
+        parentSignal.addEventListener("abort", abortFromParent, { once: true });
+        if (parentSignal.aborted) abortFromParent();
+        const timeoutId = setTimeout(() => {
+            controller.abort(
+                new Error(
+                    `Audiobookshelf stream headers timed out after ${STREAM_HEADER_TIMEOUT_MS}ms`,
+                ),
+            );
+        }, STREAM_HEADER_TIMEOUT_MS);
+        return {
+            controller,
+            headersReceived: () => clearTimeout(timeoutId),
+            dispose: () => {
+                clearTimeout(timeoutId);
+                parentSignal.removeEventListener("abort", abortFromParent);
+            },
+        };
+    }
+
+    private getCachedStreamMap(
+        audiobookId: string,
+        fingerprint: string,
+    ): CachedAudiobookStreamMap | undefined {
+        const cached = this.audiobookStreamMapCache.get(audiobookId);
+        if (
+            !cached ||
+            cached.fingerprint !== fingerprint ||
+            cached.expiresAt <= Date.now()
+        ) {
+            this.audiobookStreamMapCache.delete(audiobookId);
+            return undefined;
+        }
+        this.audiobookStreamMapCache.delete(audiobookId);
+        this.audiobookStreamMapCache.set(audiobookId, cached);
+        return cached;
+    }
+
+    private cacheStreamMap(
+        audiobookId: string,
+        entry: CachedAudiobookStreamMap,
+    ): void {
+        this.audiobookStreamMapCache.delete(audiobookId);
+        if (
+            this.audiobookStreamMapCache.size >=
+            AUDIOBOOK_STREAM_MAP_CACHE_MAX_ITEMS
+        ) {
+            const oldestKey = this.audiobookStreamMapCache.keys().next().value;
+            if (typeof oldestKey === "string") {
+                this.audiobookStreamMapCache.delete(oldestKey);
+            }
+        }
+        this.audiobookStreamMapCache.set(audiobookId, entry);
+    }
+
+    private async headTrack(
+        track: AudiobookTrack,
+        parentSignal: AbortSignal,
+    ): Promise<{ byteLength: number; contentType?: string }> {
+        const request = this.createRequestController(parentSignal);
+        try {
+            const response = await this.client!.head(track.contentPath, {
+                allowAbsoluteUrls: false,
+                timeout: STREAM_HEADER_TIMEOUT_MS,
+                signal: request.controller.signal,
+                validateStatus: (status) => status >= 200 && status < 300,
+            });
+            request.headersReceived();
+            return {
+                byteLength: contentLengthSchema.parse(
+                    response.headers["content-length"],
+                ),
+                ...(normalizedContentType(response.headers["content-type"])
+                    ? {
+                          contentType: normalizedContentType(
+                              response.headers["content-type"],
+                          ),
+                      }
+                    : {}),
+            };
+        } finally {
+            request.dispose();
+        }
+    }
+
+    private async resolveTrackMetadata(
+        audiobookId: string,
+        tracks: ReadonlyArray<AudiobookTrack>,
+        signal: AbortSignal,
+    ): Promise<ResolvedTrackMetadata> {
+        const fingerprint = streamMapFingerprint(tracks);
+        const cached = this.getCachedStreamMap(audiobookId, fingerprint);
+        const byteLengths = tracks.map(
+            (track, index) => track.byteLength ?? cached?.byteLengths[index],
+        );
+        let contentType =
+            normalizedContentType(tracks[0]?.mimeType) ?? cached?.contentType;
+        for (let index = 0; index < tracks.length; index += 1) {
+            const track = tracks[index];
+            if (!track) throw new Error("Audiobook track index is missing");
+            const needsType = index === 0 && contentType === undefined;
+            if (byteLengths[index] !== undefined && !needsType) continue;
+            const head = await this.headTrack(track, signal);
+            byteLengths[index] ??= head.byteLength;
+            if (needsType) contentType = head.contentType;
+        }
+        const resolvedLengths = z
+            .array(z.number().int().nonnegative().safe())
+            .length(tracks.length)
+            .parse(byteLengths);
+        this.cacheStreamMap(audiobookId, {
+            fingerprint,
+            byteLengths: resolvedLengths,
+            ...(contentType ? { contentType } : {}),
+            expiresAt: Date.now() + AUDIOBOOK_STREAM_MAP_CACHE_TTL_MS,
+        });
+        return {
+            byteLengths: resolvedLengths,
+            ...(contentType ? { contentType } : {}),
+        };
+    }
+
+    private async openTrackStream(
+        track: AudiobookTrack,
+        fileByteLength: number,
+        slice: AudiobookFileSlice,
+        parentSignal: AbortSignal,
+    ): Promise<OpenTrackStream> {
+        const request = this.createRequestController(parentSignal);
+        const isFullFile =
+            slice.fileStartByte === 0 &&
+            slice.fileEndByte === fileByteLength - 1;
+        try {
+            const response = await this.client!.get(track.contentPath, {
+                allowAbsoluteUrls: false,
+                responseType: "stream",
+                timeout: STREAM_HEADER_TIMEOUT_MS,
+                signal: request.controller.signal,
+                headers: isFullFile
+                    ? {}
+                    : {
+                          Range: `bytes=${slice.fileStartByte}-${slice.fileEndByte}`,
+                      },
+                validateStatus: (status) => status >= 200 && status < 300,
+            });
+            request.headersReceived();
+            if (!isFullFile && response.status !== 206) {
+                throw new Error("Audiobookshelf ignored a track byte range");
+            }
+            if (!(response.data instanceof Readable)) {
+                throw new Error(
+                    "Audiobookshelf track response is not readable",
+                );
+            }
+            return this.manageOpenTrack(
+                response.data,
+                response.headers["content-type"],
+                request,
+                parentSignal,
+            );
+        } catch (error) {
+            request.dispose();
+            throw error;
+        }
+    }
+
+    private manageOpenTrack(
+        stream: Readable,
+        contentType: unknown,
+        request: RequestController,
+        parentSignal: AbortSignal,
+    ): OpenTrackStream {
+        const destroyOnAbort = () => stream.destroy(parentSignal.reason);
+        parentSignal.addEventListener("abort", destroyOnAbort, { once: true });
+        if (parentSignal.aborted) destroyOnAbort();
+        return {
+            stream,
+            contentType: normalizedContentType(contentType),
+            close: () => {
+                parentSignal.removeEventListener("abort", destroyOnAbort);
+                stream.destroy();
+                request.dispose();
+            },
+        };
+    }
+
+    private async openSlice(
+        input: StreamSlicesInput,
+        slice: AudiobookFileSlice,
+        index: number,
+    ): Promise<OpenTrackStream> {
+        if (index === 0) return input.firstOpen;
+        const track = input.tracks[slice.fileIndex];
+        const byteLength = input.byteLengths[slice.fileIndex];
+        if (!track || byteLength === undefined) {
+            throw new Error("Audiobook stream map references a missing track");
+        }
+        return this.openTrackStream(track, byteLength, slice, input.signal);
+    }
+
+    private async *streamSlices(
+        input: StreamSlicesInput,
+    ): AsyncGenerator<Buffer> {
+        try {
+            for (let index = 0; index < input.slices.length; index += 1) {
+                const slice = input.slices[index];
+                if (!slice)
+                    throw new Error("Audiobook stream slice is missing");
+                const opened = await this.openSlice(input, slice, index);
+                try {
+                    warnOnContentTypeMismatch(
+                        input.contentType,
+                        opened.contentType,
+                        slice.fileIndex,
+                    );
+                    yield* readExactStream(
+                        opened.stream,
+                        sliceByteLength(slice),
+                    );
+                } finally {
+                    opened.close();
+                }
+            }
+        } finally {
+            input.detachDisconnect();
+        }
+    }
+
+    private async prepareAudiobookStream(
+        audiobookId: string,
+        rangeHeader: string | undefined,
+        signal: AbortSignal,
+    ): Promise<PreparedAudiobookStream> {
+        const payload = await this.getAudiobook(audiobookId, signal);
+        const tracks = parseAudiobookTracks(payload, this.baseUrl);
+        const metadata = await this.resolveTrackMetadata(
+            audiobookId,
+            tracks,
+            signal,
+        );
+        const map = buildAudiobookStreamMap(
+            metadata.byteLengths.map((byteLength, index) => ({
+                index,
+                byteLength,
+            })),
+        );
+        return {
+            tracks,
+            metadata,
+            plan: resolveStreamPlan(map, rangeHeader),
+        };
+    }
+
+    private async createAudiobookStreamResult(
+        prepared: PreparedAudiobookStream,
+        controller: AbortController,
+        detachDisconnect: () => void,
+    ): Promise<AudiobookStreamResult> {
+        const firstSlice = prepared.plan.slices[0];
+        if (!firstSlice) {
+            detachDisconnect();
+            return {
+                stream: Readable.from([]),
+                status: prepared.plan.status,
+                headers: streamHeaders(
+                    prepared.plan,
+                    prepared.metadata.contentType,
+                ),
+            };
+        }
+        const firstTrack = prepared.tracks[firstSlice.fileIndex];
+        const firstLength = prepared.metadata.byteLengths[firstSlice.fileIndex];
+        if (!firstTrack || firstLength === undefined) {
+            throw new Error("Audiobook first stream slice is invalid");
+        }
+        const firstOpen = await this.openTrackStream(
+            firstTrack,
+            firstLength,
+            firstSlice,
+            controller.signal,
+        );
+        // One book is one resource. Mixed containers keep the first file's type.
+        const contentType =
+            prepared.metadata.contentType ??
+            (firstSlice.fileIndex === 0 ? firstOpen.contentType : undefined) ??
+            "audio/mpeg";
+        const stream = Readable.from(
+            this.streamSlices({
+                tracks: prepared.tracks,
+                byteLengths: prepared.metadata.byteLengths,
+                slices: prepared.plan.slices,
+                firstOpen,
+                contentType,
+                signal: controller.signal,
+                detachDisconnect,
+            }),
+        );
+        abortOnEarlyClose(stream, controller);
+        return {
+            stream,
+            status: prepared.plan.status,
+            headers: streamHeaders(prepared.plan, contentType),
+        };
+    }
+
+    /** Stream all audiobook tracks as one byte-addressable readable stream. */
     async streamAudiobook(
         audiobookId: string,
         rangeHeader?: string,
         lifecycle?: StreamAcquisitionLifecycle,
-    ) {
-        const controller = new AbortController();
+    ): Promise<AudiobookStreamResult> {
+        const sessionController = new AbortController();
         const detachDisconnect = lifecycle
-            ? bindStreamDisconnect(lifecycle, controller)
+            ? bindStreamDisconnect(lifecycle, sessionController)
             : () => undefined;
-        const timeoutError = new Error(
-            `Audiobookshelf stream headers timed out after ${STREAM_HEADER_TIMEOUT_MS}ms`,
-        );
-        const timeoutId = setTimeout(() => {
-            if (!controller.signal.aborted) controller.abort(timeoutError);
-        }, STREAM_HEADER_TIMEOUT_MS);
-
         try {
             await this.ensureInitialized();
-            const audiobook = await this.getAudiobook(
+            const prepared = await this.prepareAudiobookStream(
                 audiobookId,
-                controller.signal,
+                rangeHeader,
+                sessionController.signal,
             );
-            const contentUrl = audiobook.media?.tracks?.[0]?.contentUrl;
-            if (!contentUrl) {
-                throw new Error("No audio track found for this audiobook");
-            }
-            const contentPath = resolveStreamContentPath(
-                contentUrl,
-                this.baseUrl,
+            return await this.createAudiobookStreamResult(
+                prepared,
+                sessionController,
+                detachDisconnect,
             );
-
-            const headers: Record<string, string> = {};
-            if (rangeHeader) headers["Range"] = rangeHeader;
-            const response = await this.client!.get(contentPath, {
-                allowAbsoluteUrls: false,
-                responseType: "stream",
-                timeout: 0,
-                signal: controller.signal,
-                headers,
-                validateStatus: (status) => status >= 200 && status < 300,
-            });
-            return {
-                stream: response.data,
-                headers: response.headers,
-                status: response.status,
-            };
         } catch (error) {
-            if (controller.signal.aborted) throw controller.signal.reason;
-            throw error;
-        } finally {
-            clearTimeout(timeoutId);
             detachDisconnect();
+            if (sessionController.signal.aborted) {
+                throw sessionController.signal.reason;
+            }
+            throw error;
         }
     }
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -26,8 +26,8 @@ Connect soundspan to Lidarr to request/download new music and trigger imports.
 Audiobook detail metadata and section navigation are served from soundspan's
 local cache. Scheduled or manual Audiobookshelf sync validates chapter coverage
 and fills section data for rows created before this model was added. Multi-file
-part boundaries remain visible in the API but are not playable in the UI while
-the stream proxy serves only the first file.
+part boundaries are playable because the stream proxy exposes all files as one
+byte-addressable audiobook resource.
 
 ### Networking note
 

--- a/frontend/features/audiobook/README.md
+++ b/frontend/features/audiobook/README.md
@@ -16,8 +16,8 @@ Start-here guide for `frontend/features/audiobook`.
 
 The detail page renders only validated cached sections. Sparse or malformed
 Audiobookshelf chapters are replaced by derived multi-file parts when possible.
-Navigation remains hidden for honest-empty results and for multi-file books
-until the stream proxy can serve more than the first file.
+Navigation remains hidden for honest-empty results. Valid chapters and
+multi-file parts seek within the concatenated audiobook stream.
 
 ## Directory Contents
 


### PR DESCRIPTION
Closes #495 (decided approach: server-side concatenated proxy; segmented/DASH explicitly untouched).

## Mechanism
Pure translation service (`audiobookStreamMap.ts`, zod-validated) maps global byte offsets to ordered per-file slices from per-file sizes (expanded ABS payload preferred, HEAD-request fallback cached per book with sync invalidation). The stream route serves one logical file:

| Response | Content-Length | Content-Range |
|---|---|---|
| 200 | total concatenated bytes | — |
| 206 | slice bytes | global range over total |
| 416 | 0 | bytes */total |

Sequential upstream pipes with exact byte enforcement; AbortController per upstream, cancelled on client disconnect; suffix/open-ended ranges; zero-length files skipped; single-file books byte-identical to today's behavior.

## Consequences
- `sectionsPlayable` no longer requires single-file — #500's parts navigation is live for multi-file books.
- Federation: no consumer change; the peer's own proxy concatenates (verified through the host route + consumer proxy chain).

## Verification
- verify: backend tsc exit 0
- verify: 5,895 tests pass (audiobook|federation pattern reached most of the backend suite, incl. all socket-bound cases codex's sandbox skipped)
- verify: byte-exact 200/206 fixtures across boundaries, 416 headers, abort-on-disconnect, HEAD cache hit/invalidation all covered by new runtime tests
- verify: npm run verify:gates exit 0