### PR TITLE
fix(security): allowlist the superseded historical tokenizer digest

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,6 +43,11 @@ regexes = [
   '''fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862''',
   '''06e405a36dfe4b9604f484f6a1e619af1a7f7d09e34a8555eb0b77b66318067f''',
   '''77ef92283d67f0d97e1454909a964afcbfa2019f0fb9f18f8e88d5c25c3ba729''',
+  # Historical only: the superseded (incorrect, truncated-download) sha256
+  # recorded for tokenizer.json before the digest was corrected. It exists in
+  # the pinning commit's history for both hardening tests; it never was and
+  # cannot be a credential.
+  '''4e105259baf1a26f1ed8b503ad09678d69d02b6be1c91faa55075a22d5bee148''',
   '''377f91458f7729a4574a84c77bdce67dbc3c58c1a345a29bbf8c4eb1307948a3''',
   '''ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e''',
 


### PR DESCRIPTION
Main's push-time Gitleaks history scan flags 2 findings: the digest-correction commit removed the old `4e105259…` value from the allowlist, but the value survives in the pinning commit's history in both hardening tests. Restored with a comment marking it historical — it is the sha256 of a truncated public download, never a credential. Verified locally: full history scan reports no leaks with this config.