### PR TITLE
fix(helm): reject removed values and the conflicting DCLAP port override

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -78,6 +78,7 @@ jobs:
             soundspan-tidal-downloader
             soundspan-ytmusic-streamer
             soundspan-audio-analyzer
+            soundspan-vibe-provider-dclap
           )
 
           max_wait_seconds=1800

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Helm chart now ships the DCLAP vibe provider component, disabled by
   default for opt-in embedding migrations.
+- Added a DCLAP provider target to the default and analysis Docker Bake groups.
 - Operators can now start a blue/green vibe embedding migration by pointing
   `VIBE_PROVIDER_URL` at a distinct provider space; Soundspan registers and
   backfills it, cuts over at configured coverage, retains the old vectors for
@@ -73,6 +74,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transient vibe-provider failures now receive bounded automatic retries, and
   malformed queue entries cannot demote completed or already-stored tracks.
 - Stale vibe claims are now recovered independently of MusicCNN queue state.
+- Helm now rejects removed `audioAnalyzerClap.*` values and the conflicting
+  `vibeProviderDclap.env.DCLAP_HTTP_PORT` override instead of rendering a broken
+  component. Chart releases now wait for the DCLAP provider image.
 - Fresh installs with only a provider-backed vibe space now cut over
   immediately instead of stalling behind an active space with no vectors.
 - The clap sidecar's embedding upsert now targets the composite

--- a/charts/soundspan/README.md
+++ b/charts/soundspan/README.md
@@ -366,6 +366,9 @@ backend:
 
 An explicit `backend.env.VIBE_PROVIDER_URL` or
 `backendWorker.env.VIBE_PROVIDER_URL` takes precedence over the generated URL.
+`vibeProviderDclap.env.DCLAP_HTTP_PORT` is reserved; set
+`vibeProviderDclap.port` so the provider, Service, probes, and backend URLs use
+the same port.
 The provider mounts the shared music volume read-only and receives only
 `INTERNAL_API_SECRET` from the chart Secret; it does not receive PostgreSQL or
 Redis credentials.
@@ -399,11 +402,9 @@ matching background workers.
 > new work is queued for them.
 >
 > In AIO mode analysis runs inside the all-in-one container and is not
-> controlled by `audioAnalyzer.enabled` or `vibeProviderDclap.enabled`; with
-> `config.features.audioAnalysis=false` they stay up and drain any leftover
-> queued work. The analyzer machine callbacks (`/api/analysis/vibe/failure`,
-> `/api/analysis/vibe/success`) remain mounted even when the flag is off so
-> in-flight work can still report results.
+> controlled by `audioAnalyzer.enabled` or `vibeProviderDclap.enabled`.
+> Setting `config.features.audioAnalysis=false` prevents the provider-backed
+> vibe consumer from starting, so it does not drain queued vibe work.
 
 ### External Database / Redis (Individual Mode)
 
@@ -514,7 +515,10 @@ Notes:
 
 ### Environment Variable Precedence and Overrides
 
-All service `*.env` maps support pass-through overrides, including keys that the chart also sets by default.
+Service `*.env` maps support pass-through overrides, including keys that the
+chart also sets by default. The reserved
+`vibeProviderDclap.env.DCLAP_HTTP_PORT` key is the exception; use
+`vibeProviderDclap.port` instead.
 
 For chart-managed containers, precedence is:
 - Service `*.env` key/value pairs

--- a/charts/soundspan/templates/NOTES.txt
+++ b/charts/soundspan/templates/NOTES.txt
@@ -34,6 +34,8 @@ Individual mode — each service runs in its own pod:
 {{- end }}
 {{- if .Values.vibeProviderDclap.enabled }}
   • DCLAP:      {{ $fullName }}-vibe-provider-dclap
+{{- else }}
+  • Vibe similarity: Inactive — set vibeProviderDclap.enabled=true to deploy the embedding provider.
 {{- end }}
 {{- end }}
 

--- a/charts/soundspan/templates/individual/vibe-provider-dclap.yaml
+++ b/charts/soundspan/templates/individual/vibe-provider-dclap.yaml
@@ -1,4 +1,5 @@
 {{- if and (eq .Values.deploymentMode "individual") .Values.vibeProviderDclap.enabled }}
