### PR TITLE
fix: preserve remote-backed library entities during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).
+- Orphan cleanup now preserves TIDAL- and YouTube Music-backed albums and artists across scheduled, library, and legacy-discovery cleanup paths, including provider links created concurrently with cleanup (#645).
 - Audiobook series and library cover-art routes now preserve Express-decoded percent signs, encoded-looking sequences, and Unicode while retaining compatibility with legacy double-encoded route parameters (#632).
 - Artist detail and discovery routes now preserve artist names with percent signs while retaining lookup compatibility for legacy double-encoded names (#632).
 - Transient authentication-backend, rate-limit, network, and timeout failures no longer clear browser sessions when Explore triggers concurrent API requests; refresh retries now distinguish temporary unavailability from rejected credentials (#635).

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -56,6 +56,7 @@ const prisma = {
         update: jest.fn(async () => undefined),
         updateMany: jest.fn(async () => ({ count: 0 })),
         delete: jest.fn(async () => undefined),
+        deleteMany: jest.fn(async () => ({ count: 1 })),
     },
     ownedAlbum: {
         findFirst: jest.fn(async () => null),
@@ -888,6 +889,29 @@ describe("discover legacy-mode runtime behavior", () => {
         expect(prisma.album.delete).toHaveBeenCalledWith({
             where: { id: "album-active" },
         });
+        expect(prisma.album.findMany).toHaveBeenCalledWith({
+            where: {
+                location: "DISCOVER",
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+            include: { artist: true, tracks: true },
+        });
+        expect(prisma.album.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: "orphan-album-1",
+                location: "DISCOVER",
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+        });
+        expect(prisma.artist.findMany).toHaveBeenCalledWith({
+            where: {
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+        });
         expect(prisma.similarArtist.deleteMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: {
@@ -898,6 +922,14 @@ describe("discover legacy-mode runtime behavior", () => {
                 },
             }),
         );
+        expect(prisma.artist.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["artist-orphan"] },
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+        });
         expect(scanQueue.add).toHaveBeenCalledWith("scan", {
             userId: "user-1",
             musicPath: "/music",

--- a/backend/src/routes/discover/legacy/clear.ts
+++ b/backend/src/routes/discover/legacy/clear.ts
@@ -715,6 +715,8 @@ export async function handleLegacyClear(
         const orphanedAlbums = await prisma.album.findMany({
             where: {
                 location: "DISCOVER",
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
             include: { artist: true, tracks: true },
         });
@@ -749,13 +751,20 @@ export async function handleLegacyClear(
                     where: { albumId: orphanAlbum.id },
                 });
                 // Delete album
-                await prisma.album.delete({
-                    where: { id: orphanAlbum.id },
+                const deletedAlbum = await prisma.album.deleteMany({
+                    where: {
+                        id: orphanAlbum.id,
+                        location: "DISCOVER",
+                        tracksTidal: { none: {} },
+                        tracksYtMusic: { none: {} },
+                    },
                 });
-                orphanedAlbumsDeleted++;
-                logger.debug(
-                    `    Deleted orphaned album: ${orphanAlbum.artist.name} - ${orphanAlbum.title}`,
-                );
+                if (deletedAlbum.count > 0) {
+                    orphanedAlbumsDeleted += deletedAlbum.count;
+                    logger.debug(
+                        `    Deleted orphaned album: ${orphanAlbum.artist.name} - ${orphanAlbum.title}`,
+                    );
+                }
             }
         }
 
@@ -788,12 +797,19 @@ export async function handleLegacyClear(
                 },
             });
 
-            await prisma.artist.deleteMany({
-                where: { id: { in: orphanIds } },
+            const deletedArtists = await prisma.artist.deleteMany({
+                where: {
+                    id: { in: orphanIds },
+                    albums: { none: {} },
+                    tracksTidal: { none: {} },
+                    tracksYtMusic: { none: {} },
+                },
             });
-            logger.debug(
-                `  Cleaned up ${orphanedArtists.length} orphaned artists`,
-            );
+            if (deletedArtists.count > 0) {
+                logger.debug(
+                    `  Cleaned up ${deletedArtists.count} orphaned artists`,
+                );
+            }
         }
 
         // Clean up orphaned DiscoveryTrack records (tracks whose album was deleted)

--- a/backend/src/routes/discover/legacy/clear.ts
+++ b/backend/src/routes/discover/legacy/clear.ts
@@ -769,6 +769,8 @@ export async function handleLegacyClear(
         const orphanedArtists = await prisma.artist.findMany({
             where: {
                 albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
         });
 

--- a/backend/src/services/__tests__/libraryOrphanCleanup.test.ts
+++ b/backend/src/services/__tests__/libraryOrphanCleanup.test.ts
@@ -58,7 +58,12 @@ describe("cleanupOrphanedLibraryEntities", () => {
         });
 
         expect(prisma.album.findMany).toHaveBeenCalledWith({
-            where: { peerId: null, tracks: { none: {} } },
+            where: {
+                peerId: null,
+                tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
             orderBy: { id: "asc" },
             take: 10_000,
             select: { id: true },
@@ -68,10 +73,17 @@ describe("cleanupOrphanedLibraryEntities", () => {
                 id: { in: ["local-album"] },
                 peerId: null,
                 tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
         });
         expect(prisma.artist.findMany).toHaveBeenCalledWith({
-            where: { peerId: null, albums: { none: {} } },
+            where: {
+                peerId: null,
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
             orderBy: { id: "asc" },
             take: 10_000,
             select: { id: true },
@@ -81,6 +93,8 @@ describe("cleanupOrphanedLibraryEntities", () => {
                 id: { in: ["local-artist"] },
                 peerId: null,
                 albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
         });
     });

--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -1990,13 +1990,23 @@ describe("MusicScannerService.scanLibrary", () => {
             },
         });
         expect(mockPrisma.album.findMany).toHaveBeenCalledWith({
-            where: { peerId: null, tracks: { none: {} } },
+            where: {
+                peerId: null,
+                tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
             orderBy: { id: "asc" },
             take: 10_000,
             select: { id: true },
         });
         expect(mockPrisma.artist.findMany).toHaveBeenCalledWith({
-            where: { peerId: null, albums: { none: {} } },
+            where: {
+                peerId: null,
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
             orderBy: { id: "asc" },
             take: 10_000,
             select: { id: true },
@@ -2021,6 +2031,8 @@ describe("MusicScannerService.scanLibrary", () => {
                 id: { in: ["album-1"] },
                 peerId: null,
                 tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
         });
         expect(mockPrisma.artist.deleteMany).toHaveBeenCalledWith({
@@ -2028,6 +2040,8 @@ describe("MusicScannerService.scanLibrary", () => {
                 id: { in: ["artist-1"] },
                 peerId: null,
                 albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
             },
         });
     });

--- a/backend/src/services/libraryOrphanCleanup.ts
+++ b/backend/src/services/libraryOrphanCleanup.ts
@@ -20,7 +20,12 @@ async function deleteOrphanedAlbums(
     writeTombstones: boolean,
 ): Promise<number> {
     const orphanedAlbums = await client.album.findMany({
-        where: { peerId: null, tracks: { none: {} } },
+        where: {
+            peerId: null,
+            tracks: { none: {} },
+            tracksTidal: { none: {} },
+            tracksYtMusic: { none: {} },
+        },
         orderBy: { id: "asc" },
         take: ORPHAN_CLEANUP_BATCH_SIZE,
         select: { id: true },
@@ -31,6 +36,8 @@ async function deleteOrphanedAlbums(
             id: { in: orphanedAlbums.map((album) => album.id) },
             peerId: null,
             tracks: { none: {} },
+            tracksTidal: { none: {} },
+            tracksYtMusic: { none: {} },
         },
     });
     if (writeTombstones && result.count > 0) {
@@ -74,7 +81,12 @@ async function deleteOrphanedArtists(
     writeTombstones: boolean,
 ): Promise<number> {
     const orphanedArtists = await client.artist.findMany({
-        where: { peerId: null, albums: { none: {} } },
+        where: {
+            peerId: null,
+            albums: { none: {} },
+            tracksTidal: { none: {} },
+            tracksYtMusic: { none: {} },
+        },
         orderBy: { id: "asc" },
         take: ORPHAN_CLEANUP_BATCH_SIZE,
         select: { id: true },
@@ -85,6 +97,8 @@ async function deleteOrphanedArtists(
             id: { in: orphanedArtists.map((artist) => artist.id) },
             peerId: null,
             albums: { none: {} },
+            tracksTidal: { none: {} },
+            tracksYtMusic: { none: {} },
         },
     });
     if (writeTombstones && result.count > 0) {

--- a/backend/src/workers/__tests__/dataIntegrity.test.ts
+++ b/backend/src/workers/__tests__/dataIntegrity.test.ts
@@ -55,6 +55,7 @@ describe("dataIntegrity worker", () => {
                     .mockResolvedValueOnce([]),
                 update: jest.fn(async () => undefined),
                 delete: jest.fn(async () => undefined),
+                deleteMany: jest.fn(async () => ({ count: 1 })),
                 updateMany: jest.fn(async () => ({ count: 0 })),
             },
             ownedAlbum: {
@@ -308,14 +309,40 @@ describe("dataIntegrity worker", () => {
             }),
         );
 
+        expect(prisma.album.findMany).toHaveBeenNthCalledWith(1, {
+            where: {
+                location: "DISCOVER",
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+            include: { artist: true },
+        });
+        expect(prisma.album.findMany).toHaveBeenNthCalledWith(3, {
+            where: {
+                tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+            include: { artist: true },
+        });
         expect(prisma.track.deleteMany).toHaveBeenCalledWith({
             where: { albumId: "discover-album-1" },
         });
-        expect(prisma.album.delete).toHaveBeenCalledWith({
-            where: { id: "discover-album-1" },
+        expect(prisma.album.deleteMany).toHaveBeenNthCalledWith(1, {
+            where: {
+                id: "discover-album-1",
+                location: "DISCOVER",
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
         });
-        expect(prisma.album.delete).toHaveBeenCalledWith({
-            where: { id: "empty-album-1" },
+        expect(prisma.album.deleteMany).toHaveBeenNthCalledWith(2, {
+            where: {
+                id: "empty-album-1",
+                tracks: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
         });
         expect(prisma.ownedAlbum.deleteMany).toHaveBeenCalledWith({
             where: { rgMbid: "rg-empty" },
@@ -339,6 +366,9 @@ describe("dataIntegrity worker", () => {
             id: "real-artist-1",
             mbid: "real-mbid",
         });
+        (prisma.artist.deleteMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
+        });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
             expect.objectContaining({
@@ -354,8 +384,20 @@ describe("dataIntegrity worker", () => {
         expect(prisma.artist.delete).toHaveBeenCalledWith({
             where: { id: "temp-artist-1" },
         });
+        expect(prisma.artist.findMany).toHaveBeenNthCalledWith(2, {
+            where: {
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
+        });
         expect(prisma.artist.deleteMany).toHaveBeenCalledWith({
-            where: { id: { in: ["orphan-artist-1"] } },
+            where: {
+                id: { in: ["orphan-artist-1"] },
+                albums: { none: {} },
+                tracksTidal: { none: {} },
+                tracksYtMusic: { none: {} },
+            },
         });
     });
 

--- a/backend/src/workers/dataIntegrity.ts
+++ b/backend/src/workers/dataIntegrity.ts
@@ -136,7 +136,11 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
         "runDataIntegrityCheck.album.findMany.discover",
         () =>
             prisma.album.findMany({
-                where: { location: "DISCOVER" },
+                where: {
+                    location: "DISCOVER",
+                    tracksTidal: { none: {} },
+                    tracksYtMusic: { none: {} },
+                },
                 include: { artist: true },
             }),
     );
@@ -188,17 +192,24 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
                     }),
             );
             // Delete album
-            await withDataIntegrityPrismaRetry(
+            const deletedAlbum = await withDataIntegrityPrismaRetry(
                 "runDataIntegrityCheck.album.delete.orphanedAlbum",
                 () =>
-                    prisma.album.delete({
-                        where: { id: album.id },
+                    prisma.album.deleteMany({
+                        where: {
+                            id: album.id,
+                            location: "DISCOVER",
+                            tracksTidal: { none: {} },
+                            tracksYtMusic: { none: {} },
+                        },
                     }),
             );
-            report.orphanedAlbums++;
-            logger.debug(
-                `     Removed orphaned album: ${album.artist.name} - ${album.title}`,
-            );
+            if (deletedAlbum.count > 0) {
+                report.orphanedAlbums += deletedAlbum.count;
+                logger.debug(
+                    `     Removed orphaned album: ${album.artist.name} - ${album.title}`,
+                );
+            }
         }
     }
 
@@ -367,13 +378,20 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
 
     for (const album of emptyAlbums) {
         // Delete the album record
-        await withDataIntegrityPrismaRetry(
+        const deletedAlbum = await withDataIntegrityPrismaRetry(
             "runDataIntegrityCheck.album.delete.empty",
             () =>
-                prisma.album.delete({
-                    where: { id: album.id },
+                prisma.album.deleteMany({
+                    where: {
+                        id: album.id,
+                        tracks: { none: {} },
+                        tracksTidal: { none: {} },
+                        tracksYtMusic: { none: {} },
+                    },
                 }),
         );
+
+        if (deletedAlbum.count === 0) continue;
 
         // Also delete any associated OwnedAlbum records
         await withDataIntegrityPrismaRetry(
@@ -384,7 +402,7 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
                 }),
         );
 
-        report.orphanedAlbums++;
+        report.orphanedAlbums += deletedAlbum.count;
         logger.debug(
             `     Removed empty album (no tracks): ${album.artist.name} - ${album.title}`,
         );
@@ -510,15 +528,20 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
         );
 
         // Delete orphaned artists
-        await withDataIntegrityPrismaRetry(
+        const deletedArtists = await withDataIntegrityPrismaRetry(
             "runDataIntegrityCheck.artist.deleteMany.orphaned",
             () =>
                 prisma.artist.deleteMany({
-                    where: { id: { in: orphanedArtists.map((a) => a.id) } },
+                    where: {
+                        id: { in: orphanedArtists.map((a) => a.id) },
+                        albums: { none: {} },
+                        tracksTidal: { none: {} },
+                        tracksYtMusic: { none: {} },
+                    },
                 }),
         );
 
-        report.orphanedArtists = orphanedArtists.length;
+        report.orphanedArtists = deletedArtists.count;
     }
 
     // 9. Clean up old DownloadJob records (older than 30 days, completed/failed)

--- a/backend/src/workers/dataIntegrity.ts
+++ b/backend/src/workers/dataIntegrity.ts
@@ -358,6 +358,8 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
             prisma.album.findMany({
                 where: {
                     tracks: { none: {} },
+                    tracksTidal: { none: {} },
+                    tracksYtMusic: { none: {} },
                 },
                 include: { artist: true },
             }),
@@ -478,6 +480,8 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
             prisma.artist.findMany({
                 where: {
                     albums: { none: {} },
+                    tracksTidal: { none: {} },
+                    tracksYtMusic: { none: {} },
                 },
             }),
     );

--- a/backend/tests-integration/libraryOrphanCleanupPostgres.integration.test.ts
+++ b/backend/tests-integration/libraryOrphanCleanupPostgres.integration.test.ts
@@ -150,27 +150,31 @@ describeWithPostgres("library orphan cleanup PostgreSQL behavior", () => {
     });
 
     it("preserves provider-backed and raced entities while deleting true orphans", async () => {
-        const findAlbums = prisma.album.findMany.bind(prisma.album) as (
+        const findAlbums = prisma.album.findMany.bind(
+            prisma.album,
+        ) as unknown as (
             args: Prisma.AlbumFindManyArgs,
         ) => Promise<Array<{ id: string }>>;
-        const findArtists = prisma.artist.findMany.bind(prisma.artist) as (
+        const findArtists = prisma.artist.findMany.bind(
+            prisma.artist,
+        ) as unknown as (
             args: Prisma.ArtistFindManyArgs,
         ) => Promise<Array<{ id: string }>>;
 
-        jest.spyOn(prisma.album, "findMany").mockImplementationOnce(
-            async (args: Prisma.AlbumFindManyArgs) => {
-                const candidates = await findAlbums(args);
-                await insertRacedAlbumLink(database);
-                return candidates;
-            },
-        );
-        jest.spyOn(prisma.artist, "findMany").mockImplementationOnce(
-            async (args: Prisma.ArtistFindManyArgs) => {
-                const candidates = await findArtists(args);
-                await insertRacedArtistLink(database);
-                return candidates;
-            },
-        );
+        jest.spyOn(prisma.album, "findMany").mockImplementationOnce((async (
+            args?: Prisma.AlbumFindManyArgs,
+        ) => {
+            const candidates = await findAlbums(args ?? {});
+            await insertRacedAlbumLink(database);
+            return candidates;
+        }) as never);
+        jest.spyOn(prisma.artist, "findMany").mockImplementationOnce((async (
+            args?: Prisma.ArtistFindManyArgs,
+        ) => {
+            const candidates = await findArtists(args ?? {});
+            await insertRacedArtistLink(database);
+            return candidates;
+        }) as never);
 
         await expect(cleanupOrphanedLibraryEntities()).resolves.toEqual({
             albumsDeleted: 1,

--- a/backend/tests-integration/libraryOrphanCleanupPostgres.integration.test.ts
+++ b/backend/tests-integration/libraryOrphanCleanupPostgres.integration.test.ts
@@ -1,0 +1,204 @@
+import type { Prisma } from "@prisma/client";
+import { Client } from "pg";
+import { cleanupOrphanedLibraryEntities } from "../src/services/libraryOrphanCleanup";
+import { prisma } from "../src/utils/db";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+
+const ids = {
+    emptyAlbum: "orphan-cleanup-empty-album",
+    emptyArtist: "orphan-cleanup-empty-artist",
+    providerAlbum: "orphan-cleanup-provider-album",
+    providerArtist: "orphan-cleanup-provider-artist",
+    racedAlbum: "orphan-cleanup-raced-album",
+    racedAlbumArtist: "orphan-cleanup-raced-album-artist",
+    racedArtist: "orphan-cleanup-raced-artist",
+} as const;
+
+async function createArtist(id: string): Promise<void> {
+    await prisma.artist.create({
+        data: {
+            id,
+            mbid: `${id}-mbid`,
+            name: id,
+            normalizedName: id,
+        },
+    });
+}
+
+async function createAlbum(id: string, artistId: string): Promise<void> {
+    await prisma.album.create({
+        data: {
+            id,
+            rgMbid: `${id}-rg-mbid`,
+            artistId,
+            title: id,
+            primaryType: "Album",
+        },
+    });
+}
+
+async function seedCatalog(): Promise<void> {
+    for (const artistId of [
+        ids.emptyArtist,
+        ids.providerArtist,
+        ids.racedAlbumArtist,
+        ids.racedArtist,
+    ]) {
+        await createArtist(artistId);
+    }
+    await createAlbum(ids.emptyAlbum, ids.emptyArtist);
+    await createAlbum(ids.providerAlbum, ids.providerArtist);
+    await createAlbum(ids.racedAlbum, ids.racedAlbumArtist);
+    await prisma.trackTidal.create({
+        data: {
+            tidalId: 646001,
+            title: "Provider track",
+            artist: "Provider artist",
+            album: "Provider album",
+            duration: 180,
+            artistId: ids.providerArtist,
+            albumId: ids.providerAlbum,
+        },
+    });
+}
+
+async function insertRacedAlbumLink(database: Client): Promise<void> {
+    await database.query(
+        `INSERT INTO "TrackTidal"
+            (id, "tidalId", title, artist, album, duration, "artistId", "albumId", "createdAt")
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
+        [
+            "orphan-cleanup-raced-album-track",
+            646002,
+            "Raced album track",
+            "Raced album artist",
+            "Raced album",
+            181,
+            ids.racedAlbumArtist,
+            ids.racedAlbum,
+        ],
+    );
+}
+
+async function insertRacedArtistLink(database: Client): Promise<void> {
+    await database.query(
+        `INSERT INTO "TrackYtMusic"
+            (id, "videoId", title, artist, album, duration, "artistId", "createdAt")
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`,
+        [
+            "orphan-cleanup-raced-artist-track",
+            "orphan-cleanup-raced-video",
+            "Raced artist track",
+            "Raced artist",
+            "Raced artist album",
+            182,
+            ids.racedArtist,
+        ],
+    );
+}
+
+async function entityIds(): Promise<{ albums: string[]; artists: string[] }> {
+    const [albums, artists] = await Promise.all([
+        prisma.album.findMany({
+            where: { id: { in: Object.values(ids) } },
+            orderBy: { id: "asc" },
+            select: { id: true },
+        }),
+        prisma.artist.findMany({
+            where: { id: { in: Object.values(ids) } },
+            orderBy: { id: "asc" },
+            select: { id: true },
+        }),
+    ]);
+    return {
+        albums: albums.map((album) => album.id),
+        artists: artists.map((artist) => artist.id),
+    };
+}
+
+describeWithPostgres("library orphan cleanup PostgreSQL behavior", () => {
+    let admin: Client;
+    let database: Client;
+
+    beforeAll(async () => {
+        admin = await createScaleDatabase(
+            integrationDatabaseUrl!,
+            databaseName!,
+        );
+        await applyScaleMigrations(process.env.DATABASE_URL!);
+        database = new Client({ connectionString: process.env.DATABASE_URL });
+        await database.connect();
+        await seedCatalog();
+    });
+
+    afterAll(async () => {
+        jest.restoreAllMocks();
+        await prisma.$disconnect();
+        await database?.end();
+        if (admin && databaseName) {
+            await dropScaleDatabase(admin, databaseName);
+        }
+    });
+
+    it("preserves provider-backed and raced entities while deleting true orphans", async () => {
+        const findAlbums = prisma.album.findMany.bind(prisma.album) as (
+            args: Prisma.AlbumFindManyArgs,
+        ) => Promise<Array<{ id: string }>>;
+        const findArtists = prisma.artist.findMany.bind(prisma.artist) as (
+            args: Prisma.ArtistFindManyArgs,
+        ) => Promise<Array<{ id: string }>>;
+
+        jest.spyOn(prisma.album, "findMany").mockImplementationOnce(
+            async (args: Prisma.AlbumFindManyArgs) => {
+                const candidates = await findAlbums(args);
+                await insertRacedAlbumLink(database);
+                return candidates;
+            },
+        );
+        jest.spyOn(prisma.artist, "findMany").mockImplementationOnce(
+            async (args: Prisma.ArtistFindManyArgs) => {
+                const candidates = await findArtists(args);
+                await insertRacedArtistLink(database);
+                return candidates;
+            },
+        );
+
+        await expect(cleanupOrphanedLibraryEntities()).resolves.toEqual({
+            albumsDeleted: 1,
+            artistsDeleted: 1,
+        });
+        await expect(entityIds()).resolves.toEqual({
+            albums: [ids.providerAlbum, ids.racedAlbum].sort(),
+            artists: [
+                ids.providerArtist,
+                ids.racedAlbumArtist,
+                ids.racedArtist,
+            ].sort(),
+        });
+
+        await expect(
+            prisma.trackTidal.findUnique({
+                where: { tidalId: 646002 },
+                select: { albumId: true, artistId: true },
+            }),
+        ).resolves.toEqual({
+            albumId: ids.racedAlbum,
+            artistId: ids.racedAlbumArtist,
+        });
+        await expect(
+            prisma.trackYtMusic.findUnique({
+                where: { videoId: "orphan-cleanup-raced-video" },
+                select: { artistId: true },
+            }),
+        ).resolves.toEqual({ artistId: ids.racedArtist });
+    });
+});


### PR DESCRIPTION

## Summary

Prevent TIDAL- and YouTube Music-backed Artist/Album records from being deleted as orphans.

The orphan-cleanup paths only considered local Track/Album relations when deciding whether an entity was unused. Remote provider rows can still legitimately reference those Artists/Albums through `TrackTidal` or `TrackYtMusic`, so cleanup could remove valid remote library metadata while the provider track remained.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Code cleanup / refactoring
- [ ] Other

## Related Issues

Fixes #645

## Changes Made

- Exclude Albums with `TrackTidal` or `TrackYtMusic` relations from orphan cleanup.
- Exclude Artists with `TrackTidal` or `TrackYtMusic` relations from orphan cleanup.
- Apply the same protection to library orphan cleanup, data-integrity cleanup, and legacy Discover cleanup.
- Preserve the delete-time guards in `libraryOrphanCleanup`.
- Update the focused orphan-cleanup regression expectations for both remote providers.

## Verification

- [x] Backend builds successfully on Node 24.
- [x] Focused Jest suite passes locally.

### Additional Verification Details

`src/services/__tests__/libraryOrphanCleanup.test.ts`

- 1 test suite passed
- 4 tests passed
- 0 tests failed

The original failure was also reproduced in a Docker deployment: remote Artist/Album metadata disappeared after cleanup/restart while the remote liked track remained. After applying the fix and restoring the metadata, a backend restart preserved the remote Artists/Albums.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's contribution guidelines
- [x] I have tested my changes
- [x] I have linked the related issue