### PR TITLE
feat(helm): ship the DCLAP vibe provider component, disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Helm chart now ships the DCLAP vibe provider component, disabled by
+  default for opt-in embedding migrations.
 - Operators can now start a blue/green vibe embedding migration by pointing
   `VIBE_PROVIDER_URL` at a distinct provider space; Soundspan registers and
   backfills it, cuts over at configured coverage, retains the old vectors for

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.2.0
+version: 2.3.0
 appVersion: "2.2.0"
 home: https://github.com/soundspan/soundspan
 sources:

--- a/charts/soundspan/README.md
+++ b/charts/soundspan/README.md
@@ -345,6 +345,27 @@ audioAnalyzerClap:
 > Unlike the sidecars above, these analyzer deployments are only used in Individual mode.
 > In AIO mode, audio analysis is built into the single AIO container.
 
+### DCLAP Vibe Provider (Individual Mode Only)
+
+The DCLAP provider is shipped but disabled by default. It is the Gate 2
+migration target for opt-in DCLAP embeddings.
+
+```yaml
+vibeProviderDclap:
+  enabled: true
+
+backend:
+  env:
+    VIBE_PROVIDER_URL: http://soundspan-vibe-provider-dclap:8091
+```
+
+Replace `soundspan` in the service hostname when using a different Helm release
+name. If `backendWorker.enabled=true`, set the same `VIBE_PROVIDER_URL` under
+`backendWorker.env` so worker-owned embedding jobs use the provider. The provider
+mounts the shared music volume read-only and receives only
+`INTERNAL_API_SECRET` from the chart Secret; it does not receive PostgreSQL or
+Redis credentials.
+
 ### Feature Flags
 
 Coarse feature flags render on the backend, backend-worker, and AIO workloads.
@@ -459,6 +480,11 @@ audioAnalyzerClap:
     - secretRef:
         name: soundspan-audio-analyzer-clap-extra-env
 
+vibeProviderDclap:
+  envFrom:
+    - secretRef:
+        name: soundspan-vibe-provider-dclap-extra-env
+
 tidalSidecar:
   envFrom:
     - secretRef:
@@ -507,6 +533,7 @@ This applies to:
 - `frontend.env`
 - `audioAnalyzer.env`
 - `audioAnalyzerClap.env`
+- `vibeProviderDclap.env`
 - `tidalSidecar.env`
 - `ytmusicStreamer.env`
 - `postgresql.env`

--- a/charts/soundspan/templates/NOTES.txt
+++ b/charts/soundspan/templates/NOTES.txt
@@ -35,6 +35,9 @@ Individual mode — each service runs in its own pod:
 {{- if .Values.audioAnalyzerClap.enabled }}
   • CLAP:       {{ $fullName }}-audio-analyzer-clap
 {{- end }}
+{{- if .Values.vibeProviderDclap.enabled }}
+  • DCLAP:      {{ $fullName }}-vibe-provider-dclap
+{{- end }}
 {{- end }}
 
 {{- if or .Values.ingress.enabled .Values.gateway.enabled }}

