### PR TITLE
fix(player): ramp volume-leveling gain changes and retry the preference load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Federation catalog parsing now bounds forward-compatible unknown-key warning samples, preventing oversized peer envelopes from crashing or creating unbounded warning state.
+- Volume leveling no longer steps audibly: mid-track gain changes (switching
+  the mode, saving a new target, or a queue-context change) ramp over a short
+  interval instead of jumping, and the player's mode/target preferences load
+  as one snapshot with bounded retries, so a transient settings failure at
+  startup no longer silently disables leveling until the page reloads.
 - Library Insights drill-downs no longer crash the Admin page: the metadata-gap Genres/Lyrics tabs and the analysis-coverage failure list read fields the API never returned, so expanding them with real data threw a client-side error. Gap tabs and the quality bitrate floor also fetch on selection now instead of requiring a separate Load press.
 - Transient playback recovery now resumes correctly after its automatic reload: the recovery listener was previously cancelled before it could restart playback, and a stale pre-failure position can no longer be restored before the track has made real startup progress.
 

--- a/frontend/components/player/hooks/gainTransition.ts
+++ b/frontend/components/player/hooks/gainTransition.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+    computeGainRampSteps,
+    GAIN_RAMP_STEP_MS,
+} from "@/lib/audio-engine/loudnessGainPolicy";
+
+export interface GainTransitionHandle {
+    cancel: () => void;
+}
+
+/**
+ * Steps the loudness gain from its current value to `to` through the
+ * policy's bounded ramp, applying the composited output state on every
+ * step. Returns a handle that cancels the remaining steps.
+ */
+export function startGainTransition(options: {
+    from: number;
+    to: number;
+    setGain: (value: number) => void;
+    applyOutputState: () => void;
+}): GainTransitionHandle {
+    const steps = computeGainRampSteps(options.from, options.to);
+    let stepIndex = 0;
+    const timer = setInterval(() => {
+        options.setGain(steps[stepIndex] ?? options.to);
+        options.applyOutputState();
+        stepIndex += 1;
+        if (stepIndex >= steps.length) clearInterval(timer);
+    }, GAIN_RAMP_STEP_MS);
+    return {
+        cancel: () => {
+            clearInterval(timer);
+        },
+    };
+}

