### PR TITLE
chore(release): stage 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2.3.1] - 2026-08-18
+
+### Added
+
+### Changed
+
+### Fixed
+
 - Fixed embedding-space index checks so existing matching indexes are not
   rebuilt on every lifecycle tick.
 - Fixed vibe worker status reads on large Redis keyspaces by using a bounded

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.3.0
-appVersion: "2.3.0"
+version: 2.3.1
+appVersion: "2.3.1"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -225,7 +225,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -280,7 +280,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -410,7 +410,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -439,7 +439,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -510,7 +510,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -575,7 +575,7 @@ vibeProviderDclap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-vibe-provider-dclap
-    tag: 2.3.0
+    tag: 2.3.1
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -852,4 +852,5 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
+
 

--- a/docs/release-notes/RELEASE_NOTES_2.3.1.md
+++ b/docs/release-notes/RELEASE_NOTES_2.3.1.md
@@ -1,0 +1,83 @@
+# [2.3.1] Release Notes - 2026-08-18
+
+## Release Summary
+
+A small, fast follow-up to 2.3.0 based on the first production deployment:
+it stops a noisy database-deadlock loop in the background embedding
+lifecycle (which was also slowing the automatic library re-analysis) and
+fixes provider health not appearing in Settings on servers with a busy
+Redis. Upgrading from 2.3.0 is a plain rolling update.
+
+## Before you upgrade
+
+**Warning:** If you run a version earlier than 2.0.0, do not upgrade directly
+to 2.3.1. Complete the 2.0.0 breaking changes first. See
+[Upgrading from an earlier version](#upgrading-from-an-earlier-version).
+
+- Straightforward rolling upgrade from 2.3.0 - no schema changes and no special procedure. If you are coming from 2.2.x, follow the 2.3.0 upgrade steps first.
+
+## Fixed
+
+- Fixed embedding-space index checks so existing matching indexes are not
+  rebuilt on every lifecycle tick.
+- Fixed vibe worker status reads on large Redis keyspaces by using a bounded
+  worker registry and removing expired entries.
+
+## Added
+
+- No new features documented in this release.
+
+## Changed
+
+- No behavior changes documented in this release.
+
+## Removed
+
+- Nothing removed in this release.
+
+## Accessibility
+
+- No accessibility improvements documented in this release.
+
+## Admin/Operations
+
+- No admin/operations updates documented in this release.
+
+## Deployment and Distribution
+
+- Docker image: `ghcr.io/soundspan/soundspan`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart name: `soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.3.1
+```
+
+## Breaking Changes
+
+- None documented in this release.
+
+## Known Issues
+
+- None documented in this release.
+
+## Compatibility and Migration
+
+- No manual migration steps required for standard Docker and Helm deployments.
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, you must complete the
+2.0.0 upgrade before you install 2.3.1. The 2.0.0 release contains breaking
+changes that later releases depend on. Read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
+
+## Full Changelog
+
+- Compare changes: [2.3.0...HEAD](https://github.com/soundspan/soundspan/compare/2.3.0...HEAD)
+- Full changelog: https://github.com/soundspan/soundspan/blob/HEAD/CHANGELOG.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-frontend",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages 2.3.1 per the release process: version-sync bumped both packages, the chart (version + appVersion), and all eight image sections; the Unreleased changelog is promoted to `[2.3.1]`; release notes generated with a plain-language summary. The patch carries the two production hotfixes from the first live 2.3.0 deployment (#579): the lifecycle index-probe deadlock loop and the keyspace-safe worker-status reads. `version-sync --check` clean; release-helper tests 7/7; file-size gate green. Rolling upgrade from 2.3.0 — no schema changes.