### PR TITLE
fix(home): route Popular Artists cards to the artist page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Popular Artists cards (home and Explore) now open the artist page directly, matching the Related Artists behavior, instead of running a name search.
 - The audio analyzer now reconnects to PostgreSQL after a server-side connection close instead of waiting for multiple worker failures, so loudness backfill jobs no longer spend retry budget on a stale connection.
 - OpenSubsonic `stream` requests now honor `timeOffset` for transcoded audio with fast ffmpeg input seeking. Offset work bypasses the reusable track-and-quality cache, shares the global ffmpeg concurrency cap, uses interval-gated stale sweeping that excludes active temporary files, and cancels and cleans up when clients disconnect (#624).
 - OpenSubsonic song and album responses now report the authenticated user's latest `played` timestamp across the shared browse, search, playlist, queue, bookmark, starred, discovery, and now-playing surfaces (#625).

--- a/frontend/features/home/components/PopularArtistsGrid.tsx
+++ b/frontend/features/home/components/PopularArtistsGrid.tsx
@@ -9,12 +9,14 @@ import {
     CarouselItem,
 } from "@/components/ui/HorizontalCarousel";
 import { memo } from "react";
+import { getArtistRouteParam } from "@/utils/artistRoute";
 
 interface PopularArtist {
     id?: string;
     name: string;
     image?: string;
     listeners?: number;
+    mbid?: string;
 }
 
 interface PopularArtistsGridProps {
@@ -37,11 +39,16 @@ const PopularArtistCard = memo(function PopularArtistCard({
     index,
 }: PopularArtistCardProps) {
     const imageUrl = getProxiedImageUrl(artist.image);
+    const artistRouteId =
+        getArtistRouteParam(
+            { mbid: artist.mbid, name: artist.name },
+            { preferLibraryId: false },
+        ) || encodeURIComponent(artist.name);
 
     return (
         <CarouselItem>
             <Link
-                href={`/search?q=${encodeURIComponent(artist.name)}`}
+                href={`/artist/${artistRouteId}`}
                 data-tv-card
                 data-tv-card-index={index}
                 tabIndex={0}

--- a/frontend/features/home/components/PopularArtistsGrid.tsx
+++ b/frontend/features/home/components/PopularArtistsGrid.tsx
@@ -10,14 +10,7 @@ import {
 } from "@/components/ui/HorizontalCarousel";
 import { memo } from "react";
 import { getArtistRouteParam } from "@/utils/artistRoute";
-
-interface PopularArtist {
-    id?: string;
-    name: string;
-    image?: string;
-    listeners?: number;
-    mbid?: string;
-}
+import type { PopularArtist } from "@/features/home/types";
 
 interface PopularArtistsGridProps {
     artists: PopularArtist[];

--- a/frontend/features/home/types.ts
+++ b/frontend/features/home/types.ts
@@ -69,4 +69,5 @@ export interface PopularArtist {
     name: string;
     image?: string;
     listeners?: number;
+    mbid?: string;
 }

--- a/frontend/tests/component/popularArtistsGrid.component.test.ts
+++ b/frontend/tests/component/popularArtistsGrid.component.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("lucide-react", {
+    namedExports: {
+        Music: () => React.createElement("svg", { "data-icon": "music" }),
+    },
+});
+
+mock.module("next/image", {
+    defaultExport: ({ alt }: { alt?: string }) =>
+        React.createElement("img", { alt }),
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getCoverArtUrl: (url: string) => `/proxied/${url}`,
+        },
+    },
+});
+
+mock.module("@/components/ui/HorizontalCarousel", {
+    namedExports: {
+        HorizontalCarousel: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement("div", null, children),
+        CarouselItem: ({ children }: { children?: React.ReactNode }) =>
+            React.createElement("div", null, children),
+    },
+});
+
+async function renderGrid(artists: Record<string, unknown>[]) {
+    const { PopularArtistsGrid } =
+        await import("../../features/home/components/PopularArtistsGrid");
+    return renderToStaticMarkup(
+        React.createElement(PopularArtistsGrid, { artists } as never),
+    );
+}
+
+test("routes cards to the artist page by MBID", async () => {
+    const html = await renderGrid([
+        {
+            id: "b49b81cc-d5b7-4bdd-aadb-385df8de69a6",
+            name: "Drake",
+            mbid: "b49b81cc-d5b7-4bdd-aadb-385df8de69a6",
+            listeners: 5000000,
+        },
+    ]);
+
+    assert.match(html, /href="\/artist\/b49b81cc-d5b7-4bdd-aadb-385df8de69a6"/);
+    assert.doesNotMatch(html, /href="\/search/);
+});
+
+test("falls back to the encoded artist name without a usable MBID", async () => {
+    const html = await renderGrid([
+        { name: "AC/DC & Friends", listeners: 1 },
+        { name: "Sigur Rós", mbid: "temp-123", listeners: 2 },
+    ]);
+
+    assert.match(html, /href="\/artist\/AC%2FDC%20%26%20Friends"/);
+    assert.match(html, /href="\/artist\/Sigur%20R%C3%B3s"/);
+    assert.doesNotMatch(html, /href="\/search/);
+    assert.doesNotMatch(html, /temp-123/);
+});


### PR DESCRIPTION
## Summary
- `PopularArtistsGrid` (home + Explore) was the only artist card in the app linking to `/search?q=<name>` instead of an artist page.
- The Last.fm popular-artists payload already carries `mbid`; the component's local interface just omitted it. Add the field and route with `getArtistRouteParam({mbid, name}, {preferLibraryId: false})` with an encoded-name fallback — the exact pattern `SimilarArtistsGrid` uses, and `/api/artists/discover/:nameOrMbid` resolves either form.

## Testing
- `npx tsc --noEmit` (frontend): clean.
- `node --test --experimental-test-module-mocks --import tsx tests/component/{homePage,explorePage}.component.test.ts`: 16/16 pass.
- Pinned prettier: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)