--- a/frontend/components/player/hooks/loudnessPrefsLoader.ts
+++ b/frontend/components/player/hooks/loudnessPrefsLoader.ts
@@ -42,6 +42,8 @@ interface LoaderState {
     disposed: boolean;
     retryTimer: ReturnType<typeof setTimeout> | null;
     inFlight: Promise<void>;
+    /** True while a continuation is queued but not yet running. */
+    queued: boolean;
 }
 
 function clearRetry(state: LoaderState): void {
@@ -80,9 +82,7 @@ function scheduleRetry(
     state.retriesUsed += 1;
     state.retryTimer = setTimeout(() => {
         state.retryTimer = null;
-        if (loadGeneration === state.generation) {
-            enqueue(state, options, loadGeneration);
-        }
+        if (loadGeneration === state.generation) enqueue(state, options);
     }, delay);
 }
 
@@ -91,8 +91,8 @@ async function run(
     options: LoudnessPrefsLoaderOptions,
     loadGeneration: number,
 ): Promise<void> {
-    // Obsolete queued generations skip before any I/O: a disposed loader
-    // or a superseded generation never fetches.
+    // Obsolete generations skip before any I/O: a disposed loader or a
+    // superseded generation never fetches.
     if (state.disposed || loadGeneration !== state.generation) return;
     const [settingsResult, featuresResult] = await Promise.allSettled([
         options.fetchSettings(),
@@ -106,11 +106,18 @@ async function run(
 function enqueue(
     state: LoaderState,
     options: LoudnessPrefsLoaderOptions,
-    loadGeneration: number,
 ): void {
+    // Coalesce: at most one continuation waits behind the in-flight load,
+    // and it executes whatever generation is current when it starts — a
+    // reload burst therefore costs one queued continuation, not one each.
+    if (state.queued) return;
+    state.queued = true;
     state.inFlight = state.inFlight
         .catch(() => undefined)
-        .then(() => run(state, options, loadGeneration));
+        .then(() => {
+            state.queued = false;
+            return run(state, options, state.generation);
+        });
 }
 
 export function createLoudnessPrefsLoader(
@@ -122,16 +129,17 @@ export function createLoudnessPrefsLoader(
         disposed: false,
         retryTimer: null,
         inFlight: Promise.resolve(),
+        queued: false,
     };
     return {
         start: () => {
-            enqueue(state, options, state.generation);
+            enqueue(state, options);
         },
         reload: () => {
             state.generation += 1;
             state.retriesUsed = 0;
             clearRetry(state);
-            enqueue(state, options, state.generation);
+            enqueue(state, options);
         },
         dispose: () => {
             state.disposed = true;

--- a/frontend/components/player/hooks/loudnessPrefsLoader.ts
+++ b/frontend/components/player/hooks/loudnessPrefsLoader.ts
@@ -3,9 +3,10 @@
 /**
  * Serialized, generation-fenced loader for the loudness preference
  * snapshot. Each reload starts a new generation: responses and retry
- * timers from older generations are ignored, and every fetch is chained
- * behind the previous one so the API client's in-flight GET coalescing
- * can never hand a post-save reload the pre-save response.
+ * timers from older generations are ignored, obsolete queued loads skip
+ * before any I/O, and every fetch is chained behind the previous one so
+ * the API client's in-flight GET coalescing can never hand a post-save
+ * reload the pre-save response.
  */
 
 export interface LoudnessPrefsSnapshot {
@@ -35,73 +36,106 @@ export interface LoudnessPrefsLoader {
     dispose: () => void;
 }
 
+interface LoaderState {
+    generation: number;
+    retriesUsed: number;
+    disposed: boolean;
+    retryTimer: ReturnType<typeof setTimeout> | null;
+    inFlight: Promise<void>;
+}
+
+function clearRetry(state: LoaderState): void {
+    if (state.retryTimer !== null) {
+        clearTimeout(state.retryTimer);
+        state.retryTimer = null;
+    }
+}
+
+function publishSnapshot(
+    options: LoudnessPrefsLoaderOptions,
+    settingsResult: PromiseSettledResult<unknown>,
+    featuresResult: PromiseSettledResult<unknown>,
+): boolean {
+    const settingsOk =
+        settingsResult.status === "fulfilled" && Boolean(settingsResult.value);
+    const featuresOk =
+        featuresResult.status === "fulfilled" && Boolean(featuresResult.value);
+    options.onSnapshot({
+        mode: settingsOk ? options.extractMode(settingsResult.value) : null,
+        targetLufs: featuresOk
+            ? options.extractTarget(featuresResult.value)
+            : null,
+        complete: settingsOk && featuresOk,
+    });
+    return settingsOk && featuresOk;
+}
+
+function scheduleRetry(
+    state: LoaderState,
+    options: LoudnessPrefsLoaderOptions,
+    loadGeneration: number,
+): void {
+    if (state.retriesUsed >= options.retryDelaysMs.length) return;
+    const delay = options.retryDelaysMs[state.retriesUsed];
+    state.retriesUsed += 1;
+    state.retryTimer = setTimeout(() => {
+        state.retryTimer = null;
+        if (loadGeneration === state.generation) {
+            enqueue(state, options, loadGeneration);
+        }
+    }, delay);
+}
+
+async function run(
+    state: LoaderState,
+    options: LoudnessPrefsLoaderOptions,
+    loadGeneration: number,
+): Promise<void> {
+    // Obsolete queued generations skip before any I/O: a disposed loader
+    // or a superseded generation never fetches.
+    if (state.disposed || loadGeneration !== state.generation) return;
+    const [settingsResult, featuresResult] = await Promise.allSettled([
+        options.fetchSettings(),
+        options.fetchFeatures(),
+    ]);
+    if (state.disposed || loadGeneration !== state.generation) return;
+    const complete = publishSnapshot(options, settingsResult, featuresResult);
+    if (!complete) scheduleRetry(state, options, loadGeneration);
+}
+
+function enqueue(
+    state: LoaderState,
+    options: LoudnessPrefsLoaderOptions,
+    loadGeneration: number,
+): void {
+    state.inFlight = state.inFlight
+        .catch(() => undefined)
+        .then(() => run(state, options, loadGeneration));
+}
+
 export function createLoudnessPrefsLoader(
     options: LoudnessPrefsLoaderOptions,
 ): LoudnessPrefsLoader {
-    let generation = 0;
-    let retriesUsed = 0;
-    let disposed = false;
-    let retryTimer: ReturnType<typeof setTimeout> | null = null;
-    let inFlight: Promise<void> = Promise.resolve();
-
-    const clearRetry = () => {
-        if (retryTimer !== null) {
-            clearTimeout(retryTimer);
-            retryTimer = null;
-        }
+    const state: LoaderState = {
+        generation: 0,
+        retriesUsed: 0,
+        disposed: false,
+        retryTimer: null,
+        inFlight: Promise.resolve(),
     };
-
-    const run = async (loadGeneration: number): Promise<void> => {
-        const [settingsResult, featuresResult] = await Promise.allSettled([
-            options.fetchSettings(),
-            options.fetchFeatures(),
-        ]);
-        if (disposed || loadGeneration !== generation) return;
-        const settingsOk =
-            settingsResult.status === "fulfilled" &&
-            Boolean(settingsResult.value);
-        const featuresOk =
-            featuresResult.status === "fulfilled" &&
-            Boolean(featuresResult.value);
-        options.onSnapshot({
-            mode: settingsOk ? options.extractMode(settingsResult.value) : null,
-            targetLufs: featuresOk
-                ? options.extractTarget(featuresResult.value)
-                : null,
-            complete: settingsOk && featuresOk,
-        });
-        const shouldRetry =
-            (!settingsOk || !featuresOk) &&
-            retriesUsed < options.retryDelaysMs.length;
-        if (shouldRetry) {
-            const delay = options.retryDelaysMs[retriesUsed];
-            retriesUsed += 1;
-            retryTimer = setTimeout(() => {
-                retryTimer = null;
-                if (loadGeneration === generation) enqueue(loadGeneration);
-            }, delay);
-        }
-    };
-
-    const enqueue = (loadGeneration: number) => {
-        inFlight = inFlight
-            .catch(() => undefined)
-            .then(() => run(loadGeneration));
-    };
-
     return {
         start: () => {
-            enqueue(generation);
+            enqueue(state, options, state.generation);
         },
         reload: () => {
-            generation += 1;
-            retriesUsed = 0;
-            clearRetry();
-            enqueue(generation);
+            state.generation += 1;
+            state.retriesUsed = 0;
+            clearRetry(state);
+            enqueue(state, options, state.generation);
         },
         dispose: () => {
-            disposed = true;
-            clearRetry();
+            state.disposed = true;
+            clearRetry(state);
         },
     };
 }

--- a/frontend/components/player/hooks/loudnessPrefsLoader.ts
+++ b/frontend/components/player/hooks/loudnessPrefsLoader.ts
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Serialized, generation-fenced loader for the loudness preference
+ * snapshot. Each reload starts a new generation: responses and retry
+ * timers from older generations are ignored, and every fetch is chained
+ * behind the previous one so the API client's in-flight GET coalescing
+ * can never hand a post-save reload the pre-save response.
+ */
+
+export interface LoudnessPrefsSnapshot {
+    /** Parsed mode, or null when the settings request failed. */
+    mode: string | null;
+    /** Server target, or null when the features request failed or omitted it. */
+    targetLufs: number | null;
+    /** True when both requests succeeded (no retry needed). */
+    complete: boolean;
+}
+
+interface LoudnessPrefsLoaderOptions {
+    fetchSettings: () => Promise<unknown>;
+    fetchFeatures: () => Promise<unknown>;
+    extractMode: (settings: unknown) => string;
+    extractTarget: (features: unknown) => number | null;
+    onSnapshot: (snapshot: LoudnessPrefsSnapshot) => void;
+    retryDelaysMs: readonly number[];
+}
+
+export interface LoudnessPrefsLoader {
+    /** Starts the initial load. */
+    start: () => void;
+    /** Invalidates in-flight work and loads a fresh snapshot. */
+    reload: () => void;
+    /** Cancels timers and ignores every outstanding response. */
+    dispose: () => void;
+}
+
+export function createLoudnessPrefsLoader(
+    options: LoudnessPrefsLoaderOptions,
+): LoudnessPrefsLoader {
+    let generation = 0;
+    let retriesUsed = 0;
+    let disposed = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let inFlight: Promise<void> = Promise.resolve();
+
+    const clearRetry = () => {
+        if (retryTimer !== null) {
+            clearTimeout(retryTimer);
+            retryTimer = null;
+        }
+    };
+
+    const run = async (loadGeneration: number): Promise<void> => {
+        const [settingsResult, featuresResult] = await Promise.allSettled([
+            options.fetchSettings(),
+            options.fetchFeatures(),
+        ]);
+        if (disposed || loadGeneration !== generation) return;
+        const settingsOk =
+            settingsResult.status === "fulfilled" &&
+            Boolean(settingsResult.value);
+        const featuresOk =
+            featuresResult.status === "fulfilled" &&
+            Boolean(featuresResult.value);
+        options.onSnapshot({
+            mode: settingsOk ? options.extractMode(settingsResult.value) : null,
+            targetLufs: featuresOk
+                ? options.extractTarget(featuresResult.value)
+                : null,
+            complete: settingsOk && featuresOk,
+        });
+        const shouldRetry =
+            (!settingsOk || !featuresOk) &&
+            retriesUsed < options.retryDelaysMs.length;
+        if (shouldRetry) {
+            const delay = options.retryDelaysMs[retriesUsed];
+            retriesUsed += 1;
+            retryTimer = setTimeout(() => {
+                retryTimer = null;
+                if (loadGeneration === generation) enqueue(loadGeneration);
+            }, delay);
+        }
+    };
+
+    const enqueue = (loadGeneration: number) => {
+        inFlight = inFlight
+            .catch(() => undefined)
+            .then(() => run(loadGeneration));
+    };
+
+    return {
+        start: () => {
+            enqueue(generation);
+        },
+        reload: () => {
+            generation += 1;
+            retriesUsed = 0;
+            clearRetry();
+            enqueue(generation);
+        },
+        dispose: () => {
+            disposed = true;
+            clearRetry();
+        },
+    };
+}

--- a/frontend/components/player/hooks/useLoudnessNormalization.ts
+++ b/frontend/components/player/hooks/useLoudnessNormalization.ts
@@ -3,9 +3,7 @@
 import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import { api } from "@/lib/api";
 import {
-    computeGainRampSteps,
     DEFAULT_LOUDNESS_TARGET_LUFS,
-    GAIN_RAMP_STEP_MS,
     isAlbumOrderedQueue,
     LOUDNESS_MODES,
     resolveLoudnessGain,
@@ -14,6 +12,11 @@ import {
 import { useAudioState } from "@/lib/audio-state-context";
 import { isEpisodeQueueItem } from "@/lib/queue-item";
 import { USER_SETTINGS_UPDATED_EVENT } from "@/lib/userSettingsEvents";
+import {
+    startGainTransition,
+    type GainTransitionHandle,
+} from "./gainTransition";
+import { createLoudnessPrefsLoader } from "./loudnessPrefsLoader";
 
 function parseLoudnessMode(value: unknown): LoudnessMode | null {
     return LOUDNESS_MODES.includes(value as LoudnessMode)
@@ -31,7 +34,7 @@ interface LoudnessPrefs {
     targetLufs: number;
 }
 
-/** Bounded retry backoff for the initial preference snapshot. */
+/** Bounded retry backoff for the preference snapshot. */
 const PREFS_RETRY_DELAYS_MS = [2_000, 5_000, 15_000] as const;
 
 function extractLoudnessMode(settings: unknown): LoudnessMode {
@@ -51,9 +54,9 @@ function extractTargetLufs(features: unknown): number | null {
  * Reads the user's loudness mode and the server target directly from the
  * API (deliberately not through react-query or the features context: this
  * hook mounts inside the playback orchestrator, whose component harness
- * provides neither). The two values load as one snapshot, retry with
- * bounded backoff when either request fails, and refresh when the settings
- * page announces a save.
+ * provides neither). The snapshot loads through a serialized,
+ * generation-fenced loader with bounded retries, and refreshes when the
+ * settings page announces a save.
  */
 function useLoudnessPrefs(): LoudnessPrefs {
     // Mode stays "off" until the stored preference loads, so gain is never
@@ -64,69 +67,38 @@ function useLoudnessPrefs(): LoudnessPrefs {
     });
 
     useEffect(() => {
-        let cancelled = false;
-        let retryTimer: ReturnType<typeof setTimeout> | null = null;
-        let retriesUsed = 0;
-
-        const load = () => {
-            void Promise.allSettled([
+        const loader = createLoudnessPrefsLoader({
+            fetchSettings: () =>
                 Promise.resolve().then(() => api.getSettings?.()),
+            fetchFeatures: () =>
                 Promise.resolve().then(() => api.getFeatures?.()),
-            ]).then(([settingsResult, featuresResult]) => {
-                if (cancelled) return;
-                const settingsOk =
-                    settingsResult.status === "fulfilled" &&
-                    Boolean(settingsResult.value);
-                const featuresOk =
-                    featuresResult.status === "fulfilled" &&
-                    Boolean(featuresResult.value);
-                const mode = settingsOk
-                    ? extractLoudnessMode(settingsResult.value)
-                    : null;
-                const target = featuresOk
-                    ? extractTargetLufs(featuresResult.value)
-                    : null;
+            extractMode: extractLoudnessMode,
+            extractTarget: extractTargetLufs,
+            retryDelaysMs: PREFS_RETRY_DELAYS_MS,
+            onSnapshot: ({ mode, targetLufs }) => {
                 setPrefs((prev) => {
                     const next = {
-                        mode: mode ?? prev.mode,
-                        targetLufs: target ?? prev.targetLufs,
+                        mode: (mode as LoudnessMode | null) ?? prev.mode,
+                        targetLufs: targetLufs ?? prev.targetLufs,
                     };
                     return next.mode === prev.mode &&
                         next.targetLufs === prev.targetLufs
                         ? prev
                         : next;
                 });
-                const shouldRetry =
-                    (!settingsOk || !featuresOk) &&
-                    retriesUsed < PREFS_RETRY_DELAYS_MS.length &&
-                    typeof window !== "undefined";
-                if (shouldRetry) {
-                    retryTimer = setTimeout(
-                        load,
-                        PREFS_RETRY_DELAYS_MS[retriesUsed],
-                    );
-                    retriesUsed += 1;
-                }
-            });
-        };
-
-        const reload = () => {
-            retriesUsed = 0;
-            if (retryTimer !== null) clearTimeout(retryTimer);
-            load();
-        };
-
-        load();
+            },
+        });
+        loader.start();
         if (typeof window === "undefined") {
-            return () => {
-                cancelled = true;
-            };
+            return loader.dispose;
         }
-        window.addEventListener(USER_SETTINGS_UPDATED_EVENT, reload);
+        window.addEventListener(USER_SETTINGS_UPDATED_EVENT, loader.reload);
         return () => {
-            cancelled = true;
-            if (retryTimer !== null) clearTimeout(retryTimer);
-            window.removeEventListener(USER_SETTINGS_UPDATED_EVENT, reload);
+            loader.dispose();
+            window.removeEventListener(
+                USER_SETTINGS_UPDATED_EVENT,
+                loader.reload,
+            );
         };
     }, []);
 
@@ -152,7 +124,7 @@ export function useLoudnessNormalization({
 }: UseLoudnessNormalizationOptions): void {
     const { currentTrack, playbackType, queue, isShuffle } = useAudioState();
     const { mode, targetLufs } = useLoudnessPrefs();
-    const rampTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const transitionRef = useRef<GainTransitionHandle | null>(null);
     const lastTrackIdRef = useRef<string | null>(null);
 
     useEffect(() => {
@@ -173,10 +145,8 @@ export function useLoudnessNormalization({
         const trackChanged = trackId !== lastTrackIdRef.current;
         lastTrackIdRef.current = trackId;
 
-        if (rampTimerRef.current !== null) {
-            clearInterval(rampTimerRef.current);
-            rampTimerRef.current = null;
-        }
+        transitionRef.current?.cancel();
+        transitionRef.current = null;
         const previous = loudnessGainFactorRef.current;
         if (previous === decision.gainFactor) return;
 
@@ -186,18 +156,14 @@ export function useLoudnessNormalization({
             return;
         }
 
-        const steps = computeGainRampSteps(previous, decision.gainFactor);
-        let stepIndex = 0;
-        rampTimerRef.current = setInterval(() => {
-            loudnessGainFactorRef.current =
-                steps[stepIndex] ?? decision.gainFactor;
-            applyCurrentOutputState();
-            stepIndex += 1;
-            if (stepIndex >= steps.length && rampTimerRef.current !== null) {
-                clearInterval(rampTimerRef.current);
-                rampTimerRef.current = null;
-            }
-        }, GAIN_RAMP_STEP_MS);
+        transitionRef.current = startGainTransition({
+            from: previous,
+            to: decision.gainFactor,
+            setGain: (value) => {
+                loudnessGainFactorRef.current = value;
+            },
+            applyOutputState: applyCurrentOutputState,
+        });
     }, [
         mode,
         targetLufs,
@@ -211,9 +177,7 @@ export function useLoudnessNormalization({
 
     useEffect(
         () => () => {
-            if (rampTimerRef.current !== null) {
-                clearInterval(rampTimerRef.current);
-            }
+            transitionRef.current?.cancel();
         },
         [],
     );

--- a/frontend/components/player/hooks/useLoudnessNormalization.ts
+++ b/frontend/components/player/hooks/useLoudnessNormalization.ts
@@ -105,16 +105,66 @@ function useLoudnessPrefs(): LoudnessPrefs {
     return prefs;
 }
 
+type AudioStateSlice = Pick<
+    ReturnType<typeof useAudioState>,
+    "currentTrack" | "playbackType" | "queue" | "isShuffle"
+>;
+
+interface GainSyncInput extends AudioStateSlice {
+    prefs: LoudnessPrefs;
+    loudnessGainFactorRef: MutableRefObject<number>;
+    applyCurrentOutputState: () => void;
+    transitionRef: MutableRefObject<GainTransitionHandle | null>;
+    lastTrackIdRef: MutableRefObject<string | null>;
+}
+
+/**
+ * Recomputes the gain decision and applies it: immediately when the track
+ * changed (the content changes anyway), through a short ramp for a
+ * mid-track mode/target/queue-context change so the volume never jumps.
+ */
+function syncLoudnessGain(input: GainSyncInput): void {
+    // A queue containing podcast episodes is never an album context.
+    const trackItems = input.queue.filter((item) => !isEpisodeQueueItem(item));
+    const isTrack = input.playbackType === "track";
+    const decision = resolveLoudnessGain({
+        mode: input.prefs.mode,
+        targetLufs: input.prefs.targetLufs,
+        isAlbumContext:
+            trackItems.length === input.queue.length &&
+            isAlbumOrderedQueue(trackItems, input.isShuffle),
+        track: isTrack ? input.currentTrack : null,
+    });
+    const trackId = isTrack ? (input.currentTrack?.id ?? null) : null;
+    const trackChanged = trackId !== input.lastTrackIdRef.current;
+    input.lastTrackIdRef.current = trackId;
+
+    input.transitionRef.current?.cancel();
+    input.transitionRef.current = null;
+    const previous = input.loudnessGainFactorRef.current;
+    if (previous === decision.gainFactor) return;
+
+    if (trackChanged || typeof window === "undefined") {
+        input.loudnessGainFactorRef.current = decision.gainFactor;
+        input.applyCurrentOutputState();
+        return;
+    }
+    input.transitionRef.current = startGainTransition({
+        from: previous,
+        to: decision.gainFactor,
+        setGain: (value) => {
+            input.loudnessGainFactorRef.current = value;
+        },
+        applyOutputState: input.applyCurrentOutputState,
+    });
+}
+
 /**
  * Keeps the loudness-normalization gain factor in sync with the current
  * track, the user's mode (Settings → Playback), and the server target
  * (issue #526). The factor is composited with user volume inside
  * applyCurrentOutputState; this hook only recomputes it and re-applies the
  * output state when the applied gain actually changes.
- *
- * A gain change caused by a track change applies immediately (the content
- * changes anyway); a mid-track change (mode, target, or queue context)
- * ramps over a short interval so the volume never jumps audibly.
  *
  * Audiobooks and podcasts are never normalized.
  */
@@ -123,50 +173,24 @@ export function useLoudnessNormalization({
     applyCurrentOutputState,
 }: UseLoudnessNormalizationOptions): void {
     const { currentTrack, playbackType, queue, isShuffle } = useAudioState();
-    const { mode, targetLufs } = useLoudnessPrefs();
+    const prefs = useLoudnessPrefs();
     const transitionRef = useRef<GainTransitionHandle | null>(null);
     const lastTrackIdRef = useRef<string | null>(null);
 
     useEffect(() => {
-        // A queue containing podcast episodes is never an album context.
-        const trackItems = queue.filter((item) => !isEpisodeQueueItem(item));
-        const isAlbumContext =
-            trackItems.length === queue.length &&
-            isAlbumOrderedQueue(trackItems, isShuffle);
-        const decision = resolveLoudnessGain({
-            mode,
-            targetLufs,
-            isAlbumContext,
-            track: playbackType === "track" ? currentTrack : null,
-        });
-
-        const trackId =
-            playbackType === "track" ? (currentTrack?.id ?? null) : null;
-        const trackChanged = trackId !== lastTrackIdRef.current;
-        lastTrackIdRef.current = trackId;
-
-        transitionRef.current?.cancel();
-        transitionRef.current = null;
-        const previous = loudnessGainFactorRef.current;
-        if (previous === decision.gainFactor) return;
-
-        if (trackChanged || typeof window === "undefined") {
-            loudnessGainFactorRef.current = decision.gainFactor;
-            applyCurrentOutputState();
-            return;
-        }
-
-        transitionRef.current = startGainTransition({
-            from: previous,
-            to: decision.gainFactor,
-            setGain: (value) => {
-                loudnessGainFactorRef.current = value;
-            },
-            applyOutputState: applyCurrentOutputState,
+        syncLoudnessGain({
+            prefs,
+            currentTrack,
+            playbackType,
+            queue,
+            isShuffle,
+            loudnessGainFactorRef,
+            applyCurrentOutputState,
+            transitionRef,
+            lastTrackIdRef,
         });
     }, [
-        mode,
-        targetLufs,
+        prefs,
         currentTrack,
         playbackType,
         queue,

--- a/frontend/components/player/hooks/useLoudnessNormalization.ts
+++ b/frontend/components/player/hooks/useLoudnessNormalization.ts
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useState, type MutableRefObject } from "react";
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import { api } from "@/lib/api";
 import {
+    computeGainRampSteps,
     DEFAULT_LOUDNESS_TARGET_LUFS,
-    LOUDNESS_MODES,
+    GAIN_RAMP_STEP_MS,
     isAlbumOrderedQueue,
+    LOUDNESS_MODES,
     resolveLoudnessGain,
     type LoudnessMode,
 } from "@/lib/audio-engine/loudnessGainPolicy";
@@ -29,11 +31,29 @@ interface LoudnessPrefs {
     targetLufs: number;
 }
 
+/** Bounded retry backoff for the initial preference snapshot. */
+const PREFS_RETRY_DELAYS_MS = [2_000, 5_000, 15_000] as const;
+
+function extractLoudnessMode(settings: unknown): LoudnessMode {
+    const stored = (settings as { loudnessMode?: unknown }).loudnessMode;
+    return parseLoudnessMode(stored) ?? "auto";
+}
+
+function extractTargetLufs(features: unknown): number | null {
+    const target = (features as { loudnessTargetLufs?: unknown })
+        .loudnessTargetLufs;
+    return typeof target === "number" && Number.isFinite(target)
+        ? target
+        : null;
+}
+
 /**
  * Reads the user's loudness mode and the server target directly from the
  * API (deliberately not through react-query or the features context: this
  * hook mounts inside the playback orchestrator, whose component harness
- * provides neither). Refreshes when the settings page announces a save.
+ * provides neither). The two values load as one snapshot, retry with
+ * bounded backoff when either request fails, and refresh when the settings
+ * page announces a save.
  */
 function useLoudnessPrefs(): LoudnessPrefs {
     // Mode stays "off" until the stored preference loads, so gain is never
@@ -45,46 +65,68 @@ function useLoudnessPrefs(): LoudnessPrefs {
 
     useEffect(() => {
         let cancelled = false;
+        let retryTimer: ReturnType<typeof setTimeout> | null = null;
+        let retriesUsed = 0;
+
         const load = () => {
-            Promise.resolve()
-                .then(() => api.getSettings?.())
-                .then((settings) => {
-                    if (cancelled || !settings) return;
-                    const stored = (settings as { loudnessMode?: unknown })
-                        .loudnessMode;
-                    const mode = parseLoudnessMode(stored) ?? "auto";
-                    setPrefs((prev) =>
-                        prev.mode === mode ? prev : { ...prev, mode },
+            void Promise.allSettled([
+                Promise.resolve().then(() => api.getSettings?.()),
+                Promise.resolve().then(() => api.getFeatures?.()),
+            ]).then(([settingsResult, featuresResult]) => {
+                if (cancelled) return;
+                const settingsOk =
+                    settingsResult.status === "fulfilled" &&
+                    Boolean(settingsResult.value);
+                const featuresOk =
+                    featuresResult.status === "fulfilled" &&
+                    Boolean(featuresResult.value);
+                const mode = settingsOk
+                    ? extractLoudnessMode(settingsResult.value)
+                    : null;
+                const target = featuresOk
+                    ? extractTargetLufs(featuresResult.value)
+                    : null;
+                setPrefs((prev) => {
+                    const next = {
+                        mode: mode ?? prev.mode,
+                        targetLufs: target ?? prev.targetLufs,
+                    };
+                    return next.mode === prev.mode &&
+                        next.targetLufs === prev.targetLufs
+                        ? prev
+                        : next;
+                });
+                const shouldRetry =
+                    (!settingsOk || !featuresOk) &&
+                    retriesUsed < PREFS_RETRY_DELAYS_MS.length &&
+                    typeof window !== "undefined";
+                if (shouldRetry) {
+                    retryTimer = setTimeout(
+                        load,
+                        PREFS_RETRY_DELAYS_MS[retriesUsed],
                     );
-                })
-                .catch(() => undefined);
-            Promise.resolve()
-                .then(() => api.getFeatures?.())
-                .then((features) => {
-                    if (cancelled || !features) return;
-                    const target = (
-                        features as { loudnessTargetLufs?: unknown }
-                    ).loudnessTargetLufs;
-                    if (typeof target !== "number" || !Number.isFinite(target))
-                        return;
-                    setPrefs((prev) =>
-                        prev.targetLufs === target
-                            ? prev
-                            : { ...prev, targetLufs: target },
-                    );
-                })
-                .catch(() => undefined);
+                    retriesUsed += 1;
+                }
+            });
         };
+
+        const reload = () => {
+            retriesUsed = 0;
+            if (retryTimer !== null) clearTimeout(retryTimer);
+            load();
+        };
+
         load();
         if (typeof window === "undefined") {
             return () => {
                 cancelled = true;
             };
         }
-        window.addEventListener(USER_SETTINGS_UPDATED_EVENT, load);
+        window.addEventListener(USER_SETTINGS_UPDATED_EVENT, reload);
         return () => {
             cancelled = true;
-            window.removeEventListener(USER_SETTINGS_UPDATED_EVENT, load);
+            if (retryTimer !== null) clearTimeout(retryTimer);
+            window.removeEventListener(USER_SETTINGS_UPDATED_EVENT, reload);
         };
     }, []);
 
@@ -98,6 +140,10 @@ function useLoudnessPrefs(): LoudnessPrefs {
  * applyCurrentOutputState; this hook only recomputes it and re-applies the
  * output state when the applied gain actually changes.
  *
+ * A gain change caused by a track change applies immediately (the content
+ * changes anyway); a mid-track change (mode, target, or queue context)
+ * ramps over a short interval so the volume never jumps audibly.
+ *
  * Audiobooks and podcasts are never normalized.
  */
 export function useLoudnessNormalization({
@@ -106,6 +152,8 @@ export function useLoudnessNormalization({
 }: UseLoudnessNormalizationOptions): void {
     const { currentTrack, playbackType, queue, isShuffle } = useAudioState();
     const { mode, targetLufs } = useLoudnessPrefs();
+    const rampTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const lastTrackIdRef = useRef<string | null>(null);
 
     useEffect(() => {
         // A queue containing podcast episodes is never an album context.
@@ -119,9 +167,37 @@ export function useLoudnessNormalization({
             isAlbumContext,
             track: playbackType === "track" ? currentTrack : null,
         });
-        if (loudnessGainFactorRef.current === decision.gainFactor) return;
-        loudnessGainFactorRef.current = decision.gainFactor;
-        applyCurrentOutputState();
+
+        const trackId =
+            playbackType === "track" ? (currentTrack?.id ?? null) : null;
+        const trackChanged = trackId !== lastTrackIdRef.current;
+        lastTrackIdRef.current = trackId;
+
+        if (rampTimerRef.current !== null) {
+            clearInterval(rampTimerRef.current);
+            rampTimerRef.current = null;
+        }
+        const previous = loudnessGainFactorRef.current;
+        if (previous === decision.gainFactor) return;
+
+        if (trackChanged || typeof window === "undefined") {
+            loudnessGainFactorRef.current = decision.gainFactor;
+            applyCurrentOutputState();
+            return;
+        }
+
+        const steps = computeGainRampSteps(previous, decision.gainFactor);
+        let stepIndex = 0;
+        rampTimerRef.current = setInterval(() => {
+            loudnessGainFactorRef.current =
+                steps[stepIndex] ?? decision.gainFactor;
+            applyCurrentOutputState();
+            stepIndex += 1;
+            if (stepIndex >= steps.length && rampTimerRef.current !== null) {
+                clearInterval(rampTimerRef.current);
+                rampTimerRef.current = null;
+            }
+        }, GAIN_RAMP_STEP_MS);
     }, [
         mode,
         targetLufs,
@@ -132,4 +208,13 @@ export function useLoudnessNormalization({
         loudnessGainFactorRef,
         applyCurrentOutputState,
     ]);
+
+    useEffect(
+        () => () => {
+            if (rampTimerRef.current !== null) {
+                clearInterval(rampTimerRef.current);
+            }
+        },
+        [],
+    );
 }

--- a/frontend/lib/audio-engine/loudnessGainPolicy.ts
+++ b/frontend/lib/audio-engine/loudnessGainPolicy.ts
@@ -183,10 +183,14 @@ export const GAIN_RAMP_STEPS = 8;
 /** Milliseconds between mid-track gain transition steps. */
 export const GAIN_RAMP_STEP_MS = 25;
 
+/** Upper bound on ramp steps so a caller can never request an unbounded loop. */
+const GAIN_RAMP_STEPS_MAX = 32;
+
 /**
- * Returns the intermediate gain factors for a smooth mid-track transition.
+ * Returns the gain factors applied during a smooth mid-track transition.
  * The sequence always ends exactly at `to`; a degenerate or non-finite
- * input collapses to a single immediate step.
+ * input collapses to a single immediate step, and the step count is
+ * clamped to a small integer bound.
  */
 export function computeGainRampSteps(
     from: number,
@@ -194,10 +198,13 @@ export function computeGainRampSteps(
     steps: number = GAIN_RAMP_STEPS,
 ): number[] {
     if (!Number.isFinite(from) || !Number.isFinite(to)) return [to];
-    if (from === to || steps <= 1) return [to];
+    const boundedSteps = Number.isFinite(steps)
+        ? Math.min(GAIN_RAMP_STEPS_MAX, Math.max(1, Math.round(steps)))
+        : GAIN_RAMP_STEPS;
+    if (from === to || boundedSteps <= 1) return [to];
     const sequence: number[] = [];
-    for (let index = 1; index <= steps; index += 1) {
-        sequence.push(from + ((to - from) * index) / steps);
+    for (let index = 1; index <= boundedSteps; index += 1) {
+        sequence.push(from + ((to - from) * index) / boundedSteps);
     }
     sequence[sequence.length - 1] = to;
     return sequence;

--- a/frontend/lib/audio-engine/loudnessGainPolicy.ts
+++ b/frontend/lib/audio-engine/loudnessGainPolicy.ts
@@ -176,3 +176,29 @@ export function resolveLoudnessGain(
         reason: grantedDb < desiredDb ? "boost_clamped" : "leveled",
     };
 }
+
+/** Number of intermediate volume steps in a mid-track gain transition. */
+export const GAIN_RAMP_STEPS = 8;
+
+/** Milliseconds between mid-track gain transition steps. */
+export const GAIN_RAMP_STEP_MS = 25;
+
+/**
+ * Returns the intermediate gain factors for a smooth mid-track transition.
+ * The sequence always ends exactly at `to`; a degenerate or non-finite
+ * input collapses to a single immediate step.
+ */
+export function computeGainRampSteps(
+    from: number,
+    to: number,
+    steps: number = GAIN_RAMP_STEPS,
+): number[] {
+    if (!Number.isFinite(from) || !Number.isFinite(to)) return [to];
+    if (from === to || steps <= 1) return [to];
+    const sequence: number[] = [];
+    for (let index = 1; index <= steps; index += 1) {
+        sequence.push(from + ((to - from) * index) / steps);
+    }
+    sequence[sequence.length - 1] = to;
+    return sequence;
+}

--- a/frontend/tests/component/useLoudnessNormalization.component.test.ts
+++ b/frontend/tests/component/useLoudnessNormalization.component.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test, type TestContext } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { USER_SETTINGS_UPDATED_EVENT } from "../../lib/userSettingsEvents";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let settingsFailures = 0;
+let featuresFailures = 0;
+let currentMode = "auto";
+let currentTarget = -18;
+
+const getSettings = mock.fn(async () => {
+    if (settingsFailures > 0) {
+        settingsFailures -= 1;
+        throw new Error("settings down");
+    }
+    return { loudnessMode: currentMode };
+});
+const getFeatures = mock.fn(async () => {
+    if (featuresFailures > 0) {
+        featuresFailures -= 1;
+        throw new Error("features down");
+    }
+    return { loudnessTargetLufs: currentTarget };
+});
+
+mock.module("@/lib/api", {
+    namedExports: { api: { getSettings, getFeatures } },
+});
+
+interface ProbeTrack {
+    id: string;
+    loudnessLufs: number | null;
+    truePeakDb: number | null;
+}
+
+const audioState: {
+    currentTrack: ProbeTrack | null;
+    playbackType: string;
+    queue: unknown[];
+    isShuffle: boolean;
+} = {
+    currentTrack: null,
+    playbackType: "track",
+    queue: [],
+    isShuffle: false,
+};
+
+mock.module("@/lib/audio-state-context", {
+    namedExports: {
+        useAudioState: () => ({ ...audioState }),
+    },
+});
+
+type UseLoudnessNormalization =
+    (typeof import("../../components/player/hooks/useLoudnessNormalization"))["useLoudnessNormalization"];
+
+let useLoudnessNormalizationHook: UseLoudnessNormalization | null = null;
+
+const gainRef = { current: 1 };
+const applyCalls: number[] = [];
+const applyCurrentOutputState = () => {
+    applyCalls.push(gainRef.current);
+};
+
+function Probe(): null {
+    assert.ok(useLoudnessNormalizationHook, "hook not loaded");
+    useLoudnessNormalizationHook({
+        loudnessGainFactorRef: gainRef,
+        applyCurrentOutputState,
+    });
+    return null;
+}
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    settingsFailures = 0;
+    featuresFailures = 0;
+    currentMode = "auto";
+    currentTarget = -18;
+    gainRef.current = 1;
+    applyCalls.length = 0;
+    getSettings.mock.resetCalls();
+    getFeatures.mock.resetCalls();
+    audioState.currentTrack = null;
+    audioState.playbackType = "track";
+    audioState.queue = [];
+    audioState.isShuffle = false;
+    document.body.replaceChildren();
+});
+
+async function flushAsync() {
+    for (let index = 0; index < 12; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+async function mountProbe() {
+    ({ useLoudnessNormalization: useLoudnessNormalizationHook } =
+        await import("../../components/player/hooks/useLoudnessNormalization"));
+    const { createRoot } = await import("react-dom/client");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(React.createElement(Probe));
+        await flushAsync();
+    });
+    return {
+        rerender: async () => {
+            await React.act(async () => {
+                root.render(React.createElement(Probe));
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+        },
+        unmount: async () => {
+            await React.act(async () => root.unmount());
+            container.remove();
+        },
+    };
+}
+
+const LOUD_TRACK: ProbeTrack = {
+    id: "track-loud",
+    loudnessLufs: -8,
+    truePeakDb: -1,
+};
+// -18 target minus -8 measured = -10 dB of attenuation.
+const LOUD_TRACK_FACTOR = 10 ** (-10 / 20);
+
+async function settleRamp(t: TestContext) {
+    await React.act(async () => {
+        t.mock.timers.tick(25 * 8);
+        await flushAsync();
+    });
+}
+
+test("a failed initial preference load retries and then applies gain", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    settingsFailures = 1;
+    featuresFailures = 1;
+    audioState.currentTrack = LOUD_TRACK;
+
+    const mounted = await mountProbe();
+    assert.equal(gainRef.current, 1);
+
+    await React.act(async () => {
+        t.mock.timers.tick(2_000);
+        await flushAsync();
+    });
+    await settleRamp(t);
+    assert.equal(getSettings.mock.callCount(), 2);
+    assert.ok(Math.abs(gainRef.current - LOUD_TRACK_FACTOR) < 1e-9);
+
+    await mounted.unmount();
+});
+
+test("a mid-track mode change ramps the gain instead of stepping", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+
+    const mounted = await mountProbe();
+    await settleRamp(t);
+    assert.ok(Math.abs(gainRef.current - LOUD_TRACK_FACTOR) < 1e-9);
+    const applied = applyCalls.length;
+
+    currentMode = "off";
+    await React.act(async () => {
+        window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        await flushAsync();
+    });
+    // The transition back to unity runs through interval steps.
+    await React.act(async () => {
+        t.mock.timers.tick(25 * 8);
+        await flushAsync();
+    });
+    const rampSteps = applyCalls.slice(applied);
+    assert.equal(rampSteps.length, 8);
+    for (let index = 1; index < rampSteps.length; index += 1) {
+        assert.ok(rampSteps[index] > rampSteps[index - 1]);
+    }
+    assert.equal(gainRef.current, 1);
+
+    await mounted.unmount();
+});
+
+test("a track change applies the new gain immediately with no ramp", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+
+    const mounted = await mountProbe();
+    await settleRamp(t);
+    const applied = applyCalls.length;
+
+    audioState.currentTrack = {
+        id: "track-quiet",
+        loudnessLufs: -18,
+        truePeakDb: -6,
+    };
+    await mounted.rerender();
+    assert.equal(applyCalls.length, applied + 1);
+    assert.equal(gainRef.current, 1);
+
+    await React.act(async () => {
+        t.mock.timers.tick(1_000);
+        await flushAsync();
+    });
+    assert.equal(applyCalls.length, applied + 1);
+
+    await mounted.unmount();
+});

--- a/frontend/tests/component/useLoudnessNormalization.component.test.ts
+++ b/frontend/tests/component/useLoudnessNormalization.component.test.ts
@@ -334,3 +334,36 @@ test("queued obsolete generations never fetch after disposal", async (t) => {
     });
     assert.equal(getSettings.mock.callCount(), 1);
 });
+
+test("a reload burst coalesces into a single queued fetch", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+    deferSettings = true;
+
+    const mounted = await mountProbe();
+    assert.equal(getSettings.mock.callCount(), 1);
+
+    currentMode = "off";
+    await React.act(async () => {
+        for (let index = 0; index < 50; index += 1) {
+            window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        }
+        await flushAsync();
+    });
+    assert.equal(getSettings.mock.callCount(), 1);
+
+    await React.act(async () => {
+        settingsResolvers[0]?.();
+        await flushAsync();
+    });
+    // Fifty reloads produced exactly one follow-up fetch.
+    assert.equal(getSettings.mock.callCount(), 2);
+    await React.act(async () => {
+        settingsResolvers[1]?.();
+        await flushAsync();
+    });
+    await settleRamp(t);
+    assert.equal(gainRef.current, 1);
+
+    await mounted.unmount();
+});

--- a/frontend/tests/component/useLoudnessNormalization.component.test.ts
+++ b/frontend/tests/component/useLoudnessNormalization.component.test.ts
@@ -13,13 +13,19 @@ let settingsFailures = 0;
 let featuresFailures = 0;
 let currentMode = "auto";
 let currentTarget = -18;
+let deferSettings = false;
+let settingsResolvers: Array<() => void> = [];
 
-const getSettings = mock.fn(async () => {
+const getSettings = mock.fn(() => {
     if (settingsFailures > 0) {
         settingsFailures -= 1;
-        throw new Error("settings down");
+        return Promise.reject(new Error("settings down"));
     }
-    return { loudnessMode: currentMode };
+    if (!deferSettings) return Promise.resolve({ loudnessMode: currentMode });
+    return new Promise((resolve) => {
+        const mode = currentMode;
+        settingsResolvers.push(() => resolve({ loudnessMode: mode }));
+    });
 });
 const getFeatures = mock.fn(async () => {
     if (featuresFailures > 0) {
@@ -88,6 +94,8 @@ after(() => {
 beforeEach(() => {
     settingsFailures = 0;
     featuresFailures = 0;
+    deferSettings = false;
+    settingsResolvers = [];
     currentMode = "auto";
     currentTarget = -18;
     gainRef.current = 1;
@@ -221,4 +229,76 @@ test("a track change applies the new gain immediately with no ramp", async (t) =
     assert.equal(applyCalls.length, applied + 1);
 
     await mounted.unmount();
+});
+
+test("a settings-event reload ignores the superseded in-flight response", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+    deferSettings = true;
+
+    const mounted = await mountProbe();
+    assert.equal(settingsResolvers.length, 1);
+    assert.equal(gainRef.current, 1);
+
+    // The user saves mode=off before the initial (auto) response arrives.
+    currentMode = "off";
+    await React.act(async () => {
+        window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        await flushAsync();
+    });
+
+    // The stale auto response settles first; the reload's own request
+    // (serialized behind it) then resolves with off.
+    await React.act(async () => {
+        settingsResolvers[0]?.();
+        await flushAsync();
+        settingsResolvers[1]?.();
+        await flushAsync();
+    });
+    await settleRamp(t);
+    assert.equal(gainRef.current, 1);
+    assert.equal(getSettings.mock.callCount(), 2);
+
+    await mounted.unmount();
+});
+
+test("a reload cancels the previous generation's pending retry", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+    settingsFailures = 1;
+
+    const mounted = await mountProbe();
+    assert.equal(getSettings.mock.callCount(), 1);
+
+    // Reload succeeds before the failed generation's 2s retry fires.
+    await React.act(async () => {
+        window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        await flushAsync();
+    });
+    assert.equal(getSettings.mock.callCount(), 2);
+
+    await React.act(async () => {
+        t.mock.timers.tick(20_000);
+        await flushAsync();
+    });
+    // No zombie retry from the superseded generation.
+    assert.equal(getSettings.mock.callCount(), 2);
+
+    await mounted.unmount();
+});
+
+test("unmount cancels pending retries entirely", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+    settingsFailures = 4;
+
+    const mounted = await mountProbe();
+    assert.equal(getSettings.mock.callCount(), 1);
+    await mounted.unmount();
+
+    await React.act(async () => {
+        t.mock.timers.tick(60_000);
+        await flushAsync();
+    });
+    assert.equal(getSettings.mock.callCount(), 1);
 });

--- a/frontend/tests/component/useLoudnessNormalization.component.test.ts
+++ b/frontend/tests/component/useLoudnessNormalization.component.test.ts
@@ -246,18 +246,25 @@ test("a settings-event reload ignores the superseded in-flight response", async 
         window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
         await flushAsync();
     });
+    // Serialization: the reload's fetch must not start while the stale
+    // request is still pending (GET coalescing would reuse its response).
+    assert.equal(getSettings.mock.callCount(), 1);
 
-    // The stale auto response settles first; the reload's own request
-    // (serialized behind it) then resolves with off.
+    // The stale auto response settles first and must be IGNORED before the
+    // fresh response arrives (a last-writer-wins loader fails here).
     await React.act(async () => {
         settingsResolvers[0]?.();
-        await flushAsync();
-        settingsResolvers[1]?.();
         await flushAsync();
     });
     await settleRamp(t);
     assert.equal(gainRef.current, 1);
     assert.equal(getSettings.mock.callCount(), 2);
+    await React.act(async () => {
+        settingsResolvers[1]?.();
+        await flushAsync();
+    });
+    await settleRamp(t);
+    assert.equal(gainRef.current, 1);
 
     await mounted.unmount();
 });
@@ -298,6 +305,31 @@ test("unmount cancels pending retries entirely", async (t) => {
 
     await React.act(async () => {
         t.mock.timers.tick(60_000);
+        await flushAsync();
+    });
+    assert.equal(getSettings.mock.callCount(), 1);
+});
+
+test("queued obsolete generations never fetch after disposal", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+    audioState.currentTrack = LOUD_TRACK;
+    deferSettings = true;
+
+    const mounted = await mountProbe();
+    assert.equal(getSettings.mock.callCount(), 1);
+
+    // Two reloads queue behind the pending initial request, then the hook
+    // unmounts. Releasing the initial response must not trigger the queued
+    // generations' fetches.
+    await React.act(async () => {
+        window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        window.dispatchEvent(new Event(USER_SETTINGS_UPDATED_EVENT));
+        await flushAsync();
+    });
+    await mounted.unmount();
+    await React.act(async () => {
+        settingsResolvers[0]?.();
+        await flushAsync();
         await flushAsync();
     });
     assert.equal(getSettings.mock.callCount(), 1);

--- a/frontend/tests/unit/loudnessGainPolicy.test.ts
+++ b/frontend/tests/unit/loudnessGainPolicy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+    computeGainRampSteps,
     isAlbumOrderedQueue,
     resolveLoudnessGain,
     type LoudnessGainInput,
@@ -235,4 +236,24 @@ test("flattened album measurements win over nested ones", () => {
         }),
     );
     assert.ok(Math.abs(decision.gainDb - -8) < 1e-9);
+});
+
+test("computeGainRampSteps interpolates monotonically and ends exactly at the target", () => {
+    const rising = computeGainRampSteps(0.5, 1, 4);
+    assert.deepEqual(rising, [0.625, 0.75, 0.875, 1]);
+    const falling = computeGainRampSteps(1, 0.5, 4);
+    assert.equal(falling.length, 4);
+    assert.equal(falling.at(-1), 0.5);
+    for (let index = 1; index < falling.length; index += 1) {
+        assert.ok(falling[index] < falling[index - 1]);
+    }
+});
+
+test("computeGainRampSteps collapses degenerate and invalid transitions", () => {
+    assert.deepEqual(computeGainRampSteps(0.8, 0.8), [0.8]);
+    assert.deepEqual(computeGainRampSteps(0.4, 0.9, 1), [0.9]);
+    assert.deepEqual(computeGainRampSteps(Number.NaN, 0.7), [0.7]);
+    assert.deepEqual(computeGainRampSteps(0.7, Number.POSITIVE_INFINITY), [
+        Number.POSITIVE_INFINITY,
+    ]);
 });

--- a/frontend/tests/unit/loudnessGainPolicy.test.ts
+++ b/frontend/tests/unit/loudnessGainPolicy.test.ts
@@ -257,3 +257,15 @@ test("computeGainRampSteps collapses degenerate and invalid transitions", () => 
         Number.POSITIVE_INFINITY,
     ]);
 });
+
+test("computeGainRampSteps clamps hostile step counts", () => {
+    assert.equal(
+        computeGainRampSteps(0, 1, Number.POSITIVE_INFINITY).length,
+        8,
+    );
+    assert.equal(computeGainRampSteps(0, 1, Number.NaN).length, 8);
+    assert.equal(computeGainRampSteps(0, 1, 2.5).length, 3);
+    assert.deepEqual(computeGainRampSteps(0, 1, 0), [1]);
+    assert.deepEqual(computeGainRampSteps(0, 1, -5), [1]);
+    assert.equal(computeGainRampSteps(0, 1, 10_000).length, 32);
+});


### PR DESCRIPTION
Closes two findings from the deep third-party review of the loudness pipeline (2.3.2's volume-leveling work).

## Stepped gain changes

Mid-track gain changes applied instantly through `setVolume`: toggling the mode, saving a new server target, a queue-context change, and — most commonly — the moment stored preferences arrived shortly after playback started, all produced an audible volume jump. Gain transitions now interpolate through a fixed 8-step ramp (~200 ms, `computeGainRampSteps` in the pure gain policy) whenever the track identity hasn't changed. A track change still applies its gain immediately, before the new audio is audible.

## One-shot preference load

The mode and target loaded as two independent single-attempt requests; a transient failure at startup silently left leveling off until a settings save or remount. They now load as one snapshot (`Promise.allSettled`) with bounded backoff retries (2 s / 5 s / 15 s), resetting on the settings-updated event.

## Tests

- Policy unit tests for the ramp math (monotonic interpolation, exact endpoint, degenerate/non-finite collapse).
- New component test mounts the hook with happy-dom + mocked timers and pins: failed-then-retried preference load ends with the correct gain; a mid-track mode change produces exactly 8 strictly-monotonic ramp steps ending at unity; a track change applies once with no interval scheduled.

Local: frontend tsc clean, lint at cap with 0 errors, 25 policy unit tests + 3 hook component tests passing, prettier and file-size gates clean.