### PR TITLE
chore(release): emit the persistent upgrade-path sections automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Release-note generation now always includes the standing 2.0.0 upgrade path
+  and accepts repeatable per-release `--upgrade-note` bullets.
+
 ### Fixed
 
 ## [2.2.0] - 2026-08-16

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -3,7 +3,7 @@
 This directory is for tracked maintainer-only guidance that still has ongoing value after AWM onboarding.
 
 - `LOGGING_STANDARDS.md` documents the current shared logging expectations for frontend, backend, and Python sidecars.
-- `RELEASE_NOTES_TEMPLATE.md` is consumed by `scripts/release/generate-notes.mjs` and guarded by a blocking release-helper test.
+- `RELEASE_NOTES_TEMPLATE.md` is consumed by `scripts/release/generate-notes.mjs`, carries the standing 2.0.0 upgrade path plus per-release `--upgrade-note` bullets, and is guarded by a blocking release-helper test.
 - `scripts/release/*.mjs` contains the tracked release-prep, chart-sync, and release-notes helpers that were kept because they are still operationally useful outside AWM.
 
 These docs are not part of the AWM control plane. Treat

--- a/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/maintainers/RELEASE_NOTES_TEMPLATE.md
@@ -4,6 +4,14 @@
 
 {{RELEASE_SUMMARY}}
 
