### PR TITLE
fix(subsonic): playlist mutations join the shared playlist lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OpenSubsonic playlist replacement and update mutations now share the Playlist-first transaction lock with generated-radio regeneration, preventing concurrent edits from deadlocking, mixing contents, or producing duplicate sort positions.
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).
 - Audiobook series and library cover-art routes now preserve Express-decoded percent signs, encoded-looking sequences, and Unicode while retaining compatibility with legacy double-encoded route parameters (#632).
 - Artist detail and discovery routes now preserve artist names with percent signs while retaining lookup compatibility for legacy double-encoded names (#632).

--- a/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
@@ -75,6 +75,7 @@ jest.mock("../../utils/db", () => ({
             deleteMany: jest.fn(),
         },
         user: { findUnique: jest.fn() },
+        $queryRaw: jest.fn(),
         $transaction: jest.fn(),
     },
 }));
@@ -222,6 +223,17 @@ describe("subsonic branch coverage focused handlers", () => {
         mockPlaylistUpdate.mockResolvedValue({ id: "playlist-1" });
         mockPlaylistItemFindMany.mockResolvedValue([]);
         mockPlaylistItemDeleteMany.mockResolvedValue({ count: 0 });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+            { id: "playlist-1", userId: "user-1", mixId: null },
+        ]);
+        (prisma.$transaction as jest.Mock).mockImplementation(
+            async (operation: unknown) => {
+                if (typeof operation === "function") {
+                    return operation(prisma);
+                }
+                return Promise.all(operation as Promise<unknown>[]);
+            },
+        );
         mockBookmarkFindMany.mockResolvedValue([]);
         mockBookmarkDeleteMany.mockResolvedValue({ count: 0 });
         mockBookmarkUpsert.mockResolvedValue({});

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -64,6 +64,7 @@ jest.mock("../../utils/db", () => ({
             findUnique: jest.fn(),
         },
         $queryRaw: jest.fn(),
+        $executeRaw: jest.fn(),
         $transaction: jest.fn(),
     },
 }));
