### PR TITLE
fix(db): enable TCP keepalive on pooled Postgres connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Backend database pool connections now enable TCP keepalive with a 10-second initial probe delay, so pooled connections crossing NAT hops (NodePort services, firewalls, cross-cluster routing) no longer die silently and surface as "Connection terminated unexpectedly" errors.
 - Library and audiobook metadata, local cover-art, and audio-stream handlers now run rate limiting before authentication and use exactly one surface-specific budget per request. Local covers retain a high-volume shared budget without weakening the original 500/minute in-memory protection on external browse image proxies. The backend also overrides vulnerable `deepmerge-ts` 7.1.5 with 8.0.0 (#647).
 - OpenSubsonic playlist replacement and update mutations now share the Playlist-first transaction lock with generated-radio regeneration, preventing concurrent edits from deadlocking, mixing contents, or producing duplicate sort positions.
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Backend database pool connections now enable TCP keepalive with a 10-second initial probe delay, so pooled connections crossing NAT hops (NodePort services, firewalls, cross-cluster routing) no longer die silently and surface as "Connection terminated unexpectedly" errors.
+- Backend database pool connections now enable TCP keepalive with a 10-second initial probe delay, which detects dead pooled connections sooner and reduces "Connection terminated unexpectedly" failures when connections cross NAT hops (NodePort services, firewalls, cross-cluster routing).
 - Library and audiobook metadata, local cover-art, and audio-stream handlers now run rate limiting before authentication and use exactly one surface-specific budget per request. Local covers retain a high-volume shared budget without weakening the original 500/minute in-memory protection on external browse image proxies. The backend also overrides vulnerable `deepmerge-ts` 7.1.5 with 8.0.0 (#647).
 - OpenSubsonic playlist replacement and update mutations now share the Playlist-first transaction lock with generated-radio regeneration, preventing concurrent edits from deadlocking, mixing contents, or producing duplicate sort positions.
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).

--- a/backend/src/utils/__tests__/prismaClientFactory.test.ts
+++ b/backend/src/utils/__tests__/prismaClientFactory.test.ts
@@ -1,0 +1,63 @@
+const prismaPgConstructor = jest.fn();
+const prismaClientConstructor = jest.fn();
+
+jest.mock("@prisma/adapter-pg", () => ({
+    PrismaPg: class {
+        constructor(...args: unknown[]) {
+            prismaPgConstructor(...args);
+        }
+    },
+}));
+
+jest.mock("@prisma/client", () => ({
+    Prisma: {},
+    PrismaClient: class {
+        constructor(...args: unknown[]) {
+            prismaClientConstructor(...args);
+        }
+    },
+}));
+
+import { createPrismaClient } from "../prismaClientFactory";
+
+describe("createPrismaClient", () => {
+    beforeEach(() => {
+        prismaPgConstructor.mockClear();
+        prismaClientConstructor.mockClear();
+    });
+
+    it("enables TCP keepalive on the pg pool", () => {
+        createPrismaClient({ databaseUrl: "postgresql://u:p@db:5432/app" });
+
+        expect(prismaPgConstructor).toHaveBeenCalledTimes(1);
+        const poolConfig = prismaPgConstructor.mock.calls[0]?.[0] as Record<
+            string,
+            unknown
+        >;
+        expect(poolConfig.keepAlive).toBe(true);
+        expect(poolConfig.keepAliveInitialDelayMillis).toBe(10_000);
+    });
+
+    it("applies pool sizing and schema options", () => {
+        createPrismaClient({
+            databaseUrl: "postgresql://u:p@db:5432/app?schema=tenant",
+            connectionLimit: 12,
+            poolTimeoutSeconds: 20,
+        });
+
+        const [poolConfig, adapterOptions] = prismaPgConstructor.mock
+            .calls[0] as [Record<string, unknown>, Record<string, unknown>];
+        expect(poolConfig.max).toBe(12);
+        expect(poolConfig.connectionTimeoutMillis).toBe(20_000);
+        expect(adapterOptions).toEqual({ schema: "tenant" });
+    });
+
+    it("rejects invalid pool bounds", () => {
+        expect(() => createPrismaClient({ connectionLimit: 0 })).toThrow(
+            "connectionLimit must be >= 1",
+        );
+        expect(() => createPrismaClient({ poolTimeoutSeconds: 0 })).toThrow(
+            "poolTimeoutSeconds must be > 0",
+        );
+    });
+});

--- a/backend/src/utils/__tests__/prismaClientFactory.test.ts
+++ b/backend/src/utils/__tests__/prismaClientFactory.test.ts
@@ -1,13 +1,6 @@
-const prismaPgConstructor = jest.fn();
-const prismaClientConstructor = jest.fn();
+import type { PrismaPg } from "@prisma/adapter-pg";
 
-jest.mock("@prisma/adapter-pg", () => ({
-    PrismaPg: class {
-        constructor(...args: unknown[]) {
-            prismaPgConstructor(...args);
-        }
-    },
-}));
+const prismaClientConstructor = jest.fn();
 
 jest.mock("@prisma/client", () => ({
     Prisma: {},
@@ -20,36 +13,62 @@ jest.mock("@prisma/client", () => ({
 
 import { createPrismaClient } from "../prismaClientFactory";
 
+interface PgPoolOptions {
+    keepAlive?: boolean;
+    keepAliveInitialDelayMillis?: number;
+    max?: number;
+    connectionTimeoutMillis?: number;
+}
+
+/**
+ * Builds the REAL PrismaPg adapter through the factory and returns the pg
+ * pool options it hands to pg.Pool. connect() constructs the pool lazily,
+ * so no database connection is opened.
+ */
+async function poolOptionsFor(
+    options: Parameters<typeof createPrismaClient>[0],
+): Promise<{ poolOptions: PgPoolOptions; adapterFactory: PrismaPg }> {
+    createPrismaClient(options);
+    const clientArgs = prismaClientConstructor.mock.calls.at(-1)?.[0] as {
+        adapter: PrismaPg;
+    };
+    const adapterFactory = clientArgs.adapter;
+    const adapter = await adapterFactory.connect();
+    const pool = adapter.underlyingDriver() as unknown as {
+        options: PgPoolOptions;
+    };
+    const poolOptions = pool.options;
+    await adapter.dispose();
+    return { poolOptions, adapterFactory };
+}
+
 describe("createPrismaClient", () => {
     beforeEach(() => {
-        prismaPgConstructor.mockClear();
         prismaClientConstructor.mockClear();
     });
 
-    it("enables TCP keepalive on the pg pool", () => {
-        createPrismaClient({ databaseUrl: "postgresql://u:p@db:5432/app" });
+    it("enables TCP keepalive on the pg pool", async () => {
+        const { poolOptions } = await poolOptionsFor({
+            databaseUrl: "postgresql://u:p@db:5432/app",
+        });
 
-        expect(prismaPgConstructor).toHaveBeenCalledTimes(1);
-        const poolConfig = prismaPgConstructor.mock.calls[0]?.[0] as Record<
-            string,
-            unknown
-        >;
-        expect(poolConfig.keepAlive).toBe(true);
-        expect(poolConfig.keepAliveInitialDelayMillis).toBe(10_000);
+        expect(poolOptions.keepAlive).toBe(true);
+        expect(poolOptions.keepAliveInitialDelayMillis).toBe(10_000);
     });
 
-    it("applies pool sizing and schema options", () => {
-        createPrismaClient({
+    it("applies pool sizing and schema options", async () => {
+        const { poolOptions, adapterFactory } = await poolOptionsFor({
             databaseUrl: "postgresql://u:p@db:5432/app?schema=tenant",
             connectionLimit: 12,
             poolTimeoutSeconds: 20,
         });
 
-        const [poolConfig, adapterOptions] = prismaPgConstructor.mock
-            .calls[0] as [Record<string, unknown>, Record<string, unknown>];
-        expect(poolConfig.max).toBe(12);
-        expect(poolConfig.connectionTimeoutMillis).toBe(20_000);
-        expect(adapterOptions).toEqual({ schema: "tenant" });
+        expect(poolOptions.max).toBe(12);
+        expect(poolOptions.connectionTimeoutMillis).toBe(20_000);
+        expect(
+            (adapterFactory as unknown as { options?: { schema?: string } })
+                .options?.schema,
+        ).toBe("tenant");
     });
 
     it("rejects invalid pool bounds", () => {

--- a/backend/src/utils/prismaClientFactory.ts
+++ b/backend/src/utils/prismaClientFactory.ts
@@ -1,6 +1,9 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
+// First keepalive probe after 10s idle; kernel defaults handle the cadence.
+const KEEP_ALIVE_INITIAL_DELAY_MS = 10_000;
+
 export interface CreatePrismaClientOptions {
     /** Maximum pooled connections (pg Pool `max`). */
     connectionLimit?: number;
@@ -48,6 +51,12 @@ export function createPrismaClient(
     const adapter = new PrismaPg(
         {
             connectionString: databaseUrl,
+            // TCP keepalive protects pooled connections that cross NAT hops
+            // (NodePort, firewalls, cross-cluster routing): without probes an
+            // idle flow's conntrack entry expires and the next query dies with
+            // "Connection terminated unexpectedly".
+            keepAlive: true,
+            keepAliveInitialDelayMillis: KEEP_ALIVE_INITIAL_DELAY_MS,
             ...(connectionLimit !== undefined ? { max: connectionLimit } : {}),
             ...(poolTimeoutSeconds !== undefined
                 ? { connectionTimeoutMillis: poolTimeoutSeconds * 1000 }

--- a/backend/src/utils/prismaClientFactory.ts
+++ b/backend/src/utils/prismaClientFactory.ts
@@ -1,7 +1,8 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
-// First keepalive probe after 10s idle; kernel defaults handle the cadence.
+// First keepalive probe after 10s idle. Node then applies its own probe
+// cadence (TCP_KEEPINTVL=1s, TCP_KEEPCNT=10) rather than kernel defaults.
 const KEEP_ALIVE_INITIAL_DELAY_MS = 10_000;
 
 export interface CreatePrismaClientOptions {


### PR DESCRIPTION
Homelab logs showed repeated `GET /api/library/radio` 500s with `Connection terminated unexpectedly` from pg-pool. The proximate cause there was database-side instability, but the failure mode is generic: the backend's pg pool runs with node-postgres defaults (`keepAlive: false`), so any pooled connection that crosses a NAT hop — NodePort services, firewalls, cross-cluster routing — can have its conntrack entry silently expire while idle or during a long-running query. The next read on that socket fails and surfaces to the user as a 500.

`prismaClientFactory` (the single place the backend builds its pg adapter) now sets `keepAlive: true` with a 10-second initial probe delay. Kernel defaults handle probe cadence after that. This keeps NAT/firewall state alive and turns silent socket death into prompt, retryable connection errors.

New unit tests for the factory: keepalive settings reach the pool config, pool sizing/schema options still apply, and invalid bounds still throw. Typecheck and prettier clean.