### PR TITLE
fix(admin): render Library Insights drill-downs with the real API shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Library Insights drill-downs no longer crash the Admin page: the metadata-gap Genres/Lyrics tabs and the analysis-coverage failure list read fields the API never returned, so expanding them with real data threw a client-side error. Gap tabs and the quality bitrate floor also fetch on selection now instead of requiring a separate Load press.
 - Transient playback recovery now resumes correctly after its automatic reload: the recovery listener was previously cancelled before it could restart playback, and a stale pre-failure position can no longer be restored before the track has made real startup progress.
 
 ### Removed

--- a/frontend/features/library-health/README.md
+++ b/frontend/features/library-health/README.md
@@ -10,11 +10,12 @@ comes from the admin-gated `/api/library-health` API via
 
 | Path                                    | Role                                                            |
 | --------------------------------------- | --------------------------------------------------------------- |
-| `format.ts`                             | Pure display formatters (bytes, kbps, coverage percent)         |
-| `hooks/useLibraryInsights.ts`           | Summary load + cache-busting refresh                            |
+| `format.ts`                             | Pure display formatters (bytes, kbps, coverage percent) and gap-row line mapping (`gapItemLine`) |
+| `hooks/useLibraryInsights.ts`           | Summary load + cache-busting refresh with a refresh token for expanded panels |
 | `hooks/usePanelLoader.ts`               | Lazy drill-down loader with stale-response protection           |
+| `hooks/useInsightPanelLoader.ts`        | Expansion-driven loader: fetches on first expand, tab/filter change, and section refresh |
 | `components/LibraryInsightsSection.tsx` | Section container composing the five panels                     |
-| `components/InsightPanel.tsx`           | Shared collapsible panel card (lazy fetch on first expand)      |
+| `components/InsightPanel.tsx`           | Shared collapsible panel card (lazy fetch on first expand, error state with Retry) |
 | `components/MetadataGapsPanel.tsx`      | Art/MBID/genre/lyrics gap counts and tabbed drill-down          |
 | `components/AnalysisCoveragePanel.tsx`  | Analysis/vibe/loudness coverage plus retry remediation actions  |
 | `components/DuplicatesPanel.tsx`        | Report-only duplicate/version clusters (durable identity tiers) |
@@ -27,5 +28,6 @@ comes from the admin-gated `/api/library-health` API via
 cd frontend
 node --test --import tsx tests/unit/libraryHealthFormat.test.ts
 node --test --experimental-test-module-mocks --import tsx tests/component/libraryInsightsSection.component.test.ts
