### PR TITLE
chore(helm): keep the chart version at 2.2.0 until release staging

### DIFF
--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.3.0
+version: 2.2.0
 appVersion: "2.2.0"
 home: https://github.com/soundspan/soundspan
 sources:


### PR DESCRIPTION
The DCLAP component PR (#553) bumped the chart version to 2.3.0 mid-cycle while appVersion and image tags stayed 2.2.0 — against the convention where `scripts/release/version-sync.mjs` moves chart version, appVersion, and tags together in the release staging commit (see the 2.2.0 stage, #522). Restore 2.2.0; the 2.3.0 stage will bump every surface at once.