### PR TITLE
fix(analysis): legacy loudness payload tolerance and database reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The audio analyzer now reconnects to PostgreSQL after a server-side connection close instead of waiting for multiple worker failures, so loudness backfill jobs no longer spend retry budget on a stale connection.
+- Loudness backfill now accepts legacy queued jobs without revision-scoped attempt keys, summarizes compatibility handling once per batch, and applies track-scoped bounded retry budgets instead of flooding logs and skipping failure bookkeeping.
 - DCLAP replicas now share one immutable 1,800-second decode cap without changing the established embedding-space identity; leftover `DCLAP_MAX_AUDIO_SECONDS` overrides are ignored with a warning.
 - DCLAP inference now decodes bounded waveforms outside the model lock under a separate two-request limit, creates mel segments lazily during serialized inference, reserves queue capacity before executor submission, returns promptly after its 100-second audio budget, and leaves 15 seconds before the backend client abort.
 - Retryable vibe-provider failures now persist a bounded retry not-before, keep provider `Retry-After` guidance between the attempt baseline and five minutes, suppress premature producer enqueue attempts, and remain subject to the existing three-attempt limit.

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -1962,7 +1962,11 @@ class AnalysisWorker:
             logger.error(f"✗ Failed: {file_path} - {features['_error']}")
             return track_id, 0, 1, 0
 
-        self._save_results(track_id, file_path, features)
+        if not self._save_results(track_id, file_path, features):
+            error = "Failed to persist analysis results"
+            self._save_failed(track_id, error, permanent=False)
+            logger.error(f"✗ Failed: {file_path} - {error}")
+            return track_id, 0, 1, 0
         logger.info(f"✓ Completed: {file_path}")
         return track_id, 1, 0, 0
 
@@ -2084,7 +2088,23 @@ class AnalysisWorker:
             f"Batch complete: {counts['completed']} succeeded, {counts['failed']} failed, {counts['permanent_failed']} permanently failed, {requeued} requeued in {elapsed:.1f}s ({rate:.1f} tracks/sec)"
         )
 
-    def _save_results(self, track_id: str, file_path: str, features: dict[str, Any]):
+    def _reset_database_after_save_failure(self) -> None:
+        """Roll back defensively and force the next database action to reconnect."""
+        try:
+            self.db.rollback()
+        except Exception as error:
+            logger.warning(f"Failed to roll back analysis save: {error}")
+        try:
+            self.db.close()
+        except Exception as error:
+            logger.warning(f"Failed to close database after analysis save failure: {error}")
+
+    def _save_results(
+        self,
+        track_id: str,
+        file_path: str,
+        features: dict[str, Any],
+    ) -> bool:
         """Save analysis results to database and resolve stale audio failures."""
         cursor = self.db.get_cursor()
         try:
@@ -2101,9 +2121,11 @@ class AnalysisWorker:
             self.db.commit()
         except Exception as e:
             logger.error(f"Failed to save results for {track_id}: {e}")
-            self.db.rollback()
+            self._reset_database_after_save_failure()
+            return False
         finally:
             cursor.close()
+        return True
 
     def _save_failed(self, track_id: str, error: str, permanent: bool = False):
         """Mark track as failed and record in EnrichmentFailure table."""

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -103,7 +103,8 @@ except RuntimeError:
 
 import psycopg2
 import redis
-from psycopg2.extras import Json, RealDictCursor
+from database_connection import DatabaseConnection
+from psycopg2.extras import Json
 
 # Essentia imports (will fail gracefully if not installed for testing)
 ESSENTIA_AVAILABLE = False
@@ -181,45 +182,9 @@ def _resolve_music_path(file_path: str) -> str | None:
     return resolve_music_path(MUSIC_PATH, file_path)
 
 
-class DatabaseConnection:
-    """PostgreSQL connection manager"""
-
-    def __init__(self, url: str):
-        """Store connection URL and initialize disconnected state."""
-        self.url = url
-        self.conn: Any | None = None
-
-    def connect(self):
-        """Establish database connection with explicit UTF-8 encoding"""
-        if not self.url:
-            raise ValueError("DATABASE_URL not set")
-
-        self.conn = psycopg2.connect(self.url, options="-c client_encoding=UTF8")
-        self.conn.set_client_encoding("UTF8")
-        self.conn.autocommit = False
-        logger.info("Connected to PostgreSQL with UTF-8 encoding")
-
-    def get_cursor(self) -> RealDictCursor:
-        """Lazily connect and return a RealDictCursor-factory cursor."""
-        if not self.conn:
-            self.connect()
-        return self.conn.cursor(cursor_factory=RealDictCursor)
-
-    def commit(self):
-        """Commit transaction"""
-        if self.conn:
-            self.conn.commit()
-
-    def rollback(self):
-        """Rollback transaction"""
-        if self.conn:
-            self.conn.rollback()
-
-    def close(self):
-        """Close connection"""
-        if self.conn:
-            self.conn.close()
-            self.conn = None
+def _is_connection_error(error: BaseException) -> bool:
+    """Return whether a worker failure represents PostgreSQL connection loss."""
+    return isinstance(error, (psycopg2.InterfaceError, psycopg2.OperationalError))
 
 
 def _get_workers_from_db() -> int:
@@ -1756,6 +1721,32 @@ class AnalysisWorker:
         finally:
             cursor.close()
 