+## Before you upgrade
+
+**Warning:** If you run a version earlier than 2.0.0, do not upgrade directly
+to {{VERSION}}. Complete the 2.0.0 breaking changes first. See
+[Upgrading from an earlier version](#upgrading-from-an-earlier-version).
+
+{{UPGRADE_NOTES}}
+
 ## Fixed
 
 {{FIXED_ITEMS}}
@@ -52,6 +60,15 @@ helm upgrade --install soundspan soundspan/soundspan --version {{VERSION}}
 ## Compatibility and Migration
 
 {{COMPATIBILITY_AND_MIGRATION}}
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, you must complete the
+2.0.0 upgrade before you install {{VERSION}}. The 2.0.0 release contains breaking
+changes that later releases depend on. Read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
 
 ## Full Changelog
 

--- a/scripts/release/__tests__/generate-notes.test.mjs
+++ b/scripts/release/__tests__/generate-notes.test.mjs
@@ -17,7 +17,7 @@ const template = path.join(
     "docs/maintainers/RELEASE_NOTES_TEMPLATE.md",
 );
 
-function runGenerator(changelogContent) {
+function runGenerator(changelogContent, additionalArgs = []) {
     const fixtureRoot = mkdtempSync(
         path.join(repoRoot, ".release-notes-test-"),
     );
@@ -37,13 +37,80 @@ function runGenerator(changelogContent) {
 
         return spawnSync(
             process.execPath,
-            [generator, "--version", "9.9.9", "--from", "HEAD", "--to", "HEAD"],
+            [
+                generator,
+                "--version",
+                "9.9.9",
+                "--from",
+                "HEAD",
+                "--to",
+                "HEAD",
+                ...additionalArgs,
+            ],
             { cwd: fixtureRoot, encoding: "utf8" },
         );
     } finally {
         rmSync(fixtureRoot, { recursive: true, force: true });
     }
 }
+
+const minimalChangelog = `# Changelog
+
+## [9.9.9] - 2026-08-13
+`;
+
+test("always renders the standing upgrade warning and upgrade path", () => {
+    const result = runGenerator(minimalChangelog);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /\*\*Warning:\*\* If you run a version earlier than 2\.0\.0, do not upgrade directly\nto 9\.9\.9\. Complete the 2\.0\.0 breaking changes first\. See\n\[Upgrading from an earlier version\]\(#upgrading-from-an-earlier-version\)\./,
+    );
+    assert.match(
+        result.stdout,
+        /## Upgrading from an earlier version\n\nIf you are upgrading from a version earlier than 2\.0\.0, you must complete the\n2\.0\.0 upgrade before you install 9\.9\.9\. The 2\.0\.0 release contains breaking\nchanges that later releases depend on\. Read the\n\[2\.0\.0 release notes\]\(https:\/\/github\.com\/soundspan\/soundspan\/blob\/2\.0\.0\/docs\/release-notes\/RELEASE_NOTES_2\.0\.0\.md\)\nand complete the\n\[2\.0\.0 upgrade guide\]\(https:\/\/github\.com\/soundspan\/soundspan\/blob\/2\.0\.0\/docs\/UPGRADING_TO_2\.0\.0\.md\)\./,
+    );
+});
+
+test("renders upgrade notes in argument order under Before you upgrade", () => {
+    const result = runGenerator(minimalChangelog, [
+        "--upgrade-note",
+        "Run the database backup first.",
+        "--upgrade-note",
+        "Restart the worker after deployment.",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /## Before you upgrade[\s\S]*- Run the database backup first\.\n- Restart the worker after deployment\.\n\n## Fixed/,
+    );
+});
+
+test("renders the default upgrade note when the flag is absent", () => {
+    const result = runGenerator(minimalChangelog);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /## Before you upgrade[\s\S]*- If you already run 2\.0\.x or later, no manual steps are required\.\n\n## Fixed/,
+    );
+});
+
+test("renders the standing sections in release-note order", () => {
+    const result = runGenerator(minimalChangelog);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+        result.stdout,
+        /## Release Summary[\s\S]*## Before you upgrade[\s\S]*## Fixed/,
+    );
+    assert.match(
+        result.stdout,
+        /## Upgrading from an earlier version[\s\S]*## Full Changelog/,
+    );
+});
 
 test("generates Accessibility bullets after the Changed section", () => {
     const result = runGenerator(`# Changelog

--- a/scripts/release/generate-notes.mjs
+++ b/scripts/release/generate-notes.mjs
@@ -14,7 +14,11 @@ import {
 
 const TEMPLATE_PATH = "docs/maintainers/RELEASE_NOTES_TEMPLATE.md";
 const DEFAULT_REPO_WEB_URL_FALLBACK = "https://github.com/soundspan/soundspan";
-const REPEATABLE_FLAGS = new Set(["known-issue", "compat-note"]);
+const REPEATABLE_FLAGS = new Set([
+    "known-issue",
+    "compat-note",
+    "upgrade-note",
+]);
 const SINGLE_VALUE_FLAGS = new Set([
     "version",
     "from",
@@ -64,6 +68,7 @@ function parseArgs(argv) {
     const options = {
         knownIssues: [],
         compatibilityNotes: [],
+        upgradeNotes: [],
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -92,6 +97,8 @@ function parseArgs(argv) {
                 options.knownIssues.push(value.trim());
             } else if (key === "compat-note") {
                 options.compatibilityNotes.push(value.trim());
+            } else if (key === "upgrade-note") {
+                options.upgradeNotes.push(value.trim());
             }
             continue;
         }
@@ -230,6 +237,13 @@ function formatBulletBlock(items, emptyLabel) {
         return `- ${emptyLabel}`;
     }
     return items.join("\n");
+}
+
+function formatArgumentBulletBlock(items, emptyLabel) {
+    return formatBulletBlock(
+        items.map((item) => `- ${item}`),
+        emptyLabel,
+    );
 }
 
 function normalizeSecurityBullets(items) {
@@ -371,6 +385,10 @@ function main() {
         options.compatibilityNotes,
         "No manual migration steps required for standard Docker and Helm deployments.",
     );
+    const upgradeNotes = formatArgumentBulletBlock(
+        options.upgradeNotes,
+        "If you already run 2.0.x or later, no manual steps are required.",
+    );
 
     const templateText = fs.readFileSync(TEMPLATE_PATH, "utf8");
     const rendered = renderTemplate(templateText, {
@@ -378,6 +396,7 @@ function main() {
         "{{RELEASE_DATE}}": releaseDate,
         "{{COMPARE_URL}}": `[${fromRef}...${toRef}](${compareUrl})`,
         "{{RELEASE_SUMMARY}}": summary,
+        "{{UPGRADE_NOTES}}": upgradeNotes,
         "{{FIXED_ITEMS}}": formatBulletBlock(
             fixedItems,
             "No bug fixes documented in this release.",


### PR DESCRIPTION
Closes the loop on the 2.2.0 notes omission (hand-fixed in #523): the persisted "Before you upgrade" warning and "Upgrading from an earlier version" section are now standing template sections with `{{VERSION}}` interpolation — impossible to forget — and `generate-notes.mjs` gains a repeatable `--upgrade-note` flag for the per-release bullets beneath the warning (default: the no-manual-steps line).

Dry-run against the real changelog renders both sections byte-identical to the corrected 2.2.0 notes.

## Verification
- verify: release-helper suite 7/7 (new: standing-section presence + interpolation, note ordering, default fallback, section ordering; existing adjacency cases updated for the new order)
- verify: npm run verify:gates exit 0