### PR TITLE
feat(nav): surface the vibe map in main navigation with an AI-blue accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an admin control to immediately enqueue a hard purge of all
   soft-removed local tracks without waiting for the retention window.
+- Added a Vibe entry to the main navigation (sidebar and mobile quick links)
+  with an AI-blue glow accent, so the vibe map is reachable without going
+  through a track's context menu.
 
 ### Changed
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -101,6 +101,16 @@ body {
     line-height: 1;
 }
 
+/* AI-blue glow for the Vibe navigation entry */
+.nav-vibe-glow {
+    color: var(--color-ai-hover);
+    text-shadow: 0 0 12px color-mix(in srgb, var(--color-ai) 65%, transparent);
+}
+
+.nav-vibe-glow:hover {
+    color: var(--color-brand-light);
+}
+
 /* Make all buttons have pointer cursor */
 button {
     cursor: pointer;

--- a/frontend/components/layout/MobileSidebar.tsx
+++ b/frontend/components/layout/MobileSidebar.tsx
@@ -14,6 +14,7 @@ import {
     Settings,
     Shield,
     Users,
+    Waves,
     X,
 } from "lucide-react";
 import { cn } from "@/utils/cn";
@@ -89,6 +90,7 @@ export function MobileSidebar({
         "/import": Download,
         "/playlist/my-liked": Heart,
         "/radio": Radio,
+        "/vibe": Waves,
         "/listen-together": Users,
     };
 

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -299,6 +299,7 @@ export function Sidebar() {
                     const isActive = pathname === item.href;
                     const badge = "badge" in item ? item.badge : null;
                     const isListenTogether = item.href === "/listen-together";
+                    const hasVibeAccent = item.accent === "vibe" && !isActive;
 
                     return (
                         <Link
@@ -321,6 +322,8 @@ export function Sidebar() {
                                             ? "text-base"
                                             : "text-sm",
                                         isActive && "text-white",
+                                        hasVibeAccent &&
+                                            "nav-vibe-glow font-bold",
                                     )}
                                 >
                                     {item.name}

--- a/frontend/components/layout/socialNavigation.ts
+++ b/frontend/components/layout/socialNavigation.ts
@@ -2,6 +2,8 @@ export interface SidebarNavigationItem {
     name: string;
     href: string;
     badge?: string;
+    /** Visual accent for special destinations (vibe = brand AI glow). */
+    accent?: "vibe";
 }
 
 export interface MobileQuickLinkItem {
@@ -13,6 +15,7 @@ export const SIDEBAR_NAVIGATION: SidebarNavigationItem[] = [
     { name: "Home", href: "/" },
     { name: "Explore", href: "/explore" },
     { name: "Library", href: "/library" },
+    { name: "Vibe", href: "/vibe", accent: "vibe" },
     { name: "Listen Together", href: "/listen-together" },
     { name: "Audiobooks", href: "/audiobooks" },
     { name: "Podcasts", href: "/podcasts" },
@@ -21,6 +24,7 @@ export const SIDEBAR_NAVIGATION: SidebarNavigationItem[] = [
 export const MOBILE_QUICK_LINKS: MobileQuickLinkItem[] = [
     { name: "Home", href: "/" },
     { name: "Explore", href: "/explore" },
+    { name: "Vibe", href: "/vibe" },
     { name: "Listen Together", href: "/listen-together" },
 ];
 

--- a/frontend/tests/unit/exploreNavigation.test.ts
+++ b/frontend/tests/unit/exploreNavigation.test.ts
@@ -5,8 +5,8 @@ import {
     MOBILE_QUICK_LINKS,
 } from "../../components/layout/socialNavigation";
 
-test("sidebar navigation has 6 items", () => {
-    assert.equal(SIDEBAR_NAVIGATION.length, 6);
+test("sidebar navigation has 7 items", () => {
+    assert.equal(SIDEBAR_NAVIGATION.length, 7);
 });
 
 test("sidebar navigation starts with Home then Explore", () => {

--- a/frontend/tests/unit/socialNavigation.test.ts
+++ b/frontend/tests/unit/socialNavigation.test.ts
@@ -68,3 +68,13 @@ test("MOBILE_QUICK_LINKS does not include /import", () => {
     );
     assert.equal(importItem, undefined, "Import should not be in mobile links");
 });
+
+test("sidebar and quick links expose the vibe map destination", () => {
+    const vibeItem = SIDEBAR_NAVIGATION.find((item) => item.href === "/vibe");
+    assert.notEqual(vibeItem, undefined, "Vibe should be in sidebar");
+    assert.equal(vibeItem?.accent, "vibe");
+    assert.equal(
+        MOBILE_QUICK_LINKS.some((link) => link.href === "/vibe"),
+        true,
+    );
+});


### PR DESCRIPTION
## Summary

The only way to reach the vibe map today is playing a track and using its context menu ("Show on Vibe Map"). This adds first-class navigation:

- **Sidebar**: new "Vibe" entry right under Library, styled with the palette's AI blue (`--color-ai-hover` + a soft `--color-ai` glow via a new `nav-vibe-glow` class in globals.css — no hardcoded hex, tokens only). Bold weight; standard active-state styling wins when on `/vibe`, and `/vibe?trackId=…` deep links still highlight the entry (pathname match excludes query).
- **Mobile quick links**: "Vibe" with a `Waves` icon (matching the vibe embeddings iconography in settings).

## Testing
- `socialNavigation` unit tests extended (vibe entry + accent pinned); the 6-item count assertion updated to 7.
- Full unit suite 971/971, targeted-coverage gate green, typecheck, prettier, hex-lint ratchet (128 ≤ 130 baseline) all pass; component suite matches the main-branch baseline.