### PR TITLE
feat(vibe): opt-in HTTP embedding-provider client for text search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,7 @@ LOG_LEVEL=debug
 # AUDIO_ANALYSIS_ENABLED=true   # Audio analysis queueing (Essentia + CLAP), mood buckets, /api/analysis, /api/vibe
 # AUDIO_ANALYSIS_QUEUE_MAX_DEPTH=100  # Maximum pending Redis jobs admitted for MusicCNN analysis
 # VIBE_ANALYSIS_QUEUE_MAX_DEPTH=100   # Maximum pending Redis jobs admitted for CLAP embeddings
+# VIBE_PROVIDER_URL=http://vibe-provider:8090  # Optional provider base URL for vibe text embeddings; unset keeps the Redis stream path
 # ANALYSIS_QUEUE_RESERVATION_TTL_SECONDS=3600  # Self-healing per-track enqueue reservation
 # DISCOVERY_ENABLED=true        # Discover Weekly cron/processor, /api/discover, /api/recommendations
 # AUTO_PLAYLISTS_ENABLED=true   # Made For You mixes on-demand generation, /api/mixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an opt-in, validated vibe-provider HTTP client for text search and
+  vocabulary generation, with active-space vector checks and bounded metrics.
+
 ### Changed
 
 - Vibe embeddings are now tracked against a versioned embedding-space registry.

--- a/backend/scripts/generateVibeVocabulary.ts
+++ b/backend/scripts/generateVibeVocabulary.ts
@@ -1,118 +1,43 @@
 // backend/scripts/generateVibeVocabulary.ts
 
-import { createClient } from "redis";
-import { randomUUID } from "crypto";
 import { writeFileSync } from "fs";
 import { join } from "path";
+import { config } from "../src/config";
 import {
     VOCAB_DEFINITIONS,
     VOCABULARY_TERMS,
 } from "../src/config/featureProfiles";
-
-const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
-
-interface VocabTerm {
-    name: string;
-    type: string;
-    embedding: number[];
-    featureProfile: Record<string, number>;
-    related?: string[];
-}
-
-async function getClapTextEmbedding(
-    redisClient: ReturnType<typeof createClient>,
-    text: string,
-): Promise<number[]> {
-    const requestId = randomUUID();
-    const responseChannel = `audio:text:embed:response:${requestId}`;
-    const requestChannel = "audio:text:embed";
-
-    const subscriber = redisClient.duplicate();
-    await subscriber.connect();
-
-    try {
-        return await new Promise<number[]>((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                reject(new Error(`Timeout getting embedding for: ${text}`));
-            }, 30000);
-
-            subscriber.subscribe(responseChannel, (message) => {
-                clearTimeout(timeout);
-                try {
-                    const data = JSON.parse(message);
-                    if (data.error) {
-                        reject(new Error(data.error));
-                    } else {
-                        resolve(data.embedding);
-                    }
-                } catch (e) {
-                    reject(new Error("Invalid response"));
-                }
-            });
-
-            redisClient.publish(
-                requestChannel,
-                JSON.stringify({ requestId, text }),
-            );
-        });
-    } finally {
-        await subscriber.unsubscribe(responseChannel);
-        await subscriber.disconnect();
-    }
-}
+import { embedText } from "../src/services/vibeProvider";
+import {
+    generateVibeVocabulary,
+    requireVibeProviderUrl,
+} from "../src/services/vibeVocabularyGenerator";
 
 async function main() {
-    console.log("Connecting to Redis...");
-    const redisClient = createClient({ url: REDIS_URL });
-    await redisClient.connect();
-
+    requireVibeProviderUrl(config.vibeProviderUrl);
     console.log(
         `Generating embeddings for ${VOCABULARY_TERMS.length} terms...`,
     );
-
-    const terms: Record<string, VocabTerm> = {};
-    let success = 0;
-    let failed = 0;
-
-    for (const termName of VOCABULARY_TERMS) {
-        const definition = VOCAB_DEFINITIONS[termName];
-
-        try {
-            process.stdout.write(`  ${termName}... `);
-            const embedding = await getClapTextEmbedding(redisClient, termName);
-
-            terms[termName] = {
-                name: termName,
-                type: definition.type,
-                embedding,
-                featureProfile: definition.featureProfile,
-                related: definition.related,
-            };
-
-            console.log(`OK (${embedding.length} dims)`);
-            success++;
-        } catch (error) {
-            console.log(`FAILED: ${error}`);
-            failed++;
-        }
-
-        // Small delay to not overwhelm the CLAP service
-        await new Promise((r) => setTimeout(r, 100));
-    }
-
-    const vocabulary = {
-        version: "1.0.0",
-        generatedAt: new Date().toISOString(),
-        terms,
-    };
+    const result = await generateVibeVocabulary({
+        termNames: VOCABULARY_TERMS,
+        definitions: VOCAB_DEFINITIONS,
+        embed: embedText,
+    });
 
     const outputPath = join(__dirname, "../src/config/vibe-vocabulary.json");
-    writeFileSync(outputPath, JSON.stringify(vocabulary, null, 2));
+    writeFileSync(outputPath, JSON.stringify(result.vocabulary, null, 2));
 
-    console.log(`\nDone! ${success} terms generated, ${failed} failed.`);
+    console.log(
+        `\nDone! ${result.succeeded} terms generated, ${result.failed.length} failed.`,
+    );
+    if (result.failed.length > 0) {
+        console.log(`Failed terms: ${result.failed.join(", ")}`);
+    }
     console.log(`Vocabulary saved to: ${outputPath}`);
-
-    await redisClient.disconnect();
 }
 
-main().catch(console.error);
+main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+});

--- a/backend/src/__tests__/config.test.ts
+++ b/backend/src/__tests__/config.test.ts
@@ -218,6 +218,44 @@ describe("config module", () => {
         });
     });
 
+    it("keeps the vibe provider disabled when its URL is absent", async () => {
+        const { config } = await loadConfigModule({
+            VIBE_PROVIDER_URL: undefined,
+        });
+
+        expect(config.vibeProviderUrl).toBeUndefined();
+    });
+
+    it.each([
+        ["http://vibe-provider:8090", "http://vibe-provider:8090"],
+        ["http://vibe-provider:8090/", "http://vibe-provider:8090"],
+        [
+            "https://example.test/internal/vibe/",
+            "https://example.test/internal/vibe",
+        ],
+    ])("normalizes VIBE_PROVIDER_URL %s", async (providerUrl, expected) => {
+        const { config } = await loadConfigModule({
+            VIBE_PROVIDER_URL: providerUrl,
+        });
+
+        expect(config.vibeProviderUrl).toBe(expected);
+    });
+
+    it.each([
+        "",
+        "   ",
+        "not-a-url",
+        "ftp://provider.test",
+        "http://user:pass@host",
+        "https://provider.test?tenant=one",
+        "https://provider.test#fragment",
+    ])("rejects invalid VIBE_PROVIDER_URL %s", async (providerUrl) => {
+        await expectStartupValidationFailure(
+            { VIBE_PROVIDER_URL: providerUrl },
+            "VIBE_PROVIDER_URL must be a valid HTTP(S) URL without credentials",
+        );
+    });
+
     it.each([
         "OIDC_ISSUER_URL",
         "OIDC_CLIENT_ID",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -128,6 +128,39 @@ const federationTombstoneRetentionEnvSchema = z
     })
     .optional();
 
