### PR TITLE
feat(federation): tolerant envelope parsing and capability advertisement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend component-test commands now fail fast with Node.js 24 upgrade
   guidance, and player hooks reject direct React Query imports that the harness
   cannot mock.
+- Federation now tolerates fields from newer peers and only sends fields that
+  each peer advertises it understands.
 
 ## [2.3.2] - 2026-08-18
 

--- a/backend/prisma/migrations/20260818180000_add_federation_peer_capabilities/migration.sql
+++ b/backend/prisma/migrations/20260818180000_add_federation_peer_capabilities/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "FederationPeer"
+ADD COLUMN "capabilities" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -493,6 +493,7 @@ model FederationPeer {
   /// AES-GCM v2 envelope; startup backfill encrypts legacy non-v2 plaintext.
   outboundToken  String?
   scopes         String[]
+  capabilities   String[]      @default([])
   inboundStatus  PeerStatus?
   outboundStatus PeerStatus?
   lastSeenAt     DateTime?

--- a/backend/src/metrics/__tests__/domainMetrics.test.ts
+++ b/backend/src/metrics/__tests__/domainMetrics.test.ts
@@ -2,6 +2,19 @@ import { Registry } from "prom-client";
 import { createDomainMetrics } from "../domainMetrics";
 
 describe("domain metrics", () => {
+    it("registers the closed federation sync skip reason", async () => {
+        const registry = new Registry();
+        const metrics = createDomainMetrics(registry);
+
+        metrics.federationSyncSkips.inc({ reason: "unknown_key_stripped" }, 2);
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            "# HELP soundspan_federation_sync_skips_total",
+        );
+        expect(exposition).toContain('reason="unknown_key_stripped"} 2');
+    });
+
     it("registers bounded federation embedding page outcomes", async () => {
         const registry = new Registry();
         const metrics = createDomainMetrics(registry);

--- a/backend/src/metrics/domainMetrics.ts
+++ b/backend/src/metrics/domainMetrics.ts
@@ -1,10 +1,14 @@
 import { Counter, type Registry } from "prom-client";
 
+/** Closed reason vocabulary for federation items not ingested as received. */
+export type FederationSyncSkipReason = "unknown_key_stripped";
+
 /** Domain counters owned by a process-local Prometheus registry. */
 export interface DomainMetrics {
     browseImageCacheRequests: Counter<"result">;
     transcodeCacheRequests: Counter<"result">;
     federationSyncs: Counter<"outcome">;
+    federationSyncSkips: Counter<"reason">;
     federationEmbeddingPages: Counter<"outcome">;
     federationEmbeddingExports: Counter<"outcome">;
 }
@@ -28,6 +32,12 @@ export function createDomainMetrics(registry: Registry): DomainMetrics {
             name: "soundspan_federation_syncs_total",
             help: "Federation peer sync processor runs by outcome.",
             labelNames: ["outcome"] as const,
+            registers: [registry],
+        }),
+        federationSyncSkips: new Counter({
+            name: "soundspan_federation_sync_skips_total",
+            help: "Federation sync fields or items not ingested as received.",
+            labelNames: ["reason"] as const,
             registers: [registry],
         }),
         federationEmbeddingPages: new Counter({

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -1,5 +1,8 @@
 import { collectDefaultMetrics, Registry } from "prom-client";
-import { createDomainMetrics } from "./domainMetrics";
+import {
+    createDomainMetrics,
+    type FederationSyncSkipReason,
+} from "./domainMetrics";
 import { createHttpRequestMetrics } from "./httpMetrics";
 import { createLoudnessMetrics } from "./loudnessMetrics";
 import {
@@ -68,6 +71,14 @@ export function recordFederationSyncOutcome(
     outcome: "success" | "failure",
 ): void {
     domainMetrics.federationSyncs.inc({ outcome });
+}
+
+/** Records bounded federation data discarded during compatibility parsing. */
+export function recordFederationSyncSkip(
+    reason: FederationSyncSkipReason,
+    count = 1,
+): void {
+    domainMetrics.federationSyncSkips.inc({ reason }, count);
 }
 
 /** Records one final vibe-provider request outcome and duration. */

--- a/backend/src/middleware/__tests__/federationAuth.test.ts
+++ b/backend/src/middleware/__tests__/federationAuth.test.ts
@@ -47,6 +47,7 @@ function peer(overrides: Record<string, unknown> = {}) {
         name: "Peer One",
         direction: "HOST",
         scopes: ["library:read", "stream:read"],
+        capabilities: ["track-attrs-loudness", "future-capability"],
         inboundStatus: "ACTIVE",
         lastSeenAt: new Date("2026-08-15T10:00:00.000Z"),
         maxConcurrentStreams: null,
@@ -200,6 +201,7 @@ describe("requireFederationPeer", () => {
             id: "peer-1",
             name: "Peer One",
             scopes: ["library:read", "stream:read"],
+            capabilities: ["track-attrs-loudness"],
             maxConcurrentStreams: null,
             maxStreamKbps: null,
         });

--- a/backend/src/middleware/federationAuth.ts
+++ b/backend/src/middleware/federationAuth.ts
@@ -7,6 +7,10 @@ import {
 import { hashApiKey } from "../utils/apiKeyHash";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import {
+    federationCapabilitiesSchema,
+    type FederationCapability,
+} from "../services/federationCapabilities";
 
 const authLogger = logger.child("FederationAuth");
 const LAST_SEEN_THROTTLE_MS = 60_000;
@@ -19,6 +23,7 @@ declare global {
                 id: string;
                 name: string;
                 scopes: string[];
+                capabilities: FederationCapability[];
                 maxConcurrentStreams: number | null;
                 maxStreamKbps: number | null;
             };
@@ -31,6 +36,7 @@ type AuthPeer = {
     name: string;
     direction: string;
     scopes: FederationScope[];
+    capabilities: FederationCapability[];
     inboundStatus: string | null;
     lastSeenAt: Date | null;
     maxConcurrentStreams: number | null;
@@ -52,6 +58,7 @@ async function resolvePeer(token: string): Promise<AuthPeer | null> {
             name: true,
             direction: true,
             scopes: true,
+            capabilities: true,
             inboundStatus: true,
             lastSeenAt: true,
             maxConcurrentStreams: true,
@@ -60,7 +67,12 @@ async function resolvePeer(token: string): Promise<AuthPeer | null> {
     });
     if (!peer) return null;
     const scopes = parseFederationScopes(peer.scopes);
-    return scopes ? { ...peer, scopes } : null;
+    const capabilities = federationCapabilitiesSchema.safeParse(
+        peer.capabilities,
+    );
+    return scopes && capabilities.success
+        ? { ...peer, scopes, capabilities: capabilities.data }
+        : null;
 }
 
 async function updateLastSeen(peer: AuthPeer, now: Date): Promise<void> {
@@ -108,6 +120,7 @@ export function requireFederationPeer(
             id: peer.id,
             name: peer.name,
             scopes: peer.scopes,
+            capabilities: peer.capabilities,
             maxConcurrentStreams: peer.maxConcurrentStreams,
             maxStreamKbps: peer.maxStreamKbps,
         };

--- a/backend/src/routes/__tests__/federationRoutes.test.ts
+++ b/backend/src/routes/__tests__/federationRoutes.test.ts
@@ -49,6 +49,7 @@ jest.mock("../../middleware/federationAuth", () => ({
                 id: "peer-1",
                 name: "Peer",
                 scopes: granted,
+                capabilities: ["track-attrs-loudness"],
                 maxConcurrentStreams: req.headers["x-test-max-concurrent"]
                     ? Number(req.headers["x-test-max-concurrent"])
                     : null,
@@ -192,6 +193,7 @@ describe("federation host routes", () => {
             limit: 500,
             includeEmbeddings: true,
             peerId: "peer-1",
+            peerCapabilities: ["track-attrs-loudness"],
             acceptsEmbeddingSpace: false,
         });
 
@@ -217,6 +219,7 @@ describe("federation host routes", () => {
             id: "artist-1",
             includeEmbeddings: false,
             peerId: "peer-1",
+            peerCapabilities: ["track-attrs-loudness"],
             acceptsEmbeddingSpace: false,
         });
     });
@@ -357,17 +360,20 @@ describe("federation host routes", () => {
                 code: "ABCDEFGH",
                 name: "Peer",
                 baseUrl: "https://peer.example",
+                capabilities: ["track-attrs-loudness", "future-capability"],
             });
 
         expect(response.status).toBe(201);
         expect(response.body).toEqual({
             peer: { id: "peer-1" },
             token: "token-once",
+            capabilities: ["track-attrs-loudness"],
         });
         expect(peers.consumeFederationPairingRequest).toHaveBeenCalledWith({
             code: "ABCDEFGH",
             name: "Peer",
             baseUrl: "https://peer.example",
+            capabilities: ["track-attrs-loudness"],
         });
     });
 

--- a/backend/src/routes/federation.ts
+++ b/backend/src/routes/federation.ts
@@ -29,6 +29,10 @@ import {
     FEDERATION_EMBEDDING_SPACE_ACCEPT_HEADER,
     FEDERATION_EMBEDDING_SPACE_HEADER,
 } from "../services/federationEmbeddingSpaceHeader";
+import {
+    federationCapabilitiesSchema,
+    FEDERATION_CAPABILITY_VALUES,
+} from "../services/federationCapabilities";
 import { audiobookshelfService } from "../services/audiobookshelf";
 import {
     consumeFederationPairingRequest,
@@ -89,6 +93,7 @@ const pairingSchema = z
         reciprocalPairingCode: pairingCodeValueSchema.optional(),
         reciprocalScopes: pairingScopesSchema.optional(),
         requestedScopes: pairingScopesSchema.optional(),
+        capabilities: federationCapabilitiesSchema,
     })
     .refine(
         (value) =>
@@ -115,6 +120,7 @@ function embeddingExportRequest(req: Request) {
     return {
         includeEmbeddings: includesEmbeddingScope(req),
         peerId: peer.id,
+        peerCapabilities: peer.capabilities,
         acceptsEmbeddingSpace: acceptsFederationEmbeddingSpace(
             req.headers[FEDERATION_EMBEDDING_SPACE_ACCEPT_HEADER.toLowerCase()],
         ),
@@ -154,7 +160,10 @@ router.post(
         const result = await consumeFederationPairingRequest(parsed.data);
         if (!result)
             return sendRouteError(res, 400, "Invalid or expired pairing code");
-        return res.status(201).json(result);
+        return res.status(201).json({
+            ...result,
+            capabilities: [...FEDERATION_CAPABILITY_VALUES],
+        });
     }),
 );
 

--- a/backend/src/services/__tests__/federationCatalog.test.ts
+++ b/backend/src/services/__tests__/federationCatalog.test.ts
@@ -196,6 +196,7 @@ describe("federation catalog exports", () => {
                 audiobooks: 6,
             },
             embeddingsAvailable: true,
+            capabilities: ["track-attrs-loudness"],
             serverTime: at,
         });
         expect(prisma.track.count).toHaveBeenCalledWith({
@@ -360,6 +361,7 @@ describe("federation catalog exports", () => {
             mediaType: "track",
             limit: 200,
             includeEmbeddings: true,
+            peerCapabilities: ["track-attrs-loudness"],
         });
 
         expect(albumResult.body.items[0]).toEqual(
@@ -437,6 +439,7 @@ describe("federation catalog exports", () => {
             mediaType: "track",
             limit: 200,
             includeEmbeddings: false,
+            peerCapabilities: ["track-attrs-loudness"],
         });
         const attributes = result.body.items[0].attributes;
 
@@ -444,20 +447,27 @@ describe("federation catalog exports", () => {
         expect("truePeakDb" in attributes).toBe(false);
     });
 
-    it("includes measured loudness attributes in exported tracks", async () => {
+    it("gates measured loudness attributes on the peer capability", async () => {
         prisma.track.findMany.mockResolvedValue([track("track-measured")]);
 
-        const result = await getFederationCatalogItems({
+        const withoutCapability = await getFederationCatalogItems({
             mediaType: "track",
             limit: 200,
             includeEmbeddings: false,
         });
-        const attributes = result.body.items[0].attributes;
+        const withCapability = await getFederationCatalogItems({
+            mediaType: "track",
+            limit: 200,
+            includeEmbeddings: false,
+            peerCapabilities: ["track-attrs-loudness"],
+        });
+        const legacyAttributes = withoutCapability.body.items[0].attributes;
+        const capableAttributes = withCapability.body.items[0].attributes;
 
-        expect("loudnessLufs" in attributes).toBe(true);
-        expect(attributes.loudnessLufs).toBe(-17.2);
-        expect("truePeakDb" in attributes).toBe(true);
-        expect(attributes.truePeakDb).toBe(-1.1);
+        expect("loudnessLufs" in legacyAttributes).toBe(false);
+        expect("truePeakDb" in legacyAttributes).toBe(false);
+        expect(capableAttributes.loudnessLufs).toBe(-17.2);
+        expect(capableAttributes.truePeakDb).toBe(-1.1);
     });
 
     it("serves embeddings to a headerless peer while the teacher space is active", async () => {

--- a/backend/src/services/__tests__/federationClient.test.ts
+++ b/backend/src/services/__tests__/federationClient.test.ts
@@ -2,6 +2,8 @@ process.env.SETTINGS_ENCRYPTION_KEY =
     process.env.SETTINGS_ENCRYPTION_KEY || "federation-client-test-key-123456";
 
 const axiosRequest = jest.fn();
+const recordFederationSyncSkip = jest.fn();
+const log = { warn: jest.fn() };
 
 jest.mock("axios", () => ({
     __esModule: true,
@@ -17,6 +19,11 @@ jest.mock("axios", () => ({
 jest.mock("../../utils/encryption", () => ({
     encrypt: jest.fn((value: string) => `v2:${value}`),
     decrypt: jest.fn((value: string) => value.replace(/^v2:/, "")),
+}));
+
+jest.mock("../../metrics", () => ({ recordFederationSyncSkip }));
+jest.mock("../../utils/logger", () => ({
+    logger: { child: jest.fn(() => log) },
 }));
 
 import {
@@ -43,6 +50,7 @@ const manifest = {
     mediaTypes: ["artist", "album", "track"],
     counts: { artists: 1, albums: 2, tracks: 3 },
     embeddingsAvailable: false,
+    capabilities: [],
     serverTime: "2026-08-15T12:00:00.000Z",
 };
 
@@ -212,6 +220,31 @@ describe("federation HTTP client", () => {
             mediaTypes: ["artist", "album", "track"],
             counts: { artists: 1, albums: 2, tracks: 3 },
         });
+    });
+
+    it("round-trips known capabilities and ignores unknown capability names", async () => {
+        const { capabilities: _capabilities, ...legacyManifest } = manifest;
+        axiosRequest
+            .mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    ...manifest,
+                    capabilities: [
+                        "track-attrs-loudness",
+                        "future-track-attrs",
+                    ],
+                },
+            })
+            .mockResolvedValueOnce({ status: 200, data: legacyManifest });
+
+        await expect(
+            createFederationClient(peer).getManifest(),
+        ).resolves.toMatchObject({
+            capabilities: ["track-attrs-loudness"],
+        });
+        await expect(
+            createFederationClient(peer).getManifest(),
+        ).resolves.toMatchObject({ capabilities: [] });
     });
 
     it("fetches one catalog item by type and encoded id", async () => {
@@ -450,6 +483,49 @@ describe("federation HTTP client", () => {
             ],
             skippedInvalid: 0,
         });
+    });
+
+    it("strips and counts unknown track attributes without skipping the envelope", async () => {
+        const forwardPeer = { ...peer, id: "forward-compatible-peer" };
+        const item = {
+            ...trackEnvelope,
+            attributes: {
+                ...trackEnvelope.attributes,
+                futureTrackScore: 0.75,
+            },
+        };
+        axiosRequest
+            .mockResolvedValueOnce({
+                status: 200,
+                data: { items: [item], nextCursor: null },
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                data: { items: [item], nextCursor: null },
+            });
+
+        const client = createFederationClient(forwardPeer);
+        const first = await client.getCatalogItems("track");
+        await client.getCatalogItems("track");
+
+        expect(first.skippedInvalid).toBe(0);
+        expect(first.items).toHaveLength(1);
+        expect(first.items[0].attributes).not.toHaveProperty(
+            "futureTrackScore",
+        );
+        expect(recordFederationSyncSkip).toHaveBeenCalledTimes(2);
+        expect(recordFederationSyncSkip).toHaveBeenCalledWith(
+            "unknown_key_stripped",
+            1,
+        );
+        expect(log.warn).toHaveBeenCalledTimes(1);
+        expect(log.warn).toHaveBeenCalledWith(
+            "Stripped unknown federation track attribute keys",
+            {
+                peerId: "forward-compatible-peer",
+                keys: ["futureTrackScore"],
+            },
+        );
     });
 
     it.each([
@@ -789,6 +865,7 @@ describe("federation HTTP client", () => {
                 },
                 token: "paired-token",
                 reciprocalPeerId: "peer-3",
+                capabilities: ["track-attrs-loudness", "future-capability"],
             },
         });
 
@@ -803,11 +880,15 @@ describe("federation HTTP client", () => {
                 options: { retryDelayMs: 0 },
             }),
         ).resolves.toEqual(
-            expect.objectContaining({ reciprocalPeerId: "peer-3" }),
+            expect.objectContaining({
+                reciprocalPeerId: "peer-3",
+                capabilities: ["track-attrs-loudness"],
+            }),
         );
         expect(axiosRequest).toHaveBeenCalledWith(
             expect.objectContaining({
                 data: expect.objectContaining({
+                    capabilities: ["track-attrs-loudness"],
                     reciprocalPairingCode: "HGFEDCBA",
                     reciprocalScopes: ["library:read", "stream:read"],
                 }),

--- a/backend/src/services/__tests__/federationPeers.test.ts
+++ b/backend/src/services/__tests__/federationPeers.test.ts
@@ -98,6 +98,7 @@ const manifest = {
     mediaTypes: ["artist", "album", "track"],
     counts: { artists: 1, albums: 2, tracks: 3 },
     embeddingsAvailable: true,
+    capabilities: ["track-attrs-loudness"],
 };
 
 describe("federation peer credentials", () => {
@@ -334,6 +335,7 @@ describe("federation consumer peers", () => {
                 inboundStatus: null,
                 outboundStatus: "ACTIVE",
                 catalogEpoch: "epoch-9",
+                capabilities: ["track-attrs-loudness"],
                 createdById: "admin-1",
                 lastSeenAt: expect.any(Date),
             }),
@@ -719,6 +721,39 @@ describe("federation pairing codes", () => {
             data: { usedAt: new Date("2026-08-15T12:00:00.000Z") },
         });
         expect(result?.token).toMatch(/^[0-9a-f]{64}$/);
+        expect(prisma.federationPeer.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ capabilities: [] }),
+            }),
+        );
+    });
+
+    it("persists capabilities advertised while consuming a pairing code", async () => {
+        prisma.federationPairingCode.findUnique.mockResolvedValue({
+            id: "code-1",
+            code: "ABCDEFGH",
+            createdById: "admin-1",
+            scopes: ["library:read"],
+            expiresAt: new Date(Date.now() + 60_000),
+            usedAt: null,
+        });
+
+        await consumePairingCode(
+            {
+                code: "ABCDEFGH",
+                name: "Peer",
+                capabilities: ["track-attrs-loudness"],
+            },
+            new Date("2026-08-15T12:00:00.000Z"),
+        );
+
+        expect(prisma.federationPeer.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    capabilities: ["track-attrs-loudness"],
+                }),
+            }),
+        );
     });
 
     it("does not mint a token when another request consumed the code first", async () => {

--- a/backend/src/services/federationCapabilities.ts
+++ b/backend/src/services/federationCapabilities.ts
@@ -1,0 +1,26 @@
+import {
+    FEDERATION_CAPABILITY_VALUES,
+    type FederationCapability,
+} from "@soundspan/media-metadata-contract";
+import { z } from "zod";
+
+const MAX_CAPABILITIES = 64;
+
+function isKnownFederationCapability(
+    value: string,
+): value is FederationCapability {
+    return FEDERATION_CAPABILITY_VALUES.some((known) => known === value);
+}
+
+/** Parses a bounded peer advertisement and ignores capabilities unknown locally. */
+export const federationCapabilitiesSchema = z
+    .array(z.string().min(1).max(128))
+    .max(MAX_CAPABILITIES)
+    .optional()
+    .default([])
+    .transform((values) => [
+        ...new Set(values.filter(isKnownFederationCapability)),
+    ]);
+
+export { FEDERATION_CAPABILITY_VALUES };
+export type { FederationCapability };

--- a/backend/src/services/federationCatalog.ts
+++ b/backend/src/services/federationCatalog.ts
@@ -5,7 +5,9 @@ import type {
     FederationMediaType,
     FederationPodcastAttributes,
     FederationTrackAttributes,
+    FederationCapability,
 } from "@soundspan/media-metadata-contract";
+import { FEDERATION_CAPABILITY_VALUES } from "@soundspan/media-metadata-contract";
 import type { Prisma } from "@prisma/client";
 import { config } from "../config";
 import { recordFederationEmbeddingExportOutcome } from "../metrics";
@@ -253,6 +255,7 @@ function albumEnvelope(row: AlbumRow): FederationMediaItemEnvelope {
 
 function trackAudioFeatures(
     row: TrackRow,
+    peerCapabilities: readonly FederationCapability[],
 ): Pick<
     FederationTrackAttributes,
     keyof Omit<
@@ -269,6 +272,7 @@ function trackAudioFeatures(
         | "embedding"
     >
 > {
+    const acceptsLoudness = peerCapabilities.includes("track-attrs-loudness");
     return {
         bpm: row.bpm,
         beatsCount: row.beatsCount,
@@ -277,11 +281,12 @@ function trackAudioFeatures(
         keyStrength: row.keyStrength,
         energy: row.energy,
         loudness: row.loudness,
-        // Old peers reject unknown keys, so omit new fields from unmeasured tracks.
-        ...(row.loudnessLufs !== null
+        ...(acceptsLoudness && row.loudnessLufs !== null
             ? { loudnessLufs: row.loudnessLufs }
             : {}),
-        ...(row.truePeakDb !== null ? { truePeakDb: row.truePeakDb } : {}),
+        ...(acceptsLoudness && row.truePeakDb !== null
+            ? { truePeakDb: row.truePeakDb }
+            : {}),
         dynamicRange: row.dynamicRange,
         danceability: row.danceability,
         valence: row.valence,
@@ -306,6 +311,7 @@ function trackAudioFeatures(
 function trackEnvelope(
     row: TrackRow,
     embedding?: number[],
+    peerCapabilities: readonly FederationCapability[] = [],
 ): FederationMediaItemEnvelope {
     return {
         id: row.id,
@@ -322,7 +328,7 @@ function trackEnvelope(
             recordingMbid: row.recordingMbid,
             isrc: row.isrc,
             audioHash: row.audioHash,
-            ...trackAudioFeatures(row),
+            ...trackAudioFeatures(row, peerCapabilities),
             ...(embedding ? { embedding } : {}),
         } satisfies FederationTrackAttributes,
     };
@@ -522,6 +528,7 @@ export async function getFederationCatalogItems(input: {
     includeEmbeddings: boolean;
     peerId?: string;
     acceptsEmbeddingSpace?: boolean;
+    peerCapabilities?: readonly FederationCapability[];
 }) {
     if (input.mediaType === "artist") {
         const rows = await loadArtistItems(input.cursor, input.limit);
@@ -551,7 +558,11 @@ export async function getFederationCatalogItems(input: {
     });
     const body = itemPage(
         rows.map((row) =>
-            trackEnvelope(row, embeddingExport.embeddings.get(row.id)),
+            trackEnvelope(
+                row,
+                embeddingExport.embeddings.get(row.id),
+                input.peerCapabilities,
+            ),
         ),
         input.limit,
     );
@@ -570,6 +581,7 @@ export async function getFederationCatalogItem(input: {
     includeEmbeddings: boolean;
     peerId?: string;
     acceptsEmbeddingSpace?: boolean;
+    peerCapabilities?: readonly FederationCapability[];
 }): Promise<FederationCatalogResponse<FederationMediaItemEnvelope> | null> {
     if (input.mediaType === "artist") {
         const row = await prisma.artist.findFirst({
@@ -609,7 +621,11 @@ export async function getFederationCatalogItem(input: {
         peerId: input.peerId,
         acceptsEmbeddingSpace: input.acceptsEmbeddingSpace,
     });
-    const body = trackEnvelope(row, embeddingExport.embeddings.get(row.id));
+    const body = trackEnvelope(
+        row,
+        embeddingExport.embeddings.get(row.id),
+        input.peerCapabilities,
+    );
     return catalogResponse(
         body,
         carriesEmbeddings([body]) ? embeddingExport.embeddingSpace : undefined,
@@ -643,6 +659,7 @@ export async function getFederationManifest(
         ] as FederationMediaType[],
         counts: { artists, albums, tracks, podcasts, audiobooks },
         embeddingsAvailable,
+        capabilities: [...FEDERATION_CAPABILITY_VALUES],
         serverTime: now,
     };
 }
@@ -793,6 +810,7 @@ function compareDeltaEvents(left: DeltaEvent, right: DeltaEvent): number {
 function mergeDeltaEvents(
     rows: DeltaRows,
     embeddingExport: EmbeddingExport,
+    peerCapabilities: readonly FederationCapability[],
 ): DeltaEvent[] {
     return [
         ...rows.artists.map((row) => ({
@@ -811,6 +829,7 @@ function mergeDeltaEvents(
             envelope: trackEnvelope(
                 row,
                 embeddingExport.embeddings.get(row.id),
+                peerCapabilities,
             ),
         })),
         ...rows.podcasts.map((row) => ({
@@ -843,6 +862,7 @@ async function buildDeltaEvents(input: {
     includeEmbeddings: boolean;
     peerId?: string;
     acceptsEmbeddingSpace?: boolean;
+    peerCapabilities?: readonly FederationCapability[];
 }): Promise<{
     events: DeltaEvent[];
     embeddingSpace?: FederationEmbeddingSpaceIdentity;
@@ -865,6 +885,7 @@ async function buildDeltaEvents(input: {
     const events = mergeDeltaEvents(
         { artists, albums, tracks, podcasts, audiobooks, tombstones },
         embeddingExport,
+        input.peerCapabilities ?? [],
     );
     return { events, embeddingSpace: embeddingExport.embeddingSpace };
 }
@@ -878,6 +899,7 @@ export async function getFederationCatalogDelta(input: {
     includeEmbeddings: boolean;
     peerId?: string;
     acceptsEmbeddingSpace?: boolean;
+    peerCapabilities?: readonly FederationCapability[];
     now?: Date;
 }) {
     const identity = await ensureFederationIdentity();

--- a/backend/src/services/federationClient.ts
+++ b/backend/src/services/federationClient.ts
@@ -2,12 +2,18 @@ import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios";
 import { BlockList, isIP } from "node:net";
 import pLimit from "p-limit";
 import { z } from "zod";
+import { recordFederationSyncSkip } from "../metrics";
+import { logger } from "../utils/logger";
 import {
     FEDERATION_SCOPE_VALUES,
     type FederationScope,
 } from "../utils/federationScopes";
 import type { ParsedFederationEmbeddingSpaceIdentity } from "./federationEmbeddingSpace";
 import { decryptFederationOutboundToken } from "./federationCredentialCipher";
+import {
+    federationCapabilitiesSchema,
+    FEDERATION_CAPABILITY_VALUES,
+} from "./federationCapabilities";
 import {
     FEDERATION_EMBEDDING_SPACE_ACCEPT_HEADER,
     FEDERATION_EMBEDDING_SPACE_ACCEPT_VALUE,
@@ -23,7 +29,10 @@ const MAX_CONCURRENT_REQUESTS = 8;
 export const MAX_PAGE_ITEMS = 500;
 const MAX_JSON_BODY_BYTES = 8 * 1024 * 1024;
 const EMBEDDING_DIMENSIONS = 512;
+const UNKNOWN_KEY_WARNING_INTERVAL_MS = 60_000;
 const requestLimit = pLimit(MAX_CONCURRENT_REQUESTS);
+const log = logger.child("FederationClient");
+const unknownKeyWarningAt = new Map<string, number>();
 const disallowedPeerAddresses = new BlockList();
 disallowedPeerAddresses.addSubnet("10.0.0.0", 8, "ipv4");
 disallowedPeerAddresses.addSubnet("172.16.0.0", 12, "ipv4");
@@ -69,7 +78,10 @@ const optionalFeatureArraySchema = z
     .max(64)
     .nullable()
     .optional();
-const trackAttributesSchema = z.strictObject({
+// This compatibility reader intentionally strips additive keys. Ingest stays
+// a whitelist because federationSyncPage.syncedFederationTrackValues maps only
+// the validated fields declared here into persistence.
+const trackAttributesSchema = z.object({
     title: z.string().min(1).max(2_000),
     discNo: z.number().int().min(0).max(10_000),
     trackNo: z.number().int().min(0).max(100_000),
@@ -108,6 +120,9 @@ const trackAttributesSchema = z.strictObject({
     lastfmTags: optionalFeatureArraySchema,
     embedding: embeddingSchema.optional(),
 });
+const knownTrackAttributeKeys = new Set(
+    Object.keys(trackAttributesSchema.shape),
+);
 
 const artistEnvelopeSchema = z.strictObject({
     id: z.string().min(1).max(128),
@@ -182,6 +197,7 @@ export const federationManifestSchema = z.looseObject({
         audiobooks: z.number().int().nonnegative().optional(),
     }),
     embeddingsAvailable: z.boolean(),
+    capabilities: federationCapabilitiesSchema,
     serverTime: dateTimeSchema.optional(),
 });
 const catalogPageShapeSchema = z.strictObject({
@@ -235,6 +251,7 @@ const pairedPeerSchema = z.strictObject({
         updatedAt: dateTimeSchema,
     }),
     token: z.string().min(1).max(4_096),
+    capabilities: federationCapabilitiesSchema,
     reciprocalPeerId: z.string().min(1).max(128).optional(),
     warning: z.string().min(1).max(500).optional(),
 });
@@ -266,6 +283,44 @@ function isKnownMediaType(
     value: string,
 ): value is z.infer<typeof mediaTypeSchema> {
     return KNOWN_MEDIA_TYPES.some((known) => known === value);
+}
+
+function unknownTrackAttributeKeys(value: unknown): string[] {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const envelope = value as Record<string, unknown>;
+    if (envelope.mediaType !== "track") return [];
+    const attributes = envelope.attributes;
+    if (
+        !attributes ||
+        typeof attributes !== "object" ||
+        Array.isArray(attributes)
+    ) {
+        return [];
+    }
+    return Object.keys(attributes).filter(
+        (key) => !knownTrackAttributeKeys.has(key),
+    );
+}
+
+function reportUnknownTrackAttributeKeys(
+    peerId: string,
+    keys: readonly string[],
+): void {
+    if (keys.length === 0) return;
+    recordFederationSyncSkip("unknown_key_stripped", keys.length);
+    const now = Date.now();
+    const previous = unknownKeyWarningAt.get(peerId);
+    if (
+        previous !== undefined &&
+        now - previous < UNKNOWN_KEY_WARNING_INTERVAL_MS
+    ) {
+        return;
+    }
+    unknownKeyWarningAt.set(peerId, now);
+    log.warn("Stripped unknown federation track attribute keys", {
+        peerId,
+        keys: [...new Set(keys)].sort(),
+    });
 }
 
 /** Peer returned a valid HTTP response outside the accepted status set. */
@@ -392,8 +447,9 @@ function parseResponse<T>(schema: z.ZodType<T>, value: unknown): T {
 function parseLenientItems<T>(
     values: readonly unknown[],
     schema: z.ZodType<T>,
-): { items: T[]; skippedInvalid: number } {
+): { items: T[]; skippedInvalid: number; strippedUnknownKeys: string[] } {
     const items: T[] = [];
+    const strippedUnknownKeys: string[] = [];
     let skippedInvalid = 0;
     for (
         let index = 0;
@@ -401,29 +457,37 @@ function parseLenientItems<T>(
         index += 1
     ) {
         const parsed = schema.safeParse(values[index]);
-        if (parsed.success) items.push(parsed.data);
-        else skippedInvalid += 1;
+        if (!parsed.success) {
+            skippedInvalid += 1;
+            continue;
+        }
+        items.push(parsed.data);
+        strippedUnknownKeys.push(...unknownTrackAttributeKeys(values[index]));
     }
-    return { items, skippedInvalid };
+    return { items, skippedInvalid, strippedUnknownKeys };
 }
 
 function parseCatalogPage(
     value: unknown,
     embeddingSpace: ParsedFederationEmbeddingSpaceIdentity | undefined,
-): FederationCatalogPage {
+): { page: FederationCatalogPage; strippedUnknownKeys: string[] } {
     const page = parseResponse(catalogPageShapeSchema, value);
     const parsed = parseLenientItems(page.items, federationEnvelopeSchema);
     return {
-        ...parsed,
-        nextCursor: page.nextCursor,
-        ...(embeddingSpace !== undefined ? { embeddingSpace } : {}),
+        page: {
+            items: parsed.items,
+            skippedInvalid: parsed.skippedInvalid,
+            nextCursor: page.nextCursor,
+            ...(embeddingSpace !== undefined ? { embeddingSpace } : {}),
+        },
+        strippedUnknownKeys: parsed.strippedUnknownKeys,
     };
 }
 
 function parseDeltaPage(
     value: unknown,
     embeddingSpace: ParsedFederationEmbeddingSpaceIdentity | undefined,
-): FederationDelta {
+): { delta: FederationDelta; strippedUnknownKeys: string[] } {
     const page = parseResponse(deltaPageShapeSchema, value);
     const changes = parseLenientItems(page.changes, federationEnvelopeSchema);
     const parsedTombstones = parseResponse(tombstonesSchema, page.tombstones);
@@ -435,14 +499,18 @@ function parseDeltaPage(
         } => isKnownMediaType(item.entityType),
     );
     return {
-        kind: "ok",
-        changes: changes.items,
-        tombstones,
-        nextCursor: page.nextCursor,
-        nextSince: page.nextSince,
-        skippedInvalid: changes.skippedInvalid,
-        skippedUnknownTombstones: parsedTombstones.length - tombstones.length,
-        ...(embeddingSpace !== undefined ? { embeddingSpace } : {}),
+        delta: {
+            kind: "ok",
+            changes: changes.items,
+            tombstones,
+            nextCursor: page.nextCursor,
+            nextSince: page.nextSince,
+            skippedInvalid: changes.skippedInvalid,
+            skippedUnknownTombstones:
+                parsedTombstones.length - tombstones.length,
+            ...(embeddingSpace !== undefined ? { embeddingSpace } : {}),
+        },
+        strippedUnknownKeys: changes.strippedUnknownKeys,
     };
 }
 
@@ -459,6 +527,7 @@ function destroyStreamBody(response: AxiosResponse): void {
 }
 
 class FederationClient {
+    private readonly peerId: string;
     private readonly baseUrl: URL;
     private readonly token: string;
     private readonly timeoutMs: number;
@@ -466,6 +535,7 @@ class FederationClient {
     private readonly retryDelayMs: number;
 
     constructor(peer: FederationClientPeer, options: FederationClientOptions) {
+        this.peerId = peer.id;
         this.baseUrl = resolveBaseUrl(
             peer.baseUrl,
             options.allowPrivatePeers ?? false,
@@ -517,6 +587,7 @@ class FederationClient {
         path: string,
         schema: z.ZodType<T>,
         config: AxiosRequestConfig = {},
+        inspectAccepted?: (value: unknown) => void,
     ): Promise<T> {
         const response = await this.request({
             method: "GET",
@@ -535,7 +606,9 @@ class FederationClient {
                 response.status >= 500,
             );
         }
-        return parseResponse(schema, response.data);
+        const parsed = parseResponse(schema, response.data);
+        inspectAccepted?.(response.data);
+        return parsed;
     }
 
     async getManifest(signal?: AbortSignal): Promise<FederationManifest> {
@@ -566,10 +639,15 @@ class FederationClient {
                 response.status >= 500,
             );
         }
-        return parseCatalogPage(
+        const parsed = parseCatalogPage(
             response.data,
             parseEmbeddingSpaceResponseHeader(response),
         );
+        reportUnknownTrackAttributeKeys(
+            this.peerId,
+            parsed.strippedUnknownKeys,
+        );
+        return parsed.page;
     }
 
     async getCatalogItem(
@@ -581,6 +659,11 @@ class FederationClient {
             `/api/federation/v1/catalog/items/${mediaType}/${encodeURIComponent(id)}`,
             federationEnvelopeSchema,
             { signal },
+            (value) =>
+                reportUnknownTrackAttributeKeys(
+                    this.peerId,
+                    unknownTrackAttributeKeys(value),
+                ),
         );
     }
 
@@ -617,10 +700,15 @@ class FederationClient {
                 response.status >= 500,
             );
         }
-        return parseDeltaPage(
+        const parsed = parseDeltaPage(
             response.data,
             parseEmbeddingSpaceResponseHeader(response),
         );
+        reportUnknownTrackAttributeKeys(
+            this.peerId,
+            parsed.strippedUnknownKeys,
+        );
+        return parsed.delta;
     }
 
     async getStream(input: {
@@ -787,6 +875,7 @@ export async function pairFederationPeer(input: {
             data: {
                 code: input.code,
                 name: input.name,
+                capabilities: [...FEDERATION_CAPABILITY_VALUES],
                 ...(input.consumerBaseUrl
                     ? { baseUrl: input.consumerBaseUrl }
                     : {}),

--- a/backend/src/services/federationPeers.ts
+++ b/backend/src/services/federationPeers.ts
@@ -19,6 +19,7 @@ import {
     decryptFederationOutboundToken,
     encryptFederationOutboundToken,
 } from "./federationCredentialCipher";
+import type { FederationCapability } from "./federationCapabilities";
 import { removeReplacementCacheFiles } from "./trackReplacement";
 
 export { FEDERATION_SCOPE_VALUES } from "../utils/federationScopes";
@@ -62,6 +63,7 @@ export interface CreateHostPeerInput {
     createdById: string;
     scopes: FederationScope[];
     baseUrl?: string;
+    capabilities?: FederationCapability[];
 }
 
 /** Validated administrator-controlled peer behavior settings. */
@@ -77,6 +79,7 @@ export interface PairingConsumeInput {
     name: string;
     baseUrl?: string;
     requestedScopes?: FederationScope[];
+    capabilities?: FederationCapability[];
 }
 
 /** A normalized active consumer URL is already linked. */
@@ -178,6 +181,7 @@ async function createPeerWithClient(
             baseUrl: input.baseUrl,
             credentialHash: credential.credentialHash,
             scopes: input.scopes,
+            capabilities: input.capabilities ?? [],
             inboundStatus: "ACTIVE",
             outboundStatus: null,
             createdById: input.createdById,
@@ -331,6 +335,7 @@ async function persistConsumerLink(
         outboundStatus: "ACTIVE" as const,
         lastSeenAt: new Date(),
         catalogEpoch: manifest.catalogEpoch,
+        capabilities: manifest.capabilities,
     };
     if (upgrade) {
         return prisma.federationPeer.update({
@@ -408,6 +413,7 @@ export async function createBothFederationPeer(
             outboundStatus: "ACTIVE",
             lastSeenAt: new Date(),
             catalogEpoch: manifest.catalogEpoch,
+            capabilities: manifest.capabilities,
             createdById: input.createdById,
         },
         select: publicPeerSelect,
@@ -582,6 +588,7 @@ export async function consumePairingCode(
             baseUrl: input.baseUrl,
             createdById: code.createdById,
             scopes,
+            capabilities: input.capabilities,
         });
     });
 }

--- a/backend/src/workers/processors/__tests__/federationHealthProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/federationHealthProcessor.test.ts
@@ -40,7 +40,10 @@ describe("federation peer health processor", () => {
         jest.clearAllMocks();
         prisma.federationPeer.findMany.mockResolvedValue([{ ...peer }]);
         prisma.federationPeer.updateMany.mockResolvedValue({ count: 1 });
-        getManifest.mockResolvedValue({ catalogEpoch: "epoch-1" });
+        getManifest.mockResolvedValue({
+            catalogEpoch: "epoch-1",
+            capabilities: ["track-attrs-loudness"],
+        });
     });
 
     it("marks successful peers active and refreshes lastSeenAt", async () => {
@@ -51,7 +54,11 @@ describe("federation peer health processor", () => {
         });
         expect(prisma.federationPeer.updateMany).toHaveBeenCalledWith({
             where: { id: "peer-1", outboundStatus: { not: "REVOKED" } },
-            data: { outboundStatus: "ACTIVE", lastSeenAt: expect.any(Date) },
+            data: {
+                outboundStatus: "ACTIVE",
+                lastSeenAt: expect.any(Date),
+                capabilities: ["track-attrs-loudness"],
+            },
         });
         expect(log.info).not.toHaveBeenCalled();
     });
@@ -93,7 +100,11 @@ describe("federation peer health processor", () => {
         );
         expect(prisma.federationPeer.updateMany).toHaveBeenCalledWith({
             where: { id: "peer-1", outboundStatus: { not: "REVOKED" } },
-            data: { outboundStatus: "ACTIVE", lastSeenAt: expect.any(Date) },
+            data: {
+                outboundStatus: "ACTIVE",
+                lastSeenAt: expect.any(Date),
+                capabilities: ["track-attrs-loudness"],
+            },
         });
         expect(prisma.federationPeer.updateMany).not.toHaveBeenCalledWith(
             expect.objectContaining({

--- a/backend/src/workers/processors/federationHealthProcessor.ts
+++ b/backend/src/workers/processors/federationHealthProcessor.ts
@@ -12,13 +12,20 @@ interface HealthCounts {
     offline: number;
 }
 
-async function markPeerActive(peer: {
-    id: string;
-    outboundStatus: string | null;
-}): Promise<void> {
+async function markPeerActive(
+    peer: {
+        id: string;
+        outboundStatus: string | null;
+    },
+    capabilities: readonly string[],
+): Promise<void> {
     await prisma.federationPeer.updateMany({
         where: { id: peer.id, outboundStatus: { not: "REVOKED" } },
-        data: { outboundStatus: "ACTIVE", lastSeenAt: new Date() },
+        data: {
+            outboundStatus: "ACTIVE",
+            lastSeenAt: new Date(),
+            capabilities: [...capabilities],
+        },
     });
     if (peer.outboundStatus !== "ACTIVE") {
         log.info(
@@ -66,10 +73,10 @@ export async function processFederationHealth(): Promise<HealthCounts> {
         if (!peer) break;
         counts.checked += 1;
         try {
-            await createFederationClient(peer, {
+            const manifest = await createFederationClient(peer, {
                 allowPrivatePeers: config.federation.allowPrivatePeers,
             }).getManifest();
-            await markPeerActive(peer);
+            await markPeerActive(peer, manifest.capabilities);
             counts.online += 1;
         } catch (_error: unknown) {
             await markPeerOffline(peer);

--- a/docs/designs/federation-protocol-compat.md
+++ b/docs/designs/federation-protocol-compat.md
@@ -1,6 +1,6 @@
 # Federation Protocol Compatibility for Additive Fields
 
-Drafted 2026-08-18 from the 2.0.0→2.3.2 review. Status: approved for implementation.
+Drafted 2026-08-18 from the 2.0.0→2.3.2 review. Status: Implemented (receiver + sender), 2026-08-18.
 
 ## Problem
 

--- a/packages/media-metadata-contract/src/index.ts
+++ b/packages/media-metadata-contract/src/index.ts
@@ -67,6 +67,13 @@ export interface CanonicalMediaSearchResult {
 export type FederationMediaType =
     "artist" | "album" | "track" | "podcast" | "audiobook";
 
+/** Complete bounded vocabulary of federation protocol capabilities. */
+export const FEDERATION_CAPABILITY_VALUES = ["track-attrs-loudness"] as const;
+
+/** Federation protocol capability understood by this release. */
+export type FederationCapability =
+    (typeof FEDERATION_CAPABILITY_VALUES)[number];
+
 /** Source discriminator emitted by unified track response serializers. */
 export type UnifiedTrackSource = "local" | "tidal" | "youtube" | "federated";
 


### PR DESCRIPTION
Implements [docs/designs/federation-protocol-compat.md](https://github.com/soundspan/soundspan/blob/main/docs/designs/federation-protocol-compat.md) — the last finding (F3) from the 2.0.0→2.3.2 review.

## What

**Receiver — tolerant track-attribute parsing.** The track envelope's `z.strictObject` becomes validate-known / strip-unknown / count-unknown. Known-field validation (types, finiteness, bounds) is byte-for-byte what it was; unknown keys are stripped before ingest, counted via `soundspan_federation_sync_skips_total{reason="unknown_key_stripped"}`, and named in a per-peer throttled log. This is safe because ingest is already a whitelist (`federationSyncPage` maps only known fields), and it ends the new-sender → old-receiver skew where every additive field made measured tracks vanish from old peers. Peer identity, space identity, and all other envelope schemas stay strict.

**Sender — capability advertisement.** The pairing exchange and manifest now carry `capabilities: string[]` (unknown entries ignored, bounded, deduped). A peer's advertised set is persisted at pairing/linking and refreshed by the existing hourly health processor — no new sync loop. Senders gate post-v1 field groups on it: the first capability, `track-attrs-loudness`, covers `loudnessLufs`/`truePeakDb`, layered on the existing omit-when-null. A peer that advertises nothing gets exactly today's payload.

Schema: `FederationPeer.capabilities String[] @default([])` + migration.

## Verification

- Full backend suite with real socket binds: **Test Suites: 398 passed (1 skipped), Tests: 6331 passed (3 skipped)**, exit 0.
- Targeted federation suites (client, catalog, peers, routes, auth middleware, health + sync processors, metrics): all green.
- `tsc --noEmit`, `format:check`, file-size guardrail: clean.
- Backward-compat tests: manifest without `capabilities` parses (defaults empty), peers advertising nothing receive no loudness fields, unknown capability strings are ignored.