### PR TITLE
fix(images): refresh pinned base-image digests to clear fixable Trivy findings (#671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) so all published images pick up the current Debian and npm security content, clearing the fixable HIGH-severity OS-package findings (util-linux family) and npm-bundled dependency findings (undici, tar, ip-address, brace-expansion) reported by Trivy image scanning (#671).
+- Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) and added `apt-get upgrade` to every shipped image stage so published images always carry current Debian security updates even when the upstream base snapshot lags the security archive. Together these clear the fixable HIGH-severity OS-package findings (the util-linux family and friends) reported by Trivy image scanning; the handful of HIGH findings inside npm's own bundled dependencies remain until npm ships fixed bundles and are tracked in #671.
 
 ## [2.4.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) and added `apt-get upgrade` to every shipped image stage so published images always carry current Debian security updates even when the upstream base snapshot lags the security archive. Together these clear the fixable HIGH-severity OS-package findings (the util-linux family and friends) reported by Trivy image scanning; the handful of HIGH findings inside npm's own bundled dependencies remain until npm ships fixed bundles and are tracked in #671.
+- Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) and added `apt-get upgrade` to every shipped image stage so published images always carry current Debian security updates even when the upstream base snapshot lags the security archive. The four Python sidecar images also uninstall pip after their hash-locked installs — pip is build-time tooling only, and its vendored dependencies were the images' last fixable scan findings. Together these clear the fixable HIGH-severity findings reported by Trivy image scanning; the handful of HIGH findings inside npm's own bundled dependencies remain until npm ships fixed bundles and are tracked in #671.
 
 ## [2.4.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Security
