### PR TITLE
fix(library): stop reporting the scheduled daily sweep as an in-flight purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Purge status no longer reports a purge as running when only the daily
+  scheduled sweep is parked in the queue.
 - The vibe map no longer fails permanently on memory-constrained deployments:
   the UMAP projection worker runs under an explicit heap ceiling
   (`VIBE_MAP_WORKER_MEMORY_MB`, default 512) and halves its track sample on

--- a/backend/src/routes/__tests__/adminRuntime.test.ts
+++ b/backend/src/routes/__tests__/adminRuntime.test.ts
@@ -337,7 +337,45 @@ describe("admin library health routes", () => {
             });
         });
 
-        it("reports an in-flight purge via queued continuation jobs", async () => {
+        it("reports a waiting purge-now singleton as in flight", async () => {
+            mockSchedulerGetJob.mockResolvedValue({
+                getState: jest.fn().mockResolvedValue("waiting"),
+            });
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(mockSchedulerGetJobs).not.toHaveBeenCalled();
+            expect(res.body).toEqual({
+                remaining: 3,
+                purging: true,
+                lastFailure: null,
+            });
+        });
+
+        it("ignores a delayed scheduled purge", async () => {
+            mockSchedulerGetJobs.mockImplementation(async (states: string[]) =>
+                states.includes("delayed")
+                    ? [{ name: "track-removal-purge", state: "delayed" }]
+                    : [],
+            );
+            const res = createRes();
+
+            await purgeStatusHandler({} as any, res);
+
+            expect(mockSchedulerGetJobs).toHaveBeenCalledWith(
+                ["active"],
+                0,
+                50,
+            );
+            expect(res.body).toEqual({
+                remaining: 3,
+                purging: false,
+                lastFailure: null,
+            });
+        });
+
+        it("reports an active scheduled purge as in flight", async () => {
             mockSchedulerGetJobs.mockResolvedValue([
                 { name: "track-removal-purge" },
             ]);
@@ -345,6 +383,11 @@ describe("admin library health routes", () => {
 
             await purgeStatusHandler({} as any, res);
 
+            expect(mockSchedulerGetJobs).toHaveBeenCalledWith(
+                ["active"],
+                0,
+                50,
+            );
             expect(res.body).toEqual({
                 remaining: 3,
                 purging: true,

--- a/backend/src/routes/adminLibraryHealthPurge.ts
+++ b/backend/src/routes/adminLibraryHealthPurge.ts
@@ -90,7 +90,7 @@ async function isPurgeInFlight(): Promise<boolean> {
         if (PURGE_STATES_IN_FLIGHT.has(state)) return true;
     }
     const active = await schedulerQueue.getJobs(
-        ["waiting", "delayed", "active"],
+        ["active"],
         0,
         FAILED_SCAN_LIMIT,
     );


### PR DESCRIPTION
## Problem

After a removed-track purge completes, Library Health stays stuck on **"Purging — 0 tracks remaining"** with a spinner, and the client keeps polling for up to 30 minutes.

## Root cause

`GET /api/admin/library-health/purge-status` decides `purging` by scanning the scheduler queue for any job named `track-removal-purge` in `waiting | delayed | active` state. The daily retention sweep is registered as a Bull **repeatable** job with that same name (`scheduler:track-removal-purge:repeat`), and Bull keeps the next iteration of a repeatable job permanently parked in `delayed` state — so the scan always matched and `purging` never went false. The startup-mode job had the same effect during its 60-second boot delay.

## Fix

`isPurgeInFlight()` now counts:
- the `purge-now` singleton in `waiting | delayed | active` (a queued user-requested purge is genuinely in flight), and
- queue jobs of that name in **`active` state only** — a scheduled sweep that is actually running still shows progress; one merely parked for its next tick does not.

No change to the remaining count, failure reporting, or response shape.

## Tests

- New regression: a delayed scheduled `track-removal-purge` job with no singleton → `purging: false`.
- Waiting singleton → `purging: true`; active scheduled job → `purging: true` (both assert the queue scan now requests `["active"]`).
- `adminRuntime.test.ts`: 18/18 pass; `tsc --noEmit` and `format:check` clean.

Fixes the stuck status reported after the first production use of Delete all now (follow-up to #585).