### PR TITLE
feat(vibe): operational resilience for metrics, cleanup, and admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   index lifecycle, statement timeouts, and retired-vector cleanup.
 - Added starter Grafana panels for provider failures, migration coverage and
   failures, provider queue depth, and suppressed federation exports.
+- Added Prometheus alert rules for vibe provider failures, stalled migrations,
+  failed tracks, queue saturation, metrics collection errors, and suppressed
+  federation exports.
+- Added vibe migration and provider state to the system status API.
+- Manual re-embed calls now leave automatic backfill headroom in the shared
+  provider queue.
 
 ### Changed
 
@@ -88,6 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lifecycle creates a missing index after backfill to heal fresh-install recall.
 - Vibe vocabulary blending is now checked against the searched embedding-space
   identity; incompatible or legacy artifacts are skipped with bounded telemetry.
+- Metrics endpoints now remain available when Redis-backed vibe queue-depth
+  collection fails, while retaining the last successful sample.
+- Legacy vibe Redis cleanup is deadline-bounded, restart-durable, safe across
+  replica races, and processes complete bounded SCAN pages.
 - Force rebuilding vibe embeddings now preserves active-space vectors, and a
   durable space marker prevents wiped spaces from triggering fresh-install
   cutover behavior.

--- a/backend/src/__tests__/workerEntrypointBehavior.test.ts
+++ b/backend/src/__tests__/workerEntrypointBehavior.test.ts
@@ -1,3 +1,6 @@
+import { Registry } from "prom-client";
+import { createVibeEmbedMetrics } from "../metrics/vibeEmbedMetrics";
+
 describe("worker entrypoint behavior", () => {
     const originalEnv = process.env;
     const originalExit = process.exit;
@@ -24,6 +27,7 @@ describe("worker entrypoint behavior", () => {
         initializeMusicConfigImpl,
         shutdownWorkersImpl,
         processExitImpl,
+        metricsRegistryOverride,
     }: {
         envOverrides?: Record<string, string>;
         dependencyProbeImpl?: () => Promise<any>;
@@ -37,6 +41,10 @@ describe("worker entrypoint behavior", () => {
         initializeMusicConfigImpl?: () => Promise<unknown>;
         shutdownWorkersImpl?: () => Promise<unknown>;
         processExitImpl?: (...args: any[]) => never | void;
+        metricsRegistryOverride?: {
+            contentType: string;
+            metrics(): Promise<string>;
+        };
     } = {}) {
         process.env = {
             ...originalEnv,
@@ -143,10 +151,12 @@ describe("worker entrypoint behavior", () => {
         jest.doMock("../workers", () => ({
             shutdownWorkers,
         }));
-        const metricsRegistry = {
-            contentType: "text/plain; version=0.0.4; charset=utf-8",
-            metrics: jest.fn(async () => "soundspan_test_metric 1\n"),
-        };
+        const metricsRegistry =
+            metricsRegistryOverride ??
+            ({
+                contentType: "text/plain; version=0.0.4; charset=utf-8",
+                metrics: jest.fn(async () => "soundspan_test_metric 1\n"),
+            } as const);
         const registerQueueMetrics = jest.fn();
         jest.doMock("../metrics", () => ({ metricsRegistry }));
         jest.doMock("../metrics/endpoint", () => ({
@@ -184,6 +194,13 @@ describe("worker entrypoint behavior", () => {
     const flushWorkerTicks = async (): Promise<void> => {
         await Promise.resolve();
         await Promise.resolve();
+    };
+
+    const waitForResponse = async (res: { writeHead: jest.Mock }) => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            if (res.writeHead.mock.calls.length > 0) return;
+            await Promise.resolve();
+        }
     };
 
     const waitForWorkerReadyLog = async (
@@ -357,6 +374,52 @@ describe("worker entrypoint behavior", () => {
         });
         expect(authorized.end).toHaveBeenCalledWith(
             "soundspan_test_metric 1\n",
+        );
+    });
+
+    it("serves worker metrics when the vibe queue collector cannot reach Redis", async () => {
+        const registry = new Registry();
+        createVibeEmbedMetrics(registry, {
+            getProviderQueueDepth: async () => {
+                throw new Error("redis unavailable");
+            },
+        });
+        const { requestHandler } = setupWorkerRuntime({
+            metricsRegistryOverride: registry,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../worker");
+        await flushWorkerTicks();
+        const handler = requestHandler();
+        const firstResponse = createHealthRes();
+        handler!(
+            {
+                url: "/metrics",
+                headers: { authorization: "Bearer metrics-token" },
+            },
+            firstResponse,
+        );
+        await waitForResponse(firstResponse);
+        expect(firstResponse.writeHead).toHaveBeenCalledWith(200, {
+            "Content-Type": registry.contentType,
+        });
+
+        const response = createHealthRes();
+        handler!(
+            {
+                url: "/metrics",
+                headers: { authorization: "Bearer metrics-token" },
+            },
+            response,
+        );
+        await waitForResponse(response);
+
+        expect(response.writeHead).toHaveBeenCalledWith(200, {
+            "Content-Type": registry.contentType,
+        });
+        expect(response.end.mock.calls[0]?.[0]).toMatch(
+            /soundspan_metrics_collection_errors_total\{collector="vibe_queue_depth"\} [1-9][0-9]*/,
         );
     });
 

--- a/backend/src/metrics/__tests__/endpoint.test.ts
+++ b/backend/src/metrics/__tests__/endpoint.test.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { Gauge, Registry } from "prom-client";
 import request from "supertest";
 import { createMetricsRouter } from "../endpoint";
+import { createVibeEmbedMetrics } from "../vibeEmbedMetrics";
 
 describe("metrics endpoint", () => {
     function createApp(options: { token?: string; publicAccess?: boolean }) {
@@ -54,5 +55,54 @@ describe("metrics endpoint", () => {
             .expect(200);
 
         expect(response.text).toContain("soundspan_test_known_value 1");
+    });
+
+    it("returns 200 when the vibe queue collector cannot reach Redis", async () => {
+        const registry = new Registry();
+        createVibeEmbedMetrics(registry, {
+            getProviderQueueDepth: async () => {
+                throw new Error("redis unavailable");
+            },
+        });
+        const router = createMetricsRouter({
+            registry,
+            publicAccess: true,
+        });
+        const route = (router as any).stack.find(
+            (entry: any) => entry.route?.path === "/metrics",
+        ).route;
+        const response = {
+            body: "",
+            statusCode: 200,
+            set: jest.fn(),
+            send: jest.fn(function (body: string) {
+                response.body = body;
+            }),
+        } as any;
+        let authorized = false;
+        route.stack[0].handle(
+            { get: jest.fn() },
+            response,
+            () => (authorized = true),
+        );
+        expect(authorized).toBe(true);
+        await route.stack[1].handle({}, response, jest.fn());
+
+        expect(response.send).toHaveBeenCalledTimes(1);
+        expect(response.statusCode).toBe(200);
+        const nextResponse = {
+            body: "",
+            statusCode: 200,
+            set: jest.fn(),
+            send: jest.fn(function (body: string) {
+                nextResponse.body = body;
+            }),
+        } as any;
+        await route.stack[1].handle({}, nextResponse, jest.fn());
+
+        expect(nextResponse.statusCode).toBe(200);
+        expect(nextResponse.body).toMatch(
+            /soundspan_metrics_collection_errors_total\{collector="vibe_queue_depth"\} [1-9][0-9]*/,
+        );
     });
 });

--- a/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
+++ b/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
@@ -107,4 +107,41 @@ describe("vibe embed metrics", () => {
         expect(getProviderQueueDepth).toHaveBeenCalledTimes(1);
         expect(exposition).toContain("soundspan_vibe_provider_queue_depth 7");
     });
+
+    it("keeps the last queue depth and records a bounded collector error", async () => {
+        const registry = new Registry();
+        const getProviderQueueDepth = jest
+            .fn<Promise<number>, []>()
+            .mockResolvedValueOnce(7)
+            .mockRejectedValueOnce(new Error("redis unavailable"));
+        createVibeEmbedMetrics(registry, { getProviderQueueDepth });
+
+        const firstExposition = await registry.metrics();
+        const degradedExposition = await registry.metrics();
+        const nextExposition = await registry.metrics();
+
+        expect(firstExposition).toContain(
+            "soundspan_vibe_provider_queue_depth 7",
+        );
+        expect(degradedExposition).toContain(
+            "soundspan_vibe_provider_queue_depth 7",
+        );
+        expect(nextExposition).toMatch(
+            /soundspan_metrics_collection_errors_total\{collector="vibe_queue_depth"\} [1-9][0-9]*/,
+        );
+    });
+
+    it("publishes queue capacity and migration state for alert ratios", async () => {
+        const registry = new Registry();
+        const { metrics } = createMetrics(registry);
+
+        metrics.setProviderQueueCapacity(100);
+        metrics.setMigrationActive(true);
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            "soundspan_vibe_provider_queue_capacity 100",
+        );
+        expect(exposition).toContain("soundspan_vibe_migration_active 1");
+    });
 });

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -102,6 +102,16 @@ export function setVibeEmbeddingCoverage(
     vibeEmbedMetrics.setCoverage(coverage);
 }
 
+/** Publishes the configured vibe provider queue admission capacity. */
+export function setVibeProviderQueueCapacity(capacity: number): void {
+    vibeEmbedMetrics.setProviderQueueCapacity(capacity);
+}
+
+/** Marks whether the worker currently owns a migrating target space. */
+export function setVibeMigrationActive(active: boolean): void {
+    vibeEmbedMetrics.setMigrationActive(active);
+}
+
 /** Records one completed federation page carrying peer embeddings. */
 export function recordFederationEmbeddingPageOutcome(
     outcome: FederationEmbeddingPageOutcome,

--- a/backend/src/metrics/vibeEmbedMetrics.ts
+++ b/backend/src/metrics/vibeEmbedMetrics.ts
@@ -36,7 +36,10 @@ export interface VibeEmbedMetrics {
     spaceTransitions: Counter<"transition">;
     providerConfigErrors: Counter<"reason">;
     vocabularySpaceMismatches: Counter<"reason">;
+    collectionErrors: Counter<"collector">;
     providerQueueDepth: Gauge;
+    providerQueueCapacity: Gauge;
+    migrationActive: Gauge;
     recordJob(outcome: VibeEmbedJobOutcome): void;
     recordSpaceTransition(transition: VibeSpaceTransition): void;
     recordProviderConfigError(reason: VibeProviderConfigErrorReason): void;
@@ -44,6 +47,8 @@ export interface VibeEmbedMetrics {
         reason: VibeVocabularySpaceMismatchReason,
     ): void;
     setCoverage(values: VibeEmbeddingCoverage): void;
+    setProviderQueueCapacity(capacity: number): void;
+    setMigrationActive(active: boolean): void;
 }
 
 /** Scrape-time dependencies for provider queue instrumentation. */
@@ -51,33 +56,46 @@ export interface VibeEmbedMetricsDependencies {
     getProviderQueueDepth(): Promise<number>;
 }
 
-/** Registers bounded audio-embedding job and target-space coverage metrics. */
-export function createVibeEmbedMetrics(
+function createOutcomeMetrics(registry: Registry) {
+    return {
+        jobs: new Counter({
+            name: "soundspan_vibe_embed_jobs_total",
+            help: "Backend-driven vibe embedding jobs by final outcome.",
+            labelNames: ["outcome"] as const,
+            registers: [registry],
+        }),
+        coverage: new Gauge({
+            name: "soundspan_vibe_embedding_coverage",
+            help: "Local-track vibe embedding coverage for the worker target space.",
+            labelNames: ["state"] as const,
+            registers: [registry],
+        }),
+        spaceTransitions: new Counter({
+            name: "soundspan_vibe_space_transitions_total",
+            help: "Embedding-space lifecycle transitions by bounded type.",
+            labelNames: ["transition"] as const,
+            registers: [registry],
+        }),
+        providerConfigErrors: new Counter({
+            name: "soundspan_vibe_provider_config_errors_total",
+            help: "Vibe provider configuration errors by bounded reason.",
+            labelNames: ["reason"] as const,
+            registers: [registry],
+        }),
+    };
+}
+
+function createQueueCollectionMetrics(
     registry: Registry,
     dependencies: VibeEmbedMetricsDependencies,
-): VibeEmbedMetrics {
-    const jobs = new Counter({
-        name: "soundspan_vibe_embed_jobs_total",
-        help: "Backend-driven vibe embedding jobs by final outcome.",
-        labelNames: ["outcome"] as const,
-        registers: [registry],
-    });
-    const coverage = new Gauge({
-        name: "soundspan_vibe_embedding_coverage",
-        help: "Local-track vibe embedding coverage for the worker target space.",
-        labelNames: ["state"] as const,
-        registers: [registry],
-    });
-    const spaceTransitions = new Counter({
-        name: "soundspan_vibe_space_transitions_total",
-        help: "Embedding-space lifecycle transitions by bounded type.",
-        labelNames: ["transition"] as const,
-        registers: [registry],
-    });
-    const providerConfigErrors = new Counter({
-        name: "soundspan_vibe_provider_config_errors_total",
-        help: "Vibe provider configuration errors by bounded reason.",
-        labelNames: ["reason"] as const,
+): Pick<
+    VibeEmbedMetrics,
+    "collectionErrors" | "providerQueueDepth" | "vocabularySpaceMismatches"
+> {
+    const collectionErrors = new Counter({
+        name: "soundspan_metrics_collection_errors_total",
+        help: "Prometheus collection errors by bounded collector name.",
+        labelNames: ["collector"] as const,
         registers: [registry],
     });
     const vocabularySpaceMismatches = new Counter({
@@ -91,33 +109,69 @@ export function createVibeEmbedMetrics(
         help: "Raw Redis job depth for the backend vibe provider queue.",
         registers: [registry],
         async collect() {
-            this.set(await dependencies.getProviderQueueDepth());
+            try {
+                this.set(await dependencies.getProviderQueueDepth());
+            } catch {
+                // Keep the last successful sample. Telemetry dependency
+                // failures must not make the complete scrape unavailable.
+                collectionErrors.inc({ collector: "vibe_queue_depth" });
+            }
         },
     });
+    providerQueueDepth.reset();
+    return { collectionErrors, providerQueueDepth, vocabularySpaceMismatches };
+}
+
+function createOperationalGauges(registry: Registry) {
+    return {
+        providerQueueCapacity: new Gauge({
+            name: "soundspan_vibe_provider_queue_capacity",
+            help: "Configured admission capacity for the vibe provider queue.",
+            registers: [registry],
+        }),
+        migrationActive: new Gauge({
+            name: "soundspan_vibe_migration_active",
+            help: "Whether this worker is targeting a migrating vibe space.",
+            registers: [registry],
+        }),
+    };
+}
+
+/** Registers bounded audio-embedding job and target-space coverage metrics. */
+export function createVibeEmbedMetrics(
+    registry: Registry,
+    dependencies: VibeEmbedMetricsDependencies,
+): VibeEmbedMetrics {
+    const outcomeMetrics = createOutcomeMetrics(registry);
+    const queueMetrics = createQueueCollectionMetrics(registry, dependencies);
+    const operationalGauges = createOperationalGauges(registry);
 
     return {
-        jobs,
-        coverage,
-        spaceTransitions,
-        providerConfigErrors,
-        vocabularySpaceMismatches,
-        providerQueueDepth,
+        ...outcomeMetrics,
+        ...queueMetrics,
+        ...operationalGauges,
         recordJob(outcome): void {
-            jobs.inc({ outcome });
+            outcomeMetrics.jobs.inc({ outcome });
         },
         recordSpaceTransition(transition): void {
-            spaceTransitions.inc({ transition });
+            outcomeMetrics.spaceTransitions.inc({ transition });
         },
         recordProviderConfigError(reason): void {
-            providerConfigErrors.inc({ reason });
+            outcomeMetrics.providerConfigErrors.inc({ reason });
         },
         recordVocabularySpaceMismatch(reason): void {
-            vocabularySpaceMismatches.inc({ reason });
+            queueMetrics.vocabularySpaceMismatches.inc({ reason });
         },
         setCoverage(values): void {
-            coverage.set({ state: "embedded" }, values.embedded);
-            coverage.set({ state: "pending" }, values.pending);
-            coverage.set({ state: "failed" }, values.failed);
+            outcomeMetrics.coverage.set({ state: "embedded" }, values.embedded);
+            outcomeMetrics.coverage.set({ state: "pending" }, values.pending);
+            outcomeMetrics.coverage.set({ state: "failed" }, values.failed);
+        },
+        setProviderQueueCapacity(capacity): void {
+            operationalGauges.providerQueueCapacity.set(capacity);
+        },
+        setMigrationActive(active): void {
+            operationalGauges.migrationActive.set(active ? 1 : 0);
         },
     };
 }

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -605,7 +605,7 @@ describe("analysis routes runtime", () => {
             expect.objectContaining({
                 queueKey: "audio:clap:queue",
                 trackId: "t1",
-                maxDepth: 2,
+                maxDepth: 1,
                 reservationTtlSeconds: 3600,
             }),
         );
@@ -617,7 +617,7 @@ describe("analysis routes runtime", () => {
         });
     });
 
-    it("deduplicates repeated force queueing and stops at the shared cap", async () => {
+    it("reserves queue headroom so automatic backfill admits after a manual burst", async () => {
         mockTrackFindMany.mockResolvedValue([
             { id: "t1", filePath: "/x.mp3", duration: 111, title: "T1" },
             { id: "t2", filePath: "/y.mp3", duration: 222, title: "T2" },
@@ -626,8 +626,11 @@ describe("analysis routes runtime", () => {
         const reservations = new Set<string>();
         let depth = 0;
         mockEnqueueReservedWork.mockImplementation(
-            async (_redis: unknown, input: { trackId: string }) => {
-                if (depth >= 2) return "full";
+            async (
+                _redis: unknown,
+                input: { trackId: string; maxDepth: number },
+            ) => {
+                if (depth >= input.maxDepth) return "full";
                 if (reservations.has(input.trackId)) return "duplicate";
                 reservations.add(input.trackId);
                 depth += 1;
@@ -636,15 +639,27 @@ describe("analysis routes runtime", () => {
         );
 
         const firstRes = createRes();
-        const secondRes = createRes();
         const request = { body: { limit: 1000, force: true } } as any;
         await postVibeStart(request, firstRes);
-        await postVibeStart(request, secondRes);
 
-        expect(firstRes.body.queued).toBe(2);
-        expect(secondRes.body.queued).toBe(0);
-        expect(reservations).toEqual(new Set(["t1", "t2"]));
-        expect(mockEnqueueReservedWork).toHaveBeenCalledTimes(4);
+        const automaticAdmission = await mockEnqueueReservedWork(redisClient, {
+            queueKey: "audio:clap:queue",
+            trackId: "automatic-oldest-pending",
+            payload: "payload",
+            maxDepth: 2,
+            reservationTtlSeconds: 3600,
+        });
+
+        expect(firstRes.body.queued).toBe(1);
+        expect(automaticAdmission).toBe("queued");
+        expect(reservations).toEqual(
+            new Set(["t1", "automatic-oldest-pending"]),
+        );
+        expect(mockEnqueueReservedWork).toHaveBeenNthCalledWith(
+            1,
+            redisClient,
+            expect.objectContaining({ maxDepth: 1 }),
+        );
     });
 
     it("returns no-op vibe start when all tracks already have embeddings", async () => {

--- a/backend/src/routes/__tests__/systemCore.test.ts
+++ b/backend/src/routes/__tests__/systemCore.test.ts
@@ -86,6 +86,20 @@ describe("system routes integration", () => {
             clapAvailable: true,
             tidalAvailable: false,
             allAvailable: false,
+            vibe: {
+                provider: {
+                    configured: true,
+                    reachable: true,
+                    checkedAt: "2026-08-17T12:00:00.000Z",
+                },
+                activeSpace: { id: "space-active", family: "teacher" },
+                migration: {
+                    spaceId: "space-migrating",
+                    family: "student",
+                    coverage: { embedded: 80, pending: 20, failed: 2 },
+                    cutoverThreshold: 0.95,
+                },
+            },
         };
         mockGetFeatures.mockResolvedValueOnce(features);
 

--- a/backend/src/routes/__tests__/systemRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemRuntime.test.ts
@@ -98,6 +98,45 @@ describe("system routes runtime", () => {
         });
     });
 
+    it("returns cached vibe provider and migration state", async () => {
+        mockGetFeatures.mockResolvedValue({
+            musicCNN: true,
+            vibeEmbeddings: true,
+            vibe: {
+                provider: {
+                    configured: true,
+                    reachable: false,
+                    checkedAt: "2026-08-17T12:00:00.000Z",
+                },
+                activeSpace: { id: "space-active", family: "teacher" },
+                migration: {
+                    spaceId: "space-migrating",
+                    family: "student",
+                    coverage: { embedded: 80, pending: 20, failed: 3 },
+                    cutoverThreshold: 0.95,
+                },
+            },
+        });
+        const res = createRes();
+
+        await getFeatures({ user: { id: "u1" } } as any, res);
+
+        expect(res.body.vibe).toEqual({
+            provider: {
+                configured: true,
+                reachable: false,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            activeSpace: { id: "space-active", family: "teacher" },
+            migration: {
+                spaceId: "space-migrating",
+                family: "student",
+                coverage: { embedded: 80, pending: 20, failed: 3 },
+                cutoverThreshold: 0.95,
+            },
+        });
+    });
+
     it("returns 500 when feature detection fails", async () => {
         mockGetFeatures.mockRejectedValueOnce(new Error("probe failed"));
         const req = { user: { id: "u1" } } as any;

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -23,6 +23,18 @@ const router = Router();
 // Redis queue key for audio analysis
 const ANALYSIS_QUEUE = "audio:analysis:queue";
 const VIBE_QUEUE = "audio:clap:queue";
+const MANUAL_VIBE_HEADROOM_FRACTION = 0.1;
+
+function manualVibeQueueMaxDepth(capacity: number): number {
+    // Manual re-embedding can consume at most 90% of the shared queue. The
+    // automatic producer retains at least one slot and 10% at normal scale,
+    // so older pending backfill continues to make progress after admin bursts.
+    const reserved = Math.max(
+        1,
+        Math.ceil(capacity * MANUAL_VIBE_HEADROOM_FRACTION),
+    );
+    return Math.max(0, capacity - reserved);
+}
 
 function buildVibePendingReset() {
     return {
@@ -31,6 +43,88 @@ function buildVibePendingReset() {
         vibeAnalysisStartedAt: null,
         vibeAnalysisStatusUpdatedAt: new Date(),
     };
+}
+
+interface ManualVibeTrack {
+    id: string;
+    filePath: string | null;
+    duration: number;
+    title: string;
+}
+
+async function resetVibeTracksForForce(force: boolean): Promise<void> {
+    if (!force) return;
+    await prisma.track.updateMany({
+        where: LOCAL_TRACK_WHERE,
+        data: {
+            ...buildVibePendingReset(),
+            vibeAnalysisRetryCount: 0,
+        },
+    });
+    await enrichmentFailureService.clearAllFailures("vibe");
+    logger.info(
+        "Preserved active vibe embeddings and reset tracks for re-generation",
+    );
+}
+
+async function findManualVibeTracks(
+    activeSpaceId: string,
+    force: boolean,
+    limit: number,
+): Promise<ManualVibeTrack[]> {
+    return prisma.track.findMany({
+        where: {
+            ...(force ? {} : missingActiveEmbeddingWhere(activeSpaceId)),
+            ...TRACK_VISIBLE_WHERE,
+            ...LOCAL_TRACK_WHERE,
+        },
+        select: {
+            id: true,
+            filePath: true,
+            duration: true,
+            title: true,
+        },
+        orderBy: { fileModified: "desc" },
+        take: limit,
+    });
+}
+
+async function markManualVibeTracksPending(
+    tracks: ManualVibeTrack[],
+    force: boolean,
+): Promise<void> {
+    if (force) return;
+    await prisma.track.updateMany({
+        where: { id: { in: tracks.map((track) => track.id) } },
+        data: buildVibePendingReset(),
+    });
+}
+
+async function enqueueManualVibeTracks(
+    tracks: ManualVibeTrack[],
+): Promise<number> {
+    const maxDepth = manualVibeQueueMaxDepth(
+        config.analysisQueues.vibeMaxDepth,
+    );
+    let queued = 0;
+    for (const track of tracks) {
+        const admission = await enqueueReservedNodeRedisWork(redisClient, {
+            queueKey: VIBE_QUEUE,
+            trackId: track.id,
+            payload: JSON.stringify({
+                trackId: track.id,
+                filePath: track.filePath,
+                duration: track.duration,
+            }),
+            maxDepth,
+            reservationTtlSeconds: config.analysisQueues.reservationTtlSeconds,
+        });
+        if (admission === "full") break;
+        if (admission !== "queued") continue;
+        queued += 1;
+        await enrichmentFailureService.clearFailure("vibe", track.id);
+    }
+    return queued;
 }
 
 /**
@@ -675,36 +769,8 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
                 : 500;
         const force = req.body.force === true;
         const activeSpace = await getActiveSpace();
-
-        if (force) {
-            await prisma.track.updateMany({
-                where: LOCAL_TRACK_WHERE,
-                data: {
-                    ...buildVibePendingReset(),
-                    vibeAnalysisRetryCount: 0,
-                },
-            });
-            await enrichmentFailureService.clearAllFailures("vibe");
-            logger.info(
-                "Preserved active vibe embeddings and reset tracks for re-generation",
-            );
-        }
-
-        const tracks = await prisma.track.findMany({
-            where: {
-                ...(force ? {} : missingActiveEmbeddingWhere(activeSpace.id)),
-                ...TRACK_VISIBLE_WHERE,
-                ...LOCAL_TRACK_WHERE,
-            },
-            select: {
-                id: true,
-                filePath: true,
-                duration: true,
-                title: true,
-            },
-            orderBy: { fileModified: "desc" },
-            take: limit,
-        });
+        await resetVibeTracksForForce(force);
+        const tracks = await findManualVibeTracks(activeSpace.id, force, limit);
 
         if (tracks.length === 0) {
             return res.json({
@@ -713,34 +779,9 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
             });
         }
 
-        // Align producer state with queue handoff: newly queued tracks should
-        // be recoverable as pending if Redis is later drained or workers are down.
-        if (!force) {
-            await prisma.track.updateMany({
-                where: { id: { in: tracks.map((track) => track.id) } },
-                data: buildVibePendingReset(),
-            });
-        }
-
-        let queued = 0;
-        for (const track of tracks) {
-            const admission = await enqueueReservedNodeRedisWork(redisClient, {
-                queueKey: VIBE_QUEUE,
-                trackId: track.id,
-                payload: JSON.stringify({
-                    trackId: track.id,
-                    filePath: track.filePath,
-                    duration: track.duration,
-                }),
-                maxDepth: config.analysisQueues.vibeMaxDepth,
-                reservationTtlSeconds:
-                    config.analysisQueues.reservationTtlSeconds,
-            });
-            if (admission === "full") break;
-            if (admission !== "queued") continue;
-            queued += 1;
-            await enrichmentFailureService.clearFailure("vibe", track.id);
-        }
+        // Align producer state with queue handoff so drained work remains pending.
+        await markManualVibeTracksPending(tracks, force);
+        const queued = await enqueueManualVibeTracks(tracks);
 
         logger.info(
             `Queued ${queued} tracks for vibe embedding${force ? " (force reset)" : ""}`,

--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -17,7 +17,43 @@ const router = Router();
  *       - apiKeyAuth: []
  *     responses:
  *       200:
- *         description: Available system features. Includes detection-based fields (musicCNN, vibeEmbeddings) plus configured feature flags (audioAnalysis, discovery, autoPlaylists).
+ *         description: Available features, configured flags, and cached vibe provider and migration state.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 vibe:
+ *                   type: object
+ *                   required: [provider, activeSpace, migration]
+ *                   properties:
+ *                     provider:
+ *                       type: object
+ *                       required: [configured, reachable, checkedAt]
+ *                       properties:
+ *                         configured: { type: boolean }
+ *                         reachable: { type: boolean, nullable: true }
+ *                         checkedAt: { type: string, format: date-time, nullable: true }
+ *                     activeSpace:
+ *                       type: object
+ *                       nullable: true
+ *                       properties:
+ *                         id: { type: string }
+ *                         family: { type: string }
+ *                     migration:
+ *                       type: object
+ *                       nullable: true
+ *                       properties:
+ *                         spaceId: { type: string }
+ *                         family: { type: string }
+ *                         coverage:
+ *                           type: object
+ *                           nullable: true
+ *                           properties:
+ *                             embedded: { type: integer, minimum: 0 }
+ *                             pending: { type: integer, minimum: 0 }
+ *                             failed: { type: integer, minimum: 0 }
+ *                         cutoverThreshold: { type: number, minimum: 0, maximum: 1 }
  *       401:
  *         description: Not authenticated
  */

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -16,6 +16,7 @@ const mockLoadSpaceVectorState = jest.fn();
 const mockGetActiveSpace = jest.fn();
 const mockLogInfo = jest.fn();
 const mockSetCoverage = jest.fn();
+const mockSetMigrationActive = jest.fn();
 
 jest.mock("../../utils/db", () => ({
     prisma: {
@@ -48,6 +49,8 @@ jest.mock("../../metrics", () => ({
     recordVibeSpaceTransition: (...args: unknown[]) =>
         mockRecordTransition(...args),
     setVibeEmbeddingCoverage: (...args: unknown[]) => mockSetCoverage(...args),
+    setVibeMigrationActive: (...args: unknown[]) =>
+        mockSetMigrationActive(...args),
 }));
 
 jest.mock("../vibeEmbeddingCoverage", () => ({
@@ -228,6 +231,7 @@ describe("embedding-space lifecycle effects", () => {
         });
         expect(mockInvalidate).toHaveBeenCalledTimes(1);
         expect(mockRecordTransition).toHaveBeenCalledWith("cutover");
+        expect(mockSetMigrationActive).toHaveBeenCalledWith(false);
         expect(mockLogInfo).toHaveBeenCalledWith(
             "Embedding-space cutover completed",
             {

--- a/backend/src/services/__tests__/featureDetection.test.ts
+++ b/backend/src/services/__tests__/featureDetection.test.ts
@@ -5,8 +5,14 @@ const mockRedisGet = jest.fn();
 const mockTrackFindFirst = jest.fn();
 const mockLoggerDebug = jest.fn();
 const mockLoggerError = jest.fn();
-const mockConfig: { vibeProviderUrl: string | undefined } = {
+const mockGetActiveSpace = jest.fn();
+const mockReadVibeWorkerStatus = jest.fn();
+const mockConfig: {
+    vibeProviderUrl: string | undefined;
+    vibeSpaceCutoverThreshold: number;
+} = {
     vibeProviderUrl: undefined,
+    vibeSpaceCutoverThreshold: 0.95,
 };
 
 jest.mock("../../config", () => ({ config: mockConfig }));
@@ -29,12 +35,24 @@ jest.mock("../../utils/logger", () => ({
         error: (...args: unknown[]) => mockLoggerError(...args),
     },
 }));
+jest.mock("../embeddingSpaces", () => ({
+    getActiveSpace: (...args: unknown[]) => mockGetActiveSpace(...args),
+}));
+jest.mock("../../workers/vibeWorkerStatus", () => ({
+    readVibeWorkerStatus: (...args: unknown[]) =>
+        mockReadVibeWorkerStatus(...args),
+}));
 
 describe("featureDetection service", () => {
     beforeEach(() => {
         jest.resetModules();
         jest.clearAllMocks();
         mockConfig.vibeProviderUrl = undefined;
+        mockGetActiveSpace.mockResolvedValue({
+            id: "space-active",
+            family: "teacher-family",
+        });
+        mockReadVibeWorkerStatus.mockResolvedValue(null);
     });
 
     async function loadService() {
@@ -58,6 +76,18 @@ describe("featureDetection service", () => {
             await expect(service.getFeatures()).resolves.toEqual({
                 musicCNN: false,
                 vibeEmbeddings: expected,
+                vibe: {
+                    provider: {
+                        configured: expected,
+                        reachable: null,
+                        checkedAt: null,
+                    },
+                    activeSpace: {
+                        id: "space-active",
+                        family: "teacher-family",
+                    },
+                    migration: null,
+                },
             });
             expect(mockRedisGet).toHaveBeenCalledTimes(1);
         },
@@ -71,6 +101,18 @@ describe("featureDetection service", () => {
         await expect(service.getFeatures()).resolves.toEqual({
             musicCNN: true,
             vibeEmbeddings: false,
+            vibe: {
+                provider: {
+                    configured: false,
+                    reachable: null,
+                    checkedAt: null,
+                },
+                activeSpace: {
+                    id: "space-active",
+                    family: "teacher-family",
+                },
+                migration: null,
+            },
         });
         expect(mockTrackFindFirst).not.toHaveBeenCalled();
     });
@@ -83,6 +125,18 @@ describe("featureDetection service", () => {
         await expect(service.getFeatures()).resolves.toEqual({
             musicCNN: false,
             vibeEmbeddings: false,
+            vibe: {
+                provider: {
+                    configured: false,
+                    reachable: null,
+                    checkedAt: null,
+                },
+                activeSpace: {
+                    id: "space-active",
+                    family: "teacher-family",
+                },
+                migration: null,
+            },
         });
         expect(mockLoggerError).toHaveBeenCalledWith(
             "[FEATURE-DETECTION] Error checking MusicCNN:",
@@ -104,6 +158,101 @@ describe("featureDetection service", () => {
         await expect(service.getFeatures()).resolves.toEqual({
             musicCNN: false,
             vibeEmbeddings: false,
+            vibe: {
+                provider: {
+                    configured: false,
+                    reachable: null,
+                    checkedAt: null,
+                },
+                activeSpace: {
+                    id: "space-active",
+                    family: "teacher-family",
+                },
+                migration: null,
+            },
         });
+    });
+
+    it("returns the worker's cached provider verdict and migration coverage", async () => {
+        mockConfig.vibeProviderUrl = "http://provider:8092";
+        mockExistsSync.mockReturnValue(true);
+        mockReadVibeWorkerStatus.mockResolvedValue({
+            providerReachability: {
+                reachable: true,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            targetSpace: {
+                id: "space-migrating",
+                family: "student-family",
+                status: "migrating",
+            },
+            coverage: { embedded: 80, pending: 20, failed: 3 },
+        });
+        const service = await loadService();
+
+        const features = await service.getFeatures();
+
+        expect(features.vibe).toEqual({
+            provider: {
+                configured: true,
+                reachable: true,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            activeSpace: {
+                id: "space-active",
+                family: "teacher-family",
+            },
+            migration: {
+                spaceId: "space-migrating",
+                family: "student-family",
+                coverage: { embedded: 80, pending: 20, failed: 3 },
+                cutoverThreshold: 0.95,
+            },
+        });
+        expect(mockReadVibeWorkerStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it("degrades cached vibe state without probing the provider inline", async () => {
+        mockConfig.vibeProviderUrl = "http://provider:8092";
+        mockExistsSync.mockReturnValue(true);
+        mockReadVibeWorkerStatus.mockRejectedValue(
+            new Error("redis unavailable"),
+        );
+        mockGetActiveSpace.mockRejectedValue(new Error("database unavailable"));
+        const service = await loadService();
+
+        const features = await service.getFeatures();
+
+        expect(features.vibe).toEqual({
+            provider: {
+                configured: true,
+                reachable: null,
+                checkedAt: null,
+            },
+            activeSpace: null,
+            migration: null,
+        });
+    });
+
+    it("hides a cached migration after that target becomes active", async () => {
+        mockConfig.vibeProviderUrl = "http://provider:8092";
+        mockExistsSync.mockReturnValue(true);
+        mockReadVibeWorkerStatus.mockResolvedValue({
+            providerReachability: {
+                reachable: true,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            targetSpace: {
+                id: "space-active",
+                family: "teacher-family",
+                status: "migrating",
+            },
+            coverage: { embedded: 95, pending: 5, failed: 0 },
+        });
+        const service = await loadService();
+
+        const features = await service.getFeatures();
+
+        expect(features.vibe.migration).toBeNull();
     });
 });

--- a/backend/src/services/embeddingSpaceLifecycle.ts
+++ b/backend/src/services/embeddingSpaceLifecycle.ts
@@ -1,5 +1,6 @@
 import {
     recordVibeSpaceTransition,
+    setVibeMigrationActive,
     setVibeEmbeddingCoverage,
 } from "../metrics";
 import { prisma } from "../utils/db";
@@ -174,6 +175,7 @@ async function completeCutover(
     await flipActiveSpace(migratingSpaceId, retiredAt);
     invalidateActiveSpaceCache();
     recordVibeSpaceTransition("cutover");
+    setVibeMigrationActive(false);
 }
 
 async function cutOverEmptyActiveSpace(

--- a/backend/src/services/featureDetection.ts
+++ b/backend/src/services/featureDetection.ts
@@ -3,16 +3,92 @@ import { config } from "../config";
 import { redisClient } from "../utils/redis";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { getActiveSpace } from "./embeddingSpaces";
+import {
+    readVibeWorkerStatus,
+    type VibeWorkerStatus,
+} from "../workers/vibeWorkerStatus";
 
 const ESSENTIA_ANALYZER_PATH = "/app/audio-analyzer/analyzer.py";
 
 export interface AvailableFeatures {
     musicCNN: boolean;
     vibeEmbeddings: boolean;
+    vibe: VibeFeatureStatus;
+}
+
+/** Compact provider and embedding-migration state for the system API. */
+export interface VibeFeatureStatus {
+    provider: {
+        configured: boolean;
+        reachable: boolean | null;
+        checkedAt: string | null;
+    };
+    activeSpace: { id: string; family: string } | null;
+    migration: {
+        spaceId: string;
+        family: string;
+        coverage: VibeWorkerStatus["coverage"];
+        cutoverThreshold: number;
+    } | null;
 }
 
 const HEARTBEAT_TTL = 300000;
 const CACHE_TTL = 60000;
+
+function buildMigration(
+    workerStatus: VibeWorkerStatus | null,
+    activeSpace: VibeFeatureStatus["activeSpace"],
+): VibeFeatureStatus["migration"] {
+    if (workerStatus?.targetSpace?.status !== "migrating") return null;
+    if (workerStatus.targetSpace.id === activeSpace?.id) return null;
+    return {
+        spaceId: workerStatus.targetSpace.id,
+        family: workerStatus.targetSpace.family,
+        coverage: workerStatus.coverage,
+        cutoverThreshold: config.vibeSpaceCutoverThreshold,
+    };
+}
+
+async function loadVibeStatus(): Promise<VibeFeatureStatus> {
+    const configured = Boolean(config.vibeProviderUrl);
+    const [activeResult, workerResult] = await Promise.allSettled([
+        getActiveSpace(),
+        configured ? readVibeWorkerStatus(redisClient) : Promise.resolve(null),
+    ]);
+    if (activeResult.status === "rejected") {
+        logger.error(
+            "Failed to read cached active vibe space",
+            activeResult.reason,
+        );
+    }
+    if (workerResult.status === "rejected") {
+        logger.error(
+            "Failed to read cached vibe worker status",
+            workerResult.reason,
+        );
+    }
+    const activeSpace =
+        activeResult.status === "fulfilled"
+            ? { id: activeResult.value.id, family: activeResult.value.family }
+            : null;
+    const workerStatus =
+        workerResult.status === "fulfilled" ? workerResult.value : null;
+    const reachability = configured
+        ? (workerStatus?.providerReachability ?? null)
+        : null;
+    return {
+        provider: {
+            configured,
+            reachable: reachability?.reachable ?? null,
+            checkedAt: reachability?.checkedAt ?? null,
+        },
+        activeSpace,
+        migration: configured
+            ? buildMigration(workerStatus, activeSpace)
+            : null,
+    };
+}
 
 class FeatureDetectionService {
     private cache: AvailableFeatures | null = null;
@@ -24,7 +100,8 @@ class FeatureDetectionService {
 
         const musicCNN = await this.checkMusicCNN();
         const vibeEmbeddings = Boolean(config.vibeProviderUrl);
-        this.cache = { musicCNN, vibeEmbeddings };
+        const vibe = await loadVibeStatus();
+        this.cache = { musicCNN, vibeEmbeddings, vibe };
         this.lastCheck = now;
         logger.debug(
             `[FEATURE-DETECTION] Features: musicCNN=${musicCNN}, vibeEmbeddings=${vibeEmbeddings}`,

--- a/backend/src/services/vibeEmbeddingCoverage.ts
+++ b/backend/src/services/vibeEmbeddingCoverage.ts
@@ -78,7 +78,8 @@ export function createVibeEmbeddingCoverageRefresher(
 /** Refreshes target-space coverage in the process-local metrics registry. */
 export async function refreshVibeEmbeddingCoverage(
     targetSpaceId?: string,
-): Promise<void> {
+): Promise<VibeEmbeddingCoverage> {
     const coverage = await loadVibeEmbeddingCoverage(targetSpaceId);
     setVibeEmbeddingCoverage(coverage);
+    return coverage;
 }

--- a/backend/src/workers/__tests__/legacyVibeRedisCleanup.test.ts
+++ b/backend/src/workers/__tests__/legacyVibeRedisCleanup.test.ts
@@ -7,6 +7,7 @@ function createClient(): jest.Mocked<LegacyVibeRedisCleanupClient> {
     return {
         del: jest.fn().mockResolvedValue(1),
         scan: jest.fn().mockResolvedValue({ cursor: "0", keys: [] }),
+        set: jest.fn().mockResolvedValue("OK"),
         ttl: jest.fn().mockResolvedValue(60),
         xGroupDestroy: jest.fn().mockResolvedValue(1),
     };
@@ -24,6 +25,11 @@ describe("legacy vibe Redis cleanup", () => {
 
         await cleanupLegacyVibeRedisArtifacts(client, logger);
 
+        expect(client.set).toHaveBeenCalledWith(
+            "soundspan:legacy-vibe-cleanup:v1",
+            "done",
+            { NX: true },
+        );
         expect(client.xGroupDestroy).toHaveBeenCalledWith(
             "audio:text:embed:requests",
             "clap:text:embed:group",
@@ -49,11 +55,11 @@ describe("legacy vibe Redis cleanup", () => {
 
         expect(client.scan).toHaveBeenNthCalledWith(1, "0", {
             MATCH: "audio:clap:queue:reserved:*",
-            COUNT: 100,
+            COUNT: 2048,
         });
         expect(client.scan).toHaveBeenNthCalledWith(2, "17", {
             MATCH: "audio:clap:queue:reserved:*",
-            COUNT: 100,
+            COUNT: 2048,
         });
         expect(client.del).toHaveBeenCalledWith(
             "audio:clap:queue:reserved:stale",
@@ -62,6 +68,94 @@ describe("legacy vibe Redis cleanup", () => {
             "audio:clap:queue:reserved:active",
         );
         expect(result).toEqual({ staleReservationsDeleted: 1 });
+    });
+
+    it("processes every reservation returned in one bounded scan page", async () => {
+        const client = createClient();
+        const keys = Array.from(
+            { length: 150 },
+            (_, index) => `audio:clap:queue:reserved:legacy-${index}`,
+        );
+        client.scan.mockResolvedValueOnce({ cursor: "0", keys });
+        client.ttl.mockResolvedValue(-1);
+
+        const result = await cleanupLegacyVibeRedisArtifacts(client, logger);
+
+        expect(client.ttl).toHaveBeenCalledTimes(150);
+        expect(client.del).toHaveBeenCalledTimes(152);
+        expect(result).toEqual({ staleReservationsDeleted: 150 });
+    });
+
+    it("stops before processing an oversized scan page", async () => {
+        const client = createClient();
+        const keys = Array.from(
+            { length: 2049 },
+            (_, index) => `audio:clap:queue:reserved:legacy-${index}`,
+        );
+        client.scan.mockResolvedValueOnce({ cursor: "17", keys });
+
+        await cleanupLegacyVibeRedisArtifacts(client, logger);
+
+        expect(client.scan).toHaveBeenCalledTimes(1);
+        expect(client.ttl).not.toHaveBeenCalled();
+        expect(client.del).toHaveBeenCalledTimes(2);
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Legacy vibe reservation scan page exceeded its key limit",
+            { cursor: "0", keyCount: 2049, maxKeysPerPage: 2048 },
+        );
+    });
+
+    it("never deletes expiring or already-missing reservations", async () => {
+        const client = createClient();
+        client.scan.mockResolvedValueOnce({
+            cursor: "0",
+            keys: [
+                "audio:clap:queue:reserved:legacy",
+                "audio:clap:queue:reserved:current",
+                "audio:clap:queue:reserved:missing",
+            ],
+        });
+        client.ttl
+            .mockResolvedValueOnce(-1)
+            .mockResolvedValueOnce(3600)
+            .mockResolvedValueOnce(-2);
+
+        await cleanupLegacyVibeRedisArtifacts(client, logger);
+
+        expect(client.del).toHaveBeenCalledWith(
+            "audio:clap:queue:reserved:legacy",
+        );
+        expect(client.del).not.toHaveBeenCalledWith(
+            "audio:clap:queue:reserved:current",
+        );
+        expect(client.del).not.toHaveBeenCalledWith(
+            "audio:clap:queue:reserved:missing",
+        );
+    });
+
+    it("skips cleanup when another replica owns the durable marker", async () => {
+        const client = createClient();
+        client.set.mockResolvedValueOnce(null);
+
+        await cleanupLegacyVibeRedisArtifacts(client, logger);
+
+        expect(client.xGroupDestroy).not.toHaveBeenCalled();
+        expect(client.del).not.toHaveBeenCalled();
+        expect(client.scan).not.toHaveBeenCalled();
+    });
+
+    it("does not scan when the durable marker claim fails", async () => {
+        const client = createClient();
+        client.set.mockRejectedValueOnce(new Error("redis unavailable"));
+
+        await cleanupLegacyVibeRedisArtifacts(client, logger);
+
+        expect(client.xGroupDestroy).not.toHaveBeenCalled();
+        expect(client.scan).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Failed to claim the legacy vibe Redis cleanup marker",
+            { error: expect.any(Error) },
+        );
     });
 
     it("continues cleaning independent artifacts after a missing group", async () => {

--- a/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
+++ b/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
@@ -2,6 +2,7 @@ jest.mock("../../config", () => ({
     config: {
         vibeProviderUrl: undefined,
         vibeEmbedConcurrency: 1,
+        analysisQueues: { vibeMaxDepth: 100 },
         features: { audioAnalysis: true },
         redisUrl: "redis://mock:6379",
         internalApiSecret: "test-secret",
@@ -36,7 +37,11 @@ describe("vibe embed worker", () => {
         const pop = jest.fn<Promise<string | null>, [string, number]>();
         const processJob = jest.fn(async () => "stored" as const);
         const requeue = jest.fn(async () => undefined);
-        const refreshCoverage = jest.fn(async () => undefined);
+        const refreshCoverage = jest.fn(async () => ({
+            embedded: 8,
+            pending: 2,
+            failed: 1,
+        }));
         const runLifecycle = jest.fn(async () => undefined);
         const cleanupLegacyArtifacts = jest.fn<Promise<void>, []>(
             async () => undefined,
@@ -44,12 +49,16 @@ describe("vibe embed worker", () => {
         const setTargetSpace = jest.fn();
         const clearTargetSpace = jest.fn();
         const recordSpaceTransition = jest.fn();
+        const setMigrationActive = jest.fn();
+        const writeStatus = jest.fn(async () => undefined);
+        const now = jest.fn(() => new Date("2026-08-17T12:00:00.000Z"));
         const resolveTargetSpace = jest.fn<
             Promise<{
                 id: string;
                 dim: number;
                 status: "active" | "migrating";
                 registered: boolean;
+                family: string;
             }>,
             []
         >(async () => ({
@@ -57,6 +66,7 @@ describe("vibe embed worker", () => {
             dim: 2,
             status: "active",
             registered: false,
+            family: "test-family",
         }));
         const logger = {
             info: jest.fn(),
@@ -76,6 +86,9 @@ describe("vibe embed worker", () => {
             setTargetSpace,
             clearTargetSpace,
             recordSpaceTransition,
+            setMigrationActive,
+            writeStatus,
+            now,
             resolveTargetSpace,
             logger,
         });
@@ -90,6 +103,8 @@ describe("vibe embed worker", () => {
             setTargetSpace,
             clearTargetSpace,
             recordSpaceTransition,
+            setMigrationActive,
+            writeStatus,
             resolveTargetSpace,
             logger,
         };
@@ -134,6 +149,18 @@ describe("vibe embed worker", () => {
         expect(harness.pop).toHaveBeenCalledWith("audio:clap:queue", 1);
         expect(harness.refreshCoverage).toHaveBeenCalledTimes(1);
         expect(harness.refreshCoverage).toHaveBeenCalledWith("space-active");
+        expect(harness.writeStatus).toHaveBeenLastCalledWith({
+            providerReachability: {
+                reachable: true,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            targetSpace: {
+                id: "space-active",
+                family: "test-family",
+                status: "active",
+            },
+            coverage: { embedded: 8, pending: 2, failed: 1 },
+        });
 
         const stopping = harness.worker.stop();
         firstPop.resolve(null);
@@ -183,6 +210,29 @@ describe("vibe embed worker", () => {
         const stopping = harness.worker.stop();
         firstPop.resolve(null);
         await stopping;
+    });
+
+    it("abandons legacy cleanup at the fixed shutdown deadline", async () => {
+        jest.useFakeTimers();
+        const firstPop = deferred<string | null>();
+        const cleanup = deferred<void>();
+        const harness = createHarness({
+            providerUrl: "http://provider:8090",
+        });
+        harness.pop.mockReturnValueOnce(firstPop.promise);
+        harness.cleanupLegacyArtifacts.mockReturnValueOnce(cleanup.promise);
+
+        await harness.worker.start();
+        await Promise.resolve();
+        const stopping = harness.worker.stop();
+        firstPop.resolve(null);
+        await jest.advanceTimersByTimeAsync(60_000);
+
+        await expect(stopping).resolves.toBeUndefined();
+        expect(harness.logger.warn).toHaveBeenCalledWith(
+            "Legacy vibe Redis cleanup abandoned at its deadline",
+            { timeoutMs: 60_000 },
+        );
     });
 
     it("finishes an in-flight job before shutdown resolves", async () => {
@@ -324,12 +374,16 @@ describe("vibe embed worker", () => {
                 dim: 2,
                 status,
                 registered: false,
+                family: "test-family",
             });
             harness.pop.mockReturnValueOnce(firstPop.promise);
 
             await expect(harness.worker.start()).resolves.toBe(true);
             expect(harness.setTargetSpace).toHaveBeenCalledWith(
                 `space-${status}`,
+            );
+            expect(harness.setMigrationActive).toHaveBeenCalledWith(
+                status === "migrating",
             );
             await flushPromises();
             expect(harness.processJob).not.toHaveBeenCalled();
@@ -350,6 +404,7 @@ describe("vibe embed worker", () => {
             dim: 2,
             status: "migrating",
             registered: true,
+            family: "test-family",
         });
         harness.pop.mockReturnValueOnce(firstPop.promise);
 
@@ -381,6 +436,7 @@ describe("vibe embed worker", () => {
                 dim: 3,
                 status: "migrating",
                 registered: false,
+                family: "test-family",
             });
         harness.pop.mockReturnValueOnce(firstPop.promise);
 
@@ -397,6 +453,14 @@ describe("vibe embed worker", () => {
             "Vibe embedding worker target-space resolution failed",
             { error },
         );
+        expect(harness.writeStatus).toHaveBeenCalledWith({
+            providerReachability: {
+                reachable: false,
+                checkedAt: "2026-08-17T12:00:00.000Z",
+            },
+            targetSpace: null,
+            coverage: null,
+        });
 
         const stopping = harness.worker.stop();
         firstPop.resolve(null);
@@ -450,6 +514,7 @@ describe("vibe embed worker", () => {
             dim: number;
             status: "active";
             registered: false;
+            family: string;
         }>();
         const firstPop = deferred<string | null>();
         const harness = createHarness({
@@ -466,6 +531,7 @@ describe("vibe embed worker", () => {
             dim: 2,
             status: "active",
             registered: false,
+            family: "test-family",
         });
 
         await expect(starting).resolves.toBe(true);

--- a/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
+++ b/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
@@ -1,0 +1,56 @@
+import {
+    readVibeWorkerStatus,
+    VIBE_WORKER_STATUS_KEY,
+    writeVibeWorkerStatus,
+    type VibeWorkerStatusRedis,
+} from "../vibeWorkerStatus";
+
+function createRedis(): jest.Mocked<VibeWorkerStatusRedis> {
+    return {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue("OK"),
+    };
+}
+
+describe("vibe worker status cache", () => {
+    const status = {
+        providerReachability: {
+            reachable: true,
+            checkedAt: "2026-08-17T12:00:00.000Z",
+        },
+        targetSpace: {
+            id: "space-migrating",
+            family: "student-family",
+            status: "migrating" as const,
+        },
+        coverage: { embedded: 80, pending: 20, failed: 3 },
+    };
+
+    it("persists the last worker-owned verdict without an expiry", async () => {
+        const redis = createRedis();
+
+        await writeVibeWorkerStatus(redis, status);
+
+        expect(redis.set).toHaveBeenCalledWith(
+            VIBE_WORKER_STATUS_KEY,
+            JSON.stringify(status),
+        );
+    });
+
+    it("reads and validates the cached worker snapshot", async () => {
+        const redis = createRedis();
+        redis.get.mockResolvedValueOnce(JSON.stringify(status));
+
+        await expect(readVibeWorkerStatus(redis)).resolves.toEqual(status);
+    });
+
+    it.each(["not-json", JSON.stringify({ reachable: "yes" })])(
+        "treats invalid cached state as unavailable",
+        async (stored) => {
+            const redis = createRedis();
+            redis.get.mockResolvedValueOnce(stored);
+
+            await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
+        },
+    );
+});

--- a/backend/src/workers/legacyVibeRedisCleanup.ts
+++ b/backend/src/workers/legacyVibeRedisCleanup.ts
@@ -5,12 +5,19 @@ const LEGACY_TEXT_EMBED_STREAM = "audio:text:embed:requests";
 const LEGACY_TEXT_EMBED_GROUP = "clap:text:embed:group";
 const LEGACY_WORKER_HEARTBEAT = "clap:worker:heartbeat";
 const RESERVATION_PATTERN = `${VIBE_PROVIDER_QUEUE_KEY}:reserved:*`;
-const SCAN_BATCH_SIZE = 100;
+const CLEANUP_MARKER_KEY = "soundspan:legacy-vibe-cleanup:v1";
+const SCAN_BATCH_SIZE = 2_048;
+const MAX_KEYS_PER_PAGE = 2_048;
 const MAX_SCAN_PAGES = 1_000;
 
 /** Minimal Redis surface required by the one-shot transition cleanup. */
 export interface LegacyVibeRedisCleanupClient {
     del(key: string): Promise<number>;
+    set(
+        key: string,
+        value: string,
+        options: { NX: true },
+    ): Promise<string | null>;
     scan(
         cursor: string,
         options: { MATCH: string; COUNT: number },
@@ -51,11 +58,25 @@ async function deleteStaleReservations(
             MATCH: RESERVATION_PATTERN,
             COUNT: SCAN_BATCH_SIZE,
         });
-        for (let index = 0; index < SCAN_BATCH_SIZE; index += 1) {
-            const key = result.keys[index];
-            if (!key) break;
+        if (result.keys.length > MAX_KEYS_PER_PAGE) {
+            logger.warn(
+                "Legacy vibe reservation scan page exceeded its key limit",
+                {
+                    cursor,
+                    keyCount: result.keys.length,
+                    maxKeysPerPage: MAX_KEYS_PER_PAGE,
+                },
+            );
+            return deleted;
+        }
+        for (const key of result.keys) {
             await runBestEffort(
                 async () => {
+                    // Safety: enqueueReservedWork is the only current producer.
+                    // Its Lua script creates each reservation with SET NX EX
+                    // atomically, so a new reservation is never momentarily
+                    // TTL-less. Therefore TTL == -1 identifies pre-atomic
+                    // legacy reservations; expiring and missing keys are kept.
                     if ((await client.ttl(key)) !== -1) return;
                     deleted += await client.del(key);
                 },
@@ -72,11 +93,31 @@ async function deleteStaleReservations(
     return deleted;
 }
 
+async function claimCleanup(
+    client: LegacyVibeRedisCleanupClient,
+    logger: CleanupLogger,
+): Promise<boolean> {
+    try {
+        const result = await client.set(CLEANUP_MARKER_KEY, "done", {
+            NX: true,
+        });
+        return result === "OK";
+    } catch (error) {
+        logger.warn("Failed to claim the legacy vibe Redis cleanup marker", {
+            error,
+        });
+        return false;
+    }
+}
+
 /** Removes retired CLAP transport artifacts without disturbing valid jobs. */
 export async function cleanupLegacyVibeRedisArtifacts(
     client: LegacyVibeRedisCleanupClient,
     logger: CleanupLogger,
 ): Promise<LegacyVibeRedisCleanupResult> {
+    if (!(await claimCleanup(client, logger))) {
+        return { staleReservationsDeleted: 0 };
+    }
     await runBestEffort(
         () =>
             client.xGroupDestroy(

--- a/backend/src/workers/vibeEmbedWorker.ts
+++ b/backend/src/workers/vibeEmbedWorker.ts
@@ -15,13 +15,22 @@ import {
     setVibeEmbeddingTargetSpaceId,
 } from "../services/embeddingSpaces";
 import { fetchProviderSpace } from "../services/vibeProvider";
-import { recordVibeSpaceTransition } from "../metrics";
+import {
+    recordVibeSpaceTransition,
+    setVibeMigrationActive,
+    setVibeProviderQueueCapacity,
+} from "../metrics";
+import type { VibeEmbeddingCoverage } from "../metrics/vibeEmbedMetrics";
 import { logger } from "../utils/logger";
 import { blockingBlPop, redisClient } from "../utils/redis";
 import {
     cleanupLegacyVibeRedisArtifacts,
     VIBE_PROVIDER_QUEUE_KEY,
 } from "./legacyVibeRedisCleanup";
+import {
+    writeVibeWorkerStatus,
+    type VibeWorkerStatus,
+} from "./vibeWorkerStatus";
 
 const BLPOP_TIMEOUT_SECONDS = 1;
 const COVERAGE_REFRESH_INTERVAL_MS = 60_000;
@@ -29,6 +38,7 @@ const SPACE_LIFECYCLE_INTERVAL_MS = 5 * 60_000;
 const POP_ERROR_BACKOFF_MS = 250;
 const TARGET_RESOLUTION_RETRY_MS = 60_000;
 const TERMINAL_TARGET_RESOLUTION_RETRY_MS = 15 * 60_000;
+const LEGACY_CLEANUP_TIMEOUT_MS = 60_000;
 
 interface WorkerLogger {
     info(message: string, context?: unknown): void;
@@ -43,21 +53,28 @@ interface VibeEmbedWorkerDependencies {
     pop(queue: string, timeoutSeconds: number): Promise<string | null>;
     processJob(
         rawJob: string,
-        targetSpace: ResolvedWorkerTargetSpace,
+        targetSpace: VibeWorkerJobTargetSpace,
     ): Promise<unknown>;
     requeue(rawJob: string): Promise<void>;
-    refreshCoverage(targetSpaceId: string): Promise<void>;
+    refreshCoverage(targetSpaceId: string): Promise<VibeEmbeddingCoverage>;
     runLifecycle(): Promise<void>;
     cleanupLegacyArtifacts(): Promise<void>;
     resolveTargetSpace(): Promise<ResolvedWorkerTargetSpace>;
     setTargetSpace(spaceId: string): void;
     clearTargetSpace(): void;
     recordSpaceTransition(transition: "registered"): void;
+    setMigrationActive(active: boolean): void;
+    writeStatus(status: VibeWorkerStatus): Promise<void>;
+    now(): Date;
     logger: WorkerLogger;
 }
 
-interface ResolvedWorkerTargetSpace extends VibeEmbedJobTargetSpace {
+interface VibeWorkerJobTargetSpace extends VibeEmbedJobTargetSpace {
     registered: boolean;
+}
+
+interface ResolvedWorkerTargetSpace extends VibeWorkerJobTargetSpace {
+    family: string;
 }
 
 /** Lifecycle surface for the backend-driven audio embedding consumer. */
@@ -68,6 +85,25 @@ export interface VibeEmbedWorker {
 
 function delay(milliseconds: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function settleAtDeadline(
+    task: Promise<void>,
+    timeoutMs: number,
+): Promise<"completed" | "deadline"> {
+    let timer: NodeJS.Timeout | null = null;
+    const deadline = new Promise<"deadline">((resolve) => {
+        timer = setTimeout(() => resolve("deadline"), timeoutMs);
+        timer.unref();
+    });
+    try {
+        return await Promise.race([
+            task.then(() => "completed" as const),
+            deadline,
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
 }
 
 function isTerminalTargetResolutionError(error: unknown): boolean {
@@ -92,6 +128,11 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private terminalResolutionFailureCount = 0;
     private cleanupStarted = false;
     private cleanupTask: Promise<void> | null = null;
+    private providerReachability:
+        | VibeWorkerStatus["providerReachability"]
+        | null = null;
+    private coverage: VibeEmbeddingCoverage | null = null;
+    private statusWriteTask: Promise<void> = Promise.resolve();
     private stopped = false;
 
     constructor(private readonly dependencies: VibeEmbedWorkerDependencies) {
@@ -101,13 +142,42 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private async refreshCoverage(): Promise<void> {
         if (!this.targetSpace) return;
         try {
-            await this.dependencies.refreshCoverage(this.targetSpace.id);
+            this.coverage = await this.dependencies.refreshCoverage(
+                this.targetSpace.id,
+            );
+            await this.publishStatus();
         } catch (error) {
             this.dependencies.logger.warn(
                 "Vibe coverage refresh failed",
                 error,
             );
         }
+    }
+
+    private async publishStatus(): Promise<void> {
+        if (!this.providerReachability) return;
+        const targetSpace = this.targetSpace
+            ? {
+                  id: this.targetSpace.id,
+                  family: this.targetSpace.family,
+                  status: this.targetSpace.status,
+              }
+            : null;
+        const status = {
+            providerReachability: this.providerReachability,
+            targetSpace,
+            coverage: this.coverage,
+        };
+        const writeTask = this.statusWriteTask
+            .then(() => this.dependencies.writeStatus(status))
+            .catch((error) => {
+                this.dependencies.logger.warn(
+                    "Failed to publish vibe worker status",
+                    error,
+                );
+            });
+        this.statusWriteTask = writeTask;
+        await writeTask;
     }
 
     private scheduleLifecycle(): void {
@@ -131,7 +201,13 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
             if (!this.targetSpace) {
                 throw new Error("Vibe embedding target space is unresolved");
             }
-            await this.dependencies.processJob(rawJob, this.targetSpace);
+            const jobTarget = {
+                id: this.targetSpace.id,
+                dim: this.targetSpace.dim,
+                status: this.targetSpace.status,
+                registered: this.targetSpace.registered,
+            };
+            await this.dependencies.processJob(rawJob, jobTarget);
         } catch (error) {
             this.dependencies.logger.error(
                 "Vibe embedding job failed before finalization",
@@ -204,6 +280,7 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
         this.terminalResolutionFailureCount = 0;
         this.targetSpace = target;
         this.dependencies.setTargetSpace(target.id);
+        this.dependencies.setMigrationActive(target.status === "migrating");
         if (target.registered) {
             this.dependencies.recordSpaceTransition("registered");
             this.dependencies.logger.warn(
@@ -211,6 +288,7 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
                 { spaceId: target.id },
             );
         }
+        void this.publishStatus();
         this.startCoverageRefresh();
         this.startLifecycleChecks();
         this.dependencies.logger.info("Vibe embedding worker started", {
@@ -224,9 +302,18 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
         try {
             const target = await this.dependencies.resolveTargetSpace();
             if (this.stopped || !this.running) return;
+            this.providerReachability = {
+                reachable: true,
+                checkedAt: this.dependencies.now().toISOString(),
+            };
             this.activateTarget(target);
         } catch (error) {
+            this.providerReachability = {
+                reachable: false,
+                checkedAt: this.dependencies.now().toISOString(),
+            };
             const retryDelayMs = this.recordTargetResolutionFailure(error);
+            void this.publishStatus();
             if (this.running) await this.waitForTargetRetry(retryDelayMs);
         }
     }
@@ -276,18 +363,30 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private startLegacyCleanup(): void {
         if (this.cleanupStarted) return;
         this.cleanupStarted = true;
-        const task = this.dependencies
-            .cleanupLegacyArtifacts()
-            .catch((error) => {
-                this.dependencies.logger.warn(
-                    "Legacy vibe Redis cleanup failed",
-                    error,
-                );
-            })
-            .finally(() => {
-                if (this.cleanupTask === task) this.cleanupTask = null;
-            });
+        const task = this.runLegacyCleanup().finally(() => {
+            if (this.cleanupTask === task) this.cleanupTask = null;
+        });
         this.cleanupTask = task;
+    }
+
+    private async runLegacyCleanup(): Promise<void> {
+        try {
+            const outcome = await settleAtDeadline(
+                this.dependencies.cleanupLegacyArtifacts(),
+                LEGACY_CLEANUP_TIMEOUT_MS,
+            );
+            if (outcome === "deadline") {
+                this.dependencies.logger.warn(
+                    "Legacy vibe Redis cleanup abandoned at its deadline",
+                    { timeoutMs: LEGACY_CLEANUP_TIMEOUT_MS },
+                );
+            }
+        } catch (error) {
+            this.dependencies.logger.warn(
+                "Legacy vibe Redis cleanup failed",
+                error,
+            );
+        }
     }
 
     async start(): Promise<boolean> {
@@ -347,7 +446,7 @@ const worker = createVibeEmbedWorker({
         await redisClient.rPush(VIBE_PROVIDER_QUEUE_KEY, rawJob);
     },
     refreshCoverage: async (targetSpaceId) => {
-        await refreshVibeEmbeddingCoverage(targetSpaceId);
+        return refreshVibeEmbeddingCoverage(targetSpaceId);
     },
     runLifecycle: async () => {
         await runEmbeddingSpaceLifecycleCheck({
@@ -368,13 +467,21 @@ const worker = createVibeEmbedWorker({
             dim: resolution.space.dim,
             status: resolution.space.status,
             registered: resolution.registered,
+            family: resolution.space.family,
         };
     },
     setTargetSpace: setVibeEmbeddingTargetSpaceId,
     clearTargetSpace: clearVibeEmbeddingTargetSpaceId,
     recordSpaceTransition: recordVibeSpaceTransition,
+    setMigrationActive: setVibeMigrationActive,
+    writeStatus: async (status) => {
+        await writeVibeWorkerStatus(redisClient, status);
+    },
+    now: () => new Date(),
     logger: log,
 });
+
+setVibeProviderQueueCapacity(config.analysisQueues.vibeMaxDepth);
 
 /** Starts the singleton consumer when provider mode is enabled. */
 export function startVibeEmbedWorker(): Promise<boolean> {

--- a/backend/src/workers/vibeWorkerStatus.ts
+++ b/backend/src/workers/vibeWorkerStatus.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+/** Shared Redis key for the worker's last provider and migration snapshot. */
+export const VIBE_WORKER_STATUS_KEY = "soundspan:vibe-worker-status:v1";
+
+const coverageSchema = z.strictObject({
+    embedded: z.number().int().nonnegative(),
+    pending: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+});
+const workerStatusSchema = z.strictObject({
+    providerReachability: z.strictObject({
+        reachable: z.boolean(),
+        checkedAt: z.iso.datetime(),
+    }),
+    targetSpace: z
+        .strictObject({
+            id: z.string().min(1),
+            family: z.string().min(1),
+            status: z.enum(["active", "migrating"]),
+        })
+        .nullable(),
+    coverage: coverageSchema.nullable(),
+});
+
+/** Last provider check and target-space state published by the worker. */
+export type VibeWorkerStatus = z.infer<typeof workerStatusSchema>;
+
+/** Minimal Redis surface for the compact worker status cache. */
+export interface VibeWorkerStatusRedis {
+    get(key: string): Promise<string | null>;
+    set(key: string, value: string): Promise<unknown>;
+}
+
+/** Persist a worker-owned status snapshot for API processes and restarts. */
+export async function writeVibeWorkerStatus(
+    redis: VibeWorkerStatusRedis,
+    status: VibeWorkerStatus,
+): Promise<void> {
+    await redis.set(VIBE_WORKER_STATUS_KEY, JSON.stringify(status));
+}
+
+/** Read a validated snapshot; corrupt or obsolete cache values are a miss. */
+export async function readVibeWorkerStatus(
+    redis: VibeWorkerStatusRedis,
+): Promise<VibeWorkerStatus | null> {
+    const stored = await redis.get(VIBE_WORKER_STATUS_KEY);
+    if (stored === null) return null;
+    try {
+        const parsed: unknown = JSON.parse(stored);
+        const status = workerStatusSchema.safeParse(parsed);
+        return status.success ? status.data : null;
+    } catch {
+        return null;
+    }
+}

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,11 @@
+# Soundspan Prometheus observability
+
+Import [`grafana-soundspan-prometheus.json`](grafana-soundspan-prometheus.json)
+for the starter Grafana dashboard. Load
+[`prometheus-alerts-soundspan.yml`](prometheus-alerts-soundspan.yml) as a
+Prometheus rule file for the matching vibe provider, migration, queue,
+collection-error, and federation alerts.
+
+Prometheus must scrape every backend and worker replica because each process
+owns its registry. The queue-capacity series is published by workers, and the
+alert expressions aggregate process-local series before evaluating thresholds.

--- a/docs/observability/prometheus-alerts-soundspan.yml
+++ b/docs/observability/prometheus-alerts-soundspan.yml
@@ -1,0 +1,70 @@
+groups:
+    - name: soundspan-vibe-operational-resilience
+      rules:
+          - alert: SoundspanVibeProviderFailureRateHigh
+            expr: |
+                (
+                  sum(rate(soundspan_vibe_provider_requests_total{outcome!="ok"}[10m]))
+                  /
+                  clamp_min(sum(rate(soundspan_vibe_provider_requests_total[10m])), 0.001)
+                ) > 0.10
+                and sum(increase(soundspan_vibe_provider_requests_total[10m])) >= 10
+            for: 10m
+            labels:
+                severity: warning
+            annotations:
+                summary: Vibe provider request failure rate is high
+                description: More than 10% of at least 10 vibe provider requests failed during the last 10 minutes.
+
+          - alert: SoundspanVibeMigrationCoverageStalled
+            expr: |
+                max(soundspan_vibe_migration_active) == 1
+                and max(changes(soundspan_vibe_embedding_coverage{state="embedded"}[30m])) == 0
+                and max(soundspan_vibe_embedding_coverage{state="pending"}) > 0
+            for: 15m
+            labels:
+                severity: warning
+            annotations:
+                summary: Vibe migration coverage is stalled
+                description: A migrating space has pending tracks but its embedded-track count has not changed for at least 30 minutes.
+
+          - alert: SoundspanVibeFailedTracksHigh
+            expr: max(soundspan_vibe_embedding_coverage{state="failed"}) > 25
+            for: 10m
+            labels:
+                severity: warning
+            annotations:
+                summary: Vibe failed-track count is high
+                description: More than 25 eligible tracks are in the failed vibe embedding state.
+
+          - alert: SoundspanVibeProviderQueueNearCapacity
+            expr: |
+                max(soundspan_vibe_provider_queue_depth)
+                /
+                clamp_min(max(soundspan_vibe_provider_queue_capacity), 1)
+                >= 0.90
+            for: 10m
+            labels:
+                severity: warning
+            annotations:
+                summary: Vibe provider queue is near capacity
+                description: Provider queue depth has remained at or above 90% of its configured admission capacity.
+
+          - alert: SoundspanMetricsCollectionErrors
+            expr: sum(increase(soundspan_metrics_collection_errors_total[10m])) > 0
+            for: 5m
+            labels:
+                severity: warning
+            annotations:
+                summary: Soundspan metrics collection is degraded
+                description: At least one bounded scrape-time collector failed during the last 10 minutes.
+
+          - alert: SoundspanFederationSuppressedExportsPostCutover
+            expr: |
+                sum(increase(soundspan_federation_embedding_exports_total{outcome="suppressed_legacy_peer"}[15m])) > 0
+            for: 0m
+            labels:
+                severity: warning
+            annotations:
+                summary: Federation exports are being suppressed after vibe cutover
+                description: A peer without embedding-space support requested embeddings after the active space left the legacy teacher space.


### PR DESCRIPTION
## Summary

X3 batch of round-2 review fixes — the operational layer:

- **`/metrics` survives Redis outages**: last-good-sample retention, initial-skip, bounded `soundspan_metrics_collection_errors_total{collector="vibe_queue_depth"}`; both API and worker endpoints pinned with rejecting-Redis tests.
- **Legacy cleanup hardening**: 60s deadline (shutdown never waits past it), durable versioned `SET NX` marker (restart/replica safe), full-page SCAN processing with a 2,048-key cap that terminates loudly, and the TTL==-1 criterion documented safe (only producer creates reservations atomically via `SET NX EX` in the admission Lua script).
- **Manual force fairness**: manual admission capped at 90% of queue capacity with guaranteed automatic-backfill headroom; regression test pins the older automatic item still admitting after a manual burst.
- **Six Prometheus alert rules** (`docs/observability/prometheus-alerts-soundspan.yml`) + observability index README.
- **System features API** exposes provider configuration/reachability, active space identity, migration coverage, and cutover threshold — from the worker's validated Redis snapshot, no per-request probing. OpenAPI synced.

## Verification

- Full backend suite (unrestricted): **390 suites passed, 6,163 tests, 0 failures.**
- Focused suites 115 tests; OpenAPI sync 4 passed; `tsc --noEmit` clean; backend `format:check` clean; alert YAML validated (1 group, 6 rules).