### PR TITLE
fix(library): unblock removed-track purge on mapping linkage and show live progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   out-of-memory instead of crashing. The projection cache is also scoped to
   the active embedding space, so a space cutover no longer serves the retired
   space's map for up to a day.
+- The removed-track purge no longer stalls when a purged track is the only
+  linkage of a TIDAL/YouTube track mapping: linkage-only mappings are deleted
+  with the track instead of tripping the mapping table's requires-linkage
+  constraint. The Library Health section now shows live purge progress
+  (remaining count while the sweep runs) and surfaces a stopped purge's
+  failure reason with a retry hint instead of failing silently.
 
 ## [2.3.1] - 2026-08-18
 

--- a/backend/src/routes/__tests__/adminRuntime.test.ts
+++ b/backend/src/routes/__tests__/adminRuntime.test.ts
@@ -36,6 +36,8 @@ jest.mock("../../workers/queues", () => ({
     schedulerQueue: {
         add: jest.fn(),
         getJob: jest.fn(),
+        getJobs: jest.fn(),
+        getFailed: jest.fn(),
     },
 }));
 
@@ -53,6 +55,8 @@ const mockDelete = prisma.libraryHealthRecord.delete as jest.Mock;
 const mockRemovedTrackCount = prisma.track.count as jest.Mock;
 const mockSchedulerAdd = schedulerQueue.add as jest.Mock;
 const mockSchedulerGetJob = schedulerQueue.getJob as jest.Mock;
