### PR TITLE
docs(mobile): Subsonic client matrix and OpenSubsonic extension roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Subsonic client guide (`docs/SUBSONIC_CLIENTS.md`): the mobile positioning statement, a per-feature compatibility matrix for Symfonium, Tempo, DSub2000, Ultrasonic, and play:Sub with per-release re-verification instructions, and the OpenSubsonic extension roadmap.
 - Library Health dashboard read model and admin API (metadata gaps, analysis coverage, duplicate clusters, storage and quality analytics).
 - Library Insights section on the Admin page: browsable panels for metadata gaps, analysis coverage with retry actions, report-only duplicate clusters, storage breakdown, and low-bitrate album detection.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For deployment variants, release channels, compose files, and updates, see [`doc
 - Kubernetes deployment: [`docs/KUBERNETES.md`](docs/KUBERNETES.md)
 - Reverse proxy and tunnel routing: [`docs/REVERSE_PROXY_AND_TUNNELS.md`](docs/REVERSE_PROXY_AND_TUNNELS.md)
 - OpenSubsonic compatibility contract: [`docs/OPENSUBSONIC_COMPATIBILITY.md`](docs/OPENSUBSONIC_COMPATIBILITY.md)
+- Subsonic client matrix and mobile guide: [`docs/SUBSONIC_CLIENTS.md`](docs/SUBSONIC_CLIENTS.md)
 - Brand usage policy: [`docs/BRAND_POLICY.md`](docs/BRAND_POLICY.md)
 
 ---
@@ -122,9 +123,11 @@ All integration endpoints below require soundspan auth (session or API key where
 
 soundspan is browser-first. Use it from your desktop or mobile browser, or install it through your browser's PWA flow for app-like behavior, background playback, media controls, and faster repeat loads.
 
-### OpenSubsonic clients
+### On mobile
 
-For third-party clients, use OpenSubsonic-compatible apps through soundspan's `/rest` interface (see [`docs/OPENSUBSONIC_COMPATIBILITY.md`](docs/OPENSUBSONIC_COMPATIBILITY.md)).
+soundspan's mobile story is deliberate: there is no native app, and none is planned. Install the PWA for the full soundspan experience, and use a Subsonic client when you want native ergonomics — offline caching, Android Auto / CarPlay, and platform audio integration through the OpenSubsonic-compatible `/rest` API. Both are first-class.
+
+A per-client compatibility matrix (Symfonium, Tempo, DSub2000, Ultrasonic, play:Sub), connection quickstart, and the extension roadmap live in [`docs/SUBSONIC_CLIENTS.md`](docs/SUBSONIC_CLIENTS.md). The authoritative protocol contract is [`docs/OPENSUBSONIC_COMPATIBILITY.md`](docs/OPENSUBSONIC_COMPATIBILITY.md).
 
 ### Android TV
 

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -639,7 +639,7 @@ async function runSubsonicFullEmulation(
         {
             index: 2,
             id: track.id,
-            current: 0,
+            currentIndex: 0,
             position: 1234,
         },
     );

--- a/docs/OPENSUBSONIC_COMPATIBILITY.md
+++ b/docs/OPENSUBSONIC_COMPATIBILITY.md
@@ -13,6 +13,10 @@ This document defines the current `/rest` compatibility contract implemented in 
 - Current OpenSubsonic compatibility milestone: `Complete` (for soundspan's in-scope music client surface)
 - Remaining missing domains are intentionally out-of-scope for this milestone unless real client demand requires promotion.
 
+## Client-Facing Companion
+
+The per-client compatibility matrix, connection quickstart, and extension roadmap live in [`SUBSONIC_CLIENTS.md`](SUBSONIC_CLIENTS.md). Update that matrix when this contract changes.
+
 ## Client Connection URL
 
 - Split frontend/backend deployments: use the frontend base URL for clients (for example `http://host:3030` in deployment, `http://host:3031` in local dev). Frontend proxies `/rest` to backend.

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ This index is the central navigation page for all project documentation under `d
 | [`../CHANGELOG.md`](../CHANGELOG.md)                             | Canonical release and feature change log for this repository                                                                    |
 | [`release-notes/`](release-notes/)                               | Per-release human-readable notes (summary, known issues, compatibility notes), generated from the CHANGELOG at release-cut time |
 | [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md) | Supported `/rest` compatibility contract, known gaps, and validation evidence                                                   |
+| [`SUBSONIC_CLIENTS.md`](SUBSONIC_CLIENTS.md) | Mobile positioning, per-client compatibility matrix, connection quickstart, and extension roadmap |
 | [`BRAND_POLICY.md`](BRAND_POLICY.md)                             | Brand usage rules, naming constraints, and attribution guidance for soundspan                                                   |
 
 ---

--- a/docs/SUBSONIC_CLIENTS.md
+++ b/docs/SUBSONIC_CLIENTS.md
@@ -1,0 +1,106 @@
+# Subsonic Clients on Mobile
+
+Last updated: 2026-08-19 (server surface as of the current main branch, including the extension-truth fixes for #624/#625/#626)
+
+## The mobile story
+
+soundspan's mobile story is deliberate: there is no native soundspan app, and none is planned.
+
+- **PWA** for the full soundspan experience: install the web app from your mobile browser for discovery, Vibe, podcasts, audiobooks, admin, and the native player.
+- **Subsonic clients** for native ergonomics: offline caching, Android Auto / CarPlay, platform audio integration, and battery-friendly playback through soundspan's OpenSubsonic-compatible `/rest` API.
+
+Both are first-class. Use the PWA when you want everything soundspan does; use a Subsonic client when you want a native music player.
+
+The authoritative protocol contract is [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md). This page is the client-facing view of that contract.
+
+## Connecting a client
+
+1. Create an app password: **Settings → Sign-in & Security → App Passwords**. The generated secret starts with `ssap_`, is shown once, works only on `/rest`, and can be revoked independently.
+2. Server URL: your normal soundspan URL (the frontend proxies `/rest` to the backend). Backend-direct deployments can target the backend port instead.
+3. Username: your soundspan username. Password: the app password.
+4. Prefer token authentication when the client offers it; every client below supports it.
+
+Supported auth modes: token (`u`+`t`+`s`), password (`u`+`p`, including `enc:` hex), and `apiKey` query auth (OpenSubsonic extension). Form-encoded POST is accepted across the surface.
+
+## Compatibility matrix
+
+Clients and versions assessed:
+
+| Client | Version | Platform | Source |
+| --- | --- | --- | --- |
+| Symfonium | 15.0.1 (2026) | Android (paid) | [symfonium.app](https://symfonium.app/) |
+| Tempo | 3.9.0 | Android (FOSS) | [github.com/CappielloAntonio/tempo](https://github.com/CappielloAntonio/tempo) |
+| DSub2000 | 5.7.4 (2026-05-17) | Android (FOSS) | [github.com/paroj/DSub2000](https://github.com/paroj/DSub2000) |
+| Ultrasonic | 4.9.0 | Android (FOSS) | [gitlab.com/ultrasonic/ultrasonic](https://gitlab.com/ultrasonic/ultrasonic) |
+| play:Sub | 2026.1.22 | iOS (paid) | [App Store](https://apps.apple.com/us/app/play-sub-music-streamer/id955329386) |
+
+Verdict legend:
+
+- **Verified** — exercised against soundspan by the request-profile matrix or smoke harness recorded in [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md).
+- **Expected** — the server implements it and the client documents support; not yet exercised on a real device against soundspan.
+- **Client N/A** — the client does not use this capability, so nothing is lost server-side.
+- **Server gap** — the client could use it but soundspan does not provide it (linked issue where one exists).
+
+| Feature | Server support | Symfonium | Tempo | DSub2000 | Ultrasonic | play:Sub |
+| --- | --- | --- | --- | --- | --- | --- |
+| Token auth (`t`/`s`) | Yes (app passwords) | Verified¹ | Expected | Verified¹ | Verified¹ | Expected |
+| Password auth (`p`) | Yes | Expected | Expected | Expected | Expected | Expected |
+| API-key auth | Yes (extension) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
+| Browse (ID3: artists/albums/songs) | Yes | Verified¹ | Expected | Verified¹ | Verified¹ | Expected |
+| Browse (folder: `getMusicDirectory`) | Yes | Expected | Expected | Expected | Expected | Expected |
+| Search (`search2`/`search3`, empty-query full sync) | Yes | Verified¹ | Expected | Verified¹ | Expected | Expected |
+| Stream with Range/seek | Yes | Verified¹ | Expected | Expected | Expected | Expected |
+| Transcoding (`maxBitRate`) | Yes (192/320 tiers) | Expected | Expected | Expected | Expected | Expected |
+| Seek in transcoded stream (`timeOffset`) | Yes (transcode tiers; raw ignores offset) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
+| Playlists (full CRUD) | Yes | Expected | Expected | Verified¹ | Expected | Expected |
+| Star / unstar / rating | Yes² (star state, 1-5 ratings, and play counts appear on every song payload) | Verified¹ | Expected | Expected | Expected | Expected |
+| Play-queue sync | Yes³ | Expected | Expected | Expected | Expected | Expected |
+| Indexed play queue (`…ByIndex`) | Yes (advertised, `currentIndex` contract) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
+| Bookmarks | Yes | Expected | Client N/A | Expected | Expected | Expected |
+| Lyrics (plain, `getLyrics`) | Yes | Client N/A⁵ | Expected | Expected | Expected | Client N/A |
+| Synced lyrics (`getLyricsBySongId`) | Yes (extension) | Expected | Expected | Client N/A | Client N/A | Client N/A |
+| ReplayGain over the API | Yes (extension, song objects) | Expected | Expected | Client N/A⁶ | Client N/A | Client N/A⁶ |
+| Last-played dates (`songPlayedDate`/`albumPlayedDate`) | Yes (per-user `played` on songs and albums) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
+| Offline cache / downloads (`download`) | Yes | Expected | Expected | Expected | Expected | Expected |
+| Scrobble / now playing | Yes | Verified¹ | Expected | Expected | Expected | Expected |
+| Jukebox control | No (out of scope) | Client N/A | Client N/A | Server gap | Server gap | Client N/A |
+| Podcasts over `/rest` | Empty stubs only⁷ | Client N/A | Client N/A | Server gap⁷ | Client N/A | Client N/A |
+| Shares | No (product decision pending) | Client N/A | Client N/A | Server gap | Client N/A | Client N/A |
+
+Notes:
+
+1. "Verified" cells rest on the curl-driven client-profile matrix and smoke harness runs recorded in [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md) (profiles: `symfonium`, `dsub`, `ultrasonic`, `amperfy`, `substreamer`). They emulate each client's documented request patterns; full GUI-client certification on real devices remains open.
+2. Album/artist star is projected onto matching tracks; there are no separate album/artist favorite tables.
+3. Queue state uses the legacy playback-state device bucket. `getPlayQueue` exchanges `current` as a song ID per the classic contract, and the ByIndex extension endpoints use `currentIndex`.
+4. Symfonium discovers capabilities via `getOpenSubsonicExtensions`; `indexBasedQueue` is advertised, so capability-driven clients can use the indexed queue endpoints.
+5. Symfonium prefers the structured `getLyricsBySongId` extension when advertised.
+6. DSub2000 and play:Sub apply gain from file tags on cached audio rather than the OpenSubsonic `replayGain` API fields.
+7. soundspan's native podcast domain is not exposed over `/rest`; `getPodcasts`/`getNewestPodcasts` return empty successes so probing clients do not fail. Use the PWA for podcasts.
+
+Client capability columns are compiled from each client's documentation, changelogs, and release notes at the versions listed; re-check them when a client ships a major release.
+
+## Extension roadmap
+
+Advertised today at v1: `apiKeyAuthentication`, `formPost`, `replayGain`, `songLyrics`, `transcodeOffset`, `songPlayedDate`, `albumPlayedDate`, `indexBasedQueue`.
+
+| Extension | State | Next step |
+| --- | --- | --- |
+| `replayGain` | Shipped (loudness work, 2.3.2) | None — gains computed against `LOUDNESS_TARGET_LUFS`; pre-rollout tracks fill in as the backfill measures them |
+| `formPost` | Shipped (validated with Music Assistant) | None |
+| `apiKeyAuthentication` | Shipped | None |
+| `songLyrics` | Shipped | None |
+| `transcodeOffset` | Shipped (#624) | None — ffmpeg input seeking on transcode tiers; raw streams ignore the offset |
+| `songPlayedDate` / `albumPlayedDate` | Shipped (#625) | None — per-user `played` timestamps on songs and albums |
+| `indexBasedQueue` | Shipped (#626) | None — advertised with the `currentIndex` wire contract |
+| Transcoding decision (`getTranscodeDecision`/`getTranscodeStream`) | Not implemented | Deferred — revisit if a target client fails a core workflow without it |
+| HLS | Not implemented | Deferred — native/Howler playback replaced segmented streaming server-wide |
+
+The exhaustive missing-endpoint catalog, non-goals, and revisit triggers live in [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md).
+
+## Keeping this matrix honest
+
+Re-test per release:
+
+1. `cd backend && npm run test:smoke` with `SMOKE_SUBSONIC_USER`/`SMOKE_SUBSONIC_PASSWORD` runs the health and Subsonic profile checks; `SMOKE_MODE=full` plus `SMOKE_REQUIRE_TRACKS=true` covers the track-dependent surface.
+2. Device passes (upgrade Expected → Verified): connect the real client with an app password and walk browse → search → stream/seek → playlist edit → star → queue restore → lyrics → offline cache. Record client version and date here.
+3. `SUBSONIC_TRACE_LOGS=true` prints per-request `/rest` trace lines (endpoint, client `c`, protocol status) without logging secrets — the fastest way to see what a misbehaving client actually sends.

--- a/docs/SUBSONIC_CLIENTS.md
+++ b/docs/SUBSONIC_CLIENTS.md
@@ -43,16 +43,16 @@ Verdict legend:
 
 | Feature | Server support | Symfonium | Tempo | DSub2000 | Ultrasonic | play:Sub |
 | --- | --- | --- | --- | --- | --- | --- |
-| Token auth (`t`/`s`) | Yes (app passwords) | Verified¹ | Expected | Verified¹ | Verified¹ | Expected |
+| Token auth (`t`/`s`) | Yes (app passwords) | Expected | Expected | Expected | Expected | Expected |
 | Password auth (`p`) | Yes | Expected | Expected | Expected | Expected | Expected |
 | API-key auth | Yes (extension) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
-| Browse (ID3: artists/albums/songs) | Yes | Verified¹ | Expected | Verified¹ | Verified¹ | Expected |
+| Browse (ID3: artists/albums/songs) | Yes | Verified¹ | Expected | Expected | Expected | Expected |
 | Browse (folder: `getMusicDirectory`) | Yes | Expected | Expected | Expected | Expected | Expected |
 | Search (`search2`/`search3`, empty-query full sync) | Yes | Verified¹ | Expected | Verified¹ | Expected | Expected |
-| Stream with Range/seek | Yes | Verified¹ | Expected | Expected | Expected | Expected |
+| Stream with Range/seek | Yes | Expected | Expected | Expected | Expected | Expected |
 | Transcoding (`maxBitRate`) | Yes (192/320 tiers) | Expected | Expected | Expected | Expected | Expected |
 | Seek in transcoded stream (`timeOffset`) | Yes (transcode tiers; raw ignores offset) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
-| Playlists (full CRUD) | Yes | Expected | Expected | Verified¹ | Expected | Expected |
+| Playlists (full CRUD) | Yes | Verified¹ | Expected | Expected | Expected | Expected |
 | Star / unstar / rating | Yes² (star state, 1-5 ratings, and play counts appear on every song payload) | Verified¹ | Expected | Expected | Expected | Expected |
 | Play-queue sync | Yes³ | Expected | Expected | Expected | Expected | Expected |
 | Indexed play queue (`…ByIndex`) | Yes (advertised, `currentIndex` contract) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
@@ -63,13 +63,13 @@ Verdict legend:
 | Last-played dates (`songPlayedDate`/`albumPlayedDate`) | Yes (per-user `played` on songs and albums) | Expected | Client N/A | Client N/A | Client N/A | Client N/A |
 | Offline cache / downloads (`download`) | Yes | Expected | Expected | Expected | Expected | Expected |
 | Scrobble / now playing | Yes | Verified¹ | Expected | Expected | Expected | Expected |
-| Jukebox control | No (out of scope) | Client N/A | Client N/A | Server gap | Server gap | Client N/A |
-| Podcasts over `/rest` | Empty stubs only⁷ | Client N/A | Client N/A | Server gap⁷ | Client N/A | Client N/A |
+| Jukebox control | No (out of scope) | Client N/A | Client N/A | Server gap | Server gap | Server gap |
+| Podcasts over `/rest` | Empty stubs only⁷ | Client N/A | Server gap⁷ | Server gap⁷ | Server gap⁷ | Server gap⁷ |
 | Shares | No (product decision pending) | Client N/A | Client N/A | Server gap | Client N/A | Client N/A |
 
 Notes:
 
-1. "Verified" cells rest on the curl-driven client-profile matrix and smoke harness runs recorded in [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md) (profiles: `symfonium`, `dsub`, `ultrasonic`, `amperfy`, `substreamer`). They emulate each client's documented request patterns; full GUI-client certification on real devices remains open.
+1. "Verified" cells rest on feature-specific request-profile evidence recorded in [`OPENSUBSONIC_COMPATIBILITY.md`](OPENSUBSONIC_COMPATIBILITY.md): a cell is Verified only when that client's profile exercised that feature (for example `symfonium` search3 full sync and playlist CRUD, `dsub` search2, `ultrasonic` getIndexes/scan, `substreamer` indexed queues). Everything else stays Expected until the profile or a real device exercises it; full GUI-client certification remains open.
 2. Album/artist star is projected onto matching tracks; there are no separate album/artist favorite tables.
 3. Queue state uses the legacy playback-state device bucket. `getPlayQueue` exchanges `current` as a song ID per the classic contract, and the ByIndex extension endpoints use `currentIndex`.
 4. Symfonium discovers capabilities via `getOpenSubsonicExtensions`; `indexBasedQueue` is advertised, so capability-driven clients can use the indexed queue endpoints.


### PR DESCRIPTION
## Summary

Closes #536 — the final piece after the extension-truth work (#628) shipped.

- **`docs/SUBSONIC_CLIENTS.md`**: the mobile positioning statement (PWA for the full experience, Subsonic clients for native ergonomics — both first-class, no native app planned), a per-feature compatibility matrix for five clients (Symfonium 15.0.1, Tempo 3.9.0, DSub2000 5.7.4, Ultrasonic 4.9.0, play:Sub 2026.1.22) with honest three-state verdicts (Verified via the request-profile matrix and smoke harness / Expected / N-A), a connection quickstart around app passwords, the extension roadmap (every advertised extension now genuinely implemented), and per-release re-verification instructions.
- README: the OpenSubsonic-clients stub becomes the "On mobile" section linking the guide.
- `docs/README.md` index row and a cross-link from `OPENSUBSONIC_COMPATIBILITY.md`.

The acceptance criteria: matrix published for ≥4 clients with versions (five), extension audit recorded with ReplayGain shipped (plus #624/#625/#626 filed AND implemented), positioning landed. Upgrade path for the matrix's Expected cells is on-device verification per the doc's instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)