### PR TITLE
docs(security): CSP style-src rationale + federation protocol-compat design

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ This index is the central navigation page for all project documentation under `d
 | Document                                                                                                     | Status       | Purpose                                                                         |
 | ------------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------------------------- |
 | [`designs/loudness-and-transitions.md`](designs/loudness-and-transitions.md)                                 | Design phase | Loudness normalization (LUFS/ReplayGain) and analysis-driven smart transitions  |
+| [`designs/federation-protocol-compat.md`](designs/federation-protocol-compat.md)                             | Approved     | Tolerant envelope parsing and capability advertisement for additive federation fields |
 | [`designs/natural-language-music.md`](designs/natural-language-music.md)                                     | Design phase | Local-LLM natural-language playlists: compile-not-generate trust boundary       |
 | [`designs/blends-and-federated-discovery.md`](designs/blends-and-federated-discovery.md)                     | Design phase | Taste vectors, max-min fairness Blends, peer catalogs as discovery surface      |
 | [`designs/vibe-embedding-provider.md`](designs/vibe-embedding-provider.md)                                   | Design phase | Pluggable vibe embedding provider, versioned embedding spaces, DCLAP default    |

--- a/docs/designs/federation-protocol-compat.md
+++ b/docs/designs/federation-protocol-compat.md
@@ -1,0 +1,35 @@
+# Federation Protocol Compatibility for Additive Fields
+
+Drafted 2026-08-18 from the 2.0.0→2.3.2 review. Status: approved for implementation.
+
+## Problem
+
+The peer track-envelope schema (`trackAttributesSchema` in `backend/src/services/federationClient.ts`) is a `z.strictObject`: any key the receiver does not know invalidates the envelope, and the page parser then skips that track (counted in `skippedInvalid`). Every additive field therefore breaks new-sender → old-receiver sync for exactly the rows that carry the new data. The loudness rollout (#591) mitigated this by omitting the new keys when null, but that only protects unmeasured rows; measured tracks still vanish from old peers, and every future field re-fights the same battle. There is no protocol version or general capability signal — only the single-purpose embedding space-capability gate from #564.
+
+## Decision
+
+Two complementary changes, shippable independently, receiver-side first:
+
+### 1. Tolerant envelope parsing (receiver)
+
+Replace the strict envelope with **validate-known, strip-unknown, count-unknown**:
+
+- Known fields keep their exact current validation (types, finiteness, bounds).
+- Unknown keys are stripped before ingest and counted in a new metric label (`soundspan_federation_sync_skips{reason="unknown_key_stripped"}` or the existing counter family's convention) plus a throttled log naming the keys, so drift is visible instead of silent.
+- This is safe because ingest is already a whitelist: `federationSyncPage` maps only known fields into the database, so an unknown key never had a write path. Envelope-level strictness was rejecting valid data over version skew — an availability defect wearing a security costume. Security posture is unchanged: known-field validation, peer authentication, and the space-identity guard all remain strict.
+
+### 2. Capability advertisement (sender gating)
+
+Extend the peer handshake/status exchange with a `capabilities: string[]` block (pattern: the embedding space-capability probe from #564, generalized). Senders gate emission of post-v1 field groups on the receiver's advertised capability (first entry: `track-attrs-loudness` covering `loudnessLufs`/`truePeakDb`). Unknown capabilities are ignored. This keeps cross-version payloads minimal and makes "what does my peer understand" observable, but tolerance (change 1) remains the actual safety net when capability data is stale or absent.
+
+## Non-goals
+
+- Renaming or retyping existing fields (still a breaking change requiring coordinated upgrade).
+- Versioning the transport or endpoints; the REST surface is unchanged.
+- Retroactive re-sync of envelopes old peers skipped before this ships (they repair on their next full sync after upgrading).
+
+## Rollout
+
+1. Ship tolerant parsing + metric (receiver). Peers benefit as they upgrade.
+2. Ship capability advertisement + loudness gating (sender) in the same or next release.
+3. Future additive fields: add to the schema as optional, assign a capability, done — no skew hazard.

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -37,6 +37,11 @@ function buildContentSecurityPolicy(nonce: string): {
     const directives = [
         "default-src 'self'",
         `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${developmentEval}`,
+        // Deliberate compromise: Next.js and the styling pipeline inject
+        // inline style attributes/tags that cannot carry nonces, so styles
+        // allow 'unsafe-inline'. Script injection stays fully nonce-gated
+        // above, which is where the XSS risk actually lives; revisit only
+        // if the framework gains nonce-able style emission.
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: blob:",
         "media-src 'self' blob:",


### PR DESCRIPTION
Two small items from the 2.0.0→HEAD review, no behavior changes:

- **CSP comment**: `style-src 'unsafe-inline'` is a deliberate Next.js constraint while script-src remains nonce + strict-dynamic gated — the directive now carries the rationale so future reviews don't re-litigate it.
- **Design doc** ([docs/designs/federation-protocol-compat.md](https://github.com/soundspan/soundspan/blob/docs/csp-style-src-rationale/docs/designs/federation-protocol-compat.md)): approves tolerant envelope parsing (validate-known, strip-and-count-unknown — safe because ingest is already a whitelist) plus generalized capability advertisement modeled on the #564 space-capability probe. Implementation follows as its own PR.

**Hold merges until 2.3.2 is tagged** — keeping the staged release (#595) clean.