+node --test --experimental-test-module-mocks --import tsx tests/component/libraryInsightsDrilldown.component.test.ts
 npx tsc --noEmit
 ```

--- a/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
+++ b/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
@@ -90,7 +90,7 @@ export function AnalysisCoveragePanel({
                             <span className="truncate">{track.title}</span>
                             <span className="text-gray-500">
                                 {" "}
-                                — {track.album.artist.name}
+                                — {track.artistName}
                                 {track.analysisError
                                     ? ` · ${track.analysisError}`
                                     : ""}

--- a/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
+++ b/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
@@ -4,22 +4,31 @@ import { useCallback, useState } from "react";
 import { api, type LibraryHealthSummary } from "@/lib/api";
 import { enrichmentApi } from "@/lib/enrichmentApi";
 import { formatCoveragePercent } from "../format";
-import { usePanelLoader } from "../hooks/usePanelLoader";
+import { useInsightPanelLoader } from "../hooks/useInsightPanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
 interface AnalysisCoveragePanelProps {
     coverage: LibraryHealthSummary["analysisCoverage"];
+    refreshToken: number;
+    /** Called after a retry action changes backend state; refreshes the section counts. */
+    onRemediated?: () => void;
 }
 
 /** Analysis, vibe, and loudness coverage with retry actions for failures. */
 export function AnalysisCoveragePanel({
     coverage,
+    refreshToken,
+    onRemediated,
 }: Readonly<AnalysisCoveragePanelProps>) {
     const fetchPage = useCallback(
         () => api.getLibraryHealthAnalysis({ limit: 50 }),
         [],
     );
-    const page = usePanelLoader(fetchPage, "Failed to load analysis coverage");
+    const page = useInsightPanelLoader(
+        fetchPage,
+        "Failed to load analysis coverage",
+        refreshToken,
+    );
     const [actionNotice, setActionNotice] = useState<string | null>(null);
     const [isActing, setIsActing] = useState(false);
 
@@ -29,7 +38,11 @@ export function AnalysisCoveragePanel({
         void action()
             .then(() => {
                 setActionNotice(done);
-                page.load();
+                if (onRemediated) {
+                    onRemediated();
+                } else {
+                    page.load();
+                }
             })
             .catch(() => {
                 setActionNotice("Action failed — check the server logs.");
@@ -48,7 +61,7 @@ export function AnalysisCoveragePanel({
         <InsightPanel
             title="Analysis coverage"
             subtitle={`Audio ${formatCoveragePercent(analysisDone, coverage.total)} · Vibe ${formatCoveragePercent(vibeDone, coverage.total)} · Loudness ${formatCoveragePercent(coverage.loudness.measured, loudnessTotal)} · ${coverage.analysisStatus.failed} failed`}
-            onFirstExpand={page.load}
+            onFirstExpand={page.onFirstExpand}
             onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}

--- a/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
+++ b/frontend/features/library-health/components/AnalysisCoveragePanel.tsx
@@ -49,6 +49,7 @@ export function AnalysisCoveragePanel({
             title="Analysis coverage"
             subtitle={`Audio ${formatCoveragePercent(analysisDone, coverage.total)} · Vibe ${formatCoveragePercent(vibeDone, coverage.total)} · Loudness ${formatCoveragePercent(coverage.loudness.measured, loudnessTotal)} · ${coverage.analysisStatus.failed} failed`}
             onFirstExpand={page.load}
+            onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}
         >

--- a/frontend/features/library-health/components/DuplicatesPanel.tsx
+++ b/frontend/features/library-health/components/DuplicatesPanel.tsx
@@ -36,6 +36,7 @@ export function DuplicatesPanel({
             subtitle={`${duplicates.clusters} clusters · ${duplicates.byTier.audioHash} exact · ${duplicates.byTier.recordingMbid} same recording · ${duplicates.byTier.isrc} same ISRC`}
             isTruncated={duplicates.isTruncated}
             onFirstExpand={page.load}
+            onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}
         >

--- a/frontend/features/library-health/components/DuplicatesPanel.tsx
+++ b/frontend/features/library-health/components/DuplicatesPanel.tsx
@@ -7,7 +7,7 @@ import {
     type LibraryHealthSummary,
 } from "@/lib/api";
 import { formatBytes } from "../format";
-import { usePanelLoader } from "../hooks/usePanelLoader";
+import { useInsightPanelLoader } from "../hooks/useInsightPanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
 const TIER_LABELS: Record<LibraryHealthDuplicateTier, string> = {
@@ -18,24 +18,30 @@ const TIER_LABELS: Record<LibraryHealthDuplicateTier, string> = {
 
 interface DuplicatesPanelProps {
     duplicates: LibraryHealthSummary["duplicates"];
+    refreshToken: number;
 }
 
 /** Report-only duplicate/version clusters found via durable track identity. */
 export function DuplicatesPanel({
     duplicates,
+    refreshToken,
 }: Readonly<DuplicatesPanelProps>) {
     const fetchPage = useCallback(
         () => api.getLibraryHealthDuplicates({ limit: 25 }),
         [],
     );
-    const page = usePanelLoader(fetchPage, "Failed to load duplicate clusters");
+    const page = useInsightPanelLoader(
+        fetchPage,
+        "Failed to load duplicate clusters",
+        refreshToken,
+    );
 
     return (
         <InsightPanel
             title="Duplicates and versions"
             subtitle={`${duplicates.clusters} clusters · ${duplicates.byTier.audioHash} exact · ${duplicates.byTier.recordingMbid} same recording · ${duplicates.byTier.isrc} same ISRC`}
             isTruncated={duplicates.isTruncated}
-            onFirstExpand={page.load}
+            onFirstExpand={page.onFirstExpand}
             onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}

--- a/frontend/features/library-health/components/InsightPanel.tsx
+++ b/frontend/features/library-health/components/InsightPanel.tsx
@@ -85,7 +85,7 @@ export function InsightPanel({
                             )}
                         </div>
                     )}
-                    {!isLoading && !error && children}
+                    {!error && children}
                 </div>
             )}
         </div>

--- a/frontend/features/library-health/components/InsightPanel.tsx
+++ b/frontend/features/library-health/components/InsightPanel.tsx
@@ -11,6 +11,8 @@ interface InsightPanelProps {
     error?: string | null;
     /** Called the first time the panel is expanded (lazy drill-down fetch). */
     onFirstExpand?: () => void;
+    /** Called by the Retry control rendered beside a load error. */
+    onRetry?: () => void;
     children: ReactNode;
 }
 
@@ -22,6 +24,7 @@ export function InsightPanel({
     isLoading = false,
     error = null,
     onFirstExpand,
+    onRetry,
     children,
 }: Readonly<InsightPanelProps>) {
     const [isExpanded, setIsExpanded] = useState(false);
@@ -69,7 +72,18 @@ export function InsightPanel({
                         </div>
                     )}
                     {error && (
-                        <div className="py-2 text-sm text-red-400">{error}</div>
+                        <div className="py-2 text-sm text-red-400 flex items-center gap-3">
+                            <span>{error}</span>
+                            {onRetry && (
+                                <button
+                                    type="button"
+                                    onClick={onRetry}
+                                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-300 hover:text-white"
+                                >
+                                    Retry
+                                </button>
+                            )}
+                        </div>
                     )}
                     {!isLoading && !error && children}
                 </div>

--- a/frontend/features/library-health/components/LibraryInsightsSection.tsx
+++ b/frontend/features/library-health/components/LibraryInsightsSection.tsx
@@ -14,7 +14,7 @@ import { StoragePanel } from "./StoragePanel";
  * duplicate clusters, and storage/quality analytics from the read-model API.
  */
 export function LibraryInsightsSection() {
-    const { summary, isLoading, isRefreshing, error, refresh } =
+    const { summary, isLoading, isRefreshing, error, refresh, refreshToken } =
         useLibraryInsights();
 
     return (
@@ -46,13 +46,27 @@ export function LibraryInsightsSection() {
             {error && <p className="py-2 text-sm text-red-400">{error}</p>}
             {summary && (
                 <div className="space-y-3">
-                    <MetadataGapsPanel gaps={summary.metadataGaps} />
+                    <MetadataGapsPanel
+                        gaps={summary.metadataGaps}
+                        refreshToken={refreshToken}
+                    />
                     <AnalysisCoveragePanel
                         coverage={summary.analysisCoverage}
+                        refreshToken={refreshToken}
+                        onRemediated={refresh}
                     />
-                    <DuplicatesPanel duplicates={summary.duplicates} />
-                    <StoragePanel storage={summary.storage} />
-                    <QualityPanel quality={summary.quality} />
+                    <DuplicatesPanel
+                        duplicates={summary.duplicates}
+                        refreshToken={refreshToken}
+                    />
+                    <StoragePanel
+                        storage={summary.storage}
+                        refreshToken={refreshToken}
+                    />
+                    <QualityPanel
+                        quality={summary.quality}
+                        refreshToken={refreshToken}
+                    />
                 </div>
             )}
         </SettingsSection>

--- a/frontend/features/library-health/components/MetadataGapsPanel.tsx
+++ b/frontend/features/library-health/components/MetadataGapsPanel.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
     api,
-    type LibraryHealthAlbumGapItem,
     type LibraryHealthGapKind,
     type LibraryHealthSummary,
-    type LibraryHealthTrackGapItem,
 } from "@/lib/api";
+import { gapItemLine } from "../format";
 import { usePanelLoader } from "../hooks/usePanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
@@ -18,24 +17,6 @@ const GAP_TABS: Array<{ kind: LibraryHealthGapKind; label: string }> = [
     { kind: "missing-lyrics", label: "Lyrics" },
 ];
 
-function isAlbumItem(
-    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
-): item is LibraryHealthAlbumGapItem {
-    return "artist" in item;
-}
-
-function gapItemLine(
-    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
-): { primary: string; secondary: string } {
-    if (isAlbumItem(item)) {
-        return { primary: item.title, secondary: item.artist.name };
-    }
-    return {
-        primary: item.title,
-        secondary: `${item.album.artist.name} — ${item.album.title}`,
-    };
-}
-
 interface MetadataGapsPanelProps {
     gaps: LibraryHealthSummary["metadataGaps"];
 }
@@ -44,11 +25,17 @@ interface MetadataGapsPanelProps {
 export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
     const [activeKind, setActiveKind] =
         useState<LibraryHealthGapKind>("missing-art");
+    const [hasExpanded, setHasExpanded] = useState(false);
     const fetchPage = useCallback(
         () => api.getLibraryHealthGaps(activeKind, { limit: 50 }),
         [activeKind],
     );
     const page = usePanelLoader(fetchPage, "Failed to load metadata gaps");
+    const { load } = page;
+
+    useEffect(() => {
+        if (hasExpanded) load();
+    }, [hasExpanded, load]);
 
     const totalGaps =
         gaps.missingArt.albums +
@@ -56,15 +43,11 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
         gaps.missingGenres +
         gaps.missingLyrics;
 
-    const selectTab = (kind: LibraryHealthGapKind) => {
-        setActiveKind(kind);
-    };
-
     return (
         <InsightPanel
             title="Metadata gaps"
             subtitle={`${gaps.missingArt.albums} albums without art · ${gaps.missingMbid.albums} albums without MBIDs · ${gaps.missingGenres} tracks without genres · ${gaps.missingLyrics} tracks without lyrics`}
-            onFirstExpand={page.load}
+            onFirstExpand={() => setHasExpanded(true)}
             isLoading={page.isLoading}
             error={page.error}
         >
@@ -73,7 +56,7 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
                     <button
                         key={tab.kind}
                         type="button"
-                        onClick={() => selectTab(tab.kind)}
+                        onClick={() => setActiveKind(tab.kind)}
                         className={`px-2 py-1 text-xs rounded-full border ${
                             tab.kind === activeKind
                                 ? "border-brand text-white bg-white/10"
@@ -83,13 +66,6 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
                         {tab.label}
                     </button>
                 ))}
