### PR TITLE
feat(admin): Library Health dashboard read model and admin API (#532 backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Added
+
+- Library Health dashboard read model and admin API (metadata gaps, analysis coverage, duplicate clusters, storage and quality analytics).
+
 ### Deprecated
 
 - `DISCOVERY_MODE=legacy` is deprecated, no longer receives fixes, and will be removed in a future release; unset `DISCOVERY_MODE` to migrate.

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -45,6 +45,7 @@ describe("api entrypoint runtime behavior", () => {
         "../routes/shareLinks",
         "../routes/federation",
         "../routes/federationAdmin",
+        "../routes/libraryHealthDashboard",
     ];
 
     const flushPromises = async (): Promise<void> => {
@@ -742,6 +743,10 @@ describe("api entrypoint runtime behavior", () => {
             "/api/browse": ["api-limiter", route("../routes/browse")],
             "/api/analysis": ["api-limiter", route("../routes/analysis")],
             "/api/admin": ["admin-surface-limiter", route("../routes/admin")],
+            "/api/library-health": [
+                "admin-surface-limiter",
+                route("../routes/libraryHealthDashboard"),
+            ],
             "/api/releases": ["api-limiter", route("../routes/releases")],
             "/api/vibe": ["api-limiter", route("../routes/vibe")],
             "/api/system": ["api-limiter", route("../routes/system")],

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -44,6 +44,7 @@ import deviceLinkRoutes from "./routes/deviceLink";
 import notificationsRoutes from "./routes/notifications";
 import browseRoutes from "./routes/browse";
 import adminRoutes from "./routes/admin";
+import libraryHealthDashboardRoutes from "./routes/libraryHealthDashboard";
 import releasesRoutes from "./routes/releases";
 import systemRoutes from "./routes/system";
 import ytMusicRoutes from "./routes/youtubeMusic";
@@ -324,6 +325,11 @@ if (config.features.audioAnalysis) {
     app.use("/api/analysis", apiLimiter, createFeatureDisabledHandler());
 }
 app.use("/api/admin", adminSurfaceLimiter, adminRoutes);
+app.use(
+    "/api/library-health",
+    adminSurfaceLimiter,
+    libraryHealthDashboardRoutes,
+);
 app.use("/api/releases", apiLimiter, releasesRoutes);
 if (config.features.audioAnalysis) {
     app.use("/api/vibe", apiLimiter, require("./routes/vibe").default);

--- a/backend/src/metrics/__tests__/libraryHealthMetrics.test.ts
+++ b/backend/src/metrics/__tests__/libraryHealthMetrics.test.ts
@@ -1,0 +1,17 @@
+import { Registry } from "prom-client";
+import { createLibraryHealthMetrics } from "../libraryHealthMetrics";
+
+describe("library health metrics", () => {
+    it("registers bounded cache labels", async () => {
+        const registry = new Registry();
+        const metrics = createLibraryHealthMetrics(registry);
+        metrics.cacheResults.inc({ panel: "duplicates", result: "hit" });
+        metrics.cacheResults.inc({ panel: "summary", result: "error" });
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            "# HELP soundspan_library_health_cache_total",
+        );
+        expect(exposition).toContain('panel="duplicates",result="hit"} 1');
+        expect(exposition).toContain('panel="summary",result="error"} 1');
+    });
+});

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -6,6 +6,11 @@ import {
 import { createHttpRequestMetrics } from "./httpMetrics";
 import { createLoudnessMetrics } from "./loudnessMetrics";
 import {
+    createLibraryHealthMetrics,
+    type LibraryHealthCachePanel,
+    type LibraryHealthCacheResult,
+} from "./libraryHealthMetrics";
+import {
     createProviderMetrics,
     type VibeProviderEndpoint,
     type VibeProviderOutcome,
@@ -35,6 +40,7 @@ collectDefaultMetrics({
 
 const httpMetrics = createHttpRequestMetrics(metricsRegistry);
 const domainMetrics = createDomainMetrics(metricsRegistry);
+const libraryHealthMetrics = createLibraryHealthMetrics(metricsRegistry);
 const providerMetrics = createProviderMetrics(metricsRegistry);
 createLoudnessMetrics(metricsRegistry, prisma);
 const vibeEmbedMetrics = createVibeEmbedMetrics(metricsRegistry, {
@@ -64,6 +70,14 @@ export function recordTranscodeCacheResult(result: "hit" | "miss"): void {
 /** Records one browse-image cache lookup. */
 export function recordBrowseImageCacheResult(result: "hit" | "miss"): void {
     domainMetrics.browseImageCacheRequests.inc({ result });
+}
+
+/** Records one Library Health panel cache outcome. */
+export function recordLibraryHealthCacheResult(
+    panel: LibraryHealthCachePanel,
+    result: LibraryHealthCacheResult,
+): void {
+    libraryHealthMetrics.cacheResults.inc({ panel, result });
 }
 
 /** Records one final federation sync outcome. */

--- a/backend/src/metrics/libraryHealthMetrics.ts
+++ b/backend/src/metrics/libraryHealthMetrics.ts
@@ -1,0 +1,29 @@
+import { Counter, type Registry } from "prom-client";
+
+/** Closed Library Health cache panel vocabulary. */
+export type LibraryHealthCachePanel =
+    | "summary"
+    | "storage"
+    | "quality"
+    | "duplicates";
+/** Closed Library Health cache result vocabulary. */
+export type LibraryHealthCacheResult = "hit" | "miss" | "error";
+
+/** Metrics registered for Library Health dashboard reads. */
+export interface LibraryHealthMetrics {
+    cacheResults: Counter<"panel" | "result">;
+}
+
+/** Registers the bounded Library Health cache result counter. */
+export function createLibraryHealthMetrics(
+    registry: Registry,
+): LibraryHealthMetrics {
+    return {
+        cacheResults: new Counter({
+            name: "soundspan_library_health_cache_total",
+            help: "Library Health dashboard cache operations by panel and result.",
+            labelNames: ["panel", "result"] as const,
+            registers: [registry],
+        }),
+    };
+}

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -82,6 +82,7 @@ route file is intentionally incremental (per touched file), not a big-bang.
 | `backend/src/routes/federationAdmin.ts`    | `/api/federation/admin` (peer lifecycle, consumer linking, and sync enqueue)                          |
 | `backend/src/routes/homepage.ts`           | `/api/homepage`                                                                                       |
 | `backend/src/routes/library.ts`            | `/api/library`                                                                                        |
+| `backend/src/routes/libraryHealthDashboard.ts` | `/api/library-health` (admin-gated read-only dashboard analytics)                                 |
 | `backend/src/routes/listeningState.ts`     | `/api/listening-state`                                                                                |
 | `backend/src/routes/listenTogether.ts`     | `/api/listen-together`                                                                                |
 | `backend/src/routes/lyrics.ts`             | `/api/lyrics`                                                                                         |

--- a/backend/src/routes/__tests__/libraryHealthDashboard.test.ts
+++ b/backend/src/routes/__tests__/libraryHealthDashboard.test.ts
@@ -1,0 +1,120 @@
+import express, {
+    type NextFunction,
+    type Request,
+    type Response,
+} from "express";
+import request from "supertest";
+
+type AuthMode = "ok" | "unauthorized" | "forbidden";
+const auth = { mode: "ok" as AuthMode };
+const summary = jest.fn();
+const gaps = jest.fn();
+const analysis = jest.fn();
+const storage = jest.fn();
+const quality = jest.fn();
+const duplicates = jest.fn();
+const invalidate = jest.fn();
+
+jest.mock("../../middleware/auth", () => ({
+    requireAuth: (_req: Request, res: Response, next: NextFunction) =>
+        auth.mode === "unauthorized"
+            ? res.status(401).json({ error: "Unauthorized" })
+            : next(),
+    requireAdmin: (_req: Request, res: Response, next: NextFunction) =>
+        auth.mode === "forbidden"
+            ? res.status(403).json({ error: "Forbidden" })
+            : next(),
+}));
+jest.mock("../../services/libraryHealthDashboard", () => ({
+    METADATA_GAP_KINDS: [
+        "missing-art",
+        "missing-mbid",
+        "missing-genres",
+        "missing-lyrics",
+    ],
+    getLibraryHealthDashboardSummary: (...args: unknown[]) => summary(...args),
+    getLibraryHealthMetadataGaps: (...args: unknown[]) => gaps(...args),
+    getLibraryHealthAnalysis: (...args: unknown[]) => analysis(...args),
+    getLibraryHealthStorage: (...args: unknown[]) => storage(...args),
+    getLibraryHealthQuality: (...args: unknown[]) => quality(...args),
+    getLibraryHealthDuplicates: (...args: unknown[]) => duplicates(...args),
+    invalidateLibraryHealthDashboardCache: (...args: unknown[]) =>
+        invalidate(...args),
+}));
+jest.mock("../../utils/logger", () => ({
+    logger: { child: () => ({ error: jest.fn() }) },
+}));
+
+import router from "../libraryHealthDashboard";
+
+const app = express();
+app.use(express.json());
+app.use("/api/library-health", router);
+
+describe("library health dashboard routes", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        auth.mode = "ok";
+        summary.mockResolvedValue({ metadataGaps: { missingLyrics: 2 } });
+        gaps.mockResolvedValue({ kind: "missing-lyrics", items: [] });
+        analysis.mockResolvedValue({ total: 4, failed: { items: [] } });
+        storage.mockResolvedValue({ formats: [], topArtists: [] });
+        quality.mockResolvedValue({ floorKbps: 192, items: [] });
+        duplicates.mockResolvedValue({ clusters: [], total: 0 });
+        invalidate.mockResolvedValue(undefined);
+    });
+
+    it.each([
+        ["unauthorized", "get", "/api/library-health/summary", 401],
+        ["forbidden", "get", "/api/library-health/summary", 403],
+        ["unauthorized", "post", "/api/library-health/refresh", 401],
+        ["forbidden", "post", "/api/library-health/refresh", 403],
+    ] as const)("returns %s for %s %s", async (mode, method, path, status) => {
+        auth.mode = mode;
+        expect((await request(app)[method](path)).status).toBe(status);
+    });
+
+    it.each([
+        "/api/library-health/gaps/not-a-gap",
+        "/api/library-health/gaps/missing-art?limit=101",
+        "/api/library-health/analysis?limit=101",
+        "/api/library-health/quality?floor=31",
+        "/api/library-health/quality?unexpected=true",
+        "/api/library-health/duplicates?limit=51",
+    ])("rejects invalid input for %s", async (path) => {
+        const response = await request(app).get(path);
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({
+            error: "Invalid library health request",
+        });
+    });
+
+    it("returns panels and refreshes the summary", async () => {
+        expect(
+            (await request(app).get("/api/library-health/summary")).body,
+        ).toEqual({ metadataGaps: { missingLyrics: 2 } });
+        await request(app).get(
+            "/api/library-health/gaps/missing-lyrics?limit=10&offset=5",
+        );
+        expect(
+            (await request(app).get("/api/library-health/analysis")).body,
+        ).toEqual({ total: 4, failed: { items: [] } });
+        expect(
+            (await request(app).get("/api/library-health/storage")).body,
+        ).toEqual({ formats: [], topArtists: [] });
+        await request(app).get("/api/library-health/quality?floor=160");
+        expect(
+            (await request(app).get("/api/library-health/duplicates")).body,
+        ).toEqual({ clusters: [], total: 0 });
+        const refreshed = await request(app).post(
+            "/api/library-health/refresh",
+        );
+        expect(gaps).toHaveBeenCalledWith("missing-lyrics", {
+            limit: 10,
+            offset: 5,
+        });
+        expect(quality).toHaveBeenCalledWith(160, { limit: 50, offset: 0 });
+        expect(invalidate).toHaveBeenCalledTimes(1);
+        expect(refreshed.body).toEqual({ metadataGaps: { missingLyrics: 2 } });
+    });
+});

--- a/backend/src/routes/libraryHealthDashboard.ts
+++ b/backend/src/routes/libraryHealthDashboard.ts
@@ -1,0 +1,320 @@
+import { Router, type Response } from "express";
+import { z } from "zod";
+import { requireAdmin, requireAuth } from "../middleware/auth";
+import { asyncHandler } from "../middleware/asyncHandler";
+import {
+    getLibraryHealthAnalysis,
+    getLibraryHealthDashboardSummary,
+    getLibraryHealthDuplicates,
+    getLibraryHealthMetadataGaps,
+    getLibraryHealthQuality,
+    getLibraryHealthStorage,
+    invalidateLibraryHealthDashboardCache,
+    METADATA_GAP_KINDS,
+} from "../services/libraryHealthDashboard";
+import { logger } from "../utils/logger";
+import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
+
+const router = Router();
+const log = logger.child("LibraryHealthDashboard");
+const emptySchema = z.strictObject({});
+const paginationShape = {
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+    offset: z.coerce.number().int().min(0).max(1_000_000).default(0),
+};
+const paginationSchema = z.strictObject(paginationShape);
+const duplicatePaginationSchema = z.strictObject({
+    ...paginationShape,
+    limit: z.coerce.number().int().min(1).max(50).default(50),
+});
+const qualityQuerySchema = z.strictObject({
+    ...paginationShape,
+    floor: z.coerce.number().min(32).max(2_000).default(192),
+});
+const gapParamsSchema = z.strictObject({
+    kind: z.enum(METADATA_GAP_KINDS),
+});
+
+function invalidRequest(res: Response): Response {
+    return sendRouteError(res, 400, "Invalid library health request");
+}
+
+function internalFailure(res: Response, operation: string, error: unknown) {
+    log.error(`${operation} failed`, { error });
+    return sendInternalRouteError(res, `Failed to ${operation}`);
+}
+
+router.use(requireAuth, requireAdmin);
+
+/**
+ * @openapi
+ * /api/library-health/summary:
+ *   get:
+ *     summary: Get all Library Health dashboard panel counts
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     responses:
+ *       200:
+ *         description: Cached dashboard summary
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [metadataGaps, analysisCoverage, storage, quality, duplicates]
+ *       400: { description: Invalid query parameters }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Summary load failed }
+ */
+router.get(
+    "/summary",
+    asyncHandler(async (req, res) => {
+        if (!emptySchema.safeParse(req.query).success)
+            return invalidRequest(res);
+        try {
+            return res.json(await getLibraryHealthDashboardSummary());
+        } catch (error) {
+            return internalFailure(res, "load library health summary", error);
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/gaps/{kind}:
+ *   get:
+ *     summary: List one metadata-gap category
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - { in: path, name: kind, required: true, schema: { type: string, enum: [missing-art, missing-mbid, missing-genres, missing-lyrics] } }
+ *       - { in: query, name: limit, schema: { type: integer, minimum: 1, maximum: 100, default: 50 } }
+ *       - { in: query, name: offset, schema: { type: integer, minimum: 0, maximum: 1000000, default: 0 } }
+ *     responses:
+ *       200:
+ *         description: Metadata-gap counts and drill-down page
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [kind, counts, items, total, limit, offset]
+ *       400: { description: Invalid kind or pagination }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Metadata-gap load failed }
+ */
+router.get(
+    "/gaps/:kind",
+    asyncHandler(async (req, res) => {
+        const params = gapParamsSchema.safeParse(req.params);
+        const query = paginationSchema.safeParse(req.query);
+        if (!params.success || !query.success) return invalidRequest(res);
+        try {
+            return res.json(
+                await getLibraryHealthMetadataGaps(
+                    params.data.kind,
+                    query.data,
+                ),
+            );
+        } catch (error) {
+            return internalFailure(
+                res,
+                "load library health metadata gaps",
+                error,
+            );
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/analysis:
+ *   get:
+ *     summary: Get analysis, vibe, and loudness coverage with failed tracks
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - { in: query, name: limit, schema: { type: integer, minimum: 1, maximum: 100, default: 50 } }
+ *       - { in: query, name: offset, schema: { type: integer, minimum: 0, maximum: 1000000, default: 0 } }
+ *     responses:
+ *       200:
+ *         description: Coverage counts and failed-track page
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [total, analysisStatus, vibeAnalysisStatus, loudness, failed]
+ *       400: { description: Invalid pagination }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Analysis coverage load failed }
+ */
+router.get(
+    "/analysis",
+    asyncHandler(async (req, res) => {
+        const query = paginationSchema.safeParse(req.query);
+        if (!query.success) return invalidRequest(res);
+        try {
+            return res.json(await getLibraryHealthAnalysis(query.data));
+        } catch (error) {
+            return internalFailure(res, "load library health analysis", error);
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/storage:
+ *   get:
+ *     summary: Get local-library storage and format analytics
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     responses:
+ *       200:
+ *         description: MIME totals, derived bitrate samples, and top storage artists
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [formats, topArtists, sampledTracks, sampleLimit, isTruncated]
+ *       400: { description: Invalid query parameters }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Storage analytics load failed }
+ */
+router.get(
+    "/storage",
+    asyncHandler(async (req, res) => {
+        if (!emptySchema.safeParse(req.query).success)
+            return invalidRequest(res);
+        try {
+            return res.json(await getLibraryHealthStorage());
+        } catch (error) {
+            return internalFailure(res, "load library health storage", error);
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/quality:
+ *   get:
+ *     summary: List lossy albums below a derived bitrate floor
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - { in: query, name: floor, schema: { type: number, minimum: 32, maximum: 2000, default: 192 } }
+ *       - { in: query, name: limit, schema: { type: integer, minimum: 1, maximum: 100, default: 50 } }
+ *       - { in: query, name: offset, schema: { type: integer, minimum: 0, maximum: 1000000, default: 0 } }
+ *     responses:
+ *       200:
+ *         description: Paginated low-bitrate lossy albums
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [floorKbps, items, total, limit, offset, sampledTracks, sampleLimit, isTruncated]
+ *       400: { description: Invalid floor or pagination }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Quality analytics load failed }
+ */
+router.get(
+    "/quality",
+    asyncHandler(async (req, res) => {
+        const query = qualityQuerySchema.safeParse(req.query);
+        if (!query.success) return invalidRequest(res);
+        const { floor, limit, offset } = query.data;
+        try {
+            return res.json(
+                await getLibraryHealthQuality(floor, { limit, offset }),
+            );
+        } catch (error) {
+            return internalFailure(res, "load library health quality", error);
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/duplicates:
+ *   get:
+ *     summary: List report-only durable-identity duplicate clusters
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - { in: query, name: limit, schema: { type: integer, minimum: 1, maximum: 50, default: 50 } }
+ *       - { in: query, name: offset, schema: { type: integer, minimum: 0, maximum: 1000000, default: 0 } }
+ *     responses:
+ *       200:
+ *         description: Tier-ordered duplicate-cluster page
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [clusters, total, byTier, isTruncated, limit, offset]
+ *       400: { description: Invalid pagination }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Duplicate cluster load failed }
+ */
+router.get(
+    "/duplicates",
+    asyncHandler(async (req, res) => {
+        const query = duplicatePaginationSchema.safeParse(req.query);
+        if (!query.success) return invalidRequest(res);
+        try {
+            return res.json(await getLibraryHealthDuplicates(query.data));
+        } catch (error) {
+            return internalFailure(
+                res,
+                "load library health duplicates",
+                error,
+            );
+        }
+    }),
+);
+
+/**
+ * @openapi
+ * /api/library-health/refresh:
+ *   post:
+ *     summary: Invalidate Library Health caches and return a fresh summary
+ *     tags: [Library Health]
+ *     security: [{ bearerAuth: [] }]
+ *     responses:
+ *       200:
+ *         description: Fresh dashboard summary
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [metadataGaps, analysisCoverage, storage, quality, duplicates]
+ *       400: { description: Invalid request }
+ *       401: { description: Not authenticated }
+ *       403: { description: Administrator access required }
+ *       500: { description: Dashboard refresh failed }
+ */
+router.post(
+    "/refresh",
+    asyncHandler(async (req, res) => {
+        if (
+            !emptySchema.safeParse(req.query).success ||
+            !emptySchema.safeParse(req.body ?? {}).success
+        ) {
+            return invalidRequest(res);
+        }
+        try {
+            await invalidateLibraryHealthDashboardCache();
+            return res.json(await getLibraryHealthDashboardSummary());
+        } catch (error) {
+            return internalFailure(
+                res,
+                "refresh library health dashboard",
+                error,
+            );
+        }
+    }),
+);
+
+export default router;

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -75,6 +75,15 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/lastfm.ts` | Core |
 | `backend/src/services/libraryRadioBuilder.ts` | Core |
 | `backend/src/services/libraryOrphanCleanup.ts` | Deletes catalog parents after their final track row is purged |
+| `backend/src/services/libraryHealthDashboard/index.ts` | Library Health read-model composition and cached panel surface |
+| `backend/src/services/libraryHealthDashboard/analysisCoverage.ts` | Local analysis, vibe, loudness, and failure coverage |
+| `backend/src/services/libraryHealthDashboard/cache.ts` | Redis caching, invalidation, and request coalescing |
+| `backend/src/services/libraryHealthDashboard/duplicateClusters.ts` | Report-only durable-identity duplicate clusters |
+| `backend/src/services/libraryHealthDashboard/metadataGaps.ts` | Local metadata-gap counts and drill-down pages |
+| `backend/src/services/libraryHealthDashboard/pagination.ts` | Bounded service-level offset pagination |
+| `backend/src/services/libraryHealthDashboard/predicates.ts` | Shared visible-local track predicate |
+| `backend/src/services/libraryHealthDashboard/qualityOutliers.ts` | Lossy album bitrate outlier analytics |
+| `backend/src/services/libraryHealthDashboard/storageAnalytics.ts` | MIME, storage, bitrate, and artist analytics |
 | `backend/src/services/libraryTrackPreferences.ts` | Core |
 | `backend/src/services/lidarr.ts` | Core |
 | `backend/src/services/listenTogether.ts` | Core |

--- a/backend/src/services/libraryHealthDashboard/__tests__/analysisCoverage.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/analysisCoverage.test.ts
@@ -1,0 +1,53 @@
+const groupBy = jest.fn();
+const count = jest.fn();
+const findMany = jest.fn();
+
+jest.mock("../../../utils/db", () => ({
+    prisma: { track: { groupBy, count, findMany } },
+}));
+
+import { getAnalysisCoverage } from "../analysisCoverage";
+
+describe("library health analysis coverage", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("normalizes null vibe status to pending and paginates failures", async () => {
+        groupBy
+            .mockResolvedValueOnce([
+                { analysisStatus: "completed", _count: 7 },
+                { analysisStatus: "failed", _count: 1 },
+            ])
+            .mockResolvedValueOnce([
+                { vibeAnalysisStatus: null, _count: 2 },
+                { vibeAnalysisStatus: "pending", _count: 3 },
+                { vibeAnalysisStatus: "completed", _count: 4 },
+            ]);
+        count
+            .mockResolvedValueOnce(5)
+            .mockResolvedValueOnce(3)
+            .mockResolvedValueOnce(1);
+        findMany.mockResolvedValueOnce([
+            {
+                id: "t1",
+                title: "Failed",
+                analysisError: "decode",
+                album: { title: "Album", artist: { name: "Artist" } },
+            },
+        ]);
+
+        const result = await getAnalysisCoverage({ limit: 10, offset: 5 });
+
+        expect(result.vibeAnalysisStatus.pending).toBe(5);
+        expect(result.loudness).toEqual({ measured: 5, missing: 3 });
+        expect(result.failed.items[0]).toEqual({
+            id: "t1",
+            title: "Failed",
+            artistName: "Artist",
+            albumTitle: "Album",
+            analysisError: "decode",
+        });
+        expect(findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ take: 10, skip: 5 }),
+        );
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/__tests__/cache.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/cache.test.ts
@@ -1,0 +1,64 @@
+const get = jest.fn();
+const setEx = jest.fn();
+const del = jest.fn();
+const record = jest.fn();
+const warn = jest.fn();
+jest.mock("../../../utils/redis", () => ({ redisClient: { get, setEx, del } }));
+jest.mock("../../../metrics", () => ({
+    recordLibraryHealthCacheResult: record,
+}));
+jest.mock("../../../utils/logger", () => ({
+    logger: { child: () => ({ warn }) },
+}));
+
+import {
+    getCachedLibraryHealthPanel,
+    invalidateLibraryHealthDashboardCache,
+    LIBRARY_HEALTH_CACHE_KEYS,
+} from "../cache";
+
+describe("library health cache", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("returns hits without loading", async () => {
+        get.mockResolvedValueOnce('{"total":2}');
+        const loader = jest.fn();
+        await expect(
+            getCachedLibraryHealthPanel("summary", loader),
+        ).resolves.toEqual({ total: 2 });
+        expect(loader).not.toHaveBeenCalled();
+        expect(record).toHaveBeenCalledWith("summary", "hit");
+    });
+
+    it("coalesces misses and caches for fifteen minutes", async () => {
+        get.mockResolvedValueOnce(null);
+        setEx.mockResolvedValueOnce("OK");
+        const loader = jest.fn(async () => ({ total: 3 }));
+        const results = await Promise.all([
+            getCachedLibraryHealthPanel("storage", loader),
+            getCachedLibraryHealthPanel("storage", loader),
+        ]);
+        expect(results).toEqual([{ total: 3 }, { total: 3 }]);
+        expect(loader).toHaveBeenCalledTimes(1);
+        expect(setEx).toHaveBeenCalledWith(
+            LIBRARY_HEALTH_CACHE_KEYS.storage,
+            900,
+            JSON.stringify({ total: 3 }),
+        );
+    });
+
+    it("fails open on Redis errors and explicitly deletes known keys", async () => {
+        get.mockRejectedValueOnce(new Error("offline"));
+        setEx.mockRejectedValueOnce(new Error("offline"));
+        await expect(
+            getCachedLibraryHealthPanel("quality", async () => ({ total: 4 })),
+        ).resolves.toEqual({ total: 4 });
+        expect(record).toHaveBeenCalledWith("quality", "error");
+        expect(warn).toHaveBeenCalled();
+        del.mockResolvedValueOnce(4);
+        await invalidateLibraryHealthDashboardCache();
+        expect(del).toHaveBeenCalledWith(
+            Object.values(LIBRARY_HEALTH_CACHE_KEYS),
+        );
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/__tests__/duplicateClusters.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/duplicateClusters.test.ts
@@ -1,0 +1,74 @@
+const groupBy = jest.fn();
+const findMany = jest.fn();
+jest.mock("../../../utils/db", () => ({
+    prisma: { track: { groupBy, findMany } },
+}));
+
+import {
+    listDuplicateClusters,
+    loadDuplicateClusterCatalog,
+} from "../duplicateClusters";
+
+describe("library health duplicate clusters", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("claims tracks at the highest durable identity tier", async () => {
+        groupBy
+            .mockResolvedValueOnce([{ audioHash: "hash", _count: { _all: 2 } }])
+            .mockResolvedValueOnce([
+                { recordingMbid: "mbid", _count: { _all: 3 } },
+            ])
+            .mockResolvedValueOnce([{ isrc: "isrc", _count: { _all: 3 } }]);
+        const album = (title: string) => ({
+            title,
+            artist: { name: "Artist" },
+        });
+        findMany.mockResolvedValueOnce([
+            {
+                id: "t1",
+                title: "Song",
+                filePath: "/a",
+                fileSize: 1,
+                mime: "audio/mpeg",
+                audioHash: "hash",
+                recordingMbid: "mbid",
+                isrc: "isrc",
+                album: album("A"),
+            },
+            {
+                id: "t2",
+                title: "Song",
+                filePath: "/b",
+                fileSize: 1,
+                mime: "audio/mpeg",
+                audioHash: "hash",
+                recordingMbid: "mbid",
+                isrc: "isrc",
+                album: album("B"),
+            },
+            {
+                id: "t3",
+                title: "Song",
+                filePath: "/c",
+                fileSize: 1,
+                mime: "audio/mpeg",
+                audioHash: null,
+                recordingMbid: "mbid",
+                isrc: "isrc",
+                album: album("C"),
+            },
+        ]);
+
+        const catalog = await loadDuplicateClusterCatalog();
+
+        expect(catalog.clusters).toHaveLength(1);
+        expect(catalog.clusters[0].tier).toBe("audioHash");
+        expect(catalog.clusters[0].members.map((row) => row.id)).toEqual([
+            "t1",
+            "t2",
+        ]);
+        expect(
+            listDuplicateClusters(catalog, { limit: 75, offset: -1 }),
+        ).toEqual(expect.objectContaining({ limit: 50, offset: 0, total: 1 }));
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/__tests__/metadataGaps.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/metadataGaps.test.ts
@@ -1,0 +1,76 @@
+const albumCount = jest.fn();
+const albumFindMany = jest.fn();
+const artistCount = jest.fn();
+const trackCount = jest.fn();
+const trackFindMany = jest.fn();
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        album: { count: albumCount, findMany: albumFindMany },
+        artist: { count: artistCount },
+        track: { count: trackCount, findMany: trackFindMany },
+    },
+}));
+
+import { getMetadataGapSummary, listMetadataGap } from "../metadataGaps";
+
+describe("library health metadata gaps", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("excludes remote temporary identities from missing MBID counts", async () => {
+        artistCount.mockResolvedValueOnce(3);
+        albumCount.mockResolvedValueOnce(4);
+        albumFindMany.mockResolvedValueOnce([]);
+
+        const result = await listMetadataGap("missing-mbid", {
+            limit: 50,
+            offset: 0,
+        });
+
+        expect(artistCount).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                AND: expect.arrayContaining([
+                    { mbid: { startsWith: "temp-" } },
+                    { NOT: { mbid: { startsWith: "temp-remote-" } } },
+                ]),
+            }),
+        });
+        expect(albumCount).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                AND: expect.arrayContaining([
+                    { rgMbid: { startsWith: "temp-" } },
+                    { NOT: { rgMbid: { startsWith: "remote:" } } },
+                ]),
+            }),
+        });
+        expect(result.counts).toEqual({ artists: 3, albums: 4 });
+    });
+
+    it("treats absent lyrics and negative-cache rows as missing", async () => {
+        trackCount.mockResolvedValueOnce(2);
+        trackFindMany.mockResolvedValueOnce([]);
+
+        await listMetadataGap("missing-lyrics", { limit: 20, offset: 0 });
+
+        expect(trackCount).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                origin: "LOCAL",
+                removedAt: null,
+                OR: [{ lyrics: null }, { lyrics: { source: "none" } }],
+            }),
+        });
+    });
+
+    it("returns all gap counts for the summary", async () => {
+        albumCount.mockResolvedValueOnce(2).mockResolvedValueOnce(4);
+        artistCount.mockResolvedValueOnce(1).mockResolvedValueOnce(3);
+        trackCount.mockResolvedValueOnce(5).mockResolvedValueOnce(6);
+
+        await expect(getMetadataGapSummary()).resolves.toEqual({
+            missingArt: { albums: 2, artists: 1 },
+            missingMbid: { albums: 4, artists: 3 },
+            missingGenres: 5,
+            missingLyrics: 6,
+        });
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/__tests__/qualityOutliers.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/qualityOutliers.test.ts
@@ -1,0 +1,57 @@
+const findMany = jest.fn();
+jest.mock("../../../utils/db", () => ({ prisma: { track: { findMany } } }));
+
+import {
+    getQualityOutliers,
+    loadLossyAlbumQualityStats,
+    LOSSY_AUDIO_MIMES,
+} from "../qualityOutliers";
+
+describe("library health quality outliers", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("uses supported lossy MIME types, ignores zero duration, and clamps pagination", async () => {
+        findMany.mockResolvedValueOnce([
+            {
+                fileSize: 4_000_000,
+                duration: 200,
+                album: {
+                    id: "al1",
+                    title: "Album",
+                    artist: { id: "a1", name: "Artist" },
+                },
+            },
+            {
+                fileSize: 9_000_000,
+                duration: 0,
+                album: {
+                    id: "al1",
+                    title: "Album",
+                    artist: { id: "a1", name: "Artist" },
+                },
+            },
+        ]);
+
+        const stats = await loadLossyAlbumQualityStats();
+        const result = getQualityOutliers(stats, 192, {
+            limit: 200,
+            offset: -4,
+        });
+
+        expect(findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    mime: { in: [...LOSSY_AUDIO_MIMES] },
+                }),
+            }),
+        );
+        expect(result).toEqual(
+            expect.objectContaining({
+                limit: 100,
+                offset: 0,
+                total: 1,
+                items: [expect.objectContaining({ averageBitrateKbps: 160 })],
+            }),
+        );
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/__tests__/storageAnalytics.test.ts
+++ b/backend/src/services/libraryHealthDashboard/__tests__/storageAnalytics.test.ts
@@ -1,0 +1,56 @@
+const groupBy = jest.fn();
+const findMany = jest.fn();
+jest.mock("../../../utils/db", () => ({
+    prisma: { track: { groupBy, findMany } },
+}));
+
+import { deriveBitrateKbps, loadStorageAnalytics } from "../storageAnalytics";
+
+describe("library health storage analytics", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it.each([0, null])("guards duration %s", (duration) => {
+        expect(deriveBitrateKbps(8_000_000, duration)).toBeNull();
+    });
+
+    it("groups formats and ranks artists", async () => {
+        groupBy.mockResolvedValueOnce([
+            {
+                mime: "audio/mpeg",
+                _count: { _all: 2 },
+                _sum: { fileSize: 16_000_000 },
+            },
+        ]);
+        findMany.mockResolvedValueOnce([
+            {
+                mime: "audio/mpeg",
+                fileSize: 8_000_000,
+                duration: 320,
+                album: { artist: { id: "a1", name: "Artist" } },
+            },
+            {
+                mime: "audio/mpeg",
+                fileSize: 8_000_000,
+                duration: 0,
+                album: { artist: { id: "a1", name: "Artist" } },
+            },
+        ]);
+
+        const result = await loadStorageAnalytics();
+
+        expect(result.formats[0]).toEqual(
+            expect.objectContaining({
+                trackCount: 2,
+                totalFileSize: 16_000_000,
+                averageBitrateKbps: 200,
+                bitrateSampleSize: 1,
+            }),
+        );
+        expect(result.topArtists[0]).toEqual({
+            artistId: "a1",
+            artistName: "Artist",
+            trackCount: 2,
+            totalFileSize: 16_000_000,
+        });
+    });
+});

--- a/backend/src/services/libraryHealthDashboard/analysisCoverage.ts
+++ b/backend/src/services/libraryHealthDashboard/analysisCoverage.ts
@@ -1,0 +1,127 @@
+import { prisma } from "../../utils/db";
+import {
+    normalizePagination,
+    type LibraryHealthPagination,
+} from "./pagination";
+import { VISIBLE_LOCAL_TRACK_WHERE } from "./predicates";
+
+/** Analysis lifecycle values written by the enrichment and vibe workers. */
+export const ANALYSIS_STATUS_VALUES = [
+    "pending",
+    "processing",
+    "failed",
+    "completed",
+] as const;
+type AnalysisStatus = (typeof ANALYSIS_STATUS_VALUES)[number];
+type StatusCounts = Record<AnalysisStatus, number>;
+
+function emptyStatusCounts(): StatusCounts {
+    return { pending: 0, processing: 0, failed: 0, completed: 0 };
+}
+
+function analysisCounts(
+    rows: Array<{ analysisStatus: string; _count: number }>,
+): StatusCounts {
+    const counts = emptyStatusCounts();
+    for (const row of rows) {
+        if (
+            ANALYSIS_STATUS_VALUES.includes(
+                row.analysisStatus as AnalysisStatus,
+            )
+        ) {
+            counts[row.analysisStatus as AnalysisStatus] += row._count;
+        }
+    }
+    return counts;
+}
+
+function vibeCounts(
+    rows: Array<{ vibeAnalysisStatus: string | null; _count: number }>,
+): StatusCounts {
+    const counts = emptyStatusCounts();
+    for (const row of rows) {
+        const status = row.vibeAnalysisStatus ?? "pending";
+        if (ANALYSIS_STATUS_VALUES.includes(status as AnalysisStatus)) {
+            counts[status as AnalysisStatus] += row._count;
+        }
+    }
+    return counts;
+}
+
+/** Returns aggregate status and loudness coverage for visible local tracks. */
+export async function getAnalysisCoverageSummary() {
+    const [analysisRows, vibeRows, measured, missing] = await Promise.all([
+        prisma.track.groupBy({
+            by: ["analysisStatus"],
+            where: VISIBLE_LOCAL_TRACK_WHERE,
+            _count: true,
+        }),
+        prisma.track.groupBy({
+            by: ["vibeAnalysisStatus"],
+            where: VISIBLE_LOCAL_TRACK_WHERE,
+            _count: true,
+        }),
+        prisma.track.count({
+            where: {
+                ...VISIBLE_LOCAL_TRACK_WHERE,
+                loudnessLufs: { not: null },
+                truePeakDb: { not: null },
+            },
+        }),
+        prisma.track.count({
+            where: {
+                ...VISIBLE_LOCAL_TRACK_WHERE,
+                OR: [{ loudnessLufs: null }, { truePeakDb: null }],
+            },
+        }),
+    ]);
+    const statuses = analysisCounts(analysisRows);
+    return {
+        total: Object.values(statuses).reduce((sum, value) => sum + value, 0),
+        analysisStatus: statuses,
+        vibeAnalysisStatus: vibeCounts(vibeRows),
+        loudness: { measured, missing },
+    };
+}
+
+async function listAnalysisFailures(pagination: LibraryHealthPagination) {
+    const page = normalizePagination(pagination);
+    const where = {
+        ...VISIBLE_LOCAL_TRACK_WHERE,
+        analysisStatus: "failed",
+    } as const;
+    const [total, rows] = await Promise.all([
+        prisma.track.count({ where }),
+        prisma.track.findMany({
+            where,
+            select: {
+                id: true,
+                title: true,
+                analysisError: true,
+                album: {
+                    select: { title: true, artist: { select: { name: true } } },
+                },
+            },
+            orderBy: [{ title: "asc" }, { id: "asc" }],
+            take: page.limit,
+            skip: page.offset,
+        }),
+    ]);
+    const items = rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        artistName: row.album.artist.name,
+        albumTitle: row.album.title,
+        analysisError: row.analysisError,
+    }));
+    return { items, total, ...page };
+}
+
+/** Returns analysis coverage plus a bounded audio-analysis failure page. */
+export async function getAnalysisCoverage(pagination: LibraryHealthPagination) {
+    const [summary, failed] = await Promise.all([
+        getAnalysisCoverageSummary(),
+        listAnalysisFailures(pagination),
+    ]);
+    return { ...summary, failed };
+}

--- a/backend/src/services/libraryHealthDashboard/cache.ts
+++ b/backend/src/services/libraryHealthDashboard/cache.ts
@@ -1,0 +1,82 @@
+import { recordLibraryHealthCacheResult } from "../../metrics";
+import type { LibraryHealthCachePanel } from "../../metrics/libraryHealthMetrics";
+import { logger } from "../../utils/logger";
+import { redisClient } from "../../utils/redis";
+import { coalesceInFlightByKey } from "../../utils/singleflight";
+
+const log = logger.child("LibraryHealthDashboard");
+const CACHE_TTL_SECONDS = 15 * 60;
+const inFlight = new Map<string, Promise<unknown>>();
+
+/** Complete versioned key set; refresh invalidation deletes only these keys. */
+export const LIBRARY_HEALTH_CACHE_KEYS = {
+    summary: "library-health:v1:summary",
+    storage: "library-health:v1:storage",
+    quality: "library-health:v1:quality",
+    duplicates: "library-health:v1:duplicates",
+} as const satisfies Record<LibraryHealthCachePanel, string>;
+
+async function readCachedPanel(panel: LibraryHealthCachePanel) {
+    try {
+        const value = await redisClient.get(LIBRARY_HEALTH_CACHE_KEYS[panel]);
+        if (value === null) {
+            recordLibraryHealthCacheResult(panel, "miss");
+            return undefined;
+        }
+        const parsed: unknown = JSON.parse(value);
+        recordLibraryHealthCacheResult(panel, "hit");
+        return parsed;
+    } catch (error) {
+        recordLibraryHealthCacheResult(panel, "error");
+        log.warn("Library Health cache read failed", { panel, error });
+        return undefined;
+    }
+}
+
+async function writeCachedPanel(
+    panel: LibraryHealthCachePanel,
+    value: unknown,
+): Promise<void> {
+    try {
+        await redisClient.setEx(
+            LIBRARY_HEALTH_CACHE_KEYS[panel],
+            CACHE_TTL_SECONDS,
+            JSON.stringify(value),
+        );
+    } catch (error) {
+        recordLibraryHealthCacheResult(panel, "error");
+        log.warn("Library Health cache write failed", { panel, error });
+    }
+}
+
+async function loadCachedPanel(
+    panel: LibraryHealthCachePanel,
+    loader: () => Promise<unknown>,
+): Promise<unknown> {
+    const cached = await readCachedPanel(panel);
+    if (cached !== undefined) return cached;
+    const value = await loader();
+    await writeCachedPanel(panel, value);
+    return value;
+}
+
+/** Reads or fills one panel cache while coalescing concurrent process-local fills. */
+export function getCachedLibraryHealthPanel<T>(
+    panel: LibraryHealthCachePanel,
+    loader: () => Promise<T>,
+): Promise<T> {
+    return coalesceInFlightByKey(
+        inFlight,
+        LIBRARY_HEALTH_CACHE_KEYS[panel],
+        () => loadCachedPanel(panel, loader),
+    ) as Promise<T>;
+}
+
+/** Deletes every known Library Health dashboard cache key. */
+export async function invalidateLibraryHealthDashboardCache(): Promise<void> {
+    try {
+        await redisClient.del(Object.values(LIBRARY_HEALTH_CACHE_KEYS));
+    } catch (error) {
+        log.warn("Library Health cache invalidation failed", { error });
+    }
+}

--- a/backend/src/services/libraryHealthDashboard/duplicateClusters.ts
+++ b/backend/src/services/libraryHealthDashboard/duplicateClusters.ts
@@ -1,0 +1,221 @@
+import { prisma } from "../../utils/db";
+import type { TrackIdentityTier } from "../trackIdentityMatcher";
+import {
+    normalizePagination,
+    type LibraryHealthPagination,
+} from "./pagination";
+import { VISIBLE_LOCAL_TRACK_WHERE } from "./predicates";
+
+/** Duplicate tiers reused from the durable track identity matcher. */
+export type DuplicateClusterTier = Extract<
+    TrackIdentityTier,
+    "audioHash" | "recordingMbid" | "isrc"
+>;
+
+const DUPLICATE_CLUSTER_KEY_LIMIT = 10_000;
+const DUPLICATE_MEMBER_LIMIT = 100_000;
+
+interface DuplicateTrackRow {
+    id: string;
+    title: string;
+    filePath: string | null;
+    fileSize: number;
+    mime: string | null;
+    audioHash: string | null;
+    recordingMbid: string | null;
+    isrc: string | null;
+    album: { title: string; artist: { name: string } };
+}
+
+export interface DuplicateCluster {
+    tier: DuplicateClusterTier;
+    identity: string;
+    memberCount: number;
+    totalFileSize: number;
+    members: Array<{
+        id: string;
+        title: string;
+        albumTitle: string;
+        artistName: string;
+        filePath: string | null;
+        fileSize: number;
+        mime: string | null;
+    }>;
+}
+
+export interface DuplicateClusterCatalog {
+    clusters: DuplicateCluster[];
+    total: number;
+    byTier: Record<DuplicateClusterTier, number>;
+    isTruncated: boolean;
+}
+
+function clusterMember(row: DuplicateTrackRow) {
+    return {
+        id: row.id,
+        title: row.title,
+        albumTitle: row.album.title,
+        artistName: row.album.artist.name,
+        filePath: row.filePath,
+        fileSize: row.fileSize,
+        mime: row.mime,
+    };
+}
+
+function addTierClusters(
+    rows: readonly DuplicateTrackRow[],
+    tier: DuplicateClusterTier,
+    keys: ReadonlySet<string>,
+    claimed: Set<string>,
+): DuplicateCluster[] {
+    const groups = new Map<string, DuplicateTrackRow[]>();
+    for (const row of rows) {
+        const identity = row[tier];
+        if (!identity || !keys.has(identity) || claimed.has(row.id)) continue;
+        const members = groups.get(identity) ?? [];
+        members.push(row);
+        groups.set(identity, members);
+    }
+    const clusters: DuplicateCluster[] = [];
+    for (const [identity, members] of groups) {
+        if (members.length < 2) continue;
+        members.forEach((member) => claimed.add(member.id));
+        clusters.push({
+            tier,
+            identity,
+            memberCount: members.length,
+            totalFileSize: members.reduce(
+                (sum, member) => sum + member.fileSize,
+                0,
+            ),
+            members: members.map(clusterMember),
+        });
+    }
+    return clusters.sort((left, right) =>
+        left.identity.localeCompare(right.identity),
+    );
+}
+
+async function loadDuplicateKeys() {
+    return Promise.all([
+        prisma.track.groupBy({
+            by: ["audioHash"],
+            where: { ...VISIBLE_LOCAL_TRACK_WHERE, audioHash: { not: null } },
+            _count: { _all: true },
+            having: { audioHash: { _count: { gt: 1 } } },
+            orderBy: { audioHash: "asc" },
+            take: DUPLICATE_CLUSTER_KEY_LIMIT + 1,
+        }),
+        prisma.track.groupBy({
+            by: ["recordingMbid"],
+            where: {
+                ...VISIBLE_LOCAL_TRACK_WHERE,
+                recordingMbid: { not: null },
+            },
+            _count: { _all: true },
+            having: { recordingMbid: { _count: { gt: 1 } } },
+            orderBy: { recordingMbid: "asc" },
+            take: DUPLICATE_CLUSTER_KEY_LIMIT + 1,
+        }),
+        prisma.track.groupBy({
+            by: ["isrc"],
+            where: { ...VISIBLE_LOCAL_TRACK_WHERE, isrc: { not: null } },
+            _count: { _all: true },
+            having: { isrc: { _count: { gt: 1 } } },
+            orderBy: { isrc: "asc" },
+            take: DUPLICATE_CLUSTER_KEY_LIMIT + 1,
+        }),
+    ]);
+}
+
+function keySet(values: ReadonlyArray<string | null>): Set<string> {
+    return new Set(
+        values
+            .slice(0, DUPLICATE_CLUSTER_KEY_LIMIT)
+            .filter((value): value is string => typeof value === "string"),
+    );
+}
+
+async function loadDuplicateMembers(
+    audioHashes: ReadonlySet<string>,
+    recordingMbids: ReadonlySet<string>,
+    isrcs: ReadonlySet<string>,
+) {
+    const or = [
+        audioHashes.size > 0 ? { audioHash: { in: [...audioHashes] } } : null,
+        recordingMbids.size > 0
+            ? { recordingMbid: { in: [...recordingMbids] } }
+            : null,
+        isrcs.size > 0 ? { isrc: { in: [...isrcs] } } : null,
+    ].filter((value): value is NonNullable<typeof value> => value !== null);
+    if (or.length === 0) return [];
+    return prisma.track.findMany({
+        where: { ...VISIBLE_LOCAL_TRACK_WHERE, OR: or },
+        select: {
+            id: true,
+            title: true,
+            filePath: true,
+            fileSize: true,
+            mime: true,
+            audioHash: true,
+            recordingMbid: true,
+            isrc: true,
+            album: {
+                select: { title: true, artist: { select: { name: true } } },
+            },
+        },
+        orderBy: { id: "asc" },
+        take: DUPLICATE_MEMBER_LIMIT + 1,
+    });
+}
+
+/** Loads bounded duplicate clusters with strict highest-tier precedence. */
+export async function loadDuplicateClusterCatalog(): Promise<DuplicateClusterCatalog> {
+    const [audioRows, recordingRows, isrcRows] = await loadDuplicateKeys();
+    const audioHashes = keySet(audioRows.map((row) => row.audioHash));
+    const recordingMbids = keySet(
+        recordingRows.map((row) => row.recordingMbid),
+    );
+    const isrcs = keySet(isrcRows.map((row) => row.isrc));
+    const loadedMembers = await loadDuplicateMembers(
+        audioHashes,
+        recordingMbids,
+        isrcs,
+    );
+    const members = loadedMembers.slice(0, DUPLICATE_MEMBER_LIMIT);
+    const claimed = new Set<string>();
+    const clusters = [
+        ...addTierClusters(members, "audioHash", audioHashes, claimed),
+        ...addTierClusters(members, "recordingMbid", recordingMbids, claimed),
+        ...addTierClusters(members, "isrc", isrcs, claimed),
+    ];
+    const byTier = { audioHash: 0, recordingMbid: 0, isrc: 0 };
+    clusters.forEach((cluster) => {
+        byTier[cluster.tier] += 1;
+    });
+    return {
+        clusters,
+        total: clusters.length,
+        byTier,
+        isTruncated:
+            loadedMembers.length > DUPLICATE_MEMBER_LIMIT ||
+            [audioRows, recordingRows, isrcRows].some(
+                (rows) => rows.length > DUPLICATE_CLUSTER_KEY_LIMIT,
+            ),
+    };
+}
+
+/** Returns one bounded duplicate-cluster page from the cached catalog. */
+export function listDuplicateClusters(
+    catalog: DuplicateClusterCatalog,
+    pagination: LibraryHealthPagination,
+) {
+    const page = normalizePagination(pagination, 50);
+    return {
+        clusters: catalog.clusters.slice(page.offset, page.offset + page.limit),
+        total: catalog.total,
+        byTier: catalog.byTier,
+        isTruncated: catalog.isTruncated,
+        ...page,
+    };
+}

--- a/backend/src/services/libraryHealthDashboard/index.ts
+++ b/backend/src/services/libraryHealthDashboard/index.ts
@@ -1,0 +1,110 @@
+import {
+    getAnalysisCoverage,
+    getAnalysisCoverageSummary,
+} from "./analysisCoverage";
+import {
+    getCachedLibraryHealthPanel,
+    invalidateLibraryHealthDashboardCache,
+} from "./cache";
+import {
+    listDuplicateClusters,
+    loadDuplicateClusterCatalog,
+} from "./duplicateClusters";
+import {
+    getMetadataGapSummary,
+    listMetadataGap,
+    type MetadataGapKind,
+} from "./metadataGaps";
+import type { LibraryHealthPagination } from "./pagination";
+import {
+    getQualityOutliers,
+    loadLossyAlbumQualityStats,
+} from "./qualityOutliers";
+import { loadStorageAnalytics } from "./storageAnalytics";
+
+export { invalidateLibraryHealthDashboardCache } from "./cache";
+export { METADATA_GAP_KINDS, type MetadataGapKind } from "./metadataGaps";
+
+/** Returns one metadata gap page. */
+export function getLibraryHealthMetadataGaps(
+    kind: MetadataGapKind,
+    pagination: LibraryHealthPagination,
+) {
+    return listMetadataGap(kind, pagination);
+}
+
+/** Returns analysis counts plus one failure page. */
+export function getLibraryHealthAnalysis(pagination: LibraryHealthPagination) {
+    return getAnalysisCoverage(pagination);
+}
+
+/** Returns cached storage analytics. */
+export function getLibraryHealthStorage() {
+    return getCachedLibraryHealthPanel("storage", loadStorageAnalytics);
+}
+
+/** Returns cached lossy album statistics filtered by the requested floor. */
+export async function getLibraryHealthQuality(
+    floorKbps: number,
+    pagination: LibraryHealthPagination,
+) {
+    const stats = await getCachedLibraryHealthPanel(
+        "quality",
+        loadLossyAlbumQualityStats,
+    );
+    return getQualityOutliers(stats, floorKbps, pagination);
+}
+
+/** Returns one page from the cached duplicate-cluster catalog. */
+export async function getLibraryHealthDuplicates(
+    pagination: LibraryHealthPagination,
+) {
+    const catalog = await getCachedLibraryHealthPanel(
+        "duplicates",
+        loadDuplicateClusterCatalog,
+    );
+    return listDuplicateClusters(catalog, pagination);
+}
+
+async function loadSummary() {
+    const [metadataGaps, analysisCoverage, storage, quality, duplicates] =
+        await Promise.all([
+            getMetadataGapSummary(),
+            getAnalysisCoverageSummary(),
+            getLibraryHealthStorage(),
+            getLibraryHealthQuality(192, { limit: 1, offset: 0 }),
+            getLibraryHealthDuplicates({ limit: 1, offset: 0 }),
+        ]);
+    return {
+        metadataGaps,
+        analysisCoverage,
+        storage: {
+            tracks: storage.formats.reduce(
+                (sum, row) => sum + row.trackCount,
+                0,
+            ),
+            totalFileSize: storage.formats.reduce(
+                (sum, row) => sum + row.totalFileSize,
+                0,
+            ),
+            mimeTypes: storage.formats.length,
+            artists: storage.topArtists.length,
+            isTruncated: storage.isTruncated,
+        },
+        quality: {
+            floorKbps: quality.floorKbps,
+            albumsBelowFloor: quality.total,
+            isTruncated: quality.isTruncated,
+        },
+        duplicates: {
+            clusters: duplicates.total,
+            byTier: duplicates.byTier,
+            isTruncated: duplicates.isTruncated,
+        },
+    };
+}
+
+/** Returns every dashboard panel count in one cached payload. */
+export function getLibraryHealthDashboardSummary() {
+    return getCachedLibraryHealthPanel("summary", loadSummary);
+}

--- a/backend/src/services/libraryHealthDashboard/metadataGaps.ts
+++ b/backend/src/services/libraryHealthDashboard/metadataGaps.ts
@@ -1,0 +1,165 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../../utils/db";
+import {
+    normalizePagination,
+    type LibraryHealthPagination,
+} from "./pagination";
+import { VISIBLE_LOCAL_TRACK_WHERE } from "./predicates";
+
+/** Metadata gap names exposed by the admin API. */
+export const METADATA_GAP_KINDS = [
+    "missing-art",
+    "missing-mbid",
+    "missing-genres",
+    "missing-lyrics",
+] as const;
+export type MetadataGapKind = (typeof METADATA_GAP_KINDS)[number];
+
+const MISSING_ART_ALBUM_WHERE = {
+    location: "LIBRARY",
+    coverUrl: null,
+    userCoverUrl: null,
+} satisfies Prisma.AlbumWhereInput;
+const MISSING_ART_ARTIST_WHERE = {
+    heroUrl: null,
+    userHeroUrl: null,
+    albums: { some: { location: "LIBRARY" } },
+} satisfies Prisma.ArtistWhereInput;
+const MISSING_MBID_ARTIST_WHERE = {
+    albums: { some: { location: "LIBRARY" } },
+    AND: [
+        { mbid: { startsWith: "temp-" } },
+        { NOT: { mbid: { startsWith: "temp-remote-" } } },
+    ],
+} satisfies Prisma.ArtistWhereInput;
+const MISSING_MBID_ALBUM_WHERE = {
+    location: "LIBRARY",
+    AND: [
+        { rgMbid: { startsWith: "temp-" } },
+        { NOT: { rgMbid: { startsWith: "remote:" } } },
+    ],
+} satisfies Prisma.AlbumWhereInput;
+const MISSING_GENRES_WHERE = {
+    ...VISIBLE_LOCAL_TRACK_WHERE,
+    essentiaGenres: { isEmpty: true },
+    trackGenres: { none: {} },
+} satisfies Prisma.TrackWhereInput;
+const MISSING_LYRICS_WHERE = {
+    ...VISIBLE_LOCAL_TRACK_WHERE,
+    OR: [{ lyrics: null }, { lyrics: { source: "none" } }],
+} satisfies Prisma.TrackWhereInput;
+
+const ALBUM_SELECT = {
+    id: true,
+    title: true,
+    rgMbid: true,
+    coverUrl: true,
+    userCoverUrl: true,
+    artist: { select: { id: true, name: true } },
+} as const;
+const TRACK_SELECT = {
+    id: true,
+    title: true,
+    filePath: true,
+    album: { select: { title: true, artist: { select: { name: true } } } },
+} as const;
+
+/** Returns all dashboard metadata-gap counts without drill-down rows. */
+export async function getMetadataGapSummary() {
+    const [artAlbums, artArtists, mbidAlbums, mbidArtists, genres, lyrics] =
+        await Promise.all([
+            prisma.album.count({ where: MISSING_ART_ALBUM_WHERE }),
+            prisma.artist.count({ where: MISSING_ART_ARTIST_WHERE }),
+            prisma.album.count({ where: MISSING_MBID_ALBUM_WHERE }),
+            prisma.artist.count({ where: MISSING_MBID_ARTIST_WHERE }),
+            prisma.track.count({ where: MISSING_GENRES_WHERE }),
+            prisma.track.count({ where: MISSING_LYRICS_WHERE }),
+        ]);
+    return {
+        missingArt: { albums: artAlbums, artists: artArtists },
+        missingMbid: { albums: mbidAlbums, artists: mbidArtists },
+        missingGenres: genres,
+        missingLyrics: lyrics,
+    };
+}
+
+async function listAlbumGap(
+    kind: "missing-art" | "missing-mbid",
+    where: Prisma.AlbumWhereInput,
+    artistWhere: Prisma.ArtistWhereInput,
+    pagination: LibraryHealthPagination,
+) {
+    const page = normalizePagination(pagination);
+    const [artists, albums, items] = await Promise.all([
+        prisma.artist.count({ where: artistWhere }),
+        prisma.album.count({ where }),
+        prisma.album.findMany({
+            where,
+            select: ALBUM_SELECT,
+            orderBy: [{ title: "asc" }, { id: "asc" }],
+            take: page.limit,
+            skip: page.offset,
+        }),
+    ]);
+    return {
+        kind,
+        counts: { artists, albums },
+        items,
+        total: albums,
+        ...page,
+    };
+}
+
+async function listTrackGap(
+    kind: "missing-genres" | "missing-lyrics",
+    where: Prisma.TrackWhereInput,
+    pagination: LibraryHealthPagination,
+) {
+    const page = normalizePagination(pagination);
+    const [total, rows] = await Promise.all([
+        prisma.track.count({ where }),
+        prisma.track.findMany({
+            where,
+            select: TRACK_SELECT,
+            orderBy: [{ title: "asc" }, { id: "asc" }],
+            take: page.limit,
+            skip: page.offset,
+        }),
+    ]);
+    const items = rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        filePath: row.filePath,
+        albumTitle: row.album.title,
+        artistName: row.album.artist.name,
+    }));
+    return { kind, counts: { tracks: total }, items, total, ...page };
+}
+
+/** Returns one bounded metadata-gap drill-down page. */
+export function listMetadataGap(
+    kind: MetadataGapKind,
+    pagination: LibraryHealthPagination,
+) {
+    if (kind === "missing-art") {
+        return listAlbumGap(
+            kind,
+            MISSING_ART_ALBUM_WHERE,
+            MISSING_ART_ARTIST_WHERE,
+            pagination,
+        );
+    }
+    if (kind === "missing-mbid") {
+        return listAlbumGap(
+            kind,
+            MISSING_MBID_ALBUM_WHERE,
+            MISSING_MBID_ARTIST_WHERE,
+            pagination,
+        );
+    }
+    return listTrackGap(
+        kind,
+        kind === "missing-genres" ? MISSING_GENRES_WHERE : MISSING_LYRICS_WHERE,
+        pagination,
+    );
+}

--- a/backend/src/services/libraryHealthDashboard/pagination.ts
+++ b/backend/src/services/libraryHealthDashboard/pagination.ts
@@ -1,0 +1,19 @@
+/** Offset pagination accepted by Library Health read models. */
+export interface LibraryHealthPagination {
+    limit: number;
+    offset: number;
+}
+
+/** Clamps service-level pagination so non-HTTP callers remain bounded. */
+export function normalizePagination(
+    pagination: LibraryHealthPagination,
+    maximumLimit = 100,
+): LibraryHealthPagination {
+    const limit = Number.isSafeInteger(pagination.limit)
+        ? Math.min(maximumLimit, Math.max(1, pagination.limit))
+        : Math.min(50, maximumLimit);
+    const offset = Number.isSafeInteger(pagination.offset)
+        ? Math.max(0, pagination.offset)
+        : 0;
+    return { limit, offset };
+}

--- a/backend/src/services/libraryHealthDashboard/predicates.ts
+++ b/backend/src/services/libraryHealthDashboard/predicates.ts
@@ -1,0 +1,11 @@
+import type { Prisma } from "@prisma/client";
+import {
+    LOCAL_TRACK_WHERE,
+    TRACK_VISIBLE_WHERE,
+} from "../../utils/librarySorting";
+
+/** Active tracks physically owned by this soundspan instance. */
+export const VISIBLE_LOCAL_TRACK_WHERE = {
+    ...TRACK_VISIBLE_WHERE,
+    ...LOCAL_TRACK_WHERE,
+} satisfies Prisma.TrackWhereInput;

--- a/backend/src/services/libraryHealthDashboard/qualityOutliers.ts
+++ b/backend/src/services/libraryHealthDashboard/qualityOutliers.ts
@@ -1,0 +1,126 @@
+import { prisma } from "../../utils/db";
+import {
+    normalizePagination,
+    type LibraryHealthPagination,
+} from "./pagination";
+import { VISIBLE_LOCAL_TRACK_WHERE } from "./predicates";
+import {
+    deriveBitrateKbps,
+    LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT,
+} from "./storageAnalytics";
+
+/** Lossy MIME values defined by the repository audio-streaming MIME map. */
+export const LOSSY_AUDIO_MIMES = [
+    "audio/mpeg",
+    "audio/mp4",
+    "audio/aac",
+    "audio/ogg",
+    "audio/opus",
+] as const;
+
+export interface LossyAlbumQuality {
+    albumId: string;
+    title: string;
+    artist: { id: string; name: string };
+    averageBitrateKbps: number;
+    trackCount: number;
+}
+
+export interface LossyAlbumQualityStats {
+    albums: LossyAlbumQuality[];
+    sampledTracks: number;
+    sampleLimit: number;
+    isTruncated: boolean;
+}
+
+function reduceAlbumQuality(
+    rows: Array<{
+        fileSize: number;
+        duration: number | null;
+        album: {
+            id: string;
+            title: string;
+            artist: { id: string; name: string };
+        };
+    }>,
+): LossyAlbumQuality[] {
+    const grouped = new Map<
+        string,
+        { album: (typeof rows)[number]["album"]; sum: number; count: number }
+    >();
+    for (const row of rows) {
+        const bitrate = deriveBitrateKbps(row.fileSize, row.duration);
+        if (bitrate === null) continue;
+        const current = grouped.get(row.album.id) ?? {
+            album: row.album,
+            sum: 0,
+            count: 0,
+        };
+        current.sum += bitrate;
+        current.count += 1;
+        grouped.set(row.album.id, current);
+    }
+    return [...grouped.values()].map(({ album, sum, count }) => ({
+        albumId: album.id,
+        title: album.title,
+        artist: album.artist,
+        averageBitrateKbps: Math.round((sum / count) * 10) / 10,
+        trackCount: count,
+    }));
+}
+
+/** Loads bounded per-album bitrate statistics for lossy local tracks. */
+export async function loadLossyAlbumQualityStats(): Promise<LossyAlbumQualityStats> {
+    const loadedRows = await prisma.track.findMany({
+        where: {
+            ...VISIBLE_LOCAL_TRACK_WHERE,
+            mime: { in: [...LOSSY_AUDIO_MIMES] },
+        },
+        select: {
+            fileSize: true,
+            duration: true,
+            album: {
+                select: {
+                    id: true,
+                    title: true,
+                    artist: { select: { id: true, name: true } },
+                },
+            },
+        },
+        orderBy: { id: "asc" },
+        take: LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT + 1,
+    });
+    const isTruncated = loadedRows.length > LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT;
+    const rows = loadedRows.slice(0, LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT);
+    return {
+        albums: reduceAlbumQuality(rows),
+        sampledTracks: rows.length,
+        sampleLimit: LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT,
+        isTruncated,
+    };
+}
+
+/** Filters and paginates cached per-album lossy bitrate statistics. */
+export function getQualityOutliers(
+    stats: LossyAlbumQualityStats,
+    floorKbps: number,
+    pagination: LibraryHealthPagination,
+) {
+    const page = normalizePagination(pagination);
+    const outliers = stats.albums
+        .filter((album) => album.averageBitrateKbps < floorKbps)
+        .sort(
+            (left, right) =>
+                left.averageBitrateKbps - right.averageBitrateKbps ||
+                left.title.localeCompare(right.title),
+        );
+    return {
+        floorKbps,
+        items: outliers.slice(page.offset, page.offset + page.limit),
+        total: outliers.length,
+        ...page,
+        sampledTracks: stats.sampledTracks,
+        sampleLimit: stats.sampleLimit,
+        isTruncated: stats.isTruncated,
+    };
+}

--- a/backend/src/services/libraryHealthDashboard/storageAnalytics.ts
+++ b/backend/src/services/libraryHealthDashboard/storageAnalytics.ts
@@ -1,0 +1,116 @@
+import { prisma } from "../../utils/db";
+import { VISIBLE_LOCAL_TRACK_WHERE } from "./predicates";
+
+/** Maximum tracks reduced in memory for ratios Prisma cannot aggregate. */
+export const LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT = 100_000;
+
+interface StorageTrackRow {
+    mime: string | null;
+    fileSize: number;
+    duration: number | null;
+    album: { artist: { id: string; name: string } };
+}
+
+/** Derives decimal kilobits per second, rejecting missing or invalid duration. */
+export function deriveBitrateKbps(
+    fileSize: number,
+    duration: number | null,
+): number | null {
+    if (!Number.isFinite(fileSize) || fileSize < 0) return null;
+    if (duration === null || !Number.isFinite(duration) || duration <= 0) {
+        return null;
+    }
+    return (fileSize * 8) / duration / 1_000;
+}
+
+function formatBitrateSamples(rows: readonly StorageTrackRow[]) {
+    const samples = new Map<string | null, { sum: number; count: number }>();
+    for (const row of rows) {
+        const bitrate = deriveBitrateKbps(row.fileSize, row.duration);
+        if (bitrate === null) continue;
+        const current = samples.get(row.mime) ?? { sum: 0, count: 0 };
+        current.sum += bitrate;
+        current.count += 1;
+        samples.set(row.mime, current);
+    }
+    return samples;
+}
+
+function topStorageArtists(rows: readonly StorageTrackRow[]) {
+    const artists = new Map<
+        string,
+        {
+            artistId: string;
+            artistName: string;
+            trackCount: number;
+            totalFileSize: number;
+        }
+    >();
+    for (const row of rows) {
+        const artist = row.album.artist;
+        const current = artists.get(artist.id) ?? {
+            artistId: artist.id,
+            artistName: artist.name,
+            trackCount: 0,
+            totalFileSize: 0,
+        };
+        current.trackCount += 1;
+        current.totalFileSize += row.fileSize;
+        artists.set(artist.id, current);
+    }
+    return [...artists.values()]
+        .sort(
+            (left, right) =>
+                right.totalFileSize - left.totalFileSize ||
+                left.artistName.localeCompare(right.artistName),
+        )
+        .slice(0, 25);
+}
+
+/** Loads MIME totals and bounded derived storage analytics. */
+export async function loadStorageAnalytics() {
+    const [groups, loadedRows] = await Promise.all([
+        prisma.track.groupBy({
+            by: ["mime"],
+            where: VISIBLE_LOCAL_TRACK_WHERE,
+            _count: { _all: true },
+            _sum: { fileSize: true },
+            orderBy: { mime: "asc" },
+        }),
+        prisma.track.findMany({
+            where: VISIBLE_LOCAL_TRACK_WHERE,
+            select: {
+                mime: true,
+                fileSize: true,
+                duration: true,
+                album: {
+                    select: { artist: { select: { id: true, name: true } } },
+                },
+            },
+            orderBy: { id: "asc" },
+            take: LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT + 1,
+        }),
+    ]);
+    const isTruncated = loadedRows.length > LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT;
+    const rows = loadedRows.slice(0, LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT);
+    const bitrateSamples = formatBitrateSamples(rows);
+    const formats = groups.map((group) => {
+        const sample = bitrateSamples.get(group.mime);
+        return {
+            mime: group.mime,
+            trackCount: group._count._all,
+            totalFileSize: group._sum.fileSize ?? 0,
+            averageBitrateKbps: sample
+                ? Math.round((sample.sum / sample.count) * 10) / 10
+                : null,
+            bitrateSampleSize: sample?.count ?? 0,
+        };
+    });
+    return {
+        formats,
+        topArtists: topStorageArtists(rows),
+        sampledTracks: rows.length,
+        sampleLimit: LIBRARY_HEALTH_TRACK_SAMPLE_LIMIT,
+        isTruncated,
+    };
+}

--- a/docs/FEATURE_INDEX.json
+++ b/docs/FEATURE_INDEX.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "id": "soundspan-feature-index",
-        "version": "2026-08-17.01",
+        "version": "2026-08-18.01",
         "description": "Machine-readable feature-to-code mapping for rapid codebase navigation and targeted verification.",
         "update_expectation": "When a feature is introduced, changed significantly, or removed, update impacted entries."
     },
@@ -102,6 +102,39 @@
                     "streamingRuntime.test.ts"
                 ],
                 "backend_contract": []
+            }
+        },
+        {
+            "id": "library-health-dashboard",
+            "name": "Library Health Dashboard",
+            "description": "Admin-only read model for metadata gaps, analysis coverage, duplicate clusters, storage use, and lossy quality outliers",
+            "frontend": {
+                "feature_dirs": [],
+                "routes": []
+            },
+            "backend": {
+                "routes": ["libraryHealthDashboard.ts"],
+                "services": [
+                    "libraryHealthDashboard/analysisCoverage.ts",
+                    "libraryHealthDashboard/cache.ts",
+                    "libraryHealthDashboard/duplicateClusters.ts",
+                    "libraryHealthDashboard/index.ts",
+                    "libraryHealthDashboard/metadataGaps.ts",
+                    "libraryHealthDashboard/qualityOutliers.ts",
+                    "libraryHealthDashboard/storageAnalytics.ts"
+                ]
+            },
+            "tests": {
+                "backend_route": ["libraryHealthDashboard.test.ts"],
+                "backend_contract": [
+                    "analysisCoverage.test.ts",
+                    "cache.test.ts",
+                    "duplicateClusters.test.ts",
+                    "libraryHealthMetrics.test.ts",
+                    "metadataGaps.test.ts",
+                    "qualityOutliers.test.ts",
+                    "storageAnalytics.test.ts"
+                ]
             }
         },
         {


### PR DESCRIPTION
Backend half of #532: the Library Health dashboard read model and admin API. The frontend dashboard is the follow-up PR.

## What

**Read-model service** (`backend/src/services/libraryHealthDashboard/` — ten focused modules, all strictly read-only):

- `metadataGaps` — counts + paginated drill-downs for missing cover art (album `coverUrl`+`userCoverUrl` both null; artist hero equivalent), missing MBIDs (the `temp-` placeholder convention, excluding `temp-remote-`/`remote:` synthetic IDs), missing genres (empty `essentiaGenres` and no `trackGenres`), and missing lyrics (no `TrackLyrics` row or the `source:"none"` negative-cache marker).
- `analysisCoverage` — audio analysis, vibe embedding, and loudness coverage over visible local tracks, with a paginated failed-track list (including `analysisError`). Legacy null vibe statuses count as pending, matching the eligibility semantics.
- `storageAnalytics` — per-MIME track counts, total bytes, and derived average bitrate (fileSize×8/duration, zero-duration guarded), plus top artists by storage. Prisma-inexpressible ratios use a deterministic bounded 100k-track reduction with an `isTruncated` flag.
- `qualityOutliers` — lossy albums below a derived-bitrate floor (query param, clamped 32..2000, default 192 kbps).
- `duplicateClusters` — report-only durable-identity clusters with strict tier precedence (`audioHash` exact duplicate → `recordingMbid` version cluster → `isrc`), reusing the `trackIdentityMatcher` tier vocabulary. A track claimed by a higher tier never reappears below. Bounded at 10k keys/tier and 100k members with N+1 truncation detection.
- `cache` — Redis, 15-minute TTL, fail-open (a Redis outage degrades to direct reads with a warning, never an error), process-local single-flight coalescing, explicit invalidation of the fixed key set. Cache results feed a new bounded counter: `soundspan_library_health_cache_total{panel, result}`.

**Route cluster** `backend/src/routes/libraryHealthDashboard.ts`, mounted at `/api/library-health` behind `adminSurfaceLimiter` + `requireAuth` + `requireAdmin`: `GET /summary`, `GET /gaps/:kind`, `GET /analysis`, `GET /storage`, `GET /quality`, `GET /duplicates`, `POST /refresh`. Strict zod on every query (unknown params rejected, pagination clamped), `asyncHandler` + canonical error helpers (zero new ad-hoc 500s), OpenAPI blocks throughout, and the mount-contract table updated.

## Safety posture

Read-only by construction: no schema changes, no migrations, no raw SQL, no Prisma writes anywhere in the new code (`/refresh` only deletes Redis keys). Duplicate clustering is suggest-only — no canonical/hide actions exist yet; when they come, they'll be reversible metadata per the issue's dedup-safety contract. All track queries are scoped to visible local tracks (`removedAt: null`, `origin: LOCAL`).

## Verification

- `npx tsc --noEmit`: exit 0.
- New suites + mount contract: `Test Suites: 8 passed, 8 total; Tests: 35 passed` (service unit tests cover tier precedence, temp-prefix exclusions, lyrics "none" semantics, bitrate zero-duration guards, cache hit/miss/error, pagination clamps; route tests cover 401/403, zod rejections, response shapes — supertest listen is sandbox-limited, CI arbitrates).
- `npm run format:check`, `npm run check:error-canon`, `node scripts/ci/check-file-size.mjs`: all pass.
- OpenAPI route-sync suite: 4/4.

Part of #532 (frontend dashboard + remediation links close it).
