### PR TITLE
ci(security): audit the DCLAP provider lock with pip-audit

### DIFF
--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -224,6 +224,12 @@ jobs:
               --ignore-vuln PYSEC-2026-1805
               --ignore-vuln PYSEC-2026-2324
               --ignore-vuln PYSEC-2026-2547
+          # DCLAP provider image is python:3.12-slim; its hash-pinned lock is
+          # compiled for 3.12, so the audit checks exactly the shipped tree.
+          - requirements: services/vibe-provider-dclap/requirements.lock
+            python-version: "3.12"
+            audit-args: --disable-pip --no-deps
+            ignore-vulns: ""
           # AIO image bakes the analyzer dependencies into its Debian-bookworm
           # system Python 3.11 site-packages; requirements-aio.lock is that
           # resolved tree.


### PR DESCRIPTION
The torch analyzer's pip-audit lane died with the analyzer, but its replacement was never covered: `services/vibe-provider-dclap/requirements.lock` had no audit lane at all — found while diagnosing the #560 auto-merge stall against stale required contexts. Adds the python-3.12 lane with an empty exception list; pre-flight local run reports no known vulnerabilities. After merge I will promote `pip-audit (services/vibe-provider-dclap/requirements.lock)` to a required status check, restoring gate parity with the removed torch lane.