### PR TITLE
refactor(vibe): confine raw pgvector SQL to the track embedding service layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Confined vibe and analysis vector SQL to the track embedding service layer.
 - Release-note generation now always includes the standing 2.0.0 upgrade path
   and accepts repeatable per-release `--upgrade-note` bullets.
 

--- a/backend/src/__tests__/trackEmbeddingsBoundary.guard.test.ts
+++ b/backend/src/__tests__/trackEmbeddingsBoundary.guard.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guard enforcing the blessed-sites rule in services/trackEmbeddings.ts: raw
+ * `track_embeddings` SQL lives in the service layer, never in route modules.
+ * Test files are excluded, matching configBoundary.guard.test.ts.
+ */
+import fs from "fs";
+import path from "path";
+
+const ROUTES_ROOT = path.resolve(__dirname, "../routes");
+const MAX_DIRECTORIES = 1_000;
+const MAX_DIRECTORY_ENTRIES = 10_000;
+
+function isExcluded(absolutePath: string): boolean {
+    const relativePath = path
+        .relative(ROUTES_ROOT, absolutePath)
+        .split(path.sep)
+        .join("/");
+    return (
+        relativePath.split("/").includes("__tests__") ||
+        relativePath.endsWith(".test.ts")
+    );
+}
+
+function scanDirectory(
+    directory: string,
+    pendingDirectories: string[],
+    offenders: string[],
+): void {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    expect(entries.length).toBeLessThanOrEqual(MAX_DIRECTORY_ENTRIES);
+    for (
+        let index = 0;
+        index < entries.length && index < MAX_DIRECTORY_ENTRIES;
+        index += 1
+    ) {
+        const entry = entries[index];
+        expect(entry).toBeDefined();
+        if (entry === undefined) continue;
+
+        const absolutePath = path.join(directory, entry.name);
+        if (isExcluded(absolutePath)) continue;
+        if (entry.isDirectory()) pendingDirectories.push(absolutePath);
+        if (
+            entry.isFile() &&
+            entry.name.endsWith(".ts") &&
+            fs.readFileSync(absolutePath, "utf8").includes("track_embeddings")
+        ) {
+            offenders.push(path.relative(ROUTES_ROOT, absolutePath));
+        }
+    }
+}
+
+function findRawTrackEmbeddingSql(): string[] {
+    const pendingDirectories = [ROUTES_ROOT];
+    const offenders: string[] = [];
+    let scannedDirectories = 0;
+
+    while (
+        pendingDirectories.length > 0 &&
+        scannedDirectories < MAX_DIRECTORIES
+    ) {
+        const directory = pendingDirectories.pop();
+        expect(directory).toBeDefined();
+        if (directory === undefined) continue;
+        scannedDirectories += 1;
+        scanDirectory(directory, pendingDirectories, offenders);
+    }
+
+    expect(scannedDirectories).toBeLessThan(MAX_DIRECTORIES);
+    expect(pendingDirectories).toHaveLength(0);
+    return offenders.sort();
+}
+
+describe("track embedding SQL boundary", () => {
+    it("keeps track_embeddings references out of route modules", () => {
+        expect(findRawTrackEmbeddingSql()).toEqual([]);
+    });
+});

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -73,12 +73,17 @@ jest.mock("../../services/enrichmentFailureService", () => ({
     },
 }));
 
+jest.mock("../../services/trackEmbeddings", () => ({
+    countEmbeddedLocalTracks: jest.fn(),
+}));
+
 import router from "../analysis";
 import { requireInternalSecret } from "../../middleware/internalAuth";
 import { prisma } from "../../utils/db";
 import { redisClient } from "../../utils/redis";
 import { getSystemSettings } from "../../utils/systemSettings";
 import { enrichmentFailureService } from "../../services/enrichmentFailureService";
+import { countEmbeddedLocalTracks } from "../../services/trackEmbeddings";
 
 const mockGroupBy = prisma.track.groupBy as jest.Mock;
 const mockTrackFindMany = prisma.track.findMany as jest.Mock;
@@ -107,6 +112,7 @@ const mockResetRetryCount =
     enrichmentFailureService.resetRetryCount as jest.Mock;
 const mockResolveByEntity =
     enrichmentFailureService.resolveByEntity as jest.Mock;
