### PR TITLE
fix(vibe)!: close the round-3 release-gate findings

### DIFF
--- a/.github/workflows/quality-visibility.yml
+++ b/.github/workflows/quality-visibility.yml
@@ -116,6 +116,10 @@ jobs:
         working-directory: backend
         run: npx prisma generate
 
+      - name: Typecheck PostgreSQL integration suite
+        working-directory: backend
+        run: npm run pretest:integration && npx tsc --noEmit -p tsconfig.integration.json
+
       - name: Run PostgreSQL integration tests
         working-directory: backend
         run: npm run test:integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,25 +37,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   index lifecycle, statement timeouts, and retired-vector cleanup.
 - Added starter Grafana panels for provider failures, migration coverage and
   failures, provider queue depth, and suppressed federation exports.
-- Added Prometheus alert rules for vibe provider failures, stalled migrations,
-  failed tracks, queue saturation, metrics collection errors, and suppressed
-  federation exports.
-- Added vibe migration and provider state to the system status API.
+- Added Prometheus alert rules for absent or stale vibe-provider heartbeats,
+  provider failures, stalled migrations, failed tracks, queue saturation,
+  metrics collection errors, and suppressed federation exports.
+- Added TTL-backed per-worker vibe migration and provider state to the system
+  status API, with a minimal provider indicator in admin settings.
 - Manual re-embed calls now leave automatic backfill headroom in the shared
   provider queue.
 
 ### Changed
 
-- Federation embedding-space headers now include an additive canonical
-  preprocessing hash. Older 2.3 peers without the field remain compatible when
-  the family, checkpoint, and dimension match, with a bounded warning.
+- Federation embedding-space headers now require the additive canonical
+  preprocessing hash whenever an identity tuple is present. The legacy window
+  applies only to a fully absent tuple in the seeded teacher space. This
+  tightens the unreleased 2.3 exchange contract; no 2.3 release used the prior
+  hashless-tuple behavior.
 - Vibe cutover now holds failure tails above the configured coverage
   tolerance unless operators explicitly acknowledge them with
   `VIBE_SPACE_CUTOVER_ALLOW_FAILED=true`.
 - Embedding-space lifecycle selection now follows the currently configured
   provider and retires abandoned migrations after the configured grace period.
-- Upgrade guidance now covers Helm reused values, the rolling migration window,
-  bare-metal stop/migrate/start order, and Compose transition verification.
+- Upgrade guidance now requires backend and worker Deployments to reach zero
+  ready replicas before Helm migration, then restores their saved replica
+  counts. It also covers reused values and Compose transition verification.
 - Vibe migration coverage telemetry now exposes failed tracks at sampling and
   cutover, while retaining the actionable coverage denominator.
 - Migrating-space vibe text scans and lifecycle coverage reads are now bounded
@@ -108,7 +112,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metrics endpoints now remain available when Redis-backed vibe queue-depth
   collection fails, while retaining the last successful sample.
 - Legacy vibe Redis cleanup is deadline-bounded, restart-durable, safe across
-  replica races, and processes complete bounded SCAN pages.
+  replica races, retries expired leases, atomically removes only non-expiring
+  reservations, and records completion only after every bounded operation.
+- Vibe invalidation now increments one generation CAS across manual rebuilds,
+  full enrichment, replacement, and stale-claim recovery. Vector storage and
+  claim completion share the same transaction, so stale workers cannot commit.
+- Workers reject retired or cleaning embedding targets transactionally, then
+  re-resolve and requeue once instead of failing the track.
+- Active-space ANN indexes now use size bands and rebuild at most once per
+  lifecycle tick when a space crosses a band boundary.
 - Retired-space cleanup now uses a durable claim across batched vector deletion
   and concurrent ANN index removal, preventing cleanup from deleting vectors
   after a space is reactivated.

