### PR TITLE
feat(search): surface external artists and tracks in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Per-peer federation health observability: bounded Prometheus sync, catalog, stream, authentication, lease, and quota metrics; an administrator health panel and API; persisted sync/error diagnostics; Grafana panels; and an example federation alert pack (#531).
+- Search results now surface external discovery: all matching Last.fm artists render in an Artists section, external track matches render in a Songs to Discover section linking to artist pages, and an exact-name external match wins the Top result over a fuzzy library match (searching "Drake" no longer tops out at an owned "Nick Drake").
+
 - Subsonic client guide (`docs/SUBSONIC_CLIENTS.md`): the mobile positioning statement, a per-feature compatibility matrix for Symfonium, Tempo, DSub2000, Ultrasonic, and play:Sub with per-release re-verification instructions, and the OpenSubsonic extension roadmap.
 - Library Health dashboard read model and admin API (metadata gaps, analysis coverage, duplicate clusters, storage and quality analytics).
 - Library Insights section on the Admin page: browsable panels for metadata gaps, analysis coverage with retry actions, report-only duplicate clusters, storage breakdown, and low-bitrate album detection.

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -19,6 +19,7 @@ import { DiscoverPodcastsGrid } from "@/features/search/components/DiscoverPodca
 import { LibraryAudiobooksGrid } from "@/features/search/components/LibraryAudiobooksGrid";
 import { LibraryTracksList } from "@/features/search/components/LibraryTracksList";
 import { SimilarArtistsGrid } from "@/features/search/components/SimilarArtistsGrid";
+import { DiscoverTracksList } from "@/features/search/components/DiscoverTracksList";
 import { AliasResolutionBanner } from "@/features/search/components/AliasResolutionBanner";
 import { SoulseekSongsList } from "@/features/search/components/SoulseekSongsList";
 import { TVSearchInput } from "@/features/search/components/TVSearchInput";
@@ -115,7 +116,23 @@ export default function SearchPage() {
     }, [urlQuery]);
 
     // Derived state
-    const topArtist = discoverResults.find((r) => r.type === "music");
+    const discoverArtists = discoverResults.filter((r) => r.type === "music");
+    const discoverTracks = discoverResults.filter((r) => r.type === "track");
+    const normalizedQuery = query.trim().toLowerCase();
+    const exactDiscoverArtist = discoverArtists.find(
+        (artist) => artist.name.trim().toLowerCase() === normalizedQuery,
+    );
+    const libraryTopArtist = libraryResults?.artists?.[0];
+    const libraryTopIsExact =
+        libraryTopArtist?.name.trim().toLowerCase() === normalizedQuery;
+    // An exact-name external match beats a fuzzy library match, so
+    // searching "Drake" surfaces Drake rather than an owned "Nick Drake".
+    const preferDiscoveryTopResult =
+        !!exactDiscoverArtist && !libraryTopIsExact;
+    const topArtist = exactDiscoverArtist ?? discoverArtists[0];
+    const secondaryDiscoverArtists = discoverArtists.filter(
+        (artist) => artist !== topArtist,
+    );
     const isLoading =
         isLibrarySearching ||
         isDiscoverSearching ||
@@ -296,6 +313,7 @@ export default function SearchPage() {
                             <TopResult
                                 libraryArtist={libraryResults?.artists?.[0]}
                                 discoveryArtist={topArtist}
+                                preferDiscovery={preferDiscoveryTopResult}
                             />
                         </div>
 
@@ -378,6 +396,9 @@ export default function SearchPage() {
                                             libraryResults?.artists?.[0]
                                         }
                                         discoveryArtist={topArtist}
+                                        preferDiscovery={
+                                            preferDiscoveryTopResult
+                                        }
                                     />
                                 </div>
                             )}
