### PR TITLE
fix(aio): run the config-runtime smoke before pruning dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -243,12 +243,17 @@ ENV NEXT_PUBLIC_BUILD_TYPE=$NEXT_PUBLIC_BUILD_TYPE
 ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
 RUN npm run build
 
+# Validate the built runtime config (headers, CSP, proxy behavior) while dev
+# dependencies are still present: the smoke imports proxy.ts via the tsx
+# loader, which npm prune removes. Production never needs tsx -- server.js
+# uses the plain-JS server-proxy and Next compiles proxy.ts during build.
+RUN npm run test:config:runtime
+
 # Prune frontend dev dependencies after build (typescript, eslint, playwright, etc.)
 # and remove Next.js build cache (not needed at runtime)
 RUN npm prune --omit=dev && \
     npm cache clean --force && \
-    rm -rf .next/cache && \
-    npm run test:config:runtime
+    rm -rf .next/cache
 
 # ============================================
 # SECURITY HARDENING


### PR DESCRIPTION
Every AIO image build on main has failed since #504 merged (first red run 16:27; all green before).

## Root cause
#504 changed `test:config:runtime` to `node --import tsx ...` because the extended smoke imports `proxy.ts` (TS source) to verify CSP behavior. The AIO Dockerfile ran that smoke at the END of the prune chain — after `npm prune --omit=dev` removed tsx (a devDependency) — so every build died with `ERR_MODULE_NOT_FOUND: tsx`.

## Fix
Reorder: smoke runs immediately after `npm run build` (dev deps present), then prune. The smoke validates the built config, which pruning doesn't change. Production is unaffected in both directions: `server.js` uses the plain-JS `server-proxy`, and Next compiles `proxy.ts` during build — the runtime never loads TS source.

## Verification
- verify: AIO hardening suite 25/25; npm run verify:gates exit 0 (incl. Dockerfile hygiene)
- Image builds run only on main — I'll watch the post-merge Image Builds run as the end-to-end proof before staging the release.