### PR TITLE
fix(vibe): cut over immediately when the active space has no vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fresh installs with only a provider-backed vibe space now cut over
+  immediately instead of stalling behind an active space with no vectors.
 - The clap sidecar's embedding upsert now targets the composite
   `(track_id, space_id)` key; against the migrated schema its previous
   single-column conflict target failed every store.

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -12,6 +12,8 @@ const mockTransaction = jest.fn();
 const mockInvalidate = jest.fn();
 const mockRecordTransition = jest.fn();
 const mockLoadCoverage = jest.fn();
+const mockLoadSpaceEmbeddedCount = jest.fn();
+const mockGetActiveSpace = jest.fn();
 const mockLogInfo = jest.fn();
 
 jest.mock("../../utils/db", () => ({
@@ -37,6 +39,7 @@ jest.mock("../../utils/db", () => ({
 }));
 
 jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
     invalidateActiveSpaceCache: () => mockInvalidate(),
 }));
 
@@ -48,6 +51,8 @@ jest.mock("../../metrics", () => ({
 jest.mock("../vibeEmbeddingCoverage", () => ({
     loadVibeEmbeddingCoverage: (...args: unknown[]) =>
         mockLoadCoverage(...args),
+    loadVibeSpaceEmbeddedCount: (...args: unknown[]) =>
+        mockLoadSpaceEmbeddedCount(...args),
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -67,6 +72,7 @@ import {
     retirementDue,
     runEmbeddingSpaceLifecycleCheck,
     shouldCutOver,
+    shouldCutOverEmptyActiveSpace,
 } from "../embeddingSpaceLifecycle";
 
 const now = new Date("2026-08-16T12:00:00.000Z");
@@ -84,6 +90,18 @@ describe("embedding-space lifecycle decisions", () => {
     ])("evaluates coverage %s at threshold %s", (coverage, threshold, due) => {
         expect(shouldCutOver(coverage, threshold)).toBe(due);
     });
+
+    it.each([
+        [0, true],
+        [1, false],
+    ])(
+        "evaluates empty-active-space cutover with %s embedded vectors",
+        (activeEmbeddedCount, due) => {
+            expect(
+                shouldCutOverEmptyActiveSpace(activeEmbeddedCount),
+            ).toBe(due);
+        },
+    );
 
     it("treats the exact grace boundary as due", () => {
         const retiredAt = new Date("2026-08-09T12:00:00.000Z");
@@ -107,6 +125,8 @@ describe("embedding-space lifecycle effects", () => {
             pending: 1,
             failed: 0,
         });
+        mockLoadSpaceEmbeddedCount.mockResolvedValue(1);
+        mockGetActiveSpace.mockResolvedValue({ id: "space_teacher_1" });
         mockTransaction.mockImplementation(
             async (operation: (tx: unknown) => Promise<unknown>) =>
                 operation({
@@ -118,7 +138,7 @@ describe("embedding-space lifecycle effects", () => {
         );
     });
 
-    it("builds the index before atomically flipping both spaces", async () => {
+    it("cuts over a covered migration when the active space has vectors", async () => {
         const order: string[] = [];
         mockFindFirst.mockResolvedValue(migrating);
         mockLoadCoverage.mockResolvedValue({
@@ -149,6 +169,9 @@ describe("embedding-space lifecycle effects", () => {
         });
 
         expect(order).toEqual(["index", "transaction"]);
+        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+            "space_teacher_1",
+        );
         expect(mockLoadCoverage).toHaveBeenCalledWith("space_student_1");
         expect(mockLogInfo).toHaveBeenCalledWith(
             "Embedding-space migration coverage sampled",
@@ -195,7 +218,7 @@ describe("embedding-space lifecycle effects", () => {
         });
     });
 
-    it("logs stalled migration coverage once without starting cutover", async () => {
+    it("keeps a sub-threshold migration when the active space has vectors", async () => {
         mockFindFirst.mockResolvedValue(migrating);
         mockLoadCoverage.mockResolvedValue({
             embedded: 80,
@@ -209,6 +232,9 @@ describe("embedding-space lifecycle effects", () => {
             now: () => now,
         });
 
+        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+            "space_teacher_1",
+        );
         expect(mockLogInfo).toHaveBeenCalledTimes(1);
         expect(mockLogInfo).toHaveBeenCalledWith(
             "Embedding-space migration coverage sampled",
@@ -220,6 +246,40 @@ describe("embedding-space lifecycle effects", () => {
         );
         expect(mockQueryRaw).not.toHaveBeenCalled();
         expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it("cuts over immediately when the active space has no embedded vectors", async () => {
+        mockFindFirst.mockResolvedValue(migrating);
+        mockLoadSpaceEmbeddedCount.mockResolvedValue(0);
+        mockLoadCoverage.mockResolvedValue({
+            embedded: 0,
+            pending: 0,
+            failed: 0,
+        });
+
+        await runEmbeddingSpaceLifecycleCheck({
+            threshold: 0.95,
+            retirementGraceDays: 7,
+            now: () => now,
+        });
+
+        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+            "space_teacher_1",
+        );
+        expect(mockLoadCoverage).not.toHaveBeenCalled();
+        expect(mockExecuteRawUnsafe).toHaveBeenCalledWith(
+            expect.stringContaining("CREATE INDEX CONCURRENTLY IF NOT EXISTS"),
+        );
+        expect(mockTransaction).toHaveBeenCalledTimes(1);
+        expect(mockInvalidate).toHaveBeenCalledTimes(1);
+        expect(mockRecordTransition).toHaveBeenCalledWith("cutover");
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            "Embedding-space cutover starting because active space has no embedded vectors",
+            {
+                activeSpaceId: "space_teacher_1",
+                migratingSpaceId: "space_student_1",
+            },
+        );
     });
 
     it("drops and rebuilds an existing invalid partial index once", async () => {

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -97,9 +97,9 @@ describe("embedding-space lifecycle decisions", () => {
     ])(
         "evaluates empty-active-space cutover with %s embedded vectors",
         (activeEmbeddedCount, due) => {
-            expect(
-                shouldCutOverEmptyActiveSpace(activeEmbeddedCount),
-            ).toBe(due);
+            expect(shouldCutOverEmptyActiveSpace(activeEmbeddedCount)).toBe(
+                due,
+            );
         },
     );
 

--- a/backend/src/services/embeddingSpaceLifecycle.ts
+++ b/backend/src/services/embeddingSpaceLifecycle.ts
@@ -1,8 +1,11 @@
 import { recordVibeSpaceTransition } from "../metrics";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
-import { invalidateActiveSpaceCache } from "./embeddingSpaces";
-import { loadVibeEmbeddingCoverage } from "./vibeEmbeddingCoverage";
+import { getActiveSpace, invalidateActiveSpaceCache } from "./embeddingSpaces";
+import {
+    loadVibeEmbeddingCoverage,
+    loadVibeSpaceEmbeddedCount,
+} from "./vibeEmbeddingCoverage";
 
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1_000;
 const RETIRED_SPACE_SCAN_LIMIT = 10;
@@ -31,6 +34,15 @@ interface LifecycleSpace {
 /** Decide whether measured coverage has reached the configured cutover floor. */
 export function shouldCutOver(coverage: number, threshold: number): boolean {
     return Number.isFinite(coverage) && coverage >= threshold;
+}
+
+/** Decide whether an empty active space permits immediate cutover. */
+export function shouldCutOverEmptyActiveSpace(
+    activeEmbeddedCount: number,
+): boolean {
+    // Pending active-space work does not protect query results and may have no
+    // deployed teacher worker capable of completing it on a fresh install.
+    return activeEmbeddedCount === 0;
 }
 
 /** Decide whether a retired space has reached its cleanup boundary. */
@@ -108,10 +120,44 @@ async function loadCoverage(spaceId: string): Promise<number> {
     return actionable === 0 ? 0 : coverage.embedded / actionable;
 }
 
+async function completeCutover(
+    migratingSpaceId: string,
+    retiredAt: Date,
+): Promise<void> {
+    await buildPartialAnnIndex(migratingSpaceId);
+    await flipActiveSpace(migratingSpaceId, retiredAt);
+    invalidateActiveSpaceCache();
+    recordVibeSpaceTransition("cutover");
+}
+
+async function cutOverEmptyActiveSpace(
+    activeSpaceId: string,
+    migratingSpaceId: string,
+    retiredAt: Date,
+): Promise<void> {
+    log.info(
+        "Embedding-space cutover starting because active space has no embedded vectors",
+        { activeSpaceId, migratingSpaceId },
+    );
+    await completeCutover(migratingSpaceId, retiredAt);
+    log.info("Embedding-space cutover completed", {
+        spaceId: migratingSpaceId,
+        reason: "empty_active_space",
+    });
+}
+
 async function cutOverIfReady(
     space: LifecycleSpace,
     config: LifecycleConfig,
 ): Promise<void> {
+    const activeSpace = await getActiveSpace();
+    const activeEmbeddedCount = await loadVibeSpaceEmbeddedCount(
+        activeSpace.id,
+    );
+    if (shouldCutOverEmptyActiveSpace(activeEmbeddedCount)) {
+        await cutOverEmptyActiveSpace(activeSpace.id, space.id, config.now());
+        return;
+    }
     const coverage = await loadCoverage(space.id);
     log.info("Embedding-space migration coverage sampled", {
         spaceId: space.id,
@@ -119,10 +165,7 @@ async function cutOverIfReady(
         thresholdPercent: config.threshold * 100,
     });
     if (!shouldCutOver(coverage, config.threshold)) return;
-    await buildPartialAnnIndex(space.id);
-    await flipActiveSpace(space.id, config.now());
-    invalidateActiveSpaceCache();
-    recordVibeSpaceTransition("cutover");
+    await completeCutover(space.id, config.now());
     log.info("Embedding-space cutover completed", {
         spaceId: space.id,
         coverage,

--- a/backend/src/services/vibeEmbeddingCoverage.ts
+++ b/backend/src/services/vibeEmbeddingCoverage.ts
@@ -9,6 +9,13 @@ interface CoverageRefresherDependencies {
     setCoverage(coverage: VibeEmbeddingCoverage): void;
 }
 
+/** Counts every stored vector in one embedding space. */
+export async function loadVibeSpaceEmbeddedCount(
+    spaceId: string,
+): Promise<number> {
+    return prisma.trackEmbedding.count({ where: { spaceId } });
+}
+
 /** Loads target-space coverage for local tracks eligible for audio analysis. */
 export async function loadVibeEmbeddingCoverage(
     targetSpaceId?: string,

--- a/docs/designs/vibe-embedding-provider.md
+++ b/docs/designs/vibe-embedding-provider.md
@@ -72,6 +72,8 @@ Invariants:
 3. When coverage reaches `VIBE_SPACE_CUTOVER_THRESHOLD` (default 95%), the worker builds the target's partial ANN index, atomically marks the old space `retired` and the target `active`, then invalidates the active-space cache.
 4. The old vectors remain available for `VIBE_SPACE_RETIREMENT_GRACE_DAYS` (default 7). The worker then deletes them in bounded batches, drops their partial index if present, clears the grace anchor to mark cleanup complete, and retains the registry identity row as history.
 
+When the active space contains zero vectors, the worker builds the target's partial ANN index and cuts over immediately without waiting for migration coverage. A fresh install may never deploy the teacher worker, and an empty active space protects no query results, so this closes the provider-only text-search dead window without sacrificing existing similarity results.
+
 Keep the torch CLAP sidecar and its Redis text-embedding handler running throughout a migration. While the configured provider's space is not active, text search falls back to that legacy text tower so queries remain in the active space. `CLAP_WORKERS=0` disables its audio workers without stopping the text handler.
 
 At the cutover boundary, a cached provider-space mismatch can keep text search on the legacy tower while ANN reads use the new active space for at most 60 seconds. This bounded cross-space window equals the provider/active-space verdict-cache TTL. The next verdict refresh sees that the configured provider now matches the active space and moves text encoding to that provider without operator action.


### PR DESCRIPTION
## Summary

Closes the fresh-install stall in the blue/green embedding-space migration. When only a provider-backed space is deployed (no teacher analyzer), the migrating space computed 0/0 coverage forever and the empty active space never yielded — leaving text vibe search dead behind a space with nothing in it.

- New pure decision `shouldCutOverEmptyActiveSpace(activeEmbeddedCount)` mirroring `shouldCutOver`'s testable shape: an active space with zero embedded vectors protects no query results, and its pending work cannot complete without a teacher deployment, so the lifecycle cuts over immediately (same ANN-index build + CAS flip path, distinct log reason).
- `loadVibeSpaceEmbeddedCount` added to the coverage service (no raw SQL outside the blessed layer).
- Coverage-threshold path unchanged for non-empty active spaces, with regression tests pinning both directions.

## Verification

- `npx jest src/services/__tests__/embeddingSpaceLifecycle.test.ts` — Test Suites: 1 passed; Tests: 14 passed; exit 0 (re-run after rebase onto main).
- `tsc --noEmit` clean.