### PR TITLE
chore(release): stage 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to soundspan are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [2.2.0] - 2026-08-16
 
 ### Added
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.1.0
-appVersion: "2.1.0"
+version: 2.2.0
+appVersion: "2.2.0"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -149,7 +149,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -226,7 +226,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -281,7 +281,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -411,7 +411,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -440,7 +440,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -511,7 +511,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -569,7 +569,7 @@ audioAnalyzerClap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer-clap
-    tag: 2.1.0
+    tag: 2.2.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -855,3 +855,4 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
+

--- a/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
@@ -16,6 +16,10 @@
 
 {{CHANGED_ITEMS}}
 
+## Removed
+
+{{REMOVED_ITEMS}}
+
 ## Accessibility
 
 {{ACCESSIBILITY_ITEMS}}

--- a/docs/release-notes/RELEASE_NOTES_2.2.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.2.0.md
@@ -1,0 +1,102 @@
+# [2.2.0] Release Notes - 2026-08-16
+
+## Release Summary
+
+A hardening and architecture release: sitewide Content-Security-Policy, Prometheus metrics, HA-correct rate limiting, cookie-session retirement, multi-file audiobook streaming, and the completion of the god-file decomposition with a CI size guardrail.
+
+## Fixed
+
+- Guarded every Python sidecar against Docker interpreter and uv lock-target
+  drift, and documented the TensorFlow 2.15 wheel ceiling that keeps the
+  Essentia analyzer on Python 3.11. (#494)
+- Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts, while navigation stays hidden when the current single-file stream proxy cannot play those seek targets. (#487)
+- Fixed multi-file audiobooks so playback continues past the first file and seeking works across file boundaries. (#495)
+- Fixed broken audiobook navigation for books whose sparse or malformed Audiobookshelf chapter markers do not cover the runtime. Valid multi-file durations now produce named parts. (#487)
+- Rate limits for security-sensitive endpoints are now enforced across backend
+  replicas and survive backend restarts, while requests degrade open on Redis
+  outages instead of failing or hanging. (#489)
+- Reaped dead-peer HTTP connections with TCP keepalive, made origin keep-alive
+  timeouts reverse-proxy safe, and kept Node's zero idle timeout so paused or
+  backpressured streams remain unaffected. (#487)
+- [Security] Added a per-request nonce Content Security Policy to every Next-served page, including share pages and PWA navigations. The policy starts in report-only mode and can be enforced with `CSP_ENFORCE=true`; optimized SVG responses retain a separate script-blocking sandbox. (#486)
+- [Security] Removed the ambient cookie credential surface from backend API
+  authentication. (#491)
+- [Security] Startup administrator password resets now invalidate outstanding access and
+  refresh JWTs and clear the dedicated Subsonic password. (#491)
+
+## Added
+
+- Added a blocking CI source-file-size guardrail with a 3,000-line hard cap,
+  a frozen per-file baseline above 1,500 lines, and ratchet-down guidance after
+  intentional splits. (#485)
+- Added bearer-protected Prometheus metrics for backend HTTP traffic, Bull queue state, process resources, cache results, and federation sync outcomes, plus optional Helm ServiceMonitors and a starter Grafana dashboard. (#490)
+
+## Changed
+
+- Reverted the audio analyzer's essentia-tensorflow pin to dev1389, the newest
+  build publishing CPython 3.11 wheels: the dev1438 bump never took effect
+  because the Docker image installs from the lock, which correctly stayed on
+  dev1389 (dev1438 ships CPython 3.14 wheels only). Dependabot now ignores
+  essentia-tensorflow for this image until a cp311 build appears or the
+  interpreter ceiling moves.
+- Split the YouTube Music streamer sidecar into focused client, search, auth,
+  streaming, library, download, browse, lifecycle, model, and runtime modules
+  while preserving its `app:app` entrypoint and HTTP behavior. (#485)
+- Documented the npm security-override lifecycle, removed obsolete backend and
+  frontend overrides, and added an enforcement gate for dangling overrides with
+  non-blocking warnings for shed candidates. (#492)
+- Restructured the programmatic playlist service into focused generator modules without changing its public contract or mix behavior.
+- Restructured the frontend audio playback orchestrator into focused policy modules and concern hooks without changing playback behavior.
+- Restructured the Spotify import service into focused matching, preview, lifecycle, playlist-building, job-management, and pending-track modules without changing its public contract or import behavior. (#485)
+- Restructured the authentication routes into per-concern modules without changing the `/api/auth` contract.
+- Restructured the Subsonic-compatible routes into per-domain modules without changing the `/rest` contract.
+- Restructured the Discover Weekly service into focused generation, recommendation, batch-lifecycle, persistence, and cleanup modules without changing its public contract.
+- Documentation drift sweep: corrected environment/deployment/API references across the docs tree and refreshed the route, feature, and test indexes.
+- Audiobook detail loads now serve validated sections and metadata from the local cache instead of fetching Audiobookshelf live. Sections are computed during sync when expanded Audiobookshelf data is available and backfilled lazily on first view for books synced before this change or from minified library listings. The retained `numChapters` column is superseded and no longer refreshed.
+
+## Removed
+
+- Retired cookie-session authentication and its Redis store. JWT, API-key,
+  Subsonic, and federation transports are unchanged; `SESSION_SECRET` remains
+  required as the JWT signing fallback. (#491)
+- Removed the never-documented `/api/spotify` endpoints, unused Spotify
+  credential settings fields, and unused Link Device settings section. Spotify
+  playlist imports through the generic `/api/import` flow are unaffected. (#484)
+
+## Accessibility
+
+- No accessibility improvements documented in this release.
+
+## Admin/Operations
+
+- No admin/operations updates documented in this release.
+
+## Deployment and Distribution
+
+- Docker image: `ghcr.io/soundspan/soundspan`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart name: `soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.2.0
+```
+
+## Breaking Changes
+
+- None documented in this release.
+
+## Known Issues
+
+- None documented in this release.
+
+## Compatibility and Migration
+
+- No manual migration steps required for standard Docker and Helm deployments.
+
+## Full Changelog
+
+- Compare changes: [2.1.0...HEAD](https://github.com/soundspan/soundspan/compare/2.1.0...HEAD)
+- Full changelog: https://github.com/soundspan/soundspan/blob/HEAD/CHANGELOG.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-frontend",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/scripts/release/__tests__/generate-notes.test.mjs
+++ b/scripts/release/__tests__/generate-notes.test.mjs
@@ -58,7 +58,7 @@ test("generates Accessibility bullets after the Changed section", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.match(
         result.stdout,
-        /## Changed\n\n- No behavior changes documented in this release\.\n\n## Accessibility\n\n- Added keyboard navigation to the release controls\./,
+        /## Removed\n\n- Nothing removed in this release\.\n\n## Accessibility\n\n- Added keyboard navigation to the release controls\./,
     );
 });
 
@@ -76,5 +76,22 @@ test("rejects a heading that is not supported", () => {
     assert.equal(
         result.stderr.trim(),
         "CHANGELOG.md section [9.9.9] contains unsupported heading(s) with bullets: experimental.",
+    );
+});
+
+test("generates Removed bullets after the Changed section", () => {
+    const result = runGenerator(`# Changelog
+
+## [9.9.9] - 2026-08-13
+
+### Removed
+
+- Retired the legacy release control surface.
+`);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /## Changed\n\n- No behavior changes documented in this release\.\n\n## Removed\n\n- Retired the legacy release control surface\.\n\n## Accessibility/,
     );
 });

--- a/scripts/release/generate-notes.mjs
+++ b/scripts/release/generate-notes.mjs
@@ -26,6 +26,7 @@ const RELEASE_CATEGORY_ALIASES = {
     fixed: ["Fixed", "Fixes"],
     added: ["Added", "New"],
     changed: ["Changed", "Updated"],
+    removed: ["Removed"],
     accessibility: ["Accessibility"],
     admin: ["Admin/Operations", "Admin", "Operations", "Database Migrations"],
     breaking: ["Breaking Changes", "Breaking"],
@@ -289,6 +290,10 @@ function loadReleaseItemsFromChangelog(version) {
         bulletsByHeading,
         RELEASE_CATEGORY_ALIASES.changed,
     );
+    const removed = pickBulletsByHeadingAliases(
+        bulletsByHeading,
+        RELEASE_CATEGORY_ALIASES.removed,
+    );
     const accessibility = pickBulletsByHeadingAliases(
         bulletsByHeading,
         RELEASE_CATEGORY_ALIASES.accessibility,
@@ -308,6 +313,7 @@ function loadReleaseItemsFromChangelog(version) {
         security,
         added,
         changed,
+        removed,
         accessibility,
         admin,
         breaking,
@@ -383,6 +389,10 @@ function main() {
         "{{CHANGED_ITEMS}}": formatBulletBlock(
             categorized.changed,
             "No behavior changes documented in this release.",
+        ),
+        "{{REMOVED_ITEMS}}": formatBulletBlock(
+            categorized.removed,
+            "Nothing removed in this release.",
         ),
         "{{ACCESSIBILITY_ITEMS}}": formatBulletBlock(
             categorized.accessibility,


### PR DESCRIPTION
Stages 2.2.0 per the release process: `version-sync.mjs --write` bumped both packages, the chart (version + appVersion), and all eight image-tag sections; the changelog Unreleased section is promoted to `[2.2.0]`; `generate-notes.mjs` produced `docs/release-notes/RELEASE_NOTES_2.2.0.md` from the maintainers template.

**Version note:** MINOR (2.2.0) rather than a patch because the changelog carries a real Added section — Prometheus metrics, CSP, the CI size guardrail — and the changelog contract declares SemVer.

**Tooling addition (test-first):** the notes generator and template now support the standard Keep a Changelog `Removed` category (the session-retirement entry lives there); blocking release-helper tests extended and green.

## Verification
- verify: version-sync --check clean across all surfaces
- verify: npm run verify:gates exit 0 (incl. release-version validator and release-helper tests)
- verify: generate-notes 3/3 tests

After merge: publish GitHub release `2.2.0` (bare-version tag per the 2.1.0 pattern) with the notes as body, which triggers the version-tagged image builds — the AIO pipeline was fixed and proven green on main in #515 first.