### PR TITLE
feat(radio): /radio station cards open generated playlists like the Explore tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Backend database pool connections now enable TCP keepalive with a 10-second initial probe delay, which detects dead pooled connections sooner and reduces "Connection terminated unexpectedly" failures when connections cross NAT hops (NodePort services, firewalls, cross-cluster routing).
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Library and audiobook metadata, local cover-art, and audio-stream handlers now run rate limiting before authentication and use exactly one surface-specific budget per request. Local covers retain a high-volume shared budget without weakening the original 500/minute in-memory protection on external browse image proxies. The backend also overrides vulnerable `deepmerge-ts` 7.1.5 with 8.0.0 (#647).
 - OpenSubsonic playlist replacement and update mutations now share the Playlist-first transaction lock with generated-radio regeneration, preventing concurrent edits from deadlocking, mixing contents, or producing duplicate sort positions.
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).
@@ -106,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Fixed the 2.3.2 audio-analyzer images failing to start because new loudness
   modules were missing from both the standalone and all-in-one images.
 
@@ -174,6 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - The DCLAP provider no longer exhausts memory on very long tracks because
   audio decoding is capped and mel segments stream through inference.
 - Purge status no longer reports a purge as running when only the daily
@@ -210,6 +216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Fixed embedding-space index checks so existing matching indexes are not
   rebuilt on every lifecycle tick.
@@ -315,6 +323,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Provider heartbeats now re-probe reachability each cycle, migration progress
   is visible in settings, coverage sampling is statement-time bounded, and Helm
   upgrade guidance waits for old backend and worker pods to be deleted.
@@ -381,6 +391,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Fixed the local-profile Docker build for the MusicCNN audio analyzer by using
   the repository root, matching the root-relative paths its Dockerfile uses.
 - The interface font (Montserrat) is now bundled with the app instead of
@@ -425,6 +437,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audiobook detail loads now serve validated sections and metadata from the local cache instead of fetching Audiobookshelf live. Sections are computed during sync when expanded Audiobookshelf data is available and backfilled lazily on first view for books synced before this change or from minified library listings. The retained `numChapters` column is superseded and no longer refreshed.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Guarded every Python sidecar against Docker interpreter and uv lock-target
   drift, and documented the TensorFlow 2.15 wheel ceiling that keeps the
@@ -572,6 +586,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - OIDC browser flows now bind callback and one-time hand-off tokens to the
   initiating browser, count redirect responses against rate limits, serialize
   role demotion and identity unlink guards, enforce one identity per provider
@@ -624,6 +640,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - M3U playlist import previews no longer fail with a 15-second timeout on
   large libraries. The frontend now gives the M3U preview the same 60-second
   window as URL imports. The backend now matches entries against a prebuilt
@@ -638,6 +656,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The CLAP analyzer image now ships `pgrep` so the Helm chart's default liveness and readiness probes work (#448).
 
@@ -986,6 +1006,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of being dropped.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The release-notes generator now supports the Accessibility changelog section.
 - The all-in-one image builds again by copying the Prisma config's database-URL
@@ -1872,6 +1894,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - The vibe map's `/api/vibe/map` projection worker now loads under tsx dev mode: tsx's loader hooks don't propagate into `worker_threads`, so the `.ts` UMAP worker registers tsx in its own `execArgv` (compiled `dist/` deployments are unaffected).
 - Direct Soulseek downloads now require an administrator, matching the existing
   server-side authorization on YouTube acquisition and preventing ordinary