--- a/charts/soundspan/templates/individual/vibe-provider-dclap.yaml
+++ b/charts/soundspan/templates/individual/vibe-provider-dclap.yaml
@@ -1,0 +1,177 @@
+{{- if and (eq .Values.deploymentMode "individual") .Values.vibeProviderDclap.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "soundspan.fullname" . }}-vibe-provider-dclap
+  labels:
+    {{- include "soundspan.componentLabels" (dict "context" . "component" "vibe-provider-dclap") | nindent 4 }}
+spec:
+  replicas: {{ .Values.vibeProviderDclap.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "vibe-provider-dclap") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "soundspan.componentPodLabels" (dict "context" . "component" "vibe-provider-dclap") | nindent 8 }}
+      {{- with .Values.global.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "soundspan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+      containers:
+        - name: vibe-provider-dclap
+          image: {{ include "soundspan.image" .Values.vibeProviderDclap.image | quote }}
+          imagePullPolicy: {{ .Values.vibeProviderDclap.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.vibeProviderDclap.port }}
+              protocol: TCP
+          {{- $vibeProviderDclapEnv := .Values.vibeProviderDclap.env | default (dict) }}
+          {{- $vibeProviderDclapExplicitEnvKeys := dict
+            "MUSIC_PATH" true
+            "DCLAP_HTTP_PORT" true
+            "INTERNAL_API_SECRET" true
+            "TZ" true
+          }}
+          env:
+            {{- if hasKey $vibeProviderDclapEnv "MUSIC_PATH" }}
+            - name: MUSIC_PATH
+              value: {{ index $vibeProviderDclapEnv "MUSIC_PATH" | quote }}
+            {{- else }}
+            - name: MUSIC_PATH
+              value: /music
+            {{- end }}
+            {{- if hasKey $vibeProviderDclapEnv "DCLAP_HTTP_PORT" }}
+            - name: DCLAP_HTTP_PORT
+              value: {{ index $vibeProviderDclapEnv "DCLAP_HTTP_PORT" | quote }}
+            {{- else }}
+            - name: DCLAP_HTTP_PORT
+              value: {{ .Values.vibeProviderDclap.port | quote }}
+            {{- end }}
+            {{- if hasKey $vibeProviderDclapEnv "INTERNAL_API_SECRET" }}
+            - name: INTERNAL_API_SECRET
+              value: {{ index $vibeProviderDclapEnv "INTERNAL_API_SECRET" | quote }}
+            {{- else }}
+            # Import only the provider auth key. This workload needs no database
+            # or Redis credentials from the chart-managed Secret.
+            - name: INTERNAL_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "soundspan.secretName" . }}
+                  key: INTERNAL_API_SECRET
+            {{- end }}
+            {{- if hasKey $vibeProviderDclapEnv "TZ" }}
+            - name: TZ
+              value: {{ index $vibeProviderDclapEnv "TZ" | quote }}
+            {{- else }}
+            - name: TZ
+              value: {{ .Values.config.timezone | quote }}
+            {{- end }}
+            {{- range $key := keys $vibeProviderDclapEnv | sortAlpha }}
+            {{- if not (hasKey $vibeProviderDclapExplicitEnvKeys $key) }}
+            - name: {{ $key }}
+              value: {{ index $vibeProviderDclapEnv $key | quote }}
+            {{- end }}
+            {{- end }}
+          {{- $globalEnv := .Values.global.env | default (dict) }}
+          {{- $globalEnvFrom := .Values.global.envFrom | default (list) }}
+          {{- $vibeProviderDclapEnvFrom := .Values.vibeProviderDclap.envFrom | default (list) }}
+          {{- if or (gt (len $globalEnv) 0) (gt (len $globalEnvFrom) 0) (gt (len $vibeProviderDclapEnvFrom) 0) }}
+          envFrom:
+            {{- if gt (len $globalEnv) 0 }}
+            - configMapRef:
+                name: {{ include "soundspan.fullname" . }}-global-env
+            {{- end }}
+            {{- with $globalEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $vibeProviderDclapEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: music
+              mountPath: /music
+              readOnly: true
+          # The HTTP health route requires X-Internal-Secret. Kubernetes
+          # httpGet probes cannot source that header from a Secret.
+          {{- with .Values.vibeProviderDclap.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.vibeProviderDclap.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.vibeProviderDclap.resources | nindent 12 }}
+      volumes:
+        - name: music
+          {{- if .Values.music.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.music.persistence.existingClaim }}
+          {{- else if .Values.music.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "soundspan.fullname" . }}-music
+          {{- else if .Values.music.hostPath }}
+          hostPath:
+            path: {{ .Values.music.hostPath }}
+            type: Directory
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.vibeProviderDclap.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.vibeProviderDclap.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.vibeProviderDclap.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      {{- with .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "soundspan.fullname" . }}-vibe-provider-dclap
+  labels:
+    {{- include "soundspan.componentLabels" (dict "context" . "component" "vibe-provider-dclap") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.vibeProviderDclap.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "soundspan.componentSelectorLabels" (dict "context" . "component" "vibe-provider-dclap") | nindent 4 }}
+{{- end }}

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -621,6 +621,60 @@ audioAnalyzerClap:
     runtimeClassName: ""
 
 # =============================================================================
+# VIBE PROVIDERS (optional, individual mode only)
+# =============================================================================
+
+# -- Disabled by default; Gate 2 / migration target for DCLAP embeddings.
+vibeProviderDclap:
+  enabled: false
+  replicas: 1
+  image:
+    repository: ghcr.io/soundspan/soundspan-vibe-provider-dclap
+    tag: 2.2.0
+    # -- Immutable sha256 digest. When set, takes precedence over tag.
+    digest: ""
+    pullPolicy: Always
+  port: 8091
+  resources:
+    requests:
+      memory: 1Gi
+    limits:
+      memory: 2560Mi
+  # TCP probes avoid the authenticated /health route, whose required internal
+  # secret header cannot be sourced from a Kubernetes httpGet probe.
+  livenessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  env:
+    DCLAP_ONNX_INTRA_OP_THREADS: "1"
+    MODEL_IDLE_TIMEOUT: "300"
+  # -- Additional environment variable sources for DCLAP provider container.
+  # Example:
+  # envFrom:
+  #   - secretRef:
+  #       name: soundspan-vibe-provider-dclap-extra-env
+  envFrom: []
+  # Optional service-specific scheduling overrides (fallback to global values when empty)
+  nodeSelector: {}
+  tolerations: []
+  # Supports full Kubernetes affinity schema, including:
+  # - nodeAffinity
+  # - podAffinity
+  # - podAntiAffinity
+  affinity: {}
+
+# =============================================================================
 # SHARED CONFIGURATION
 # =============================================================================
 
@@ -855,4 +909,3 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
-

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -66,19 +66,21 @@ Images are published to GHCR.
 | Frontend                         | `ghcr.io/soundspan/soundspan-frontend:latest`            | 3030 |
 | Audio Analyzer                   | `ghcr.io/soundspan/soundspan-audio-analyzer:latest`      | —    |
 | Audio Analyzer CLAP              | `ghcr.io/soundspan/soundspan-audio-analyzer-clap:latest` | —    |
+| DCLAP Vibe Provider              | `ghcr.io/soundspan/soundspan-vibe-provider-dclap:latest` | 8091 |
 | TIDAL Sidecar                    | `ghcr.io/soundspan/soundspan-tidal-downloader:latest`    | 8585 |
 | YT Music Streamer                | `ghcr.io/soundspan/soundspan-ytmusic-streamer:latest`    | 8586 |
 
 Notes:
 
 - The backend worker image is only used in `deploymentMode: individual`.
+- The default-off DCLAP provider is only used in `deploymentMode: individual`.
 - AIO mode still uses the single `ghcr.io/soundspan/soundspan` image.
 
 ## Storage Class Guidance (RWX vs RWO)
 
 | Volume          | Access mode | Reason                                                   |
 | --------------- | ----------- | -------------------------------------------------------- |
-| `music`         | RWX         | Shared across backend, sidecars, and analyzers           |
+| `music`         | RWX         | Shared across backend, sidecars, analyzers, and providers |
 | `downloads`     | RWO         | Compose-only Lidarr add-on; not provisioned by the chart |
 | `postgres_data` | RWO         | Single PostgreSQL pod                                    |
 | `backend_cache` | RWO         | Backend-local transcode cache                            |
@@ -124,6 +126,7 @@ non-root.
 | YT Music Streamer                | Yes          | `GET /health`                                                                      |
 | Audio Analyzer                   | No           | Process check                                                                      |
 | Audio Analyzer CLAP              | No           | Import check                                                                       |
+| DCLAP Vibe Provider              | No           | TCP socket on `:8091` (`/health` requires internal authentication)                 |
 | AIO                              | Yes          | `GET /` on `:3030`                                                                 |
 
 ## Prometheus Scraping

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -124,12 +124,13 @@ tmp_individual_reserved_labels="$(mktemp)"
 tmp_individual_oidc="$(mktemp)"
 tmp_global_env="$(mktemp)"
 tmp_sidecars="$(mktemp)"
+tmp_dclap="$(mktemp)"
 tmp_secret="$(mktemp)"
 tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
 tmp_metrics="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_oidc" "$tmp_aio_digests" "$tmp_aio_reserved_labels" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_individual_reserved_labels" "$tmp_individual_oidc" "$tmp_global_env" "$tmp_sidecars" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid" "$tmp_metrics"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_oidc" "$tmp_aio_digests" "$tmp_aio_reserved_labels" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_individual_reserved_labels" "$tmp_individual_oidc" "$tmp_global_env" "$tmp_sidecars" "$tmp_dclap" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid" "$tmp_metrics"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -386,6 +387,7 @@ digest_tidal="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 digest_ytmusic="sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 digest_analyzer="sha256:1111111111111111111111111111111111111111111111111111111111111111"
 digest_clap="sha256:2222222222222222222222222222222222222222222222222222222222222222"
+digest_dclap="sha256:3333333333333333333333333333333333333333333333333333333333333333"
 
 echo "[CHECK] render AIO application image by digest"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
@@ -405,6 +407,7 @@ helm template "$RELEASE_NAME" "$CHART_PATH" \
   --set ytmusicStreamer.enabled=true \
   --set audioAnalyzer.enabled=true \
   --set audioAnalyzerClap.enabled=true \
+  --set vibeProviderDclap.enabled=true \
   --set backend.image.digest="$digest_backend" \
   --set backendWorker.image.digest="$digest_worker" \
   --set frontend.image.digest="$digest_frontend" \
@@ -412,6 +415,7 @@ helm template "$RELEASE_NAME" "$CHART_PATH" \
   --set ytmusicStreamer.image.digest="$digest_ytmusic" \
   --set audioAnalyzer.image.digest="$digest_analyzer" \
   --set audioAnalyzerClap.image.digest="$digest_clap" \
+  --set vibeProviderDclap.image.digest="$digest_dclap" \
   >"$tmp_individual_digests"
 
 assert_deployment_image "backend Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-backend" "ghcr.io/soundspan/soundspan-backend@${digest_backend}"
@@ -421,6 +425,7 @@ assert_deployment_image "TIDAL Deployment" "$tmp_individual_digests" "${RELEASE_
 assert_deployment_image "YT Music Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-ytmusic" "ghcr.io/soundspan/soundspan-ytmusic-streamer@${digest_ytmusic}"
 assert_deployment_image "audio analyzer Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-audio-analyzer" "ghcr.io/soundspan/soundspan-audio-analyzer@${digest_analyzer}"
 assert_deployment_image "CLAP analyzer Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-audio-analyzer-clap" "ghcr.io/soundspan/soundspan-audio-analyzer-clap@${digest_clap}"
+assert_deployment_image "DCLAP provider Deployment" "$tmp_individual_digests" "${RELEASE_NAME}-vibe-provider-dclap" "ghcr.io/soundspan/soundspan-vibe-provider-dclap@${digest_dclap}"
 
 echo "[CHECK] reject malformed application image digests"
 if helm template "$RELEASE_NAME" "$CHART_PATH" --set aio.image.digest=sha256:not-a-digest >/dev/null 2>&1; then
@@ -479,6 +484,67 @@ for sidecar in tidal ytmusic; do
   fi
 done
 assert_service_selectors_isolated "individual with HTTP sidecars" "$tmp_sidecars"
+
+echo "[CHECK] render default-off DCLAP provider in individual mode"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  >"$tmp_dclap"
+if line_match '^  name: '"$RELEASE_NAME"'-vibe-provider-dclap$' "$tmp_dclap"; then
+  echo "[ERROR] DCLAP provider must be disabled by default" >&2
+  exit 1
+fi
+
+echo "[CHECK] keep the DCLAP provider individual-mode-only"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set vibeProviderDclap.enabled=true \
+  >"$tmp_dclap"
+if line_match '^  name: '"$RELEASE_NAME"'-vibe-provider-dclap$' "$tmp_dclap"; then
+  echo "[ERROR] DCLAP provider must not render in AIO mode" >&2
+  exit 1
+fi
+
+echo "[CHECK] render enabled DCLAP provider without data-plane credentials"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set deploymentMode=individual \
+  --set vibeProviderDclap.enabled=true \
+  --set vibeProviderDclap.replicas=2 \
+  --set-string vibeProviderDclap.env.MODEL_IDLE_TIMEOUT=600 \
+  >"$tmp_dclap"
+
+for kind in Deployment Service; do
+  if ! RESOURCE_KIND="$kind" RESOURCE_NAME="${RELEASE_NAME}-vibe-provider-dclap" perl -0777 -ne '
+      for my $doc (split /^---/m, $_) {
+          next unless $doc =~ /^kind: \Q$ENV{RESOURCE_KIND}\E$/m;
+          exit 0 if $doc =~ /^  name: \Q$ENV{RESOURCE_NAME}\E$/m;
+      }
+      exit 1' "$tmp_dclap"; then
+    echo "[ERROR] enabled DCLAP provider missing ${kind}" >&2
+    exit 1
+  fi
+done
+
+if ! DEPLOYMENT_NAME="${RELEASE_NAME}-vibe-provider-dclap" SECRET_NAME="$RELEASE_NAME" perl -0777 -ne '
+    for my $doc (split /^---/m, $_) {
+        next unless $doc =~ /^kind:\s*Deployment$/m;
+        next unless $doc =~ /^  name: \Q$ENV{DEPLOYMENT_NAME}\E$/m;
+        exit 1 if $doc =~ /name:\s+(?:DATABASE_URL|REDIS_URL|POSTGRES_USER|POSTGRES_PASSWORD|POSTGRES_DB)\b/;
+        exit 0 if $doc =~ /^  replicas:\s+2$/m
+            && $doc =~ /containerPort:\s+8091\b/
+            && $doc =~ /tcpSocket:\s+port:\s+http/s
+            && $doc =~ /name:\s+MUSIC_PATH\s+value:\s+\/music/s
+            && $doc =~ /name:\s+DCLAP_HTTP_PORT\s+value:\s+"8091"/s
+            && $doc =~ /name:\s+DCLAP_ONNX_INTRA_OP_THREADS\s+value:\s+"1"/s
+            && $doc =~ /name:\s+MODEL_IDLE_TIMEOUT\s+value:\s+"600"/s
+            && $doc =~ /mountPath:\s+\/music\s+readOnly:\s+true/s
+            && $doc =~ /limits:\s+memory:\s+2560Mi/s
+            && $doc =~ /requests:\s+memory:\s+1Gi/s
+            && $doc =~ /name:\s+INTERNAL_API_SECRET\s+valueFrom:\s+secretKeyRef:\s+name:\s+\Q$ENV{SECRET_NAME}\E\s+key:\s+INTERNAL_API_SECRET/s;
+    }
+    exit 1' "$tmp_dclap"; then
+  echo "[ERROR] DCLAP provider wiring, overrides, probes, or credential isolation are invalid" >&2
+  exit 1
+fi
+assert_service_selectors_isolated "individual with DCLAP provider" "$tmp_dclap"
 
 # Secret generation (F22): the stable-lookup template must still render a
 # complete Secret on first install / dry-run (where `lookup` returns nil and the


### PR DESCRIPTION
## Summary

soundspan#547 shipped the `vibe-provider-dclap` sidecar into Compose behind an opt-in profile, but the Helm chart never gained the component — Compose users could opt in, Helm users could not. This closes the parity gap the same way: shipped, disabled by default.

- New `vibeProviderDclap` values block + `templates/individual/vibe-provider-dclap.yaml` (Deployment + ClusterIP Service on 8091), mirroring the tidal/ytmusic sidecar conventions end-to-end (component labels, env-map override pattern, envFrom wiring, scheduling override fallbacks, image digest support).
- Credential isolation: the provider receives only `INTERNAL_API_SECRET` via an explicit `secretKeyRef` — no `DATABASE_URL`/`REDIS_URL`/Postgres credentials anywhere in the rendered manifests.
- TCP probes with a template comment: the `/health` route requires the `X-Internal-Secret` header, which Kubernetes `httpGet` probes cannot source from a Secret.
- Music volume mounted read-only with the same claim wiring as the analyzers; individual-mode-only, matching the clap analyzer's gating.
- `scripts/helm-chart-render-check.sh` gains three checks: default-off, never renders in AIO mode, and enabled-render asserts wiring/overrides/probes plus a negative assertion that no data-plane credentials appear.
- Chart `2.2.0` → `2.3.0`; README, NOTES.txt, and docs/KUBERNETES.md updated.

## Verification

- `npm run verify:helm` (helm lint + full render-check suite) green, re-run after rebase onto main.