@@ -530,6 +551,32 @@ export default function SearchPage() {
                             <LibraryAudiobooksGrid
                                 audiobooks={libraryResults.audiobooks}
                             />
+                        </section>
+                    )}
+
+                {/* Discover Artists — external matches beyond the top result */}
+                {hasSearched &&
+                    showDiscover &&
+                    !isPodcastTab &&
+                    (sectionView === null || isArtistsView) &&
+                    secondaryDiscoverArtists.length > 0 && (
+                        <SimilarArtistsGrid
+                            similarArtists={secondaryDiscoverArtists}
+                            title="Artists"
+                        />
+                    )}
+
+                {/* Songs to Discover — external track matches */}
+                {hasSearched &&
+                    showDiscover &&
+                    !isPodcastTab &&
+                    !isSectionView &&
+                    discoverTracks.length > 0 && (
+                        <section>
+                            <h2 className="text-2xl font-bold text-white mb-6">
+                                Songs to Discover
+                            </h2>
+                            <DiscoverTracksList tracks={discoverTracks} />
                         </section>
                     )}
 

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -621,9 +621,12 @@ export default function SearchPage() {
                               (!libraryResults.artists?.length &&
                                   !libraryResults.albums?.length &&
                                   !libraryResults.tracks?.length &&
-                                  !libraryResults.podcasts?.length &&
                                   !libraryResults.audiobooks?.length &&
-                                  !libraryResults.episodes?.length))) && (
+                                  // Library podcasts render only on the All
+                                  // and Podcasts tabs; episodes only under
+                                  // the podcast tab handled above.
+                                  (!showPodcastResults ||
+                                      !libraryResults.podcasts?.length)))) && (
                         <div className="flex flex-col items-center justify-center py-24 text-center">
                             <SearchIcon className="w-16 h-16 text-gray-400 mb-4" />
                             <h3 className="text-xl font-bold text-white mb-2">

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -20,6 +20,7 @@ import { LibraryAudiobooksGrid } from "@/features/search/components/LibraryAudio
 import { LibraryTracksList } from "@/features/search/components/LibraryTracksList";
 import { SimilarArtistsGrid } from "@/features/search/components/SimilarArtistsGrid";
 import { DiscoverTracksList } from "@/features/search/components/DiscoverTracksList";
+import { deriveDiscoverySelection } from "@/features/search/discoverySelection";
 import { AliasResolutionBanner } from "@/features/search/components/AliasResolutionBanner";
 import { SoulseekSongsList } from "@/features/search/components/SoulseekSongsList";
 import { TVSearchInput } from "@/features/search/components/TVSearchInput";
@@ -116,32 +117,29 @@ export default function SearchPage() {
     }, [urlQuery]);
 
     // Derived state
-    const discoverArtists = discoverResults.filter((r) => r.type === "music");
-    const discoverTracks = discoverResults.filter((r) => r.type === "track");
-    const normalizedQuery = query.trim().toLowerCase();
-    const exactDiscoverArtist = discoverArtists.find(
-        (artist) => artist.name.trim().toLowerCase() === normalizedQuery,
-    );
-    const libraryTopArtist = libraryResults?.artists?.[0];
-    const libraryTopIsExact =
-        libraryTopArtist?.name.trim().toLowerCase() === normalizedQuery;
+    const showLibrary =
+        filterTab === "all" || filterTab === "library" || filterTab === "peers";
+    const showDiscover = filterTab === "all" || filterTab === "discover";
+    const showSoulseek = filterTab === "all" || filterTab === "soulseek";
     // An exact-name external match beats a fuzzy library match, so
     // searching "Drake" surfaces Drake rather than an owned "Nick Drake".
-    const preferDiscoveryTopResult =
-        !!exactDiscoverArtist && !libraryTopIsExact;
-    const topArtist = exactDiscoverArtist ?? discoverArtists[0];
-    const secondaryDiscoverArtists = discoverArtists.filter(
-        (artist) => artist !== topArtist,
-    );
+    const {
+        topArtist,
+        preferDiscovery: preferDiscoveryTopResult,
+        secondaryArtists: secondaryDiscoverArtists,
+        tracks: discoverTracks,
+    } = deriveDiscoverySelection({
+        discoverResults,
+        query,
+        aliasCanonical: aliasInfo?.canonical,
+        libraryTopName: libraryResults?.artists?.[0]?.name ?? null,
+        showDiscover,
+    });
     const isLoading =
         isLibrarySearching ||
         isDiscoverSearching ||
         isSoulseekSearching ||
         isSoulseekPolling;
