### PR TITLE
fix(home): remove decorative play overlay from trending playlist cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Popular Artists cards (home and Explore) now open the artist page directly, matching the Related Artists behavior, instead of running a name search.
+- Trending Community Playlists cards (home and Explore) no longer show a play-button overlay on hover; the cards only navigate to the playlist and never started playback.
 - The audio analyzer now reconnects to PostgreSQL after a server-side connection close instead of waiting for multiple worker failures, so loudness backfill jobs no longer spend retry budget on a stale connection.
 - OpenSubsonic `stream` requests now honor `timeOffset` for transcoded audio with fast ffmpeg input seeking. Offset work bypasses the reusable track-and-quality cache, shares the global ffmpeg concurrency cap, uses interval-gated stale sweeping that excludes active temporary files, and cancels and cleans up when clients disconnect (#624).
 - OpenSubsonic song and album responses now report the authenticated user's latest `played` timestamp across the shared browse, search, playlist, queue, bookmark, starred, discovery, and now-playing surfaces (#625).

--- a/frontend/features/home/components/FeaturedPlaylistsGrid.tsx
+++ b/frontend/features/home/components/FeaturedPlaylistsGrid.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Music2, Loader2 } from "lucide-react";
+import { Music2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
     HorizontalCarousel,
     CarouselItem,
 } from "@/components/ui/HorizontalCarousel";
 import { memo, useCallback } from "react";
-import { usePlayButtonFeedback } from "@/hooks/usePlayButtonFeedback";
 import type { PlaylistPreview } from "@/hooks/useQueries";
 
 export type { PlaylistPreview };