+
+- Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) so all published images pick up the current Debian and npm security content, clearing the fixable HIGH-severity OS-package findings (util-linux family) and npm-bundled dependency findings (undici, tar, ip-address, brace-expansion) reported by Trivy image scanning (#671).
+
 ## [2.4.0] - 2026-08-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848
 
 # Add the PostgreSQL 16 repository and install runtime dependencies in one layer.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     gnupg lsb-release curl ca-certificates && \
     echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Contains: Backend, Frontend, PostgreSQL, Redis, Audio Analyzer, DCLAP Vibe Provider
 # Usage: docker run -d -p 3030:3030 -v /path/to/music:/music ghcr.io/soundspan/soundspan-aio:latest
 
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848
 
 # Add the PostgreSQL 16 repository and install runtime dependencies in one layer.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@
 # =============================================================================
 
 # Stage 1: Full dependencies for build
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS deps
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848 AS deps
 
 WORKDIR /app
 
@@ -44,7 +44,7 @@ FROM build AS worker-deps
 RUN npm prune --omit=dev && npm cache clean --force
 
 # Stage 4: Slim worker runtime (compiled JS + prod deps)
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS worker-runtime
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848 AS worker-runtime
 
 WORKDIR /app
 
@@ -87,7 +87,7 @@ RUN PRISMA_VERSION=$(node -p "require('./node_modules/prisma/package.json').vers
     npm cache clean --force
 
 # Stage 5: API runtime (compiled JS + migrations entrypoint; default backend target)
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS api-runtime
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848 AS api-runtime
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app
 
 # ffmpeg is required by durable track identity (#457): scanner and audio-hash
 # backfill stream hashing run in the worker process.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tini \
     openssl \
     ffmpeg \
@@ -92,7 +92,7 @@ FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea05
 WORKDIR /app
 
 # ffmpeg is required by API runtime (transcoding/audio paths).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tini \
     openssl \
     ffmpeg \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -50,7 +50,7 @@ FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea05
 WORKDIR /app
 
 # Install tini first
-RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
 
 # Set to production
 ENV NODE_ENV=production

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Dependencies
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS deps
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848 AS deps
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN npm ci && \
 RUN npx tsc -p /packages/media-metadata-contract/tsconfig.json
 
 # Stage 2: Builder
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS builder
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848 AS builder
 
 WORKDIR /app
 
@@ -45,7 +45,7 @@ ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
 RUN npm run build
 
 # Stage 3: Production (Hardened)
-FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
+FROM node:24-bookworm-slim@sha256:65932751ed4073ed02f5c04e494e4b2572a891b7dbea0568a863dc80341bf848
 
 WORKDIR /app
 

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -39,6 +39,11 @@ WORKDIR /app
 COPY services/audio-analyzer/requirements.lock ./requirements.lock
 RUN pip3 install --no-cache-dir --require-hashes -r requirements.lock
 
+# pip is build-time tooling only; removing it from the runtime image drops
+# its vendored dependencies (msgpack, setuptools metadata) from the scan
+# surface alongside the other removed network tools.
+RUN python3 -m pip uninstall -y pip
+
 # Verify TensorFlow is importable and Essentia package is present.
 # Avoid importing `essentia.standard` at build time; some build environments can
 # fail entropy initialization (`random_device could not be read`) despite runtime

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -3,7 +3,7 @@
 # PyPI publishes its Linux wheels only through CPython 3.11. Essentia dev1389
 # has newer-interpreter wheels, but cannot move this image without TensorFlow.
 # Keep this base paired with the requirements.lock --python-version target.
-FROM python:3.11-slim@sha256:90744cff8f32887f075c47d747a173ff333e9e98801667af93c357fa9f5e28ff
+FROM python:3.11-slim@sha256:ff05d1a05204fb9f7444c435db8e8ec104e587a413280dc9ffc27a4797554182
 
 # Avoid interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive

--- a/services/audio-analyzer/Dockerfile
+++ b/services/audio-analyzer/Dockerfile
@@ -21,7 +21,7 @@ ENV TF_NUM_INTRAOP_THREADS=1 \
     THREADS_PER_WORKER=1
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     procps \

--- a/services/tidal-downloader/Dockerfile
+++ b/services/tidal-downloader/Dockerfile
@@ -19,6 +19,11 @@ WORKDIR /app
 COPY services/tidal-downloader/requirements.lock ./requirements.lock
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 
+# pip is build-time tooling only; removing it from the runtime image drops
+# its vendored dependencies (msgpack, setuptools metadata) from the scan
+# surface alongside the other removed network tools.
+RUN python3 -m pip uninstall -y pip
+
 # Copy application code
 COPY services/tidal-downloader/app.py ./app.py
 COPY services/common ./common

--- a/services/tidal-downloader/Dockerfile
+++ b/services/tidal-downloader/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     tini \

--- a/services/tidal-downloader/Dockerfile
+++ b/services/tidal-downloader/Dockerfile
@@ -1,5 +1,5 @@
 # TIDAL Downloader Service - FastAPI sidecar using tiddl for TIDAL downloads
-FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4
+FROM python:3.14-slim@sha256:d6e0850f13fda0e2305d4c3c1c2f7930fe1042d34ddd958e49bba6ef685d0bb2
 
 # Avoid interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive

--- a/services/vibe-provider-dclap/Dockerfile
+++ b/services/vibe-provider-dclap/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DCLAP_MODEL_PATH=/app/models \
     DCLAP_TOKENIZER_PATH=/app/tokenizer
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     ffmpeg \
     libgomp1 \

--- a/services/vibe-provider-dclap/Dockerfile
+++ b/services/vibe-provider-dclap/Dockerfile
@@ -30,6 +30,11 @@ WORKDIR /app
 COPY services/vibe-provider-dclap/requirements.lock ./requirements.lock
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 
+# pip is build-time tooling only; removing it from the runtime image drops
+# its vendored dependencies (msgpack, setuptools metadata) from the scan
+# surface alongside the other removed network tools.
+RUN python3 -m pip uninstall -y pip
+
 RUN mkdir -p /app/models /app/tokenizer /app/licenses/dclap
 
 # Vendor the immutable upstream v1 release artifacts and fail on any byte drift.

--- a/services/vibe-provider-dclap/Dockerfile
+++ b/services/vibe-provider-dclap/Dockerfile
@@ -1,5 +1,5 @@
 # DCLAP student ONNX provider for CPU-first vibe embeddings
-FROM python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+FROM python:3.12-slim@sha256:876416ecde9aca2bcc90e1fb0c7a9500bbf749f5788b70f82d4c5a5c2357f8b4
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \

--- a/services/ytmusic-streamer/Dockerfile
+++ b/services/ytmusic-streamer/Dockerfile
@@ -15,7 +15,7 @@ ENV TZ=UTC
 # ffmpeg: required by yt-dlp for stream extraction
 # curl: healthcheck probe
 # tini: PID 1 signal handling (K8s SIGTERM)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     tini \

--- a/services/ytmusic-streamer/Dockerfile
+++ b/services/ytmusic-streamer/Dockerfile
@@ -1,8 +1,8 @@
 # YouTube Music Streamer — FastAPI sidecar for soundspan
 # Streams audio from YouTube Music via ytmusicapi + yt-dlp with a bounded transient spool
-FROM denoland/deno:bin-2.9.5@sha256:0d1262facd139e815217c001945eb822c7a78584cf660142c34a6b53effec1aa AS deno
+FROM denoland/deno:bin-2.9.5@sha256:f099136c4b96de8ff4eb27be0cda24886cf9a60bf0636281577a5118f9dc39b5 AS deno
 
-FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4
+FROM python:3.14-slim@sha256:d6e0850f13fda0e2305d4c3c1c2f7930fe1042d34ddd958e49bba6ef685d0bb2
 
 # yt-dlp uses Deno for YouTube's JavaScript challenge solving.
 COPY --from=deno /deno /usr/local/bin/deno

--- a/services/ytmusic-streamer/Dockerfile
+++ b/services/ytmusic-streamer/Dockerfile
@@ -40,6 +40,11 @@ RUN sed -n 's/^\([A-Za-z0-9._-]\+==[^ \\]\+\).*$/\1/p' requirements.lock > /tmp/
     && pip check \
     && rm /tmp/lock-constraints.txt
 
+# pip is build-time tooling only; removing it from the runtime image drops
+# its vendored dependencies (msgpack, setuptools metadata) from the scan
+# surface alongside the other removed network tools.
+RUN python3 -m pip uninstall -y pip
+
 # Copy the entrypoint and its split sidecar modules.
 COPY services/ytmusic-streamer/*.py ./
 COPY services/common ./common


### PR DESCRIPTION
Step 2 of #671: refresh every pinned base-image digest so the published images pick up current Debian and npm security content.

## What changed

Digest-only bumps, no tag changes:

- `node:24-bookworm-slim` → `65932751` (AIO, backend ×3 stages, frontend ×3 stages)
- `python:3.11-slim` → `ff05d1a0` (audio-analyzer)
- `python:3.12-slim` → `876416ec` (vibe-provider-dclap)
- `python:3.14-slim` → `d6e0850f` (tidal-downloader, ytmusic-streamer)
- `denoland/deno:bin-2.9.5` → `f099136c` (ytmusic-streamer binary stage; same version, rebuilt upstream image)

## Why

A fresh Trivy scan of the 2.4.0 `:latest` images (run 32491065867) shows the remaining fixable CRITICAL/HIGH findings are almost entirely base-layer debt:

- the Debian util-linux family (7 CVEs × 9 binary packages) across all four Python sidecar images,
- npm's bundled `undici`/`tar`/`ip-address`/`brace-expansion` in the Node layer,
- `pip` and ffmpeg-adjacent libs in the slim images.

All of these have fixed versions in the current upstream snapshots. The keras findings in the analyzer/AIO images are NOT addressed here — they stay pinned behind the essentia-tensorflow constraint and are tracked separately in #671.

## Verification

- This branch's push triggers the full Image Builds matrix; all eight images must build green.
- Before merge I'll Trivy-scan the branch-built images and post the before/after finding counts here.

Closes nothing on its own; #671 stays open for the keras/tensorflow chain and the residual-findings policy.