### PR TITLE
feat(settings): modernize Cache & Automation and scope enrichment to existing tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constraint. The Library Health section now shows live purge progress
   (remaining count while the sweep runs) and surfaces a stopped purge's
   failure reason with a retry hint instead of failing silently.
+- Modernized the Cache & Automation settings section: enrichment cards now
+  share the app's status palette (success/warning/error plus the AI accent
+  for background stages), a stage that finished with failures shows a
+  warning state instead of a green check, the header pill names the analysis
+  actually outstanding (audio, vibe embeddings, or both), Re-run and
+  Re-enrich controls carry explanatory tooltips, and Re-enrich All asks for
+  confirmation before starting an hours-long rebuild.
+
+### Fixed
+
+- Enrichment progress, failure counts, and completion no longer include
+  soft-removed tracks, so cleared or purged tracks stop showing as failed
+  analysis and the live status no longer sticks on "Processing podcasts"
+  after a cycle. Retry Failed Analysis skips removed tracks instead of
+  re-queueing files that no longer exist.
 
 ## [2.3.1] - 2026-08-18
 

--- a/backend/src/routes/__tests__/analysisRuntime.test.ts
+++ b/backend/src/routes/__tests__/analysisRuntime.test.ts
@@ -348,7 +348,11 @@ describe("analysis routes runtime", () => {
         await postRetryFailed(req, res);
 
         expect(mockTrackUpdateMany).toHaveBeenCalledWith({
-            where: { analysisStatus: "failed", origin: "LOCAL" },
+            where: {
+                analysisStatus: "failed",
+                removedAt: null,
+                origin: "LOCAL",
+            },
             data: {
                 analysisStatus: "pending",
                 analysisError: null,

--- a/backend/src/routes/analysis.ts
+++ b/backend/src/routes/analysis.ts
@@ -309,6 +309,7 @@ router.post("/retry-failed", requireAuth, requireAdmin, async (req, res) => {
         const result = await prisma.track.updateMany({
             where: {
                 analysisStatus: "failed",
+                removedAt: null,
                 ...LOCAL_TRACK_WHERE,
             },
             data: {

--- a/backend/src/utils/librarySorting.ts
+++ b/backend/src/utils/librarySorting.ts
@@ -6,6 +6,16 @@ export const TRACK_VISIBLE_WHERE = {
 } satisfies Prisma.TrackWhereInput;
 
 /** Shared predicate for tracks physically owned by this soundspan instance. */
+/**
+ * Local tracks that still exist on disk — the enrichment-eligible set.
+ * Soft-removed tracks have no file, so counting or resetting them inflates
+ * pending/failed totals and blocks completion.
+ */
+export const ENRICHABLE_TRACK_WHERE = {
+    origin: "LOCAL",
+    removedAt: null,
+} satisfies Prisma.TrackWhereInput;
+
 export const LOCAL_TRACK_WHERE = {
     origin: "LOCAL",
 } satisfies Prisma.TrackWhereInput;

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -15,7 +15,11 @@ describe("unified enrichment runtime behavior", () => {
         const trackCountMock = jest.fn(async (args?: { where?: any }) => {
             const where = args?.where;
             if (!where) return 10;
-            if (where.origin === "LOCAL" && Object.keys(where).length === 1)
+            if (
+                where.origin === "LOCAL" &&
+                where.removedAt === null &&
+                Object.keys(where).length === 2
+            )
                 return 10;
             if (where.AND) return 6;
             if (where.analysisStatus === "completed") return 4;
@@ -479,7 +483,7 @@ describe("unified enrichment runtime behavior", () => {
         );
         expect(prisma.trackEmbedding.deleteMany).not.toHaveBeenCalled();
         expect(prisma.track.updateMany).toHaveBeenCalledWith({
-            where: { origin: "LOCAL" },
+            where: { origin: "LOCAL", removedAt: null },
             data: expect.objectContaining({
                 vibeAnalysisStatus: "pending",
                 vibeAnalysisGeneration: { increment: 1 },
@@ -753,7 +757,7 @@ describe("unified enrichment runtime behavior", () => {
         const result = await enrichment.reRunMoodTagsOnly();
 
         expect(prisma.track.updateMany).toHaveBeenCalledWith({
-            where: { origin: "LOCAL" },
+            where: { origin: "LOCAL", removedAt: null },
             data: { lastfmTags: [] },
         });
         expect(claimRedisPrimary.set).toHaveBeenCalledTimes(1);

--- a/backend/src/workers/enrichmentCycleState.ts
+++ b/backend/src/workers/enrichmentCycleState.ts
@@ -1,0 +1,18 @@
+import { enrichmentStateService } from "../services/enrichmentState";
+
+/**
+ * Point the live enrichment phase at the outstanding background stage after
+ * a cycle ends. The cycle's last phase is podcasts, so without this repoint
+ * an incomplete library stays pinned on "Processing podcasts" while only
+ * background audio or vibe analysis is actually outstanding.
+ */
+export async function repointBackgroundPhase(progress: {
+    audioAnalysis: { pending: number; processing: number };
+}): Promise<void> {
+    const audioOutstanding =
+        progress.audioAnalysis.pending + progress.audioAnalysis.processing > 0;
+    await enrichmentStateService.updateState({
+        status: "running",
+        currentPhase: audioOutstanding ? "audio" : "vibe",
+    });
+}

--- a/backend/src/workers/enrichmentMoodTags.ts
+++ b/backend/src/workers/enrichmentMoodTags.ts
@@ -1,0 +1,88 @@
+/** Mood-tag vocabulary and filtering shared by the enrichment worker. */
+
+// Mood tags to extract from Last.fm
+const MOOD_TAGS = new Set([
+    // Energy/Activity
+    "chill",
+    "relax",
+    "relaxing",
+    "calm",
+    "peaceful",
+    "ambient",
+    "energetic",
+    "upbeat",
+    "hype",
+    "party",
+    "dance",
+    "workout",
+    "gym",
+    "running",
+    "exercise",
+    "motivation",
+    // Emotions
+    "sad",
+    "melancholy",
+    "melancholic",
+    "depressing",
+    "heartbreak",
+    "happy",
+    "feel good",
+    "feel-good",
+    "joyful",
+    "uplifting",
+    "angry",
+    "aggressive",
+    "intense",
+    "romantic",
+    "love",
+    "sensual",
+    // Time/Setting
+    "night",
+    "late night",
+    "evening",
+    "morning",
+    "summer",
+    "winter",
+    "rainy",
+    "sunny",
+    "driving",
+    "road trip",
+    "travel",
+    // Activity
+    "study",
+    "focus",
+    "concentration",
+    "work",
+    "sleep",
+    "sleeping",
+    "bedtime",
+    // Vibe
+    "dreamy",
+    "atmospheric",
+    "ethereal",
+    "spacey",
+    "groovy",
+    "funky",
+    "smooth",
+    "dark",
+    "moody",
+    "brooding",
+    "epic",
+    "cinematic",
+    "dramatic",
+    "nostalgic",
+    "throwback",
+]);
+
+export function filterMoodTags(tags: string[]): string[] {
+    return tags
+        .map((t) => t.toLowerCase().trim())
+        .filter((t) => {
+            if (MOOD_TAGS.has(t)) return true;
+            for (const mood of MOOD_TAGS) {
+                if (t.includes(mood)) return true;
+            }
+            return false;
+        })
+        .slice(0, 10);
+}

--- a/backend/src/workers/enrichmentTimeout.ts
+++ b/backend/src/workers/enrichmentTimeout.ts
@@ -1,0 +1,21 @@
+/**
+ * Timeout wrapper to prevent operations from hanging indefinitely
+ * If an operation takes longer than the timeout, it will fail and move to the next item
+ */
+export async function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    errorMessage: string,
+): Promise<T> {
+    let timer: NodeJS.Timeout;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+    });
+    return Promise.race([promise, timeoutPromise]).finally(() =>
+        clearTimeout(timer),
+    );
+}
+
+/**
+ * Filter tags to only include mood-relevant ones
+ */

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -30,7 +30,13 @@ import { featureDetection } from "../services/featureDetection";
 import { moodBucketService } from "../services/moodBucketService";
 import pLimit from "p-limit";
 import { enqueueReservedWork } from "./enrichmentQueue";
-import { LOCAL_TRACK_WHERE } from "../utils/librarySorting";
+import { filterMoodTags } from "./enrichmentMoodTags";
+import { withTimeout } from "./enrichmentTimeout";
+import { repointBackgroundPhase } from "./enrichmentCycleState";
+import {
+    ENRICHABLE_TRACK_WHERE,
+    LOCAL_TRACK_WHERE,
+} from "../utils/librarySorting";
 import { getActiveSpace } from "../services/embeddingSpaces";
 import { findLocalTracksNeedingActiveEmbedding } from "../services/trackEmbeddings";
 
@@ -74,114 +80,6 @@ let currentBatchFailures: BatchFailures = {
 
 // Session-level failure counter (accumulates across cycles, reset on enrichment start)
 let sessionFailureCount = { artists: 0, tracks: 0, audio: 0 };
-
-// Mood tags to extract from Last.fm
-const MOOD_TAGS = new Set([
-    // Energy/Activity
-    "chill",
-    "relax",
-    "relaxing",
-    "calm",
-    "peaceful",
-    "ambient",
-    "energetic",
-    "upbeat",
-    "hype",
-    "party",
-    "dance",
-    "workout",
-    "gym",
-    "running",
-    "exercise",
-    "motivation",
-    // Emotions
-    "sad",
-    "melancholy",
-    "melancholic",
-    "depressing",
-    "heartbreak",
-    "happy",
-    "feel good",
-    "feel-good",
-    "joyful",
-    "uplifting",
-    "angry",
-    "aggressive",
-    "intense",
-    "romantic",
-    "love",
-    "sensual",
-    // Time/Setting
-    "night",
-    "late night",
-    "evening",
-    "morning",
-    "summer",
-    "winter",
-    "rainy",
-    "sunny",
-    "driving",
-    "road trip",
-    "travel",
-    // Activity
-    "study",
-    "focus",
-    "concentration",
-    "work",
-    "sleep",
-    "sleeping",
-    "bedtime",
-    // Vibe
-    "dreamy",
-    "atmospheric",
-    "ethereal",
-    "spacey",
-    "groovy",
-    "funky",
-    "smooth",
-    "dark",
-    "moody",
-    "brooding",
-    "epic",
-    "cinematic",
-    "dramatic",
-    "nostalgic",
-    "throwback",
-]);
-
-/**
- * Timeout wrapper to prevent operations from hanging indefinitely
- * If an operation takes longer than the timeout, it will fail and move to the next item
- */
-async function withTimeout<T>(
-    promise: Promise<T>,
-    timeoutMs: number,
-    errorMessage: string,
-): Promise<T> {
-    let timer: NodeJS.Timeout;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
-    });
-    return Promise.race([promise, timeoutPromise]).finally(() =>
-        clearTimeout(timer),
-    );
-}
-
-/**
- * Filter tags to only include mood-relevant ones
- */
-function filterMoodTags(tags: string[]): string[] {
-    return tags
-        .map((t) => t.toLowerCase().trim())
-        .filter((t) => {
-            if (MOOD_TAGS.has(t)) return true;
-            for (const mood of MOOD_TAGS) {
-                if (t.includes(mood)) return true;
-            }
-            return false;
-        })
-        .slice(0, 10);
-}
 
 /**
  * Initialize Redis connection for audio analysis queue
@@ -568,7 +466,7 @@ export async function runFullEnrichment(options?: {
     });
 
     await prisma.track.updateMany({
-        where: LOCAL_TRACK_WHERE,
+        where: ENRICHABLE_TRACK_WHERE,
         data: {
             lastfmTags: [],
             analysisStatus: "pending",
@@ -576,7 +474,11 @@ export async function runFullEnrichment(options?: {
     });
 
     if (forceVibeRebuild) {
-        await invalidateVibeAnalysis(prisma, LOCAL_TRACK_WHERE, new Date());
+        await invalidateVibeAnalysis(
+            prisma,
+            ENRICHABLE_TRACK_WHERE,
+            new Date(),
+        );
 
         await enrichmentFailureService.clearAllFailures("vibe");
 
@@ -627,7 +529,7 @@ export async function resetMoodTagsOnly(): Promise<{ count: number }> {
     log.debug("Resetting ONLY mood tags...");
 
     const result = await prisma.track.updateMany({
-        where: LOCAL_TRACK_WHERE,
+        where: ENRICHABLE_TRACK_WHERE,
         data: { lastfmTags: [] },
     });
 
@@ -878,6 +780,10 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
                     );
                 }
             }
+        }
+
+        if (!progress.isFullyComplete) {
+            await repointBackgroundPhase(progress);
         }
 
         if (progress.isFullyComplete) {
@@ -1643,16 +1549,17 @@ export async function getEnrichmentProgress() {
                     by: ["enrichmentStatus"],
                     _count: true,
                 }),
-                prisma.track.count({ where: LOCAL_TRACK_WHERE }),
+                prisma.track.count({ where: ENRICHABLE_TRACK_WHERE }),
                 prisma.$queryRaw<{ count: bigint }[]>`
                 SELECT COUNT(*) as count
                 FROM "Track"
                 WHERE "filePath" IS NOT NULL
                   AND origin = ${"LOCAL"}::"TrackOrigin"
+                  AND "removedAt" IS NULL
             `,
                 prisma.track.count({
                     where: {
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                         AND: [
                             { NOT: { lastfmTags: { equals: [] } } },
                             { NOT: { lastfmTags: { equals: null } } },
@@ -1662,42 +1569,45 @@ export async function getEnrichmentProgress() {
                 prisma.track.count({
                     where: {
                         analysisStatus: "completed",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
                 prisma.track.count({
                     where: {
                         analysisStatus: "pending",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
                 prisma.track.count({
                     where: {
                         analysisStatus: "processing",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
                 prisma.track.count({
                     where: {
                         analysisStatus: "failed",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
                 prisma.$queryRaw<{ count: bigint }[]>`
                 SELECT COUNT(*) as count
                 FROM track_embeddings te
+                JOIN "Track" t ON te.track_id = t.id
                 WHERE te.space_id = ${activeSpace.id}
+                  AND t.origin = ${"LOCAL"}::"TrackOrigin"
+                  AND t."removedAt" IS NULL
             `,
                 prisma.track.count({
                     where: {
                         vibeAnalysisStatus: "processing",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
                 prisma.track.count({
                     where: {
                         vibeAnalysisStatus: "failed",
-                        ...LOCAL_TRACK_WHERE,
+                        ...ENRICHABLE_TRACK_WHERE,
                     },
                 }),
             ]);
@@ -1888,7 +1798,7 @@ export async function reRunAudioAnalysisOnly(): Promise<number> {
     await audioAnalysisCleanupService.cleanupStaleProcessing();
 
     const tracks = await prisma.track.findMany({
-        where: { analysisStatus: "pending", ...LOCAL_TRACK_WHERE },
+        where: { analysisStatus: "pending", ...ENRICHABLE_TRACK_WHERE },
         select: { id: true },
     });
 

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -26,6 +26,7 @@ import {
     Waves,
 } from "lucide-react";
 import { EnrichmentFailuresModal } from "@/components/EnrichmentFailuresModal";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 const logger = createFrontendLogger("Settings.CacheSection");
 
@@ -61,6 +62,22 @@ function ProgressBar({
     );
 }
 
+/** Name the analysis still outstanding so the pill matches reality. */
+function backgroundAnalysisLabel(progress: {
+    audioAnalysis: { pending: number; processing: number };
+    clapEmbeddings: { pending: number; processing: number };
+}): string {
+    const audioBusy =
+        progress.audioAnalysis.pending + progress.audioAnalysis.processing > 0;
+    const vibeBusy =
+        progress.clapEmbeddings.pending + progress.clapEmbeddings.processing >
+        0;
+    if (audioBusy && vibeBusy)
+        return "Audio analysis & vibe embeddings running";
+    if (vibeBusy) return "Vibe embeddings running";
+    return "Audio analysis running";
+}
+
 // Enrichment stage component
 function EnrichmentStage({
     icon: Icon,
@@ -84,20 +101,30 @@ function EnrichmentStage({
     processing?: number;
 }) {
     const unresolved = Math.max(0, total - (completed + failed));
-    const isComplete = unresolved === 0 && processing === 0;
     const hasActivity = processing > 0;
+    // Semantic states share the app's status tokens: success when everything
+    // resolved cleanly, warning when the stage finished but left failures.
+    const isSettled = unresolved === 0 && processing === 0;
+    const isComplete = isSettled && failed === 0;
+    const settledWithFailures = isSettled && failed > 0;
 
     return (
         <div className="flex items-start gap-3 py-2">
             <div
                 className={`mt-0.5 p-1.5 rounded-lg ${
-                    isComplete ? "bg-green-500/20" : "bg-white/5"
+                    isComplete
+                        ? "bg-success/20"
+                        : settledWithFailures
+                          ? "bg-warning/20"
+                          : "bg-white/5"
                 }`}
             >
                 {isComplete ? (
-                    <CheckCircle className="w-4 h-4 text-green-400" />
+                    <CheckCircle className="w-4 h-4 text-success" />
                 ) : hasActivity ? (
                     <Loader2 className="w-4 h-4 text-brand animate-spin" />
+                ) : settledWithFailures ? (
+                    <AlertTriangle className="w-4 h-4 text-warning" />
                 ) : (
                     <Icon className="w-4 h-4 text-white/40" />
                 )}
@@ -119,10 +146,12 @@ function EnrichmentStage({
                         progress={progress}
                         color={
                             isComplete
-                                ? "bg-green-500"
-                                : isBackground
-                                  ? "bg-ai"
-                                  : "bg-brand"
+                                ? "bg-success"
+                                : settledWithFailures
+                                  ? "bg-warning"
+                                  : isBackground
+                                    ? "bg-ai"
+                                    : "bg-brand"
                         }
                     />
                 </div>
@@ -136,7 +165,7 @@ function EnrichmentStage({
                         </span>
                     )}
                     {failed > 0 && (
-                        <span className="text-red-400">{failed} failed</span>
+                        <span className="text-error">{failed} failed</span>
                     )}
                 </div>
             </div>
@@ -174,6 +203,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
         assigned: number;
     } | null>(null);
     const [retryingFailed, setRetryingFailed] = useState(false);
+    const [showReEnrichConfirm, setShowReEnrichConfirm] = useState(false);
     const [retryResult, setRetryResult] = useState<{ reset: number } | null>(
         null,
     );
@@ -586,7 +616,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                     </div>
                 ) : isProgressError && !enrichmentProgress ? (
                     <div className="mb-6 p-4 bg-white/5 rounded-lg border border-red-500/20 flex items-center justify-between">
-                        <span className="text-sm text-red-400">
+                        <span className="text-sm text-error">
                             Failed to load enrichment status
                         </span>
                         <button
@@ -604,13 +634,15 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             </h3>
                             {enrichmentProgress.coreComplete &&
                                 !enrichmentProgress.isFullyComplete && (
-                                    <span className="text-xs text-ai-hover flex items-center gap-1">
+                                    <span className="text-xs text-brand flex items-center gap-1">
                                         <Loader2 className="w-3 h-3 animate-spin" />
-                                        Audio analysis running
+                                        {backgroundAnalysisLabel(
+                                            enrichmentProgress,
+                                        )}
                                     </span>
                                 )}
                             {enrichmentProgress.isFullyComplete && (
-                                <span className="text-xs text-green-400 flex items-center gap-1">
+                                <span className="text-xs text-success flex items-center gap-1">
                                     <CheckCircle className="w-3 h-3" />
                                     Complete
                                 </span>
@@ -639,6 +671,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                 </div>
                                 <button
                                     onClick={handleResetArtists}
+                                    title="Reset artist metadata for the whole library and fetch it again in the background."
                                     disabled={
                                         resettingArtists ||
                                         syncing ||
@@ -676,6 +709,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                 </div>
                                 <button
                                     onClick={handleResetMoodTags}
+                                    title="Clear all mood tags and fetch them again in the background."
                                     disabled={
                                         resettingMoodTags ||
                                         syncing ||
@@ -724,6 +758,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     </div>
                                     <button
                                         onClick={handleResetAudioAnalysis}
+                                        title="Reset audio analysis for every track and re-run it in the background. Can take a long time on large libraries."
                                         disabled={
                                             resettingAudio ||
                                             syncing ||
@@ -819,6 +854,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                                                 progress={
                                                                     migrationPercent
                                                                 }
+                                                                color="bg-ai"
                                                             />
                                                         </div>
                                                         <p className="mt-1 text-[10px] text-white/40">
@@ -830,10 +866,19 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                                                 migrationCoverage.pending
                                                             }{" "}
                                                             pending ·{" "}
-                                                            {
-                                                                migrationCoverage.failed
-                                                            }{" "}
-                                                            failed
+                                                            <span
+                                                                className={
+                                                                    migrationCoverage.failed >
+                                                                    0
+                                                                        ? "text-error"
+                                                                        : undefined
+                                                                }
+                                                            >
+                                                                {
+                                                                    migrationCoverage.failed
+                                                                }{" "}
+                                                                failed
+                                                            </span>
                                                         </p>
                                                     </>
                                                 ) : (
@@ -855,6 +900,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                     </div>
                                     <button
                                         onClick={handleResetVibeEmbeddings}
+                                        title="Rebuild vibe embeddings for every track in the background. Can take hours on large libraries."
                                         disabled={
                                             resettingVibe ||
                                             syncing ||
@@ -897,18 +943,20 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         reEnriching ||
                                         isEnrichmentActive
                                     }
+                                    title="Enrich only items that are new or missing data. Safe to run any time; usually finishes quickly."
                                     className="px-3 py-1.5 text-xs bg-white text-black font-medium rounded-full
                                     hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed transition-transform"
                                 >
                                     {syncing ? "Syncing..." : "Sync New"}
                                 </button>
                                 <button
-                                    onClick={handleFullEnrichment}
+                                    onClick={() => setShowReEnrichConfirm(true)}
                                     disabled={
                                         syncing ||
                                         reEnriching ||
                                         isEnrichmentActive
                                     }
+                                    title="Re-run metadata enrichment for the entire library in the background. Can take hours on large libraries."
                                     className="px-3 py-1.5 text-xs bg-white text-black font-medium rounded-full
                                     hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed transition-transform"
                                 >
@@ -924,8 +972,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         "running" ? (
                                             <button
                                                 onClick={handlePause}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-yellow-600 text-white rounded-full
-                                                hover:bg-yellow-700 transition-colors"
+                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-warning text-black rounded-full
+                                                hover:opacity-85 transition-opacity"
                                             >
                                                 <Pause className="w-3 h-3" />
                                                 Pause
@@ -933,8 +981,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         ) : (
                                             <button
                                                 onClick={handleResume}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-green-600 text-white rounded-full
-                                                hover:bg-green-700 transition-colors"
+                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-success text-black rounded-full
+                                                hover:opacity-85 transition-opacity"
                                             >
                                                 <Play className="w-3 h-3" />
                                                 Resume
@@ -942,8 +990,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         )}
                                         <button
                                             onClick={handleStop}
-                                            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-red-600 text-white rounded-full
-                                            hover:bg-red-700 transition-colors"
+                                            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-error text-white rounded-full
+                                            hover:opacity-85 transition-opacity"
                                         >
                                             <StopCircle className="w-3 h-3" />
                                             Stop
@@ -957,8 +1005,8 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         onClick={() =>
                                             setShowFailuresModal(true)
                                         }
-                                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-red-500/20 text-red-400 border border-red-500/30 rounded-full
-                                        hover:bg-red-500/30 transition-colors ml-auto"
+                                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-error/20 text-error border border-error/30 rounded-full
+                                        hover:bg-error/30 transition-colors ml-auto"
                                     >
                                         <AlertTriangle className="w-3 h-3" />
                                         View Failures ({totalFailures})
@@ -1027,7 +1075,7 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                                         )}
                                         {enrichmentState.status ===
                                             "stopping" && (
-                                            <StopCircle className="w-3 h-3 text-red-400 animate-pulse" />
+                                            <StopCircle className="w-3 h-3 text-error animate-pulse" />
                                         )}
                                         <span className="text-white/70">
                                             {enrichmentState.status ===
@@ -1302,19 +1350,19 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             : "Backfill Mood Buckets"}
                     </button>
                     {retryResult && (
-                        <p className="text-sm text-green-400">
+                        <p className="text-sm text-success">
                             Reset {retryResult.reset} failed tracks to pending
                         </p>
                     )}
                     {moodBucketBackfillResult && (
-                        <p className="text-sm text-green-400">
+                        <p className="text-sm text-success">
                             Mood bucket backfill complete: processed{" "}
                             {moodBucketBackfillResult.processed}, assigned{" "}
                             {moodBucketBackfillResult.assigned}
                         </p>
                     )}
                     {cleanupResult && cleanupResult.totalCleaned > 0 && (
-                        <p className="text-sm text-green-400">
+                        <p className="text-sm text-success">
                             Cleaned:{" "}
                             {cleanupResult.cleaned.discoveryBatches.cleaned}{" "}
                             batches,{" "}
@@ -1330,13 +1378,23 @@ export function CacheSection({ settings, onUpdate }: CacheSectionProps) {
                             No stale jobs found
                         </p>
                     )}
-                    {error && <p className="text-sm text-red-400">{error}</p>}
+                    {error && <p className="text-sm text-error">{error}</p>}
                 </div>
             </SettingsSection>
 
             <EnrichmentFailuresModal
                 isOpen={showFailuresModal}
                 onClose={() => setShowFailuresModal(false)}
+            />
+
+            <ConfirmDialog
+                isOpen={showReEnrichConfirm}
+                onClose={() => setShowReEnrichConfirm(false)}
+                onConfirm={() => void handleFullEnrichment()}
+                title="Re-enrich the entire library?"
+                message="This re-runs metadata enrichment for every artist and track in the background, plus vibe embeddings and mood buckets if their checkboxes are enabled below. On large libraries this can take hours. Playback keeps working while it runs."
+                confirmText="Re-enrich All"
+                variant="warning"
             />
         </>
     );


### PR DESCRIPTION
## Summary

Field feedback: the Cache & Automation section used colors from all over the palette, said "Audio analysis running" when only vibe embeddings were running, kept "Processing podcasts" pinned forever, showed a stale "1132 failed" after the failing tracks were purged from the library, and its powerful buttons ("Re-run", "Re-enrich All") gave no hint of what they do or how long they take.

### Backend — one root cause behind three symptoms
Every enrichment progress count filtered only `origin: LOCAL`, **including soft-removed tracks**. Removed tracks kept `analysisStatus: failed`/`pending`, which (1) inflated the "N failed" display even after a purge, (2) made `isFullyComplete` unreachable, and (3) therefore left the live status pinned at `running/podcasts` — the last phase of every cycle — forever.
- New `ENRICHABLE_TRACK_WHERE` (`origin: LOCAL, removedAt: null`) applied to all progress counts, both raw SQL counts (CLAP-eligible + embedded, now joined to visible tracks), the full-reset and mood-tag-reset paths, and `POST /api/analysis/retry-failed`.
- Cycle end now repoints the live phase at the actually-outstanding background stage (audio → vibe) instead of leaving "podcasts".

### Frontend — consistent semantics
- `EnrichmentStage` uses the design tokens: **success** (clean complete), **warning** (settled with failures — no more green check over a red failure count, fixing the artist-metadata oddity), **brand** spinner for activity, **ai** bars for background stages, **error** for failure counts.
- Header pill now says "Audio analysis running", "Vibe embeddings running", or both — computed from what's actually outstanding — in the same brand blue as the stage spinners (was a third blue).
- Pause/Resume/Stop/View-Failures buttons and result/status lines moved off raw `yellow-600`/`green-600`/`red-400` onto `warning`/`success`/`error` tokens; embedding-migration sub-panel bar uses the AI accent and its failed count turns red only when non-zero.
- All four **Re-run** buttons and **Sync New**/**Re-enrich All** have explanatory tooltips; **Re-enrich All** now opens a ConfirmDialog warning it can take hours.
- Worker slimming for the size ratchet: mood-tag vocabulary/filter and the timeout wrapper extracted to `enrichmentMoodTags.ts`/`enrichmentTimeout.ts`.

## Testing
- Backend: 241 worker-suite tests green (runtime mocks updated to pin the new `removedAt: null` contract), analysis route tests, full tsc, prettier, error-canon + file-size ratchets.
- Frontend: typecheck, prettier, component suite at main baseline.