-                <button
-                    type="button"
-                    onClick={page.load}
-                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-400"
-                >
-                    Load
-                </button>
             </div>
             {page.data && page.data.kind === activeKind ? (
                 <ul className="space-y-1">
@@ -107,6 +83,11 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
                             </li>
                         );
                     })}
+                    {page.data.items.length === 0 && (
+                        <li className="text-xs text-gray-500">
+                            Nothing is missing in this category.
+                        </li>
+                    )}
                     {page.data.total > page.data.items.length && (
                         <li className="text-xs text-gray-500 pt-1">
                             Showing {page.data.items.length} of{" "}
@@ -114,11 +95,7 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
                         </li>
                     )}
                 </ul>
-            ) : (
-                <p className="text-xs text-gray-500">
-                    Pick a category and press Load to list affected items.
-                </p>
-            )}
+            ) : null}
             <p className="text-xs text-gray-500 mt-3">
                 Fix these from Cache &amp; Automation: metadata enrichment fills
                 art, MBIDs, and genres, and lyrics are fetched during

--- a/frontend/features/library-health/components/MetadataGapsPanel.tsx
+++ b/frontend/features/library-health/components/MetadataGapsPanel.tsx
@@ -48,6 +48,7 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
             title="Metadata gaps"
             subtitle={`${gaps.missingArt.albums} albums without art · ${gaps.missingMbid.albums} albums without MBIDs · ${gaps.missingGenres} tracks without genres · ${gaps.missingLyrics} tracks without lyrics`}
             onFirstExpand={() => setHasExpanded(true)}
+            onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}
         >

--- a/frontend/features/library-health/components/MetadataGapsPanel.tsx
+++ b/frontend/features/library-health/components/MetadataGapsPanel.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
     api,
     type LibraryHealthGapKind,
     type LibraryHealthSummary,
 } from "@/lib/api";
 import { gapItemLine } from "../format";
