### PR TITLE
fix(vibe): stop the index-probe deadlock loop; make status reads keyspace-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed embedding-space index checks so existing matching indexes are not
+  rebuilt on every lifecycle tick.
+- Fixed vibe worker status reads on large Redis keyspaces by using a bounded
+  worker registry and removing expired entries.
+
 ## [2.3.0] - 2026-08-17
 
 ### Added

--- a/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
+++ b/backend/src/services/__tests__/embeddingSpaceLifecycle.test.ts
@@ -77,6 +77,7 @@ import {
     MAX_RETIREMENT_DELETE_BATCHES,
     RETIREMENT_DELETE_BATCH_SIZE,
     annIndexListsForVectorCount,
+    ensureSpaceAnnIndex,
     retirementDue,
     runEmbeddingSpaceLifecycleCheck,
     shouldBuildAnnIndex,
@@ -309,30 +310,56 @@ describe("embedding-space lifecycle effects", () => {
         expect(mockRecordTransition).toHaveBeenCalledWith("cutover");
     });
 
-    it("keeps an existing valid partial index", async () => {
-        mockFindFirst.mockResolvedValue(migrating);
-        mockLoadCoverage.mockResolvedValue({
-            embedded: ANN_INDEX_MIN_VECTOR_COUNT,
-            pending: 0,
-            failed: 0,
-        });
-        mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
-        mockQueryRaw.mockResolvedValue([
-            { isValid: true, options: ["lists=40"] },
-        ]);
+    it.each([
+        ["array", ["lists=40"]],
+        ["PostgreSQL array string", "{lists=40}"],
+    ])(
+        "keeps an existing valid partial index from the %s adapter representation",
+        async (_representation, lists) => {
+            mockFindFirst.mockResolvedValue(migrating);
+            mockLoadCoverage.mockResolvedValue({
+                embedded: ANN_INDEX_MIN_VECTOR_COUNT,
+                pending: 0,
+                failed: 0,
+            });
+            mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
+            mockQueryRaw.mockResolvedValue([
+                { isValid: true, options: lists, lists },
+            ]);
 
-        await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
+            await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 
-        expect(mockExecuteRawUnsafe).not.toHaveBeenCalled();
-        expect(mockUpdateMany).toHaveBeenCalledWith({
-            where: {
-                id: "space_student_1",
-                status: "migrating",
-                cleaningAt: null,
-            },
-            data: { status: "active", retiredAt: null, cleaningAt: null },
-        });
-    });
+            expect(mockExecuteRawUnsafe).not.toHaveBeenCalled();
+            expect(mockUpdateMany).toHaveBeenCalledWith({
+                where: {
+                    id: "space_student_1",
+                    status: "migrating",
+                    cleaningAt: null,
+                },
+                data: { status: "active", retiredAt: null, cleaningAt: null },
+            });
+        },
+    );
+
+    it.each(["40P01", "42P07", "42710", "23505"])(
+        "re-probes after recoverable CREATE INDEX SQLSTATE %s",
+        async (code) => {
+            mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
+            mockQueryRaw
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([{ isValid: true, lists: "40" }]);
+            mockExecuteRawUnsafe.mockRejectedValueOnce({
+                meta: { driverAdapterError: { cause: { code } } },
+            });
+
+            await expect(ensureSpaceAnnIndex("space_teacher_1")).resolves.toBe(
+                true,
+            );
+
+            expect(mockQueryRaw).toHaveBeenCalledTimes(2);
+            expect(mockExecuteRawUnsafe).toHaveBeenCalledTimes(1);
+        },
+    );
 
     it("keeps a sub-threshold migration when the active space has vectors", async () => {
         mockFindFirst.mockResolvedValue(migrating);
@@ -437,9 +464,7 @@ describe("embedding-space lifecycle effects", () => {
             failed: 0,
         });
         mockEmbeddingCount.mockResolvedValue(ANN_INDEX_MIN_VECTOR_COUNT);
-        mockQueryRaw.mockResolvedValue([
-            { isValid: false, options: ["lists=40"] },
-        ]);
+        mockQueryRaw.mockResolvedValue([{ isValid: false, lists: "40" }]);
 
         await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 
@@ -478,9 +503,7 @@ describe("embedding-space lifecycle effects", () => {
 
     it("rebuilds at most once when the active space crosses a list band", async () => {
         mockEmbeddingCount.mockResolvedValue(2_500);
-        mockQueryRaw.mockResolvedValue([
-            { isValid: true, options: ["lists=40"] },
-        ]);
+        mockQueryRaw.mockResolvedValue([{ isValid: true, lists: "40" }]);
 
         await runEmbeddingSpaceLifecycleCheck(lifecycleConfig);
 

--- a/backend/src/services/embeddingSpaceLifecycle.ts
+++ b/backend/src/services/embeddingSpaceLifecycle.ts
@@ -112,11 +112,52 @@ interface AnnIndexState {
     lists: number | null;
 }
 
-function parseIndexLists(options: readonly string[] | null): number | null {
-    const value = options?.find((option) => option.startsWith("lists="));
-    if (!value) return null;
-    const lists = Number.parseInt(value.slice("lists=".length), 10);
+const MAX_INDEX_OPTION_COUNT = 16;
+const RECOVERABLE_INDEX_CREATE_SQLSTATES = new Set([
+    "40P01", // deadlock_detected
+    "42P07", // duplicate_table (indexes are relations)
+    "42710", // duplicate_object
+    "23505", // concurrent pg_class uniqueness race
+]);
+
+function parseIndexLists(value: unknown): number | null {
+    let serialized = value;
+    if (Array.isArray(value)) {
+        if (value.length > MAX_INDEX_OPTION_COUNT) return null;
+        serialized = value.find(
+            (option) =>
+                typeof option === "string" && option.startsWith("lists="),
+        );
+    }
+    if (typeof serialized !== "string") return null;
+    const match = serialized
+        .trim()
+        .match(/^(?:\{)?(?:lists=)?([1-9]\d*)(?:\})?$/);
+    if (!match) return null;
+    const lists = Number(match[1]);
     return Number.isSafeInteger(lists) && lists > 0 ? lists : null;
+}
+
+function postgresErrorCode(error: unknown): string | null {
+    if (typeof error !== "object" || error === null) return null;
+    const record = error as Record<string, unknown>;
+    const meta =
+        typeof record.meta === "object" && record.meta !== null
+            ? (record.meta as Record<string, unknown>)
+            : null;
+    const adapter =
+        typeof meta?.driverAdapterError === "object" &&
+        meta.driverAdapterError !== null
+            ? (meta.driverAdapterError as Record<string, unknown>)
+            : null;
+    const cause =
+        typeof adapter?.cause === "object" && adapter.cause !== null
+            ? (adapter.cause as Record<string, unknown>)
+            : null;
+    for (const candidate of [record, meta, cause]) {
+        if (typeof candidate?.code === "string") return candidate.code;
+    }
+    return null;
 }
 
 async function loadPartialAnnIndex(
@@ -125,22 +166,28 @@ async function loadPartialAnnIndex(
     const validatedId = validatedSpaceId(spaceId);
     const indexName = partialIndexName(validatedId);
     const rows = await prisma.$queryRaw<
-        Array<{ isValid: boolean; options: string[] | null }>
+        Array<{ isValid: boolean; lists: unknown }>
     >`
         SELECT index_row.indisvalid AS "isValid",
-               index_class.reloptions AS options
+               (
+                   SELECT option_value
+                   FROM pg_catalog.pg_options_to_table(index_class.reloptions)
+                   WHERE option_name = 'lists'
+                   LIMIT 1
+               ) AS lists
         FROM pg_catalog.pg_index index_row
         INNER JOIN pg_catalog.pg_class index_class
             ON index_class.oid = index_row.indexrelid
-        INNER JOIN pg_catalog.pg_namespace namespace
-            ON namespace.oid = index_class.relnamespace
+        INNER JOIN pg_catalog.pg_class table_class
+            ON table_class.oid = index_row.indrelid
         WHERE index_class.relname = ${indexName}
-          AND namespace.nspname = current_schema()
+          AND index_class.relnamespace = table_class.relnamespace
+          AND table_class.oid = pg_catalog.to_regclass('track_embeddings')
         LIMIT 1
     `;
     const row = rows[0];
     return row
-        ? { isValid: row.isValid, lists: parseIndexLists(row.options) }
+        ? { isValid: row.isValid, lists: parseIndexLists(row.lists) }
         : null;
 }
 
@@ -173,7 +220,16 @@ export async function ensureSpaceAnnIndex(spaceId: string): Promise<boolean> {
     }
     if (current?.isValid && current.lists === desiredLists) return true;
     if (current) await dropPartialAnnIndex(spaceId);
-    await createPartialAnnIndex(spaceId, desiredLists);
+    try {
+        await createPartialAnnIndex(spaceId, desiredLists);
+    } catch (error) {
+        const code = postgresErrorCode(error);
+        if (!code || !RECOVERABLE_INDEX_CREATE_SQLSTATES.has(code)) {
+            throw error;
+        }
+        const reprobed = await loadPartialAnnIndex(spaceId);
+        if (!reprobed?.isValid || reprobed.lists !== desiredLists) throw error;
+    }
     return true;
 }
 

--- a/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
+++ b/backend/src/workers/__tests__/vibeWorkerStatus.test.ts
@@ -1,6 +1,7 @@
 import {
     readVibeWorkerStatus,
     VIBE_WORKER_STATUS_KEY_PREFIX,
+    VIBE_WORKER_STATUS_REGISTRY_KEY,
     writeVibeWorkerStatus,
     type VibeWorkerStatusRedis,
 } from "../vibeWorkerStatus";
@@ -8,7 +9,9 @@ import {
 function createRedis(): jest.Mocked<VibeWorkerStatusRedis> {
     return {
         mGet: jest.fn().mockResolvedValue([]),
-        scan: jest.fn().mockResolvedValue({ cursor: "0", keys: [] }),
+        sAdd: jest.fn().mockResolvedValue(1),
+        sMembers: jest.fn().mockResolvedValue([]),
+        sRem: jest.fn().mockResolvedValue(0),
         set: jest.fn().mockResolvedValue("OK"),
     };
 }
@@ -32,22 +35,26 @@ describe("vibe worker status cache", () => {
 
         await writeVibeWorkerStatus(redis, status, "worker-1");
 
+        expect(redis.sAdd).toHaveBeenCalledWith(
+            VIBE_WORKER_STATUS_REGISTRY_KEY,
+            `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-1`,
+        );
         expect(redis.set).toHaveBeenCalledWith(
             `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-1`,
             JSON.stringify(status),
             { PX: 180_000 },
         );
+        expect(redis.sAdd.mock.invocationCallOrder[0]).toBeLessThan(
+            redis.set.mock.invocationCallOrder[0],
+        );
     });
 
     it("reports the newest fresh worker snapshot", async () => {
         const redis = createRedis();
-        redis.scan.mockResolvedValueOnce({
-            cursor: "0",
-            keys: [
-                `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-old`,
-                `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-new`,
-            ],
-        });
+        redis.sMembers.mockResolvedValueOnce([
+            `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-old`,
+            `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-new`,
+        ]);
         redis.mGet.mockResolvedValueOnce([
             JSON.stringify({
                 ...status,
@@ -66,21 +73,22 @@ describe("vibe worker status cache", () => {
 
     it("treats an expired key omitted by Redis as stale", async () => {
         const redis = createRedis();
-        redis.scan.mockResolvedValueOnce({
-            cursor: "0",
-            keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-expired`],
-        });
+        const expiredKey = `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-expired`;
+        redis.sMembers.mockResolvedValueOnce([expiredKey]);
         redis.mGet.mockResolvedValueOnce([null]);
 
         await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
+        expect(redis.sRem).toHaveBeenCalledWith(
+            VIBE_WORKER_STATUS_REGISTRY_KEY,
+            [expiredKey],
+        );
     });
 
     it("treats an over-age checkedAt as stale while its Redis key survives", async () => {
         const redis = createRedis();
-        redis.scan.mockResolvedValueOnce({
-            cursor: "0",
-            keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-stale`],
-        });
+        redis.sMembers.mockResolvedValueOnce([
+            `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-stale`,
+        ]);
         redis.mGet.mockResolvedValueOnce([JSON.stringify(status)]);
 
         await expect(
@@ -92,13 +100,43 @@ describe("vibe worker status cache", () => {
         "treats invalid cached state as unavailable",
         async (stored) => {
             const redis = createRedis();
-            redis.scan.mockResolvedValueOnce({
-                cursor: "0",
-                keys: [`${VIBE_WORKER_STATUS_KEY_PREFIX}worker-invalid`],
-            });
+            redis.sMembers.mockResolvedValueOnce([
+                `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-invalid`,
+            ]);
             redis.mGet.mockResolvedValueOnce([stored]);
 
             await expect(readVibeWorkerStatus(redis)).resolves.toBeNull();
         },
     );
+
+    it("returns live status and removes dead registry keys", async () => {
+        const redis = createRedis();
+        const deadKey = `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-dead`;
+        const liveKey = `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-live`;
+        redis.sMembers.mockResolvedValueOnce([deadKey, liveKey]);
+        redis.mGet.mockResolvedValueOnce([null, JSON.stringify(status)]);
+
+        await expect(
+            readVibeWorkerStatus(redis, new Date("2026-08-17T12:01:00.000Z")),
+        ).resolves.toEqual(status);
+        expect(redis.sRem).toHaveBeenCalledWith(
+            VIBE_WORKER_STATUS_REGISTRY_KEY,
+            [deadKey],
+        );
+    });
+
+    it("rejects a registry above its defensive cardinality bound", async () => {
+        const redis = createRedis();
+        redis.sMembers.mockResolvedValueOnce(
+            Array.from(
+                { length: 257 },
+                (_, index) => `${VIBE_WORKER_STATUS_KEY_PREFIX}worker-${index}`,
+            ),
+        );
+
+        await expect(readVibeWorkerStatus(redis)).rejects.toThrow(
+            "Vibe worker status registry exceeded its cardinality bound",
+        );
+        expect(redis.mGet).not.toHaveBeenCalled();
+    });
 });

--- a/backend/src/workers/vibeWorkerStatus.ts
+++ b/backend/src/workers/vibeWorkerStatus.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { logger } from "../utils/logger";
 
+function registryErrorClass(error: unknown): string {
+    if (error instanceof Error && error.name.trim().length > 0) {
+        return error.name.slice(0, 128);
+    }
+    return "UnknownError";
+}
+
 /** Namespace for TTL-bound per-worker provider status keys. */
 export const VIBE_WORKER_STATUS_KEY_PREFIX = "soundspan:vibe-worker-status:v2:";
 /** Exact-key registry used to discover TTL-bound worker snapshots. */
@@ -101,7 +108,7 @@ async function removeDeadRegistryKeys(
         await redis.sRem(VIBE_WORKER_STATUS_REGISTRY_KEY, keys);
     } catch (error) {
         log.warn("Vibe worker status registry cleanup failed", {
-            errorClass: error instanceof Error ? error.name : typeof error,
+            errorClass: registryErrorClass(error),
         });
     }
 }

--- a/backend/src/workers/vibeWorkerStatus.ts
+++ b/backend/src/workers/vibeWorkerStatus.ts
@@ -1,14 +1,19 @@
 import { z } from "zod";
+import { logger } from "../utils/logger";
 
 /** Namespace for TTL-bound per-worker provider status keys. */
 export const VIBE_WORKER_STATUS_KEY_PREFIX = "soundspan:vibe-worker-status:v2:";
+/** Exact-key registry used to discover TTL-bound worker snapshots. */
+export const VIBE_WORKER_STATUS_REGISTRY_KEY =
+    "soundspan:vibe-worker-status:v2:registry";
 /** Cadence shared by worker publishing and reader-side freshness checks. */
 export const VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS = 60_000;
 /** Three missed one-minute refreshes expire a dead worker's verdict. */
 export const VIBE_WORKER_STATUS_TTL_MS =
     3 * VIBE_WORKER_STATUS_PUBLISH_INTERVAL_MS;
-const MAX_STATUS_SCAN_PAGES = 100;
-const STATUS_SCAN_COUNT = 128;
+const MAX_STATUS_REGISTRY_SIZE = 256;
+const WORKER_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const log = logger.child("VibeWorkerStatus");
 
 const coverageSchema = z.strictObject({
     embedded: z.number().int().nonnegative(),
@@ -37,15 +42,14 @@ export type VibeWorkerStatus = z.infer<typeof workerStatusSchema>;
 /** Minimal Redis surface for TTL-bound worker status aggregation. */
 export interface VibeWorkerStatusRedis {
     mGet(keys: string[]): Promise<Array<string | null>>;
-    scan(
-        cursor: string,
-        options: { MATCH: string; COUNT: number },
-    ): Promise<{ cursor: string; keys: string[] }>;
+    sAdd(key: string, member: string): Promise<unknown>;
+    sMembers(key: string): Promise<string[]>;
+    sRem(key: string, members: string[]): Promise<unknown>;
     set(key: string, value: string, options: { PX: number }): Promise<unknown>;
 }
 
 function workerStatusKey(workerId: string): string {
-    if (!/^[A-Za-z0-9_-]{1,128}$/.test(workerId)) {
+    if (!WORKER_ID_PATTERN.test(workerId) || workerId === "registry") {
         throw new Error("Vibe worker id is invalid");
     }
     return `${VIBE_WORKER_STATUS_KEY_PREFIX}${workerId}`;
@@ -57,7 +61,9 @@ export async function writeVibeWorkerStatus(
     status: VibeWorkerStatus,
     workerId: string,
 ): Promise<void> {
-    await redis.set(workerStatusKey(workerId), JSON.stringify(status), {
+    const key = workerStatusKey(workerId);
+    await redis.sAdd(VIBE_WORKER_STATUS_REGISTRY_KEY, key);
+    await redis.set(key, JSON.stringify(status), {
         PX: VIBE_WORKER_STATUS_TTL_MS,
     });
 }
@@ -78,28 +84,50 @@ function isStatusFresh(status: VibeWorkerStatus, nowMs: number): boolean {
     return nowMs - checkedAtMs <= VIBE_WORKER_STATUS_TTL_MS;
 }
 
+function isRegisteredStatusKey(key: string): boolean {
+    if (!key.startsWith(VIBE_WORKER_STATUS_KEY_PREFIX)) return false;
+    if (key === VIBE_WORKER_STATUS_REGISTRY_KEY) return false;
+    return WORKER_ID_PATTERN.test(
+        key.slice(VIBE_WORKER_STATUS_KEY_PREFIX.length),
+    );
+}
+
+async function removeDeadRegistryKeys(
+    redis: VibeWorkerStatusRedis,
+    keys: string[],
+): Promise<void> {
+    if (keys.length === 0) return;
+    try {
+        await redis.sRem(VIBE_WORKER_STATUS_REGISTRY_KEY, keys);
+    } catch (error) {
+        log.warn("Vibe worker status registry cleanup failed", {
+            errorClass: error instanceof Error ? error.name : typeof error,
+        });
+    }
+}
+
 async function loadFreshStatusValues(
     redis: VibeWorkerStatusRedis,
 ): Promise<string[]> {
-    let cursor = "0";
-    const values: string[] = [];
-    for (let page = 0; page < MAX_STATUS_SCAN_PAGES; page += 1) {
-        const result = await redis.scan(cursor, {
-            MATCH: `${VIBE_WORKER_STATUS_KEY_PREFIX}*`,
-            COUNT: STATUS_SCAN_COUNT,
-        });
-        if (result.keys.length > STATUS_SCAN_COUNT) {
-            throw new Error("Vibe worker status scan page exceeded its bound");
-        }
-        if (result.keys.length > 0) {
-            const pageValues = await redis.mGet(result.keys);
-            for (const value of pageValues)
-                if (value !== null) values.push(value);
-        }
-        cursor = result.cursor;
-        if (cursor === "0") return values;
+    const members = await redis.sMembers(VIBE_WORKER_STATUS_REGISTRY_KEY);
+    if (members.length > MAX_STATUS_REGISTRY_SIZE) {
+        throw new Error(
+            "Vibe worker status registry exceeded its cardinality bound",
+        );
     }
-    throw new Error("Vibe worker status scan exceeded its page bound");
+    const keys = members.filter(isRegisteredStatusKey);
+    const invalidKeys = members.filter((key) => !isRegisteredStatusKey(key));
+    if (keys.length === 0) {
+        await removeDeadRegistryKeys(redis, invalidKeys);
+        return [];
+    }
+    const values = await redis.mGet(keys);
+    if (values.length !== keys.length) {
+        throw new Error("Vibe worker status registry read was incomplete");
+    }
+    const deadKeys = keys.filter((_key, index) => values[index] === null);
+    await removeDeadRegistryKeys(redis, [...invalidKeys, ...deadKeys]);
+    return values.filter((value): value is string => value !== null);
 }
 
 /** Read the newest validated, unexpired worker snapshot. */

--- a/backend/tests-integration/vibeSearchPostgres.integration.test.ts
+++ b/backend/tests-integration/vibeSearchPostgres.integration.test.ts
@@ -317,6 +317,24 @@ describeWithPostgres("vibe search PostgreSQL correctness", () => {
         expect(
             indexes.some((index) => index.name.includes("space_empty")),
         ).toBe(false);
+
+        const adapterRows = await prisma.$queryRaw<Array<{ options: unknown }>>`
+            SELECT reloptions AS options
+            FROM pg_catalog.pg_class
+            WHERE relname = ${indexName}
+            LIMIT 1
+        `;
+        expect(adapterRows).toEqual([{ options: ["lists=40"] }]);
+
+        const executeRawSpy = jest.spyOn(prisma, "$executeRawUnsafe");
+        try {
+            await expect(ensureSpaceAnnIndex(TEACHER_SPACE_ID)).resolves.toBe(
+                true,
+            );
+            expect(executeRawSpy).not.toHaveBeenCalled();
+        } finally {
+            executeRawSpy.mockRestore();
+        }
     });
 
     it("matches exact and ANN top-k at the first size band", async () => {


### PR DESCRIPTION
## Summary

Two production defects observed on the first live 2.3.0 deployment:

1. **Lifecycle deadlock loop** (every tick, both workers): the index probe compared `lists` from client-side `pg_class.reloptions` deserialization, which differs under the Prisma 7 driver adapter — a valid, correctly sized index read as mismatched, so both replicas looped `CREATE INDEX CONCURRENTLY` into mutual `40P01` deadlocks (log noise, wasted ticks, throttled backfill). The probe now extracts `lists` as scalar text via `pg_options_to_table` anchored by `to_regclass` (no client-side array parsing, no `current_schema()` dependency), normalizes all representations defensively, and re-probes on `40P01`/`42P07`/`42710`/`23505` instead of looping. Real-PG integration pin: second `ensureSpaceAnnIndex` call performs **zero DDL**.
2. **Provider health unreadable in Settings**: the status reader's bounded SCAN can't traverse a ~14k-key production keyspace to find 3 status keys (MATCH filters after iteration). Publishers now register exact key names in a bounded set (`…:v2:registry`, cap 256); the reader uses `SMEMBERS` + one `MGET` and prunes dead members. TTL and `checkedAt` freshness semantics unchanged.

## Verification

- Full backend suite: **392 suites, 6,222 tests, 0 failures** (unrestricted).
- Real-PostgreSQL integration: **8/8** including the new no-DDL pin.
- `tsc --noEmit` (backend + integration config) clean; backend `format:check` clean.