### PR TITLE
feat(vibe): embedding-space registry and space-scoped vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Vibe embeddings are now tracked against a versioned embedding-space registry.
+  The backend and audio-analyzer-clap images must be upgraded together for this
+  release; older CLAP images cannot write embeddings against the new schema.
 - Confined vibe and analysis vector SQL to the track embedding service layer.
 - Release-note generation now always includes the standing 2.0.0 upgrade path
   and accepts repeatable per-release `--upgrade-note` bullets.

--- a/backend/prisma/migrations/20260816120000_add_embedding_space_registry/migration.sql
+++ b/backend/prisma/migrations/20260816120000_add_embedding_space_registry/migration.sql
@@ -1,0 +1,73 @@
+-- Register embedding spaces so stored vectors are never queried outside the
+-- model and preprocessing identity that gives them meaning.
+
+-- This repo's migrations apply statement-by-statement (autocommit), so wrap
+-- the whole change in one transaction: a mid-file failure must leave no
+-- partial DDL, and the ADD COLUMN lock must be held through SET NOT NULL so
+-- a still-running old sidecar cannot slip a NULL space_id row in between.
+-- (Safe here: no CONCURRENTLY and no ALTER TYPE ADD VALUE in this file.)
+BEGIN;
+
+-- CreateEnum
+CREATE TYPE "EmbeddingSpaceStatus" AS ENUM ('active', 'migrating', 'retired');
+
+-- CreateTable
+CREATE TABLE "embedding_spaces" (
+    "id" TEXT NOT NULL,
+    "family" TEXT NOT NULL,
+    "checkpoint_hash" TEXT NOT NULL,
+    "dim" INTEGER NOT NULL,
+    "preprocessing" JSONB NOT NULL,
+    "status" "EmbeddingSpaceStatus" NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "embedding_spaces_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "embedding_spaces_family_checkpoint_hash_key"
+    ON "embedding_spaces"("family", "checkpoint_hash");
+CREATE INDEX "embedding_spaces_status_idx" ON "embedding_spaces"("status");
+
+-- Prisma cannot model partial unique indexes. This raw index follows the
+-- existing raw pgvector-index precedent and enforces one active space.
+CREATE UNIQUE INDEX "embedding_spaces_one_active_idx"
+    ON "embedding_spaces" ((1)) WHERE "status" = 'active';
+
+-- Seed the canonical LAION-CLAP music_audioset embedding space.
+INSERT INTO "embedding_spaces" (
+    "id",
+    "family",
+    "checkpoint_hash",
+    "dim",
+    "preprocessing",
+    "status"
+) VALUES (
+    'space_clap_music_audioset_v1',
+    'clap-music-audioset',
+    'fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd',
+    512,
+    '{"sampleRateHz": 48000, "mono": true, "maxDurationSeconds": 60, "window": "middle", "loader": "librosa"}'::jsonb,
+    'active'
+);
+
+-- Add the nullable column first, then backfill every historical embedding.
+-- Both former model_version values identify this same canonical space.
+ALTER TABLE "track_embeddings" ADD COLUMN "space_id" TEXT;
+UPDATE "track_embeddings" SET "space_id" = 'space_clap_music_audioset_v1';
+ALTER TABLE "track_embeddings" ALTER COLUMN "space_id" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "track_embeddings"
+    ADD CONSTRAINT "track_embeddings_space_id_fkey"
+    FOREIGN KEY ("space_id") REFERENCES "embedding_spaces"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "track_embeddings_space_id_idx" ON "track_embeddings"("space_id");
+
+-- Remove the ambiguous free-form model identity.
+DROP INDEX "track_embeddings_model_version_idx";
+ALTER TABLE "track_embeddings" DROP COLUMN "model_version";
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1323,6 +1323,12 @@ enum PeerStatus {
   REVOKED
 }
 
+enum EmbeddingSpaceStatus {
+  active
+  migrating
+  retired
+}
+
 model TrackLyrics {
   id           String   @id @default(cuid())
   trackId      String   @unique
@@ -1336,14 +1342,30 @@ model TrackLyrics {
   @@index([trackId])
 }
 
-model TrackEmbedding {
-  trackId      String                     @id @map("track_id")
-  embedding    Unsupported("vector(512)")
-  modelVersion String                     @default("laion-clap-music") @map("model_version") @db.VarChar(50)
-  analyzedAt   DateTime                   @default(now()) @map("analyzed_at") @db.Timestamptz
-  track        Track                      @relation(fields: [trackId], references: [id], onDelete: Cascade)
+model EmbeddingSpace {
+  id             String               @id @default(cuid())
+  family         String
+  checkpointHash String               @map("checkpoint_hash")
+  dim            Int
+  preprocessing  Json
+  status         EmbeddingSpaceStatus
+  createdAt      DateTime             @default(now()) @map("created_at") @db.Timestamptz
+  embeddings     TrackEmbedding[]
 
-  @@index([modelVersion])
+  @@unique([family, checkpointHash])
+  @@index([status])
+  @@map("embedding_spaces")
+}
+
+model TrackEmbedding {
+  trackId    String                     @id @map("track_id")
+  embedding  Unsupported("vector(512)")
+  spaceId    String                     @map("space_id")
+  analyzedAt DateTime                   @default(now()) @map("analyzed_at") @db.Timestamptz
+  track      Track                      @relation(fields: [trackId], references: [id], onDelete: Cascade)
+  space      EmbeddingSpace             @relation(fields: [spaceId], references: [id], onDelete: Restrict)
+
+  @@index([spaceId])
   @@map("track_embeddings")
 }
 

--- a/backend/src/__tests__/embeddingSpaceMigration.test.ts
+++ b/backend/src/__tests__/embeddingSpaceMigration.test.ts
@@ -1,0 +1,41 @@
+import fs from "fs";
+import path from "path";
+
+describe("embedding-space registry migration", () => {
+    const migrationPath = path.resolve(
+        __dirname,
+        "../../prisma/migrations/20260816120000_add_embedding_space_registry/migration.sql",
+    );
+    const migration = fs.readFileSync(migrationPath, "utf8");
+
+    it("seeds the canonical CLAP space with its fixed identity", () => {
+        expect(migration).toContain("space_clap_music_audioset_v1");
+        expect(migration).toContain(
+            "fae3e9c087f2909c28a09dc31c8dfcdacbc42ba44c70e972b58c1bd1caf6dedd",
+        );
+        expect(migration).toContain('"sampleRateHz": 48000');
+        expect(migration).toContain(
+            'CREATE UNIQUE INDEX "embedding_spaces_one_active_idx"',
+        );
+    });
+
+    it("backfills before enforcing the space foreign key contract", () => {
+        const backfill = migration.indexOf(
+            'UPDATE "track_embeddings" SET "space_id"',
+        );
+        const notNull = migration.indexOf(
+            'ALTER COLUMN "space_id" SET NOT NULL',
+        );
+
+        expect(backfill).toBeGreaterThan(-1);
+        expect(notNull).toBeGreaterThan(backfill);
+        expect(migration).toContain("ON DELETE RESTRICT");
+    });
+
+    it("removes the ambiguous model-version column", () => {
+        expect(migration).toContain(
+            'DROP INDEX "track_embeddings_model_version_idx"',
+        );
+        expect(migration).toContain('DROP COLUMN "model_version"');
+    });
+});

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -75,6 +75,16 @@ jest.mock("../../services/enrichmentFailureService", () => ({
 
 jest.mock("../../services/trackEmbeddings", () => ({
     countEmbeddedLocalTracks: jest.fn(),
+    missingActiveEmbeddingWhere: (spaceId: string) => ({
+        OR: [
+            { embedding: null },
+            { embedding: { is: { spaceId: { not: spaceId } } } },
+        ],
+    }),
+}));
+
+jest.mock("../../services/embeddingSpaces", () => ({
+    getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
 }));
 
 import router from "../analysis";
@@ -686,7 +696,10 @@ describe("analysis routes runtime", () => {
         await postVibeStart(req, res);
 
         expect(mockTrackEmbeddingDeleteMany).toHaveBeenCalledWith({
-            where: { track: { origin: "LOCAL" } },
+            where: {
+                spaceId: "space-active",
+                track: { origin: "LOCAL" },
+            },
         });
         expect(mockQueryRaw).not.toHaveBeenCalled();
         expect(mockTrackUpdateMany).toHaveBeenCalledWith({
@@ -714,6 +727,20 @@ describe("analysis routes runtime", () => {
         const req = { body: {} } as any;
         const res = createRes();
         await postVibeStart(req, res);
+        expect(mockTrackFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    OR: [
+                        { embedding: null },
+                        {
+                            embedding: {
+                                is: { spaceId: { not: "space-active" } },
+                            },
+                        },
+                    ],
+                }),
+            }),
+        );
         expect(res.body).toEqual({
             message: "All tracks have vibe embeddings",
             queued: 0,

--- a/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
@@ -67,6 +67,10 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
+jest.mock("../../services/embeddingSpaces", () => ({
+    getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
+}));
+
 jest.mock("../../utils/embedding", () => {
     const actual = jest.requireActual("../../utils/embedding");
     return {
@@ -168,16 +172,29 @@ describe("vibe calibration runtime", () => {
         expect(typeof res.body.updatedAt).toBe("string");
         expect(res.body.quantiles).toHaveLength(101);
         expect(isMonotonicNonDecreasing(res.body.quantiles)).toBe(true);
+        expect(mockEmbeddingCount).toHaveBeenCalledWith({
+            where: {
+                spaceId: "space-active",
+                track: { origin: "LOCAL" },
+            },
+        });
 
         // The id scan is bounded and index-ordered — never a full-table
         // random sort touching the vector column.
         expect(mockEmbeddingFindMany).toHaveBeenCalledWith(
             expect.objectContaining({
+                where: expect.objectContaining({
+                    spaceId: "space-active",
+                }),
                 select: { trackId: true },
                 orderBy: { trackId: "asc" },
                 take: expect.any(Number),
             }),
         );
+
+        const [query, ...values] = mockQueryRaw.mock.calls[0];
+        expect(query.join(" ")).toContain("te.space_id =");
+        expect(values).toContain("space-active");
 
         expect(mockRedisSetEx).toHaveBeenCalledWith(
             "vibe:calibration:v1:50",

--- a/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
+++ b/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 
+const mockGetActiveSpace = jest.fn();
+
 jest.mock("crypto", () => ({
     randomUUID: jest.fn(() => "req-123"),
 }));
@@ -51,6 +53,10 @@ jest.mock("../../utils/annQuery", () => ({
 
 jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
+}));
+
+jest.mock("../../services/embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
 }));
 
 jest.mock("../../utils/embedding", () => {
@@ -127,11 +133,13 @@ function createRes() {
 describe("vibe canonical error response shape", () => {
     const similarHandler = getGetHandler("/similar/:trackId");
     const searchHandler = getPostHandler("/search");
+    const statusHandler = getGetHandler("/status");
 
     beforeEach(() => {
         jest.clearAllMocks();
         mockRedisXAdd.mockResolvedValue("1712345-0");
         mockRedisDel.mockResolvedValue(1);
+        mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
     });
 
     it("returns only the canonical error field when no similar tracks exist", async () => {
@@ -163,6 +171,21 @@ describe("vibe canonical error response shape", () => {
         expect(res.statusCode).toBe(504);
         expect(res.body).toEqual({
             error: "Text embedding service unavailable",
+        });
+        expect(res.body).not.toHaveProperty("message");
+    });
+
+    it("keeps the canonical error shape when no embedding space is active", async () => {
+        mockGetActiveSpace.mockRejectedValueOnce(
+            new Error("No active embedding space is configured"),
+        );
+        const res = createRes();
+
+        await statusHandler({ user: { id: "user-1" } } as any, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({
+            error: "Failed to get embedding status",
         });
         expect(res.body).not.toHaveProperty("message");
     });

--- a/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
@@ -60,6 +60,10 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
+jest.mock("../../services/embeddingSpaces", () => ({
+    getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
+}));
+
 jest.mock("../../utils/embedding", () => {
     const actual = jest.requireActual("../../utils/embedding");
     return {

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -57,6 +57,10 @@ jest.mock("../../services/umapProjection", () => ({
     computeMapProjection: jest.fn(),
 }));
 
+jest.mock("../../services/embeddingSpaces", () => ({
+    getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
+}));
+
 jest.mock("../../utils/embedding", () => {
     const actual = jest.requireActual("../../utils/embedding");
     return {

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -5,7 +5,11 @@ import { redisClient } from "../utils/redis";
 import { requireAuth, requireAdmin } from "../middleware/auth";
 import { getSystemSettings } from "../utils/systemSettings";
 import { enrichmentFailureService } from "../services/enrichmentFailureService";
-import { countEmbeddedLocalTracks } from "../services/trackEmbeddings";
+import {
+    countEmbeddedLocalTracks,
+    missingActiveEmbeddingWhere,
+} from "../services/trackEmbeddings";
+import { getActiveSpace } from "../services/embeddingSpaces";
 import analysisInternalRoutes from "./analysisInternal";
 import os from "os";
 import {
@@ -786,11 +790,15 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
                 ? Math.min(requestedLimit, 1000)
                 : 500;
         const force = req.body.force === true;
+        const activeSpace = await getActiveSpace();
 
         // If force mode, delete all existing embeddings first
         if (force) {
             await prisma.trackEmbedding.deleteMany({
-                where: { track: LOCAL_TRACK_WHERE },
+                where: {
+                    spaceId: activeSpace.id,
+                    track: LOCAL_TRACK_WHERE,
+                },
             });
             await prisma.track.updateMany({
                 where: LOCAL_TRACK_WHERE,
@@ -806,7 +814,7 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
         // Find tracks without vibe embeddings (all tracks if force was used)
         const tracks = await prisma.track.findMany({
             where: {
-                embedding: null,
+                ...missingActiveEmbeddingWhere(activeSpace.id),
                 ...TRACK_VISIBLE_WHERE,
                 ...LOCAL_TRACK_WHERE,
             },

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -47,6 +47,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/discovery/index.ts` | Discovery |
 | `backend/src/services/discoveryLogger.ts` | Core |
 | `backend/src/services/downloadQueue.ts` | Core |
+| `backend/src/services/embeddingSpaces.ts` | Active embedding-space registry lookup and process-local cache |
 | `backend/src/services/enrichment.ts` | Core |
 | `backend/src/services/enrichmentFailureService.ts` | Core |
 | `backend/src/services/enrichmentState.ts` | Core |

--- a/backend/src/services/__tests__/audioAnalysisCleanup.test.ts
+++ b/backend/src/services/__tests__/audioAnalysisCleanup.test.ts
@@ -33,6 +33,9 @@ describe("audioAnalysisCleanupService", () => {
         jest.doMock("../enrichmentFailureService", () => ({
             enrichmentFailureService,
         }));
+        jest.doMock("../embeddingSpaces", () => ({
+            getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
+        }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const module = require("../audioAnalysisCleanup");
@@ -117,6 +120,10 @@ describe("audioAnalysisCleanupService", () => {
         prisma.track.update.mockResolvedValue({});
 
         const result = await service.cleanupStaleProcessing();
+
+        const [query, ...values] = prisma.$queryRaw.mock.calls[0];
+        expect(query.join(" ")).toContain("space_id =");
+        expect(values).toContain("space-active");
 
         expect(prisma.track.update).toHaveBeenCalledWith({
             where: { id: "track-1" },

--- a/backend/src/services/__tests__/embeddingSpaces.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaces.test.ts
@@ -1,0 +1,176 @@
+const mockFindMany = jest.fn();
+const mockLoggerError = jest.fn();
+const mockChild = jest.fn((_scope: string) => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: mockLoggerError,
+    child: jest.fn(),
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        embeddingSpace: {
+            findMany: (...args: unknown[]) => mockFindMany(...args),
+        },
+    },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: { child: (scope: string) => mockChild(scope) },
+}));
+
+import {
+    getActiveSpace,
+    invalidateActiveSpaceCache,
+    NoActiveEmbeddingSpaceError,
+} from "../embeddingSpaces";
+
+const activeSpace = {
+    id: "space-active",
+    family: "clap-music-audioset",
+    checkpointHash: "checkpoint-hash",
+    dim: 512,
+    preprocessing: { sampleRateHz: 48000, mono: true },
+    createdAt: new Date("2026-08-16T12:00:00.000Z"),
+};
+
+describe("embeddingSpaces", () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(
+            new Date("2026-08-16T12:00:00.000Z"),
+        );
+        jest.clearAllMocks();
+        invalidateActiveSpaceCache();
+        mockFindMany.mockResolvedValue([activeSpace]);
+    });
+
+    afterEach(() => {
+        invalidateActiveSpaceCache();
+        jest.useRealTimers();
+    });
+
+    it("caches one active space for sixty seconds", async () => {
+        await expect(getActiveSpace()).resolves.toMatchObject({
+            id: "space-active",
+            dim: 512,
+        });
+        await getActiveSpace();
+        expect(mockFindMany).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(59_999);
+        await getActiveSpace();
+        expect(mockFindMany).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(2);
+        await getActiveSpace();
+        expect(mockFindMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("invalidates the cached active space explicitly", async () => {
+        await getActiveSpace();
+        invalidateActiveSpaceCache();
+        await getActiveSpace();
+
+        expect(mockFindMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws a typed error when no space is active", async () => {
+        mockFindMany.mockResolvedValue([]);
+
+        const promise = getActiveSpace();
+        await expect(promise).rejects.toBeInstanceOf(
+            NoActiveEmbeddingSpaceError,
+        );
+        await expect(promise).rejects.toMatchObject({
+            code: "NO_ACTIVE_EMBEDDING_SPACE",
+        });
+    });
+
+    it("shares one in-flight load between concurrent callers", async () => {
+        let resolveLoad: (rows: unknown[]) => void = () => {};
+        mockFindMany.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveLoad = resolve;
+                }),
+        );
+
+        const first = getActiveSpace();
+        const second = getActiveSpace();
+        resolveLoad([activeSpace]);
+
+        await expect(first).resolves.toMatchObject({ id: "space-active" });
+        await expect(second).resolves.toMatchObject({ id: "space-active" });
+        expect(mockFindMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("never lets a load started before invalidation repopulate the cache", async () => {
+        let resolveLoad: (rows: unknown[]) => void = () => {};
+        mockFindMany.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveLoad = resolve;
+                }),
+        );
+
+        const stale = getActiveSpace();
+        invalidateActiveSpaceCache();
+        resolveLoad([activeSpace]);
+        await expect(stale).resolves.toMatchObject({ id: "space-active" });
+
+        await getActiveSpace();
+        expect(mockFindMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the in-flight load after a rejection", async () => {
+        mockFindMany
+            .mockRejectedValueOnce(new Error("db down"))
+            .mockResolvedValueOnce([activeSpace]);
+
+        await expect(getActiveSpace()).rejects.toThrow("db down");
+        await expect(getActiveSpace()).resolves.toMatchObject({
+            id: "space-active",
+        });
+        expect(mockFindMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache a zero-active failure", async () => {
+        mockFindMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([activeSpace]);
+
+        await expect(getActiveSpace()).rejects.toBeInstanceOf(
+            NoActiveEmbeddingSpaceError,
+        );
+        await expect(getActiveSpace()).resolves.toMatchObject({
+            id: "space-active",
+        });
+        expect(mockFindMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs an invariant error and returns the oldest active space", async () => {
+        const newer = {
+            ...activeSpace,
+            id: "space-newer",
+            createdAt: new Date("2026-08-16T13:00:00.000Z"),
+        };
+        mockFindMany.mockResolvedValue([activeSpace, newer]);
+
+        await expect(getActiveSpace()).resolves.toMatchObject({
+            id: "space-active",
+        });
+
+        expect(mockFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { status: "active" },
+                orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+                take: 2,
+            }),
+        );
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Multiple active embedding spaces violate the registry invariant; using the oldest",
+            { activeSpaceIds: ["space-active", "space-newer"] },
+        );
+    });
+});

--- a/backend/src/services/__tests__/featureDetection.test.ts
+++ b/backend/src/services/__tests__/featureDetection.test.ts
@@ -6,6 +6,7 @@ const mockTrackFindFirst = jest.fn();
 const mockTrackEmbeddingCount = jest.fn();
 const mockLoggerDebug = jest.fn();
 const mockLoggerError = jest.fn();
+const mockGetActiveSpace = jest.fn();
 
 jest.mock("fs", () => ({
     existsSync: (...args: unknown[]) => mockExistsSync(...args),
@@ -35,10 +36,15 @@ jest.mock("../../utils/logger", () => ({
     },
 }));
 
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
+}));
+
 describe("featureDetection service", () => {
     beforeEach(() => {
         jest.resetModules();
         jest.clearAllMocks();
+        mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
     });
 
     async function loadService() {
@@ -81,6 +87,9 @@ describe("featureDetection service", () => {
         expect(mockRedisGet).toHaveBeenCalledWith("audio:worker:heartbeat");
         expect(mockRedisGet).toHaveBeenCalledWith("clap:worker:heartbeat");
         expect(mockTrackEmbeddingCount).toHaveBeenCalledTimes(1);
+        expect(mockTrackEmbeddingCount).toHaveBeenCalledWith({
+            where: { spaceId: "space-active" },
+        });
     });
 
     it("falls back to database feature presence when heartbeat is stale or missing", async () => {

--- a/backend/src/services/__tests__/hybridSimilarity.test.ts
+++ b/backend/src/services/__tests__/hybridSimilarity.test.ts
@@ -3,6 +3,7 @@ const mockRunAnnQuery = jest.fn();
 const mockGetFeatures = jest.fn();
 const mockLoggerDebug = jest.fn();
 const mockLoggerWarn = jest.fn();
+const mockGetActiveSpace = jest.fn();
 
 jest.mock("../../utils/db", () => ({
     prisma: {
@@ -32,6 +33,10 @@ jest.mock("../../utils/logger", () => ({
         debug: (...args: unknown[]) => mockLoggerDebug(...args),
         warn: (...args: unknown[]) => mockLoggerWarn(...args),
     },
+}));
+
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
 }));
 
 import { findSimilarTracks, type SimilarTrack } from "../hybridSimilarity";
@@ -65,6 +70,8 @@ describe("hybridSimilarity service", () => {
         mockGetFeatures.mockReset();
         mockLoggerDebug.mockReset();
         mockLoggerWarn.mockReset();
+        mockGetActiveSpace.mockReset();
+        mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
     });
 
     it("uses hybrid mode (via the ANN helper) when both feature systems are available", async () => {
@@ -100,6 +107,12 @@ describe("hybridSimilarity service", () => {
             values: unknown[];
         };
         expect(sqlArg.values).toContain(sourceTrackId);
+        expect(sqlArg.values).toContain("space-active");
+        expect(
+            (
+                mockRunAnnQuery.mock.calls[0]?.[0] as { strings: string[] }
+            ).strings.join(" "),
+        ).toContain("te.space_id =");
         expect(
             sqlArg.values.filter((value: unknown) => value === limit * 5)
                 .length,
@@ -140,6 +153,12 @@ describe("hybridSimilarity service", () => {
             values: unknown[];
         };
         expect(sqlArg.values).toContain(sourceTrackId);
+        expect(sqlArg.values).toContain("space-active");
+        expect(
+            (
+                mockRunAnnQuery.mock.calls[0]?.[0] as { strings: string[] }
+            ).strings.join(" "),
+        ).toContain("te.space_id =");
         expect(
             sqlArg.values.filter((value: unknown) => value === 100),
         ).toHaveLength(1);

--- a/backend/src/services/__tests__/trackEmbeddings.test.ts
+++ b/backend/src/services/__tests__/trackEmbeddings.test.ts
@@ -1,9 +1,20 @@
 jest.mock("../../utils/db", () => ({
-    prisma: { $executeRaw: jest.fn(), $queryRaw: jest.fn() },
+    prisma: {
+        $executeRaw: jest.fn(),
+        $queryRaw: jest.fn(),
+        track: { findMany: jest.fn() },
+        trackEmbedding: { deleteMany: jest.fn() },
+    },
 }));
 
 jest.mock("../../utils/annQuery", () => ({
     runAnnQuery: jest.fn(),
+}));
+
+const mockGetActiveSpace = jest.fn();
+
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
 }));
 
 import { prisma } from "../../utils/db";
@@ -12,8 +23,10 @@ import * as embeddingUtils from "../../utils/embedding";
 import {
     countEmbeddedBrowsableTracks,
     countEmbeddedLocalTracks,
+    deleteActiveLocalTrackEmbeddings,
     fetchEmbeddingsByTrackIds,
     fetchTrackEmbedding,
+    findLocalTracksNeedingActiveEmbedding,
     findNearestToEmbedding,
     findTracksByTextEmbedding,
     upsertTrackEmbedding,
@@ -25,6 +38,13 @@ const parseEmbeddingSpy = jest.spyOn(embeddingUtils, "parseEmbedding");
 
 beforeEach(() => {
     jest.clearAllMocks();
+    mockGetActiveSpace.mockResolvedValue({
+        id: "space-active",
+        family: "clap-music-audioset",
+        checkpointHash: "checkpoint-hash",
+        dim: 512,
+        preprocessing: {},
+    });
 });
 
 describe("upsertTrackEmbedding", () => {
@@ -34,6 +54,11 @@ describe("upsertTrackEmbedding", () => {
         await upsertTrackEmbedding("track-1", Array(512).fill(0.25));
 
         expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+        const [query, ...values] = (prisma.$executeRaw as jest.Mock).mock
+            .calls[0];
+        expect(query.join(" ")).toContain("space_id");
+        expect(query.join(" ")).not.toContain("model_version");
+        expect(values).toContain("space-active");
     });
 
     it("rejects malformed vectors before writing", async () => {
@@ -41,6 +66,41 @@ describe("upsertTrackEmbedding", () => {
             "512 finite values",
         );
         expect(prisma.$executeRaw).not.toHaveBeenCalled();
+    });
+});
+
+describe("active-space maintenance", () => {
+    it("selects local tracks missing an active-space embedding", async () => {
+        (prisma.track.findMany as jest.Mock).mockResolvedValue([]);
+
+        await findLocalTracksNeedingActiveEmbedding(25);
+
+        expect(prisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    AND: expect.arrayContaining([
+                        expect.objectContaining({
+                            OR: expect.arrayContaining([{ embedding: null }]),
+                        }),
+                    ]),
+                }),
+                take: 25,
+            }),
+        );
+    });
+
+    it("deletes only local vectors in the active space", async () => {
+        (prisma.trackEmbedding.deleteMany as jest.Mock).mockResolvedValue({
+            count: 3,
+        });
+
+        await expect(deleteActiveLocalTrackEmbeddings()).resolves.toBe(3);
+        expect(prisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
+            where: {
+                spaceId: "space-active",
+                track: { origin: "LOCAL" },
+            },
+        });
     });
 });
 
@@ -53,6 +113,7 @@ describe("fetchEmbeddingsByTrackIds", () => {
         const query = (prisma.$queryRaw as jest.Mock).mock.calls[0][0];
         expect(query.join(" ")).toContain('JOIN "Track"');
         expect(query.join(" ")).toContain('t."removedAt" IS NULL');
+        expect(query.join(" ")).toContain("te.space_id =");
     });
 
     it("does not query for an empty track list", async () => {
@@ -69,6 +130,9 @@ describe("fetchTrackEmbedding", () => {
             0.25, -0.5, 1,
         ]);
         expect(parseEmbeddingSpy).toHaveBeenCalledWith("[0.25,-0.5,1]");
+        const [query, ...values] = mockQueryRaw.mock.calls[0];
+        expect(query.join(" ")).toContain("te.space_id =");
+        expect(values).toContain("space-active");
     });
 
     it("returns null when the track has no embedding row", async () => {
@@ -88,6 +152,8 @@ describe("findNearestToEmbedding", () => {
         expect(mockRunAnnQuery).toHaveBeenCalledTimes(1);
         const query = mockRunAnnQuery.mock.calls[0][0];
         expect(query.strings.join(" ")).toContain("FROM track_embeddings te");
+        expect(query.strings.join(" ")).toContain("te.space_id =");
+        expect(query.values).toContain("space-active");
         expect(query.strings.join(" ")).not.toContain("!= ALL");
     });
 
@@ -99,6 +165,7 @@ describe("findNearestToEmbedding", () => {
         const query = mockRunAnnQuery.mock.calls[0][0];
         expect(query.strings.join(" ")).toContain("!= ALL");
         expect(query.values).toContainEqual(["track-2"]);
+        expect(query.values).toContain("space-active");
     });
 });
 
@@ -114,6 +181,8 @@ describe("findTracksByTextEmbedding", () => {
         expect(mockRunAnnQuery).toHaveBeenCalledTimes(1);
         const query = mockRunAnnQuery.mock.calls[0][0];
         expect(query.strings.join(" ")).toContain("FROM track_embeddings te");
+        expect(query.strings.join(" ")).toContain("te.space_id =");
+        expect(query.values).toContain("space-active");
         const values = query.values as unknown[];
         // Pin binding positions so a maxDistance/candidateLimit swap cannot
         // pass: LIMIT binds last, preceded by the ORDER BY vector, preceded
@@ -132,6 +201,7 @@ describe("embedding counts", () => {
 
         const query = mockQueryRaw.mock.calls[0][0];
         expect(query.join(" ")).toContain("FROM track_embeddings te");
+        expect(query.join(" ")).toContain("te.space_id =");
     });
 
     it("counts only local embeddings for analysis status", async () => {
@@ -141,6 +211,7 @@ describe("embedding counts", () => {
 
         const query = mockQueryRaw.mock.calls[0][0];
         expect(query.join(" ")).toContain("t.origin =");
+        expect(query.join(" ")).toContain("te.space_id =");
     });
 
     it("returns zero when a count query has no rows", async () => {

--- a/backend/src/services/__tests__/umapProjection.test.ts
+++ b/backend/src/services/__tests__/umapProjection.test.ts
@@ -37,6 +37,7 @@ const mockUmapLoggerDebug = jest.fn<(...args: unknown[]) => void>();
 const mockUmapLoggerInfo = jest.fn<(...args: unknown[]) => void>();
 const mockUmapLoggerWarn = jest.fn<(...args: unknown[]) => void>();
 const mockUmapLoggerError = jest.fn<(...args: unknown[]) => void>();
+const mockGetActiveSpace = jest.fn<() => Promise<{ id: string }>>();
 
 let pipeline: MockPipeline;
 let workerBehavior: ((worker: MockWorker) => void) | null = null;
@@ -116,6 +117,10 @@ jest.mock("../../utils/embedding", () => ({
     parseEmbedding: (embedding: string) => mockParseEmbedding(embedding),
 }));
 
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: () => mockGetActiveSpace(),
+}));
+
 jest.mock("worker_threads", () => ({
     Worker: MockWorker,
 }));
@@ -191,6 +196,7 @@ describe("computeMapProjection", () => {
         mockParseEmbedding.mockImplementation(
             (embedding: string) => JSON.parse(embedding) as number[],
         );
+        mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
     });
 
     it("returns cached projection data without querying the database", async () => {
@@ -221,6 +227,11 @@ describe("computeMapProjection", () => {
         await flushMicrotasks();
 
         expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+        const [query, ...values] = mockQueryRaw.mock.calls[0];
+        expect((query as readonly string[]).join(" ")).toContain(
+            "te.space_id =",
+        );
+        expect(values).toContain("space-active");
         expect(workers).toHaveLength(1);
         expect(mockUmapLoggerInfo).toHaveBeenCalledWith(
             "[VIBE-MAP] Waiting for in-progress computation",

--- a/backend/src/services/audioAnalysisCleanup.ts
+++ b/backend/src/services/audioAnalysisCleanup.ts
@@ -2,6 +2,7 @@ import { prisma } from "../utils/db";
 import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
 import { logger } from "../utils/logger";
 import { enrichmentFailureService } from "./enrichmentFailureService";
+import { getActiveSpace } from "./embeddingSpaces";
 
 const STALE_THRESHOLD_MINUTES = 15;
 const MAX_RETRIES = 3;
@@ -110,6 +111,7 @@ class AudioAnalysisCleanupService {
         if (staleTracks.length === 0) {
             return { reset: 0, permanentlyFailed: 0, recovered: 0 };
         }
+        const activeSpace = await getActiveSpace();
 
         logger.debug(
             `[AudioAnalysisCleanup] Found ${staleTracks.length} stale tracks (processing > ${STALE_THRESHOLD_MINUTES} min)`,
@@ -126,7 +128,10 @@ class AudioAnalysisCleanupService {
             const existingEmbedding = await prisma.$queryRaw<
                 { count: bigint }[]
             >`
-                SELECT COUNT(*) as count FROM track_embeddings WHERE track_id = ${track.id}
+                SELECT COUNT(*) as count
+                FROM track_embeddings
+                WHERE track_id = ${track.id}
+                  AND space_id = ${activeSpace.id}
             `;
 
             if (Number(existingEmbedding[0]?.count) > 0) {

--- a/backend/src/services/embeddingSpaces.ts
+++ b/backend/src/services/embeddingSpaces.ts
@@ -1,0 +1,99 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import { logger } from "../utils/logger";
+
+const CACHE_TTL_MS = 60_000;
+const log = logger.child("EmbeddingSpaces");
+
+/** Identity and vector contract for the embedding space serving requests. */
+export interface ActiveEmbeddingSpace {
+    id: string;
+    family: string;
+    checkpointHash: string;
+    dim: number;
+    preprocessing: Prisma.JsonValue;
+}
+
+/** Raised when the registry has no space available to serve vibe requests. */
+export class NoActiveEmbeddingSpaceError extends Error {
+    readonly code = "NO_ACTIVE_EMBEDDING_SPACE";
+
+    constructor() {
+        super("No active embedding space is configured");
+        this.name = "NoActiveEmbeddingSpaceError";
+    }
+}
+
+let cachedSpace: ActiveEmbeddingSpace | null = null;
+let cacheExpiresAt = 0;
+let inFlightLoad: Promise<ActiveEmbeddingSpace> | null = null;
+
+function toActiveSpace(
+    row: ActiveEmbeddingSpace & { createdAt: Date },
+): ActiveEmbeddingSpace {
+    return {
+        id: row.id,
+        family: row.family,
+        checkpointHash: row.checkpointHash,
+        dim: row.dim,
+        preprocessing: row.preprocessing,
+    };
+}
+
+async function loadActiveSpace(): Promise<ActiveEmbeddingSpace> {
+    const rows = await prisma.embeddingSpace.findMany({
+        where: { status: "active" },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        take: 2,
+        select: {
+            id: true,
+            family: true,
+            checkpointHash: true,
+            dim: true,
+            preprocessing: true,
+            createdAt: true,
+        },
+    });
+    if (rows.length === 0) throw new NoActiveEmbeddingSpaceError();
+    if (rows.length > 1) {
+        log.error(
+            "Multiple active embedding spaces violate the registry invariant; using the oldest",
+            { activeSpaceIds: rows.map((row) => row.id) },
+        );
+    }
+    return toActiveSpace(rows[0]);
+}
+
+/**
+ * Resolve the oldest active embedding space with a 60-second local cache.
+ * Single-flight: concurrent callers share one load, and a load started
+ * before an invalidation never repopulates the cache afterwards.
+ */
+export async function getActiveSpace(): Promise<ActiveEmbeddingSpace> {
+    if (cachedSpace && Date.now() < cacheExpiresAt) return cachedSpace;
+    if (inFlightLoad) return inFlightLoad;
+
+    const load = loadActiveSpace().then(
+        (activeSpace) => {
+            if (inFlightLoad === load) {
+                cachedSpace = activeSpace;
+                cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+                inFlightLoad = null;
+            }
+            return activeSpace;
+        },
+        (error: unknown) => {
+            if (inFlightLoad === load) inFlightLoad = null;
+            throw error;
+        },
+    );
+    inFlightLoad = load;
+    return load;
+}
+
+/** Clear the process-local active-space cache for cutover and test control. */
+export function invalidateActiveSpaceCache(): void {
+    cachedSpace = null;
+    cacheExpiresAt = 0;
+    inFlightLoad = null;
+}

--- a/backend/src/services/featureDetection.ts
+++ b/backend/src/services/featureDetection.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { redisClient } from "../utils/redis";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { getActiveSpace } from "./embeddingSpaces";
 
 // Analyzer script paths in the Docker image
 const ESSENTIA_ANALYZER_PATH = "/app/audio-analyzer/analyzer.py";
@@ -87,7 +88,10 @@ class FeatureDetectionService {
                 }
             }
 
-            const embeddingCount = await prisma.trackEmbedding.count();
+            const activeSpace = await getActiveSpace();
+            const embeddingCount = await prisma.trackEmbedding.count({
+                where: { spaceId: activeSpace.id },
+            });
             return embeddingCount > 0;
         } catch (error) {
             logger.error("[FEATURE-DETECTION] Error checking CLAP:", error);

--- a/backend/src/services/hybridSimilarity.ts
+++ b/backend/src/services/hybridSimilarity.ts
@@ -8,6 +8,7 @@ import {
     TRACK_BROWSE_SQL,
     trackBrowseSql,
 } from "../utils/libraryRadioPredicates";
+import { getActiveSpace } from "./embeddingSpaces";
 
 export interface SimilarTrack {
     id: string;
@@ -144,6 +145,7 @@ async function findSimilarHybrid(
 ): Promise<SimilarTrack[]> {
     // Fetch 5x candidates from CLAP to ensure good coverage after re-ranking
     const candidateLimit = Math.max(limit * CANDIDATE_MULTIPLIER, limit);
+    const activeSpace = await getActiveSpace();
 
     const results = await runAnnQuery<SimilarTrack[]>(Prisma.sql`
         WITH source AS (
@@ -155,6 +157,7 @@ async function findSimilarHybrid(
             JOIN "Track" t ON te.track_id = t.id
             WHERE t."removedAt" IS NULL
               AND ${TRACK_BROWSE_SQL}
+              AND te.space_id = ${activeSpace.id}
               AND te.track_id = ${trackId}
         ),
         clap_candidates AS (
@@ -165,6 +168,7 @@ async function findSimilarHybrid(
             JOIN "Track" candidate_track ON te.track_id = candidate_track.id
             WHERE candidate_track."removedAt" IS NULL
               AND ${trackBrowseSql("candidate_track")}
+              AND te.space_id = ${activeSpace.id}
               AND te.track_id != ${trackId}
             ORDER BY te.embedding <=> (SELECT embedding FROM source)
             LIMIT ${candidateLimit}
@@ -212,6 +216,7 @@ async function findSimilarClapOnly(
     limit: number,
 ): Promise<SimilarTrack[]> {
     const candidateLimit = Math.max(limit * CANDIDATE_MULTIPLIER, limit);
+    const activeSpace = await getActiveSpace();
     const results = await runAnnQuery<SimilarTrack[]>(Prisma.sql`
         WITH source AS (
             SELECT te.embedding
@@ -219,6 +224,7 @@ async function findSimilarClapOnly(
             JOIN "Track" source_track ON te.track_id = source_track.id
             WHERE source_track."removedAt" IS NULL
               AND ${trackBrowseSql("source_track")}
+              AND te.space_id = ${activeSpace.id}
               AND te.track_id = ${trackId}
         )
         SELECT
@@ -242,6 +248,7 @@ async function findSimilarClapOnly(
         JOIN "Artist" ar ON a."artistId" = ar.id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
           AND te.track_id != ${trackId}
         ORDER BY distance
         LIMIT ${candidateLimit}

--- a/backend/src/services/trackEmbeddings.ts
+++ b/backend/src/services/trackEmbeddings.ts
@@ -3,6 +3,8 @@ import { prisma } from "../utils/db";
 import { parseEmbedding } from "../utils/embedding";
 import { runAnnQuery } from "../utils/annQuery";
 import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
+import { getActiveSpace } from "./embeddingSpaces";
+import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
 
 /**
  * trackEmbeddings — service-layer reads of the pgvector `track_embeddings`
@@ -58,7 +60,58 @@ export interface TextSearchResult {
     speechiness: number | null;
 }
 
-const EMBEDDING_DIMENSIONS = 512;
+/** Prisma relation filter for tracks without a vector in `activeSpaceId`. */
+export function missingActiveEmbeddingWhere(
+    activeSpaceId: string,
+): Prisma.TrackWhereInput {
+    return {
+        OR: [
+            { embedding: null },
+            {
+                embedding: {
+                    is: { spaceId: { not: activeSpaceId } },
+                },
+            },
+        ],
+    };
+}
+
+/** Select bounded local queue candidates missing an active-space vector. */
+export async function findLocalTracksNeedingActiveEmbedding(
+    limit: number,
+): Promise<Array<{ id: string; filePath: string | null }>> {
+    const activeSpace = await getActiveSpace();
+    return prisma.track.findMany({
+        where: {
+            removedAt: null,
+            ...LOCAL_TRACK_WHERE,
+            AND: [
+                missingActiveEmbeddingWhere(activeSpace.id),
+                {
+                    OR: [
+                        { vibeAnalysisStatus: null },
+                        { vibeAnalysisStatus: "pending" },
+                    ],
+                },
+            ],
+        },
+        select: { id: true, filePath: true },
+        take: limit,
+        orderBy: { fileModified: "desc" },
+    });
+}
+
+/** Delete active-space vectors for local tracks during a forced rebuild. */
+export async function deleteActiveLocalTrackEmbeddings(): Promise<number> {
+    const activeSpace = await getActiveSpace();
+    const result = await prisma.trackEmbedding.deleteMany({
+        where: {
+            spaceId: activeSpace.id,
+            track: LOCAL_TRACK_WHERE,
+        },
+    });
+    return result.count;
+}
 
 /** Upserts one validated CLAP vector received from a trusted service boundary. */
 export async function upsertTrackEmbedding(
@@ -66,18 +119,24 @@ export async function upsertTrackEmbedding(
     embedding: readonly number[],
 ): Promise<void> {
     if (
-        embedding.length !== EMBEDDING_DIMENSIONS ||
+        embedding.length === 0 ||
         embedding.some((value) => !Number.isFinite(value))
     ) {
-        throw new Error("Track embedding must contain 512 finite values");
+        throw new Error("Track embedding must contain only finite values");
+    }
+    const activeSpace = await getActiveSpace();
+    if (embedding.length !== activeSpace.dim) {
+        throw new Error(
+            `Track embedding must contain ${activeSpace.dim} finite values`,
+        );
     }
     const vector = `[${embedding.join(",")}]`;
     await prisma.$executeRaw`
-        INSERT INTO track_embeddings (track_id, embedding, model_version, analyzed_at)
-        VALUES (${trackId}, ${vector}::vector, 'laion-clap-music', NOW())
+        INSERT INTO track_embeddings (track_id, embedding, space_id, analyzed_at)
+        VALUES (${trackId}, ${vector}::vector, ${activeSpace.id}, NOW())
         ON CONFLICT (track_id) DO UPDATE SET
             embedding = EXCLUDED.embedding,
-            model_version = EXCLUDED.model_version,
+            space_id = EXCLUDED.space_id,
             analyzed_at = EXCLUDED.analyzed_at
     `;
 }
@@ -92,6 +151,7 @@ export async function fetchEmbeddingsByTrackIds(
     trackIds: readonly string[],
 ): Promise<TrackEmbeddingRow[]> {
     if (trackIds.length === 0) return [];
+    const activeSpace = await getActiveSpace();
     const rows = await prisma.$queryRaw<
         { trackId: string; embedding: string }[]
     >`
@@ -100,6 +160,7 @@ export async function fetchEmbeddingsByTrackIds(
         JOIN "Track" t ON t.id = te.track_id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
           AND te.track_id = ANY(${trackIds as string[]})
     `;
     return rows.map((row) => ({
@@ -114,12 +175,15 @@ export async function fetchEmbeddingsByTrackIds(
 export async function fetchTrackEmbedding(
     trackId: string,
 ): Promise<number[] | null> {
+    const activeSpace = await getActiveSpace();
     const rows = await prisma.$queryRaw<{ embedding: string }[]>`
         SELECT te.embedding::text
         FROM track_embeddings te
         JOIN "Track" t ON te.track_id = t.id
         WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL} AND te.track_id = ${trackId}
+          AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
+          AND te.track_id = ${trackId}
         LIMIT 1
     `;
     if (!rows.length) return null;
@@ -132,6 +196,7 @@ export async function findNearestToEmbedding(
     limit: number,
     excludeIds: string[] = [],
 ): Promise<NearestTrackRow[]> {
+    const activeSpace = await getActiveSpace();
     if (excludeIds.length > 0) {
         return runAnnQuery<NearestTrackRow[]>(Prisma.sql`
             SELECT
@@ -146,6 +211,7 @@ export async function findNearestToEmbedding(
             JOIN "Artist" ar ON a."artistId" = ar.id
             WHERE t."removedAt" IS NULL
               AND ${TRACK_BROWSE_SQL}
+              AND te.space_id = ${activeSpace.id}
               AND te.track_id != ALL(${excludeIds}::text[])
             ORDER BY te.embedding <=> ${embedding}::vector
             LIMIT ${limit}
@@ -164,6 +230,7 @@ export async function findNearestToEmbedding(
         JOIN "Artist" ar ON a."artistId" = ar.id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
         ORDER BY te.embedding <=> ${embedding}::vector
         LIMIT ${limit}
     `);
@@ -175,6 +242,7 @@ export async function findTracksByTextEmbedding(
     maxDistance: number,
     candidateLimit: number,
 ): Promise<TextSearchResult[]> {
+    const activeSpace = await getActiveSpace();
     return runAnnQuery<TextSearchResult[]>(Prisma.sql`
         SELECT
             t.id,
@@ -200,6 +268,7 @@ export async function findTracksByTextEmbedding(
         JOIN "Artist" ar ON a."artistId" = ar.id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
           AND te.embedding <=> ${searchEmbedding}::vector <= ${maxDistance}
         ORDER BY te.embedding <=> ${searchEmbedding}::vector
         LIMIT ${candidateLimit}
@@ -208,12 +277,14 @@ export async function findTracksByTextEmbedding(
 
 /** Counts embeddings for tracks visible on browsable library surfaces. */
 export async function countEmbeddedBrowsableTracks(): Promise<number> {
+    const activeSpace = await getActiveSpace();
     const embeddedTracks = await prisma.$queryRaw<{ count: bigint }[]>`
         SELECT COUNT(*) as count
         FROM track_embeddings te
         JOIN "Track" t ON te.track_id = t.id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
     `;
 
     return Number(embeddedTracks[0]?.count || 0);
@@ -221,12 +292,14 @@ export async function countEmbeddedBrowsableTracks(): Promise<number> {
 
 /** Counts embeddings for local tracks included in analysis status. */
 export async function countEmbeddedLocalTracks(): Promise<number> {
+    const activeSpace = await getActiveSpace();
     const embeddingCount = await prisma.$queryRaw<{ count: bigint }[]>`
         SELECT COUNT(*) as count
         FROM track_embeddings te
         INNER JOIN "Track" t ON t.id = te.track_id
         WHERE t."removedAt" IS NULL
           AND t.origin = ${"LOCAL"}::"TrackOrigin"
+          AND te.space_id = ${activeSpace.id}
     `;
     return Number(embeddingCount[0]?.count || 0);
 }

--- a/backend/src/services/umapProjection.ts
+++ b/backend/src/services/umapProjection.ts
@@ -6,6 +6,7 @@ import { redisClient } from "../utils/redis";
 import { logger } from "../utils/logger";
 import { parseEmbedding } from "../utils/embedding";
 import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
+import { getActiveSpace } from "./embeddingSpaces";
 
 const MIN_TRACKS_FOR_UMAP = 5;
 const MAX_EMBEDDINGS = 15000;
@@ -260,6 +261,7 @@ function runUmapInWorker(
 
 async function doCompute(): Promise<VibeMapResponse> {
     const startedAt = Date.now();
+    const activeSpace = await getActiveSpace();
 
     const rows = await prisma.$queryRaw<
         Array<TrackRow & { embedding: string }>
@@ -287,6 +289,7 @@ async function doCompute(): Promise<VibeMapResponse> {
         JOIN "Artist" ar ON a."artistId" = ar.id
         WHERE t."removedAt" IS NULL
           AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${activeSpace.id}
         ORDER BY RANDOM()
         LIMIT ${MAX_EMBEDDINGS}
     `;

--- a/backend/src/services/vibeCalibration.ts
+++ b/backend/src/services/vibeCalibration.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../utils/db";
 import { parseEmbedding } from "../utils/embedding";
+import { getActiveSpace } from "./embeddingSpaces";
 
 /**
  * vibeCalibration — bounded sampling of pairwise CLAP cosine distances.
@@ -100,8 +101,12 @@ function validateEmbeddings(embeddings: number[][]): void {
 
 /** Number of tracks with a CLAP embedding row (pure Prisma count). */
 export async function countEmbeddedTracks(): Promise<number> {
+    const activeSpace = await getActiveSpace();
     return prisma.trackEmbedding.count({
-        where: { track: { origin: "LOCAL" } },
+        where: {
+            spaceId: activeSpace.id,
+            track: { origin: "LOCAL" },
+        },
     });
 }
 
@@ -156,8 +161,12 @@ function pickRandom<T>(items: T[], count: number): T[] {
  * bounded by CALIBRATION_SAMPLE_SIZE (≤ 200 ⇒ ≤ 19,900 distance pairs).
  */
 export async function computeCalibration(): Promise<CalibrationPayload> {
+    const activeSpace = await getActiveSpace();
     const idRows = await prisma.trackEmbedding.findMany({
-        where: { track: { origin: "LOCAL" } },
+        where: {
+            spaceId: activeSpace.id,
+            track: { origin: "LOCAL" },
+        },
         select: { trackId: true },
         orderBy: { trackId: "asc" },
         take: CALIBRATION_ID_SCAN_CAP,
@@ -172,6 +181,7 @@ export async function computeCalibration(): Promise<CalibrationPayload> {
         FROM track_embeddings te
         JOIN "Track" t ON t.id = te.track_id
         WHERE t.origin = ${"LOCAL"}::"TrackOrigin"
+          AND te.space_id = ${activeSpace.id}
           AND te.track_id = ANY(${sampledIds})
     `;
 

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -48,6 +48,9 @@ describe("unified enrichment runtime behavior", () => {
                 findMany: jest.fn(async () => []),
                 update: jest.fn(async () => undefined),
             },
+            trackEmbedding: {
+                deleteMany: jest.fn(async () => ({ count: 0 })),
+            },
             enrichmentFailure: {
                 count: jest.fn(async () => 1),
             },
@@ -242,6 +245,9 @@ describe("unified enrichment runtime behavior", () => {
                 getFeatures,
             },
         }));
+        jest.doMock("../../services/embeddingSpaces", () => ({
+            getActiveSpace: jest.fn(async () => ({ id: "space-active" })),
+        }));
         jest.doMock("../../services/moodBucketService", () => ({
             moodBucketService,
         }));
@@ -290,6 +296,13 @@ describe("unified enrichment runtime behavior", () => {
         expect(progress.audioAnalysis.completed).toBe(4);
         expect(progress.clapEmbeddings.completed).toBe(2);
         expect(progress.coreComplete).toBe(false);
+        const embeddingCountCall = (
+            prisma.$queryRaw as jest.Mock
+        ).mock.calls.find(([query]) =>
+            query.join(" ").includes("FROM track_embeddings te"),
+        );
+        expect(embeddingCountCall?.[0].join(" ")).toContain("te.space_id =");
+        expect(embeddingCountCall?.slice(1)).toContain("space-active");
 
         await expect(enrichment.resetArtistsOnly()).resolves.toEqual({
             count: 3,
@@ -463,7 +476,12 @@ describe("unified enrichment runtime behavior", () => {
                 data: { enrichmentStatus: "pending" },
             }),
         );
-        expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
+            where: {
+                spaceId: "space-active",
+                track: { origin: "LOCAL" },
+            },
+        });
         expect(enrichmentFailureService.clearAllFailures).toHaveBeenCalledWith(
             "vibe",
         );
@@ -665,7 +683,24 @@ describe("unified enrichment runtime behavior", () => {
 
         expect(prisma.track.findMany).toHaveBeenCalledWith(
             expect.objectContaining({
-                where: expect.objectContaining({ embedding: null }),
+                where: expect.objectContaining({
+                    AND: expect.arrayContaining([
+                        {
+                            OR: [
+                                { embedding: null },
+                                {
+                                    embedding: {
+                                        is: {
+                                            spaceId: {
+                                                not: "space-active",
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ]),
+                }),
                 take: 100,
             }),
         );
@@ -2068,7 +2103,7 @@ describe("unified enrichment runtime behavior", () => {
         (prisma.artist.findMany as jest.Mock).mockResolvedValueOnce([]);
         (prisma.track.findMany as jest.Mock).mockImplementation(
             async (query?: any) =>
-                query?.where?.embedding === null
+                query?.where?.AND?.[0]?.OR?.[0]?.embedding === null
                     ? [
                           {
                               id: "track-vibe-fail",
@@ -2200,7 +2235,7 @@ describe("unified enrichment runtime behavior", () => {
             .mockResolvedValueOnce([{ count: BigInt(1) }]);
         (prisma.track.findMany as jest.Mock).mockImplementation(
             async (query?: any) =>
-                query?.where?.embedding === null
+                query?.where?.AND?.[0]?.OR?.[0]?.embedding === null
                     ? [
                           {
                               id: "track-vibe-ok",

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -30,6 +30,11 @@ import { moodBucketService } from "../services/moodBucketService";
 import pLimit from "p-limit";
 import { enqueueReservedWork } from "./enrichmentQueue";
 import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
+import { getActiveSpace } from "../services/embeddingSpaces";
+import {
+    deleteActiveLocalTrackEmbeddings,
+    findLocalTracksNeedingActiveEmbedding,
+} from "../services/trackEmbeddings";
 
 const log = logger.child("Enrichment");
 
@@ -573,12 +578,7 @@ export async function runFullEnrichment(options?: {
     });
 
     if (forceVibeRebuild) {
-        await prisma.$executeRaw`
-            DELETE FROM track_embeddings te
-            USING "Track" t
-            WHERE t.id = te.track_id
-              AND t.origin = ${"LOCAL"}::"TrackOrigin"
-        `;
+        await deleteActiveLocalTrackEmbeddings();
 
         await prisma.track.updateMany({
             where: LOCAL_TRACK_WHERE,
@@ -1397,20 +1397,9 @@ async function queueVibeEmbeddings(): Promise<number> {
     const tracks = await withEnrichmentPrismaRetry(
         "queueVibeEmbeddings.track.select",
         () =>
-            prisma.track.findMany({
-                where: {
-                    embedding: null,
-                    removedAt: null,
-                    ...LOCAL_TRACK_WHERE,
-                    OR: [
-                        { vibeAnalysisStatus: null },
-                        { vibeAnalysisStatus: "pending" },
-                    ],
-                },
-                select: { id: true, filePath: true },
-                take: config.analysisQueues.vibeMaxDepth,
-                orderBy: { fileModified: "desc" },
-            }),
+            findLocalTracksNeedingActiveEmbedding(
+                config.analysisQueues.vibeMaxDepth,
+            ),
     );
 
     if (tracks.length === 0) {
@@ -1654,68 +1643,76 @@ export async function getEnrichmentProgress() {
         clapEmbeddingCount,
         clapProcessing,
         clapFailedByStatus,
-    ] = await withEnrichmentPrismaRetry("getEnrichmentProgress.dbReads", () =>
-        prisma.$transaction([
-            prisma.artist.groupBy({
-                by: ["enrichmentStatus"],
-                _count: true,
-            }),
-            prisma.track.count({ where: LOCAL_TRACK_WHERE }),
-            prisma.$queryRaw<{ count: bigint }[]>`
+    ] = await withEnrichmentPrismaRetry(
+        "getEnrichmentProgress.dbReads",
+        async () => {
+            // Resolved inside the retry wrapper so a transient DB failure here is
+            // retried exactly like the reads it scopes.
+            const activeSpace = await getActiveSpace();
+            return prisma.$transaction([
+                prisma.artist.groupBy({
+                    by: ["enrichmentStatus"],
+                    _count: true,
+                }),
+                prisma.track.count({ where: LOCAL_TRACK_WHERE }),
+                prisma.$queryRaw<{ count: bigint }[]>`
                 SELECT COUNT(*) as count
                 FROM "Track"
                 WHERE "filePath" IS NOT NULL
                   AND origin = ${"LOCAL"}::"TrackOrigin"
             `,
-            prisma.track.count({
-                where: {
-                    ...LOCAL_TRACK_WHERE,
-                    AND: [
-                        { NOT: { lastfmTags: { equals: [] } } },
-                        { NOT: { lastfmTags: { equals: null } } },
-                    ],
-                },
-            }),
-            prisma.track.count({
-                where: {
-                    analysisStatus: "completed",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-            prisma.track.count({
-                where: {
-                    analysisStatus: "pending",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-            prisma.track.count({
-                where: {
-                    analysisStatus: "processing",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-            prisma.track.count({
-                where: {
-                    analysisStatus: "failed",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-            prisma.$queryRaw<{ count: bigint }[]>`
-                SELECT COUNT(*) as count FROM track_embeddings
+                prisma.track.count({
+                    where: {
+                        ...LOCAL_TRACK_WHERE,
+                        AND: [
+                            { NOT: { lastfmTags: { equals: [] } } },
+                            { NOT: { lastfmTags: { equals: null } } },
+                        ],
+                    },
+                }),
+                prisma.track.count({
+                    where: {
+                        analysisStatus: "completed",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+                prisma.track.count({
+                    where: {
+                        analysisStatus: "pending",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+                prisma.track.count({
+                    where: {
+                        analysisStatus: "processing",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+                prisma.track.count({
+                    where: {
+                        analysisStatus: "failed",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+                prisma.$queryRaw<{ count: bigint }[]>`
+                SELECT COUNT(*) as count
+                FROM track_embeddings te
+                WHERE te.space_id = ${activeSpace.id}
             `,
-            prisma.track.count({
-                where: {
-                    vibeAnalysisStatus: "processing",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-            prisma.track.count({
-                where: {
-                    vibeAnalysisStatus: "failed",
-                    ...LOCAL_TRACK_WHERE,
-                },
-            }),
-        ]),
+                prisma.track.count({
+                    where: {
+                        vibeAnalysisStatus: "processing",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+                prisma.track.count({
+                    where: {
+                        vibeAnalysisStatus: "failed",
+                        ...LOCAL_TRACK_WHERE,
+                    },
+                }),
+            ]);
+        },
     );
 
     const artistTotal = artistCounts.reduce((sum, s) => sum + s._count, 0);

--- a/docs/designs/vibe-embedding-provider.md
+++ b/docs/designs/vibe-embedding-provider.md
@@ -1,6 +1,6 @@
 # Pluggable Vibe Embedding Provider
 
-Spec drafted 2026-08-16 for [issue #537](https://github.com/soundspan/soundspan/issues/537). Status: accepted design, implementation not started. Decision record: keep the LAION-CLAP `music_audioset` 512-dimension embedding space; adopt DCLAP's distilled ONNX student as the default provider; formalize provider and embedding-space abstractions so future model changes are operational rollouts, not schema migrations.
+Spec drafted 2026-08-16 for [issue #537](https://github.com/soundspan/soundspan/issues/537). Status: accepted design; the registry portion of rollout phase 1 is implemented by migration `20260816120000_add_embedding_space_registry`; remaining provider work has not started. Decision record: keep the LAION-CLAP `music_audioset` 512-dimension embedding space; adopt DCLAP's distilled ONNX student as the default provider; formalize provider and embedding-space abstractions so future model changes are operational rollouts, not schema migrations.
 
 Related: cross-peer taste vectors in Blends ([issue #529](https://github.com/soundspan/soundspan/issues/529)) and federated discovery ([issue #530](https://github.com/soundspan/soundspan/issues/530)) depend on the space-identity contract defined here.
 

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -74,7 +74,7 @@ const BASELINE = Object.freeze({
     "backend/src/services/simpleDownloadManager.ts": 2387,
     "backend/src/services/spotify.ts": 1624,
     "backend/src/workers/processors/federationSyncProcessor.ts": 1545,
-    "backend/src/workers/unifiedEnrichment.ts": 1997,
+    "backend/src/workers/unifiedEnrichment.ts": 1994,
     "frontend/app/playlist/[id]/page.tsx": 1566,
     "frontend/app/vibe/page.tsx": 1528,
     "frontend/components/player/AudioPlaybackOrchestrator.tsx": 2997,

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -151,11 +151,7 @@ def resolve_active_space_id(db: "DatabaseConnection") -> str:
 def _is_embedding_space_insert_error(error: Exception) -> bool:
     """Return whether an insert failure can reflect stale space/schema state."""
     message = str(error).lower()
-    return (
-        "foreign key" in message
-        or "space_id" in message
-        or "embedding_spaces" in message
-    )
+    return "foreign key" in message or "space_id" in message or "embedding_spaces" in message
 
 
 def _resolve_music_path(file_path: str) -> str | None:

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -29,6 +29,7 @@ import threading
 import time
 import traceback
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -93,6 +94,7 @@ NUM_WORKERS = get_int_env("NUM_WORKERS", 2)
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:3006")
 MODEL_IDLE_TIMEOUT = get_int_env("MODEL_IDLE_TIMEOUT", 300)
 IDLE_POLL_SECONDS = 5
+ACTIVE_SPACE_CACHE_TTL_SECONDS = 300
 
 # Queue and channel names
 ANALYSIS_QUEUE = "audio:clap:queue"
@@ -111,6 +113,49 @@ MODEL_VERSION = "laion-clap-music-v1"
 # 60 seconds captures the "vibe" without intros/outros and reduces memory usage
 MAX_AUDIO_DURATION = 60  # seconds
 CLAP_SAMPLE_RATE = 48000  # 48kHz for CLAP model
+
+
+class ActiveEmbeddingSpaceNotFoundError(RuntimeError):
+    """Raised when a vibe embedding cannot be stamped with an active space."""
+
+
+def resolve_active_space_id(db: "DatabaseConnection") -> str:
+    """Resolve the oldest active embedding-space ID from PostgreSQL."""
+    cursor = db.get_cursor()
+    try:
+        cursor.execute(
+            """
+            SELECT id, created_at FROM embedding_spaces
+            WHERE status = 'active'
+            ORDER BY created_at ASC
+        """
+        )
+        rows = cursor.fetchall()
+    finally:
+        cursor.close()
+
+    if not rows:
+        raise ActiveEmbeddingSpaceNotFoundError(
+            "No active embedding space is registered; embedding was not stored"
+        )
+
+    active_ids = [str(row["id"]) for row in rows]
+    if len(active_ids) > 1:
+        logger.warning(
+            f"Multiple active embedding spaces found; using oldest {active_ids[0]}. "
+            f"Active ids: {', '.join(active_ids)}"
+        )
+    return active_ids[0]
+
+
+def _is_embedding_space_insert_error(error: Exception) -> bool:
+    """Return whether an insert failure can reflect stale space/schema state."""
+    message = str(error).lower()
+    return (
+        "foreign key" in message
+        or "space_id" in message
+        or "embedding_spaces" in message
+    )
 
 
 def _resolve_music_path(file_path: str) -> str | None:
@@ -338,10 +383,13 @@ class CLAPAnalyzer:
 class DatabaseConnection:
     """PostgreSQL connection manager with pgvector support and auto-reconnect"""
 
-    def __init__(self, url: str):
+    def __init__(self, url: str, clock: Callable[[], float] | None = None):
         """Store connection URL and initialize disconnected state."""
         self.url = url
         self.conn = None
+        self._clock = clock or time.monotonic
+        self._active_space_id: str | None = None
+        self._active_space_resolved_at: float | None = None
 
     def connect(self):
         """Establish database connection with pgvector extension"""
@@ -381,6 +429,24 @@ class DatabaseConnection:
         if not self.is_connected():
             self.reconnect()
         return self.conn.cursor(cursor_factory=RealDictCursor)
+
+    def get_active_space_id(self) -> str:
+        """Return the cached active embedding-space ID within its TTL."""
+        now = self._clock()
+        if self._active_space_id is not None and self._active_space_resolved_at is not None:
+            cache_age = now - self._active_space_resolved_at
+            if cache_age <= ACTIVE_SPACE_CACHE_TTL_SECONDS:
+                return self._active_space_id
+
+        space_id = resolve_active_space_id(self)
+        self._active_space_id = space_id
+        self._active_space_resolved_at = now
+        return space_id
+
+    def invalidate_active_space_id(self) -> None:
+        """Clear the active embedding-space cache before a forced refresh."""
+        self._active_space_id = None
+        self._active_space_resolved_at = None
 
     def commit(self):
         if self.conn:
@@ -491,7 +557,11 @@ class Worker:
             return
 
         # Store embedding in database
-        success = self._store_embedding(track_id, embedding)
+        try:
+            success = self._store_embedding(track_id, embedding)
+        except ActiveEmbeddingSpaceNotFoundError as error:
+            self._mark_failed(track_id, str(error))
+            return
 
         if success:
             self._update_track_status(track_id, "completed")
@@ -606,34 +676,79 @@ class Worker:
 
     def _store_embedding(self, track_id: str, embedding: np.ndarray) -> bool:
         """Store the embedding in the track_embeddings table"""
+        try:
+            space_id = self.db.get_active_space_id()
+        except ActiveEmbeddingSpaceNotFoundError:
+            raise
+        except Exception as error:
+            self._log_embedding_store_failure(track_id, error)
+            return False
+
+        embedding_list = embedding.tolist()
+        try:
+            self._insert_embedding(track_id, embedding_list, space_id)
+            return True
+        except Exception as error:
+            self.db.rollback()
+            if not _is_embedding_space_insert_error(error):
+                self._log_embedding_store_failure(track_id, error)
+                return False
+
+        logger.warning(
+            f"Embedding insert for {track_id} failed on embedding-space "
+            "schema state; refreshing the active embedding space once"
+        )
+        return self._retry_embedding_store(track_id, embedding_list)
+
+    def _retry_embedding_store(self, track_id: str, embedding_list: list[float]) -> bool:
+        """Retry one embedding insert after forcing an active-space refresh."""
+        self.db.invalidate_active_space_id()
+        try:
+            space_id = self.db.get_active_space_id()
+        except ActiveEmbeddingSpaceNotFoundError:
+            raise
+        except Exception as error:
+            self._log_embedding_store_failure(track_id, error)
+            return False
+
+        try:
+            self._insert_embedding(track_id, embedding_list, space_id)
+            return True
+        except Exception as error:
+            self.db.rollback()
+            self._log_embedding_store_failure(track_id, error)
+            return False
+
+    def _insert_embedding(
+        self,
+        track_id: str,
+        embedding_list: list[float],
+        space_id: str,
+    ) -> None:
+        """Execute one space-stamped embedding upsert."""
         cursor = self.db.get_cursor()
         try:
-            # Convert numpy array to list for pgvector
-            embedding_list = embedding.tolist()
-
             cursor.execute(
                 """
-                INSERT INTO track_embeddings (track_id, embedding, model_version, analyzed_at)
+                INSERT INTO track_embeddings (track_id, embedding, space_id, analyzed_at)
                 VALUES (%s, %s::vector, %s, %s)
                 ON CONFLICT (track_id)
                 DO UPDATE SET
                     embedding = EXCLUDED.embedding,
-                    model_version = EXCLUDED.model_version,
+                    space_id = EXCLUDED.space_id,
                     analyzed_at = EXCLUDED.analyzed_at
             """,
-                (track_id, embedding_list, MODEL_VERSION, datetime.now(UTC)),
+                (track_id, embedding_list, space_id, datetime.now(UTC)),
             )
-
             self.db.commit()
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to store embedding for {track_id}: {e}")
-            traceback.print_exc()
-            self.db.rollback()
-            return False
         finally:
             cursor.close()
+
+    @staticmethod
+    def _log_embedding_store_failure(track_id: str, error: Exception) -> None:
+        """Log a terminal embedding-store failure with its active traceback."""
+        logger.error(f"Failed to store embedding for {track_id}: {error}")
+        traceback.print_exc()
 
 
 class TextEmbedHandler:

--- a/services/audio-analyzer-clap/tests/test_reliability.py
+++ b/services/audio-analyzer-clap/tests/test_reliability.py
@@ -1,6 +1,8 @@
 """Red-phase contracts for CLAP analyzer runtime reliability."""
 
 import importlib.util
+import json
+import logging
 import sys
 import threading
 import time
@@ -25,6 +27,79 @@ class ResponseError(Exception):
 
 class FakeRedisClient:
     """Placeholder client returned by the recording Redis constructor."""
+
+
+class FakeClock:
+    """Controllable monotonic clock for cache-expiry tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class RecordingSpaceCursor:
+    """Record embedding-space reads and embedding writes."""
+
+    def __init__(self, connection: "RecordingSpaceConnection") -> None:
+        self.connection = connection
+        self.rows: list[dict[str, Any]] = []
+        self.closed = False
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self.connection.executions.append((query, params))
+        if "FROM embedding_spaces" in query:
+            self.connection.resolve_calls += 1
+            self.rows = list(self.connection.active_rows)
+            return
+        if "INSERT INTO track_embeddings" not in query:
+            return
+        self.connection.insert_attempts.append((query, params))
+        if self.connection.insert_errors:
+            raise self.connection.insert_errors.pop(0)
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class RecordingSpaceConnection:
+    """Minimal connection that drives resolver and storage behavior."""
+
+    def __init__(self, active_rows: list[dict[str, Any]]) -> None:
+        self.active_rows = active_rows
+        self.executions: list[tuple[str, Any]] = []
+        self.insert_attempts: list[tuple[str, Any]] = []
+        self.insert_errors: list[Exception] = []
+        self.resolve_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
+
+    def cursor(self, cursor_factory: Any = None) -> RecordingSpaceCursor:
+        assert cursor_factory is RealDictCursor
+        return RecordingSpaceCursor(self)
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+
+
+def _database_with_space_rows(
+    module: ModuleType,
+    active_rows: list[dict[str, Any]],
+    clock: FakeClock | None = None,
+) -> tuple[Any, RecordingSpaceConnection]:
+    """Build the production wrapper around a deterministic fake connection."""
+    database = module.DatabaseConnection("postgresql://test", clock=clock or FakeClock())
+    connection = RecordingSpaceConnection(active_rows)
+    database.conn = connection
+    database.is_connected = lambda: True
+    return database, connection
 
 
 def _stub_torch() -> ModuleType:
@@ -374,3 +449,178 @@ def test_clap_analyzer_source_does_not_use_deprecated_datetime_utcnow() -> None:
 
     assert "datetime.utcnow" not in source
     assert "utcnow()" not in source
+
+
+def test_resolve_active_space_id_returns_single_active_id(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    database, connection = _database_with_space_rows(
+        module,
+        [{"id": "space-current", "created_at": "2026-08-16T12:00:00Z"}],
+    )
+
+    resolved = module.resolve_active_space_id(database)
+
+    assert resolved == "space-current"
+    query = connection.executions[0][0]
+    assert "SELECT id, created_at FROM embedding_spaces" in query
+    assert "WHERE status = 'active'" in query
+    assert "ORDER BY created_at ASC" in query
+
+
+def test_resolve_active_space_id_uses_oldest_and_warns_for_multiple_actives(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    module, _ = loaded_analyzer
+    database, _ = _database_with_space_rows(
+        module,
+        [
+            {"id": "space-oldest", "created_at": "2026-08-16T12:00:00Z"},
+            {"id": "space-newest", "created_at": "2026-08-16T13:00:00Z"},
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING, logger=module.logger.name):
+        resolved = module.resolve_active_space_id(database)
+
+    assert resolved == "space-oldest"
+    assert "space-oldest" in caplog.text
+    assert "space-newest" in caplog.text
+
+
+def test_missing_active_space_marks_job_failed_without_insert(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module, _ = loaded_analyzer
+    database, connection = _database_with_space_rows(module, [])
+    failures: list[tuple[str, str]] = []
+    audio_path = tmp_path / "track.flac"
+    audio_path.touch()
+
+    class FakeJobRedis:
+        def blpop(self, _queue: str, timeout: int) -> tuple[str, bytes]:
+            assert timeout == module.SLEEP_INTERVAL
+            job = {"trackId": "track-1", "filePath": audio_path.name}
+            return module.ANALYSIS_QUEUE, json.dumps(job).encode()
+
+    class FakeAnalyzer:
+        def get_audio_embedding(
+            self,
+            _audio_path: str,
+            _duration: float | None,
+        ) -> np.ndarray:
+            return np.zeros(512, dtype=np.float32)
+
+    worker = module.Worker(1, FakeAnalyzer(), threading.Event())
+    worker.redis_client = FakeJobRedis()
+    worker.db = database
+    monkeypatch.setattr(module, "MUSIC_PATH", str(tmp_path))
+    monkeypatch.setattr(worker, "_claim_track", lambda _track_id: True)
+    monkeypatch.setattr(worker, "_release_queue_reservation", lambda _track_id: None)
+    monkeypatch.setattr(
+        worker,
+        "_mark_failed",
+        lambda track_id, error: failures.append((track_id, error)),
+    )
+
+    worker._process_job()
+
+    assert failures == [
+        ("track-1", "No active embedding space is registered; embedding was not stored")
+    ]
+    assert connection.insert_attempts == []
+
+
+def test_store_embedding_writes_space_id_without_model_version(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    database, connection = _database_with_space_rows(
+        module,
+        [{"id": "space-current", "created_at": "2026-08-16T12:00:00Z"}],
+    )
+    worker = module.Worker(1, None, threading.Event())
+    worker.db = database
+
+    stored = worker._store_embedding("track-1", np.zeros(512, dtype=np.float32))
+
+    assert stored is True
+    query, params = connection.insert_attempts[0]
+    assert "space_id" in query
+    assert "model_version" not in query
+    assert params[2] == "space-current"
+
+
+def test_active_space_cache_is_honored_then_refreshed_after_ttl(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    clock = FakeClock()
+    database, connection = _database_with_space_rows(
+        module,
+        [{"id": "space-old", "created_at": "2026-08-16T12:00:00Z"}],
+        clock,
+    )
+
+    assert database.get_active_space_id() == "space-old"
+    connection.active_rows = [{"id": "space-new", "created_at": "2026-08-16T13:00:00Z"}]
+    clock.now = module.ACTIVE_SPACE_CACHE_TTL_SECONDS
+    assert database.get_active_space_id() == "space-old"
+    clock.now = module.ACTIVE_SPACE_CACHE_TTL_SECONDS + 1
+    assert database.get_active_space_id() == "space-new"
+    assert connection.resolve_calls == 2
+
+
+def test_store_embedding_does_not_retry_unrelated_insert_failures(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    database, connection = _database_with_space_rows(
+        module,
+        [{"id": "space-old", "created_at": "2026-08-16T12:00:00Z"}],
+    )
+    assert database.get_active_space_id() == "space-old"
+    connection.insert_errors.append(
+        RuntimeError(
+            'null value in column "analyzed_at" violates not-null constraint'
+        )
+    )
+    worker = module.Worker(1, None, threading.Event())
+    worker.db = database
+
+    stored = worker._store_embedding("track-1", np.zeros(512, dtype=np.float32))
+
+    assert stored is False
+    assert len(connection.insert_attempts) == 1
+    assert connection.resolve_calls == 1
+
+
+def test_store_embedding_reresolves_once_after_foreign_key_failure(
+    loaded_analyzer: tuple[ModuleType, list[tuple[Any, ...]]],
+) -> None:
+    module, _ = loaded_analyzer
+    database, connection = _database_with_space_rows(
+        module,
+        [{"id": "space-old", "created_at": "2026-08-16T12:00:00Z"}],
+    )
+    assert database.get_active_space_id() == "space-old"
+    connection.active_rows = [{"id": "space-new", "created_at": "2026-08-16T13:00:00Z"}]
+    connection.insert_errors.append(
+        RuntimeError('violates foreign key constraint "track_embeddings_space_id_fkey"')
+    )
+    worker = module.Worker(1, None, threading.Event())
+    worker.db = database
+
+    stored = worker._store_embedding("track-1", np.zeros(512, dtype=np.float32))
+
+    assert stored is True
+    assert [params[2] for _, params in connection.insert_attempts] == [
+        "space-old",
+        "space-new",
+    ]
+    assert connection.resolve_calls == 2
+    assert connection.rollback_calls == 1

--- a/services/audio-analyzer-clap/tests/test_reliability.py
+++ b/services/audio-analyzer-clap/tests/test_reliability.py
@@ -585,9 +585,7 @@ def test_store_embedding_does_not_retry_unrelated_insert_failures(
     )
     assert database.get_active_space_id() == "space-old"
     connection.insert_errors.append(
-        RuntimeError(
-            'null value in column "analyzed_at" violates not-null constraint'
-        )
+        RuntimeError('null value in column "analyzed_at" violates not-null constraint')
     )
     worker = module.Worker(1, None, threading.Event())
     worker.db = database


### PR DESCRIPTION
## Summary

Phase 1 of #537 (design: `docs/designs/vibe-embedding-provider.md`): vectors get a real identity contract so future model changes are operational rollouts, not schema migrations.

- **Registry**: `embedding_spaces` table (family, checkpoint hash, dim, preprocessing JSON, `active|migrating|retired` status) seeded with the canonical LAION-CLAP `music_audioset` space (`space_clap_music_audioset_v1`, checkpoint sha256 pinned to the Dockerfile-verified weights). A raw partial unique index enforces exactly one `active` space at the database level.
- **Migration**: adds `track_embeddings.space_id`, backfills every row (both historical `model_version` strings denoted this same space), `SET NOT NULL`, FK `ON DELETE RESTRICT`, then drops `model_version`. Wrapped in an explicit `BEGIN;/COMMIT;` — this repo applies migrations statement-by-statement, and the wrap makes mid-file failure recoverable and holds the lock so a still-running old sidecar cannot race a NULL row between backfill and `NOT NULL`.
- **Backend**: new `services/embeddingSpaces.ts` (cached active-space lookup, 60s TTL, single-flight, invalidation-safe); every vector query site now filters on the active space — trackEmbeddings, hybridSimilarity (both branches), umapProjection, vibeCalibration, audioAnalysisCleanup, featureDetection, enrichment queue selection/counts/force-reset, and the vibe admin routes. With exactly one space, behavior is identical to before — that was the acceptance bar, held by the existing compat suites.
- **Sidecar**: `analyzer.py` resolves the active space id from the registry (zero active → job fails via the existing failure flow, never an unstamped insert; multiple → oldest wins with a warning; 300s cache with one re-resolve retry on stale-schema insert errors) and writes `space_id`. The Redis text-embed protocol is untouched.

## Compatibility

Backend and `audio-analyzer-clap` images must upgrade together this release: older clap images cannot write embeddings against the new schema. Called out in the CHANGELOG for release notes to carry.

## Verification

- Backend: 16 targeted suites / 237 tests green (compat suites changed only where they pinned the removed `model_version`); `tsc --noEmit`; prettier; file-size guardrail (unifiedEnrichment baseline ratcheted 1997 → 1994); route-error canon.
- Python: 38 tests green including new resolver coverage (0/1/many active, cache TTL, FK-failure re-resolve retry, negative case pinning that unrelated insert errors do not trigger re-resolve); ruff clean.
- Adversarial review to zero findings: migration transactionality fixed after review caught the statement-by-statement application reality; retry-wrapper coverage restored on the enrichment progress path; single-flight cache race coverage added.