### PR TITLE
fix(compose): build both analyzer sidecars from the repository root in local profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the local-profile Docker builds for both audio analyzer sidecars:
+  their compose entries now build from the repository root, matching the
+  root-relative paths their Dockerfiles have always used.
 - Hardened blue/green vibe migrations so completed post-cutover tails
   self-heal into the target space, text search stays in the active space,
   failed concurrent ANN indexes recover, terminal worker startup retries are

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -51,7 +51,8 @@ services:
     audio-analyzer-local:
         profiles: ["audio-analysis"]
         build:
-            context: ./services/audio-analyzer
+            context: .
+            dockerfile: services/audio-analyzer/Dockerfile
         environment:
             # Connect to host machine's services (or Docker services)
             REDIS_URL: redis://redis-local:6379
@@ -77,7 +78,8 @@ services:
     audio-analyzer-clap-local:
         profiles: ["audio-analysis"]
         build:
-            context: ./services/audio-analyzer-clap
+            context: .
+            dockerfile: services/audio-analyzer-clap/Dockerfile
         environment:
             REDIS_URL: redis://redis-local:6379
             DATABASE_URL: postgresql://soundspan:soundspan@postgres-local:5432/soundspan


### PR DESCRIPTION
## Summary

`docker-compose.local.yml` built `audio-analyzer-local` and `audio-analyzer-clap-local` with `context: ./services/<name>`, but both Dockerfiles copy repo-root-relative paths (`services/<name>/...` plus the shared `services/common`), so these local-profile builds have failed at their first COPY since being introduced. Both entries now use the repository root as context with an explicit `dockerfile:` path — the exact shape the `vibe-provider-dclap-local` entry already uses.

Sibling check: those two were the only offenders; no other compose file declares a service-directory build context.

## Verification

- `docker compose -f docker-compose.local.yml --profile audio-analysis --profile vibe-provider-dclap config` validates.
- A synthetic image build replicating every `COPY` statement from both Dockerfiles against the root context succeeds (exercises exactly the failing step class in seconds; the real builds were skipped because each pulls multi-gigabyte model artifacts, and the copy layer is the only thing this change touches).
- Prettier clean; CHANGELOG `[Unreleased]` Fixed entry added.