-    const showLibrary =
-        filterTab === "all" || filterTab === "library" || filterTab === "peers";
-    const showDiscover = filterTab === "all" || filterTab === "discover";
-    const showSoulseek = filterTab === "all" || filterTab === "soulseek";
     const showPodcastResults = filterTab === "all" || isPodcastTab;
     const discoverPodcastResults = discoverResults.filter(
         (result) => result.type === "podcast",
@@ -598,6 +596,8 @@ export default function SearchPage() {
                     (isPodcastTab
                         ? !hasPodcastResults
                         : !topArtist &&
+                          secondaryDiscoverArtists.length === 0 &&
+                          discoverTracks.length === 0 &&
                           discoverPodcastResults.length === 0 &&
                           soulseekResults.length === 0 &&
                           (!libraryResults ||

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -20,7 +20,10 @@ import { LibraryAudiobooksGrid } from "@/features/search/components/LibraryAudio
 import { LibraryTracksList } from "@/features/search/components/LibraryTracksList";
 import { SimilarArtistsGrid } from "@/features/search/components/SimilarArtistsGrid";
 import { DiscoverTracksList } from "@/features/search/components/DiscoverTracksList";
-import { deriveDiscoverySelection } from "@/features/search/discoverySelection";
+import {
+    deriveDiscoverySelection,
+    normalizeArtistName,
+} from "@/features/search/discoverySelection";
 import { AliasResolutionBanner } from "@/features/search/components/AliasResolutionBanner";
 import { SoulseekSongsList } from "@/features/search/components/SoulseekSongsList";
 import { TVSearchInput } from "@/features/search/components/TVSearchInput";
@@ -121,6 +124,11 @@ export default function SearchPage() {
         filterTab === "all" || filterTab === "library" || filterTab === "peers";
     const showDiscover = filterTab === "all" || filterTab === "discover";
     const showSoulseek = filterTab === "all" || filterTab === "soulseek";
+    // Only offer the library artist as a top result when the active
+    // filter shows library sources at all.
+    const visibleLibraryTopArtist = showLibrary
+        ? libraryResults?.artists?.[0]
+        : undefined;
     // An exact-name external match beats a fuzzy library match, so
     // searching "Drake" surfaces Drake rather than an owned "Nick Drake".
     const {
@@ -132,9 +140,18 @@ export default function SearchPage() {
         discoverResults,
         query,
         aliasCanonical: aliasInfo?.canonical,
-        libraryTopName: libraryResults?.artists?.[0]?.name ?? null,
+        libraryTopName: visibleLibraryTopArtist?.name ?? null,
         showDiscover,
     });
+    // Related Artists should never repeat the artist shown as top result.
+    const visibleSimilarArtists = topArtist
+        ? similarArtists.filter(
+              (candidate) =>
+                  normalizeArtistName(candidate.name) !==
+                      normalizeArtistName(topArtist.name) &&
+                  (!candidate.mbid || candidate.mbid !== topArtist.mbid),
+          )
+        : similarArtists;
     const isLoading =
         isLibrarySearching ||
         isDiscoverSearching ||
@@ -151,7 +168,7 @@ export default function SearchPage() {
         libraryPodcasts.length > 0 || discoverPodcastResults.length > 0;
 
     // Determine if we should show the 2-column layout
-    const hasTopResult = libraryResults?.artists?.[0] || topArtist;
+    const hasTopResult = visibleLibraryTopArtist || topArtist;
     const hasTracks = libraryTracks.length > 0 || soulseekResults.length > 0;
     const show2ColumnLayout =
         hasSearched &&
@@ -309,7 +326,7 @@ export default function SearchPage() {
                         {/* Left Column: Top Result */}
                         <div>
                             <TopResult
-                                libraryArtist={libraryResults?.artists?.[0]}
+                                libraryArtist={visibleLibraryTopArtist}
                                 discoveryArtist={topArtist}
                                 preferDiscovery={preferDiscoveryTopResult}
                             />
@@ -390,9 +407,7 @@ export default function SearchPage() {
                             !isPodcastTab && (
                                 <div>
                                     <TopResult
-                                        libraryArtist={
-                                            libraryResults?.artists?.[0]
-                                        }
+                                        libraryArtist={visibleLibraryTopArtist}
                                         discoveryArtist={topArtist}
                                         preferDiscovery={
                                             preferDiscoveryTopResult
@@ -583,9 +598,9 @@ export default function SearchPage() {
                     showDiscover &&
                     !isPodcastTab &&
                     (sectionView === null || isArtistsView) &&
-                    similarArtists.length > 0 && (
+                    visibleSimilarArtists.length > 0 && (
                         <SimilarArtistsGrid
-                            similarArtists={similarArtists}
+                            similarArtists={visibleSimilarArtists}
                             titleHref={sectionViewLinks.artists}
                         />
                     )}
@@ -598,9 +613,11 @@ export default function SearchPage() {
                         : !topArtist &&
                           secondaryDiscoverArtists.length === 0 &&
                           discoverTracks.length === 0 &&
-                          discoverPodcastResults.length === 0 &&
-                          soulseekResults.length === 0 &&
-                          (!libraryResults ||
+                          (!showPodcastResults ||
+                              discoverPodcastResults.length === 0) &&
+                          (!showSoulseek || soulseekResults.length === 0) &&
+                          (!showLibrary ||
+                              !libraryResults ||
                               (!libraryResults.artists?.length &&
                                   !libraryResults.albums?.length &&
                                   !libraryResults.tracks?.length &&

--- a/frontend/features/search/components/DiscoverTracksList.tsx
+++ b/frontend/features/search/components/DiscoverTracksList.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Music } from "lucide-react";
+import { DiscoverResult } from "../types";
+import { api } from "@/lib/api";
+import { getArtistRouteParam } from "@/utils/artistRoute";
+
+interface DiscoverTracksListProps {
+    tracks: DiscoverResult[];
+    limit?: number | null;
+}
+
+const getProxiedImageUrl = (imageUrl: string | undefined): string | null => {
+    if (!imageUrl) return null;
+    return api.getCoverArtUrl(imageUrl, 100);
+};
+
+const getTrackArtistHref = (track: DiscoverResult): string | null => {
+    if (!track.artist) return null;
+    const routeParam =
+        getArtistRouteParam(
+            { name: track.artist },
+            { preferLibraryId: false },
+        ) || encodeURIComponent(track.artist);
+    return `/artist/${routeParam}`;
+};
+
+/**
+ * Renders external (Last.fm) track search results so users can discover
+ * songs that are not in their library and jump to the artist page.
+ */
+export function DiscoverTracksList({
+    tracks,
+    limit = 10,
+}: DiscoverTracksListProps) {
+    if (tracks.length === 0) {
+        return null;
+    }
+
+    const visibleTracks = limit === null ? tracks : tracks.slice(0, limit);
+
+    return (
+        <div className="space-y-1" data-tv-section="search-discover-tracks">
+            {visibleTracks.map((track, index) => {
+                const imageUrl = getProxiedImageUrl(track.image);
+                const artistHref = getTrackArtistHref(track);
+                const key = `discover-track-${track.id || track.name}-${index}`;
+
+                const artwork = (
+                    <div className="relative w-10 h-10 rounded bg-surface-elevated flex items-center justify-center overflow-hidden shrink-0">
+                        {imageUrl ? (
+                            <Image
+                                src={imageUrl}
+                                alt={track.name}
+                                fill
+                                sizes="40px"
+                                className="object-cover"
+                                unoptimized
+                            />
+                        ) : (
+                            <Music className="w-5 h-5 text-gray-400" />
+                        )}
+                    </div>
+                );
+
+                const body = (
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-white truncate">
+                            {track.name}
+                        </p>
+                        <p className="text-xs text-gray-400 truncate">
+                            {track.artist}
+                            {track.album ? ` — ${track.album}` : ""}
+                        </p>
+                    </div>
+                );
+
+                if (!artistHref) {
+                    return (
+                        <div
+                            key={key}
+                            className="flex items-center gap-4 p-3 rounded-lg"
+                        >
+                            {artwork}
+                            {body}
+                        </div>
+                    );
+                }
+
+                return (
+                    <Link
+                        key={key}
+                        href={artistHref}
+                        className="flex items-center gap-4 p-3 rounded-lg hover:bg-white/5 transition-colors"
+                        data-tv-card
+                        data-tv-card-index={index}
+                        tabIndex={0}
+                    >
+                        {artwork}
+                        {body}
+                    </Link>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/features/search/components/TopResult.tsx
+++ b/frontend/features/search/components/TopResult.tsx
@@ -8,21 +8,30 @@ import { PeerBadge } from "@/components/ui/PeerBadge";
 interface TopResultProps {
     libraryArtist?: Artist;
     discoveryArtist?: DiscoverResult;
+    preferDiscovery?: boolean;
 }
 
 /**
  * Renders the TopResult component.
  */
-export function TopResult({ libraryArtist, discoveryArtist }: TopResultProps) {
-    // Prefer library artist over discovery
+export function TopResult({
+    libraryArtist,
+    discoveryArtist,
+    preferDiscovery = false,
+}: TopResultProps) {
+    // Prefer library artist over discovery unless the discovery result is
+    // an exact match for the query and the library artist is only fuzzy.
     if (!libraryArtist && !discoveryArtist) {
         return null;
     }
 
-    const isLibrary = !!libraryArtist;
+    const isLibrary =
+        !!libraryArtist && !(preferDiscovery && !!discoveryArtist);
 
     // Get the display name
-    const name = libraryArtist?.name || discoveryArtist?.name || "";
+    const name = isLibrary
+        ? libraryArtist?.name || ""
+        : discoveryArtist?.name || "";
 
     // Get the artist ID for linking - prefer MBID for consistent URLs
     const artistId = isLibrary
@@ -74,7 +83,8 @@ export function TopResult({ libraryArtist, discoveryArtist }: TopResultProps) {
                         {name}
                     </h3>
                     <p className="text-sm text-white font-bold">Artist</p>
-                    {libraryArtist?.source === "federated" &&
+                    {isLibrary &&
+                        libraryArtist?.source === "federated" &&
                         libraryArtist.peer && (
                             <PeerBadge
                                 className="mt-2"

--- a/frontend/features/search/discoverySelection.ts
+++ b/frontend/features/search/discoverySelection.ts
@@ -1,0 +1,85 @@
+import type { DiscoverResult } from "./types";
+
+export interface DiscoverySelectionInput {
+    discoverResults: DiscoverResult[];
+    query: string;
+    aliasCanonical?: string | null;
+    libraryTopName?: string | null;
+    showDiscover: boolean;
+}
+
+export interface DiscoverySelection {
+    /** The external artist to offer as the top result, if any. */
+    topArtist: DiscoverResult | undefined;
+    /** True when the external artist should beat the library artist. */
+    preferDiscovery: boolean;
+    /** True when TopResult will actually display the external artist. */
+    discoveryShownAsTop: boolean;
+    /** External artists for the Artists section (top excluded only when shown). */
+    secondaryArtists: DiscoverResult[];
+    /** External track matches. */
+    tracks: DiscoverResult[];
+}
+
+/**
+ * Normalizes an artist name for exact-match comparison: trims, lowercases,
+ * and strips diacritics so a corrected "bjork" query matches "Björk".
+ */
+export function normalizeArtistName(value: string): string {
+    return value.trim().toLowerCase().normalize("NFKD").replace(/\p{M}/gu, "");
+}
+
+/**
+ * Derives which external search results to surface and whether an
+ * exact-name external match should beat a fuzzy library match, honoring
+ * the active source filter and the backend's alias correction.
+ */
+export function deriveDiscoverySelection({
+    discoverResults,
+    query,
+    aliasCanonical,
+    libraryTopName,
+    showDiscover,
+}: DiscoverySelectionInput): DiscoverySelection {
+    // Nothing external is selectable when the active filter hides discovery.
+    if (!showDiscover) {
+        return {
+            topArtist: undefined,
+            preferDiscovery: false,
+            discoveryShownAsTop: false,
+            secondaryArtists: [],
+            tracks: [],
+        };
+    }
+
+    const artists = discoverResults.filter((r) => r.type === "music");
+    const tracks = discoverResults.filter((r) => r.type === "track");
+
+    const exactTargets = [query, aliasCanonical ?? ""]
+        .map((value) => normalizeArtistName(value))
+        .filter(Boolean);
+
+    const matchesExactly = (name: string) =>
+        exactTargets.includes(normalizeArtistName(name));
+
+    const exactArtist = artists.find((artist) => matchesExactly(artist.name));
+    const libraryTopIsExact =
+        !!libraryTopName && matchesExactly(libraryTopName);
+
+    const topArtist = exactArtist ?? artists[0];
+    const preferDiscovery = !!exactArtist && !libraryTopIsExact;
+    const discoveryShownAsTop =
+        !!topArtist && (preferDiscovery || !libraryTopName);
+
+    const secondaryArtists = discoveryShownAsTop
+        ? artists.filter((artist) => artist !== topArtist)
+        : artists;
+
+    return {
+        topArtist,
+        preferDiscovery,
+        discoveryShownAsTop,
+        secondaryArtists,
+        tracks,
+    };
+}

--- a/frontend/features/search/hooks/useSearchData.ts
+++ b/frontend/features/search/hooks/useSearchData.ts
@@ -4,6 +4,7 @@ import {
     useDiscoverSimilarArtistsQuery,
 } from "@/hooks/useQueries";
 import type { SearchResult, DiscoverResult, AliasInfo } from "../types";
+import { deriveDiscoverySelection } from "../discoverySelection";
 import { useMemo } from "react";
 
 interface UseSearchDataProps {
@@ -64,11 +65,19 @@ export function useSearchData({
         return discoverData?.aliasInfo || null;
     }, [discoverData]);
 
-    // Derive top artist for the similar artists query
+    // Derive top artist for the similar artists query, using the same
+    // exact-match-aware selection the search page shows as the top result.
     const topArtist = useMemo(() => {
-        const first = discoverResults.find((r) => r.type === "music");
-        return first ? { name: first.name, mbid: first.mbid || "" } : null;
-    }, [discoverResults]);
+        const selection = deriveDiscoverySelection({
+            discoverResults,
+            query,
+            aliasCanonical: aliasInfo?.canonical,
+            libraryTopName: null,
+            showDiscover: true,
+        });
+        const seed = selection.topArtist;
+        return seed ? { name: seed.name, mbid: seed.mbid || "" } : null;
+    }, [discoverResults, query, aliasInfo]);
 
     // Separate query for similar artists -- fires after discover results load
     const { data: similarData } = useDiscoverSimilarArtistsQuery(

--- a/frontend/features/search/types.ts
+++ b/frontend/features/search/types.ts
@@ -99,12 +99,13 @@ export interface SearchResult {
 }
 
 export interface DiscoverResult {
-    type: "music" | "podcast";
+    type: "music" | "podcast" | "track";
     id?: string;
     name: string;
     mbid?: string;
     image?: string;
     artist?: string;
+    album?: string | null;
     coverUrl?: string;
     description?: string;
     feedUrl?: string;

--- a/frontend/tests/component/searchExternalDiscovery.component.test.ts
+++ b/frontend/tests/component/searchExternalDiscovery.component.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("lucide-react", {
+    namedExports: {
+        Music: () => React.createElement("svg", { "data-icon": "music" }),
+    },
+});
+
+mock.module("next/image", {
+    defaultExport: ({ alt }: { alt?: string }) =>
+        React.createElement("img", { alt }),
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getCoverArtUrl: (url: string) => `/proxied/${url}`,
+        },
+    },
+});
+
+mock.module("@/components/ui/PeerBadge", {
+    namedExports: {
+        PeerBadge: () => React.createElement("span"),
+    },
+});
+
+mock.module("@/lib/format", {
+    namedExports: {
+        formatListeners: (value: number) => String(value),
+    },
+});
+
+const libraryArtist = {
+    id: "lib-1",
+    name: "Nick Drake",
+    heroUrl: "",
+};
+
+const discoveryArtist = {
+    type: "music",
+    name: "Drake",
+    mbid: "b49b81cc-d5b7-4bdd-aadb-385df8de69a6",
+    image: "",
+};
+
+async function renderTopResult(preferDiscovery: boolean) {
+    const { TopResult } =
+        await import("../../features/search/components/TopResult");
+    return renderToStaticMarkup(
+        React.createElement(TopResult, {
+            libraryArtist,
+            discoveryArtist,
+            preferDiscovery,
+        } as never),
+    );
+}
+
+test("top result prefers the library artist by default", async () => {
+    const html = await renderTopResult(false);
+    assert.match(html, /Nick Drake/);
+    assert.match(html, /href="\/artist\/lib-1"/);
+});
+
+test("top result prefers an exact external match when asked", async () => {
+    const html = await renderTopResult(true);
+    assert.match(html, />Drake</);
+    assert.match(html, /href="\/artist\/b49b81cc-d5b7-4bdd-aadb-385df8de69a6"/);
+    assert.doesNotMatch(html, /Nick Drake/);
+});
+
+test("discover tracks render artist links and album context", async () => {
+    const { DiscoverTracksList } =
+        await import("../../features/search/components/DiscoverTracksList");
+    const html = renderToStaticMarkup(
+        React.createElement(DiscoverTracksList, {
+            tracks: [
+                {
+                    type: "track",
+                    id: "t1",
+                    name: "Headlines",
+                    artist: "Drake",
+                    album: "Take Care",
+                    image: "",
+                },
+                {
+                    type: "track",
+                    id: "t2",
+                    name: "Orphan Song",
+                    artist: "",
+                    album: null,
+                    image: "",
+                },
+            ],
+        } as never),
+    );
+
+    assert.match(html, /Headlines/);
+    assert.match(html, /Drake — Take Care/);
+    assert.match(html, /href="\/artist\/Drake"/);
+    assert.match(html, /Orphan Song/);
+    assert.doesNotMatch(html, /href="\/artist\/"/);
+});

--- a/frontend/tests/unit/discoverySelection.test.ts
+++ b/frontend/tests/unit/discoverySelection.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    deriveDiscoverySelection,
+    normalizeArtistName,
+} from "../../features/search/discoverySelection";
+import type { DiscoverResult } from "../../features/search/types";
+
+const artist = (name: string, mbid?: string): DiscoverResult => ({
+    type: "music",
+    name,
+    mbid,
+});
+
+const track = (name: string, artistName: string): DiscoverResult => ({
+    type: "track",
+    name,
+    artist: artistName,
+});
+
+test("normalizeArtistName strips case, whitespace, and diacritics", () => {
+    assert.equal(normalizeArtistName("  Björk "), "bjork");
+    assert.equal(normalizeArtistName("DRAKE"), "drake");
+});
+
+test("exact external match beats a fuzzy library match", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Drake", "mbid-1"), artist("Drake Bell")],
+        query: "drake",
+        aliasCanonical: null,
+        libraryTopName: "Nick Drake",
+        showDiscover: true,
+    });
+
+    assert.equal(selection.topArtist?.name, "Drake");
+    assert.equal(selection.preferDiscovery, true);
+    assert.equal(selection.discoveryShownAsTop, true);
+    assert.deepEqual(
+        selection.secondaryArtists.map((a) => a.name),
+        ["Drake Bell"],
+    );
+});
+
+test("an exact library match keeps the library artist on top", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Drake Bell")],
+        query: "drake",
+        aliasCanonical: null,
+        libraryTopName: "Drake",
+        showDiscover: true,
+    });
+
+    assert.equal(selection.preferDiscovery, false);
+    // The library side wins, so no external artist is consumed by the
+    // top result and all of them stay in the Artists section.
+    assert.equal(selection.discoveryShownAsTop, false);
+    assert.deepEqual(
+        selection.secondaryArtists.map((a) => a.name),
+        ["Drake Bell"],
+    );
+});
+
+test("alias-corrected queries count as exact matches", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Björk", "mbid-b")],
+        query: "bjork",
+        aliasCanonical: "Björk",
+        libraryTopName: "Bjorn Again",
+        showDiscover: true,
+    });
+
+    assert.equal(selection.topArtist?.name, "Björk");
+    assert.equal(selection.preferDiscovery, true);
+});
+
+test("library and peers filters select nothing external", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Drake"), track("Headlines", "Drake")],
+        query: "drake",
+        aliasCanonical: null,
+        libraryTopName: "Nick Drake",
+        showDiscover: false,
+    });
+
+    assert.equal(selection.topArtist, undefined);
+    assert.equal(selection.preferDiscovery, false);
+    assert.deepEqual(selection.secondaryArtists, []);
+    assert.deepEqual(selection.tracks, []);
+});
+
+test("no library artist means the external top comes off the artist list", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Drake"), artist("Drake Bell")],
+        query: "drizzy",
+        aliasCanonical: null,
+        libraryTopName: null,
+        showDiscover: true,
+    });
+
+    assert.equal(selection.topArtist?.name, "Drake");
+    assert.equal(selection.discoveryShownAsTop, true);
+    assert.deepEqual(
+        selection.secondaryArtists.map((a) => a.name),
+        ["Drake Bell"],
+    );
+});
+
+test("tracks pass through when discovery is visible", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [track("Headlines", "Drake")],
+        query: "headlines",
+        aliasCanonical: null,
+        libraryTopName: null,
+        showDiscover: true,
+    });
+
+    assert.equal(selection.tracks.length, 1);
+    assert.equal(selection.topArtist, undefined);
+});

--- a/frontend/tests/unit/discoverySelection.test.ts
+++ b/frontend/tests/unit/discoverySelection.test.ts
@@ -61,10 +61,25 @@ test("an exact library match keeps the library artist on top", () => {
 });
 
 test("alias-corrected queries count as exact matches", () => {
+    // "beatles" only matches "The Beatles" through the alias canonical,
+    // not through normalization, so this pins the alias path itself.
     const selection = deriveDiscoverySelection({
-        discoverResults: [artist("Björk", "mbid-b")],
+        discoverResults: [artist("The Beatles", "mbid-b")],
+        query: "beatles",
+        aliasCanonical: "The Beatles",
+        libraryTopName: "Beatallica",
+        showDiscover: true,
+    });
+
+    assert.equal(selection.topArtist?.name, "The Beatles");
+    assert.equal(selection.preferDiscovery, true);
+});
+
+test("diacritic-only differences count as exact without an alias", () => {
+    const selection = deriveDiscoverySelection({
+        discoverResults: [artist("Björk", "mbid-bj")],
         query: "bjork",
-        aliasCanonical: "Björk",
+        aliasCanonical: null,
         libraryTopName: "Bjorn Again",
         showDiscover: true,
     });


### PR DESCRIPTION
## Summary
Phase 1 of the search-discovery overhaul (all frontend; the data was already fetched and thrown away):

- **Top result relevance**: an exact-name external artist match now beats a fuzzy library match — searching "Drake" surfaces Drake instead of an owned "Nick Drake". `TopResult` gains a `preferDiscovery` prop; name/image/peer-badge resolution all follow the chosen side (the old code could show the library name with the external link).
- **Artists section**: the remaining external artist matches (previously only `[0]` was used) render via the existing grid component.
- **Songs to Discover**: external track matches (previously fetched by `/api/search/discover` and silently dropped) render as a list with artwork, artist — album context, and artist-page links.

Follow-ups in flight separately: track → album resolution + download affordance (backend service in review), YT/Tidal text-search sections.

## Testing
- New behavioral component tests: library-first default, exact-external preference (caught a real name/link mismatch bug during development), track list rendering with and without artist links — 3/3 pass.
- `tsc --noEmit` clean; frontend lint 0 errors; pinned prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)