### PR TITLE
fix(analyzer): ship all analyzer modules in both container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guidance, and player hooks reject direct React Query imports that the harness
   cannot mock.
 
+### Fixed
+
+- Fixed the 2.3.2 audio-analyzer images failing to start because new loudness
+  modules were missing from both the standalone and all-in-one images.
+
 ## [2.3.2] - 2026-08-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN echo "Downloading Essentia ML models for Enhanced vibe matching..." && \
     ls -lh /app/models/
 
 # Copy audio analyzer modules
-COPY services/audio-analyzer/analyzer.py services/audio-analyzer/loudness.py services/audio-analyzer/model_paths.py /app/audio-analyzer/
+COPY services/audio-analyzer/*.py /app/audio-analyzer/
 # Shared sidecar logging helpers (used by analyzer services)
 COPY services/common /app/services/common
 

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -16,6 +16,25 @@ const dockerfilePaths = [
     "services/vibe-provider-dclap/Dockerfile",
 ];
 
+const serviceDockerfilePaths = [
+    "Dockerfile",
+    ...fs
+        .readdirSync(path.join(repoRoot, "services"), { withFileTypes: true })
+        .filter(
+            (entry) =>
+                entry.isDirectory() &&
+                fs.existsSync(
+                    path.join(repoRoot, "services", entry.name, "Dockerfile"),
+                ),
+        )
+        .map((entry) => `services/${entry.name}/Dockerfile`)
+        .sort(),
+];
+
+// Keys use "Dockerfile path:Python source path". Add only documented cases
+// where a top-level sidecar module must intentionally remain outside an image.
+const pythonSidecarCopyExclusions = new Set();
+
 const chartComponentDockerfiles = new Map([
     ["aio", "Dockerfile"],
     ["backend", "backend/Dockerfile"],
@@ -198,13 +217,50 @@ function componentDockerfile(componentName) {
 }
 
 function dockerCopySources(stage) {
-    return stage.split(/\r?\n/).flatMap((line) => {
-        const match = line.match(/^\s*COPY\s+(.+)$/i);
-        if (!match) return [];
-        const tokens = match[1].trim().split(/\s+/);
-        const operands = tokens.filter((token) => !token.startsWith("--"));
-        return operands.slice(0, -1);
-    });
+    return stage
+        .replace(/\\\r?\n\s*/g, " ")
+        .split(/\r?\n/)
+        .flatMap((line) => {
+            const match = line.match(/^\s*COPY\s+(.+)$/i);
+            if (!match) return [];
+            const tokens = match[1].trim().split(/\s+/);
+            const operands = tokens.filter((token) => !token.startsWith("--"));
+            return operands.slice(0, -1);
+        });
+}
+
+function copiedPythonSidecarDirectories(sources) {
+    return [
+        ...new Set(
+            sources.flatMap((source) => {
+                const normalizedSource = path.posix.normalize(source);
+                const match = normalizedSource.match(
+                    /^services\/([^/]+)\/(?:[^/]+\.py|\*\.py)$/,
+                );
+                return match ? [match[1]] : [];
+            }),
+        ),
+    ].sort();
+}
+
+function topLevelPythonFiles(serviceDirectory) {
+    const relativeDirectory = `services/${serviceDirectory}`;
+    return fs
+        .readdirSync(path.join(repoRoot, relativeDirectory), {
+            withFileTypes: true,
+        })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".py"))
+        .map((entry) => `${relativeDirectory}/${entry.name}`)
+        .sort();
+}
+
+function sourceCopiesPythonFile(source, relativePath) {
+    const normalizedSource = path.posix.normalize(source);
+    const normalizedPath = path.posix.normalize(relativePath);
+    return (
+        normalizedSource === normalizedPath ||
+        normalizedSource === `${path.posix.dirname(normalizedPath)}/*.py`
+    );
 }
 
 function sourceCopiesFile(source, relativePath) {
@@ -645,4 +701,33 @@ test("13. Helm exec probe binaries exist in component runtime images", () => {
             `charts/soundspan/values.yaml: ${reference.component}.${reference.probeName} exec binary "${reference.binary}" is not proven present in ${relativePath}; install ${packageName ?? "a mapped provider package"} in the runtime image or document a base-image family assumption`,
         );
     }
+});
+
+test("14. sidecar images copy every top-level Python module", () => {
+    const missingFiles = [];
+
+    for (const relativePath of serviceDockerfilePaths) {
+        const sources = dockerCopySources(readRepoFile(relativePath));
+        const serviceDirectories = copiedPythonSidecarDirectories(sources);
+
+        for (const serviceDirectory of serviceDirectories) {
+            for (const pythonFile of topLevelPythonFiles(serviceDirectory)) {
+                const exclusionKey = `${relativePath}:${pythonFile}`;
+                if (pythonSidecarCopyExclusions.has(exclusionKey)) continue;
+                if (
+                    !sources.some((source) =>
+                        sourceCopiesPythonFile(source, pythonFile),
+                    )
+                ) {
+                    missingFiles.push(`${relativePath}: ${pythonFile}`);
+                }
+            }
+        }
+    }
+
+    assert.deepEqual(
+        missingFiles,
+        [],
+        `Dockerfile COPY instructions omit top-level sidecar modules:\n${missingFiles.join("\n")}`,
+    );
 });

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -95,7 +95,7 @@ RUN echo "Models downloaded:" && ls -lh /app/models/
 # above (this formerly-inline install was converted to the lock — roadmap F50).
 
 # Copy application code
-COPY services/audio-analyzer/analyzer.py services/audio-analyzer/loudness.py services/audio-analyzer/model_paths.py /app/
+COPY services/audio-analyzer/*.py /app/
 COPY services/common /app/services/common
 
 # Create non-root user


### PR DESCRIPTION
Production hotfix for the 2.3.2 analyzer crashloop (`ModuleNotFoundError: No module named 'audio_paths'`), confirmed on a live Kubernetes deploy.

## Root cause

The loudness campaign made `analyzer.py` import four sibling modules (`audio_paths`, `loudness`, `loudness_backfill`, `model_paths`). Both the standalone [services/audio-analyzer/Dockerfile](https://github.com/soundspan/soundspan/blob/main/services/audio-analyzer/Dockerfile) and the root AIO Dockerfile copied an explicit file list that omitted `audio_paths.py` and `loudness_backfill.py` — so every 2.3.2 analyzer image dies at import. Deploys self-mitigate only because the rollout sticks on the old ReplicaSet.

## Fix

- Both COPY lines become `COPY services/audio-analyzer/*.py` (the future-proof pattern ytmusic-streamer already uses).
- New dockerfile-hygiene assertion: any Dockerfile that copies a sidecar's Python files must cover every top-level `.py` module in that sidecar (explicit name or glob), with a documented — currently empty — exclusion list. Verified guard-first: with the old COPY lines it fails naming exactly the two missing files per image; adversarially re-breaking the AIO line after the fix fails it again.

## Verification

- `node --test scripts/ci/dockerfile-hygiene.test.mjs`: 16/16 pass, exit 0 (15/16 + named failures with the broken COPY lines).
- Root `format:check`: clean.
- No backend/frontend source changes.

Follow-up: staging 2.3.3 immediately after merge.