+const mockCountEmbeddedLocalTracks = countEmbeddedLocalTracks as jest.Mock;
 
 function findRouteLayer(
     stack: any[],
@@ -239,6 +245,7 @@ describe("analysis routes runtime", () => {
         mockGetFailures.mockResolvedValue({ failures: [] });
         mockResetRetryCount.mockResolvedValue({});
         mockResolveByEntity.mockResolvedValue({});
+        mockCountEmbeddedLocalTracks.mockResolvedValue(0);
 
         process.env.INTERNAL_API_SECRET = "test-secret";
         jest.spyOn(os, "cpus").mockReturnValue(new Array(8).fill({}) as any);
@@ -256,7 +263,7 @@ describe("analysis routes runtime", () => {
             { analysisStatus: "pending", _count: 5 },
         ]);
         mockRedisLLen.mockResolvedValue(3);
-        mockQueryRaw.mockResolvedValue([{ count: BigInt(4) }]);
+        mockCountEmbeddedLocalTracks.mockResolvedValue(4);
 
         const req = { user: { id: "u1" } } as any;
         const res = createRes();

--- a/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
@@ -67,15 +67,19 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
-jest.mock("../../utils/embedding", () => ({
-    parseEmbedding: jest.fn((text: string) => {
-        const values = text
-            .replace(/[\[\]]/g, "")
-            .split(",")
-            .map(Number);
-        return values;
-    }),
-}));
+jest.mock("../../utils/embedding", () => {
+    const actual = jest.requireActual("../../utils/embedding");
+    return {
+        ...actual,
+        parseEmbedding: jest.fn((text: string) => {
+            const values = text
+                .replace(/[\[\]]/g, "")
+                .split(",")
+                .map(Number);
+            return values;
+        }),
+    };
+});
 
 jest.mock("../../services/vibeVocabulary", () => ({
     loadVocabulary: jest.fn(),

--- a/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
+++ b/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
@@ -53,15 +53,19 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
-jest.mock("../../utils/embedding", () => ({
-    parseEmbedding: jest.fn((text: string) => {
-        const values = text
-            .replace(/[\[\]]/g, "")
-            .split(",")
-            .map(Number);
-        return values;
-    }),
-}));
+jest.mock("../../utils/embedding", () => {
+    const actual = jest.requireActual("../../utils/embedding");
+    return {
+        ...actual,
+        parseEmbedding: jest.fn((text: string) => {
+            const values = text
+                .replace(/[\[\]]/g, "")
+                .split(",")
+                .map(Number);
+            return values;
+        }),
+    };
+});
 
 jest.mock("../../services/vibeVocabulary", () => ({
     loadVocabulary: jest.fn(),

--- a/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
@@ -49,11 +49,9 @@ jest.mock("../../services/hybridSimilarity", () => ({
     findSimilarTracks: jest.fn(),
 }));
 
-// Same boundary as vibeSearchCompat.test.ts: the ANN sites (findNearestToEmbedding)
-// route through the F14 helper, which applies ivfflat.probes in a transaction.
-// Mock it at that boundary so these tests assert route BEHAVIOUR on canned rows.
-// Plain embedding lookups (fetchTrackEmbedding, the mood-bucket join) stay on
-// prisma.$queryRaw.
+// Same boundary as vibeSearchCompat.test.ts: the track-embedding service routes
+// ANN queries through the F14 helper, which applies ivfflat.probes in a
+// transaction. Plain embedding lookups use the mocked prisma.$queryRaw boundary.
 jest.mock("../../utils/annQuery", () => ({
     runAnnQuery: jest.fn(),
 }));
@@ -62,15 +60,19 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
-jest.mock("../../utils/embedding", () => ({
-    parseEmbedding: jest.fn((text: string) => {
-        const values = text
-            .replace(/[\[\]]/g, "")
-            .split(",")
-            .map(Number);
-        return values;
-    }),
-}));
+jest.mock("../../utils/embedding", () => {
+    const actual = jest.requireActual("../../utils/embedding");
+    return {
+        ...actual,
+        parseEmbedding: jest.fn((text: string) => {
+            const values = text
+                .replace(/[\[\]]/g, "")
+                .split(",")
+                .map(Number);
+            return values;
+        }),
+    };
+});
 
 jest.mock("../../services/vibeVocabulary", () => ({
     loadVocabulary: jest.fn(),

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -45,11 +45,10 @@ jest.mock("../../services/hybridSimilarity", () => ({
     findSimilarTracks: jest.fn(),
 }));
 
-// The vibe ANN sites (findNearestToEmbedding + text-vibe search) route through
-// the F14 helper, which applies ivfflat.probes in a transaction. Mock it at that
-// boundary so these tests still assert route BEHAVIOUR on canned neighbour rows.
-// The plain embedding lookups (fetchTrackEmbedding) and the status count remain
-// on prisma.$queryRaw.
+// The track-embedding service routes its ANN sites through the F14 helper,
+// which applies ivfflat.probes in a transaction. Mock it at that boundary so
+// these tests still assert route BEHAVIOUR on canned neighbour rows. Plain
+// embedding lookups and status counts use the mocked prisma.$queryRaw boundary.
 jest.mock("../../utils/annQuery", () => ({
     runAnnQuery: jest.fn(),
 }));
@@ -58,15 +57,19 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
-jest.mock("../../utils/embedding", () => ({
-    parseEmbedding: jest.fn((text: string) => {
-        const values = text
-            .replace(/[\[\]]/g, "")
-            .split(",")
-            .map(Number);
-        return values;
-    }),
-}));
+jest.mock("../../utils/embedding", () => {
+    const actual = jest.requireActual("../../utils/embedding");
+    return {
+        ...actual,
+        parseEmbedding: jest.fn((text: string) => {
+            const values = text
+                .replace(/[\[\]]/g, "")
+                .split(",")
+                .map(Number);
+            return values;
+        }),
+    };
+});
 
 jest.mock("../../services/vibeVocabulary", () => ({
     loadVocabulary: jest.fn(),

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -5,6 +5,7 @@ import { redisClient } from "../utils/redis";
 import { requireAuth, requireAdmin } from "../middleware/auth";
 import { getSystemSettings } from "../utils/systemSettings";
 import { enrichmentFailureService } from "../services/enrichmentFailureService";
+import { countEmbeddedLocalTracks } from "../services/trackEmbeddings";
 import analysisInternalRoutes from "./analysisInternal";
 import os from "os";
 import {
@@ -74,14 +75,7 @@ router.get("/status", requireAuth, async (req, res) => {
         const queueLength = await redisClient.lLen(ANALYSIS_QUEUE);
 
         // Get CLAP embedding count
-        const embeddingCount = await prisma.$queryRaw<{ count: bigint }[]>`
-            SELECT COUNT(*) as count
-            FROM track_embeddings te
-            INNER JOIN "Track" t ON t.id = te.track_id
-            WHERE t."removedAt" IS NULL
-              AND t.origin = ${"LOCAL"}::"TrackOrigin"
-        `;
-        const withEmbeddings = Number(embeddingCount[0]?.count || 0);
+        const withEmbeddings = await countEmbeddedLocalTracks();
 
         const progress = total > 0 ? Math.round((completed / total) * 100) : 0;
 

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -1,15 +1,13 @@
 import { Request, Response, Router } from "express";
 import { randomUUID } from "crypto";
-import { Prisma } from "@prisma/client";
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
-import { runAnnQuery } from "../utils/annQuery";
 import {
     TRACK_BROWSE_WHERE,
     TRACK_VISIBLE_WHERE,
 } from "../utils/librarySorting";
 import { blockingBlPop, redisClient } from "../utils/redis";
-import { parseEmbedding } from "../utils/embedding";
+import { blendEmbeddings, lerpEmbedding } from "../utils/embedding";
 import { requireAuth } from "../middleware/auth";
 import { asyncHandler } from "../middleware/asyncHandler";
 import { findSimilarTracks } from "../services/hybridSimilarity";
@@ -40,11 +38,18 @@ import {
     MoodType,
     MOOD_BUCKET_MIN_SCORE,
 } from "../services/moodBucketService";
-import { fetchEmbeddingsByTrackIds } from "../services/trackEmbeddings";
+import {
+    countEmbeddedBrowsableTracks,
+    fetchEmbeddingsByTrackIds,
+    fetchTrackEmbedding,
+    findNearestToEmbedding,
+    findTracksByTextEmbedding,
+    type NearestTrackRow,
+    type TextSearchResult,
+} from "../services/trackEmbeddings";
 import { parseJourneyRequest } from "./vibeJourneyRequest";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 import { coalesceInFlightByKey } from "../utils/singleflight";
-import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
 
 const router = Router();
 
@@ -59,27 +64,6 @@ const MAX_TEXT_SEARCH_QUERY_LENGTH = 512;
 // at most 30 seconds. Retaining 100 entries leaves burst headroom without
 // allowing timed-out request payloads to accumulate indefinitely.
 const TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH = 100;
-
-interface TextSearchResult {
-    id: string;
-    title: string;
-    duration: number;
-    trackNo: number;
-    distance: number;
-    albumId: string;
-    albumTitle: string;
-    albumCoverUrl: string | null;
-    artistId: string;
-    artistName: string;
-    // Audio features for re-ranking
-    energy: number | null;
-    valence: number | null;
-    danceability: number | null;
-    acousticness: number | null;
-    instrumentalness: number | null;
-    arousal: number | null;
-    speechiness: number | null;
-}
 
 async function buildTrackPreferenceScoreMapForUser(
     userId: string | undefined,
@@ -177,102 +161,6 @@ router.get(
         }
     }),
 );
-
-/**
- * Fetch a single track's CLAP embedding from pgvector.
- */
-async function fetchTrackEmbedding(trackId: string): Promise<number[] | null> {
-    const rows = await prisma.$queryRaw<{ embedding: string }[]>`
-        SELECT te.embedding::text
-        FROM track_embeddings te
-        JOIN "Track" t ON te.track_id = t.id
-        WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL} AND te.track_id = ${trackId}
-        LIMIT 1
-    `;
-    if (!rows.length) return null;
-    return parseEmbedding(rows[0].embedding);
-}
-
-/**
- * Linearly interpolate between two embedding vectors.
- */
-function lerpEmbedding(a: number[], b: number[], t: number): number[] {
-    return a.map((v, i) => v * (1 - t) + b[i] * t);
-}
-
-/**
- * Weighted average of multiple embeddings.
- */
-function blendEmbeddings(embeddings: number[][], weights: number[]): number[] {
-    const dim = embeddings[0].length;
-    const totalWeight = weights.reduce((s, w) => s + w, 0);
-    const result = new Array<number>(dim).fill(0);
-    for (let i = 0; i < embeddings.length; i++) {
-        const w = weights[i] / totalWeight;
-        for (let d = 0; d < dim; d++) {
-            result[d] += embeddings[i][d] * w;
-        }
-    }
-    return result;
-}
-
-interface NearestTrackRow {
-    id: string;
-    title: string;
-    distance: number;
-    albumId: string;
-    albumTitle: string;
-    albumCoverUrl: string | null;
-    artistId: string;
-    artistName: string;
-    energy: number | null;
-    valence: number | null;
-    danceability: number | null;
-    arousal: number | null;
-}
-
-async function findNearestToEmbedding(
-    embedding: number[],
-    limit: number,
-    excludeIds: string[] = [],
-): Promise<NearestTrackRow[]> {
-    if (excludeIds.length > 0) {
-        return runAnnQuery<NearestTrackRow[]>(Prisma.sql`
-            SELECT
-                t.id, t.title,
-                te.embedding <=> ${embedding}::vector AS distance,
-                a.id AS "albumId", a.title AS "albumTitle", a."coverUrl" AS "albumCoverUrl",
-                ar.id AS "artistId", ar.name AS "artistName",
-                t.energy, t.valence, t.danceability, t.arousal
-            FROM track_embeddings te
-            JOIN "Track" t ON te.track_id = t.id
-            JOIN "Album" a ON t."albumId" = a.id
-            JOIN "Artist" ar ON a."artistId" = ar.id
-            WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-              AND te.track_id != ALL(${excludeIds}::text[])
-            ORDER BY te.embedding <=> ${embedding}::vector
-            LIMIT ${limit}
-        `);
-    }
-    return runAnnQuery<NearestTrackRow[]>(Prisma.sql`
-        SELECT
-            t.id, t.title,
-            te.embedding <=> ${embedding}::vector AS distance,
-            a.id AS "albumId", a.title AS "albumTitle", a."coverUrl" AS "albumCoverUrl",
-            ar.id AS "artistId", ar.name AS "artistName",
-            t.energy, t.valence, t.danceability, t.arousal
-        FROM track_embeddings te
-        JOIN "Track" t ON te.track_id = t.id
-        JOIN "Album" a ON t."albumId" = a.id
-        JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-        ORDER BY te.embedding <=> ${embedding}::vector
-        LIMIT ${limit}
-    `);
-}
 
 function formatNearestTrack(row: NearestTrackRow) {
     return {
@@ -475,7 +363,7 @@ async function resolveTrackDestination(
         include: { album: { include: { artist: true } } },
     });
     if (!destinationTrack) {
-        // TOCTOU: the track_embeddings row fetched above (fetchTrackEmbedding
+        // TOCTOU: the embedding row fetched above (fetchTrackEmbedding
         // succeeded) can outlive its Track row for a moment if the track is
         // deleted between the two queries — TrackEmbedding has onDelete:
         // Cascade, so this is a genuine race window, not a stale-row bug.
@@ -1295,37 +1183,12 @@ router.post(
                 // Query for similar tracks using the (possibly expanded) embedding
                 // Fetch more candidates for re-ranking (3x limit)
                 // Filter by max distance to exclude poor matches
-                const similarTracks = await runAnnQuery<
-                    TextSearchResult[]
-                >(Prisma.sql`
-                SELECT
-                    t.id,
-                    t.title,
-                    t.duration,
-                    t."trackNo",
-                    te.embedding <=> ${searchEmbedding}::vector AS distance,
-                    a.id as "albumId",
-                    a.title as "albumTitle",
-                    a."coverUrl" as "albumCoverUrl",
-                    ar.id as "artistId",
-                    ar.name as "artistName",
-                    t.energy,
-                    t.valence,
-                    t.danceability,
-                    t.acousticness,
-                    t.instrumentalness,
-                    t.arousal,
-                    t.speechiness
-                FROM track_embeddings te
-                JOIN "Track" t ON te.track_id = t.id
-                JOIN "Album" a ON t."albumId" = a.id
-                JOIN "Artist" ar ON a."artistId" = ar.id
-                WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-                  AND te.embedding <=> ${searchEmbedding}::vector <= ${maxDistance}
-                ORDER BY te.embedding <=> ${searchEmbedding}::vector
-                LIMIT ${limit * 3}
-            `);
+                const candidateLimit = limit * 3;
+                const similarTracks = await findTracksByTextEmbedding(
+                    searchEmbedding,
+                    maxDistance,
+                    candidateLimit,
+                );
 
                 logger.info(
                     `Vibe search "${normalizedQuery}": found ${similarTracks.length} candidates above ${Math.round(similarityThreshold * 100)}% similarity (max distance: ${maxDistance.toFixed(2)})`,
@@ -1458,15 +1321,7 @@ router.get(
                 where: { ...TRACK_VISIBLE_WHERE, ...TRACK_BROWSE_WHERE },
             });
 
-            const embeddedTracks = await prisma.$queryRaw<{ count: bigint }[]>`
-            SELECT COUNT(*) as count
-            FROM track_embeddings te
-            JOIN "Track" t ON te.track_id = t.id
-            WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-        `;
-
-            const embeddedCount = Number(embeddedTracks[0]?.count || 0);
+            const embeddedCount = await countEmbeddedBrowsableTracks();
             const progress =
                 totalTracks > 0
                     ? Math.round((embeddedCount / totalTracks) * 100)

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -133,7 +133,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/tidal.ts` | Core |
 | `backend/src/services/tidalStreaming.ts` | Core |
 | `backend/src/services/trackMappingService.ts` | Core |
-| `backend/src/services/trackEmbeddings.ts` | Vibe embedding reads |
+| `backend/src/services/trackEmbeddings.ts` | Vibe pgvector reads, ANN queries, and embedding counts |
 | `backend/src/services/trackIdentityMatcher.ts` | Durable track move identity matching |
 | `backend/src/services/trackPreference.ts` | Core |
 | `backend/src/services/trackReconciliation.ts` | Core |

--- a/backend/src/services/__tests__/trackEmbeddings.test.ts
+++ b/backend/src/services/__tests__/trackEmbeddings.test.ts
@@ -2,11 +2,26 @@ jest.mock("../../utils/db", () => ({
     prisma: { $executeRaw: jest.fn(), $queryRaw: jest.fn() },
 }));
 
+jest.mock("../../utils/annQuery", () => ({
+    runAnnQuery: jest.fn(),
+}));
+
 import { prisma } from "../../utils/db";
+import { runAnnQuery } from "../../utils/annQuery";
+import * as embeddingUtils from "../../utils/embedding";
 import {
+    countEmbeddedBrowsableTracks,
+    countEmbeddedLocalTracks,
     fetchEmbeddingsByTrackIds,
+    fetchTrackEmbedding,
+    findNearestToEmbedding,
+    findTracksByTextEmbedding,
     upsertTrackEmbedding,
 } from "../trackEmbeddings";
+
+const mockQueryRaw = prisma.$queryRaw as jest.Mock;
+const mockRunAnnQuery = runAnnQuery as jest.Mock;
+const parseEmbeddingSpy = jest.spyOn(embeddingUtils, "parseEmbedding");
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -43,5 +58,95 @@ describe("fetchEmbeddingsByTrackIds", () => {
     it("does not query for an empty track list", async () => {
         await expect(fetchEmbeddingsByTrackIds([])).resolves.toEqual([]);
         expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    });
+});
+
+describe("fetchTrackEmbedding", () => {
+    it("parses the returned pgvector text", async () => {
+        mockQueryRaw.mockResolvedValue([{ embedding: "[0.25,-0.5,1]" }]);
+
+        await expect(fetchTrackEmbedding("track-1")).resolves.toEqual([
+            0.25, -0.5, 1,
+        ]);
+        expect(parseEmbeddingSpy).toHaveBeenCalledWith("[0.25,-0.5,1]");
+    });
+
+    it("returns null when the track has no embedding row", async () => {
+        mockQueryRaw.mockResolvedValue([]);
+
+        await expect(fetchTrackEmbedding("track-1")).resolves.toBeNull();
+    });
+});
+
+describe("findNearestToEmbedding", () => {
+    it("routes the unfiltered ANN query through runAnnQuery", async () => {
+        const rows = [{ id: "track-1", distance: 0.1 }];
+        mockRunAnnQuery.mockResolvedValue(rows);
+
+        await expect(findNearestToEmbedding([0.1, 0.2], 5)).resolves.toBe(rows);
+
+        expect(mockRunAnnQuery).toHaveBeenCalledTimes(1);
+        const query = mockRunAnnQuery.mock.calls[0][0];
+        expect(query.strings.join(" ")).toContain("FROM track_embeddings te");
+        expect(query.strings.join(" ")).not.toContain("!= ALL");
+    });
+
+    it("preserves the exclusion branch", async () => {
+        mockRunAnnQuery.mockResolvedValue([]);
+
+        await findNearestToEmbedding([0.1, 0.2], 5, ["track-2"]);
+
+        const query = mockRunAnnQuery.mock.calls[0][0];
+        expect(query.strings.join(" ")).toContain("!= ALL");
+        expect(query.values).toContainEqual(["track-2"]);
+    });
+});
+
+describe("findTracksByTextEmbedding", () => {
+    it("routes the bounded text-search ANN query through runAnnQuery", async () => {
+        const rows = [{ id: "track-1", distance: 0.2 }];
+        mockRunAnnQuery.mockResolvedValue(rows);
+
+        await expect(
+            findTracksByTextEmbedding([0.25, 0.75], 0.8, 60),
+        ).resolves.toBe(rows);
+
+        expect(mockRunAnnQuery).toHaveBeenCalledTimes(1);
+        const query = mockRunAnnQuery.mock.calls[0][0];
+        expect(query.strings.join(" ")).toContain("FROM track_embeddings te");
+        const values = query.values as unknown[];
+        // Pin binding positions so a maxDistance/candidateLimit swap cannot
+        // pass: LIMIT binds last, preceded by the ORDER BY vector, preceded
+        // by the distance bound.
+        expect(values[values.length - 1]).toBe(60);
+        expect(values[values.length - 2]).toEqual([0.25, 0.75]);
+        expect(values[values.length - 3]).toBe(0.8);
+    });
+});
+
+describe("embedding counts", () => {
+    it("counts browsable embeddings and parses bigint rows", async () => {
+        mockQueryRaw.mockResolvedValue([{ count: BigInt(4) }]);
+
+        await expect(countEmbeddedBrowsableTracks()).resolves.toBe(4);
+
+        const query = mockQueryRaw.mock.calls[0][0];
+        expect(query.join(" ")).toContain("FROM track_embeddings te");
+    });
+
+    it("counts only local embeddings for analysis status", async () => {
+        mockQueryRaw.mockResolvedValue([{ count: BigInt(3) }]);
+
+        await expect(countEmbeddedLocalTracks()).resolves.toBe(3);
+
+        const query = mockQueryRaw.mock.calls[0][0];
+        expect(query.join(" ")).toContain("t.origin =");
+    });
+
+    it("returns zero when a count query has no rows", async () => {
+        mockQueryRaw.mockResolvedValue([]);
+
+        await expect(countEmbeddedBrowsableTracks()).resolves.toBe(0);
+        await expect(countEmbeddedLocalTracks()).resolves.toBe(0);
     });
 });

--- a/backend/src/services/trackEmbeddings.ts
+++ b/backend/src/services/trackEmbeddings.ts
@@ -1,5 +1,7 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../utils/db";
 import { parseEmbedding } from "../utils/embedding";
+import { runAnnQuery } from "../utils/annQuery";
 import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
 
 /**
@@ -16,6 +18,44 @@ import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
 export interface TrackEmbeddingRow {
     trackId: string;
     embedding: number[];
+}
+
+/** Track row returned by nearest-neighbor embedding queries. */
+export interface NearestTrackRow {
+    id: string;
+    title: string;
+    distance: number;
+    albumId: string;
+    albumTitle: string;
+    albumCoverUrl: string | null;
+    artistId: string;
+    artistName: string;
+    energy: number | null;
+    valence: number | null;
+    danceability: number | null;
+    arousal: number | null;
+}
+
+/** Track row returned by text-embedding search queries. */
+export interface TextSearchResult {
+    id: string;
+    title: string;
+    duration: number;
+    trackNo: number;
+    distance: number;
+    albumId: string;
+    albumTitle: string;
+    albumCoverUrl: string | null;
+    artistId: string;
+    artistName: string;
+    // Audio features for re-ranking
+    energy: number | null;
+    valence: number | null;
+    danceability: number | null;
+    acousticness: number | null;
+    instrumentalness: number | null;
+    arousal: number | null;
+    speechiness: number | null;
 }
 
 const EMBEDDING_DIMENSIONS = 512;
@@ -66,4 +106,127 @@ export async function fetchEmbeddingsByTrackIds(
         trackId: row.trackId,
         embedding: parseEmbedding(row.embedding),
     }));
+}
+
+/**
+ * Fetch a single track's CLAP embedding from pgvector.
+ */
+export async function fetchTrackEmbedding(
+    trackId: string,
+): Promise<number[] | null> {
+    const rows = await prisma.$queryRaw<{ embedding: string }[]>`
+        SELECT te.embedding::text
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL} AND te.track_id = ${trackId}
+        LIMIT 1
+    `;
+    if (!rows.length) return null;
+    return parseEmbedding(rows[0].embedding);
+}
+
+/** Finds the closest browsable tracks to an embedding. */
+export async function findNearestToEmbedding(
+    embedding: number[],
+    limit: number,
+    excludeIds: string[] = [],
+): Promise<NearestTrackRow[]> {
+    if (excludeIds.length > 0) {
+        return runAnnQuery<NearestTrackRow[]>(Prisma.sql`
+            SELECT
+                t.id, t.title,
+                te.embedding <=> ${embedding}::vector AS distance,
+                a.id AS "albumId", a.title AS "albumTitle", a."coverUrl" AS "albumCoverUrl",
+                ar.id AS "artistId", ar.name AS "artistName",
+                t.energy, t.valence, t.danceability, t.arousal
+            FROM track_embeddings te
+            JOIN "Track" t ON te.track_id = t.id
+            JOIN "Album" a ON t."albumId" = a.id
+            JOIN "Artist" ar ON a."artistId" = ar.id
+            WHERE t."removedAt" IS NULL
+              AND ${TRACK_BROWSE_SQL}
+              AND te.track_id != ALL(${excludeIds}::text[])
+            ORDER BY te.embedding <=> ${embedding}::vector
+            LIMIT ${limit}
+        `);
+    }
+    return runAnnQuery<NearestTrackRow[]>(Prisma.sql`
+        SELECT
+            t.id, t.title,
+            te.embedding <=> ${embedding}::vector AS distance,
+            a.id AS "albumId", a.title AS "albumTitle", a."coverUrl" AS "albumCoverUrl",
+            ar.id AS "artistId", ar.name AS "artistName",
+            t.energy, t.valence, t.danceability, t.arousal
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        JOIN "Album" a ON t."albumId" = a.id
+        JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL}
+        ORDER BY te.embedding <=> ${embedding}::vector
+        LIMIT ${limit}
+    `);
+}
+
+/** Finds browsable tracks nearest to a text-search embedding. */
+export async function findTracksByTextEmbedding(
+    searchEmbedding: number[],
+    maxDistance: number,
+    candidateLimit: number,
+): Promise<TextSearchResult[]> {
+    return runAnnQuery<TextSearchResult[]>(Prisma.sql`
+        SELECT
+            t.id,
+            t.title,
+            t.duration,
+            t."trackNo",
+            te.embedding <=> ${searchEmbedding}::vector AS distance,
+            a.id as "albumId",
+            a.title as "albumTitle",
+            a."coverUrl" as "albumCoverUrl",
+            ar.id as "artistId",
+            ar.name as "artistName",
+            t.energy,
+            t.valence,
+            t.danceability,
+            t.acousticness,
+            t.instrumentalness,
+            t.arousal,
+            t.speechiness
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        JOIN "Album" a ON t."albumId" = a.id
+        JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL}
+          AND te.embedding <=> ${searchEmbedding}::vector <= ${maxDistance}
+        ORDER BY te.embedding <=> ${searchEmbedding}::vector
+        LIMIT ${candidateLimit}
+    `);
+}
+
+/** Counts embeddings for tracks visible on browsable library surfaces. */
+export async function countEmbeddedBrowsableTracks(): Promise<number> {
+    const embeddedTracks = await prisma.$queryRaw<{ count: bigint }[]>`
+        SELECT COUNT(*) as count
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL}
+    `;
+
+    return Number(embeddedTracks[0]?.count || 0);
+}
+
+/** Counts embeddings for local tracks included in analysis status. */
+export async function countEmbeddedLocalTracks(): Promise<number> {
+    const embeddingCount = await prisma.$queryRaw<{ count: bigint }[]>`
+        SELECT COUNT(*) as count
+        FROM track_embeddings te
+        INNER JOIN "Track" t ON t.id = te.track_id
+        WHERE t."removedAt" IS NULL
+          AND t.origin = ${"LOCAL"}::"TrackOrigin"
+    `;
+    return Number(embeddingCount[0]?.count || 0);
 }

--- a/backend/src/utils/__tests__/embedding.test.ts
+++ b/backend/src/utils/__tests__/embedding.test.ts
@@ -1,4 +1,52 @@
-import { parseEmbedding } from "../embedding";
+import { blendEmbeddings, lerpEmbedding, parseEmbedding } from "../embedding";
+
+describe("lerpEmbedding", () => {
+    it("returns the endpoints at t=0 and t=1", () => {
+        const start = [1, 2, 3];
+        const end = [4, 6, 8];
+
+        expect(lerpEmbedding(start, end, 0)).toEqual(start);
+        expect(lerpEmbedding(start, end, 1)).toEqual(end);
+    });
+
+    it("interpolates the midpoint", () => {
+        expect(lerpEmbedding([0, 2, 4], [2, 4, 8], 0.5)).toEqual([1, 3, 6]);
+    });
+
+    it("preserves the first embedding dimension", () => {
+        expect(lerpEmbedding([0, 2], [2, 4, 8], 0.5)).toHaveLength(2);
+    });
+});
+
+describe("blendEmbeddings", () => {
+    it("computes a weighted blend", () => {
+        expect(
+            blendEmbeddings(
+                [
+                    [1, 3],
+                    [5, 7],
+                ],
+                [1, 3],
+            ),
+        ).toEqual([4, 6]);
+    });
+
+    it("preserves the first embedding dimension", () => {
+        expect(
+            blendEmbeddings(
+                [
+                    [1, 2, 3],
+                    [5, 6, 7],
+                ],
+                [1, 1],
+            ),
+        ).toHaveLength(3);
+    });
+
+    it("preserves NaN results when the total weight is zero", () => {
+        expect(blendEmbeddings([[1, 2]], [0])).toEqual([NaN, NaN]);
+    });
+});
 
 describe("parseEmbedding", () => {
     it("parses valid embedding strings across numeric formats", () => {

--- a/backend/src/utils/embedding.ts
+++ b/backend/src/utils/embedding.ts
@@ -28,3 +28,29 @@ export function parseEmbedding(text: string): number[] {
 
     return numbers;
 }
+
+/**
+ * Linearly interpolate between two embedding vectors.
+ */
+export function lerpEmbedding(a: number[], b: number[], t: number): number[] {
+    return a.map((v, i) => v * (1 - t) + b[i] * t);
+}
+
+/**
+ * Weighted average of multiple embeddings.
+ */
+export function blendEmbeddings(
+    embeddings: number[][],
+    weights: number[],
+): number[] {
+    const dim = embeddings[0].length;
+    const totalWeight = weights.reduce((s, w) => s + w, 0);
+    const result = new Array<number>(dim).fill(0);
+    for (let i = 0; i < embeddings.length; i++) {
+        const w = weights[i] / totalWeight;
+        for (let d = 0; d < dim; d++) {
+            result[d] += embeddings[i][d] * w;
+        }
+    }
+    return result;
+}

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -65,7 +65,6 @@ const BASELINE = Object.freeze({
     "backend/src/routes/podcasts.ts": 2541,
     "backend/src/routes/streaming.ts": 1621,
     "backend/src/routes/systemSettings.ts": 1556,
-    "backend/src/routes/vibe.ts": 1581,
     "backend/src/routes/youtubeMusic.ts": 1612,
     "backend/src/services/lidarr.ts": 2990,
     "backend/src/services/listenTogetherManager.ts": 1501,


### PR DESCRIPTION
## Summary

`services/trackEmbeddings.ts` declares itself the blessed home for raw pgvector reads, but `routes/vibe.ts` and `routes/analysis.ts` still carried their own inline vector SQL. This is a pure relocation: every query moves byte-identically into the service layer, routes call named functions, and a boundary guard test enforces the rule going forward.

- Moved into `services/trackEmbeddings.ts`: `fetchTrackEmbedding`, `findNearestToEmbedding` (+`NearestTrackRow`), `findTracksByTextEmbedding` (+`TextSearchResult`), `countEmbeddedBrowsableTracks`, `countEmbeddedLocalTracks`.
- The two COUNT queries are deliberately not merged: the vibe status count applies the full browse predicate (federation visibility, dedup) while the analysis count is `origin = LOCAL` only.
- Pure vector math (`lerpEmbedding`, `blendEmbeddings`) moved to `utils/embedding.ts` with unit tests pinning current behavior, including the zero-total-weight edge case.
- New guard test `trackEmbeddingsBoundary.guard.test.ts` (route modules must not reference `track_embeddings`; test files excluded, matching the config boundary guard).
- `routes/vibe.ts` shrinks 1581 → 1436 lines; its frozen file-size baseline entry is removed per the guardrail's own policy (below the 1500 ratchet cap).

Groundwork for #537 phase 1 (embedding-space registry), which needs every vector query in one place to thread space scoping.

## Verification

- Targeted jest: 10 suites / 132 tests green (embedding, trackEmbeddings, boundary guard, vibeSearchCompat, vibeJourneyRuntime, vibeJourneyRequest, vibeErrorShapeCanon, vibeCalibrationRuntime, analysisRuntime, hybridSimilarity); route-suite diffs are mock-target only, zero behavioral expectations changed.
- SQL verified token-identical to the pre-move inline queries (normalized whitespace only); text-search parameter binding positions pinned by test.
- `tsc --noEmit`, prettier check, file-size guardrail all green.