+const vibeProviderUrlEnvSchema = z
+    .string()
+    .trim()
+    .refine(
+        (value) => {
+            try {
+                const url = new URL(value);
+                return (
+                    (url.protocol === "http:" || url.protocol === "https:") &&
+                    !url.username &&
+                    !url.password &&
+                    !url.search &&
+                    !url.hash
+                );
+            } catch {
+                return false;
+            }
+        },
+        {
+            message:
+                "VIBE_PROVIDER_URL must be a valid HTTP(S) URL without credentials",
+        },
+    )
+    .optional();
+
+function normalizeVibeProviderUrl(
+    value: string | undefined,
+): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) return undefined;
+    return trimmed.replace(/\/+$/, "");
+}
+
 type OidcEnvInput = {
     LOCAL_LOGIN_ENABLED?: string;
     OIDC_ENABLED?: string;
@@ -304,6 +337,7 @@ const envSchema = z
         SETTINGS_ENCRYPTION_KEY: z.string().optional(),
         ENCRYPTION_KEY: z.string().optional(),
         INTERNAL_API_SECRET: z.string().optional(),
+        VIBE_PROVIDER_URL: vibeProviderUrlEnvSchema,
         METRICS_TOKEN: z.string().optional(),
         METRICS_PUBLIC: z.string().optional(),
         PORT: z.string().optional(),
@@ -446,6 +480,10 @@ export const config = {
     // DATABASE_URL and REDIS_URL are validated by envSchema above, so they're guaranteed to exist
     databaseUrl: databaseUrl!,
     redisUrl: process.env.REDIS_URL!,
+
+    // Optional text-embedding provider base URL. Absence preserves the legacy
+    // Redis-stream transport used by vibe search.
+    vibeProviderUrl: normalizeVibeProviderUrl(process.env.VIBE_PROVIDER_URL),
 
     // Required stable deployment secret retained as the JWT signing fallback
     // and final API-key pepper fallback. It no longer configures sessions.

--- a/backend/src/metrics/__tests__/providerMetrics.test.ts
+++ b/backend/src/metrics/__tests__/providerMetrics.test.ts
@@ -1,0 +1,23 @@
+import { Registry } from "prom-client";
+import { createProviderMetrics } from "../providerMetrics";
+
+describe("vibe provider metrics", () => {
+    it("registers bounded endpoint and outcome labels", async () => {
+        const registry = new Registry();
+        const metrics = createProviderMetrics(registry);
+
+        metrics.record("text", "ok", 0.125);
+        metrics.record("space", "mismatch", 0.25);
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            'soundspan_vibe_provider_requests_total{endpoint="text",outcome="ok"} 1',
+        );
+        expect(exposition).toContain(
+            'soundspan_vibe_provider_requests_total{endpoint="space",outcome="mismatch"} 1',
+        );
+        expect(exposition).toContain(
+            'soundspan_vibe_provider_request_seconds_sum{endpoint="text"} 0.125',
+        );
+    });
+});

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -1,6 +1,11 @@
 import { collectDefaultMetrics, Registry } from "prom-client";
 import { createDomainMetrics } from "./domainMetrics";
 import { createHttpRequestMetrics } from "./httpMetrics";
+import {
+    createProviderMetrics,
+    type VibeProviderEndpoint,
+    type VibeProviderOutcome,
+} from "./providerMetrics";
 
 /** Single process-local Prometheus registry. */
 export const metricsRegistry = new Registry();
@@ -12,6 +17,7 @@ collectDefaultMetrics({
 
 const httpMetrics = createHttpRequestMetrics(metricsRegistry);
 const domainMetrics = createDomainMetrics(metricsRegistry);
+const providerMetrics = createProviderMetrics(metricsRegistry);
 
 /** Express middleware recording bounded HTTP request duration labels. */
 export const httpMetricsMiddleware = httpMetrics.middleware;
@@ -31,4 +37,13 @@ export function recordFederationSyncOutcome(
     outcome: "success" | "failure",
 ): void {
     domainMetrics.federationSyncs.inc({ outcome });
+}
+
+/** Records one final vibe-provider request outcome and duration. */
+export function recordVibeProviderRequest(
+    endpoint: VibeProviderEndpoint,
+    outcome: VibeProviderOutcome,
+    durationSeconds: number,
+): void {
+    providerMetrics.record(endpoint, outcome, durationSeconds);
 }

--- a/backend/src/metrics/providerMetrics.ts
+++ b/backend/src/metrics/providerMetrics.ts
@@ -1,0 +1,52 @@
+import { Counter, Histogram, type Registry } from "prom-client";
+
+/** Closed endpoint vocabulary for provider request telemetry. */
+export type VibeProviderEndpoint = "space" | "text" | "audio";
+
+/** Closed outcome vocabulary for provider request telemetry. */
+export type VibeProviderOutcome =
+    | "ok"
+    | "timeout"
+    | "auth"
+    | "contract"
+    | "mismatch"
+    | "error";
+
+/** Vibe provider instruments owned by one Prometheus registry. */
+export interface ProviderMetrics {
+    requests: Counter<"endpoint" | "outcome">;
+    duration: Histogram<"endpoint">;
+    record(
+        endpoint: VibeProviderEndpoint,
+        outcome: VibeProviderOutcome,
+        durationSeconds: number,
+    ): void;
+}
+
+/** Registers bounded provider request metrics against a registry. */
+export function createProviderMetrics(registry: Registry): ProviderMetrics {
+    const requests = new Counter({
+        name: "soundspan_vibe_provider_requests_total",
+        help: "Vibe provider HTTP requests by endpoint and final outcome.",
+        labelNames: ["endpoint", "outcome"] as const,
+        registers: [registry],
+    });
+    const duration = new Histogram({
+        name: "soundspan_vibe_provider_request_seconds",
+        help: "Vibe provider HTTP request duration in seconds.",
+        labelNames: ["endpoint"] as const,
+        buckets: [
+            0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
+        ],
+        registers: [registry],
+    });
+
+    return {
+        requests,
+        duration,
+        record(endpoint, outcome, durationSeconds): void {
+            requests.inc({ endpoint, outcome });
+            duration.observe({ endpoint }, durationSeconds);
+        },
+    };
+}

--- a/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeCalibrationRuntime.test.ts
@@ -96,6 +96,11 @@ jest.mock("../../services/vibeVocabulary", () => ({
     rerankWithFeatures: jest.fn((tracks: unknown[]) => tracks),
 }));
 
+jest.mock("../../services/textEmbedding", () => ({
+    resolveTextEmbedding: jest.fn(),
+    TextEmbeddingTimeoutError: class TextEmbeddingTimeoutError extends Error {},
+}));
+
 import router from "../vibe";
 import { prisma } from "../../utils/db";
 import { redisClient } from "../../utils/redis";

--- a/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
+++ b/backend/src/routes/__tests__/vibeErrorShapeCanon.test.ts
@@ -1,6 +1,29 @@
 import { Request, Response } from "express";
 
 const mockGetActiveSpace = jest.fn();
+let mockVibeProviderUrl: string | undefined;
+const mockProviderEmbedText = jest.fn();
+
+jest.mock("../../config", () => ({
+    config: {
+        get vibeProviderUrl() {
+            return mockVibeProviderUrl;
+        },
+    },
+}));
+
+jest.mock("../../services/vibeProvider", () => {
+    class VibeProviderError extends Error {}
+    return {
+        embedText: (...args: unknown[]) => mockProviderEmbedText(...args),
+        VibeProviderError,
+        VibeProviderTimeoutError: class VibeProviderTimeoutError extends VibeProviderError {},
+        VibeProviderUnavailableError: class VibeProviderUnavailableError extends VibeProviderError {},
+        VibeProviderAuthError: class VibeProviderAuthError extends VibeProviderError {},
+        VibeProviderContractError: class VibeProviderContractError extends VibeProviderError {},
+        VibeProviderSpaceMismatchError: class VibeProviderSpaceMismatchError extends VibeProviderError {},
+    };
+});
 
 jest.mock("crypto", () => ({
     randomUUID: jest.fn(() => "req-123"),
@@ -137,6 +160,7 @@ describe("vibe canonical error response shape", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockVibeProviderUrl = undefined;
         mockRedisXAdd.mockResolvedValue("1712345-0");
         mockRedisDel.mockResolvedValue(1);
         mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
@@ -173,6 +197,30 @@ describe("vibe canonical error response shape", () => {
             error: "Text embedding service unavailable",
         });
         expect(res.body).not.toHaveProperty("message");
+    });
+
+    it("keeps the canonical timeout shape in provider mode", async () => {
+        const { VibeProviderTimeoutError } = jest.requireMock(
+            "../../services/vibeProvider",
+        ) as { VibeProviderTimeoutError: new () => Error };
+        mockVibeProviderUrl = "http://vibe-provider:8090";
+        mockProviderEmbedText.mockRejectedValueOnce(
+            new VibeProviderTimeoutError(),
+        );
+        const req = {
+            body: { query: "quiet focus" },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await searchHandler(req, res);
+
+        expect(res.statusCode).toBe(504);
+        expect(res.body).toEqual({
+            error: "Text embedding service unavailable",
+        });
+        expect(res.body).not.toHaveProperty("message");
+        expect(mockRedisXAdd).not.toHaveBeenCalled();
     });
 
     it("keeps the canonical error shape when no embedding space is active", async () => {

--- a/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
+++ b/backend/src/routes/__tests__/vibeJourneyRuntime.test.ts
@@ -89,6 +89,11 @@ jest.mock("../../services/vibeVocabulary", () => ({
     rerankWithFeatures: jest.fn((tracks: unknown[]) => tracks),
 }));
 
+jest.mock("../../services/textEmbedding", () => ({
+    resolveTextEmbedding: jest.fn(),
+    TextEmbeddingTimeoutError: class TextEmbeddingTimeoutError extends Error {},
+}));
+
 import router from "../vibe";
 import { prisma } from "../../utils/db";
 import { runAnnQuery } from "../../utils/annQuery";

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -1,5 +1,29 @@
 import { Request, Response } from "express";
 
+let mockVibeProviderUrl: string | undefined;
+const mockProviderEmbedText = jest.fn();
+
+jest.mock("../../config", () => ({
+    config: {
+        get vibeProviderUrl() {
+            return mockVibeProviderUrl;
+        },
+    },
+}));
+
+jest.mock("../../services/vibeProvider", () => {
+    class VibeProviderError extends Error {}
+    return {
+        embedText: (...args: unknown[]) => mockProviderEmbedText(...args),
+        VibeProviderError,
+        VibeProviderTimeoutError: class VibeProviderTimeoutError extends VibeProviderError {},
+        VibeProviderUnavailableError: class VibeProviderUnavailableError extends VibeProviderError {},
+        VibeProviderAuthError: class VibeProviderAuthError extends VibeProviderError {},
+        VibeProviderContractError: class VibeProviderContractError extends VibeProviderError {},
+        VibeProviderSpaceMismatchError: class VibeProviderSpaceMismatchError extends VibeProviderError {},
+    };
+});
+
 jest.mock("crypto", () => ({
     randomUUID: jest.fn(() => "req-123"),
 }));
@@ -158,6 +182,7 @@ describe("vibe search transport compatibility", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockVibeProviderUrl = undefined;
         mockTrackCount.mockResolvedValue(0);
         mockTrackFindUnique.mockResolvedValue(null);
         mockRedisXAdd.mockResolvedValue("1712345-0");
@@ -471,6 +496,105 @@ describe("vibe search transport compatibility", () => {
         expect(mockRedisDel).toHaveBeenCalledWith(
             "audio:text:embed:response:req-123",
         );
+        expect(mockProviderEmbedText).not.toHaveBeenCalled();
+    });
+
+    describe("provider mode", () => {
+        beforeEach(() => {
+            mockVibeProviderUrl = "http://vibe-provider:8090";
+            mockProviderEmbedText.mockResolvedValue([0.6, 0.8]);
+            mockRunAnnQuery.mockResolvedValue([
+                {
+                    id: "track-provider",
+                    title: "Provider Track",
+                    duration: 180,
+                    trackNo: 1,
+                    distance: 0.2,
+                    albumId: "album-1",
+                    albumTitle: "Album One",
+                    albumCoverUrl: null,
+                    artistId: "artist-1",
+                    artistName: "Artist One",
+                    energy: 0.8,
+                    valence: 0.7,
+                    danceability: 0.6,
+                    acousticness: 0.1,
+                    instrumentalness: 0.05,
+                    arousal: 0.7,
+                    speechiness: 0.12,
+                },
+            ]);
+        });
+
+        it("drives vibe search without reaching the legacy Redis transport", async () => {
+            const req = {
+                body: { query: "  quiet focus  ", limit: 10 },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+
+            await searchHandler(req, res);
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual(
+                expect.objectContaining({
+                    query: "quiet focus",
+                    tracks: [expect.objectContaining({ id: "track-provider" })],
+                }),
+            );
+            expect(mockProviderEmbedText).toHaveBeenCalledWith("quiet focus");
+            expect(mockRedisXAdd).not.toHaveBeenCalled();
+            expect(mockBlockingBlPop).not.toHaveBeenCalled();
+            expect(mockRedisDel).not.toHaveBeenCalled();
+        });
+
+        it("maps an unavailable provider to the canonical 504 response", async () => {
+            const { VibeProviderUnavailableError } = jest.requireMock(
+                "../../services/vibeProvider",
+            ) as { VibeProviderUnavailableError: new () => Error };
+            mockProviderEmbedText.mockRejectedValueOnce(
+                new VibeProviderUnavailableError(),
+            );
+            const req = {
+                body: { query: "quiet focus" },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+
+            await searchHandler(req, res);
+
+            expect(res.statusCode).toBe(504);
+            expect(res.body).toEqual({
+                error: "Text embedding service unavailable",
+            });
+            expect(mockRedisXAdd).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            "VibeProviderAuthError",
+            "VibeProviderContractError",
+            "VibeProviderSpaceMismatchError",
+        ] as const)("maps %s to the canonical 500 response", async (name) => {
+            const providerErrors = jest.requireMock(
+                "../../services/vibeProvider",
+            ) as Record<typeof name, new () => Error>;
+            mockProviderEmbedText.mockRejectedValueOnce(
+                new providerErrors[name](),
+            );
+            const req = {
+                body: { query: "quiet focus" },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+
+            await searchHandler(req, res);
+
+            expect(res.statusCode).toBe(500);
+            expect(res.body).toEqual({
+                error: "Failed to search tracks by vibe",
+            });
+            expect(mockRedisXAdd).not.toHaveBeenCalled();
+        });
     });
 
     it("returns 504 when no embedding response arrives before timeout", async () => {

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -1,12 +1,11 @@
 import { Request, Response, Router } from "express";
-import { randomUUID } from "crypto";
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import {
     TRACK_BROWSE_WHERE,
     TRACK_VISIBLE_WHERE,
 } from "../utils/librarySorting";
-import { blockingBlPop, redisClient } from "../utils/redis";
+import { redisClient } from "../utils/redis";
 import { blendEmbeddings, lerpEmbedding } from "../utils/embedding";
 import { requireAuth } from "../middleware/auth";
 import { asyncHandler } from "../middleware/asyncHandler";
@@ -50,20 +49,18 @@ import {
 import { parseJourneyRequest } from "./vibeJourneyRequest";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 import { coalesceInFlightByKey } from "../utils/singleflight";
+import {
+    resolveTextEmbedding,
+    TextEmbeddingProviderError,
+    TextEmbeddingTimeoutError,
+} from "../services/textEmbedding";
 
 const router = Router();
 
 // Load vocabulary at module initialization
 loadVocabulary();
 
-const TEXT_EMBED_REQUEST_STREAM = "audio:text:embed:requests";
-const TEXT_EMBED_RESPONSE_PREFIX = "audio:text:embed:response:";
-const TEXT_EMBED_TIMEOUT_SECONDS = 30;
 const MAX_TEXT_SEARCH_QUERY_LENGTH = 512;
-// The CLAP consumer handles one request per replica at a time and callers wait
-// at most 30 seconds. Retaining 100 entries leaves burst headroom without
-// allowing timed-out request payloads to accumulate indefinitely.
-const TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH = 100;
 
 async function buildTrackPreferenceScoreMapForUser(
     userId: string | undefined,
@@ -994,14 +991,6 @@ function distanceToSimilarity(distance: number): number {
 // 0.65 = 65% match, meaning distance <= 0.7
 const MIN_SEARCH_SIMILARITY = 0.6;
 
-interface TextEmbedResponsePayload {
-    requestId: string;
-    success: boolean;
-    embedding: number[] | null;
-    modelVersion: string;
-    error?: string;
-}
-
 /**
  * @openapi
  * /api/vibe/search:
@@ -1106,172 +1095,128 @@ router.post(
             // similarity = 1 - (distance / 2), so distance = 2 * (1 - similarity)
             const maxDistance = 2 * (1 - similarityThreshold);
 
-            const requestId = randomUUID();
-            const responseKey = `${TEXT_EMBED_RESPONSE_PREFIX}${requestId}`;
             const normalizedQuery = query.trim();
+            const textEmbedding = await resolveTextEmbedding(normalizedQuery);
 
-            try {
-                // Queue text-embedding request via Redis Streams to ensure a single
-                // CLAP replica claims and processes each request.
-                await redisClient.xAdd(
-                    TEXT_EMBED_REQUEST_STREAM,
-                    "*",
-                    {
-                        requestId,
-                        text: normalizedQuery,
-                        responseKey,
-                    },
-                    {
-                        TRIM: {
-                            strategy: "MAXLEN",
-                            strategyModifier: "~",
-                            threshold: TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH,
-                        },
-                    },
+            // Query expansion with vocabulary
+            const vocab = getVocabulary();
+            let searchEmbedding = textEmbedding;
+            let genreConfidence = 0;
+            let matchedTerms: VocabTerm[] = [];
+
+            if (vocab) {
+                const expansion = expandQueryWithVocabulary(
+                    textEmbedding,
+                    normalizedQuery,
+                    vocab,
                 );
-
-                // Wait for response from the CLAP worker.
-                const response = await blockingBlPop(
-                    responseKey,
-                    TEXT_EMBED_TIMEOUT_SECONDS,
-                );
-
-                if (!response?.element) {
-                    throw new Error("Text embedding request timed out");
-                }
-
-                let payload: TextEmbedResponsePayload;
-                try {
-                    payload = JSON.parse(
-                        response.element,
-                    ) as TextEmbedResponsePayload;
-                } catch (_error) {
-                    throw new Error("Invalid response from analyzer");
-                }
-
-                if (payload.error) {
-                    throw new Error(payload.error);
-                }
-
-                if (!Array.isArray(payload.embedding)) {
-                    throw new Error("Invalid response from analyzer");
-                }
-
-                const textEmbedding = payload.embedding;
-
-                // Query expansion with vocabulary
-                const vocab = getVocabulary();
-                let searchEmbedding = textEmbedding;
-                let genreConfidence = 0;
-                let matchedTerms: VocabTerm[] = [];
-
-                if (vocab) {
-                    const expansion = expandQueryWithVocabulary(
-                        textEmbedding,
-                        normalizedQuery,
-                        vocab,
-                    );
-                    searchEmbedding = expansion.embedding;
-                    genreConfidence = expansion.genreConfidence;
-                    matchedTerms = expansion.matchedTerms;
-
-                    logger.info(
-                        `[VIBE-SEARCH] Query "${normalizedQuery}" expanded with terms: ${matchedTerms.map((t) => t.name).join(", ") || "none"}, genre confidence: ${(genreConfidence * 100).toFixed(0)}%`,
-                    );
-                }
-
-                // Query for similar tracks using the (possibly expanded) embedding
-                // Fetch more candidates for re-ranking (3x limit)
-                // Filter by max distance to exclude poor matches
-                const candidateLimit = limit * 3;
-                const similarTracks = await findTracksByTextEmbedding(
-                    searchEmbedding,
-                    maxDistance,
-                    candidateLimit,
-                );
+                searchEmbedding = expansion.embedding;
+                genreConfidence = expansion.genreConfidence;
+                matchedTerms = expansion.matchedTerms;
 
                 logger.info(
-                    `Vibe search "${normalizedQuery}": found ${similarTracks.length} candidates above ${Math.round(similarityThreshold * 100)}% similarity (max distance: ${maxDistance.toFixed(2)})`,
+                    `[VIBE-SEARCH] Query "${normalizedQuery}" expanded with terms: ${matchedTerms.map((t) => t.name).join(", ") || "none"}, genre confidence: ${(genreConfidence * 100).toFixed(0)}%`,
                 );
-
-                // Re-rank using audio features if we have vocabulary matches
-                let rankedTracks:
-                    | typeof similarTracks
-                    | ReturnType<typeof rerankWithFeatures<TextSearchResult>> =
-                    similarTracks;
-                if (vocab && matchedTerms.length > 0) {
-                    const reranked = rerankWithFeatures(
-                        similarTracks,
-                        matchedTerms,
-                        genreConfidence,
-                    );
-                    rankedTracks = reranked.slice(0, limit);
-
-                    logger.info(
-                        `[VIBE-SEARCH] Re-ranked ${similarTracks.length} candidates, top result: ${rankedTracks[0]?.title || "none"}`,
-                    );
-                } else {
-                    rankedTracks = similarTracks.slice(0, limit);
-                }
-
-                // If we have results, log the similarity range
-                if (rankedTracks.length > 0) {
-                    const first = rankedTracks[0];
-                    const last = rankedTracks[rankedTracks.length - 1];
-                    const bestSim =
-                        "finalScore" in first
-                            ? first.finalScore
-                            : distanceToSimilarity(first.distance);
-                    const worstSim =
-                        "finalScore" in last
-                            ? last.finalScore
-                            : distanceToSimilarity(last.distance);
-                    logger.info(
-                        `Vibe search similarity range: ${Math.round(bestSim * 100)}% - ${Math.round(worstSim * 100)}%`,
-                    );
-                }
-
-                const tracks = rankedTracks.map((row) => ({
-                    id: row.id,
-                    title: row.title,
-                    duration: row.duration,
-                    trackNo: row.trackNo,
-                    distance: row.distance,
-                    similarity:
-                        "finalScore" in row
-                            ? row.finalScore
-                            : distanceToSimilarity(row.distance),
-                    album: {
-                        id: row.albumId,
-                        title: row.albumTitle,
-                        coverUrl: row.albumCoverUrl,
-                    },
-                    artist: {
-                        id: row.artistId,
-                        name: row.artistName,
-                    },
-                }));
-
-                res.json({
-                    query: normalizedQuery,
-                    tracks,
-                    minSimilarity: similarityThreshold,
-                    totalAboveThreshold: tracks.length,
-                    debug: {
-                        matchedTerms: matchedTerms.map((t) => t.name),
-                        genreConfidence,
-                        featureWeight:
-                            matchedTerms.length > 0
-                                ? 0.2 + genreConfidence * 0.5
-                                : 0,
-                    },
-                });
-            } finally {
-                await redisClient.del(responseKey).catch(() => {});
             }
-        } catch (error: any) {
+
+            // Query for similar tracks using the (possibly expanded) embedding
+            // Fetch more candidates for re-ranking (3x limit)
+            // Filter by max distance to exclude poor matches
+            const candidateLimit = limit * 3;
+            const similarTracks = await findTracksByTextEmbedding(
+                searchEmbedding,
+                maxDistance,
+                candidateLimit,
+            );
+
+            logger.info(
+                `Vibe search "${normalizedQuery}": found ${similarTracks.length} candidates above ${Math.round(similarityThreshold * 100)}% similarity (max distance: ${maxDistance.toFixed(2)})`,
+            );
+
+            // Re-rank using audio features if we have vocabulary matches
+            let rankedTracks:
+                | typeof similarTracks
+                | ReturnType<typeof rerankWithFeatures<TextSearchResult>> =
+                similarTracks;
+            if (vocab && matchedTerms.length > 0) {
+                const reranked = rerankWithFeatures(
+                    similarTracks,
+                    matchedTerms,
+                    genreConfidence,
+                );
+                rankedTracks = reranked.slice(0, limit);
+
+                logger.info(
+                    `[VIBE-SEARCH] Re-ranked ${similarTracks.length} candidates, top result: ${rankedTracks[0]?.title || "none"}`,
+                );
+            } else {
+                rankedTracks = similarTracks.slice(0, limit);
+            }
+
+            // If we have results, log the similarity range
+            if (rankedTracks.length > 0) {
+                const first = rankedTracks[0];
+                const last = rankedTracks[rankedTracks.length - 1];
+                const bestSim =
+                    "finalScore" in first
+                        ? first.finalScore
+                        : distanceToSimilarity(first.distance);
+                const worstSim =
+                    "finalScore" in last
+                        ? last.finalScore
+                        : distanceToSimilarity(last.distance);
+                logger.info(
+                    `Vibe search similarity range: ${Math.round(bestSim * 100)}% - ${Math.round(worstSim * 100)}%`,
+                );
+            }
+
+            const tracks = rankedTracks.map((row) => ({
+                id: row.id,
+                title: row.title,
+                duration: row.duration,
+                trackNo: row.trackNo,
+                distance: row.distance,
+                similarity:
+                    "finalScore" in row
+                        ? row.finalScore
+                        : distanceToSimilarity(row.distance),
+                album: {
+                    id: row.albumId,
+                    title: row.albumTitle,
+                    coverUrl: row.albumCoverUrl,
+                },
+                artist: {
+                    id: row.artistId,
+                    name: row.artistName,
+                },
+            }));
+
+            res.json({
+                query: normalizedQuery,
+                tracks,
+                minSimilarity: similarityThreshold,
+                totalAboveThreshold: tracks.length,
+                debug: {
+                    matchedTerms: matchedTerms.map((t) => t.name),
+                    genreConfidence,
+                    featureWeight:
+                        matchedTerms.length > 0
+                            ? 0.2 + genreConfidence * 0.5
+                            : 0,
+                },
+            });
+        } catch (error: unknown) {
             logger.error("Vibe text search error:", error);
-            if (error.message?.includes("timed out")) {
+            if (error instanceof TextEmbeddingProviderError) {
+                return sendInternalRouteError(
+                    res,
+                    "Failed to search tracks by vibe",
+                );
+            }
+            if (
+                error instanceof TextEmbeddingTimeoutError ||
+                (error instanceof Error && error.message.includes("timed out"))
+            ) {
                 return sendRouteError(
                     res,
                     504,

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -131,6 +131,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/spotifyImport/state.ts` | Shared Spotify import persistence, retry, cache, and logger state |
 | `backend/src/services/spotifyImport/types.ts` | Shared Spotify import contracts |
 | `backend/src/services/staleJobCleanup.ts` | Core |
+| `backend/src/services/textEmbedding.ts` | Config-selected provider or legacy Redis text-embedding transport |
 | `backend/src/services/tidal.ts` | Core |
 | `backend/src/services/tidalStreaming.ts` | Core |
 | `backend/src/services/trackMappingService.ts` | Core |
@@ -143,7 +144,9 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/unifiedTrackResponse.ts` | Core |
 | `backend/src/services/vibeAnalysisCleanup.ts` | Core |
 | `backend/src/services/vibeCalibration.ts` | Vibe distance calibration |
+| `backend/src/services/vibeProvider.ts` | Validated, bounded vibe-provider HTTP client and active-space trust boundary |
 | `backend/src/services/vibeVocabulary.ts` | Core |
+| `backend/src/services/vibeVocabularyGenerator.ts` | Testable provider-backed vocabulary artifact generation |
 | `backend/src/services/wikidata.ts` | Core |
 | `backend/src/services/workerEventLoopMonitor.ts` | Core |
 | `backend/src/services/youtubeDownload.ts` | Core |

--- a/backend/src/services/__tests__/vibeProvider.test.ts
+++ b/backend/src/services/__tests__/vibeProvider.test.ts
@@ -1,0 +1,333 @@
+const mockGetActiveSpace = jest.fn();
+const mockRecordVibeProviderRequest = jest.fn();
+const mockConfig = {
+    vibeProviderUrl: "http://provider.test/base/",
+    internalApiSecret: "internal-secret",
+};
+
+jest.mock("../../config", () => ({ config: mockConfig }));
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
+}));
+jest.mock("../../metrics", () => ({
+    recordVibeProviderRequest: (...args: unknown[]) =>
+        mockRecordVibeProviderRequest(...args),
+}));
+
+import {
+    embedAudio,
+    embedText,
+    fetchProviderSpace,
+    VibeProviderAuthError,
+    VibeProviderContractError,
+    VibeProviderServerError,
+    VibeProviderSpaceMismatchError,
+    VibeProviderTimeoutError,
+    VibeProviderUnavailableError,
+} from "../vibeProvider";
+
+const mockFetch = jest.fn();
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}
+
+function expectMetric(endpoint: string, outcome: string): void {
+    expect(mockRecordVibeProviderRequest).toHaveBeenCalledWith(
+        endpoint,
+        outcome,
+        expect.any(Number),
+    );
+}
+
+describe("vibe provider client", () => {
+    beforeAll(() => {
+        jest.spyOn(global, "fetch").mockImplementation(mockFetch);
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetActiveSpace.mockResolvedValue({
+            id: "space-active",
+            family: "clap-music-audioset",
+            checkpointHash: "sha256:fixture",
+            dim: 2,
+            preprocessing: { sampleRateHz: 48_000 },
+        });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("fetches and validates the active provider space", async () => {
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({
+                family: "clap-music-audioset",
+                checkpointHash: "sha256:fixture",
+                dim: 2,
+                sampleRateHz: 48_000,
+                preprocessing: { mono: true },
+                revision: "2026-08-16",
+                textTower: true,
+            }),
+        );
+
+        await expect(fetchProviderSpace()).resolves.toEqual(
+            expect.objectContaining({
+                family: "clap-music-audioset",
+                checkpointHash: "sha256:fixture",
+                dim: 2,
+                textTower: true,
+            }),
+        );
+        expect(mockFetch).toHaveBeenCalledWith(
+            "http://provider.test/base/v1/space",
+            expect.objectContaining({
+                method: "GET",
+                headers: expect.objectContaining({
+                    "X-Internal-Secret": "internal-secret",
+                }),
+            }),
+        );
+        expectMetric("space", "ok");
+    });
+
+    it("accepts additive provider space fields", async () => {
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({
+                family: "clap-music-audioset",
+                checkpointHash: "sha256:fixture",
+                dim: 2,
+                sampleRateHz: 48_000,
+                preprocessing: { mono: true },
+                revision: "2026-08-16",
+                textTower: true,
+                futureCapability: "supported",
+            }),
+        );
+
+        const providerSpace = await fetchProviderSpace();
+
+        expect(providerSpace).toEqual({
+            family: "clap-music-audioset",
+            checkpointHash: "sha256:fixture",
+            dim: 2,
+            sampleRateHz: 48_000,
+            preprocessing: { mono: true },
+            revision: "2026-08-16",
+            textTower: true,
+        });
+        expectMetric("space", "ok");
+    });
+
+    it("embeds text and audio through their bounded endpoints", async () => {
+        mockFetch
+            .mockResolvedValueOnce(jsonResponse({ vector: [0.6, 0.8] }))
+            .mockResolvedValueOnce(jsonResponse({ vector: [0, 1] }));
+
+        await expect(embedText("quiet focus")).resolves.toEqual([0.6, 0.8]);
+        await expect(embedAudio("track-123")).resolves.toEqual([0, 1]);
+
+        expect(mockFetch).toHaveBeenNthCalledWith(
+            1,
+            "http://provider.test/base/v1/embed/text",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ text: "quiet focus" }),
+            }),
+        );
+        expect(mockFetch).toHaveBeenNthCalledWith(
+            2,
+            "http://provider.test/base/v1/embed/audio",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ trackRef: "track-123" }),
+            }),
+        );
+        expectMetric("text", "ok");
+        expectMetric("audio", "ok");
+    });
+
+    it("aborts a text request at its timeout", async () => {
+        jest.useFakeTimers();
+        mockFetch.mockImplementationOnce(
+            (_url: string, init: RequestInit) =>
+                new Promise<Response>((_resolve, reject) => {
+                    init.signal?.addEventListener("abort", () => {
+                        reject(new DOMException("aborted", "AbortError"));
+                    });
+                }),
+        );
+
+        const request = embedText("slow query");
+        const rejection = expect(request).rejects.toBeInstanceOf(
+            VibeProviderTimeoutError,
+        );
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await rejection;
+        expectMetric("text", "timeout");
+    });
+
+    it("classifies a deadline during response body reading as a timeout", async () => {
+        jest.useFakeTimers();
+        mockFetch.mockImplementationOnce((_url: string, init: RequestInit) =>
+            Promise.resolve(
+                new Response(
+                    new ReadableStream<Uint8Array>({
+                        start(controller) {
+                            controller.enqueue(
+                                new TextEncoder().encode('{"vector":'),
+                            );
+                            init.signal?.addEventListener("abort", () => {
+                                controller.error(
+                                    new DOMException("aborted", "AbortError"),
+                                );
+                            });
+                        },
+                    }),
+                    {
+                        status: 200,
+                        headers: { "content-type": "application/json" },
+                    },
+                ),
+            ),
+        );
+
+        const request = embedText("slow body");
+        const rejection = expect(request).rejects.toBeInstanceOf(
+            VibeProviderTimeoutError,
+        );
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await rejection;
+        expectMetric("text", "timeout");
+    });
+
+    it("maps an authentication rejection", async () => {
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({ error: "unauthorized" }, 401),
+        );
+
+        const request = embedText("quiet focus");
+        await expect(request).rejects.toBeInstanceOf(VibeProviderAuthError);
+        await expect(request).rejects.toMatchObject({
+            message: "unauthorized",
+        });
+        expectMetric("text", "auth");
+    });
+
+    it("classifies authentication by status when the error body is non-conforming", async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ message: "x" }, 401));
+
+        const request = embedText("quiet focus");
+        await expect(request).rejects.toBeInstanceOf(VibeProviderAuthError);
+        await expect(request).rejects.toMatchObject({
+            message: "Vibe provider authentication failed",
+        });
+        expectMetric("text", "auth");
+    });
+
+    it("classifies provider failures by status when the error body is not JSON", async () => {
+        mockFetch.mockResolvedValueOnce(
+            new Response("<html>bad gateway</html>", {
+                status: 502,
+                headers: { "content-type": "text/html" },
+            }),
+        );
+
+        const request = embedText("quiet focus");
+        await expect(request).rejects.toBeInstanceOf(VibeProviderServerError);
+        await expect(request).rejects.toMatchObject({
+            message: "Vibe provider returned 502",
+        });
+        expectMetric("text", "error");
+    });
+
+    it("keeps a non-JSON success body classified as a contract failure", async () => {
+        mockFetch.mockResolvedValueOnce(
+            new Response("<html>unexpected success</html>", {
+                status: 200,
+                headers: { "content-type": "text/html" },
+            }),
+        );
+
+        await expect(embedText("quiet focus")).rejects.toBeInstanceOf(
+            VibeProviderContractError,
+        );
+        expectMetric("text", "contract");
+    });
+
+    it("rejects malformed success bodies", async () => {
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({ vector: "not-a-vector" }),
+        );
+
+        await expect(embedText("quiet focus")).rejects.toBeInstanceOf(
+            VibeProviderContractError,
+        );
+        expectMetric("text", "contract");
+    });
+
+    it("rejects vectors with the wrong active-space dimension", async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ vector: [1] }));
+
+        await expect(embedText("quiet focus")).rejects.toBeInstanceOf(
+            VibeProviderContractError,
+        );
+        expectMetric("text", "contract");
+    });
+
+    it("rejects vectors outside the unit-norm tolerance", async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ vector: [0.5, 0.5] }));
+
+        await expect(embedText("quiet focus")).rejects.toBeInstanceOf(
+            VibeProviderContractError,
+        );
+        expectMetric("text", "contract");
+    });
+
+    it("rejects a provider bound to a different active space", async () => {
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({
+                family: "other-family",
+                checkpointHash: "sha256:fixture",
+                dim: 2,
+                sampleRateHz: 48_000,
+                preprocessing: { mono: true },
+                revision: "2026-08-16",
+                textTower: true,
+            }),
+        );
+
+        await expect(fetchProviderSpace()).rejects.toBeInstanceOf(
+            VibeProviderSpaceMismatchError,
+        );
+        expectMetric("space", "mismatch");
+    });
+
+    it("distinguishes provider 5xx from an unreachable provider", async () => {
+        mockFetch
+            .mockResolvedValueOnce(jsonResponse({ error: "not ready" }, 503))
+            .mockRejectedValueOnce(new TypeError("fetch failed"));
+
+        await expect(embedText("first query")).rejects.toBeInstanceOf(
+            VibeProviderServerError,
+        );
+        expectMetric("text", "error");
+
+        mockRecordVibeProviderRequest.mockClear();
+        await expect(embedText("second query")).rejects.toBeInstanceOf(
+            VibeProviderUnavailableError,
+        );
+        expectMetric("text", "error");
+    });
+});

--- a/backend/src/services/__tests__/vibeVocabularyGenerator.test.ts
+++ b/backend/src/services/__tests__/vibeVocabularyGenerator.test.ts
@@ -1,0 +1,81 @@
+import {
+    generateVibeVocabulary,
+    requireVibeProviderUrl,
+} from "../vibeVocabularyGenerator";
+
+describe("vibe vocabulary generator", () => {
+    it("transforms provider embeddings into the existing vocabulary schema", async () => {
+        const embed = jest
+            .fn<Promise<number[]>, [string]>()
+            .mockResolvedValueOnce([1, 0])
+            .mockResolvedValueOnce([0, 1]);
+
+        const result = await generateVibeVocabulary({
+            termNames: ["ambient", "energetic"],
+            definitions: {
+                ambient: {
+                    type: "genre",
+                    featureProfile: { energy: 0.2 },
+                    related: ["drone"],
+                },
+                energetic: {
+                    type: "mood",
+                    featureProfile: { energy: 0.9 },
+                },
+            },
+            embed,
+            generatedAt: "2026-08-16T12:00:00.000Z",
+        });
+
+        expect(result).toEqual({
+            vocabulary: {
+                version: "1.0.0",
+                generatedAt: "2026-08-16T12:00:00.000Z",
+                terms: {
+                    ambient: {
+                        name: "ambient",
+                        type: "genre",
+                        embedding: [1, 0],
+                        featureProfile: { energy: 0.2 },
+                        related: ["drone"],
+                    },
+                    energetic: {
+                        name: "energetic",
+                        type: "mood",
+                        embedding: [0, 1],
+                        featureProfile: { energy: 0.9 },
+                    },
+                },
+            },
+            succeeded: 2,
+            failed: [],
+        });
+    });
+
+    it("keeps successful terms when one provider request fails", async () => {
+        const embed = jest
+            .fn<Promise<number[]>, [string]>()
+            .mockRejectedValueOnce(new Error("provider unavailable"))
+            .mockResolvedValueOnce([0, 1]);
+
+        const result = await generateVibeVocabulary({
+            termNames: ["ambient", "energetic"],
+            definitions: {
+                ambient: { type: "genre", featureProfile: {} },
+                energetic: { type: "mood", featureProfile: {} },
+            },
+            embed,
+            generatedAt: "2026-08-16T12:00:00.000Z",
+        });
+
+        expect(result.succeeded).toBe(1);
+        expect(result.failed).toEqual(["ambient"]);
+        expect(Object.keys(result.vocabulary.terms)).toEqual(["energetic"]);
+    });
+
+    it("requires the provider URL with an operator-facing message", () => {
+        expect(() => requireVibeProviderUrl(undefined)).toThrow(
+            "VIBE_PROVIDER_URL is required to generate the vibe vocabulary",
+        );
+    });
+});

--- a/backend/src/services/textEmbedding.ts
+++ b/backend/src/services/textEmbedding.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "crypto";
+import { config } from "../config";
+import { blockingBlPop, redisClient } from "../utils/redis";
+import {
+    embedText,
+    VibeProviderError,
+    VibeProviderTimeoutError,
+    VibeProviderUnavailableError,
+} from "./vibeProvider";
+
+const TEXT_EMBED_REQUEST_STREAM = "audio:text:embed:requests";
+const TEXT_EMBED_RESPONSE_PREFIX = "audio:text:embed:response:";
+const TEXT_EMBED_TIMEOUT_SECONDS = 30;
+const TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH = 100;
+
+interface LegacyTextEmbedResponse {
+    requestId: string;
+    success: boolean;
+    embedding: number[] | null;
+    modelVersion: string;
+    error?: string;
+}
+
+/** Stable timeout identity consumed by the vibe route error mapper. */
+export class TextEmbeddingTimeoutError extends Error {
+    constructor(options?: ErrorOptions) {
+        super("Text embedding request timed out", options);
+        this.name = "TextEmbeddingTimeoutError";
+    }
+}
+
+/**
+ * Stable non-timeout provider-failure identity. The route maps this before
+ * any message inspection so provider-controlled error text can never steer
+ * the HTTP status.
+ */
+export class TextEmbeddingProviderError extends Error {
+    constructor(options?: ErrorOptions) {
+        super("Text embedding provider request failed", options);
+        this.name = "TextEmbeddingProviderError";
+    }
+}
+
+function parseLegacyResponse(value: string): number[] {
+    let payload: LegacyTextEmbedResponse;
+    try {
+        payload = JSON.parse(value) as LegacyTextEmbedResponse;
+    } catch {
+        throw new Error("Invalid response from analyzer");
+    }
+    if (payload.error) throw new Error(payload.error);
+    if (!Array.isArray(payload.embedding)) {
+        throw new Error("Invalid response from analyzer");
+    }
+    return payload.embedding;
+}
+
+async function embedTextWithLegacyStream(text: string): Promise<number[]> {
+    const requestId = randomUUID();
+    const responseKey = `${TEXT_EMBED_RESPONSE_PREFIX}${requestId}`;
+    try {
+        await redisClient.xAdd(
+            TEXT_EMBED_REQUEST_STREAM,
+            "*",
+            { requestId, text, responseKey },
+            {
+                TRIM: {
+                    strategy: "MAXLEN",
+                    strategyModifier: "~",
+                    threshold: TEXT_EMBED_REQUEST_STREAM_MAX_LENGTH,
+                },
+            },
+        );
+        const response = await blockingBlPop(
+            responseKey,
+            TEXT_EMBED_TIMEOUT_SECONDS,
+        );
+        if (!response?.element) throw new TextEmbeddingTimeoutError();
+        return parseLegacyResponse(response.element);
+    } finally {
+        await redisClient.del(responseKey).catch(() => {});
+    }
+}
+
+/** Resolve text embeddings through provider mode or the unchanged legacy stream. */
+export async function resolveTextEmbedding(text: string): Promise<number[]> {
+    if (!config.vibeProviderUrl) return embedTextWithLegacyStream(text);
+    try {
+        return await embedText(text);
+    } catch (error) {
+        if (
+            error instanceof VibeProviderTimeoutError ||
+            error instanceof VibeProviderUnavailableError
+        ) {
+            throw new TextEmbeddingTimeoutError({ cause: error });
+        }
+        if (error instanceof VibeProviderError) {
+            throw new TextEmbeddingProviderError({ cause: error });
+        }
+        throw error;
+    }
+}

--- a/backend/src/services/vibeProvider.ts
+++ b/backend/src/services/vibeProvider.ts
@@ -1,0 +1,307 @@
+import { z } from "zod";
+import { config } from "../config";
+import { recordVibeProviderRequest } from "../metrics";
+import type {
+    VibeProviderEndpoint,
+    VibeProviderOutcome,
+} from "../metrics/providerMetrics";
+import { getActiveSpace, type ActiveEmbeddingSpace } from "./embeddingSpaces";
+
+/** Shared deadline for provider identity and health operations. */
+export const PROVIDER_SPACE_HEALTH_TIMEOUT_MS = 5_000;
+/** Deadline for provider text inference. */
+export const PROVIDER_TEXT_TIMEOUT_MS = 30_000;
+/** Deadline for provider audio inference. */
+export const PROVIDER_AUDIO_TIMEOUT_MS = 120_000;
+
+const UNIT_NORM_TOLERANCE = 1e-3;
+const textInputSchema = z.string().min(1).max(2_048);
+const trackRefSchema = z.string().min(1);
+const vectorResponseSchema = z.strictObject({
+    vector: z.array(z.number().finite()),
+});
+const errorResponseSchema = z.object({
+    error: z.string().min(1),
+});
+const providerSpaceSchema = z.object({
+    family: z.string().min(1),
+    checkpointHash: z.string().min(1),
+    dim: z.number().int().positive(),
+    sampleRateHz: z.number().int().positive(),
+    preprocessing: z.record(z.string(), z.unknown()),
+    revision: z.string().min(1),
+    textTower: z.boolean(),
+});
+
+/** Validated provider embedding-space identity and capability metadata. */
+export type ProviderSpace = z.infer<typeof providerSpaceSchema>;
+
+type VibeProviderErrorCode =
+    | "unreachable"
+    | "timeout"
+    | "auth"
+    | "contract"
+    | "provider_5xx"
+    | "request_rejected"
+    | "space_mismatch";
+
+/** Base class for stable vibe-provider failure classification. */
+export class VibeProviderError extends Error {
+    constructor(
+        public readonly code: VibeProviderErrorCode,
+        message: string,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
+        this.name = "VibeProviderError";
+    }
+}
+
+/** Raised when the configured provider cannot be reached. */
+export class VibeProviderUnavailableError extends VibeProviderError {
+    constructor(cause?: unknown) {
+        super("unreachable", "Vibe provider is unreachable", { cause });
+        this.name = "VibeProviderUnavailableError";
+    }
+}
+
+/** Raised when a provider operation exceeds its fixed deadline. */
+export class VibeProviderTimeoutError extends VibeProviderError {
+    constructor(cause?: unknown) {
+        super("timeout", "Vibe provider request timed out", { cause });
+        this.name = "VibeProviderTimeoutError";
+    }
+}
+
+/** Raised when the provider rejects the internal credential. */
+export class VibeProviderAuthError extends VibeProviderError {
+    constructor(message = "Vibe provider authentication failed") {
+        super("auth", message);
+        this.name = "VibeProviderAuthError";
+    }
+}
+
+/** Raised when provider data violates the v1 wire or vector contract. */
+export class VibeProviderContractError extends VibeProviderError {
+    constructor(cause?: unknown) {
+        super("contract", "Vibe provider returned an invalid response", {
+            cause,
+        });
+        this.name = "VibeProviderContractError";
+    }
+}
+
+/** Raised when the provider reports an internal service failure. */
+export class VibeProviderServerError extends VibeProviderError {
+    constructor(
+        public readonly status: number,
+        message = `Vibe provider returned ${status}`,
+    ) {
+        super("provider_5xx", message);
+        this.name = "VibeProviderServerError";
+    }
+}
+
+/** Raised when the provider rejects a validly transported request. */
+export class VibeProviderRequestError extends VibeProviderError {
+    constructor(
+        public readonly status: number,
+        message = `Vibe provider rejected the request (${status})`,
+    ) {
+        super("request_rejected", message);
+        this.name = "VibeProviderRequestError";
+    }
+}
+
+/** Raised when provider and active registry identities differ. */
+export class VibeProviderSpaceMismatchError extends VibeProviderError {
+    constructor() {
+        super(
+            "space_mismatch",
+            "Vibe provider does not match the active space",
+        );
+        this.name = "VibeProviderSpaceMismatchError";
+    }
+}
+
+function metricOutcome(error: unknown): VibeProviderOutcome {
+    if (error instanceof VibeProviderTimeoutError) return "timeout";
+    if (error instanceof VibeProviderAuthError) return "auth";
+    if (error instanceof VibeProviderContractError) return "contract";
+    if (error instanceof VibeProviderSpaceMismatchError) return "mismatch";
+    return "error";
+}
+
+function providerUrl(path: string): string {
+    const baseUrl = config.vibeProviderUrl;
+    if (!baseUrl) throw new VibeProviderUnavailableError();
+    return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function requestHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+    };
+    if (config.internalApiSecret) {
+        headers["X-Internal-Secret"] = config.internalApiSecret;
+    }
+    return headers;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+    try {
+        return await response.json();
+    } catch (error) {
+        throw new VibeProviderContractError(error);
+    }
+}
+
+function throwForStatus(status: number, body: unknown): never {
+    const parsedError = errorResponseSchema.safeParse(body);
+    const message = parsedError.success ? parsedError.data.error : undefined;
+    if (status === 401) throw new VibeProviderAuthError(message);
+    if (status >= 500) throw new VibeProviderServerError(status, message);
+    throw new VibeProviderRequestError(status, message);
+}
+
+async function parseErrorBody(response: Response): Promise<unknown> {
+    try {
+        return await response.json();
+    } catch {
+        return undefined;
+    }
+}
+
+async function requestJson(
+    path: string,
+    timeoutMs: number,
+    init: Pick<RequestInit, "method" | "body">,
+): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetch(providerUrl(path), {
+            ...init,
+            headers: requestHeaders(),
+            redirect: "error",
+            signal: controller.signal,
+        });
+        if (!response.ok) {
+            const body = await parseErrorBody(response);
+            throwForStatus(response.status, body);
+        }
+        return await parseJson(response);
+    } catch (error) {
+        if (controller.signal.aborted)
+            throw new VibeProviderTimeoutError(error);
+        if (error instanceof VibeProviderError) throw error;
+        throw new VibeProviderUnavailableError(error);
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function observeRequest<T>(
+    endpoint: VibeProviderEndpoint,
+    operation: () => Promise<T>,
+): Promise<T> {
+    const startedAt = process.hrtime.bigint();
+    try {
+        const result = await operation();
+        const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
+        recordVibeProviderRequest(endpoint, "ok", seconds);
+        return result;
+    } catch (error) {
+        const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
+        recordVibeProviderRequest(endpoint, metricOutcome(error), seconds);
+        throw error;
+    }
+}
+
+function parseWithContract<T>(schema: z.ZodType<T>, value: unknown): T {
+    const parsed = schema.safeParse(value);
+    if (!parsed.success) throw new VibeProviderContractError(parsed.error);
+    return parsed.data;
+}
+
+function assertUnitVector(
+    vector: readonly number[],
+    activeSpace: ActiveEmbeddingSpace,
+): void {
+    if (vector.length !== activeSpace.dim) {
+        throw new VibeProviderContractError();
+    }
+    const squaredNorm = vector.reduce((sum, value) => sum + value * value, 0);
+    const norm = Math.sqrt(squaredNorm);
+    if (Math.abs(norm - 1) > UNIT_NORM_TOLERANCE) {
+        throw new VibeProviderContractError();
+    }
+}
+
+/** Assert that provider identity matches the active registry tuple. */
+export function assertProviderMatchesActiveSpace(
+    providerSpace: ProviderSpace,
+    activeSpace: ActiveEmbeddingSpace,
+): void {
+    const matches =
+        providerSpace.family === activeSpace.family &&
+        providerSpace.checkpointHash === activeSpace.checkpointHash &&
+        providerSpace.dim === activeSpace.dim;
+    if (!matches) throw new VibeProviderSpaceMismatchError();
+}
+
+/** Fetch and validate provider identity against the active registry space. */
+export async function fetchProviderSpace(): Promise<ProviderSpace> {
+    return observeRequest("space", async () => {
+        const body = await requestJson(
+            "/v1/space",
+            PROVIDER_SPACE_HEALTH_TIMEOUT_MS,
+            { method: "GET" },
+        );
+        const providerSpace = parseWithContract(providerSpaceSchema, body);
+        const activeSpace = await getActiveSpace();
+        assertProviderMatchesActiveSpace(providerSpace, activeSpace);
+        return providerSpace;
+    });
+}
+
+async function embed(
+    endpoint: "text" | "audio",
+    path: string,
+    body: Readonly<Record<string, string>>,
+    timeoutMs: number,
+): Promise<number[]> {
+    return observeRequest(endpoint, async () => {
+        const response = await requestJson(path, timeoutMs, {
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        const parsed = parseWithContract(vectorResponseSchema, response);
+        const activeSpace = await getActiveSpace();
+        assertUnitVector(parsed.vector, activeSpace);
+        return parsed.vector;
+    });
+}
+
+/** Embed text through the configured provider and active-space trust boundary. */
+export async function embedText(text: string): Promise<number[]> {
+    const validatedText = parseWithContract(textInputSchema, text);
+    return embed(
+        "text",
+        "/v1/embed/text",
+        { text: validatedText },
+        PROVIDER_TEXT_TIMEOUT_MS,
+    );
+}
+
+/** Embed one provider-owned track reference through the active-space boundary. */
+export async function embedAudio(trackRef: string): Promise<number[]> {
+    const validatedTrackRef = parseWithContract(trackRefSchema, trackRef);
+    return embed(
+        "audio",
+        "/v1/embed/audio",
+        { trackRef: validatedTrackRef },
+        PROVIDER_AUDIO_TIMEOUT_MS,
+    );
+}

--- a/backend/src/services/vibeVocabularyGenerator.ts
+++ b/backend/src/services/vibeVocabularyGenerator.ts
@@ -1,0 +1,69 @@
+import type { VocabTermDefinition } from "../config/featureProfiles";
+import type { Vocabulary } from "./vibeVocabulary";
+
+interface GenerateVocabularyOptions {
+    termNames: readonly string[];
+    definitions: Readonly<Record<string, VocabTermDefinition>>;
+    embed(text: string): Promise<number[]>;
+    generatedAt?: string;
+}
+
+/** Result of one bounded, sequential vocabulary generation pass. */
+export interface GenerateVocabularyResult {
+    vocabulary: Vocabulary;
+    succeeded: number;
+    failed: string[];
+}
+
+/** Require explicit provider opt-in before the operator script starts work. */
+export function requireVibeProviderUrl(
+    providerUrl: string | undefined,
+): string {
+    if (!providerUrl) {
+        throw new Error(
+            "VIBE_PROVIDER_URL is required to generate the vibe vocabulary",
+        );
+    }
+    return providerUrl;
+}
+
+/** Build the existing vocabulary artifact from provider text embeddings. */
+export async function generateVibeVocabulary(
+    options: GenerateVocabularyOptions,
+): Promise<GenerateVocabularyResult> {
+    const terms: Vocabulary["terms"] = {};
+    const failed: string[] = [];
+    let succeeded = 0;
+
+    for (let index = 0; index < options.termNames.length; index += 1) {
+        const termName = options.termNames[index];
+        const definition = options.definitions[termName];
+        if (!definition) {
+            failed.push(termName);
+            continue;
+        }
+        try {
+            const embedding = await options.embed(termName);
+            terms[termName] = {
+                name: termName,
+                type: definition.type,
+                embedding,
+                featureProfile: definition.featureProfile,
+                related: definition.related,
+            };
+            succeeded += 1;
+        } catch {
+            failed.push(termName);
+        }
+    }
+
+    return {
+        vocabulary: {
+            version: "1.0.0",
+            generatedAt: options.generatedAt ?? new Date().toISOString(),
+            terms,
+        },
+        succeeded,
+        failed,
+    };
+}

--- a/docs/designs/vibe-embedding-provider.md
+++ b/docs/designs/vibe-embedding-provider.md
@@ -1,6 +1,6 @@
 # Pluggable Vibe Embedding Provider
 
-Spec drafted 2026-08-16 for [issue #537](https://github.com/soundspan/soundspan/issues/537). Status: accepted design; the registry portion of rollout phase 1 is implemented by migration `20260816120000_add_embedding_space_registry`; remaining provider work has not started. Decision record: keep the LAION-CLAP `music_audioset` 512-dimension embedding space; adopt DCLAP's distilled ONNX student as the default provider; formalize provider and embedding-space abstractions so future model changes are operational rollouts, not schema migrations.
+Spec drafted 2026-08-16 for [issue #537](https://github.com/soundspan/soundspan/issues/537). Status: accepted design; the registry portion of rollout phase 1 is implemented by migration `20260816120000_add_embedding_space_registry`; the backend provider client has landed, while the sidecar HTTP layer and audio-path migration remain separate rollout work. Decision record: keep the LAION-CLAP `music_audioset` 512-dimension embedding space; adopt DCLAP's distilled ONNX student as the default provider; formalize provider and embedding-space abstractions so future model changes are operational rollouts, not schema migrations.
 
 Related: cross-peer taste vectors in Blends ([issue #529](https://github.com/soundspan/soundspan/issues/529)) and federated discovery ([issue #530](https://github.com/soundspan/soundspan/issues/530)) depend on the space-identity contract defined here.
 
@@ -31,7 +31,8 @@ POST /v1/embed/audio    { trackRef | upload }  -> { vector: float[dim] }
 POST /v1/embed/text     { text }               -> { vector: float[dim] }
 GET  /v1/space                                  -> { family, checkpointHash,
                                                     dim, sampleRateHz,
-                                                    preprocessing, revision }
+                                                    preprocessing, revision,
+                                                    textTower }
 ```
 
 Rules:

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -126,6 +126,8 @@ const LEAK_BASELINE = Object.freeze({
     // moodBucketService.ts remaining 1: error-classification const (~L185), never a response body; frozen under the slice-E scope guard.
     // moodBucketService.ts +1: Redis retry classification's ternary-consequent error.message (~L193); frozen under the ratchet-widening (slice-X1) scope guard.
     "backend/src/services/moodBucketService.ts": 2,
+    // vibeProvider.ts remaining 1: the provider's {error} body string becomes the typed VibeProvider*Error message for logs and cause chains (~parseErrorBody); routes map every provider error to canonical response text via the TextEmbeddingProviderError guard before responding, so the string never reaches a client body.
+    "backend/src/services/vibeProvider.ts": 1,
     // musicScanner.ts remaining 1: per-file scan-error detail stored in scan progress/health records (~L211); server-side scan state, admin-only surface.
     "backend/src/services/musicScanner.ts": 1,
     // podcastCache.ts remaining 2: cover-sync failure strings recorded server-side (~L90, ~L172); frozen under the slice-E scope guard.


### PR DESCRIPTION
## Summary

Backend half of the provider HTTP contract from `docs/designs/vibe-embedding-provider.md` (#537 phase 1). The sidecar half ships separately against the same wire contract.

- **Client** (`services/vibeProvider.ts`): `fetchProviderSpace` / `embedText` / `embedAudio` with zod-validated responses, AbortController deadlines (5s space / 30s text / 120s audio), no user-facing retry, conditional `X-Internal-Secret`, and a hard trust boundary — every vector is checked against the **active registry space** for dimension, unit L2 norm (1e-3), and finiteness before anything can use it. Typed error taxonomy maps 1:1 onto bounded `soundspan_vibe_provider_requests_total{endpoint,outcome}` metrics plus a latency histogram.
- **Text path** (`services/textEmbedding.ts`): `/api/vibe/search` resolves query embeddings through the provider when `VIBE_PROVIDER_URL` is set; unset keeps the legacy Redis-stream path token-identical (moved, not rewritten — pinned by the unchanged compat suites). Provider-down and timeout map to the same 504 the legacy path produces; non-timeout provider failures carry a typed identity the route checks before any message inspection, so provider-controlled error text can never steer the HTTP status.
- **Space schema forward-compatibility**: `/v1/space` parsing ignores unknown additive fields; the design doc's contract sketch now records the full field set (`revision`, `textTower`).
- **Vocabulary script**: `generateVibeVocabulary.ts` was dead code on a removed pub/sub protocol; it now drives the provider client with its transform extracted into a testable module, same output schema.
- `routes/vibe.ts` shrinks 1436 → ~1380 lines.

## Verification

- Targeted jest green across client, resolver, route-compat, error-canon, metrics, and config suites (red-then-green per change); `tsc --noEmit`; prettier; file-size + route-error-canon gates.
- Adversarial review to zero findings across two rounds: body-stall timeout classification, status-first error classification with non-conforming bodies, provider-down 504 parity, loose space schema, and mock-hierarchy alignment all landed with pinning tests.