### PR TITLE
fix: use canonical remote track IDs for preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).
 - Audiobook series and library cover-art routes now preserve Express-decoded percent signs, encoded-looking sequences, and Unicode while retaining compatibility with legacy double-encoded route parameters (#632).
 - Artist detail and discovery routes now preserve artist names with percent signs while retaining lookup compatibility for legacy double-encoded names (#632).
 - Transient authentication-backend, rate-limit, network, and timeout failures no longer clear browser sessions when Explore triggers concurrent API requests; refresh retries now distinguish temporary unavailability from rejected credentials (#635).

--- a/frontend/app/artist/[id]/page.tsx
+++ b/frontend/app/artist/[id]/page.tsx
@@ -16,6 +16,7 @@ import { api } from "@/lib/api";
 import { toast } from "sonner";
 import { useListenTogether } from "@/lib/listen-together-context";
 import { PlaylistSelector } from "@/components/ui/PlaylistSelector";
+import { resolvePreferenceTrackId } from "@/lib/trackRef";
 
 // Hooks
 import { useArtistData } from "@/features/artist/hooks/useArtistData";
@@ -199,7 +200,11 @@ export default function ArtistPage() {
     }
 
     const formatTrackForPlayback = (t: Track) => ({
-        id: t.id,
+        id: resolvePreferenceTrackId({
+            ...t,
+            hasLocalFile:
+                typeof t.filePath === "string" && t.filePath.trim().length > 0,
+        }),
         title: t.title,
         artist: {
             name: t.artist?.name || artist!.name,

--- a/frontend/features/artist/components/PopularTracks.tsx
+++ b/frontend/features/artist/components/PopularTracks.tsx
@@ -109,6 +109,13 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                 !isTidalTrack &&
                 !isYtMusic;
 
+            const preferenceTrackId =
+                isTidalTrack && track.tidalTrackId
+                    ? `tidal:${track.tidalTrackId}`
+                    : isYtMusic && track.youtubeVideoId
+                      ? `yt:${track.youtubeVideoId}`
+                      : track.id;
+
             return {
                 titleBadges: (
                     <>
@@ -145,11 +152,14 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                             </span>
                         )}
                         <TrackPreferenceButtons
-                            trackId={track.id}
+                            trackId={preferenceTrackId}
                             mode="both"
                             buttonSizeClassName="h-8 w-8"
                             iconSizeClassName="h-4 w-4"
-                            metadata={buildPreferenceMetadata(track)}
+                            metadata={buildPreferenceMetadata({
+                                ...track,
+                                id: preferenceTrackId,
+                            })}
                         />
                         {isPlayable && (
                             <TrackOverflowMenu

--- a/frontend/features/artist/components/PopularTracks.tsx
+++ b/frontend/features/artist/components/PopularTracks.tsx
@@ -14,6 +14,7 @@ import type { TrackRowItem, TrackRowSlots, RowState } from "@/components/track";
 import { TrackOverflowMenu } from "@/components/ui/TrackOverflowMenu";
 import { TrackPreferenceButtons } from "@/components/player/TrackPreferenceButtons";
 import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
+import { resolvePreferenceTrackId } from "@/lib/trackRef";
 
 /** Default number of popular tracks shown in collapsed state. */
 export const POPULAR_COLLAPSED_COUNT = 5;
@@ -109,12 +110,10 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                 !isTidalTrack &&
                 !isYtMusic;
 
-            const preferenceTrackId =
-                isTidalTrack && track.tidalTrackId
-                    ? `tidal:${track.tidalTrackId}`
-                    : isYtMusic && track.youtubeVideoId
-                      ? `yt:${track.youtubeVideoId}`
-                      : track.id;
+            const preferenceTrackId = resolvePreferenceTrackId({
+                ...track,
+                hasLocalFile,
+            });
 
             return {
                 titleBadges: (

--- a/frontend/lib/trackRef.ts
+++ b/frontend/lib/trackRef.ts
@@ -1,4 +1,7 @@
-import type { CanonicalMediaSource } from "@soundspan/media-metadata-contract";
+import type {
+    CanonicalMediaSource,
+    UnifiedTrackSource,
+} from "@soundspan/media-metadata-contract";
 
 export type TrackRef =
     | { trackId: string }
@@ -28,6 +31,8 @@ type ProviderSource = CanonicalMediaSource;
 
 type TrackRefInput = {
     id?: string | null;
+    hasLocalFile?: boolean;
+    source?: UnifiedTrackSource | null;
     title?: string | null;
     displayTitle?: string | null;
     duration?: number | string | null;
@@ -166,6 +171,62 @@ function resolveTidalTrackId(input: TrackRefInput): number | null {
     }
 
     return null;
+}
+
+function hasPersistedPreferenceIdentity(input: TrackRefInput): boolean {
+    return (
+        input.hasLocalFile === true ||
+        input.source === "local" ||
+        input.source === "federated" ||
+        resolveStreamSource(input) === "local"
+    );
+}
+
+/**
+ * Resolves the stable track identity shared by preferences and player surfaces.
+ * Persisted local and federated rows retain their database id even when provider
+ * metadata has enriched the row for fallback playback.
+ */
+export function resolvePreferenceTrackId(
+    input: TrackRefInput & { id: string },
+): string {
+    if (hasPersistedPreferenceIdentity(input)) {
+        return input.id;
+    }
+
+    const prefixed = prefixedTrackIdRef(input.id);
+    if (prefixed && "tidalTrackId" in prefixed) {
+        return `tidal:${prefixed.tidalTrackId}`;
+    }
+    if (prefixed && "youtubeVideoId" in prefixed) {
+        return `yt:${prefixed.youtubeVideoId}`;
+    }
+
+    const providerSource =
+        resolveStreamSource(input) ??
+        (input.source === "tidal" || input.source === "youtube"
+            ? input.source
+            : null);
+    const tidalTrackId = resolveTidalTrackId(input);
+    const youtubeVideoId = resolveYouTubeVideoId(input);
+
+    if (providerSource === "tidal" && tidalTrackId !== null) {
+        return `tidal:${tidalTrackId}`;
+    }
+    if (
+        (providerSource === "youtube" || providerSource === "youtube-direct") &&
+        youtubeVideoId
+    ) {
+        return `yt:${youtubeVideoId}`;
+    }
+    if (tidalTrackId !== null) {
+        return `tidal:${tidalTrackId}`;
+    }
+    if (youtubeVideoId) {
+        return `yt:${youtubeVideoId}`;
+    }
+
+    return input.id;
 }
 
 /**

--- a/frontend/tests/component/artistTrackPreferenceIdentity.component.test.ts
+++ b/frontend/tests/component/artistTrackPreferenceIdentity.component.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import type { Root } from "react-dom/client";
+
+GlobalRegistrator.register();
+
+type PreferenceSignal = "thumbs_up" | "thumbs_down" | "clear";
+
+interface PreferenceResponse {
+    trackId: string;
+    signal: PreferenceSignal;
+    state: "liked" | "disliked" | "neutral";
+    score: number;
+    likedAt: string | null;
+    dislikedAt: string | null;
+    updatedAt: string;
+}
+
+interface PreferenceCall {
+    trackId: string;
+    signal: PreferenceSignal;
+    metadata?: Record<string, unknown>;
+}
+
+interface TestTrack {
+    id: string;
+    title: string;
+    duration: number;
+    artist: { name: string };
+    album: { title: string };
+    streamSource: "tidal" | "youtube";
+    tidalTrackId?: number;
+    youtubeVideoId?: string;
+    hasLocalFile: boolean;
+}
+
+interface MountedPreferences {
+    container: HTMLDivElement;
+    root: Root;
+    queryClient: QueryClient;
+    localPreferenceId: string;
+    remotePreferenceId: string;
+}
+
+type PreferenceButtonComponent =
+    typeof import("../../components/player/TrackPreferenceButtons").TrackPreferenceButtons;
+type MetadataBuilder =
+    typeof import("../../hooks/useTrackPreference").buildPreferenceMetadata;
+
+const localTrack: TestTrack = {
+    id: "local-track-id",
+    title: "Local Match",
+    duration: 180,
+    artist: { name: "Artist" },
+    album: { title: "Unknown Album" },
+    streamSource: "tidal",
+    tidalTrackId: 101,
+    hasLocalFile: true,
+};
+
+const remoteTrack: TestTrack = {
+    id: "provider-result-id",
+    title: "Remote Match",
+    duration: 200,
+    artist: { name: "Artist" },
+    album: { title: "Unknown Album" },
+    streamSource: "youtube",
+    youtubeVideoId: "video-202",
+    hasLocalFile: false,
+};
+
+const preferences = new Map<string, PreferenceResponse>();
+const getCalls: string[] = [];
+const setCalls: PreferenceCall[] = [];
+
+function preferenceResponse(
+    trackId: string,
+    signal: PreferenceSignal,
+): PreferenceResponse {
+    const isLiked = signal === "thumbs_up";
+    const isDisliked = signal === "thumbs_down";
+
+    return {
+        trackId,
+        signal,
+        state: isLiked ? "liked" : isDisliked ? "disliked" : "neutral",
+        score: isLiked ? 1 : isDisliked ? -1 : 0,
+        likedAt: isLiked ? "2026-08-19T12:00:00.000Z" : null,
+        dislikedAt: isDisliked ? "2026-08-19T12:00:00.000Z" : null,
+        updatedAt: "2026-08-19T12:00:00.000Z",
+    };
+}
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getTrackPreference: async (trackId: string) => {
+                getCalls.push(trackId);
+                return (
+                    preferences.get(trackId) ??
+                    preferenceResponse(trackId, "clear")
+                );
+            },
+            setTrackPreference: async (
+                trackId: string,
+                signal: PreferenceSignal,
+                metadata?: Record<string, unknown>,
+            ) => {
+                setCalls.push({ trackId, signal, metadata });
+                const response = preferenceResponse(trackId, signal);
+                preferences.set(trackId, response);
+                return response;
+            },
+        },
+    },
+});
+
+after(() => {
+    GlobalRegistrator.unregister();
+});
+
+beforeEach(() => {
+    preferences.clear();
+    preferences.set(
+        "local-track-id",
+        preferenceResponse("local-track-id", "thumbs_up"),
+    );
+    getCalls.length = 0;
+    setCalls.length = 0;
+});
+
+async function flushQueries() {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+        await React.act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+    }
+}
+
+function preferenceControl(
+    Component: PreferenceButtonComponent,
+    buildMetadata: MetadataBuilder,
+    track: TestTrack,
+    trackId: string,
+    testId: string,
+) {
+    return React.createElement(
+        "div",
+        { "data-testid": testId },
+        React.createElement(Component, {
+            trackId,
+            metadata: buildMetadata({ ...track, id: trackId }),
+        }),
+    );
+}
+
+async function mountPreferences(): Promise<MountedPreferences> {
+    const { resolvePreferenceTrackId } = await import("../../lib/trackRef");
+    const { buildPreferenceMetadata } =
+        await import("../../hooks/useTrackPreference");
+    const { TrackPreferenceButtons } =
+        await import("../../components/player/TrackPreferenceButtons");
+    const { createRoot } = await import("react-dom/client");
+    const localPreferenceId = resolvePreferenceTrackId(localTrack);
+    const remotePreferenceId = resolvePreferenceTrackId(remoteTrack);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(
+                QueryClientProvider,
+                { client: queryClient },
+                React.createElement(
+                    React.Fragment,
+                    null,
+                    preferenceControl(
+                        TrackPreferenceButtons,
+                        buildPreferenceMetadata,
+                        localTrack,
+                        localPreferenceId,
+                        "local-preference",
+                    ),
+                    preferenceControl(
+                        TrackPreferenceButtons,
+                        buildPreferenceMetadata,
+                        remoteTrack,
+                        remotePreferenceId,
+                        "remote-preference",
+                    ),
+                ),
+            ),
+        );
+    });
+
+    return {
+        container,
+        root,
+        queryClient,
+        localPreferenceId,
+        remotePreferenceId,
+    };
+}
+
+async function cleanupPreferences(mounted: MountedPreferences) {
+    await React.act(async () => mounted.root.unmount());
+    mounted.container.remove();
+    mounted.queryClient.clear();
+}
+
+function getPreferenceButton(container: HTMLDivElement, testId: string) {
+    const button = container.querySelector<HTMLButtonElement>(
+        `[data-testid="${testId}"] button`,
+    );
+    assert.ok(button);
+    return button;
+}
+
+test("artist preferences preserve local identity and persist remote provider identity", async (testContext) => {
+    const mounted = await mountPreferences();
+    testContext.after(() => cleanupPreferences(mounted));
+    await flushQueries();
+
+    const localButton = getPreferenceButton(
+        mounted.container,
+        "local-preference",
+    );
+    const remoteButton = getPreferenceButton(
+        mounted.container,
+        "remote-preference",
+    );
+    assert.equal(mounted.localPreferenceId, "local-track-id");
+    assert.equal(mounted.remotePreferenceId, "yt:video-202");
+    assert.equal(localButton.getAttribute("aria-label"), "Unlike");
+    assert.equal(remoteButton.getAttribute("aria-label"), "Like");
+    assert.deepEqual(getCalls.sort(), ["local-track-id", "yt:video-202"]);
+
+    await React.act(async () => remoteButton.click());
+    await flushQueries();
+
+    assert.equal(remoteButton.getAttribute("aria-label"), "Unlike");
+    assert.deepEqual(setCalls, [
+        {
+            trackId: "yt:video-202",
+            signal: "thumbs_up",
+            metadata: {
+                title: "Remote Match",
+                artist: "Artist",
+                album: "Unknown Album",
+                duration: 200,
+                thumbnailUrl: undefined,
+            },
+        },
+    ]);
+});

--- a/frontend/tests/component/providerTrackLists.component.test.ts
+++ b/frontend/tests/component/providerTrackLists.component.test.ts
@@ -251,9 +251,12 @@ test("artist PopularTracks limits visible items and renders provider states", as
             album: { id: "unknown", title: "Unknown Album", coverArt: null },
         },
         {
-            id: "p-preview",
-            title: "Preview Only",
+            id: "p-local-enriched",
+            title: "Local Provider Match",
             duration: 180,
+            filePath: "/music/local-provider-match.flac",
+            streamSource: "tidal",
+            tidalTrackId: 99,
             album: { id: "", title: "Unknown Album", coverArt: null },
         },
         {
@@ -317,7 +320,11 @@ test("artist PopularTracks limits visible items and renders provider states", as
     assert.match(html, /data-track-id="yt:yt-id"/);
     assert.match(html, /data-track-id="tidal:101"/);
 
-    // Non-provider tracks keep their original local/discovery IDs.
+    // Provider-enriched persisted tracks keep their original local ID.
+    assert.match(html, /data-track-id="p-local-enriched"/);
+    assert.doesNotMatch(html, /data-track-id="tidal:99"/);
+
+    // Non-provider tracks keep their original discovery IDs.
     assert.match(html, /data-track-id="p-loading"/);
 
     assert.doesNotMatch(html, /Hidden Sixth/);

--- a/frontend/tests/component/providerTrackLists.component.test.ts
+++ b/frontend/tests/component/providerTrackLists.component.test.ts
@@ -312,6 +312,14 @@ test("artist PopularTracks limits visible items and renders provider states", as
     assert.match(html, /YT/);
     assert.match(html, /IN QUEUE/);
     assert.match(html, /#12/);
+
+    // Remote provider tracks must use canonical IDs for preference actions.
+    assert.match(html, /data-track-id="yt:yt-id"/);
+    assert.match(html, /data-track-id="tidal:101"/);
+
+    // Non-provider tracks keep their original local/discovery IDs.
+    assert.match(html, /data-track-id="p-loading"/);
+
     assert.doesNotMatch(html, /Hidden Sixth/);
 });
 


### PR DESCRIPTION
## Summary

Fix preference actions for TIDAL and YouTube Music tracks shown in artist Popular Tracks.

Provider-matched tracks can have a normal discovery/local `track.id` while their canonical remote IDs are available separately. Playback works using the provider-specific ID, but `PopularTracks` was passing the original `track.id` to the preference controls, so remote likes/dislikes could fail to persist correctly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Code cleanup / refactoring
- [ ] Other

## Related Issues

Fixes #642

## Changes Made

- Use `tidal:<tidalTrackId>` for TIDAL preference actions.
- Use `yt:<youtubeVideoId>` for YouTube Music preference actions.
- Preserve the existing `track.id` for non-provider tracks.
- Pass the canonical ID into preference metadata as well.
- Add regression coverage for TIDAL, YouTube Music, and non-provider tracks.

## Verification

- [x] Tests pass locally
- [x] Additional targeted checks

### Additional Verification Details

Targeted frontend component test:

`frontend/tests/component/providerTrackLists.component.test.ts`

Result:

- 4 tests passed
- 0 tests failed

The fix was also verified in a Docker deployment by successfully liking a remote TIDAL artist track after the change.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's contribution guidelines
- [x] I have tested my changes
- [x] I have linked the related issue