### PR TITLE
feat(admin): collapsible library health list and immediate purge of removed tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an admin control to immediately enqueue a hard purge of all
+  soft-removed local tracks without waiting for the retention window.
+
 ### Changed
 
 ### Fixed

--- a/backend/src/routes/__tests__/admin.test.ts
+++ b/backend/src/routes/__tests__/admin.test.ts
@@ -35,6 +35,13 @@ const mockPrisma = {
         count: jest.fn(),
         delete: jest.fn(),
     },
+    track: {
+        count: jest.fn(),
+    },
+};
+
+const mockSchedulerQueue = {
+    add: jest.fn(),
 };
 
 const mockLogger = {
@@ -42,7 +49,9 @@ const mockLogger = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    child: jest.fn(),
 };
+mockLogger.child.mockReturnValue(mockLogger);
 
 jest.mock("../../middleware/auth", () => ({
     requireAuth: mockRequireAuth,
@@ -57,6 +66,10 @@ jest.mock("../../utils/logger", () => ({
     logger: mockLogger,
 }));
 
+jest.mock("../../workers/queues", () => ({
+    schedulerQueue: mockSchedulerQueue,
+}));
+
 jest.mock("../../config", () => ({
     config: { workers: { trackRemovalRetentionDays: 90 } },
 }));
@@ -66,6 +79,8 @@ import router from "../admin";
 const mockFindMany = mockPrisma.libraryHealthRecord.findMany as jest.Mock;
 const mockCount = mockPrisma.libraryHealthRecord.count as jest.Mock;
 const mockDelete = mockPrisma.libraryHealthRecord.delete as jest.Mock;
+const mockRemovedTrackCount = mockPrisma.track.count as jest.Mock;
+const mockSchedulerAdd = mockSchedulerQueue.add as jest.Mock;
 const mockLoggerError = mockLogger.error as jest.Mock;
 
 function createApp() {
@@ -126,6 +141,8 @@ describe("admin routes", () => {
         ]);
         mockCount.mockResolvedValue(2);
         mockDelete.mockResolvedValue({ id: "record-1" });
+        mockRemovedTrackCount.mockResolvedValue(2);
+        mockSchedulerAdd.mockResolvedValue({ id: "purge-now" });
     });
 
     it("GET /api/admin/library-health returns records with track details and total count", async () => {
@@ -241,6 +258,11 @@ describe("admin routes", () => {
             "delete",
             "/api/admin/library-health/record-1",
         ],
+        [
+            "POST /api/admin/library-health/purge-removed",
+            "post",
+            "/api/admin/library-health/purge-removed",
+        ],
     ] as const)(
         "%s requires admin middleware",
         async (_label, method, path) => {
@@ -257,6 +279,8 @@ describe("admin routes", () => {
             expect(mockFindMany).not.toHaveBeenCalled();
             expect(mockCount).not.toHaveBeenCalled();
             expect(mockDelete).not.toHaveBeenCalled();
+            expect(mockRemovedTrackCount).not.toHaveBeenCalled();
+            expect(mockSchedulerAdd).not.toHaveBeenCalled();
 
             jest.clearAllMocks();
             mockAuthFailureState.mode = "forbidden";
@@ -270,6 +294,8 @@ describe("admin routes", () => {
             expect(mockFindMany).not.toHaveBeenCalled();
             expect(mockCount).not.toHaveBeenCalled();
             expect(mockDelete).not.toHaveBeenCalled();
+            expect(mockRemovedTrackCount).not.toHaveBeenCalled();
+            expect(mockSchedulerAdd).not.toHaveBeenCalled();
         },
     );
 });

--- a/backend/src/routes/__tests__/adminRuntime.test.ts
+++ b/backend/src/routes/__tests__/adminRuntime.test.ts
@@ -6,12 +6,17 @@ jest.mock("../../middleware/auth", () => ({
 }));
 
 jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
+    logger: (() => {
+        const mockLogger = {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            child: jest.fn(),
+        };
+        mockLogger.child.mockReturnValue(mockLogger);
+        return mockLogger;
+    })(),
 }));
 
 jest.mock("../../utils/db", () => ({
@@ -21,6 +26,15 @@ jest.mock("../../utils/db", () => ({
             count: jest.fn(),
             delete: jest.fn(),
         },
+        track: {
+            count: jest.fn(),
+        },
+    },
+}));
+
+jest.mock("../../workers/queues", () => ({
+    schedulerQueue: {
+        add: jest.fn(),
     },
 }));
 
@@ -30,12 +44,15 @@ jest.mock("../../config", () => ({
 
 import router from "../admin";
 import { prisma } from "../../utils/db";
+import { schedulerQueue } from "../../workers/queues";
 
 const mockFindMany = prisma.libraryHealthRecord.findMany as jest.Mock;
 const mockCount = prisma.libraryHealthRecord.count as jest.Mock;
 const mockDelete = prisma.libraryHealthRecord.delete as jest.Mock;
+const mockRemovedTrackCount = prisma.track.count as jest.Mock;
+const mockSchedulerAdd = schedulerQueue.add as jest.Mock;
 
-function getHandler(path: string, method: "get" | "delete") {
+function getHandler(path: string, method: "get" | "post" | "delete") {
     const layer = (router as any).stack.find(
         (entry: any) =>
             entry.route?.path === path && entry.route?.methods?.[method],
@@ -69,6 +86,10 @@ describe("admin library health routes", () => {
         "/library-health/:recordId",
         "delete",
     );
+    const purgeRemovedTracksHandler = getHandler(
+        "/library-health/purge-removed",
+        "post",
+    );
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -94,6 +115,12 @@ describe("admin library health routes", () => {
             },
         ]);
         mockDelete.mockResolvedValue({ id: "record-1" });
+        mockRemovedTrackCount.mockResolvedValue(3);
+        mockSchedulerAdd.mockResolvedValue({ id: "purge-now" });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it("returns library health records for admins", async () => {
@@ -154,5 +181,72 @@ describe("admin library health routes", () => {
         });
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({ success: true });
+    });
+
+    it("returns the number of removed local tracks matched for purge", async () => {
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(mockRemovedTrackCount).toHaveBeenCalledWith({
+            where: {
+                origin: "LOCAL",
+                removedAt: { not: null },
+            },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ enqueued: true, matched: 3 });
+    });
+
+    it("skips the purge job when no removed local tracks match", async () => {
+        mockRemovedTrackCount.mockResolvedValueOnce(0);
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(mockSchedulerAdd).not.toHaveBeenCalled();
+        expect(res.body).toEqual({ enqueued: false, matched: 0 });
+    });
+
+    it("uses a singleton job id for the purge-now sweep", async () => {
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(mockSchedulerAdd).toHaveBeenCalledWith(
+            "track-removal-purge",
+            expect.any(Object),
+            expect.objectContaining({
+                jobId: "scheduler:track-removal-purge:purge-now",
+            }),
+        );
+    });
+
+    it("pins the purge-now cutoff to the current instant", async () => {
+        const now = new Date("2026-08-18T15:30:00.000Z");
+        jest.useFakeTimers().setSystemTime(now);
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(mockSchedulerAdd).toHaveBeenCalledWith(
+            "track-removal-purge",
+            { cutoffAt: now.toISOString() },
+            expect.any(Object),
+        );
+    });
+
+    it("returns a safe error when the purge-now job cannot be enqueued", async () => {
+        mockSchedulerAdd.mockRejectedValueOnce(
+            new Error("redis details must stay internal"),
+        );
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({
+            error: "Failed to enqueue removed track purge",
+        });
     });
 });

--- a/backend/src/routes/__tests__/adminRuntime.test.ts
+++ b/backend/src/routes/__tests__/adminRuntime.test.ts
@@ -35,6 +35,7 @@ jest.mock("../../utils/db", () => ({
 jest.mock("../../workers/queues", () => ({
     schedulerQueue: {
         add: jest.fn(),
+        getJob: jest.fn(),
     },
 }));
 
@@ -51,6 +52,7 @@ const mockCount = prisma.libraryHealthRecord.count as jest.Mock;
 const mockDelete = prisma.libraryHealthRecord.delete as jest.Mock;
 const mockRemovedTrackCount = prisma.track.count as jest.Mock;
 const mockSchedulerAdd = schedulerQueue.add as jest.Mock;
+const mockSchedulerGetJob = schedulerQueue.getJob as jest.Mock;
 
 function getHandler(path: string, method: "get" | "post" | "delete") {
     const layer = (router as any).stack.find(
@@ -117,6 +119,7 @@ describe("admin library health routes", () => {
         mockDelete.mockResolvedValue({ id: "record-1" });
         mockRemovedTrackCount.mockResolvedValue(3);
         mockSchedulerAdd.mockResolvedValue({ id: "purge-now" });
+        mockSchedulerGetJob.mockResolvedValue(undefined);
     });
 
     afterEach(() => {
@@ -234,6 +237,66 @@ describe("admin library health routes", () => {
             { cutoffAt: now.toISOString() },
             expect.any(Object),
         );
+    });
+
+    it.each(["failed", "waiting"])(
+        "replaces a %s purge-now job with a freshly pinned sweep",
+        async (state) => {
+            const now = new Date("2026-08-18T15:30:00.000Z");
+            jest.useFakeTimers().setSystemTime(now);
+            const remove = jest.fn().mockResolvedValue(undefined);
+            const getState = jest.fn().mockResolvedValue(state);
+            mockSchedulerGetJob.mockResolvedValueOnce({ getState, remove });
+            const res = createRes();
+
+            await purgeRemovedTracksHandler({} as any, res);
+
+            expect(mockSchedulerGetJob).toHaveBeenCalledWith(
+                "scheduler:track-removal-purge:purge-now",
+            );
+            expect(getState).toHaveBeenCalledTimes(1);
+            expect(remove).toHaveBeenCalledTimes(1);
+            expect(mockSchedulerAdd).toHaveBeenCalledWith(
+                "track-removal-purge",
+                { cutoffAt: now.toISOString() },
+                expect.objectContaining({
+                    jobId: "scheduler:track-removal-purge:purge-now",
+                }),
+            );
+            expect(res.body).toEqual({ enqueued: true, matched: 3 });
+        },
+    );
+
+    it("leaves an active purge-now job in place", async () => {
+        const remove = jest.fn();
+        mockSchedulerGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("active"),
+            remove,
+        });
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(remove).not.toHaveBeenCalled();
+        expect(mockSchedulerAdd).not.toHaveBeenCalled();
+        expect(res.body).toEqual({ enqueued: true, matched: 3 });
+    });
+
+    it("falls back to add when replacing a purge-now job races its state", async () => {
+        const remove = jest
+            .fn()
+            .mockRejectedValue(new Error("job is already active"));
+        mockSchedulerGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("waiting"),
+            remove,
+        });
+        const res = createRes();
+
+        await purgeRemovedTracksHandler({} as any, res);
+
+        expect(remove).toHaveBeenCalledTimes(1);
+        expect(mockSchedulerAdd).toHaveBeenCalledTimes(1);
+        expect(res.body).toEqual({ enqueued: true, matched: 3 });
     });
 
     it("returns a safe error when the purge-now job cannot be enqueued", async () => {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -9,6 +9,8 @@ import {
 } from "../utils/encryptedColumns";
 import { getPepperFingerprint, isHashedApiKey } from "../utils/apiKeyHash";
 import { config } from "../config";
+import { asyncHandler } from "../middleware/asyncHandler";
+import { handlePurgeRemovedTracksNow } from "./adminLibraryHealthPurge";
 
 const router = Router();
 
@@ -150,6 +152,40 @@ router.get("/library-health", async (_req, res) => {
         });
     }
 });
+
+/**
+ * @openapi
+ * /api/admin/library-health/purge-removed:
+ *   post:
+ *     summary: Immediately purge all soft-removed local tracks
+ *     tags: [Admin]
+ *     security:
+ *       - apiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Purge sweep enqueue result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [enqueued, matched]
+ *               properties:
+ *                 enqueued:
+ *                   type: boolean
+ *                 matched:
+ *                   type: integer
+ *                   minimum: 0
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
+ *       500:
+ *         description: Purge sweep could not be enqueued
+ */
+router.post(
+    "/library-health/purge-removed",
+    asyncHandler(handlePurgeRemovedTracksNow),
+);
 
 /**
  * @openapi

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -9,7 +9,6 @@ import {
 } from "../utils/encryptedColumns";
 import { getPepperFingerprint, isHashedApiKey } from "../utils/apiKeyHash";
 import { config } from "../config";
-import { asyncHandler } from "../middleware/asyncHandler";
 import { handlePurgeRemovedTracksNow } from "./adminLibraryHealthPurge";
 
 const router = Router();
@@ -182,10 +181,7 @@ router.get("/library-health", async (_req, res) => {
  *       500:
  *         description: Purge sweep could not be enqueued
  */
-router.post(
-    "/library-health/purge-removed",
-    asyncHandler(handlePurgeRemovedTracksNow),
-);
+router.post("/library-health/purge-removed", handlePurgeRemovedTracksNow);
 
 /**
  * @openapi

--- a/backend/src/routes/adminLibraryHealthPurge.ts
+++ b/backend/src/routes/adminLibraryHealthPurge.ts
@@ -24,12 +24,35 @@ async function countRemovedLocalTracks(): Promise<number> {
     });
 }
 
-async function enqueuePurgeAt(cutoff: Date): Promise<void> {
+async function addPurgeAt(cutoff: Date): Promise<void> {
     await schedulerQueue.add(
         TRACK_REMOVAL_PURGE_JOB_NAME,
         { cutoffAt: cutoff.toISOString() },
         PURGE_NOW_JOB_OPTIONS,
     );
+}
+
+async function enqueuePurgeAt(cutoff: Date): Promise<void> {
+    const existingJob = await schedulerQueue.getJob(PURGE_NOW_JOB_ID);
+    if (!existingJob) {
+        await addPurgeAt(cutoff);
+        return;
+    }
+
+    const state = await existingJob.getState();
+    if (state === "active") {
+        // The running sweep covers removals before its cutoff; a residual
+        // window after that cutoff requires a later purge request.
+        return;
+    }
+
+    try {
+        await existingJob.remove();
+        await addPurgeAt(cutoff);
+    } catch (error) {
+        log.warn("Purge-now replacement raced job state; retrying add:", error);
+        await addPurgeAt(cutoff);
+    }
 }
 
 /** Enqueues one singleton sweep that purges all currently removed local tracks. */

--- a/backend/src/routes/adminLibraryHealthPurge.ts
+++ b/backend/src/routes/adminLibraryHealthPurge.ts
@@ -1,0 +1,55 @@
+import type { Request, Response } from "express";
+import { prisma } from "../utils/db";
+import { logger } from "../utils/logger";
+import { schedulerQueue } from "../workers/queues";
+import { TRACK_REMOVAL_PURGE_JOB_NAME } from "../workers/processors/trackRemovalPurgeProcessor";
+import { sendInternalRouteError } from "./routeErrorResponse";
+
+const log = logger.child("AdminLibraryHealthPurge");
+const PURGE_NOW_JOB_ID = "scheduler:track-removal-purge:purge-now";
+const PURGE_NOW_JOB_OPTIONS = {
+    attempts: 3,
+    backoff: { type: "exponential" as const, delay: 5_000 },
+    jobId: PURGE_NOW_JOB_ID,
+    removeOnComplete: true,
+    removeOnFail: 10,
+};
+
+async function countRemovedLocalTracks(): Promise<number> {
+    return prisma.track.count({
+        where: {
+            origin: "LOCAL",
+            removedAt: { not: null },
+        },
+    });
+}
+
+async function enqueuePurgeAt(cutoff: Date): Promise<void> {
+    await schedulerQueue.add(
+        TRACK_REMOVAL_PURGE_JOB_NAME,
+        { cutoffAt: cutoff.toISOString() },
+        PURGE_NOW_JOB_OPTIONS,
+    );
+}
+
+/** Enqueues one singleton sweep that purges all currently removed local tracks. */
+export async function handlePurgeRemovedTracksNow(
+    _req: Request,
+    res: Response,
+): Promise<Response> {
+    try {
+        const matched = await countRemovedLocalTracks();
+        if (matched === 0) {
+            return res.json({ enqueued: false, matched });
+        }
+
+        await enqueuePurgeAt(new Date());
+        return res.json({ enqueued: true, matched });
+    } catch (error) {
+        log.error("Enqueue removed track purge error:", error);
+        return sendInternalRouteError(
+            res,
+            "Failed to enqueue removed track purge",
+        );
+    }
+}

--- a/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
@@ -9,9 +9,10 @@ describe("trackRemovalPurgeProcessor", () => {
         candidates: Array<{
             id: string;
             origin?: "LOCAL" | "FEDERATED";
+            removedAt?: Date | null;
         }>,
         retentionDays = 90,
-        deletedCount = candidates.length,
+        deletedCount?: number,
         federationEnabled = false,
     ) {
         const logger = {
@@ -26,16 +27,20 @@ describe("trackRemovalPurgeProcessor", () => {
         let prisma: any;
         prisma = {
             track: {
-                findMany: jest.fn(
-                    async (args: { where?: { origin?: string } }) =>
-                        args.where?.origin === "LOCAL"
-                            ? candidates.filter(
-                                  (track) => track.origin !== "FEDERATED",
-                              )
-                            : candidates,
+                findMany: jest.fn(async (args: any) =>
+                    candidates.filter((track) => {
+                        const isLocal = track.origin !== "FEDERATED";
+                        const isBeforeCutoff =
+                            track.removedAt === undefined ||
+                            (track.removedAt !== null &&
+                                track.removedAt < args.where.removedAt.lt);
+                        const isAfterCursor =
+                            !args.where.id?.gt || track.id > args.where.id.gt;
+                        return isLocal && isBeforeCutoff && isAfterCursor;
+                    }),
                 ),
-                deleteMany: jest.fn(async (_args: unknown) => ({
-                    count: deletedCount,
+                deleteMany: jest.fn(async (args: any) => ({
+                    count: deletedCount ?? args.where.id.in.length,
                 })),
             },
             federationTombstone: {
@@ -91,7 +96,7 @@ describe("trackRemovalPurgeProcessor", () => {
         return { id: "track-removal-purge-1", data } as any;
     }
 
-    it("purges only tracks older than the retention boundary and runs cleanup", async () => {
+    it("derives the legacy retention cutoff when the payload is absent", async () => {
         jest.useFakeTimers().setSystemTime(
             new Date("2026-08-14T12:00:00.000Z"),
         );
@@ -103,7 +108,7 @@ describe("trackRemovalPurgeProcessor", () => {
         } = loadProcessor([{ id: "track-old" }]);
 
         await expect(
-            module.processTrackRemovalPurge(buildJob({ mode: "startup" })),
+            module.processTrackRemovalPurge(buildJob()),
         ).resolves.toEqual({ deleted: 1, continued: false });
 
         expect(prisma.track.findMany).toHaveBeenCalledWith({
@@ -124,6 +129,35 @@ describe("trackRemovalPurgeProcessor", () => {
         });
         expect(cleanupOrphanedLibraryEntities).toHaveBeenCalledTimes(1);
         expect(backfillAllArtistCounts).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses an explicit initial cutoff and never purges tracks without removedAt", async () => {
+        const cutoff = new Date("2026-08-18T12:00:00.000Z");
+        const { module, prisma } = loadProcessor([
+            {
+                id: "track-before-cutoff",
+                removedAt: new Date("2026-08-18T11:59:59.999Z"),
+            },
+            { id: "track-active", removedAt: null },
+            {
+                id: "track-at-cutoff",
+                removedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+        ]);
+
+        await expect(
+            module.processTrackRemovalPurge(
+                buildJob({ cutoffAt: cutoff.toISOString() }),
+            ),
+        ).resolves.toEqual({ deleted: 1, continued: false });
+
+        expect(prisma.track.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["track-before-cutoff"] },
+                origin: "LOCAL",
+                removedAt: { lt: cutoff },
+            },
+        });
     });
 
     it("writes track tombstones and cleans expired tombstones on a federation terminal page", async () => {

--- a/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
@@ -309,6 +309,24 @@ describe("trackRemovalPurgeProcessor", () => {
         },
     );
 
+    it.each([
+        {
+            startAfterId: "track-100",
+            deletedSoFar: 100,
+        },
+        {
+            cutoffAt: "2026-05-16T12:00:00.000Z",
+            deletedSoFar: 100,
+        },
+    ])("rejects incomplete continuation data %#", async (data) => {
+        const { module, prisma } = loadProcessor([]);
+
+        await expect(
+            module.processTrackRemovalPurge(buildJob(data)),
+        ).rejects.toBeDefined();
+        expect(prisma.track.findMany).not.toHaveBeenCalled();
+    });
+
     it("refreshes the catalog once after a multi-page sweep and logs the cumulative count", async () => {
         const firstPage = Array.from({ length: 101 }, (_, index) => ({
             id: `track-${index.toString().padStart(3, "0")}`,

--- a/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
+++ b/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
@@ -34,13 +34,14 @@ const purgeJobDataSchema = z
     .superRefine((data, context) => {
         const hasStartAfterId = Boolean(data.startAfterId);
         const hasCutoffAt = Boolean(data.cutoffAt);
-        if (hasStartAfterId !== hasCutoffAt) {
+        if (hasStartAfterId && !hasCutoffAt) {
             context.addIssue({
                 code: "custom",
-                message: "Track removal purge cursor and cutoff must be paired",
+                path: ["cutoffAt"],
+                message: "Track removal purge continuation requires a cutoff",
             });
         }
-        const hasContinuation = hasStartAfterId && hasCutoffAt;
+        const hasContinuation = hasStartAfterId;
         if (hasContinuation !== (data.deletedSoFar !== undefined)) {
             context.addIssue({
                 code: "custom",
@@ -54,7 +55,7 @@ const purgeJobDataSchema = z
 /** Bull job name for expired soft-removed track purge pages. */
 export const TRACK_REMOVAL_PURGE_JOB_NAME = "track-removal-purge";
 
-/** Persisted data for one bounded purge page or its continuation. */
+/** Persisted data for a scheduled purge, explicit-cutoff sweep, or continuation. */
 export interface TrackRemovalPurgeJobData {
     mode?: "startup" | "repeat";
     startAfterId?: string;

--- a/frontend/features/settings/components/sections/LibraryHealthSection.tsx
+++ b/frontend/features/settings/components/sections/LibraryHealthSection.tsx
@@ -43,6 +43,7 @@ export function LibraryHealthSection() {
     const handleRefresh = () => {
         setIsLoading(true);
         setError(null);
+        setPurgeNotice(null);
         loadRecords();
     };
 

--- a/frontend/features/settings/components/sections/LibraryHealthSection.tsx
+++ b/frontend/features/settings/components/sections/LibraryHealthSection.tsx
@@ -15,7 +15,9 @@ export function LibraryHealthSection() {
     const [trackRemovalRetentionDays, setTrackRemovalRetentionDays] =
         useState(0);
     const [isLoading, setIsLoading] = useState(true);
+    const [isPurging, setIsPurging] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [purgeNotice, setPurgeNotice] = useState<string | null>(null);
 
     const loadRecords = useCallback(() => {
         void api
@@ -42,6 +44,28 @@ export function LibraryHealthSection() {
         setIsLoading(true);
         setError(null);
         loadRecords();
+    };
+
+    const handlePurgeAll = async () => {
+        setIsPurging(true);
+        setError(null);
+        setPurgeNotice(null);
+        try {
+            const result = await api.purgeRemovedTracks();
+            setPurgeNotice(
+                result.enqueued
+                    ? `Purge started for ${result.matched} removed track` +
+                          `${result.matched === 1 ? "" : "s"}. Records ` +
+                          `disappear as the purge completes; refresh to ` +
+                          `follow progress.`
+                    : "No removed tracks to purge.",
+            );
+            loadRecords();
+        } catch {
+            setError("Failed to start the purge");
+        } finally {
+            setIsPurging(false);
+        }
     };
 
     const handleDismiss = async (recordId: string) => {
@@ -76,9 +100,12 @@ export function LibraryHealthSection() {
                 removedPendingPurgeCount={removedPendingPurgeCount}
                 trackRemovalRetentionDays={trackRemovalRetentionDays}
                 isLoading={isLoading}
+                isPurging={isPurging}
                 error={error}
+                purgeNotice={purgeNotice}
                 onRefresh={handleRefresh}
                 onDismiss={(recordId) => void handleDismiss(recordId)}
+                onPurgeAll={() => void handlePurgeAll()}
             />
         </SettingsSection>
     );

--- a/frontend/features/settings/components/sections/libraryHealthDetails.tsx
+++ b/frontend/features/settings/components/sections/libraryHealthDetails.tsx
@@ -1,7 +1,12 @@
-import type { ElementType } from "react";
+"use client";
+
+import { useState, type ElementType } from "react";
 import type { LibraryHealthRecord } from "@/lib/api";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
     AlertTriangle,
+    ChevronDown,
+    ChevronRight,
     FileWarning,
     Loader2,
     RefreshCw,
@@ -39,9 +44,12 @@ interface LibraryHealthDetailsProps {
     removedPendingPurgeCount: number;
     trackRemovalRetentionDays: number;
     isLoading: boolean;
+    isPurging: boolean;
     error: string | null;
+    purgeNotice: string | null;
     onRefresh: () => void;
     onDismiss: (recordId: string) => void;
+    onPurgeAll: () => void;
 }
 
 function statusForRecord(record: LibraryHealthRecord): StatusConfig {
@@ -54,19 +62,43 @@ function statusForRecord(record: LibraryHealthRecord): StatusConfig {
 function RemovedTrackSummary({
     count,
     retentionDays,
-}: Readonly<{ count: number; retentionDays: number }>) {
+    isPurging,
+    onPurgeAll,
+}: Readonly<{
+    count: number;
+    retentionDays: number;
+    isPurging: boolean;
+    onPurgeAll: () => void;
+}>) {
     if (count === 0) return null;
     return (
         <div className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2">
-            <p className="text-xs font-medium text-gray-300">
-                {count} removed, pending purge
-            </p>
-            <p className="mt-1 text-[11px] text-gray-400">
-                A rescan restores these tracks if their files return. SoundSpan
-                permanently purges them after {retentionDays} day
-                {retentionDays === 1 ? "" : "s"}, as configured by{" "}
-                <code>TRACK_REMOVAL_RETENTION_DAYS</code>.
-            </p>
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium text-gray-300">
+                        {count} removed, pending purge
+                    </p>
+                    <p className="mt-1 text-[11px] text-gray-400">
+                        A rescan restores these tracks if their files return.
+                        SoundSpan permanently purges them after {retentionDays}{" "}
+                        day
+                        {retentionDays === 1 ? "" : "s"}, as configured by{" "}
+                        <code>TRACK_REMOVAL_RETENTION_DAYS</code>.
+                    </p>
+                </div>
+                <button
+                    onClick={onPurgeAll}
+                    disabled={isPurging}
+                    className="flex items-center gap-1.5 shrink-0 px-2.5 py-1.5 text-xs font-medium text-red-400 border border-red-400/40 rounded-md hover:bg-red-400/10 transition-colors disabled:opacity-50"
+                >
+                    {isPurging ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    ) : (
+                        <Trash2 className="w-3.5 h-3.5" />
+                    )}
+                    Delete all now
+                </button>
+            </div>
         </div>
     );
 }
@@ -124,6 +156,56 @@ function LibraryHealthRecordRow({
     );
 }
 
+/** Renders the full record list; mounted only while expanded. */
+export function LibraryHealthRecordList({
+    records,
+    onDismiss,
+}: Readonly<{
+    records: LibraryHealthRecord[];
+    onDismiss: (recordId: string) => void;
+}>) {
+    return (
+        <div className="rounded-lg border border-white/5 overflow-hidden divide-y divide-white/5">
+            {records.map((record) => (
+                <LibraryHealthRecordRow
+                    key={record.id}
+                    record={record}
+                    onDismiss={onDismiss}
+                />
+            ))}
+        </div>
+    );
+}
+
+function RecordListToggle({
+    isExpanded,
+    count,
+    onToggle,
+}: Readonly<{ isExpanded: boolean; count: number; onToggle: () => void }>) {
+    const Chevron = isExpanded ? ChevronDown : ChevronRight;
+    return (
+        <button
+            onClick={onToggle}
+            aria-expanded={isExpanded}
+            className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+        >
+            <Chevron className="w-3.5 h-3.5" />
+            {isExpanded
+                ? "Hide records"
+                : `Show ${count} record${count === 1 ? "" : "s"}`}
+        </button>
+    );
+}
+
+function purgeConfirmMessage(count: number, retentionDays: number): string {
+    const tracks = `${count} removed track${count === 1 ? "" : "s"}`;
+    return (
+        `Permanently delete ${tracks} right now instead of after the ` +
+        `${retentionDays}-day retention window. Play history and playlist ` +
+        `entries for these tracks are deleted with them. This cannot be undone.`
+    );
+}
+
 /** Renders the response-driven Library Health details and record states. */
 export function LibraryHealthDetails({
     records,
@@ -131,10 +213,15 @@ export function LibraryHealthDetails({
     removedPendingPurgeCount,
     trackRemovalRetentionDays,
     isLoading,
+    isPurging,
     error,
+    purgeNotice,
     onRefresh,
     onDismiss,
+    onPurgeAll,
 }: LibraryHealthDetailsProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [showPurgeConfirm, setShowPurgeConfirm] = useState(false);
     return (
         <div className="space-y-3">
             <div className="flex items-center justify-between">
@@ -155,8 +242,13 @@ export function LibraryHealthDetails({
             <RemovedTrackSummary
                 count={removedPendingPurgeCount}
                 retentionDays={trackRemovalRetentionDays}
+                isPurging={isPurging}
+                onPurgeAll={() => setShowPurgeConfirm(true)}
             />
             {error && <p className="text-sm text-red-400 py-2">{error}</p>}
+            {purgeNotice && (
+                <p className="text-sm text-gray-300 py-2">{purgeNotice}</p>
+            )}
             {isLoading && records.length === 0 && (
                 <div className="flex items-center justify-center py-8">
                     <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
@@ -170,16 +262,32 @@ export function LibraryHealthDetails({
                 </div>
             )}
             {records.length > 0 && (
-                <div className="rounded-lg border border-white/5 overflow-hidden divide-y divide-white/5">
-                    {records.map((record) => (
-                        <LibraryHealthRecordRow
-                            key={record.id}
-                            record={record}
+                <>
+                    <RecordListToggle
+                        isExpanded={isExpanded}
+                        count={records.length}
+                        onToggle={() => setIsExpanded((previous) => !previous)}
+                    />
+                    {isExpanded && (
+                        <LibraryHealthRecordList
+                            records={records}
                             onDismiss={onDismiss}
                         />
-                    ))}
-                </div>
+                    )}
+                </>
             )}
+            <ConfirmDialog
+                isOpen={showPurgeConfirm}
+                onClose={() => setShowPurgeConfirm(false)}
+                onConfirm={onPurgeAll}
+                title="Delete all removed tracks"
+                message={purgeConfirmMessage(
+                    removedPendingPurgeCount,
+                    trackRemovalRetentionDays,
+                )}
+                confirmText="Delete all now"
+                variant="danger"
+            />
         </div>
     );
 }

--- a/frontend/features/settings/components/sections/libraryHealthDetails.tsx
+++ b/frontend/features/settings/components/sections/libraryHealthDetails.tsx
@@ -47,6 +47,8 @@ interface LibraryHealthDetailsProps {
     isPurging: boolean;
     error: string | null;
     purgeNotice: string | null;
+    /** Initial expansion state of the record list; collapsed by default. */
+    defaultExpanded?: boolean;
     onRefresh: () => void;
     onDismiss: (recordId: string) => void;
     onPurgeAll: () => void;
@@ -87,6 +89,7 @@ function RemovedTrackSummary({
                     </p>
                 </div>
                 <button
+                    type="button"
                     onClick={onPurgeAll}
                     disabled={isPurging}
                     className="flex items-center gap-1.5 shrink-0 px-2.5 py-1.5 text-xs font-medium text-red-400 border border-red-400/40 rounded-md hover:bg-red-400/10 transition-colors disabled:opacity-50"
@@ -156,8 +159,10 @@ function LibraryHealthRecordRow({
     );
 }
 
+const RECORD_LIST_ID = "library-health-record-list";
+
 /** Renders the full record list; mounted only while expanded. */
-export function LibraryHealthRecordList({
+function LibraryHealthRecordList({
     records,
     onDismiss,
 }: Readonly<{
@@ -165,7 +170,10 @@ export function LibraryHealthRecordList({
     onDismiss: (recordId: string) => void;
 }>) {
     return (
-        <div className="rounded-lg border border-white/5 overflow-hidden divide-y divide-white/5">
+        <div
+            id={RECORD_LIST_ID}
+            className="rounded-lg border border-white/5 overflow-hidden divide-y divide-white/5"
+        >
             {records.map((record) => (
                 <LibraryHealthRecordRow
                     key={record.id}
@@ -185,8 +193,10 @@ function RecordListToggle({
     const Chevron = isExpanded ? ChevronDown : ChevronRight;
     return (
         <button
+            type="button"
             onClick={onToggle}
             aria-expanded={isExpanded}
+            aria-controls={RECORD_LIST_ID}
             className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors"
         >
             <Chevron className="w-3.5 h-3.5" />
@@ -216,11 +226,12 @@ export function LibraryHealthDetails({
     isPurging,
     error,
     purgeNotice,
+    defaultExpanded = false,
     onRefresh,
     onDismiss,
     onPurgeAll,
 }: LibraryHealthDetailsProps) {
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
     const [showPurgeConfirm, setShowPurgeConfirm] = useState(false);
     return (
         <div className="space-y-3">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -251,6 +251,12 @@ export interface LibraryHealthResponse {
     trackRemovalRetentionDays: number;
 }
 
+/** Typed response from POST /api/admin/library-health/purge-removed. */
+export interface PurgeRemovedTracksResponse {
+    enqueued: boolean;
+    matched: number;
+}
+
 export interface ShareLinkRecord {
     id: string;
     token: string;

--- a/frontend/lib/api/library.ts
+++ b/frontend/lib/api/library.ts
@@ -3,6 +3,7 @@ import type {
     AlbumPreferenceResponse,
     LibraryHealthResponse,
     LikedPlaylistResponse,
+    PurgeRemovedTracksResponse,
     TrackPreferenceResponse,
     TrackPreferenceSignal,
 } from "../api";
@@ -325,6 +326,13 @@ export function WithLibrary<TBase extends ApiClientConstructor>(Base: TBase) {
             return this.request<{ success: boolean }>(
                 `/admin/library-health/${recordId}`,
                 { method: "DELETE" },
+            );
+        }
+
+        async purgeRemovedTracks() {
+            return this.request<PurgeRemovedTracksResponse>(
+                "/admin/library-health/purge-removed",
+                { method: "POST" },
             );
         }
 

--- a/frontend/tests/component/libraryHealthDetails.component.test.ts
+++ b/frontend/tests/component/libraryHealthDetails.component.test.ts
@@ -120,17 +120,19 @@ test("library health surfaces purge notices", async () => {
     assert.match(html, /Purge started for 1 removed track\./);
 });
 
-test("library health record list distinguishes removed tracks pending purge", async () => {
-    const { LibraryHealthRecordList } =
+test("library health expanded list distinguishes removed tracks pending purge", async () => {
+    const { LibraryHealthDetails } =
         await import("../../features/settings/components/sections/libraryHealthDetails");
 
     const html = renderToStaticMarkup(
-        React.createElement(LibraryHealthRecordList, {
-            records: RECORDS,
-            onDismiss: () => undefined,
+        React.createElement(LibraryHealthDetails, {
+            ...DETAILS_PROPS,
+            defaultExpanded: true,
         }),
     );
 
+    assert.match(html, /aria-expanded="true"/);
+    assert.match(html, /Hide records/);
     assert.match(html, /Removed, pending purge/);
     assert.match(html, />Missing</);
     assert.match(html, /\/music\/removed\.flac/);

--- a/frontend/tests/component/libraryHealthDetails.component.test.ts
+++ b/frontend/tests/component/libraryHealthDetails.component.test.ts
@@ -9,67 +9,130 @@ const Icon = (props: Record<string, unknown> = {}) =>
 mock.module("lucide-react", {
     namedExports: {
         AlertTriangle: Icon,
+        ChevronDown: Icon,
+        ChevronRight: Icon,
         FileWarning: Icon,
         Loader2: Icon,
         RefreshCw: Icon,
         Trash2: Icon,
+        X: Icon,
     },
 });
 
-test("library health distinguishes and counts removed tracks pending purge", async () => {
+const RECORDS = [
+    {
+        id: "removed-record",
+        trackId: "removed-track",
+        status: "MISSING_FROM_DISK" as const,
+        filePath: "/music/removed.flac",
+        detail: null,
+        detectedAt: "2026-08-14T00:00:00.000Z",
+        updatedAt: "2026-08-14T00:00:00.000Z",
+        track: {
+            id: "removed-track",
+            title: "Removed Track",
+            removedAt: "2026-08-14T00:00:00.000Z",
+        },
+    },
+    {
+        id: "missing-record",
+        trackId: "missing-track",
+        status: "MISSING_FROM_DISK" as const,
+        filePath: "/music/missing.flac",
+        detail: null,
+        detectedAt: "2026-08-14T00:00:00.000Z",
+        updatedAt: "2026-08-14T00:00:00.000Z",
+        track: {
+            id: "missing-track",
+            title: "Transiently Missing Track",
+            removedAt: null,
+        },
+    },
+];
+
+const DETAILS_PROPS = {
+    records: RECORDS,
+    total: 2,
+    removedPendingPurgeCount: 1,
+    trackRemovalRetentionDays: 90,
+    isLoading: false,
+    isPurging: false,
+    error: null,
+    purgeNotice: null,
+    onRefresh: () => undefined,
+    onDismiss: () => undefined,
+    onPurgeAll: () => undefined,
+};
+
+test("library health summarizes removed tracks and collapses the record list by default", async () => {
     const { LibraryHealthDetails } =
         await import("../../features/settings/components/sections/libraryHealthDetails");
 
     const html = renderToStaticMarkup(
-        React.createElement(LibraryHealthDetails, {
-            records: [
-                {
-                    id: "removed-record",
-                    trackId: "removed-track",
-                    status: "MISSING_FROM_DISK",
-                    filePath: "/music/removed.flac",
-                    detail: null,
-                    detectedAt: "2026-08-14T00:00:00.000Z",
-                    updatedAt: "2026-08-14T00:00:00.000Z",
-                    track: {
-                        id: "removed-track",
-                        title: "Removed Track",
-                        removedAt: "2026-08-14T00:00:00.000Z",
-                    },
-                },
-                {
-                    id: "missing-record",
-                    trackId: "missing-track",
-                    status: "MISSING_FROM_DISK",
-                    filePath: "/music/missing.flac",
-                    detail: null,
-                    detectedAt: "2026-08-14T00:00:00.000Z",
-                    updatedAt: "2026-08-14T00:00:00.000Z",
-                    track: {
-                        id: "missing-track",
-                        title: "Transiently Missing Track",
-                        removedAt: null,
-                    },
-                },
-            ],
-            total: 2,
-            removedPendingPurgeCount: 1,
-            trackRemovalRetentionDays: 90,
-            isLoading: false,
-            error: null,
-            onRefresh: () => undefined,
-            onDismiss: () => undefined,
-        }),
+        React.createElement(LibraryHealthDetails, DETAILS_PROPS),
     );
 
     assert.match(html, /2 issues detected/);
     assert.match(html, /1 removed, pending purge/);
-    assert.match(html, /Removed, pending purge/);
-    assert.match(html, />Missing</);
     assert.match(
         html,
         /A rescan restores these tracks if their files return\./,
     );
     assert.match(html, /TRACK_REMOVAL_RETENTION_DAYS/);
     assert.match(html, /90 days/);
+
+    // Collapsed by default: the toggle advertises the hidden rows and no
+    // per-record content is mounted.
+    assert.match(html, /Show 2 records/);
+    assert.match(html, /aria-expanded="false"/);
+    assert.doesNotMatch(html, /\/music\/removed\.flac/);
+    assert.doesNotMatch(html, /Removed Track/);
+});
+
+test("library health offers a purge-all button only when removed tracks are pending", async () => {
+    const { LibraryHealthDetails } =
+        await import("../../features/settings/components/sections/libraryHealthDetails");
+
+    const withRemoved = renderToStaticMarkup(
+        React.createElement(LibraryHealthDetails, DETAILS_PROPS),
+    );
+    assert.match(withRemoved, /Delete all now/);
+
+    const withoutRemoved = renderToStaticMarkup(
+        React.createElement(LibraryHealthDetails, {
+            ...DETAILS_PROPS,
+            removedPendingPurgeCount: 0,
+        }),
+    );
+    assert.doesNotMatch(withoutRemoved, /Delete all now/);
+});
+
+test("library health surfaces purge notices", async () => {
+    const { LibraryHealthDetails } =
+        await import("../../features/settings/components/sections/libraryHealthDetails");
+
+    const html = renderToStaticMarkup(
+        React.createElement(LibraryHealthDetails, {
+            ...DETAILS_PROPS,
+            purgeNotice: "Purge started for 1 removed track.",
+        }),
+    );
+    assert.match(html, /Purge started for 1 removed track\./);
+});
+
+test("library health record list distinguishes removed tracks pending purge", async () => {
+    const { LibraryHealthRecordList } =
+        await import("../../features/settings/components/sections/libraryHealthDetails");
+
+    const html = renderToStaticMarkup(
+        React.createElement(LibraryHealthRecordList, {
+            records: RECORDS,
+            onDismiss: () => undefined,
+        }),
+    );
+
+    assert.match(html, /Removed, pending purge/);
+    assert.match(html, />Missing</);
+    assert.match(html, /\/music\/removed\.flac/);
+    assert.match(html, /Transiently Missing Track/);
 });


### PR DESCRIPTION
## Summary

Two admin quality-of-life improvements to **Admin → Library Health**, prompted by a library-wide file rename that left 2,586 stale "removed, pending purge" records rendering as one giant flat list.

### Collapsible record list
- The record list now mounts **collapsed by default** behind a chevron toggle that shows the hidden count ("Show 2,586 records").
- Rows are fully unmounted while collapsed, so the admin page no longer renders thousands of DOM nodes up front.
- Toggle carries `aria-expanded`/`aria-controls`; a `defaultExpanded` prop controls initial state.

### Delete all now
- New **`POST /api/admin/library-health/purge-removed`** (admin-only): counts local tracks with `removedAt` set and enqueues the existing `track-removal-purge` sweep with the **cutoff pinned to now**, so batching, federation tombstones, orphaned album/artist cleanup, and artist-count backfill all reuse the tested worker path instead of waiting out `TRACK_REMOVAL_RETENTION_DAYS`.
- Singleton job id with replace-unless-active semantics: a finished/failed/waiting job is removed and re-added with a fresh cutoff, so a failed sweep can never jam the button; an active sweep is left running.
- Tracks with `removedAt: null` (flag-only health records) are never touched; the boundary is pinned by tests (`< cutoff` deleted, `== cutoff` and `null` kept).
- Frontend: destructive-styled **Delete all now** button (only when removed tracks are pending) behind a `ConfirmDialog` that spells out the play-history/playlist loss, with in-flight disable and a progress notice.

### Compatibility
- Purge job payload stays backwards compatible: scheduled jobs with no payload keep the retention-derived cutoff; continuation payload pairing rules are unchanged and now pinned by negative tests.
- `GET /library-health` response shape unchanged.

## Testing
- Backend: 39 tests across route runtime, supertest middleware, purge processor, and OpenAPI sync suites; full `tsc --noEmit`; prettier; route-error canon + file-size ratchets.
- Frontend: component tests for collapsed default, expanded rendering, purge button visibility, and purge notice; `tsc`; prettier; eslint (0 errors); hex ratchet.
- Independent adversarial review round completed; all findings fixed (notably the singleton job-id jam).