### PR TITLE
feat(admin): Library Insights dashboard section (#532 frontend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Library Health dashboard read model and admin API (metadata gaps, analysis coverage, duplicate clusters, storage and quality analytics).
+- Library Insights section on the Admin page: browsable panels for metadata gaps, analysis coverage with retry actions, report-only duplicate clusters, storage breakdown, and low-bitrate album detection.
 
 ### Deprecated
 

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -21,6 +21,7 @@ const baseSidebarItems: SidebarItem[] = [
     { id: "storage", label: "Storage" },
     { id: "library-safety", label: "Library Safety" },
     { id: "library-health", label: "Library Health" },
+    { id: "library-insights", label: "Library Insights" },
     { id: "cache", label: "Cache & Automation" },
     { id: "users", label: "Users" },
 ];
@@ -93,6 +94,14 @@ const LibraryHealthSection = dynamic(
     () =>
         import("@/features/settings/components/sections/LibraryHealthSection").then(
             (mod) => mod.LibraryHealthSection,
+        ),
+    { loading: renderSectionFallback },
+);
+
+const LibraryInsightsSection = dynamic(
+    () =>
+        import("@/features/library-health/components/LibraryInsightsSection").then(
+            (mod) => mod.LibraryInsightsSection,
         ),
     { loading: renderSectionFallback },
 );
@@ -312,6 +321,8 @@ export default function AdminPage() {
                 />
 
                 <LibraryHealthSection />
+
+                <LibraryInsightsSection />
 
                 <CacheSection
                     settings={systemSettings}

--- a/frontend/features/README.md
+++ b/frontend/features/README.md
@@ -20,6 +20,7 @@ Start-here index for domain modules under `frontend/features`.
 | `explore`   | `frontend/features/explore/README.md`   | `frontend/app/explore/page.tsx`<br>`frontend/app/library/page.tsx`<br>`frontend/app/page.tsx`<br>`frontend/app/radio/page.tsx` |
 | `home`      | `frontend/features/home/README.md`      | `frontend/app/explore/page.tsx`<br>`frontend/app/library/page.tsx`<br>`frontend/app/page.tsx`<br>`frontend/app/radio/page.tsx` |
 | `library`   | `frontend/features/library/README.md`   | `frontend/app/explore/page.tsx`<br>`frontend/app/library/page.tsx`<br>`frontend/app/page.tsx`<br>`frontend/app/radio/page.tsx` |
+| `library-health` | `frontend/features/library-health/README.md` | `frontend/app/admin/page.tsx`                                                                                             |
 | `podcast`   | `frontend/features/podcast/README.md`   | `frontend/app/podcasts/page.tsx`                                                                                               |
 | `search`    | `frontend/features/search/README.md`    | `frontend/app/playlists/page.tsx`<br>`frontend/app/search/page.tsx`                                                            |
 | `settings`  | `frontend/features/settings/README.md`  | `frontend/app/device/page.tsx`<br>`frontend/app/settings/page.tsx`                                                             |

--- a/frontend/features/library-health/README.md
+++ b/frontend/features/library-health/README.md
@@ -1,0 +1,31 @@
+# library-health
+
+Library Insights dashboard (issue #532): admin-facing read-model panels for
+metadata gaps, analysis coverage, duplicate clusters, and storage/quality
+analytics. Rendered on the Admin page as the `library-insights` section; data
+comes from the admin-gated `/api/library-health` API via
+`frontend/lib/api/libraryHealth.ts`.
+
+## Directory Contents
+
+| Path                                    | Role                                                            |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `format.ts`                             | Pure display formatters (bytes, kbps, coverage percent)         |
+| `hooks/useLibraryInsights.ts`           | Summary load + cache-busting refresh                            |
+| `hooks/usePanelLoader.ts`               | Lazy drill-down loader with stale-response protection           |
+| `components/LibraryInsightsSection.tsx` | Section container composing the five panels                     |
+| `components/InsightPanel.tsx`           | Shared collapsible panel card (lazy fetch on first expand)      |
+| `components/MetadataGapsPanel.tsx`      | Art/MBID/genre/lyrics gap counts and tabbed drill-down          |
+| `components/AnalysisCoveragePanel.tsx`  | Analysis/vibe/loudness coverage plus retry remediation actions  |
+| `components/DuplicatesPanel.tsx`        | Report-only duplicate/version clusters (durable identity tiers) |
+| `components/StoragePanel.tsx`           | Per-format storage and largest artists                          |
+| `components/QualityPanel.tsx`           | Lossy albums below a selectable bitrate floor                   |
+
+## Targeted verification commands
+
+```bash
+cd frontend
+node --test --import tsx tests/unit/libraryHealthFormat.test.ts
+node --test --experimental-test-module-mocks --import tsx tests/component/libraryInsightsSection.component.test.ts
+npx tsc --noEmit
+```

--- a/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
+++ b/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { api, type LibraryHealthSummary } from "@/lib/api";
+import { enrichmentApi } from "@/lib/enrichmentApi";
+import { formatCoveragePercent } from "../format";
+import { usePanelLoader } from "../hooks/usePanelLoader";
+import { InsightPanel } from "./InsightPanel";
+
+interface AnalysisCoveragePanelProps {
+    coverage: LibraryHealthSummary["analysisCoverage"];
+}
+
+/** Analysis, vibe, and loudness coverage with retry actions for failures. */
+export function AnalysisCoveragePanel({
+    coverage,
+}: Readonly<AnalysisCoveragePanelProps>) {
+    const fetchPage = useCallback(
+        () => api.getLibraryHealthAnalysis({ limit: 50 }),
+        [],
+    );
+    const page = usePanelLoader(fetchPage, "Failed to load analysis coverage");
+    const [actionNotice, setActionNotice] = useState<string | null>(null);
+    const [isActing, setIsActing] = useState(false);
+
+    const runAction = (action: () => Promise<unknown>, done: string) => {
+        setIsActing(true);
+        setActionNotice(null);
+        void action()
+            .then(() => {
+                setActionNotice(done);
+                page.load();
+            })
+            .catch(() => {
+                setActionNotice("Action failed — check the server logs.");
+            })
+            .finally(() => {
+                setIsActing(false);
+            });
+    };
+
+    const analysisDone = coverage.analysisStatus.completed;
+    const vibeDone = coverage.vibeAnalysisStatus.completed;
+    const loudnessTotal =
+        coverage.loudness.measured + coverage.loudness.missing;
+
+    return (
+        <InsightPanel
+            title="Analysis coverage"
+            subtitle={`Audio ${formatCoveragePercent(analysisDone, coverage.total)} · Vibe ${formatCoveragePercent(vibeDone, coverage.total)} · Loudness ${formatCoveragePercent(coverage.loudness.measured, loudnessTotal)} · ${coverage.analysisStatus.failed} failed`}
+            onFirstExpand={page.load}
+            isLoading={page.isLoading}
+            error={page.error}
+        >
+            <div className="flex flex-wrap gap-2 mb-3">
+                <button
+                    type="button"
+                    disabled={isActing}
+                    onClick={() =>
+                        runAction(
+                            () => api.retryFailedAnalysis(),
+                            "Failed audio analysis re-queued.",
+                        )
+                    }
+                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-300 disabled:opacity-50"
+                >
+                    Retry failed audio analysis
+                </button>
+                <button
+                    type="button"
+                    disabled={isActing}
+                    onClick={() =>
+                        runAction(
+                            () => enrichmentApi.retryVibeEmbeddings(),
+                            "Failed vibe embeddings re-queued.",
+                        )
+                    }
+                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-300 disabled:opacity-50"
+                >
+                    Retry failed vibe embeddings
+                </button>
+            </div>
+            {actionNotice && (
+                <p className="text-xs text-gray-400 mb-2">{actionNotice}</p>
+            )}
+            {page.data && page.data.failed.items.length > 0 && (
+                <ul className="space-y-1">
+                    {page.data.failed.items.map((track) => (
+                        <li key={track.id} className="text-sm text-gray-300">
+                            <span className="truncate">{track.title}</span>
+                            <span className="text-gray-500">
+                                {" "}
+                                — {track.album.artist.name}
+                                {track.analysisError
+                                    ? ` · ${track.analysisError}`
+                                    : ""}
+                            </span>
+                        </li>
+                    ))}
+                    {page.data.failed.total > page.data.failed.items.length && (
+                        <li className="text-xs text-gray-500 pt-1">
+                            Showing {page.data.failed.items.length} of{" "}
+                            {page.data.failed.total} failed tracks.
+                        </li>
+                    )}
+                </ul>
+            )}
+            {page.data && page.data.failed.items.length === 0 && (
+                <p className="text-xs text-gray-500">
+                    No failed tracks. Pending tracks are processed by the
+                    analysis workers automatically.
+                </p>
+            )}
+        </InsightPanel>
+    );
+}

--- a/frontend/features/library-health/components/DuplicatesPanel.tsx
+++ b/frontend/features/library-health/components/DuplicatesPanel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+    api,
+    type LibraryHealthDuplicateTier,
+    type LibraryHealthSummary,
+} from "@/lib/api";
+import { formatBytes } from "../format";
+import { usePanelLoader } from "../hooks/usePanelLoader";
+import { InsightPanel } from "./InsightPanel";
+
+const TIER_LABELS: Record<LibraryHealthDuplicateTier, string> = {
+    audioHash: "Exact audio duplicate",
+    recordingMbid: "Same recording",
+    isrc: "Same ISRC",
+};
+
+interface DuplicatesPanelProps {
+    duplicates: LibraryHealthSummary["duplicates"];
+}
+
+/** Report-only duplicate/version clusters found via durable track identity. */
+export function DuplicatesPanel({
+    duplicates,
+}: Readonly<DuplicatesPanelProps>) {
+    const fetchPage = useCallback(
+        () => api.getLibraryHealthDuplicates({ limit: 25 }),
+        [],
+    );
+    const page = usePanelLoader(fetchPage, "Failed to load duplicate clusters");
+
+    return (
+        <InsightPanel
+            title="Duplicates and versions"
+            subtitle={`${duplicates.clusters} clusters · ${duplicates.byTier.audioHash} exact · ${duplicates.byTier.recordingMbid} same recording · ${duplicates.byTier.isrc} same ISRC`}
+            isTruncated={duplicates.isTruncated}
+            onFirstExpand={page.load}
+            isLoading={page.isLoading}
+            error={page.error}
+        >
+            <p className="text-xs text-gray-500 mb-3">
+                Detection is report-only: nothing is hidden, merged, or deleted.
+                Your files are never touched.
+            </p>
+            {page.data && (
+                <ul className="space-y-3">
+                    {page.data.clusters.map((cluster) => (
+                        <li
+                            key={`${cluster.tier}:${cluster.identity}`}
+                            className="text-sm text-gray-300"
+                        >
+                            <div className="text-xs text-gray-400 mb-1">
+                                {TIER_LABELS[cluster.tier]} ·{" "}
+                                {cluster.memberCount} tracks ·{" "}
+                                {formatBytes(cluster.totalFileSize)}
+                            </div>
+                            <ul className="space-y-0.5 pl-3 border-l border-white/10">
+                                {cluster.members.map((member) => (
+                                    <li
+                                        key={member.id}
+                                        className="flex justify-between gap-3"
+                                    >
+                                        <span className="truncate">
+                                            {member.title}
+                                            <span className="text-gray-500">
+                                                {" "}
+                                                — {member.artistName} ·{" "}
+                                                {member.albumTitle}
+                                            </span>
+                                        </span>
+                                        <span className="text-gray-500 whitespace-nowrap">
+                                            {formatBytes(member.fileSize)}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </li>
+                    ))}
+                    {page.data.clusters.length === 0 && (
+                        <li className="text-xs text-gray-500">
+                            No duplicate clusters found.
+                        </li>
+                    )}
+                    {page.data.total > page.data.clusters.length && (
+                        <li className="text-xs text-gray-500">
+                            Showing {page.data.clusters.length} of{" "}
+                            {page.data.total} clusters.
+                        </li>
+                    )}
+                </ul>
+            )}
+        </InsightPanel>
+    );
+}

--- a/frontend/features/library-health/components/InsightPanel.tsx
+++ b/frontend/features/library-health/components/InsightPanel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+
+interface InsightPanelProps {
+    title: string;
+    subtitle: string;
+    isTruncated?: boolean;
+    isLoading?: boolean;
+    error?: string | null;
+    /** Called the first time the panel is expanded (lazy drill-down fetch). */
+    onFirstExpand?: () => void;
+    children: ReactNode;
+}
+
+/** Collapsible card shared by every Library Insights drill-down panel. */
+export function InsightPanel({
+    title,
+    subtitle,
+    isTruncated = false,
+    isLoading = false,
+    error = null,
+    onFirstExpand,
+    children,
+}: Readonly<InsightPanelProps>) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [hasExpanded, setHasExpanded] = useState(false);
+    const Chevron = isExpanded ? ChevronDown : ChevronRight;
+
+    const toggle = () => {
+        const next = !isExpanded;
+        setIsExpanded(next);
+        if (next && !hasExpanded) {
+            setHasExpanded(true);
+            onFirstExpand?.();
+        }
+    };
+
+    return (
+        <div className="bg-white/5 rounded-lg border border-white/10">
+            <button
+                type="button"
+                onClick={toggle}
+                className="w-full flex items-center justify-between gap-3 p-4 text-left"
+                aria-expanded={isExpanded}
+            >
+                <div>
+                    <div className="text-sm font-medium text-white">
+                        {title}
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                        {subtitle}
+                        {isTruncated && (
+                            <span className="ml-2 text-amber-400">
+                                (large library: counts are sampled)
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <Chevron className="w-4 h-4 text-gray-400 shrink-0" />
+            </button>
+            {isExpanded && (
+                <div className="px-4 pb-4">
+                    {isLoading && (
+                        <div className="flex items-center gap-2 py-2 text-sm text-gray-300">
+                            <Loader2 className="w-4 h-4 animate-spin text-brand" />
+                            Loading…
+                        </div>
+                    )}
+                    {error && (
+                        <div className="py-2 text-sm text-red-400">{error}</div>
+                    )}
+                    {!isLoading && !error && children}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/features/library-health/components/LibraryInsightsSection.tsx
+++ b/frontend/features/library-health/components/LibraryInsightsSection.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Loader2, RefreshCw } from "lucide-react";
+import { SettingsSection } from "@/features/settings/components/ui";
+import { useLibraryInsights } from "../hooks/useLibraryInsights";
+import { AnalysisCoveragePanel } from "./AnalysisCoveragePanel";
+import { DuplicatesPanel } from "./DuplicatesPanel";
+import { MetadataGapsPanel } from "./MetadataGapsPanel";
+import { QualityPanel } from "./QualityPanel";
+import { StoragePanel } from "./StoragePanel";
+
+/**
+ * Library Health dashboard (issue #532): metadata gaps, analysis coverage,
+ * duplicate clusters, and storage/quality analytics from the read-model API.
+ */
+export function LibraryInsightsSection() {
+    const { summary, isLoading, isRefreshing, error, refresh } =
+        useLibraryInsights();
+
+    return (
+        <SettingsSection
+            id="library-insights"
+            title="Library Insights"
+            description="What the enrichment pipeline knows about your library: metadata gaps, analysis coverage, duplicates, and storage. Counts are cached for 15 minutes."
+            titleExtra={
+                <button
+                    type="button"
+                    onClick={refresh}
+                    disabled={isRefreshing || isLoading}
+                    className="p-1 text-gray-400 hover:text-white disabled:opacity-50"
+                    title="Recompute now"
+                    aria-label="Recompute library insights"
+                >
+                    <RefreshCw
+                        className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`}
+                    />
+                </button>
+            }
+        >
+            {isLoading && (
+                <div className="flex items-center gap-2 py-2 text-sm text-gray-300">
+                    <Loader2 className="w-4 h-4 animate-spin text-brand" />
+                    Loading library insights…
+                </div>
+            )}
+            {error && <p className="py-2 text-sm text-red-400">{error}</p>}
+            {summary && (
+                <div className="space-y-3">
+                    <MetadataGapsPanel gaps={summary.metadataGaps} />
+                    <AnalysisCoveragePanel
+                        coverage={summary.analysisCoverage}
+                    />
+                    <DuplicatesPanel duplicates={summary.duplicates} />
+                    <StoragePanel storage={summary.storage} />
+                    <QualityPanel quality={summary.quality} />
+                </div>
+            )}
+        </SettingsSection>
+    );
+}

--- a/frontend/features/library-health/components/MetadataGapsPanel.tsx
+++ b/frontend/features/library-health/components/MetadataGapsPanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+    api,
+    type LibraryHealthAlbumGapItem,
+    type LibraryHealthGapKind,
+    type LibraryHealthSummary,
+    type LibraryHealthTrackGapItem,
+} from "@/lib/api";
+import { usePanelLoader } from "../hooks/usePanelLoader";
+import { InsightPanel } from "./InsightPanel";
+
+const GAP_TABS: Array<{ kind: LibraryHealthGapKind; label: string }> = [
+    { kind: "missing-art", label: "Cover art" },
+    { kind: "missing-mbid", label: "MusicBrainz IDs" },
+    { kind: "missing-genres", label: "Genres" },
+    { kind: "missing-lyrics", label: "Lyrics" },
+];
+
+function isAlbumItem(
+    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
+): item is LibraryHealthAlbumGapItem {
+    return "artist" in item;
+}
+
+function gapItemLine(
+    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
+): { primary: string; secondary: string } {
+    if (isAlbumItem(item)) {
+        return { primary: item.title, secondary: item.artist.name };
+    }
+    return {
+        primary: item.title,
+        secondary: `${item.album.artist.name} — ${item.album.title}`,
+    };
+}
+
+interface MetadataGapsPanelProps {
+    gaps: LibraryHealthSummary["metadataGaps"];
+}
+
+/** Metadata-gap counts with a tabbed drill-down into each category. */
+export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
+    const [activeKind, setActiveKind] =
+        useState<LibraryHealthGapKind>("missing-art");
+    const fetchPage = useCallback(
+        () => api.getLibraryHealthGaps(activeKind, { limit: 50 }),
+        [activeKind],
+    );
+    const page = usePanelLoader(fetchPage, "Failed to load metadata gaps");
+
+    const totalGaps =
+        gaps.missingArt.albums +
+        gaps.missingMbid.albums +
+        gaps.missingGenres +
+        gaps.missingLyrics;
+
+    const selectTab = (kind: LibraryHealthGapKind) => {
+        setActiveKind(kind);
+    };
+
+    return (
+        <InsightPanel
+            title="Metadata gaps"
+            subtitle={`${gaps.missingArt.albums} albums without art · ${gaps.missingMbid.albums} albums without MBIDs · ${gaps.missingGenres} tracks without genres · ${gaps.missingLyrics} tracks without lyrics`}
+            onFirstExpand={page.load}
+            isLoading={page.isLoading}
+            error={page.error}
+        >
+            <div className="flex flex-wrap gap-2 mb-3">
+                {GAP_TABS.map((tab) => (
+                    <button
+                        key={tab.kind}
+                        type="button"
+                        onClick={() => selectTab(tab.kind)}
+                        className={`px-2 py-1 text-xs rounded-full border ${
+                            tab.kind === activeKind
+                                ? "border-brand text-white bg-white/10"
+                                : "border-white/10 text-gray-400"
+                        }`}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+                <button
+                    type="button"
+                    onClick={page.load}
+                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-400"
+                >
+                    Load
+                </button>
+            </div>
+            {page.data && page.data.kind === activeKind ? (
+                <ul className="space-y-1">
+                    {page.data.items.map((item) => {
+                        const line = gapItemLine(item);
+                        return (
+                            <li
+                                key={item.id}
+                                className="text-sm text-gray-300 flex justify-between gap-3"
+                            >
+                                <span className="truncate">{line.primary}</span>
+                                <span className="text-gray-500 truncate">
+                                    {line.secondary}
+                                </span>
+                            </li>
+                        );
+                    })}
+                    {page.data.total > page.data.items.length && (
+                        <li className="text-xs text-gray-500 pt-1">
+                            Showing {page.data.items.length} of{" "}
+                            {page.data.total}.
+                        </li>
+                    )}
+                </ul>
+            ) : (
+                <p className="text-xs text-gray-500">
+                    Pick a category and press Load to list affected items.
+                </p>
+            )}
+            <p className="text-xs text-gray-500 mt-3">
+                Fix these from Cache &amp; Automation: metadata enrichment fills
+                art, MBIDs, and genres, and lyrics are fetched during
+                enrichment. {totalGaps === 0 && "Everything is covered."}
+            </p>
+        </InsightPanel>
+    );
+}

--- a/frontend/features/library-health/components/QualityPanel.tsx
+++ b/frontend/features/library-health/components/QualityPanel.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { api, type LibraryHealthSummary } from "@/lib/api";
+import { formatKbps } from "../format";
+import { usePanelLoader } from "../hooks/usePanelLoader";
+import { InsightPanel } from "./InsightPanel";
+
+const FLOOR_CHOICES = [128, 192, 256, 320] as const;
+
+interface QualityPanelProps {
+    quality: LibraryHealthSummary["quality"];
+}
+
+/** Lossy albums whose derived average bitrate sits below a chosen floor. */
+export function QualityPanel({ quality }: Readonly<QualityPanelProps>) {
+    const [floor, setFloor] = useState(quality.floorKbps);
+    const fetchPage = useCallback(
+        () => api.getLibraryHealthQuality(floor, { limit: 50 }),
+        [floor],
+    );
+    const page = usePanelLoader(fetchPage, "Failed to load quality outliers");
+
+    return (
+        <InsightPanel
+            title="Quality outliers"
+            subtitle={`${quality.albumsBelowFloor} lossy albums below ${quality.floorKbps} kbps`}
+            isTruncated={quality.isTruncated}
+            onFirstExpand={page.load}
+            isLoading={page.isLoading}
+            error={page.error}
+        >
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+                <span className="text-xs text-gray-400">Bitrate floor:</span>
+                {FLOOR_CHOICES.map((choice) => (
+                    <button
+                        key={choice}
+                        type="button"
+                        onClick={() => setFloor(choice)}
+                        className={`px-2 py-1 text-xs rounded-full border ${
+                            choice === floor
+                                ? "border-brand text-white bg-white/10"
+                                : "border-white/10 text-gray-400"
+                        }`}
+                    >
+                        {choice} kbps
+                    </button>
+                ))}
+                <button
+                    type="button"
+                    onClick={page.load}
+                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-400"
+                >
+                    Apply
+                </button>
+            </div>
+            {page.data && (
+                <ul className="space-y-1">
+                    {page.data.items.map((album) => (
+                        <li
+                            key={album.albumId}
+                            className="text-sm text-gray-300 flex justify-between gap-3"
+                        >
+                            <span className="truncate">
+                                {album.title}
+                                <span className="text-gray-500">
+                                    {" "}
+                                    — {album.artist.name}
+                                </span>
+                            </span>
+                            <span className="text-gray-500 whitespace-nowrap">
+                                ~{formatKbps(album.averageBitrateKbps)} ·{" "}
+                                {album.trackCount} tracks
+                            </span>
+                        </li>
+                    ))}
+                    {page.data.items.length === 0 && (
+                        <li className="text-xs text-gray-500">
+                            No lossy albums below this floor.
+                        </li>
+                    )}
+                    {page.data.total > page.data.items.length && (
+                        <li className="text-xs text-gray-500 pt-1">
+                            Showing {page.data.items.length} of{" "}
+                            {page.data.total}.
+                        </li>
+                    )}
+                </ul>
+            )}
+        </InsightPanel>
+    );
+}

--- a/frontend/features/library-health/components/StoragePanel.tsx
+++ b/frontend/features/library-health/components/StoragePanel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback } from "react";
+import { api, type LibraryHealthSummary } from "@/lib/api";
+import { formatBytes, formatKbps } from "../format";
+import { usePanelLoader } from "../hooks/usePanelLoader";
+import { InsightPanel } from "./InsightPanel";
+
+interface StoragePanelProps {
+    storage: LibraryHealthSummary["storage"];
+}
+
+/** Storage breakdown by format plus the artists using the most space. */
+export function StoragePanel({ storage }: Readonly<StoragePanelProps>) {
+    const fetchReport = useCallback(() => api.getLibraryHealthStorage(), []);
+    const report = usePanelLoader(fetchReport, "Failed to load storage report");
+
+    return (
+        <InsightPanel
+            title="Storage"
+            subtitle={`${storage.tracks} tracks · ${formatBytes(storage.totalFileSize)} across ${storage.mimeTypes} formats`}
+            isTruncated={storage.isTruncated}
+            onFirstExpand={report.load}
+            isLoading={report.isLoading}
+            error={report.error}
+        >
+            {report.data && (
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <h3 className="text-xs font-medium text-gray-400 mb-1">
+                            By format
+                        </h3>
+                        <ul className="space-y-1">
+                            {report.data.formats.map((format) => (
+                                <li
+                                    key={format.mime ?? "unknown"}
+                                    className="text-sm text-gray-300 flex justify-between gap-3"
+                                >
+                                    <span className="truncate">
+                                        {format.mime ?? "Unknown format"}
+                                    </span>
+                                    <span className="text-gray-500 whitespace-nowrap">
+                                        {format.trackCount} ·{" "}
+                                        {formatBytes(format.totalFileSize)} · ~
+                                        {formatKbps(format.averageBitrateKbps)}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 className="text-xs font-medium text-gray-400 mb-1">
+                            Largest artists
+                        </h3>
+                        <ul className="space-y-1">
+                            {report.data.topArtists.map((artist) => (
+                                <li
+                                    key={artist.artistId}
+                                    className="text-sm text-gray-300 flex justify-between gap-3"
+                                >
+                                    <span className="truncate">
+                                        {artist.artistName}
+                                    </span>
+                                    <span className="text-gray-500 whitespace-nowrap">
+                                        {artist.trackCount} ·{" "}
+                                        {formatBytes(artist.totalFileSize)}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            )}
+        </InsightPanel>
+    );
+}

--- a/frontend/features/library-health/format.ts
+++ b/frontend/features/library-health/format.ts
@@ -1,0 +1,31 @@
+/** Pure display formatters for the Library Insights dashboard. */
+
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
+/** Formats a byte count as a compact human-readable size. */
+export function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) return "—";
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < BYTE_UNITS.length - 1) {
+        value /= 1024;
+        unit += 1;
+    }
+    const digits = value >= 100 || unit === 0 ? 0 : 1;
+    return `${value.toFixed(digits)} ${BYTE_UNITS[unit]}`;
+}
+
+/** Formats a derived bitrate in kbps, or an em dash when unknown. */
+export function formatKbps(kbps: number | null): string {
+    if (kbps === null || !Number.isFinite(kbps) || kbps < 0) return "—";
+    return `${Math.round(kbps)} kbps`;
+}
+
+/** Formats a completed/total pair as a whole-number percentage string. */
+export function formatCoveragePercent(done: number, total: number): string {
+    if (!Number.isFinite(done) || !Number.isFinite(total) || total <= 0) {
+        return "—";
+    }
+    const clamped = Math.min(Math.max(done, 0), total);
+    return `${Math.round((clamped / total) * 100)}%`;
+}

--- a/frontend/features/library-health/hooks/useLibraryInsights.ts
+++ b/frontend/features/library-health/hooks/useLibraryInsights.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { api, type LibraryHealthSummary } from "@/lib/api";
+
+export interface LibraryInsightsState {
+    summary: LibraryHealthSummary | null;
+    isLoading: boolean;
+    isRefreshing: boolean;
+    error: string | null;
+    refresh: () => void;
+}
+
+/** Loads the cached dashboard summary and exposes a cache-busting refresh. */
+export function useLibraryInsights(): LibraryInsightsState {
+    const [summary, setSummary] = useState<LibraryHealthSummary | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        void api
+            .getLibraryHealthSummary()
+            .then((data) => {
+                if (!cancelled) setSummary(data);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setError("Failed to load library insights");
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const refresh = useCallback(() => {
+        setIsRefreshing(true);
+        setError(null);
+        void api
+            .refreshLibraryHealthDashboard()
+            .then(setSummary)
+            .catch(() => {
+                setError("Failed to refresh library insights");
+            })
+            .finally(() => {
+                setIsRefreshing(false);
+            });
+    }, []);
+
+    return { summary, isLoading, isRefreshing, error, refresh };
+}

--- a/frontend/features/library-health/hooks/usePanelLoader.ts
+++ b/frontend/features/library-health/hooks/usePanelLoader.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface PanelLoaderState<T> {
+    data: T | null;
+    isLoading: boolean;
+    error: string | null;
+    load: () => void;
+}
+
+/**
+ * Lazy loader for one dashboard drill-down panel: nothing is fetched until
+ * the first load() call, and stale responses from superseded loads are
+ * dropped so rapid re-loads cannot render out of order.
+ */
+export function usePanelLoader<T>(
+    fetcher: () => Promise<T>,
+    errorMessage: string,
+): PanelLoaderState<T> {
+    const [data, setData] = useState<T | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const loadSequence = useRef(0);
+
+    const load = useCallback(() => {
+        loadSequence.current += 1;
+        const sequence = loadSequence.current;
+        setIsLoading(true);
+        setError(null);
+        void fetcher()
+            .then((value) => {
+                if (sequence !== loadSequence.current) return;
+                setData(value);
+            })
+            .catch(() => {
+                if (sequence !== loadSequence.current) return;
+                setError(errorMessage);
+            })
+            .finally(() => {
+                if (sequence !== loadSequence.current) return;
+                setIsLoading(false);
+            });
+    }, [fetcher, errorMessage]);
+
+    return { data, isLoading, error, load };
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -8,6 +8,20 @@ import { WithDiscover } from "./api/discover";
 import { WithDownloads } from "./api/downloads";
 import { WithImports } from "./api/imports";
 import { WithLibrary } from "./api/library";
+import { WithLibraryHealthDashboard } from "./api/libraryHealth";
+export type {
+    LibraryHealthAnalysisPage,
+    LibraryHealthDuplicatesPage,
+    LibraryHealthDuplicateTier,
+    LibraryHealthGapKind,
+    LibraryHealthGapPage,
+    LibraryHealthAlbumGapItem,
+    LibraryHealthTrackGapItem,
+    LibraryHealthQualityPage,
+    LibraryHealthStatusCounts,
+    LibraryHealthStorageReport,
+    LibraryHealthSummary,
+} from "./api/libraryHealth";
 import { WithListenGroups } from "./api/listenGroups";
 import { WithMedia } from "./api/media";
 import { WithMetadata } from "./api/metadata";
@@ -475,30 +489,32 @@ export interface PlaybackClientMetricInput {
     fields?: Record<string, unknown>;
 }
 
-class ApiClient extends WithListenGroups(
-    WithFederation(
-        WithTidal(
-            WithYouTube(
-                WithYtMusic(
-                    WithVibe(
-                        WithAudiobooks(
-                            WithPodcasts(
-                                WithSoulseek(
-                                    WithEnrichment(
-                                        WithMetadata(
-                                            WithNotifications(
-                                                WithDiscover(
-                                                    WithImports(
-                                                        WithDownloads(
-                                                            WithAuth(
-                                                                WithConnectors(
-                                                                    WithSettings(
-                                                                        WithPlays(
-                                                                            WithRecommendations(
-                                                                                WithMedia(
-                                                                                    WithPlaylists(
-                                                                                        WithLibrary(
-                                                                                            ApiClientCore,
+class ApiClient extends WithLibraryHealthDashboard(
+    WithListenGroups(
+        WithFederation(
+            WithTidal(
+                WithYouTube(
+                    WithYtMusic(
+                        WithVibe(
+                            WithAudiobooks(
+                                WithPodcasts(
+                                    WithSoulseek(
+                                        WithEnrichment(
+                                            WithMetadata(
+                                                WithNotifications(
+                                                    WithDiscover(
+                                                        WithImports(
+                                                            WithDownloads(
+                                                                WithAuth(
+                                                                    WithConnectors(
+                                                                        WithSettings(
+                                                                            WithPlays(
+                                                                                WithRecommendations(
+                                                                                    WithMedia(
+                                                                                        WithPlaylists(
+                                                                                            WithLibrary(
+                                                                                                ApiClientCore,
+                                                                                            ),
                                                                                         ),
                                                                                     ),
                                                                                 ),

--- a/frontend/lib/api/libraryHealth.ts
+++ b/frontend/lib/api/libraryHealth.ts
@@ -1,0 +1,228 @@
+import { type ApiClientConstructor } from "./core";
+
+/** Metadata-gap drill-down categories served by the dashboard API. */
+export type LibraryHealthGapKind =
+    | "missing-art"
+    | "missing-mbid"
+    | "missing-genres"
+    | "missing-lyrics";
+
+export type LibraryHealthDuplicateTier = "audioHash" | "recordingMbid" | "isrc";
+
+export interface LibraryHealthStatusCounts {
+    pending: number;
+    processing: number;
+    failed: number;
+    completed: number;
+}
+
+export interface LibraryHealthSummary {
+    metadataGaps: {
+        missingArt: { albums: number; artists: number };
+        missingMbid: { albums: number; artists: number };
+        missingGenres: number;
+        missingLyrics: number;
+    };
+    analysisCoverage: {
+        total: number;
+        analysisStatus: LibraryHealthStatusCounts;
+        vibeAnalysisStatus: LibraryHealthStatusCounts;
+        loudness: { measured: number; missing: number };
+    };
+    storage: {
+        tracks: number;
+        totalFileSize: number;
+        mimeTypes: number;
+        artists: number;
+        isTruncated: boolean;
+    };
+    quality: {
+        floorKbps: number;
+        albumsBelowFloor: number;
+        isTruncated: boolean;
+    };
+    duplicates: {
+        clusters: number;
+        byTier: Record<LibraryHealthDuplicateTier, number>;
+        isTruncated: boolean;
+    };
+}
+
+export interface LibraryHealthAlbumGapItem {
+    id: string;
+    title: string;
+    rgMbid: string;
+    coverUrl: string | null;
+    userCoverUrl: string | null;
+    artist: { id: string; name: string };
+}
+
+export interface LibraryHealthTrackGapItem {
+    id: string;
+    title: string;
+    filePath: string | null;
+    album: { title: string; artist: { name: string } };
+}
+
+export interface LibraryHealthGapPage {
+    kind: LibraryHealthGapKind;
+    counts: Record<string, number>;
+    items: Array<LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem>;
+    total: number;
+    limit: number;
+    offset: number;
+}
+
+export interface LibraryHealthAnalysisPage {
+    total: number;
+    analysisStatus: LibraryHealthStatusCounts;
+    vibeAnalysisStatus: LibraryHealthStatusCounts;
+    loudness: { measured: number; missing: number };
+    failed: {
+        items: Array<{
+            id: string;
+            title: string;
+            analysisError: string | null;
+            album: { title: string; artist: { name: string } };
+        }>;
+        total: number;
+        limit: number;
+        offset: number;
+    };
+}
+
+export interface LibraryHealthStorageReport {
+    formats: Array<{
+        mime: string | null;
+        trackCount: number;
+        totalFileSize: number;
+        averageBitrateKbps: number | null;
+        bitrateSampleSize: number;
+    }>;
+    topArtists: Array<{
+        artistId: string;
+        artistName: string;
+        trackCount: number;
+        totalFileSize: number;
+    }>;
+    sampledTracks: number;
+    sampleLimit: number;
+    isTruncated: boolean;
+}
+
+export interface LibraryHealthQualityPage {
+    floorKbps: number;
+    items: Array<{
+        albumId: string;
+        title: string;
+        artist: { id: string; name: string };
+        averageBitrateKbps: number;
+        trackCount: number;
+    }>;
+    total: number;
+    limit: number;
+    offset: number;
+    sampledTracks: number;
+    sampleLimit: number;
+    isTruncated: boolean;
+}
+
+export interface LibraryHealthDuplicatesPage {
+    clusters: Array<{
+        tier: LibraryHealthDuplicateTier;
+        identity: string;
+        memberCount: number;
+        totalFileSize: number;
+        members: Array<{
+            id: string;
+            title: string;
+            albumTitle: string;
+            artistName: string;
+            filePath: string | null;
+            fileSize: number;
+            mime: string | null;
+        }>;
+    }>;
+    total: number;
+    byTier: Record<LibraryHealthDuplicateTier, number>;
+    isTruncated: boolean;
+    limit: number;
+    offset: number;
+}
+
+export interface LibraryHealthPageQuery {
+    limit?: number;
+    offset?: number;
+}
+
+function pageParams(query: LibraryHealthPageQuery): string {
+    const params = new URLSearchParams();
+    if (query.limit !== undefined) params.set("limit", String(query.limit));
+    if (query.offset !== undefined) params.set("offset", String(query.offset));
+    const encoded = params.toString();
+    return encoded ? `?${encoded}` : "";
+}
+
+/** Add Library Health dashboard operations to an API client base class. */
+export function WithLibraryHealthDashboard<TBase extends ApiClientConstructor>(
+    Base: TBase,
+) {
+    abstract class LibraryHealthDashboardApi extends Base {
+        async getLibraryHealthSummary() {
+            return this.request<LibraryHealthSummary>(
+                "/library-health/summary",
+            );
+        }
+
+        async getLibraryHealthGaps(
+            kind: LibraryHealthGapKind,
+            query: LibraryHealthPageQuery = {},
+        ) {
+            return this.request<LibraryHealthGapPage>(
+                `/library-health/gaps/${kind}${pageParams(query)}`,
+            );
+        }
+
+        async getLibraryHealthAnalysis(query: LibraryHealthPageQuery = {}) {
+            return this.request<LibraryHealthAnalysisPage>(
+                `/library-health/analysis${pageParams(query)}`,
+            );
+        }
+
+        async getLibraryHealthStorage() {
+            return this.request<LibraryHealthStorageReport>(
+                "/library-health/storage",
+            );
+        }
+
+        async getLibraryHealthQuality(
+            floor?: number,
+            query: LibraryHealthPageQuery = {},
+        ) {
+            const params = new URLSearchParams();
+            if (floor !== undefined) params.set("floor", String(floor));
+            if (query.limit !== undefined)
+                params.set("limit", String(query.limit));
+            if (query.offset !== undefined)
+                params.set("offset", String(query.offset));
+            const encoded = params.toString();
+            return this.request<LibraryHealthQualityPage>(
+                `/library-health/quality${encoded ? `?${encoded}` : ""}`,
+            );
+        }
+
+        async getLibraryHealthDuplicates(query: LibraryHealthPageQuery = {}) {
+            return this.request<LibraryHealthDuplicatesPage>(
+                `/library-health/duplicates${pageParams(query)}`,
+            );
+        }
+
+        async refreshLibraryHealthDashboard() {
+            return this.request<LibraryHealthSummary>(
+                "/library-health/refresh",
+                { method: "POST" },
+            );
+        }
+    }
+    return LibraryHealthDashboardApi;
+}

--- a/frontend/tests/component/libraryInsightsSection.component.test.ts
+++ b/frontend/tests/component/libraryInsightsSection.component.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const Icon = (props: Record<string, unknown> = {}) =>
+    React.createElement("svg", props);
+
+mock.module("lucide-react", {
+    namedExports: {
+        ChevronDown: Icon,
+        ChevronRight: Icon,
+        Loader2: Icon,
+        RefreshCw: Icon,
+    },
+});
+
+mock.module("@/lib/enrichmentApi", {
+    namedExports: {
+        enrichmentApi: {
+            retryVibeEmbeddings: async () => ({ enqueued: 0 }),
+        },
+    },
+});
+
+const SUMMARY = {
+    metadataGaps: {
+        missingArt: { albums: 12, artists: 3 },
+        missingMbid: { albums: 7, artists: 2 },
+        missingGenres: 44,
+        missingLyrics: 310,
+    },
+    analysisCoverage: {
+        total: 200,
+        analysisStatus: {
+            pending: 10,
+            processing: 0,
+            failed: 4,
+            completed: 186,
+        },
+        vibeAnalysisStatus: {
+            pending: 20,
+            processing: 0,
+            failed: 0,
+            completed: 180,
+        },
+        loudness: { measured: 150, missing: 50 },
+    },
+    storage: {
+        tracks: 200,
+        totalFileSize: 5 * 1024 ** 3,
+        mimeTypes: 3,
+        artists: 25,
+        isTruncated: false,
+    },
+    quality: { floorKbps: 192, albumsBelowFloor: 6, isTruncated: false },
+    duplicates: {
+        clusters: 9,
+        byTier: { audioHash: 5, recordingMbid: 3, isrc: 1 },
+        isTruncated: true,
+    },
+};
+
+async function renderPanels() {
+    const [gaps, analysis, duplicates, storage, quality] = await Promise.all([
+        import("../../features/library-health/components/MetadataGapsPanel"),
+        import("../../features/library-health/components/AnalysisCoveragePanel"),
+        import("../../features/library-health/components/DuplicatesPanel"),
+        import("../../features/library-health/components/StoragePanel"),
+        import("../../features/library-health/components/QualityPanel"),
+    ]);
+    return renderToStaticMarkup(
+        React.createElement(
+            "div",
+            null,
+            React.createElement(gaps.MetadataGapsPanel, {
+                gaps: SUMMARY.metadataGaps,
+            }),
+            React.createElement(analysis.AnalysisCoveragePanel, {
+                coverage: SUMMARY.analysisCoverage,
+            }),
+            React.createElement(duplicates.DuplicatesPanel, {
+                duplicates: SUMMARY.duplicates,
+            }),
+            React.createElement(storage.StoragePanel, {
+                storage: SUMMARY.storage,
+            }),
+            React.createElement(quality.QualityPanel, {
+                quality: SUMMARY.quality,
+            }),
+        ),
+    );
+}
+
+test("library insights panels summarize every panel family while collapsed", async () => {
+    const html = await renderPanels();
+
+    assert.match(html, /Metadata gaps/);
+    assert.match(html, /12 albums without art/);
+    assert.match(html, /7 albums without MBIDs/);
+    assert.match(html, /44 tracks without genres/);
+    assert.match(html, /310 tracks without lyrics/);
+
+    assert.match(html, /Analysis coverage/);
+    assert.match(html, /Audio 93%/);
+    assert.match(html, /Vibe 90%/);
+    assert.match(html, /Loudness 75%/);
+    assert.match(html, /4 failed/);
+
+    assert.match(html, /Duplicates and versions/);
+    assert.match(html, /9 clusters/);
+    assert.match(html, /5 exact/);
+    assert.match(html, /large library: counts are sampled/);
+
+    assert.match(html, /Storage/);
+    assert.match(html, /200 tracks/);
+    assert.match(html, /5\.0 GB/);
+
+    assert.match(html, /Quality outliers/);
+    assert.match(html, /6 lossy albums below 192 kbps/);
+});
+
+test("library insights panels start collapsed with no drill-down content mounted", async () => {
+    const html = await renderPanels();
+
+    assert.match(html, /aria-expanded="false"/);
+    assert.doesNotMatch(html, /Retry failed audio analysis/);
+    assert.doesNotMatch(html, /Bitrate floor/);
+    assert.doesNotMatch(html, /report-only/);
+});

--- a/frontend/tests/unit/apiClientSurface.test.ts
+++ b/frontend/tests/unit/apiClientSurface.test.ts
@@ -103,6 +103,12 @@ const EXPECTED_PUBLIC_METHODS: readonly string[] = [
     "getInviteCodes",
     "getLibraryDeletePolicy",
     "getLibraryHealth",
+    "getLibraryHealthAnalysis",
+    "getLibraryHealthDuplicates",
+    "getLibraryHealthGaps",
+    "getLibraryHealthQuality",
+    "getLibraryHealthStorage",
+    "getLibraryHealthSummary",
     "getLikedPlaylist",
     "getLocalTrackAudioInfo",
     "getLyrics",
@@ -224,6 +230,7 @@ const EXPECTED_PUBLIC_METHODS: readonly string[] = [
     "redeemOidcInvite",
     "refreshAllPodcasts",
     "refreshBaseUrl",
+    "refreshLibraryHealthDashboard",
     "refreshMixes",
     "register",
     "removeDiscoverExclusion",
@@ -308,5 +315,5 @@ test("api facade exposes every pinned public method", () => {
 });
 
 test("api facade public surface count is pinned", () => {
-    assert.equal(EXPECTED_PUBLIC_METHODS.length, 288);
+    assert.equal(EXPECTED_PUBLIC_METHODS.length, 295);
 });

--- a/frontend/tests/unit/libraryHealthFormat.test.ts
+++ b/frontend/tests/unit/libraryHealthFormat.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    formatBytes,
+    formatCoveragePercent,
+    formatKbps,
+} from "../../features/library-health/format";
+
+test("formatBytes scales units and guards invalid input", () => {
+    assert.equal(formatBytes(0), "0 B");
+    assert.equal(formatBytes(512), "512 B");
+    assert.equal(formatBytes(2048), "2.0 KB");
+    assert.equal(formatBytes(5 * 1024 * 1024), "5.0 MB");
+    assert.equal(formatBytes(120 * 1024 ** 3), "120 GB");
+    assert.equal(formatBytes(-1), "—");
+    assert.equal(formatBytes(Number.NaN), "—");
+});
+
+test("formatKbps rounds and guards missing samples", () => {
+    assert.equal(formatKbps(191.6), "192 kbps");
+    assert.equal(formatKbps(1411), "1411 kbps");
+    assert.equal(formatKbps(null), "—");
+    assert.equal(formatKbps(-5), "—");
+});
+
+test("formatCoveragePercent clamps and guards empty libraries", () => {
+    assert.equal(formatCoveragePercent(50, 200), "25%");
+    assert.equal(formatCoveragePercent(200, 200), "100%");
+    assert.equal(formatCoveragePercent(250, 200), "100%");
+    assert.equal(formatCoveragePercent(-5, 200), "0%");
+    assert.equal(formatCoveragePercent(1, 0), "—");
+});


### PR DESCRIPTION
Frontend half of #532, on top of the merged read-model API (#612): the Library Health dashboard, rendered as a **Library Insights** section on the Admin page (sidebar entry right below the existing Library Health file-problems section).

## What you get

Five collapsible panels, each summarizing its counts while collapsed and fetching its drill-down lazily on first expand:

- **Metadata gaps** — albums without art, albums/artists without real MusicBrainz IDs, tracks without genres or lyrics; tabbed drill-down lists with a pointer to the enrichment tools that fix each gap.
- **Analysis coverage** — audio/vibe/loudness coverage percentages and the failed-track list with the actual analyzer errors, plus one-click **Retry failed audio analysis** and **Retry failed vibe embeddings** actions wired to the existing re-queue endpoints.
- **Duplicates and versions** — report-only clusters labeled by identity tier (exact audio duplicate / same recording / same ISRC) with per-cluster size totals, and an explicit "your files are never touched" note.
- **Storage** — per-format track counts, bytes, and derived average bitrate, next to the artists using the most space.
- **Quality outliers** — lossy albums below a selectable bitrate floor (128/192/256/320 kbps).

Truncation flags from the API surface as a "large library: counts are sampled" hint. The section header has a recompute button that busts the 15-minute server cache.

## Implementation

- New feature module `frontend/features/library-health/` (components + hooks + pure `format.ts`), indexed in `features/README.md` with its own README and verification commands.
- New `WithLibraryHealthDashboard` mixin (`frontend/lib/api/libraryHealth.ts`) typed to the #612 response shapes; api-surface pin updated (288 → 295 methods).
- `usePanelLoader` gives every drill-down lazy first-expand fetching with stale-response sequencing, so rapid tab switches can't render out of order.
- No react-query in the new code — plain state/effect like the sibling admin sections.

## Verification

- Frontend unit suite: 997/997 pass, exit 0 (new: format helpers with guard cases; api-surface pin).
- New component test (`libraryInsightsSection.component.test.ts`): all five panel families render their collapsed summaries from fixtures; drill-down content stays unmounted until expand.
- `npx tsc --noEmit` exit 0; `npm run lint` 0 errors / 183 warnings (at the cap, none new); prettier clean; file-size guardrail passed.

Closes #532.
