### PR TITLE
fix(vibe)!: harden the space-migration lifecycle against traced defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Vibe migration coverage telemetry now exposes failed tracks at sampling and
+  cutover, while retaining the actionable coverage denominator.
+- Migrating-space vibe text scans and lifecycle coverage reads are now bounded
+  by a statement timeout, candidate cap, existence query, and two-query sampler.
+- Vibe provider registration now rejects preprocessing mismatches for an
+  existing model tuple and records the configuration error.
 - During a vibe embedding-space migration, text search now embeds and queries
   in the provider's registered space, returning partial results that grow with
   the backfill instead of using the removed legacy analyzer stream.
@@ -61,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Force rebuilding vibe embeddings now preserves active-space vectors, and a
+  durable space marker prevents wiped spaces from triggering fresh-install
+  cutover behavior.
+- Transient vibe-provider failures now receive bounded automatic retries, and
+  malformed queue entries cannot demote completed or already-stored tracks.
+- Stale vibe claims are now recovered independently of MusicCNN queue state.
 - Fresh installs with only a provider-backed vibe space now cut over
   immediately instead of stalling behind an active space with no vectors.
 - The clap sidecar's embedding upsert now targets the composite

--- a/backend/prisma/migrations/20260817120000_add_embedding_space_had_vectors/migration.sql
+++ b/backend/prisma/migrations/20260817120000_add_embedding_space_had_vectors/migration.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Persist whether a space has ever served stored vectors. Existing populated
+-- spaces are marked during rollout so later vector loss cannot be mistaken
+-- for a fresh-install active space.
+ALTER TABLE "embedding_spaces"
+    ADD COLUMN "had_vectors" BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE "embedding_spaces" AS space
+SET "had_vectors" = TRUE
+WHERE EXISTS (
+    SELECT 1
+    FROM "track_embeddings" AS embedding
+    WHERE embedding."space_id" = space."id"
+);
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1349,6 +1349,7 @@ model EmbeddingSpace {
   dim            Int
   preprocessing  Json
   status         EmbeddingSpaceStatus
+  hadVectors     Boolean              @default(false) @map("had_vectors")
   createdAt      DateTime             @default(now()) @map("created_at") @db.Timestamptz
   retiredAt      DateTime?            @map("retired_at") @db.Timestamptz
   embeddings     TrackEmbedding[]

--- a/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
+++ b/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
@@ -59,4 +59,16 @@ describe("vibe embed metrics", () => {
         expect(exposition).toContain('transition="cutover"} 1');
         expect(exposition).toContain('transition="retired_cleaned"} 1');
     });
+
+    it("emits bounded provider configuration errors", async () => {
+        const registry = new Registry();
+        const metrics = createVibeEmbedMetrics(registry);
+
+        metrics.recordProviderConfigError("preprocessing_mismatch");
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            'soundspan_vibe_provider_config_errors_total{reason="preprocessing_mismatch"} 1',
+        );
+    });
 });

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -11,6 +11,7 @@ import {
     createVibeEmbedMetrics,
     type VibeEmbedJobOutcome,
     type VibeEmbeddingCoverage,
+    type VibeProviderConfigErrorReason,
     type VibeSpaceTransition,
 } from "./vibeEmbedMetrics";
 
@@ -66,6 +67,13 @@ export function recordVibeSpaceTransition(
     transition: VibeSpaceTransition,
 ): void {
     vibeEmbedMetrics.recordSpaceTransition(transition);
+}
+
+/** Records one rejected provider configuration. */
+export function recordVibeProviderConfigError(
+    reason: VibeProviderConfigErrorReason,
+): void {
+    vibeEmbedMetrics.recordProviderConfigError(reason);
 }
 
 /** Replaces the worker target-space audio embedding coverage gauge values. */

--- a/backend/src/metrics/vibeEmbedMetrics.ts
+++ b/backend/src/metrics/vibeEmbedMetrics.ts
@@ -14,6 +14,9 @@ export type VibeEmbedJobOutcome =
 /** Closed embedding-space transition vocabulary. */
 export type VibeSpaceTransition = "registered" | "cutover" | "retired_cleaned";
 
+/** Closed provider configuration error vocabulary. */
+export type VibeProviderConfigErrorReason = "preprocessing_mismatch";
+
 /** Worker target-space coverage values exposed by the worker process. */
 export interface VibeEmbeddingCoverage {
     embedded: number;
@@ -26,8 +29,10 @@ export interface VibeEmbedMetrics {
     jobs: Counter<"outcome">;
     coverage: Gauge<"state">;
     spaceTransitions: Counter<"transition">;
+    providerConfigErrors: Counter<"reason">;
     recordJob(outcome: VibeEmbedJobOutcome): void;
     recordSpaceTransition(transition: VibeSpaceTransition): void;
+    recordProviderConfigError(reason: VibeProviderConfigErrorReason): void;
     setCoverage(values: VibeEmbeddingCoverage): void;
 }
 
@@ -51,16 +56,26 @@ export function createVibeEmbedMetrics(registry: Registry): VibeEmbedMetrics {
         labelNames: ["transition"] as const,
         registers: [registry],
     });
