### PR TITLE
chore(dependabot): stop proposing base-interpreter bumps for the capped sidecars

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -174,6 +174,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # The base interpreter is capped at Python 3.11 by essentia-tensorflow's wheel history
+    # (see the Dockerfile comment and the lock-target guard test). Interpreter
+    # bumps happen deliberately with a lock re-resolution, never via
+    # unaccompanied base-image updates.
+    ignore:
+      - dependency-name: python
     groups:
       minor-and-patch:
         update-types:
@@ -185,6 +191,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # The base interpreter is held on 3.12 until the full transitive set is re-resolved and tested under a newer interpreter
+    # (see the Dockerfile comment and the lock-target guard test). Interpreter
+    # bumps happen deliberately with a lock re-resolution, never via
+    # unaccompanied base-image updates.
+    ignore:
+      - dependency-name: python
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
Ends the recreate-close loop for the sidecar python base images (#461/#463, now #518/#519): both closed rounds failed the lock-target guards exactly as designed, and the interpreter ceilings are documented (audio-analyzer: essentia cp311 ceiling; clap: deliberate hold per #494). Ignores the `python` docker dependency in those two directories with the rationale and the un-ignore path inline, matching the essentia pip ignore precedent.

verify: dependabot.yml parses as valid YAML.