### PR TITLE
fix(clap): upsert embeddings against the composite key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The clap sidecar's embedding upsert now targets the composite
+  `(track_id, space_id)` key; against the migrated schema its previous
+  single-column conflict target failed every store.
 - Fixed the local-profile Docker builds for both audio analyzer sidecars:
   their compose entries now build from the repository root, matching the
   root-relative paths their Dockerfiles have always used.

--- a/services/audio-analyzer-clap/analyzer.py
+++ b/services/audio-analyzer-clap/analyzer.py
@@ -775,10 +775,9 @@ class Worker:
                 """
                 INSERT INTO track_embeddings (track_id, embedding, space_id, analyzed_at)
                 VALUES (%s, %s::vector, %s, %s)
-                ON CONFLICT (track_id)
+                ON CONFLICT (track_id, space_id)
                 DO UPDATE SET
                     embedding = EXCLUDED.embedding,
-                    space_id = EXCLUDED.space_id,
                     analyzed_at = EXCLUDED.analyzed_at
             """,
                 (track_id, embedding_list, space_id, datetime.now(UTC)),

--- a/services/audio-analyzer-clap/tests/test_reliability.py
+++ b/services/audio-analyzer-clap/tests/test_reliability.py
@@ -607,6 +607,10 @@ def test_store_embedding_writes_space_id_without_model_version(
     query, params = connection.insert_attempts[0]
     assert "space_id" in query
     assert "model_version" not in query
+    # The composite primary key from the migration machinery is the only
+    # unique constraint; a single-column conflict target fails every insert.
+    assert "ON CONFLICT (track_id, space_id)" in query
+    assert 'SET\n                    "space_id"' not in query
     assert params[2] == "space-current"
 
 


### PR DESCRIPTION
## Summary

Production regression found deploying main: the migration machinery (#548) moved `track_embeddings` to a composite `(track_id, space_id)` primary key and updated the backend upsert — but the clap sidecar's own INSERT still declared `ON CONFLICT (track_id)`, which matches no remaining unique constraint. Against the migrated schema, **every legacy-path embedding store fails** with `InvalidColumnReference`, marking each claimed track `failed` with a retry increment. #548's scope fence excluded `services/`, and its review verified backend call sites only — the sidecar write path slipped between the fences.

One-line fix: the conflict target names the composite key (and the update arm drops its now-redundant `space_id` reassignment). A test pins the composite conflict target so a future key change cannot silently strand the sidecar again.

This matters for every deployment that upgrades without configuring `VIBE_PROVIDER_URL` — the legacy sidecar path remains their only embedder.

## Verification

63 sidecar tests green including the new pin; ruff format + check; strict mypy on both analyzer modules; CHANGELOG entry.