--- a/backend/src/__tests__/workerEntrypointBehavior.test.ts
+++ b/backend/src/__tests__/workerEntrypointBehavior.test.ts
@@ -383,6 +383,7 @@ describe("worker entrypoint behavior", () => {
             getProviderQueueDepth: async () => {
                 throw new Error("redis unavailable");
             },
+            getProviderStatusFresh: async () => false,
         });
         const { requestHandler } = setupWorkerRuntime({
             metricsRegistryOverride: registry,

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -640,9 +640,9 @@ export const config = {
     },
 
     // pgvector ivfflat.probes: how many of the index's inverted lists each ANN
-    // ("similar tracks" / vibe) query scans. The track_embeddings index is built
-    // WITH (lists = 224); Postgres defaults probes to 1, so an unconfigured query
-    // scans 1/224 lists and recall is silently near-random. Applied per-query on
+    // ("similar tracks" / vibe) query scans. The indexes use size-banded lists
+    // capped at 224; Postgres defaults probes to 1, so an unconfigured query
+    // scans one list and recall can be silently near-random. Applied per-query on
     // the same pooled connection via utils/annQuery.ts (roadmap F14). Higher =
     // better recall, more list scans (≈ linear cost). Default is benchmark-chosen
     // for the local corpus (recall@10 ≥ ~0.95); see scripts/benchmark-ivfflat-probes.ts.

--- a/backend/src/metrics/__tests__/endpoint.test.ts
+++ b/backend/src/metrics/__tests__/endpoint.test.ts
@@ -63,6 +63,7 @@ describe("metrics endpoint", () => {
             getProviderQueueDepth: async () => {
                 throw new Error("redis unavailable");
             },
+            getProviderStatusFresh: async () => false,
         });
         const router = createMetricsRouter({
             registry,

--- a/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
+++ b/backend/src/metrics/__tests__/vibeEmbedMetrics.test.ts
@@ -4,11 +4,14 @@ import { createVibeEmbedMetrics } from "../vibeEmbedMetrics";
 describe("vibe embed metrics", () => {
     function createMetrics(registry: Registry, queueDepth = 0) {
         const getProviderQueueDepth = jest.fn(async () => queueDepth);
+        const getProviderStatusFresh = jest.fn(async () => true);
         return {
             metrics: createVibeEmbedMetrics(registry, {
                 getProviderQueueDepth,
+                getProviderStatusFresh,
             }),
             getProviderQueueDepth,
+            getProviderStatusFresh,
         };
     }
 
@@ -114,7 +117,10 @@ describe("vibe embed metrics", () => {
             .fn<Promise<number>, []>()
             .mockResolvedValueOnce(7)
             .mockRejectedValueOnce(new Error("redis unavailable"));
-        createVibeEmbedMetrics(registry, { getProviderQueueDepth });
+        createVibeEmbedMetrics(registry, {
+            getProviderQueueDepth,
+            getProviderStatusFresh: jest.fn(async () => true),
+        });
 
         const firstExposition = await registry.metrics();
         const degradedExposition = await registry.metrics();
@@ -143,5 +149,27 @@ describe("vibe embed metrics", () => {
             "soundspan_vibe_provider_queue_capacity 100",
         );
         expect(exposition).toContain("soundspan_vibe_migration_active 1");
+    });
+
+    it("collects provider heartbeat freshness on each scrape", async () => {
+        const registry = new Registry();
+        const { getProviderStatusFresh } = createMetrics(registry);
+
+        const exposition = await registry.metrics();
+
+        expect(getProviderStatusFresh).toHaveBeenCalledTimes(1);
+        expect(exposition).toContain("soundspan_vibe_provider_status_fresh 1");
+    });
+
+    it("publishes zero when no provider heartbeat is fresh", async () => {
+        const registry = new Registry();
+        createVibeEmbedMetrics(registry, {
+            getProviderQueueDepth: jest.fn(async () => 0),
+            getProviderStatusFresh: jest.fn(async () => false),
+        });
+
+        await expect(registry.metrics()).resolves.toContain(
+            "soundspan_vibe_provider_status_fresh 0",
+        );
     });
 });

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -38,6 +38,13 @@ const vibeEmbedMetrics = createVibeEmbedMetrics(metricsRegistry, {
         const { redisClient } = await import("../utils/redis");
         return redisClient.lLen(VIBE_PROVIDER_QUEUE_KEY);
     },
+    getProviderStatusFresh: async () => {
+        const [{ redisClient }, { readVibeWorkerStatus }] = await Promise.all([
+            import("../utils/redis"),
+            import("../workers/vibeWorkerStatus"),
+        ]);
+        return (await readVibeWorkerStatus(redisClient)) !== null;
+    },
 });
 
 /** Express middleware recording bounded HTTP request duration labels. */

--- a/backend/src/metrics/vibeEmbedMetrics.ts
+++ b/backend/src/metrics/vibeEmbedMetrics.ts
@@ -38,6 +38,7 @@ export interface VibeEmbedMetrics {
     vocabularySpaceMismatches: Counter<"reason">;
     collectionErrors: Counter<"collector">;
     providerQueueDepth: Gauge;
+    providerStatusFresh: Gauge;
     providerQueueCapacity: Gauge;
     migrationActive: Gauge;
     recordJob(outcome: VibeEmbedJobOutcome): void;
@@ -54,6 +55,7 @@ export interface VibeEmbedMetrics {
 /** Scrape-time dependencies for provider queue instrumentation. */
 export interface VibeEmbedMetricsDependencies {
     getProviderQueueDepth(): Promise<number>;
+    getProviderStatusFresh(): Promise<boolean>;
 }
 
 function createOutcomeMetrics(registry: Registry) {
@@ -90,7 +92,10 @@ function createQueueCollectionMetrics(
     dependencies: VibeEmbedMetricsDependencies,
 ): Pick<
     VibeEmbedMetrics,
-    "collectionErrors" | "providerQueueDepth" | "vocabularySpaceMismatches"
+    | "collectionErrors"
+    | "providerQueueDepth"
+    | "providerStatusFresh"
+    | "vocabularySpaceMismatches"
 > {
     const collectionErrors = new Counter({
         name: "soundspan_metrics_collection_errors_total",
@@ -119,7 +124,25 @@ function createQueueCollectionMetrics(
         },
     });
     providerQueueDepth.reset();
-    return { collectionErrors, providerQueueDepth, vocabularySpaceMismatches };
+    const providerStatusFresh = new Gauge({
+        name: "soundspan_vibe_provider_status_fresh",
+        help: "Whether Redis contains at least one unexpired vibe worker status heartbeat.",
+        registers: [registry],
+        async collect() {
+            try {
+                this.set((await dependencies.getProviderStatusFresh()) ? 1 : 0);
+            } catch {
+                this.set(0);
+                collectionErrors.inc({ collector: "vibe_provider_status" });
+            }
+        },
+    });
+    return {
+        collectionErrors,
+        providerQueueDepth,
+        providerStatusFresh,
+        vocabularySpaceMismatches,
+    };
 }
 
 function createOperationalGauges(registry: Registry) {

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -708,6 +708,7 @@ describe("analysis routes runtime", () => {
                 vibeAnalysisStartedAt: null,
                 vibeAnalysisRetryCount: 0,
                 vibeAnalysisStatusUpdatedAt: expect.any(Date),
+                vibeAnalysisGeneration: { increment: 1 },
             }),
         });
         expect(mockRedisMulti).not.toHaveBeenCalled();

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -107,6 +107,7 @@ const prisma = {
         findFirst: jest.fn(),
         findUnique: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(async () => ({ count: 1 })),
     },
     systemSettings: {
         findUnique: jest.fn(),
@@ -1145,15 +1146,16 @@ describe("enrichment route runtime behavior", () => {
             res,
         );
 
-        expect(mockTrackUpdate).toHaveBeenCalledWith({
+        expect(prisma.track.updateMany).toHaveBeenCalledWith({
             where: { id: "track-vibe" },
-            data: {
+            data: expect.objectContaining({
                 vibeAnalysisStatus: "pending",
                 vibeAnalysisError: null,
                 vibeAnalysisRetryCount: 0,
                 vibeAnalysisStartedAt: null,
                 vibeAnalysisStatusUpdatedAt: expect.any(Date),
-            },
+                vibeAnalysisGeneration: { increment: 1 },
+            }),
         });
         expect(res.body).toEqual({
             message:

--- a/backend/src/routes/__tests__/systemCore.test.ts
+++ b/backend/src/routes/__tests__/systemCore.test.ts
@@ -91,6 +91,7 @@ describe("system routes integration", () => {
                     configured: true,
                     reachable: true,
                     checkedAt: "2026-08-17T12:00:00.000Z",
+                    fresh: true,
                 },
                 activeSpace: { id: "space-active", family: "teacher" },
                 migration: {

--- a/backend/src/routes/__tests__/systemRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemRuntime.test.ts
@@ -107,6 +107,7 @@ describe("system routes runtime", () => {
                     configured: true,
                     reachable: false,
                     checkedAt: "2026-08-17T12:00:00.000Z",
+                    fresh: true,
                 },
                 activeSpace: { id: "space-active", family: "teacher" },
                 migration: {
@@ -126,6 +127,7 @@ describe("system routes runtime", () => {
                 configured: true,
                 reachable: false,
                 checkedAt: "2026-08-17T12:00:00.000Z",
+                fresh: true,
             },
             activeSpace: { id: "space-active", family: "teacher" },
             migration: {

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -17,6 +17,7 @@ import {
 } from "../utils/librarySorting";
 import { config } from "../config";
 import { enqueueReservedNodeRedisWork } from "../workers/enrichmentQueue";
+import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
 
 const router = Router();
 
@@ -54,14 +55,7 @@ interface ManualVibeTrack {
 
 async function resetVibeTracksForForce(force: boolean): Promise<void> {
     if (!force) return;
-    await prisma.track.updateMany({
-        where: LOCAL_TRACK_WHERE,
-        data: {
-            ...buildVibePendingReset(),
-            vibeAnalysisRetryCount: 0,
-            vibeAnalysisGeneration: { increment: 1 },
-        },
-    });
+    await invalidateVibeAnalysis(prisma, LOCAL_TRACK_WHERE, new Date());
     await enrichmentFailureService.clearAllFailures("vibe");
     logger.info(
         "Preserved active vibe embeddings and reset tracks for re-generation",
@@ -820,29 +814,27 @@ router.post("/vibe/start", requireAuth, requireAdmin, async (req, res) => {
  */
 router.post("/vibe/retry", requireAuth, requireAdmin, async (req, res) => {
     try {
-        const result = await prisma.track.updateMany({
-            where: {
+        const reset = await invalidateVibeAnalysis(
+            prisma,
+            {
                 vibeAnalysisStatus: "failed",
                 ...LOCAL_TRACK_WHERE,
             },
-            data: {
-                ...buildVibePendingReset(),
-                vibeAnalysisRetryCount: 0,
-            },
-        });
+            new Date(),
+        );
 
-        if (result.count === 0) {
+        if (reset === 0) {
             return res.json({
                 message: "No vibe failures to retry",
                 reset: 0,
             });
         }
 
-        logger.info(`Reset ${result.count} failed vibe embeddings for retry`);
+        logger.info(`Reset ${reset} failed vibe embeddings for retry`);
 
         res.json({
-            message: `Reset ${result.count} failed tracks for vibe embedding retry`,
-            reset: result.count,
+            message: `Reset ${reset} failed tracks for vibe embedding retry`,
+            reset,
         });
     } catch (error: any) {
         logger.error("Retry vibe failures error:", error);

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -33,6 +33,7 @@ import { config } from "../config";
 import { sendFeatureDisabled } from "../utils/featureGate";
 import { parseBoundedInt } from "../utils/queryParams";
 import { sendRouteError } from "./routeErrorResponse";
+import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
 
 const router = Router();
 
@@ -1202,17 +1203,13 @@ router.post("/retry", requireAdmin, async (req, res) => {
                         continue;
                     }
 
-                    await prisma.track.update({
-                        where: { id: failure.entityId },
-                        data: {
-                            vibeAnalysisStatus: "pending",
-                            vibeAnalysisError: null,
-                            vibeAnalysisRetryCount: 0,
-                            vibeAnalysisStartedAt: null,
-                            vibeAnalysisStatusUpdatedAt: new Date(),
-                        },
-                    });
-                    queued++;
+                    const reset = await invalidateVibeAnalysis(
+                        prisma,
+                        { id: failure.entityId },
+                        new Date(),
+                    );
+                    if (reset === 1) queued++;
+                    else skipped++;
                 }
             } catch (error) {
                 logger.error(

--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -29,11 +29,12 @@ const router = Router();
  *                   properties:
  *                     provider:
  *                       type: object
- *                       required: [configured, reachable, checkedAt]
+ *                       required: [configured, reachable, checkedAt, fresh]
  *                       properties:
  *                         configured: { type: boolean }
  *                         reachable: { type: boolean, nullable: true }
  *                         checkedAt: { type: string, format: date-time, nullable: true }
+ *                         fresh: { type: boolean }
  *                     activeSpace:
  *                       type: object
  *                       nullable: true

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -140,7 +140,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/tidal.ts` | Core |
 | `backend/src/services/tidalStreaming.ts` | Core |
 | `backend/src/services/trackMappingService.ts` | Core |
-| `backend/src/services/trackEmbeddings.ts` | Vibe pgvector reads, ANN queries, and embedding counts |
+| `backend/src/services/trackEmbeddings.ts` | Transactional vibe pgvector reads, writes, generation finalization, ANN queries, and embedding counts |
 | `backend/src/services/trackIdentityMatcher.ts` | Durable track move identity matching |
 | `backend/src/services/trackPreference.ts` | Core |
 | `backend/src/services/trackReconciliation.ts` | Core |
@@ -152,6 +152,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/vibeEmbedJobs.ts` | Provider-backed audio embedding job lifecycle |
 | `backend/src/services/vibeEmbeddingCoverage.ts` | Worker target-space audio embedding coverage metrics |
 | `backend/src/services/vibeEmbeddingEligibility.ts` | Shared local-track eligibility for vibe production and coverage |
+| `backend/src/services/vibeInvalidation.ts` | Atomic vibe-state reset and generation invalidation fence |
 | `backend/src/services/vibeProvider.ts` | Validated, bounded vibe-provider HTTP client and registry-space trust boundaries |
 | `backend/src/services/vibeVocabulary.ts` | Core |
 | `backend/src/services/vibeVocabularyGenerator.ts` | Testable provider-backed vocabulary artifact generation |

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -76,6 +76,7 @@ import {
     ANN_INDEX_MIN_VECTOR_COUNT,
     MAX_RETIREMENT_DELETE_BATCHES,
     RETIREMENT_DELETE_BATCH_SIZE,
+    annIndexListsForVectorCount,
     retirementDue,
     runEmbeddingSpaceLifecycleCheck,
     shouldBuildAnnIndex,
@@ -139,6 +140,17 @@ describe("embedding-space lifecycle decisions", () => {
         [ANN_INDEX_MIN_VECTOR_COUNT + 1, true],
     ])("builds an ANN index for %s vectors: %s", (vectorCount, expected) => {
         expect(shouldBuildAnnIndex(vectorCount)).toBe(expected);
+    });
+
+    it.each([
+        [999, null],
+        [1_000, 40],
+        [2_499, 40],
+        [2_500, 100],
+        [5_000, 200],
+        [10_000, 224],
+    ])("sizes %s vectors into the %s-list band", (rows, lists) => {
+        expect(annIndexListsForVectorCount(rows)).toBe(lists);
     });
 });
 
@@ -305,7 +317,9 @@ describe("embedding-space lifecycle effects", () => {
             failed: 0,
         });
         mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
-        mockQueryRaw.mockResolvedValue([{ isValid: true }]);
+        mockQueryRaw.mockResolvedValue([
+            { isValid: true, options: ["lists=40"] },
+        ]);
 
         await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 
@@ -345,7 +359,7 @@ describe("embedding-space lifecycle effects", () => {
                 failed: 10,
             },
         );
-        expect(mockQueryRaw).not.toHaveBeenCalled();
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
         expect(mockTransaction).not.toHaveBeenCalled();
     });
 
@@ -423,7 +437,9 @@ describe("embedding-space lifecycle effects", () => {
             failed: 0,
         });
         mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
-        mockQueryRaw.mockResolvedValue([{ isValid: false }]);
+        mockQueryRaw.mockResolvedValue([
+            { isValid: false, options: ["lists=40"] },
+        ]);
 
         await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 
@@ -456,8 +472,27 @@ describe("embedding-space lifecycle effects", () => {
 
         await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 
-        expect(mockQueryRaw).not.toHaveBeenCalled();
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
         expect(mockExecuteRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it("rebuilds at most once when the active space crosses a list band", async () => {
+        mockEmbeddingCount.mockResolvedValue(2_500);
+        mockQueryRaw.mockResolvedValue([
+            { isValid: true, options: ["lists=40"] },
+        ]);
+
+        await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
+
+        expect(mockExecuteRawUnsafe).toHaveBeenCalledTimes(2);
+        expect(mockExecuteRawUnsafe).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("DROP INDEX CONCURRENTLY"),
+        );
+        expect(mockExecuteRawUnsafe).toHaveBeenNthCalledWith(
+            2,
+            expect.stringContaining("WITH (lists = 100)"),
+        );
     });
 
     it("selects the current provider migration instead of an older abandoned space", async () => {

--- a/backend/src/services/__tests__/featureDetection.test.ts
+++ b/backend/src/services/__tests__/featureDetection.test.ts
@@ -81,6 +81,7 @@ describe("featureDetection service", () => {
                         configured: expected,
                         reachable: null,
                         checkedAt: null,
+                        fresh: false,
                     },
                     activeSpace: {
                         id: "space-active",
@@ -106,6 +107,7 @@ describe("featureDetection service", () => {
                     configured: false,
                     reachable: null,
                     checkedAt: null,
+                    fresh: false,
                 },
                 activeSpace: {
                     id: "space-active",
@@ -130,6 +132,7 @@ describe("featureDetection service", () => {
                     configured: false,
                     reachable: null,
                     checkedAt: null,
+                    fresh: false,
                 },
                 activeSpace: {
                     id: "space-active",
@@ -163,6 +166,7 @@ describe("featureDetection service", () => {
                     configured: false,
                     reachable: null,
                     checkedAt: null,
+                    fresh: false,
                 },
                 activeSpace: {
                     id: "space-active",
@@ -197,6 +201,7 @@ describe("featureDetection service", () => {
                 configured: true,
                 reachable: true,
                 checkedAt: "2026-08-17T12:00:00.000Z",
+                fresh: true,
             },
             activeSpace: {
                 id: "space-active",
@@ -228,6 +233,7 @@ describe("featureDetection service", () => {
                 configured: true,
                 reachable: null,
                 checkedAt: null,
+                fresh: false,
             },
             activeSpace: null,
             migration: null,

--- a/backend/src/services/__tests__/federationEmbeddingSpace.test.ts
+++ b/backend/src/services/__tests__/federationEmbeddingSpace.test.ts
@@ -45,10 +45,10 @@ describe("federation embedding-space decision", () => {
         }
     });
 
-    it("accepts a 2.3 tuple without preprocessingHash when the original fields match", () => {
+    it("rejects a present tuple without preprocessingHash", () => {
         const { preprocessingHash: _omitted, ...legacyTuple } = tuple;
         expect(decideFederationEmbeddingPage(legacyTuple, canonicalSpace)).toBe(
-            "stored",
+            "skipped_mismatch",
         );
     });
 

--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -1318,6 +1318,7 @@ describe("MusicScannerService.scanLibrary", () => {
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([candidate]);
         mockPrisma.track.upsert.mockResolvedValueOnce(candidate);
+        mockPrisma.track.updateMany.mockResolvedValueOnce({ count: 1 });
         mockPrisma.transcodedFile.findMany.mockResolvedValueOnce([
             { cachePath: "track-old-high.mp3" },
         ]);
@@ -1331,7 +1332,7 @@ describe("MusicScannerService.scanLibrary", () => {
                 tracksRemoved: 0,
             }),
         );
-        expect(mockPrisma.track.update).toHaveBeenCalledWith({
+        expect(mockPrisma.track.updateMany).toHaveBeenCalledWith({
             where: { id: "track-old" },
             data: expect.objectContaining({
                 filePath: "Artist/Album/01 Song.flac",
@@ -1346,6 +1347,7 @@ describe("MusicScannerService.scanLibrary", () => {
                 vibeAnalysisRetryCount: 0,
                 vibeAnalysisStartedAt: null,
                 vibeAnalysisStatusUpdatedAt: expect.any(Date),
+                vibeAnalysisGeneration: { increment: 1 },
             }),
         });
         expect(mockPrisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
@@ -1377,6 +1379,7 @@ describe("MusicScannerService.scanLibrary", () => {
         ).mockResolvedValue([audioFile]);
         mockPrisma.track.findMany.mockResolvedValueOnce([oldTrack]);
         mockPrisma.track.upsert.mockResolvedValueOnce({ id: "track-old" });
+        mockPrisma.track.updateMany.mockResolvedValueOnce({ count: 1 });
         mockComputeAudioStreamHash.mockResolvedValueOnce(newHash);
         mockPrisma.transcodedFile.findMany.mockResolvedValueOnce([
             { cachePath: "track-old-medium.mp3" },
@@ -1397,7 +1400,7 @@ describe("MusicScannerService.scanLibrary", () => {
                 update: expect.objectContaining({ audioHash: newHash }),
             }),
         );
-        expect(mockPrisma.track.update).toHaveBeenCalledWith({
+        expect(mockPrisma.track.updateMany).toHaveBeenCalledWith({
             where: { id: "track-old" },
             data: expect.objectContaining({
                 analysisStatus: "pending",
@@ -1405,6 +1408,7 @@ describe("MusicScannerService.scanLibrary", () => {
                 analysisRetryCount: 0,
                 vibeAnalysisStatus: "pending",
                 vibeAnalysisRetryCount: 0,
+                vibeAnalysisGeneration: { increment: 1 },
             }),
         });
         expect(mockPrisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({
@@ -1594,6 +1598,7 @@ describe("MusicScannerService.scanLibrary", () => {
         ).mockResolvedValue([audioFile]);
         mockComputeAudioStreamHash.mockResolvedValueOnce(newHash);
         mockPrisma.track.upsert.mockResolvedValueOnce(candidate);
+        mockPrisma.track.updateMany.mockResolvedValueOnce({ count: 1 });
         mockPrisma.track.findMany
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([])
@@ -1605,7 +1610,7 @@ describe("MusicScannerService.scanLibrary", () => {
 
         const result = await scanner.scanLibrary("/music");
 
-        expect(mockPrisma.track.update).toHaveBeenCalledWith({
+        expect(mockPrisma.track.updateMany).toHaveBeenCalledWith({
             where: { id: "track-removed" },
             data: expect.objectContaining({
                 filePath: "New/01 Song.flac",
@@ -1613,6 +1618,7 @@ describe("MusicScannerService.scanLibrary", () => {
                 removedAt: null,
                 analysisStatus: "pending",
                 vibeAnalysisStatus: "pending",
+                vibeAnalysisGeneration: { increment: 1 },
             }),
         });
         expect(mockPrisma.trackEmbedding.deleteMany).toHaveBeenCalledWith({

--- a/backend/src/services/__tests__/trackEmbeddings.test.ts
+++ b/backend/src/services/__tests__/trackEmbeddings.test.ts
@@ -3,7 +3,7 @@ jest.mock("../../utils/db", () => ({
         $executeRaw: jest.fn(),
         $queryRaw: jest.fn(),
         $transaction: jest.fn(),
-        track: { findMany: jest.fn() },
+        track: { findMany: jest.fn(), updateMany: jest.fn() },
         embeddingSpace: {
             findUnique: jest.fn(),
             updateMany: jest.fn(),
@@ -48,9 +48,11 @@ beforeEach(() => {
         async (operation: (transaction: unknown) => Promise<unknown>) =>
             operation({
                 $executeRaw: prisma.$executeRaw,
+                $queryRaw: prisma.$queryRaw,
                 embeddingSpace: {
                     updateMany: prisma.embeddingSpace.updateMany,
                 },
+                track: { updateMany: prisma.track.updateMany },
             }),
     );
     mockGetActiveSpace.mockResolvedValue({
@@ -66,9 +68,7 @@ beforeEach(() => {
 describe("upsertTrackEmbedding", () => {
     it("writes a complete finite CLAP vector", async () => {
         (prisma.$executeRaw as jest.Mock).mockResolvedValue(1);
-        (prisma.embeddingSpace.findUnique as jest.Mock).mockResolvedValue({
-            dim: 512,
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ dim: 512 }]);
         (prisma.embeddingSpace.updateMany as jest.Mock).mockResolvedValue({
             count: 1,
         });
@@ -87,21 +87,21 @@ describe("upsertTrackEmbedding", () => {
         expect(query.join(" ")).not.toContain("model_version");
         expect(values).toContain("space-target");
         expect(query.join(" ")).toContain("ON CONFLICT (track_id, space_id)");
-        expect(prisma.embeddingSpace.findUnique).toHaveBeenCalledWith({
-            where: { id: "space-target" },
-            select: { dim: true },
-        });
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
         expect(prisma.embeddingSpace.updateMany).toHaveBeenCalledWith({
-            where: { id: "space-target", hadVectors: false },
+            where: {
+                id: "space-target",
+                status: { in: ["active", "migrating"] },
+                cleaningAt: null,
+                hadVectors: false,
+            },
             data: { hadVectors: true },
         });
     });
 
     it("rolls back the vector write when the hadVectors marker fails", async () => {
         (prisma.$executeRaw as jest.Mock).mockResolvedValue(1);
-        (prisma.embeddingSpace.findUnique as jest.Mock).mockResolvedValue({
-            dim: 2,
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ dim: 2 }]);
         (prisma.embeddingSpace.updateMany as jest.Mock).mockRejectedValue(
             new Error("marker write failed"),
         );
@@ -116,13 +116,77 @@ describe("upsertTrackEmbedding", () => {
     });
 
     it("rejects malformed vectors before writing", async () => {
-        (prisma.embeddingSpace.findUnique as jest.Mock).mockResolvedValue({
-            dim: 2,
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ dim: 2 }]);
         await expect(
             upsertTrackEmbedding("track-1", [0.25], "space-two-dimensional"),
         ).rejects.toThrow("2 finite values");
         expect(prisma.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it("rejects a retired target before writing", async () => {
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([]);
+
+        await expect(
+            upsertTrackEmbedding("track-1", [0.6, 0.8], "space-retired"),
+        ).rejects.toMatchObject({
+            name: "EmbeddingTargetInvalidatedError",
+            spaceId: "space-retired",
+        });
+
+        expect(prisma.$executeRaw).not.toHaveBeenCalled();
+        expect(prisma.embeddingSpace.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("completes only the claimed generation in the vector transaction", async () => {
+        const completedAt = new Date("2026-08-17T12:00:00.000Z");
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ dim: 2 }]);
+        (prisma.track.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+        (prisma.$executeRaw as jest.Mock).mockResolvedValue(1);
+        (prisma.embeddingSpace.updateMany as jest.Mock).mockResolvedValue({
+            count: 0,
+        });
+
+        await upsertTrackEmbedding(
+            "track-claimed",
+            [0.6, 0.8],
+            "space-target",
+            { generation: 7, completedAt },
+        );
+
+        expect(prisma.track.updateMany).toHaveBeenCalledWith({
+            where: {
+                id: "track-claimed",
+                origin: "LOCAL",
+                removedAt: null,
+                vibeAnalysisStatus: "processing",
+                vibeAnalysisGeneration: 7,
+            },
+            data: {
+                vibeAnalysisStatus: "completed",
+                vibeAnalysisError: null,
+                vibeAnalysisStartedAt: null,
+                vibeAnalysisStatusUpdatedAt: completedAt,
+            },
+        });
+    });
+
+    it("aborts a stale generation before the vector upsert", async () => {
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ dim: 2 }]);
+        (prisma.track.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+        await expect(
+            upsertTrackEmbedding("track-stale", [0.6, 0.8], "space-target", {
+                generation: 4,
+                completedAt: new Date("2026-08-17T12:00:00.000Z"),
+            }),
+        ).rejects.toMatchObject({
+            name: "VibeEmbeddingGenerationMismatchError",
+            trackId: "track-stale",
+            generation: 4,
+        });
+
+        expect(prisma.$executeRaw).not.toHaveBeenCalled();
+        expect(prisma.embeddingSpace.updateMany).not.toHaveBeenCalled();
     });
 });
 

--- a/backend/src/services/__tests__/trackReplacement.test.ts
+++ b/backend/src/services/__tests__/trackReplacement.test.ts
@@ -1,0 +1,39 @@
+jest.mock("../../config", () => ({
+    config: { music: { transcodeCachePath: "/tmp/soundspan-test-cache" } },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: { child: () => ({ warn: jest.fn() }) },
+}));
+
+jest.mock("../../utils/db", () => ({ prisma: {} }));
+
+import { applyTrackReplacement } from "../trackReplacement";
+
+describe("track replacement", () => {
+    it("invalidates vibe work with a generation increment in the transaction", async () => {
+        const transaction = {
+            track: { updateMany: jest.fn(async () => ({ count: 1 })) },
+            trackEmbedding: {
+                deleteMany: jest.fn(async () => ({ count: 1 })),
+            },
+            transcodedFile: {
+                findMany: jest.fn(async () => [{ cachePath: "track.opus" }]),
+                deleteMany: jest.fn(async () => ({ count: 1 })),
+            },
+        };
+
+        await expect(
+            applyTrackReplacement(transaction as never, "track-1"),
+        ).resolves.toEqual(["track.opus"]);
+
+        expect(transaction.track.updateMany).toHaveBeenCalledWith({
+            where: { id: "track-1" },
+            data: expect.objectContaining({
+                analysisStatus: "pending",
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisGeneration: { increment: 1 },
+            }),
+        });
+    });
+});

--- a/backend/src/services/__tests__/vibeAnalysisCleanup.test.ts
+++ b/backend/src/services/__tests__/vibeAnalysisCleanup.test.ts
@@ -1,12 +1,12 @@
 const mockTrackFindMany = jest.fn();
-const mockTrackUpdate = jest.fn();
+const mockTrackUpdateMany = jest.fn();
 const mockLoggerDebug = jest.fn();
 
 jest.mock("../../utils/db", () => ({
     prisma: {
         track: {
             findMany: (...args: unknown[]) => mockTrackFindMany(...args),
-            update: (...args: unknown[]) => mockTrackUpdate(...args),
+            updateMany: (...args: unknown[]) => mockTrackUpdateMany(...args),
         },
     },
 }));
@@ -42,15 +42,19 @@ describe("vibeAnalysisCleanupService", () => {
                     },
                 ],
             },
-            include: {
+            select: {
+                id: true,
+                title: true,
+                vibeAnalysisGeneration: true,
+                vibeAnalysisStatusUpdatedAt: true,
                 album: {
-                    include: {
+                    select: {
                         artist: { select: { name: true } },
                     },
                 },
             },
         });
-        expect(mockTrackUpdate).not.toHaveBeenCalled();
+        expect(mockTrackUpdateMany).not.toHaveBeenCalled();
         expect(result).toEqual({ reset: 0 });
     });
 
@@ -59,34 +63,55 @@ describe("vibeAnalysisCleanupService", () => {
             {
                 id: "t1",
                 title: "Track One",
+                vibeAnalysisGeneration: 3,
+                vibeAnalysisStatusUpdatedAt: new Date(
+                    "2026-08-17T10:00:00.000Z",
+                ),
                 album: { artist: { name: "Artist One" } },
             },
             {
                 id: "t2",
                 title: "Track Two",
+                vibeAnalysisGeneration: 5,
+                vibeAnalysisStatusUpdatedAt: null,
                 album: { artist: { name: "Artist Two" } },
             },
         ]);
-        mockTrackUpdate.mockResolvedValue({});
+        mockTrackUpdateMany.mockResolvedValue({ count: 1 });
 
         const result =
             await vibeAnalysisCleanupService.cleanupStaleProcessing();
 
-        expect(mockTrackUpdate).toHaveBeenCalledTimes(2);
-        expect(mockTrackUpdate).toHaveBeenNthCalledWith(1, {
-            where: { id: "t1" },
-            data: {
-                vibeAnalysisStatus: null,
-                vibeAnalysisStatusUpdatedAt: null,
-            },
-        });
-        expect(mockTrackUpdate).toHaveBeenNthCalledWith(2, {
-            where: { id: "t2" },
-            data: {
-                vibeAnalysisStatus: null,
-                vibeAnalysisStatusUpdatedAt: null,
-            },
-        });
+        expect(mockTrackUpdateMany).toHaveBeenCalledTimes(2);
+        expect(mockTrackUpdateMany).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                where: {
+                    id: "t1",
+                    vibeAnalysisStatus: "processing",
+                    vibeAnalysisGeneration: 3,
+                    vibeAnalysisStatusUpdatedAt: new Date(
+                        "2026-08-17T10:00:00.000Z",
+                    ),
+                },
+                data: expect.objectContaining({
+                    vibeAnalysisStatus: "pending",
+                    vibeAnalysisGeneration: { increment: 1 },
+                }),
+            }),
+        );
+        expect(mockTrackUpdateMany).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    id: "t2",
+                    vibeAnalysisGeneration: 5,
+                }),
+                data: expect.objectContaining({
+                    vibeAnalysisGeneration: { increment: 1 },
+                }),
+            }),
+        );
         expect(mockLoggerDebug).toHaveBeenCalledWith(
             "[VibeAnalysisCleanup] Found 2 stale vibe tracks (processing > 30 min)",
         );
@@ -104,14 +129,16 @@ describe("vibeAnalysisCleanupService", () => {
             {
                 id: "t1",
                 title: "Track One",
+                vibeAnalysisGeneration: 0,
+                vibeAnalysisStatusUpdatedAt: null,
                 album: { artist: { name: "Artist One" } },
             },
         ]);
-        mockTrackUpdate.mockRejectedValueOnce(new Error("write failed"));
+        mockTrackUpdateMany.mockRejectedValueOnce(new Error("write failed"));
 
         await expect(
             vibeAnalysisCleanupService.cleanupStaleProcessing(),
         ).rejects.toThrow("write failed");
-        expect(mockTrackUpdate).toHaveBeenCalledTimes(1);
+        expect(mockTrackUpdateMany).toHaveBeenCalledTimes(1);
     });
 });

--- a/backend/src/services/__tests__/vibeEmbedJobs.test.ts
+++ b/backend/src/services/__tests__/vibeEmbedJobs.test.ts
@@ -30,6 +30,10 @@ import {
     VibeProviderTimeoutError,
     VibeProviderUnavailableError,
 } from "../vibeProvider";
+import {
+    EmbeddingTargetInvalidatedError,
+    VibeEmbeddingGenerationMismatchError,
+} from "../trackEmbeddings";
 
 describe("vibe provider retry classification", () => {
     it.each([
@@ -152,24 +156,12 @@ describe("vibe embed job processor", () => {
             "track-1",
             [0.6, 0.8],
             "space-provider",
+            {
+                generation: 0,
+                completedAt: new Date("2026-08-16T12:00:00.000Z"),
+            },
         );
-        expect(harness.prisma.track.updateMany).toHaveBeenLastCalledWith({
-            where: {
-                id: "track-1",
-                origin: "LOCAL",
-                removedAt: null,
-                vibeAnalysisStatus: "processing",
-                vibeAnalysisGeneration: 0,
-            },
-            data: {
-                vibeAnalysisStatus: "completed",
-                vibeAnalysisError: null,
-                vibeAnalysisStartedAt: null,
-                vibeAnalysisStatusUpdatedAt: new Date(
-                    "2026-08-16T12:00:00.000Z",
-                ),
-            },
-        });
+        expect(harness.prisma.track.updateMany).toHaveBeenCalledTimes(1);
         expect(harness.resolveByEntity).toHaveBeenCalledWith("vibe", "track-1");
         expect(harness.recordOutcome).toHaveBeenCalledWith("stored");
     });
@@ -593,20 +585,21 @@ describe("vibe embed job processor", () => {
                 vibeAnalysisRetryCount: 0,
                 vibeAnalysisGeneration: 0,
             })
-            .mockResolvedValueOnce({ id: "track-force-race" })
             .mockResolvedValueOnce({
                 id: "track-force-race",
                 title: "Force Race",
                 vibeAnalysisStatus: "pending",
                 vibeAnalysisRetryCount: 0,
                 vibeAnalysisGeneration: 1,
-            })
-            .mockResolvedValueOnce({ id: "track-force-race" });
+            });
         harness.prisma.track.updateMany
             .mockResolvedValueOnce({ count: 1 })
-            .mockResolvedValueOnce({ count: 0 })
-            .mockResolvedValueOnce({ count: 1 })
             .mockResolvedValueOnce({ count: 1 });
+        harness.upsertTrackEmbedding
+            .mockRejectedValueOnce(
+                new VibeEmbeddingGenerationMismatchError("track-force-race", 0),
+            )
+            .mockResolvedValueOnce(undefined);
         const payload = JSON.stringify({
             trackId: "track-force-race",
             filePath: "artist/force.flac",
@@ -621,16 +614,6 @@ describe("vibe embed job processor", () => {
             2,
             expect.objectContaining({
                 where: expect.objectContaining({
-                    vibeAnalysisStatus: "processing",
-                    vibeAnalysisGeneration: 0,
-                }),
-            }),
-        );
-        expect(harness.prisma.track.updateMany).toHaveBeenNthCalledWith(
-            4,
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    vibeAnalysisStatus: "processing",
                     vibeAnalysisGeneration: 1,
                 }),
             }),
@@ -686,11 +669,15 @@ describe("vibe embed job processor", () => {
         });
     });
 
-    it("does not store when the track is removed during inference", async () => {
+    it("treats a removed track during transactional finalization as stale", async () => {
         const harness = createHarness();
-        harness.prisma.track.findFirst
-            .mockResolvedValueOnce({ id: "track-4", title: "Track Four" })
-            .mockResolvedValueOnce(null);
+        harness.prisma.track.findFirst.mockResolvedValueOnce({
+            id: "track-4",
+            title: "Track Four",
+        });
+        harness.upsertTrackEmbedding.mockRejectedValueOnce(
+            new VibeEmbeddingGenerationMismatchError("track-4", 0),
+        );
 
         await expect(
             harness.processJob(
@@ -699,10 +686,45 @@ describe("vibe embed job processor", () => {
                     filePath: "artist/track.flac",
                 }),
             ),
-        ).resolves.toBe("track_missing");
+        ).resolves.toBe("stale_claim");
 
         expect(harness.embedAudio).toHaveBeenCalledTimes(1);
-        expect(harness.upsertTrackEmbedding).not.toHaveBeenCalled();
-        expect(harness.recordOutcome).toHaveBeenCalledWith("track_missing");
+        expect(harness.upsertTrackEmbedding).toHaveBeenCalledTimes(1);
+        expect(harness.recordOutcome).toHaveBeenCalledWith("stale_claim");
+    });
+
+    it("resets and surfaces a target invalidation without marking the track failed", async () => {
+        const harness = createHarness();
+        const error = new EmbeddingTargetInvalidatedError("space-provider");
+        harness.prisma.track.findFirst.mockResolvedValueOnce({
+            id: "track-retired-target",
+            title: "Retired Target",
+            vibeAnalysisGeneration: 6,
+        });
+        harness.upsertTrackEmbedding.mockRejectedValueOnce(error);
+
+        await expect(
+            harness.processJob(
+                JSON.stringify({
+                    trackId: "track-retired-target",
+                    filePath: "artist/track.flac",
+                }),
+            ),
+        ).rejects.toBe(error);
+
+        expect(harness.prisma.track.updateMany).toHaveBeenLastCalledWith({
+            where: {
+                id: "track-retired-target",
+                origin: "LOCAL",
+                removedAt: null,
+                vibeAnalysisStatus: "processing",
+                vibeAnalysisGeneration: 6,
+            },
+            data: expect.objectContaining({
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisStartedAt: null,
+            }),
+        });
+        expect(harness.recordFailure).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/services/__tests__/vibeInvalidation.test.ts
+++ b/backend/src/services/__tests__/vibeInvalidation.test.ts
@@ -1,0 +1,28 @@
+import { invalidateVibeAnalysis } from "../vibeInvalidation";
+
+describe("vibe analysis invalidation", () => {
+    it("resets state and increments the generation in one update", async () => {
+        const updateMany = jest.fn(async () => ({ count: 2 }));
+        const now = new Date("2026-08-17T12:00:00.000Z");
+
+        await expect(
+            invalidateVibeAnalysis(
+                { track: { updateMany } },
+                { origin: "LOCAL" },
+                now,
+            ),
+        ).resolves.toBe(2);
+
+        expect(updateMany).toHaveBeenCalledWith({
+            where: { origin: "LOCAL" },
+            data: {
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisError: null,
+                vibeAnalysisRetryCount: 0,
+                vibeAnalysisStartedAt: null,
+                vibeAnalysisStatusUpdatedAt: now,
+                vibeAnalysisGeneration: { increment: 1 },
+            },
+        });
+    });
+});

--- a/backend/src/services/embeddingSpaceLifecycle.ts
+++ b/backend/src/services/embeddingSpaceLifecycle.ts
@@ -16,7 +16,6 @@ const MILLIS_PER_DAY = 24 * 60 * 60 * 1_000;
 const RETIRED_SPACE_SCAN_LIMIT = 10;
 const CLEANING_CLAIM_STALE_MS = 60 * 60 * 1_000;
 const SPACE_ID_PATTERN = /^[A-Za-z0-9_]{1,48}$/;
-const ANN_INDEX_LISTS = 224;
 const log =
     typeof (logger as { child?: unknown }).child === "function"
         ? logger.child("EmbeddingSpaceLifecycle")
@@ -27,10 +26,28 @@ export const RETIREMENT_DELETE_BATCH_SIZE = 500;
 /** Fixed per-run bound so a large retired space resumes on the next tick. */
 export const MAX_RETIREMENT_DELETE_BATCHES = 20;
 /**
- * Conservative training floor for the retained 224-list IVFFlat shape.
- * This supplies at least four vectors per list and bounds exact scans at 999.
+ * Conservative training floor for the first size-banded IVFFlat shape.
+ * Spaces below this size remain exact scans.
  */
 export const ANN_INDEX_MIN_VECTOR_COUNT = 1_000;
+
+/** Select the stable IVFFlat list band for a space's current vector count. */
+export function annIndexListsForVectorCount(
+    vectorCount: number,
+): number | null {
+    if (!Number.isSafeInteger(vectorCount) || vectorCount < 0) return null;
+    if (vectorCount < ANN_INDEX_MIN_VECTOR_COUNT) return null;
+    // pgvector's README recommends rows/1000 below one million rows as a
+    // starting point, then measuring recall against exact search. Soundspan's
+    // existing 15k-row benchmark selected 224 lists with 32 probes, so these
+    // stepped rows/25 bands avoid per-insert rebuilds while converging on that
+    // measured shape; the PostgreSQL integration suite pins exact top-k at the
+    // first band edge.
+    if (vectorCount < 2_500) return 40;
+    if (vectorCount < 5_000) return 100;
+    if (vectorCount < 10_000) return 200;
+    return 224;
+}
 
 interface LifecycleConfig {
     threshold: number;
@@ -90,11 +107,28 @@ function partialIndexName(spaceId: string): string {
     return `track_embeddings_${validatedSpaceId(spaceId)}_ivfflat_idx`;
 }
 
-async function buildPartialAnnIndex(spaceId: string): Promise<void> {
+interface AnnIndexState {
+    isValid: boolean;
+    lists: number | null;
+}
+
+function parseIndexLists(options: readonly string[] | null): number | null {
+    const value = options?.find((option) => option.startsWith("lists="));
+    if (!value) return null;
+    const lists = Number.parseInt(value.slice("lists=".length), 10);
+    return Number.isSafeInteger(lists) && lists > 0 ? lists : null;
+}
+
+async function loadPartialAnnIndex(
+    spaceId: string,
+): Promise<AnnIndexState | null> {
     const validatedId = validatedSpaceId(spaceId);
     const indexName = partialIndexName(validatedId);
-    const rows = await prisma.$queryRaw<Array<{ isValid: boolean }>>`
-        SELECT index_row.indisvalid AS "isValid"
+    const rows = await prisma.$queryRaw<
+        Array<{ isValid: boolean; options: string[] | null }>
+    >`
+        SELECT index_row.indisvalid AS "isValid",
+               index_class.reloptions AS options
         FROM pg_catalog.pg_index index_row
         INNER JOIN pg_catalog.pg_class index_class
             ON index_class.oid = index_row.indexrelid
@@ -104,15 +138,25 @@ async function buildPartialAnnIndex(spaceId: string): Promise<void> {
           AND namespace.nspname = current_schema()
         LIMIT 1
     `;
-    if (rows[0]?.isValid === true) return;
-    if (rows[0]?.isValid === false) await dropPartialAnnIndex(validatedId);
+    const row = rows[0];
+    return row
+        ? { isValid: row.isValid, lists: parseIndexLists(row.options) }
+        : null;
+}
+
+async function createPartialAnnIndex(
+    spaceId: string,
+    lists: number,
+): Promise<void> {
+    const validatedId = validatedSpaceId(spaceId);
+    const indexName = partialIndexName(validatedId);
     // PostgreSQL cannot parameterize identifiers or a partial-index predicate,
     // and CREATE INDEX CONCURRENTLY must run outside a transaction. The value
     // is a registry-owned id validated above, never request or operator input.
     await prisma.$executeRawUnsafe(
         `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${indexName}" ` +
             `ON track_embeddings USING ivfflat (embedding vector_cosine_ops) ` +
-            `WITH (lists = ${ANN_INDEX_LISTS}) WHERE space_id = '${validatedId}'`,
+            `WITH (lists = ${lists}) WHERE space_id = '${validatedId}'`,
     );
 }
 
@@ -121,8 +165,15 @@ export async function ensureSpaceAnnIndex(spaceId: string): Promise<boolean> {
     const vectorCount = await prisma.trackEmbedding.count({
         where: { spaceId },
     });
-    if (!shouldBuildAnnIndex(vectorCount)) return false;
-    await buildPartialAnnIndex(spaceId);
+    const desiredLists = annIndexListsForVectorCount(vectorCount);
+    const current = await loadPartialAnnIndex(spaceId);
+    if (desiredLists === null) {
+        if (current) await dropPartialAnnIndex(spaceId);
+        return false;
+    }
+    if (current?.isValid && current.lists === desiredLists) return true;
+    if (current) await dropPartialAnnIndex(spaceId);
+    await createPartialAnnIndex(spaceId, desiredLists);
     return true;
 }
 

--- a/backend/src/services/featureDetection.ts
+++ b/backend/src/services/featureDetection.ts
@@ -23,6 +23,7 @@ export interface VibeFeatureStatus {
         configured: boolean;
         reachable: boolean | null;
         checkedAt: string | null;
+        fresh: boolean;
     };
     activeSpace: { id: string; family: string } | null;
     migration: {
@@ -82,6 +83,7 @@ async function loadVibeStatus(): Promise<VibeFeatureStatus> {
             configured,
             reachable: reachability?.reachable ?? null,
             checkedAt: reachability?.checkedAt ?? null,
+            fresh: workerStatus !== null,
         },
         activeSpace,
         migration: configured

--- a/backend/src/services/federationEmbeddingSpace.ts
+++ b/backend/src/services/federationEmbeddingSpace.ts
@@ -72,7 +72,7 @@ export function decideFederationEmbeddingPage(
         pageTuple.checkpointHash === localSpace.checkpointHash &&
         pageTuple.dim === localSpace.dim;
     if (!baseMatches) return "skipped_mismatch";
-    if (pageTuple.preprocessingHash === undefined) return "stored";
+    if (pageTuple.preprocessingHash === undefined) return "skipped_mismatch";
     return pageTuple.preprocessingHash ===
         embeddingPreprocessingHash(localSpace.preprocessing)
         ? "stored"
@@ -82,7 +82,6 @@ export function decideFederationEmbeddingPage(
 /** Mutable once-per-sync warning latches owned by the caller's sync context. */
 export interface FederationEmbeddingWarningLatches {
     embeddingWarningEmitted: boolean;
-    legacyPreprocessingWarningEmitted: boolean;
 }
 
 export interface ScopedEmbeddingPageInput {
@@ -97,8 +96,7 @@ export interface ScopedEmbeddingPageInput {
 
 /**
  * Decide one synced page's embedding outcome and emit each per-sync warning at
- * most once: accepting a hash-less 2.3 peer page, and skipping a page whose
- * space does not match the local active space.
+ * most once when a page's space does not match the local active space.
  */
 export function decideScopedEmbeddingPage(
     input: ScopedEmbeddingPageInput,
@@ -110,18 +108,6 @@ export function decideScopedEmbeddingPage(
         input.pageTuple,
         input.localEmbeddingSpace,
     );
-    if (
-        outcome === "stored" &&
-        input.pageTuple != null &&
-        input.pageTuple.preprocessingHash === undefined &&
-        !input.warnings.legacyPreprocessingWarningEmitted
-    ) {
-        input.warnings.legacyPreprocessingWarningEmitted = true;
-        input.warn(
-            "Accepting federation embeddings from a 2.3 peer without preprocessingHash",
-            { peerId: input.peerId },
-        );
-    }
     if (outcome === "stored" || input.warnings.embeddingWarningEmitted) {
         return outcome;
     }

--- a/backend/src/services/federationEmbeddingSpaceHeader.ts
+++ b/backend/src/services/federationEmbeddingSpaceHeader.ts
@@ -45,7 +45,7 @@ export function encodeFederationEmbeddingSpaceHeader(
     );
 }
 
-/** Parse the additive tuple; preprocessingHash is optional for older 2.3 peers. */
+/** Parse the tuple; policy rejects a present tuple without preprocessingHash. */
 export function parseFederationEmbeddingSpaceHeader(
     value: unknown,
 ): ParsedFederationEmbeddingSpaceIdentity | undefined {

--- a/backend/src/services/trackEmbeddings.ts
+++ b/backend/src/services/trackEmbeddings.ts
@@ -66,9 +66,129 @@ export interface TextSearchResult {
     speechiness: number | null;
 }
 
+/** Claimed local vibe generation finalized with its vector write. */
+export interface VibeEmbeddingWriteClaim {
+    generation: number;
+    completedAt: Date;
+}
+
+/** Raised when a cached worker target can no longer accept vectors. */
+export class EmbeddingTargetInvalidatedError extends Error {
+    readonly code = "EMBEDDING_TARGET_INVALIDATED";
+
+    constructor(public readonly spaceId: string) {
+        super(`Embedding space ${spaceId} no longer accepts vector writes`);
+        this.name = "EmbeddingTargetInvalidatedError";
+    }
+}
+
+/** Raised when an invalidated local job loses its generation fence. */
+export class VibeEmbeddingGenerationMismatchError extends Error {
+    readonly code = "VIBE_EMBEDDING_GENERATION_MISMATCH";
+
+    constructor(
+        public readonly trackId: string,
+        public readonly generation: number,
+    ) {
+        super(`Track ${trackId} no longer owns vibe generation ${generation}`);
+        this.name = "VibeEmbeddingGenerationMismatchError";
+    }
+}
+
 function boundedTextSearchCandidateLimit(candidateLimit: number): number {
     if (!Number.isFinite(candidateLimit)) return 1;
     return Math.min(Math.max(1, Math.trunc(candidateLimit)), 300);
+}
+
+function validateEmbeddingValues(embedding: readonly number[]): void {
+    if (
+        embedding.length === 0 ||
+        embedding.some((value) => !Number.isFinite(value))
+    ) {
+        throw new Error("Track embedding must contain only finite values");
+    }
+}
+
+async function lockWritableEmbeddingSpace(
+    transaction: Prisma.TransactionClient,
+    spaceId: string,
+): Promise<number> {
+    const spaces = await transaction.$queryRaw<Array<{ dim: number }>>`
+        SELECT dim
+        FROM embedding_spaces
+        WHERE id = ${spaceId}
+          AND status IN ('active', 'migrating')
+          AND cleaning_at IS NULL
+        FOR SHARE
+    `;
+    const targetSpace = spaces[0];
+    if (!targetSpace) throw new EmbeddingTargetInvalidatedError(spaceId);
+    return targetSpace.dim;
+}
+
+async function finalizeVibeEmbeddingClaim(
+    transaction: Prisma.TransactionClient,
+    trackId: string,
+    claim: VibeEmbeddingWriteClaim | undefined,
+): Promise<void> {
+    if (!claim) return;
+    const completed = await transaction.track.updateMany({
+        where: {
+            id: trackId,
+            origin: "LOCAL",
+            removedAt: null,
+            vibeAnalysisStatus: "processing",
+            vibeAnalysisGeneration: claim.generation,
+        },
+        data: {
+            vibeAnalysisStatus: "completed",
+            vibeAnalysisError: null,
+            vibeAnalysisStartedAt: null,
+            vibeAnalysisStatusUpdatedAt: claim.completedAt,
+        },
+    });
+    if (completed.count !== 1) {
+        throw new VibeEmbeddingGenerationMismatchError(
+            trackId,
+            claim.generation,
+        );
+    }
+}
+
+async function writeEmbeddingVector(
+    transaction: Prisma.TransactionClient,
+    trackId: string,
+    vector: string,
+    spaceId: string,
+): Promise<void> {
+    const written = await transaction.$executeRaw`
+        INSERT INTO track_embeddings (track_id, embedding, space_id, analyzed_at)
+        VALUES (${trackId}, ${vector}::vector, ${spaceId}, NOW())
+        ON CONFLICT (track_id, space_id) DO UPDATE SET
+            embedding = EXCLUDED.embedding,
+            analyzed_at = EXCLUDED.analyzed_at
+    `;
+    if (written !== 1) {
+        throw new Error("Track embedding upsert did not affect one row");
+    }
+}
+
+async function markEmbeddingSpacePopulated(
+    transaction: Prisma.TransactionClient,
+    spaceId: string,
+): Promise<void> {
+    const marked = await transaction.embeddingSpace.updateMany({
+        where: {
+            id: spaceId,
+            status: { in: ["active", "migrating"] },
+            cleaningAt: null,
+            hadVectors: false,
+        },
+        data: { hadVectors: true },
+    });
+    if (marked.count < 0 || marked.count > 1) {
+        throw new Error("Embedding-space marker update was inconsistent");
+    }
 }
 
 /** Prisma relation filter for tracks without a vector in `targetSpaceId`. */
@@ -103,44 +223,23 @@ export async function upsertTrackEmbedding(
     trackId: string,
     embedding: readonly number[],
     spaceId: string,
+    claim?: VibeEmbeddingWriteClaim,
 ): Promise<void> {
-    if (
-        embedding.length === 0 ||
-        embedding.some((value) => !Number.isFinite(value))
-    ) {
-        throw new Error("Track embedding must contain only finite values");
-    }
-    const targetSpace = await prisma.embeddingSpace.findUnique({
-        where: { id: spaceId },
-        select: { dim: true },
-    });
-    if (!targetSpace) {
-        throw new Error(`Embedding space ${spaceId} is not registered`);
-    }
-    if (embedding.length !== targetSpace.dim) {
-        throw new Error(
-            `Track embedding must contain ${targetSpace.dim} finite values`,
-        );
-    }
+    validateEmbeddingValues(embedding);
     const vector = `[${embedding.join(",")}]`;
     await prisma.$transaction(async (transaction) => {
-        const written = await transaction.$executeRaw`
-            INSERT INTO track_embeddings (track_id, embedding, space_id, analyzed_at)
-            VALUES (${trackId}, ${vector}::vector, ${spaceId}, NOW())
-            ON CONFLICT (track_id, space_id) DO UPDATE SET
-                embedding = EXCLUDED.embedding,
-                analyzed_at = EXCLUDED.analyzed_at
-        `;
-        if (written !== 1) {
-            throw new Error("Track embedding upsert did not affect one row");
+        const expectedDim = await lockWritableEmbeddingSpace(
+            transaction,
+            spaceId,
+        );
+        if (embedding.length !== expectedDim) {
+            throw new Error(
+                `Track embedding must contain ${expectedDim} finite values`,
+            );
         }
-        const marked = await transaction.embeddingSpace.updateMany({
-            where: { id: spaceId, hadVectors: false },
-            data: { hadVectors: true },
-        });
-        if (marked.count < 0 || marked.count > 1) {
-            throw new Error("Embedding-space marker update was inconsistent");
-        }
+        await finalizeVibeEmbeddingClaim(transaction, trackId, claim);
+        await writeEmbeddingVector(transaction, trackId, vector, spaceId);
+        await markEmbeddingSpacePopulated(transaction, spaceId);
     });
 }
 

--- a/backend/src/services/trackReplacement.ts
+++ b/backend/src/services/trackReplacement.ts
@@ -4,6 +4,7 @@ import type { Prisma } from "@prisma/client";
 import { config } from "../config";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { invalidateVibeAnalysis } from "./vibeInvalidation";
 
 const replacementLogger = logger.child("TrackReplacement");
 
@@ -12,7 +13,7 @@ type ReplacementTransaction = Pick<
     "track" | "trackEmbedding" | "transcodedFile"
 >;
 
-type TrackUpdateData = Prisma.TrackUpdateArgs["data"];
+type TrackUpdateData = Prisma.TrackUpdateManyMutationInput;
 
 function replacementResetData(now: Date) {
     return {
@@ -21,11 +22,6 @@ function replacementResetData(now: Date) {
         analysisError: null,
         analysisRetryCount: 0,
         analysisStartedAt: null,
-        vibeAnalysisStatus: "pending",
-        vibeAnalysisError: null,
-        vibeAnalysisRetryCount: 0,
-        vibeAnalysisStartedAt: null,
-        vibeAnalysisStatusUpdatedAt: now,
     } satisfies TrackUpdateData;
 }
 
@@ -43,10 +39,16 @@ export async function applyTrackReplacement(
         where: { trackId },
         select: { cachePath: true },
     });
-    await transaction.track.update({
-        where: { id: trackId },
-        data: { ...trackData, ...replacementResetData(new Date()) },
-    });
+    const invalidatedAt = new Date();
+    const updated = await invalidateVibeAnalysis(
+        transaction,
+        { id: trackId },
+        invalidatedAt,
+        { ...trackData, ...replacementResetData(invalidatedAt) },
+    );
+    if (updated !== 1) {
+        throw new Error("Track replacement requires exactly one track");
+    }
     await transaction.trackEmbedding.deleteMany({ where: { trackId } });
     await transaction.transcodedFile.deleteMany({ where: { trackId } });
     return cachedFiles.map((file) => file.cachePath);

--- a/backend/src/services/vibeAnalysisCleanup.ts
+++ b/backend/src/services/vibeAnalysisCleanup.ts
@@ -1,7 +1,7 @@
 import { prisma } from "../utils/db";
 import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
 import { logger } from "../utils/logger";
-import { enrichmentFailureService } from "./enrichmentFailureService";
+import { invalidateVibeAnalysis } from "./vibeInvalidation";
 
 const STALE_THRESHOLD_MINUTES = 30; // Longer than audio analysis due to CLAP processing time
 
@@ -28,9 +28,13 @@ class VibeAnalysisCleanupService {
                     },
                 ],
             },
-            include: {
+            select: {
+                id: true,
+                title: true,
+                vibeAnalysisGeneration: true,
+                vibeAnalysisStatusUpdatedAt: true,
                 album: {
-                    include: {
+                    select: {
                         artist: { select: { name: true } },
                     },
                 },
@@ -50,17 +54,21 @@ class VibeAnalysisCleanupService {
         for (const track of staleTracks) {
             const trackName = `${track.album.artist.name} - ${track.title}`;
 
-            // Reset to null (pending state)
-            await prisma.track.update({
-                where: { id: track.id },
-                data: {
-                    vibeAnalysisStatus: null,
-                    vibeAnalysisStatusUpdatedAt: null,
+            const reset = await invalidateVibeAnalysis(
+                prisma,
+                {
+                    id: track.id,
+                    vibeAnalysisStatus: "processing",
+                    vibeAnalysisGeneration: track.vibeAnalysisGeneration,
+                    vibeAnalysisStatusUpdatedAt:
+                        track.vibeAnalysisStatusUpdatedAt,
                 },
-            });
+                new Date(),
+            );
+            if (reset === 0) continue;
 
             logger.debug(`[VibeAnalysisCleanup] Reset for retry: ${trackName}`);
-            resetCount++;
+            resetCount += reset;
         }
 
         return { reset: resetCount };

--- a/backend/src/services/vibeEmbedJobs.ts
+++ b/backend/src/services/vibeEmbedJobs.ts
@@ -5,7 +5,12 @@ import { prisma } from "../utils/db";
 import { redisClient } from "../utils/redis";
 import { logger } from "../utils/logger";
 import { enrichmentFailureService } from "./enrichmentFailureService";
-import { upsertTrackEmbedding } from "./trackEmbeddings";
+import {
+    EmbeddingTargetInvalidatedError,
+    upsertTrackEmbedding,
+    VibeEmbeddingGenerationMismatchError,
+    type VibeEmbeddingWriteClaim,
+} from "./trackEmbeddings";
 import { embedAudio, VibeProviderError } from "./vibeProvider";
 import type { EmbeddingVectorSpace } from "./vibeProvider";
 import { vibeEmbeddingTargetGateWhere } from "./vibeEmbeddingEligibility";
@@ -80,6 +85,7 @@ interface VibeEmbedJobDependencies {
         trackId: string,
         embedding: readonly number[],
         spaceId: string,
+        claim: VibeEmbeddingWriteClaim,
     ): Promise<void>;
     failureService: FailureServicePort;
     releaseReservation(trackId: string): Promise<void>;
@@ -326,24 +332,10 @@ async function handleGenerationFailure(
     await markFailed(dependencies, track, error);
 }
 
-async function markCompleted(
+async function resolveStaleFailure(
     dependencies: VibeEmbedJobDependencies,
     track: TrackSnapshot,
-): Promise<boolean> {
-    const updated = await dependencies.prisma.track.updateMany({
-        where: {
-            ...activeTrackWhere(track.id),
-            vibeAnalysisStatus: "processing",
-            vibeAnalysisGeneration: track.vibeAnalysisGeneration ?? 0,
-        },
-        data: {
-            vibeAnalysisStatus: "completed",
-            vibeAnalysisError: null,
-            vibeAnalysisStartedAt: null,
-            vibeAnalysisStatusUpdatedAt: dependencies.now(),
-        },
-    });
-    if (updated.count !== 1) return false;
+): Promise<void> {
     await dependencies.failureService
         .resolveByEntity("vibe", track.id)
         .catch((error) => {
@@ -352,7 +344,29 @@ async function markCompleted(
                 error,
             });
         });
-    return true;
+}
+
+async function resetInvalidatedTargetClaim(
+    dependencies: VibeEmbedJobDependencies,
+    track: TrackSnapshot,
+    error: unknown,
+): Promise<void> {
+    const updated = await dependencies.prisma.track.updateMany({
+        where: {
+            ...activeTrackWhere(track.id),
+            vibeAnalysisStatus: "processing",
+            vibeAnalysisGeneration: track.vibeAnalysisGeneration ?? 0,
+        },
+        data: {
+            vibeAnalysisStatus: "pending",
+            vibeAnalysisError: failureMessage(dependencies, error),
+            vibeAnalysisStartedAt: null,
+            vibeAnalysisStatusUpdatedAt: dependencies.now(),
+        },
+    });
+    if (updated.count < 0 || updated.count > 1) {
+        throw new Error("Target invalidation reset was inconsistent");
+    }
 }
 
 function finish(
@@ -391,23 +405,31 @@ async function processValidJob(
         return finish(dependencies, "embed_failed");
     }
     try {
-        const stillActive = await findActiveTrack(
-            dependencies.prisma,
-            track.id,
-        );
-        if (!stillActive) return finish(dependencies, "track_missing");
         // Status fields are intentionally shared across spaces because one
         // provider target is filled at a time in this worker process.
         await dependencies.upsertTrackEmbedding(
             track.id,
             vector,
             dependencies.targetSpaceId,
+            {
+                generation: claimedTrack.vibeAnalysisGeneration ?? 0,
+                completedAt: dependencies.now(),
+            },
         );
-        if (!(await markCompleted(dependencies, claimedTrack))) {
-            return finish(dependencies, "stale_claim");
-        }
+        await resolveStaleFailure(dependencies, claimedTrack);
         return finish(dependencies, "stored");
     } catch (error) {
+        if (error instanceof VibeEmbeddingGenerationMismatchError) {
+            return finish(dependencies, "stale_claim");
+        }
+        if (error instanceof EmbeddingTargetInvalidatedError) {
+            await resetInvalidatedTargetClaim(
+                dependencies,
+                claimedTrack,
+                error,
+            );
+            throw error;
+        }
         await markFailed(dependencies, claimedTrack, error);
         return finish(dependencies, "embed_failed");
     }

--- a/backend/src/services/vibeInvalidation.ts
+++ b/backend/src/services/vibeInvalidation.ts
@@ -1,0 +1,34 @@
+import type { Prisma } from "@prisma/client";
+
+interface VibeInvalidationStore {
+    track: {
+        updateMany(
+            args: Prisma.TrackUpdateManyArgs,
+        ): Promise<{ count: number }>;
+    };
+}
+
+/** Atomically invalidates matching vibe work and advances its fencing token. */
+export async function invalidateVibeAnalysis(
+    store: VibeInvalidationStore,
+    where: Prisma.TrackWhereInput,
+    invalidatedAt: Date,
+    additionalData: Prisma.TrackUpdateManyMutationInput = {},
+): Promise<number> {
+    const result = await store.track.updateMany({
+        where,
+        data: {
+            ...additionalData,
+            vibeAnalysisStatus: "pending",
+            vibeAnalysisError: null,
+            vibeAnalysisRetryCount: 0,
+            vibeAnalysisStartedAt: null,
+            vibeAnalysisStatusUpdatedAt: invalidatedAt,
+            vibeAnalysisGeneration: { increment: 1 },
+        },
+    });
+    if (!Number.isSafeInteger(result.count) || result.count < 0) {
+        throw new Error("Vibe invalidation returned an invalid update count");
+    }
+    return result.count;
+}

--- a/backend/src/utils/annQuery.ts
+++ b/backend/src/utils/annQuery.ts
@@ -40,10 +40,10 @@ function isStatementTimeout(error: unknown): boolean {
  * Run a pgvector ANN query with `ivfflat.probes` applied on the SAME pooled
  * connection as the query (roadmap F14).
  *
- * The `track_embeddings` index is `ivfflat ... WITH (lists = 224)`. Postgres
- * defaults `ivfflat.probes` to 1, so an unconfigured ANN query scans only 1 of
- * the 224 inverted lists and recall is silently near-random. This helper is the
- * single place that fixes that: it wraps the caller's ANN query in an explicit
+ * The `track_embeddings` indexes use size-banded lists capped at 224. Postgres
+ * defaults `ivfflat.probes` to 1, so an unconfigured ANN query scans only one
+ * inverted list and recall can be silently near-random. This helper wraps the
+ * caller's ANN query in an explicit
  * batch `$transaction` alongside a probes-setting statement.
  *
  * Two footguns this shape avoids, both verified on the live DB:

--- a/backend/src/workers/__tests__/legacyVibeRedisCleanup.test.ts
+++ b/backend/src/workers/__tests__/legacyVibeRedisCleanup.test.ts
@@ -6,9 +6,11 @@ import {
 function createClient(): jest.Mocked<LegacyVibeRedisCleanupClient> {
     return {
         del: jest.fn().mockResolvedValue(1),
+        destroy: jest.fn(),
+        eval: jest.fn().mockResolvedValue(1),
+        get: jest.fn().mockResolvedValue(null),
         scan: jest.fn().mockResolvedValue({ cursor: "0", keys: [] }),
         set: jest.fn().mockResolvedValue("OK"),
-        ttl: jest.fn().mockResolvedValue(60),
         xGroupDestroy: jest.fn().mockResolvedValue(1),
     };
 }
@@ -17,161 +19,149 @@ describe("legacy vibe Redis cleanup", () => {
     const logger = { warn: jest.fn() };
 
     beforeEach(() => {
-        logger.warn.mockClear();
+        jest.clearAllMocks();
+        jest.useRealTimers();
     });
 
-    it("removes the retired stream, consumer group, and heartbeat", async () => {
+    afterEach(() => jest.useRealTimers());
+
+    it("uses an expiring owner lease and writes completion only after success", async () => {
         const client = createClient();
 
-        await cleanupLegacyVibeRedisArtifacts(client, logger);
+        await cleanupLegacyVibeRedisArtifacts(client, logger, {
+            ownerToken: "owner-1",
+        });
 
         expect(client.set).toHaveBeenCalledWith(
-            "soundspan:legacy-vibe-cleanup:v1",
-            "done",
-            { NX: true },
+            "soundspan:legacy-vibe-cleanup:v1:lease",
+            "owner-1",
+            { NX: true, PX: 120_000 },
         );
-        expect(client.xGroupDestroy).toHaveBeenCalledWith(
-            "audio:text:embed:requests",
-            "clap:text:embed:group",
+        expect(client.eval).toHaveBeenLastCalledWith(
+            expect.stringContaining("redis.call('SET', KEYS[2], 'done')"),
+            {
+                keys: [
+                    "soundspan:legacy-vibe-cleanup:v1:lease",
+                    "soundspan:legacy-vibe-cleanup:v1",
+                ],
+                arguments: ["owner-1"],
+            },
         );
-        expect(client.del).toHaveBeenCalledWith("audio:text:embed:requests");
-        expect(client.del).toHaveBeenCalledWith("clap:worker:heartbeat");
     });
 
-    it("scans bounded pages and deletes only reservations missing a TTL", async () => {
+    it("retries after an earlier owner's lease expires", async () => {
+        const first = createClient();
+        first.set.mockResolvedValueOnce(null);
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(first, logger),
+        ).resolves.toEqual({ staleReservationsDeleted: 0 });
+
+        const later = createClient();
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(later, logger),
+        ).resolves.toEqual({ staleReservationsDeleted: 0 });
+
+        expect(first.xGroupDestroy).not.toHaveBeenCalled();
+        expect(later.xGroupDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not write completion after an operation fails", async () => {
         const client = createClient();
-        client.scan
-            .mockResolvedValueOnce({
-                cursor: "17",
-                keys: [
-                    "audio:clap:queue:reserved:stale",
-                    "audio:clap:queue:reserved:active",
-                ],
-            })
-            .mockResolvedValueOnce({ cursor: "0", keys: [] });
-        client.ttl.mockResolvedValueOnce(-1).mockResolvedValueOnce(120);
+        client.del.mockRejectedValueOnce(new Error("redis unavailable"));
 
-        const result = await cleanupLegacyVibeRedisArtifacts(client, logger);
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(client, logger),
+        ).rejects.toThrow("redis unavailable");
 
-        expect(client.scan).toHaveBeenNthCalledWith(1, "0", {
-            MATCH: "audio:clap:queue:reserved:*",
-            COUNT: 2048,
+        expect(client.eval).not.toHaveBeenCalledWith(
+            expect.stringContaining("redis.call('SET', KEYS[2], 'done')"),
+            expect.anything(),
+        );
+    });
+
+    it("treats an already-absent consumer group as cleaned", async () => {
+        const client = createClient();
+        client.xGroupDestroy.mockRejectedValueOnce(
+            new Error("NOGROUP missing"),
+        );
+
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(client, logger, {
+                ownerToken: "owner-absent-group",
+            }),
+        ).resolves.toEqual({ staleReservationsDeleted: 0 });
+
+        expect(client.eval).toHaveBeenLastCalledWith(
+            expect.stringContaining("redis.call('SET', KEYS[2], 'done')"),
+            expect.objectContaining({ arguments: ["owner-absent-group"] }),
+        );
+    });
+
+    it("checks TTL and deletes each legacy reservation atomically", async () => {
+        const client = createClient();
+        client.scan.mockResolvedValueOnce({
+            cursor: "0",
+            keys: ["audio:clap:queue:reserved:legacy"],
         });
-        expect(client.scan).toHaveBeenNthCalledWith(2, "17", {
-            MATCH: "audio:clap:queue:reserved:*",
-            COUNT: 2048,
-        });
-        expect(client.del).toHaveBeenCalledWith(
-            "audio:clap:queue:reserved:stale",
+        client.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(1);
+
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(client, logger),
+        ).resolves.toEqual({ staleReservationsDeleted: 1 });
+
+        expect(client.eval).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("redis.call('TTL', KEYS[1]) == -1"),
+            { keys: ["audio:clap:queue:reserved:legacy"] },
         );
         expect(client.del).not.toHaveBeenCalledWith(
-            "audio:clap:queue:reserved:active",
+            "audio:clap:queue:reserved:legacy",
         );
-        expect(result).toEqual({ staleReservationsDeleted: 1 });
     });
 
-    it("processes every reservation returned in one bounded scan page", async () => {
+    it("destroys the cleanup connection when one Redis operation exceeds its bound", async () => {
+        jest.useFakeTimers();
         const client = createClient();
-        const keys = Array.from(
-            { length: 150 },
-            (_, index) => `audio:clap:queue:reserved:legacy-${index}`,
+        client.get.mockImplementationOnce(() => new Promise(() => undefined));
+
+        const cleanup = cleanupLegacyVibeRedisArtifacts(client, logger, {
+            operationTimeoutMs: 25,
+        });
+        const rejection = expect(cleanup).rejects.toThrow(
+            "Redis operation timed out",
         );
-        client.scan.mockResolvedValueOnce({ cursor: "0", keys });
-        client.ttl.mockResolvedValue(-1);
+        await jest.advanceTimersByTimeAsync(25);
 
-        const result = await cleanupLegacyVibeRedisArtifacts(client, logger);
-
-        expect(client.ttl).toHaveBeenCalledTimes(150);
-        expect(client.del).toHaveBeenCalledTimes(152);
-        expect(result).toEqual({ staleReservationsDeleted: 150 });
+        await rejection;
+        expect(client.destroy).toHaveBeenCalledTimes(1);
     });
 
     it("stops before processing an oversized scan page", async () => {
         const client = createClient();
         const keys = Array.from(
-            { length: 2049 },
+            { length: 2_049 },
             (_, index) => `audio:clap:queue:reserved:legacy-${index}`,
         );
         client.scan.mockResolvedValueOnce({ cursor: "17", keys });
 
-        await cleanupLegacyVibeRedisArtifacts(client, logger);
-
-        expect(client.scan).toHaveBeenCalledTimes(1);
-        expect(client.ttl).not.toHaveBeenCalled();
-        expect(client.del).toHaveBeenCalledTimes(2);
+        await expect(
+            cleanupLegacyVibeRedisArtifacts(client, logger),
+        ).rejects.toThrow("exceeded its key limit");
         expect(logger.warn).toHaveBeenCalledWith(
             "Legacy vibe reservation scan page exceeded its key limit",
-            { cursor: "0", keyCount: 2049, maxKeysPerPage: 2048 },
+            { cursor: "0", keyCount: 2_049, maxKeysPerPage: 2_048 },
         );
     });
 
-    it("never deletes expiring or already-missing reservations", async () => {
+    it("skips completed cleanup without acquiring a lease", async () => {
         const client = createClient();
-        client.scan.mockResolvedValueOnce({
-            cursor: "0",
-            keys: [
-                "audio:clap:queue:reserved:legacy",
-                "audio:clap:queue:reserved:current",
-                "audio:clap:queue:reserved:missing",
-            ],
-        });
-        client.ttl
-            .mockResolvedValueOnce(-1)
-            .mockResolvedValueOnce(3600)
-            .mockResolvedValueOnce(-2);
-
-        await cleanupLegacyVibeRedisArtifacts(client, logger);
-
-        expect(client.del).toHaveBeenCalledWith(
-            "audio:clap:queue:reserved:legacy",
-        );
-        expect(client.del).not.toHaveBeenCalledWith(
-            "audio:clap:queue:reserved:current",
-        );
-        expect(client.del).not.toHaveBeenCalledWith(
-            "audio:clap:queue:reserved:missing",
-        );
-    });
-
-    it("skips cleanup when another replica owns the durable marker", async () => {
-        const client = createClient();
-        client.set.mockResolvedValueOnce(null);
-
-        await cleanupLegacyVibeRedisArtifacts(client, logger);
-
-        expect(client.xGroupDestroy).not.toHaveBeenCalled();
-        expect(client.del).not.toHaveBeenCalled();
-        expect(client.scan).not.toHaveBeenCalled();
-    });
-
-    it("does not scan when the durable marker claim fails", async () => {
-        const client = createClient();
-        client.set.mockRejectedValueOnce(new Error("redis unavailable"));
-
-        await cleanupLegacyVibeRedisArtifacts(client, logger);
-
-        expect(client.xGroupDestroy).not.toHaveBeenCalled();
-        expect(client.scan).not.toHaveBeenCalled();
-        expect(logger.warn).toHaveBeenCalledWith(
-            "Failed to claim the legacy vibe Redis cleanup marker",
-            { error: expect.any(Error) },
-        );
-    });
-
-    it("continues cleaning independent artifacts after a missing group", async () => {
-        const client = createClient();
-        client.xGroupDestroy.mockRejectedValueOnce(new Error("NOGROUP"));
+        client.get.mockResolvedValueOnce("done");
 
         await expect(
             cleanupLegacyVibeRedisArtifacts(client, logger),
         ).resolves.toEqual({ staleReservationsDeleted: 0 });
 
-        expect(client.del).toHaveBeenCalledWith("audio:text:embed:requests");
-        expect(client.del).toHaveBeenCalledWith("clap:worker:heartbeat");
-        expect(client.scan).toHaveBeenCalledTimes(1);
-        expect(logger.warn).toHaveBeenCalledWith(
-            "Failed to remove the legacy text-embedding consumer group",
-            { error: expect.any(Error) },
-        );
+        expect(client.set).not.toHaveBeenCalled();
+        expect(client.scan).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -478,6 +478,13 @@ describe("unified enrichment runtime behavior", () => {
             }),
         );
         expect(prisma.trackEmbedding.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.track.updateMany).toHaveBeenCalledWith({
+            where: { origin: "LOCAL" },
+            data: expect.objectContaining({
+                vibeAnalysisStatus: "pending",
+                vibeAnalysisGeneration: { increment: 1 },
+            }),
+        });
         expect(enrichmentFailureService.clearAllFailures).toHaveBeenCalledWith(
             "vibe",
         );

--- a/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
+++ b/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
@@ -15,6 +15,7 @@ import {
     EmbeddingSpacePreprocessingMismatchError,
     RetiredEmbeddingSpaceError,
 } from "../../services/embeddingSpaces";
+import { EmbeddingTargetInvalidatedError } from "../../services/trackEmbeddings";
 
 const flushPromises = async (): Promise<void> => {
     await new Promise<void>((resolve) => setImmediate(resolve));
@@ -339,6 +340,57 @@ describe("vibe embed worker", () => {
         expect(harness.requeue).toHaveBeenCalledWith("unfinished-job");
         const stopping = harness.worker.stop();
         secondPop.resolve(null);
+        await stopping;
+    });
+
+    it("requeues once and succeeds after a target is retired", async () => {
+        const finalPop = deferred<string | null>();
+        const harness = createHarness({
+            providerUrl: "http://provider:8090",
+        });
+        harness.resolveTargetSpace
+            .mockResolvedValueOnce({
+                id: "space-retired",
+                dim: 2,
+                status: "migrating",
+                registered: false,
+                family: "test-family",
+            })
+            .mockResolvedValueOnce({
+                id: "space-new",
+                dim: 2,
+                status: "active",
+                registered: false,
+                family: "test-family",
+            });
+        harness.pop
+            .mockResolvedValueOnce("target-invalidated-job")
+            .mockResolvedValueOnce("target-invalidated-job")
+            .mockReturnValueOnce(finalPop.promise);
+        harness.processJob
+            .mockRejectedValueOnce(
+                new EmbeddingTargetInvalidatedError("space-retired"),
+            )
+            .mockResolvedValueOnce("stored");
+
+        await harness.worker.start();
+        await flushPromises();
+        await flushPromises();
+
+        expect(harness.requeue).toHaveBeenCalledTimes(1);
+        expect(harness.resolveTargetSpace).toHaveBeenCalledTimes(2);
+        expect(harness.processJob).toHaveBeenNthCalledWith(
+            2,
+            "target-invalidated-job",
+            expect.objectContaining({ id: "space-new", status: "active" }),
+        );
+        expect(harness.logger.info).toHaveBeenCalledWith(
+            "Vibe embedding target invalidated; resolving a fresh target",
+            { spaceId: "space-retired" },
+        );
+
+        const stopping = harness.worker.stop();
+        finalPop.resolve(null);
         await stopping;
     });
 

--- a/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
+++ b/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
@@ -1,13 +1,14 @@
 import {
     readVibeWorkerStatus,
-    VIBE_WORKER_STATUS_KEY,
+    VIBE_WORKER_STATUS_KEY_PREFIX,
     writeVibeWorkerStatus,
     type VibeWorkerStatusRedis,
 } from "../vibeWorkerStatus";
 
 function createRedis(): jest.Mocked<VibeWorkerStatusRedis> {
     return {
-        get: jest.fn().mockResolvedValue(null),
+        mGet: jest.fn().mockResolvedValue([]),
+        scan: jest.fn().mockResolvedValue({ cursor: "0", keys: [] }),
         set: jest.fn().mockResolvedValue("OK"),
     };
 }
@@ -26,29 +27,61 @@ describe("vibe worker status cache", () => {
         coverage: { embedded: 80, pending: 20, failed: 3 },
     };
 
-    it("persists the last worker-owned verdict without an expiry", async () => {
+    it("persists a per-worker heartbeat for three refresh intervals", async () => {
         const redis = createRedis();
 
-        await writeVibeWorkerStatus(redis, status);
+        await writeVibeWorkerStatus(redis, status, "worker-1");
 
         expect(redis.set).toHaveBeenCalledWith(
-            VIBE_WORKER_STATUS_KEY,
+            `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-1`,
             JSON.stringify(status),
+            { PX: 180_000 },
         );
     });
 
-    it("reads and validates the cached worker snapshot", async () => {
+    it("reports the newest fresh worker snapshot", async () => {
         const redis = createRedis();
-        redis.get.mockResolvedValueOnce(JSON.stringify(status));
+        redis.scan.mockResolvedValueOnce({
+            cursor: "0",
+            keys: [
+                `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-old`,
+                `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-new`,
+            ],
+        });
+        redis.mGet.mockResolvedValueOnce([
+            JSON.stringify({
+                ...status,
+                providerReachability: {
+                    reachable: false,
+                    checkedAt: "2026-08-17T11:59:00.000Z",
+                },
+            }),
+            JSON.stringify(status),
+        ]);
 
         await expect(readVibeWorkerStatus(redis)).resolves.toEqual(status);
+    });
+
+    it("treats an expired key omitted by Redis as stale", async () => {
+        const redis = createRedis();
+        redis.scan.mockResolvedValueOnce({
+            cursor: "0",
+            keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-expired`],
+        });
+        redis.mGet.mockResolvedValueOnce([null]);
+
+        await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
     });
 
     it.each(["not-json", JSON.stringify({ reachable: "yes" })])(
         "treats invalid cached state as unavailable",
         async (stored) => {
             const redis = createRedis();
-            redis.get.mockResolvedValueOnce(stored);
+            redis.scan.mockResolvedValueOnce({
+                cursor: "0",
+                keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-invalid`],
+            });
+            redis.mGet.mockResolvedValueOnce([stored]);
 
             await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
         },

--- a/backend/src/workers/legacyVibeRedisCleanup.ts
+++ b/backend/src/workers/legacyVibeRedisCleanup.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /** Redis key for provider-backed audio embedding jobs. */
 export const VIBE_PROVIDER_QUEUE_KEY = "audio:clap:queue";
 
@@ -6,23 +8,46 @@ const LEGACY_TEXT_EMBED_GROUP = "clap:text:embed:group";
 const LEGACY_WORKER_HEARTBEAT = "clap:worker:heartbeat";
 const RESERVATION_PATTERN = `${VIBE_PROVIDER_QUEUE_KEY}:reserved:*`;
 const CLEANUP_MARKER_KEY = "soundspan:legacy-vibe-cleanup:v1";
+const CLEANUP_LEASE_KEY = `${CLEANUP_MARKER_KEY}:lease`;
+const CLEANUP_LEASE_MS = 120_000;
+const CLEANUP_DEADLINE_MS = 55_000;
+const REDIS_OPERATION_TIMEOUT_MS = 5_000;
 const SCAN_BATCH_SIZE = 2_048;
 const MAX_KEYS_PER_PAGE = 2_048;
 const MAX_SCAN_PAGES = 1_000;
+const DELETE_TTL_LESS_RESERVATION_SCRIPT = `
+if redis.call('TTL', KEYS[1]) == -1 then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+`;
+const COMPLETE_CLEANUP_SCRIPT = `
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call('SET', KEYS[2], 'done')
+redis.call('DEL', KEYS[1])
+return 1
+`;
 
 /** Minimal Redis surface required by the one-shot transition cleanup. */
 export interface LegacyVibeRedisCleanupClient {
     del(key: string): Promise<number>;
+    destroy(): void;
+    eval(
+        script: string,
+        options: { keys: string[]; arguments?: string[] },
+    ): Promise<unknown>;
+    get(key: string): Promise<string | null>;
     set(
         key: string,
         value: string,
-        options: { NX: true },
+        options: { NX: true; PX: number },
     ): Promise<string | null>;
     scan(
         cursor: string,
         options: { MATCH: string; COUNT: number },
     ): Promise<{ cursor: string; keys: string[] }>;
-    ttl(key: string): Promise<number>;
     xGroupDestroy(key: string, group: string): Promise<number>;
 }
 
@@ -30,34 +55,58 @@ interface CleanupLogger {
     warn(message: string, context?: unknown): void;
 }
 
+interface CleanupOptions {
+    deadlineMs?: number;
+    operationTimeoutMs?: number;
+    now?: () => number;
+    ownerToken?: string;
+}
+
 /** Summary of transition artifacts removed from Redis. */
 export interface LegacyVibeRedisCleanupResult {
     staleReservationsDeleted: number;
 }
 
-async function runBestEffort(
-    operation: () => Promise<unknown>,
-    description: string,
-    logger: CleanupLogger,
-): Promise<void> {
+async function runRedisOperation<T>(
+    client: LegacyVibeRedisCleanupClient,
+    operation: () => Promise<T>,
+    deadlineAt: number,
+    operationTimeoutMs: number,
+    now: () => number,
+): Promise<T> {
+    const remainingMs = deadlineAt - now();
+    if (remainingMs <= 0)
+        throw new Error("Legacy vibe cleanup deadline exceeded");
+    const timeoutMs = Math.min(remainingMs, operationTimeoutMs);
+    let timer: NodeJS.Timeout | null = null;
+    const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+            client.destroy();
+            reject(new Error("Legacy vibe cleanup Redis operation timed out"));
+        }, timeoutMs);
+        timer.unref();
+    });
     try {
-        await operation();
-    } catch (error) {
-        logger.warn(`Failed to ${description}`, { error });
+        return await Promise.race([operation(), timeout]);
+    } finally {
+        if (timer) clearTimeout(timer);
     }
 }
 
 async function deleteStaleReservations(
     client: LegacyVibeRedisCleanupClient,
     logger: CleanupLogger,
+    run: <T>(operation: () => Promise<T>) => Promise<T>,
 ): Promise<number> {
     let cursor = "0";
     let deleted = 0;
     for (let page = 0; page < MAX_SCAN_PAGES; page += 1) {
-        const result = await client.scan(cursor, {
-            MATCH: RESERVATION_PATTERN,
-            COUNT: SCAN_BATCH_SIZE,
-        });
+        const result = await run(() =>
+            client.scan(cursor, {
+                MATCH: RESERVATION_PATTERN,
+                COUNT: SCAN_BATCH_SIZE,
+            }),
+        );
         if (result.keys.length > MAX_KEYS_PER_PAGE) {
             logger.warn(
                 "Legacy vibe reservation scan page exceeded its key limit",
@@ -67,46 +116,60 @@ async function deleteStaleReservations(
                     maxKeysPerPage: MAX_KEYS_PER_PAGE,
                 },
             );
-            return deleted;
+            throw new Error(
+                "Legacy vibe reservation scan page exceeded its key limit",
+            );
         }
         for (const key of result.keys) {
-            await runBestEffort(
-                async () => {
-                    // Safety: enqueueReservedWork is the only current producer.
-                    // Its Lua script creates each reservation with SET NX EX
-                    // atomically, so a new reservation is never momentarily
-                    // TTL-less. Therefore TTL == -1 identifies pre-atomic
-                    // legacy reservations; expiring and missing keys are kept.
-                    if ((await client.ttl(key)) !== -1) return;
-                    deleted += await client.del(key);
-                },
-                `remove stale vibe reservation ${key}`,
-                logger,
+            const removed = await run(() =>
+                client.eval(DELETE_TTL_LESS_RESERVATION_SCRIPT, {
+                    keys: [key],
+                }),
             );
+            if (removed !== 0 && removed !== 1) {
+                throw new Error(
+                    "Legacy vibe cleanup returned an invalid delete result",
+                );
+            }
+            deleted += removed;
         }
         cursor = result.cursor;
         if (cursor === "0") return deleted;
     }
-    logger.warn("Legacy vibe reservation scan reached its page limit", {
-        maxPages: MAX_SCAN_PAGES,
-    });
-    return deleted;
+    throw new Error("Legacy vibe reservation scan reached its page limit");
 }
 
 async function claimCleanup(
     client: LegacyVibeRedisCleanupClient,
-    logger: CleanupLogger,
+    ownerToken: string,
+    run: <T>(operation: () => Promise<T>) => Promise<T>,
 ): Promise<boolean> {
-    try {
-        const result = await client.set(CLEANUP_MARKER_KEY, "done", {
-            NX: true,
-        });
-        return result === "OK";
-    } catch (error) {
-        logger.warn("Failed to claim the legacy vibe Redis cleanup marker", {
-            error,
-        });
+    if ((await run(() => client.get(CLEANUP_MARKER_KEY))) === "done")
         return false;
+    const claimed = await run(() =>
+        client.set(CLEANUP_LEASE_KEY, ownerToken, {
+            NX: true,
+            PX: CLEANUP_LEASE_MS,
+        }),
+    );
+    if (claimed !== "OK") return false;
+    return (await run(() => client.get(CLEANUP_MARKER_KEY))) !== "done";
+}
+
+async function destroyLegacyConsumerGroup(
+    client: LegacyVibeRedisCleanupClient,
+    run: <T>(operation: () => Promise<T>) => Promise<T>,
+): Promise<void> {
+    try {
+        await run(() =>
+            client.xGroupDestroy(
+                LEGACY_TEXT_EMBED_STREAM,
+                LEGACY_TEXT_EMBED_GROUP,
+            ),
+        );
+    } catch (error) {
+        if (error instanceof Error && error.message.includes("NOGROUP")) return;
+        throw error;
     }
 }
 
@@ -114,39 +177,38 @@ async function claimCleanup(
 export async function cleanupLegacyVibeRedisArtifacts(
     client: LegacyVibeRedisCleanupClient,
     logger: CleanupLogger,
+    options: CleanupOptions = {},
 ): Promise<LegacyVibeRedisCleanupResult> {
-    if (!(await claimCleanup(client, logger))) {
+    const now = options.now ?? Date.now;
+    const deadlineAt = now() + (options.deadlineMs ?? CLEANUP_DEADLINE_MS);
+    const operationTimeoutMs =
+        options.operationTimeoutMs ?? REDIS_OPERATION_TIMEOUT_MS;
+    const ownerToken = options.ownerToken ?? randomUUID();
+    const run = <T>(operation: () => Promise<T>) =>
+        runRedisOperation(
+            client,
+            operation,
+            deadlineAt,
+            operationTimeoutMs,
+            now,
+        );
+    if (!(await claimCleanup(client, ownerToken, run))) {
         return { staleReservationsDeleted: 0 };
     }
-    await runBestEffort(
-        () =>
-            client.xGroupDestroy(
-                LEGACY_TEXT_EMBED_STREAM,
-                LEGACY_TEXT_EMBED_GROUP,
-            ),
-        "remove the legacy text-embedding consumer group",
+    await destroyLegacyConsumerGroup(client, run);
+    await run(() => client.del(LEGACY_TEXT_EMBED_STREAM));
+    await run(() => client.del(LEGACY_WORKER_HEARTBEAT));
+    const staleReservationsDeleted = await deleteStaleReservations(
+        client,
         logger,
+        run,
     );
-    await runBestEffort(
-        () => client.del(LEGACY_TEXT_EMBED_STREAM),
-        "remove the legacy text-embedding stream",
-        logger,
+    const completed = await run(() =>
+        client.eval(COMPLETE_CLEANUP_SCRIPT, {
+            keys: [CLEANUP_LEASE_KEY, CLEANUP_MARKER_KEY],
+            arguments: [ownerToken],
+        }),
     );
-    await runBestEffort(
-        () => client.del(LEGACY_WORKER_HEARTBEAT),
-        "remove the legacy CLAP worker heartbeat",
-        logger,
-    );
-    let staleReservationsDeleted = 0;
-    await runBestEffort(
-        async () => {
-            staleReservationsDeleted = await deleteStaleReservations(
-                client,
-                logger,
-            );
-        },
-        "scan legacy vibe queue reservations",
-        logger,
-    );
+    if (completed !== 1) throw new Error("Legacy vibe cleanup lease was lost");
     return { staleReservationsDeleted };
 }

--- a/backend/src/workers/processors/__tests__/federationSyncProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/federationSyncProcessor.test.ts
@@ -1521,7 +1521,7 @@ describe("federation sync processor", () => {
         );
     });
 
-    it("accepts a matching 2.3 tuple without preprocessingHash and warns once", async () => {
+    it("rejects a present tuple without preprocessingHash and warns once", async () => {
         const { preprocessingHash: _omitted, ...olderTuple } = embeddingSpace;
         client.getCatalogItems.mockImplementation((type: string) =>
             Promise.resolve(
@@ -1533,15 +1533,17 @@ describe("federation sync processor", () => {
 
         await processFederationSync(job());
 
-        expect(upsertTrackEmbedding).toHaveBeenCalledWith(
-            "fed-track-row",
-            track.attributes.embedding,
-            activeSpace.id,
+        expect(upsertTrackEmbedding).not.toHaveBeenCalled();
+        expect(recordFederationEmbeddingPageOutcome).toHaveBeenCalledWith(
+            "skipped_mismatch",
         );
         expect(mockLog.warn).toHaveBeenCalledTimes(1);
         expect(mockLog.warn).toHaveBeenCalledWith(
-            "Accepting federation embeddings from a 2.3 peer without preprocessingHash",
-            { peerId: "peer-1" },
+            "Skipping federation embeddings because the page space does not match the local active space",
+            expect.objectContaining({
+                peerId: "peer-1",
+                outcome: "skipped_mismatch",
+            }),
         );
     });
 

--- a/backend/src/workers/processors/federationSyncProcessor.ts
+++ b/backend/src/workers/processors/federationSyncProcessor.ts
@@ -84,7 +84,6 @@ interface SyncContext {
     skippedUnknownTombstones: number;
     localEmbeddingSpace: ActiveEmbeddingSpace | null;
     embeddingWarningEmitted: boolean;
-    legacyPreprocessingWarningEmitted: boolean;
 }
 
 /** Bounded summary of one completed peer sync. */
@@ -126,7 +125,6 @@ function newSyncContext(
         skippedUnknownTombstones: 0,
         localEmbeddingSpace,
         embeddingWarningEmitted: localEmbeddingSpace === null,
-        legacyPreprocessingWarningEmitted: false,
     };
 }
 

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -24,6 +24,7 @@ import { enrichmentFailureService } from "../services/enrichmentFailureService";
 import { audioAnalysisCleanupService } from "../services/audioAnalysisCleanup";
 import { rateLimiter } from "../services/rateLimiter";
 import { vibeAnalysisCleanupService } from "../services/vibeAnalysisCleanup";
+import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
 import { getSystemSettings } from "../utils/systemSettings";
 import { featureDetection } from "../services/featureDetection";
 import { moodBucketService } from "../services/moodBucketService";
@@ -575,14 +576,7 @@ export async function runFullEnrichment(options?: {
     });
 
     if (forceVibeRebuild) {
-        await prisma.track.updateMany({
-            where: LOCAL_TRACK_WHERE,
-            data: {
-                vibeAnalysisStatus: "pending",
-                vibeAnalysisStartedAt: null,
-                vibeAnalysisStatusUpdatedAt: new Date(),
-            },
-        });
+        await invalidateVibeAnalysis(prisma, LOCAL_TRACK_WHERE, new Date());
 
         await enrichmentFailureService.clearAllFailures("vibe");
 

--- a/backend/src/workers/vibeEmbedWorker.ts
+++ b/backend/src/workers/vibeEmbedWorker.ts
@@ -1,4 +1,5 @@
 import pLimit from "p-limit";
+import { randomUUID } from "node:crypto";
 import { config } from "../config";
 import {
     processVibeEmbedJob,
@@ -16,6 +17,7 @@ import {
     setVibeEmbeddingTargetSpaceId,
 } from "../services/embeddingSpaces";
 import { fetchProviderSpace } from "../services/vibeProvider";
+import { EmbeddingTargetInvalidatedError } from "../services/trackEmbeddings";
 import {
     recordVibeSpaceTransition,
     setVibeMigrationActive,
@@ -40,6 +42,7 @@ const POP_ERROR_BACKOFF_MS = 250;
 const TARGET_RESOLUTION_RETRY_MS = 60_000;
 const TERMINAL_TARGET_RESOLUTION_RETRY_MS = 15 * 60_000;
 const LEGACY_CLEANUP_TIMEOUT_MS = 60_000;
+const VIBE_WORKER_ID = `${process.pid}-${randomUUID()}`;
 
 interface WorkerLogger {
     info(message: string, context?: unknown): void;
@@ -119,6 +122,7 @@ function isTerminalTargetResolutionError(error: unknown): boolean {
 class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private readonly limit: ReturnType<typeof pLimit>;
     private readonly active = new Set<Promise<void>>();
+    private readonly targetInvalidationRetries = new Set<string>();
     private running = false;
     private loopPromise: Promise<void> | null = null;
     private coverageInterval: NodeJS.Timeout | null = null;
@@ -209,7 +213,12 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
                 registered: this.targetSpace.registered,
             };
             await this.dependencies.processJob(rawJob, jobTarget);
+            this.targetInvalidationRetries.delete(rawJob);
         } catch (error) {
+            if (error instanceof EmbeddingTargetInvalidatedError) {
+                await this.handleTargetInvalidation(rawJob, error);
+                return;
+            }
             this.dependencies.logger.error(
                 "Vibe embedding job failed before finalization",
                 error,
@@ -220,6 +229,46 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
                     requeueError,
                 );
             });
+        }
+    }
+
+    private clearResolvedTarget(): void {
+        this.targetSpace = null;
+        this.coverage = null;
+        this.dependencies.clearTargetSpace();
+        this.dependencies.setMigrationActive(false);
+        if (this.coverageInterval) clearInterval(this.coverageInterval);
+        this.coverageInterval = null;
+        if (this.lifecycleInterval) clearInterval(this.lifecycleInterval);
+        this.lifecycleInterval = null;
+    }
+
+    private async handleTargetInvalidation(
+        rawJob: string,
+        error: EmbeddingTargetInvalidatedError,
+    ): Promise<void> {
+        this.clearResolvedTarget();
+        if (this.targetInvalidationRetries.has(rawJob)) {
+            this.targetInvalidationRetries.delete(rawJob);
+            this.dependencies.logger.warn(
+                "Vibe job target changed twice; deferred to producer retry",
+                { spaceId: error.spaceId },
+            );
+            return;
+        }
+        this.targetInvalidationRetries.add(rawJob);
+        this.dependencies.logger.info(
+            "Vibe embedding target invalidated; resolving a fresh target",
+            { spaceId: error.spaceId },
+        );
+        try {
+            await this.dependencies.requeue(rawJob);
+        } catch (requeueError) {
+            this.targetInvalidationRetries.delete(rawJob);
+            this.dependencies.logger.error(
+                "Failed to requeue target-invalidated vibe job",
+                requeueError,
+            );
         }
     }
 
@@ -418,8 +467,7 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
         this.cleanupTask = null;
         await this.loopPromise;
         this.loopPromise = null;
-        this.targetSpace = null;
-        this.dependencies.clearTargetSpace();
+        this.clearResolvedTarget();
     }
 }
 
@@ -460,8 +508,24 @@ const worker = createVibeEmbedWorker({
         });
     },
     cleanupLegacyArtifacts: async () => {
-        const result = await cleanupLegacyVibeRedisArtifacts(redisClient, log);
-        log.info("Legacy vibe Redis cleanup completed", result);
+        const cleanupClient = redisClient.duplicate();
+        try {
+            const connected = await settleAtDeadline(
+                cleanupClient.connect().then(() => undefined),
+                5_000,
+            );
+            if (connected === "deadline") {
+                cleanupClient.destroy();
+                throw new Error("Legacy vibe Redis cleanup connect timed out");
+            }
+            const result = await cleanupLegacyVibeRedisArtifacts(
+                cleanupClient,
+                log,
+            );
+            log.info("Legacy vibe Redis cleanup completed", result);
+        } finally {
+            if (cleanupClient.isOpen) cleanupClient.destroy();
+        }
     },
     resolveTargetSpace: async () => {
         const providerSpace = await fetchProviderSpace();
@@ -479,7 +543,7 @@ const worker = createVibeEmbedWorker({
     recordSpaceTransition: recordVibeSpaceTransition,
     setMigrationActive: setVibeMigrationActive,
     writeStatus: async (status) => {
-        await writeVibeWorkerStatus(redisClient, status);
+        await writeVibeWorkerStatus(redisClient, status, VIBE_WORKER_ID);
     },
     now: () => new Date(),
     logger: log,

--- a/backend/src/workers/vibeWorkerStatus.ts
+++ b/backend/src/workers/vibeWorkerStatus.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
-/** Shared Redis key for the worker's last provider and migration snapshot. */
-export const VIBE_WORKER_STATUS_KEY = "soundspan:vibe-worker-status:v1";
+/** Namespace for TTL-bound per-worker provider status keys. */
+export const VIBE_WORKER_STATUS_KEY_PREFIX = "soundspan:vibe-worker-status:v2:";
+/** Three missed one-minute refreshes expire a dead worker's verdict. */
+export const VIBE_WORKER_STATUS_TTL_MS = 180_000;
+const MAX_STATUS_SCAN_PAGES = 100;
+const STATUS_SCAN_COUNT = 128;
 
 const coverageSchema = z.strictObject({
     embedded: z.number().int().nonnegative(),
@@ -23,28 +27,38 @@ const workerStatusSchema = z.strictObject({
     coverage: coverageSchema.nullable(),
 });
 
-/** Last provider check and target-space state published by the worker. */
+/** Last provider check and target-space state published by one worker. */
 export type VibeWorkerStatus = z.infer<typeof workerStatusSchema>;
 
-/** Minimal Redis surface for the compact worker status cache. */
+/** Minimal Redis surface for TTL-bound worker status aggregation. */
 export interface VibeWorkerStatusRedis {
-    get(key: string): Promise<string | null>;
-    set(key: string, value: string): Promise<unknown>;
+    mGet(keys: string[]): Promise<Array<string | null>>;
+    scan(
+        cursor: string,
+        options: { MATCH: string; COUNT: number },
+    ): Promise<{ cursor: string; keys: string[] }>;
+    set(key: string, value: string, options: { PX: number }): Promise<unknown>;
 }
 
-/** Persist a worker-owned status snapshot for API processes and restarts. */
+function workerStatusKey(workerId: string): string {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(workerId)) {
+        throw new Error("Vibe worker id is invalid");
+    }
+    return `${VIBE_WORKER_STATUS_KEY_PREFIX}${workerId}`;
+}
+
+/** Persist one worker snapshot with a bounded heartbeat lifetime. */
 export async function writeVibeWorkerStatus(
     redis: VibeWorkerStatusRedis,
     status: VibeWorkerStatus,
+    workerId: string,
 ): Promise<void> {
-    await redis.set(VIBE_WORKER_STATUS_KEY, JSON.stringify(status));
+    await redis.set(workerStatusKey(workerId), JSON.stringify(status), {
+        PX: VIBE_WORKER_STATUS_TTL_MS,
+    });
 }
 
-/** Read a validated snapshot; corrupt or obsolete cache values are a miss. */
-export async function readVibeWorkerStatus(
-    redis: VibeWorkerStatusRedis,
-): Promise<VibeWorkerStatus | null> {
-    const stored = await redis.get(VIBE_WORKER_STATUS_KEY);
+function parseWorkerStatus(stored: string | null): VibeWorkerStatus | null {
     if (stored === null) return null;
     try {
         const parsed: unknown = JSON.parse(stored);
@@ -53,4 +67,44 @@ export async function readVibeWorkerStatus(
     } catch {
         return null;
     }
+}
+
+async function loadFreshStatusValues(
+    redis: VibeWorkerStatusRedis,
+): Promise<string[]> {
+    let cursor = "0";
+    const values: string[] = [];
+    for (let page = 0; page < MAX_STATUS_SCAN_PAGES; page += 1) {
+        const result = await redis.scan(cursor, {
+            MATCH: `${VIBE_WORKER_STATUS_KEY_PREFIX}*`,
+            COUNT: STATUS_SCAN_COUNT,
+        });
+        if (result.keys.length > STATUS_SCAN_COUNT) {
+            throw new Error("Vibe worker status scan page exceeded its bound");
+        }
+        if (result.keys.length > 0) {
+            const pageValues = await redis.mGet(result.keys);
+            for (const value of pageValues)
+                if (value !== null) values.push(value);
+        }
+        cursor = result.cursor;
+        if (cursor === "0") return values;
+    }
+    throw new Error("Vibe worker status scan exceeded its page bound");
+}
+
+/** Read the newest validated, unexpired worker snapshot. */
+export async function readVibeWorkerStatus(
+    redis: VibeWorkerStatusRedis,
+): Promise<VibeWorkerStatus | null> {
+    const statuses = (await loadFreshStatusValues(redis))
+        .map(parseWorkerStatus)
+        .filter((status): status is VibeWorkerStatus => status !== null);
+    if (statuses.length === 0) return null;
+    statuses.sort((left, right) =>
+        right.providerReachability.checkedAt.localeCompare(
+            left.providerReachability.checkedAt,
+        ),
+    );
+    return statuses[0];
 }

--- a/backend/tests-integration/vibeSearchPostgres.integration.test.ts
+++ b/backend/tests-integration/vibeSearchPostgres.integration.test.ts
@@ -8,6 +8,11 @@ import {
     runEmbeddingSpaceLifecycleCheck,
 } from "../src/services/embeddingSpaceLifecycle";
 import { invalidateActiveSpaceCache } from "../src/services/embeddingSpaces";
+import {
+    EmbeddingTargetInvalidatedError,
+    upsertTrackEmbedding,
+    VibeEmbeddingGenerationMismatchError,
+} from "../src/services/trackEmbeddings";
 import { runAnnQuery } from "../src/utils/annQuery";
 import { prisma } from "../src/utils/db";
 
@@ -28,6 +33,7 @@ const MIGRATIONS = [
 interface IndexRow {
     name: string;
     isValid: boolean;
+    options: string[] | null;
     predicate: string | null;
 }
 
@@ -48,6 +54,7 @@ async function loadEmbeddingIndexes(client: Client): Promise<IndexRow[]> {
     const result = await client.query<IndexRow>(`
         SELECT index_class.relname AS name,
                index_row.indisvalid AS "isValid",
+               index_class.reloptions AS options,
                pg_get_expr(index_row.indpred, index_row.indrelid) AS predicate
         FROM pg_catalog.pg_index index_row
         JOIN pg_catalog.pg_class table_class
@@ -65,7 +72,18 @@ async function loadEmbeddingIndexes(client: Client): Promise<IndexRow[]> {
 
 async function seedVersion22Schema(client: Client): Promise<void> {
     await client.query(`
-        CREATE TABLE "Track" ("id" TEXT PRIMARY KEY);
+        CREATE TYPE "TrackOrigin" AS ENUM ('LOCAL', 'FEDERATED');
+        CREATE TABLE "Track" (
+            "id" TEXT PRIMARY KEY,
+            "origin" "TrackOrigin" NOT NULL DEFAULT 'LOCAL',
+            "removedAt" TIMESTAMP(3),
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "vibeAnalysisStatus" TEXT,
+            "vibeAnalysisStartedAt" TIMESTAMP(3),
+            "vibeAnalysisError" TEXT,
+            "vibeAnalysisRetryCount" INTEGER NOT NULL DEFAULT 0,
+            "vibeAnalysisStatusUpdatedAt" TIMESTAMP(3)
+        );
         CREATE TABLE "track_embeddings" (
             "track_id" TEXT PRIMARY KEY REFERENCES "Track"("id") ON DELETE CASCADE,
             "embedding" vector(512) NOT NULL,
@@ -81,6 +99,92 @@ async function seedVersion22Schema(client: Client): Promise<void> {
         INSERT INTO "track_embeddings" ("track_id", "embedding")
             VALUES ('seed-track', '${VECTOR}'::vector);
     `);
+}
+
+async function insertComparisonCorpus(
+    client: Client,
+    spaceId: string,
+): Promise<void> {
+    await client.query(
+        `INSERT INTO embedding_spaces (
+            id, family, checkpoint_hash, dim, preprocessing, status
+         ) VALUES ($1, 'comparison', 'comparison-hash', 512, '{}'::jsonb, 'migrating')`,
+        [spaceId],
+    );
+    await client.query(
+        `INSERT INTO "Track" ("id")
+         SELECT 'comparison-track-' || value
+         FROM generate_series(1, $1::int) AS value`,
+        [ANN_INDEX_MIN_VECTOR_COUNT],
+    );
+    await client.query(
+        `INSERT INTO track_embeddings (track_id, space_id, embedding)
+         SELECT 'comparison-track-' || value,
+                $1,
+                ('[' || (1 - value::double precision / 2000)::text || ',' ||
+                 (value::double precision / 2000)::text || ',' ||
+                 array_to_string(array_fill(0::integer, ARRAY[510]), ',') || ']')::vector
+         FROM generate_series(1, $2::int) AS value`,
+        [spaceId, ANN_INDEX_MIN_VECTOR_COUNT],
+    );
+}
+
+async function queryNearestIds(
+    client: Client,
+    spaceId: string,
+    exact: boolean,
+): Promise<string[]> {
+    await client.query("BEGIN");
+    try {
+        if (exact) {
+            await client.query("SET LOCAL enable_indexscan = off");
+        } else {
+            // Route through the ivfflat scan (see loadAnnPlan): with seq,
+            // bitmap, and sort disabled, the ordered ivfflat scan is the only
+            // viable plan, so this result set genuinely exercises the index.
+            await client.query("SET LOCAL enable_seqscan = off");
+            await client.query("SET LOCAL enable_bitmapscan = off");
+            await client.query("SET LOCAL enable_sort = off");
+            await client.query("SET LOCAL ivfflat.probes = 32");
+        }
+        const result = await client.query<{ trackId: string }>(
+            `SELECT track_id AS "trackId"
+             FROM track_embeddings
+             WHERE space_id = $1
+             ORDER BY embedding <=> $2::vector, track_id
+             LIMIT 10`,
+            [spaceId, VECTOR],
+        );
+        return result.rows.map((row) => row.trackId);
+    } finally {
+        await client.query("ROLLBACK");
+    }
+}
+
+async function loadAnnPlan(client: Client, spaceId: string): Promise<string> {
+    await client.query("BEGIN");
+    try {
+        await client.query("SET LOCAL enable_seqscan = off");
+        await client.query("SET LOCAL enable_bitmapscan = off");
+        // The btree space_id index plus an explicit Sort can legitimately
+        // out-cost the ivfflat scan on small corpora; disabling Sort leaves
+        // the ordered ivfflat scan as the only viable plan, making both this
+        // probe and the ANN result set deterministic.
+        await client.query("SET LOCAL enable_sort = off");
+        await client.query("SET LOCAL ivfflat.probes = 32");
+        const result = await client.query<Record<string, string>>(
+            `EXPLAIN (COSTS OFF)
+             SELECT track_id
+             FROM track_embeddings
+             WHERE space_id = $1
+             ORDER BY embedding <=> $2::vector
+             LIMIT 10`,
+            [spaceId, VECTOR],
+        );
+        return result.rows.map((row) => row["QUERY PLAN"]).join("\n");
+    } finally {
+        await client.query("ROLLBACK");
+    }
 }
 
 async function applyMigrations(client: Client): Promise<void> {
@@ -204,6 +308,7 @@ describeWithPostgres("vibe search PostgreSQL correctness", () => {
             expect.objectContaining({
                 name: indexName,
                 isValid: true,
+                options: expect.arrayContaining(["lists=40"]),
                 predicate: expect.stringContaining(
                     `space_id = '${TEACHER_SPACE_ID}'`,
                 ),
@@ -212,6 +317,83 @@ describeWithPostgres("vibe search PostgreSQL correctness", () => {
         expect(
             indexes.some((index) => index.name.includes("space_empty")),
         ).toBe(false);
+    });
+
+    it("matches exact and ANN top-k at the first size band", async () => {
+        const spaceId = "space_ann_comparison";
+        await insertComparisonCorpus(database, spaceId);
+        await expect(ensureSpaceAnnIndex(spaceId)).resolves.toBe(true);
+        await database.query("ANALYZE track_embeddings");
+
+        const exactIds = await queryNearestIds(database, spaceId, true);
+        const annIds = await queryNearestIds(database, spaceId, false);
+        const plan = await loadAnnPlan(database, spaceId);
+        expect(annIds).toEqual(exactIds);
+        expect(plan).toContain(`track_embeddings_${spaceId}_ivfflat_idx`);
+    });
+
+    it("rolls back a vector write when the generation CAS is stale", async () => {
+        await database.query(`
+            INSERT INTO "Track" (
+                "id", "vibeAnalysisStatus", "vibeAnalysisGeneration"
+            ) VALUES ('stale-generation-track', 'processing', 2)
+        `);
+        await expect(
+            upsertTrackEmbedding(
+                "stale-generation-track",
+                Array(512).fill(0),
+                "space_ann_comparison",
+                { generation: 1, completedAt: new Date() },
+            ),
+        ).rejects.toBeInstanceOf(VibeEmbeddingGenerationMismatchError);
+
+        const state = await database.query<{
+            status: string;
+            generation: number;
+            vectors: string;
+        }>(`
+            SELECT track."vibeAnalysisStatus" AS status,
+                   track."vibeAnalysisGeneration" AS generation,
+                   COUNT(embedding.track_id)::text AS vectors
+            FROM "Track" track
+            LEFT JOIN track_embeddings embedding
+              ON embedding.track_id = track.id
+            WHERE track.id = 'stale-generation-track'
+            GROUP BY track."vibeAnalysisStatus", track."vibeAnalysisGeneration"
+        `);
+        expect(state.rows).toEqual([
+            { status: "processing", generation: 2, vectors: "0" },
+        ]);
+    });
+
+    it("rejects writes into a retired embedding space", async () => {
+        await database.query(`
+            INSERT INTO embedding_spaces (
+                id, family, checkpoint_hash, dim, preprocessing, status
+            ) VALUES (
+                'space_retired_write', 'retired-write', 'retired-write-hash',
+                512, '{}'::jsonb, 'retired'
+            )
+        `);
+        await database.query(`
+            INSERT INTO "Track" (
+                "id", "vibeAnalysisStatus", "vibeAnalysisGeneration"
+            ) VALUES ('retired-write-track', 'processing', 0)
+        `);
+        await expect(
+            upsertTrackEmbedding(
+                "retired-write-track",
+                Array(512).fill(0),
+                "space_retired_write",
+                { generation: 0, completedAt: new Date() },
+            ),
+        ).rejects.toBeInstanceOf(EmbeddingTargetInvalidatedError);
+
+        const vectors = await database.query<{ count: string }>(`
+            SELECT COUNT(*)::text AS count FROM track_embeddings
+            WHERE track_id = 'retired-write-track'
+        `);
+        expect(vectors.rows).toEqual([{ count: "0" }]);
     });
 
     it("maps a real Prisma P2010 statement-timeout envelope carrying 57014", async () => {
@@ -251,6 +433,8 @@ describeWithPostgres("vibe search PostgreSQL correctness", () => {
         const config = {
             threshold: 0.95,
             retirementGraceDays: 7,
+            allowFailed: false,
+            currentProviderSpaceId: TEACHER_SPACE_ID,
             now: () => new Date("2026-08-17T00:00:00.000Z"),
         };
         await runEmbeddingSpaceLifecycleCheck(config);
@@ -273,5 +457,71 @@ describeWithPostgres("vibe search PostgreSQL correctness", () => {
             GROUP BY space.retired_at
         `);
         expect(afterSecond.rows).toEqual([{ count: "0", retiredAt: null }]);
+    });
+
+    it("preserves vectors when reactivation wins a cleanup interleaving", async () => {
+        const cleanup = new Client({
+            connectionString: process.env.DATABASE_URL,
+        });
+        const reactivation = new Client({
+            connectionString: process.env.DATABASE_URL,
+        });
+        const retiredAt = new Date("2026-07-01T00:00:00.000Z");
+        const claimedAt = new Date("2026-08-17T00:00:00.000Z");
+        await Promise.all([cleanup.connect(), reactivation.connect()]);
+        try {
+            await database.query(
+                `INSERT INTO embedding_spaces (
+                    id, family, checkpoint_hash, dim, preprocessing,
+                    status, retired_at
+                 ) VALUES (
+                    'space_reactivated', 'reactivated', 'reactivated-hash',
+                    512, '{}'::jsonb, 'retired', $1
+                 )`,
+                [retiredAt],
+            );
+            await insertVectors(
+                database,
+                "space_reactivated",
+                "reactivated-track-",
+                1,
+                1,
+            );
+            await cleanup.query(
+                `UPDATE embedding_spaces SET cleaning_at = $1
+                 WHERE id = 'space_reactivated' AND status = 'retired'`,
+                [claimedAt],
+            );
+            await reactivation.query(`
+                UPDATE embedding_spaces
+                SET status = 'migrating', retired_at = NULL, cleaning_at = NULL
+                WHERE id = 'space_reactivated'
+            `);
+
+            await cleanup.query("BEGIN");
+            const claim = await cleanup.query(
+                `UPDATE embedding_spaces SET cleaning_at = cleaning_at
+                 WHERE id = 'space_reactivated'
+                   AND status = 'retired'
+                   AND retired_at = $1
+                   AND cleaning_at = $2`,
+                [retiredAt, claimedAt],
+            );
+            if (claim.rowCount === 1) {
+                await cleanup.query(
+                    "DELETE FROM track_embeddings WHERE space_id = 'space_reactivated'",
+                );
+            }
+            await cleanup.query("COMMIT");
+
+            expect(claim.rowCount).toBe(0);
+            const remaining = await database.query<{ count: string }>(`
+                SELECT COUNT(*)::text AS count FROM track_embeddings
+                WHERE space_id = 'space_reactivated'
+            `);
+            expect(remaining.rows).toEqual([{ count: "1" }]);
+        } finally {
+            await Promise.all([cleanup.end(), reactivation.end()]);
+        }
     });
 });

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -83,13 +83,42 @@ install/upgrade rendering. `helm lint` alone exits successfully and does not
 enforce it.
 
 This upgrade changes the track-embedding composite key while individual-mode
-Deployments may still run 2.2 pods. Scale the backend and backend-worker
-Deployments to zero before `helm upgrade`. Let the upgrade restore their
-configured replica counts. If you do not stop both workloads, accept a brief
-error window while 2.2 pods overlap the 2.3 migration. The chart exposes
-`backend.strategy.type` and `backendWorker.strategy.type`. Setting both to
-`Recreate` prevents old and new pods from overlapping within each Deployment,
-but it does not coordinate the two Deployments.
+Deployments may still run 2.2 pods. Stop both workloads before `helm upgrade`.
+Set the namespace and the two rendered Deployment names. Save the original
+replica counts, then scale both Deployments to zero and wait until no ready
+replicas remain:
+
+```bash
+namespace=soundspan
+backend_deployment=soundspan-backend
+worker_deployment=soundspan-backend-worker
+backend_replicas=$(kubectl -n "$namespace" get deployment "$backend_deployment" -o jsonpath='{.spec.replicas}')
+worker_replicas=$(kubectl -n "$namespace" get deployment "$worker_deployment" -o jsonpath='{.spec.replicas}')
+kubectl -n "$namespace" scale deployment \
+  "$backend_deployment" "$worker_deployment" --replicas=0
+for attempt in $(seq 1 60); do
+  backend_ready=$(kubectl -n "$namespace" get deployment "$backend_deployment" -o jsonpath='{.status.readyReplicas}')
+  worker_ready=$(kubectl -n "$namespace" get deployment "$worker_deployment" -o jsonpath='{.status.readyReplicas}')
+  if [ "${backend_ready:-0}" = 0 ] && [ "${worker_ready:-0}" = 0 ]; then break; fi
+  if [ "$attempt" = 60 ]; then echo 'Timed out waiting for zero ready replicas' >&2; exit 1; fi
+  sleep 5
+done
+kubectl -n "$namespace" get deployment \
+  "$backend_deployment" "$worker_deployment" \
+  -o custom-columns=NAME:.metadata.name,READY:.status.readyReplicas
+```
+
+The verification output must show `0` ready replicas for both Deployments.
+Run `helm upgrade`, then restore and verify the saved replica counts:
+
+```bash
+kubectl -n "$namespace" scale deployment "$backend_deployment" \
+  --replicas="$backend_replicas"
+kubectl -n "$namespace" scale deployment "$worker_deployment" \
+  --replicas="$worker_replicas"
+kubectl -n "$namespace" rollout status deployment/"$backend_deployment" --timeout=5m
+kubectl -n "$namespace" rollout status deployment/"$worker_deployment" --timeout=5m
+```
 
 **Bare-metal or custom deployment:** stop the backend and every worker before
 applying the 2.3 database migration. Run this command from the backend

--- a/docs/observability/prometheus-alerts-soundspan.yml
+++ b/docs/observability/prometheus-alerts-soundspan.yml
@@ -16,6 +16,17 @@ groups:
                 summary: Vibe provider request failure rate is high
                 description: More than 10% of at least 10 vibe provider requests failed during the last 10 minutes.
 
+          - alert: SoundspanVibeProviderHeartbeatStale
+            expr: |
+                max(soundspan_vibe_provider_status_fresh) == 0
+                or absent(soundspan_vibe_provider_status_fresh)
+            for: 5m
+            labels:
+                severity: warning
+            annotations:
+                summary: Vibe provider worker heartbeat is absent or stale
+                description: No fresh per-worker vibe provider status heartbeat has been observed for at least 5 minutes.
+
           - alert: SoundspanVibeMigrationCoverageStalled
             expr: |
                 max(soundspan_vibe_migration_active) == 1

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -151,6 +151,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
     const {
         musicCNN,
         vibeEmbeddings,
+        vibe,
         loading: featuresLoading,
     } = useFeatures();
     const [syncing, setSyncing] = useState(false);
@@ -745,9 +746,9 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
 
                             {/* CLAP Embeddings (Vibe Similarity) with Re-run button */}
                             {!featuresLoading && vibeEmbeddings ? (
-                                enrichmentProgress.clapEmbeddings && (
-                                    <div className="flex items-start gap-2">
-                                        <div className="flex-1">
+                                <div className="flex items-start gap-2">
+                                    <div className="flex-1">
+                                        {enrichmentProgress.clapEmbeddings && (
                                             <EnrichmentStage
                                                 icon={Waves}
                                                 label="Vibe Embeddings"
@@ -776,24 +777,35 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                                 }
                                                 isBackground={true}
                                             />
-                                        </div>
-                                        <button
-                                            onClick={handleResetVibeEmbeddings}
-                                            disabled={
-                                                resettingVibe ||
-                                                syncing ||
-                                                reEnriching ||
-                                                isEnrichmentActive
-                                            }
-                                            className="mt-1 px-2 py-1 text-[10px] bg-white/5 text-white/60 rounded-full
-                                                hover:bg-white/10 hover:text-white/80 disabled:opacity-30 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
+                                        )}
+                                        <p
+                                            role="status"
+                                            className="mt-1 text-xs text-white/50"
                                         >
-                                            {resettingVibe
-                                                ? "Resetting..."
-                                                : "Re-run"}
-                                        </button>
+                                            Provider{" "}
+                                            {!vibe.provider.fresh
+                                                ? "status stale"
+                                                : vibe.provider.reachable
+                                                  ? "reachable"
+                                                  : "unreachable"}
+                                        </p>
                                     </div>
-                                )
+                                    <button
+                                        onClick={handleResetVibeEmbeddings}
+                                        disabled={
+                                            resettingVibe ||
+                                            syncing ||
+                                            reEnriching ||
+                                            isEnrichmentActive
+                                        }
+                                        className="mt-1 px-2 py-1 text-[10px] bg-white/5 text-white/60 rounded-full
+                                                hover:bg-white/10 hover:text-white/80 disabled:opacity-30 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
+                                    >
+                                        {resettingVibe
+                                            ? "Resetting..."
+                                            : "Re-run"}
+                                    </button>
+                                </div>
                             ) : !featuresLoading ? (
                                 <div className="opacity-50 py-2">
                                     <h4 className="text-sm font-medium text-gray-300">

--- a/frontend/lib/api/settings.ts
+++ b/frontend/lib/api/settings.ts
@@ -1,5 +1,37 @@
 import { type ApiClientConstructor, type ApiData } from "./core";
 
+/** Provider and migration state returned by the system features endpoint. */
+export interface VibeSystemStatus {
+    provider: {
+        configured: boolean;
+        reachable: boolean | null;
+        checkedAt: string | null;
+        fresh: boolean;
+    };
+    activeSpace: { id: string; family: string } | null;
+    migration: {
+        spaceId: string;
+        family: string;
+        coverage: {
+            embedded: number;
+            pending: number;
+            failed: number;
+        } | null;
+        cutoverThreshold: number;
+    } | null;
+}
+
+/** Feature flags and typed vibe status returned by the backend. */
+export interface SystemFeatures {
+    musicCNN: boolean;
+    vibeEmbeddings: boolean;
+    audioAnalysis: boolean;
+    discovery: boolean;
+    autoPlaylists: boolean;
+    federation: boolean;
+    vibe: VibeSystemStatus;
+}
+
 /** Add settings-domain operations to an API client base class. */
 export function WithSettings<TBase extends ApiClientConstructor>(Base: TBase) {
     abstract class SettingsApi extends Base {
@@ -52,22 +84,8 @@ export function WithSettings<TBase extends ApiClientConstructor>(Base: TBase) {
         }
 
         // System Features
-        async getFeatures(): Promise<{
-            musicCNN: boolean;
-            vibeEmbeddings: boolean;
-            audioAnalysis: boolean;
-            discovery: boolean;
-            autoPlaylists: boolean;
-            federation: boolean;
-        }> {
-            return this.request<{
-                musicCNN: boolean;
-                vibeEmbeddings: boolean;
-                audioAnalysis: boolean;
-                discovery: boolean;
-                autoPlaylists: boolean;
-                federation: boolean;
-            }>("/system/features");
+        async getFeatures(): Promise<SystemFeatures> {
+            return this.request<SystemFeatures>("/system/features");
         }
 
         // System UI Settings (non-sensitive, available to all authenticated users)

--- a/frontend/lib/features-context.tsx
+++ b/frontend/lib/features-context.tsx
@@ -13,6 +13,7 @@ import {
 import { api } from "./api";
 import { useVisibilityGatedInterval } from "../hooks/useVisibilityGatedInterval";
 import { frontendLogger as sharedFrontendLogger } from "./logger";
+import type { VibeSystemStatus } from "./api/settings";
 
 interface FeaturesState {
     musicCNN: boolean;
@@ -21,6 +22,7 @@ interface FeaturesState {
     discovery: boolean;
     autoPlaylists: boolean;
     federation: boolean;
+    vibe: VibeSystemStatus;
     showVersion: boolean;
     loading: boolean;
 }
@@ -35,6 +37,16 @@ const defaultState: FeaturesState = {
     discovery: true,
     autoPlaylists: true,
     federation: false,
+    vibe: {
+        provider: {
+            configured: false,
+            reachable: null,
+            checkedAt: null,
+            fresh: false,
+        },
+        activeSpace: null,
+        migration: null,
+    },
     showVersion: false,
     loading: true,
 };
@@ -61,6 +73,7 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
                 discovery: features.discovery ?? true,
                 autoPlaylists: features.autoPlaylists ?? true,
                 federation: features.federation ?? false,
+                vibe: features.vibe,
                 showVersion: uiSettings.showVersion,
                 loading: false,
             });
@@ -75,6 +88,7 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
                           discovery: true,
                           autoPlaylists: true,
                           federation: false,
+                          vibe: defaultState.vibe,
                           showVersion: false,
                           loading: false,
                       }

--- a/frontend/tests/component/cacheSection.component.test.ts
+++ b/frontend/tests/component/cacheSection.component.test.ts
@@ -14,6 +14,16 @@ mock.module("@/lib/features-context", {
             discovery: true,
             autoPlaylists: true,
             federation: false,
+            vibe: {
+                provider: {
+                    configured: true,
+                    reachable: true,
+                    checkedAt: "2026-08-17T12:00:00.000Z",
+                    fresh: true,
+                },
+                activeSpace: { id: "space-active", family: "teacher" },
+                migration: null,
+            },
             showVersion: false,
             loading: false,
         }),
@@ -112,6 +122,7 @@ test("renders live vibe embedding progress without the retired worker control", 
     );
 
     assert.match(html, /Vibe Embeddings/);
+    assert.match(html, /Provider\s+reachable/);
     assert.match(html, /Re-run/);
     assert.doesNotMatch(html, /Vibe Embedding Workers/);
 });

--- a/frontend/tests/component/featuresContext.component.test.ts
+++ b/frontend/tests/component/featuresContext.component.test.ts
@@ -24,6 +24,16 @@ const apiExports = {
                 discovery: true,
                 autoPlaylists: true,
                 federation: true,
+                vibe: {
+                    provider: {
+                        configured: true,
+                        reachable: true,
+                        checkedAt: "2026-08-17T12:00:00.000Z",
+                        fresh: true,
+                    },
+                    activeSpace: { id: "space-active", family: "teacher" },
+                    migration: null,
+                },
             };
         },
         getUiSettings: async () => {


### PR DESCRIPTION
## Summary

X5 — all eight round-3 release-gate findings, each pinned:

1. **Generation CAS everywhere** (High): centralized vibe invalidation increments `vibeAnalysisGeneration` for manual force, full-enrichment force, and replacement; the vector write CAS-validates status+generation in the upsert transaction.
2. **Retired-space write rejection** (High): the same transaction validates target-space `status IN (active,migrating) AND cleaning_at IS NULL`; rejection triggers target re-resolution + bounded requeue, never a failed mark.
3. **UPGRADING** (High-doc): mixed-version overlap alternative removed; scale-to-zero with verification commands required around `prisma migrate deploy`.
4. **Cleanup lease** (Med): owner-token lease with expiry; permanent marker only post-success; atomic Lua TTL-recheck-and-delete; per-command deadlines; `stop()` bounded.
5. **Federation hash requirement** (Med): tuple present → `preprocessingHash` required and matched; legacy window only for fully-absent tuples against the seeded teacher space (same-release tightening, noted in CHANGELOG).
6. **Provider status freshness** (Med): per-worker TTL heartbeats, freshness-aggregated reader, typed exposure through the features API + small admin indicator, `soundspan_vibe_provider_status_fresh` gauge + staleness alert (7 rules total).
7. **Integration contract** (Med): lifecycle config typed correctly; CI job now typechecks `tsconfig.integration.json`; suite extended with stale-generation rollback, retired-space rejection, two-connection cleanup interleaving, and exact-vs-ANN top-k.
8. **ANN size bands** (Low): none <1k, stepped bands to 224; one healing rebuild per tick; recall pinned at the first band.

Review of the exact-vs-ANN test on live Postgres surfaced planner realities worth noting: the btree+Sort plan legitimately out-costs ivfflat on small corpora, so the probe and result queries disable seq/bitmap/sort to make the ivfflat path deterministic — verified against pgvector/pg16.

Coverage-sampling audit (item 9): already bounded — two aggregate queries per sample on slow cadences; no change needed.

## Verification

- Full backend suite: **392 suites passed, 6,212 tests, 0 failures** (unrestricted).
- Real-PostgreSQL integration: **8/8 passed** against pgvector/pg16 (evidence includes the forced-ivfflat plan).
- Backend + integration `tsc --noEmit` clean; frontend typecheck + component tests green; per-package `format:check` clean; file-size gate green; alerts YAML parses (1 group, 7 rules).