### PR TITLE
fix(vibe): close the round-4 release blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Provider heartbeats now re-probe reachability each cycle, migration progress
+  is visible in settings, coverage sampling is statement-time bounded, and Helm
+  upgrade guidance waits for old backend and worker pods to be deleted.
 - The legacy global ANN index is now dropped, so space-scoped vector queries
   cannot lose results through cross-space approximation.
 - ANN indexes now build only after a space crosses a size floor, and the active

--- a/backend/src/services/__tests__/vibeEmbeddingCoverage.test.ts
+++ b/backend/src/services/__tests__/vibeEmbeddingCoverage.test.ts
@@ -3,9 +3,22 @@ const mockTrackGroupBy = jest.fn();
 const mockEmbeddingFindFirst = jest.fn();
 const mockSpaceFindUnique = jest.fn();
 const mockGetTargetSpaceId = jest.fn();
+const mockQueryRaw = jest.fn();
+const mockTransaction = jest.fn();
+const mockSetCoverage = jest.fn();
+const mockCollectionErrorInc = jest.fn();
+
+jest.mock("../../metrics", () => ({
+    metricsRegistry: {
+        getSingleMetric: () => ({ inc: mockCollectionErrorInc }),
+    },
+    setVibeEmbeddingCoverage: (...args: unknown[]) => mockSetCoverage(...args),
+}));
 
 jest.mock("../../utils/db", () => ({
     prisma: {
+        $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+        $transaction: (...args: unknown[]) => mockTransaction(...args),
         track: {
             count: (...args: unknown[]) => mockTrackCount(...args),
             groupBy: (...args: unknown[]) => mockTrackGroupBy(...args),
@@ -28,11 +41,16 @@ import {
     createVibeEmbeddingCoverageRefresher,
     loadVibeEmbeddingCoverage,
     loadVibeSpaceVectorState,
+    refreshVibeEmbeddingCoverage,
 } from "../vibeEmbeddingCoverage";
 
 describe("vibe embedding coverage refresh", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockQueryRaw.mockResolvedValue([{ set_config: "10000" }]);
+        mockTransaction.mockImplementation(async (queries: unknown[]) =>
+            Promise.all(queries),
+        );
     });
 
     it("counts only eligible tracks in the active space", async () => {
@@ -70,6 +88,9 @@ describe("vibe embedding coverage refresh", () => {
         });
         expect(mockTrackCount).toHaveBeenCalledTimes(1);
         expect(mockTrackGroupBy).toHaveBeenCalledTimes(1);
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+        expect(mockQueryRaw.mock.calls[0]?.[1]).toBe("10000");
+        expect(mockTransaction).toHaveBeenCalledTimes(1);
     });
 
     it("checks active-space emptiness with an existence query", async () => {
@@ -110,6 +131,25 @@ describe("vibe embedding coverage refresh", () => {
             embedded: 12,
             pending: 4,
             failed: 1,
+        });
+    });
+
+    it("retains the previous sample when the bounded query times out", async () => {
+        const previous = { embedded: 10, pending: 5, failed: 1 };
+        mockTrackCount.mockResolvedValueOnce(12);
+        mockTrackGroupBy.mockResolvedValueOnce([]);
+        mockTransaction.mockRejectedValueOnce({
+            code: "P2010",
+            meta: { code: "57014" },
+        });
+
+        await expect(
+            refreshVibeEmbeddingCoverage("target-space", previous),
+        ).resolves.toEqual(previous);
+
+        expect(mockSetCoverage).not.toHaveBeenCalled();
+        expect(mockCollectionErrorInc).toHaveBeenCalledWith({
+            collector: "vibe_embedding_coverage",
         });
     });
 });

--- a/backend/src/services/vibeEmbeddingCoverage.ts
+++ b/backend/src/services/vibeEmbeddingCoverage.ts
@@ -1,12 +1,55 @@
-import { setVibeEmbeddingCoverage } from "../metrics";
+import { metricsRegistry, setVibeEmbeddingCoverage } from "../metrics";
 import type { VibeEmbeddingCoverage } from "../metrics/vibeEmbedMetrics";
 import { prisma } from "../utils/db";
+import { logger } from "../utils/logger";
 import { getVibeEmbeddingTargetSpaceId } from "./embeddingSpaces";
 import { vibeEmbeddingEligibleTrackWhere } from "./vibeEmbeddingEligibility";
 
 interface CoverageRefresherDependencies {
     loadCoverage(): Promise<VibeEmbeddingCoverage>;
     setCoverage(coverage: VibeEmbeddingCoverage): void;
+}
+
+const COVERAGE_STATEMENT_TIMEOUT_MS = 10_000;
+const STATEMENT_TIMEOUT_SQLSTATE = "57014";
+const COLLECTION_ERRORS_METRIC = "soundspan_metrics_collection_errors_total";
+const log =
+    typeof (logger as { child?: unknown }).child === "function"
+        ? logger.child("VibeEmbeddingCoverage")
+        : logger;
+
+class VibeEmbeddingCoverageTimeoutError extends Error {
+    constructor(cause: unknown) {
+        super("Vibe embedding coverage sampling timed out", { cause });
+        this.name = "VibeEmbeddingCoverageTimeoutError";
+    }
+}
+
+function nestedErrorCode(candidate: unknown): string | undefined {
+    if (typeof candidate !== "object" || candidate === null) return undefined;
+    const code = (candidate as Record<string, unknown>).code;
+    return typeof code === "string" ? code : undefined;
+}
+
+function isStatementTimeout(error: unknown): boolean {
+    if (nestedErrorCode(error) === STATEMENT_TIMEOUT_SQLSTATE) return true;
+    if (typeof error !== "object" || error === null) return false;
+    const meta = (error as Record<string, unknown>).meta;
+    if (nestedErrorCode(meta) === STATEMENT_TIMEOUT_SQLSTATE) return true;
+    if (typeof meta !== "object" || meta === null) return false;
+    const adapter = (meta as Record<string, unknown>).driverAdapterError;
+    if (typeof adapter !== "object" || adapter === null) return false;
+    return (
+        nestedErrorCode((adapter as Record<string, unknown>).cause) ===
+        STATEMENT_TIMEOUT_SQLSTATE
+    );
+}
+
+function recordCoverageCollectionError(): void {
+    const counter = metricsRegistry.getSingleMetric(
+        COLLECTION_ERRORS_METRIC,
+    ) as { inc(labels: Readonly<{ collector: string }>): void } | undefined;
+    counter?.inc({ collector: "vibe_embedding_coverage" });
 }
 
 /** Loads durable vector-presence history for instant-cutover decisions. */
@@ -34,35 +77,44 @@ export async function loadVibeEmbeddingCoverage(
     const resolvedTargetSpaceId =
         targetSpaceId ?? (await getVibeEmbeddingTargetSpaceId());
     const eligibleWhere = vibeEmbeddingEligibleTrackWhere();
-    const [embedded, missingByStatus] = await Promise.all([
-        prisma.track.count({
-            where: {
-                ...eligibleWhere,
-                embeddings: { some: { spaceId: resolvedTargetSpaceId } },
-            },
-        }),
-        prisma.track.groupBy({
-            by: ["vibeAnalysisStatus"],
-            where: {
-                ...eligibleWhere,
-                embeddings: { none: { spaceId: resolvedTargetSpaceId } },
-            },
-            _count: true,
-        }),
-    ]);
-    const failed =
-        missingByStatus.find((row) => row.vibeAnalysisStatus === "failed")
-            ?._count ?? 0;
-    const pending = missingByStatus.reduce(
-        (count, row) =>
-            row.vibeAnalysisStatus === "failed" ? count : count + row._count,
-        0,
-    );
-    return {
-        embedded,
-        failed,
-        pending,
-    };
+    try {
+        const [, embedded, missingByStatus] = await prisma.$transaction([
+            prisma.$queryRaw`SELECT set_config('statement_timeout', ${String(COVERAGE_STATEMENT_TIMEOUT_MS)}, true)`,
+            prisma.track.count({
+                where: {
+                    ...eligibleWhere,
+                    embeddings: { some: { spaceId: resolvedTargetSpaceId } },
+                },
+            }),
+            prisma.track.groupBy({
+                by: ["vibeAnalysisStatus"],
+                where: {
+                    ...eligibleWhere,
+                    embeddings: { none: { spaceId: resolvedTargetSpaceId } },
+                },
+                _count: true,
+            }),
+        ]);
+        const failed =
+            missingByStatus.find((row) => row.vibeAnalysisStatus === "failed")
+                ?._count ?? 0;
+        const pending = missingByStatus.reduce(
+            (count, row) =>
+                row.vibeAnalysisStatus === "failed"
+                    ? count
+                    : count + row._count,
+            0,
+        );
+        return { embedded, failed, pending };
+    } catch (error) {
+        if (!isStatementTimeout(error)) throw error;
+        recordCoverageCollectionError();
+        log.warn("Vibe embedding coverage sampling timed out", {
+            targetSpaceId: resolvedTargetSpaceId,
+            timeoutMs: COVERAGE_STATEMENT_TIMEOUT_MS,
+        });
+        throw new VibeEmbeddingCoverageTimeoutError(error);
+    }
 }
 
 /** Creates the slow worker-owned coverage refresh operation. */
@@ -78,8 +130,16 @@ export function createVibeEmbeddingCoverageRefresher(
 /** Refreshes target-space coverage in the process-local metrics registry. */
 export async function refreshVibeEmbeddingCoverage(
     targetSpaceId?: string,
-): Promise<VibeEmbeddingCoverage> {
-    const coverage = await loadVibeEmbeddingCoverage(targetSpaceId);
-    setVibeEmbeddingCoverage(coverage);
-    return coverage;
+    previousCoverage: VibeEmbeddingCoverage | null = null,
+): Promise<VibeEmbeddingCoverage | null> {
+    try {
+        const coverage = await loadVibeEmbeddingCoverage(targetSpaceId);
+        setVibeEmbeddingCoverage(coverage);
+        return coverage;
+    } catch (error) {
+        if (error instanceof VibeEmbeddingCoverageTimeoutError) {
+            return previousCoverage;
+        }
+        throw error;
+    }
 }

--- a/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
+++ b/backend/src/workers/__tests__/vibeEmbedWorker.test.ts
@@ -43,6 +43,7 @@ describe("vibe embed worker", () => {
             pending: 2,
             failed: 1,
         }));
+        const probeProvider = jest.fn(async () => undefined);
         const runLifecycle = jest.fn(async () => undefined);
         const cleanupLegacyArtifacts = jest.fn<Promise<void>, []>(
             async () => undefined,
@@ -81,6 +82,7 @@ describe("vibe embed worker", () => {
             pop,
             processJob,
             requeue,
+            probeProvider,
             refreshCoverage,
             runLifecycle,
             cleanupLegacyArtifacts,
@@ -98,6 +100,7 @@ describe("vibe embed worker", () => {
             pop,
             processJob,
             requeue,
+            probeProvider,
             refreshCoverage,
             runLifecycle,
             cleanupLegacyArtifacts,
@@ -106,6 +109,7 @@ describe("vibe embed worker", () => {
             recordSpaceTransition,
             setMigrationActive,
             writeStatus,
+            now,
             resolveTargetSpace,
             logger,
         };
@@ -149,7 +153,10 @@ describe("vibe embed worker", () => {
         await flushPromises();
         expect(harness.pop).toHaveBeenCalledWith("audio:clap:queue", 1);
         expect(harness.refreshCoverage).toHaveBeenCalledTimes(1);
-        expect(harness.refreshCoverage).toHaveBeenCalledWith("space-active");
+        expect(harness.refreshCoverage).toHaveBeenCalledWith(
+            "space-active",
+            null,
+        );
         expect(harness.writeStatus).toHaveBeenLastCalledWith({
             providerReachability: {
                 reachable: true,
@@ -414,6 +421,43 @@ describe("vibe embed worker", () => {
         await stopping;
     });
 
+    it("publishes an unreachable provider verdict within one live-worker cadence", async () => {
+        jest.useFakeTimers();
+        const firstPop = deferred<string | null>();
+        const harness = createHarness({
+            providerUrl: "http://provider:8090",
+        });
+        harness.pop.mockReturnValueOnce(firstPop.promise);
+
+        await harness.worker.start();
+        await Promise.resolve();
+        harness.probeProvider.mockRejectedValueOnce(
+            new TypeError("provider connection refused"),
+        );
+        harness.now.mockReturnValue(new Date("2026-08-17T12:01:00.000Z"));
+
+        await jest.advanceTimersByTimeAsync(60_000);
+
+        expect(harness.probeProvider).toHaveBeenCalledTimes(1);
+        expect(harness.writeStatus).toHaveBeenLastCalledWith({
+            providerReachability: {
+                reachable: false,
+                checkedAt: "2026-08-17T12:01:00.000Z",
+                errorClass: "TypeError",
+            },
+            targetSpace: {
+                id: "space-active",
+                family: "test-family",
+                status: "active",
+            },
+            coverage: { embedded: 8, pending: 2, failed: 1 },
+        });
+
+        const stopping = harness.worker.stop();
+        firstPop.resolve(null);
+        await stopping;
+    });
+
     it.each(["active", "migrating"] as const)(
         "targets a provider resolved to a %s space",
         async (status) => {
@@ -509,6 +553,7 @@ describe("vibe embed worker", () => {
             providerReachability: {
                 reachable: false,
                 checkedAt: "2026-08-17T12:00:00.000Z",
+                errorClass: "Error",
             },
             targetSpace: null,
             coverage: null,

--- a/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
+++ b/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
@@ -59,7 +59,9 @@ describe("vibe worker status cache", () => {
             JSON.stringify(status),
         ]);
 
-        await expect(readVibeWorkerStatus(redis)).resolves.toEqual(status);
+        await expect(
+            readVibeWorkerStatus(redis, new Date("2026-08-17T12:01:00.000Z")),
+        ).resolves.toEqual(status);
     });
 
     it("treats an expired key omitted by Redis as stale", async () => {
@@ -71,6 +73,19 @@ describe("vibe worker status cache", () => {
         redis.mGet.mockResolvedValueOnce([null]);
 
         await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
+    });
+
+    it("treats an over-age checkedAt as stale while its Redis key survives", async () => {
+        const redis = createRedis();
+        redis.scan.mockResolvedValueOnce({
+            cursor: "0",
+            keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-stale`],
+        });
+        redis.mGet.mockResolvedValueOnce([JSON.stringify(status)]);
+
+        await expect(
+            readVibeWorkerStatus(redis, new Date("2026-08-17T12:03:00.001Z")),
+        ).resolves.toBeNull();
     });
 
     it.each(["not-json", JSON.stringify({ reachable: "yes" })])(

--- a/backend/src/workers/vibeEmbedWorker.ts
+++ b/backend/src/workers/vibeEmbedWorker.ts
@@ -31,17 +31,18 @@ import {
     VIBE_PROVIDER_QUEUE_KEY,
 } from "./legacyVibeRedisCleanup";
 import {
+    VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS,
     writeVibeWorkerStatus,
     type VibeWorkerStatus,
 } from "./vibeWorkerStatus";
 
 const BLPOP_TIMEOUT_SECONDS = 1;
-const COVERAGE_REFRESH_INTERVAL_MS = 60_000;
 const SPACE_LIFECYCLE_INTERVAL_MS = 5 * 60_000;
 const POP_ERROR_BACKOFF_MS = 250;
 const TARGET_RESOLUTION_RETRY_MS = 60_000;
 const TERMINAL_TARGET_RESOLUTION_RETRY_MS = 15 * 60_000;
 const LEGACY_CLEANUP_TIMEOUT_MS = 60_000;
+const PROVIDER_STATUS_PROBE_TIMEOUT_MS = 3_000;
 const VIBE_WORKER_ID = `${process.pid}-${randomUUID()}`;
 
 interface WorkerLogger {
@@ -60,7 +61,11 @@ interface VibeEmbedWorkerDependencies {
         targetSpace: VibeWorkerJobTargetSpace,
     ): Promise<unknown>;
     requeue(rawJob: string): Promise<void>;
-    refreshCoverage(targetSpaceId: string): Promise<VibeEmbeddingCoverage>;
+    probeProvider(): Promise<unknown>;
+    refreshCoverage(
+        targetSpaceId: string,
+        previousCoverage: VibeEmbeddingCoverage | null,
+    ): Promise<VibeEmbeddingCoverage | null>;
     runLifecycle(): Promise<void>;
     cleanupLegacyArtifacts(): Promise<void>;
     resolveTargetSpace(): Promise<ResolvedWorkerTargetSpace>;
@@ -118,6 +123,13 @@ function isTerminalTargetResolutionError(error: unknown): boolean {
     );
 }
 
+function providerErrorClass(error: unknown): string {
+    if (error instanceof Error && error.name.trim().length > 0) {
+        return error.name.slice(0, 128);
+    }
+    return "UnknownError";
+}
+
 /** Creates a provider-gated, bounded, drainable audio embedding worker. */
 class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private readonly limit: ReturnType<typeof pLimit>;
@@ -128,6 +140,7 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private coverageInterval: NodeJS.Timeout | null = null;
     private lifecycleInterval: NodeJS.Timeout | null = null;
     private lifecycleTask: Promise<void> | null = null;
+    private statusRefreshTask: Promise<void> | null = null;
     private targetSpace: ResolvedWorkerTargetSpace | null = null;
     private retryWake: (() => void) | null = null;
     private terminalResolutionFailureCount = 0;
@@ -147,16 +160,47 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     private async refreshCoverage(): Promise<void> {
         if (!this.targetSpace) return;
         try {
-            this.coverage = await this.dependencies.refreshCoverage(
+            const coverage = await this.dependencies.refreshCoverage(
                 this.targetSpace.id,
+                this.coverage,
             );
-            await this.publishStatus();
+            if (coverage !== null) this.coverage = coverage;
         } catch (error) {
             this.dependencies.logger.warn(
                 "Vibe coverage refresh failed",
                 error,
             );
         }
+    }
+
+    private async refreshProviderReachability(): Promise<void> {
+        try {
+            await this.dependencies.probeProvider();
+            this.providerReachability = {
+                reachable: true,
+                checkedAt: this.dependencies.now().toISOString(),
+            };
+        } catch (error) {
+            this.providerReachability = {
+                reachable: false,
+                checkedAt: this.dependencies.now().toISOString(),
+                errorClass: providerErrorClass(error),
+            };
+        }
+    }
+
+    private async refreshStatus(): Promise<void> {
+        await this.refreshProviderReachability();
+        await this.refreshCoverage();
+        await this.publishStatus();
+    }
+
+    private scheduleStatusRefresh(): void {
+        if (this.statusRefreshTask) return;
+        const task = this.refreshStatus().finally(() => {
+            if (this.statusRefreshTask === task) this.statusRefreshTask = null;
+        });
+        this.statusRefreshTask = task;
     }
 
     private async publishStatus(): Promise<void> {
@@ -361,6 +405,7 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
             this.providerReachability = {
                 reachable: false,
                 checkedAt: this.dependencies.now().toISOString(),
+                errorClass: providerErrorClass(error),
             };
             const retryDelayMs = this.recordTargetResolutionFailure(error);
             void this.publishStatus();
@@ -393,10 +438,10 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
     }
 
     private startCoverageRefresh(): void {
-        void this.refreshCoverage();
+        void this.refreshCoverage().then(() => this.publishStatus());
         this.coverageInterval = setInterval(
-            () => void this.refreshCoverage(),
-            COVERAGE_REFRESH_INTERVAL_MS,
+            () => this.scheduleStatusRefresh(),
+            VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS,
         );
         this.coverageInterval.unref();
     }
@@ -461,6 +506,8 @@ class VibeEmbedWorkerRuntime implements VibeEmbedWorker {
         this.coverageInterval = null;
         if (this.lifecycleInterval) clearInterval(this.lifecycleInterval);
         this.lifecycleInterval = null;
+        await this.statusRefreshTask;
+        this.statusRefreshTask = null;
         await this.lifecycleTask;
         this.lifecycleTask = null;
         await this.cleanupTask;
@@ -494,8 +541,19 @@ const worker = createVibeEmbedWorker({
     requeue: async (rawJob) => {
         await redisClient.rPush(VIBE_PROVIDER_QUEUE_KEY, rawJob);
     },
-    refreshCoverage: async (targetSpaceId) => {
-        return refreshVibeEmbeddingCoverage(targetSpaceId);
+    probeProvider: async () => {
+        const outcome = await settleAtDeadline(
+            fetchProviderSpace().then(() => undefined),
+            PROVIDER_STATUS_PROBE_TIMEOUT_MS,
+        );
+        if (outcome === "deadline") {
+            const error = new Error("Vibe provider status probe timed out");
+            error.name = "VibeProviderProbeTimeoutError";
+            throw error;
+        }
+    },
+    refreshCoverage: async (targetSpaceId, previousCoverage) => {
+        return refreshVibeEmbeddingCoverage(targetSpaceId, previousCoverage);
     },
     runLifecycle: async () => {
         const currentProviderSpaceId = await getVibeEmbeddingTargetSpaceId();

--- a/backend/src/workers/vibeWorkerStatus.ts
+++ b/backend/src/workers/vibeWorkerStatus.ts
@@ -2,8 +2,11 @@ import { z } from "zod";
 
 /** Namespace for TTL-bound per-worker provider status keys. */
 export const VIBE_WORKER_STATUS_KEY_PREFIX = "soundspan:vibe-worker-status:v2:";
+/** Cadence shared by worker publishing and reader-side freshness checks. */
+export const VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS = 60_000;
 /** Three missed one-minute refreshes expire a dead worker's verdict. */
-export const VIBE_WORKER_STATUS_TTL_MS = 180_000;
+export const VIBE_WORKER_STATUS_TTL_MS =
+    3 * VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS;
 const MAX_STATUS_SCAN_PAGES = 100;
 const STATUS_SCAN_COUNT = 128;
 
@@ -16,6 +19,7 @@ const workerStatusSchema = z.strictObject({
     providerReachability: z.strictObject({
         reachable: z.boolean(),
         checkedAt: z.iso.datetime(),
+        errorClass: z.string().min(1).max(128).optional(),
     }),
     targetSpace: z
         .strictObject({
@@ -69,6 +73,11 @@ function parseWorkerStatus(stored: string | null): VibeWorkerStatus | null {
     }
 }
 
+function isStatusFresh(status: VibeWorkerStatus, nowMs: number): boolean {
+    const checkedAtMs = Date.parse(status.providerReachability.checkedAt);
+    return nowMs - checkedAtMs <= VIBE_WORKER_STATUS_TTL_MS;
+}
+
 async function loadFreshStatusValues(
     redis: VibeWorkerStatusRedis,
 ): Promise<string[]> {
@@ -96,10 +105,15 @@ async function loadFreshStatusValues(
 /** Read the newest validated, unexpired worker snapshot. */
 export async function readVibeWorkerStatus(
     redis: VibeWorkerStatusRedis,
+    now: Date = new Date(),
 ): Promise<VibeWorkerStatus | null> {
+    const nowMs = now.getTime();
     const statuses = (await loadFreshStatusValues(redis))
         .map(parseWorkerStatus)
-        .filter((status): status is VibeWorkerStatus => status !== null);
+        .filter(
+            (status): status is VibeWorkerStatus =>
+                status !== null && isStatusFresh(status, nowMs),
+        );
     if (statuses.length === 0) return null;
     statuses.sort((left, right) =>
         right.providerReachability.checkedAt.localeCompare(

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -56,14 +56,25 @@ docker compose config
 ```
 
 Remove any custom override that still declares `audio-analyzer-clap`. Then
-recreate the stack with orphan removal:
+fully stop every backend API and worker container. Stop any surviving torch
+analyzer before a 2.3 entrypoint can run the migration:
+
+```bash
+docker compose stop backend backend-worker
+docker ps --filter name=audio-analyzer-clap -q | xargs -r docker stop
+docker compose ps --status running --format '{{.Name}}' backend backend-worker
+docker ps --filter name=audio-analyzer-clap --format '{{.Names}}'
+```
+
+The last two commands must print no container names. Recreate the stack only
+after every old writer has terminated:
 
 ```bash
 docker compose up -d --remove-orphans
 ```
 
-Verify that no torch analyzer container remains. This command must print no
-container names:
+Verify that the removed torch analyzer did not return. This command must print
+no container names:
 
 ```bash
 docker ps --filter name=audio-analyzer-clap --format '{{.Names}}'
@@ -84,45 +95,70 @@ enforce it.
 
 This upgrade changes the track-embedding composite key while individual-mode
 Deployments may still run 2.2 pods. Stop both workloads before `helm upgrade`.
-Set the namespace and the two rendered Deployment names. Save the original
-replica counts, then scale both Deployments to zero and wait until no ready
-replicas remain:
+Set the namespace, Helm release, chart name label, and the two rendered
+Deployment names. The chart's pod selectors contain
+`app.kubernetes.io/name`, `app.kubernetes.io/instance`, and
+`app.kubernetes.io/component`. If `nameOverride` is set, use that value for
+`chart_name`. Save the original replica counts, then scale the backend and the
+optional backend worker to zero:
 
 ```bash
 namespace=soundspan
+release=soundspan
+chart_name=soundspan
 backend_deployment=soundspan-backend
 worker_deployment=soundspan-backend-worker
+backend_selector="app.kubernetes.io/name=$chart_name,app.kubernetes.io/instance=$release,app.kubernetes.io/component=backend"
+worker_selector="app.kubernetes.io/name=$chart_name,app.kubernetes.io/instance=$release,app.kubernetes.io/component=backend-worker"
 backend_replicas=$(kubectl -n "$namespace" get deployment "$backend_deployment" -o jsonpath='{.spec.replicas}')
-worker_replicas=$(kubectl -n "$namespace" get deployment "$worker_deployment" -o jsonpath='{.spec.replicas}')
-kubectl -n "$namespace" scale deployment \
-  "$backend_deployment" "$worker_deployment" --replicas=0
-for attempt in $(seq 1 60); do
-  backend_ready=$(kubectl -n "$namespace" get deployment "$backend_deployment" -o jsonpath='{.status.readyReplicas}')
-  worker_ready=$(kubectl -n "$namespace" get deployment "$worker_deployment" -o jsonpath='{.status.readyReplicas}')
-  if [ "${backend_ready:-0}" = 0 ] && [ "${worker_ready:-0}" = 0 ]; then break; fi
-  if [ "$attempt" = 60 ]; then echo 'Timed out waiting for zero ready replicas' >&2; exit 1; fi
-  sleep 5
-done
-kubectl -n "$namespace" get deployment \
-  "$backend_deployment" "$worker_deployment" \
-  -o custom-columns=NAME:.metadata.name,READY:.status.readyReplicas
+worker_present=false
+if kubectl -n "$namespace" get deployment "$worker_deployment" >/dev/null 2>&1; then
+  worker_present=true
+  worker_replicas=$(kubectl -n "$namespace" get deployment "$worker_deployment" -o jsonpath='{.spec.replicas}')
+fi
+kubectl -n "$namespace" scale deployment "$backend_deployment" --replicas=0
+if [ "$worker_present" = true ]; then
+  kubectl -n "$namespace" scale deployment "$worker_deployment" --replicas=0
+fi
 ```
 
-The verification output must show `0` ready replicas for both Deployments.
-Run `helm upgrade`, then restore and verify the saved replica counts:
+Warning: zero ready replicas is not sufficient. A terminating 2.2 pod can
+continue draining work. Wait for Kubernetes to delete every pod selected by
+both chart workloads:
+
+```bash
+if [ -n "$(kubectl -n "$namespace" get pod -l "$backend_selector" -o name)" ]; then
+  kubectl -n "$namespace" wait --for=delete pod \
+    -l "$backend_selector" --timeout=5m
+fi
+if [ "$worker_present" = true ]; then
+  if [ -n "$(kubectl -n "$namespace" get pod -l "$worker_selector" -o name)" ]; then
+    kubectl -n "$namespace" wait --for=delete pod \
+      -l "$worker_selector" --timeout=5m
+  fi
+fi
+```
+
+Run `helm upgrade` only after both waits succeed. Then restore and verify the
+saved replica counts:
 
 ```bash
 kubectl -n "$namespace" scale deployment "$backend_deployment" \
   --replicas="$backend_replicas"
-kubectl -n "$namespace" scale deployment "$worker_deployment" \
-  --replicas="$worker_replicas"
+if [ "$worker_present" = true ]; then
+  kubectl -n "$namespace" scale deployment "$worker_deployment" \
+    --replicas="$worker_replicas"
+fi
 kubectl -n "$namespace" rollout status deployment/"$backend_deployment" --timeout=5m
-kubectl -n "$namespace" rollout status deployment/"$worker_deployment" --timeout=5m
+if [ "$worker_present" = true ]; then
+  kubectl -n "$namespace" rollout status deployment/"$worker_deployment" --timeout=5m
+fi
 ```
 
 **Bare-metal or custom deployment:** stop the backend and every worker before
-applying the 2.3 database migration. Run this command from the backend
-directory with the deployment's `DATABASE_URL`:
+applying the 2.3 database migration. Confirm that every process has fully exited;
+do not rely on readiness or shutdown initiation alone. Run this command from
+the backend directory with the deployment's `DATABASE_URL`:
 
 ```bash
 DATABASE_URL='postgresql://soundspan:password@database:5432/soundspan' npx prisma migrate deploy

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -562,6 +562,16 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
         enrichmentState?.status === "running" ||
         enrichmentState?.status === "paused";
     const totalFailures = failureCounts?.total || 0;
+    const migrationCoverage = vibe.migration?.coverage;
+    const migrationActionable = migrationCoverage
+        ? migrationCoverage.embedded + migrationCoverage.pending
+        : 0;
+    const migrationPercent =
+        migrationCoverage && migrationActionable > 0
+            ? Math.round(
+                  (migrationCoverage.embedded / migrationActionable) * 100,
+              )
+            : 0;
 
     return (
         <>
@@ -789,6 +799,59 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                                   ? "reachable"
                                                   : "unreachable"}
                                         </p>
+                                        {vibe.migration && (
+                                            <div
+                                                role="status"
+                                                aria-label="Vibe embedding migration"
+                                                className="mt-2 rounded-lg border border-white/10 bg-white/5 p-3"
+                                            >
+                                                <p className="text-xs font-medium text-white/80">
+                                                    Embedding migration
+                                                </p>
+                                                <p className="mt-1 text-[11px] text-white/50">
+                                                    Target space family:{" "}
+                                                    {vibe.migration.family}
+                                                </p>
+                                                {migrationCoverage ? (
+                                                    <>
+                                                        <div className="mt-2">
+                                                            <ProgressBar
+                                                                progress={
+                                                                    migrationPercent
+                                                                }
+                                                            />
+                                                        </div>
+                                                        <p className="mt-1 text-[10px] text-white/40">
+                                                            {
+                                                                migrationCoverage.embedded
+                                                            }{" "}
+                                                            embedded ·{" "}
+                                                            {
+                                                                migrationCoverage.pending
+                                                            }{" "}
+                                                            pending ·{" "}
+                                                            {
+                                                                migrationCoverage.failed
+                                                            }{" "}
+                                                            failed
+                                                        </p>
+                                                    </>
+                                                ) : (
+                                                    <p className="mt-2 text-[11px] text-white/40">
+                                                        Awaiting coverage sample
+                                                    </p>
+                                                )}
+                                                <p className="mt-1 text-[10px] text-white/40">
+                                                    Cutover threshold:{" "}
+                                                    {Math.round(
+                                                        vibe.migration
+                                                            .cutoverThreshold *
+                                                            100,
+                                                    )}
+                                                    %
+                                                </p>
+                                            </div>
+                                        )}
                                     </div>
                                     <button
                                         onClick={handleResetVibeEmbeddings}

--- a/frontend/tests/component/cacheSection.component.test.ts
+++ b/frontend/tests/component/cacheSection.component.test.ts
@@ -5,6 +5,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { SystemSettings } from "../../features/settings/types";
 
+const activeMigration = {
+    spaceId: "space-migrating",
+    family: "student",
+    coverage: { embedded: 80, pending: 20, failed: 3 },
+    cutoverThreshold: 0.95,
+};
+let migration: typeof activeMigration | null = activeMigration;
+
 mock.module("@/lib/features-context", {
     namedExports: {
         useFeatures: () => ({
@@ -22,7 +30,7 @@ mock.module("@/lib/features-context", {
                     fresh: true,
                 },
                 activeSpace: { id: "space-active", family: "teacher" },
-                migration: null,
+                migration,
             },
             showVersion: false,
             loading: false,
@@ -85,7 +93,7 @@ const settings: SystemSettings = {
     showVersion: false,
 };
 
-test("renders live vibe embedding progress without the retired worker control", async () => {
+async function renderCacheSection(): Promise<string> {
     const { CacheSection } =
         await import("../../features/settings/components/sections/CacheSection");
     const queryClient = new QueryClient();
@@ -110,7 +118,7 @@ test("renders live vibe embedding progress without the retired worker control", 
         isFullyComplete: false,
     });
 
-    const html = renderToStaticMarkup(
+    return renderToStaticMarkup(
         React.createElement(
             QueryClientProvider,
             { client: queryClient },
@@ -120,9 +128,28 @@ test("renders live vibe embedding progress without the retired worker control", 
             }),
         ),
     );
+}
+
+test("renders live vibe embedding progress without the retired worker control", async () => {
+    migration = activeMigration;
+    const html = await renderCacheSection();
 
     assert.match(html, /Vibe Embeddings/);
     assert.match(html, /Provider\s+reachable/);
+    assert.match(html, /Embedding migration/);
+    assert.match(html, /Target space family:\s*student/);
+    assert.match(html, /80%/);
+    assert.match(html, /3 failed/);
+    assert.match(html, /Cutover threshold:\s*95%/);
     assert.match(html, /Re-run/);
     assert.doesNotMatch(html, /Vibe Embedding Workers/);
+});
+
+test("hides migration progress when no migration is active", async () => {
+    migration = null;
+
+    const html = await renderCacheSection();
+
+    assert.doesNotMatch(html, /Embedding migration/);
+    assert.doesNotMatch(html, /Target space family:/);
 });


### PR DESCRIPTION
## Summary

X6 — the four remaining release-gate blockers:

1. **Helm quiescence** (High-doc): UPGRADING now scales backend + optional worker to zero and waits for **pod deletion** via the chart's actual selector labels (not zero-Ready, which permits draining-pod writes during the incompatible migration); replica counts saved/restored; compose + bare-metal require full termination.
2. **Fresh reachability verdicts** (Med): heartbeats re-probe the provider's authenticated space endpoint each publish cycle (3s deadline) and publish fresh `checkedAt`/error class; the reader rejects snapshots older than 3× the publish interval regardless of Redis TTL. Dead-provider-live-worker flips within one cadence — tested.
3. **Migration visibility** (Med): settings renders active-migration family, actionable coverage %, embedded/pending/failed, and the cutover threshold (component-tested for present/absent; file stays under its ratchet).
4. **Bounded coverage sampling** (Med): count/groupBy run under a transaction-local 10s statement timeout in one Prisma batch; timeout keeps the prior sample, logs once, and increments the bounded collection-error label.

## Verification

- Full backend suite (unrestricted): **392 suites, 6,215 tests, 0 failures.**
- Real-PostgreSQL integration: **8/8** against pgvector/pg16.
- Backend + frontend typecheck clean; per-package `format:check` clean; file-size gate green; targeted + component tests pass.