### PR TITLE
fix(artists): stop double-decoding artist route params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Artist detail and discovery routes now preserve artist names with percent signs while retaining lookup compatibility for legacy double-encoded names (#632).
 - Popular Artists cards (home and Explore) now open the artist page directly, matching the Related Artists behavior, instead of running a name search.
 - The audio analyzer now reconnects to PostgreSQL after a server-side connection close instead of waiting for multiple worker failures, so loudness backfill jobs no longer spend retry budget on a stale connection.
 - OpenSubsonic `stream` requests now honor `timeOffset` for transcoded audio with fast ffmpeg input seeking. Offset work bypasses the reusable track-and-quality cache, shares the global ffmpeg concurrency cap, uses interval-gated stale sweeping that excludes active temporary files, and cancels and cleans up when clients disconnect (#624).

--- a/backend/src/routes/__tests__/artistRouteName.test.ts
+++ b/backend/src/routes/__tests__/artistRouteName.test.ts
@@ -1,0 +1,40 @@
+import { findRouteNameMatch, normalizeRouteName } from "../artistRouteName";
+
+describe("normalizeRouteName", () => {
+    it.each([
+        ["100% Pure", ["100% Pure"]],
+        ["A/B", ["A/B"]],
+        ["Earth, Wind & Fire", ["Earth, Wind & Fire"]],
+        ["Björk", ["Björk"]],
+        ["A%2FB", ["A%2FB", "A/B"]],
+        ["Legacy%20Artist", ["Legacy%20Artist", "Legacy Artist"]],
+        ["incomplete%2", ["incomplete%2"]],
+    ])("returns ordered candidates for %s", (raw, expected) => {
+        expect(normalizeRouteName(raw)).toEqual(expected);
+    });
+});
+
+describe("findRouteNameMatch", () => {
+    it("tries the raw name before the legacy decoded fallback", async () => {
+        const lookup = jest.fn(async (candidate: string) =>
+            candidate === "Legacy Artist" ? candidate : null,
+        );
+
+        await expect(
+            findRouteNameMatch("Legacy%20Artist", lookup),
+        ).resolves.toBe("Legacy Artist");
+        expect(lookup.mock.calls).toEqual([
+            ["Legacy%20Artist"],
+            ["Legacy Artist"],
+        ]);
+    });
+
+    it("does not decode after the raw name matches", async () => {
+        const lookup = jest.fn(async (candidate: string) => candidate);
+
+        await expect(findRouteNameMatch("A%2FB", lookup)).resolves.toBe(
+            "A%2FB",
+        );
+        expect(lookup).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
+++ b/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
@@ -175,11 +175,13 @@ describe("artists preview (YT Music) routes", () => {
     // ── GET /preview/:artistName/:trackTitle ───────────────────────
 
     describe("GET /preview/:artistName/:trackTitle", () => {
+        // Express decodes route params once before handlers run, so
+        // req.params carries the plain (already-decoded) values.
         const buildReq = (artist: string, track: string) =>
             ({
                 params: {
-                    artistName: encodeURIComponent(artist),
-                    trackTitle: encodeURIComponent(track),
+                    artistName: artist,
+                    trackTitle: track,
                 },
             }) as any;
 

--- a/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
+++ b/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
@@ -304,6 +304,29 @@ describe("artists preview (YT Music) routes", () => {
                 expect.any(Object),
             );
         });
+
+        it.each([
+            ["100% Pure", "yt-preview:100% pure:test track"],
+            ["A%2FB", "yt-preview:a%2fb:test track"],
+        ])(
+            "uses the post-Express artist param %s verbatim for preview lookup",
+            async (artist, expectedCacheKey) => {
+                const res = createRes();
+                await getPreview(buildReq(artist, "Test Track"), res);
+
+                expect(mockRedisGet).toHaveBeenCalledWith(expectedCacheKey);
+                expect(mockSearch).toHaveBeenCalledWith(
+                    "__public__",
+                    `${artist} Test Track`,
+                    "songs",
+                );
+                expect(mockRedisSet).toHaveBeenCalledWith(
+                    expectedCacheKey,
+                    "null",
+                    expect.any(Object),
+                );
+            },
+        );
     });
 
     // ── GET /preview-stream/:videoId ───────────────────────────────

--- a/backend/src/routes/__tests__/artistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/artistsRuntime.test.ts
@@ -197,8 +197,8 @@ describe("artists routes runtime", () => {
 
         const req = {
             params: {
-                artistName: encodeURIComponent("AC/DC"),
-                trackTitle: encodeURIComponent("Back In Black"),
+                artistName: "AC/DC",
+                trackTitle: "Back In Black",
             },
         } as any;
         const res = createRes();
@@ -219,8 +219,8 @@ describe("artists routes runtime", () => {
 
         const req = {
             params: {
-                artistName: encodeURIComponent("No Artist"),
-                trackTitle: encodeURIComponent("No Track"),
+                artistName: "No Artist",
+                trackTitle: "No Track",
             },
         } as any;
         const res = createRes();
@@ -236,8 +236,8 @@ describe("artists routes runtime", () => {
 
         const req = {
             params: {
-                artistName: encodeURIComponent("Artist"),
-                trackTitle: encodeURIComponent("Track"),
+                artistName: "Artist",
+                trackTitle: "Track",
             },
         } as any;
         const res = createRes();
@@ -289,7 +289,7 @@ describe("artists routes runtime", () => {
         ]);
 
         const req = {
-            params: { nameOrMbid: encodeURIComponent("Recovery Artist") },
+            params: { nameOrMbid: "Recovery Artist" },
             query: {
                 includeDiscography: "0",
                 includeTopTracks: "0",
@@ -317,9 +317,85 @@ describe("artists routes runtime", () => {
             }),
         );
         expect(mockRedisSetEx).toHaveBeenCalledWith(
-            "discovery:artist:Recovery%20Artist:disc:0:top:0:sim:0",
+            "discovery:artist:Recovery Artist:disc:0:top:0:sim:0",
             24 * 60 * 60,
             expect.any(String),
+        );
+    });
+
+    it.each(["100% Pure", "A/B", "Earth, Wind & Fire", "Björk", "A%2FB"])(
+        "preserves the Express-decoded artist name %s for /discover",
+        async (routeName) => {
+            mockSearchArtist.mockImplementation(async (candidate: string) =>
+                candidate === routeName
+                    ? [{ id: "resolved-mbid", name: routeName }]
+                    : [],
+            );
+
+            const req = {
+                params: { nameOrMbid: routeName },
+                query: {
+                    includeDiscography: "false",
+                    includeTopTracks: "false",
+                    includeSimilarArtists: "false",
+                },
+            } as any;
+            const res = createRes();
+
+            await getDiscover(req, res);
+
+            expect(mockSearchArtist).toHaveBeenNthCalledWith(1, routeName, 1);
+            expect(mockGetArtistInfo).toHaveBeenCalledWith(
+                routeName,
+                "resolved-mbid",
+            );
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual(
+                expect.objectContaining({
+                    mbid: "resolved-mbid",
+                    name: routeName,
+                }),
+            );
+        },
+    );
+
+    it("falls back to a decoded artist name for legacy double-encoded /discover requests", async () => {
+        const storedName = "Legacy / Artist";
+        const legacyRouteParam = encodeURIComponent(storedName);
+        mockSearchArtist.mockImplementation(async (candidate: string) =>
+            candidate === storedName
+                ? [{ id: "legacy-mbid", name: storedName }]
+                : [],
+        );
+
+        const req = {
+            params: { nameOrMbid: legacyRouteParam },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+        } as any;
+        const res = createRes();
+
+        await getDiscover(req, res);
+
+        expect(mockSearchArtist).toHaveBeenNthCalledWith(
+            1,
+            legacyRouteParam,
+            1,
+        );
+        expect(mockSearchArtist).toHaveBeenNthCalledWith(2, storedName, 1);
+        expect(mockGetArtistInfo).toHaveBeenCalledWith(
+            storedName,
+            "legacy-mbid",
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                mbid: "legacy-mbid",
+                name: storedName,
+            }),
         );
     });
 
@@ -483,7 +559,7 @@ describe("artists routes runtime", () => {
         );
 
         const req = {
-            params: { nameOrMbid: encodeURIComponent("The Artist") },
+            params: { nameOrMbid: "The Artist" },
             query: {
                 includeDiscography: "yes",
                 includeTopTracks: "1",
@@ -559,7 +635,7 @@ describe("artists routes runtime", () => {
 
         expect(mockRedisSetEx).toHaveBeenCalledTimes(1);
         expect(mockRedisSetEx).toHaveBeenCalledWith(
-            "discovery:artist:The%20Artist:disc:1:top:1:sim:1",
+            "discovery:artist:The Artist:disc:1:top:1:sim:1",
             24 * 60 * 60,
             expect.any(String),
         );

--- a/backend/src/routes/__tests__/artistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/artistsRuntime.test.ts
@@ -399,6 +399,111 @@ describe("artists routes runtime", () => {
         );
     });
 
+    it("prefers an exact legacy /discover match over a fuzzy raw match", async () => {
+        mockSearchArtist.mockImplementation(async (candidate: string) => {
+            if (candidate === "Legacy%20Artist") {
+                return [{ id: "raw-fuzzy-mbid", name: "Legacy Artists" }];
+            }
+            if (candidate === "Legacy Artist") {
+                return [{ id: "legacy-exact-mbid", name: "Legacy Artist" }];
+            }
+            return [];
+        });
+
+        const req = {
+            params: { nameOrMbid: "Legacy%20Artist" },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+        } as any;
+        const res = createRes();
+
+        await getDiscover(req, res);
+
+        expect(mockSearchArtist.mock.calls).toEqual([
+            ["Legacy%20Artist", 1],
+            ["Legacy Artist", 1],
+        ]);
+        expect(mockGetArtistInfo).toHaveBeenCalledWith(
+            "Legacy Artist",
+            "legacy-exact-mbid",
+        );
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                mbid: "legacy-exact-mbid",
+                name: "Legacy Artist",
+            }),
+        );
+    });
+
+    it("keeps an exact raw /discover match without trying the legacy candidate", async () => {
+        mockSearchArtist.mockResolvedValueOnce([
+            { id: "raw-exact-mbid", name: "a%2fb" },
+        ]);
+
+        const req = {
+            params: { nameOrMbid: "A%2FB" },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+        } as any;
+        const res = createRes();
+
+        await getDiscover(req, res);
+
+        expect(mockSearchArtist).toHaveBeenCalledTimes(1);
+        expect(mockSearchArtist).toHaveBeenCalledWith("A%2FB", 1);
+        expect(mockGetArtistInfo).toHaveBeenCalledWith(
+            "a%2fb",
+            "raw-exact-mbid",
+        );
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                mbid: "raw-exact-mbid",
+                name: "a%2fb",
+            }),
+        );
+    });
+
+    it("preserves the fuzzy raw /discover result when neither candidate matches exactly", async () => {
+        mockSearchArtist.mockImplementation(async (candidate: string) =>
+            candidate === "Legacy%20Artist"
+                ? [{ id: "raw-fuzzy-mbid", name: "Legacy Artists" }]
+                : [{ id: "legacy-fuzzy-mbid", name: "Legacy Artiste" }],
+        );
+
+        const req = {
+            params: { nameOrMbid: "Legacy%20Artist" },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+        } as any;
+        const res = createRes();
+
+        await getDiscover(req, res);
+
+        expect(mockSearchArtist.mock.calls).toEqual([
+            ["Legacy%20Artist", 1],
+            ["Legacy Artist", 1],
+        ]);
+        expect(mockGetArtistInfo).toHaveBeenCalledWith(
+            "Legacy Artists",
+            "raw-fuzzy-mbid",
+        );
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                mbid: "raw-fuzzy-mbid",
+                name: "Legacy Artists",
+            }),
+        );
+    });
+
     it("returns 404 when MBID-only discover cannot resolve artist name", async () => {
         const mbid = "11111111-1111-1111-1111-111111111111";
         mockGetArtist.mockRejectedValueOnce(new Error("not found"));

--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -197,10 +197,10 @@ function createRes() {
     return res;
 }
 
-function createMockArtist() {
+function createMockArtist(name = "AC/DC") {
     return {
         id: "artist-1",
-        name: "AC/DC",
+        name,
         mbid: "mbid-artist-1",
         heroUrl: null,
         userHeroUrl: null,
@@ -229,8 +229,8 @@ describe("library artist lookup compatibility", () => {
             decodedName: "artist-local-id-123",
         },
         {
-            label: "url-encoded artist name",
-            routeParam: encodeURIComponent("AC/DC"),
+            label: "Express-decoded artist name",
+            routeParam: "AC/DC",
             decodedName: "AC/DC",
         },
         {
@@ -288,6 +288,94 @@ describe("library artist lookup compatibility", () => {
             );
         },
     );
+
+    it.each(["100% Pure", "A/B", "Earth, Wind & Fire", "Björk", "A%2FB"])(
+        "finds the stored artist named %s without decoding the route param again",
+        async (storedName) => {
+            mockArtistFindFirst.mockImplementation(async (args: any) => {
+                const nameCandidate = args.where.OR.find(
+                    (candidate: any) => candidate.name,
+                )?.name.equals;
+                return nameCandidate === storedName
+                    ? createMockArtist(storedName)
+                    : null;
+            });
+
+            const req = {
+                params: { id: storedName },
+                query: {
+                    includeDiscography: "false",
+                    includeTopTracks: "false",
+                    includeSimilarArtists: "false",
+                },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+
+            await artistHandler(req, res);
+
+            expect(mockArtistFindFirst).toHaveBeenCalledTimes(1);
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual(
+                expect.objectContaining({
+                    id: "artist-1",
+                    name: storedName,
+                }),
+            );
+        },
+    );
+
+    it("falls back to the decoded artist name for legacy double-encoded library requests", async () => {
+        const storedName = "Legacy / Artist";
+        const legacyRouteParam = encodeURIComponent(storedName);
+        mockArtistFindFirst.mockImplementation(async (args: any) => {
+            const nameCandidate = args.where.OR.find(
+                (candidate: any) => candidate.name,
+            )?.name.equals;
+            return nameCandidate === storedName
+                ? createMockArtist(storedName)
+                : null;
+        });
+
+        const req = {
+            params: { id: legacyRouteParam },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await artistHandler(req, res);
+
+        expect(mockArtistFindFirst).toHaveBeenCalledTimes(2);
+        expect(mockArtistFindFirst.mock.calls[0][0].where.OR).toEqual(
+            expect.arrayContaining([
+                {
+                    name: {
+                        equals: legacyRouteParam,
+                        mode: "insensitive",
+                    },
+                },
+            ]),
+        );
+        expect(mockArtistFindFirst.mock.calls[1][0].where.OR).toEqual(
+            expect.arrayContaining([
+                {
+                    name: { equals: storedName, mode: "insensitive" },
+                },
+            ]),
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                id: "artist-1",
+                name: storedName,
+            }),
+        );
+    });
 
     it("returns 404 when artist does not exist", async () => {
         mockArtistFindFirst.mockResolvedValueOnce(null);

--- a/backend/src/routes/artistRouteName.ts
+++ b/backend/src/routes/artistRouteName.ts
@@ -1,0 +1,34 @@
+const PERCENT_ESCAPE_PATTERN = /%[0-9a-f]{2}/i;
+
+/**
+ * Returns an Express-decoded artist name followed by its legacy
+ * double-encoded fallback, when that fallback is valid and distinct.
+ */
+export function normalizeRouteName(raw: string): readonly string[] {
+    if (!PERCENT_ESCAPE_PATTERN.test(raw)) {
+        return [raw];
+    }
+
+    try {
+        const decoded = decodeURIComponent(raw);
+        return decoded === raw ? [raw] : [raw, decoded];
+    } catch {
+        return [raw];
+    }
+}
+
+/**
+ * Looks up an artist route name raw-first, then uses the valid legacy
+ * double-encoded candidate only when the raw name has no match.
+ */
+export async function findRouteNameMatch<T>(
+    raw: string,
+    lookup: (candidate: string) => Promise<T | null>,
+): Promise<T | null> {
+    const [routeName, legacyName] = normalizeRouteName(raw);
+    const match = await lookup(routeName);
+    if (match !== null || !legacyName) {
+        return match;
+    }
+    return lookup(legacyName);
+}

--- a/backend/src/routes/artistRouteName.ts
+++ b/backend/src/routes/artistRouteName.ts
@@ -18,17 +18,27 @@ export function normalizeRouteName(raw: string): readonly string[] {
 }
 
 /**
- * Looks up an artist route name raw-first, then uses the valid legacy
- * double-encoded candidate only when the raw name has no match.
+ * Looks up an artist route name raw-first. When provided, `matchesCandidate`
+ * allows an exact legacy match to replace a fuzzy raw match while preserving
+ * the raw result when neither candidate matches exactly.
  */
 export async function findRouteNameMatch<T>(
     raw: string,
     lookup: (candidate: string) => Promise<T | null>,
+    matchesCandidate?: (candidate: string, match: T) => boolean,
 ): Promise<T | null> {
     const [routeName, legacyName] = normalizeRouteName(raw);
-    const match = await lookup(routeName);
-    if (match !== null || !legacyName) {
-        return match;
+    const rawMatch = await lookup(routeName);
+    const rawMatches =
+        rawMatch !== null &&
+        (!matchesCandidate || matchesCandidate(routeName, rawMatch));
+    if (!legacyName || rawMatches) {
+        return rawMatch;
     }
-    return lookup(legacyName);
+
+    const legacyMatch = await lookup(legacyName);
+    const legacyMatches =
+        legacyMatch !== null &&
+        (!matchesCandidate || matchesCandidate(legacyName, legacyMatch));
+    return legacyMatches ? legacyMatch : rawMatch;
 }

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -11,6 +11,7 @@ import { requireAuthOrToken } from "../middleware/auth";
 import { ytMusicStreamLimiter } from "../middleware/rateLimiter";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
+import { findRouteNameMatch } from "./artistRouteName";
 
 const router = Router();
 
@@ -84,9 +85,8 @@ router.get<{ artistName: string; trackTitle: string }>(
     requireAuthOrToken,
     async (req, res) => {
         try {
-            const { artistName, trackTitle } = req.params;
-            const decodedArtist = decodeURIComponent(artistName);
-            const decodedTrack = decodeURIComponent(trackTitle);
+            const { artistName: decodedArtist, trackTitle: decodedTrack } =
+                req.params;
 
             const settings = await getSystemSettings();
             if (!settings.ytMusicEnabled) {
@@ -372,19 +372,23 @@ router.get<{ nameOrMbid: string }>(
                 );
 
             let mbid: string | null = isMbid ? nameOrMbid : null;
-            let artistName: string = isMbid
-                ? ""
-                : decodeURIComponent(nameOrMbid);
+            let artistName = isMbid ? "" : nameOrMbid;
 
             // If we have a name but no MBID, search for it
             if (!mbid && artistName) {
-                const mbResults = await musicBrainzService.searchArtist(
+                const mbResult = await findRouteNameMatch(
                     artistName,
-                    1,
+                    async (candidate) => {
+                        const [result] = await musicBrainzService.searchArtist(
+                            candidate,
+                            1,
+                        );
+                        return result ?? null;
+                    },
                 );
-                if (mbResults.length > 0) {
-                    mbid = mbResults[0].id;
-                    artistName = mbResults[0].name;
+                if (mbResult) {
+                    mbid = mbResult.id;
+                    artistName = mbResult.name;
                 }
             }
 

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -11,6 +11,7 @@ import { requireAuthOrToken } from "../middleware/auth";
 import { ytMusicStreamLimiter } from "../middleware/rateLimiter";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
+import { normalizeArtistName } from "../utils/artistNormalization";
 import { findRouteNameMatch } from "./artistRouteName";
 
 const router = Router();
@@ -385,6 +386,9 @@ router.get<{ nameOrMbid: string }>(
                         );
                         return result ?? null;
                     },
+                    (candidate, result) =>
+                        normalizeArtistName(result.name) ===
+                        normalizeArtistName(candidate),
                 );
                 if (mbResult) {
                     mbid = mbResult.id;

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -44,6 +44,7 @@ import {
     isSafeRecursiveDeletionTarget,
     libraryDeletionLogger,
 } from "../../utils/libraryDeletion";
+import { findRouteNameMatch } from "../artistRouteName";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -485,22 +486,21 @@ export async function handleGetArtist(
         federationPeer: {
             select: { id: true, name: true, outboundStatus: true },
         },
-        // Note: similarFrom (FK-based) is no longer used for display
-        // We now use similarArtistsJson which is fetched by default
+        // similarFrom is retired; similarArtistsJson is fetched by default.
     };
 
-    // Single query with OR to find artist by ID, name, or MBID
-    const decodedName = decodeURIComponent(idParam);
-    const artist = await prisma.artist.findFirst({
-        where: {
-            OR: [
-                { id: idParam },
-                { name: { equals: decodedName, mode: "insensitive" } },
-                { mbid: idParam },
-            ],
-        },
-        include: artistInclude,
-    });
+    const artist = await findRouteNameMatch(idParam, (name) =>
+        prisma.artist.findFirst({
+            where: {
+                OR: [
+                    { id: idParam },
+                    { name: { equals: name, mode: "insensitive" } },
+                    { mbid: idParam },
+                ],
+            },
+            include: artistInclude,
+        }),
+    );
 
     if (!artist) {
         return sendRouteError(res, 404, "Artist not found");


### PR DESCRIPTION
## Summary
Fixes #632. Express decodes route params once; the library artist lookup and the discovery endpoint both called `decodeURIComponent` again. For names containing a literal `%` (e.g. `100% Pure`) the second decode threw `URIError` — the frontend swallowed it and rendered an owned artist as discovery content — and names like `A%2FB` were silently mutated to `A/B`.

- New `normalizeRouteName`/`findRouteNameMatch` helpers: use the Express-decoded param as-is (raw-first), with a tolerant legacy double-encoded fallback tried only on a raw miss (library) or when the raw value cleanly decodes to something different (discovery).
- Regression coverage: `%`, `/`, `&`, unicode, the exact `100% Pure` and `A%2FB` cases, malformed encodings, and the legacy double-encoded client form, on both endpoints.
- The YT preview route tests previously modeled pre-Express (encoded) params to satisfy the old double decode; the fixture now models what Express actually delivers.

Out of scope (same anti-pattern, flagged for follow-up): `audiobooks.ts:566` (`seriesName`) and `library/coverArt.ts:203` (`coverId`).

## Testing
- Targeted jest: 66/66 across the four touched suites (caught and fixed 2 preview-fixture failures the sandboxed run missed).
- `tsc --noEmit` clean; pinned prettier + `format:check` clean; route-error-canon and file-size ratchets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)