+    def _recover_worker(self) -> None:
+        """Reconnect dependencies and run maintenance after repeated failures."""
+        try:
+            self.db.close()
+            time.sleep(2)
+            self.db.connect()
+            self._cleanup_stale_processing()
+            self._retry_failed_tracks()
+            if self.pool_active and not self._check_pool_health():
+                self._recreate_pool()
+        except Exception as reconnect_error:
+            logger.error(f"Recovery failed: {reconnect_error}")
+
+    def _handle_worker_error(self, error: Exception) -> None:
+        """Apply immediate database recovery or the general five-error threshold."""
+        logger.error(f"Worker error: {error}")
+        traceback.print_exc()
+        self.consecutive_empty += 1
+        connection_error = _is_connection_error(error)
+        if connection_error or self.consecutive_empty >= 5:
+            reason = "PostgreSQL connection error" if connection_error else "Multiple errors"
+            logger.info(f"{reason}, attempting recovery...")
+            self._recover_worker()
+            self.consecutive_empty = 0
+        time.sleep(BRPOP_TIMEOUT)
+
     def start(self):
         """Start processing jobs with BRPOP-driven event loop"""
         cpu_count = os.cpu_count() or 4
@@ -1859,25 +1850,7 @@ class AnalysisWorker:
                     self._cleanup_stale_processing()
                     continue
                 except Exception as e:
-                    logger.error(f"Worker error: {e}")
-                    traceback.print_exc()
-                    self.consecutive_empty += 1
-
-                    if self.consecutive_empty >= 5:
-                        logger.info("Multiple consecutive errors, attempting recovery...")
-                        try:
-                            self.db.close()
-                            time.sleep(2)
-                            self.db.connect()
-                            self._cleanup_stale_processing()
-                            self._retry_failed_tracks()
-                            if self.pool_active and not self._check_pool_health():
-                                self._recreate_pool()
-                        except Exception as reconnect_err:
-                            logger.error(f"Recovery failed: {reconnect_err}")
-                        self.consecutive_empty = 0
-
-                    time.sleep(BRPOP_TIMEOUT)
+                    self._handle_worker_error(e)
         finally:
             self._shutdown_pool()
             if self.pubsub:

--- a/services/audio-analyzer/database_connection.py
+++ b/services/audio-analyzer/database_connection.py
@@ -1,0 +1,122 @@
+"""Self-healing PostgreSQL connection manager for the audio analyzer."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+logger = logging.getLogger("audio-analyzer")
+
+
+class _DatabaseCursor(Protocol):
+    """Describe cursor operations used by analyzer persistence."""
+
+    def execute(self, query: object, params: object = None) -> None: ...
+
+    def fetchone(self) -> Mapping[str, Any] | None: ...
+
+    def fetchall(self) -> list[Mapping[str, Any]]: ...
+
+    def close(self) -> None: ...
+
+
+class _PostgresConnection(Protocol):
+    """Describe the psycopg2 connection surface owned by this manager."""
+
+    closed: int
+    autocommit: bool
+
+    def set_client_encoding(self, encoding: str) -> None: ...
+
+    def cursor(self, *, cursor_factory: object) -> _DatabaseCursor: ...
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class DatabaseConnection:
+    """Own one analyzer PostgreSQL connection and bounded cursor recovery."""
+
+    def __init__(self, url: str) -> None:
+        """Store the connection URL and initialize disconnected state."""
+        self.url = url
+        self.conn: _PostgresConnection | None = None
+
+    def connect(self) -> None:
+        """Establish a database connection with explicit UTF-8 encoding."""
+        if not self.url:
+            raise ValueError("DATABASE_URL not set")
+        self.conn = psycopg2.connect(self.url, options="-c client_encoding=UTF8")
+        self.conn.set_client_encoding("UTF8")
+        self.conn.autocommit = False
+        logger.info("Connected to PostgreSQL with UTF-8 encoding")
+
+    def get_cursor(self) -> _DatabaseCursor:
+        """Return a dictionary cursor, reconnecting once after connection loss."""
+        if self.conn is None or self.conn.closed:
+            self.connect()
+        connection = self._require_connection()
+        try:
+            return connection.cursor(cursor_factory=RealDictCursor)
+        except (psycopg2.InterfaceError, psycopg2.OperationalError):
+            self._discard_connection()
+            self.connect()
+            return self._require_connection().cursor(cursor_factory=RealDictCursor)
+
+    def commit(self) -> None:
+        """Commit once, resetting future work after a connection failure."""
+        if self.conn is None:
+            return
+        if self.conn.closed:
+            self.conn = None
+            return
+        try:
+            connection = self.conn
+            connection.commit()
+        except (psycopg2.InterfaceError, psycopg2.OperationalError):
+            self._discard_connection()
+            raise
+
+    def rollback(self) -> None:
+        """Roll back when possible without masking an earlier connection error."""
+        if self.conn is None:
+            return
+        if self.conn.closed:
+            self.conn = None
+            return
+        try:
+            connection = self.conn
+            connection.rollback()
+        except (psycopg2.InterfaceError, psycopg2.OperationalError):
+            self._discard_connection()
+
+    def close(self) -> None:
+        """Close and detach the current connection."""
+        connection = self.conn
+        self.conn = None
+        if connection is not None:
+            connection.close()
+
+    def _discard_connection(self) -> None:
+        """Detach a failed connection while suppressing defensive-close errors."""
+        connection = self.conn
+        self.conn = None
+        if connection is None:
+            return
+        try:
+            connection.close()
+        except Exception:
+            logger.debug("Ignoring error while discarding PostgreSQL connection", exc_info=True)
+
+    def _require_connection(self) -> _PostgresConnection:
+        """Return the established connection or fail on a broken connect contract."""
+        if self.conn is None:
+            raise RuntimeError("PostgreSQL connect returned without a connection")
+        return self.conn

--- a/services/audio-analyzer/database_connection.py
+++ b/services/audio-analyzer/database_connection.py
@@ -53,9 +53,20 @@ class DatabaseConnection:
         """Establish a database connection with explicit UTF-8 encoding."""
         if not self.url:
             raise ValueError("DATABASE_URL not set")
-        self.conn = psycopg2.connect(self.url, options="-c client_encoding=UTF8")
-        self.conn.set_client_encoding("UTF8")
-        self.conn.autocommit = False
+        connection = psycopg2.connect(self.url, options="-c client_encoding=UTF8")
+        try:
+            connection.set_client_encoding("UTF8")
+            connection.autocommit = False
+        except Exception:
+            try:
+                connection.close()
+            except Exception:
+                logger.debug(
+                    "Ignoring error while closing an uninitialized PostgreSQL connection",
+                    exc_info=True,
+                )
+            raise
+        self.conn = connection
         logger.info("Connected to PostgreSQL with UTF-8 encoding")
 
     def get_cursor(self) -> _DatabaseCursor:
@@ -72,13 +83,13 @@ class DatabaseConnection:
 
     def commit(self) -> None:
         """Commit once, resetting future work after a connection failure."""
-        if self.conn is None:
-            return
-        if self.conn.closed:
+        connection = self.conn
+        if connection is None:
+            raise psycopg2.InterfaceError("Cannot commit without a PostgreSQL connection")
+        if connection.closed:
             self.conn = None
-            return
+            raise psycopg2.InterfaceError("Cannot commit a closed PostgreSQL connection")
         try:
-            connection = self.conn
             connection.commit()
         except (psycopg2.InterfaceError, psycopg2.OperationalError):
             self._discard_connection()

--- a/services/audio-analyzer/loudness_backfill.py
+++ b/services/audio-analyzer/loudness_backfill.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Callable, Mapping, Sequence
 from hashlib import sha256
 from typing import Any, Literal, Protocol, TypedDict
@@ -22,10 +23,10 @@ logger = configure_service_logger("audio-analyzer").getChild("LoudnessBackfill")
 LOUDNESS_ATTEMPT_KEY_PREFIX = "audio:analysis:loudness:attempts:"
 LOUDNESS_OUTCOME_KEY_PREFIX = "audio:analysis:loudness:outcomes:"
 LOUDNESS_BACKFILL_MAX_FAILURES = 3
-MAX_LOUDNESS_ATTEMPT_KEY_BYTES = 160
 LOUDNESS_ATTEMPT_TTL_SECONDS = 30 * 24 * 60 * 60
 LOUDNESS_TRANSIENT_COOLDOWN_SECONDS = 24 * 60 * 60
 PERMANENT_FAILURE_MARKER = "permanent"
+_PRODUCER_ATTEMPT_KEY_SUFFIX = re.compile(r"[0-9a-f]{64}")
 
 _INCREMENT_FAILURES_SCRIPT = """
 local attempts = redis.call("INCR", KEYS[1])