+{{- $vibeProviderDclapEnv := .Values.vibeProviderDclap.env | default (dict) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,6 @@ spec:
             - name: http
               containerPort: {{ .Values.vibeProviderDclap.port }}
               protocol: TCP
-          {{- $vibeProviderDclapEnv := .Values.vibeProviderDclap.env | default (dict) }}
           {{- $vibeProviderDclapExplicitEnvKeys := dict
             "MUSIC_PATH" true
             "DCLAP_HTTP_PORT" true
@@ -52,13 +52,8 @@ spec:
             - name: MUSIC_PATH
               value: /music
             {{- end }}
-            {{- if hasKey $vibeProviderDclapEnv "DCLAP_HTTP_PORT" }}
-            - name: DCLAP_HTTP_PORT
-              value: {{ index $vibeProviderDclapEnv "DCLAP_HTTP_PORT" | quote }}
-            {{- else }}
             - name: DCLAP_HTTP_PORT
               value: {{ .Values.vibeProviderDclap.port | quote }}
-            {{- end }}
             {{- if hasKey $vibeProviderDclapEnv "INTERNAL_API_SECRET" }}
             - name: INTERNAL_API_SECRET
               value: {{ index $vibeProviderDclapEnv "INTERNAL_API_SECRET" | quote }}

--- a/charts/soundspan/templates/validate-values.yaml
+++ b/charts/soundspan/templates/validate-values.yaml
@@ -1,0 +1,7 @@
+{{- if hasKey .Values "audioAnalyzerClap" -}}
+{{- fail "audioAnalyzerClap values were removed; set vibeProviderDclap.enabled instead; see the 2.3.0 entry in docs/UPGRADING.md" -}}
+{{- end -}}
+{{- $vibeProviderDclapEnv := .Values.vibeProviderDclap.env | default (dict) -}}
+{{- if hasKey $vibeProviderDclapEnv "DCLAP_HTTP_PORT" -}}
+{{- fail "set vibeProviderDclap.port instead of env.DCLAP_HTTP_PORT" -}}
+{{- end -}}

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -126,7 +126,6 @@ aio:
     AUDIO_BRPOP_TIMEOUT: "30"
     AUDIO_REDIS_SOCKET_TIMEOUT: "35"
     AUDIO_MODEL_IDLE_TIMEOUT: "300"
-    CLAP_REDIS_SOCKET_TIMEOUT: "10"
   # -- Additional environment variable sources for AIO container.
   # Example:
   # envFrom:
@@ -732,8 +731,8 @@ config:
     nameClaim: name
     providerName: SSO
   # -- Flush Redis with FLUSHALL on backend startup.
-  #    Default false to preserve Redis Streams/group metadata used by
-  #    multi-replica analyzer services (for example CLAP text embedding).
+  #    Default false to preserve live provider job queues and cross-pod
+  #    coordination state.
   #    Set true only for fully disposable local/dev Redis instances.
   redisFlushOnStartup: false
   # -- Lidarr integration

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -7,7 +7,8 @@
                 "backend-worker",
                 "tidal-downloader",
                 "ytmusic-streamer",
-                "audio-analyzer"
+                "audio-analyzer",
+                "vibe-provider-dclap"
             ]
         },
         "core": {
@@ -20,7 +21,7 @@
             "targets": ["tidal-downloader", "ytmusic-streamer"]
         },
         "analysis": {
-            "targets": ["audio-analyzer"]
+            "targets": ["audio-analyzer", "vibe-provider-dclap"]
         },
         "aio": {
             "targets": ["soundspan-aio"]
@@ -88,6 +89,12 @@
             "context": ".",
             "dockerfile": "services/audio-analyzer/Dockerfile",
             "tags": ["soundspan-audio-analyzer:latest"]
+        },
+
+        "vibe-provider-dclap": {
+            "context": ".",
+            "dockerfile": "services/vibe-provider-dclap/Dockerfile",
+            "tags": ["soundspan-vibe-provider-dclap:latest"]
         },
 
         "soundspan-aio": {

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -101,6 +101,23 @@ assert_deployment_env_absent() {
   fi
 }
 
+assert_template_rejected() {
+  local description="$1"
+  local expected_message="$2"
+  shift 2
+  local output
+
+  if output="$(helm template "$RELEASE_NAME" "$CHART_PATH" "$@" 2>&1)"; then
+    echo "[ERROR] ${description} was accepted" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected_message"* ]]; then
+    echo "[ERROR] ${description} failed without the expected message: ${expected_message}" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
 assert_oidc_env() {
   local deployment_name="$1"
   local manifest_file="$2"
@@ -159,6 +176,7 @@ tmp_individual_external_database="$(mktemp)"
 tmp_individual_digests="$(mktemp)"
 tmp_individual_reserved_labels="$(mktemp)"
 tmp_individual_oidc="$(mktemp)"
+tmp_individual_notes="$(mktemp)"
 tmp_global_env="$(mktemp)"
 tmp_sidecars="$(mktemp)"
 tmp_dclap_default="$(mktemp)"
@@ -170,7 +188,7 @@ tmp_secret_explicit="$(mktemp)"
 tmp_secret_existing="$(mktemp)"
 tmp_frontend_uid="$(mktemp)"
 tmp_metrics="$(mktemp)"
-trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_oidc" "$tmp_aio_digests" "$tmp_aio_reserved_labels" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_individual_reserved_labels" "$tmp_individual_oidc" "$tmp_global_env" "$tmp_sidecars" "$tmp_dclap_default" "$tmp_dclap_aio" "$tmp_dclap_enabled" "$tmp_dclap_override" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid" "$tmp_metrics"' EXIT
+trap 'rm -f "$tmp_aio" "$tmp_aio_sidecars" "$tmp_aio_rotated_secrets" "$tmp_aio_secret_overrides" "$tmp_aio_oidc" "$tmp_aio_digests" "$tmp_aio_reserved_labels" "$tmp_individual_ha" "$tmp_individual_component_database" "$tmp_individual_external_database" "$tmp_individual_digests" "$tmp_individual_reserved_labels" "$tmp_individual_oidc" "$tmp_individual_notes" "$tmp_global_env" "$tmp_sidecars" "$tmp_dclap_default" "$tmp_dclap_aio" "$tmp_dclap_enabled" "$tmp_dclap_override" "$tmp_secret" "$tmp_secret_explicit" "$tmp_secret_existing" "$tmp_frontend_uid" "$tmp_metrics"' EXIT
 
 echo "[CHECK] helm lint (${CHART_PATH})"
 helm lint "$CHART_PATH"
@@ -186,6 +204,7 @@ if ! line_match '^  name: '"$RELEASE_NAME"'$' "$tmp_aio"; then
   exit 1
 fi
 assert_service_selectors_isolated "default AIO" "$tmp_aio"
+assert_deployment_env_absent "$RELEASE_NAME" "CLAP_REDIS_SOCKET_TIMEOUT" "$tmp_aio"
 if line_match '^kind: ServiceMonitor$' "$tmp_aio"; then
   echo "[ERROR] ServiceMonitor must be disabled by default" >&2
   exit 1
@@ -532,6 +551,22 @@ if line_match '^  name: '"$RELEASE_NAME"'-vibe-provider-dclap$' "$tmp_dclap_defa
 fi
 assert_deployment_env_absent "${RELEASE_NAME}-backend" "VIBE_PROVIDER_URL" "$tmp_dclap_default"
 
+echo "[CHECK] explain inactive vibe similarity in individual-mode notes"
+helm install "$RELEASE_NAME" "$CHART_PATH" \
+  --dry-run=client \
+  --set deploymentMode=individual \
+  >"$tmp_individual_notes"
+if ! line_match 'Vibe similarity: Inactive — set vibeProviderDclap.enabled=true to deploy the embedding provider.' "$tmp_individual_notes"; then
+  echo "[ERROR] individual-mode notes missing inactive vibe similarity guidance" >&2
+  exit 1
+fi
+
+echo "[CHECK] reject removed audioAnalyzerClap values"
+assert_template_rejected \
+  "removed audioAnalyzerClap values" \
+  "audioAnalyzerClap values were removed; set vibeProviderDclap.enabled instead; see the 2.3.0 entry in docs/UPGRADING.md" \
+  --set audioAnalyzerClap.enabled=true
+
 echo "[CHECK] keep the DCLAP provider individual-mode-only"
 helm template "$RELEASE_NAME" "$CHART_PATH" \
   --set vibeProviderDclap.enabled=true \
@@ -590,6 +625,12 @@ if ! DEPLOYMENT_NAME="${RELEASE_NAME}-vibe-provider-dclap" SECRET_NAME="$RELEASE
   exit 1
 fi
 assert_service_selectors_isolated "individual with DCLAP provider" "$tmp_dclap_enabled"
+
+echo "[CHECK] reject DCLAP_HTTP_PORT env override"
+assert_template_rejected \
+  "vibeProviderDclap.env.DCLAP_HTTP_PORT" \
+  "set vibeProviderDclap.port instead of env.DCLAP_HTTP_PORT" \
+  --set-string vibeProviderDclap.env.DCLAP_HTTP_PORT=8199
 
 echo "[CHECK] preserve explicit backend VIBE_PROVIDER_URL override"
 helm template "$RELEASE_NAME" "$CHART_PATH" \


### PR DESCRIPTION
## Summary

Chart/CI batch of the transition-review fixes (adversarial review of the 2.3.0 torch→DCLAP flip):

- **Reproduced defect fixed**: `vibeProviderDclap.env.DCLAP_HTTP_PORT` changed what the provider listens on while the Service/probes/backend URL follow `.port` — the env key is now reserved; template validation `fail`s with "set vibeProviderDclap.port instead". Negative render test added.
- Surviving `audioAnalyzerClap.*` values (even `{}`) now fail template validation with 2.3.0 upgrade guidance instead of being silently ignored while vibe features quietly stay off. Negative render test added.
- Individual-mode NOTES state when vibe similarity is inactive and how to enable it.
- `helm-chart-release.yml` waits for the `soundspan-vibe-provider-dclap` image (the chart could previously publish before its image existed).
- Removed the ignored `CLAP_REDIS_SOCKET_TIMEOUT` AIO value; Redis flush guidance now names live state. Chart README loses the false "AIO drains leftover vibe work" claim and the deleted-callback docs.
- `docker-bake.json` gains the `vibe-provider-dclap` target in `default`/`analysis` groups.

## Verification

- `npm run verify:helm` fully green including both new negative tests; `helm lint` clean.
- `jq` validates the bake target + group membership (buildx unavailable locally; CI's Image Builds is the real bake gate).
- Prettier clean on `docker-bake.json`.