@@ -194,6 +195,7 @@ describe("subsonic Tier B handlers", () => {
     ).trackRating;
     const mockTransaction = prisma.$transaction as jest.Mock;
     const mockQueryRaw = prisma.$queryRaw as jest.Mock;
+    const mockExecuteRaw = prisma.$executeRaw as jest.Mock;
     const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
     const mockScanGetActive = scanQueue.getActive as jest.Mock;
     const mockScanGetWaiting = scanQueue.getWaiting as jest.Mock;
@@ -306,6 +308,46 @@ describe("subsonic Tier B handlers", () => {
         expect(mockPlaylistCreate).not.toHaveBeenCalled();
     });
 
+    it("returns song-not-found before ownership for a foreign createPlaylist target with a malformed song ID", async () => {
+        await handleCreatePlaylist(
+            buildReq({
+                playlistId: "pl-foreign-playlist",
+                songId: ["al-not-a-song"],
+            }),
+            buildRes(),
+        );
+
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            70,
+            "Song not found",
+            "json",
+            undefined,
+        );
+        expect(mockQueryRaw).not.toHaveBeenCalled();
+    });
+
+    it("returns song-not-found before ownership for a foreign createPlaylist target with a missing song", async () => {
+        mockTrackFindMany.mockResolvedValueOnce([]);
+
+        await handleCreatePlaylist(
+            buildReq({
+                playlistId: "pl-foreign-playlist",
+                songId: ["tr-track-missing"],
+            }),
+            buildRes(),
+        );
+
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            70,
+            "Song not found",
+            "json",
+            undefined,
+        );
+        expect(mockQueryRaw).not.toHaveBeenCalled();
+    });
+
     it("returns not-authorized when createPlaylist update target is not owned", async () => {
         mockTrackFindMany.mockResolvedValue([{ id: "track-1" }]);
         mockPlaylistFindFirst.mockResolvedValue(null);
@@ -386,7 +428,7 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
-    it("locks an existing createPlaylist target before reads and writes", async () => {
+    it("validates songs before locking an existing createPlaylist target", async () => {
         mockTrackFindMany.mockResolvedValue([{ id: "track-9" }]);
 
         await handleCreatePlaylist(
@@ -404,10 +446,10 @@ describe("subsonic Tier B handlers", () => {
             "playlist-1",
             "user-1",
         );
-        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
-            mockTrackFindMany.mock.invocationCallOrder[0],
-        );
         expect(mockTrackFindMany.mock.invocationCallOrder[0]).toBeLessThan(
+            mockQueryRaw.mock.invocationCallOrder[0],
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
             mockPlaylistUpdate.mock.invocationCallOrder[0],
         );
         expect(mockPlaylistUpdate.mock.invocationCallOrder[0]).toBeLessThan(
@@ -419,12 +461,7 @@ describe("subsonic Tier B handlers", () => {
         mockPlaylistFindFirst.mockResolvedValue({ id: "playlist-1" });
         mockPlaylistItemFindMany
             .mockResolvedValueOnce([{ id: "item-1" }, { id: "item-2" }])
-            .mockResolvedValueOnce([{ trackId: "track-2" }])
-            .mockResolvedValueOnce([
-                { id: "item-2" },
-                { id: "item-3" },
-                { id: "item-4" },
-            ]);
+            .mockResolvedValueOnce([{ trackId: "track-2" }]);
         mockTrackFindMany.mockResolvedValue([
             { id: "track-3" },
             { id: "track-4" },
@@ -454,7 +491,17 @@ describe("subsonic Tier B handlers", () => {
             ],
             skipDuplicates: true,
         });
-        expect(mockTransaction).toHaveBeenCalled();
+        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+        expect(mockExecuteRaw).toHaveBeenCalledWith(
+            expect.anything(),
+            "playlist-1",
+            1000,
+        );
+        expect(mockPlaylistItemUpdate).not.toHaveBeenCalled();
+        expect(mockTransaction).toHaveBeenCalledWith(expect.any(Function), {
+            maxWait: 2000,
+            timeout: 15000,
+        });
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),
             {},
@@ -466,8 +513,7 @@ describe("subsonic Tier B handlers", () => {
     it("locks updatePlaylist before ownership, item, and maximum-sort work", async () => {
         mockPlaylistItemFindMany
             .mockResolvedValueOnce([{ id: "item-1" }])
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([{ id: "item-2" }]);
+            .mockResolvedValueOnce([]);
         mockTrackFindMany.mockResolvedValue([{ id: "track-3" }]);
         mockPlaylistItemAggregate.mockResolvedValue({ _max: { sort: 0 } });
 
@@ -543,6 +589,48 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
+    it("returns not-authorized before parsing a malformed song for a foreign updatePlaylist target", async () => {
+        mockQueryRaw.mockResolvedValueOnce([]);
+
+        await handleUpdatePlaylist(
+            buildReq({
+                playlistId: "pl-foreign-playlist",
+                songIdToAdd: ["al-not-a-song"],
+            }),
+            buildRes(),
+        );
+
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            50,
+            "Not authorized to modify this playlist",
+            "json",
+            undefined,
+        );
+        expect(mockTrackFindMany).not.toHaveBeenCalled();
+    });
+
+    it("returns not-authorized before validating a missing song for a foreign updatePlaylist target", async () => {
+        mockQueryRaw.mockResolvedValueOnce([]);
+
+        await handleUpdatePlaylist(
+            buildReq({
+                playlistId: "pl-foreign-playlist",
+                songIdToAdd: ["tr-track-missing"],
+            }),
+            buildRes(),
+        );
+
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            50,
+            "Not authorized to modify this playlist",
+            "json",
+            undefined,
+        );
+        expect(mockTrackFindMany).not.toHaveBeenCalled();
+    });
+
     it("returns song-not-found when updatePlaylist add list contains malformed song IDs", async () => {
         mockPlaylistFindFirst.mockResolvedValue({ id: "playlist-1" });
 
@@ -609,7 +697,6 @@ describe("subsonic Tier B handlers", () => {
 
     it("updates playlist metadata name when only name is provided", async () => {
         mockPlaylistFindFirst.mockResolvedValue({ id: "playlist-1" });
-        mockPlaylistItemFindMany.mockResolvedValueOnce([]);
 
         await handleUpdatePlaylist(
             buildReq({
@@ -623,6 +710,11 @@ describe("subsonic Tier B handlers", () => {
             where: { id: "playlist-1" },
             data: { name: "Only Rename" },
         });
+        expect(mockPlaylistItemFindMany).not.toHaveBeenCalled();
+        expect(mockPlaylistItemDeleteMany).not.toHaveBeenCalled();
+        expect(mockPlaylistItemCreateMany).not.toHaveBeenCalled();
+        expect(mockPlaylistItemUpdate).not.toHaveBeenCalled();
+        expect(mockExecuteRaw).not.toHaveBeenCalled();
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),
             {},

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -63,6 +63,7 @@ jest.mock("../../utils/db", () => ({
         user: {
             findUnique: jest.fn(),
         },
+        $queryRaw: jest.fn(),
         $transaction: jest.fn(),
     },
 }));
@@ -192,6 +193,7 @@ describe("subsonic Tier B handlers", () => {
         }
     ).trackRating;
     const mockTransaction = prisma.$transaction as jest.Mock;
+    const mockQueryRaw = prisma.$queryRaw as jest.Mock;
     const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
     const mockScanGetActive = scanQueue.getActive as jest.Mock;
     const mockScanGetWaiting = scanQueue.getWaiting as jest.Mock;
@@ -209,6 +211,7 @@ describe("subsonic Tier B handlers", () => {
         mockTrackRating.findMany.mockResolvedValue([]);
         mockTrackRating.upsert.mockResolvedValue({});
         mockTrackRating.deleteMany.mockResolvedValue({ count: 0 });
+        mockTrackFindMany.mockResolvedValue([]);
         mockTrackAggregate.mockResolvedValue({ _sum: { duration: null } });
         mockTrackGroupBy.mockResolvedValue([]);
         mockPlaylistItemFindMany.mockResolvedValue([]);
@@ -216,7 +219,15 @@ describe("subsonic Tier B handlers", () => {
         mockPlaylistFindFirst.mockResolvedValue(null);
         mockUserFindUnique.mockResolvedValue(null);
         mockPlaylistItemUpdate.mockResolvedValue({});
-        mockTransaction.mockResolvedValue([]);
+        mockQueryRaw.mockResolvedValue([
+            { id: "playlist-1", userId: "user-1", mixId: null },
+        ]);
+        mockTransaction.mockImplementation(async (operation: unknown) => {
+            if (typeof operation === "function") {
+                return operation(prisma);
+            }
+            return Promise.all(operation as Promise<unknown>[]);
+        });
         mockScanGetActive.mockResolvedValue([]);
         mockScanGetWaiting.mockResolvedValue([]);
         mockScanGetDelayed.mockResolvedValue([]);
@@ -298,6 +309,7 @@ describe("subsonic Tier B handlers", () => {
     it("returns not-authorized when createPlaylist update target is not owned", async () => {
         mockTrackFindMany.mockResolvedValue([{ id: "track-1" }]);
         mockPlaylistFindFirst.mockResolvedValue(null);
+        mockQueryRaw.mockResolvedValueOnce([]);
 
         await handleCreatePlaylist(
             buildReq({
@@ -374,6 +386,35 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
+    it("locks an existing createPlaylist target before reads and writes", async () => {
+        mockTrackFindMany.mockResolvedValue([{ id: "track-9" }]);
+
+        await handleCreatePlaylist(
+            buildReq({
+                playlistId: "pl-playlist-1",
+                name: "Locked Rename",
+                songId: ["tr-track-9"],
+            }),
+            buildRes(),
+        );
+
+        expect(typeof mockTransaction.mock.calls[0]?.[0]).toBe("function");
+        expect(mockQueryRaw).toHaveBeenCalledWith(
+            expect.anything(),
+            "playlist-1",
+            "user-1",
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+            mockTrackFindMany.mock.invocationCallOrder[0],
+        );
+        expect(mockTrackFindMany.mock.invocationCallOrder[0]).toBeLessThan(
+            mockPlaylistUpdate.mock.invocationCallOrder[0],
+        );
+        expect(mockPlaylistUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+            mockPlaylistItemDeleteMany.mock.invocationCallOrder[0],
+        );
+    });
+
     it("updates a playlist by removing indices, adding tracks, and reindexing", async () => {
         mockPlaylistFindFirst.mockResolvedValue({ id: "playlist-1" });
         mockPlaylistItemFindMany
@@ -422,6 +463,43 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
+    it("locks updatePlaylist before ownership, item, and maximum-sort work", async () => {
+        mockPlaylistItemFindMany
+            .mockResolvedValueOnce([{ id: "item-1" }])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{ id: "item-2" }]);
+        mockTrackFindMany.mockResolvedValue([{ id: "track-3" }]);
+        mockPlaylistItemAggregate.mockResolvedValue({ _max: { sort: 0 } });
+
+        await handleUpdatePlaylist(
+            buildReq({
+                playlistId: "pl-playlist-1",
+                songIndexToRemove: ["0"],
+                songIdToAdd: ["tr-track-3"],
+            }),
+            buildRes(),
+        );
+
+        expect(typeof mockTransaction.mock.calls[0]?.[0]).toBe("function");
+        expect(mockQueryRaw).toHaveBeenCalledWith(
+            expect.anything(),
+            "playlist-1",
+            "user-1",
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+            mockTrackFindMany.mock.invocationCallOrder[0],
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+            mockPlaylistItemFindMany.mock.invocationCallOrder[0],
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+            mockPlaylistItemAggregate.mock.invocationCallOrder[0],
+        );
+        expect(mockQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+            mockPlaylistItemDeleteMany.mock.invocationCallOrder[0],
+        );
+    });
+
     it("returns playlist-not-found when updatePlaylist playlistId cannot be parsed", async () => {
         await handleUpdatePlaylist(
             buildReq({
@@ -447,6 +525,7 @@ describe("subsonic Tier B handlers", () => {
 
     it("returns not-authorized when updatePlaylist target is not owned", async () => {
         mockPlaylistFindFirst.mockResolvedValue(null);
+        mockQueryRaw.mockResolvedValueOnce([]);
 
         await handleUpdatePlaylist(
             buildReq({

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -495,7 +495,6 @@ describe("subsonic Tier B handlers", () => {
         expect(mockExecuteRaw).toHaveBeenCalledWith(
             expect.anything(),
             "playlist-1",
-            1000,
         );
         expect(mockPlaylistItemUpdate).not.toHaveBeenCalled();
         expect(mockTransaction).toHaveBeenCalledWith(expect.any(Function), {

--- a/backend/src/routes/subsonic/playlists.ts
+++ b/backend/src/routes/subsonic/playlists.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "@prisma/client";
 import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
 import {
+    PLAYLIST_REORDER_MAX_ITEMS,
     PlaylistMutationLockNotFoundError,
     requirePlaylistMutationLock,
 } from "../../services/playlistMutationLock";
@@ -26,6 +27,9 @@ import {
 } from "./shared";
 
 type PlaylistMutationResult = "ok" | "trackNotFound";
+
+const PLAYLIST_TRANSACTION_MAX_WAIT_MS = 2_000;
+const PLAYLIST_TRANSACTION_TIMEOUT_MS = 15_000;
 
 async function getPlaylistDurations(
     playlists: Array<{ id: string; _count: { items: number } }>,
@@ -295,11 +299,8 @@ async function replaceLockedPlaylistItems(
     userId: string,
     name: string,
     trackIds: string[],
-): Promise<PlaylistMutationResult> {
+): Promise<void> {
     await requirePlaylistMutationLock(tx, playlistId, userId);
-    if (!(await ensureLibraryTracksExist(trackIds, tx))) {
-        return "trackNotFound";
-    }
     if (name) {
         await tx.playlist.update({
             where: { id: playlistId },
@@ -317,7 +318,6 @@ async function replaceLockedPlaylistItems(
             skipDuplicates: true,
         });
     }
-    return "ok";
 }
 
 function sendPlaylistMutationNotAuthorized(
@@ -388,9 +388,15 @@ export async function handleCreatePlaylist(
     }
 
     try {
+        const tracksExist = await ensureLibraryTracksExist(trackIds);
+        if (!tracksExist) {
+            sendPlaylistTrackNotFound(res, format, callback);
+            return;
+        }
+
         if (rawPlaylistId) {
             const playlistId = parseSubsonicId(rawPlaylistId, "playlist").id;
-            const result = await prisma.$transaction((tx) =>
+            await prisma.$transaction((tx) =>
                 replaceLockedPlaylistItems(
                     tx,
                     playlistId,
@@ -399,19 +405,10 @@ export async function handleCreatePlaylist(
                     trackIds,
                 ),
             );
-            if (result === "trackNotFound") {
-                sendPlaylistTrackNotFound(res, format, callback);
-                return;
-            }
             sendSubsonicSuccess(res, {}, format, callback);
             return;
         }
 
-        const tracksExist = await ensureLibraryTracksExist(trackIds);
-        if (!tracksExist) {
-            sendPlaylistTrackNotFound(res, format, callback);
-            return;
-        }
         const playlist = await prisma.playlist.create({
             data: {
                 userId: req.user!.id,
@@ -460,8 +457,8 @@ async function removeLockedPlaylistIndexes(
     tx: Prisma.TransactionClient,
     playlistId: string,
     rawIndexes: string[],
-): Promise<void> {
-    if (rawIndexes.length === 0) return;
+): Promise<boolean> {
+    if (rawIndexes.length === 0) return false;
     const currentItems = await tx.playlistItem.findMany({
         where: { playlistId },
         orderBy: { sort: "asc" },
@@ -470,18 +467,19 @@ async function removeLockedPlaylistIndexes(
     const itemIds = parseRemovalIndexes(rawIndexes)
         .filter((index) => index < currentItems.length)
         .map((index) => currentItems[index].id);
-    if (itemIds.length === 0) return;
+    if (itemIds.length === 0) return false;
     await tx.playlistItem.deleteMany({
         where: { id: { in: itemIds } },
     });
+    return true;
 }
 
 async function appendLockedPlaylistTracks(
     tx: Prisma.TransactionClient,
     playlistId: string,
     trackIds: string[],
-): Promise<void> {
-    if (trackIds.length === 0) return;
+): Promise<boolean> {
+    if (trackIds.length === 0) return false;
     const [existingItems, maximum] = await Promise.all([
         tx.playlistItem.findMany({
             where: { playlistId },
@@ -496,7 +494,7 @@ async function appendLockedPlaylistTracks(
     const additions = trackIds.filter(
         (trackId) => !existingTrackIds.has(trackId),
     );
-    if (additions.length === 0) return;
+    if (additions.length === 0) return false;
     const startSort = (maximum._max.sort ?? -1) + 1;
     await tx.playlistItem.createMany({
         data: additions.map((trackId, index) => ({
@@ -506,25 +504,30 @@ async function appendLockedPlaylistTracks(
         })),
         skipDuplicates: true,
     });
+    return true;
 }
 
 async function reindexLockedPlaylistItems(
     tx: Prisma.TransactionClient,
     playlistId: string,
 ): Promise<void> {
-    const items = await tx.playlistItem.findMany({
-        where: { playlistId },
-        orderBy: { sort: "asc" },
-        select: { id: true },
-    });
-    await Promise.all(
-        items.map((item, sort) =>
-            tx.playlistItem.update({
-                where: { id: item.id },
-                data: { sort },
-            }),
-        ),
-    );
+    await tx.$executeRaw`
+        WITH ranked AS (
+            SELECT
+                item.id,
+                (ROW_NUMBER() OVER (
+                    ORDER BY item.sort ASC, item.id ASC
+                ) - 1)::integer AS "nextSort"
+            FROM "PlaylistItem" item
+            WHERE item."playlistId" = ${playlistId}
+            ORDER BY item.sort ASC, item.id ASC
+            LIMIT ${PLAYLIST_REORDER_MAX_ITEMS}
+        )
+        UPDATE "PlaylistItem" item
+        SET sort = ranked."nextSort"
+        FROM ranked
+        WHERE item.id = ranked.id
+    `;
 }
 
 async function updateLockedPlaylist(
@@ -533,9 +536,15 @@ async function updateLockedPlaylist(
     userId: string,
     name: string,
     rawIndexes: string[],
-    trackIdsToAdd: string[],
+    rawSongIdsToAdd: string[],
 ): Promise<PlaylistMutationResult> {
     await requirePlaylistMutationLock(tx, playlistId, userId);
+    let trackIdsToAdd: string[];
+    try {
+        trackIdsToAdd = parseTrackIdsFromQueryValues(rawSongIdsToAdd);
+    } catch {
+        return "trackNotFound";
+    }
     if (!(await ensureLibraryTracksExist(trackIdsToAdd, tx))) {
         return "trackNotFound";
     }
@@ -545,9 +554,19 @@ async function updateLockedPlaylist(
             data: { name },
         });
     }
-    await removeLockedPlaylistIndexes(tx, playlistId, rawIndexes);
-    await appendLockedPlaylistTracks(tx, playlistId, trackIdsToAdd);
-    await reindexLockedPlaylistItems(tx, playlistId);
+    const removedItems = await removeLockedPlaylistIndexes(
+        tx,
+        playlistId,
+        rawIndexes,
+    );
+    const appendedItems = await appendLockedPlaylistTracks(
+        tx,
+        playlistId,
+        trackIdsToAdd,
+    );
+    if (removedItems || appendedItems) {
+        await reindexLockedPlaylistItems(tx, playlistId);
+    }
     return "ok";
 }
 
@@ -589,24 +608,21 @@ export async function handleUpdatePlaylist(
         return;
     }
 
-    let trackIdsToAdd: string[] = [];
     try {
-        trackIdsToAdd = parseTrackIdsFromQueryValues(rawSongIdsToAdd);
-    } catch {
-        sendPlaylistTrackNotFound(res, format, callback);
-        return;
-    }
-
-    try {
-        const result = await prisma.$transaction((tx) =>
-            updateLockedPlaylist(
-                tx,
-                playlistId,
-                req.user!.id,
-                rawName,
-                rawSongIndexesToRemove,
-                trackIdsToAdd,
-            ),
+        const result = await prisma.$transaction(
+            (tx) =>
+                updateLockedPlaylist(
+                    tx,
+                    playlistId,
+                    req.user!.id,
+                    rawName,
+                    rawSongIndexesToRemove,
+                    rawSongIdsToAdd,
+                ),
+            {
+                maxWait: PLAYLIST_TRANSACTION_MAX_WAIT_MS,
+                timeout: PLAYLIST_TRANSACTION_TIMEOUT_MS,
+            },
         );
         if (result === "trackNotFound") {
             sendPlaylistTrackNotFound(res, format, callback);

--- a/backend/src/routes/subsonic/playlists.ts
+++ b/backend/src/routes/subsonic/playlists.ts
@@ -2,7 +2,6 @@ import type { Prisma } from "@prisma/client";
 import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
 import {
-    PLAYLIST_REORDER_MAX_ITEMS,
     PlaylistMutationLockNotFoundError,
     requirePlaylistMutationLock,
 } from "../../services/playlistMutationLock";
@@ -511,6 +510,8 @@ async function reindexLockedPlaylistItems(
     tx: Prisma.TransactionClient,
     playlistId: string,
 ): Promise<void> {
+    // One set-based statement over the complete item set: a partial
+    // (capped) reindex could leave sort gaps on oversized playlists.
     await tx.$executeRaw`
         WITH ranked AS (
             SELECT
@@ -520,8 +521,6 @@ async function reindexLockedPlaylistItems(
                 ) - 1)::integer AS "nextSort"
             FROM "PlaylistItem" item
             WHERE item."playlistId" = ${playlistId}
-            ORDER BY item.sort ASC, item.id ASC
-            LIMIT ${PLAYLIST_REORDER_MAX_ITEMS}
         )
         UPDATE "PlaylistItem" item
         SET sort = ranked."nextSort"

--- a/backend/src/routes/subsonic/playlists.ts
+++ b/backend/src/routes/subsonic/playlists.ts
@@ -1,5 +1,10 @@
+import type { Prisma } from "@prisma/client";
 import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
+import {
+    PlaylistMutationLockNotFoundError,
+    requirePlaylistMutationLock,
+} from "../../services/playlistMutationLock";
 import { standardPlaylistListWhere } from "../../services/radioPlaylistIdentity";
 import { parseSubsonicId, toSubsonicId } from "../../utils/subsonicIds";
 import {
@@ -19,6 +24,8 @@ import {
     SONG_LOUDNESS_ALBUM_SELECT,
     SONG_LOUDNESS_TRACK_SELECT,
 } from "./shared";
+
+type PlaylistMutationResult = "ok" | "trackNotFound";
 
 async function getPlaylistDurations(
     playlists: Array<{ id: string; _count: { items: number } }>,
@@ -282,6 +289,65 @@ export async function handleGetPlaylist(
     }
 }
 
+async function replaceLockedPlaylistItems(
+    tx: Prisma.TransactionClient,
+    playlistId: string,
+    userId: string,
+    name: string,
+    trackIds: string[],
+): Promise<PlaylistMutationResult> {
+    await requirePlaylistMutationLock(tx, playlistId, userId);
+    if (!(await ensureLibraryTracksExist(trackIds, tx))) {
+        return "trackNotFound";
+    }
+    if (name) {
+        await tx.playlist.update({
+            where: { id: playlistId },
+            data: { name },
+        });
+    }
+    if (trackIds.length > 0) {
+        await tx.playlistItem.deleteMany({ where: { playlistId } });
+        await tx.playlistItem.createMany({
+            data: trackIds.map((trackId, sort) => ({
+                playlistId,
+                trackId,
+                sort,
+            })),
+            skipDuplicates: true,
+        });
+    }
+    return "ok";
+}
+
+function sendPlaylistMutationNotAuthorized(
+    res: Response,
+    format: ReturnType<typeof getRequestContext>["format"],
+    callback: string | undefined,
+): void {
+    sendSubsonicError(
+        res,
+        SubsonicErrorCode.NOT_AUTHORIZED,
+        "Not authorized to modify this playlist",
+        format,
+        callback,
+    );
+}
+
+function sendPlaylistTrackNotFound(
+    res: Response,
+    format: ReturnType<typeof getRequestContext>["format"],
+    callback: string | undefined,
+): void {
+    sendSubsonicError(
+        res,
+        SubsonicErrorCode.NOT_FOUND,
+        "Song not found",
+        format,
+        callback,
+    );
+}
+
 /**
  * Executes handleCreatePlaylist.
  */
@@ -322,73 +388,30 @@ export async function handleCreatePlaylist(
     }
 
     try {
-        const tracksExist = await ensureLibraryTracksExist(trackIds);
-        if (!tracksExist) {
-            sendSubsonicError(
-                res,
-                SubsonicErrorCode.NOT_FOUND,
-                "Song not found",
-                format,
-                callback,
-            );
-            return;
-        }
-
         if (rawPlaylistId) {
             const playlistId = parseSubsonicId(rawPlaylistId, "playlist").id;
-            const existing = await prisma.playlist.findFirst({
-                where: {
-                    id: playlistId,
-                    userId: req.user!.id,
-                },
-                select: {
-                    id: true,
-                },
-            });
-
-            if (!existing) {
-                sendSubsonicError(
-                    res,
-                    SubsonicErrorCode.NOT_AUTHORIZED,
-                    "Not authorized to modify this playlist",
-                    format,
-                    callback,
-                );
+            const result = await prisma.$transaction((tx) =>
+                replaceLockedPlaylistItems(
+                    tx,
+                    playlistId,
+                    req.user!.id,
+                    rawName,
+                    trackIds,
+                ),
+            );
+            if (result === "trackNotFound") {
+                sendPlaylistTrackNotFound(res, format, callback);
                 return;
             }
-
-            if (rawName) {
-                await prisma.playlist.update({
-                    where: {
-                        id: playlistId,
-                    },
-                    data: {
-                        name: rawName,
-                    },
-                });
-            }
-
-            if (trackIds.length > 0) {
-                await prisma.playlistItem.deleteMany({
-                    where: {
-                        playlistId,
-                    },
-                });
-
-                await prisma.playlistItem.createMany({
-                    data: trackIds.map((trackId, index) => ({
-                        playlistId,
-                        trackId,
-                        sort: index,
-                    })),
-                    skipDuplicates: true,
-                });
-            }
-
             sendSubsonicSuccess(res, {}, format, callback);
             return;
         }
 
+        const tracksExist = await ensureLibraryTracksExist(trackIds);
+        if (!tracksExist) {
+            sendPlaylistTrackNotFound(res, format, callback);
+            return;
+        }
         const playlist = await prisma.playlist.create({
             data: {
                 userId: req.user!.id,
@@ -408,7 +431,11 @@ export async function handleCreatePlaylist(
         }
 
         sendSubsonicSuccess(res, {}, format, callback);
-    } catch {
+    } catch (error) {
+        if (error instanceof PlaylistMutationLockNotFoundError) {
+            sendPlaylistMutationNotAuthorized(res, format, callback);
+            return;
+        }
         sendSubsonicError(
             res,
             SubsonicErrorCode.GENERIC,
@@ -417,6 +444,111 @@ export async function handleCreatePlaylist(
             callback,
         );
     }
+}
+
+function parseRemovalIndexes(rawIndexes: string[]): number[] {
+    return Array.from(
+        new Set(
+            rawIndexes
+                .map((value) => Number.parseInt(value, 10))
+                .filter((value) => Number.isInteger(value) && value >= 0),
+        ),
+    );
+}
+
+async function removeLockedPlaylistIndexes(
+    tx: Prisma.TransactionClient,
+    playlistId: string,
+    rawIndexes: string[],
+): Promise<void> {
+    if (rawIndexes.length === 0) return;
+    const currentItems = await tx.playlistItem.findMany({
+        where: { playlistId },
+        orderBy: { sort: "asc" },
+        select: { id: true },
+    });
+    const itemIds = parseRemovalIndexes(rawIndexes)
+        .filter((index) => index < currentItems.length)
+        .map((index) => currentItems[index].id);
+    if (itemIds.length === 0) return;
+    await tx.playlistItem.deleteMany({
+        where: { id: { in: itemIds } },
+    });
+}
+
+async function appendLockedPlaylistTracks(
+    tx: Prisma.TransactionClient,
+    playlistId: string,
+    trackIds: string[],
+): Promise<void> {
+    if (trackIds.length === 0) return;
+    const [existingItems, maximum] = await Promise.all([
+        tx.playlistItem.findMany({
+            where: { playlistId },
+            select: { trackId: true },
+        }),
+        tx.playlistItem.aggregate({
+            where: { playlistId },
+            _max: { sort: true },
+        }),
+    ]);
+    const existingTrackIds = new Set(existingItems.map((item) => item.trackId));
+    const additions = trackIds.filter(
+        (trackId) => !existingTrackIds.has(trackId),
+    );
+    if (additions.length === 0) return;
+    const startSort = (maximum._max.sort ?? -1) + 1;
+    await tx.playlistItem.createMany({
+        data: additions.map((trackId, index) => ({
+            playlistId,
+            trackId,
+            sort: startSort + index,
+        })),
+        skipDuplicates: true,
+    });
+}
+
+async function reindexLockedPlaylistItems(
+    tx: Prisma.TransactionClient,
+    playlistId: string,
+): Promise<void> {
+    const items = await tx.playlistItem.findMany({
+        where: { playlistId },
+        orderBy: { sort: "asc" },
+        select: { id: true },
+    });
+    await Promise.all(
+        items.map((item, sort) =>
+            tx.playlistItem.update({
+                where: { id: item.id },
+                data: { sort },
+            }),
+        ),
+    );
+}
+
+async function updateLockedPlaylist(
+    tx: Prisma.TransactionClient,
+    playlistId: string,
+    userId: string,
+    name: string,
+    rawIndexes: string[],
+    trackIdsToAdd: string[],
+): Promise<PlaylistMutationResult> {
+    await requirePlaylistMutationLock(tx, playlistId, userId);
+    if (!(await ensureLibraryTracksExist(trackIdsToAdd, tx))) {
+        return "trackNotFound";
+    }
+    if (name) {
+        await tx.playlist.update({
+            where: { id: playlistId },
+            data: { name },
+        });
+    }
+    await removeLockedPlaylistIndexes(tx, playlistId, rawIndexes);
+    await appendLockedPlaylistTracks(tx, playlistId, trackIdsToAdd);
+    await reindexLockedPlaylistItems(tx, playlistId);
+    return "ok";
 }
 
 /**
@@ -457,172 +589,35 @@ export async function handleUpdatePlaylist(
         return;
     }
 
+    let trackIdsToAdd: string[] = [];
     try {
-        const playlist = await prisma.playlist.findFirst({
-            where: {
-                id: playlistId,
-                userId: req.user!.id,
-            },
-            select: {
-                id: true,
-            },
-        });
+        trackIdsToAdd = parseTrackIdsFromQueryValues(rawSongIdsToAdd);
+    } catch {
+        sendPlaylistTrackNotFound(res, format, callback);
+        return;
+    }
 
-        if (!playlist) {
-            sendSubsonicError(
-                res,
-                SubsonicErrorCode.NOT_AUTHORIZED,
-                "Not authorized to modify this playlist",
-                format,
-                callback,
-            );
+    try {
+        const result = await prisma.$transaction((tx) =>
+            updateLockedPlaylist(
+                tx,
+                playlistId,
+                req.user!.id,
+                rawName,
+                rawSongIndexesToRemove,
+                trackIdsToAdd,
+            ),
+        );
+        if (result === "trackNotFound") {
+            sendPlaylistTrackNotFound(res, format, callback);
             return;
         }
-
-        if (rawName) {
-            await prisma.playlist.update({
-                where: {
-                    id: playlistId,
-                },
-                data: {
-                    name: rawName,
-                },
-            });
-        }
-
-        if (rawSongIndexesToRemove.length > 0) {
-            const indexesToRemove = Array.from(
-                new Set(
-                    rawSongIndexesToRemove
-                        .map((value) => Number.parseInt(value, 10))
-                        .filter(
-                            (value) => Number.isInteger(value) && value >= 0,
-                        ),
-                ),
-            );
-
-            const currentItems = await prisma.playlistItem.findMany({
-                where: {
-                    playlistId,
-                },
-                orderBy: {
-                    sort: "asc",
-                },
-                select: {
-                    id: true,
-                },
-            });
-
-            const itemIdsToDelete = indexesToRemove
-                .filter((index) => index < currentItems.length)
-                .map((index) => currentItems[index].id);
-
-            if (itemIdsToDelete.length > 0) {
-                await prisma.playlistItem.deleteMany({
-                    where: {
-                        id: {
-                            in: itemIdsToDelete,
-                        },
-                    },
-                });
-            }
-        }
-
-        if (rawSongIdsToAdd.length > 0) {
-            let trackIdsToAdd: string[] = [];
-            try {
-                trackIdsToAdd = parseTrackIdsFromQueryValues(rawSongIdsToAdd);
-            } catch {
-                sendSubsonicError(
-                    res,
-                    SubsonicErrorCode.NOT_FOUND,
-                    "Song not found",
-                    format,
-                    callback,
-                );
-                return;
-            }
-
-            const tracksExist = await ensureLibraryTracksExist(trackIdsToAdd);
-            if (!tracksExist) {
-                sendSubsonicError(
-                    res,
-                    SubsonicErrorCode.NOT_FOUND,
-                    "Song not found",
-                    format,
-                    callback,
-                );
-                return;
-            }
-
-            const [existingItems, maxSortResult] = await Promise.all([
-                prisma.playlistItem.findMany({
-                    where: {
-                        playlistId,
-                    },
-                    select: {
-                        trackId: true,
-                    },
-                }),
-                prisma.playlistItem.aggregate({
-                    where: {
-                        playlistId,
-                    },
-                    _max: {
-                        sort: true,
-                    },
-                }),
-            ]);
-
-            const existingTrackIds = new Set(
-                existingItems.map((item) => item.trackId),
-            );
-            const filteredTrackIds = trackIdsToAdd.filter(
-                (trackId) => !existingTrackIds.has(trackId),
-            );
-
-            if (filteredTrackIds.length > 0) {
-                const startSort = (maxSortResult._max.sort ?? -1) + 1;
-                await prisma.playlistItem.createMany({
-                    data: filteredTrackIds.map((trackId, index) => ({
-                        playlistId,
-                        trackId,
-                        sort: startSort + index,
-                    })),
-                    skipDuplicates: true,
-                });
-            }
-        }
-
-        const itemsToReindex = await prisma.playlistItem.findMany({
-            where: {
-                playlistId,
-            },
-            orderBy: {
-                sort: "asc",
-            },
-            select: {
-                id: true,
-            },
-        });
-
-        if (itemsToReindex.length > 0) {
-            await prisma.$transaction(
-                itemsToReindex.map((item, index) =>
-                    prisma.playlistItem.update({
-                        where: {
-                            id: item.id,
-                        },
-                        data: {
-                            sort: index,
-                        },
-                    }),
-                ),
-            );
-        }
-
         sendSubsonicSuccess(res, {}, format, callback);
-    } catch {
+    } catch (error) {
+        if (error instanceof PlaylistMutationLockNotFoundError) {
+            sendPlaylistMutationNotAuthorized(res, format, callback);
+            return;
+        }
         sendSubsonicError(
             res,
             SubsonicErrorCode.GENERIC,

--- a/backend/src/routes/subsonic/shared.ts
+++ b/backend/src/routes/subsonic/shared.ts
@@ -937,12 +937,16 @@ function parseEntityIdsFromQueryValues(
     return parsedIds;
 }
 
-async function ensureLibraryTracksExist(trackIds: string[]): Promise<boolean> {
+/** Checks visible Subsonic tracks through the supplied database scope. */
+async function ensureLibraryTracksExist(
+    trackIds: string[],
+    client: Pick<Prisma.TransactionClient, "track"> = prisma,
+): Promise<boolean> {
     if (trackIds.length === 0) {
         return true;
     }
 
-    const tracks = await prisma.track.findMany({
+    const tracks = await client.track.findMany({
         where: {
             ...LIBRARY_TRACK_WHERE,
             id: {

--- a/backend/src/services/playlistMutationLock.ts
+++ b/backend/src/services/playlistMutationLock.ts
@@ -9,6 +9,14 @@ export type LockedPlaylist = {
     mixId: string | null;
 };
 
+/** Signals that an owned playlist row could not be locked for mutation. */
+export class PlaylistMutationLockNotFoundError extends Error {
+    constructor() {
+        super("Owned playlist disappeared before mutation");
+        this.name = "PlaylistMutationLockNotFoundError";
+    }
+}
+
 /** Locks an owned playlist row so every item mutation uses Playlist-first order. */
 export async function takePlaylistLock(
     tx: Prisma.TransactionClient,
@@ -33,7 +41,7 @@ export async function requirePlaylistMutationLock(
 ): Promise<void> {
     const playlist = await takePlaylistLock(tx, playlistId, userId);
     if (!playlist) {
-        throw new Error("Owned playlist disappeared before mutation");
+        throw new PlaylistMutationLockNotFoundError();
     }
 }
 

--- a/backend/tests-integration/radioPlaylistConcurrencyPostgres.integration.test.ts
+++ b/backend/tests-integration/radioPlaylistConcurrencyPostgres.integration.test.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
 import { Client } from "pg";
 
 const mockSelectLibraryRadioStationTracks = jest.fn();
@@ -16,6 +17,7 @@ import {
     regenerateRadioPlaylist,
 } from "../src/services/radioPlaylistService";
 import playlistRouter from "../src/routes/playlists";
+import { handleUpdatePlaylist } from "../src/routes/subsonic/playlists";
 import { prisma } from "../src/utils/db";
 import {
     applyScaleMigrations,
@@ -42,6 +44,12 @@ type RouteResponse = {
     body: unknown;
     status(code: number): RouteResponse;
     json(body: unknown): RouteResponse;
+};
+
+type SubsonicRouteResponse = {
+    response: Response;
+    readonly statusCode: number;
+    readonly body: unknown;
 };
 
 function tracks(prefix: string, count: number, start = 1) {
@@ -161,6 +169,37 @@ function createRouteResponse(): RouteResponse {
     };
 }
 
+function createSubsonicRouteResponse(): SubsonicRouteResponse {
+    let statusCode = 200;
+    let body: unknown;
+    const response = {
+        locals: {},
+        status(code: number) {
+            statusCode = code;
+            return this;
+        },
+        set() {
+            return this;
+        },
+        type() {
+            return this;
+        },
+        send(value: unknown) {
+            body = typeof value === "string" ? JSON.parse(value) : value;
+            return this;
+        },
+    } as unknown as Response;
+    return {
+        response,
+        get statusCode() {
+            return statusCode;
+        },
+        get body() {
+            return body;
+        },
+    };
+}
+
 function getOrdinaryAddHandler() {
     type RouterLayer = {
         route?: {
@@ -228,6 +267,27 @@ async function removePlaylistItemThroughRoute(
         } as never,
         response as never,
         (() => undefined) as never,
+    );
+}
+
+async function updatePlaylistThroughSubsonic(
+    response: Response,
+): Promise<void> {
+    await handleUpdatePlaylist(
+        {
+            query: {
+                f: "json",
+                playlistId: `pl-${PLAYLIST_ID}`,
+                songIndexToRemove: "0",
+                songIdToAdd: "tr-track-11",
+            },
+            user: {
+                id: USER_ID,
+                username: "radio-concurrency-user",
+                role: "USER",
+            },
+        } as unknown as Request,
+        response,
     );
 }
 
@@ -505,6 +565,80 @@ describeWithPostgres("radio playlist PostgreSQL concurrency", () => {
             expect(response.body).toEqual({
                 message: "Track removed from playlist",
             });
+        } finally {
+            if (blockerOpen) await blocker.query("ROLLBACK");
+            await Promise.allSettled(pendingOperations);
+        }
+    });
+
+    it("serializes Subsonic mutation with regeneration without deadlock or mixed state", async () => {
+        await seedPlaylist(10);
+        const target = await prisma.playlistItem.findFirstOrThrow({
+            where: { playlistId: PLAYLIST_ID },
+            select: { id: true },
+            orderBy: { sort: "asc" },
+        });
+        mockSelectLibraryRadioStationTracks.mockResolvedValue({
+            tracks: tracks("replacement-1", REPLACEMENT_TRACK_COUNT),
+        });
+        const response = createSubsonicRouteResponse();
+        let blockerOpen = false;
+        const pendingOperations: Promise<unknown>[] = [];
+
+        try {
+            await blocker.query("BEGIN");
+            blockerOpen = true;
+            await blocker.query(
+                'SELECT id FROM "PlaylistItem" WHERE id = $1 FOR UPDATE',
+                [target.id],
+            );
+
+            const subsonicMutation = updatePlaylistThroughSubsonic(
+                response.response,
+            );
+            pendingOperations.push(subsonicMutation);
+            await waitForWaitingConnections(
+                database,
+                1,
+                "Subsonic playlist mutation did not wait for the item lock",
+            );
+
+            const regenerate = regenerateRadioPlaylist(USER_ID, PLAYLIST_ID);
+            pendingOperations.push(regenerate);
+            await waitForWaitingConnections(
+                database,
+                2,
+                "Radio regeneration did not wait behind the Subsonic mutation",
+            );
+            expect(mockSelectLibraryRadioStationTracks).not.toHaveBeenCalled();
+
+            await blocker.query("COMMIT");
+            blockerOpen = false;
+            const results = await Promise.allSettled([
+                subsonicMutation,
+                regenerate,
+            ]);
+
+            expect(results.map((result) => result.status)).toEqual([
+                "fulfilled",
+                "fulfilled",
+            ]);
+            expect(response.statusCode).toBe(200);
+            expect(response.body).toMatchObject({
+                "subsonic-response": { status: "ok" },
+            });
+            const rows = await database.query<{
+                trackId: string;
+                sort: number;
+            }>(`
+                SELECT "trackId", sort FROM "PlaylistItem"
+                WHERE "playlistId" = '${PLAYLIST_ID}' ORDER BY sort
+            `);
+            expect(rows.rows).toEqual(
+                tracks("replacement-1", REPLACEMENT_TRACK_COUNT).map(
+                    (track, index) => ({ trackId: track.id, sort: index }),
+                ),
+            );
         } finally {
             if (blockerOpen) await blocker.query("ROLLBACK");
             await Promise.allSettled(pendingOperations);


### PR DESCRIPTION
## Summary
Closes the High that escaped into #648's merge: Subsonic `createPlaylist?playlistId` (delete-and-recreate) and `updatePlaylist` (remove/add/reindex) mutated `PlaylistItem` rows with no outer transaction and no shared lock, so a Subsonic client editing a station playlist could interleave with regeneration — mixed contents or duplicate sort positions. Both flows now acquire `requirePlaylistMutationLock` (id + userId) first inside interactive transactions; Subsonic response shapes and error codes unchanged; generated playlists stay directly addressable per the documented compatibility contract.

## Testing
- Live-PostgreSQL Subsonic-mutation-vs-regenerate case (5-case integration suite green against pgvector:pg16).
- subsonicTierB + radioPlaylists + playlistsRuntime — 158/158 unsandboxed; tsc clean; pinned prettier, canon, file-size, OpenAPI sync all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)