@@ -1948,6 +1972,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Queue auto-advance can no longer land on a silently paused next track (#53). Track-end advancement now _declares_ play intent — the end handler stamps a bounded (30s) intent that the next load consumes for its autoplay decision — instead of inferring it from transient UI playing state, which raced the element's `pause`→`ended` event pair under the native engine (the element's pause fires before ended, so both the isPlaying mirror and `engine.isPlaying()` could read false by load time). And when autoplay is rejected with `NotAllowedError` in a hidden tab (auto-advance while tabbed away), the native engine now retries `play()` once on the hidden→visible transition instead of sitting silent until a user gesture; the one-shot gesture retry stays armed as the fallback, and a user pause in between is respected.
 - Clearing the queue actually sticks now (#52). `DELETE /api/playback-state` removed only the caller's device row, while `GET /api/playback-state` still fell back to the shared pre-device `legacy` row and opportunistically re-migrated it onto the device — so the next playback-state poll resurrected the entire cleared queue within a minute. An explicit clear now deletes the legacy row along with the device row; the GET fallback's legacy migration for genuinely new devices is unchanged.
 - Repaired the five backend radio test failures that shipped silently with 1.7.0's generation-diversity work (#46): the library route tests' config mock lacked the new `generationDiversity` block, their mock chains didn't account for the diversify stage's artist lookup query, and the vibe random-filler matcher still required the `take` parameter that #46 replaced with uniform sampling. The backend "Tests + Coverage" job is a non-blocking visibility job, so the failures never turned a run red — worth revisiting alongside the CI gating gap tracked in #54.
@@ -1967,6 +1993,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Genre radio, auto-mixes, and every other generated queue are no longer dominated by the same 1-3 artists (#46). All generation surfaces now select through one shared damped-proportional artist allocator (each artist weighs `n^alpha`, default alpha `0.5`, under a hard per-artist ceiling, default 30% of queue size — both env-tunable via `GENERATION_ARTIST_WEIGHT_ALPHA` / `GENERATION_ARTIST_SHARE_CEILING`), so large discographies still carry more weight than one-hit wonders without ever being a majority. Pool construction biases fixed everywhere: genre radio prefers track-level genre evidence (Last.fm track tags, Essentia) over whole-discography artist tags and samples pools uniformly instead of taking a deterministic unordered slice (decade/mood/workout/discovery/favorites radio and the vibe fallbacks likewise); the mix artist-cap's refill-after-relaxation no longer un-caps itself (a shorter diverse playlist beats a full-length dominated one); mood buckets sample a 500-track quality band instead of a deterministic top-100; the Subsonic `getSongsByGenre` alphabetical slice became a day-stable seeded shuffle (pagination stays coherent within a day); and the frontend's no-op client-side "diversifier" was removed (diversity is enforced server-side). Daily/weekly mixes remain deterministic per seed. The playlist-diversity baseline script now also asserts the weighting bound on its artist-skewed stratum.
 
 ### Changed
@@ -1976,6 +2004,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.1] - 2026-07-08
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The empty-string overwrite hazard is closed for **all** stored secrets, not just TIDAL. `POST /api/system-settings` now treats every encrypted secret field (`lidarrApiKey`, `lidarrWebhookSecret`, `openaiApiKey`, `fanartApiKey`, `lastfmApiKey`, `audiobookshelfApiKey`, `soulseekPassword`, `spotifyClientSecret`, `ytMusicClientSecret`) as write-only with explicit semantics: a non-empty value replaces the secret, an empty string is a no-op (so a settings-form round-trip can never wipe a stored credential), and `null` explicitly clears it. The guard iterates the canonical `ENCRYPTED_SETTINGS_COLUMNS` list, so future secret columns are covered automatically, and the post-save consumers (`.env` file sync, Lidarr webhook auto-configuration) resolve the same effective values — previously the `.env` sync wrote `null` over `LIDARR_API_KEY`/`FANART_API_KEY`/`OPENAI_API_KEY`/`AUDIOBOOKSHELF_API_KEY` on the identical empty-string round-trip. Note: clearing a secret from the settings UI (by emptying the field) is no longer possible — disable the service instead, or send an explicit `null` via the API. The Soulseek connection is also no longer bounced when the settings form round-trips an empty password.
 - Library scans no longer starve the worker's event loop and get the worker killed. The 1.6.0 opus-duration fix made every file pay for a full-file `duration: true` parse; with the scanner's 10-way concurrency a large scan pegged the single Node thread for minutes, so Bull couldn't renew job locks ("Missing lock"/"job stalled" errors, scans endlessly re-queued) and the liveness probe timed out until the kubelet killed the worker — on repeat, on both replicas. The scanner now does a cheap header-only parse first and pays for the full-file parse only when the header lacks a duration (ogg/opus, e.g. YouTube downloads), preserving the 1.6.0 fix at a fraction of the cost.
@@ -2001,6 +2031,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted playback state (server and local) round-trips mixed queues; queues saved by older clients are migrated as music tracks automatically.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Invite-code registration is now race-safe. The use-count check and increment were separated (check read before the transaction, increment unconditional), so two concurrent registrations on a single-use code could both succeed and push `useCount` past `maxUses`. Consumption is now an atomic conditional update (`useCount < maxUses`) inside the registration transaction; if no use remains the transaction aborts and no account is created.
 - The `library-scan` queue no longer grows Redis unbounded. Most enqueue sites added scan jobs without retention options, so completed/failed records accumulated forever. The queue now defaults to keeping the last 100 completed (still enough for the recent-job status lookup) and 200 failed jobs.
@@ -2097,6 +2129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Admin Library Health now loads and dismisses health records through dedicated `/api/admin/library-health` endpoints instead of failing on a missing backend route.
 - Library validation no longer deletes unrelated health records (e.g. `UNREADABLE_METADATA`) when clearing `MISSING_FROM_DISK` entries for tracks that reappear on disk.
 - Generic import job cancellation now uses an intermediate `cancelling` state so late cancellations after playlist creation record the completed playlist instead of discarding it.
@@ -2117,6 +2151,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Frontend queued-track ID memoization now stays stable when queue membership is unchanged, reducing queue-derived state churn across local playback and Listen Together sessions.
 - Remote liked-track metadata now repairs itself when placeholder-only TIDAL or YouTube entries are liked or replayed, and the background TIDAL repair job no longer depends on whichever unrelated authenticated user happens to sort first in the database.
 - Listen Together queue creation and shared-queue additions once again truncate overflow beyond the 500-track cap instead of rejecting oversized requests outright.
@@ -2131,6 +2167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Foreground recovery now detects tracks that finished while the screen was locked and advances to the next track instead of replaying the same one.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Fixed playback not advancing to the next queued track when the phone screen is locked (Android PWA and background tabs). Browsers throttle JavaScript timers when the page is hidden, preventing the audio engine from detecting track completion. The player now listens for the native HTML5 audio `ended` event as a fallback, and foreground recovery on unlock advances to the next track when the current one finished while backgrounded.
 
@@ -2153,6 +2191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Listen Together: fixed a guest recovery race where follower-side stall/handoff recovery could run in parallel with session resync after mid-track buffering, causing doubled playback or unintended stops.
 - Library scan now promotes preexisting remote album rows into owned library albums when local files arrive, preventing downloaded albums from staying hidden behind `REMOTE` state.
 - Track-mapping reconciliation now sweeps forward through the backlog instead of retrying the same oldest skipped rows forever, so imported provider tracks can switch over to local copies after scan.
@@ -2168,6 +2208,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concurrent audio transcodes for the same track and quality now share a single ffmpeg job instead of spawning duplicates, and the transcoded file cache uses upsert to prevent duplicate-record races.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Listen Together: fixed a race condition where hard-refreshing the page with a large queue could disconnect the user from the session due to the Socket.IO payload exceeding the buffer limit.
 - Listen Together: fixed duplicate resume and recovery races in the playback orchestrator, including follower pause recovery and reconnect delta suppression that could cause playback state to flicker.
@@ -2240,6 +2282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Fixed remote stream duration display where TIDAL HI_RES_LOSSLESS fragmented MP4 streams reported only the first fragment's duration (~4 seconds) instead of the full track length.
 - Fixed playlist and Subsonic serializers to handle nullable track references safely after the remote-track schema changes.
 - Fixed track-mapping batch validation to reject payloads missing all linkage keys.
@@ -2298,6 +2342,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Profile picture serving returned JSON-serialized byte arrays (`{"0":255,"1":216,...}`) instead of binary image data because Express `res.send()` doesn't handle `Uint8Array` from Prisma. Fixed by wrapping with `Buffer.from()`.
 - Profile picture avatar never recovered from initial 404 — once `imgError` was set (no picture uploaded yet), it stayed true permanently even after uploading. Added cross-component event dispatch and cache-busting query parameter.
 - Library could appear empty in the UI due to the Next.js API proxy double-decompressing gzip responses. Node.js `fetch` auto-decompresses but preserves `Content-Encoding` headers, causing the browser to attempt a second decompression. Fixed by stripping compression-related headers in the proxy.
@@ -2349,6 +2395,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Fixed transient Listen Together socket conflicts for `seek()`/`reportReady()` with bounded retry, backoff, and jitter.
 - Fixed segmented-playback recovery so local player state remains authoritative for resume position and play/pause intent after disruptions.
 - Fixed long buffering/spinner stalls by keeping heartbeat checks active during buffering and retrying segmented startup within bounded stage/window budgets before surfacing timeout errors.
@@ -2398,6 +2446,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Reduced unnecessary client API traffic by removing render-phase state writes and consolidating overlapping polling ownership in activity/download/playback flows.
 - Added backend response compression for compressible API responses while excluding stream/media and `no-transform` responses.
 - Added missing `next/image` `sizes` attributes across fixed-size image callsites to improve responsive image selection.
@@ -2427,6 +2477,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Fixed queue insertion behavior so Add to Queue appends to the queue tail instead of being inserted after the current track.
 - Fixed overlay player layering so playlist picker/menus render inside the correct z-index context.
 - Fixed mobile track-row spacing and control sizing on small screens.
@@ -2449,6 +2501,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
+
 - Reduced repeated-artist clustering across radio/vibe/discovery recommendation paths and applied light thumbs weighting.
 - Fixed repeated thumbs taps so active thumbs-up/down cleanly toggle back to neutral; opposite action now cleanly overrides prior state.
 - Fixed intermittent UI navigation stalls by re-enabling sidebar route prefetch and bypassing Next.js route-transition requests in the service worker.
@@ -2467,6 +2521,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated preflight/index validation flow to rebuild indexes before strict verification, reducing stale-index blocking during release checks.
 
 ### Fixed
+
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Activity Social tab no longer flickers to "Social status unavailable" during transient refresh failures when cached online users are already available.
 - Fixed off-theme discover play controls so they match the active UI color system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Backend database pool connections now enable TCP keepalive with a 10-second initial probe delay, which detects dead pooled connections sooner and reduces "Connection terminated unexpectedly" failures when connections cross NAT hops (NodePort services, firewalls, cross-cluster routing).
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
+- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, decade stations outside the generated-playlist API's accepted range are no longer offered, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 - Library and audiobook metadata, local cover-art, and audio-stream handlers now run rate limiting before authentication and use exactly one surface-specific budget per request. Local covers retain a high-volume shared budget without weakening the original 500/minute in-memory protection on external browse image proxies. The backend also overrides vulnerable `deepmerge-ts` 7.1.5 with 8.0.0 (#647).
 - OpenSubsonic playlist replacement and update mutations now share the Playlist-first transaction lock with generated-radio regeneration, preventing concurrent edits from deadlocking, mixing contents, or producing duplicate sort positions.
 - Artist Popular Tracks now preserve persisted local and federated preference IDs after provider enrichment and use the same canonical remote ID for playback and heart state, preventing likes from switching identity (#642).
@@ -108,8 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Fixed the 2.3.2 audio-analyzer images failing to start because new loudness
   modules were missing from both the standalone and all-in-one images.
 
@@ -178,8 +175,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - The DCLAP provider no longer exhausts memory on very long tracks because
   audio decoding is capped and mel segments stream through inference.
 - Purge status no longer reports a purge as running when only the daily
@@ -216,8 +211,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Fixed embedding-space index checks so existing matching indexes are not
   rebuilt on every lifecycle tick.
@@ -323,8 +316,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Provider heartbeats now re-probe reachability each cycle, migration progress
   is visible in settings, coverage sampling is statement-time bounded, and Helm
   upgrade guidance waits for old backend and worker pods to be deleted.
@@ -391,8 +382,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Fixed the local-profile Docker build for the MusicCNN audio analyzer by using
   the repository root, matching the root-relative paths its Dockerfile uses.
 - The interface font (Montserrat) is now bundled with the app instead of
@@ -437,8 +426,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audiobook detail loads now serve validated sections and metadata from the local cache instead of fetching Audiobookshelf live. Sections are computed during sync when expanded Audiobookshelf data is available and backfilled lazily on first view for books synced before this change or from minified library listings. The retained `numChapters` column is superseded and no longer refreshed.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Guarded every Python sidecar against Docker interpreter and uv lock-target
   drift, and documented the TensorFlow 2.15 wheel ceiling that keeps the
@@ -586,8 +573,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - OIDC browser flows now bind callback and one-time hand-off tokens to the
   initiating browser, count redirect responses against rate limits, serialize
   role demotion and identity unlink guards, enforce one identity per provider
@@ -640,8 +625,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - M3U playlist import previews no longer fail with a 15-second timeout on
   large libraries. The frontend now gives the M3U preview the same 60-second
   window as URL imports. The backend now matches entries against a prebuilt
@@ -656,8 +639,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The CLAP analyzer image now ships `pgrep` so the Helm chart's default liveness and readiness probes work (#448).
 
@@ -1006,8 +987,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of being dropped.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The release-notes generator now supports the Accessibility changelog section.
 - The all-in-one image builds again by copying the Prisma config's database-URL
@@ -1894,8 +1873,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - The vibe map's `/api/vibe/map` projection worker now loads under tsx dev mode: tsx's loader hooks don't propagate into `worker_threads`, so the `.ts` UMAP worker registers tsx in its own `execArgv` (compiled `dist/` deployments are unaffected).
 - Direct Soulseek downloads now require an administrator, matching the existing
   server-side authorization on YouTube acquisition and preventing ordinary
@@ -1972,8 +1949,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Queue auto-advance can no longer land on a silently paused next track (#53). Track-end advancement now _declares_ play intent — the end handler stamps a bounded (30s) intent that the next load consumes for its autoplay decision — instead of inferring it from transient UI playing state, which raced the element's `pause`→`ended` event pair under the native engine (the element's pause fires before ended, so both the isPlaying mirror and `engine.isPlaying()` could read false by load time). And when autoplay is rejected with `NotAllowedError` in a hidden tab (auto-advance while tabbed away), the native engine now retries `play()` once on the hidden→visible transition instead of sitting silent until a user gesture; the one-shot gesture retry stays armed as the fallback, and a user pause in between is respected.
 - Clearing the queue actually sticks now (#52). `DELETE /api/playback-state` removed only the caller's device row, while `GET /api/playback-state` still fell back to the shared pre-device `legacy` row and opportunistically re-migrated it onto the device — so the next playback-state poll resurrected the entire cleared queue within a minute. An explicit clear now deletes the legacy row along with the device row; the GET fallback's legacy migration for genuinely new devices is unchanged.
 - Repaired the five backend radio test failures that shipped silently with 1.7.0's generation-diversity work (#46): the library route tests' config mock lacked the new `generationDiversity` block, their mock chains didn't account for the diversify stage's artist lookup query, and the vibe random-filler matcher still required the `take` parameter that #46 replaced with uniform sampling. The backend "Tests + Coverage" job is a non-blocking visibility job, so the failures never turned a run red — worth revisiting alongside the CI gating gap tracked in #54.
@@ -1993,8 +1968,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Genre radio, auto-mixes, and every other generated queue are no longer dominated by the same 1-3 artists (#46). All generation surfaces now select through one shared damped-proportional artist allocator (each artist weighs `n^alpha`, default alpha `0.5`, under a hard per-artist ceiling, default 30% of queue size — both env-tunable via `GENERATION_ARTIST_WEIGHT_ALPHA` / `GENERATION_ARTIST_SHARE_CEILING`), so large discographies still carry more weight than one-hit wonders without ever being a majority. Pool construction biases fixed everywhere: genre radio prefers track-level genre evidence (Last.fm track tags, Essentia) over whole-discography artist tags and samples pools uniformly instead of taking a deterministic unordered slice (decade/mood/workout/discovery/favorites radio and the vibe fallbacks likewise); the mix artist-cap's refill-after-relaxation no longer un-caps itself (a shorter diverse playlist beats a full-length dominated one); mood buckets sample a 500-track quality band instead of a deterministic top-100; the Subsonic `getSongsByGenre` alphabetical slice became a day-stable seeded shuffle (pagination stays coherent within a day); and the frontend's no-op client-side "diversifier" was removed (diversity is enforced server-side). Daily/weekly mixes remain deterministic per seed. The playlist-diversity baseline script now also asserts the weighting bound on its artist-skewed stratum.
 
 ### Changed
@@ -2004,8 +1977,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.1] - 2026-07-08
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - The empty-string overwrite hazard is closed for **all** stored secrets, not just TIDAL. `POST /api/system-settings` now treats every encrypted secret field (`lidarrApiKey`, `lidarrWebhookSecret`, `openaiApiKey`, `fanartApiKey`, `lastfmApiKey`, `audiobookshelfApiKey`, `soulseekPassword`, `spotifyClientSecret`, `ytMusicClientSecret`) as write-only with explicit semantics: a non-empty value replaces the secret, an empty string is a no-op (so a settings-form round-trip can never wipe a stored credential), and `null` explicitly clears it. The guard iterates the canonical `ENCRYPTED_SETTINGS_COLUMNS` list, so future secret columns are covered automatically, and the post-save consumers (`.env` file sync, Lidarr webhook auto-configuration) resolve the same effective values — previously the `.env` sync wrote `null` over `LIDARR_API_KEY`/`FANART_API_KEY`/`OPENAI_API_KEY`/`AUDIOBOOKSHELF_API_KEY` on the identical empty-string round-trip. Note: clearing a secret from the settings UI (by emptying the field) is no longer possible — disable the service instead, or send an explicit `null` via the API. The Soulseek connection is also no longer bounced when the settings form round-trips an empty password.
 - Library scans no longer starve the worker's event loop and get the worker killed. The 1.6.0 opus-duration fix made every file pay for a full-file `duration: true` parse; with the scanner's 10-way concurrency a large scan pegged the single Node thread for minutes, so Bull couldn't renew job locks ("Missing lock"/"job stalled" errors, scans endlessly re-queued) and the liveness probe timed out until the kubelet killed the worker — on repeat, on both replicas. The scanner now does a cheap header-only parse first and pays for the full-file parse only when the header lacks a duration (ogg/opus, e.g. YouTube downloads), preserving the 1.6.0 fix at a fraction of the cost.
@@ -2031,8 +2002,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted playback state (server and local) round-trips mixed queues; queues saved by older clients are migrated as music tracks automatically.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Invite-code registration is now race-safe. The use-count check and increment were separated (check read before the transaction, increment unconditional), so two concurrent registrations on a single-use code could both succeed and push `useCount` past `maxUses`. Consumption is now an atomic conditional update (`useCount < maxUses`) inside the registration transaction; if no use remains the transaction aborts and no account is created.
 - The `library-scan` queue no longer grows Redis unbounded. Most enqueue sites added scan jobs without retention options, so completed/failed records accumulated forever. The queue now defaults to keeping the last 100 completed (still enough for the recent-job status lookup) and 200 failed jobs.
@@ -2129,8 +2098,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Admin Library Health now loads and dismisses health records through dedicated `/api/admin/library-health` endpoints instead of failing on a missing backend route.
 - Library validation no longer deletes unrelated health records (e.g. `UNREADABLE_METADATA`) when clearing `MISSING_FROM_DISK` entries for tracks that reappear on disk.
 - Generic import job cancellation now uses an intermediate `cancelling` state so late cancellations after playlist creation record the completed playlist instead of discarding it.
@@ -2151,8 +2118,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Frontend queued-track ID memoization now stays stable when queue membership is unchanged, reducing queue-derived state churn across local playback and Listen Together sessions.
 - Remote liked-track metadata now repairs itself when placeholder-only TIDAL or YouTube entries are liked or replayed, and the background TIDAL repair job no longer depends on whichever unrelated authenticated user happens to sort first in the database.
 - Listen Together queue creation and shared-queue additions once again truncate overflow beyond the 500-track cap instead of rejecting oversized requests outright.
@@ -2167,8 +2132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Foreground recovery now detects tracks that finished while the screen was locked and advances to the next track instead of replaying the same one.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Fixed playback not advancing to the next queued track when the phone screen is locked (Android PWA and background tabs). Browsers throttle JavaScript timers when the page is hidden, preventing the audio engine from detecting track completion. The player now listens for the native HTML5 audio `ended` event as a fallback, and foreground recovery on unlock advances to the next track when the current one finished while backgrounded.
 
@@ -2191,8 +2154,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Listen Together: fixed a guest recovery race where follower-side stall/handoff recovery could run in parallel with session resync after mid-track buffering, causing doubled playback or unintended stops.
 - Library scan now promotes preexisting remote album rows into owned library albums when local files arrive, preventing downloaded albums from staying hidden behind `REMOTE` state.
 - Track-mapping reconciliation now sweeps forward through the backlog instead of retrying the same oldest skipped rows forever, so imported provider tracks can switch over to local copies after scan.
@@ -2208,8 +2169,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concurrent audio transcodes for the same track and quality now share a single ffmpeg job instead of spawning duplicates, and the transcoded file cache uses upsert to prevent duplicate-record races.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Listen Together: fixed a race condition where hard-refreshing the page with a large queue could disconnect the user from the session due to the Socket.IO payload exceeding the buffer limit.
 - Listen Together: fixed duplicate resume and recovery races in the playback orchestrator, including follower pause recovery and reconnect delta suppression that could cause playback state to flicker.
@@ -2282,8 +2241,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Fixed remote stream duration display where TIDAL HI_RES_LOSSLESS fragmented MP4 streams reported only the first fragment's duration (~4 seconds) instead of the full track length.
 - Fixed playlist and Subsonic serializers to handle nullable track references safely after the remote-track schema changes.
 - Fixed track-mapping batch validation to reject payloads missing all linkage keys.
@@ -2342,8 +2299,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Profile picture serving returned JSON-serialized byte arrays (`{"0":255,"1":216,...}`) instead of binary image data because Express `res.send()` doesn't handle `Uint8Array` from Prisma. Fixed by wrapping with `Buffer.from()`.
 - Profile picture avatar never recovered from initial 404 — once `imgError` was set (no picture uploaded yet), it stayed true permanently even after uploading. Added cross-component event dispatch and cache-busting query parameter.
 - Library could appear empty in the UI due to the Next.js API proxy double-decompressing gzip responses. Node.js `fetch` auto-decompresses but preserves `Content-Encoding` headers, causing the browser to attempt a second decompression. Fixed by stripping compression-related headers in the proxy.
@@ -2395,8 +2350,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Fixed transient Listen Together socket conflicts for `seek()`/`reportReady()` with bounded retry, backoff, and jitter.
 - Fixed segmented-playback recovery so local player state remains authoritative for resume position and play/pause intent after disruptions.
 - Fixed long buffering/spinner stalls by keeping heartbeat checks active during buffering and retrying segmented startup within bounded stage/window budgets before surfacing timeout errors.
@@ -2446,8 +2399,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Reduced unnecessary client API traffic by removing render-phase state writes and consolidating overlapping polling ownership in activity/download/playback flows.
 - Added backend response compression for compressible API responses while excluding stream/media and `no-transform` responses.
 - Added missing `next/image` `sizes` attributes across fixed-size image callsites to improve responsive image selection.
@@ -2477,8 +2428,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Fixed queue insertion behavior so Add to Queue appends to the queue tail instead of being inserted after the current track.
 - Fixed overlay player layering so playlist picker/menus render inside the correct z-index context.
 - Fixed mobile track-row spacing and control sizing on small screens.
@@ -2501,8 +2450,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
-
 - Reduced repeated-artist clustering across radio/vibe/discovery recommendation paths and applied light thumbs weighting.
 - Fixed repeated thumbs taps so active thumbs-up/down cleanly toggle back to neutral; opposite action now cleanly overrides prior state.
 - Fixed intermittent UI navigation stalls by re-enabling sidebar route prefetch and bypassing Next.js route-transition requests in the service worker.
@@ -2521,8 +2468,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated preflight/index validation flow to rebuild indexes before strict verification, reducing stale-index blocking during release checks.
 
 ### Fixed
-
-- Radio station cards on the /radio page now open generated playlists (like the Explore tiles) instead of instantly replacing the queue, covering dynamically generated genre and decade stations; Shuffle All keeps its instant-play behavior. The shared open flow lives in one helper used by both pages, and the hover play-button overlay is gone from station cards — a spinner shows only while a station opens.
 
 - Activity Social tab no longer flickers to "Social status unavailable" during transient refresh failures when cached online users are already available.
 - Fixed off-theme discover play controls so they match the active UI color system.

--- a/frontend/app/radio/page.tsx
+++ b/frontend/app/radio/page.tsx
@@ -2,30 +2,18 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
 import { AudioLines } from "lucide-react";
-import { api, type RadioPlaylistFilter } from "@/lib/api";
 import { useAudioControls } from "@/lib/audio-controls-context";
 import { openRadioStation } from "@/lib/radio/openRadioStation";
-import { PageHeader } from "@/components/layout/PageHeader";
 import {
-    RadioStationCard,
-    RadioStationCardStation,
-} from "@/components/ui/RadioStationCard";
-
-// Narrow the card's loose filter union so non-shuffle stations are provably
-// valid generated-playlist filters.
-type RadioStation = Omit<RadioStationCardStation, "filter"> & {
-    filter: { type: "all" } | RadioPlaylistFilter;
-};
-
-interface GenreCount {
-    genre: string;
-    count: number;
-}
+    useRadioPageStations,
+    type RadioPageStation,
+} from "@/lib/radio/radioPageStations";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RadioStationCard } from "@/components/ui/RadioStationCard";
 
 // Static radio stations
-const STATIC_STATIONS: RadioStation[] = [
+const STATIC_STATIONS: RadioPageStation[] = [
     {
         id: "all",
         name: "Shuffle All",
@@ -60,90 +48,6 @@ const STATIC_STATIONS: RadioStation[] = [
     },
 ];
 
-interface DecadeCount {
-    decade: number;
-    count: number;
-}
-
-// Decade color mapping - covers from 1700s (classical) to 2020s
-const DECADE_COLORS: Record<number, string> = {
-    1700: "from-amber-800/30 to-yellow-900/30",
-    1710: "from-amber-700/30 to-yellow-800/30",
-    1720: "from-amber-700/30 to-yellow-800/30",
-    1730: "from-amber-700/30 to-yellow-800/30",
-    1740: "from-amber-700/30 to-yellow-800/30",
-    1750: "from-amber-600/30 to-yellow-700/30",
-    1760: "from-amber-600/30 to-yellow-700/30",
-    1770: "from-amber-600/30 to-yellow-700/30",
-    1780: "from-amber-600/30 to-yellow-700/30",
-    1790: "from-amber-600/30 to-yellow-700/30",
-    1800: "from-slate-600/30 to-gray-700/30",
-    1810: "from-slate-600/30 to-gray-700/30",
-    1820: "from-slate-500/30 to-gray-600/30",
-    1830: "from-slate-500/30 to-gray-600/30",
-    1840: "from-slate-500/30 to-gray-600/30",
-    1850: "from-slate-400/30 to-gray-500/30",
-    1860: "from-slate-400/30 to-gray-500/30",
-    1870: "from-slate-400/30 to-gray-500/30",
-    1880: "from-slate-400/30 to-gray-500/30",
-    1890: "from-slate-400/30 to-gray-500/30",
-    1900: "from-sepia-400/30 to-amber-500/30",
-    1910: "from-amber-400/30 to-yellow-500/30",
-    1920: "from-yellow-500/30 to-amber-600/30",
-    1930: "from-orange-400/30 to-amber-500/30",
-    1940: "from-red-400/30 to-orange-500/30",
-    1950: "from-pink-400/30 to-red-500/30",
-    1960: "from-amber-500/30 to-orange-600/30",
-    1970: "from-orange-500/30 to-red-600/30",
-    1980: "from-fuchsia-500/30 to-purple-600/30",
-    1990: "from-purple-500/30 to-violet-600/30",
-    2000: "from-blue-500/30 to-cyan-600/30",
-    2010: "from-teal-500/30 to-emerald-600/30",
-    2020: "from-orange-500/30 to-amber-600/30",
-};
-
-const getDecadeColor = (decade: number): string => {
-    return DECADE_COLORS[decade] || "from-gray-500/30 to-slate-600/30";
-};
-
-const getDecadeName = (decade: number): string => {
-    if (decade < 1900) return `${decade}s`;
-    if (decade < 2000) return `${decade.toString().slice(2)}s`;
-    return `${decade}s`;
-};
-
-const getDecadeDescription = (decade: number, count: number): string => {
-    return `${decade}-${decade + 9} • ${count} tracks`;
-};
-
-// Genre color mapping
-const GENRE_COLORS: Record<string, string> = {
-    rock: "from-red-500/30 to-orange-600/30",
-    pop: "from-pink-500/30 to-rose-600/30",
-    "hip hop": "from-purple-500/30 to-indigo-600/30",
-    "hip-hop": "from-purple-500/30 to-indigo-600/30",
-    rap: "from-purple-500/30 to-indigo-600/30",
-    electronic: "from-cyan-500/30 to-blue-600/30",
-    jazz: "from-amber-500/30 to-yellow-600/30",
-    classical: "from-slate-400/30 to-gray-500/30",
-    metal: "from-zinc-600/30 to-neutral-700/30",
-    country: "from-orange-400/30 to-amber-500/30",
-    folk: "from-green-500/30 to-emerald-600/30",
-    indie: "from-violet-500/30 to-purple-600/30",
-    alternative: "from-indigo-500/30 to-blue-600/30",
-    "r&b": "from-fuchsia-500/30 to-pink-600/30",
-    soul: "from-amber-600/30 to-orange-700/30",
-    blues: "from-blue-600/30 to-indigo-700/30",
-    punk: "from-lime-500/30 to-green-600/30",
-    reggae: "from-green-400/30 to-yellow-500/30",
-    default: "from-gray-500/30 to-slate-600/30",
-};
-
-const getGenreColor = (genre: string): string => {
-    const lower = genre.toLowerCase();
-    return GENRE_COLORS[lower] || GENRE_COLORS.default;
-};
-
 // Section Header Component
 function SectionHeader({
     title,
@@ -162,6 +66,42 @@ function SectionHeader({
     );
 }
 
+function StationGridSkeleton() {
+    return (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                    key={i}
+                    className="aspect-square rounded-lg bg-white/5 animate-pulse"
+                />
+            ))}
+        </div>
+    );
+}
+
+function StationGrid({
+    stations,
+    loadingStation,
+    onOpen,
+}: {
+    stations: RadioPageStation[];
+    loadingStation: string | null;
+    onOpen: (station: RadioPageStation) => void;
+}) {
+    return (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+            {stations.map((station) => (
+                <RadioStationCard
+                    key={station.id}
+                    station={station}
+                    onPlay={() => onOpen(station)}
+                    isLoading={loadingStation === station.id}
+                />
+            ))}
+        </div>
+    );
+}
+
 /**
  * Renders the RadioPage component.
  */
@@ -169,28 +109,9 @@ export default function RadioPage() {
     const router = useRouter();
     const { playTracks } = useAudioControls();
     const [loadingStation, setLoadingStation] = useState<string | null>(null);
+    const { genreStations, decadeStations, isLoading } = useRadioPageStations();
 
-    // Fetch genres from library
-    const { data: genresData, isLoading: genresLoading } = useQuery({
-        queryKey: ["library", "genres"],
-        queryFn: () => api.get<{ genres: GenreCount[] }>("/library/genres"),
-        staleTime: 5 * 60 * 1000,
-        select: (data) => (data.genres || []).filter((g) => g.count >= 15),
-    });
-
-    // Fetch decades from library
-    const { data: decadesData, isLoading: decadesLoading } = useQuery({
-        queryKey: ["library", "decades"],
-        queryFn: () => api.get<{ decades: DecadeCount[] }>("/library/decades"),
-        staleTime: 5 * 60 * 1000,
-        select: (data) => data.decades || [],
-    });
-
-    const genres = genresData ?? [];
-    const decades = decadesData ?? [];
-    const isLoading = genresLoading || decadesLoading;
-
-    const handleStation = async (station: RadioStation) => {
+    const handleStation = async (station: RadioPageStation) => {
         setLoadingStation(station.id);
         try {
             await openRadioStation(station, {
@@ -201,26 +122,6 @@ export default function RadioPage() {
             setLoadingStation(null);
         }
     };
-
-    // Create genre stations from library
-    const genreStations: RadioStation[] = genres.map((g) => ({
-        id: `genre-${g.genre}`,
-        name: g.genre,
-        description: `${g.count} tracks`,
-        color: getGenreColor(g.genre),
-        filter: { type: "genre" as const, value: g.genre },
-        minTracks: 15,
-    }));
-
-    // Create decade stations from library (dynamically based on what's available)
-    const decadeStations: RadioStation[] = decades.map((d) => ({
-        id: `decade-${d.decade}`,
-        name: getDecadeName(d.decade),
-        description: getDecadeDescription(d.decade, d.count),
-        color: getDecadeColor(d.decade),
-        filter: { type: "decade" as const, value: d.decade.toString() },
-        minTracks: 15,
-    }));
 
     return (
         <div className="min-h-screen relative">
@@ -247,7 +148,7 @@ export default function RadioPage() {
                 {/* Header */}
                 <PageHeader
                     title="Radio Stations"
-                    subtitle="Continuous shuffle from your library"
+                    subtitle="Generated stations from your library"
                     icon={AudioLines}
                     className="mb-8"
                 />
@@ -256,18 +157,13 @@ export default function RadioPage() {
                 <section className="mb-10">
                     <SectionHeader
                         title="Quick Start"
-                        description="Jump into your music instantly"
+                        description="Open a ready-made station from your library"
                     />
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                        {STATIC_STATIONS.map((station) => (
-                            <RadioStationCard
-                                key={station.id}
-                                station={station}
-                                onPlay={() => handleStation(station)}
-                                isLoading={loadingStation === station.id}
-                            />
-                        ))}
-                    </div>
+                    <StationGrid
+                        stations={STATIC_STATIONS}
+                        loadingStation={loadingStation}
+                        onOpen={handleStation}
+                    />
                 </section>
 
                 {/* Genres Section */}
@@ -278,27 +174,13 @@ export default function RadioPage() {
                             description="Shuffle tracks from specific genres"
                         />
                         {isLoading ? (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                                {Array.from({ length: 6 }).map((_, i) => (
-                                    <div
-                                        key={i}
-                                        className="aspect-square rounded-lg bg-white/5 animate-pulse"
-                                    />
-                                ))}
-                            </div>
+                            <StationGridSkeleton />
                         ) : (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                                {genreStations.map((station) => (
-                                    <RadioStationCard
-                                        key={station.id}
-                                        station={station}
-                                        onPlay={() => handleStation(station)}
-                                        isLoading={
-                                            loadingStation === station.id
-                                        }
-                                    />
-                                ))}
-                            </div>
+                            <StationGrid
+                                stations={genreStations}
+                                loadingStation={loadingStation}
+                                onOpen={handleStation}
+                            />
                         )}
                     </section>
                 )}
@@ -311,27 +193,13 @@ export default function RadioPage() {
                             description="Travel through time with your music"
                         />
                         {isLoading ? (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                                {Array.from({ length: 6 }).map((_, i) => (
-                                    <div
-                                        key={i}
-                                        className="aspect-square rounded-lg bg-white/5 animate-pulse"
-                                    />
-                                ))}
-                            </div>
+                            <StationGridSkeleton />
                         ) : (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                                {decadeStations.map((station) => (
-                                    <RadioStationCard
-                                        key={station.id}
-                                        station={station}
-                                        onPlay={() => handleStation(station)}
-                                        isLoading={
-                                            loadingStation === station.id
-                                        }
-                                    />
-                                ))}
-                            </div>
+                            <StationGrid
+                                stations={decadeStations}
+                                loadingStation={loadingStation}
+                                onOpen={handleStation}
+                            />
                         )}
                     </section>
                 )}

--- a/frontend/app/radio/page.tsx
+++ b/frontend/app/radio/page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { AudioLines, Shuffle } from "lucide-react";
-import { api } from "@/lib/api";
+import { AudioLines } from "lucide-react";
+import { api, type RadioPlaylistFilter } from "@/lib/api";
 import { useAudioControls } from "@/lib/audio-controls-context";
-import { Track } from "@/lib/audio-state-context";
-import { toast } from "sonner";
-import { shuffleArray } from "@/utils/shuffle";
+import { openRadioStation } from "@/lib/radio/openRadioStation";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 import {
     RadioStationCard,
     RadioStationCardStation,
 } from "@/components/ui/RadioStationCard";
 
-type RadioStation = RadioStationCardStation;
+// Narrow the card's loose filter union so non-shuffle stations are provably
+// valid generated-playlist filters.
+type RadioStation = Omit<RadioStationCardStation, "filter"> & {
+    filter: { type: "all" } | RadioPlaylistFilter;
+};
 
 interface GenreCount {
     genre: string;
@@ -164,6 +166,7 @@ function SectionHeader({
  * Renders the RadioPage component.
  */
 export default function RadioPage() {
+    const router = useRouter();
     const { playTracks } = useAudioControls();
     const [loadingStation, setLoadingStation] = useState<string | null>(null);
 
@@ -187,45 +190,13 @@ export default function RadioPage() {
     const decades = decadesData ?? [];
     const isLoading = genresLoading || decadesLoading;
 
-    const startRadio = async (station: RadioStation) => {
+    const handleStation = async (station: RadioStation) => {
         setLoadingStation(station.id);
-
         try {
-            const params = new URLSearchParams();
-            params.set("type", station.filter.type);
-            if (station.filter.value) {
-                params.set("value", station.filter.value);
-            }
-            params.set("limit", "100");
-
-            const response = await api.get<{ tracks: Track[] }>(
-                `/library/radio?${params.toString()}`,
-            );
-
-            if (!response.tracks || response.tracks.length === 0) {
-                toast.error(`No tracks found for ${station.name}`);
-                return;
-            }
-
-            if (response.tracks.length < (station.minTracks || 10)) {
-                toast.error(`Not enough tracks for ${station.name} radio`, {
-                    description: `Found ${response.tracks.length}, need at least ${station.minTracks || 10}`,
-                });
-                return;
-            }
-
-            // Shuffle the tracks
-            const shuffled = shuffleArray(response.tracks);
-
-            // Start playing
-            playTracks(shuffled, 0);
-            toast.success(`${station.name} Radio`, {
-                description: `Shuffling ${shuffled.length} tracks`,
-                icon: <Shuffle className="w-4 h-4" />,
+            await openRadioStation(station, {
+                push: router.push,
+                playTracks,
             });
-        } catch (error) {
-            sharedFrontendLogger.error("Failed to start radio:", error);
-            toast.error("Failed to start radio station");
         } finally {
             setLoadingStation(null);
         }
@@ -292,7 +263,7 @@ export default function RadioPage() {
                             <RadioStationCard
                                 key={station.id}
                                 station={station}
-                                onPlay={() => startRadio(station)}
+                                onPlay={() => handleStation(station)}
                                 isLoading={loadingStation === station.id}
                             />
                         ))}
@@ -321,7 +292,7 @@ export default function RadioPage() {
                                     <RadioStationCard
                                         key={station.id}
                                         station={station}
-                                        onPlay={() => startRadio(station)}
+                                        onPlay={() => handleStation(station)}
                                         isLoading={
                                             loadingStation === station.id
                                         }
@@ -354,7 +325,7 @@ export default function RadioPage() {
                                     <RadioStationCard
                                         key={station.id}
                                         station={station}
-                                        onPlay={() => startRadio(station)}
+                                        onPlay={() => handleStation(station)}
                                         isLoading={
                                             loadingStation === station.id
                                         }
@@ -372,10 +343,11 @@ export default function RadioPage() {
                     </h3>
                     <p className="text-sm text-white/60">
                         Radio stations are generated from your personal music
-                        library. As you add more music, new genre and decade
-                        stations will automatically appear. Each station
-                        requires a minimum number of tracks to ensure a good
-                        listening experience.
+                        library. Opening a station builds a playlist you can
+                        replay, regenerate, or extend with more tracks — Shuffle
+                        All starts playing your whole library right away. As you
+                        add more music, new genre and decade stations will
+                        automatically appear.
                     </p>
                 </div>
             </div>

--- a/frontend/components/ui/RadioStationCard.tsx
+++ b/frontend/components/ui/RadioStationCard.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Play, Loader2 } from "lucide-react";
-import { cn } from "@/utils/cn";
-import { usePlayButtonFeedback } from "@/hooks/usePlayButtonFeedback";
+import { Loader2 } from "lucide-react";
 import { RadioStationMosaic } from "@/app/radio/RadioStationMosaic";
 
 export interface RadioStationCardStation {
@@ -32,20 +30,18 @@ interface RadioStationCardProps {
 
 /**
  * Square radio station card with mosaic cover art, gradient overlay,
- * hover play button, and title + description below.
+ * and title + description below. The whole card is the click target;
+ * a spinner appears over the art while the station opens.
  */
 export function RadioStationCard({
     station,
     onPlay,
     isLoading,
 }: RadioStationCardProps) {
-    const { showSpinner, triggerPlayFeedback } = usePlayButtonFeedback();
-
     const handlePlayClick = () => {
         if (isLoading) {
             return;
         }
-        triggerPlayFeedback();
         onPlay();
     };
 
@@ -65,23 +61,14 @@ export function RadioStationCard({
                 <div
                     className={`absolute inset-0 bg-gradient-to-br ${station.color} opacity-40 pointer-events-none`}
                 />
-                {/* Play button — bottom-right, appears on hover */}
-                <div
-                    className={cn(
-                        "absolute bottom-2 right-2 transition-all duration-200",
-                        isLoading || showSpinner
-                            ? "opacity-100 translate-y-0"
-                            : "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 translate-y-2 group-hover:translate-y-0 group-focus-visible:translate-y-0",
-                    )}
-                >
-                    <div className="w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl hover:scale-105 transition-transform">
-                        {isLoading || showSpinner ? (
+                {/* Loading spinner — bottom-right, only while the station opens */}
+                {isLoading && (
+                    <div className="absolute bottom-2 right-2">
+                        <div className="w-10 h-10 rounded-full bg-brand-hover flex items-center justify-center shadow-xl">
                             <Loader2 className="w-4 h-4 text-black animate-spin" />
-                        ) : (
-                            <Play className="w-4 h-4 fill-current text-black ml-0.5" />
-                        )}
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
             {/* Title + description below art */}
             <h3 className="text-sm font-semibold text-white truncate">

--- a/frontend/features/home/components/LibraryRadioStations.tsx
+++ b/frontend/features/home/components/LibraryRadioStations.tsx
@@ -2,12 +2,9 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { shuffleArray } from "@/utils/shuffle";
-import { Shuffle } from "lucide-react";
 import { api, type RadioPlaylistFilter } from "@/lib/api";
 import { useAudioControls } from "@/lib/audio-controls-context";
-import type { Track } from "@/lib/audio-state-context";
-import { toast } from "sonner";
+import { openRadioStation } from "@/lib/radio/openRadioStation";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 import {
     RadioStationCard,
@@ -226,50 +223,13 @@ export function LibraryRadioStations({
         ? (externalLoading ?? false)
         : internalData.isLoading;
 
-    const startShuffleAll = async (station: RadioStation) => {
-        const params = new URLSearchParams({ type: "all", limit: "100" });
-        const response = await api.get<{ tracks: Track[] }>(
-            `/library/radio?${params.toString()}`,
-        );
-
-        if (!response.tracks || response.tracks.length === 0) {
-            toast.error(`No tracks found for ${station.name}`);
-            return;
-        }
-
-        if (response.tracks.length < (station.minTracks || 10)) {
-            toast.error(`Not enough tracks for ${station.name} radio`, {
-                description: `Found ${response.tracks.length}, need at least ${station.minTracks || 10}`,
-            });
-            return;
-        }
-
-        const shuffled = shuffleArray(response.tracks);
-        playTracks(shuffled, 0);
-        toast.success(`${station.name} Radio`, {
-            description: `Shuffling ${shuffled.length} tracks`,
-            icon: <Shuffle className="w-4 h-4" />,
-        });
-    };
-
-    const openGeneratedPlaylist = async (filter: RadioPlaylistFilter) => {
-        const response = await api.createRadioPlaylist({
-            filter,
-        });
-        router.push(`/playlist/${response.playlistId}`);
-    };
-
     const handleStation = async (station: RadioStation) => {
         setLoadingStation(station.id);
         try {
-            if (station.filter.type === "all") {
-                await startShuffleAll(station);
-            } else {
-                await openGeneratedPlaylist(station.filter);
-            }
-        } catch (error) {
-            sharedFrontendLogger.error("Failed to open radio station:", error);
-            toast.error("Failed to open radio station");
+            await openRadioStation(station, {
+                push: router.push,
+                playTracks,
+            });
         } finally {
             setLoadingStation(null);
         }

--- a/frontend/features/home/components/LibraryRadioStations.tsx
+++ b/frontend/features/home/components/LibraryRadioStations.tsx
@@ -4,7 +4,10 @@ import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { api, type RadioPlaylistFilter } from "@/lib/api";
 import { useAudioControls } from "@/lib/audio-controls-context";
-import { openRadioStation } from "@/lib/radio/openRadioStation";
+import {
+    isGeneratedPlaylistDecade,
+    openRadioStation,
+} from "@/lib/radio/openRadioStation";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 import {
     RadioStationCard,
@@ -145,7 +148,11 @@ export function useLibraryRadioData(skip = false) {
                     genresRes.genres || [],
                 );
                 setGenres(validGenres);
-                setDecades((decadesRes.decades || []).slice(0, 4));
+                setDecades(
+                    (decadesRes.decades || [])
+                        .filter((d) => isGeneratedPlaylistDecade(d.decade))
+                        .slice(0, 4),
+                );
             } catch (error) {
                 sharedFrontendLogger.error(
                     "Failed to fetch radio data:",

--- a/frontend/lib/radio/openRadioStation.tsx
+++ b/frontend/lib/radio/openRadioStation.tsx
@@ -1,0 +1,94 @@
+import { Shuffle } from "lucide-react";
+import { toast } from "sonner";
+import { api, type RadioPlaylistFilter } from "@/lib/api";
+import type { Track } from "@/lib/audio-state-context";
+import { shuffleArray } from "@/utils/shuffle";
+import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
+
+const SHUFFLE_ALL_TRACK_LIMIT = 100;
+const DEFAULT_MIN_TRACKS = 10;
+
+/** The station fields the open flow needs, shared by Explore and /radio. */
+export interface OpenableRadioStation {
+    id: string;
+    name: string;
+    minTracks?: number;
+    filter: { type: "all" } | RadioPlaylistFilter;
+}
+
+/** User-facing feedback seams, injectable for tests. */
+export interface RadioStationNotifier {
+    error: (message: string, options?: { description?: string }) => void;
+    stationStarted: (name: string, trackCount: number) => void;
+}
+
+const defaultNotifier: RadioStationNotifier = {
+    error: (message, options) => toast.error(message, options),
+    stationStarted: (name, trackCount) =>
+        toast.success(`${name} Radio`, {
+            description: `Shuffling ${trackCount} tracks`,
+            icon: <Shuffle className="w-4 h-4" />,
+        }),
+};
+
+/** Callbacks the calling component provides from its own hooks. */
+export interface OpenRadioStationHandlers {
+    push: (path: string) => void;
+    playTracks: (tracks: Track[], startIndex: number) => void;
+    notifier?: RadioStationNotifier;
+}
+
+async function startShuffleAll(
+    station: OpenableRadioStation,
+    playTracks: OpenRadioStationHandlers["playTracks"],
+    notifier: RadioStationNotifier,
+): Promise<void> {
+    const params = new URLSearchParams({
+        type: "all",
+        limit: String(SHUFFLE_ALL_TRACK_LIMIT),
+    });
+    const response = await api.get<{ tracks: Track[] }>(
+        `/library/radio?${params.toString()}`,
+    );
+
+    if (!response.tracks || response.tracks.length === 0) {
+        notifier.error(`No tracks found for ${station.name}`);
+        return;
+    }
+
+    const minTracks = station.minTracks || DEFAULT_MIN_TRACKS;
+    if (response.tracks.length < minTracks) {
+        notifier.error(`Not enough tracks for ${station.name} radio`, {
+            description: `Found ${response.tracks.length}, need at least ${minTracks}`,
+        });
+        return;
+    }
+
+    const shuffled = shuffleArray(response.tracks);
+    playTracks(shuffled, 0);
+    notifier.stationStarted(station.name, shuffled.length);
+}
+
+/**
+ * Opens a radio station: Shuffle All starts instant playback of the whole
+ * library; every other station creates a generated playlist and navigates
+ * to its page. Errors surface as a toast; the promise always resolves.
+ */
+export async function openRadioStation(
+    station: OpenableRadioStation,
+    { push, playTracks, notifier = defaultNotifier }: OpenRadioStationHandlers,
+): Promise<void> {
+    try {
+        if (station.filter.type === "all") {
+            await startShuffleAll(station, playTracks, notifier);
+            return;
+        }
+        const response = await api.createRadioPlaylist({
+            filter: station.filter,
+        });
+        push(`/playlist/${response.playlistId}`);
+    } catch (error) {
+        sharedFrontendLogger.error("Failed to open radio station:", error);
+        notifier.error("Failed to open radio station");
+    }
+}

--- a/frontend/lib/radio/openRadioStation.tsx
+++ b/frontend/lib/radio/openRadioStation.tsx
@@ -7,6 +7,22 @@ import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 
 const SHUFFLE_ALL_TRACK_LIMIT = 100;
 const DEFAULT_MIN_TRACKS = 10;
+const GENERATED_PLAYLIST_DECADE_MIN = 1000;
+const GENERATED_PLAYLIST_DECADE_MAX = 2090;
+
+/**
+ * The generated-playlist API only accepts decade values 1000-2090 in steps
+ * of ten. Library years are unbounded (metadata edits allow any year), so
+ * station producers must filter decades the API would reject.
+ */
+export function isGeneratedPlaylistDecade(decade: number): boolean {
+    return (
+        Number.isInteger(decade) &&
+        decade % 10 === 0 &&
+        decade >= GENERATED_PLAYLIST_DECADE_MIN &&
+        decade <= GENERATED_PLAYLIST_DECADE_MAX
+    );
+}
 
 /** The station fields the open flow needs, shared by Explore and /radio. */
 export interface OpenableRadioStation {

--- a/frontend/lib/radio/radioPageStations.ts
+++ b/frontend/lib/radio/radioPageStations.ts
@@ -1,0 +1,161 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type RadioPlaylistFilter } from "@/lib/api";
+import type { RadioStationCardStation } from "@/components/ui/RadioStationCard";
+import { isGeneratedPlaylistDecade } from "@/lib/radio/openRadioStation";
+
+/**
+ * Station shape used by the /radio page: the card's loose filter union is
+ * narrowed so non-shuffle stations are provably valid playlist filters.
+ */
+export type RadioPageStation = Omit<RadioStationCardStation, "filter"> & {
+    filter: { type: "all" } | RadioPlaylistFilter;
+};
+
+export interface GenreCount {
+    genre: string;
+    count: number;
+}
+
+export interface DecadeCount {
+    decade: number;
+    count: number;
+}
+
+const MIN_GENRE_TRACKS = 15;
+
+// Decade color mapping - covers from 1700s (classical) to 2020s
+const DECADE_COLORS: Record<number, string> = {
+    1700: "from-amber-800/30 to-yellow-900/30",
+    1710: "from-amber-700/30 to-yellow-800/30",
+    1720: "from-amber-700/30 to-yellow-800/30",
+    1730: "from-amber-700/30 to-yellow-800/30",
+    1740: "from-amber-700/30 to-yellow-800/30",
+    1750: "from-amber-600/30 to-yellow-700/30",
+    1760: "from-amber-600/30 to-yellow-700/30",
+    1770: "from-amber-600/30 to-yellow-700/30",
+    1780: "from-amber-600/30 to-yellow-700/30",
+    1790: "from-amber-600/30 to-yellow-700/30",
+    1800: "from-slate-600/30 to-gray-700/30",
+    1810: "from-slate-600/30 to-gray-700/30",
+    1820: "from-slate-500/30 to-gray-600/30",
+    1830: "from-slate-500/30 to-gray-600/30",
+    1840: "from-slate-500/30 to-gray-600/30",
+    1850: "from-slate-400/30 to-gray-500/30",
+    1860: "from-slate-400/30 to-gray-500/30",
+    1870: "from-slate-400/30 to-gray-500/30",
+    1880: "from-slate-400/30 to-gray-500/30",
+    1890: "from-slate-400/30 to-gray-500/30",
+    1900: "from-sepia-400/30 to-amber-500/30",
+    1910: "from-amber-400/30 to-yellow-500/30",
+    1920: "from-yellow-500/30 to-amber-600/30",
+    1930: "from-orange-400/30 to-amber-500/30",
+    1940: "from-red-400/30 to-orange-500/30",
+    1950: "from-pink-400/30 to-red-500/30",
+    1960: "from-amber-500/30 to-orange-600/30",
+    1970: "from-orange-500/30 to-red-600/30",
+    1980: "from-fuchsia-500/30 to-purple-600/30",
+    1990: "from-purple-500/30 to-violet-600/30",
+    2000: "from-blue-500/30 to-cyan-600/30",
+    2010: "from-teal-500/30 to-emerald-600/30",
+    2020: "from-orange-500/30 to-amber-600/30",
+};
+
+const getDecadeColor = (decade: number): string => {
+    return DECADE_COLORS[decade] || "from-gray-500/30 to-slate-600/30";
+};
+
+const getDecadeName = (decade: number): string => {
+    if (decade < 1900) return `${decade}s`;
+    if (decade < 2000) return `${decade.toString().slice(2)}s`;
+    return `${decade}s`;
+};
+
+const getDecadeDescription = (decade: number, count: number): string => {
+    return `${decade}-${decade + 9} • ${count} tracks`;
+};
+
+// Genre color mapping
+const GENRE_COLORS: Record<string, string> = {
+    rock: "from-red-500/30 to-orange-600/30",
+    pop: "from-pink-500/30 to-rose-600/30",
+    "hip hop": "from-purple-500/30 to-indigo-600/30",
+    "hip-hop": "from-purple-500/30 to-indigo-600/30",
+    rap: "from-purple-500/30 to-indigo-600/30",
+    electronic: "from-cyan-500/30 to-blue-600/30",
+    jazz: "from-amber-500/30 to-yellow-600/30",
+    classical: "from-slate-400/30 to-gray-500/30",
+    metal: "from-zinc-600/30 to-neutral-700/30",
+    country: "from-orange-400/30 to-amber-500/30",
+    folk: "from-green-500/30 to-emerald-600/30",
+    indie: "from-violet-500/30 to-purple-600/30",
+    alternative: "from-indigo-500/30 to-blue-600/30",
+    "r&b": "from-fuchsia-500/30 to-pink-600/30",
+    soul: "from-amber-600/30 to-orange-700/30",
+    blues: "from-blue-600/30 to-indigo-700/30",
+    punk: "from-lime-500/30 to-green-600/30",
+    reggae: "from-green-400/30 to-yellow-500/30",
+    default: "from-gray-500/30 to-slate-600/30",
+};
+
+const getGenreColor = (genre: string): string => {
+    const lower = genre.toLowerCase();
+    return GENRE_COLORS[lower] || GENRE_COLORS.default;
+};
+
+/** Builds genre stations from library counts, skipping sparse genres. */
+export function buildGenreStations(genres: GenreCount[]): RadioPageStation[] {
+    return genres
+        .filter((g) => g.count >= MIN_GENRE_TRACKS)
+        .map((g) => ({
+            id: `genre-${g.genre}`,
+            name: g.genre,
+            description: `${g.count} tracks`,
+            color: getGenreColor(g.genre),
+            filter: { type: "genre" as const, value: g.genre },
+            minTracks: 15,
+        }));
+}
+
+/**
+ * Builds decade stations from library counts, dropping decades the
+ * generated-playlist API rejects.
+ */
+export function buildDecadeStations(
+    decades: DecadeCount[],
+): RadioPageStation[] {
+    return decades
+        .filter((d) => isGeneratedPlaylistDecade(d.decade))
+        .map((d) => ({
+            id: `decade-${d.decade}`,
+            name: getDecadeName(d.decade),
+            description: getDecadeDescription(d.decade, d.count),
+            color: getDecadeColor(d.decade),
+            filter: { type: "decade" as const, value: d.decade.toString() },
+            minTracks: 15,
+        }));
+}
+
+const STATION_DATA_STALE_TIME_MS = 5 * 60 * 1000;
+
+/** Fetches library genre/decade counts and derives /radio station lists. */
+export function useRadioPageStations() {
+    const { data: genreStations, isLoading: genresLoading } = useQuery({
+        queryKey: ["library", "genres"],
+        queryFn: () => api.get<{ genres: GenreCount[] }>("/library/genres"),
+        staleTime: STATION_DATA_STALE_TIME_MS,
+        select: (data) => buildGenreStations(data.genres || []),
+    });
+
+    const { data: decadeStations, isLoading: decadesLoading } = useQuery({
+        queryKey: ["library", "decades"],
+        queryFn: () => api.get<{ decades: DecadeCount[] }>("/library/decades"),
+        staleTime: STATION_DATA_STALE_TIME_MS,
+        select: (data) => buildDecadeStations(data.decades || []),
+    });
+
+    return {
+        genreStations: genreStations ?? [],
+        decadeStations: decadeStations ?? [],
+        isLoading: genresLoading || decadesLoading,
+    };
+}

--- a/frontend/tests/component/openRadioStation.component.test.ts
+++ b/frontend/tests/component/openRadioStation.component.test.ts
@@ -167,6 +167,18 @@ test("Shuffle All refuses to play below the station minimum", async () => {
     assert.match(state.errorToasts[0] ?? "", /Not enough tracks/);
 });
 
+test("decade guard accepts only API-valid decades", async () => {
+    const { isGeneratedPlaylistDecade } =
+        await import("../../lib/radio/openRadioStation");
+
+    for (const valid of [1000, 1700, 1990, 2020, 2090]) {
+        assert.equal(isGeneratedPlaylistDecade(valid), true, `${valid}`);
+    }
+    for (const invalid of [990, 2100, 1995, 2020.5, Number.NaN]) {
+        assert.equal(isGeneratedPlaylistDecade(invalid), false, `${invalid}`);
+    }
+});
+
 test("generation failures surface a toast and resolve", async () => {
     const openRadioStation = await loadHelper();
     state.failCreate = true;

--- a/frontend/tests/component/openRadioStation.component.test.ts
+++ b/frontend/tests/component/openRadioStation.component.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { beforeEach, mock, test } from "node:test";
+import React from "react";
+
+const state = {
+    createCalls: [] as Array<Record<string, unknown>>,
+    getCalls: [] as string[],
+    playCalls: [] as Array<{ count: number; startIndex: number }>,
+    pushCalls: [] as string[],
+    errorToasts: [] as string[],
+    successToasts: [] as string[],
+    trackCount: 12,
+    failCreate: false,
+};
+
+mock.module("lucide-react", {
+    namedExports: {
+        Shuffle: () => React.createElement("svg"),
+    },
+});
+
+const notifier = {
+    error: (message: string) => {
+        state.errorToasts.push(message);
+    },
+    stationStarted: (name: string) => {
+        state.successToasts.push(name);
+    },
+};
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            createRadioPlaylist: async (input: Record<string, unknown>) => {
+                if (state.failCreate) {
+                    throw new Error("generation failed");
+                }
+                state.createCalls.push(input);
+                return { playlistId: "generated-42", entries: [] };
+            },
+            get: async (path: string) => {
+                state.getCalls.push(path);
+                return {
+                    tracks: Array.from(
+                        { length: state.trackCount },
+                        (_, index) => ({
+                            id: `track-${index}`,
+                            title: `Track ${index}`,
+                        }),
+                    ),
+                };
+            },
+        },
+    },
+});
+
+mock.module("@/utils/shuffle", {
+    namedExports: {
+        shuffleArray: <T>(values: T[]) => values,
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: {
+            error: () => undefined,
+        },
+    },
+});
+
+beforeEach(() => {
+    state.createCalls.length = 0;
+    state.getCalls.length = 0;
+    state.playCalls.length = 0;
+    state.pushCalls.length = 0;
+    state.errorToasts.length = 0;
+    state.successToasts.length = 0;
+    state.trackCount = 12;
+    state.failCreate = false;
+});
+
+async function loadHelper() {
+    const mod = await import("../../lib/radio/openRadioStation");
+    const named = mod as unknown as {
+        openRadioStation?: (
+            station: Record<string, unknown>,
+            handlers: Record<string, unknown>,
+        ) => Promise<void>;
+    };
+    const cjsDefault = (
+        mod as {
+            default?: {
+                openRadioStation?: (
+                    station: Record<string, unknown>,
+                    handlers: Record<string, unknown>,
+                ) => Promise<void>;
+            };
+        }
+    ).default;
+    const openRadioStation =
+        named.openRadioStation ?? cjsDefault?.openRadioStation;
+    assert.ok(openRadioStation, "openRadioStation export is available");
+    return openRadioStation;
+}
+
+const handlers = {
+    push: (path: string) => state.pushCalls.push(path),
+    playTracks: (tracks: unknown[], startIndex: number) =>
+        state.playCalls.push({ count: tracks.length, startIndex }),
+    notifier,
+};
+
+test("filtered stations create a generated playlist and navigate", async () => {
+    const openRadioStation = await loadHelper();
+    await openRadioStation(
+        {
+            id: "genre-rock",
+            name: "Rock",
+            filter: { type: "genre", value: "rock" },
+            minTracks: 15,
+        },
+        handlers,
+    );
+
+    assert.deepEqual(state.createCalls, [
+        { filter: { type: "genre", value: "rock" } },
+    ]);
+    assert.deepEqual(state.pushCalls, ["/playlist/generated-42"]);
+    assert.equal(state.playCalls.length, 0);
+    assert.deepEqual(state.getCalls, []);
+});
+
+test("Shuffle All fetches tracks and starts instant playback", async () => {
+    const openRadioStation = await loadHelper();
+    await openRadioStation(
+        {
+            id: "all",
+            name: "Shuffle All",
+            filter: { type: "all" },
+            minTracks: 10,
+        },
+        handlers,
+    );
+
+    assert.equal(state.createCalls.length, 0);
+    assert.equal(state.pushCalls.length, 0);
+    assert.deepEqual(state.playCalls, [{ count: 12, startIndex: 0 }]);
+    assert.match(state.getCalls[0] ?? "", /^\/library\/radio\?/);
+    assert.equal(state.successToasts.length, 1);
+});
+
+test("Shuffle All refuses to play below the station minimum", async () => {
+    const openRadioStation = await loadHelper();
+    state.trackCount = 3;
+    await openRadioStation(
+        {
+            id: "all",
+            name: "Shuffle All",
+            filter: { type: "all" },
+            minTracks: 10,
+        },
+        handlers,
+    );
+
+    assert.equal(state.playCalls.length, 0);
+    assert.equal(state.errorToasts.length, 1);
+    assert.match(state.errorToasts[0] ?? "", /Not enough tracks/);
+});
+
+test("generation failures surface a toast and resolve", async () => {
+    const openRadioStation = await loadHelper();
+    state.failCreate = true;
+    await openRadioStation(
+        {
+            id: "decade-1990",
+            name: "90s",
+            filter: { type: "decade", value: "1990" },
+        },
+        handlers,
+    );
+
+    assert.equal(state.pushCalls.length, 0);
+    assert.equal(state.playCalls.length, 0);
+    assert.deepEqual(state.errorToasts, ["Failed to open radio station"]);
+});

--- a/frontend/tests/component/radioPageStations.component.test.ts
+++ b/frontend/tests/component/radioPageStations.component.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+mock.module("@tanstack/react-query", {
+    namedExports: {
+        useQuery: () => ({ data: undefined, isLoading: true }),
+    },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: { get: async () => ({}) },
+    },
+});
+
+async function loadBuilders() {
+    const mod = await import("../../lib/radio/radioPageStations");
+    const named =
+        mod as unknown as typeof import("../../lib/radio/radioPageStations");
+    const cjsDefault = (
+        mod as {
+            default?: typeof import("../../lib/radio/radioPageStations");
+        }
+    ).default;
+    const buildGenreStations =
+        named.buildGenreStations ?? cjsDefault?.buildGenreStations;
+    const buildDecadeStations =
+        named.buildDecadeStations ?? cjsDefault?.buildDecadeStations;
+    assert.ok(buildGenreStations, "buildGenreStations export is available");
+    assert.ok(buildDecadeStations, "buildDecadeStations export is available");
+    return { buildGenreStations, buildDecadeStations };
+}
+
+test("genre stations skip sparse genres and carry playlist filters", async () => {
+    const { buildGenreStations } = await loadBuilders();
+    const stations = buildGenreStations([
+        { genre: "Rock", count: 30 },
+        { genre: "Ambient", count: 4 },
+    ]);
+
+    assert.deepEqual(
+        stations.map((s) => ({ id: s.id, filter: s.filter })),
+        [{ id: "genre-Rock", filter: { type: "genre", value: "Rock" } }],
+    );
+});
+
+test("decade stations drop values the generated-playlist API rejects", async () => {
+    const { buildDecadeStations } = await loadBuilders();
+    const stations = buildDecadeStations([
+        { decade: 1990, count: 40 },
+        { decade: 2100, count: 16 },
+        { decade: 990, count: 12 },
+        { decade: 1995, count: 9 },
+    ]);
+
+    assert.deepEqual(
+        stations.map((s) => ({ id: s.id, filter: s.filter })),
+        [{ id: "decade-1990", filter: { type: "decade", value: "1990" } }],
+    );
+});

--- a/frontend/tests/component/radioPageWiring.component.test.ts
+++ b/frontend/tests/component/radioPageWiring.component.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+after(async () => {
+    await GlobalRegistrator.unregister();
+});
+
+const state = {
+    openCalls: [] as Array<{ id: string; filter: Record<string, unknown> }>,
+};
+
+// The station open flow is covered by the openRadioStation suite and the
+// station builders by the radioPageStations suite; this file pins the /radio
+// PAGE wiring: every card's onPlay routes through the shared helper with the
+// station's filter intact.
+mock.module("@/lib/radio/openRadioStation", {
+    namedExports: {
+        openRadioStation: async (station: {
+            id: string;
+            filter: Record<string, unknown>;
+        }) => {
+            state.openCalls.push({ id: station.id, filter: station.filter });
+        },
+    },
+});
+
+mock.module("@/lib/radio/radioPageStations", {
+    namedExports: {
+        useRadioPageStations: () => ({
+            genreStations: [
+                {
+                    id: "genre-Rock",
+                    name: "Rock",
+                    description: "30 tracks",
+                    color: "from-red-500/30 to-orange-600/30",
+                    filter: { type: "genre", value: "Rock" },
+                    minTracks: 15,
+                },
+            ],
+            decadeStations: [
+                {
+                    id: "decade-1990",
+                    name: "90s",
+                    description: "1990-1999 • 40 tracks",
+                    color: "from-purple-500/30 to-violet-600/30",
+                    filter: { type: "decade", value: "1990" },
+                    minTracks: 15,
+                },
+            ],
+            isLoading: false,
+        }),
+    },
+});
+
+mock.module("@/lib/audio-controls-context", {
+    namedExports: {
+        useAudioControls: () => ({
+            playTracks: () => undefined,
+        }),
+    },
+});
+
+mock.module("next/navigation", {
+    namedExports: {
+        useRouter: () => ({
+            push: () => undefined,
+        }),
+    },
+});
+
+mock.module("@/components/ui/RadioStationCard", {
+    namedExports: {
+        RadioStationCard: ({
+            station,
+            onPlay,
+        }: {
+            station: { id: string; name: string };
+            onPlay: () => void;
+        }) =>
+            React.createElement(
+                "button",
+                {
+                    type: "button",
+                    "data-station-id": station.id,
+                    onClick: onPlay,
+                },
+                station.name,
+            ),
+    },
+});
+
+mock.module("@/components/layout/PageHeader", {
+    namedExports: {
+        PageHeader: ({ title }: { title: string }) =>
+            React.createElement("div", null, title),
+    },
+});
+
+mock.module("lucide-react", {
+    namedExports: {
+        AudioLines: () => React.createElement("svg"),
+    },
+});
+
+beforeEach(() => {
+    state.openCalls.length = 0;
+});
+
+async function renderRadioPage(t: {
+    after: (fn: () => Promise<void> | void) => void;
+}) {
+    const { createRoot } = await import("react-dom/client");
+    const RadioPage = (await import("../../app/radio/page")).default;
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    t.after(async () => {
+        await React.act(async () => root.unmount());
+    });
+    await React.act(async () => {
+        root.render(React.createElement(RadioPage));
+    });
+    return container;
+}
+
+async function clickStation(container: Element, stationId: string) {
+    const tile = container.querySelector(`[data-station-id='${stationId}']`);
+    assert.ok(tile, `station tile ${stationId} is rendered`);
+    await React.act(async () => {
+        tile.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+}
+
+test("static and dynamic cards route through the shared open helper", async (t) => {
+    const container = await renderRadioPage(t);
+
+    await clickStation(container, "workout");
+    await clickStation(container, "genre-Rock");
+    await clickStation(container, "decade-1990");
+    await clickStation(container, "all");
+
+    assert.deepEqual(state.openCalls, [
+        { id: "workout", filter: { type: "workout" } },
+        { id: "genre-Rock", filter: { type: "genre", value: "Rock" } },
+        { id: "decade-1990", filter: { type: "decade", value: "1990" } },
+        { id: "all", filter: { type: "all" } },
+    ]);
+});

--- a/frontend/tests/component/radioStationCard.component.test.ts
+++ b/frontend/tests/component/radioStationCard.component.test.ts
@@ -1,31 +1,14 @@
 import assert from "node:assert/strict";
-import { beforeEach, mock, test } from "node:test";
+import { mock, test } from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-
-const feedbackState = {
-    showSpinner: false,
-    triggerCalls: 0,
-};
 
 const Icon = ({ "data-icon": dataIcon }: { "data-icon"?: string }) =>
     React.createElement("svg", { "data-icon": dataIcon });
 
 mock.module("lucide-react", {
     namedExports: {
-        Play: () => React.createElement(Icon, { "data-icon": "play" }),
         Loader2: () => React.createElement(Icon, { "data-icon": "loader" }),
-    },
-});
-
-mock.module("@/hooks/usePlayButtonFeedback", {
-    namedExports: {
-        usePlayButtonFeedback: () => ({
-            showSpinner: feedbackState.showSpinner,
-            triggerPlayFeedback: () => {
-                feedbackState.triggerCalls += 1;
-            },
-        }),
     },
 });
 
@@ -38,11 +21,6 @@ mock.module("@/app/radio/RadioStationMosaic", {
                 filter.type,
             ),
     },
-});
-
-beforeEach(() => {
-    feedbackState.showSpinner = false;
-    feedbackState.triggerCalls = 0;
 });
 
 type Station = {
@@ -99,7 +77,7 @@ test("RadioStationCard renders station metadata and mosaic", async () => {
     assert.match(html, /genre/);
 });
 
-test("RadioStationCard shows play icon when not loading", async () => {
+test("RadioStationCard renders no play overlay or spinner at rest", async () => {
     const RadioStationCard = await loadCardComponent();
     const html = renderToStaticMarkup(
         React.createElement(RadioStationCard, {
@@ -109,11 +87,11 @@ test("RadioStationCard shows play icon when not loading", async () => {
         }),
     );
 
-    assert.match(html, /data-icon="play"/);
+    assert.doesNotMatch(html, /data-icon="play"/);
     assert.doesNotMatch(html, /data-icon="loader"/);
 });
 
-test("RadioStationCard shows spinner icon while loading or play feedback spinner is active", async () => {
+test("RadioStationCard shows spinner only while loading", async () => {
     const RadioStationCard = await loadCardComponent();
 
     const loadingHtml = renderToStaticMarkup(
@@ -124,19 +102,10 @@ test("RadioStationCard shows spinner icon while loading or play feedback spinner
         }),
     );
     assert.match(loadingHtml, /data-icon="loader"/);
-
-    feedbackState.showSpinner = true;
-    const feedbackSpinnerHtml = renderToStaticMarkup(
-        React.createElement(RadioStationCard, {
-            station: baseStation,
-            onPlay: () => undefined,
-            isLoading: false,
-        }),
-    );
-    assert.match(feedbackSpinnerHtml, /data-icon="loader"/);
+    assert.doesNotMatch(loadingHtml, /data-icon="play"/);
 });
 
-test("RadioStationCard click handler triggers feedback and onPlay callback", async () => {
+test("RadioStationCard click handler invokes the onPlay callback", async () => {
     const RadioStationCard = await loadCardComponent();
     let playCalls = 0;
 
@@ -153,7 +122,6 @@ test("RadioStationCard click handler triggers feedback and onPlay callback", asy
 
     onClick?.();
 
-    assert.equal(feedbackState.triggerCalls, 1);
     assert.equal(playCalls, 1);
     assert.equal((element.props as { disabled?: boolean }).disabled, false);
 });
@@ -176,6 +144,5 @@ test("RadioStationCard suppresses click side effects while loading", async () =>
 
     onClick?.();
 
-    assert.equal(feedbackState.triggerCalls, 0);
     assert.equal(playCalls, 0);
 });


### PR DESCRIPTION
The ephemeral-playlist flow from #648 covered the Explore tiles but not the /radio page: its Quick Start, genre, and decade cards (the latter two generated dynamically from the library) still fetched 100 tracks and replaced the queue.

## What changed

- New shared helper `frontend/lib/radio/openRadioStation.tsx` holds the single open flow: Shuffle All keeps instant playback of the whole library; every other station creates a generated playlist and navigates to its page (regenerate/extend buttons included). Both `LibraryRadioStations` (Explore/home) and the /radio page now call it, so the two surfaces can no longer drift. Notifications are injectable for tests; the sonner-backed default keeps the existing toasts.
- The /radio page handler shrinks to a loading-state wrapper around the helper, with the station type narrowed so dynamic genre/decade filters are provably valid playlist filters at compile time.
- `RadioStationCard` loses the hover play-button overlay — cards navigate to a playlist page now, so the play affordance was misleading. A spinner still appears in the corner while a station opens. Page copy updated to describe the playlist behavior.

## Tests

- New DOM-free suite for the shared helper: filtered stations create + navigate without playback; Shuffle All fetches, enforces the station minimum, and plays; generation failures toast and resolve.
- Card suite rewritten: no overlay at rest, spinner only while loading, click/disabled behavior.
- The existing Explore generated-playlist component suite passes unchanged against the shared helper.
- Full frontend component suite: 618/618 on Node 24. Typecheck, lint, and prettier clean.