-import { usePanelLoader } from "../hooks/usePanelLoader";
+import { useInsightPanelLoader } from "../hooks/useInsightPanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
 const GAP_TABS: Array<{ kind: LibraryHealthGapKind; label: string }> = [
@@ -19,23 +19,25 @@ const GAP_TABS: Array<{ kind: LibraryHealthGapKind; label: string }> = [
 
 interface MetadataGapsPanelProps {
     gaps: LibraryHealthSummary["metadataGaps"];
+    refreshToken: number;
 }
 
 /** Metadata-gap counts with a tabbed drill-down into each category. */
-export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
+export function MetadataGapsPanel({
+    gaps,
+    refreshToken,
+}: Readonly<MetadataGapsPanelProps>) {
     const [activeKind, setActiveKind] =
         useState<LibraryHealthGapKind>("missing-art");
-    const [hasExpanded, setHasExpanded] = useState(false);
     const fetchPage = useCallback(
         () => api.getLibraryHealthGaps(activeKind, { limit: 50 }),
         [activeKind],
     );
-    const page = usePanelLoader(fetchPage, "Failed to load metadata gaps");
-    const { load } = page;
-
-    useEffect(() => {
-        if (hasExpanded) load();
-    }, [hasExpanded, load]);
+    const page = useInsightPanelLoader(
+        fetchPage,
+        "Failed to load metadata gaps",
+        refreshToken,
+    );
 
     const totalGaps =
         gaps.missingArt.albums +
@@ -47,7 +49,7 @@ export function MetadataGapsPanel({ gaps }: Readonly<MetadataGapsPanelProps>) {
         <InsightPanel
             title="Metadata gaps"
             subtitle={`${gaps.missingArt.albums} albums without art · ${gaps.missingMbid.albums} albums without MBIDs · ${gaps.missingGenres} tracks without genres · ${gaps.missingLyrics} tracks without lyrics`}
-            onFirstExpand={() => setHasExpanded(true)}
+            onFirstExpand={page.onFirstExpand}
             onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}

--- a/frontend/features/library-health/components/QualityPanel.tsx
+++ b/frontend/features/library-health/components/QualityPanel.tsx
@@ -1,38 +1,40 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { api, type LibraryHealthSummary } from "@/lib/api";
 import { formatKbps } from "../format";
-import { usePanelLoader } from "../hooks/usePanelLoader";
+import { useInsightPanelLoader } from "../hooks/useInsightPanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
 const FLOOR_CHOICES = [128, 192, 256, 320] as const;
 
 interface QualityPanelProps {
     quality: LibraryHealthSummary["quality"];
+    refreshToken: number;
 }
 
 /** Lossy albums whose derived average bitrate sits below a chosen floor. */
-export function QualityPanel({ quality }: Readonly<QualityPanelProps>) {
+export function QualityPanel({
+    quality,
+    refreshToken,
+}: Readonly<QualityPanelProps>) {
     const [floor, setFloor] = useState(quality.floorKbps);
-    const [hasExpanded, setHasExpanded] = useState(false);
     const fetchPage = useCallback(
         () => api.getLibraryHealthQuality(floor, { limit: 50 }),
         [floor],
     );
-    const page = usePanelLoader(fetchPage, "Failed to load quality outliers");
-    const { load } = page;
-
-    useEffect(() => {
-        if (hasExpanded) load();
-    }, [hasExpanded, load]);
+    const page = useInsightPanelLoader(
+        fetchPage,
+        "Failed to load quality outliers",
+        refreshToken,
+    );
 
     return (
         <InsightPanel
             title="Quality outliers"
             subtitle={`${quality.albumsBelowFloor} lossy albums below ${quality.floorKbps} kbps`}
             isTruncated={quality.isTruncated}
-            onFirstExpand={() => setHasExpanded(true)}
+            onFirstExpand={page.onFirstExpand}
             onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}

--- a/frontend/features/library-health/components/QualityPanel.tsx
+++ b/frontend/features/library-health/components/QualityPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api, type LibraryHealthSummary } from "@/lib/api";
 import { formatKbps } from "../format";
 import { usePanelLoader } from "../hooks/usePanelLoader";
@@ -15,18 +15,24 @@ interface QualityPanelProps {
 /** Lossy albums whose derived average bitrate sits below a chosen floor. */
 export function QualityPanel({ quality }: Readonly<QualityPanelProps>) {
     const [floor, setFloor] = useState(quality.floorKbps);
+    const [hasExpanded, setHasExpanded] = useState(false);
     const fetchPage = useCallback(
         () => api.getLibraryHealthQuality(floor, { limit: 50 }),
         [floor],
     );
     const page = usePanelLoader(fetchPage, "Failed to load quality outliers");
+    const { load } = page;
+
+    useEffect(() => {
+        if (hasExpanded) load();
+    }, [hasExpanded, load]);
 
     return (
         <InsightPanel
             title="Quality outliers"
             subtitle={`${quality.albumsBelowFloor} lossy albums below ${quality.floorKbps} kbps`}
             isTruncated={quality.isTruncated}
-            onFirstExpand={page.load}
+            onFirstExpand={() => setHasExpanded(true)}
             isLoading={page.isLoading}
             error={page.error}
         >
@@ -46,13 +52,6 @@ export function QualityPanel({ quality }: Readonly<QualityPanelProps>) {
                         {choice} kbps
                     </button>
                 ))}
-                <button
-                    type="button"
-                    onClick={page.load}
-                    className="px-2 py-1 text-xs rounded-full border border-white/10 text-gray-400"
-                >
-                    Apply
-                </button>
             </div>
             {page.data && (
                 <ul className="space-y-1">

--- a/frontend/features/library-health/components/QualityPanel.tsx
+++ b/frontend/features/library-health/components/QualityPanel.tsx
@@ -33,6 +33,7 @@ export function QualityPanel({ quality }: Readonly<QualityPanelProps>) {
             subtitle={`${quality.albumsBelowFloor} lossy albums below ${quality.floorKbps} kbps`}
             isTruncated={quality.isTruncated}
             onFirstExpand={() => setHasExpanded(true)}
+            onRetry={page.load}
             isLoading={page.isLoading}
             error={page.error}
         >

--- a/frontend/features/library-health/components/QualityPanel.tsx
+++ b/frontend/features/library-health/components/QualityPanel.tsx
@@ -56,7 +56,7 @@ export function QualityPanel({
                     </button>
                 ))}
             </div>
-            {page.data && (
+            {page.data && page.data.floorKbps === floor && (
                 <ul className="space-y-1">
                     {page.data.items.map((album) => (
                         <li

--- a/frontend/features/library-health/components/StoragePanel.tsx
+++ b/frontend/features/library-health/components/StoragePanel.tsx
@@ -21,6 +21,7 @@ export function StoragePanel({ storage }: Readonly<StoragePanelProps>) {
             subtitle={`${storage.tracks} tracks · ${formatBytes(storage.totalFileSize)} across ${storage.mimeTypes} formats`}
             isTruncated={storage.isTruncated}
             onFirstExpand={report.load}
+            onRetry={report.load}
             isLoading={report.isLoading}
             error={report.error}
         >

--- a/frontend/features/library-health/components/StoragePanel.tsx
+++ b/frontend/features/library-health/components/StoragePanel.tsx
@@ -3,24 +3,32 @@
 import { useCallback } from "react";
 import { api, type LibraryHealthSummary } from "@/lib/api";
 import { formatBytes, formatKbps } from "../format";
-import { usePanelLoader } from "../hooks/usePanelLoader";
+import { useInsightPanelLoader } from "../hooks/useInsightPanelLoader";
 import { InsightPanel } from "./InsightPanel";
 
 interface StoragePanelProps {
     storage: LibraryHealthSummary["storage"];
+    refreshToken: number;
 }
 
 /** Storage breakdown by format plus the artists using the most space. */
-export function StoragePanel({ storage }: Readonly<StoragePanelProps>) {
+export function StoragePanel({
+    storage,
+    refreshToken,
+}: Readonly<StoragePanelProps>) {
     const fetchReport = useCallback(() => api.getLibraryHealthStorage(), []);
-    const report = usePanelLoader(fetchReport, "Failed to load storage report");
+    const report = useInsightPanelLoader(
+        fetchReport,
+        "Failed to load storage report",
+        refreshToken,
+    );
 
     return (
         <InsightPanel
             title="Storage"
             subtitle={`${storage.tracks} tracks · ${formatBytes(storage.totalFileSize)} across ${storage.mimeTypes} formats`}
             isTruncated={storage.isTruncated}
-            onFirstExpand={report.load}
+            onFirstExpand={report.onFirstExpand}
             onRetry={report.load}
             isLoading={report.isLoading}
             error={report.error}

--- a/frontend/features/library-health/format.ts
+++ b/frontend/features/library-health/format.ts
@@ -1,6 +1,31 @@
 /** Pure display formatters for the Library Insights dashboard. */
 
+import type {
+    LibraryHealthAlbumGapItem,
+    LibraryHealthTrackGapItem,
+} from "@/lib/api";
+
 const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
+/** Narrows a metadata-gap item to the album shape (nested artist object). */
+export function isAlbumGapItem(
+    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
+): item is LibraryHealthAlbumGapItem {
+    return "artist" in item;
+}
+
+/** Maps one metadata-gap item to its primary/secondary display line. */
+export function gapItemLine(
+    item: LibraryHealthAlbumGapItem | LibraryHealthTrackGapItem,
+): { primary: string; secondary: string } {
+    if (isAlbumGapItem(item)) {
+        return { primary: item.title, secondary: item.artist.name };
+    }
+    return {
+        primary: item.title,
+        secondary: `${item.artistName} — ${item.albumTitle}`,
+    };
+}
 
 /** Formats a byte count as a compact human-readable size. */
 export function formatBytes(bytes: number): string {

--- a/frontend/features/library-health/hooks/useInsightPanelLoader.ts
+++ b/frontend/features/library-health/hooks/useInsightPanelLoader.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { usePanelLoader, type PanelLoaderState } from "./usePanelLoader";
+
+export interface InsightPanelLoaderState<T> extends PanelLoaderState<T> {
+    /** Wire to InsightPanel.onFirstExpand; arms the loader effect. */
+    onFirstExpand: () => void;
+}
+
+/**
+ * Panel loader driven by expansion state: nothing is fetched until the panel
+ * first expands, the panel refetches whenever its fetcher changes (tab or
+ * filter selection), and a section-level refreshToken bump reloads every
+ * panel that has been expanded.
+ */
+export function useInsightPanelLoader<T>(
+    fetcher: () => Promise<T>,
+    errorMessage: string,
+    refreshToken: number,
+): InsightPanelLoaderState<T> {
+    const page = usePanelLoader(fetcher, errorMessage);
+    const [hasExpanded, setHasExpanded] = useState(false);
+    const { load } = page;
+
+    useEffect(() => {
+        if (hasExpanded) load();
+    }, [hasExpanded, load, refreshToken]);
+
+    const onFirstExpand = useCallback(() => {
+        setHasExpanded(true);
+    }, []);
+
+    return { ...page, onFirstExpand };
+}

--- a/frontend/features/library-health/hooks/useLibraryInsights.ts
+++ b/frontend/features/library-health/hooks/useLibraryInsights.ts
@@ -9,6 +9,8 @@ export interface LibraryInsightsState {
     isRefreshing: boolean;
     error: string | null;
     refresh: () => void;
+    /** Increments when a cache-busting refresh succeeds; expanded panels reload on change. */
+    refreshToken: number;
 }
 
 /** Loads the cached dashboard summary and exposes a cache-busting refresh. */
@@ -17,6 +19,7 @@ export function useLibraryInsights(): LibraryInsightsState {
     const [isLoading, setIsLoading] = useState(true);
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [refreshToken, setRefreshToken] = useState(0);
 
     useEffect(() => {
         let cancelled = false;
@@ -43,7 +46,10 @@ export function useLibraryInsights(): LibraryInsightsState {
         setError(null);
         void api
             .refreshLibraryHealthDashboard()
-            .then(setSummary)
+            .then((data) => {
+                setSummary(data);
+                setRefreshToken((token) => token + 1);
+            })
             .catch(() => {
                 setError("Failed to refresh library insights");
             })
@@ -52,5 +58,5 @@ export function useLibraryInsights(): LibraryInsightsState {
             });
     }, []);
 
-    return { summary, isLoading, isRefreshing, error, refresh };
+    return { summary, isLoading, isRefreshing, error, refresh, refreshToken };
 }

--- a/frontend/lib/api/libraryHealth.ts
+++ b/frontend/lib/api/libraryHealth.ts
@@ -61,7 +61,8 @@ export interface LibraryHealthTrackGapItem {
     id: string;
     title: string;
     filePath: string | null;
-    album: { title: string; artist: { name: string } };
+    albumTitle: string;
+    artistName: string;
 }
 
 export interface LibraryHealthGapPage {
@@ -83,7 +84,8 @@ export interface LibraryHealthAnalysisPage {
             id: string;
             title: string;
             analysisError: string | null;
-            album: { title: string; artist: { name: string } };
+            artistName: string;
+            albumTitle: string;
         }>;
         total: number;
         limit: number;

--- a/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
+++ b/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const Icon = (props: Record<string, unknown> = {}) =>
+    React.createElement("svg", props);
+
+mock.module("lucide-react", {
+    namedExports: {
+        ChevronDown: Icon,
+        ChevronRight: Icon,
+        Loader2: Icon,
+        RefreshCw: Icon,
+    },
+});
+
+// Fixtures mirror the EXACT payloads the backend read model returns:
+// album gap items nest the artist object; track gap items and analysis
+// failures are flat (artistName/albumTitle). See
+// backend/src/services/libraryHealthDashboard/{metadataGaps,analysisCoverage}.ts.
+const ALBUM_GAP_PAGE = {
+    kind: "missing-art",
+    counts: { artists: 1, albums: 1 },
+    items: [
+        {
+            id: "album-1",
+            title: "Bare Album",
+            rgMbid: "temp-1",
+            coverUrl: null,
+            userCoverUrl: null,
+            artist: { id: "artist-1", name: "Cover Artist" },
+        },
+    ],
+    total: 1,
+    limit: 50,
+    offset: 0,
+};
+const TRACK_GAP_PAGE = {
+    kind: "missing-genres",
+    counts: { tracks: 1 },
+    items: [
+        {
+            id: "track-1",
+            title: "Genreless Track",
+            filePath: "/music/track.flac",
+            albumTitle: "Some Album",
+            artistName: "Some Artist",
+        },
+    ],
+    total: 1,
+    limit: 50,
+    offset: 0,
+};
+const ANALYSIS_PAGE = {
+    total: 10,
+    analysisStatus: { pending: 0, processing: 0, failed: 1, completed: 9 },
+    vibeAnalysisStatus: { pending: 0, processing: 0, failed: 0, completed: 10 },
+    loudness: { measured: 10, missing: 0 },
+    failed: {
+        items: [
+            {
+                id: "track-9",
+                title: "Broken Track",
+                analysisError: "decode failed",
+                artistName: "Failing Artist",
+                albumTitle: "Failing Album",
+            },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+    },
+};
+
+const getLibraryHealthGaps = mock.fn(async (kind: string) =>
+    kind === "missing-art" ? ALBUM_GAP_PAGE : { ...TRACK_GAP_PAGE, kind },
+);
+const getLibraryHealthAnalysis = mock.fn(async () => ANALYSIS_PAGE);
+const retryFailedAnalysis = mock.fn(async () => ({ enqueued: 1 }));
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getLibraryHealthGaps,
+            getLibraryHealthAnalysis,
+            retryFailedAnalysis,
+        },
+    },
+});
+
+mock.module("@/lib/enrichmentApi", {
+    namedExports: {
+        enrichmentApi: { retryVibeEmbeddings: async () => ({ enqueued: 0 }) },
+    },
+});
+
+const SUMMARY_GAPS = {
+    missingArt: { albums: 1, artists: 1 },
+    missingMbid: { albums: 0, artists: 0 },
+    missingGenres: 1,
+    missingLyrics: 0,
+};
+const SUMMARY_COVERAGE = {
+    total: 10,
+    analysisStatus: { pending: 0, processing: 0, failed: 1, completed: 9 },
+    vibeAnalysisStatus: { pending: 0, processing: 0, failed: 0, completed: 10 },
+    loudness: { measured: 10, missing: 0 },
+};
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    getLibraryHealthGaps.mock.resetCalls();
+    getLibraryHealthAnalysis.mock.resetCalls();
+    document.body.replaceChildren();
+});
+
+async function mountPanel(
+    load: () => Promise<{ element: React.ReactElement }>,
+) {
+    const { element } = await load();
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+    return {
+        container,
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+async function click(target: Element | undefined | null) {
+    assert.ok(target instanceof HTMLElement, "expected clickable element");
+    await React.act(async () => {
+        target.click();
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+function panelHeader(): HTMLButtonElement {
+    const header = document.querySelector("button[aria-expanded]");
+    assert.ok(header instanceof HTMLButtonElement, "missing panel header");
+    return header;
+}
+
+function tabButton(label: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.trim() === label,
+    );
+    assert.ok(button instanceof HTMLButtonElement, `missing ${label} tab`);
+    return button;
+}
+
+test("metadata gaps drill-down renders backend album and track shapes", async () => {
+    const mounted = await mountPanel(async () => {
+        const { MetadataGapsPanel } =
+            await import("../../features/library-health/components/MetadataGapsPanel");
+        return {
+            element: React.createElement(MetadataGapsPanel, {
+                gaps: SUMMARY_GAPS,
+            }),
+        };
+    });
+
+    await click(panelHeader());
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 1);
+    assert.match(document.body.textContent ?? "", /Bare Album/);
+    assert.match(document.body.textContent ?? "", /Cover Artist/);
+
+    await click(tabButton("Genres"));
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 2);
+    assert.equal(
+        getLibraryHealthGaps.mock.calls[1]?.arguments[0],
+        "missing-genres",
+    );
+    assert.match(document.body.textContent ?? "", /Genreless Track/);
+    assert.match(document.body.textContent ?? "", /Some Artist — Some Album/);
+
+    await mounted.unmount();
+});
+
+test("analysis coverage drill-down renders backend failed-track shape", async () => {
+    const mounted = await mountPanel(async () => {
+        const { AnalysisCoveragePanel } =
+            await import("../../features/library-health/components/AnalysisCoveragePanel");
+        return {
+            element: React.createElement(AnalysisCoveragePanel, {
+                coverage: SUMMARY_COVERAGE,
+            }),
+        };
+    });
+
+    await click(panelHeader());
+    assert.equal(getLibraryHealthAnalysis.mock.callCount(), 1);
+    assert.match(document.body.textContent ?? "", /Broken Track/);
+    assert.match(document.body.textContent ?? "", /Failing Artist/);
+    assert.match(document.body.textContent ?? "", /decode failed/);
+
+    await mounted.unmount();
+});

--- a/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
+++ b/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
@@ -91,11 +91,42 @@ const getLibraryHealthGaps = mock.fn(async (kind: string) => {
 const getLibraryHealthAnalysis = mock.fn(async () => ANALYSIS_PAGE);
 const retryFailedAnalysis = mock.fn(async () => ({ enqueued: 1 }));
 
+function qualityPage(floor: number) {
+    return {
+        floorKbps: floor,
+        items: [
+            {
+                albumId: "album-q",
+                title: `Album under ${floor}`,
+                artist: { id: "artist-q", name: "Lossy Artist" },
+                averageBitrateKbps: floor - 20,
+                trackCount: 9,
+            },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+        sampledTracks: 10,
+        sampleLimit: 100_000,
+        isTruncated: false,
+    };
+}
+
+let deferQualityLoads = false;
+let qualityResolvers: Array<() => void> = [];
+const getLibraryHealthQuality = mock.fn((floor: number) => {
+    if (!deferQualityLoads) return Promise.resolve(qualityPage(floor));
+    return new Promise((resolve) => {
+        qualityResolvers.push(() => resolve(qualityPage(floor)));
+    });
+});
+
 mock.module("@/lib/api", {
     namedExports: {
         api: {
             getLibraryHealthGaps,
             getLibraryHealthAnalysis,
+            getLibraryHealthQuality,
             retryFailedAnalysis,
         },
     },
@@ -130,8 +161,12 @@ after(() => {
 
 beforeEach(() => {
     failGapLoads = 0;
+    deferQualityLoads = false;
+    qualityResolvers = [];
     getLibraryHealthGaps.mock.resetCalls();
     getLibraryHealthAnalysis.mock.resetCalls();
+    getLibraryHealthQuality.mock.resetCalls();
+    retryFailedAnalysis.mock.resetCalls();
     document.body.replaceChildren();
 });
 
@@ -149,6 +184,13 @@ async function mountPanel(
     });
     return {
         container,
+        rerender: async (nextElement: React.ReactElement) => {
+            await React.act(async () => {
+                root.render(nextElement);
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+        },
         unmount: async () => {
             await React.act(async () => root.unmount());
             container.remove();
@@ -186,6 +228,7 @@ test("metadata gaps drill-down renders backend album and track shapes", async ()
         return {
             element: React.createElement(MetadataGapsPanel, {
                 gaps: SUMMARY_GAPS,
+                refreshToken: 0,
             }),
         };
     });
@@ -215,6 +258,7 @@ test("a failed panel load shows an error with a working Retry control", async ()
         return {
             element: React.createElement(MetadataGapsPanel, {
                 gaps: SUMMARY_GAPS,
+                refreshToken: 0,
             }),
         };
     });
@@ -244,6 +288,7 @@ test("analysis coverage drill-down renders backend failed-track shape", async ()
         return {
             element: React.createElement(AnalysisCoveragePanel, {
                 coverage: SUMMARY_COVERAGE,
+                refreshToken: 0,
             }),
         };
     });
@@ -253,6 +298,90 @@ test("analysis coverage drill-down renders backend failed-track shape", async ()
     assert.match(document.body.textContent ?? "", /Broken Track/);
     assert.match(document.body.textContent ?? "", /Failing Artist/);
     assert.match(document.body.textContent ?? "", /decode failed/);
+
+    await mounted.unmount();
+});
+
+test("quality panel fetches on expand and floor selection, latest selection wins", async () => {
+    const { QualityPanel } =
+        await import("../../features/library-health/components/QualityPanel");
+    const mounted = await mountPanel(async () => ({
+        element: React.createElement(QualityPanel, {
+            quality: {
+                floorKbps: 192,
+                albumsBelowFloor: 1,
+                isTruncated: false,
+            },
+            refreshToken: 0,
+        }),
+    }));
+
+    await click(panelHeader());
+    assert.equal(getLibraryHealthQuality.mock.callCount(), 1);
+    assert.equal(getLibraryHealthQuality.mock.calls[0]?.arguments[0], 192);
+    assert.match(document.body.textContent ?? "", /Album under 192/);
+
+    deferQualityLoads = true;
+    await click(tabButton("128 kbps"));
+    await click(tabButton("256 kbps"));
+    assert.equal(getLibraryHealthQuality.mock.callCount(), 3);
+    assert.equal(getLibraryHealthQuality.mock.calls[1]?.arguments[0], 128);
+    assert.equal(getLibraryHealthQuality.mock.calls[2]?.arguments[0], 256);
+
+    // Resolve out of order: the superseded 128 response must not render.
+    const [resolve128, resolve256] = qualityResolvers;
+    await React.act(async () => {
+        resolve256?.();
+        await Promise.resolve();
+        resolve128?.();
+        await Promise.resolve();
+    });
+    assert.match(document.body.textContent ?? "", /Album under 256/);
+    assert.doesNotMatch(document.body.textContent ?? "", /Album under 128/);
+
+    await mounted.unmount();
+});
+
+test("a refresh-token bump reloads an expanded panel", async () => {
+    const { MetadataGapsPanel } =
+        await import("../../features/library-health/components/MetadataGapsPanel");
+    const mounted = await mountPanel(async () => ({
+        element: React.createElement(MetadataGapsPanel, {
+            gaps: SUMMARY_GAPS,
+            refreshToken: 0,
+        }),
+    }));
+
+    await click(panelHeader());
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 1);
+
+    await mounted.rerender(
+        React.createElement(MetadataGapsPanel, {
+            gaps: SUMMARY_GAPS,
+            refreshToken: 1,
+        }),
+    );
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 2);
+
+    await mounted.unmount();
+});
+
+test("analysis retry action reports remediation to the section", async () => {
+    const { AnalysisCoveragePanel } =
+        await import("../../features/library-health/components/AnalysisCoveragePanel");
+    const onRemediated = mock.fn();
+    const mounted = await mountPanel(async () => ({
+        element: React.createElement(AnalysisCoveragePanel, {
+            coverage: SUMMARY_COVERAGE,
+            refreshToken: 0,
+            onRemediated,
+        }),
+    }));
+
+    await click(panelHeader());
+    await click(tabButton("Retry failed audio analysis"));
+    assert.equal(retryFailedAnalysis.mock.callCount(), 1);
+    assert.equal(onRemediated.mock.callCount(), 1);
 
     await mounted.unmount();
 });

--- a/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
+++ b/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
@@ -78,9 +78,16 @@ const ANALYSIS_PAGE = {
     },
 };
 
-const getLibraryHealthGaps = mock.fn(async (kind: string) =>
-    kind === "missing-art" ? ALBUM_GAP_PAGE : { ...TRACK_GAP_PAGE, kind },
-);
+let failGapLoads = 0;
+const getLibraryHealthGaps = mock.fn(async (kind: string) => {
+    if (failGapLoads > 0) {
+        failGapLoads -= 1;
+        throw new Error("network down");
+    }
+    return kind === "missing-art"
+        ? ALBUM_GAP_PAGE
+        : { ...TRACK_GAP_PAGE, kind };
+});
 const getLibraryHealthAnalysis = mock.fn(async () => ANALYSIS_PAGE);
 const retryFailedAnalysis = mock.fn(async () => ({ enqueued: 1 }));
 
@@ -122,6 +129,7 @@ after(() => {
 });
 
 beforeEach(() => {
+    failGapLoads = 0;
     getLibraryHealthGaps.mock.resetCalls();
     getLibraryHealthAnalysis.mock.resetCalls();
     document.body.replaceChildren();
@@ -195,6 +203,36 @@ test("metadata gaps drill-down renders backend album and track shapes", async ()
     );
     assert.match(document.body.textContent ?? "", /Genreless Track/);
     assert.match(document.body.textContent ?? "", /Some Artist — Some Album/);
+
+    await mounted.unmount();
+});
+
+test("a failed panel load shows an error with a working Retry control", async () => {
+    failGapLoads = 1;
+    const mounted = await mountPanel(async () => {
+        const { MetadataGapsPanel } =
+            await import("../../features/library-health/components/MetadataGapsPanel");
+        return {
+            element: React.createElement(MetadataGapsPanel, {
+                gaps: SUMMARY_GAPS,
+            }),
+        };
+    });
+
+    await click(panelHeader());
+    assert.match(
+        document.body.textContent ?? "",
+        /Failed to load metadata gaps/,
+    );
+    assert.doesNotMatch(document.body.textContent ?? "", /Bare Album/);
+
+    await click(tabButton("Retry"));
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 2);
+    assert.doesNotMatch(
+        document.body.textContent ?? "",
+        /Failed to load metadata gaps/,
+    );
+    assert.match(document.body.textContent ?? "", /Bare Album/);
 
     await mounted.unmount();
 });

--- a/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
+++ b/frontend/tests/component/libraryInsightsDrilldown.component.test.ts
@@ -121,15 +121,17 @@ const getLibraryHealthQuality = mock.fn((floor: number) => {
     });
 });
 
+// Section-level methods are attached below (Object.assign) once their
+// fixtures are defined; the mocked module keeps this object's identity.
+const apiMock: Record<string, unknown> = {
+    getLibraryHealthGaps,
+    getLibraryHealthAnalysis,
+    getLibraryHealthQuality,
+    retryFailedAnalysis,
+};
+
 mock.module("@/lib/api", {
-    namedExports: {
-        api: {
-            getLibraryHealthGaps,
-            getLibraryHealthAnalysis,
-            getLibraryHealthQuality,
-            retryFailedAnalysis,
-        },
-    },
+    namedExports: { api: apiMock },
 });
 
 mock.module("@/lib/enrichmentApi", {
@@ -167,6 +169,8 @@ beforeEach(() => {
     getLibraryHealthAnalysis.mock.resetCalls();
     getLibraryHealthQuality.mock.resetCalls();
     retryFailedAnalysis.mock.resetCalls();
+    getLibraryHealthSummary.mock.resetCalls();
+    refreshLibraryHealthDashboard.mock.resetCalls();
     document.body.replaceChildren();
 });
 
@@ -323,6 +327,9 @@ test("quality panel fetches on expand and floor selection, latest selection wins
 
     deferQualityLoads = true;
     await click(tabButton("128 kbps"));
+    // While the replacement request is pending, the previous floor's rows
+    // must not render beside the newly selected floor.
+    assert.doesNotMatch(document.body.textContent ?? "", /Album under 192/);
     await click(tabButton("256 kbps"));
     assert.equal(getLibraryHealthQuality.mock.callCount(), 3);
     assert.equal(getLibraryHealthQuality.mock.calls[1]?.arguments[0], 128);
@@ -382,6 +389,139 @@ test("analysis retry action reports remediation to the section", async () => {
     await click(tabButton("Retry failed audio analysis"));
     assert.equal(retryFailedAnalysis.mock.callCount(), 1);
     assert.equal(onRemediated.mock.callCount(), 1);
+
+    await mounted.unmount();
+});
+
+// --- Section-level integration: real wiring from Recompute/remediation to panels ---
+
+const SECTION_SUMMARY_INITIAL = {
+    metadataGaps: SUMMARY_GAPS,
+    analysisCoverage: SUMMARY_COVERAGE,
+    storage: {
+        tracks: 10,
+        totalFileSize: 1024,
+        mimeTypes: 1,
+        artists: 2,
+        isTruncated: false,
+    },
+    quality: { floorKbps: 192, albumsBelowFloor: 1, isTruncated: false },
+    duplicates: {
+        clusters: 0,
+        byTier: { audioHash: 0, recordingMbid: 0, isrc: 0 },
+        isTruncated: false,
+    },
+};
+const SECTION_SUMMARY_REFRESHED = {
+    ...SECTION_SUMMARY_INITIAL,
+    metadataGaps: { ...SUMMARY_GAPS, missingArt: { albums: 7, artists: 3 } },
+    analysisCoverage: {
+        ...SUMMARY_COVERAGE,
+        analysisStatus: { pending: 0, processing: 0, failed: 0, completed: 10 },
+    },
+};
+
+const getLibraryHealthSummary = mock.fn(async () => SECTION_SUMMARY_INITIAL);
+const refreshLibraryHealthDashboard = mock.fn(
+    async () => SECTION_SUMMARY_REFRESHED,
+);
+const getLibraryHealthStorage = mock.fn(async () => ({
+    formats: [],
+    topArtists: [],
+    sampledTracks: 0,
+    sampleLimit: 100_000,
+    isTruncated: false,
+}));
+const getLibraryHealthDuplicates = mock.fn(async () => ({
+    clusters: [],
+    total: 0,
+    byTier: { audioHash: 0, recordingMbid: 0, isrc: 0 },
+    isTruncated: false,
+    limit: 25,
+    offset: 0,
+}));
+
+Object.assign(apiMock, {
+    getLibraryHealthSummary,
+    refreshLibraryHealthDashboard,
+    getLibraryHealthStorage,
+    getLibraryHealthDuplicates,
+});
+
+mock.module("@/features/settings/components/ui", {
+    namedExports: {
+        SettingsSection: (props: {
+            title: string;
+            titleExtra?: React.ReactNode;
+            description?: string;
+            children?: React.ReactNode;
+        }) =>
+            React.createElement(
+                "section",
+                null,
+                React.createElement("h2", null, props.title),
+                props.titleExtra,
+                props.children,
+            ),
+    },
+});
+
+function headerByTitle(title: string): HTMLButtonElement {
+    const header = Array.from(
+        document.querySelectorAll("button[aria-expanded]"),
+    ).find((candidate) => candidate.textContent?.includes(title));
+    assert.ok(header instanceof HTMLButtonElement, `missing ${title} header`);
+    return header;
+}
+
+function sectionButton(label: string): HTMLButtonElement {
+    const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) =>
+            candidate.getAttribute("aria-label") === label ||
+            candidate.textContent?.trim() === label,
+    );
+    assert.ok(button instanceof HTMLButtonElement, `missing ${label} button`);
+    return button;
+}
+
+test("Recompute now reloads expanded panels and updates headlines through the real section wiring", async () => {
+    const mounted = await mountPanel(async () => {
+        const { LibraryInsightsSection } =
+            await import("../../features/library-health/components/LibraryInsightsSection");
+        return { element: React.createElement(LibraryInsightsSection) };
+    });
+
+    assert.equal(getLibraryHealthSummary.mock.callCount(), 1);
+    assert.match(document.body.textContent ?? "", /1 albums without art/);
+
+    await click(headerByTitle("Metadata gaps"));
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 1);
+
+    await click(sectionButton("Recompute library insights"));
+    assert.equal(refreshLibraryHealthDashboard.mock.callCount(), 1);
+    assert.match(document.body.textContent ?? "", /7 albums without art/);
+    assert.equal(getLibraryHealthGaps.mock.callCount(), 2);
+
+    await mounted.unmount();
+});
+
+test("analysis retry refreshes the section headline through the real wiring", async () => {
+    const mounted = await mountPanel(async () => {
+        const { LibraryInsightsSection } =
+            await import("../../features/library-health/components/LibraryInsightsSection");
+        return { element: React.createElement(LibraryInsightsSection) };
+    });
+
+    assert.match(document.body.textContent ?? "", /1 failed/);
+
+    await click(headerByTitle("Analysis coverage"));
+    assert.equal(getLibraryHealthAnalysis.mock.callCount(), 1);
+
+    await click(sectionButton("Retry failed audio analysis"));
+    assert.equal(retryFailedAnalysis.mock.callCount(), 1);
+    assert.equal(refreshLibraryHealthDashboard.mock.callCount(), 1);
+    assert.match(document.body.textContent ?? "", /0 failed/);
+    assert.equal(getLibraryHealthAnalysis.mock.callCount(), 2);
 
     await mounted.unmount();
 });

--- a/frontend/tests/component/libraryInsightsSection.component.test.ts
+++ b/frontend/tests/component/libraryInsightsSection.component.test.ts
@@ -75,18 +75,23 @@ async function renderPanels() {
             null,
             React.createElement(gaps.MetadataGapsPanel, {
                 gaps: SUMMARY.metadataGaps,
+                refreshToken: 0,
             }),
             React.createElement(analysis.AnalysisCoveragePanel, {
                 coverage: SUMMARY.analysisCoverage,
+                refreshToken: 0,
             }),
             React.createElement(duplicates.DuplicatesPanel, {
                 duplicates: SUMMARY.duplicates,
+                refreshToken: 0,
             }),
             React.createElement(storage.StoragePanel, {
                 storage: SUMMARY.storage,
+                refreshToken: 0,
             }),
             React.createElement(quality.QualityPanel, {
                 quality: SUMMARY.quality,
+                refreshToken: 0,
             }),
         ),
     );

--- a/frontend/tests/unit/libraryHealthFormat.test.ts
+++ b/frontend/tests/unit/libraryHealthFormat.test.ts
@@ -4,6 +4,8 @@ import {
     formatBytes,
     formatCoveragePercent,
     formatKbps,
+    gapItemLine,
+    isAlbumGapItem,
 } from "../../features/library-health/format";
 
 test("formatBytes scales units and guards invalid input", () => {
@@ -29,4 +31,39 @@ test("formatCoveragePercent clamps and guards empty libraries", () => {
     assert.equal(formatCoveragePercent(250, 200), "100%");
     assert.equal(formatCoveragePercent(-5, 200), "0%");
     assert.equal(formatCoveragePercent(1, 0), "—");
+});
+
+// These fixtures mirror the exact row shapes produced by the backend
+// read model (listAlbumGap / listTrackGap): album items carry a nested
+// artist object, track items carry flat artistName/albumTitle fields.
+const ALBUM_GAP_ITEM = {
+    id: "album-1",
+    title: "Album Title",
+    rgMbid: "temp-abc",
+    coverUrl: null,
+    userCoverUrl: null,
+    artist: { id: "artist-1", name: "Album Artist" },
+};
+const TRACK_GAP_ITEM = {
+    id: "track-1",
+    title: "Track Title",
+    filePath: "/music/a.flac",
+    albumTitle: "Track Album",
+    artistName: "Track Artist",
+};
+
+test("gapItemLine renders album items from the backend album-gap shape", () => {
+    assert.equal(isAlbumGapItem(ALBUM_GAP_ITEM), true);
+    assert.deepEqual(gapItemLine(ALBUM_GAP_ITEM), {
+        primary: "Album Title",
+        secondary: "Album Artist",
+    });
+});
+
+test("gapItemLine renders track items from the backend track-gap shape", () => {
+    assert.equal(isAlbumGapItem(TRACK_GAP_ITEM), false);
+    assert.deepEqual(gapItemLine(TRACK_GAP_ITEM), {
+        primary: "Track Title",
+        secondary: "Track Artist — Track Album",
+    });
 });


### PR DESCRIPTION
Fixes the "problems loading some of the views" reports on the Library Insights dashboard.

## What was broken

Two drill-downs typed a nested \`album: { title, artist: { name } }\` object that the read-model API never returned (the backend has always produced flat \`albumTitle\`/\`artistName\` rows, pinned by its own service tests):

- **Metadata gaps → Genres / Lyrics tabs** read \`item.album.artist.name\` and threw a client-side TypeError as soon as real rows rendered.
- **Analysis coverage → failed-track list** read \`track.album.artist.name\` and crashed the same way whenever any track had failed analysis.

Because the crash is a React render error, it took down the whole Admin page section — nothing was logged server-side, which is why the cluster logs were clean. The existing component test only rendered collapsed panels, so the drill-down shapes were never exercised.

## The fix

- Align the frontend types (\`LibraryHealthTrackGapItem\`, analysis failed items) with the backend's flat row shape, and fix both renderers.
- Move the gap-line mapping into the pure \`format.ts\` module (\`gapItemLine\`, \`isAlbumGapItem\`).
- Gap tabs and the quality bitrate floor now fetch on selection. The old flow only fetched on a separate Load/Apply press, which both hid the crash and made tab switches look broken.

## Tests

- New interactive component test (\`libraryInsightsDrilldown.component.test.ts\`) mounts the panels with happy-dom, expands them, switches tabs, and asserts against fixtures that mirror the exact backend payloads — it fails with a TypeError on the previous code.
- Unit tests pin \`gapItemLine\` against both real row shapes.
- Local: frontend tsc clean, 933/933 unit tests pass, targeted component tests pass, eslint at the 183-warning cap with 0 errors, prettier clean, file-size gate clean.