@@ -301,12 +302,10 @@ def _legacy_attempt_key(track_id: str) -> str:
 def _attempt_key_for_job(job: AnalysisQueueJob) -> str:
     """Return a validated producer key or a bounded compatibility fallback."""
     attempt_key = job.get("loudnessAttemptKey")
-    if (
-        isinstance(attempt_key, str)
-        and attempt_key.startswith(LOUDNESS_ATTEMPT_KEY_PREFIX)
-        and len(attempt_key.encode("utf-8")) <= MAX_LOUDNESS_ATTEMPT_KEY_BYTES
-    ):
-        return attempt_key
+    if isinstance(attempt_key, str) and attempt_key.startswith(LOUDNESS_ATTEMPT_KEY_PREFIX):
+        suffix = attempt_key[len(LOUDNESS_ATTEMPT_KEY_PREFIX) :]
+        if _PRODUCER_ATTEMPT_KEY_SUFFIX.fullmatch(suffix) is not None:
+            return attempt_key
     track_id = job["trackId"]
     if "loudnessAttemptKey" in job:
         logger.warning(

--- a/services/audio-analyzer/loudness_backfill.py
+++ b/services/audio-analyzer/loudness_backfill.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Mapping, Sequence
+from hashlib import sha256
 from typing import Any, Literal, Protocol, TypedDict
 
 from loudness import (
@@ -289,16 +290,31 @@ def _process_job(
     return "measured" if persisted else "already_measured"
 
 
-def _validated_attempt_key(job: AnalysisQueueJob) -> str | None:
-    """Return a bounded producer-owned attempt key from an internal queue job."""
+def _legacy_attempt_key(track_id: str) -> str:
+    """Return a bounded track-scoped attempt key for a legacy queue job."""
+    # Producer keys reset per file revision. This transitional fallback intentionally
+    # shares one failure budget across every legacy revision of the same track.
+    digest = sha256(track_id.encode()).hexdigest()
+    return f"{LOUDNESS_ATTEMPT_KEY_PREFIX}legacy:{digest}"
+
+
+def _attempt_key_for_job(job: AnalysisQueueJob) -> str:
+    """Return a validated producer key or a bounded compatibility fallback."""
     attempt_key = job.get("loudnessAttemptKey")
-    if not isinstance(attempt_key, str):
-        return None
-    if not attempt_key.startswith(LOUDNESS_ATTEMPT_KEY_PREFIX):
-        return None
-    if len(attempt_key.encode("utf-8")) > MAX_LOUDNESS_ATTEMPT_KEY_BYTES:
-        return None
-    return attempt_key
+    if (
+        isinstance(attempt_key, str)
+        and attempt_key.startswith(LOUDNESS_ATTEMPT_KEY_PREFIX)
+        and len(attempt_key.encode("utf-8")) <= MAX_LOUDNESS_ATTEMPT_KEY_BYTES
+    ):
+        return attempt_key
+    track_id = job["trackId"]
+    if "loudnessAttemptKey" in job:
+        logger.warning(
+            "Using legacy fallback attempt key for loudness track %s "
+            "after an invalid producer attempt key",
+            track_id,
+        )
+    return _legacy_attempt_key(track_id)
 
 
 def _record_job_result(
@@ -307,12 +323,8 @@ def _record_job_result(
     bookkeeping: LoudnessBackfillBookkeeping,
 ) -> None:
     """Persist the bounded attempt transition and its final outcome."""
-    attempt_key = _validated_attempt_key(job)
+    attempt_key = _attempt_key_for_job(job)
     track_id = job["trackId"]
-    if attempt_key is None:
-        logger.warning("Permanently skipping loudness backfill with invalid attempt key")
-        bookkeeping.increment_outcome("permanently_skipped")
-        return
     if result == "already_measured":
         bookkeeping.clear_failures(attempt_key)
         return
@@ -348,7 +360,10 @@ def process_loudness_backfill_jobs(
     path_size: PathSize = os.path.getsize,
 ) -> None:
     """Process loudness-only jobs sequentially and always release reservations."""
+    legacy_fallback_jobs = 0
     for job in jobs:
+        if "loudnessAttemptKey" not in job:
+            legacy_fallback_jobs += 1
         track = (job["trackId"], job.get("filePath", ""))
         result: JobResult
         try:
@@ -379,3 +394,8 @@ def process_loudness_backfill_jobs(
             )
         finally:
             release_reservations([track])
+    if legacy_fallback_jobs > 0:
+        logger.info(
+            "Using legacy fallback attempt keys for %d loudness jobs without a producer key",
+            legacy_fallback_jobs,
+        )

--- a/services/audio-analyzer/tests/conftest.py
+++ b/services/audio-analyzer/tests/conftest.py
@@ -146,11 +146,19 @@ def loaded_analyzer() -> Iterator[ModuleType]:
     psycopg2_stub = ModuleType("psycopg2")
     extras_stub = ModuleType("psycopg2.extras")
 
+    class InterfaceError(Exception):
+        """Represent a closed PostgreSQL connection in analyzer tests."""
+
+    class OperationalError(Exception):
+        """Represent a transient PostgreSQL connection failure in analyzer tests."""
+
     def connect(*args: Any, **kwargs: Any) -> None:
         """Reject attempts to construct a real PostgreSQL connection."""
         raise AssertionError("PostgreSQL must not be created by these unit tests")
 
     psycopg2_stub.connect = connect  # type: ignore[attr-defined]
+    psycopg2_stub.InterfaceError = InterfaceError  # type: ignore[attr-defined]
+    psycopg2_stub.OperationalError = OperationalError  # type: ignore[attr-defined]
     psycopg2_stub.extras = extras_stub  # type: ignore[attr-defined]
     extras_stub.RealDictCursor = RealDictCursor  # type: ignore[attr-defined]
     extras_stub.Json = Json  # type: ignore[attr-defined]
@@ -161,6 +169,9 @@ def loaded_analyzer() -> Iterator[ModuleType]:
     monkeypatch.setitem(sys.modules, "redis", redis_stub)
     monkeypatch.setitem(sys.modules, "psycopg2", psycopg2_stub)
     monkeypatch.setitem(sys.modules, "psycopg2.extras", extras_stub)
+    connection_module = sys.modules.get("database_connection")
+    if connection_module is not None:
+        monkeypatch.setattr(connection_module, "psycopg2", psycopg2_stub)
 
     spec = importlib.util.spec_from_file_location("audio_analyzer_behavior_module", ANALYZER_PATH)
     assert spec is not None

--- a/services/audio-analyzer/tests/conftest.py
+++ b/services/audio-analyzer/tests/conftest.py
@@ -72,11 +72,14 @@ class FakeDatabaseConnection:
         self,
         results: list[list[dict[str, Any]]] | None = None,
         fail_on_execute: int | None = None,
+        commit_error: Exception | None = None,
     ) -> None:
         self.cursor = FakeCursor(results, fail_on_execute)
+        self.commit_error = commit_error
         self.get_cursor_calls = 0
         self.commit_calls = 0
         self.rollback_calls = 0
+        self.close_calls = 0
 
     def get_cursor(self) -> FakeCursor:
         """Return the recording cursor."""
@@ -86,10 +89,16 @@ class FakeDatabaseConnection:
     def commit(self) -> None:
         """Record a transaction commit."""
         self.commit_calls += 1
+        if self.commit_error is not None:
+            raise self.commit_error
 
     def rollback(self) -> None:
         """Record a transaction rollback."""
         self.rollback_calls += 1
+
+    def close(self) -> None:
+        """Record a connection-manager reset."""
+        self.close_calls += 1
 
 
 class FakePipeline:

--- a/services/audio-analyzer/tests/test_batch_timeout_requeue.py
+++ b/services/audio-analyzer/tests/test_batch_timeout_requeue.py
@@ -204,7 +204,7 @@ def test_handle_batch_timeout_drains_requeues_and_fails_by_attempt_state(
     monkeypatch.setattr(
         worker,
         "_save_results",
-        lambda *args: (saved_results.append(args) or True),
+        lambda *args: saved_results.append(args) or True,
     )
     monkeypatch.setattr(
         worker,

--- a/services/audio-analyzer/tests/test_batch_timeout_requeue.py
+++ b/services/audio-analyzer/tests/test_batch_timeout_requeue.py
@@ -201,7 +201,11 @@ def test_handle_batch_timeout_drains_requeues_and_fails_by_attempt_state(
     saved_failures: list[tuple[str, str, bool]] = []
     requeues: list[tuple[list[tuple[str, str]], str]] = []
 
-    monkeypatch.setattr(worker, "_save_results", lambda *args: saved_results.append(args))
+    monkeypatch.setattr(
+        worker,
+        "_save_results",
+        lambda *args: (saved_results.append(args) or True),
+    )
     monkeypatch.setattr(
         worker,
         "_save_failed",

--- a/services/audio-analyzer/tests/test_database_connection.py
+++ b/services/audio-analyzer/tests/test_database_connection.py
@@ -19,15 +19,25 @@ class FakeConnection:
         closed: bool = False,
         commit_error: Exception | None = None,
         rollback_error: Exception | None = None,
+        encoding_error: Exception | None = None,
     ) -> None:
         self.closed = closed
+        self.autocommit = True
         self.cursor_results = list(cursor_results or [])
         self.commit_error = commit_error
         self.rollback_error = rollback_error
+        self.encoding_error = encoding_error
+        self.client_encodings: list[str] = []
         self.cursor_calls = 0
         self.commit_calls = 0
         self.rollback_calls = 0
         self.close_calls = 0
+
+    def set_client_encoding(self, encoding: str) -> None:
+        """Record client setup and raise its programmed failure."""
+        self.client_encodings.append(encoding)
+        if self.encoding_error is not None:
+            raise self.encoding_error
 
     def cursor(self, *, cursor_factory: object) -> object:
         """Return or raise the next programmed cursor result."""
@@ -93,6 +103,27 @@ def test_get_cursor_reconnects_when_connection_is_closed(
 
     assert cursor is expected_cursor
     assert len(connect_calls) == 1
+
+
+def test_connect_does_not_publish_connection_when_client_setup_fails(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Close a partially configured connection without publishing it."""
+    connection = FakeConnection(encoding_error=RuntimeError("encoding setup failed"))
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    monkeypatch.setattr(
+        loaded_analyzer.psycopg2,
+        "connect",
+        lambda *_args, **_kwargs: connection,
+    )
+
+    with pytest.raises(RuntimeError, match="encoding setup failed"):
+        database.connect()
+
+    assert database.conn is None
+    assert connection.client_encodings == ["UTF8"]
+    assert connection.close_calls == 1
 
 
 def test_get_cursor_reconnects_once_after_interface_error(
@@ -192,6 +223,31 @@ def test_commit_connection_error_propagates_without_retry(
 
     assert connection.commit_calls == 1
     assert connection.close_calls == 1
+    assert database.conn is None
+
+
+def test_commit_without_connection_raises_interface_error(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Reject a commit when no transaction-owning connection exists."""
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+
+    with pytest.raises(loaded_analyzer.psycopg2.InterfaceError, match="commit"):
+        database.commit()
+
+
+def test_commit_with_closed_connection_raises_interface_error(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Reject a commit after the transaction-owning connection has closed."""
+    connection = FakeConnection(closed=True)
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = connection
+
+    with pytest.raises(loaded_analyzer.psycopg2.InterfaceError, match="commit"):
+        database.commit()
+
+    assert connection.commit_calls == 0
     assert database.conn is None
 
 

--- a/services/audio-analyzer/tests/test_database_connection.py
+++ b/services/audio-analyzer/tests/test_database_connection.py
@@ -1,0 +1,256 @@
+"""Behavioral coverage for analyzer PostgreSQL connection recovery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+class FakeConnection:
+    """Expose programmable psycopg2 connection operations."""
+
+    def __init__(
+        self,
+        cursor_results: list[object] | None = None,
+        *,
+        closed: bool = False,
+        commit_error: Exception | None = None,
+        rollback_error: Exception | None = None,
+    ) -> None:
+        self.closed = closed
+        self.cursor_results = list(cursor_results or [])
+        self.commit_error = commit_error
+        self.rollback_error = rollback_error
+        self.cursor_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.close_calls = 0
+
+    def cursor(self, *, cursor_factory: object) -> object:
+        """Return or raise the next programmed cursor result."""
+        assert cursor_factory is not None
+        self.cursor_calls += 1
+        result = self.cursor_results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def commit(self) -> None:
+        """Record a commit and raise its programmed failure."""
+        self.commit_calls += 1
+        if self.commit_error is not None:
+            raise self.commit_error
+
+    def rollback(self) -> None:
+        """Record a rollback and raise its programmed failure."""
+        self.rollback_calls += 1
+        if self.rollback_error is not None:
+            raise self.rollback_error
+
+    def close(self) -> None:
+        """Record closure and mark the connection closed."""
+        self.close_calls += 1
+        self.closed = True
+
+
+def _replace_connection_on_connect(
+    database: Any,
+    connections: list[FakeConnection],
+    calls: list[None],
+) -> Callable[[], None]:
+    """Return a connect replacement that installs one programmed connection."""
+
+    def connect() -> None:
+        calls.append(None)
+        database.conn = connections.pop(0)
+
+    return connect
+
+
+def test_get_cursor_reconnects_when_connection_is_closed(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replace a server-closed connection before requesting a cursor."""
+    expected_cursor = object()
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = FakeConnection(closed=True)
+    connect_calls: list[None] = []
+    monkeypatch.setattr(
+        database,
+        "connect",
+        _replace_connection_on_connect(
+            database,
+            [FakeConnection([expected_cursor])],
+            connect_calls,
+        ),
+    )
+
+    cursor = database.get_cursor()
+
+    assert cursor is expected_cursor
+    assert len(connect_calls) == 1
+
+
+def test_get_cursor_reconnects_once_after_interface_error(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry cursor creation once on a transient connection failure."""
+    expected_cursor = object()
+    initial = FakeConnection([loaded_analyzer.psycopg2.InterfaceError("closed")])
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = initial
+    connect_calls: list[None] = []
+    monkeypatch.setattr(
+        database,
+        "connect",
+        _replace_connection_on_connect(
+            database,
+            [FakeConnection([expected_cursor])],
+            connect_calls,
+        ),
+    )
+
+    cursor = database.get_cursor()
+
+    assert cursor is expected_cursor
+    assert initial.close_calls == 1
+    assert len(connect_calls) == 1
+
+
+def test_get_cursor_propagates_after_one_failed_retry(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bound cursor recovery to one reconnect attempt."""
+    error_type = loaded_analyzer.psycopg2.OperationalError
+    initial = FakeConnection([error_type("first failure")])
+    replacement = FakeConnection([error_type("retry failure")])
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = initial
+    connect_calls: list[None] = []
+    monkeypatch.setattr(
+        database,
+        "connect",
+        _replace_connection_on_connect(database, [replacement], connect_calls),
+    )
+
+    with pytest.raises(error_type, match="retry failure"):
+        database.get_cursor()
+
+    assert initial.cursor_calls == 1
+    assert replacement.cursor_calls == 1
+    assert len(connect_calls) == 1
+
+
+def test_rollback_clears_a_closed_connection_without_raising(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Drop a dead connection without creating a secondary rollback error."""
+    connection = FakeConnection(closed=True)
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = connection
+
+    database.rollback()
+
+    assert connection.rollback_calls == 0
+    assert database.conn is None
+
+
+def test_rollback_connection_error_is_suppressed_and_clears_connection(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Suppress rollback connection failures so callers retain the first error."""
+    connection = FakeConnection(
+        rollback_error=loaded_analyzer.psycopg2.InterfaceError("closed during rollback")
+    )
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = connection
+
+    database.rollback()
+
+    assert connection.rollback_calls == 1
+    assert connection.close_calls == 1
+    assert database.conn is None
+
+
+def test_commit_connection_error_propagates_without_retry(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Surface an ambiguous commit failure and reset only future work."""
+    error_type = loaded_analyzer.psycopg2.OperationalError
+    connection = FakeConnection(commit_error=error_type("commit lost connection"))
+    database = loaded_analyzer.DatabaseConnection("postgresql://test")
+    database.conn = connection
+
+    with pytest.raises(error_type, match="commit lost connection"):
+        database.commit()
+
+    assert connection.commit_calls == 1
+    assert connection.close_calls == 1
+    assert database.conn is None
+
+
+@pytest.mark.parametrize("error_name", ["InterfaceError", "OperationalError"])
+def test_connection_error_classification_accepts_psycopg2_disconnects(
+    loaded_analyzer: ModuleType,
+    error_name: str,
+) -> None:
+    """Classify both psycopg2 connection-failure families for fast recovery."""
+    error_type = getattr(loaded_analyzer.psycopg2, error_name)
+
+    assert loaded_analyzer._is_connection_error(error_type("database unavailable")) is True
+
+
+def test_connection_error_classification_rejects_other_failures(
+    loaded_analyzer: ModuleType,
+) -> None:
+    """Keep the existing five-error threshold for non-database failures."""
+    assert loaded_analyzer._is_connection_error(RuntimeError("analysis failed")) is False
+
+
+def test_worker_connection_error_invokes_recovery_before_loop_sleep(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run recovery immediately when the worker sees a database disconnect."""
+    worker = object.__new__(loaded_analyzer.AnalysisWorker)
+    worker.consecutive_empty = 0
+    events: list[tuple[str, int | None]] = []
+    monkeypatch.setattr(worker, "_recover_worker", lambda: events.append(("recover", None)))
+    monkeypatch.setattr(
+        loaded_analyzer.time,
+        "sleep",
+        lambda seconds: events.append(("sleep", seconds)),
+    )
+    monkeypatch.setattr(loaded_analyzer.traceback, "print_exc", lambda: None)
+
+    worker._handle_worker_error(loaded_analyzer.psycopg2.InterfaceError("closed"))
+
+    assert events == [("recover", None), ("sleep", loaded_analyzer.BRPOP_TIMEOUT)]
+    assert worker.consecutive_empty == 0
+
+
+def test_worker_other_errors_keep_five_error_recovery_threshold(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Delay recovery for an ordinary worker failure until its fifth occurrence."""
+    worker = object.__new__(loaded_analyzer.AnalysisWorker)
+    worker.consecutive_empty = 3
+    recoveries: list[None] = []
+    monkeypatch.setattr(worker, "_recover_worker", lambda: recoveries.append(None))
+    monkeypatch.setattr(loaded_analyzer.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(loaded_analyzer.traceback, "print_exc", lambda: None)
+
+    worker._handle_worker_error(RuntimeError("analysis failed"))
+    assert recoveries == []
+    assert worker.consecutive_empty == 4
+
+    worker._handle_worker_error(RuntimeError("analysis failed again"))
+    assert recoveries == [None]
+    assert worker.consecutive_empty == 0

--- a/services/audio-analyzer/tests/test_failure_resolution.py
+++ b/services/audio-analyzer/tests/test_failure_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import Future
 from datetime import UTC, datetime
 from types import ModuleType
 from typing import Any
@@ -98,4 +99,34 @@ def test_save_results_rolls_back_and_closes_cursor_on_database_error(
     assert len(database.cursor.executions) == 1
     assert database.commit_calls == 0
     assert database.rollback_calls == 1
+    assert database.close_calls == 1
     assert database.cursor.closed is True
+
+
+def test_completed_future_commit_error_uses_retryable_failure_path(
+    loaded_analyzer: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Count a failed commit as retryable work and record the track failure."""
+    database = FakeDatabaseConnection(
+        commit_error=loaded_analyzer.psycopg2.OperationalError("commit lost connection")
+    )
+    worker = _build_worker(loaded_analyzer, database)
+    failures: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        worker,
+        "_save_failed",
+        lambda track_id, error, permanent=False: failures.append(
+            (track_id, error, permanent)
+        ),
+    )
+    future: Future[tuple[str, str, dict[str, Any]]] = Future()
+    future.set_result(("track-a", "/music/a.flac", _analysis_features()))
+
+    outcome = worker._save_completed_future(future)
+
+    assert outcome == ("track-a", 0, 1, 0)
+    assert failures == [("track-a", "Failed to persist analysis results", False)]
+    assert database.commit_calls == 1
+    assert database.rollback_calls == 1
+    assert database.close_calls == 1

--- a/services/audio-analyzer/tests/test_failure_resolution.py
+++ b/services/audio-analyzer/tests/test_failure_resolution.py
@@ -116,9 +116,7 @@ def test_completed_future_commit_error_uses_retryable_failure_path(
     monkeypatch.setattr(
         worker,
         "_save_failed",
-        lambda track_id, error, permanent=False: failures.append(
-            (track_id, error, permanent)
-        ),
+        lambda track_id, error, permanent=False: failures.append((track_id, error, permanent)),
     )
     future: Future[tuple[str, str, dict[str, Any]]] = Future()
     future.set_result(("track-a", "/music/a.flac", _analysis_features()))

--- a/services/audio-analyzer/tests/test_loudness_backfill.py
+++ b/services/audio-analyzer/tests/test_loudness_backfill.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from hashlib import sha256
 from types import ModuleType
 from typing import Any
 
@@ -100,6 +101,12 @@ def _job(track_id: str, loudness_only: bool = True) -> dict[str, Any]:
         "loudnessOnly": loudness_only,
         "loudnessAttemptKey": f"audio:analysis:loudness:attempts:{track_id}",
     }
+
+
+def _legacy_attempt_key(track_id: str) -> str:
+    """Build the expected compatibility key for a legacy queue payload."""
+    digest = sha256(track_id.encode()).hexdigest()
+    return f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}legacy:{digest}"
 
 
 def _release_recorder() -> tuple[
@@ -265,6 +272,145 @@ def test_loudness_job_releases_reservation_after_measurement_failure() -> None:
     assert bookkeeping.attempts[_job("track-failed")["loudnessAttemptKey"]] == 1
     assert bookkeeping.outcomes == ["transient_failure"]
     assert releases == [[("track-failed", "Artist/track-failed.flac")]]
+
+
+def test_keyless_legacy_jobs_share_a_bounded_track_failure_budget() -> None:
+    """Apply bounded retries to legacy jobs under one track-scoped fallback key."""
+    database = FakeDatabaseConnection(
+        [[{"loudnessLufs": None}], [{"loudnessLufs": None}], [{"loudnessLufs": None}]]
+    )
+    bookkeeping = _Bookkeeping()
+    releases, release = _release_recorder()
+    legacy_job = _job("legacy-track")
+    del legacy_job["loudnessAttemptKey"]
+    measure_calls: list[str] = []
+
+    loudness_backfill.process_loudness_backfill_jobs(
+        [legacy_job, legacy_job, legacy_job],
+        database=database,
+        release_reservations=release,
+        resolve_path=lambda _path: "/music/Artist/legacy-track.flac",
+        max_file_size_mb=500,
+        timeout_seconds=120,
+        bookkeeping=bookkeeping,
+        measure=lambda path, _timeout: (
+            measure_calls.append(path) or {"measurement": None, "failure": "transient"}
+        ),
+        path_exists=lambda _path: True,
+        path_size=lambda _path: 1024,
+    )
+
+    attempt_key = _legacy_attempt_key("legacy-track")
+    assert measure_calls == ["/music/Artist/legacy-track.flac"] * 3
+    assert bookkeeping.attempts == {attempt_key: 3}
+    assert bookkeeping.cooldowns == [attempt_key]
+    assert bookkeeping.permanent == set()
+    assert bookkeeping.outcomes == ["transient_failure"] * 3
+    assert releases == [[("legacy-track", "Artist/legacy-track.flac")]] * 3
+
+
+@pytest.mark.parametrize(
+    "malformed_key",
+    [
+        "wrong-prefix:revision",
+        f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{'x' * 161}",
+    ],
+)
+def test_malformed_attempt_key_uses_fallback_and_warns_once(
+    malformed_key: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Recover malformed producer keys while retaining one diagnostic warning."""
+    database = FakeDatabaseConnection([[{"loudnessLufs": None}]])
+    bookkeeping = _Bookkeeping()
+    _releases, release = _release_recorder()
+    job = _job("malformed-track")
+    job["loudnessAttemptKey"] = malformed_key
+
+    with caplog.at_level(logging.WARNING):
+        loudness_backfill.process_loudness_backfill_jobs(
+            [job],
+            database=database,
+            release_reservations=release,
+            resolve_path=lambda _path: "/music/Artist/malformed-track.flac",
+            max_file_size_mb=500,
+            timeout_seconds=120,
+            bookkeeping=bookkeeping,
+            measure=lambda _path, _timeout: {"measurement": None, "failure": "transient"},
+            path_exists=lambda _path: True,
+            path_size=lambda _path: 1024,
+        )
+
+    warning_records = [
+        record for record in caplog.records if "invalid producer attempt key" in record.getMessage()
+    ]
+    assert bookkeeping.attempts == {_legacy_attempt_key("malformed-track"): 1}
+    assert bookkeeping.outcomes == ["transient_failure"]
+    assert len(warning_records) == 1
+    assert "malformed-track" in warning_records[0].getMessage()
+
+
+def test_valid_producer_attempt_key_keeps_revision_scoped_bookkeeping() -> None:
+    """Preserve the producer key for current queue payloads."""
+    database = FakeDatabaseConnection([[{"loudnessLufs": None}]])
+    bookkeeping = _Bookkeeping()
+    _releases, release = _release_recorder()
+    job = _job("current-track")
+
+    loudness_backfill.process_loudness_backfill_jobs(
+        [job],
+        database=database,
+        release_reservations=release,
+        resolve_path=lambda _path: "/music/Artist/current-track.flac",
+        max_file_size_mb=500,
+        timeout_seconds=120,
+        bookkeeping=bookkeeping,
+        measure=lambda _path, _timeout: {"measurement": None, "failure": "transient"},
+        path_exists=lambda _path: True,
+        path_size=lambda _path: 1024,
+    )
+
+    assert bookkeeping.attempts == {job["loudnessAttemptKey"]: 1}
+    assert bookkeeping.outcomes == ["transient_failure"]
+
+
+def test_mixed_batch_logs_one_keyless_fallback_summary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Summarize keyless compatibility handling once for the complete batch."""
+    database = FakeDatabaseConnection(
+        [[{"loudnessLufs": -17.0}], [{"loudnessLufs": -18.0}], [{"loudnessLufs": -19.0}]]
+    )
+    bookkeeping = _Bookkeeping()
+    _releases, release = _release_recorder()
+    keyed_job = _job("current-track")
+    legacy_jobs = [_job("legacy-one"), _job("legacy-two")]
+    for job in legacy_jobs:
+        del job["loudnessAttemptKey"]
+
+    with caplog.at_level(logging.INFO):
+        loudness_backfill.process_loudness_backfill_jobs(
+            [keyed_job, *legacy_jobs],
+            database=database,
+            release_reservations=release,
+            resolve_path=lambda path: f"/music/{path}",
+            max_file_size_mb=500,
+            timeout_seconds=120,
+            bookkeeping=bookkeeping,
+            path_exists=lambda _path: True,
+            path_size=lambda _path: 1024,
+        )
+
+    summary_records = [
+        record
+        for record in caplog.records
+        if "Using legacy fallback attempt keys" in record.getMessage()
+    ]
+    assert len(summary_records) == 1
+    assert summary_records[0].levelno == logging.INFO
+    assert summary_records[0].getMessage() == (
+        "Using legacy fallback attempt keys for 2 loudness jobs without a producer key"
+    )
 
 
 def test_loudness_job_releases_reservation_after_unexpected_failure() -> None:

--- a/services/audio-analyzer/tests/test_loudness_backfill.py
+++ b/services/audio-analyzer/tests/test_loudness_backfill.py
@@ -100,9 +100,7 @@ def _job(track_id: str, loudness_only: bool = True) -> dict[str, Any]:
         "filePath": f"Artist/{track_id}.flac",
         "duration": 180,
         "loudnessOnly": loudness_only,
-        "loudnessAttemptKey": (
-            f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{revision_digest}"
-        ),
+        "loudnessAttemptKey": (f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{revision_digest}"),
     }
 
 

--- a/services/audio-analyzer/tests/test_loudness_backfill.py
+++ b/services/audio-analyzer/tests/test_loudness_backfill.py
@@ -94,12 +94,15 @@ class _BookkeepingRedis:
 
 def _job(track_id: str, loudness_only: bool = True) -> dict[str, Any]:
     """Build one analyzer queue payload."""
+    revision_digest = sha256(track_id.encode()).hexdigest()
     return {
         "trackId": track_id,
         "filePath": f"Artist/{track_id}.flac",
         "duration": 180,
         "loudnessOnly": loudness_only,
-        "loudnessAttemptKey": f"audio:analysis:loudness:attempts:{track_id}",
+        "loudnessAttemptKey": (
+            f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{revision_digest}"
+        ),
     }
 
 
@@ -313,6 +316,10 @@ def test_keyless_legacy_jobs_share_a_bounded_track_failure_budget() -> None:
     "malformed_key",
     [
         "wrong-prefix:revision",
+        loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX,
+        f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}not-a-digest",
+        f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{'A' * 64}",
+        f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}legacy:{'a' * 64}",
         f"{loudness_backfill.LOUDNESS_ATTEMPT_KEY_PREFIX}{'x' * 161}",
     ],
 )

--- a/services/audio-analyzer/tests/test_pool_crash_recovery.py
+++ b/services/audio-analyzer/tests/test_pool_crash_recovery.py
@@ -68,7 +68,7 @@ def test_consume_batch_results_requeues_unfinalized_tracks_after_pool_crash(
     monkeypatch.setattr(
         worker,
         "_save_results",
-        lambda *args: (saved_results.append(args) or True),
+        lambda *args: saved_results.append(args) or True,
     )
     monkeypatch.setattr(
         worker,

--- a/services/audio-analyzer/tests/test_pool_crash_recovery.py
+++ b/services/audio-analyzer/tests/test_pool_crash_recovery.py
@@ -65,7 +65,11 @@ def test_consume_batch_results_requeues_unfinalized_tracks_after_pool_crash(
     worker = _build_worker(loaded_analyzer)
     saved_results: list[tuple[str, str, dict[str, Any]]] = []
     requeues: list[tuple[list[tuple[str, str]], str]] = []
-    monkeypatch.setattr(worker, "_save_results", lambda *args: saved_results.append(args))
+    monkeypatch.setattr(
+        worker,
+        "_save_results",
+        lambda *args: (saved_results.append(args) or True),
+    )
     monkeypatch.setattr(
         worker,
         "_requeue_tracks_for_retry",


### PR DESCRIPTION
## Summary

Fixes two production log floods reported on the homelab deployment.

**Legacy attempt keys.** The `loudnessAttemptKey` scheme arrived in #620; jobs enqueued by any earlier backend (the pre-upgrade Redis backlog, or a version-skewed producer) have no key. The analyzer logged `Permanently skipping loudness backfill with invalid attempt key` per job — misleading, because the measurement still ran; only bookkeeping was skipped. Worse, keyless jobs whose measurement failed transiently never incremented a failure counter, so the sweep re-enqueued them forever. Keyless/malformed payloads now derive a bounded per-track fallback key (`legacy:` + sha256 of the track id), restoring the full retry-budget/parking/cooldown semantics; keyless jobs log one INFO summary per batch; `permanently_skipped` counts only real permanent parking.

**Database reconnection.** `DatabaseConnection.get_cursor` only connected when no connection existed — a connection Postgres closed stayed as a dead object, raising `InterfaceError: connection already closed` on every call, and the worker loop only recovered after five consecutive errors. The connection wrapper (extracted to `database_connection.py`) now treats a closed connection as absent and does one bounded reconnect-and-retry; rollback failures reset the connection instead of double-faulting; commits are never retried; the worker loop classifies `InterfaceError`/`OperationalError` for immediate recovery while keeping the five-error threshold for everything else.

## Verification

- 89 analyzer pytest tests pass (new coverage for fallback keys, mixed batches, closed-connection reconnect, single-retry bounds, immediate worker recovery).
- ruff check + format clean; targeted mypy clean.
- dockerfile-hygiene suite 16/16 (the image glob COPY covers the new module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)