### PR TITLE
chore(release): stage 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+## [2.3.3] - 2026-08-18
+
 ### Changed
 
 - Frontend component-test commands now fail fast with Node.js 24 upgrade

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^8.6.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.3.2
-appVersion: "2.3.2"
+version: 2.3.3
+appVersion: "2.3.3"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -225,7 +225,7 @@ backendWorker:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -280,7 +280,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -410,7 +410,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-downloader
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -439,7 +439,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -510,7 +510,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -575,7 +575,7 @@ vibeProviderDclap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-vibe-provider-dclap
-    tag: 2.3.2
+    tag: 2.3.3
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -34,6 +34,7 @@ data volume while the container is stopped.
 
 | Upgrading across | Action needed? |
 | ---------------- | -------------- |
+| **2.3.3** | None — plain rolling update; a small database change applies automatically. If you are on 2.3.2, upgrade promptly: its audio-analyzer container could not start, so loudness measurement was paused until this release. |
 | **2.3.2** | None — plain rolling update; database changes apply automatically. Heads-up: volume leveling is new and on by default; each listener can turn it off under Settings → Playback. |
 | **2.3.0** | Usually automatic. AIO: the standard down/pull/up above is the whole upgrade. Split-stack Compose and Helm: read the section — old analyzer containers must be fully stopped. Back up the database first: no image-only downgrade after this one. |
 | **2.0.0** | **Yes — follow the [dedicated 2.0.0 guide](UPGRADING_TO_2.0.0.md).** Required secrets, client re-auth, and more. |

--- a/docs/release-notes/RELEASE_NOTES_2.3.3.md
+++ b/docs/release-notes/RELEASE_NOTES_2.3.3.md
@@ -1,0 +1,110 @@
+# [2.3.3] Release Notes - 2026-08-18
+
+## Release Summary
+
+This is a fix release for everyone who upgraded to 2.3.2. The 2.3.2 audio
+analyzer container could not start — two of the new volume-leveling files
+never made it into the image — so audio analysis and loudness measurement
+were silently stalled: Kubernetes deployments kept running the old analyzer,
+and the all-in-one image restarted its analyzer in a loop. 2.3.3 ships
+complete analyzer images and adds a build-time check so an incomplete image
+can never pass CI again. The release also makes federation tolerant of
+version differences between peers: a newer peer's extra fields no longer
+cause tracks to be skipped, and servers now only send fields a peer
+understands. Upgrading from 2.3.x is a plain rolling update.
+
+## Before you upgrade
+
+**Warning:** If you run a version earlier than 2.0.0, do not upgrade directly
+to 2.3.3. Complete the 2.0.0 breaking changes first. See
+[Upgrading from an earlier version](#upgrading-from-an-earlier-version).
+
+- Straightforward rolling upgrade from 2.3.x - a small database migration
+  runs automatically and no special procedure is needed. If you are coming
+  from 2.2.x or earlier, follow the 2.3.0 upgrade steps first.
+- If you are on 2.3.2, upgrade promptly: loudness measurement has not been
+  running since you upgraded. It resumes automatically on 2.3.3 and catches
+  up in the background.
+
+## Fixed
+
+- Fixed the 2.3.2 audio-analyzer images failing to start because two new
+  loudness modules were missing from both the standalone and all-in-one
+  images. On Kubernetes this looked like a stuck rollout with the new
+  analyzer pod in CrashLoopBackOff; on the all-in-one image the analyzer
+  restarted in a loop in the background. A new CI check now verifies every
+  analyzer module is present in the images before a release can build.
+
+## Added
+
+- Federation peers now advertise what they understand ("capabilities")
+  when pairing and during regular health checks, so servers on different
+  versions only exchange fields both sides support.
+
+## Changed
+
+- Federation sync now tolerates fields from newer peers instead of skipping
+  the affected tracks. Unknown fields are safely ignored and counted, so
+  mixed-version federations keep syncing fully during upgrades.
+- For contributors: the frontend component-test commands now fail fast with
+  clear guidance when run on Node.js older than 24 instead of failing with
+  dozens of confusing errors.
+
+## Removed
+
+- None documented in this release.
+
+## Accessibility
+
+- No accessibility improvements documented in this release.
+
+## Admin/Operations
+
+- Federation compatibility is observable: fields stripped from newer peers
+  are counted in `soundspan_federation_sync_skips_total` on the metrics
+  endpoint, with the peer and field names in the server log.
+- A `capabilities` column is added to the federation peer table
+  automatically at startup. No action needed.
+
+## Deployment and Distribution
+
+- Docker image: `ghcr.io/soundspan/soundspan`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart name: `soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.3.3
+```
+
+## Breaking Changes
+
+- None.
+
+## Known Issues
+
+- Libraries that spent time on 2.3.2 will have a loudness-measurement
+  backlog; it clears automatically in the background after upgrading, and
+  volume leveling covers more of the library as it converges.
+
+## Compatibility and Migration
+
+- The federation peer capabilities column is added automatically at
+  startup. No manual migration steps for standard Docker and Helm
+  deployments.
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, you must complete the
+2.0.0 upgrade before you install 2.3.3. The 2.0.0 release contains breaking
+changes that later releases depend on. Read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
+
+## Full Changelog
+
+- Compare changes: [2.3.2...HEAD](https://github.com/soundspan/soundspan/compare/2.3.2...HEAD)
+- Full changelog: https://github.com/soundspan/soundspan/blob/HEAD/CHANGELOG.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-frontend",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "license": "GPL-3.0",
             "dependencies": {
                 "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages the 2.3.3 fix release. **Merge is the release decision — held for the maintainer.**

## Scope (from Unreleased)

- **Fix (the reason for this release):** the 2.3.2 audio-analyzer images could not start — `audio_paths.py` and `loudness_backfill.py` were missing from both the standalone and AIO images (#605), stalling loudness measurement for every 2.3.2 deploy. Includes the new dockerfile-hygiene assertion that prevents incomplete sidecar images from passing CI.
- Federation version-skew tolerance + capability advertisement (#603) — includes an automatic `capabilities` column migration on the federation peer table.
- Component-harness Node 24 fail-fast + player-hook lint guard (#602, contributor-facing).

## Staged in this commit

- backend/frontend `package.json` + lockfiles → 2.3.3
- Chart `version`/`appVersion` and all 8 `values.yaml` image tags → 2.3.3
- CHANGELOG promotion, `docs/release-notes/RELEASE_NOTES_2.3.3.md`, UPGRADING index row

## Verification

- `verify:helm`: render checks pass with the new versions.
- `verify:gates`: pass (includes release-version validator + repo-wide prettier).
- Scale-smoke triggers automatically on this branch push — treat red as a release blocker.

After merge: tag + `gh release create` publishes the versioned images and chart, then the homelab chart PR follows (supersedes #1429 with 2.3.3).