@@ -27,10 +26,7 @@ const PlaylistCard = memo(function PlaylistCard({
     index,
     onClick,
 }: PlaylistCardProps) {
-    const { showSpinner, triggerPlayFeedback } = usePlayButtonFeedback();
-
     const handleClick = () => {
-        triggerPlayFeedback();
         onClick(playlist.id);
     };
 
@@ -55,22 +51,6 @@ const PlaylistCard = memo(function PlaylistCard({
                             <Music2 className="w-10 h-10 text-gray-400" />
                         </div>
                     )}
-                    {/* Play button on hover */}
-                    <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-200">
-                        <div className="w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
-                            {showSpinner ? (
-                                <Loader2 className="w-4 h-4 text-black animate-spin" />
-                            ) : (
-                                <svg
-                                    viewBox="0 0 24 24"
-                                    className="w-4 h-4 text-black ml-0.5"
-                                    fill="currentColor"
-                                >
-                                    <path d="M8 5v14l11-7z" />
-                                </svg>
-                            )}
-                        </div>
-                    </div>
                 </div>
                 <h3 className="text-sm font-semibold text-white truncate">
                     {playlist.title}

--- a/frontend/tests/component/featuredPlaylistsGrid.component.test.ts
+++ b/frontend/tests/component/featuredPlaylistsGrid.component.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { after, beforeEach, mock, test } from "node:test";
 import React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 GlobalRegistrator.register();
@@ -9,8 +8,8 @@ GlobalRegistrator.register();
     globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-after(() => {
-    GlobalRegistrator.unregister();
+after(async () => {
+    await GlobalRegistrator.unregister();
 });
 
 const pushCalls: string[] = [];
@@ -49,40 +48,24 @@ const playlists = [
         id: "pl-1",
         title: "Community Favorites",
         type: "playlist",
-        imageUrl: "",
+        imageUrl: "https://example.com/cover.jpg",
         trackCount: 12,
     },
 ];
 
-async function renderGrid() {
-    const { FeaturedPlaylistsGrid } =
-        await import("../../features/home/components/FeaturedPlaylistsGrid");
-    return renderToStaticMarkup(
-        React.createElement(FeaturedPlaylistsGrid, {
-            playlists,
-        } as never),
-    );
-}
-
-test("renders playlist cards without a play-button affordance", async () => {
-    const html = await renderGrid();
-
-    assert.match(html, /Community Favorites/);
-    assert.match(html, /12 songs/);
-    assert.match(html, /data-tv-card/);
-    assert.match(html, /tabindex="0"/i);
-    assert.doesNotMatch(html, /bg-brand-hover/);
-    assert.doesNotMatch(html, /M8 5v14l11-7z/);
-    assert.doesNotMatch(html, /animate-spin/);
-});
-
-test("clicking a card navigates to the playlist page", async () => {
+async function renderIntoDom(t: {
+    after: (fn: () => Promise<void> | void) => void;
+}) {
     const { createRoot } = await import("react-dom/client");
     const { FeaturedPlaylistsGrid } =
         await import("../../features/home/components/FeaturedPlaylistsGrid");
     const container = document.createElement("div");
     const root = createRoot(container);
-
+    t.after(async () => {
+        await React.act(async () => {
+            root.unmount();
+        });
+    });
     await React.act(async () => {
         root.render(
             React.createElement(FeaturedPlaylistsGrid, {
@@ -90,6 +73,31 @@ test("clicking a card navigates to the playlist page", async () => {
             } as never),
         );
     });
+    return container;
+}
+
+test("renders playlist cards with artwork only — no overlaid controls", async (t) => {
+    const container = await renderIntoDom(t);
+
+    const card = container.querySelector("[data-tv-card]");
+    assert.ok(card, "expected a playlist card to render");
+    assert.match(card.textContent ?? "", /Community Favorites/);
+    assert.match(card.textContent ?? "", /12 songs/);
+    assert.equal(card.getAttribute("tabindex"), "0");
+
+    // Behavioral invariant: nothing interactive or decorative sits on top
+    // of the artwork. The artwork wrapper holds exactly the image (or the
+    // fallback icon) and no buttons or overlay elements of any styling.
+    const artworkWrapper = card.querySelector("img")?.parentElement;
+    assert.ok(artworkWrapper, "expected the artwork wrapper to render");
+    assert.equal(artworkWrapper.children.length, 1);
+    assert.equal(artworkWrapper.children[0]?.tagName.toLowerCase(), "img");
+    assert.equal(card.querySelectorAll("button").length, 0);
+    assert.equal(card.querySelectorAll("svg").length, 0);
+});
+
+test("clicking a card navigates to the playlist page", async (t) => {
+    const container = await renderIntoDom(t);
 
     const card = container.querySelector("[data-tv-card]");
     assert.ok(card, "expected a playlist card to render");
@@ -99,8 +107,4 @@ test("clicking a card navigates to the playlist page", async () => {
     });
 
     assert.deepEqual(pushCalls, ["/explore/yt-playlist/pl-1"]);
-
-    await React.act(async () => {
-        root.unmount();
-    });
 });

--- a/frontend/tests/component/featuredPlaylistsGrid.component.test.ts
+++ b/frontend/tests/component/featuredPlaylistsGrid.component.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+after(() => {
+    GlobalRegistrator.unregister();
+});
+
+const pushCalls: string[] = [];
+
+mock.module("next/navigation", {
+    namedExports: {
+        useRouter: () => ({
+            push: (url: string) => {
+                pushCalls.push(url);
+            },
+        }),
+    },
+});
+
+mock.module("lucide-react", {
+    namedExports: {
+        Music2: () => React.createElement("svg", { "data-icon": "music2" }),
+    },
+});
+
+mock.module("@/components/ui/HorizontalCarousel", {
+    namedExports: {
+        HorizontalCarousel: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement("div", null, children),
+        CarouselItem: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement("div", null, children),
+    },
+});
+
+beforeEach(() => {
+    pushCalls.length = 0;
+});
+
+const playlists = [
+    {
+        id: "pl-1",
+        title: "Community Favorites",
+        type: "playlist",
+        imageUrl: "",
+        trackCount: 12,
+    },
+];
+
+async function renderGrid() {
+    const { FeaturedPlaylistsGrid } =
+        await import("../../features/home/components/FeaturedPlaylistsGrid");
+    return renderToStaticMarkup(
+        React.createElement(FeaturedPlaylistsGrid, {
+            playlists,
+        } as never),
+    );
+}
+
+test("renders playlist cards without a play-button affordance", async () => {
+    const html = await renderGrid();
+
+    assert.match(html, /Community Favorites/);
+    assert.match(html, /12 songs/);
+    assert.match(html, /data-tv-card/);
+    assert.match(html, /tabindex="0"/i);
+    assert.doesNotMatch(html, /bg-brand-hover/);
+    assert.doesNotMatch(html, /M8 5v14l11-7z/);
+    assert.doesNotMatch(html, /animate-spin/);
+});
+
+test("clicking a card navigates to the playlist page", async () => {
+    const { createRoot } = await import("react-dom/client");
+    const { FeaturedPlaylistsGrid } =
+        await import("../../features/home/components/FeaturedPlaylistsGrid");
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(FeaturedPlaylistsGrid, {
+                playlists,
+            } as never),
+        );
+    });
+
+    const card = container.querySelector("[data-tv-card]");
+    assert.ok(card, "expected a playlist card to render");
+
+    await React.act(async () => {
+        card.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+
+    assert.deepEqual(pushCalls, ["/explore/yt-playlist/pl-1"]);
+
+    await React.act(async () => {
+        root.unmount();
+    });
+});


### PR DESCRIPTION
## Summary
- The playlist cards rendered by `FeaturedPlaylistsGrid` (home page "Trending Community Playlists" and the Explore provider tab) showed a blue play-button overlay on hover.
- The overlay was purely decorative: the card's click handler only navigates to `/explore/yt-playlist/:id`; nothing ever played, and the spinner flashed during a route change.
- Remove the overlay and the now-unused `usePlayButtonFeedback`/`Loader2` imports. CHANGELOG entry included.

## Testing
- `npx tsc --noEmit` (frontend): clean.
- `node --test --experimental-test-module-mocks --import tsx tests/component/{homePage,providerTabSection,explorePage}.component.test.ts`: 20/20 pass.
- Pinned prettier check: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)