+    const providerConfigErrors = new Counter({
+        name: "soundspan_vibe_provider_config_errors_total",
+        help: "Vibe provider configuration errors by bounded reason.",
+        labelNames: ["reason"] as const,
+        registers: [registry],
+    });
 
     return {
         jobs,
         coverage,
         spaceTransitions,
+        providerConfigErrors,
         recordJob(outcome): void {
             jobs.inc({ outcome });
         },
         recordSpaceTransition(transition): void {
             spaceTransitions.inc({ transition });
+        },
+        recordProviderConfigError(reason): void {
+            providerConfigErrors.inc({ reason });
         },
         setCoverage(values): void {
             coverage.set({ state: "embedded" }, values.embedded);

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -1,5 +1,21 @@
 import os from "os";
 
+const mockEnqueueReservedWork = jest.fn();
+
+jest.mock("../../config", () => ({
+    config: {
+        analysisQueues: {
+            vibeMaxDepth: 2,
+            reservationTtlSeconds: 3600,
+        },
+    },
+}));
+
+jest.mock("../../workers/enrichmentQueue", () => ({
+    enqueueReservedNodeRedisWork: (...args: unknown[]) =>
+        mockEnqueueReservedWork(...args),
+}));
+
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (req: any, _res: any, next: () => void) => {
         if (req.headers?.["x-api-key"] === "non-admin-key") {
@@ -216,6 +232,7 @@ describe("analysis routes runtime", () => {
         mockRedisRPush.mockResolvedValue(1);
         mockRedisPublish.mockResolvedValue(1);
         mockRedisMulti.mockImplementation(() => createPipeline());
+        mockEnqueueReservedWork.mockResolvedValue("queued");
 
         mockGetSystemSettings.mockResolvedValue({
             audioAnalyzerWorkers: 2,
@@ -557,9 +574,7 @@ describe("analysis routes runtime", () => {
         expect(okRes.statusCode).toBe(200);
     });
 
-    it("queues vibe embedding jobs in force mode and clears failures", async () => {
-        const pipeline = createPipeline();
-        mockRedisMulti.mockReturnValue(pipeline);
+    it("queues vibe embedding jobs in force mode without deleting active vectors", async () => {
         mockTrackFindMany.mockResolvedValue([
             { id: "t1", filePath: "/x.mp3", duration: 111, title: "T1" },
             { id: "t2", filePath: "/y.mp3", duration: 222, title: "T2" },
@@ -570,12 +585,7 @@ describe("analysis routes runtime", () => {
 
         await postVibeStart(req, res);
 
-        expect(mockTrackEmbeddingDeleteMany).toHaveBeenCalledWith({
-            where: {
-                spaceId: "space-active",
-                track: { origin: "LOCAL" },
-            },
-        });
+        expect(mockTrackEmbeddingDeleteMany).not.toHaveBeenCalled();
         expect(mockQueryRaw).not.toHaveBeenCalled();
         expect(mockTrackUpdateMany).toHaveBeenCalledWith({
             where: { origin: "LOCAL" },
@@ -588,13 +598,53 @@ describe("analysis routes runtime", () => {
             }),
         });
         expect(mockClearAllFailures).toHaveBeenCalledWith("vibe");
-        expect(pipeline.rPush).toHaveBeenCalledTimes(2);
+        expect(mockEnqueueReservedWork).toHaveBeenCalledTimes(2);
+        expect(mockEnqueueReservedWork).toHaveBeenNthCalledWith(
+            1,
+            redisClient,
+            expect.objectContaining({
+                queueKey: "audio:clap:queue",
+                trackId: "t1",
+                maxDepth: 2,
+                reservationTtlSeconds: 3600,
+            }),
+        );
         expect(mockClearFailure).toHaveBeenCalledWith("vibe", "t1");
         expect(mockClearFailure).toHaveBeenCalledWith("vibe", "t2");
         expect(res.body).toEqual({
             message: "Queued 2 tracks for vibe embedding",
             queued: 2,
         });
+    });
+
+    it("deduplicates repeated force queueing and stops at the shared cap", async () => {
+        mockTrackFindMany.mockResolvedValue([
+            { id: "t1", filePath: "/x.mp3", duration: 111, title: "T1" },
+            { id: "t2", filePath: "/y.mp3", duration: 222, title: "T2" },
+            { id: "t3", filePath: "/z.mp3", duration: 333, title: "T3" },
+        ]);
+        const reservations = new Set<string>();
+        let depth = 0;
+        mockEnqueueReservedWork.mockImplementation(
+            async (_redis: unknown, input: { trackId: string }) => {
+                if (depth >= 2) return "full";
+                if (reservations.has(input.trackId)) return "duplicate";
+                reservations.add(input.trackId);
+                depth += 1;
+                return "queued";
+            },
+        );
+
+        const firstRes = createRes();
+        const secondRes = createRes();
+        const request = { body: { limit: 1000, force: true } } as any;
+        await postVibeStart(request, firstRes);
+        await postVibeStart(request, secondRes);
+
+        expect(firstRes.body.queued).toBe(2);
+        expect(secondRes.body.queued).toBe(0);
+        expect(reservations).toEqual(new Set(["t1", "t2"]));
+        expect(mockEnqueueReservedWork).toHaveBeenCalledTimes(4);
     });
 
     it("returns no-op vibe start when all tracks already have embeddings", async () => {

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -695,6 +695,26 @@ describe("vibe search transport compatibility", () => {
         expect(mockProviderEmbedText).not.toHaveBeenCalled();
     });
 
+    it("maps a bounded embedding scan timeout to the canonical 504 response", async () => {
+        mockRunAnnQuery.mockRejectedValueOnce(
+            new Error("Vibe text search query timed out"),
+        );
+        const res = createRes();
+
+        await searchHandler(
+            {
+                body: { query: "quiet focus" },
+                user: { id: "user-1" },
+            } as any,
+            res,
+        );
+
+        expect(res.statusCode).toBe(504);
+        expect(res.body).toEqual({
+            error: "Text embedding service unavailable",
+        });
+    });
+
     it("expands and reranks vibe search results when vocabulary matches exist", async () => {
         mockProviderEmbedText.mockResolvedValueOnce([0.5, 0.25]);
         mockGetVocabulary.mockReturnValueOnce({ id: "mock-vocab" });

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -15,6 +15,8 @@ import {
     LOCAL_TRACK_WHERE,
     TRACK_VISIBLE_WHERE,
 } from "../utils/librarySorting";
+import { config } from "../config";
+import { enqueueReservedNodeRedisWork } from "../workers/enrichmentQueue";
 
 const router = Router();
 
@@ -649,7 +651,7 @@ router.put("/workers", requireAuth, requireAdmin, async (req, res) => {
  *               force:
  *                 type: boolean
  *                 default: false
- *                 description: If true, delete all existing embeddings and re-queue all tracks
+ *                 description: If true, preserve active vectors, reset analysis state, and re-queue all tracks
  *     responses:
  *       200:
  *         description: Tracks queued for vibe embedding generation
@@ -662,7 +664,7 @@ router.put("/workers", requireAuth, requireAdmin, async (req, res) => {
  * POST /api/analysis/vibe/start
  * Queue tracks for vibe embedding generation (admin only)
  *
- * @param force - If true, delete all embeddings and re-queue all tracks
+ * @param force - If true, preserve active vectors and re-queue all tracks
  */
 router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
     try {
@@ -674,14 +676,7 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
         const force = req.body.force === true;
         const activeSpace = await getActiveSpace();
 
-        // If force mode, delete all existing embeddings first
         if (force) {
-            await prisma.trackEmbedding.deleteMany({
-                where: {
-                    spaceId: activeSpace.id,
-                    track: LOCAL_TRACK_WHERE,
-                },
-            });
             await prisma.track.updateMany({
                 where: LOCAL_TRACK_WHERE,
                 data: {
@@ -690,13 +685,14 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
                 },
             });
             await enrichmentFailureService.clearAllFailures("vibe");
-            logger.info("Cleared all vibe embeddings for re-generation");
+            logger.info(
+                "Preserved active vibe embeddings and reset tracks for re-generation",
+            );
         }
 
-        // Find tracks without vibe embeddings (all tracks if force was used)
         const tracks = await prisma.track.findMany({
             where: {
-                ...missingActiveEmbeddingWhere(activeSpace.id),
+                ...(force ? {} : missingActiveEmbeddingWhere(activeSpace.id)),
                 ...TRACK_VISIBLE_WHERE,
                 ...LOCAL_TRACK_WHERE,
             },
@@ -726,32 +722,33 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
             });
         }
 
-        // Queue tracks for provider-backed vibe embedding.
-        const pipeline = redisClient.multi();
+        let queued = 0;
         for (const track of tracks) {
-            pipeline.rPush(
-                VIBE_QUEUE,
-                JSON.stringify({
+            const admission = await enqueueReservedNodeRedisWork(redisClient, {
+                queueKey: VIBE_QUEUE,
+                trackId: track.id,
+                payload: JSON.stringify({
                     trackId: track.id,
                     filePath: track.filePath,
                     duration: track.duration,
                 }),
-            );
-        }
-        await pipeline.exec();
-
-        // Clear any existing vibe failures for these tracks
-        for (const track of tracks) {
+                maxDepth: config.analysisQueues.vibeMaxDepth,
+                reservationTtlSeconds:
+                    config.analysisQueues.reservationTtlSeconds,
+            });
+            if (admission === "full") break;
+            if (admission !== "queued") continue;
+            queued += 1;
             await enrichmentFailureService.clearFailure("vibe", track.id);
         }
 
         logger.info(
-            `Queued ${tracks.length} tracks for vibe embedding${force ? " (force reset)" : ""}`,
+            `Queued ${queued} tracks for vibe embedding${force ? " (force reset)" : ""}`,
         );
 
         res.json({
-            message: `Queued ${tracks.length} tracks for vibe embedding`,
-            queued: tracks.length,
+            message: `Queued ${queued} tracks for vibe embedding`,
+            queued,
         });
     } catch (error: any) {
         logger.error("Start vibe embedding error:", error);

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -17,13 +17,7 @@ import {
     resolveTrackPreference,
     TRACK_DISLIKE_ENTITY_TYPE,
 } from "../services/trackPreference";
-import {
-    getVocabulary,
-    expandQueryWithVocabulary,
-    rerankWithFeatures,
-    loadVocabulary,
-    VocabTerm,
-} from "../services/vibeVocabulary";
+import { loadVocabulary } from "../services/vibeVocabulary";
 import {
     CALIBRATION_MIN_EMBEDDED_TRACKS,
     computeCalibration,
@@ -42,26 +36,25 @@ import {
     fetchEmbeddingsByTrackIds,
     fetchTrackEmbedding,
     findNearestToEmbedding,
-    findTracksByTextEmbedding,
     type NearestTrackRow,
-    type TextSearchResult,
 } from "../services/trackEmbeddings";
 import { getActiveSpace } from "../services/embeddingSpaces";
 import { parseJourneyRequest } from "./vibeJourneyRequest";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 import { coalesceInFlightByKey } from "../utils/singleflight";
 import {
-    resolveTextEmbedding,
     TextEmbeddingProviderError,
     TextEmbeddingTimeoutError,
 } from "../services/textEmbedding";
+import {
+    executeVibeSearch,
+    parseVibeSearchRequest,
+} from "../services/vibeSearch";
 
 const router = Router();
 
 // Load vocabulary at module initialization
 loadVocabulary();
-
-const MAX_TEXT_SEARCH_QUERY_LENGTH = 512;
 
 async function buildTrackPreferenceScoreMapForUser(
     userId: string | undefined,
@@ -984,16 +977,6 @@ router.get<{ trackId: string }>(
     }),
 );
 
-// Convert CLAP cosine distance (0-2 range) to similarity percentage (0-1)
-// distance 0 = identical, distance 1 = orthogonal, distance 2 = opposite
-function distanceToSimilarity(distance: number): number {
-    return Math.max(0, 1 - distance / 2);
-}
-
-// Minimum similarity threshold for search results
-// 0.65 = 65% match, meaning distance <= 0.7
-const MIN_SEARCH_SIMILARITY = 0.6;
-
 /**
  * @openapi
  * /api/vibe/search:
@@ -1060,155 +1043,9 @@ router.post(
     requireAuth,
     asyncHandler(async (req, res) => {
         try {
-            const { query, limit: requestedLimit, minSimilarity } = req.body;
-
-            if (!query || typeof query !== "string") {
-                return sendRouteError(
-                    res,
-                    400,
-                    "Query must be at least 2 characters",
-                );
-            }
-
-            if (query.length > MAX_TEXT_SEARCH_QUERY_LENGTH) {
-                return sendRouteError(
-                    res,
-                    400,
-                    `Query must be at most ${MAX_TEXT_SEARCH_QUERY_LENGTH} characters`,
-                );
-            }
-
-            if (query.trim().length < 2) {
-                return sendRouteError(
-                    res,
-                    400,
-                    "Query must be at least 2 characters",
-                );
-            }
-
-            const limit = Math.min(Math.max(1, requestedLimit || 20), 100);
-
-            // Allow override but default to MIN_SEARCH_SIMILARITY
-            const similarityThreshold =
-                typeof minSimilarity === "number"
-                    ? Math.max(0, Math.min(1, minSimilarity))
-                    : MIN_SEARCH_SIMILARITY;
-
-            // Convert similarity threshold to max distance
-            // similarity = 1 - (distance / 2), so distance = 2 * (1 - similarity)
-            const maxDistance = 2 * (1 - similarityThreshold);
-
-            const normalizedQuery = query.trim();
-            const textEmbedding = await resolveTextEmbedding(normalizedQuery);
-
-            // Query expansion with vocabulary
-            const vocab = getVocabulary();
-            let searchEmbedding = textEmbedding.embedding;
-            let genreConfidence = 0;
-            let matchedTerms: VocabTerm[] = [];
-
-            if (vocab) {
-                const expansion = expandQueryWithVocabulary(
-                    textEmbedding.embedding,
-                    normalizedQuery,
-                    vocab,
-                );
-                searchEmbedding = expansion.embedding;
-                genreConfidence = expansion.genreConfidence;
-                matchedTerms = expansion.matchedTerms;
-
-                logger.info(
-                    `[VIBE-SEARCH] Query "${normalizedQuery}" expanded with terms: ${matchedTerms.map((t) => t.name).join(", ") || "none"}, genre confidence: ${(genreConfidence * 100).toFixed(0)}%`,
-                );
-            }
-
-            // Query for similar tracks using the (possibly expanded) embedding
-            // Fetch more candidates for re-ranking (3x limit)
-            // Filter by max distance to exclude poor matches
-            const candidateLimit = limit * 3;
-            const similarTracks = await findTracksByTextEmbedding(
-                searchEmbedding,
-                maxDistance,
-                candidateLimit,
-                textEmbedding.spaceId,
-            );
-
-            logger.info(
-                `Vibe search "${normalizedQuery}": found ${similarTracks.length} candidates above ${Math.round(similarityThreshold * 100)}% similarity (max distance: ${maxDistance.toFixed(2)})`,
-            );
-
-            // Re-rank using audio features if we have vocabulary matches
-            let rankedTracks:
-                | typeof similarTracks
-                | ReturnType<typeof rerankWithFeatures<TextSearchResult>> =
-                similarTracks;
-            if (vocab && matchedTerms.length > 0) {
-                const reranked = rerankWithFeatures(
-                    similarTracks,
-                    matchedTerms,
-                    genreConfidence,
-                );
-                rankedTracks = reranked.slice(0, limit);
-
-                logger.info(
-                    `[VIBE-SEARCH] Re-ranked ${similarTracks.length} candidates, top result: ${rankedTracks[0]?.title || "none"}`,
-                );
-            } else {
-                rankedTracks = similarTracks.slice(0, limit);
-            }
-
-            // If we have results, log the similarity range
-            if (rankedTracks.length > 0) {
-                const first = rankedTracks[0];
-                const last = rankedTracks[rankedTracks.length - 1];
-                const bestSim =
-                    "finalScore" in first
-                        ? first.finalScore
-                        : distanceToSimilarity(first.distance);
-                const worstSim =
-                    "finalScore" in last
-                        ? last.finalScore
-                        : distanceToSimilarity(last.distance);
-                logger.info(
-                    `Vibe search similarity range: ${Math.round(bestSim * 100)}% - ${Math.round(worstSim * 100)}%`,
-                );
-            }
-
-            const tracks = rankedTracks.map((row) => ({
-                id: row.id,
-                title: row.title,
-                duration: row.duration,
-                trackNo: row.trackNo,
-                distance: row.distance,
-                similarity:
-                    "finalScore" in row
-                        ? row.finalScore
-                        : distanceToSimilarity(row.distance),
-                album: {
-                    id: row.albumId,
-                    title: row.albumTitle,
-                    coverUrl: row.albumCoverUrl,
-                },
-                artist: {
-                    id: row.artistId,
-                    name: row.artistName,
-                },
-            }));
-
-            res.json({
-                query: normalizedQuery,
-                tracks,
-                minSimilarity: similarityThreshold,
-                totalAboveThreshold: tracks.length,
-                debug: {
-                    matchedTerms: matchedTerms.map((t) => t.name),
-                    genreConfidence,
-                    featureWeight:
-                        matchedTerms.length > 0
-                            ? 0.2 + genreConfidence * 0.5
-                            : 0,
-                },
-            });
+            const parsed = parseVibeSearchRequest(req.body);
+            if (!parsed.ok) return sendRouteError(res, 400, parsed.error);
+            res.json(await executeVibeSearch(parsed.value));
         } catch (error: unknown) {
             logger.error("Vibe text search error:", error);
             if (error instanceof TextEmbeddingProviderError) {

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -12,9 +12,10 @@ const mockTransaction = jest.fn();
 const mockInvalidate = jest.fn();
 const mockRecordTransition = jest.fn();
 const mockLoadCoverage = jest.fn();
-const mockLoadSpaceEmbeddedCount = jest.fn();
+const mockLoadSpaceVectorState = jest.fn();
 const mockGetActiveSpace = jest.fn();
 const mockLogInfo = jest.fn();
+const mockSetCoverage = jest.fn();
 
 jest.mock("../../utils/db", () => ({
     prisma: {
@@ -46,13 +47,14 @@ jest.mock("../embeddingSpaces", () => ({
 jest.mock("../../metrics", () => ({
     recordVibeSpaceTransition: (...args: unknown[]) =>
         mockRecordTransition(...args),
+    setVibeEmbeddingCoverage: (...args: unknown[]) => mockSetCoverage(...args),
 }));
 
 jest.mock("../vibeEmbeddingCoverage", () => ({
     loadVibeEmbeddingCoverage: (...args: unknown[]) =>
         mockLoadCoverage(...args),
-    loadVibeSpaceEmbeddedCount: (...args: unknown[]) =>
-        mockLoadSpaceEmbeddedCount(...args),
+    loadVibeSpaceVectorState: (...args: unknown[]) =>
+        mockLoadSpaceVectorState(...args),
 }));
 
 jest.mock("../../utils/logger", () => ({
@@ -92,12 +94,14 @@ describe("embedding-space lifecycle decisions", () => {
     });
 
     it.each([
-        [0, true],
-        [1, false],
+        [false, false, true],
+        [false, true, false],
+        [true, false, false],
+        [true, true, false],
     ])(
-        "evaluates empty-active-space cutover with %s embedded vectors",
-        (activeEmbeddedCount, due) => {
-            expect(shouldCutOverEmptyActiveSpace(activeEmbeddedCount)).toBe(
+        "evaluates empty-active-space cutover with hasVectors=%s and hadVectors=%s",
+        (hasVectors, hadVectors, due) => {
+            expect(shouldCutOverEmptyActiveSpace(hasVectors, hadVectors)).toBe(
                 due,
             );
         },
@@ -125,8 +129,14 @@ describe("embedding-space lifecycle effects", () => {
             pending: 1,
             failed: 0,
         });
-        mockLoadSpaceEmbeddedCount.mockResolvedValue(1);
-        mockGetActiveSpace.mockResolvedValue({ id: "space_teacher_1" });
+        mockLoadSpaceVectorState.mockResolvedValue({
+            hasVectors: true,
+            hadVectors: true,
+        });
+        mockGetActiveSpace.mockResolvedValue({
+            id: "space_teacher_1",
+            hadVectors: true,
+        });
         mockTransaction.mockImplementation(
             async (operation: (tx: unknown) => Promise<unknown>) =>
                 operation({
@@ -169,7 +179,7 @@ describe("embedding-space lifecycle effects", () => {
         });
 
         expect(order).toEqual(["index", "transaction"]);
-        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+        expect(mockLoadSpaceVectorState).toHaveBeenCalledWith(
             "space_teacher_1",
         );
         expect(mockLoadCoverage).toHaveBeenCalledWith("space_student_1");
@@ -179,8 +189,16 @@ describe("embedding-space lifecycle effects", () => {
                 spaceId: "space_student_1",
                 coveragePercent: 95,
                 thresholdPercent: 95,
+                embedded: 95,
+                pending: 5,
+                failed: 20,
             },
         );
+        expect(mockSetCoverage).toHaveBeenCalledWith({
+            embedded: 95,
+            pending: 5,
+            failed: 20,
+        });
         expect(mockExecuteRawUnsafe).toHaveBeenCalledWith(
             expect.stringContaining("CREATE INDEX CONCURRENTLY IF NOT EXISTS"),
         );
@@ -194,6 +212,14 @@ describe("embedding-space lifecycle effects", () => {
         });
         expect(mockInvalidate).toHaveBeenCalledTimes(1);
         expect(mockRecordTransition).toHaveBeenCalledWith("cutover");
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            "Embedding-space cutover completed",
+            {
+                spaceId: "space_student_1",
+                coverage: 0.95,
+                failed: 20,
+            },
+        );
     });
 
     it("keeps an existing valid partial index", async () => {
@@ -232,7 +258,7 @@ describe("embedding-space lifecycle effects", () => {
             now: () => now,
         });
 
-        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+        expect(mockLoadSpaceVectorState).toHaveBeenCalledWith(
             "space_teacher_1",
         );
         expect(mockLogInfo).toHaveBeenCalledTimes(1);
@@ -242,15 +268,25 @@ describe("embedding-space lifecycle effects", () => {
                 spaceId: "space_student_1",
                 coveragePercent: 80,
                 thresholdPercent: 95,
+                embedded: 80,
+                pending: 20,
+                failed: 10,
             },
         );
         expect(mockQueryRaw).not.toHaveBeenCalled();
         expect(mockTransaction).not.toHaveBeenCalled();
     });
 
-    it("cuts over immediately when the active space has no embedded vectors", async () => {
+    it("cuts over immediately when a fresh active space has no vectors", async () => {
         mockFindFirst.mockResolvedValue(migrating);
-        mockLoadSpaceEmbeddedCount.mockResolvedValue(0);
+        mockLoadSpaceVectorState.mockResolvedValue({
+            hasVectors: false,
+            hadVectors: false,
+        });
+        mockGetActiveSpace.mockResolvedValue({
+            id: "space_teacher_1",
+            hadVectors: false,
+        });
         mockLoadCoverage.mockResolvedValue({
             embedded: 0,
             pending: 0,
@@ -263,10 +299,10 @@ describe("embedding-space lifecycle effects", () => {
             now: () => now,
         });
 
-        expect(mockLoadSpaceEmbeddedCount).toHaveBeenCalledWith(
+        expect(mockLoadSpaceVectorState).toHaveBeenCalledWith(
             "space_teacher_1",
         );
-        expect(mockLoadCoverage).not.toHaveBeenCalled();
+        expect(mockLoadCoverage).toHaveBeenCalledWith("space_student_1");
         expect(mockExecuteRawUnsafe).toHaveBeenCalledWith(
             expect.stringContaining("CREATE INDEX CONCURRENTLY IF NOT EXISTS"),
         );
@@ -280,6 +316,41 @@ describe("embedding-space lifecycle effects", () => {
                 migratingSpaceId: "space_student_1",
             },
         );
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            "Embedding-space cutover completed",
+            {
+                spaceId: "space_student_1",
+                reason: "empty_active_space",
+                failed: 0,
+            },
+        );
+    });
+
+    it("does not instant-cut over a wiped active space that previously had vectors", async () => {
+        mockFindFirst.mockResolvedValue(migrating);
+        mockLoadSpaceVectorState.mockResolvedValue({
+            hasVectors: false,
+            hadVectors: true,
+        });
+        mockGetActiveSpace.mockResolvedValue({
+            id: "space_teacher_1",
+            hadVectors: true,
+        });
+        mockLoadCoverage.mockResolvedValue({
+            embedded: 1,
+            pending: 99,
+            failed: 4,
+        });
+
+        await runEmbeddingSpaceLifecycleCheck({
+            threshold: 0.95,
+            retirementGraceDays: 7,
+            now: () => now,
+        });
+
+        expect(mockLoadCoverage).toHaveBeenCalledWith("space_student_1");
+        expect(mockTransaction).not.toHaveBeenCalled();
+        expect(mockRecordTransition).not.toHaveBeenCalledWith("cutover");
     });
 
     it("drops and rebuilds an existing invalid partial index once", async () => {

--- a/backend/src/services/__tests__/embeddingSpaces.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaces.test.ts
@@ -2,6 +2,7 @@ const mockFindMany = jest.fn();
 const mockFindUnique = jest.fn();
 const mockCreate = jest.fn();
 const mockLoggerError = jest.fn();
+const mockRecordProviderConfigError = jest.fn();
 const mockChild = jest.fn((_scope: string) => ({
     debug: jest.fn(),
     info: jest.fn(),
@@ -24,8 +25,14 @@ jest.mock("../../utils/logger", () => ({
     logger: { child: (scope: string) => mockChild(scope) },
 }));
 
+jest.mock("../../metrics", () => ({
+    recordVibeProviderConfigError: (...args: unknown[]) =>
+        mockRecordProviderConfigError(...args),
+}));
+
 import {
     EmbeddingSpaceDimensionMismatchError,
+    EmbeddingSpacePreprocessingMismatchError,
     findRegisteredProviderEmbeddingSpace,
     getActiveSpace,
     invalidateActiveSpaceCache,
@@ -241,6 +248,49 @@ describe("provider embedding-space resolution", () => {
             expect(mockCreate).not.toHaveBeenCalled();
         },
     );
+
+    it("accepts canonically identical preprocessing documents", async () => {
+        mockFindUnique.mockResolvedValue({
+            ...registrySpace,
+            preprocessing: { window: "middle", mono: true },
+        });
+
+        await expect(
+            resolveProviderEmbeddingSpace({
+                ...providerSpace,
+                preprocessing: { mono: true, window: "middle" },
+            }),
+        ).resolves.toEqual({
+            space: expect.objectContaining({ id: "space-student" }),
+            registered: false,
+        });
+        expect(mockRecordProviderConfigError).not.toHaveBeenCalled();
+    });
+
+    it("refuses a tuple whose preprocessing document differs", async () => {
+        mockFindUnique.mockResolvedValue({
+            ...registrySpace,
+            preprocessing: { mono: false, window: "middle" },
+        });
+
+        const resolution = resolveProviderEmbeddingSpace(providerSpace);
+
+        await expect(resolution).rejects.toBeInstanceOf(
+            EmbeddingSpacePreprocessingMismatchError,
+        );
+        await expect(resolution).rejects.toMatchObject({
+            code: "EMBEDDING_SPACE_PREPROCESSING_MISMATCH",
+            spaceId: "space-student",
+        });
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Embedding-space provider preprocessing does not match the registered tuple",
+            { spaceId: "space-student" },
+        );
+        expect(mockRecordProviderConfigError).toHaveBeenCalledWith(
+            "preprocessing_mismatch",
+        );
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
 
     it("registers an unknown provider as migrating", async () => {
         mockFindUnique.mockResolvedValue(null);

--- a/backend/src/services/__tests__/trackEmbeddings.test.ts
+++ b/backend/src/services/__tests__/trackEmbeddings.test.ts
@@ -3,8 +3,10 @@ jest.mock("../../utils/db", () => ({
         $executeRaw: jest.fn(),
         $queryRaw: jest.fn(),
         track: { findMany: jest.fn() },
-        trackEmbedding: { deleteMany: jest.fn() },
-        embeddingSpace: { findUnique: jest.fn() },
+        embeddingSpace: {
+            findUnique: jest.fn(),
+            updateMany: jest.fn(),
+        },
     },
 }));
 
@@ -27,7 +29,6 @@ import * as embeddingUtils from "../../utils/embedding";
 import {
     countEmbeddedBrowsableTracks,
     countEmbeddedLocalTracks,
-    deleteActiveLocalTrackEmbeddings,
     fetchEmbeddingsByTrackIds,
     fetchTrackEmbedding,
     findLocalTracksNeedingActiveEmbedding,
@@ -58,6 +59,9 @@ describe("upsertTrackEmbedding", () => {
         (prisma.embeddingSpace.findUnique as jest.Mock).mockResolvedValue({
             dim: 512,
         });
+        (prisma.embeddingSpace.updateMany as jest.Mock).mockResolvedValue({
+            count: 1,
+        });
 
         await upsertTrackEmbedding(
             "track-1",
@@ -75,6 +79,10 @@ describe("upsertTrackEmbedding", () => {
         expect(prisma.embeddingSpace.findUnique).toHaveBeenCalledWith({
             where: { id: "space-target" },
             select: { dim: true },
+        });
+        expect(prisma.embeddingSpace.updateMany).toHaveBeenCalledWith({
+            where: { id: "space-target", hadVectors: false },
+            data: { hadVectors: true },
         });
     });
 
@@ -101,9 +109,14 @@ describe("active-space maintenance", () => {
                     origin: "LOCAL",
                     removedAt: null,
                     filePath: { not: null },
-                    embeddings: {
-                        none: { spaceId: "space-target" },
-                    },
+                    OR: expect.arrayContaining([
+                        {
+                            vibeAnalysisStatus: "completed",
+                            embeddings: {
+                                none: { spaceId: "space-target" },
+                            },
+                        },
+                    ]),
                 }),
                 take: 25,
             }),
@@ -120,13 +133,20 @@ describe("active-space maintenance", () => {
             expect(prisma.track.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: expect.objectContaining({
-                        embeddings: {
-                            none: { spaceId: targetSpaceId },
-                        },
                         OR: [
-                            { vibeAnalysisStatus: null },
                             { vibeAnalysisStatus: "pending" },
-                            { vibeAnalysisStatus: "completed" },
+                            {
+                                vibeAnalysisStatus: null,
+                                embeddings: {
+                                    none: { spaceId: targetSpaceId },
+                                },
+                            },
+                            {
+                                vibeAnalysisStatus: "completed",
+                                embeddings: {
+                                    none: { spaceId: targetSpaceId },
+                                },
+                            },
                         ],
                     }),
                 }),
@@ -143,26 +163,33 @@ describe("active-space maintenance", () => {
         expect(prisma.track.findMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: expect.objectContaining({
-                    embeddings: {
-                        none: { spaceId: "space-worker-target" },
-                    },
+                    OR: expect.arrayContaining([
+                        {
+                            vibeAnalysisStatus: "completed",
+                            embeddings: {
+                                none: { spaceId: "space-worker-target" },
+                            },
+                        },
+                    ]),
                 }),
             }),
         );
     });
 
-    it("deletes only local vectors in the active space", async () => {
-        (prisma.trackEmbedding.deleteMany as jest.Mock).mockResolvedValue({
-            count: 3,
-        });
+    it("selects pending rebuild tracks even when a target vector already exists", async () => {
+        (prisma.track.findMany as jest.Mock).mockResolvedValue([]);
 
-        await expect(deleteActiveLocalTrackEmbeddings()).resolves.toBe(3);
-        expect(prisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
-            where: {
-                spaceId: "space-active",
-                track: { origin: "LOCAL" },
-            },
-        });
+        await findLocalTracksNeedingActiveEmbedding(25, "space-target");
+
+        expect(prisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    OR: expect.arrayContaining([
+                        { vibeAnalysisStatus: "pending" },
+                    ]),
+                }),
+            }),
+        );
     });
 });
 
@@ -252,6 +279,24 @@ describe("findTracksByTextEmbedding", () => {
         expect(values[values.length - 1]).toBe(60);
         expect(values[values.length - 2]).toEqual([0.25, 0.75]);
         expect(values[values.length - 3]).toBe(0.8);
+        expect(mockRunAnnQuery).toHaveBeenCalledWith(query, undefined, {
+            statementTimeoutMs: 5_000,
+            timeoutMessage: "Vibe text search query timed out",
+        });
+    });
+
+    it("caps exact-scan candidates at the route maximum", async () => {
+        mockRunAnnQuery.mockResolvedValue([]);
+
+        await findTracksByTextEmbedding(
+            [0.25, 0.75],
+            0.8,
+            50_000,
+            "space-migrating",
+        );
+
+        const query = mockRunAnnQuery.mock.calls[0][0];
+        expect(query.values[query.values.length - 1]).toBe(300);
     });
 });
 

--- a/backend/src/services/__tests__/vibeEmbedJobs.test.ts
+++ b/backend/src/services/__tests__/vibeEmbedJobs.test.ts
@@ -19,7 +19,35 @@ jest.mock("../../utils/logger", () => ({
     logger: mockLogger,
 }));
 
-import { createVibeEmbedJobProcessor } from "../vibeEmbedJobs";
+import {
+    createVibeEmbedJobProcessor,
+    isTransientVibeProviderFailure,
+} from "../vibeEmbedJobs";
+import {
+    VibeProviderContractError,
+    VibeProviderRequestError,
+    VibeProviderServerError,
+    VibeProviderTimeoutError,
+    VibeProviderUnavailableError,
+} from "../vibeProvider";
+
+describe("vibe provider retry classification", () => {
+    it.each([
+        new VibeProviderTimeoutError(),
+        new VibeProviderUnavailableError(),
+        new VibeProviderServerError(503),
+    ])("classifies %s as transient", (error) => {
+        expect(isTransientVibeProviderFailure(error)).toBe(true);
+    });
+
+    it.each([
+        new VibeProviderContractError(),
+        new VibeProviderRequestError(404),
+        new Error("database write failed"),
+    ])("classifies %s as terminal", (error) => {
+        expect(isTransientVibeProviderFailure(error)).toBe(false);
+    });
+});
 
 describe("vibe embed job processor", () => {
     beforeEach(() => {
@@ -43,6 +71,7 @@ describe("vibe embed job processor", () => {
         const describeFailure = jest.fn((error: unknown) =>
             error instanceof Error ? error.message : "Embedding failed",
         );
+        const isTransientFailure = jest.fn(() => false);
         const now = jest.fn(() => new Date("2026-08-16T12:00:00.000Z"));
         const processJob = createVibeEmbedJobProcessor({
             targetSpaceId: "space-provider",
@@ -54,6 +83,7 @@ describe("vibe embed job processor", () => {
             releaseReservation,
             recordOutcome,
             describeFailure,
+            isTransientFailure,
             now,
         });
 
@@ -65,6 +95,7 @@ describe("vibe embed job processor", () => {
             resolveByEntity,
             releaseReservation,
             recordOutcome,
+            isTransientFailure,
             processJob,
         };
     }
@@ -91,11 +122,16 @@ describe("vibe embed job processor", () => {
                 id: "track-1",
                 origin: "LOCAL",
                 removedAt: null,
-                embeddings: { none: { spaceId: "space-provider" } },
                 OR: [
-                    { vibeAnalysisStatus: null },
                     { vibeAnalysisStatus: "pending" },
-                    { vibeAnalysisStatus: "completed" },
+                    {
+                        vibeAnalysisStatus: null,
+                        embeddings: { none: { spaceId: "space-provider" } },
+                    },
+                    {
+                        vibeAnalysisStatus: "completed",
+                        embeddings: { none: { spaceId: "space-provider" } },
+                    },
                 ],
             },
             data: {
@@ -155,17 +191,14 @@ describe("vibe embed job processor", () => {
                 id: "track-2",
                 origin: "LOCAL",
                 removedAt: null,
-                OR: [
-                    { vibeAnalysisStatus: null },
-                    { vibeAnalysisStatus: "pending" },
-                    { vibeAnalysisStatus: "processing" },
-                    { vibeAnalysisStatus: "completed" },
-                ],
+                vibeAnalysisStatus: "processing",
+                vibeAnalysisRetryCount: 0,
             },
             data: {
                 vibeAnalysisStatus: "failed",
                 vibeAnalysisError: truncated,
                 vibeAnalysisRetryCount: { increment: 1 },
+                vibeAnalysisStartedAt: null,
                 vibeAnalysisStatusUpdatedAt: new Date(
                     "2026-08-16T12:00:00.000Z",
                 ),
@@ -180,6 +213,77 @@ describe("vibe embed job processor", () => {
         });
         expect(harness.upsertTrackEmbedding).not.toHaveBeenCalled();
         expect(harness.recordOutcome).toHaveBeenCalledWith("embed_failed");
+    });
+
+    it("resets transient provider failures to pending below the retry bound", async () => {
+        const harness = createHarness();
+        const transient = new Error("provider unavailable");
+        harness.prisma.track.findFirst.mockResolvedValue({
+            id: "track-retry",
+            title: "Retry Track",
+            vibeAnalysisRetryCount: 0,
+        });
+        harness.embedAudio.mockRejectedValue(transient);
+        harness.isTransientFailure.mockReturnValue(true);
+
+        await expect(
+            harness.processJob(
+                JSON.stringify({
+                    trackId: "track-retry",
+                    filePath: "artist/retry.flac",
+                }),
+            ),
+        ).resolves.toBe("embed_failed");
+
+        expect(harness.prisma.track.updateMany).toHaveBeenLastCalledWith({
+            where: {
+                id: "track-retry",
+                origin: "LOCAL",
+                removedAt: null,
+                vibeAnalysisStatus: "processing",
+                vibeAnalysisRetryCount: 0,
+            },
+            data: {
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisError: "provider unavailable",
+                vibeAnalysisRetryCount: { increment: 1 },
+                vibeAnalysisStartedAt: null,
+                vibeAnalysisStatusUpdatedAt: new Date(
+                    "2026-08-16T12:00:00.000Z",
+                ),
+            },
+        });
+        expect(harness.recordFailure).not.toHaveBeenCalled();
+    });
+
+    it("marks transient provider failures terminal at the retry bound", async () => {
+        const harness = createHarness();
+        harness.prisma.track.findFirst.mockResolvedValue({
+            id: "track-exhausted",
+            title: "Exhausted Track",
+            vibeAnalysisRetryCount: 2,
+        });
+        harness.embedAudio.mockRejectedValue(new Error("provider timeout"));
+        harness.isTransientFailure.mockReturnValue(true);
+
+        await harness.processJob(
+            JSON.stringify({
+                trackId: "track-exhausted",
+                filePath: "artist/exhausted.flac",
+            }),
+        );
+
+        expect(harness.prisma.track.updateMany).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    vibeAnalysisStatus: "failed",
+                    vibeAnalysisRetryCount: { increment: 1 },
+                }),
+            }),
+        );
+        expect(harness.recordFailure).toHaveBeenCalledWith(
+            expect.objectContaining({ entityId: "track-exhausted" }),
+        );
     });
 
     it.each(["not-json", JSON.stringify({ filePath: "track.flac" })])(
@@ -229,8 +333,8 @@ describe("vibe embed job processor", () => {
                         { vibeAnalysisStatus: null },
                         { vibeAnalysisStatus: "pending" },
                         { vibeAnalysisStatus: "processing" },
-                        { vibeAnalysisStatus: "completed" },
                     ],
+                    embeddings: { none: { spaceId: "space-provider" } },
                 },
                 data: {
                     vibeAnalysisStatus: "failed",
@@ -256,20 +360,38 @@ describe("vibe embed job processor", () => {
         },
     );
 
-    it("never demotes a settled track on an invalid payload", async () => {
+    it("never demotes a completed track on an invalid payload", async () => {
         const harness = createHarness();
         harness.prisma.track.findFirst.mockResolvedValue({
             id: "track-3",
             title: "Track Three",
+            vibeAnalysisStatus: "completed",
+            embeddings: [],
         });
-        harness.prisma.track.updateMany.mockResolvedValue({ count: 0 });
 
         await expect(
             harness.processJob(JSON.stringify({ trackId: "track-3" })),
         ).resolves.toBe("invalid_payload");
 
         expect(harness.recordFailure).not.toHaveBeenCalled();
+        expect(harness.prisma.track.updateMany).not.toHaveBeenCalled();
         expect(harness.releaseReservation).toHaveBeenCalledWith("track-3");
+    });
+
+    it("never demotes a track with a target-space vector on an invalid payload", async () => {
+        const harness = createHarness();
+        harness.prisma.track.findFirst.mockResolvedValue({
+            id: "track-stored",
+            title: "Stored Track",
+            vibeAnalysisStatus: "pending",
+            embeddings: [{ spaceId: "space-provider" }],
+        });
+
+        await harness.processJob(JSON.stringify({ trackId: "track-stored" }));
+
+        expect(harness.prisma.track.updateMany).not.toHaveBeenCalled();
+        expect(harness.recordFailure).not.toHaveBeenCalled();
+        expect(harness.recordOutcome).toHaveBeenCalledWith("invalid_payload");
     });
 
     it.each(["../x", "/music/x", "..\\x", "artist/\0x"])(
@@ -325,7 +447,11 @@ describe("vibe embed job processor", () => {
                 origin: "LOCAL",
                 removedAt: null,
             },
-            select: { id: true, title: true },
+            select: {
+                id: true,
+                title: true,
+                vibeAnalysisRetryCount: true,
+            },
         });
         expect(harness.releaseReservation).toHaveBeenCalledWith(
             "removed-track",
@@ -381,11 +507,16 @@ describe("vibe embed job processor", () => {
                 id: "track-migrating",
                 origin: "LOCAL",
                 removedAt: null,
-                embeddings: { none: { spaceId: "space-provider" } },
                 OR: [
-                    { vibeAnalysisStatus: null },
                     { vibeAnalysisStatus: "pending" },
-                    { vibeAnalysisStatus: "completed" },
+                    {
+                        vibeAnalysisStatus: null,
+                        embeddings: { none: { spaceId: "space-provider" } },
+                    },
+                    {
+                        vibeAnalysisStatus: "completed",
+                        embeddings: { none: { spaceId: "space-provider" } },
+                    },
                 ],
             },
             data: expect.objectContaining({
@@ -415,11 +546,13 @@ describe("vibe embed job processor", () => {
         expect(harness.upsertTrackEmbedding).not.toHaveBeenCalled();
     });
 
-    it("allows a failure write to settle a completed track claimed for the target", async () => {
+    it("marks a pending track failed for an invalid payload", async () => {
         const harness = createHarness();
         harness.prisma.track.findFirst.mockResolvedValue({
             id: "track-invalid",
             title: "Invalid Track",
+            vibeAnalysisStatus: "pending",
+            embeddings: [],
         });
 
         await harness.processJob(JSON.stringify({ trackId: "track-invalid" }));
@@ -433,8 +566,8 @@ describe("vibe embed job processor", () => {
                     { vibeAnalysisStatus: null },
                     { vibeAnalysisStatus: "pending" },
                     { vibeAnalysisStatus: "processing" },
-                    { vibeAnalysisStatus: "completed" },
                 ],
+                embeddings: { none: { spaceId: "space-provider" } },
             },
             data: expect.objectContaining({ vibeAnalysisStatus: "failed" }),
         });

--- a/backend/src/services/__tests__/vibeEmbedMigrationFlow.test.ts
+++ b/backend/src/services/__tests__/vibeEmbedMigrationFlow.test.ts
@@ -10,21 +10,26 @@ const tracks = [
     },
 ];
 
-function statusMatches(
-    or: Array<{ vibeAnalysisStatus: string | null }>,
+function targetGateMatches(
+    or: Array<{
+        vibeAnalysisStatus: string | null;
+        embeddings?: { none: { spaceId: string } };
+    }>,
 ): boolean {
-    return or.some(
-        (candidate) =>
-            candidate.vibeAnalysisStatus === tracks[0].vibeAnalysisStatus,
-    );
+    return or.some((candidate) => {
+        if (candidate.vibeAnalysisStatus !== tracks[0].vibeAnalysisStatus) {
+            return false;
+        }
+        const targetSpaceId = candidate.embeddings?.none.spaceId;
+        return (
+            !targetSpaceId || !tracks[0].embeddingSpaceIds.has(targetSpaceId)
+        );
+    });
 }
 
 const mockTrackFindMany = jest.fn(async (args: any) => {
-    const missing = args.where.embeddings.none.spaceId as string;
     const statuses = args.where.OR;
-    if (tracks[0].embeddingSpaceIds.has(missing) || !statusMatches(statuses)) {
-        return [];
-    }
+    if (!targetGateMatches(statuses)) return [];
     return [{ id: tracks[0].id, filePath: tracks[0].filePath }];
 });
 const mockTrackFindFirst = jest.fn(async () => ({
@@ -32,13 +37,7 @@ const mockTrackFindFirst = jest.fn(async () => ({
     title: tracks[0].title,
 }));
 const mockTrackUpdateMany = jest.fn(async (args: any) => {
-    const targetSpaceId = args.where.embeddings?.none.spaceId as
-        | string
-        | undefined;
-    if (
-        !statusMatches(args.where.OR) ||
-        (targetSpaceId && tracks[0].embeddingSpaceIds.has(targetSpaceId))
-    ) {
+    if (!targetGateMatches(args.where.OR)) {
         return { count: 0 };
     }
     tracks[0].vibeAnalysisStatus = args.data.vibeAnalysisStatus;
@@ -120,6 +119,7 @@ describe("target-space selection through claim", () => {
             releaseReservation: jest.fn(async () => undefined),
             recordOutcome: jest.fn(),
             describeFailure: jest.fn(() => "failed"),
+            isTransientFailure: jest.fn(() => false),
             now: () => new Date("2026-08-16T12:00:00.000Z"),
         });
     }

--- a/backend/src/services/__tests__/vibeEmbeddingCoverage.test.ts
+++ b/backend/src/services/__tests__/vibeEmbeddingCoverage.test.ts
@@ -1,9 +1,21 @@
 const mockTrackCount = jest.fn();
+const mockTrackGroupBy = jest.fn();
+const mockEmbeddingFindFirst = jest.fn();
+const mockSpaceFindUnique = jest.fn();
 const mockGetTargetSpaceId = jest.fn();
 
 jest.mock("../../utils/db", () => ({
     prisma: {
-        track: { count: (...args: unknown[]) => mockTrackCount(...args) },
+        track: {
+            count: (...args: unknown[]) => mockTrackCount(...args),
+            groupBy: (...args: unknown[]) => mockTrackGroupBy(...args),
+        },
+        trackEmbedding: {
+            findFirst: (...args: unknown[]) => mockEmbeddingFindFirst(...args),
+        },
+        embeddingSpace: {
+            findUnique: (...args: unknown[]) => mockSpaceFindUnique(...args),
+        },
     },
 }));
 
@@ -15,6 +27,7 @@ jest.mock("../embeddingSpaces", () => ({
 import {
     createVibeEmbeddingCoverageRefresher,
     loadVibeEmbeddingCoverage,
+    loadVibeSpaceVectorState,
 } from "../vibeEmbeddingCoverage";
 
 describe("vibe embedding coverage refresh", () => {
@@ -24,10 +37,11 @@ describe("vibe embedding coverage refresh", () => {
 
     it("counts only eligible tracks in the active space", async () => {
         mockGetTargetSpaceId.mockResolvedValue("active-space");
-        mockTrackCount
-            .mockResolvedValueOnce(20)
-            .mockResolvedValueOnce(12)
-            .mockResolvedValueOnce(3);
+        mockTrackCount.mockResolvedValueOnce(12);
+        mockTrackGroupBy.mockResolvedValueOnce([
+            { vibeAnalysisStatus: "pending", _count: 5 },
+            { vibeAnalysisStatus: "failed", _count: 3 },
+        ]);
 
         await expect(
             loadVibeEmbeddingCoverage("target-space"),
@@ -37,7 +51,7 @@ describe("vibe embedding coverage refresh", () => {
             failed: 3,
         });
 
-        expect(mockTrackCount).toHaveBeenNthCalledWith(2, {
+        expect(mockTrackCount).toHaveBeenCalledWith({
             where: {
                 origin: "LOCAL",
                 removedAt: null,
@@ -45,14 +59,36 @@ describe("vibe embedding coverage refresh", () => {
                 embeddings: { some: { spaceId: "target-space" } },
             },
         });
-        expect(mockTrackCount).toHaveBeenNthCalledWith(3, {
+        expect(mockTrackGroupBy).toHaveBeenCalledWith({
+            by: ["vibeAnalysisStatus"],
             where: expect.objectContaining({
                 origin: "LOCAL",
                 removedAt: null,
-                vibeAnalysisStatus: "failed",
                 embeddings: { none: { spaceId: "target-space" } },
             }),
+            _count: true,
         });
+        expect(mockTrackCount).toHaveBeenCalledTimes(1);
+        expect(mockTrackGroupBy).toHaveBeenCalledTimes(1);
+    });
+
+    it("checks active-space emptiness with an existence query", async () => {
+        mockEmbeddingFindFirst.mockResolvedValueOnce({ trackId: "track-1" });
+        mockSpaceFindUnique.mockResolvedValueOnce({ hadVectors: true });
+
+        await expect(loadVibeSpaceVectorState("space-active")).resolves.toEqual(
+            { hasVectors: true, hadVectors: true },
+        );
+
+        expect(mockEmbeddingFindFirst).toHaveBeenNthCalledWith(1, {
+            where: { spaceId: "space-active" },
+            select: { trackId: true },
+        });
+        expect(mockSpaceFindUnique).toHaveBeenCalledWith({
+            where: { id: "space-active" },
+            select: { hadVectors: true },
+        });
+        expect(mockTrackCount).not.toHaveBeenCalled();
     });
 
     it("loads and emits counts for the active space", async () => {

--- a/backend/src/services/__tests__/vibeProvider.test.ts
+++ b/backend/src/services/__tests__/vibeProvider.test.ts
@@ -8,6 +8,8 @@ const mockConfig = {
 jest.mock("../../config", () => ({ config: mockConfig }));
 jest.mock("../embeddingSpaces", () => ({
     getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
+    embeddingPreprocessingMatches: (left: unknown, right: unknown) =>
+        JSON.stringify(left) === JSON.stringify(right),
 }));
 jest.mock("../../metrics", () => ({
     recordVibeProviderRequest: (...args: unknown[]) =>

--- a/backend/src/services/__tests__/vibeSearch.test.ts
+++ b/backend/src/services/__tests__/vibeSearch.test.ts
@@ -1,0 +1,55 @@
+jest.mock("../../utils/logger", () => ({
+    logger: { info: jest.fn() },
+}));
+jest.mock("../trackEmbeddings", () => ({
+    findTracksByTextEmbedding: jest.fn(),
+}));
+jest.mock("../textEmbedding", () => ({ resolveTextEmbedding: jest.fn() }));
+jest.mock("../vibeVocabulary", () => ({
+    expandQueryWithVocabulary: jest.fn(),
+    getVocabulary: jest.fn(() => null),
+    rerankWithFeatures: jest.fn(),
+}));
+
+import {
+    distanceToSearchSimilarity,
+    parseVibeSearchRequest,
+} from "../vibeSearch";
+
+describe("vibe search decisions", () => {
+    it.each([undefined, null, 42, " ", "a"])(
+        "rejects an invalid query %p",
+        (query) => {
+            expect(parseVibeSearchRequest({ query })).toEqual({
+                ok: false,
+                error: "Query must be at least 2 characters",
+            });
+        },
+    );
+
+    it("normalizes and bounds search controls", () => {
+        expect(
+            parseVibeSearchRequest({
+                query: "  quiet focus  ",
+                limit: 500,
+                minSimilarity: -2,
+            }),
+        ).toEqual({
+            ok: true,
+            value: {
+                normalizedQuery: "quiet focus",
+                limit: 100,
+                similarityThreshold: 0,
+            },
+        });
+    });
+
+    it.each([
+        [0, 1],
+        [0.7, 0.65],
+        [2, 0],
+        [3, 0],
+    ])("maps distance %s to similarity %s", (distance, similarity) => {
+        expect(distanceToSearchSimilarity(distance)).toBe(similarity);
+    });
+});

--- a/backend/src/services/embeddingSpaceLifecycle.ts
+++ b/backend/src/services/embeddingSpaceLifecycle.ts
@@ -1,11 +1,15 @@
-import { recordVibeSpaceTransition } from "../metrics";
+import {
+    recordVibeSpaceTransition,
+    setVibeEmbeddingCoverage,
+} from "../metrics";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { getActiveSpace, invalidateActiveSpaceCache } from "./embeddingSpaces";
 import {
     loadVibeEmbeddingCoverage,
-    loadVibeSpaceEmbeddedCount,
+    loadVibeSpaceVectorState,
 } from "./vibeEmbeddingCoverage";
+import type { VibeEmbeddingCoverage } from "../metrics/vibeEmbedMetrics";
 
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1_000;
 const RETIRED_SPACE_SCAN_LIMIT = 10;
@@ -38,11 +42,12 @@ export function shouldCutOver(coverage: number, threshold: number): boolean {
 
 /** Decide whether an empty active space permits immediate cutover. */
 export function shouldCutOverEmptyActiveSpace(
-    activeEmbeddedCount: number,
+    activeHasVectors: boolean,
+    activeHadVectors: boolean,
 ): boolean {
     // Pending active-space work does not protect query results and may have no
     // deployed teacher worker capable of completing it on a fresh install.
-    return activeEmbeddedCount === 0;
+    return !activeHasVectors && !activeHadVectors;
 }
 
 /** Decide whether a retired space has reached its cleanup boundary. */
@@ -114,10 +119,27 @@ async function flipActiveSpace(
     });
 }
 
-async function loadCoverage(spaceId: string): Promise<number> {
+interface CoverageSample extends VibeEmbeddingCoverage {
+    ratio: number;
+}
+
+async function sampleCoverage(
+    spaceId: string,
+    threshold: number,
+): Promise<CoverageSample> {
     const coverage = await loadVibeEmbeddingCoverage(spaceId);
     const actionable = coverage.embedded + coverage.pending;
-    return actionable === 0 ? 0 : coverage.embedded / actionable;
+    const ratio = actionable === 0 ? 0 : coverage.embedded / actionable;
+    setVibeEmbeddingCoverage(coverage);
+    log.info("Embedding-space migration coverage sampled", {
+        spaceId,
+        coveragePercent: ratio * 100,
+        thresholdPercent: threshold * 100,
+        embedded: coverage.embedded,
+        pending: coverage.pending,
+        failed: coverage.failed,
+    });
+    return { ...coverage, ratio };
 }
 
 async function completeCutover(
@@ -134,6 +156,7 @@ async function cutOverEmptyActiveSpace(
     activeSpaceId: string,
     migratingSpaceId: string,
     retiredAt: Date,
+    failed: number,
 ): Promise<void> {
     log.info(
         "Embedding-space cutover starting because active space has no embedded vectors",
@@ -143,6 +166,7 @@ async function cutOverEmptyActiveSpace(
     log.info("Embedding-space cutover completed", {
         spaceId: migratingSpaceId,
         reason: "empty_active_space",
+        failed,
     });
 }
 
@@ -151,24 +175,28 @@ async function cutOverIfReady(
     config: LifecycleConfig,
 ): Promise<void> {
     const activeSpace = await getActiveSpace();
-    const activeEmbeddedCount = await loadVibeSpaceEmbeddedCount(
-        activeSpace.id,
-    );
-    if (shouldCutOverEmptyActiveSpace(activeEmbeddedCount)) {
-        await cutOverEmptyActiveSpace(activeSpace.id, space.id, config.now());
+    const activeVectorState = await loadVibeSpaceVectorState(activeSpace.id);
+    const coverage = await sampleCoverage(space.id, config.threshold);
+    if (
+        shouldCutOverEmptyActiveSpace(
+            activeVectorState.hasVectors,
+            activeVectorState.hadVectors,
+        )
+    ) {
+        await cutOverEmptyActiveSpace(
+            activeSpace.id,
+            space.id,
+            config.now(),
+            coverage.failed,
+        );
         return;
     }
-    const coverage = await loadCoverage(space.id);
-    log.info("Embedding-space migration coverage sampled", {
-        spaceId: space.id,
-        coveragePercent: coverage * 100,
-        thresholdPercent: config.threshold * 100,
-    });
-    if (!shouldCutOver(coverage, config.threshold)) return;
+    if (!shouldCutOver(coverage.ratio, config.threshold)) return;
     await completeCutover(space.id, config.now());
     log.info("Embedding-space cutover completed", {
         spaceId: space.id,
-        coverage,
+        coverage: coverage.ratio,
+        failed: coverage.failed,
     });
 }
 

--- a/backend/src/services/embeddingSpaces.ts
+++ b/backend/src/services/embeddingSpaces.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@prisma/client";
+import { recordVibeProviderConfigError } from "../metrics";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 
@@ -15,6 +16,7 @@ export interface ActiveEmbeddingSpace {
     checkpointHash: string;
     dim: number;
     preprocessing: Prisma.JsonValue;
+    hadVectors: boolean;
 }
 
 /** Registry row used by provider migration and lifecycle orchestration. */
@@ -79,6 +81,18 @@ export class EmbeddingSpaceDimensionMismatchError extends Error {
     }
 }
 
+/** Raised when a provider tuple reuses incompatible preprocessing. */
+export class EmbeddingSpacePreprocessingMismatchError extends Error {
+    readonly code = "EMBEDDING_SPACE_PREPROCESSING_MISMATCH";
+
+    constructor(public readonly spaceId: string) {
+        super(
+            `Embedding space ${spaceId} has different registered preprocessing`,
+        );
+        this.name = "EmbeddingSpacePreprocessingMismatchError";
+    }
+}
+
 let cachedSpace: ActiveEmbeddingSpace | null = null;
 let cacheExpiresAt = 0;
 let inFlightLoad: Promise<ActiveEmbeddingSpace> | null = null;
@@ -90,6 +104,7 @@ const providerSpaceSelect = {
     checkpointHash: true,
     dim: true,
     preprocessing: true,
+    hadVectors: true,
     status: true,
     retiredAt: true,
     createdAt: true,
@@ -104,6 +119,7 @@ function toActiveSpace(
         checkpointHash: row.checkpointHash,
         dim: row.dim,
         preprocessing: row.preprocessing,
+        hadVectors: row.hadVectors,
     };
 }
 
@@ -118,6 +134,7 @@ async function loadActiveSpace(): Promise<ActiveEmbeddingSpace> {
             checkpointHash: true,
             dim: true,
             preprocessing: true,
+            hadVectors: true,
             createdAt: true,
         },
     });
@@ -185,7 +202,47 @@ function resolveRegisteredProviderSpace(
             providerSpace.dim,
         );
     }
+    if (
+        !embeddingPreprocessingMatches(
+            space.preprocessing,
+            providerSpace.preprocessing,
+        )
+    ) {
+        log.error(
+            "Embedding-space provider preprocessing does not match the registered tuple",
+            { spaceId: space.id },
+        );
+        recordVibeProviderConfigError("preprocessing_mismatch");
+        throw new EmbeddingSpacePreprocessingMismatchError(space.id);
+    }
     return assertUsableProviderSpace(space);
+}
+
+function canonicalJson(
+    value: Prisma.JsonValue | Prisma.InputJsonValue,
+): string {
+    return JSON.stringify(value, (_key, nestedValue: unknown) => {
+        if (
+            nestedValue === null ||
+            typeof nestedValue !== "object" ||
+            Array.isArray(nestedValue)
+        ) {
+            return nestedValue;
+        }
+        return Object.fromEntries(
+            Object.entries(nestedValue).sort(([left], [right]) =>
+                left.localeCompare(right),
+            ),
+        );
+    });
+}
+
+/** Compare preprocessing documents without depending on JSON object key order. */
+export function embeddingPreprocessingMatches(
+    registered: Prisma.JsonValue,
+    provider: Prisma.InputJsonValue,
+): boolean {
+    return canonicalJson(registered) === canonicalJson(provider);
 }
 
 function isUniqueConstraintError(error: unknown): boolean {

--- a/backend/src/services/trackEmbeddings.ts
+++ b/backend/src/services/trackEmbeddings.ts
@@ -7,7 +7,6 @@ import {
     getActiveSpace,
     getVibeEmbeddingTargetSpaceId,
 } from "./embeddingSpaces";
-import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
 import {
     vibeEmbeddingEligibleTrackWhere,
     vibeEmbeddingTargetGateWhere,
@@ -67,6 +66,11 @@ export interface TextSearchResult {
     speechiness: number | null;
 }
 
+function boundedTextSearchCandidateLimit(candidateLimit: number): number {
+    if (!Number.isFinite(candidateLimit)) return 1;
+    return Math.min(Math.max(1, Math.trunc(candidateLimit)), 300);
+}
+
 /** Prisma relation filter for tracks without a vector in `targetSpaceId`. */
 export function missingActiveEmbeddingWhere(
     targetSpaceId: string,
@@ -92,18 +96,6 @@ export async function findLocalTracksNeedingActiveEmbedding(
         take: limit,
         orderBy: { fileModified: "desc" },
     });
-}
-
-/** Delete active-space vectors for local tracks during a forced rebuild. */
-export async function deleteActiveLocalTrackEmbeddings(): Promise<number> {
-    const activeSpace = await getActiveSpace();
-    const result = await prisma.trackEmbedding.deleteMany({
-        where: {
-            spaceId: activeSpace.id,
-            track: LOCAL_TRACK_WHERE,
-        },
-    });
-    return result.count;
 }
 
 /** Upserts one validated CLAP vector received from a trusted service boundary. */
@@ -138,6 +130,10 @@ export async function upsertTrackEmbedding(
             embedding = EXCLUDED.embedding,
             analyzed_at = EXCLUDED.analyzed_at
     `;
+    await prisma.embeddingSpace.updateMany({
+        where: { id: spaceId, hadVectors: false },
+        data: { hadVectors: true },
+    });
 }
 
 /**
@@ -243,9 +239,11 @@ export async function findTracksByTextEmbedding(
     spaceId?: string,
 ): Promise<TextSearchResult[]> {
     const resolvedSpaceId = spaceId ?? (await getActiveSpace()).id;
+    const boundedCandidateLimit =
+        boundedTextSearchCandidateLimit(candidateLimit);
     // Migrating spaces have no ANN index before cutover, so pgvector uses an
     // exact scan during this bounded migration window.
-    return runAnnQuery<TextSearchResult[]>(Prisma.sql`
+    const query = Prisma.sql`
         SELECT
             t.id,
             t.title,
@@ -273,8 +271,12 @@ export async function findTracksByTextEmbedding(
           AND te.space_id = ${resolvedSpaceId}
           AND te.embedding <=> ${searchEmbedding}::vector <= ${maxDistance}
         ORDER BY te.embedding <=> ${searchEmbedding}::vector
-        LIMIT ${candidateLimit}
-    `);
+        LIMIT ${boundedCandidateLimit}
+    `;
+    return runAnnQuery<TextSearchResult[]>(query, undefined, {
+        statementTimeoutMs: 5_000,
+        timeoutMessage: "Vibe text search query timed out",
+    });
 }
 
 /** Counts embeddings for tracks visible on browsable library surfaces. */

--- a/backend/src/services/vibeEmbedJobs.ts
+++ b/backend/src/services/vibeEmbedJobs.ts
@@ -13,6 +13,7 @@ import { vibeEmbeddingTargetGateWhere } from "./vibeEmbeddingEligibility";
 const VIBE_QUEUE = "audio:clap:queue";
 const MAX_ERROR_LENGTH = 500;
 const INVALID_PAYLOAD_ERROR = "Invalid vibe embedding job payload";
+export const MAX_VIBE_ANALYSIS_RETRIES = 3;
 const jobLog =
     typeof (logger as { child?: unknown }).child === "function"
         ? logger.child("VibeEmbedJobs")
@@ -36,7 +37,13 @@ const vibeEmbedJobSchema = z.strictObject({
 const vibeEmbedTrackIdSchema = z.object({ trackId: trackIdSchema });
 
 type VibeEmbedJob = z.infer<typeof vibeEmbedJobSchema>;
-type TrackSnapshot = { id: string; title: string };
+type TrackSnapshot = {
+    id: string;
+    title: string;
+    vibeAnalysisRetryCount?: number;
+    vibeAnalysisStatus?: string | null;
+    embeddings?: Array<{ spaceId: string }>;
+};
 type ParsedVibeEmbedJob =
     | { kind: "valid"; job: VibeEmbedJob }
     | { kind: "invalid"; trackId: string | null };
@@ -77,6 +84,7 @@ interface VibeEmbedJobDependencies {
     releaseReservation(trackId: string): Promise<void>;
     recordOutcome(outcome: VibeEmbedJobOutcome): void;
     describeFailure(error: unknown): string;
+    isTransientFailure(error: unknown): boolean;
     now(): Date;
 }
 
@@ -110,7 +118,26 @@ async function findActiveTrack(
 ): Promise<TrackSnapshot | null> {
     return db.track.findFirst({
         where: activeTrackWhere(trackId),
-        select: { id: true, title: true },
+        select: { id: true, title: true, vibeAnalysisRetryCount: true },
+    });
+}
+
+async function findTrackForInvalidPayload(
+    dependencies: VibeEmbedJobDependencies,
+    trackId: string,
+): Promise<TrackSnapshot | null> {
+    return dependencies.prisma.track.findFirst({
+        where: activeTrackWhere(trackId),
+        select: {
+            id: true,
+            title: true,
+            vibeAnalysisStatus: true,
+            embeddings: {
+                where: { spaceId: dependencies.targetSpaceId },
+                select: { spaceId: true },
+                take: 1,
+            },
+        },
     });
 }
 
@@ -160,7 +187,6 @@ function failureStatusWhere() {
         { vibeAnalysisStatus: null },
         { vibeAnalysisStatus: "pending" },
         { vibeAnalysisStatus: "processing" },
-        { vibeAnalysisStatus: "completed" },
     ];
 }
 
@@ -176,12 +202,12 @@ async function markFailedWithMessage(
     track: TrackSnapshot,
     errorMessage: string,
 ): Promise<boolean> {
-    // The claim may begin from completed when its target-space vector is
-    // absent, while processing covers failures after the claim succeeds.
+    // Invalid payloads may settle only unfinished rows without target vectors.
     const updated = await dependencies.prisma.track.updateMany({
         where: {
             ...activeTrackWhere(track.id),
             OR: failureStatusWhere(),
+            embeddings: { none: { spaceId: dependencies.targetSpaceId } },
         },
         data: {
             vibeAnalysisStatus: "failed",
@@ -211,11 +237,68 @@ async function markFailed(
     track: TrackSnapshot,
     error: unknown,
 ): Promise<void> {
-    await markFailedWithMessage(
-        dependencies,
-        track,
-        failureMessage(dependencies, error),
-    );
+    const errorMessage = failureMessage(dependencies, error);
+    const retryCount = track.vibeAnalysisRetryCount ?? 0;
+    const updated = await dependencies.prisma.track.updateMany({
+        where: {
+            ...activeTrackWhere(track.id),
+            vibeAnalysisStatus: "processing",
+            vibeAnalysisRetryCount: retryCount,
+        },
+        data: {
+            vibeAnalysisStatus: "failed",
+            vibeAnalysisError: errorMessage,
+            vibeAnalysisRetryCount: { increment: 1 },
+            vibeAnalysisStartedAt: null,
+            vibeAnalysisStatusUpdatedAt: dependencies.now(),
+        },
+    });
+    if (updated.count === 0) return;
+    await dependencies.failureService.recordFailure({
+        entityType: "vibe",
+        entityId: track.id,
+        entityName: track.title,
+        errorMessage,
+        errorCode: "VIBE_EMBEDDING_FAILED",
+    });
+}
+
+async function resetTransientFailure(
+    dependencies: VibeEmbedJobDependencies,
+    track: TrackSnapshot,
+    error: unknown,
+): Promise<boolean> {
+    const retryCount = track.vibeAnalysisRetryCount ?? 0;
+    if (
+        !dependencies.isTransientFailure(error) ||
+        retryCount + 1 >= MAX_VIBE_ANALYSIS_RETRIES
+    ) {
+        return false;
+    }
+    const updated = await dependencies.prisma.track.updateMany({
+        where: {
+            ...activeTrackWhere(track.id),
+            vibeAnalysisStatus: "processing",
+            vibeAnalysisRetryCount: retryCount,
+        },
+        data: {
+            vibeAnalysisStatus: "pending",
+            vibeAnalysisError: failureMessage(dependencies, error),
+            vibeAnalysisRetryCount: { increment: 1 },
+            vibeAnalysisStartedAt: null,
+            vibeAnalysisStatusUpdatedAt: dependencies.now(),
+        },
+    });
+    return updated.count === 1;
+}
+
+async function handleGenerationFailure(
+    dependencies: VibeEmbedJobDependencies,
+    track: TrackSnapshot,
+    error: unknown,
+): Promise<void> {
+    if (await resetTransientFailure(dependencies, track, error)) return;
+    await markFailed(dependencies, track, error);
 }
 
 async function markCompleted(
@@ -265,11 +348,17 @@ async function processValidJob(
         return finish(dependencies, "stale_claim");
     }
 
+    let vector: number[];
     try {
-        const vector = await dependencies.embedAudio(job.filePath, {
+        vector = await dependencies.embedAudio(job.filePath, {
             id: dependencies.targetSpaceId,
             dim: dependencies.targetSpaceDim,
         });
+    } catch (error) {
+        await handleGenerationFailure(dependencies, track, error);
+        return finish(dependencies, "embed_failed");
+    }
+    try {
         const stillActive = await findActiveTrack(
             dependencies.prisma,
             track.id,
@@ -298,9 +387,19 @@ async function processInvalidJob(
     if (trackId === null) return finish(dependencies, "invalid_payload");
 
     await releaseReservation(dependencies, trackId);
-    const track = await findActiveTrack(dependencies.prisma, trackId);
-    if (track) {
+    const track = await findTrackForInvalidPayload(dependencies, trackId);
+    const protectedTrack =
+        track?.vibeAnalysisStatus === "completed" ||
+        (track?.embeddings?.length ?? 0) > 0;
+    if (track && !protectedTrack) {
         await markFailedWithMessage(dependencies, track, INVALID_PAYLOAD_ERROR);
+    } else if (track) {
+        jobLog.warn(
+            "Dropped invalid vibe embedding job for a protected track",
+            {
+                trackId,
+            },
+        );
     }
     return finish(dependencies, "invalid_payload");
 }
@@ -340,6 +439,16 @@ function describeVibeEmbedFailure(error: unknown): string {
     }
 }
 
+/** Classifies provider failures that are safe for bounded automatic retry. */
+export function isTransientVibeProviderFailure(error: unknown): boolean {
+    return (
+        error instanceof VibeProviderError &&
+        (error.code === "timeout" ||
+            error.code === "unreachable" ||
+            error.code === "provider_5xx")
+    );
+}
+
 /** Process one queued audio-embedding job for an explicit provider space. */
 export async function processVibeEmbedJob(
     rawJob: string,
@@ -357,6 +466,7 @@ export async function processVibeEmbedJob(
         },
         recordOutcome: recordVibeEmbedJobOutcome,
         describeFailure: describeVibeEmbedFailure,
+        isTransientFailure: isTransientVibeProviderFailure,
         now: () => new Date(),
     })(rawJob);
 }

--- a/backend/src/services/vibeEmbeddingCoverage.ts
+++ b/backend/src/services/vibeEmbeddingCoverage.ts
@@ -9,11 +9,22 @@ interface CoverageRefresherDependencies {
     setCoverage(coverage: VibeEmbeddingCoverage): void;
 }
 
-/** Counts every stored vector in one embedding space. */
-export async function loadVibeSpaceEmbeddedCount(
+/** Loads durable vector-presence history for instant-cutover decisions. */
+export async function loadVibeSpaceVectorState(
     spaceId: string,
-): Promise<number> {
-    return prisma.trackEmbedding.count({ where: { spaceId } });
+): Promise<{ hasVectors: boolean; hadVectors: boolean }> {
+    const [embedding, space] = await Promise.all([
+        prisma.trackEmbedding.findFirst({
+            where: { spaceId },
+            select: { trackId: true },
+        }),
+        prisma.embeddingSpace.findUnique({
+            where: { id: spaceId },
+            select: { hadVectors: true },
+        }),
+    ]);
+    if (!space) throw new Error(`Embedding space ${spaceId} is not registered`);
+    return { hasVectors: embedding !== null, hadVectors: space.hadVectors };
 }
 
 /** Loads target-space coverage for local tracks eligible for audio analysis. */
@@ -23,26 +34,34 @@ export async function loadVibeEmbeddingCoverage(
     const resolvedTargetSpaceId =
         targetSpaceId ?? (await getVibeEmbeddingTargetSpaceId());
     const eligibleWhere = vibeEmbeddingEligibleTrackWhere();
-    const [total, embedded, failed] = await Promise.all([
-        prisma.track.count({ where: eligibleWhere }),
+    const [embedded, missingByStatus] = await Promise.all([
         prisma.track.count({
             where: {
                 ...eligibleWhere,
                 embeddings: { some: { spaceId: resolvedTargetSpaceId } },
             },
         }),
-        prisma.track.count({
+        prisma.track.groupBy({
+            by: ["vibeAnalysisStatus"],
             where: {
                 ...eligibleWhere,
                 embeddings: { none: { spaceId: resolvedTargetSpaceId } },
-                vibeAnalysisStatus: "failed",
             },
+            _count: true,
         }),
     ]);
+    const failed =
+        missingByStatus.find((row) => row.vibeAnalysisStatus === "failed")
+            ?._count ?? 0;
+    const pending = missingByStatus.reduce(
+        (count, row) =>
+            row.vibeAnalysisStatus === "failed" ? count : count + row._count,
+        0,
+    );
     return {
         embedded,
         failed,
-        pending: Math.max(0, total - embedded - failed),
+        pending,
     };
 }
 

--- a/backend/src/services/vibeEmbeddingEligibility.ts
+++ b/backend/src/services/vibeEmbeddingEligibility.ts
@@ -15,11 +15,16 @@ export function vibeEmbeddingTargetGateWhere(
     targetSpaceId: string,
 ): Prisma.TrackWhereInput {
     return {
-        embeddings: { none: { spaceId: targetSpaceId } },
         OR: [
-            { vibeAnalysisStatus: null },
             { vibeAnalysisStatus: "pending" },
-            { vibeAnalysisStatus: "completed" },
+            {
+                vibeAnalysisStatus: null,
+                embeddings: { none: { spaceId: targetSpaceId } },
+            },
+            {
+                vibeAnalysisStatus: "completed",
+                embeddings: { none: { spaceId: targetSpaceId } },
+            },
         ],
     };
 }

--- a/backend/src/services/vibeProvider.ts
+++ b/backend/src/services/vibeProvider.ts
@@ -5,7 +5,11 @@ import type {
     VibeProviderEndpoint,
     VibeProviderOutcome,
 } from "../metrics/providerMetrics";
-import { getActiveSpace, type ActiveEmbeddingSpace } from "./embeddingSpaces";
+import {
+    embeddingPreprocessingMatches,
+    getActiveSpace,
+    type ActiveEmbeddingSpace,
+} from "./embeddingSpaces";
 
 /** Shared deadline for provider identity and health operations. */
 export const PROVIDER_SPACE_HEALTH_TIMEOUT_MS = 5_000;
@@ -362,7 +366,11 @@ export function assertProviderMatchesActiveSpace(
     const matches =
         providerSpace.family === activeSpace.family &&
         providerSpace.checkpointHash === activeSpace.checkpointHash &&
-        providerSpace.dim === activeSpace.dim;
+        providerSpace.dim === activeSpace.dim &&
+        embeddingPreprocessingMatches(
+            activeSpace.preprocessing,
+            providerSpace.preprocessing,
+        );
     if (!matches) throw new VibeProviderSpaceMismatchError();
 }
 

--- a/backend/src/services/vibeSearch.ts
+++ b/backend/src/services/vibeSearch.ts
@@ -1,0 +1,171 @@
+import { logger } from "../utils/logger";
+import {
+    findTracksByTextEmbedding,
+    type TextSearchResult,
+} from "./trackEmbeddings";
+import { resolveTextEmbedding } from "./textEmbedding";
+import {
+    expandQueryWithVocabulary,
+    getVocabulary,
+    rerankWithFeatures,
+    type VocabTerm,
+} from "./vibeVocabulary";
+
+const MAX_TEXT_SEARCH_QUERY_LENGTH = 512;
+const MIN_SEARCH_SIMILARITY = 0.6;
+
+interface ParsedVibeSearchRequest {
+    normalizedQuery: string;
+    limit: number;
+    similarityThreshold: number;
+}
+
+/** Result of validating and normalizing an untrusted vibe-search body. */
+export type VibeSearchRequestResult =
+    | { ok: true; value: ParsedVibeSearchRequest }
+    | { ok: false; error: string };
+
+interface RankedSearchTrack extends TextSearchResult {
+    finalScore?: number;
+}
+
+interface SearchExpansion {
+    embedding: number[];
+    genreConfidence: number;
+    matchedTerms: VocabTerm[];
+}
+
+/** Convert CLAP cosine distance to the route's zero-to-one similarity. */
+export function distanceToSearchSimilarity(distance: number): number {
+    return Math.max(0, 1 - distance / 2);
+}
+
+/** Validate and normalize a vibe-search request without I/O. */
+export function parseVibeSearchRequest(body: unknown): VibeSearchRequestResult {
+    const input = body as Record<string, unknown> | null;
+    const query = input?.query;
+    if (typeof query !== "string") {
+        return { ok: false, error: "Query must be at least 2 characters" };
+    }
+    if (query.length > MAX_TEXT_SEARCH_QUERY_LENGTH) {
+        return {
+            ok: false,
+            error: `Query must be at most ${MAX_TEXT_SEARCH_QUERY_LENGTH} characters`,
+        };
+    }
+    const normalizedQuery = query.trim();
+    if (normalizedQuery.length < 2) {
+        return { ok: false, error: "Query must be at least 2 characters" };
+    }
+    const requestedLimit = Number(input?.limit || 20);
+    const limit = Math.min(Math.max(1, requestedLimit), 100);
+    const requestedSimilarity = input?.minSimilarity;
+    const similarityThreshold =
+        typeof requestedSimilarity === "number"
+            ? Math.max(0, Math.min(1, requestedSimilarity))
+            : MIN_SEARCH_SIMILARITY;
+    return { ok: true, value: { normalizedQuery, limit, similarityThreshold } };
+}
+
+function expandSearch(
+    embedding: number[],
+    normalizedQuery: string,
+): SearchExpansion {
+    const vocabulary = getVocabulary();
+    if (!vocabulary) {
+        return { embedding, genreConfidence: 0, matchedTerms: [] };
+    }
+    const expansion = expandQueryWithVocabulary(
+        embedding,
+        normalizedQuery,
+        vocabulary,
+    );
+    logger.info(
+        `[VIBE-SEARCH] Query "${normalizedQuery}" expanded with terms: ${expansion.matchedTerms.map((term) => term.name).join(", ") || "none"}, genre confidence: ${(expansion.genreConfidence * 100).toFixed(0)}%`,
+    );
+    return expansion;
+}
+
+function rankTracks(
+    tracks: TextSearchResult[],
+    expansion: SearchExpansion,
+    limit: number,
+): RankedSearchTrack[] {
+    if (expansion.matchedTerms.length === 0) return tracks.slice(0, limit);
+    const reranked = rerankWithFeatures(
+        tracks,
+        expansion.matchedTerms,
+        expansion.genreConfidence,
+    );
+    const ranked = reranked.slice(0, limit);
+    logger.info(
+        `[VIBE-SEARCH] Re-ranked ${tracks.length} candidates, top result: ${ranked[0]?.title || "none"}`,
+    );
+    return ranked;
+}
+
+function searchSimilarity(track: RankedSearchTrack): number {
+    return track.finalScore ?? distanceToSearchSimilarity(track.distance);
+}
+
+function logSimilarityRange(tracks: RankedSearchTrack[]): void {
+    if (tracks.length === 0) return;
+    const best = searchSimilarity(tracks[0]);
+    const worst = searchSimilarity(tracks[tracks.length - 1]);
+    logger.info(
+        `Vibe search similarity range: ${Math.round(best * 100)}% - ${Math.round(worst * 100)}%`,
+    );
+}
+
+function serializeTrack(row: RankedSearchTrack) {
+    return {
+        id: row.id,
+        title: row.title,
+        duration: row.duration,
+        trackNo: row.trackNo,
+        distance: row.distance,
+        similarity: searchSimilarity(row),
+        album: {
+            id: row.albumId,
+            title: row.albumTitle,
+            coverUrl: row.albumCoverUrl,
+        },
+        artist: { id: row.artistId, name: row.artistName },
+    };
+}
+
+/** Execute validated provider-backed vibe search and build its response body. */
+export async function executeVibeSearch(input: ParsedVibeSearchRequest) {
+    const textEmbedding = await resolveTextEmbedding(input.normalizedQuery);
+    const expansion = expandSearch(
+        textEmbedding.embedding,
+        input.normalizedQuery,
+    );
+    const maxDistance = 2 * (1 - input.similarityThreshold);
+    const candidates = await findTracksByTextEmbedding(
+        expansion.embedding,
+        maxDistance,
+        input.limit * 3,
+        textEmbedding.spaceId,
+    );
+    logger.info(
+        `Vibe search "${input.normalizedQuery}": found ${candidates.length} candidates above ${Math.round(input.similarityThreshold * 100)}% similarity (max distance: ${maxDistance.toFixed(2)})`,
+    );
+    const ranked = rankTracks(candidates, expansion, input.limit);
+    logSimilarityRange(ranked);
+    const tracks = ranked.map(serializeTrack);
+    return {
+        query: input.normalizedQuery,
+        tracks,
+        minSimilarity: input.similarityThreshold,
+        totalAboveThreshold: tracks.length,
+        debug: {
+            matchedTerms: expansion.matchedTerms.map((term) => term.name),
+            genreConfidence: expansion.genreConfidence,
+            featureWeight:
+                expansion.matchedTerms.length > 0
+                    ? 0.2 + expansion.genreConfidence * 0.5
+                    : 0,
+        },
+    };
+}

--- a/backend/src/utils/__tests__/annQuery.test.ts
+++ b/backend/src/utils/__tests__/annQuery.test.ts
@@ -121,4 +121,44 @@ describe("runAnnQuery (F14 ivfflat.probes helper)", () => {
         expect(batch[0].__sqlArgs).toContain("7");
         expect(batch[0].__sqlArgs).not.toContain("7.9");
     });
+
+    it("applies a transaction-local statement timeout before a bounded query", async () => {
+        mockTransaction.mockResolvedValueOnce([
+            [{ set_config: "12" }],
+            [{ set_config: "5000" }],
+            [],
+        ]);
+        const query = Prisma.sql`SELECT 1`;
+
+        await runAnnQuery(query, undefined, {
+            statementTimeoutMs: 5_000,
+            timeoutMessage: "Vibe text search query timed out",
+        });
+
+        const batch = mockTransaction.mock.calls[0][0] as Descriptor[];
+        expect(batch).toHaveLength(3);
+        expect((batch[1].__sqlArgs[0] as string[]).join(" ")).toContain(
+            "statement_timeout",
+        );
+        expect(batch[1].__sqlArgs).toContain("5000");
+        expect(batch[2].__sqlArgs[0]).toBe(query);
+    });
+
+    it("maps PostgreSQL statement cancellation to the caller's bounded error", async () => {
+        mockTransaction.mockRejectedValueOnce(
+            Object.assign(
+                new Error("canceling statement due to statement timeout"),
+                {
+                    code: "57014",
+                },
+            ),
+        );
+
+        await expect(
+            runAnnQuery(Prisma.sql`SELECT 1`, undefined, {
+                statementTimeoutMs: 5_000,
+                timeoutMessage: "Vibe text search query timed out",
+            }),
+        ).rejects.toThrow("Vibe text search query timed out");
+    });
 });

--- a/backend/src/utils/annQuery.ts
+++ b/backend/src/utils/annQuery.ts
@@ -2,6 +2,20 @@ import type { Prisma } from "@prisma/client";
 import { prisma } from "./db";
 import { config } from "../config";
 
+interface AnnQueryOptions {
+    statementTimeoutMs: number;
+    timeoutMessage: string;
+}
+
+function isStatementTimeout(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "57014"
+    );
+}
+
 /**
  * Run a pgvector ANN query with `ivfflat.probes` applied on the SAME pooled
  * connection as the query (roadmap F14).
@@ -38,6 +52,7 @@ import { config } from "../config";
 export async function runAnnQuery<T>(
     annQuery: Prisma.Sql,
     probes: number = config.ivfflatProbes,
+    options?: AnnQueryOptions,
 ): Promise<T> {
     // Clamp to ivfflat.probes' valid domain, 1..32768. An out-of-range value
     // does NOT error: Postgres emits only a server-log WARNING (invisible to
@@ -48,9 +63,26 @@ export async function runAnnQuery<T>(
     // single consumption point, so a misconfigured IVFFLAT_PROBES (0, negative,
     // huge, fractional) degrades to the nearest valid value instead.
     const effectiveProbes = Math.min(32768, Math.max(1, Math.trunc(probes)));
-    const [, rows] = await prisma.$transaction([
+    const statements = [
         prisma.$queryRaw`SELECT set_config('ivfflat.probes', ${String(effectiveProbes)}, true)`,
-        prisma.$queryRaw<T>(annQuery),
-    ]);
-    return rows;
+    ];
+    if (options) {
+        const timeoutMs = Math.min(
+            60_000,
+            Math.max(1, Math.trunc(options.statementTimeoutMs)),
+        );
+        statements.push(
+            prisma.$queryRaw`SELECT set_config('statement_timeout', ${String(timeoutMs)}, true)`,
+        );
+    }
+    statements.push(prisma.$queryRaw<T>(annQuery));
+    try {
+        const results = await prisma.$transaction(statements);
+        return results[results.length - 1] as T;
+    } catch (error) {
+        if (options && isStatementTimeout(error)) {
+            throw new Error(options.timeoutMessage, { cause: error });
+        }
+        throw error;
+    }
 }

--- a/backend/src/workers/__tests__/enrichmentQueue.test.ts
+++ b/backend/src/workers/__tests__/enrichmentQueue.test.ts
@@ -1,5 +1,7 @@
 import {
+    enqueueReservedNodeRedisWork,
     enqueueReservedWork,
+    type EnrichmentQueueNodeRedis,
     type EnrichmentQueueRedis,
 } from "../enrichmentQueue";
 
@@ -48,5 +50,26 @@ describe("enrichment queue admission", () => {
                 reservationTtlSeconds: 3600,
             }),
         ).rejects.toThrow("Unexpected enrichment queue admission result");
+    });
+
+    it("uses the same queue and reservation keys through node-redis", async () => {
+        const client: EnrichmentQueueNodeRedis = {
+            eval: jest.fn().mockResolvedValue(1),
+        };
+
+        await expect(
+            enqueueReservedNodeRedisWork(client, {
+                queueKey: "audio:clap:queue",
+                trackId: "track-1",
+                payload: "payload",
+                maxDepth: 25,
+                reservationTtlSeconds: 3600,
+            }),
+        ).resolves.toBe("queued");
+
+        expect(client.eval).toHaveBeenCalledWith(expect.any(String), {
+            keys: ["audio:clap:queue", "audio:clap:queue:reserved:track-1"],
+            arguments: ["25", "3600", "payload"],
+        });
     });
 });

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -477,12 +477,7 @@ describe("unified enrichment runtime behavior", () => {
                 data: { enrichmentStatus: "pending" },
             }),
         );
-        expect(prisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
-            where: {
-                spaceId: "space-active",
-                track: { origin: "LOCAL" },
-            },
-        });
+        expect(prisma.trackEmbedding.deleteMany).not.toHaveBeenCalled();
         expect(enrichmentFailureService.clearAllFailures).toHaveBeenCalledWith(
             "vibe",
         );
@@ -685,13 +680,20 @@ describe("unified enrichment runtime behavior", () => {
         expect(prisma.track.findMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: expect.objectContaining({
-                    embeddings: {
-                        none: { spaceId: "space-active" },
-                    },
                     OR: [
-                        { vibeAnalysisStatus: null },
                         { vibeAnalysisStatus: "pending" },
-                        { vibeAnalysisStatus: "completed" },
+                        {
+                            vibeAnalysisStatus: null,
+                            embeddings: {
+                                none: { spaceId: "space-active" },
+                            },
+                        },
+                        {
+                            vibeAnalysisStatus: "completed",
+                            embeddings: {
+                                none: { spaceId: "space-active" },
+                            },
+                        },
                     ],
                 }),
                 take: 100,
@@ -772,7 +774,7 @@ describe("unified enrichment runtime behavior", () => {
         ).toHaveBeenCalled();
         expect(
             vibeAnalysisCleanupService.cleanupStaleProcessing,
-        ).not.toHaveBeenCalled();
+        ).toHaveBeenCalledTimes(1);
         expect(claimRedisPrimary.eval).toHaveBeenCalledTimes(1);
         expect(result).toEqual({ artists: 0, tracks: 0, audioQueued: 0 });
     });
@@ -2096,7 +2098,10 @@ describe("unified enrichment runtime behavior", () => {
         (prisma.artist.findMany as jest.Mock).mockResolvedValueOnce([]);
         (prisma.track.findMany as jest.Mock).mockImplementation(
             async (query?: any) =>
-                query?.where?.embeddings?.none?.spaceId === "space-active"
+                query?.where?.OR?.some(
+                    (candidate: any) =>
+                        candidate.embeddings?.none?.spaceId === "space-active",
+                )
                     ? [
                           {
                               id: "track-vibe-fail",
@@ -2228,7 +2233,10 @@ describe("unified enrichment runtime behavior", () => {
             .mockResolvedValueOnce([{ count: BigInt(1) }]);
         (prisma.track.findMany as jest.Mock).mockImplementation(
             async (query?: any) =>
-                query?.where?.embeddings?.none?.spaceId === "space-active"
+                query?.where?.OR?.some(
+                    (candidate: any) =>
+                        candidate.embeddings?.none?.spaceId === "space-active",
+                )
                     ? [
                           {
                               id: "track-vibe-ok",
@@ -2250,6 +2258,30 @@ describe("unified enrichment runtime behavior", () => {
         expect(logger.debug).toHaveBeenCalledWith(
             "Queued 1 tracks for vibe embedding",
         );
+    });
+
+    it("runs vibe cleanup while the audio queue is nonzero", async () => {
+        const {
+            prisma,
+            getFeatures,
+            vibeAnalysisCleanupService,
+            queueRedisPrimary,
+        } = setupUnifiedEnrichmentMocks();
+        getFeatures.mockResolvedValue({ vibeEmbeddings: true });
+        (prisma.track.count as jest.Mock).mockResolvedValue(0);
+        (queueRedisPrimary.llen as jest.Mock).mockResolvedValue(7);
+        (
+            vibeAnalysisCleanupService.cleanupStaleProcessing as jest.Mock
+        ).mockResolvedValue({ reset: 1 });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const enrichment = require("../unifiedEnrichment");
+        await enrichment.__unifiedEnrichmentTestables.executeVibePhase();
+
+        expect(
+            vibeAnalysisCleanupService.cleanupStaleProcessing,
+        ).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).not.toHaveBeenCalled();
     });
 
     it("retries enrichment progress reads on rust panic prisma errors", async () => {

--- a/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
+++ b/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
@@ -11,6 +11,7 @@ jest.mock("../../config", () => ({
 import { createVibeEmbedWorker } from "../vibeEmbedWorker";
 import {
     EmbeddingSpaceDimensionMismatchError,
+    EmbeddingSpacePreprocessingMismatchError,
     RetiredEmbeddingSpaceError,
 } from "../../services/embeddingSpaces";
 
@@ -355,6 +356,7 @@ describe("vibe embed worker", () => {
     it.each([
         new RetiredEmbeddingSpaceError("space-retired"),
         new EmbeddingSpaceDimensionMismatchError("space-mismatch", 512, 768),
+        new EmbeddingSpacePreprocessingMismatchError("space-mismatch"),
     ])(
         "rate-limits terminal target resolution error $name on a longer retry interval",
         async (error) => {

--- a/backend/src/workers/enrichmentQueue.ts
+++ b/backend/src/workers/enrichmentQueue.ts
@@ -7,10 +7,18 @@ export interface EnrichmentQueueRedis {
     ): Promise<unknown>;
 }
 
+/** Minimal node-redis surface required for atomic enrichment admission. */
+export interface EnrichmentQueueNodeRedis {
+    eval(
+        script: string,
+        options: { keys: string[]; arguments: string[] },
+    ): Promise<unknown>;
+}
+
 /** Outcome returned by atomic enrichment queue admission. */
 export type EnrichmentQueueAdmission = "queued" | "duplicate" | "full";
 
-interface EnqueueReservedWorkInput {
+export interface EnqueueReservedWorkInput {
     queueKey: string;
     trackId: string;
     payload: string;
@@ -31,6 +39,23 @@ redis.call("RPUSH", KEYS[1], ARGV[3])
 return 1
 `;
 
+function admissionArguments(input: EnqueueReservedWorkInput): string[] {
+    return [
+        input.queueKey,
+        `${input.queueKey}:reserved:${input.trackId}`,
+        String(input.maxDepth),
+        String(input.reservationTtlSeconds),
+        input.payload,
+    ];
+}
+
+function parseAdmission(result: unknown): EnrichmentQueueAdmission {
+    if (result === 1) return "queued";
+    if (result === 0) return "duplicate";
+    if (result === -1) return "full";
+    throw new Error(`Unexpected enrichment queue admission result: ${result}`);
+}
+
 /** Atomically enforce queue depth and a per-track enqueue reservation. */
 export async function enqueueReservedWork(
     redis: EnrichmentQueueRedis,
@@ -39,15 +64,20 @@ export async function enqueueReservedWork(
     const result = await redis.eval(
         ADMIT_WORK_SCRIPT,
         2,
-        input.queueKey,
-        `${input.queueKey}:reserved:${input.trackId}`,
-        String(input.maxDepth),
-        String(input.reservationTtlSeconds),
-        input.payload,
+        ...admissionArguments(input),
     );
+    return parseAdmission(result);
+}
 
-    if (result === 1) return "queued";
-    if (result === 0) return "duplicate";
-    if (result === -1) return "full";
-    throw new Error(`Unexpected enrichment queue admission result: ${result}`);
+/** Apply the same atomic reservation admission through node-redis. */
+export async function enqueueReservedNodeRedisWork(
+    redis: EnrichmentQueueNodeRedis,
+    input: EnqueueReservedWorkInput,
+): Promise<EnrichmentQueueAdmission> {
+    const args = admissionArguments(input);
+    const result = await redis.eval(ADMIT_WORK_SCRIPT, {
+        keys: args.slice(0, 2),
+        arguments: args.slice(2),
+    });
+    return parseAdmission(result);
 }

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -31,10 +31,7 @@ import pLimit from "p-limit";
 import { enqueueReservedWork } from "./enrichmentQueue";
 import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
 import { getActiveSpace } from "../services/embeddingSpaces";
-import {
-    deleteActiveLocalTrackEmbeddings,
-    findLocalTracksNeedingActiveEmbedding,
-} from "../services/trackEmbeddings";
+import { findLocalTracksNeedingActiveEmbedding } from "../services/trackEmbeddings";
 
 const log = logger.child("Enrichment");
 
@@ -578,8 +575,6 @@ export async function runFullEnrichment(options?: {
     });
 
     if (forceVibeRebuild) {
-        await deleteActiveLocalTrackEmbeddings();
-
         await prisma.track.updateMany({
             where: LOCAL_TRACK_WHERE,
             data: {
@@ -592,7 +587,7 @@ export async function runFullEnrichment(options?: {
         await enrichmentFailureService.clearAllFailures("vibe");
 
         log.info(
-            "forceVibeRebuild enabled: cleared CLAP embeddings and reset vibe analysis state to pending",
+            "forceVibeRebuild enabled: preserved active vectors and reset vibe analysis state to pending",
         );
     }
 
@@ -1583,6 +1578,11 @@ async function executeVibePhase(): Promise<number> {
         return 0;
     }
 
+    const { reset } = await vibeAnalysisCleanupService.cleanupStaleProcessing();
+    if (reset > 0) {
+        log.debug(`Cleaned up ${reset} stale vibe processing entries`);
+    }
+
     const audioProcessing = await withEnrichmentPrismaRetry(
         "executeVibePhase.audioProcessing.count",
         () =>
@@ -1608,11 +1608,6 @@ async function executeVibePhase(): Promise<number> {
             `Skipping vibe phase - audio still running (${audioProcessing} processing, ${audioQueue} queued)`,
         );
         return 0;
-    }
-
-    const { reset } = await vibeAnalysisCleanupService.cleanupStaleProcessing();
-    if (reset > 0) {
-        log.debug(`Cleaned up ${reset} stale vibe processing entries`);
     }
 
     const result = await queueVibeEmbeddings();
@@ -1940,6 +1935,7 @@ export const __unifiedEnrichmentTestables = {
     runEnrichmentCycle,
     enrichArtistsBatch,
     enrichTrackTagsBatch,
+    executeVibePhase,
     __setRuntimeStateForTests: (
         nextState: Partial<{
             isRunning: boolean;

--- a/backend/src/workers/vibeEmbedWorker.ts
+++ b/backend/src/workers/vibeEmbedWorker.ts
@@ -9,6 +9,7 @@ import { runEmbeddingSpaceLifecycleCheck } from "../services/embeddingSpaceLifec
 import {
     clearVibeEmbeddingTargetSpaceId,
     EmbeddingSpaceDimensionMismatchError,
+    EmbeddingSpacePreprocessingMismatchError,
     resolveProviderEmbeddingSpace,
     RetiredEmbeddingSpaceError,
     setVibeEmbeddingTargetSpaceId,
@@ -68,7 +69,8 @@ function delay(milliseconds: number): Promise<void> {
 function isTerminalTargetResolutionError(error: unknown): boolean {
     return (
         error instanceof RetiredEmbeddingSpaceError ||
-        error instanceof EmbeddingSpaceDimensionMismatchError
+        error instanceof EmbeddingSpaceDimensionMismatchError ||
+        error instanceof EmbeddingSpacePreprocessingMismatchError
     );
 }
 

--- a/docs/designs/vibe-embedding-provider.md
+++ b/docs/designs/vibe-embedding-provider.md
@@ -53,6 +53,7 @@ EmbeddingSpace {
   dim           int
   preprocessing json      // sample rate, mel config, mono/stereo policy
   status        enum      // active | migrating | retired
+  hadVectors    boolean   // durable once the space receives its first vector
   createdAt     timestamp
 }
 TrackEmbedding.spaceId -> EmbeddingSpace.id   // replaces model_version
@@ -61,6 +62,7 @@ TrackEmbedding.spaceId -> EmbeddingSpace.id   // replaces model_version
 Invariants:
 
 - **Exactly one `active` space** serves all similarity queries, radio, mixes, Discover Weekly, and text search. Outside the bounded cutover cache window documented below, queries never cross spaces.
+- A registered tuple includes canonicalized preprocessing. Reusing `(family, checkpointHash, dim)` with different preprocessing is a provider-configuration error and never mixes vectors or creates a duplicate tuple.
 - The existing global ANN index continues to serve the active space. A partial ANN index for a migrating space is created immediately before cutover and dropped after that space is later retired and cleaned.
 - In steady state, text queries encode through the active space's text tower. During migration, the backend uses the fallback and bounded cutover behavior documented below instead of requesting `/v1/embed/text` from a provider whose space is not active.
 - Cross-peer vector exchange (Blends, federated discovery) transmits `(spaceId identity tuple, vector)`; peers compare identity tuples and only consume vectors whose space matches their own active space. Mismatch downgrades cross-peer features to metadata-level gracefully.
@@ -72,15 +74,15 @@ Invariants:
 3. When coverage reaches `VIBE_SPACE_CUTOVER_THRESHOLD` (default 95%), the worker builds the target's partial ANN index, atomically marks the old space `retired` and the target `active`, then invalidates the active-space cache.
 4. The old vectors remain available for `VIBE_SPACE_RETIREMENT_GRACE_DAYS` (default 7). The worker then deletes them in bounded batches, drops their partial index if present, clears the grace anchor to mark cleanup complete, and retains the registry identity row as history.
 
-When the active space contains zero vectors, the worker builds the target's partial ANN index and cuts over immediately without waiting for migration coverage. A fresh install may never deploy the teacher worker, and an empty active space protects no query results, so this closes the provider-only text-search dead window without sacrificing existing similarity results.
+When the active space contains zero vectors and its durable `hadVectors` marker is false, the worker builds the target's partial ANN index and cuts over immediately without waiting for migration coverage. The embedding store sets the marker on the first vector, and the migration backfills it for existing populated spaces. A later wipe therefore cannot masquerade as a fresh install. A genuinely fresh install may never deploy the teacher worker, so the guarded shortcut still closes the provider-only text-search dead window.
 
-While the configured provider serves a registered migrating space, text search embeds and queries in that provider space, returning partial results that grow with the backfill; the 60-second provider-space cache continues routing to the same space across cutover and then refreshes its active status.
+While the configured provider serves a registered migrating space, text search embeds and queries in that provider space, returning partial results that grow with the backfill; its exact scan has a fixed candidate bound and a transaction-local statement timeout. The 60-second provider-space cache continues routing to the same space across cutover and then refreshes its active status.
 
-Migration exposes two intentional operational lenses. The vibe embedding coverage gauge measures the migrating worker target so operators can assess cutover readiness. Enrichment progress and feature detection continue to measure the active space because they describe the vectors currently serving user queries.
+Migration exposes two intentional operational lenses. The vibe embedding coverage gauge and lifecycle logs measure embedded, pending, and failed counts for the migrating worker target so operators can assess cutover readiness and see the permanently failed tail excluded from the actionable denominator. Cutover completion logs retain that failed count. Enrichment progress and feature detection continue to measure the active space because they describe the vectors currently serving user queries.
 
 Tracks added while a migration is running receive only the migrating-space vector. They become available to active-space similarity features at cutover; the worker does not also write the old active space during the migration.
 
-The producer and claim gate continuously admit `null`, `pending`, or `completed` tracks that lack a vector in the worker's target space. This automatically heals migration and post-cutover tails. `POST /api/analysis/vibe/start` remains available as a break-glass way to enqueue missing active-space vectors immediately, but normal tail recovery does not require it.
+The producer and claim gate continuously admit `null` or `completed` tracks that lack a vector in the worker's target space, plus `pending` rebuild tracks whether or not an older target vector exists. Transient provider timeouts, connection failures, and 5xx responses return to `pending` under a three-attempt bound; content and contract failures remain terminal. This automatically heals migration and post-cutover tails. `POST /api/analysis/vibe/start` remains available as a break-glass way to enqueue missing active-space vectors immediately. Its force mode preserves serving vectors, resets track state, and uses the same bounded per-track reservation admission as the automatic producer.
 
 To abort before cutover, delete the migrating space's vectors first, then delete its registry row; `ON DELETE RESTRICT` enforces that order. To roll back after cutover but within grace, atomically return the new space to `migrating` or `retired` and restore the prior retired space to `active`. This release does not add an administration endpoint for either operation.
 


### PR DESCRIPTION
## Summary

Core lifecycle batch of the transition-review fixes — every P0/P1 the upgrade-path review traced in the migration machinery, each with pinned tests:

1. **Premature-cutover class killed**: force rebuild preserves active-space vectors (re-embeds through normal claim/backfill); instant cutover now requires a durable never-had-vectors marker (`hadVectors` column, migration `20260817120000_add_embedding_space_had_vectors`, backfilled; set once by the store path). Wiped spaces can't fake "fresh install".
2. **Manual queueing bounded + deduplicated** through the automatic producer's reservation admission (no more 1,000 raw duplicate pushes per force call).
3. **Transient failures retry** (timeout/connection/5xx → pending under a 3-attempt bound); terminal failures fail fast; **poison payloads can no longer demote completed tracks** or tracks already carrying the target vector.
4. **Failed-tail visibility**: coverage logs/gauges + the cutover completion log include the failed count the actionable denominator excludes.
5. **Stuck-vibe recovery decoupled** from the MusicCNN processing/queue gate.
6. **Bounded hot paths**: transaction-local 5s statement timeout + 300-candidate cap on the pre-cutover exact scan (cancellation maps to the existing bounded 504); emptiness via `findFirst`; coverage reduced to two queries.
7. **Preprocessing-aware registration**: canonicalized comparison; same-tuple/different-preprocessing providers are refused with a terminal config error + `soundspan_vibe_provider_config_errors_total`.
8. **Search handler decomposed** (~170 lines → route orchestration + focused `vibeSearch.ts` helpers), behavior pinned by the existing compat suite.

## Verification

- Touched suites: 16 suites, 260 tests passed.
- Full backend suite (unrestricted, contract package built): **389 suites passed, 6,134 tests, 0 failures.**
- `tsc --noEmit` clean; backend `format:check` clean; migration validated statement-by-statement; `prisma validate` clean.