### PR TITLE
fix(deps): revert essentia-tensorflow pin to the newest cp311 build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # essentia-tensorflow builds newer than dev1389 publish CPython 3.14 wheels
+    # only; this image is capped at Python 3.11 by that same package's wheel
+    # history (see services/audio-analyzer/requirements.txt). Unignore when a
+    # cp311 build appears or the interpreter ceiling moves.
+    ignore:
+      - dependency-name: essentia-tensorflow
     groups:
       minor-and-patch:
         update-types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reverted the audio analyzer's essentia-tensorflow pin to dev1389, the newest
+  build publishing CPython 3.11 wheels: the dev1438 bump never took effect
+  because the Docker image installs from the lock, which correctly stayed on
+  dev1389 (dev1438 ships CPython 3.14 wheels only). Dependabot now ignores
+  essentia-tensorflow for this image until a cp311 build appears or the
+  interpreter ceiling moves.
 - Split the YouTube Music streamer sidecar into focused client, search, auth,
   streaming, library, download, browse, lifecycle, model, and runtime modules
   while preserving its `app:app` entrypoint and HTTP behavior. (#485)

--- a/services/audio-analyzer/requirements.txt
+++ b/services/audio-analyzer/requirements.txt
@@ -15,7 +15,7 @@ tensorflow>=2.13.0,<2.16.0
 # Essentia publishes only pre-release dev builds, making uv's unpinned selection
 # cache-sensitive across cold builds. Pin the newest CPython 3.11 build for
 # identical model behavior in both analyzers (roadmap F50 reproducible lock).
-essentia-tensorflow==2.1b6.dev1438
+essentia-tensorflow==2.1b6.dev1389
 
 # Queue and database
 redis>=6.4.0


### PR DESCRIPTION
Follow-up to the txt/lock drift found during #494.

## What happened
Dependabot #465 bumped `requirements.txt` to essentia-tensorflow 2.1b6.dev1438, but the lock (which the Docker image actually installs from) stayed on dev1389 — so the bump was inert. PyPI evidence: **dev1438 publishes cp314 wheels only** (macOS arm64/x86_64 + manylinux cp314); no cp311 wheel exists. The image is capped at Python 3.11 by essentia's own wheel history (#494's documented ceiling), so per the decision rule the pin reverts rather than the lock re-resolving.

Amusingly, the requirements.txt comment block already documented the cp314-only situation while carrying the contradictory pin — the pin now matches its own documentation.

## Changes
- `requirements.txt`: dev1438 → dev1389 (lock untouched; txt and lock now agree)
- `.github/dependabot.yml`: ignore essentia-tensorflow for /services/audio-analyzer with the rationale and un-ignore condition inline — prevents the bump from boomeranging weekly

## Verification
- verify: pytest services/audio-analyzer/tests — 35/35 including the lock-target guard
- verify: npm run verify:gates exit 0
- verify: PyPI file listing for dev1438 confirmed cp314-only before deciding