### PR TITLE
docs(design): loudness+transitions, natural-language music, blends+federated discovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,9 @@ This index is the central navigation page for all project documentation under `d
 
 | Document                                                                                                     | Status       | Purpose                                                                         |
 | ------------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------------------------- |
+| [`designs/loudness-and-transitions.md`](designs/loudness-and-transitions.md)                                 | Design phase | Loudness normalization (LUFS/ReplayGain) and analysis-driven smart transitions  |
+| [`designs/natural-language-music.md`](designs/natural-language-music.md)                                     | Design phase | Local-LLM natural-language playlists: compile-not-generate trust boundary       |
+| [`designs/blends-and-federated-discovery.md`](designs/blends-and-federated-discovery.md)                     | Design phase | Taste vectors, max-min fairness Blends, peer catalogs as discovery surface      |
 | [`designs/provider-strategy-track-mapping.md`](designs/provider-strategy-track-mapping.md)                   | Design phase | Provider strategy overhaul, browse redesign, TrackMapping data model            |
 | [`designs/explore-page-consolidation.md`](designs/explore-page-consolidation.md)                             | Design phase | Merge Home/Browse/Radio/Discovery into single Explore page                      |
 | [`designs/durable-track-identity.md`](designs/durable-track-identity.md)                                     | Shipped      | Durable local track identity, soft removal, revival, and retention purge design |

--- a/docs/designs/blends-and-federated-discovery.md
+++ b/docs/designs/blends-and-federated-discovery.md
@@ -32,6 +32,15 @@ Blend tracks resolve per listener: local copy if the listener's library (or dedu
 
 ## Federated discovery
 
+### Phase 0 — federated public playlists and presence (maintainer-directed first increment)
+
+Ships before any taste-vector work; requires none of the embedding-space machinery — only surfaces that already exist (catalog sync, federation auth, the stream proxy, the social/activity feed).
+
+- **Public playlists across peers**: playlists a user marks public become visible to trusted peers with discovery opt-in — browsable in a "From PeerName" shelf, loadable, and playable. Playlist metadata (name, owner display name, track references, cover) exchanges over a new authenticated federation endpoint; track rows resolve per listener local-first via durable identity/dedup, then peer stream proxy, with the standard offline row states. A peer playlist can be followed (live reference, updates with the source) or copied (snapshot into the local library); acquisition affordances apply to peer-only tracks.
+- **User status across peers**: presence (online/listening state) and now-playing/recently-played activity from federated friends appear in the existing social/activity surface, badged with their home peer. Exchange is lightweight polling or piggybacked on existing peer sync heartbeats — no new realtime channel in phase 0; freshness is minutes, not seconds, and the UI says so.
+- **Privacy model**: two gates compose — the operator-level federation discovery opt-in (per peer, both directions), and a **per-user visibility setting** controlling whether that user's public playlists and presence federate at all (playlist publicness alone does not imply federation). Presence sharing is per-user opt-out within an enabled peering, playlist federation per-user opt-in-by-public-flag; both documented in the federation privacy contract alongside the taste-vector rules.
+- **Telemetry**: peer playlist follows/copies/plays and presence-fetch health join the per-peer counters (issue #531).
+
 ### Candidate sourcing
 
 - Peer catalogs (already synced) join the Discover Weekly/radio candidate pool when the peer relationship has **discovery opt-in** (new flag, both directions, default off).
@@ -53,6 +62,7 @@ Per-peer counters (bounded labels, extending #531): candidates offered/accepted 
 
 ## Rollout and testing
 
+0. **Federated public playlists + presence** (no vector dependency; first social increment) →
 1. Taste vectors + local 2-user Blend (fairness + attribution + refresh) →
 2. Cross-peer blend membership (vector sharing contract + revocation) →
 3. Federated discovery candidates behind opt-in + ratio cap →

--- a/docs/designs/blends-and-federated-discovery.md
+++ b/docs/designs/blends-and-federated-discovery.md
@@ -1,0 +1,71 @@
+# Blends and Federated Discovery
+
+Spec drafted 2026-08-16 for [issue #529](https://github.com/soundspan/soundspan/issues/529) (Blends) and [issue #530](https://github.com/soundspan/soundspan/issues/530) (federated discovery). Status: design phase. Shared foundation: per-user **taste vectors** and the embedding-space identity contract from `vibe-embedding-provider.md`. Peer observability ([issue #531](https://github.com/soundspan/soundspan/issues/531)) instruments everything here.
+
+## Taste vectors (shared primitive)
+
+A user's taste is represented as **k weighted centroids** (k≤5) over their track embeddings, not one mean — eclectic taste survives clustering, collapses under averaging.
+
+- Inputs: play history (recency-decayed half-life ~90 days), thumbs (up boosts, down excludes the neighborhood), likes; skips damp. All signals already exist.
+- Computed per user on a weekly worker + on-demand invalidation after heavy listening days (threshold on new-play count).
+- Stored with `spaceId`; recomputed automatically on embedding-space cutover (registry migration hooks).
+- Cold start (< N plays): fall back to library-composition centroids (what they *have*), flagged `lowConfidence` so consumers can weight accordingly.
+
+## Blends
+
+### Generation
+
+- Members: 2..M users, local or cross-peer. Candidate pool: union of members' accessible catalogs (local library; peer catalogs only where that peer's sharing already permits the member).
+- Scoring: **max–min fairness** — a candidate's score is the *minimum* over members of its best affinity to that member's centroids. Averages find the bland intersection; max–min finds tracks each member genuinely rates. Tie-shaping: prefer tracks strong for members whose representation in the running playlist is lowest (running fairness balance).
+- Constraints reuse the programmatic-playlist toolkit: artist caps, recent-play exclusion per member, target length, optional energy curve.
+- **Attribution**: each pick stores the member whose affinity carried it (argmax contributor) → "here because of Sam" badges. Refresh weekly via the existing scheduler; members can pin tracks (pinned survive refresh).
+
+### Cross-peer membership
+
+- A remote member's home peer computes their taste vectors locally and shares `{spaceId identity tuple, centroids, weights, lowConfidence}` through a new authenticated federation endpoint — **history never crosses the wire, only derived vectors**.
+- Space mismatch (peers on different embedding spaces) ⇒ that member participates via metadata-only affinity (genre/artist overlap), badged as approximate; never silently degraded.
+- Privacy contract (documented in the federation docs): centroids reveal taste direction, not listening events; sharing is opt-in **per blend membership**, revocable (revocation deletes the vectors on the consuming peer — deletion API + test); vectors carry no track references.
+
+### Playback
+
+Blend tracks resolve per listener: local copy if the listener's library (or dedup identity) has it, else peer stream via the existing federation proxy, else greyed with the acquisition affordance (below).
+
+## Federated discovery
+
+### Candidate sourcing
+
+- Peer catalogs (already synced) join the Discover Weekly/radio candidate pool when the peer relationship has **discovery opt-in** (new flag, both directions, default off).
+- Affinity scoring needs embeddings for peer tracks: preferred — peers share per-track embedding vectors during catalog sync when spaces match (bulk, batched, sync-time not query-time); fallback — metadata-level scoring, badged approximate. Space rules identical to blends.
+- **Ratio cap**: peer-sourced picks ≤ configurable share of any generated list (default 20%), and never displace a strictly-better local pick (peer candidates compete only for their capped slots).
+
+### Identity and dedup
+
+Durable track identity + dedup arbitration guarantee a peer track that matches a local one is treated as the local track (no "new to you" lies, no duplicate rows). Recommendation surfaces show provenance only when the track is genuinely peer-only.
+
+### Degradation and acquisition
+
+- Peer offline at play time: skip forward with a subtle "unavailable — PeerName offline" row state; weekly playlists never contain dead rows silently (the row renders with state).
+- **"Get it locally"**: any peer-only pick offers one-tap add to the acquisition want-list (existing Lidarr/Soulseek pipeline) — discovery converts into library growth. Metrics count conversions.
+
+### Telemetry
+
+Per-peer counters (bounded labels, extending #531): candidates offered/accepted into lists, plays of peer-sourced picks, availability failures, acquisition conversions. These tune the ratio cap from data.
+
+## Rollout and testing
+
+1. Taste vectors + local 2-user Blend (fairness + attribution + refresh) →
+2. Cross-peer blend membership (vector sharing contract + revocation) →
+3. Federated discovery candidates behind opt-in + ratio cap →
+4. Acquisition hook + telemetry-driven tuning.
+- Tests: fairness scoring fixtures (constructed member clusters with known correct picks, incl. the average-vs-max–min discriminating case); cold-start; attribution correctness; vector-sharing auth/revocation (federation runtime suites); space-mismatch degradation; ratio-cap enforcement; offline-row states (component harness).
+
+## Non-goals
+
+- Global/public peer discovery directories (trust stays operator-configured).
+- Sharing raw play history or per-track user signals across peers, ever.
+- Real-time collaborative queues (Listen Together exists; blends are asynchronous artifacts).
+
+## Open questions
+
+- Blend size ceiling M (proposal: 8) and whether >2-member blends need per-member weight sliders.
+- Whether taste centroids should also power a local "taste match %" between users on the same instance (cheap, fun, zero privacy cost locally — likely yes, small follow-up).

--- a/docs/designs/loudness-and-transitions.md
+++ b/docs/designs/loudness-and-transitions.md
@@ -1,0 +1,66 @@
+# Loudness Normalization and Smart Transitions
+
+Spec drafted 2026-08-16 for [issue #526](https://github.com/soundspan/soundspan/issues/526) (loudness) and [issue #527](https://github.com/soundspan/soundspan/issues/527) (transitions). Status: design phase. The two features share analyzer plumbing and are sequenced: transitions assume leveled loudness.
+
+## Problem
+
+Playback volume varies wildly across a mixed library (quiet 90s masters next to loudness-war rips), and every transition is a hard cut. The analyzer visits every file and already stores BPM and energy, but playback uses none of it.
+
+## Part 1 — Loudness normalization
+
+### Measurement
+
+- `services/audio-analyzer` gains an EBU R128 pass emitting **integrated LUFS** and **true peak (dBTP)** per track. Implementation candidate order: ffmpeg `loudnorm` in analysis mode (already in the image, print_format json) over Essentia's `LoudnessEBUR128` — pick by benchmarking both on the analyzer's decode path; record the choice and why here when implemented.
+- Album aggregation: album gain computed per EBU R128 over the concatenated program (approximated as duration-weighted energy mean of track measurements — exact concatenation is not worth a second decode pass; note the approximation).
+- Schema: nullable `loudnessLufs`, `truePeakDb` on Track; `albumLoudnessLufs` on Album. Backfill through the existing re-analysis queue at low priority; coverage gauge on the metrics registry.
+
+### Application (client-side)
+
+- Gain = `target − measured`, target default **−18 LUFS** (ReplayGain 2 reference; commercial streamers use −14 to −16, but self-hosted libraries skew dynamic — default documented and configurable per server, `LOUDNESS_TARGET_LUFS`).
+- **Positive gain clamp:** limit boost to `min(+3 dB, headroom to 0 dBTP)` using true peak — never introduce clipping to normalize a quiet track.
+- Modes per user: `off | track | album | auto` (auto = album gain inside album context, track gain in shuffle/radio/mix). Default: `auto` once shipped, `off` during rollout release.
+- Engine application: both direct engines composite a gain factor into their volume pipeline (multiplicative with user volume). No new AudioContext requirement on the default path — element volume compositing suffices; where a context already exists (iOS-standalone bridge), a GainNode is acceptable but not required. Missing measurement ⇒ gain 0 for that track; **no mid-queue jump handling beyond that** (a measured→unmeasured boundary plays both at their natural relationship, same as today).
+- Transcoding/offline: measurement reflects the source file; client-side gain is codec-independent, so transcoded streams inherit correct leveling. Offline downloads play through the same player pipeline and use the same stored values.
+
+### Subsonic surface
+
+- Implement the OpenSubsonic **ReplayGain extension**: `replayGain` object (trackGain, albumGain, trackPeak, albumPeak) on song child elements; advertise in `getOpenSubsonicExtensions`. Update `docs/OPENSUBSONIC_COMPATIBILITY.md`. This alone upgrades Symfonium-class clients.
+
+## Part 2 — Smart transitions
+
+### Phase T1 — silence handling
+
+- Analyzer emits `leadingSilenceMs`, `trailingSilenceMs` (threshold −60 dBFS relative, minimum 200 ms to count). Player trims in **non-album contexts only** (radio, mixes, shuffle, playlists with the setting on); album playback stays untouched (gapless art is deliberate).
+- Trim = seek offset on start + early-advance near end via the existing track-end watchdog path; no engine API change.
+
+### Phase T2 — adaptive crossfade
+
+- New pure policy module beside `nextTrackPreloadPolicy`: inputs `(current: {bpm, energy, trailingSilence}, next: {bpm, energy, leadingSilence}, context)` → `{ type: cut | fade, fadeMs, nextStartOffsetMs }`. Deterministic table, unit-fixtured:
+  - album context → `cut` (never fade inside albums)
+  - energy step down > threshold → longer fade (up to 6 s)
+  - matched high energy → short fade (1–2 s)
+  - either track shorter than 30 s, or classical/spoken genre tags → `cut`
+- User modes: `off | fixed(n) | smart`. Smart requires loudness shipped (fades between unleveled tracks pump).
+- **Engine capability contract:** crossfade needs two simultaneous voices. The engine interface gains optional `supportsDualVoice`; howler slot: yes (parallel Howl instances — the preload instance becomes the second voice); native element engine: second `<audio>` element behind the same gesture/session rules — must not regress the iOS interruption-survival behavior, so background transitions degrade to `cut` when the page is hidden; declared per engine and reflected in settings UI (mode greyed with reason when unsupported).
+- Fade curves: equal-power. Gain compositing must stack correctly with loudness gain and user volume (single multiplicative chain, tested).
+
+### Phase T3 (stretch, separate decision) — beat alignment
+
+Requires beat-grid phase data the analyzer does not store; explicitly out of scope until T1/T2 ship and a beat-tracking pass is costed.
+
+## Rollout and testing
+
+1. Loudness measurement + backfill (no playback change) → 2. player gain + modes + Subsonic extension → 3. T1 silence → 4. T2 crossfade.
+- Policy modules: pure unit fixtures (the campaign pattern). Engines: component-harness cases for gain compositing and dual-voice fallback. Measurement: golden-file tests with generated tones (known LUFS) through the analyzer pass.
+- Metrics: histogram of applied gain (bounded buckets) to observe real-library spread; counter of clamped boosts.
+
+## Non-goals
+
+- Server-side loudness rewriting or tag writing (library files are never modified).
+- DSP beyond gain (EQ, dynamics) — separate future discussion.
+- Crossfade in Subsonic clients (client-side concern; they get ReplayGain data only).
+
+## Open questions
+
+- Whether `auto` should become default at ship or one release later (proposal: one release later, after gain-histogram data).
+- Genre-exclusion list for smart fades (classical/spoken/live) — tag-based heuristic vs user-managed list.

--- a/docs/designs/loudness-and-transitions.md
+++ b/docs/designs/loudness-and-transitions.md
@@ -18,7 +18,7 @@ Playback volume varies wildly across a mixed library (quiet 90s masters next to 
 
 - Gain = `target − measured`, target default **−18 LUFS** (ReplayGain 2 reference; commercial streamers use −14 to −16, but self-hosted libraries skew dynamic — default documented and configurable per server, `LOUDNESS_TARGET_LUFS`).
 - **Positive gain clamp:** limit boost to `min(+3 dB, headroom to 0 dBTP)` using true peak — never introduce clipping to normalize a quiet track.
-- Modes per user: `off | track | album | auto` (auto = album gain inside album context, track gain in shuffle/radio/mix). Default: `auto` once shipped, `off` during rollout release.
+- Modes per user: `off | track | album | auto` (auto = album gain inside album context, track gain in shuffle/radio/mix). **Default: `auto` at ship** (maintainer decision 2026-08-16): the true-peak boost clamp is the safety mechanism, cut-only attenuation cannot clip, and `off` stays one toggle away. Release notes call out the behavior change prominently.
 - Engine application: both direct engines composite a gain factor into their volume pipeline (multiplicative with user volume). No new AudioContext requirement on the default path — element volume compositing suffices; where a context already exists (iOS-standalone bridge), a GainNode is acceptable but not required. Missing measurement ⇒ gain 0 for that track; **no mid-queue jump handling beyond that** (a measured→unmeasured boundary plays both at their natural relationship, same as today).
 - Transcoding/offline: measurement reflects the source file; client-side gain is codec-independent, so transcoded streams inherit correct leveling. Offline downloads play through the same player pipeline and use the same stored values.
 
@@ -62,5 +62,4 @@ Requires beat-grid phase data the analyzer does not store; explicitly out of sco
 
 ## Open questions
 
-- Whether `auto` should become default at ship or one release later (proposal: one release later, after gain-histogram data).
 - Genre-exclusion list for smart fades (classical/spoken/live) — tag-based heuristic vs user-managed list.

--- a/docs/designs/natural-language-music.md
+++ b/docs/designs/natural-language-music.md
@@ -1,0 +1,63 @@
+# Natural-Language Music Control (Local LLM)
+
+Spec drafted 2026-08-16 for [issue #528](https://github.com/soundspan/soundspan/issues/528). Status: design phase. Principle: the model **compiles intent; it never picks songs and never mutates state**. Taste quality comes from the existing embedding/query machinery; the LLM only translates language into it.
+
+## Problem
+
+The query surface (text→music embedding search, filters, mix parameters, energy curves) is powerful but only reachable through UI affordances. "Rainy Sunday, nothing I've played this month, build toward energy" is expressible in the primitives today — there is just no way to say it.
+
+## Provider configuration
+
+- `LLM_BASE_URL`, `LLM_API_KEY` (optional), `LLM_MODEL` — OpenAI-compatible chat completions; covers LM Studio, Ollama, vLLM, llama.cpp server, and hosted endpoints with one client. Absent `LLM_BASE_URL` ⇒ every surface hidden; zero behavioral difference from today.
+- Backend-only calls (never browser); bounded per the external-work rules: request timeout (default 30 s), no automatic retry inside a user-facing request, one in-flight compilation per user, rate-limited alongside the other abuse-control limiters (Redis-shared).
+- Health probe on settings save (one tiny completion) so misconfiguration surfaces immediately, not on first use.
+
+## The compilation contract (trust boundary)
+
+The model receives a single tool schema `compile_playlist_plan` describing the query surface and must return one call:
+
+```
+{
+  seedText?: string            // -> CLAP text-tower embedding query
+  filters?: {
+    genresAny?, genresNone?, yearRange?,
+    excludePlayedWithinDays?, minPlayCount?, likedOnly?,
+    artistsAny?, artistsNone?
+  }
+  audio?: { energyRange?, bpmRange? }
+  shape?: { targetLength?, energyCurve?: "flat"|"rise"|"fall"|"arc",
+            artistCap?, ordering?: "similarity"|"shuffled"|"curve" }
+  title?: string
+}
+```
+
+- **Zod-validated**; unknown fields rejected; every enum/range clamped server-side to the same bounds the UI enforces. Validation failure ⇒ one repair round-trip (schema + error returned to the model), then graceful "couldn't parse that — try rephrasing" with tappable example prompts. Never a silent fallback playlist.
+- Execution maps plan → existing services (embedding search, programmatic-playlist toolkit, artist caps, energy curve via stored analyzer data). **No SQL, no identifiers, no free-form execution derived from model output.** The schema is the entire capability ceiling.
+- **Injection stance:** track/artist names inside prompts (e.g., "more like Album X") are untrusted text; because the only tool is the read-only plan above, injected instructions can at worst shape a playlist. Invariant to preserve forever: this feature never gains a state-mutating tool. Recorded as a hard rule, tested by a guard that the tool registry contains exactly one read-only entry.
+
+## Surfaces
+
+1. **Playlist builder prompt** ("Describe it") → compiled plan → preview with the plan rendered as human-readable chips (the filters it understood — transparency doubles as debugging) → save.
+2. **Saved plans are living**: a generated playlist stores `{prompt, compiledPlan, spaceId}` and can refresh on demand or schedule — natural-language smart playlists. Refresh re-executes the stored plan (no LLM call unless the user edits the prompt); embedding queries re-encode seedText only if the active embedding space changed (space contract from `vibe-embedding-provider.md`).
+3. **"Why this pick"** on Discover Weekly/radio items: the recommendation pipeline already knows its reasons (similarity contributors, genre/tag matches, play-history signals). A template assembles the factual skeleton; the LLM only rewrites it conversationally. **Facts from the pipeline, phrasing from the model** — with the template-only version as the no-LLM fallback, so explanations ship even without a configured model.
+4. **Naming/描述 suggestions** for any playlist (cheapest surface, good first ship).
+
+## Model-quality reality
+
+Small local models will emit invalid plans. Mitigations: the single-tool schema (no tool choice to get wrong), one repair round, low temperature default, canned example prompts in the UI, and a settings-page "test a prompt" box showing the compiled chips. Quality floor is honest: parsing quality varies by model; taste quality does not (it never depends on the model).
+
+## Rollout and testing
+
+1. Naming/descriptions → 2. playlist builder + saved plans → 3. explanations.
+- Tests: schema validation fixtures (valid/invalid/hostile plans incl. injection-shaped strings); plan-execution mapping against mocked services; repair-round behavior; guard test pinning the read-only tool registry; zero-config invisibility test.
+- Metrics: compilation success/repair/fail counters; latency histogram (bounded).
+
+## Non-goals
+
+- Model-side song selection, conversational agents with memory, voice, or any write-capable tool.
+- Bundling or recommending specific models beyond documented setup examples (LM Studio, Ollama).
+
+## Open questions
+
+- Whether scheduled refresh of saved plans should re-prompt the LLM when the prompt text is unchanged (current position: no — determinism and zero idle LLM load win).
+- Prompt-library sharing between users on an instance (nice social touch; defer to the social wave).


### PR DESCRIPTION
Completes the design wave for the feature slate (#526-#530), following `vibe-embedding-provider.md`:

- **loudness-and-transitions.md** (#526, #527): EBU R128 integrated LUFS + true peak at analysis; client-side gain with a +3 dB/true-peak boost clamp, four user modes; OpenSubsonic ReplayGain extension; silence trim (non-album contexts); adaptive crossfade as a pure policy table with an explicit per-engine dual-voice capability contract and iOS background degradation to cuts.
- **natural-language-music.md** (#528): compile-not-generate — one zod-validated read-only plan schema as the entire capability ceiling, one repair round then honest failure, living saved plans (prompt + plan + spaceId), facts-from-pipeline/phrasing-from-model explanations with a no-LLM template fallback, and a guard test pinning the tool registry read-only forever.
- **blends-and-federated-discovery.md** (#529, #530): k-centroid taste vectors (recency/thumbs weighted, cold-start fallback), max-min fairness scoring with per-track attribution, cross-peer membership sharing vectors-never-history with per-blend opt-in and tested revocation, ratio-capped peer discovery candidates that never displace better local picks, offline row states, and the get-it-locally acquisition hook.

verify: npm run verify:gates exit 0; docs index updated.