### PR TITLE
chore(vibe)!: round-2 polish for Helm, images, frontend, and upgrade docs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -35,6 +35,17 @@ regexes = [
   # comparison; not real key material. Hit at commit ab0bfc44 (2 lines).
   '''a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4''',
 
+  # Dockerfile + services/vibe-provider-dclap/Dockerfile -- pinned SHA-256
+  # content digests of the six PUBLIC laion/clap-htsat-unfused tokenizer
+  # files both images verify after download (supply-chain integrity, not
+  # credentials). 64-hex assignments trip generic-api-key.
+  '''9efb9557bc804f2ca6e394486af2e45dfed0b18554909735a99c6220b84e4288''',
+  '''fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862''',
+  '''06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f''',
+  '''4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148''',
+  '''377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3''',
+  '''ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e''',
+
   # services/vibe-provider-dclap/Dockerfile -- TOKENIZER_REVISION is the
   # public immutable Hugging Face git commit of laion/clap-htsat-unfused
   # that the build vendors tokenizer files from. A 40-hex assignment trips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operators can now start a blue/green vibe embedding migration by pointing
   `VIBE_PROVIDER_URL` at a distinct provider space; Soundspan registers and
   backfills it, cuts over at configured coverage, retains the prior space's
-  vectors for a 2.3 space-level rollback during the grace period, and then
-  cleans them. This does not support downgrading 2.3 database state to 2.2
-  images; that rollback requires a pre-upgrade database backup and restore.
+  vectors during the grace period, and then cleans them. Before cutover, unset
+  the provider to abandon the migration while the prior space remains active.
+  Downgrading 2.3 database state to 2.2 images requires a pre-upgrade database
+  backup and restore.
 - Added read-only provider-fidelity validation tooling for real-library paired
   cosine, teacher-indexed neighbor overlap, text-query overlap, and inclusive
   same-space gate reports.
@@ -53,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VIBE_SPACE_CUTOVER_ALLOW_FAILED=true`.
 - Embedding-space lifecycle selection now follows the currently configured
   provider and retires abandoned migrations after the configured grace period.
+- Upgrade guidance now covers Helm reused values, the rolling migration window,
+  bare-metal stop/migrate/start order, and Compose transition verification.
 - Vibe migration coverage telemetry now exposes failed tracks at sampling and
   cutover, while retaining the actionable coverage denominator.
 - Migrating-space vibe text scans and lifecycle coverage reads are now bounded
@@ -116,6 +119,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   space, so migrated tracks receive the full provider retry budget.
 - Provider 5xx availability failures now return 503 from vibe search, provider
   contract and space mismatches return 502, and timeouts remain 504.
+- Helm accepts absent or null removed analyzer values while rejecting non-null
+  legacy configuration.
+- DCLAP tokenizer artifacts are byte-verified in both the standalone and AIO
+  images.
+- The Vibe UI now distinguishes provider-unavailable errors from transient
+  provider timeouts.
 - Force rebuilding vibe embeddings now preserves active-space vectors, and a
   durable space marker prevents wiped spaces from triggering fresh-install
   cutover behavior.

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,13 @@ RUN set -eu; \
     for TOKENIZER_FILE in config.json merges.txt special_tokens_map.json tokenizer.json tokenizer_config.json vocab.json; do \
         curl --fail --location --retry 3 --connect-timeout 30 --max-time 600 \
             --output "/app/vibe-provider-dclap/tokenizer/${TOKENIZER_FILE}" "${TOKENIZER_URL}/${TOKENIZER_FILE}"; \
-    done
+    done; \
+    echo "9efb9557bc804f2ca6e394486af2e45dfed0b18554909735a99c6220b84e4288  /app/vibe-provider-dclap/tokenizer/config.json" | sha256sum -c -; \
+    echo "fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862  /app/vibe-provider-dclap/tokenizer/merges.txt" | sha256sum -c -; \
+    echo "06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f  /app/vibe-provider-dclap/tokenizer/special_tokens_map.json" | sha256sum -c -; \
+    echo "4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148  /app/vibe-provider-dclap/tokenizer/tokenizer.json" | sha256sum -c -; \
+    echo "377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3  /app/vibe-provider-dclap/tokenizer/tokenizer_config.json" | sha256sum -c -; \
+    echo "ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e  /app/vibe-provider-dclap/tokenizer/vocab.json" | sha256sum -c -
 
 COPY services/vibe-provider-dclap/__main__.py services/vibe-provider-dclap/http_server.py \
     services/vibe-provider-dclap/inference.py services/vibe-provider-dclap/model_provider.py \

--- a/charts/soundspan/README.md
+++ b/charts/soundspan/README.md
@@ -373,6 +373,19 @@ The provider mounts the shared music volume read-only and receives only
 `INTERNAL_API_SECRET` from the chart Secret; it does not receive PostgreSQL or
 Redis credentials.
 
+The removed `audioAnalyzerClap` value may be absent or explicitly `null`, since
+both configure nothing. Any non-null legacy value stops `helm template` and
+install/upgrade rendering with migration guidance. `helm lint` does not enforce
+this template guard and exits successfully, so render the chart before an
+upgrade.
+
+Warning: `helm upgrade --reuse-values` from 2.2 carries the removed
+`audioAnalyzerClap.*` map forward and triggers that guard. Use
+`--reset-then-reuse-values` with Helm 3.14 or newer, or supply a clean values
+file that omits the legacy map. See
+[`docs/UPGRADING.md`](../../docs/UPGRADING.md) for the 2.3 migration window and
+workload ordering.
+
 ### Feature Flags
 
 Coarse feature flags render on the backend, backend-worker, and AIO workloads.

--- a/charts/soundspan/templates/validate-values.yaml
+++ b/charts/soundspan/templates/validate-values.yaml
@@ -1,4 +1,4 @@
-{{- if hasKey .Values "audioAnalyzerClap" -}}
+{{- if and (hasKey .Values "audioAnalyzerClap") (not (kindIs "invalid" .Values.audioAnalyzerClap)) -}}
 {{- fail "audioAnalyzerClap values were removed; set vibeProviderDclap.enabled instead; see the 2.3.0 entry in docs/UPGRADING.md" -}}
 {{- end -}}
 {{- $vibeProviderDclapEnv := .Values.vibeProviderDclap.env | default (dict) -}}

--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -68,6 +68,10 @@ services:
       - FEDERATION_ENABLED=${FEDERATION_ENABLED:-false}
       - FEDERATION_TOMBSTONE_RETENTION_DAYS=${FEDERATION_TOMBSTONE_RETENTION_DAYS:-90}
       - FEDERATION_SYNC_INTERVAL_MINUTES=${FEDERATION_SYNC_INTERVAL_MINUTES:-15}
+      # DCLAP provider routing, idle unloading, and ONNX CPU concurrency
+      - VIBE_PROVIDER_URL=${VIBE_PROVIDER_URL:-http://localhost:8092}
+      - MODEL_IDLE_TIMEOUT=${MODEL_IDLE_TIMEOUT:-300}
+      - DCLAP_ONNX_INTRA_OP_THREADS=${DCLAP_ONNX_INTRA_OP_THREADS:-1}
       # MusicCNN queue socket timeout; runtime enforces at least BRPOP timeout + 5s
       - AUDIO_REDIS_SOCKET_TIMEOUT=${AUDIO_REDIS_SOCKET_TIMEOUT:-35}
       # Lidarr webhook callback URL - how Lidarr reaches soundspan when downloads complete

--- a/docs/CONFIGURATION_AND_SECURITY.md
+++ b/docs/CONFIGURATION_AND_SECURITY.md
@@ -148,7 +148,7 @@ Cookie-session authentication has been removed. Each authenticated request now u
 | OpenSubsonic `/rest` | Per-request token plus salt, password transport, or an `ssap_` app password; API keys use the separate `apiKey` parameter | The token is a per-request digest with no independent server-side lifetime. Dedicated Subsonic and app-password credentials remain valid until changed, cleared, or revoked. | Change or clear the dedicated Subsonic password. Revoke an app password individually. Account password changes and administrator-set passwords clear the dedicated Subsonic password. |
 | External API clients | `X-API-Key` header | 90 days from creation | Delete the API key. |
 | Federation peer API | Dedicated opaque `Authorization: Bearer` peer credential | No automatic expiry. | Rotate the credential, revoke the peer, or delete the peer. |
-| Internal analyzer callbacks | `x-internal-secret` header | No automatic expiry. | Rotate `INTERNAL_API_SECRET` across the backend and sidecars, then restart them. |
+| Internal sidecar requests | `x-internal-secret` header | No automatic expiry. | Rotate `INTERNAL_API_SECRET` across the backend and sidecars, then restart them. |
 
 - Token refresh uses `/api/auth/refresh`.
 - `SESSION_SECRET` remains required as the JWT signing fallback when `JWT_SECRET` is unset.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -37,31 +37,72 @@ empty libraries whose active space has never held vectors cut over immediately.
 the 2.3.0 migration begins. The 2.2.0 code does not understand the 2.3.0
 embedding-space schema or the DCLAP student vectors. Back up PostgreSQL before
 the upgrade. To roll back the release, restore that database backup and then
-redeploy the 2.2.0 images. The prior vectors retained during the grace period
-support an embedding-space rollback within the 2.3.0 migration lifecycle; they
-do not make a 2.2.0 image rollback safe.
+redeploy the 2.2.0 images. Before embedding-space cutover, you may instead
+abandon the DCLAP migration while staying on 2.3.0. Unset `VIBE_PROVIDER_URL`
+on the backend and workers, then restart them. The provider lifecycle stops,
+the prior active space keeps serving, and partial migrating-space vectors
+remain unused. After cutover, use the database restore and 2.2.0 image redeploy
+described above.
 
 **Compose warning:** Compose does not stop a service removed from the file; the
 old analyzer container becomes an orphan. A surviving analyzer writes with the
 removed single-space contract, so every embedding store against the new
-composite schema fails and can leave tracks permanently failed. Remove any
-custom override that still declares `audio-analyzer-clap`, then recreate the
-stack with orphan removal:
+composite schema fails and can leave tracks permanently failed. Use the same
+`-f` arguments as your normal deployment for every command. First, render the
+merged configuration so stale overrides are visible:
+
+```bash
+docker compose config
+```
+
+Remove any custom override that still declares `audio-analyzer-clap`. Then
+recreate the stack with orphan removal:
 
 ```bash
 docker compose up -d --remove-orphans
 ```
 
-Use the same `-f` arguments as your normal deployment if you select Compose
-files explicitly. The old torch image can be removed after the orphaned
-container is gone. Helm operators must replace
-`audioAnalyzerClap.enabled=true` with `vibeProviderDclap.enabled=true`; the DCLAP
-provider remains opt-in in individual Helm mode.
+Verify that no torch analyzer container remains. This command must print no
+container names:
 
-**Bare-metal or custom deployment:** run the provider with the music library
-mounted read-only, publish its HTTP port only where the backend and worker can
-reach it, and use the same internal secret on both sides. This example binds the
-provider to loopback for a backend on the same host:
+```bash
+docker ps --filter name=audio-analyzer-clap --format '{{.Names}}'
+```
+
+Lingering `CLAP_*` environment variables are inert and may be deleted. The old
+torch image can be removed after the orphaned container is gone. AIO operators
+may override `VIBE_PROVIDER_URL`, `MODEL_IDLE_TIMEOUT`, and
+`DCLAP_ONNX_INTRA_OP_THREADS` directly in the host environment. Use the AIO
+memory envelope in [DEPLOYMENT.md](DEPLOYMENT.md) when sizing the container.
+
+**Helm warning:** a 2.2 upgrade with `--reuse-values` carries the removed
+`audioAnalyzerClap.*` map forward and fails with the chart's migration message.
+Use `--reset-then-reuse-values` with Helm 3.14 or newer, or supply a clean
+values file that omits the legacy map. The guard runs during template or
+install/upgrade rendering. `helm lint` alone exits successfully and does not
+enforce it.
+
+This upgrade changes the track-embedding composite key while individual-mode
+Deployments may still run 2.2 pods. Scale the backend and backend-worker
+Deployments to zero before `helm upgrade`. Let the upgrade restore their
+configured replica counts. If you do not stop both workloads, accept a brief
+error window while 2.2 pods overlap the 2.3 migration. The chart exposes
+`backend.strategy.type` and `backendWorker.strategy.type`. Setting both to
+`Recreate` prevents old and new pods from overlapping within each Deployment,
+but it does not coordinate the two Deployments.
+
+**Bare-metal or custom deployment:** stop the backend and every worker before
+applying the 2.3 database migration. Run this command from the backend
+directory with the deployment's `DATABASE_URL`:
+
+```bash
+DATABASE_URL='postgresql://soundspan:password@database:5432/soundspan' npx prisma migrate deploy
+```
+
+Run the provider with the music library mounted read-only. Publish its HTTP port
+only where the backend and workers can reach it. Use the same internal secret
+on both sides. This example binds the provider to loopback for a backend on the
+same host:
 
 ```bash
 export INTERNAL_API_SECRET="replace-with-the-existing-soundspan-secret"
@@ -75,8 +116,9 @@ docker run -d \
 ```
 
 Set `VIBE_PROVIDER_URL=http://127.0.0.1:8092` on the backend and every worker
-process. A minimal systemd-managed Docker unit uses an environment file so the
-secret is not embedded in the unit:
+process. Start the provider first, then the backend, then the workers. A minimal
+systemd-managed Docker unit uses an environment file so the secret is not
+embedded in the unit:
 
 ```ini
 [Unit]

--- a/docs/designs/vibe-embedding-provider.md
+++ b/docs/designs/vibe-embedding-provider.md
@@ -88,7 +88,7 @@ Tracks added while a migration is running receive only the migrating-space vecto
 
 The producer and claim gate continuously admit `null` or `completed` tracks that lack a vector in the worker's target space, plus `pending` rebuild tracks whether or not an older target vector exists. Transient provider timeouts, connection failures, and 5xx responses return to `pending` under a three-attempt bound; content and contract failures remain terminal. This automatically heals migration and post-cutover tails. `POST /api/analysis/vibe/start` remains available as a break-glass way to enqueue missing active-space vectors immediately. Its force mode preserves serving vectors, resets track state, and uses the same bounded per-track reservation admission as the automatic producer.
 
-To abort before cutover, delete the migrating space's vectors first, then delete its registry row; `ON DELETE RESTRICT` enforces that order. To roll back after cutover but within grace, atomically return the new space to `migrating` or `retired` and restore the prior retired space to `active`. This release does not add an administration endpoint for either operation.
+To abandon the migration before cutover, unset `VIBE_PROVIDER_URL` on the backend and workers, then restart them. Provider registration, backfill, and lifecycle checks stop; the prior active space continues serving, and partial migrating-space vectors remain unused. This release has no administration endpoint for deleting that partial state or reversing a completed cutover. After cutover, release rollback requires the pre-upgrade database restore documented in `docs/UPGRADING.md`.
 
 ## Default provider: DCLAP student (ONNX)
 

--- a/frontend/app/vibe/page.tsx
+++ b/frontend/app/vibe/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/utils/cn";
-import { api } from "@/lib/api";
+import { api, vibeErrorMessage } from "@/lib/api";
 import { useFeatures } from "@/lib/features-context";
 import { useAudio } from "@/lib/audio-context";
 import { useAudioState } from "@/lib/audio-state-context";
@@ -19,10 +19,10 @@ import {
     Shuffle,
     X,
     AudioWaveform,
+    Map,
 } from "lucide-react";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 import { VibeMapTab } from "@/components/vibe/VibeMapTab";
-import { Map } from "lucide-react";
 
 interface TrackFeatures {
     energy: number;
@@ -892,9 +892,7 @@ function VibePageContent() {
                 setSimilarTracks(similarWithFeatures);
             } catch (err) {
                 setError(
-                    err instanceof Error
-                        ? err.message
-                        : "Failed to load similar tracks",
+                    vibeErrorMessage(err, "Failed to load similar tracks"),
                 );
             } finally {
                 setIsLoading(false);
@@ -946,7 +944,7 @@ function VibePageContent() {
                 );
                 setSimilarTracks(tracksWithFeatures);
             } catch (err) {
-                setError(err instanceof Error ? err.message : "Search failed");
+                setError(vibeErrorMessage(err, "Search failed"));
             } finally {
                 setIsSearching(false);
             }
@@ -978,9 +976,7 @@ function VibePageContent() {
                 setSelectedMatch(null);
             } catch (err) {
                 setError(
-                    err instanceof Error
-                        ? err.message
-                        : "Failed to load similar tracks",
+                    vibeErrorMessage(err, "Failed to load similar tracks"),
                 );
             } finally {
                 setIsLoading(false);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -27,6 +27,8 @@ import type {
     SegmentedStreamingSourceType,
 } from "@soundspan/media-metadata-contract";
 
+export { vibeErrorMessage } from "./api/vibe";
+
 // Mood Mix Types (Legacy - for old presets endpoint)
 export interface MoodPreset {
     id: string;

--- a/frontend/lib/api/core.ts
+++ b/frontend/lib/api/core.ts
@@ -17,6 +17,19 @@ interface ApiError extends Error {
     data?: Record<string, unknown>;
 }
 
+/** Narrow an unknown failure to an API error with the requested HTTP status. */
+export function hasApiErrorStatus(
+    error: unknown,
+    status: number,
+): error is Error & { status: number } {
+    return (
+        error instanceof Error &&
+        "status" in error &&
+        typeof error.status === "number" &&
+        error.status === status
+    );
+}
+
 export interface ServiceTestResult {
     success?: boolean;
     version?: string;

--- a/frontend/lib/api/vibe.ts
+++ b/frontend/lib/api/vibe.ts
@@ -1,4 +1,15 @@
-import { type ApiClientConstructor } from "./core";
+import { hasApiErrorStatus, type ApiClientConstructor } from "./core";
+
+/** Map Vibe API failures to concise operator or retry guidance. */
+export function vibeErrorMessage(error: unknown, fallback: string): string {
+    if (hasApiErrorStatus(error, 503)) {
+        return "Vibe matching is unavailable. Enable or check the DCLAP vibe provider, then try again.";
+    }
+    if (hasApiErrorStatus(error, 504)) {
+        return "Vibe matching timed out. Try again in a moment.";
+    }
+    return error instanceof Error ? error.message : fallback;
+}
 
 /** Add Vibe-domain operations to an API client base class. */
 export function WithVibe<TBase extends ApiClientConstructor>(Base: TBase) {

--- a/frontend/tests/unit/vibeErrorMessage.test.ts
+++ b/frontend/tests/unit/vibeErrorMessage.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { vibeErrorMessage } from "../../lib/api/vibe";
+
+function apiError(status: number, message: string): Error {
+    return Object.assign(new Error(message), { status });
+}
+
+test("maps provider-unavailable errors to configuration guidance", () => {
+    assert.equal(
+        vibeErrorMessage(apiError(503, "provider unavailable"), "fallback"),
+        "Vibe matching is unavailable. Enable or check the DCLAP vibe provider, then try again.",
+    );
+});
+
+test("maps provider timeouts to transient retry guidance", () => {
+    assert.equal(
+        vibeErrorMessage(apiError(504, "provider timed out"), "fallback"),
+        "Vibe matching timed out. Try again in a moment.",
+    );
+});
+
+test("preserves other API errors and the non-error fallback", () => {
+    assert.equal(
+        vibeErrorMessage(new Error("bad request"), "fallback"),
+        "bad request",
+    );
+    assert.equal(vibeErrorMessage("unknown", "fallback"), "fallback");
+});

--- a/scripts/helm-chart-render-check.sh
+++ b/scripts/helm-chart-render-check.sh
@@ -561,7 +561,14 @@ if ! line_match 'Vibe similarity: Inactive — set vibeProviderDclap.enabled=tru
   exit 1
 fi
 
-echo "[CHECK] reject removed audioAnalyzerClap values"
+echo "[CHECK] accept absent and explicitly null audioAnalyzerClap values"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  >"$tmp_dclap_default"
+helm template "$RELEASE_NAME" "$CHART_PATH" \
+  --set audioAnalyzerClap=null \
+  >"$tmp_dclap_default"
+
+echo "[CHECK] reject non-null removed audioAnalyzerClap values"
 assert_template_rejected \
   "removed audioAnalyzerClap values" \
   "audioAnalyzerClap values were removed; set vibeProviderDclap.enabled instead; see the 2.3.0 entry in docs/UPGRADING.md" \

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -111,13 +111,10 @@ def register_error_handlers(app: FastAPI, logger: logging.Logger) -> None:
 def require_internal_secret(request: Request) -> None:
     """FastAPI dependency: authenticate machine-to-machine sidecar calls.
 
-    Mirrors the backend's ``middleware/internalAuth.ts`` guard (F30): the
-    ``/health`` path is exempt (k8s probes + the backend's own sidecar health
-    checks call it without the secret), and the guard **fails closed** — if
-    ``INTERNAL_API_SECRET`` is unset, empty, or equal to the repo-published
-    default every non-health request is rejected with 403 rather than allowed
-    through. The ``x-internal-secret`` header is compared in constant time via
-    ``hmac.compare_digest``.
+    The ``/health`` path is exempt for local and orchestrator probes. Every
+    other request fails closed with 403 when ``INTERNAL_API_SECRET`` is unset,
+    empty, set to the published default, or different from the constant-time
+    ``x-internal-secret`` header comparison.
     """
     if request.url.path == "/health":
         return

--- a/services/vibe-provider-dclap/Dockerfile
+++ b/services/vibe-provider-dclap/Dockerfile
@@ -53,7 +53,13 @@ RUN set -eu; \
     for TOKENIZER_FILE in config.json merges.txt special_tokens_map.json tokenizer.json tokenizer_config.json vocab.json; do \
         curl --fail --location --retry 3 --connect-timeout 30 --max-time 600 \
             --output "/app/tokenizer/${TOKENIZER_FILE}" "${TOKENIZER_URL}/${TOKENIZER_FILE}"; \
-    done
+    done; \
+    echo "9efb9557bc804f2ca6e394486af2e45dfed0b18554909735a99c6220b84e4288  /app/tokenizer/config.json" | sha256sum -c -; \
+    echo "fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862  /app/tokenizer/merges.txt" | sha256sum -c -; \
+    echo "06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f  /app/tokenizer/special_tokens_map.json" | sha256sum -c -; \
+    echo "4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148  /app/tokenizer/tokenizer.json" | sha256sum -c -; \
+    echo "377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3  /app/tokenizer/tokenizer_config.json" | sha256sum -c -; \
+    echo "ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e  /app/tokenizer/vocab.json" | sha256sum -c -
 
 COPY services/vibe-provider-dclap/__main__.py /app/__main__.py
 COPY services/vibe-provider-dclap/http_server.py /app/http_server.py

--- a/services/vibe-provider-dclap/tests/test_dockerfile.py
+++ b/services/vibe-provider-dclap/tests/test_dockerfile.py
@@ -6,6 +6,14 @@ from pathlib import Path
 
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = (SERVICE_ROOT / "Dockerfile").read_text(encoding="utf-8")
+TOKENIZER_SHA256 = {
+    "config.json": "9efb9557bc804f2ca6e394486af2e45dfed0b18554909735a99c6220b84e4288",
+    "merges.txt": "fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862",
+    "special_tokens_map.json": "06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f",
+    "tokenizer.json": "4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148",
+    "tokenizer_config.json": "377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3",
+    "vocab.json": "ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e",
+}
 
 
 def test_model_artifacts_are_sha256_verified() -> None:
@@ -13,7 +21,7 @@ def test_model_artifacts_are_sha256_verified() -> None:
     assert "17860403f8fc90aff8ac0632a0741eb5e58d8c0b0ad2fce5ced967274b0ea971" in DOCKERFILE
     assert "2a735b23c2aad7b12d9ffc85334cebcc659c07696d2ff60e2e378da28b6df657" in DOCKERFILE
     assert "200d48f3905ff1f272af5006dd9851f94071a7dde4eafd9c07bc09c5ac65a714" in DOCKERFILE
-    assert DOCKERFILE.count("sha256sum -c -") == 3
+    assert DOCKERFILE.count("sha256sum -c -") == 9
 
 
 def test_tokenizer_is_commit_pinned_and_runtime_offline() -> None:
@@ -21,6 +29,9 @@ def test_tokenizer_is_commit_pinned_and_runtime_offline() -> None:
     assert "8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a" in DOCKERFILE
     assert "TRANSFORMERS_OFFLINE=1" in DOCKERFILE
     assert "HF_HUB_OFFLINE=1" in DOCKERFILE
+    for filename, digest in TOKENIZER_SHA256.items():
+        assert f"{digest}  /app/tokenizer/{filename}" in DOCKERFILE
+    assert DOCKERFILE.count("sha256sum -c -") == 9
 
 
 def test_image_runs_nonroot_with_authenticated_healthcheck() -> None:

--- a/tests/test_aio_image_hardening.py
+++ b/tests/test_aio_image_hardening.py
@@ -16,6 +16,14 @@ HEALTHCHECK = REPO_ROOT / "healthcheck-prod.js"
 COMPOSE_FILE = REPO_ROOT / "docker-compose.aio.yml"
 CHART_DEPLOYMENT = REPO_ROOT / "charts/soundspan/templates/aio/deployment.yaml"
 POSTGRES_CREDENTIALS = REPO_ROOT / "scripts/aio-postgres-credentials.sh"
+TOKENIZER_SHA256 = {
+    "config.json": "9efb9557bc804f2ca6e394486af2e45dfed0b18554909735a99c6220b84e4288",
+    "merges.txt": "fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862",
+    "special_tokens_map.json": "06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f",
+    "tokenizer.json": "4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148",
+    "tokenizer_config.json": "377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3",
+    "vocab.json": "ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e",
+}
 
 
 def _heredoc(dockerfile: str, target: str) -> str:
@@ -295,7 +303,10 @@ def test_analysis_tuning_env_is_parameterized() -> None:
         "8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a",
     ):
         assert pinned_value in dockerfile
-    assert dockerfile.count("sha256sum -c -") == 13
+    for filename, digest in TOKENIZER_SHA256.items():
+        path = f"/app/vibe-provider-dclap/tokenizer/{filename}"
+        assert f"{digest}  {path}" in dockerfile
+    assert dockerfile.count("sha256sum -c -") == 19
     assert "services/vibe-provider-dclap/LICENSE" in dockerfile
     assert "services/vibe-provider-dclap/NOTICE.md" in dockerfile
     assert 'TRANSFORMERS_OFFLINE="1"' in provider
@@ -309,6 +320,18 @@ def test_analysis_tuning_env_is_parameterized() -> None:
     assert "%(ENV_MUSIC_PATH)s" in provider
     assert "DATABASE_URL" not in provider
     assert "REDIS_URL" not in provider
+
+
+def test_aio_compose_exposes_provider_tuning_defaults() -> None:
+    """Allow host-level DCLAP tuning without a Compose override file."""
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+    expected = (
+        "VIBE_PROVIDER_URL=${VIBE_PROVIDER_URL:-http://localhost:8092}",
+        "MODEL_IDLE_TIMEOUT=${MODEL_IDLE_TIMEOUT:-300}",
+        "DCLAP_ONNX_INTRA_OP_THREADS=${DCLAP_ONNX_INTRA_OP_THREADS:-1}",
+    )
+    for setting in expected:
+        assert setting in compose
 
 
 def test_every_supervisord_env_placeholder_is_exported() -> None:


### PR DESCRIPTION
## Summary

X4 batch — the remaining nine round-2 findings:

- **Helm null tolerance**: absent/`null` `audioAnalyzerClap` accepted; only live legacy config rejected. Render checks cover all three cases; chart README documents that `helm lint` shows but does not enforce the failure. `--reset-then-reuse-values` guidance added for 2.2 upgraders.
- **Tokenizer byte-pinning**: all six vendored tokenizer files SHA-256-verified in both the AIO and sidecar images (digests in the Dockerfiles), with hardening tests asserting each filename→digest mapping — closing the drift hole outside the combined checkpoint identity.
- **Frontend 503/504 split**: typed API status guard; provider-unavailable shows configuration/availability guidance, timeout shows retry guidance; unit-tested; `vibe/page.tsx` stays under its size baseline (1,520/1,528).
- **Upgrade docs**: Helm rolling-migration compatibility window (scale-to-zero option + strategy knobs), bare-metal stop → `prisma migrate deploy` → ordered start, honest rollback semantics (pre-cutover: unset provider; post-cutover: DB restore), compose verification checklist (`docker compose config`, torch-container check, `CLAP_*` cleanup), and AIO provider tuning passthrough (`VIBE_PROVIDER_URL`, `MODEL_IDLE_TIMEOUT`, `DCLAP_ONNX_INTRA_OP_THREADS`) in `docker-compose.aio.yml`.
- Callback residue removed from `sidecar_runtime_utils.py` and the security guide.

## Verification

- `npm run verify:helm` fully green after rebase (incl. the three-case validation matrix); AIO hardening 26 passed; sidecar Dockerfile tests 4 passed; frontend typecheck + targeted unit test green; file-size gate green; all three AIO compose variants render.