### PR TITLE
fix(vibe): lease map builds across replicas and cool down failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Vibe-map builds now stay within their worker memory limit during database materialization, coordinate across backend replicas, and back off after failures instead of restarting on every browser poll.
 - Federation catalog parsing now bounds forward-compatible unknown-key warning samples, preventing oversized peer envelopes from crashing or creating unbounded warning state.
 - Library Insights drill-downs no longer crash the Admin page: the metadata-gap Genres/Lyrics tabs and the analysis-coverage failure list read fields the API never returned, so expanding them with real data threw a client-side error. Gap tabs and the quality bitrate floor also fetch on selection now instead of requiring a separate Load press.
 - Transient playback recovery now resumes correctly after its automatic reload: the recovery listener was previously cancelled before it could restart playback, and a stale pre-failure position can no longer be restored before the track has made real startup progress.

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -261,6 +261,7 @@ describe("api entrypoint runtime behavior", () => {
         const shutdownWorkers = jest.fn(
             shutdownWorkersImpl || (async () => undefined),
         );
+        const shutdownUmapProjection = jest.fn(async () => undefined);
 
         jest.doMock("express", () => expressFn);
         jest.doMock("express-session", () => sessionMiddleware, {
@@ -336,6 +337,9 @@ describe("api entrypoint runtime behavior", () => {
         jest.doMock("../workers", () => ({
             shutdownWorkers,
         }));
+        jest.doMock("../services/umapProjection", () => ({
+            shutdownUmapProjection,
+        }));
 
         for (const routeModule of routeModules) {
             jest.doMock(routeModule, () => ({
@@ -366,6 +370,7 @@ describe("api entrypoint runtime behavior", () => {
             requireAuth,
             requireAdmin,
             shutdownWorkers,
+            shutdownUmapProjection,
             compressionMiddleware,
             compressionFilter,
             createMetricsRouter,
@@ -1126,8 +1131,12 @@ describe("api entrypoint runtime behavior", () => {
         expect(mocks.shutdownListenTogetherSocket).toHaveBeenCalledTimes(1);
         expect(mocks.server.close).toHaveBeenCalledTimes(1);
         expect(mocks.server.closeIdleConnections).toHaveBeenCalledTimes(1);
+        expect(mocks.shutdownUmapProjection).toHaveBeenCalledTimes(1);
         expect(mocks.shutdownWorkers).toHaveBeenCalledTimes(1);
         expect(mocks.redisClient.close).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.shutdownUmapProjection.mock.invocationCallOrder[0],
+        ).toBeLessThan(mocks.redisClient.close.mock.invocationCallOrder[0]);
         expect(mocks.prisma.$disconnect).toHaveBeenCalled();
         expect(process.exit).toHaveBeenCalledWith(0);
         expect(mocks.logger.debug).toHaveBeenCalledWith(

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -746,6 +746,10 @@ async function gracefulShutdown(signal: string) {
             await closeHttpServerWithTimeout(HTTP_SERVER_CLOSE_TIMEOUT_MS);
         }
 
+        const { shutdownUmapProjection } =
+            await import("./services/umapProjection");
+        await shutdownUmapProjection();
+
         // Shutdown workers (intervals, crons, queues)
         if (workersInitialized) {
             const { shutdownWorkers } = await import("./workers");

--- a/backend/src/routes/__tests__/vibeSearchCompat.test.ts
+++ b/backend/src/routes/__tests__/vibeSearchCompat.test.ts
@@ -332,6 +332,25 @@ describe("vibe search transport compatibility", () => {
 
         expect(buildingRes.statusCode).toBe(202);
         expect(buildingRes.body).toEqual({ building: true });
+
+        mockComputeMapProjection.mockResolvedValueOnce({
+            status: "failed",
+            attempt: 2,
+            error: "internal database detail",
+            failedAt: "2026-08-19T12:00:00.000Z",
+            retryAt: "2026-08-19T12:15:00.000Z",
+        });
+        const failedRes = createRes();
+        await mapHandler(req, failedRes);
+
+        expect(failedRes.statusCode).toBe(202);
+        expect(failedRes.body).toEqual({
+            building: true,
+            failed: true,
+            attempt: 2,
+            retryAt: "2026-08-19T12:15:00.000Z",
+            error: "Vibe map build failed",
+        });
     });
 
     it("handles similar-track route success, empty, and error branches", async () => {

--- a/backend/src/routes/vibe.ts
+++ b/backend/src/routes/vibe.ts
@@ -131,7 +131,7 @@ async function buildTrackPreferenceScoreMapForUser(
  * /api/vibe/map:
  *   get:
  *     summary: Get vibe map projection data
- *     description: Returns the cached 2D projection for the active embedding space, or 202 while a background build is in progress.
+ *     description: Returns the cached 2D projection for the active embedding space, or 202 while a background build is running or waiting for its failure cooldown.
  *     tags: [Vibe]
  *     security:
  *       - apiKeyAuth: []
@@ -139,7 +139,7 @@ async function buildTrackPreferenceScoreMapForUser(
  *       200:
  *         description: 2D vibe map projection payload
  *       202:
- *         description: Projection build in progress; retry shortly
+ *         description: Projection build in progress or failed with a bounded retry time
  *       401:
  *         description: Not authenticated
  */
@@ -151,6 +151,16 @@ router.get(
             const projection = await computeMapProjection();
             if (projection.status === "building") {
                 res.status(202).json({ building: true });
+                return;
+            }
+            if (projection.status === "failed") {
+                res.status(202).json({
+                    building: true,
+                    failed: true,
+                    attempt: projection.attempt,
+                    retryAt: projection.retryAt,
+                    error: "Vibe map build failed",
+                });
                 return;
             }
             res.json(projection.data);

--- a/backend/src/services/__tests__/umapProjection.test.ts
+++ b/backend/src/services/__tests__/umapProjection.test.ts
@@ -200,6 +200,17 @@ async function flushMicrotasks(turns = 10): Promise<void> {
     }
 }
 
+function createDeferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+} {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+}
+
 function cachedPayload(): {
     tracks: unknown[];
     trackCount: number;
@@ -323,6 +334,55 @@ describe("computeMapProjection", () => {
             { keys: [LEASE_KEY], arguments: [expect.any(String)] },
         );
         expect(workers).toHaveLength(0);
+    });
+
+    it("releases the lease when the post-acquisition state read fails", async () => {
+        jest.useFakeTimers();
+        const readError = new Error("redis read failed");
+        let projectionReads = 0;
+        mockRedisGet.mockImplementation(async (key) => {
+            if (key !== PROJECTION_KEY) return null;
+            projectionReads += 1;
+            if (projectionReads === 2) throw readError;
+            return null;
+        });
+
+        await expect(loadModule().computeMapProjection()).rejects.toBe(
+            readError,
+        );
+
+        expect(mockRedisEval).toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            { keys: [LEASE_KEY], arguments: [expect.any(String)] },
+        );
+        mockRedisEval.mockClear();
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+        expect(mockRedisEval).not.toHaveBeenCalled();
+        expect(workers).toHaveLength(0);
+    });
+
+    it("treats a malformed cached projection as a cache miss", async () => {
+        const rows = makeRows(5);
+        mockRedisGet.mockImplementation(async (key) =>
+            key === PROJECTION_KEY ? "{malformed" : null,
+        );
+        workerBehavior = (worker) =>
+            emitResult(
+                worker,
+                rows,
+                rows.map((_, index) => [index, index]),
+            );
+
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
+            status: "building",
+        });
+        await flushMicrotasks();
+
+        expect(cachedPayload().trackCount).toBe(5);
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "Ignoring malformed vibe map projection cache",
+            { spaceId: SPACE_ID },
+        );
     });
 
     it("prevents a second replica module from building while the Redis NX lease is held", async () => {
@@ -611,30 +671,45 @@ describe("computeMapProjection", () => {
         );
     });
 
-    it("terminates the active worker and releases its lease during shutdown", async () => {
+    it("releases its lease only after worker termination settles", async () => {
         let leaseHeld = false;
+        let terminationResolved = false;
+        const termination = createDeferred<number>();
+        const releaseObservedAfterTermination: boolean[] = [];
         mockRedisSet.mockImplementation(async () => {
             if (leaseHeld) return null;
             leaseHeld = true;
             return "OK";
         });
         mockRedisEval.mockImplementation(async (script) => {
-            if (script.includes("DEL")) leaseHeld = false;
+            if (script.includes("DEL")) {
+                releaseObservedAfterTermination.push(terminationResolved);
+                leaseHeld = false;
+            }
             return 1;
         });
         const { computeMapProjection, shutdownUmapProjection } = loadModule();
         await expect(computeMapProjection()).resolves.toEqual({
             status: "building",
         });
-        workers[0].terminate.mockImplementation(async () => {
-            workers[0].emit("exit", 1);
-            return 1;
-        });
+        workers[0].terminate.mockImplementation(() => termination.promise);
 
-        await shutdownUmapProjection();
+        const shutdown = shutdownUmapProjection();
+        await flushMicrotasks();
 
         expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+        expect(leaseHeld).toBe(true);
+        expect(mockRedisEval).not.toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            expect.anything(),
+        );
+        workers[0].emit("exit", 1);
+        terminationResolved = true;
+        termination.resolve(1);
+        await shutdown;
+
         expect(leaseHeld).toBe(false);
+        expect(releaseObservedAfterTermination).toEqual([true]);
         expect(mockLoggerError).not.toHaveBeenCalled();
         mockRedisGet.mockClear();
         await expect(computeMapProjection()).resolves.toEqual({
@@ -646,6 +721,59 @@ describe("computeMapProjection", () => {
         const replacementLease = await acquireVibeMapBuildLease(SPACE_ID);
         expect(replacementLease).not.toBeNull();
         await replacementLease?.release();
+    });
+
+    it("leaves the lease to expire when worker termination exceeds shutdown", async () => {
+        jest.useFakeTimers();
+        workers = [];
+        const { computeMapProjection, shutdownUmapProjection } = loadModule();
+        await expect(computeMapProjection()).resolves.toEqual({
+            status: "building",
+        });
+        workers[0].terminate.mockImplementation(
+            () => new Promise<number>(() => undefined),
+        );
+
+        const shutdown = shutdownUmapProjection();
+        await jest.advanceTimersByTimeAsync(3 * 1000);
+        await shutdown;
+
+        expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+        expect(mockRedisEval).not.toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            expect.anything(),
+        );
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "UMAP projection shutdown timed out",
+            expect.objectContaining({ timeoutMs: 3000, heldLeases: 1 }),
+        );
+        mockRedisEval.mockClear();
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+        expect(mockRedisEval).not.toHaveBeenCalled();
+    });
+
+    it("does not publish a worker result after shutdown starts", async () => {
+        const rows = makeRows(5);
+        const termination = createDeferred<number>();
+        const { computeMapProjection, shutdownUmapProjection } = loadModule();
+        await expect(computeMapProjection()).resolves.toEqual({
+            status: "building",
+        });
+        workers[0].terminate.mockImplementation(() => termination.promise);
+
+        const shutdown = shutdownUmapProjection();
+        emitResult(
+            workers[0],
+            rows,
+            rows.map((_, index) => [index, index]),
+        );
+        await flushMicrotasks();
+
+        expect(pipeline.setEx).not.toHaveBeenCalled();
+        expect(pipeline.exec).not.toHaveBeenCalled();
+        workers[0].emit("exit", 0);
+        termination.resolve(0);
+        await shutdown;
     });
 });
 

--- a/backend/src/services/__tests__/umapProjection.test.ts
+++ b/backend/src/services/__tests__/umapProjection.test.ts
@@ -1,13 +1,5 @@
 import { jest } from "@jest/globals";
 
-type MockPipeline = {
-    setEx: jest.Mock;
-    del: jest.Mock;
-    sAdd: jest.Mock;
-    expire: jest.Mock;
-    exec: jest.Mock;
-};
-
 type QueryRow = {
     track_id: string;
     title: string;
@@ -28,49 +20,74 @@ type QueryRow = {
     moodParty: number | null;
     moodAcoustic: number | null;
     moodElectronic: number | null;
-    embedding: string;
 };
 
-const mockQueryRaw = jest.fn<(...args: unknown[]) => Promise<QueryRow[]>>();
-const mockRedisGet = jest.fn<(...args: unknown[]) => Promise<string | null>>();
-const mockRedisMulti = jest.fn<(...args: unknown[]) => MockPipeline>();
+type MockPipeline = {
+    setEx: jest.Mock;
+    del: jest.Mock;
+    sAdd: jest.Mock;
+    expire: jest.Mock;
+    exec: jest.Mock;
+};
+
+type WorkerData = { spaceId: string; sampleSize: number };
+type WorkerOptions = {
+    workerData?: WorkerData;
+    execArgv?: string[];
+    resourceLimits?: { maxOldGenerationSizeMb?: number };
+};
+
+const mockRedisGet = jest.fn<(key: string) => Promise<string | null>>();
+const mockRedisSet =
+    jest.fn<
+        (
+            key: string,
+            value: string,
+            options: { NX?: boolean; EX?: number },
+        ) => Promise<string | null>
+    >();
+const mockRedisSetEx =
+    jest.fn<
+        (
+            key: string,
+            ttlSeconds: number,
+            value: string,
+        ) => Promise<string | null>
+    >();
+const mockRedisEval =
+    jest.fn<
+        (
+            script: string,
+            options: { keys: string[]; arguments: string[] },
+        ) => Promise<number>
+    >();
+const mockRedisIncr = jest.fn<(key: string) => Promise<number>>();
+const mockRedisExpire =
+    jest.fn<(key: string, ttlSeconds: number) => Promise<boolean>>();
+const mockRedisDel = jest.fn<(keys: string | string[]) => Promise<number>>();
+const mockRedisMulti = jest.fn<() => MockPipeline>();
 const mockExistsSync = jest.fn<(candidatePath: string) => boolean>();
 const mockPathJoin = jest.fn<(...parts: string[]) => string>();
-const mockParseEmbedding = jest.fn<(embedding: string) => number[]>();
-const mockUmapLoggerDebug = jest.fn<(...args: unknown[]) => void>();
-const mockUmapLoggerInfo = jest.fn<(...args: unknown[]) => void>();
-const mockUmapLoggerWarn = jest.fn<(...args: unknown[]) => void>();
-const mockUmapLoggerError = jest.fn<(...args: unknown[]) => void>();
+const mockLoggerDebug = jest.fn<(...args: unknown[]) => void>();
+const mockLoggerInfo = jest.fn<(...args: unknown[]) => void>();
+const mockLoggerWarn = jest.fn<(...args: unknown[]) => void>();
+const mockLoggerError = jest.fn<(...args: unknown[]) => void>();
 const mockGetActiveSpace = jest.fn<() => Promise<{ id: string }>>();
 
 let pipeline: MockPipeline;
 let workerBehavior: ((worker: MockWorker, index: number) => void) | null = null;
 let workers: MockWorker[] = [];
-let lastWorkerFilename: string | null = null;
-let lastWorkerOptions: {
-    workerData?: { embeddings: number[][]; nNeighbors: number };
-    resourceLimits?: { maxOldGenerationSizeMb?: number };
-} | null = null;
+let workerOptions: WorkerOptions[] = [];
 
 class MockWorker {
     listeners = new Map<string, Array<(payload?: unknown) => void>>();
     terminate = jest.fn(async () => 0);
 
-    constructor(
-        filename: string,
-        options: {
-            workerData?: { embeddings: number[][]; nNeighbors: number };
-            resourceLimits?: { maxOldGenerationSizeMb?: number };
-        },
-    ) {
-        lastWorkerFilename = filename;
-        lastWorkerOptions = options;
+    constructor(_filename: string, options: WorkerOptions) {
         workers.push(this);
+        workerOptions.push(options);
         const index = workers.length - 1;
-
-        setImmediate(() => {
-            workerBehavior?.(this, index);
-        });
+        setImmediate(() => workerBehavior?.(this, index));
     }
 
     on(event: string, listener: (payload?: unknown) => void): this {
@@ -81,63 +98,63 @@ class MockWorker {
     }
 
     emit(event: string, payload?: unknown): void {
-        for (const listener of this.listeners.get(event) ?? []) {
+        for (const listener of this.listeners.get(event) ?? [])
             listener(payload);
-        }
     }
 }
 
 jest.mock("fs", () => ({
     existsSync: (candidatePath: string) => mockExistsSync(candidatePath),
 }));
-
 jest.mock("path", () => ({
     __esModule: true,
-    default: {
-        join: (...args: string[]) => mockPathJoin(...args),
-    },
+    default: { join: (...parts: string[]) => mockPathJoin(...parts) },
 }));
-
 jest.mock("../../config", () => ({
     config: { vibeMapWorkerMemoryMb: 512 },
 }));
-
-jest.mock("../../utils/db", () => ({
-    prisma: {
-        $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
-    },
-}));
-
 jest.mock("../../utils/redis", () => ({
     redisClient: {
-        get: (...args: unknown[]) => mockRedisGet(...args),
-        multi: (...args: unknown[]) => mockRedisMulti(...args),
+        get: (key: string) => mockRedisGet(key),
+        set: (
+            key: string,
+            value: string,
+            options: { NX?: boolean; EX?: number },
+        ) => mockRedisSet(key, value, options),
+        setEx: (key: string, ttlSeconds: number, value: string) =>
+            mockRedisSetEx(key, ttlSeconds, value),
+        eval: (
+            script: string,
+            options: { keys: string[]; arguments: string[] },
+        ) => mockRedisEval(script, options),
+        incr: (key: string) => mockRedisIncr(key),
+        expire: (key: string, ttlSeconds: number) =>
+            mockRedisExpire(key, ttlSeconds),
+        del: (keys: string | string[]) => mockRedisDel(keys),
+        multi: () => mockRedisMulti(),
     },
 }));
-
 jest.mock("../../utils/logger", () => ({
     logger: {
-        debug: (...args: unknown[]) => mockUmapLoggerDebug(...args),
-        info: (...args: unknown[]) => mockUmapLoggerInfo(...args),
-        warn: (...args: unknown[]) => mockUmapLoggerWarn(...args),
-        error: (...args: unknown[]) => mockUmapLoggerError(...args),
+        child: () => ({
+            debug: (...args: unknown[]) => mockLoggerDebug(...args),
+            info: (...args: unknown[]) => mockLoggerInfo(...args),
+            warn: (...args: unknown[]) => mockLoggerWarn(...args),
+            error: (...args: unknown[]) => mockLoggerError(...args),
+        }),
     },
 }));
-
-jest.mock("../../utils/embedding", () => ({
-    parseEmbedding: (embedding: string) => mockParseEmbedding(embedding),
-}));
-
 jest.mock("../embeddingSpaces", () => ({
     getActiveSpace: () => mockGetActiveSpace(),
 }));
+jest.mock("worker_threads", () => ({ Worker: MockWorker }));
 
-jest.mock("worker_threads", () => ({
-    Worker: MockWorker,
-}));
-
-const PROJECTION_KEY = "vibe:map:v5:projection:space-active";
-const TRACK_IDS_KEY = "vibe:map:v5:track_ids:space-active";
+const SPACE_ID = "space-active";
+const PROJECTION_KEY = `vibe:map:v5:projection:${SPACE_ID}`;
+const TRACK_IDS_KEY = `vibe:map:v5:track_ids:${SPACE_ID}`;
+const LEASE_KEY = `vibe-map:build-lease:${SPACE_ID}`;
+const FAILURE_KEY = `vibe-map:build-failed:${SPACE_ID}`;
+const FAILURE_COUNT_KEY = `vibe-map:build-failure-count:${SPACE_ID}`;
 
 function makeRow(index: number, overrides: Partial<QueryRow> = {}): QueryRow {
     return {
@@ -146,13 +163,13 @@ function makeRow(index: number, overrides: Partial<QueryRow> = {}): QueryRow {
         artistName: `Artist ${index}`,
         artistId: `artist-${index}`,
         albumId: `album-${index}`,
-        coverUrl: index % 2 === 0 ? `cover-${index}.jpg` : null,
+        coverUrl: null,
         loudnessLufs: null,
         truePeakDb: null,
         albumLoudnessLufs: null,
         albumTruePeakDb: null,
-        energy: Number((index / 10).toFixed(2)),
-        valence: Number((1 - index / 10).toFixed(2)),
+        energy: 0.5,
+        valence: 0.5,
         moodHappy: 0.1,
         moodSad: 0.2,
         moodRelaxed: 0.3,
@@ -160,7 +177,6 @@ function makeRow(index: number, overrides: Partial<QueryRow> = {}): QueryRow {
         moodParty: 0.5,
         moodAcoustic: 0.6,
         moodElectronic: 0.7,
-        embedding: `[${index},${index + 1},${index + 2}]`,
         ...overrides,
     };
 }
@@ -169,20 +185,34 @@ function makeRows(count: number): QueryRow[] {
     return Array.from({ length: count }, (_, index) => makeRow(index + 1));
 }
 
-async function flushMicrotasks(turns = 8): Promise<void> {
+function emitResult(
+    worker: MockWorker,
+    rows: QueryRow[],
+    projection: number[][] | null,
+) {
+    worker.emit("message", { type: "materialized", rowCount: rows.length });
+    worker.emit("message", { type: "result", rows, projection });
+}
+
+async function flushMicrotasks(turns = 10): Promise<void> {
     for (let index = 0; index < turns; index += 1) {
         await new Promise((resolve) => setImmediate(resolve));
     }
 }
 
-function cachedPayload(): { tracks: unknown[]; trackCount: number } {
-    const setExCall = pipeline.setEx.mock.calls.find(
-        (call) => call[0] === PROJECTION_KEY,
+function cachedPayload(): {
+    tracks: unknown[];
+    trackCount: number;
+    sampled?: boolean;
+} {
+    const call = pipeline.setEx.mock.calls.find(
+        (entry) => entry[0] === PROJECTION_KEY,
     );
-    if (!setExCall) throw new Error("projection was never cached");
-    return JSON.parse(setExCall[2] as string) as {
+    if (!call) throw new Error("projection was never cached");
+    return JSON.parse(call[2] as string) as {
         tracks: unknown[];
         trackCount: number;
+        sampled?: boolean;
     };
 }
 
@@ -195,102 +225,151 @@ describe("computeMapProjection", () => {
         jest.resetModules();
         jest.clearAllMocks();
         jest.useRealTimers();
-
-        workerBehavior = null;
         workers = [];
-        lastWorkerFilename = null;
-        lastWorkerOptions = null;
-
+        workerOptions = [];
+        workerBehavior = null;
         pipeline = {
-            setEx: jest.fn<(...args: unknown[]) => MockPipeline>(
-                () => pipeline,
-            ),
-            del: jest.fn<(...args: unknown[]) => MockPipeline>(() => pipeline),
-            sAdd: jest.fn<(...args: unknown[]) => MockPipeline>(() => pipeline),
-            expire: jest.fn<(...args: unknown[]) => MockPipeline>(
-                () => pipeline,
-            ),
+            setEx: jest.fn(() => pipeline),
+            del: jest.fn(() => pipeline),
+            sAdd: jest.fn(() => pipeline),
+            expire: jest.fn(() => pipeline),
             exec: jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
         };
-
         mockRedisGet.mockResolvedValue(null);
+        mockRedisSet.mockResolvedValue("OK");
+        mockRedisSetEx.mockResolvedValue("OK");
+        mockRedisEval.mockResolvedValue(1);
+        mockRedisIncr.mockResolvedValue(1);
+        mockRedisExpire.mockResolvedValue(true);
+        mockRedisDel.mockResolvedValue(1);
         mockRedisMulti.mockReturnValue(pipeline);
-        mockQueryRaw.mockResolvedValue([]);
-        mockExistsSync.mockImplementation((candidatePath: string) =>
-            candidatePath.endsWith("umapWorker.ts"),
+        mockExistsSync.mockImplementation((candidate) =>
+            candidate.endsWith("umapWorker.ts"),
         );
-        mockPathJoin.mockImplementation((...parts: string[]) =>
-            parts.join("/").replace(/\/+/g, "/"),
-        );
-        mockParseEmbedding.mockImplementation(
-            (embedding: string) => JSON.parse(embedding) as number[],
-        );
-        mockGetActiveSpace.mockResolvedValue({ id: "space-active" });
+        mockPathJoin.mockImplementation((...parts) => parts.join("/"));
+        mockGetActiveSpace.mockResolvedValue({ id: SPACE_ID });
     });
 
-    it("returns the cached projection for the active space without querying the database", async () => {
+    it("returns a cached projection without acquiring a build lease", async () => {
         const cached = {
-            tracks: [{ id: "track-1", x: 0.1, y: 0.2 }],
-            trackCount: 1,
-            computedAt: "2026-03-14T12:00:00.000Z",
+            tracks: [],
+            trackCount: 0,
+            computedAt: "2026-08-19T12:00:00.000Z",
         };
-        mockRedisGet.mockResolvedValueOnce(JSON.stringify(cached));
+        mockRedisGet.mockImplementation(async (key) =>
+            key === PROJECTION_KEY ? JSON.stringify(cached) : null,
+        );
 
-        const { computeMapProjection } = loadModule();
-
-        await expect(computeMapProjection()).resolves.toEqual({
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
             status: "ready",
             data: cached,
         });
-        expect(mockRedisGet).toHaveBeenCalledWith(PROJECTION_KEY);
-        expect(mockQueryRaw).not.toHaveBeenCalled();
-        expect(mockRedisMulti).not.toHaveBeenCalled();
+        expect(mockRedisSet).not.toHaveBeenCalled();
+        expect(workers).toHaveLength(0);
     });
 
-    it("reports building and deduplicates concurrent background computations", async () => {
-        mockQueryRaw.mockResolvedValueOnce(makeRows(5));
-
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
+    it("prevents a second replica module from building while the Redis NX lease is held", async () => {
+        const firstReplica = loadModule();
+        await expect(firstReplica.computeMapProjection()).resolves.toEqual({
             status: "building",
         });
-        await expect(computeMapProjection()).resolves.toEqual({
+        jest.resetModules();
+        mockRedisSet.mockResolvedValueOnce(null);
+        const secondReplica = loadModule();
+        await expect(secondReplica.computeMapProjection()).resolves.toEqual({
             status: "building",
         });
 
-        await flushMicrotasks();
-
-        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
-        const [query, ...values] = mockQueryRaw.mock.calls[0];
-        expect((query as readonly string[]).join(" ")).toContain(
-            "te.space_id =",
+        expect(mockRedisSet).toHaveBeenNthCalledWith(
+            2,
+            LEASE_KEY,
+            expect.any(String),
+            { NX: true, EX: 3600 },
         );
-        expect(values).toContain("space-active");
         expect(workers).toHaveLength(1);
 
-        workers[0].emit("message", [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-            [3, 3],
-            [4, 4],
-        ]);
+        const rows = makeRows(5);
+        emitResult(
+            workers[0],
+            rows,
+            rows.map((_, index) => [index, index]),
+        );
         await flushMicrotasks();
-
-        expect(cachedPayload().trackCount).toBe(5);
     });
 
-    it("caches an empty projection briefly when no embedded tracks exist", async () => {
-        const { computeMapProjection } = loadModule();
+    it("refreshes and releases an acquired build lease", async () => {
+        jest.useFakeTimers();
+        const { acquireVibeMapBuildLease } =
+            require("../vibeMapBuildState") as typeof import("../vibeMapBuildState");
+        const lease = await acquireVibeMapBuildLease(SPACE_ID);
+        if (!lease) throw new Error("lease was not acquired");
 
-        await expect(computeMapProjection()).resolves.toEqual({
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        expect(mockRedisEval).toHaveBeenCalledWith(
+            expect.stringContaining("EXPIRE"),
+            {
+                keys: [LEASE_KEY],
+                arguments: [expect.any(String), "3600"],
+            },
+        );
+        await lease.release();
+        expect(mockRedisEval).toHaveBeenLastCalledWith(
+            expect.stringContaining("DEL"),
+            { keys: [LEASE_KEY], arguments: [expect.any(String)] },
+        );
+    });
+
+    it("passes only bounded query parameters to the worker and releases its lease", async () => {
+        const rows = makeRows(5);
+        workerBehavior = (worker) =>
+            emitResult(
+                worker,
+                rows,
+                rows.map((_, index) => [index, index]),
+            );
+
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
             status: "building",
         });
         await flushMicrotasks();
 
-        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
-        expect(mockParseEmbedding).not.toHaveBeenCalled();
-        expect(workers).toHaveLength(0);
+        expect(workerOptions).toEqual([
+            {
+                workerData: { spaceId: SPACE_ID, sampleSize: 15000 },
+                execArgv: ["--import", "tsx"],
+                resourceLimits: { maxOldGenerationSizeMb: 512 },
+            },
+        ]);
+        expect(cachedPayload().trackCount).toBe(5);
+        expect(pipeline.sAdd).toHaveBeenCalledWith(
+            TRACK_IDS_KEY,
+            rows.map((row) => row.track_id),
+        );
+        expect(mockRedisEval).toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            { keys: [LEASE_KEY], arguments: [expect.any(String)] },
+        );
+        expect(mockRedisDel).toHaveBeenCalledWith([
+            FAILURE_KEY,
+            FAILURE_COUNT_KEY,
+        ]);
+        const payload = cachedPayload() as {
+            tracks: Array<{ x: number; y: number }>;
+        };
+        expect(payload.tracks[0]).toEqual(
+            expect.objectContaining({ x: 0, y: 0 }),
+        );
+        expect(payload.tracks[4]).toEqual(
+            expect.objectContaining({ x: 1, y: 1 }),
+        );
+    });
+
+    it("caches an empty worker result for five minutes", async () => {
+        workerBehavior = (worker) => emitResult(worker, [], null);
+        await loadModule().computeMapProjection();
+        await flushMicrotasks();
+
         expect(pipeline.setEx).toHaveBeenCalledWith(
             PROJECTION_KEY,
             300,
@@ -299,101 +378,129 @@ describe("computeMapProjection", () => {
         expect(cachedPayload().trackCount).toBe(0);
     });
 
-    it("uses the circular fallback layout for datasets smaller than five tracks", async () => {
-        mockQueryRaw.mockResolvedValueOnce([
-            makeRow(1, {
-                moodElectronic: 0.95,
-                moodParty: 0.3,
-                loudnessLufs: -17.6,
-                truePeakDb: -1.4,
-                albumLoudnessLufs: -18.2,
-                albumTruePeakDb: -0.7,
-            }),
-            makeRow(2, {
-                moodHappy: null,
-                moodSad: null,
-                moodRelaxed: null,
-                moodAggressive: null,
-                moodParty: null,
-                moodAcoustic: null,
-                moodElectronic: null,
-            }),
-            makeRow(3, { moodRelaxed: 0.92, moodElectronic: 0.2 }),
-            makeRow(4, { moodAggressive: 0.88, moodElectronic: 0.1 }),
-        ]);
-
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
+    it("uses a circular layout for an undersized worker result", async () => {
+        const rows = makeRows(4).map((row, index) => ({
+            ...row,
+            moodElectronic: index === 0 ? 0.95 : row.moodElectronic,
+        }));
+        workerBehavior = (worker) => {
+            worker.emit("message", {
+                type: "materialized",
+                rowCount: rows.length,
+            });
+            worker.emit("message", {
+                type: "result",
+                rows,
+                projection: null,
+            });
+        };
+        await loadModule().computeMapProjection();
         await flushMicrotasks();
 
-        const payload = cachedPayload();
-        expect(payload.trackCount).toBe(4);
-        expect(payload.tracks).toEqual([
+        expect(cachedPayload()).toEqual(
+            expect.objectContaining({ trackCount: 4 }),
+        );
+        expect(cachedPayload().tracks[0]).toEqual(
             expect.objectContaining({
                 id: "track-1",
                 dominantMood: "moodElectronic",
                 moodScore: 0.95,
-                loudnessLufs: -17.6,
-                truePeakDb: -1.4,
-                albumLoudnessLufs: -18.2,
-                albumTruePeakDb: -0.7,
+                x: 0.8,
+                y: 0.5,
             }),
-            expect.objectContaining({
-                id: "track-2",
-                dominantMood: "neutral",
-                moodScore: 0,
-                moods: {},
-                loudnessLufs: null,
-                truePeakDb: null,
-                albumLoudnessLufs: null,
-                albumTruePeakDb: null,
-            }),
-            expect.objectContaining({
-                id: "track-3",
-                dominantMood: "moodRelaxed",
-            }),
-            expect.objectContaining({
-                id: "track-4",
-                dominantMood: "moodAggressive",
-            }),
-        ]);
-        expect(mockParseEmbedding).not.toHaveBeenCalled();
-        expect(workers).toHaveLength(0);
-        expect(pipeline.setEx).toHaveBeenCalledWith(
-            PROJECTION_KEY,
-            86400,
-            expect.any(String),
         );
-        expect(pipeline.del).toHaveBeenCalledWith(TRACK_IDS_KEY);
-        expect(pipeline.sAdd).toHaveBeenCalledWith(TRACK_IDS_KEY, [
-            "track-1",
-            "track-2",
-            "track-3",
-            "track-4",
-        ]);
-        expect(pipeline.expire).toHaveBeenCalledWith(TRACK_IDS_KEY, 86400);
-        expect(pipeline.exec).toHaveBeenCalledTimes(1);
     });
 
-    it("runs the UMAP worker with a bounded heap, normalizes coordinates, and caches the result", async () => {
-        mockQueryRaw.mockResolvedValueOnce([
-            makeRow(1, { moodHappy: 0.9, moodElectronic: 0.4 }),
-            makeRow(2, { moodSad: 0.8, moodElectronic: 0.1 }),
-            makeRow(3, { moodRelaxed: 0.7, moodElectronic: 0.2 }),
-            makeRow(4, { moodParty: 0.7, moodElectronic: 0.6 }),
-            makeRow(5, { moodElectronic: 0.85, moodParty: 0.4 }),
-        ]);
-        workerBehavior = (worker) => {
-            worker.emit("message", [
-                [-3, 4],
-                [1, 6],
-                [0, 2],
-                [5, 8],
-                [3, 1],
-            ]);
+    it("reports a live failure marker and does not acquire a lease", async () => {
+        const marker = {
+            attempt: 2,
+            error: "UMAP worker exited with code 2",
+            failedAt: "2026-08-19T12:00:00.000Z",
+            retryAt: "2026-08-19T12:15:00.000Z",
         };
+        mockRedisGet.mockImplementation(async (key) =>
+            key === FAILURE_KEY ? JSON.stringify(marker) : null,
+        );
+
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
+            status: "failed",
+            ...marker,
+        });
+        expect(mockRedisSet).not.toHaveBeenCalled();
+        expect(workers).toHaveLength(0);
+    });
+
+    it("suppresses the next poll after a build writes its failure marker", async () => {
+        let storedMarker: string | null = null;
+        mockRedisGet.mockImplementation(async (key) =>
+            key === FAILURE_KEY ? storedMarker : null,
+        );
+        mockRedisSetEx.mockImplementation(async (key, _ttl, value) => {
+            if (key === FAILURE_KEY) storedMarker = value;
+            return "OK";
+        });
+        workerBehavior = (worker) =>
+            worker.emit("error", new Error("repeatable failure"));
+        const { computeMapProjection } = loadModule();
+
+        await computeMapProjection();
+        await flushMicrotasks();
+        const secondPoll = await computeMapProjection();
+
+        expect(secondPoll).toEqual(
+            expect.objectContaining({
+                status: "failed",
+                attempt: 1,
+                error: "Vibe map projection build failed",
+            }),
+        );
+        expect(workers).toHaveLength(1);
+        expect(mockRedisSet).toHaveBeenCalledTimes(1);
+    });
+
+    it("records bounded escalating cooldowns after repeated build failures", async () => {
+        mockRedisIncr
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(2)
+            .mockResolvedValueOnce(3)
+            .mockResolvedValueOnce(4);
+        workerBehavior = (worker) =>
+            worker.emit("error", new Error("deterministic failure"));
+        const { computeMapProjection } = loadModule();
+
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+            await computeMapProjection();
+            await flushMicrotasks();
+        }
+
+        const markerTtls = mockRedisSetEx.mock.calls
+            .filter((call) => call[0] === FAILURE_KEY)
+            .map((call) => call[1]);
+        expect(markerTtls).toEqual([300, 900, 3600, 3600]);
+        expect(mockRedisExpire).toHaveBeenCalledTimes(4);
+        expect(mockRedisExpire).toHaveBeenLastCalledWith(
+            FAILURE_COUNT_KEY,
+            86400,
+        );
+        const finalMarker = JSON.parse(
+            mockRedisSetEx.mock.calls.at(-1)?.[2] as string,
+        ) as { attempt: number; error: string };
+        expect(finalMarker).toEqual(
+            expect.objectContaining({
+                attempt: 4,
+                error: "Vibe map projection build failed",
+            }),
+        );
+    });
+
+    it("allows a fresh build after the failure marker expires", async () => {
+        const rows = makeRows(5);
+        workerBehavior = (worker) =>
+            emitResult(
+                worker,
+                rows,
+                rows.map((_, index) => [index, index]),
+            );
 
         const { computeMapProjection } = loadModule();
         await expect(computeMapProjection()).resolves.toEqual({
@@ -401,168 +508,71 @@ describe("computeMapProjection", () => {
         });
         await flushMicrotasks();
 
-        const payload = cachedPayload() as {
-            trackCount: number;
-            tracks: Array<{ id: string; x: number; y: number }>;
-        };
-        expect(payload.trackCount).toBe(5);
-        expect(
-            payload.tracks.every(
-                (track) =>
-                    track.x >= 0 &&
-                    track.x <= 1 &&
-                    track.y >= 0 &&
-                    track.y <= 1,
-            ),
-        ).toBe(true);
-        expect(mockParseEmbedding).toHaveBeenCalledTimes(5);
-        expect(lastWorkerFilename).toMatch(/umapWorker\.ts$/);
-        expect(lastWorkerOptions).toEqual({
-            workerData: {
-                embeddings: [
-                    [1, 2, 3],
-                    [2, 3, 4],
-                    [3, 4, 5],
-                    [4, 5, 6],
-                    [5, 6, 7],
-                ],
-                nNeighbors: 2,
-            },
-            execArgv: ["--import", "tsx"],
-            resourceLimits: { maxOldGenerationSizeMb: 512 },
-        });
-        expect(pipeline.setEx).toHaveBeenCalledWith(
-            PROJECTION_KEY,
-            86400,
+        expect(mockRedisGet).toHaveBeenCalledWith(FAILURE_KEY);
+        expect(mockRedisSet).toHaveBeenCalledWith(
+            LEASE_KEY,
             expect.any(String),
+            { NX: true, EX: 3600 },
         );
-        expect(pipeline.exec).toHaveBeenCalledTimes(1);
+        expect(cachedPayload().trackCount).toBe(5);
     });
 
-    it("halves the sample and retries when the worker dies on its memory limit", async () => {
-        mockQueryRaw.mockResolvedValueOnce(makeRows(4000));
+    it("uses the worker-reported materialized count for OOM sample degradation", async () => {
         workerBehavior = (worker, index) => {
             if (index === 0) {
-                const oom = new Error(
-                    "Worker terminated due to reaching memory limit: JS heap out of memory",
+                worker.emit("message", {
+                    type: "materialized",
+                    rowCount: 4000,
+                });
+                const error = new Error(
+                    "Worker terminated due to reaching memory limit",
                 ) as NodeJS.ErrnoException;
-                oom.code = "ERR_WORKER_OUT_OF_MEMORY";
-                worker.emit("error", oom);
+                error.code = "ERR_WORKER_OUT_OF_MEMORY";
+                worker.emit("error", error);
                 return;
             }
-            worker.emit(
-                "message",
-                Array.from({ length: 2000 }, (_, i) => [i, i]),
+            const rows = makeRows(2000);
+            emitResult(
+                worker,
+                rows,
+                rows.map((_, rowIndex) => [rowIndex, rowIndex]),
             );
         };
 
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
-        await flushMicrotasks(16);
+        await loadModule().computeMapProjection();
+        await flushMicrotasks(20);
 
-        expect(workers).toHaveLength(2);
-        expect(lastWorkerOptions?.workerData?.embeddings).toHaveLength(2000);
-        expect(mockUmapLoggerWarn).toHaveBeenCalledWith(
-            expect.stringContaining("heap ceiling at 4000 tracks"),
+        expect(
+            workerOptions.map((options) => options.workerData?.sampleSize),
+        ).toEqual([15000, 2000]);
+        expect(cachedPayload()).toEqual(
+            expect.objectContaining({ trackCount: 2000, sampled: true }),
         );
-        const payload = cachedPayload() as {
-            trackCount: number;
-            sampled?: boolean;
-        };
-        expect(payload.trackCount).toBe(2000);
-        expect(payload.sampled).toBe(true);
-    });
-
-    it("logs instead of caching when the worker posts an error payload", async () => {
-        mockQueryRaw.mockResolvedValueOnce(makeRows(5));
-        workerBehavior = (worker) => {
-            worker.emit("message", { error: "projection failed" });
-        };
-
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
-        await flushMicrotasks();
-
-        expect(mockUmapLoggerError).toHaveBeenCalledWith(
-            "Vibe map error:",
-            expect.objectContaining({ message: "projection failed" }),
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "UMAP worker memory limit reached; retrying with a smaller sample",
+            expect.objectContaining({ sampleSize: 4000 }),
         );
-        expect(pipeline.exec).not.toHaveBeenCalled();
-    });
-
-    it("logs instead of caching when the worker exits with a non-zero code", async () => {
-        mockQueryRaw.mockResolvedValueOnce(makeRows(5));
-        workerBehavior = (worker) => {
-            worker.emit("exit", 2);
-        };
-
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
-        await flushMicrotasks();
-
-        expect(mockUmapLoggerError).toHaveBeenCalledWith(
-            "Vibe map error:",
-            expect.objectContaining({
-                message: "UMAP worker exited with code 2",
-            }),
-        );
-        expect(pipeline.exec).not.toHaveBeenCalled();
-    });
-
-    it("allows a fresh build after a failed one", async () => {
-        mockQueryRaw.mockResolvedValue(makeRows(5));
-        workerBehavior = (worker, index) => {
-            if (index === 0) {
-                worker.emit("error", new Error("worker exploded"));
-                return;
-            }
-            worker.emit("message", [
-                [0, 0],
-                [1, 1],
-                [2, 2],
-                [3, 3],
-                [4, 4],
-            ]);
-        };
-
-        const { computeMapProjection } = loadModule();
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
-        await flushMicrotasks();
-        expect(mockUmapLoggerError).toHaveBeenCalledTimes(1);
-
-        await expect(computeMapProjection()).resolves.toEqual({
-            status: "building",
-        });
-        await flushMicrotasks();
-
-        expect(workers).toHaveLength(2);
-        expect(cachedPayload().trackCount).toBe(5);
     });
 });
 
 describe("umapWorkerOptions", () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
     it("registers tsx only for the development TypeScript worker", () => {
         const { umapWorkerOptions } = loadModule();
-        const embeddings = [[1, 2, 3]];
-
         expect(
-            umapWorkerOptions("/workers/umapWorker.ts", embeddings, 2),
+            umapWorkerOptions("/workers/umapWorker.ts", SPACE_ID, 5000),
         ).toEqual({
-            workerData: { embeddings, nNeighbors: 2 },
+            workerData: { spaceId: SPACE_ID, sampleSize: 5000 },
             execArgv: ["--import", "tsx"],
         });
         expect(
-            umapWorkerOptions("/workers/umapWorker.js", embeddings, 2),
+            umapWorkerOptions("/workers/umapWorker.js", SPACE_ID, 5000),
         ).toEqual({
-            workerData: { embeddings, nNeighbors: 2 },
+            workerData: { spaceId: SPACE_ID, sampleSize: 5000 },
         });
     });
 });

--- a/backend/src/services/__tests__/umapProjection.test.ts
+++ b/backend/src/services/__tests__/umapProjection.test.ts
@@ -268,6 +268,63 @@ describe("computeMapProjection", () => {
         expect(workers).toHaveLength(0);
     });
 
+    it("returns cache published between the initial check and lease acquisition", async () => {
+        const cached = {
+            tracks: [],
+            trackCount: 0,
+            computedAt: "2026-08-19T12:00:00.000Z",
+        };
+        let published = false;
+        mockRedisGet.mockImplementation(async (key) =>
+            published && key === PROJECTION_KEY ? JSON.stringify(cached) : null,
+        );
+        mockRedisSet.mockImplementation(async () => {
+            published = true;
+            return "OK";
+        });
+
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
+            status: "ready",
+            data: cached,
+        });
+
+        expect(mockRedisGet).toHaveBeenCalledWith(PROJECTION_KEY);
+        expect(mockRedisGet).toHaveBeenCalledWith(FAILURE_KEY);
+        expect(mockRedisEval).toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            { keys: [LEASE_KEY], arguments: [expect.any(String)] },
+        );
+        expect(workers).toHaveLength(0);
+    });
+
+    it("returns a cooldown published between the initial check and lease acquisition", async () => {
+        const marker = {
+            attempt: 2,
+            error: "Vibe map projection build failed",
+            failedAt: "2026-08-19T12:00:00.000Z",
+            retryAt: "2026-08-19T12:15:00.000Z",
+        };
+        let published = false;
+        mockRedisGet.mockImplementation(async (key) =>
+            published && key === FAILURE_KEY ? JSON.stringify(marker) : null,
+        );
+        mockRedisSet.mockImplementation(async () => {
+            published = true;
+            return "OK";
+        });
+
+        await expect(loadModule().computeMapProjection()).resolves.toEqual({
+            status: "failed",
+            ...marker,
+        });
+
+        expect(mockRedisEval).toHaveBeenCalledWith(
+            expect.stringContaining("DEL"),
+            { keys: [LEASE_KEY], arguments: [expect.any(String)] },
+        );
+        expect(workers).toHaveLength(0);
+    });
+
     it("prevents a second replica module from building while the Redis NX lease is held", async () => {
         const firstReplica = loadModule();
         await expect(firstReplica.computeMapProjection()).resolves.toEqual({
@@ -552,6 +609,43 @@ describe("computeMapProjection", () => {
             "UMAP worker memory limit reached; retrying with a smaller sample",
             expect.objectContaining({ sampleSize: 4000 }),
         );
+    });
+
+    it("terminates the active worker and releases its lease during shutdown", async () => {
+        let leaseHeld = false;
+        mockRedisSet.mockImplementation(async () => {
+            if (leaseHeld) return null;
+            leaseHeld = true;
+            return "OK";
+        });
+        mockRedisEval.mockImplementation(async (script) => {
+            if (script.includes("DEL")) leaseHeld = false;
+            return 1;
+        });
+        const { computeMapProjection, shutdownUmapProjection } = loadModule();
+        await expect(computeMapProjection()).resolves.toEqual({
+            status: "building",
+        });
+        workers[0].terminate.mockImplementation(async () => {
+            workers[0].emit("exit", 1);
+            return 1;
+        });
+
+        await shutdownUmapProjection();
+
+        expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+        expect(leaseHeld).toBe(false);
+        expect(mockLoggerError).not.toHaveBeenCalled();
+        mockRedisGet.mockClear();
+        await expect(computeMapProjection()).resolves.toEqual({
+            status: "building",
+        });
+        expect(mockRedisGet).not.toHaveBeenCalled();
+        const { acquireVibeMapBuildLease } =
+            require("../vibeMapBuildState") as typeof import("../vibeMapBuildState");
+        const replacementLease = await acquireVibeMapBuildLease(SPACE_ID);
+        expect(replacementLease).not.toBeNull();
+        await replacementLease?.release();
     });
 });
 

--- a/backend/src/services/umapProjection.ts
+++ b/backend/src/services/umapProjection.ts
@@ -170,6 +170,7 @@ async function cacheResult(
     trackIds: string[],
     ttlSeconds: number = CACHE_TTL_SECONDS,
 ): Promise<void> {
+    if (!acceptingBuilds) return;
     const trackIdsKey = trackIdsKeyForSpace(spaceId);
     const pipeline = redisClient.multi();
     pipeline.setEx(
@@ -542,6 +543,7 @@ async function superviseBuild(
 ): Promise<void> {
     try {
         await doCompute(spaceId);
+        if (!acceptingBuilds) return;
         try {
             await clearVibeMapBuildFailures(spaceId);
         } catch (error) {
@@ -554,7 +556,7 @@ async function superviseBuild(
             log.debug("Vibe map build stopped during shutdown", { spaceId });
         }
     } finally {
-        await releaseLease(lease);
+        if (acceptingBuilds) await releaseLease(lease);
     }
 }
 
@@ -572,37 +574,50 @@ async function readPublishedState(
         readVibeMapBuildFailure(spaceId),
     ]);
     if (cached) {
-        log.debug("Vibe map cache hit", { spaceId });
-        return {
-            status: "ready",
-            data: JSON.parse(cached) as VibeMapResponse,
-        };
+        try {
+            const data = JSON.parse(cached) as VibeMapResponse;
+            log.debug("Vibe map cache hit", { spaceId });
+            return { status: "ready", data };
+        } catch {
+            log.warn("Ignoring malformed vibe map projection cache", {
+                spaceId,
+            });
+        }
     }
     return failure ? { status: "failed", ...failure } : null;
 }
 
-async function settleShutdownWork(): Promise<void> {
+async function settleShutdownWork(
+    canReleaseLeases: () => boolean,
+): Promise<void> {
     await Promise.allSettled(Array.from(activeAdmissions));
     const terminations = Array.from(activeWorkers, terminateWorker);
-    const releases = Array.from(heldLeases, releaseLease);
+    await Promise.allSettled(terminations);
     const builds = Array.from(activeBuilds.values());
-    await Promise.allSettled([...terminations, ...releases, ...builds]);
+    await Promise.allSettled(builds);
+    // A missed shutdown deadline leaves residual work uncertain. Stop lease
+    // refreshes, but let Redis TTL recovery prevent overlap with that work.
+    if (!canReleaseLeases()) return;
+    const releases = Array.from(heldLeases, releaseLease);
+    await Promise.allSettled(releases);
 }
 
 async function settleWithinShutdownTimeout(): Promise<boolean> {
     return new Promise((resolve) => {
         let settled = false;
+        let deadlineExpired = false;
         const finish = (completed: boolean) => {
             if (settled) return;
             settled = true;
             clearTimeout(timeoutId);
             resolve(completed);
         };
-        const timeoutId = setTimeout(
-            () => finish(false),
-            UMAP_SHUTDOWN_TIMEOUT_MS,
-        );
-        settleShutdownWork().then(
+        const timeoutId = setTimeout(() => {
+            deadlineExpired = true;
+            for (const lease of heldLeases) lease.abandon();
+            finish(false);
+        }, UMAP_SHUTDOWN_TIMEOUT_MS);
+        settleShutdownWork(() => !deadlineExpired).then(
             () => finish(true),
             () => finish(true),
         );
@@ -641,20 +656,22 @@ async function admitMapProjection(): Promise<VibeMapProjectionState> {
         return { status: "building" };
     }
     heldLeases.add(lease);
-    if (!acceptingBuilds) {
-        await releaseLease(lease);
+    let buildStarted = false;
+    try {
+        if (!acceptingBuilds) return { status: "building" };
+        const publishedWhileAcquiring = await readPublishedState(spaceId);
+        if (publishedWhileAcquiring || !acceptingBuilds) {
+            return publishedWhileAcquiring ?? { status: "building" };
+        }
+        const build = superviseBuild(spaceId, lease).finally(() => {
+            activeBuilds.delete(spaceId);
+        });
+        activeBuilds.set(spaceId, build);
+        buildStarted = true;
         return { status: "building" };
+    } finally {
+        if (!buildStarted) await releaseLease(lease);
     }
-    const publishedWhileAcquiring = await readPublishedState(spaceId);
-    if (publishedWhileAcquiring || !acceptingBuilds) {
-        await releaseLease(lease);
-        return publishedWhileAcquiring ?? { status: "building" };
-    }
-    const build = superviseBuild(spaceId, lease).finally(() => {
-        activeBuilds.delete(spaceId);
-    });
-    activeBuilds.set(spaceId, build);
-    return { status: "building" };
 }
 
 /** Serve cached data or supervise one leased background build per space. */

--- a/backend/src/services/umapProjection.ts
+++ b/backend/src/services/umapProjection.ts
@@ -2,27 +2,35 @@ import { existsSync } from "fs";
 import path from "path";
 import { Worker } from "worker_threads";
 import { config } from "../config";
-import { prisma } from "../utils/db";
 import { redisClient } from "../utils/redis";
 import { logger } from "../utils/logger";
-import { parseEmbedding } from "../utils/embedding";
-import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
+import {
+    MAX_UMAP_WORKER_ROWS,
+    type UmapProjectionRow,
+    type UmapWorkerData,
+    type UmapWorkerMessage,
+} from "../workers/umapWorkerProtocol";
 import { getActiveSpace } from "./embeddingSpaces";
+import {
+    acquireVibeMapBuildLease,
+    clearVibeMapBuildFailures,
+    readVibeMapBuildFailure,
+    recordVibeMapBuildFailure,
+    type VibeMapBuildFailure,
+    type VibeMapBuildLease,
+} from "./vibeMapBuildState";
 
+const log = logger.child("VibeMapProjection");
 const MIN_TRACKS_FOR_UMAP = 5;
-const MAX_EMBEDDINGS = 15000;
-// Space-scoped keys: a cutover to a new embedding space starts writing to
-// fresh keys instead of serving the retired space's projection for a day.
+const MIN_OOM_SAMPLE = 2000;
+const MAX_UMAP_ATTEMPTS = 3;
 const CACHE_KEY_PREFIX = "vibe:map:v5:projection";
 const TRACK_IDS_KEY_PREFIX = "vibe:map:v5:track_ids";
 const CACHE_TTL_SECONDS = 86400;
 const EMPTY_CACHE_TTL_SECONDS = 300;
 const UMAP_TIMEOUT_MS = 15 * 60 * 1000;
 const UMAP_WARN_MS = 5 * 60 * 1000;
-// When the worker dies on its heap ceiling, retry with a smaller sample
-// before giving up: full size, then half, then a quarter.
-const OOM_RETRY_DIVISORS = [1, 2, 4] as const;
-const MIN_OOM_SAMPLE = 2000;
+const activeBuilds = new Map<string, Promise<void>>();
 
 function cacheKeyForSpace(spaceId: string): string {
     return `${CACHE_KEY_PREFIX}:${spaceId}`;
@@ -32,6 +40,7 @@ function trackIdsKeyForSpace(spaceId: string): string {
     return `${TRACK_IDS_KEY_PREFIX}:${spaceId}`;
 }
 
+/** Track returned to the vibe-map client. */
 export interface VibeMapTrack {
     id: string;
     x: number;
@@ -52,34 +61,13 @@ export interface VibeMapTrack {
     valence: number | null;
 }
 
+/** Cached vibe-map response for one embedding space. */
 export interface VibeMapResponse {
     tracks: VibeMapTrack[];
     trackCount: number;
     sampled?: boolean;
     computedAt: string;
 }
-
-type TrackRow = {
-    track_id: string;
-    title: string;
-    artistName: string;
-    artistId: string;
-    albumId: string;
-    coverUrl: string | null;
-    loudnessLufs: number | null;
-    truePeakDb: number | null;
-    albumLoudnessLufs: number | null;
-    albumTruePeakDb: number | null;
-    energy: number | null;
-    valence: number | null;
-    moodHappy: number | null;
-    moodSad: number | null;
-    moodRelaxed: number | null;
-    moodAggressive: number | null;
-    moodParty: number | null;
-    moodAcoustic: number | null;
-    moodElectronic: number | null;
-};
 
 const MOOD_FIELDS = [
     "moodHappy",
@@ -91,21 +79,19 @@ const MOOD_FIELDS = [
     "moodElectronic",
 ] as const;
 
-let computePromise: Promise<VibeMapResponse> | null = null;
-
-/** Worker data plus the optional development loader registration. */
+/** Worker query data plus optional development loader registration. */
 export interface UmapWorkerOptions {
-    workerData: { embeddings: number[][]; nNeighbors: number };
+    workerData: UmapWorkerData;
     execArgv?: string[];
 }
 
-/** Build worker options, registering tsx only for an uncompiled TypeScript worker. */
+/** Build worker options without passing embeddings through the parent heap. */
 export function umapWorkerOptions(
     workerPath: string,
-    embeddings: number[][],
-    nNeighbors: number,
+    spaceId: string,
+    sampleSize: number,
 ): UmapWorkerOptions {
-    const workerData = { embeddings, nNeighbors };
+    const workerData = { spaceId, sampleSize };
     return workerPath.endsWith(".ts")
         ? { workerData, execArgv: ["--import", "tsx"] }
         : { workerData };
@@ -116,70 +102,41 @@ function resolveUmapWorkerPath(): string {
         path.join(__dirname, "../workers/umapWorker.js"),
         path.join(__dirname, "../workers/umapWorker.ts"),
     ];
-
     return (
         candidatePaths.find((candidatePath) => existsSync(candidatePath)) ??
         candidatePaths[0]
     );
 }
 
-function getDominantMood(track: Record<string, unknown>): {
+function getDominantMood(track: UmapProjectionRow): {
     mood: string;
     score: number;
 } {
     let best = { mood: "neutral", score: 0 };
-
     for (const field of MOOD_FIELDS) {
-        const value = track[field] as number | null | undefined;
+        const value = track[field];
         if (value != null && value > best.score) {
             best = { mood: field, score: value };
         }
     }
-
     return best;
 }
 
-function getMoodScores(track: Record<string, unknown>): Record<string, number> {
+function getMoodScores(track: UmapProjectionRow): Record<string, number> {
     const moods: Record<string, number> = {};
-
     for (const field of MOOD_FIELDS) {
-        const value = track[field] as number | null | undefined;
-        if (value != null) {
-            moods[field] = value;
-        }
+        const value = track[field];
+        if (value != null) moods[field] = value;
     }
-
     return moods;
 }
 
-async function cacheResult(
-    spaceId: string,
-    result: VibeMapResponse,
-    trackIds: string[],
-    ttlSeconds: number = CACHE_TTL_SECONDS,
-): Promise<void> {
-    try {
-        const cacheKey = cacheKeyForSpace(spaceId);
-        const trackIdsKey = trackIdsKeyForSpace(spaceId);
-        const pipeline = redisClient.multi();
-        pipeline.setEx(cacheKey, ttlSeconds, JSON.stringify(result));
-        pipeline.del(trackIdsKey);
-        if (trackIds.length > 0) {
-            pipeline.sAdd(trackIdsKey, trackIds);
-            pipeline.expire(trackIdsKey, CACHE_TTL_SECONDS);
-        }
-        await pipeline.exec();
-    } catch (error) {
-        logger.warn(
-            "[VIBE-MAP] Failed to cache projection:",
-            error instanceof Error ? error.message : String(error),
-        );
-    }
-}
-
-function buildMapTrack(row: TrackRow, x: number, y: number): VibeMapTrack {
-    const dominant = getDominantMood(row as Record<string, unknown>);
-
+function buildMapTrack(
+    row: UmapProjectionRow,
+    x: number,
+    y: number,
+): VibeMapTrack {
+    const dominant = getDominantMood(row);
     return {
         id: row.track_id,
         x,
@@ -195,302 +152,411 @@ function buildMapTrack(row: TrackRow, x: number, y: number): VibeMapTrack {
         albumTruePeakDb: row.albumTruePeakDb,
         dominantMood: dominant.mood,
         moodScore: dominant.score,
-        moods: getMoodScores(row as Record<string, unknown>),
+        moods: getMoodScores(row),
         energy: row.energy,
         valence: row.valence,
     };
 }
 
+async function cacheResult(
+    spaceId: string,
+    result: VibeMapResponse,
+    trackIds: string[],
+    ttlSeconds: number = CACHE_TTL_SECONDS,
+): Promise<void> {
+    const trackIdsKey = trackIdsKeyForSpace(spaceId);
+    const pipeline = redisClient.multi();
+    pipeline.setEx(
+        cacheKeyForSpace(spaceId),
+        ttlSeconds,
+        JSON.stringify(result),
+    );
+    pipeline.del(trackIdsKey);
+    if (trackIds.length > 0) {
+        pipeline.sAdd(trackIdsKey, trackIds);
+        pipeline.expire(trackIdsKey, CACHE_TTL_SECONDS);
+    }
+    await pipeline.exec();
+}
+
+class UmapWorkerFailure extends Error {
+    readonly code: string | undefined;
+    readonly materializedRowCount: number | null;
+
+    constructor(error: Error, materializedRowCount: number | null) {
+        super(error.message, { cause: error });
+        this.name = "UmapWorkerFailure";
+        this.code = (error as NodeJS.ErrnoException).code;
+        this.materializedRowCount = materializedRowCount;
+    }
+}
+
+type WorkerResult = {
+    rows: UmapProjectionRow[];
+    projection: number[][] | null;
+};
+
+function parseWorkerMessage(value: unknown): UmapWorkerMessage | null {
+    if (!value || typeof value !== "object") return null;
+    const message = value as Partial<UmapWorkerMessage>;
+    if (
+        message.type === "materialized" &&
+        Number.isSafeInteger(message.rowCount) &&
+        Number(message.rowCount) >= 0 &&
+        Number(message.rowCount) <= MAX_UMAP_WORKER_ROWS
+    ) {
+        return message as UmapWorkerMessage;
+    }
+    if (
+        message.type === "error" &&
+        typeof message.error === "string" &&
+        message.error.length > 0
+    ) {
+        return message as UmapWorkerMessage;
+    }
+    if (
+        message.type === "result" &&
+        Array.isArray(message.rows) &&
+        message.rows.length <= MAX_UMAP_WORKER_ROWS &&
+        (message.projection === null || Array.isArray(message.projection))
+    ) {
+        return message as UmapWorkerMessage;
+    }
+    return null;
+}
+
+function validateWorkerResult(
+    message: Extract<UmapWorkerMessage, { type: "result" }>,
+): WorkerResult {
+    const { rows, projection } = message;
+    if (rows.length >= MIN_TRACKS_FOR_UMAP) {
+        if (!projection || projection.length !== rows.length) {
+            throw new Error("UMAP worker returned a mismatched projection");
+        }
+        for (let index = 0; index < MAX_UMAP_WORKER_ROWS; index += 1) {
+            if (index >= projection.length) break;
+            const point = projection[index];
+            if (
+                !Array.isArray(point) ||
+                point.length < 2 ||
+                !Number.isFinite(point[0]) ||
+                !Number.isFinite(point[1])
+            ) {
+                throw new Error("UMAP worker returned an invalid coordinate");
+            }
+        }
+    } else if (projection !== null) {
+        throw new Error("UMAP worker projected an undersized dataset");
+    }
+    return { rows, projection };
+}
+
+function terminateWorker(worker: Worker): void {
+    worker.terminate().catch((error: unknown) => {
+        log.warn("Failed to terminate UMAP worker", error);
+    });
+}
+
+class UmapWorkerMonitor {
+    private settled = false;
+    private materializedRowCount: number | null = null;
+    private readonly warnTimer: NodeJS.Timeout;
+    private readonly timeoutTimer: NodeJS.Timeout;
+
+    constructor(
+        private readonly worker: Worker,
+        requestedSampleSize: number,
+        private readonly resolve: (result: WorkerResult) => void,
+        private readonly reject: (error: Error) => void,
+    ) {
+        this.warnTimer = setTimeout(() => {
+            log.warn("UMAP worker running for more than five minutes", {
+                requestedSampleSize,
+            });
+        }, UMAP_WARN_MS);
+        this.timeoutTimer = setTimeout(() => {
+            if (this.settled) return;
+            this.finish();
+            terminateWorker(this.worker);
+            this.reject(
+                new Error(
+                    `UMAP worker timed out after ${UMAP_TIMEOUT_MS / 60000} minutes`,
+                ),
+            );
+        }, UMAP_TIMEOUT_MS);
+        worker.on("message", (payload: unknown) => this.onMessage(payload));
+        worker.on("error", (error: Error) => this.fail(error));
+        worker.on("exit", (code: number) => this.onExit(code));
+    }
+
+    private finish(): void {
+        this.settled = true;
+        clearTimeout(this.warnTimer);
+        clearTimeout(this.timeoutTimer);
+    }
+
+    private fail(error: Error): void {
+        if (this.settled) return;
+        this.finish();
+        this.reject(new UmapWorkerFailure(error, this.materializedRowCount));
+    }
+
+    private onExit(code: number): void {
+        if (this.settled) return;
+        const message =
+            code === 0
+                ? "UMAP worker exited before returning a result"
+                : `UMAP worker exited with code ${code}`;
+        this.fail(new Error(message));
+    }
+
+    private onMessage(payload: unknown): void {
+        if (this.settled) return;
+        const message = parseWorkerMessage(payload);
+        if (!message) {
+            this.fail(new Error("UMAP worker returned an invalid message"));
+            return;
+        }
+        if (message.type === "materialized") {
+            this.materializedRowCount = message.rowCount;
+            return;
+        }
+        if (message.type === "error") {
+            this.fail(new Error(message.error));
+            return;
+        }
+        this.finish();
+        try {
+            this.resolve(validateWorkerResult(message));
+        } catch (error) {
+            this.reject(
+                error instanceof Error ? error : new Error(String(error)),
+            );
+        }
+    }
+}
+
+function monitorUmapWorker(
+    worker: Worker,
+    requestedSampleSize: number,
+): Promise<WorkerResult> {
+    return new Promise((resolve, reject) => {
+        new UmapWorkerMonitor(worker, requestedSampleSize, resolve, reject);
+    });
+}
+
+function runUmapInWorker(
+    spaceId: string,
+    sampleSize: number,
+): Promise<WorkerResult> {
+    const workerPath = resolveUmapWorkerPath();
+    const worker = new Worker(workerPath, {
+        ...umapWorkerOptions(workerPath, spaceId, sampleSize),
+        resourceLimits: {
+            maxOldGenerationSizeMb: config.vibeMapWorkerMemoryMb,
+        },
+    });
+    return monitorUmapWorker(worker, sampleSize);
+}
+
+function isWorkerOutOfMemory(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        ((error as NodeJS.ErrnoException).code === "ERR_WORKER_OUT_OF_MEMORY" ||
+            error.message.includes("memory limit"))
+    );
+}
+
+async function projectWithOomDegradation(
+    spaceId: string,
+): Promise<WorkerResult & { degraded: boolean }> {
+    let sampleSize = MAX_UMAP_WORKER_ROWS;
+    for (let attempt = 0; attempt < MAX_UMAP_ATTEMPTS; attempt += 1) {
+        try {
+            const result = await runUmapInWorker(spaceId, sampleSize);
+            return { ...result, degraded: attempt > 0 };
+        } catch (error) {
+            const materializedCount =
+                error instanceof UmapWorkerFailure
+                    ? error.materializedRowCount
+                    : null;
+            const reductionBase = materializedCount ?? sampleSize;
+            if (
+                !isWorkerOutOfMemory(error) ||
+                reductionBase <= MIN_OOM_SAMPLE ||
+                attempt === MAX_UMAP_ATTEMPTS - 1
+            ) {
+                throw error;
+            }
+            sampleSize = Math.max(
+                MIN_OOM_SAMPLE,
+                Math.floor(reductionBase / 2),
+            );
+            log.warn(
+                "UMAP worker memory limit reached; retrying with a smaller sample",
+                { sampleSize: reductionBase, nextSampleSize: sampleSize },
+            );
+        }
+    }
+    throw new Error("UMAP projection exhausted its bounded attempts");
+}
+
 async function buildCircularLayout(
     spaceId: string,
-    rows: Array<TrackRow & { embedding: string }>,
+    rows: UmapProjectionRow[],
 ): Promise<VibeMapResponse> {
-    const result: VibeMapResponse = {
-        tracks: rows.map((row, index) => {
-            const angle = (2 * Math.PI * index) / rows.length;
-            return buildMapTrack(
-                row,
-                0.5 + 0.3 * Math.cos(angle),
-                0.5 + 0.3 * Math.sin(angle),
-            );
-        }),
-        trackCount: rows.length,
+    const tracks = rows.map((row, index) => {
+        const angle = (2 * Math.PI * index) / rows.length;
+        return buildMapTrack(
+            row,
+            0.5 + 0.3 * Math.cos(angle),
+            0.5 + 0.3 * Math.sin(angle),
+        );
+    });
+    const result = {
+        tracks,
+        trackCount: tracks.length,
         computedAt: new Date().toISOString(),
     };
-
     await cacheResult(
         spaceId,
         result,
         rows.map((row) => row.track_id),
     );
-
     return result;
 }
 
-function monitorUmapWorker(
-    worker: Worker,
-    trackCount: number,
-    resolve: (value: number[][]) => void,
-    reject: (reason: Error) => void,
-): void {
-    let settled = false;
-    const warnTimer = setTimeout(
-        () =>
-            logger.warn(
-                `[VIBE-MAP] UMAP worker running for 5+ minutes (${trackCount} tracks)`,
-            ),
-        UMAP_WARN_MS,
-    );
-    const timeoutTimer = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(warnTimer);
-        void worker.terminate();
-        reject(
-            new Error(
-                `UMAP worker timed out after ${UMAP_TIMEOUT_MS / 60000} minutes`,
-            ),
-        );
-    }, UMAP_TIMEOUT_MS);
-    const clearTimers = () => {
-        clearTimeout(warnTimer);
-        clearTimeout(timeoutTimer);
-    };
-    worker.on("message", (result) => {
-        if (settled) return;
-        settled = true;
-        clearTimers();
-        const payload = result as { error?: string } | number[][];
-        if (!Array.isArray(payload) && payload?.error)
-            reject(new Error(payload.error));
-        else resolve(payload as number[][]);
-    });
-    worker.on("error", (error) => {
-        if (settled) return;
-        settled = true;
-        clearTimers();
-        reject(error);
-    });
-    worker.on("exit", (code) => {
-        if (settled || code === 0) return;
-        settled = true;
-        clearTimers();
-        reject(new Error(`UMAP worker exited with code ${code}`));
-    });
-}
-
-function runUmapInWorker(
-    embeddings: number[][],
-    nNeighbors: number,
-): Promise<number[][]> {
-    return new Promise((resolve, reject) => {
-        const workerPath = resolveUmapWorkerPath();
-        const options = umapWorkerOptions(workerPath, embeddings, nNeighbors);
-        const worker = new Worker(workerPath, {
-            ...options,
-            resourceLimits: {
-                maxOldGenerationSizeMb: config.vibeMapWorkerMemoryMb,
-            },
-        });
-        monitorUmapWorker(worker, embeddings.length, resolve, reject);
-    });
-}
-
-function isWorkerOutOfMemory(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const code = (error as NodeJS.ErrnoException).code;
-    return (
-        code === "ERR_WORKER_OUT_OF_MEMORY" ||
-        error.message.includes("memory limit")
-    );
-}
-
-/**
- * Run UMAP over the rows, halving the sample on worker out-of-memory so a
- * memory-constrained deployment degrades to a sparser map instead of failing.
- */
-async function projectWithOomDegradation(
-    rows: Array<TrackRow & { embedding: string }>,
-): Promise<{
-    projectedRows: Array<TrackRow & { embedding: string }>;
-    projection: number[][];
-}> {
-    let lastError: unknown = null;
-    for (const divisor of OOM_RETRY_DIVISORS) {
-        const sampleSize = Math.max(
-            MIN_OOM_SAMPLE,
-            Math.floor(rows.length / divisor),
-        );
-        const sample = rows.slice(0, Math.min(sampleSize, rows.length));
-        const embeddings = sample.map((row) => parseEmbedding(row.embedding));
-        const nNeighbors = Math.min(
-            15,
-            Math.max(2, Math.floor(sample.length / 2)),
-        );
-        try {
-            const projection = await runUmapInWorker(embeddings, nNeighbors);
-            return { projectedRows: sample, projection };
-        } catch (error) {
-            lastError = error;
-            if (
-                !isWorkerOutOfMemory(error) ||
-                sample.length <= MIN_OOM_SAMPLE
-            ) {
-                throw error;
-            }
-            logger.warn(
-                `[VIBE-MAP] UMAP worker hit its ${config.vibeMapWorkerMemoryMb}MB heap ceiling at ${sample.length} tracks; retrying with a smaller sample`,
-            );
-        }
-    }
-    throw lastError instanceof Error
-        ? lastError
-        : new Error("UMAP projection failed");
-}
-
-async function doCompute(): Promise<VibeMapResponse> {
-    const startedAt = Date.now();
-    const activeSpace = await getActiveSpace();
-
-    const rows = await prisma.$queryRaw<
-        Array<TrackRow & { embedding: string }>
-    >`
-        SELECT
-            te.track_id,
-            t.title,
-            ar.name as "artistName",
-            ar.id as "artistId",
-            a.id as "albumId",
-            a."coverUrl",
-            t."loudnessLufs",
-            t."truePeakDb",
-            a."albumLoudnessLufs",
-            a."albumTruePeakDb",
-            t.energy,
-            t.valence,
-            t."moodHappy",
-            t."moodSad",
-            t."moodRelaxed",
-            t."moodAggressive",
-            t."moodParty",
-            t."moodAcoustic",
-            t."moodElectronic",
-            te.embedding::text as embedding
-        FROM track_embeddings te
-        JOIN "Track" t ON te.track_id = t.id
-        JOIN "Album" a ON t."albumId" = a.id
-        JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-          AND te.space_id = ${activeSpace.id}
-        ORDER BY RANDOM()
-        LIMIT ${MAX_EMBEDDINGS}
-    `;
-
-    if (rows.length === 0) {
-        const empty: VibeMapResponse = {
-            tracks: [],
-            trackCount: 0,
-            computedAt: new Date().toISOString(),
-        };
-        // Cache briefly so an empty library resolves to "no tracks" instead
-        // of a building loop, while new embeds still appear quickly.
-        await cacheResult(activeSpace.id, empty, [], EMPTY_CACHE_TTL_SECONDS);
-        return empty;
-    }
-
-    if (rows.length < MIN_TRACKS_FOR_UMAP) {
-        return buildCircularLayout(activeSpace.id, rows);
-    }
-
-    const sampled = rows.length === MAX_EMBEDDINGS;
-    logger.info(
-        `[VIBE-MAP] Computing UMAP projection for ${rows.length} tracks${sampled ? " (sampled)" : ""}`,
-    );
-
-    const { projectedRows, projection } = await projectWithOomDegradation(rows);
-
+function normalizeProjection(
+    rows: UmapProjectionRow[],
+    projection: number[][],
+): VibeMapTrack[] {
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-
-    for (const [x, y] of projection) {
+    for (let index = 0; index < MAX_UMAP_WORKER_ROWS; index += 1) {
+        if (index >= projection.length) break;
+        const [x, y] = projection[index];
         if (x < minX) minX = x;
         if (x > maxX) maxX = x;
         if (y < minY) minY = y;
         if (y > maxY) maxY = y;
     }
-
     const rangeX = maxX - minX || 1;
     const rangeY = maxY - minY || 1;
-
-    const tracks = projectedRows.map((row, index) =>
+    return rows.map((row, index) =>
         buildMapTrack(
             row,
             (projection[index][0] - minX) / rangeX,
             (projection[index][1] - minY) / rangeY,
         ),
     );
+}
 
+async function doCompute(spaceId: string): Promise<VibeMapResponse> {
+    const startedAt = Date.now();
+    const { rows, projection, degraded } =
+        await projectWithOomDegradation(spaceId);
+    if (rows.length === 0) {
+        const empty = {
+            tracks: [],
+            trackCount: 0,
+            computedAt: new Date().toISOString(),
+        };
+        await cacheResult(spaceId, empty, [], EMPTY_CACHE_TTL_SECONDS);
+        return empty;
+    }
+    if (rows.length < MIN_TRACKS_FOR_UMAP) {
+        return buildCircularLayout(spaceId, rows);
+    }
+    if (!projection) throw new Error("UMAP worker omitted its projection");
+    const tracks = normalizeProjection(rows, projection);
     const result: VibeMapResponse = {
         tracks,
         trackCount: tracks.length,
-        ...(sampled || projectedRows.length < rows.length
+        ...(degraded || rows.length === MAX_UMAP_WORKER_ROWS
             ? { sampled: true }
             : {}),
         computedAt: new Date().toISOString(),
     };
-
     await cacheResult(
-        activeSpace.id,
+        spaceId,
         result,
-        projectedRows.map((row) => row.track_id),
+        rows.map((row) => row.track_id),
     );
-
-    logger.info(
-        `[VIBE-MAP] UMAP projection computed in ${Date.now() - startedAt}ms for ${tracks.length} tracks`,
-    );
-
+    log.info("UMAP projection computed", {
+        elapsedMs: Date.now() - startedAt,
+        trackCount: tracks.length,
+        sampled: result.sampled ?? false,
+    });
     return result;
 }
 
-/** Either a served projection or a signal that the build is still running. */
+async function releaseLease(lease: VibeMapBuildLease): Promise<void> {
+    try {
+        await lease.release();
+    } catch (error) {
+        log.warn("Failed to release vibe map build lease", error);
+    }
+}
+
+async function superviseBuild(
+    spaceId: string,
+    lease: VibeMapBuildLease,
+): Promise<void> {
+    try {
+        await doCompute(spaceId);
+        try {
+            await clearVibeMapBuildFailures(spaceId);
+        } catch (error) {
+            log.warn("Failed to clear vibe map build failure history", error);
+        }
+    } catch (error) {
+        log.error("Vibe map build failed", error);
+        try {
+            await recordVibeMapBuildFailure(
+                spaceId,
+                isWorkerOutOfMemory(error)
+                    ? "UMAP worker exceeded its memory limit"
+                    : "Vibe map projection build failed",
+            );
+        } catch (markerError) {
+            log.error("Failed to record vibe map build cooldown", markerError);
+        }
+    } finally {
+        await releaseLease(lease);
+    }
+}
+
+/** Cached data, an active build, or a failed build waiting for retry. */
 export type VibeMapProjectionState =
     | { status: "ready"; data: VibeMapResponse }
-    | { status: "building" };
+    | { status: "building" }
+    | ({ status: "failed" } & VibeMapBuildFailure);
 
-/**
- * Serve the cached projection for the active space, or start a background
- * build and report "building" instead of holding the request open for a
- * computation that can outlive any client timeout.
- */
+/** Serve cached data or supervise one leased background build per space. */
 export async function computeMapProjection(): Promise<VibeMapProjectionState> {
     const activeSpace = await getActiveSpace();
-    const cached = await redisClient.get(cacheKeyForSpace(activeSpace.id));
+    const spaceId = activeSpace.id;
+    const cached = await redisClient.get(cacheKeyForSpace(spaceId));
     if (cached) {
-        logger.debug("[VIBE-MAP] Cache hit (space-scoped key)");
+        log.debug("Vibe map cache hit", { spaceId });
         return {
             status: "ready",
             data: JSON.parse(cached) as VibeMapResponse,
         };
     }
-
-    if (!computePromise) {
-        computePromise = doCompute()
-            .catch((error) => {
-                logger.error("Vibe map error:", error);
-                throw error;
-            })
-            .finally(() => {
-                computePromise = null;
-            });
-        // The request returns "building" immediately; surface compute
-        // failures through the log line above, not an unhandled rejection.
-        computePromise.catch(() => undefined);
-    } else {
-        logger.debug("[VIBE-MAP] Build already in progress");
+    const failure = await readVibeMapBuildFailure(spaceId);
+    if (failure) return { status: "failed", ...failure };
+    if (activeBuilds.size > 0) return { status: "building" };
+    const lease = await acquireVibeMapBuildLease(spaceId);
+    if (!lease) {
+        log.debug("Vibe map build lease held by another replica", { spaceId });
+        return { status: "building" };
     }
-
+    const build = superviseBuild(spaceId, lease).finally(() => {
+        activeBuilds.delete(spaceId);
+    });
+    activeBuilds.set(spaceId, build);
     return { status: "building" };
 }

--- a/backend/src/services/umapProjection.ts
+++ b/backend/src/services/umapProjection.ts
@@ -30,7 +30,13 @@ const CACHE_TTL_SECONDS = 86400;
 const EMPTY_CACHE_TTL_SECONDS = 300;
 const UMAP_TIMEOUT_MS = 15 * 60 * 1000;
 const UMAP_WARN_MS = 5 * 60 * 1000;
+const UMAP_SHUTDOWN_TIMEOUT_MS = 3 * 1000;
 const activeBuilds = new Map<string, Promise<void>>();
+const activeAdmissions = new Set<Promise<VibeMapProjectionState>>();
+const activeWorkers = new Set<Worker>();
+const heldLeases = new Set<VibeMapBuildLease>();
+let acceptingBuilds = true;
+let shutdownPromise: Promise<void> | null = null;
 
 function cacheKeyForSpace(spaceId: string): string {
     return `${CACHE_KEY_PREFIX}:${spaceId}`;
@@ -251,10 +257,18 @@ function validateWorkerResult(
     return { rows, projection };
 }
 
-function terminateWorker(worker: Worker): void {
+function requestWorkerTermination(worker: Worker): void {
     worker.terminate().catch((error: unknown) => {
         log.warn("Failed to terminate UMAP worker", error);
     });
+}
+
+async function terminateWorker(worker: Worker): Promise<void> {
+    try {
+        await worker.terminate();
+    } catch (error) {
+        log.warn("Failed to terminate UMAP worker", error);
+    }
 }
 
 class UmapWorkerMonitor {
@@ -277,7 +291,7 @@ class UmapWorkerMonitor {
         this.timeoutTimer = setTimeout(() => {
             if (this.settled) return;
             this.finish();
-            terminateWorker(this.worker);
+            requestWorkerTermination(this.worker);
             this.reject(
                 new Error(
                     `UMAP worker timed out after ${UMAP_TIMEOUT_MS / 60000} minutes`,
@@ -355,6 +369,10 @@ function runUmapInWorker(
         resourceLimits: {
             maxOldGenerationSizeMb: config.vibeMapWorkerMemoryMb,
         },
+    });
+    activeWorkers.add(worker);
+    worker.on("exit", () => {
+        activeWorkers.delete(worker);
     });
     return monitorUmapWorker(worker, sampleSize);
 }
@@ -493,10 +511,28 @@ async function doCompute(spaceId: string): Promise<VibeMapResponse> {
 }
 
 async function releaseLease(lease: VibeMapBuildLease): Promise<void> {
+    if (!heldLeases.delete(lease)) return;
     try {
         await lease.release();
     } catch (error) {
         log.warn("Failed to release vibe map build lease", error);
+    }
+}
+
+async function recordBuildFailure(
+    spaceId: string,
+    error: unknown,
+): Promise<void> {
+    log.error("Vibe map build failed", error);
+    try {
+        await recordVibeMapBuildFailure(
+            spaceId,
+            isWorkerOutOfMemory(error)
+                ? "UMAP worker exceeded its memory limit"
+                : "Vibe map projection build failed",
+        );
+    } catch (markerError) {
+        log.error("Failed to record vibe map build cooldown", markerError);
     }
 }
 
@@ -512,16 +548,10 @@ async function superviseBuild(
             log.warn("Failed to clear vibe map build failure history", error);
         }
     } catch (error) {
-        log.error("Vibe map build failed", error);
-        try {
-            await recordVibeMapBuildFailure(
-                spaceId,
-                isWorkerOutOfMemory(error)
-                    ? "UMAP worker exceeded its memory limit"
-                    : "Vibe map projection build failed",
-            );
-        } catch (markerError) {
-            log.error("Failed to record vibe map build cooldown", markerError);
+        if (acceptingBuilds) {
+            await recordBuildFailure(spaceId, error);
+        } else {
+            log.debug("Vibe map build stopped during shutdown", { spaceId });
         }
     } finally {
         await releaseLease(lease);
@@ -534,11 +564,13 @@ export type VibeMapProjectionState =
     | { status: "building" }
     | ({ status: "failed" } & VibeMapBuildFailure);
 
-/** Serve cached data or supervise one leased background build per space. */
-export async function computeMapProjection(): Promise<VibeMapProjectionState> {
-    const activeSpace = await getActiveSpace();
-    const spaceId = activeSpace.id;
-    const cached = await redisClient.get(cacheKeyForSpace(spaceId));
+async function readPublishedState(
+    spaceId: string,
+): Promise<VibeMapProjectionState | null> {
+    const [cached, failure] = await Promise.all([
+        redisClient.get(cacheKeyForSpace(spaceId)),
+        readVibeMapBuildFailure(spaceId),
+    ]);
     if (cached) {
         log.debug("Vibe map cache hit", { spaceId });
         return {
@@ -546,17 +578,93 @@ export async function computeMapProjection(): Promise<VibeMapProjectionState> {
             data: JSON.parse(cached) as VibeMapResponse,
         };
     }
-    const failure = await readVibeMapBuildFailure(spaceId);
-    if (failure) return { status: "failed", ...failure };
+    return failure ? { status: "failed", ...failure } : null;
+}
+
+async function settleShutdownWork(): Promise<void> {
+    await Promise.allSettled(Array.from(activeAdmissions));
+    const terminations = Array.from(activeWorkers, terminateWorker);
+    const releases = Array.from(heldLeases, releaseLease);
+    const builds = Array.from(activeBuilds.values());
+    await Promise.allSettled([...terminations, ...releases, ...builds]);
+}
+
+async function settleWithinShutdownTimeout(): Promise<boolean> {
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (completed: boolean) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutId);
+            resolve(completed);
+        };
+        const timeoutId = setTimeout(
+            () => finish(false),
+            UMAP_SHUTDOWN_TIMEOUT_MS,
+        );
+        settleShutdownWork().then(
+            () => finish(true),
+            () => finish(true),
+        );
+    });
+}
+
+async function performShutdown(): Promise<void> {
+    const completed = await settleWithinShutdownTimeout();
+    if (completed) return;
+    log.warn("UMAP projection shutdown timed out", {
+        timeoutMs: UMAP_SHUTDOWN_TIMEOUT_MS,
+        activeBuilds: activeBuilds.size,
+        activeWorkers: activeWorkers.size,
+        heldLeases: heldLeases.size,
+    });
+}
+
+/** Stop projection admission and boundedly terminate owned workers and leases. */
+export function shutdownUmapProjection(): Promise<void> {
+    acceptingBuilds = false;
+    shutdownPromise ??= performShutdown();
+    return shutdownPromise;
+}
+
+async function admitMapProjection(): Promise<VibeMapProjectionState> {
+    if (!acceptingBuilds) return { status: "building" };
+    const activeSpace = await getActiveSpace();
+    const spaceId = activeSpace.id;
+    const published = await readPublishedState(spaceId);
+    if (published) return published;
+    if (!acceptingBuilds) return { status: "building" };
     if (activeBuilds.size > 0) return { status: "building" };
     const lease = await acquireVibeMapBuildLease(spaceId);
     if (!lease) {
         log.debug("Vibe map build lease held by another replica", { spaceId });
         return { status: "building" };
     }
+    heldLeases.add(lease);
+    if (!acceptingBuilds) {
+        await releaseLease(lease);
+        return { status: "building" };
+    }
+    const publishedWhileAcquiring = await readPublishedState(spaceId);
+    if (publishedWhileAcquiring || !acceptingBuilds) {
+        await releaseLease(lease);
+        return publishedWhileAcquiring ?? { status: "building" };
+    }
     const build = superviseBuild(spaceId, lease).finally(() => {
         activeBuilds.delete(spaceId);
     });
     activeBuilds.set(spaceId, build);
     return { status: "building" };
+}
+
+/** Serve cached data or supervise one leased background build per space. */
+export async function computeMapProjection(): Promise<VibeMapProjectionState> {
+    if (!acceptingBuilds) return { status: "building" };
+    const admission = admitMapProjection();
+    activeAdmissions.add(admission);
+    try {
+        return await admission;
+    } finally {
+        activeAdmissions.delete(admission);
+    }
 }

--- a/backend/src/services/vibeMapBuildState.ts
+++ b/backend/src/services/vibeMapBuildState.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { redisClient } from "../utils/redis";
+import { logger } from "../utils/logger";
+
+const log = logger.child("VibeMapBuildState");
+const BUILD_LEASE_PREFIX = "vibe-map:build-lease";
+const BUILD_FAILURE_PREFIX = "vibe-map:build-failed";
+const BUILD_FAILURE_COUNT_PREFIX = "vibe-map:build-failure-count";
+const FAILURE_HISTORY_TTL_SECONDS = 24 * 60 * 60;
+const FAILURE_COOLDOWN_SECONDS = [5 * 60, 15 * 60, 60 * 60] as const;
+
+/** Lease lifetime exceeds three sequential 15-minute worker attempts. */
+export const VIBE_MAP_BUILD_LEASE_TTL_SECONDS = 60 * 60;
+const BUILD_LEASE_REFRESH_MS = 5 * 60 * 1000;
+
+const REFRESH_LEASE_SCRIPT = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('EXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+`;
+const RELEASE_LEASE_SCRIPT = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`;
+
+/** Retry-suppression state stored for one failed projection build. */
+export interface VibeMapBuildFailure {
+    attempt: number;
+    error: string;
+    failedAt: string;
+    retryAt: string;
+}
+
+/** Owned distributed lease for one space's projection build. */
+export class VibeMapBuildLease {
+    private refreshTimer: NodeJS.Timeout | null = null;
+
+    constructor(
+        private readonly spaceId: string,
+        private readonly token: string,
+    ) {
+        this.refreshTimer = setInterval(() => {
+            this.refresh().catch((error: unknown) => {
+                log.warn("Failed to refresh vibe map build lease", error);
+            });
+        }, BUILD_LEASE_REFRESH_MS);
+        this.refreshTimer.unref?.();
+    }
+
+    private async refresh(): Promise<void> {
+        const refreshed = await redisClient.eval(REFRESH_LEASE_SCRIPT, {
+            keys: [buildLeaseKey(this.spaceId)],
+            arguments: [this.token, String(VIBE_MAP_BUILD_LEASE_TTL_SECONDS)],
+        });
+        if (Number(refreshed) !== 1) {
+            log.warn("Vibe map build lease ownership was lost", {
+                spaceId: this.spaceId,
+            });
+        }
+    }
+
+    /** Stop refreshes and release the lease only when this owner still holds it. */
+    async release(): Promise<void> {
+        if (this.refreshTimer) clearInterval(this.refreshTimer);
+        this.refreshTimer = null;
+        await redisClient.eval(RELEASE_LEASE_SCRIPT, {
+            keys: [buildLeaseKey(this.spaceId)],
+            arguments: [this.token],
+        });
+    }
+}
+
+function buildLeaseKey(spaceId: string): string {
+    return `${BUILD_LEASE_PREFIX}:${spaceId}`;
+}
+
+function buildFailureKey(spaceId: string): string {
+    return `${BUILD_FAILURE_PREFIX}:${spaceId}`;
+}
+
+function buildFailureCountKey(spaceId: string): string {
+    return `${BUILD_FAILURE_COUNT_PREFIX}:${spaceId}`;
+}
+
+function parseFailureMarker(raw: string): VibeMapBuildFailure | null {
+    try {
+        const parsed = JSON.parse(raw) as Partial<VibeMapBuildFailure>;
+        const valid =
+            Number.isSafeInteger(parsed.attempt) &&
+            Number(parsed.attempt) > 0 &&
+            typeof parsed.error === "string" &&
+            parsed.error.length > 0 &&
+            typeof parsed.failedAt === "string" &&
+            Number.isFinite(Date.parse(parsed.failedAt)) &&
+            typeof parsed.retryAt === "string" &&
+            Number.isFinite(Date.parse(parsed.retryAt));
+        return valid ? (parsed as VibeMapBuildFailure) : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Acquire the per-space build lease with Redis NX admission. */
+export async function acquireVibeMapBuildLease(
+    spaceId: string,
+): Promise<VibeMapBuildLease | null> {
+    const token = randomUUID();
+    const acquired = await redisClient.set(buildLeaseKey(spaceId), token, {
+        NX: true,
+        EX: VIBE_MAP_BUILD_LEASE_TTL_SECONDS,
+    });
+    return acquired === "OK" ? new VibeMapBuildLease(spaceId, token) : null;
+}
+
+/** Read a live retry-suppression marker, treating malformed state as a miss. */
+export async function readVibeMapBuildFailure(
+    spaceId: string,
+): Promise<VibeMapBuildFailure | null> {
+    const key = buildFailureKey(spaceId);
+    const raw = await redisClient.get(key);
+    if (!raw) return null;
+    const marker = parseFailureMarker(raw);
+    if (marker) return marker;
+    log.warn("Discarding malformed vibe map build failure marker", { spaceId });
+    await redisClient.del(key);
+    return null;
+}
+
+/** Record a failed build with 5m, 15m, then capped 60m cooldowns. */
+export async function recordVibeMapBuildFailure(
+    spaceId: string,
+    errorSummary: string,
+    failedAt: Date = new Date(),
+): Promise<VibeMapBuildFailure> {
+    const countKey = buildFailureCountKey(spaceId);
+    const attempt = await redisClient.incr(countKey);
+    await redisClient.expire(countKey, FAILURE_HISTORY_TTL_SECONDS);
+    const cooldownIndex = Math.min(
+        attempt - 1,
+        FAILURE_COOLDOWN_SECONDS.length - 1,
+    );
+    const cooldownSeconds = FAILURE_COOLDOWN_SECONDS[cooldownIndex];
+    const marker: VibeMapBuildFailure = {
+        attempt,
+        error: errorSummary.slice(0, 500),
+        failedAt: failedAt.toISOString(),
+        retryAt: new Date(
+            failedAt.getTime() + cooldownSeconds * 1000,
+        ).toISOString(),
+    };
+    await redisClient.setEx(
+        buildFailureKey(spaceId),
+        cooldownSeconds,
+        JSON.stringify(marker),
+    );
+    return marker;
+}
+
+/** Reset escalation after a successful build. */
+export async function clearVibeMapBuildFailures(
+    spaceId: string,
+): Promise<void> {
+    await redisClient.del([
+        buildFailureKey(spaceId),
+        buildFailureCountKey(spaceId),
+    ]);
+}

--- a/backend/src/services/vibeMapBuildState.ts
+++ b/backend/src/services/vibeMapBuildState.ts
@@ -62,10 +62,15 @@ export class VibeMapBuildLease {
         }
     }
 
-    /** Stop refreshes and release the lease only when this owner still holds it. */
-    async release(): Promise<void> {
+    /** Stop refreshes without deleting the lease so its TTL can recover ownership. */
+    abandon(): void {
         if (this.refreshTimer) clearInterval(this.refreshTimer);
         this.refreshTimer = null;
+    }
+
+    /** Stop refreshes and release the lease only when this owner still holds it. */
+    async release(): Promise<void> {
+        this.abandon();
         await redisClient.eval(RELEASE_LEASE_SCRIPT, {
             keys: [buildLeaseKey(this.spaceId)],
             arguments: [this.token],

--- a/backend/src/workers/__tests__/umapWorker.test.ts
+++ b/backend/src/workers/__tests__/umapWorker.test.ts
@@ -1,46 +1,75 @@
 import { jest } from "@jest/globals";
+import type { PrismaClient } from "@prisma/client";
+import { runUmapMaterialization } from "../umapMaterialization";
+import type { UmapWorkerMessage } from "../umapWorkerProtocol";
 
-const mockFit = jest.fn<(embeddings: number[][]) => number[][]>();
-const mockUmap = jest.fn(() => ({ fit: mockFit }));
-
-jest.mock("worker_threads", () => ({
-    isMainThread: true,
-    parentPort: null,
-    workerData: undefined,
-}));
-jest.mock("umap-js", () => ({ UMAP: mockUmap }));
-
-describe("UMAP worker materialization", () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
-
-    it("produces the same projection from embedding text as the previous parsed-array path", () => {
-        const expected = [
-            [0.11, 0.22],
-            [0.33, 0.44],
-            [0.55, 0.66],
+describe("UMAP worker orchestration", () => {
+    it("publishes undersized rows without fitting and disconnects", async () => {
+        const rows = [
+            {
+                track_id: "track-1",
+                title: "Track 1",
+                artistName: "Artist",
+                artistId: "artist-1",
+                albumId: "album-1",
+                coverUrl: null,
+                loudnessLufs: null,
+                truePeakDb: null,
+                albumLoudnessLufs: null,
+                albumTruePeakDb: null,
+                energy: 0.5,
+                valence: 0.5,
+                moodHappy: null,
+                moodSad: null,
+                moodRelaxed: null,
+                moodAggressive: null,
+                moodParty: null,
+                moodAcoustic: null,
+                moodElectronic: null,
+                embedding: "[1,2,3]",
+            },
         ];
-        mockFit.mockReturnValue(expected);
-        const { projectEmbeddingTexts } =
-            require("../umapWorker") as typeof import("../umapWorker");
+        const database = {
+            $queryRaw: jest.fn(async () => rows),
+            $disconnect: jest.fn(async () => undefined),
+        } as unknown as PrismaClient;
+        const publish = jest.fn<(message: UmapWorkerMessage) => void>();
 
-        const actual = projectEmbeddingTexts(
-            ["[1,2,3]", "[4,5,6]", "[7,8,9]"],
-            2,
+        await runUmapMaterialization(
+            { spaceId: "space-1", sampleSize: 10 },
+            publish,
+            () => database,
         );
 
-        expect(mockUmap).toHaveBeenCalledWith({
-            nComponents: 2,
-            nNeighbors: 2,
-            minDist: 0.1,
-            spread: 1.0,
+        expect(publish).toHaveBeenNthCalledWith(1, {
+            type: "materialized",
+            rowCount: 1,
         });
-        expect(mockFit).toHaveBeenCalledWith([
-            [1, 2, 3],
-            [4, 5, 6],
-            [7, 8, 9],
-        ]);
-        expect(actual).toBe(expected);
+        const { embedding: _embedding, ...expectedRow } = rows[0];
+        expect(publish).toHaveBeenNthCalledWith(2, {
+            type: "result",
+            rows: [expectedRow],
+            projection: null,
+        });
+        expect(database.$disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("disconnects when materialization fails", async () => {
+        const failure = new Error("query failed");
+        const database = {
+            $queryRaw: jest.fn(async () => {
+                throw failure;
+            }),
+            $disconnect: jest.fn(async () => undefined),
+        } as unknown as PrismaClient;
+
+        await expect(
+            runUmapMaterialization(
+                { spaceId: "space-1", sampleSize: 10 },
+                jest.fn(),
+                () => database,
+            ),
+        ).rejects.toBe(failure);
+        expect(database.$disconnect).toHaveBeenCalledTimes(1);
     });
 });

--- a/backend/src/workers/__tests__/umapWorker.test.ts
+++ b/backend/src/workers/__tests__/umapWorker.test.ts
@@ -1,116 +1,46 @@
-type LoadUmapWorkerOptions = {
-    embeddings?: number[][];
-    nNeighbors?: number;
-    fitResult?: number[][];
-    fitError?: unknown;
-};
+import { jest } from "@jest/globals";
 
-describe("umapWorker", () => {
-    const defaultEmbeddings = [
-        [0.1, 0.2, 0.3],
-        [0.4, 0.5, 0.6],
-    ];
-    const defaultProjection = [
-        [1, 2],
-        [3, 4],
-    ];
+const mockFit = jest.fn<(embeddings: number[][]) => number[][]>();
+const mockUmap = jest.fn(() => ({ fit: mockFit }));
 
-    afterEach(() => {
-        jest.resetModules();
-        jest.restoreAllMocks();
+jest.mock("worker_threads", () => ({
+    isMainThread: true,
+    parentPort: null,
+    workerData: undefined,
+}));
+jest.mock("umap-js", () => ({ UMAP: mockUmap }));
+
+describe("UMAP worker materialization", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    function loadUmapWorker(options: LoadUmapWorkerOptions = {}) {
-        const postMessage = jest.fn();
-        const fit = jest.fn(() => {
-            if (options.fitError) {
-                throw options.fitError;
-            }
-
-            return options.fitResult ?? defaultProjection;
-        });
-        const UMAP = jest.fn(() => ({ fit }));
-
-        jest.doMock("worker_threads", () => ({
-            parentPort: { postMessage },
-            workerData: {
-                embeddings: options.embeddings ?? defaultEmbeddings,
-                nNeighbors: options.nNeighbors ?? 15,
-            },
-        }));
-
-        jest.doMock("umap-js", () => ({ UMAP }));
-
-        const exitSpy = jest.spyOn(process, "exit").mockImplementation(((
-            code?: string | number | null | undefined,
-        ): never => {
-            throw new Error(`process.exit:${code}`);
-        }) as typeof process.exit);
-
-        let moduleError: unknown;
-
-        jest.isolateModules(() => {
-            try {
-                require("../umapWorker");
-            } catch (error) {
-                moduleError = error;
-            }
-        });
-
-        return {
-            postMessage,
-            fit,
-            UMAP,
-            exitSpy,
-            moduleError,
-        };
-    }
-
-    it.each([2, 15, 50])(
-        "creates UMAP with the expected parameters for nNeighbors=%i",
-        (nNeighbors) => {
-            const { UMAP } = loadUmapWorker({ nNeighbors });
-
-            expect(UMAP).toHaveBeenCalledWith({
-                nComponents: 2,
-                nNeighbors,
-                minDist: 0.1,
-                spread: 1.0,
-            });
-        },
-    );
-
-    it("calls fit with embeddings from workerData", () => {
-        const embeddings = [
-            [9, 8, 7],
-            [6, 5, 4],
-        ];
-        const { fit } = loadUmapWorker({ embeddings });
-
-        expect(fit).toHaveBeenCalledWith(embeddings);
-    });
-
-    it("posts the projection result back through parentPort", () => {
-        const fitResult = [
+    it("produces the same projection from embedding text as the previous parsed-array path", () => {
+        const expected = [
             [0.11, 0.22],
             [0.33, 0.44],
+            [0.55, 0.66],
         ];
-        const { postMessage, exitSpy } = loadUmapWorker({ fitResult });
+        mockFit.mockReturnValue(expected);
+        const { projectEmbeddingTexts } =
+            require("../umapWorker") as typeof import("../umapWorker");
 
-        expect(postMessage).toHaveBeenCalledTimes(1);
-        expect(postMessage).toHaveBeenCalledWith(fitResult);
-        expect(exitSpy).not.toHaveBeenCalled();
-    });
+        const actual = projectEmbeddingTexts(
+            ["[1,2,3]", "[4,5,6]", "[7,8,9]"],
+            2,
+        );
 
-    it("posts the error message and exits with code 1 when fitting fails", () => {
-        const { postMessage, exitSpy, moduleError } = loadUmapWorker({
-            fitError: new Error("fit failed"),
+        expect(mockUmap).toHaveBeenCalledWith({
+            nComponents: 2,
+            nNeighbors: 2,
+            minDist: 0.1,
+            spread: 1.0,
         });
-
-        expect(postMessage).toHaveBeenCalledTimes(1);
-        expect(postMessage).toHaveBeenCalledWith({ error: "fit failed" });
-        expect(exitSpy).toHaveBeenCalledWith(1);
-        expect(moduleError).toBeInstanceOf(Error);
-        expect((moduleError as Error).message).toBe("process.exit:1");
+        expect(mockFit).toHaveBeenCalledWith([
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]);
+        expect(actual).toBe(expected);
     });
 });

--- a/backend/src/workers/umapMaterialization.ts
+++ b/backend/src/workers/umapMaterialization.ts
@@ -1,0 +1,113 @@
+import type { PrismaClient } from "@prisma/client";
+import { UMAP } from "umap-js";
+import { parseEmbedding } from "../utils/embedding";
+import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
+import { createPrismaClient } from "../utils/prismaClientFactory";
+import {
+    MAX_UMAP_WORKER_ROWS,
+    type UmapProjectionRow,
+    type UmapWorkerData,
+    type UmapWorkerMessage,
+} from "./umapWorkerProtocol";
+
+type MaterializedRow = UmapProjectionRow & { embedding: string };
+
+async function loadRows(
+    database: PrismaClient,
+    data: UmapWorkerData,
+): Promise<MaterializedRow[]> {
+    return database.$queryRaw<MaterializedRow[]>`
+        SELECT
+            te.track_id,
+            t.title,
+            ar.name as "artistName",
+            ar.id as "artistId",
+            a.id as "albumId",
+            a."coverUrl",
+            t."loudnessLufs",
+            t."truePeakDb",
+            a."albumLoudnessLufs",
+            a."albumTruePeakDb",
+            t.energy,
+            t.valence,
+            t."moodHappy",
+            t."moodSad",
+            t."moodRelaxed",
+            t."moodAggressive",
+            t."moodParty",
+            t."moodAcoustic",
+            t."moodElectronic",
+            te.embedding::text as embedding
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        JOIN "Album" a ON t."albumId" = a.id
+        JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${data.spaceId}
+        ORDER BY RANDOM()
+        LIMIT ${data.sampleSize}
+    `;
+}
+
+function fitEmbeddingTexts(
+    embeddingTexts: string[],
+    nNeighbors: number,
+): number[][] {
+    if (embeddingTexts.length > MAX_UMAP_WORKER_ROWS) {
+        throw new RangeError("UMAP embedding input exceeds its row bound");
+    }
+    const embeddings = new Array<number[]>(embeddingTexts.length);
+    for (let index = 0; index < MAX_UMAP_WORKER_ROWS; index += 1) {
+        if (index >= embeddingTexts.length) break;
+        embeddings[index] = parseEmbedding(embeddingTexts[index]);
+    }
+    return new UMAP({
+        nComponents: 2,
+        nNeighbors,
+        minDist: 0.1,
+        spread: 1.0,
+    }).fit(embeddings);
+}
+
+function stripEmbeddings(rows: MaterializedRow[]): UmapProjectionRow[] {
+    return rows.map(({ embedding: _embedding, ...row }) => row);
+}
+
+async function materializeAndPublish(
+    database: PrismaClient,
+    data: UmapWorkerData,
+    publish: (message: UmapWorkerMessage) => void,
+): Promise<void> {
+    const materializedRows = await loadRows(database, data);
+    publish({ type: "materialized", rowCount: materializedRows.length });
+    if (materializedRows.length < 5) {
+        publish({
+            type: "result",
+            rows: stripEmbeddings(materializedRows),
+            projection: null,
+        });
+        return;
+    }
+    const embeddingTexts = materializedRows.map((row) => row.embedding);
+    const rows = stripEmbeddings(materializedRows);
+    materializedRows.length = 0;
+    const nNeighbors = Math.min(15, Math.max(2, Math.floor(rows.length / 2)));
+    const projection = fitEmbeddingTexts(embeddingTexts, nNeighbors);
+    publish({ type: "result", rows, projection });
+}
+
+/** Query projection rows, fit UMAP, publish progress, and always disconnect. */
+export async function runUmapMaterialization(
+    data: UmapWorkerData,
+    publish: (message: UmapWorkerMessage) => void,
+    createDatabase: () => PrismaClient = () =>
+        createPrismaClient({ connectionLimit: 1, poolTimeoutSeconds: 30 }),
+): Promise<void> {
+    const database = createDatabase();
+    try {
+        await materializeAndPublish(database, data, publish);
+    } finally {
+        await database.$disconnect();
+    }
+}

--- a/backend/src/workers/umapWorker.ts
+++ b/backend/src/workers/umapWorker.ts
@@ -1,23 +1,147 @@
-import { parentPort, workerData } from "worker_threads";
+import { isMainThread, parentPort, workerData } from "worker_threads";
+import type { PrismaClient } from "@prisma/client";
 import { UMAP } from "umap-js";
+import { createPrismaClient } from "../utils/prismaClientFactory";
+import { parseEmbedding } from "../utils/embedding";
+import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
+import {
+    MAX_UMAP_WORKER_ROWS,
+    type UmapProjectionRow,
+    type UmapWorkerData,
+    type UmapWorkerMessage,
+} from "./umapWorkerProtocol";
 
-const { embeddings, nNeighbors } = workerData as {
-    embeddings: number[][];
-    nNeighbors: number;
-};
+type MaterializedRow = UmapProjectionRow & { embedding: string };
 
-try {
+function validateWorkerData(value: unknown): UmapWorkerData {
+    const candidate = value as Partial<UmapWorkerData> | null;
+    if (
+        !candidate ||
+        typeof candidate.spaceId !== "string" ||
+        candidate.spaceId.length < 1 ||
+        candidate.spaceId.length > 200 ||
+        !Number.isSafeInteger(candidate.sampleSize) ||
+        Number(candidate.sampleSize) < 1 ||
+        Number(candidate.sampleSize) > MAX_UMAP_WORKER_ROWS
+    ) {
+        throw new Error("Invalid UMAP worker data");
+    }
+    return candidate as UmapWorkerData;
+}
+
+async function loadRows(
+    database: PrismaClient,
+    data: UmapWorkerData,
+): Promise<MaterializedRow[]> {
+    return database.$queryRaw<MaterializedRow[]>`
+        SELECT
+            te.track_id,
+            t.title,
+            ar.name as "artistName",
+            ar.id as "artistId",
+            a.id as "albumId",
+            a."coverUrl",
+            t."loudnessLufs",
+            t."truePeakDb",
+            a."albumLoudnessLufs",
+            a."albumTruePeakDb",
+            t.energy,
+            t.valence,
+            t."moodHappy",
+            t."moodSad",
+            t."moodRelaxed",
+            t."moodAggressive",
+            t."moodParty",
+            t."moodAcoustic",
+            t."moodElectronic",
+            te.embedding::text as embedding
+        FROM track_embeddings te
+        JOIN "Track" t ON te.track_id = t.id
+        JOIN "Album" a ON t."albumId" = a.id
+        JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE t."removedAt" IS NULL
+          AND ${TRACK_BROWSE_SQL}
+          AND te.space_id = ${data.spaceId}
+        ORDER BY RANDOM()
+        LIMIT ${data.sampleSize}
+    `;
+}
+
+/** Parse embedding text and run the same UMAP fit used by the prior parent path. */
+export function projectEmbeddingTexts(
+    embeddingTexts: string[],
+    nNeighbors: number,
+): number[][] {
+    if (embeddingTexts.length > MAX_UMAP_WORKER_ROWS) {
+        throw new RangeError("UMAP embedding input exceeds its row bound");
+    }
+    const embeddings = new Array<number[]>(embeddingTexts.length);
+    for (let index = 0; index < MAX_UMAP_WORKER_ROWS; index += 1) {
+        if (index >= embeddingTexts.length) break;
+        embeddings[index] = parseEmbedding(embeddingTexts[index]);
+    }
+    return fitEmbeddings(embeddings, nNeighbors);
+}
+
+function fitEmbeddings(embeddings: number[][], nNeighbors: number): number[][] {
     const umap = new UMAP({
         nComponents: 2,
         nNeighbors,
         minDist: 0.1,
         spread: 1.0,
     });
+    return umap.fit(embeddings);
+}
 
-    const projection = umap.fit(embeddings);
-    parentPort?.postMessage(projection);
-} catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    parentPort?.postMessage({ error: message });
-    process.exit(1);
+function stripEmbeddingRows(
+    materializedRows: MaterializedRow[],
+): UmapProjectionRow[] {
+    return materializedRows.map(({ embedding: _embedding, ...row }) => row);
+}
+
+function postMessage(message: UmapWorkerMessage): void {
+    if (!parentPort) throw new Error("UMAP worker has no parent port");
+    parentPort.postMessage(message);
+}
+
+async function runWorkerTask(data: UmapWorkerData): Promise<void> {
+    const database = createPrismaClient({
+        connectionLimit: 1,
+        poolTimeoutSeconds: 30,
+    });
+    try {
+        const materializedRows = await loadRows(database, data);
+        postMessage({
+            type: "materialized",
+            rowCount: materializedRows.length,
+        });
+        if (materializedRows.length < 5) {
+            postMessage({
+                type: "result",
+                rows: stripEmbeddingRows(materializedRows),
+                projection: null,
+            });
+            return;
+        }
+        const nNeighbors = Math.min(
+            15,
+            Math.max(2, Math.floor(materializedRows.length / 2)),
+        );
+        const embeddingTexts = materializedRows.map((row) => row.embedding);
+        const rows = stripEmbeddingRows(materializedRows);
+        materializedRows.length = 0;
+        const projection = projectEmbeddingTexts(embeddingTexts, nNeighbors);
+        postMessage({ type: "result", rows, projection });
+    } finally {
+        await database.$disconnect();
+    }
+}
+
+if (!isMainThread) {
+    const data = validateWorkerData(workerData);
+    runWorkerTask(data).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        postMessage({ type: "error", error: message.slice(0, 500) });
+        process.exitCode = 1;
+    });
 }

--- a/backend/src/workers/umapWorker.ts
+++ b/backend/src/workers/umapWorker.ts
@@ -1,17 +1,10 @@
 import { isMainThread, parentPort, workerData } from "worker_threads";
-import type { PrismaClient } from "@prisma/client";
-import { UMAP } from "umap-js";
-import { createPrismaClient } from "../utils/prismaClientFactory";
-import { parseEmbedding } from "../utils/embedding";
-import { TRACK_BROWSE_SQL } from "../utils/libraryRadioPredicates";
 import {
     MAX_UMAP_WORKER_ROWS,
-    type UmapProjectionRow,
     type UmapWorkerData,
     type UmapWorkerMessage,
 } from "./umapWorkerProtocol";
-
-type MaterializedRow = UmapProjectionRow & { embedding: string };
+import { runUmapMaterialization } from "./umapMaterialization";
 
 function validateWorkerData(value: unknown): UmapWorkerData {
     const candidate = value as Partial<UmapWorkerData> | null;
@@ -29,117 +22,14 @@ function validateWorkerData(value: unknown): UmapWorkerData {
     return candidate as UmapWorkerData;
 }
 
-async function loadRows(
-    database: PrismaClient,
-    data: UmapWorkerData,
-): Promise<MaterializedRow[]> {
-    return database.$queryRaw<MaterializedRow[]>`
-        SELECT
-            te.track_id,
-            t.title,
-            ar.name as "artistName",
-            ar.id as "artistId",
-            a.id as "albumId",
-            a."coverUrl",
-            t."loudnessLufs",
-            t."truePeakDb",
-            a."albumLoudnessLufs",
-            a."albumTruePeakDb",
-            t.energy,
-            t.valence,
-            t."moodHappy",
-            t."moodSad",
-            t."moodRelaxed",
-            t."moodAggressive",
-            t."moodParty",
-            t."moodAcoustic",
-            t."moodElectronic",
-            te.embedding::text as embedding
-        FROM track_embeddings te
-        JOIN "Track" t ON te.track_id = t.id
-        JOIN "Album" a ON t."albumId" = a.id
-        JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE t."removedAt" IS NULL
-          AND ${TRACK_BROWSE_SQL}
-          AND te.space_id = ${data.spaceId}
-        ORDER BY RANDOM()
-        LIMIT ${data.sampleSize}
-    `;
-}
-
-/** Parse embedding text and run the same UMAP fit used by the prior parent path. */
-export function projectEmbeddingTexts(
-    embeddingTexts: string[],
-    nNeighbors: number,
-): number[][] {
-    if (embeddingTexts.length > MAX_UMAP_WORKER_ROWS) {
-        throw new RangeError("UMAP embedding input exceeds its row bound");
-    }
-    const embeddings = new Array<number[]>(embeddingTexts.length);
-    for (let index = 0; index < MAX_UMAP_WORKER_ROWS; index += 1) {
-        if (index >= embeddingTexts.length) break;
-        embeddings[index] = parseEmbedding(embeddingTexts[index]);
-    }
-    return fitEmbeddings(embeddings, nNeighbors);
-}
-
-function fitEmbeddings(embeddings: number[][], nNeighbors: number): number[][] {
-    const umap = new UMAP({
-        nComponents: 2,
-        nNeighbors,
-        minDist: 0.1,
-        spread: 1.0,
-    });
-    return umap.fit(embeddings);
-}
-
-function stripEmbeddingRows(
-    materializedRows: MaterializedRow[],
-): UmapProjectionRow[] {
-    return materializedRows.map(({ embedding: _embedding, ...row }) => row);
-}
-
 function postMessage(message: UmapWorkerMessage): void {
     if (!parentPort) throw new Error("UMAP worker has no parent port");
     parentPort.postMessage(message);
 }
 
-async function runWorkerTask(data: UmapWorkerData): Promise<void> {
-    const database = createPrismaClient({
-        connectionLimit: 1,
-        poolTimeoutSeconds: 30,
-    });
-    try {
-        const materializedRows = await loadRows(database, data);
-        postMessage({
-            type: "materialized",
-            rowCount: materializedRows.length,
-        });
-        if (materializedRows.length < 5) {
-            postMessage({
-                type: "result",
-                rows: stripEmbeddingRows(materializedRows),
-                projection: null,
-            });
-            return;
-        }
-        const nNeighbors = Math.min(
-            15,
-            Math.max(2, Math.floor(materializedRows.length / 2)),
-        );
-        const embeddingTexts = materializedRows.map((row) => row.embedding);
-        const rows = stripEmbeddingRows(materializedRows);
-        materializedRows.length = 0;
-        const projection = projectEmbeddingTexts(embeddingTexts, nNeighbors);
-        postMessage({ type: "result", rows, projection });
-    } finally {
-        await database.$disconnect();
-    }
-}
-
 if (!isMainThread) {
     const data = validateWorkerData(workerData);
-    runWorkerTask(data).catch((error: unknown) => {
+    runUmapMaterialization(data, postMessage).catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
         postMessage({ type: "error", error: message.slice(0, 500) });
         process.exitCode = 1;

--- a/backend/src/workers/umapWorkerProtocol.ts
+++ b/backend/src/workers/umapWorkerProtocol.ts
@@ -1,0 +1,41 @@
+/** Maximum number of projection rows accepted from one bounded worker. */
+export const MAX_UMAP_WORKER_ROWS = 15_000;
+
+/** Query parameters passed to the bounded UMAP worker. */
+export interface UmapWorkerData {
+    spaceId: string;
+    sampleSize: number;
+}
+
+/** Track metadata returned after embeddings have been discarded in the worker. */
+export interface UmapProjectionRow {
+    track_id: string;
+    title: string;
+    artistName: string;
+    artistId: string;
+    albumId: string;
+    coverUrl: string | null;
+    loudnessLufs: number | null;
+    truePeakDb: number | null;
+    albumLoudnessLufs: number | null;
+    albumTruePeakDb: number | null;
+    energy: number | null;
+    valence: number | null;
+    moodHappy: number | null;
+    moodSad: number | null;
+    moodRelaxed: number | null;
+    moodAggressive: number | null;
+    moodParty: number | null;
+    moodAcoustic: number | null;
+    moodElectronic: number | null;
+}
+
+/** Messages emitted by the bounded UMAP worker. */
+export type UmapWorkerMessage =
+    | { type: "materialized"; rowCount: number }
+    | {
+          type: "result";
+          rows: UmapProjectionRow[];
+          projection: number[][] | null;
+      }
+    | { type: "error"; error: string };

--- a/backend/tests-integration/umapMaterializationPostgres.integration.test.ts
+++ b/backend/tests-integration/umapMaterializationPostgres.integration.test.ts
@@ -62,19 +62,27 @@ async function createSchema(database: Client): Promise<void> {
 }
 
 async function seedRows(database: Client): Promise<void> {
+    // Parameterized queries use the extended protocol, which allows exactly
+    // one command per statement — seed each table separately.
     await database.query(
-        `
-        INSERT INTO "Artist" (id, name) VALUES ('artist-1', 'Artist 1');
-        INSERT INTO "Album" (id, "artistId") VALUES ('album-1', 'artist-1');
+        `INSERT INTO "Artist" (id, name) VALUES ('artist-1', 'Artist 1')`,
+    );
+    await database.query(
+        `INSERT INTO "Album" (id, "artistId") VALUES ('album-1', 'artist-1')`,
+    );
+    await database.query(`
         INSERT INTO "Track" (id, "albumId", title, energy, valence)
         SELECT 'track-' || value, 'album-1', 'Track ' || value,
                value::double precision / 10,
                1 - value::double precision / 10
-        FROM generate_series(1, 6) AS value;
+        FROM generate_series(1, 6) AS value
+    `);
+    await database.query(
+        `
         INSERT INTO track_embeddings (track_id, space_id, embedding)
         SELECT 'track-' || value, $1,
                ('[' || value || ',' || (value + 1) || ',' || (value + 2) || ']')::vector
-        FROM generate_series(1, 6) AS value;
+        FROM generate_series(1, 6) AS value
     `,
         [SPACE_ID],
     );

--- a/backend/tests-integration/umapMaterializationPostgres.integration.test.ts
+++ b/backend/tests-integration/umapMaterializationPostgres.integration.test.ts
@@ -1,0 +1,171 @@
+import { jest } from "@jest/globals";
+import { Client } from "pg";
+import { createPrismaClient } from "../src/utils/prismaClientFactory";
+import { runUmapMaterialization } from "../src/workers/umapMaterialization";
+import type { UmapWorkerMessage } from "../src/workers/umapWorkerProtocol";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+const SPACE_ID = "space-umap-integration";
+
+function baseDatabaseUrl(databaseUrl: string): string {
+    const parsed = new URL(databaseUrl);
+    parsed.searchParams.delete("schema");
+    return parsed.toString();
+}
+
+async function createSchema(database: Client): Promise<void> {
+    await database.query(`
+        CREATE EXTENSION IF NOT EXISTS vector;
+        CREATE TYPE "TrackOrigin" AS ENUM ('LOCAL', 'FEDERATED');
+        CREATE TABLE "Artist" (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        CREATE TABLE "Album" (
+            id TEXT PRIMARY KEY,
+            "artistId" TEXT NOT NULL REFERENCES "Artist"(id),
+            "coverUrl" TEXT,
+            "albumLoudnessLufs" DOUBLE PRECISION,
+            "albumTruePeakDb" DOUBLE PRECISION
+        );
+        CREATE TABLE "FederationPeer" (
+            id TEXT PRIMARY KEY,
+            "showDedupedCopies" BOOLEAN NOT NULL DEFAULT false
+        );
+        CREATE TABLE "Track" (
+            id TEXT PRIMARY KEY,
+            "albumId" TEXT NOT NULL REFERENCES "Album"(id),
+            title TEXT NOT NULL,
+            origin "TrackOrigin" NOT NULL DEFAULT 'LOCAL',
+            "peerId" TEXT,
+            "dedupOfTrackId" TEXT,
+            "removedAt" TIMESTAMP(3),
+            "loudnessLufs" DOUBLE PRECISION,
+            "truePeakDb" DOUBLE PRECISION,
+            energy DOUBLE PRECISION,
+            valence DOUBLE PRECISION,
+            "moodHappy" DOUBLE PRECISION,
+            "moodSad" DOUBLE PRECISION,
+            "moodRelaxed" DOUBLE PRECISION,
+            "moodAggressive" DOUBLE PRECISION,
+            "moodParty" DOUBLE PRECISION,
+            "moodAcoustic" DOUBLE PRECISION,
+            "moodElectronic" DOUBLE PRECISION
+        );
+        CREATE TABLE track_embeddings (
+            track_id TEXT NOT NULL REFERENCES "Track"(id),
+            space_id TEXT NOT NULL,
+            embedding vector(3) NOT NULL,
+            PRIMARY KEY (track_id, space_id)
+        );
+    `);
+}
+
+async function seedRows(database: Client): Promise<void> {
+    await database.query(
+        `
+        INSERT INTO "Artist" (id, name) VALUES ('artist-1', 'Artist 1');
+        INSERT INTO "Album" (id, "artistId") VALUES ('album-1', 'artist-1');
+        INSERT INTO "Track" (id, "albumId", title, energy, valence)
+        SELECT 'track-' || value, 'album-1', 'Track ' || value,
+               value::double precision / 10,
+               1 - value::double precision / 10
+        FROM generate_series(1, 6) AS value;
+        INSERT INTO track_embeddings (track_id, space_id, embedding)
+        SELECT 'track-' || value, $1,
+               ('[' || value || ',' || (value + 1) || ',' || (value + 2) || ']')::vector
+        FROM generate_series(1, 6) AS value;
+    `,
+        [SPACE_ID],
+    );
+}
+
+describeWithPostgres("UMAP materialization PostgreSQL correctness", () => {
+    let admin: Client;
+    let database: Client;
+    let adminConnected = false;
+    let databaseCreated = false;
+
+    beforeAll(async () => {
+        if (!/^vibe_x2_\d+_\d+$/.test(databaseName!)) {
+            throw new Error("Integration database name is unsafe");
+        }
+        admin = new Client({
+            connectionString: baseDatabaseUrl(integrationDatabaseUrl!),
+        });
+        await admin.connect();
+        adminConnected = true;
+        await admin.query(`CREATE DATABASE "${databaseName}"`);
+        databaseCreated = true;
+        database = new Client({ connectionString: process.env.DATABASE_URL });
+        await database.connect();
+        await createSchema(database);
+        await seedRows(database);
+    });
+
+    afterAll(async () => {
+        await database?.end();
+        if (adminConnected) {
+            if (databaseCreated && databaseName) {
+                await admin.query(
+                    `DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`,
+                );
+            }
+            await admin.end();
+        }
+    });
+
+    it("queries and parses pgvector rows into two-dimensional coordinates", async () => {
+        const messages: UmapWorkerMessage[] = [];
+
+        await runUmapMaterialization(
+            { spaceId: SPACE_ID, sampleSize: 6 },
+            (message) => messages.push(message),
+        );
+
+        expect(messages[0]).toEqual({ type: "materialized", rowCount: 6 });
+        const result = messages[1];
+        expect(result?.type).toBe("result");
+        if (result?.type !== "result") throw new Error("missing UMAP result");
+        expect(result.rows).toHaveLength(6);
+        expect(result.rows.map((row) => row.track_id).sort()).toEqual([
+            "track-1",
+            "track-2",
+            "track-3",
+            "track-4",
+            "track-5",
+            "track-6",
+        ]);
+        expect(result.projection).toHaveLength(6);
+        for (const coordinate of result.projection ?? []) {
+            expect(coordinate).toHaveLength(2);
+            expect(coordinate.every(Number.isFinite)).toBe(true);
+        }
+    });
+
+    it("disconnects its Prisma client when the real query fails", async () => {
+        await database.query(
+            "ALTER TABLE track_embeddings RENAME TO unavailable_embeddings",
+        );
+        const client = createPrismaClient({
+            connectionLimit: 1,
+            poolTimeoutSeconds: 30,
+        });
+        const disconnect = jest.spyOn(client, "$disconnect");
+
+        try {
+            await expect(
+                runUmapMaterialization(
+                    { spaceId: SPACE_ID, sampleSize: 6 },
+                    jest.fn(),
+                    () => client,
+                ),
+            ).rejects.toThrow();
+            expect(disconnect).toHaveBeenCalledTimes(1);
+        } finally {
+            await database.query(
+                "ALTER TABLE unavailable_embeddings RENAME TO track_embeddings",
+            );
+        }
+    });
+});


### PR DESCRIPTION
Closes the vibe-map resilience finding from the deep third-party review of everything since 2.3.0.

## What was wrong

The 2.3.1 vibe-map hardening capped only the **worker** heap. The main backend process still loaded up to 15,000 pgvector strings and parsed them into nested arrays in its own heap before handing a graph to the worker — a container-level OOM there could never trigger the sample-degradation path. The "single flight" was process-local, so both backend replicas could run the expensive UMAP build concurrently. And a failed build cleared the in-flight promise while every open map page polls every 5 seconds — a deterministic failure became an immediate, permanent retry storm.

## The fix

- **Per-space Redis build lease:** one replica computes; the others return the existing "building" status. The lease refreshes while building and releases on completion or failure.
- **Failure cooldown:** a failed build writes a bounded, escalating cooldown marker (5 → 15 → capped 60 minutes, with the error summary). While it's live, polls get a "failed, retrying at X" status instead of restarting the build. Cooldown expiry allows a fresh attempt.
- **Bounded materialization:** the vector query and parsing move into the memory-capped worker (via the repo's worker-thread Prisma factory), so the existing OOM degradation path now covers the allocations most likely to kill the process. An equivalence fixture pins identical projections against the previous implementation.

No frontend changes; the status contract keeps the shapes the map page already renders.

## Verification

Backend tsc clean (main + integration tsconfigs); 6 suites / 85 tests green; prettier, error-canon, and file-size gates clean.