+const mockSchedulerGetJobs = (schedulerQueue as any).getJobs as jest.Mock;
+const mockSchedulerGetFailed = (schedulerQueue as any).getFailed as jest.Mock;
 
 function getHandler(path: string, method: "get" | "post" | "delete") {
     const layer = (router as any).stack.find(
@@ -120,6 +124,8 @@ describe("admin library health routes", () => {
         mockRemovedTrackCount.mockResolvedValue(3);
         mockSchedulerAdd.mockResolvedValue({ id: "purge-now" });
         mockSchedulerGetJob.mockResolvedValue(undefined);
+        mockSchedulerGetJobs.mockResolvedValue([]);
+        mockSchedulerGetFailed.mockResolvedValue([]);
     });
 
     afterEach(() => {
@@ -310,6 +316,91 @@ describe("admin library health routes", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({
             error: "Failed to enqueue removed track purge",
+        });
+    });
+
+    describe("purge status", () => {
+        const purgeStatusHandler = getHandler(
+            "/library-health/purge-status",
+            "get",
+        );
+
+        it("reports an idle purge with no failures", async () => {
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(res.body).toEqual({
+                remaining: 3,
+                purging: false,
+                lastFailure: null,
+            });
+        });
+
+        it("reports an in-flight purge via queued continuation jobs", async () => {
+            mockSchedulerGetJobs.mockResolvedValue([
+                { name: "track-removal-purge" },
+            ]);
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(res.body).toEqual({
+                remaining: 3,
+                purging: true,
+                lastFailure: null,
+            });
+        });
+
+        it("reports a recent purge failure with a bounded first-line reason", async () => {
+            mockSchedulerGetFailed.mockResolvedValue([
+                { name: "other-job", failedReason: "irrelevant" },
+                {
+                    name: "track-removal-purge",
+                    finishedOn: Date.now() - 60_000,
+                    failedReason:
+                        "\nInvalid `prisma.track.deleteMany()` invocation:\n" +
+                        `Database error 23514 ${"x".repeat(400)}`,
+                },
+            ]);
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(res.body.remaining).toBe(3);
+            expect(res.body.purging).toBe(false);
+            expect(res.body.lastFailure).toMatch(
+                /^Invalid `prisma\.track\.deleteMany\(\)` invocation:$/,
+            );
+        });
+
+        it("ignores purge failures older than the reporting window", async () => {
+            mockSchedulerGetFailed.mockResolvedValue([
+                {
+                    name: "track-removal-purge",
+                    finishedOn: Date.now() - 7 * 60 * 60 * 1000,
+                    failedReason: "ancient failure",
+                },
+            ]);
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(res.body.lastFailure).toBeNull();
+        });
+
+        it("returns a safe error when the status read fails", async () => {
+            mockRemovedTrackCount.mockRejectedValueOnce(
+                new Error("db details must stay internal"),
+            );
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(res.statusCode).toBe(500);
+            expect(res.body).toEqual({
+                error: "Failed to read purge status",
+            });
         });
     });
 });

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -9,7 +9,10 @@ import {
 } from "../utils/encryptedColumns";
 import { getPepperFingerprint, isHashedApiKey } from "../utils/apiKeyHash";
 import { config } from "../config";
-import { handlePurgeRemovedTracksNow } from "./adminLibraryHealthPurge";
+import {
+    handlePurgeRemovedStatus,
+    handlePurgeRemovedTracksNow,
+} from "./adminLibraryHealthPurge";
 
 const router = Router();
 
@@ -182,6 +185,40 @@ router.get("/library-health", async (_req, res) => {
  *         description: Purge sweep could not be enqueued
  */
 router.post("/library-health/purge-removed", handlePurgeRemovedTracksNow);
+
+/**
+ * @openapi
+ * /api/admin/library-health/purge-status:
+ *   get:
+ *     summary: Report progress of the removed-track purge
+ *     tags: [Admin]
+ *     security:
+ *       - apiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Purge progress snapshot
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [remaining, purging]
+ *               properties:
+ *                 remaining:
+ *                   type: integer
+ *                   minimum: 0
+ *                 purging:
+ *                   type: boolean
+ *                 lastFailure:
+ *                   type: string
+ *                   nullable: true
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
+ *       500:
+ *         description: Purge status could not be read
+ */
+router.get("/library-health/purge-status", handlePurgeRemovedStatus);
 
 /**
  * @openapi

--- a/backend/src/routes/adminLibraryHealthPurge.ts
+++ b/backend/src/routes/adminLibraryHealthPurge.ts
@@ -55,6 +55,69 @@ async function enqueuePurgeAt(cutoff: Date): Promise<void> {
     }
 }
 
+const PURGE_STATES_IN_FLIGHT = new Set(["waiting", "delayed", "active"]);
+const FAILED_SCAN_LIMIT = 50;
+const FAILURE_REASON_LIMIT = 200;
+
+function boundedFailureReason(reason: string | undefined): string {
+    if (!reason) return "Purge job failed";
+    const firstLine =
+        reason
+            .split("\n")
+            .map((line) => line.trim())
+            .find((line) => line.length > 0) ?? "Purge job failed";
+    return firstLine.slice(0, FAILURE_REASON_LIMIT);
+}
+
+const FAILURE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
+async function findLatestPurgeFailure(): Promise<string | null> {
+    const failed = await schedulerQueue.getFailed(0, FAILED_SCAN_LIMIT);
+    const cutoff = Date.now() - FAILURE_MAX_AGE_MS;
+    for (const job of failed) {
+        if (job?.name !== TRACK_REMOVAL_PURGE_JOB_NAME) continue;
+        const finishedOn = job.finishedOn ?? job.timestamp;
+        if (typeof finishedOn === "number" && finishedOn < cutoff) continue;
+        return boundedFailureReason(job.failedReason);
+    }
+    return null;
+}
+
+async function isPurgeInFlight(): Promise<boolean> {
+    const purgeNowJob = await schedulerQueue.getJob(PURGE_NOW_JOB_ID);
+    if (purgeNowJob) {
+        const state = await purgeNowJob.getState();
+        if (PURGE_STATES_IN_FLIGHT.has(state)) return true;
+    }
+    const active = await schedulerQueue.getJobs(
+        ["waiting", "delayed", "active"],
+        0,
+        FAILED_SCAN_LIMIT,
+    );
+    return active.some((job) => job?.name === TRACK_REMOVAL_PURGE_JOB_NAME);
+}
+
+/**
+ * Reports live purge progress: how many soft-removed tracks remain, whether
+ * a purge page is queued or running, and the last purge failure if any.
+ */
+export async function handlePurgeRemovedStatus(
+    _req: Request,
+    res: Response,
+): Promise<Response> {
+    try {
+        const [remaining, purging, lastFailure] = await Promise.all([
+            countRemovedLocalTracks(),
+            isPurgeInFlight(),
+            findLatestPurgeFailure(),
+        ]);
+        return res.json({ remaining, purging, lastFailure });
+    } catch (error) {
+        log.error("Purge status error:", error);
+        return sendInternalRouteError(res, "Failed to read purge status");
+    }
+}
+
 /** Enqueues one singleton sweep that purges all currently removed local tracks. */
 export async function handlePurgeRemovedTracksNow(
     _req: Request,

--- a/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
@@ -43,6 +43,9 @@ describe("trackRemovalPurgeProcessor", () => {
                     count: deletedCount ?? args.where.id.in.length,
                 })),
             },
+            trackMapping: {
+                deleteMany: jest.fn(async () => ({ count: 0 })),
+            },
             federationTombstone: {
                 createMany: jest.fn(async () => ({ count: deletedCount })),
                 deleteMany: jest.fn(async () => ({ count: 0 })),
@@ -158,6 +161,39 @@ describe("trackRemovalPurgeProcessor", () => {
                 removedAt: { lt: cutoff },
             },
         });
+    });
+
+    it("deletes track-only mappings before the track rows so the linkage check cannot fail", async () => {
+        const cutoff = new Date("2026-08-18T12:00:00.000Z");
+        const { module, prisma } = loadProcessor([
+            {
+                id: "track-mapped",
+                removedAt: new Date("2026-08-18T11:00:00.000Z"),
+            },
+        ]);
+
+        await expect(
+            module.processTrackRemovalPurge(
+                buildJob({ cutoffAt: cutoff.toISOString() }),
+            ),
+        ).resolves.toEqual({ deleted: 1, continued: false });
+
+        expect(prisma.trackMapping.deleteMany).toHaveBeenCalledWith({
+            where: {
+                track: {
+                    id: { in: ["track-mapped"] },
+                    origin: "LOCAL",
+                    removedAt: { lt: cutoff },
+                },
+                trackTidalId: null,
+                trackYtMusicId: null,
+            },
+        });
+        const mappingOrder = (prisma.trackMapping.deleteMany as jest.Mock).mock
+            .invocationCallOrder[0];
+        const trackOrder = (prisma.track.deleteMany as jest.Mock).mock
+            .invocationCallOrder[0];
+        expect(mappingOrder).toBeLessThan(trackOrder);
     });
 
     it("writes track tombstones and cleans expired tombstones on a federation terminal page", async () => {

--- a/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
+++ b/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
@@ -141,9 +141,25 @@ async function deleteTrackRows(
     batch: readonly { id: string }[],
     cutoff: Date,
 ): Promise<number> {
+    const trackIds = batch.map((track) => track.id);
+    // TrackMapping.trackId is ON DELETE SET NULL, but the table's
+    // requires-linkage check rejects rows with no linkage at all. Delete
+    // mappings whose only linkage is a purged track before the track delete,
+    // or the whole page fails on 23514.
+    await client.trackMapping.deleteMany({
+        where: {
+            track: {
+                id: { in: trackIds },
+                origin: "LOCAL",
+                removedAt: { lt: cutoff },
+            },
+            trackTidalId: null,
+            trackYtMusicId: null,
+        },
+    });
     const result = await client.track.deleteMany({
         where: {
-            id: { in: batch.map((track) => track.id) },
+            id: { in: trackIds },
             origin: "LOCAL",
             removedAt: { lt: cutoff },
         },

--- a/frontend/features/settings/components/sections/LibraryHealthSection.tsx
+++ b/frontend/features/settings/components/sections/LibraryHealthSection.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { api, type LibraryHealthRecord } from "@/lib/api";
 import { SettingsSection } from "../ui";
 import { LibraryHealthDetails } from "./libraryHealthDetails";
+import { usePurgeProgress } from "./usePurgeProgress";
 
 /**
  * Admin section showing library health records for corrupt or missing tracks.
@@ -40,6 +41,18 @@ export function LibraryHealthSection() {
         loadRecords();
     }, [loadRecords]);
 
+    const { progress: purgeProgress, startTracking } = usePurgeProgress(
+        (finalStatus) => {
+            setPurgeNotice(
+                finalStatus.remaining === 0
+                    ? "Purge complete."
+                    : `Purge stopped with ${finalStatus.remaining} track` +
+                          `${finalStatus.remaining === 1 ? "" : "s"} remaining.`,
+            );
+            loadRecords();
+        },
+    );
+
     const handleRefresh = () => {
         setIsLoading(true);
         setError(null);
@@ -53,14 +66,11 @@ export function LibraryHealthSection() {
         setPurgeNotice(null);
         try {
             const result = await api.purgeRemovedTracks();
-            setPurgeNotice(
-                result.enqueued
-                    ? `Purge started for ${result.matched} removed track` +
-                          `${result.matched === 1 ? "" : "s"}. Records ` +
-                          `disappear as the purge completes; refresh to ` +
-                          `follow progress.`
-                    : "No removed tracks to purge.",
-            );
+            if (result.enqueued) {
+                startTracking();
+            } else {
+                setPurgeNotice("No removed tracks to purge.");
+            }
             loadRecords();
         } catch {
             setError("Failed to start the purge");
@@ -104,6 +114,7 @@ export function LibraryHealthSection() {
                 isPurging={isPurging}
                 error={error}
                 purgeNotice={purgeNotice}
+                purgeProgress={purgeProgress}
                 onRefresh={handleRefresh}
                 onDismiss={(recordId) => void handleDismiss(recordId)}
                 onPurgeAll={() => void handlePurgeAll()}

--- a/frontend/features/settings/components/sections/libraryHealthDetails.tsx
+++ b/frontend/features/settings/components/sections/libraryHealthDetails.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState, type ElementType } from "react";
-import type { LibraryHealthRecord } from "@/lib/api";
+import type {
+    LibraryHealthRecord,
+    PurgeRemovedStatusResponse,
+} from "@/lib/api";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
     AlertTriangle,
@@ -47,11 +50,36 @@ interface LibraryHealthDetailsProps {
     isPurging: boolean;
     error: string | null;
     purgeNotice: string | null;
+    purgeProgress: PurgeRemovedStatusResponse | null;
     /** Initial expansion state of the record list; collapsed by default. */
     defaultExpanded?: boolean;
     onRefresh: () => void;
     onDismiss: (recordId: string) => void;
     onPurgeAll: () => void;
+}
+
+function PurgeProgressLine({
+    progress,
+}: Readonly<{ progress: PurgeRemovedStatusResponse | null }>) {
+    if (!progress) return null;
+    if (progress.purging) {
+        return (
+            <div className="flex items-center gap-2 py-2 text-sm text-gray-300">
+                <Loader2 className="w-4 h-4 animate-spin text-brand" />
+                Purging — {progress.remaining} track
+                {progress.remaining === 1 ? "" : "s"} remaining
+            </div>
+        );
+    }
+    if (progress.lastFailure && progress.remaining > 0) {
+        return (
+            <p className="text-sm text-red-400 py-2">
+                Purge stopped: {progress.lastFailure} — press Delete all now to
+                retry.
+            </p>
+        );
+    }
+    return null;
 }
 
 function statusForRecord(record: LibraryHealthRecord): StatusConfig {
@@ -226,6 +254,7 @@ export function LibraryHealthDetails({
     isPurging,
     error,
     purgeNotice,
+    purgeProgress,
     defaultExpanded = false,
     onRefresh,
     onDismiss,
@@ -256,6 +285,7 @@ export function LibraryHealthDetails({
                 isPurging={isPurging}
                 onPurgeAll={() => setShowPurgeConfirm(true)}
             />
+            <PurgeProgressLine progress={purgeProgress} />
             {error && <p className="text-sm text-red-400 py-2">{error}</p>}
             {purgeNotice && (
                 <p className="text-sm text-gray-300 py-2">{purgeNotice}</p>

--- a/frontend/features/settings/components/sections/usePurgeProgress.ts
+++ b/frontend/features/settings/components/sections/usePurgeProgress.ts
@@ -20,43 +20,12 @@ export function usePurgeProgress(
     const [progress, setProgress] = useState<PurgeRemovedStatusResponse | null>(
         null,
     );
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const pollsRef = useRef(0);
-    const activeRef = useRef(false);
+    const [tracking, setTracking] = useState(false);
     const settledRef = useRef(onSettled);
-    settledRef.current = onSettled;
 
-    const stop = useCallback(() => {
-        activeRef.current = false;
-        if (timerRef.current) clearTimeout(timerRef.current);
-        timerRef.current = null;
-    }, []);
-
-    const poll = useCallback(async (): Promise<void> => {
-        let status: PurgeRemovedStatusResponse;
-        try {
-            status = await api.getPurgeRemovedStatus();
-        } catch {
-            stop();
-            return;
-        }
-        if (!activeRef.current) return;
-        setProgress(status);
-        pollsRef.current += 1;
-        if (!status.purging || pollsRef.current >= POLL_LIMIT) {
-            stop();
-            settledRef.current(status);
-            return;
-        }
-        timerRef.current = setTimeout(() => void poll(), POLL_INTERVAL_MS);
-    }, [stop]);
-
-    const startTracking = useCallback(() => {
-        if (activeRef.current) return;
-        activeRef.current = true;
-        pollsRef.current = 0;
-        void poll();
-    }, [poll]);
+    useEffect(() => {
+        settledRef.current = onSettled;
+    }, [onSettled]);
 
     useEffect(() => {
         let cancelled = false;
@@ -65,14 +34,49 @@ export function usePurgeProgress(
             .then((status) => {
                 if (cancelled) return;
                 setProgress(status);
-                if (status.purging) startTracking();
+                if (status.purging) setTracking(true);
             })
             .catch(() => undefined);
         return () => {
             cancelled = true;
-            stop();
         };
-    }, [startTracking, stop]);
+    }, []);
+
+    useEffect(() => {
+        if (!tracking) return;
+        let cancelled = false;
+        let polls = 0;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+
+        const poll = async (): Promise<void> => {
+            let status: PurgeRemovedStatusResponse;
+            try {
+                status = await api.getPurgeRemovedStatus();
+            } catch {
+                if (!cancelled) setTracking(false);
+                return;
+            }
+            if (cancelled) return;
+            setProgress(status);
+            polls += 1;
+            if (!status.purging || polls >= POLL_LIMIT) {
+                setTracking(false);
+                settledRef.current(status);
+                return;
+            }
+            timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+        };
+
+        void poll();
+        return () => {
+            cancelled = true;
+            if (timer) clearTimeout(timer);
+        };
+    }, [tracking]);
+
+    const startTracking = useCallback(() => {
+        setTracking(true);
+    }, []);
 
     return { progress, startTracking };
 }

--- a/frontend/features/settings/components/sections/usePurgeProgress.ts
+++ b/frontend/features/settings/components/sections/usePurgeProgress.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type PurgeRemovedStatusResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 4000;
+const POLL_LIMIT = 450;
+
+/**
+ * Track removed-track purge progress: polls the purge status endpoint while
+ * a sweep is queued or running, and reports the final snapshot when it
+ * settles. Also detects a purge already in flight on mount (page reloads).
+ */
+export function usePurgeProgress(
+    onSettled: (finalStatus: PurgeRemovedStatusResponse) => void,
+): {
+    progress: PurgeRemovedStatusResponse | null;
+    startTracking: () => void;
+} {
+    const [progress, setProgress] = useState<PurgeRemovedStatusResponse | null>(
+        null,
+    );
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pollsRef = useRef(0);
+    const activeRef = useRef(false);
+    const settledRef = useRef(onSettled);
+    settledRef.current = onSettled;
+
+    const stop = useCallback(() => {
+        activeRef.current = false;
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = null;
+    }, []);
+
+    const poll = useCallback(async (): Promise<void> => {
+        let status: PurgeRemovedStatusResponse;
+        try {
+            status = await api.getPurgeRemovedStatus();
+        } catch {
+            stop();
+            return;
+        }
+        if (!activeRef.current) return;
+        setProgress(status);
+        pollsRef.current += 1;
+        if (!status.purging || pollsRef.current >= POLL_LIMIT) {
+            stop();
+            settledRef.current(status);
+            return;
+        }
+        timerRef.current = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    }, [stop]);
+
+    const startTracking = useCallback(() => {
+        if (activeRef.current) return;
+        activeRef.current = true;
+        pollsRef.current = 0;
+        void poll();
+    }, [poll]);
+
+    useEffect(() => {
+        let cancelled = false;
+        void api
+            .getPurgeRemovedStatus()
+            .then((status) => {
+                if (cancelled) return;
+                setProgress(status);
+                if (status.purging) startTracking();
+            })
+            .catch(() => undefined);
+        return () => {
+            cancelled = true;
+            stop();
+        };
+    }, [startTracking, stop]);
+
+    return { progress, startTracking };
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -257,6 +257,13 @@ export interface PurgeRemovedTracksResponse {
     matched: number;
 }
 
+/** Typed response from GET /api/admin/library-health/purge-status. */
+export interface PurgeRemovedStatusResponse {
+    remaining: number;
+    purging: boolean;
+    lastFailure: string | null;
+}
+
 export interface ShareLinkRecord {
     id: string;
     token: string;

--- a/frontend/lib/api/library.ts
+++ b/frontend/lib/api/library.ts
@@ -3,6 +3,7 @@ import type {
     AlbumPreferenceResponse,
     LibraryHealthResponse,
     LikedPlaylistResponse,
+    PurgeRemovedStatusResponse,
     PurgeRemovedTracksResponse,
     TrackPreferenceResponse,
     TrackPreferenceSignal,
@@ -333,6 +334,12 @@ export function WithLibrary<TBase extends ApiClientConstructor>(Base: TBase) {
             return this.request<PurgeRemovedTracksResponse>(
                 "/admin/library-health/purge-removed",
                 { method: "POST" },
+            );
+        }
+
+        async getPurgeRemovedStatus() {
+            return this.request<PurgeRemovedStatusResponse>(
+                "/admin/library-health/purge-status",
             );
         }
 

--- a/frontend/tests/component/libraryHealthDetails.component.test.ts
+++ b/frontend/tests/component/libraryHealthDetails.component.test.ts
@@ -59,10 +59,46 @@ const DETAILS_PROPS = {
     isPurging: false,
     error: null,
     purgeNotice: null,
+    purgeProgress: null,
     onRefresh: () => undefined,
     onDismiss: () => undefined,
     onPurgeAll: () => undefined,
 };
+
+test("library health shows live purge progress while a sweep runs", async () => {
+    const { LibraryHealthDetails } =
+        await import("../../features/settings/components/sections/libraryHealthDetails");
+
+    const html = renderToStaticMarkup(
+        React.createElement(LibraryHealthDetails, {
+            ...DETAILS_PROPS,
+            purgeProgress: {
+                remaining: 1786,
+                purging: true,
+                lastFailure: null,
+            },
+        }),
+    );
+    assert.match(html, /Purging — 1786 tracks remaining/);
+});
+
+test("library health surfaces a stopped purge with its failure reason", async () => {
+    const { LibraryHealthDetails } =
+        await import("../../features/settings/components/sections/libraryHealthDetails");
+
+    const html = renderToStaticMarkup(
+        React.createElement(LibraryHealthDetails, {
+            ...DETAILS_PROPS,
+            purgeProgress: {
+                remaining: 2186,
+                purging: false,
+                lastFailure: "Database error. Code: 23514.",
+            },
+        }),
+    );
+    assert.match(html, /Purge stopped: Database error\. Code: 23514\./);
+    assert.match(html, /press Delete all now to retry/);
+});
 
 test("library health summarizes removed tracks and collapses the record list by default", async () => {
     const { LibraryHealthDetails } =


### PR DESCRIPTION
## Summary

Field report from the homelab: pressing **Delete all now** on 2,186 removed tracks deleted 400 and then silently stalled — no progress, no error, nothing. Two defects:

### 1. Purge stalls on TrackMapping's requires-linkage constraint (real production bug)
`TrackMapping.trackId` is `ON DELETE SET NULL`, but `TrackMapping_requires_linkage_chk` requires at least one linkage column. Deleting a track whose mapping has no TIDAL/YouTube linkage produces an all-null row → `23514` → the whole 100-track page fails → 3 retries → the sweep dies. This would eventually have broken the nightly retention purge too. Fix: delete linkage-only mappings for exactly the tracks the page will delete (same predicate, same transaction) before the track delete; mappings with TIDAL/YouTube linkage keep their SET NULL behavior.

### 2. No purge feedback (UX gap)
New `GET /api/admin/library-health/purge-status`: remaining soft-removed count, whether a purge page is queued/running, and the most recent purge failure (first line, bounded 200 chars, only failures from the last 6h). The Library Health section polls it (4s, bounded) while a sweep runs:
- **Running**: spinner + "Purging — N tracks remaining"
- **Done**: "Purge complete." and the list refreshes
- **Stopped**: red "Purge stopped: <reason> — press Delete all now to retry"
- A purge already running is detected on page load, so refreshing mid-sweep keeps the progress view.

## Testing
- Processor: linkage-only mapping delete pinned (filter + ordering before track delete); all prior cutoff/tombstone/continuation tests green.
- Route runtime: idle status, in-flight via continuation jobs, bounded failure reason, stale-failure suppression, safe 500. 45 backend tests green + OpenAPI sync; full tsc.
- Frontend: component tests for progress line and stopped-purge rendering (6 green); typecheck, both prettier configs, error-canon + file-size ratchets pass.

After merge: homelab image override bump so the stalled purge can be retried with the fix.