### PR TITLE
chore(frontend): deprecate the Tauri desktop integration (phase 1 of #607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `DISCOVERY_MODE=legacy` is deprecated, no longer receives fixes, and will be removed in a future release; unset `DISCOVERY_MODE` to migrate.
+- The Tauri desktop integration (the `tauri-native` engine mode and the desktop auto-upgrade path) is deprecated, no longer receives fixes, and will be removed in a future release; playback continues on the standard web engines.
 
 ## [2.3.3] - 2026-08-18
 

--- a/docs/FEATURE_INDEX.json
+++ b/docs/FEATURE_INDEX.json
@@ -765,7 +765,7 @@
         {
             "id": "native-audio-engine",
             "name": "Native Audio Engine",
-            "description": "Default native <audio>-element playback engine (fourth pluggable backend alongside Howler/Video.js/Tauri) with a pure engine-selection policy (Android WebView pin, Tauri auto-upgrade suppression); implemented entirely under frontend/lib/audio-engine/ (nativeAudioElementEngine.ts, nativeAudioElementPolicy.ts, engineSelectionPolicy.ts, engineMode.ts). See docs/NATIVE_AUDIO_ENGINE.md.",
+            "description": "Default native <audio>-element playback engine (fourth pluggable backend alongside Howler/Video.js/Tauri, the latter deprecated per issue #607) with a pure engine-selection policy (Android WebView pin, Tauri auto-upgrade suppression); implemented entirely under frontend/lib/audio-engine/ (nativeAudioElementEngine.ts, nativeAudioElementPolicy.ts, engineSelectionPolicy.ts, engineMode.ts). See docs/NATIVE_AUDIO_ENGINE.md.",
             "frontend": {
                 "feature_dirs": [],
                 "routes": []

--- a/docs/NATIVE_AUDIO_ENGINE.md
+++ b/docs/NATIVE_AUDIO_ENGINE.md
@@ -38,7 +38,7 @@ The flag doubles as a live diagnostic: a user reporting double-play or backgroun
 Selection is explicit and unit-tested (`frontend/lib/audio-engine/engineSelectionPolicy.ts`), highest priority first:
 
 1. **Platform pins.** Android WebView is pinned to Howler even when the flag is `native` — Howler's Web Audio mode is the established fix for crackling/popping on track changes there.
-2. **The engine-mode flag.** `native` (the default when unset) selects the native element engine and fully suppresses the Tauri auto-upgrade path; `howler` selects the legacy engine with the Tauri platform upgrade allowed.
+2. **The engine-mode flag.** `native` (the default when unset) selects the native element engine and fully suppresses the Tauri auto-upgrade path; `howler` selects the legacy engine with the Tauri platform upgrade allowed. The Tauri desktop integration (the auto-upgrade path and the `tauri-native` mode) is deprecated and will be removed in a future release (issue #607).
 3. **Default.** Native (`DEFAULT_STREAMING_ENGINE_MODE` in `frontend/lib/audio-engine/types.ts`).
 
 ## Architecture
@@ -73,7 +73,7 @@ The bridge is gated to **iOS user agent AND `display-mode: standalone`** only, s
 All playback client metrics (`[Playback][ClientMetric]` log lines and the backend beacon) carry two engine tags:
 
 - `engineMode` — the deployment flag (`STREAMING_ENGINE_MODE` as resolved). Identifies the rollout cohort.
-- `activeEngine` — the engine actually driving playback at the moment of the event (`howler`, `native`, `tauri-native`, or `videojs`). Platform pins (Android WebView → howler), the Tauri upgrade, and per-source videojs routing make this legitimately diverge from `engineMode`, so use `activeEngine` for performance/error comparison and `engineMode` for cohort segmentation. A divergence outside those known cases (e.g. `engineMode: native` with `activeEngine: howler` on a non-WebView client) indicates a selection-policy bug.
+- `activeEngine` — the engine actually driving playback at the moment of the event (`howler`, `native`, `tauri-native` (deprecated, issue #607), or `videojs`). Platform pins (Android WebView → howler), the Tauri upgrade, and per-source videojs routing make this legitimately diverge from `engineMode`, so use `activeEngine` for performance/error comparison and `engineMode` for cohort segmentation. A divergence outside those known cases (e.g. `engineMode: native` with `activeEngine: howler` on a non-WebView client) indicates a selection-policy bug.
 
 For 2.0.0 log queries, `player.howler_startup` became
 `player.engine_startup`, and client-signal ingestion moved from
@@ -101,4 +101,4 @@ Those were the exit criteria for flipping the default (met during the 1.7.0 soak
 
 ## Rollout
 
-Opt-in flag (1.7.0) → soaked on the operator deployment → default flipped to `native` in 1.8.0. Howler remains the gated fallback (not removed). Out of scope: removing Howler/Video.js/Tauri adapters, crossfade, and true bit-perfect hi-res output (impossible from web APIs).
+Opt-in flag (1.7.0) → soaked on the operator deployment → default flipped to `native` in 1.8.0. Howler remains the gated fallback (not removed). Out of scope at rollout time: removing Howler/Video.js/Tauri adapters, crossfade, and true bit-perfect hi-res output (impossible from web APIs). Since then, removal of the Tauri adapter (issue #607) and of the Video.js segmented engine (issue #534) has been planned via deprecation.

--- a/frontend/lib/audio-engine/engineFactory.ts
+++ b/frontend/lib/audio-engine/engineFactory.ts
@@ -1,17 +1,22 @@
 import type { AudioEngine } from "./types";
 import { isTauriEnvironment, needsNativeAudio } from "./tauriDetection";
 import { HowlerEngineAdapter } from "./howlerEngineAdapter";
+import { warnTauriDeprecationOnce } from "./tauriDeprecation";
 
 /**
  * Create the appropriate audio engine for the current platform.
  *
  * - Tauri + Windows/Android -> TauriNativeEngineAdapter (bypasses Chromium 48kHz cap)
  * - Everything else -> HowlerEngineAdapter (standard web audio)
+ *
+ * @deprecated The Tauri desktop integration is deprecated and slated for
+ * removal (issue #607); this factory goes with it.
  */
 export async function createAudioEngine(): Promise<AudioEngine> {
     if (isTauriEnvironment()) {
         const native = await needsNativeAudio();
         if (native) {
+            warnTauriDeprecationOnce("native engine upgrade");
             const { TauriNativeEngineAdapter } =
                 await import("./tauriNativeEngineAdapter");
             return new TauriNativeEngineAdapter();

--- a/frontend/lib/audio-engine/tauriDeprecation.ts
+++ b/frontend/lib/audio-engine/tauriDeprecation.ts
@@ -1,0 +1,27 @@
+import { frontendLogger, type FrontendLogger } from "../logger";
+
+export const TAURI_DEPRECATION_MESSAGE =
+    "The Tauri desktop integration is deprecated, no longer receives fixes, and will be removed in a future release; playback continues on the standard web engines.";
+
+let warnedTauriDeprecation = false;
+
+/**
+ * Warns once per process/session when the deprecated Tauri desktop path
+ * engages (issue #607 phase 1). The single-fire guard keeps the warning
+ * visible without spamming per-request or per-render call sites.
+ */
+export function warnTauriDeprecationOnce(
+    context: string,
+    logger: FrontendLogger = frontendLogger,
+): void {
+    if (warnedTauriDeprecation) {
+        return;
+    }
+    warnedTauriDeprecation = true;
+    logger.warn(`[TauriDeprecation] (${context}) ${TAURI_DEPRECATION_MESSAGE}`);
+}
+
+/** Resets the single-fire guard so tests can exercise the warning path. */
+export function resetTauriDeprecationWarningForTests(): void {
+    warnedTauriDeprecation = false;
+}

--- a/frontend/lib/audio-engine/tauriDetection.ts
+++ b/frontend/lib/audio-engine/tauriDetection.ts
@@ -1,5 +1,8 @@
 /**
  * Check if running inside a Tauri application.
+ *
+ * @deprecated The Tauri desktop integration is deprecated and slated for
+ * removal (issue #607).
  */
 export function isTauriEnvironment(): boolean {
     return typeof window !== "undefined" && "__TAURI__" in window;

--- a/frontend/lib/audio-engine/tauriNativeEngineAdapter.ts
+++ b/frontend/lib/audio-engine/tauriNativeEngineAdapter.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated The Tauri desktop integration is deprecated and slated for
+ * removal (issue #607); this adapter and its `@tauri-apps/*` dependencies
+ * go with it.
+ */
 import type {
     AudioEngine,
     AudioEngineBufferingPayload,

--- a/frontend/lib/audio-engine/types.ts
+++ b/frontend/lib/audio-engine/types.ts
@@ -4,6 +4,8 @@ export type StreamingEngineMode =
     | "videojs"
     | "howler"
     | "native"
+    // Deprecated (issue #607): the Tauri desktop integration is slated for
+    // removal; "tauri-native" will leave this union with it.
     | "tauri-native";
 
 // The native element engine is the default direct-playback engine as

--- a/frontend/lib/runtime-config/normalization.ts
+++ b/frontend/lib/runtime-config/normalization.ts
@@ -1,3 +1,4 @@
+import { warnTauriDeprecationOnce } from "../audio-engine/tauriDeprecation";
 import type { StreamingEngineMode } from "../audio-engine/types";
 
 const VALID_STREAMING_ENGINE_MODES = new Set<StreamingEngineMode>([
@@ -132,6 +133,9 @@ export const buildRuntimeConfigPayload = (
     env: RuntimeConfigEnvironment,
 ): string => {
     const mode = normalizeStreamingEngineMode(env.STREAMING_ENGINE_MODE);
+    if (mode === "tauri-native") {
+        warnTauriDeprecationOnce("STREAMING_ENGINE_MODE=tauri-native");
+    }
     const modeJson = mode ? JSON.stringify(mode) : "null";
     const segmentedVhsProfile = normalizeSegmentedVhsProfile(
         env.SEGMENTED_VHS_PROFILE,

--- a/frontend/tests/unit/tauriDeprecation.test.ts
+++ b/frontend/tests/unit/tauriDeprecation.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    TAURI_DEPRECATION_MESSAGE,
+    resetTauriDeprecationWarningForTests,
+    warnTauriDeprecationOnce,
+} from "../../lib/audio-engine/tauriDeprecation";
+import type { FrontendLogger } from "../../lib/logger";
+import { buildRuntimeConfigPayload } from "../../lib/runtime-config/normalization";
+
+const createRecordingLogger = (): {
+    logger: FrontendLogger;
+    warnings: string[];
+} => {
+    const warnings: string[] = [];
+    const record = (message: string) => {
+        warnings.push(message);
+    };
+    const logger: FrontendLogger = {
+        debug: record,
+        info: record,
+        warn: (message: string) => {
+            warnings.push(message);
+        },
+        error: record,
+        child: () => logger,
+    };
+    return { logger, warnings };
+};
+
+test("warnTauriDeprecationOnce warns exactly once per process", () => {
+    resetTauriDeprecationWarningForTests();
+    const { logger, warnings } = createRecordingLogger();
+
+    warnTauriDeprecationOnce("engine upgrade", logger);
+    warnTauriDeprecationOnce("engine upgrade", logger);
+    warnTauriDeprecationOnce("runtime config", logger);
+
+    assert.equal(warnings.length, 1);
+    assert.ok(warnings[0].includes("engine upgrade"));
+    assert.ok(warnings[0].includes(TAURI_DEPRECATION_MESSAGE));
+});
+
+test("Tauri deprecation message states removal and migration", () => {
+    assert.ok(TAURI_DEPRECATION_MESSAGE.includes("deprecated"));
+    assert.ok(
+        TAURI_DEPRECATION_MESSAGE.includes("removed in a future release"),
+    );
+});
+
+test("buildRuntimeConfigPayload warns once when tauri-native is configured", (t) => {
+    resetTauriDeprecationWarningForTests();
+    const warn = t.mock.method(console, "warn");
+
+    const first = buildRuntimeConfigPayload({
+        STREAMING_ENGINE_MODE: "tauri-native",
+    });
+    const second = buildRuntimeConfigPayload({
+        STREAMING_ENGINE_MODE: "tauri-native",
+    });
+
+    assert.ok(first.includes('STREAMING_ENGINE_MODE: "tauri-native"'));
+    assert.equal(first, second);
+    const deprecationWarnings = warn.mock.calls.filter((call) =>
+        String(call.arguments[0]).includes(TAURI_DEPRECATION_MESSAGE),
+    );
+    assert.equal(deprecationWarnings.length, 1);
+
+    resetTauriDeprecationWarningForTests();
+});
+
+test("buildRuntimeConfigPayload does not warn for non-Tauri modes", (t) => {
+    resetTauriDeprecationWarningForTests();
+    const warn = t.mock.method(console, "warn");
+
+    buildRuntimeConfigPayload({ STREAMING_ENGINE_MODE: "native" });
+    buildRuntimeConfigPayload({ STREAMING_ENGINE_MODE: "videojs" });
+    buildRuntimeConfigPayload({});
+
+    const deprecationWarnings = warn.mock.calls.filter((call) =>
+        String(call.arguments[0]).includes(TAURI_DEPRECATION_MESSAGE),
+    );
+    assert.equal(deprecationWarnings.length, 0);
+});


### PR DESCRIPTION
Phase 1 of #607: mark the Tauri desktop integration deprecated with zero behavior change.

## Why

The Tauri desktop app is discontinued. The desktop shell never lived in this repository — what is here is the web frontend's half of the contract: `tauriDetection.ts`, the 500-line `tauriNativeEngineAdapter.ts`, the factory that exists only to pick it, the `tauri-native` mode string, and the `allowTauriUpgrade` suppression machinery. The adapter is already dead code in every shipping deployment (default `native` mode suppresses the upgrade path; both container entrypoints reject `tauri-native`), so deprecation is announcement plus a targeted warning, not a behavior change.

## What

- New `frontend/lib/audio-engine/tauriDeprecation.ts`: a single-fire `warnTauriDeprecationOnce(context, logger?)` with an injectable logger and a test reset hook.
- The warning fires in exactly two places: when `createAudioEngine()` is actually about to hand playback to the Tauri adapter (a real desktop-app session), and when `STREAMING_ENGINE_MODE=tauri-native` is supplied to `buildRuntimeConfigPayload` (server-side, non-container runs — the entrypoints already reject the value). Web users on default deployments never see it.
- `@deprecated` notices on `createAudioEngine`, `tauriDetection.ts`, `tauriNativeEngineAdapter.ts`, and the `tauri-native` union member.
- Docs: `NATIVE_AUDIO_ENGINE.md` selection/telemetry/rollout sections annotated; `FEATURE_INDEX.json` description updated; CHANGELOG `### Deprecated` entry.

Phase 2 (removal: the three modules, the union member, `allowTauriUpgrade`, and the `@tauri-apps/*` dependencies) lands in a follow-up per the issue's phase plan.

## Verification

- `npm run test:unit` (frontend): 1000 tests, 1000 pass, exit 0 — includes the new `tauriDeprecation.test.ts` (single-fire, config-triggered warn, negative cases).
- `npx tsc --noEmit`: exit 0. `npm run lint`: 0 errors, 183 warnings (exactly at the cap, no new warnings). `npm run format:check`: clean.
- `node scripts/ci/check-file-size.mjs`: passed.
- Root prettier check on CHANGELOG.md, docs/NATIVE_AUDIO_ENGINE.md, docs/FEATURE_INDEX.json: clean.

Closes nothing yet — phase 2 closes #607.
