### PR TITLE
fix(enrichment): reconcile failure log with live state and restore failure detail UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Library Enrichment failures view no longer disagrees with the summary tiles: stale failure-log rows whose track, artist, audio analysis, or vibe embedding has since recovered (for example after a bulk re-queue or an embedding-space migration) are now reconciled against live state when the failures dialog opens, after "Retry all", and at the start of every full enrichment run, so the "View Failures" count converges to what is actually failed. Failure rows also show a sanitized error summary and error code again instead of "Unknown error" (the 2.4.0 sanitization had stripped the detail the dialog rendered), an unfinished enrichment stage no longer rounds up to a misleading "100%", and the dialog's header, tabs, and action bars keep their size instead of being crushed by a long failure list.
+
 ### Security
 
 - Refreshed every pinned base-image digest (`node:24-bookworm-slim`, `python:3.11-slim`, `python:3.12-slim`, `python:3.14-slim`, and the `denoland/deno:bin-2.9.5` binary stage) and added `apt-get upgrade` to every shipped image stage so published images always carry current Debian security updates even when the upstream base snapshot lags the security archive. The four Python sidecar images also uninstall pip after their hash-locked installs — pip is build-time tooling only, and its vendored dependencies were the images' last fixable scan findings. Together these clear the fixable HIGH-severity findings reported by Trivy image scanning; the handful of HIGH findings inside npm's own bundled dependencies remain until npm ships fixed bundles and are tracked in #671.

--- a/backend/src/__tests__/enrichmentRouteAuthz.test.ts
+++ b/backend/src/__tests__/enrichmentRouteAuthz.test.ts
@@ -33,6 +33,10 @@ const mockGetFailureCounts = jest.fn(async () => ({
     vibe: 0,
     total: 0,
 }));
+const mockReconcileFailures = jest.fn(async () => ({
+    resolved: 12,
+    checked: 20,
+}));
 const mockSystemSettingsFindUnique = jest.fn(async () => ({
     autoEnrichMetadata: true,
 }));
@@ -83,6 +87,7 @@ jest.mock("../services/enrichmentFailureService", () => ({
     enrichmentFailureService: {
         getFailures: mockGetFailures,
         getFailureCounts: mockGetFailureCounts,
+        reconcileWithLiveState: mockReconcileFailures,
     },
 }));
 
@@ -280,5 +285,25 @@ describe("enrichment router authorization", () => {
             total: 0,
         });
         expect(mockGetFailureCounts).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects non-admin users on POST /failures/reconcile", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/failures/reconcile")
+            .set("x-test-role", "user");
+
+        expect(response.status).toBe(403);
+        expect(response.body).toEqual({ error: "Admin access required" });
+        expect(mockReconcileFailures).not.toHaveBeenCalled();
+    });
+
+    it("allows admins on POST /failures/reconcile", async () => {
+        const response = await request(buildApp())
+            .post("/api/enrichment/failures/reconcile")
+            .set("x-test-role", "admin");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ resolved: 12, checked: 20 });
+        expect(mockReconcileFailures).toHaveBeenCalledTimes(1);
     });
 });

--- a/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
@@ -183,7 +183,7 @@ describe("GET /api/enrichment/failures bounded query parameters", () => {
         });
     });
 
-    it("returns a client-safe DTO without worker errors or filesystem metadata", async () => {
+    it("returns sanitized failure details without filesystem metadata", async () => {
         mockGetFailures.mockResolvedValueOnce({
             failures: [
                 {
@@ -191,8 +191,9 @@ describe("GET /api/enrichment/failures bounded query parameters", () => {
                     entityType: "audio",
                     entityId: "track-1",
                     entityName: "Example Track",
-                    errorMessage: "SECRET_LEAK_MARKER: decoder crashed",
-                    errorCode: "WORKER_SECRET_CODE",
+                    errorMessage:
+                        "decoder crashed at /srv/music/private/track.flac using https://worker:secret@example.test/jobs/1",
+                    errorCode: "AUDIO_DECODER_FAILED",
                     retryCount: 2,
                     maxRetries: 3,
                     firstFailedAt: new Date("2026-08-10T12:00:00.000Z"),
@@ -219,6 +220,9 @@ describe("GET /api/enrichment/failures bounded query parameters", () => {
                     entityType: "audio",
                     entityId: "track-1",
                     entityName: "Example Track",
+                    errorSummary:
+                        "decoder crashed at [path] using https://example.test/[...]",
+                    errorCode: "AUDIO_DECODER_FAILED",
                     retryCount: 2,
                     maxRetries: 3,
                     firstFailedAt: "2026-08-10T12:00:00.000Z",
@@ -231,9 +235,7 @@ describe("GET /api/enrichment/failures bounded query parameters", () => {
             ],
             total: 1,
         });
-        expect(JSON.stringify(response.body)).not.toContain(
-            "SECRET_LEAK_MARKER",
-        );
+        expect(JSON.stringify(response.body)).not.toContain("worker:secret");
         expect(JSON.stringify(response.body)).not.toContain("/srv/music");
     });
 });

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -1077,10 +1077,7 @@ describe("enrichment route runtime behavior", () => {
 
     it("reconciles failure rows and returns a safe error on failure", async () => {
         const res = createRes();
-        await reconcileFailuresHandler(
-            { user: { id: "admin-1" } } as any,
-            res,
-        );
+        await reconcileFailuresHandler({ user: { id: "admin-1" } } as any, res);
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({ resolved: 4, checked: 9 });
 

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -48,6 +48,7 @@ jest.mock("../../services/enrichmentFailureService", () => ({
     enrichmentFailureService: {
         getFailures: jest.fn(),
         getFailureCounts: jest.fn(),
+        reconcileWithLiveState: jest.fn(),
         resetRetryCount: jest.fn(),
         getFailure: jest.fn(),
         resolveFailures: jest.fn(),
@@ -185,6 +186,8 @@ const mockApplyAlbumEnrichment =
 const mockGetFailures = enrichmentFailureService.getFailures as jest.Mock;
 const mockGetFailureCounts =
     enrichmentFailureService.getFailureCounts as jest.Mock;
+const mockReconcileWithLiveState =
+    enrichmentFailureService.reconcileWithLiveState as jest.Mock;
 const mockResetRetryCount =
     enrichmentFailureService.resetRetryCount as jest.Mock;
 const mockGetFailure = enrichmentFailureService.getFailure as jest.Mock;
@@ -271,6 +274,10 @@ describe("enrichment route runtime behavior", () => {
     const startHandler = getRouteHandler("/start", "post");
     const failuresGetHandler = getRouteHandler("/failures", "get");
     const failureCountsHandler = getRouteHandler("/failures/counts", "get");
+    const reconcileFailuresHandler = getRouteHandler(
+        "/failures/reconcile",
+        "post",
+    );
     const retryHandler = getRouteHandler("/retry", "post");
     const skipHandler = getRouteHandler("/skip", "post");
     const searchArtistsHandler = getRouteHandler(
@@ -358,6 +365,10 @@ describe("enrichment route runtime behavior", () => {
             artist: 1,
             track: 2,
             audio: 3,
+        });
+        mockReconcileWithLiveState.mockResolvedValue({
+            resolved: 4,
+            checked: 9,
         });
         mockResetRetryCount.mockResolvedValue(undefined);
         mockGetFailure.mockResolvedValue(null);
@@ -1062,6 +1073,30 @@ describe("enrichment route runtime behavior", () => {
         expect(errorRes.body).toEqual({
             error: "Failed to get failure counts",
         });
+    });
+
+    it("reconciles failure rows and returns a safe error on failure", async () => {
+        const res = createRes();
+        await reconcileFailuresHandler(
+            { user: { id: "admin-1" } } as any,
+            res,
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ resolved: 4, checked: 9 });
+
+        mockReconcileWithLiveState.mockRejectedValueOnce(
+            new Error("database secret"),
+        );
+        const errorRes = createRes();
+        await reconcileFailuresHandler(
+            { user: { id: "admin-1" } } as any,
+            errorRes,
+        );
+        expect(errorRes.statusCode).toBe(500);
+        expect(errorRes.body).toEqual({
+            error: "Failed to reconcile failures",
+        });
+        expect(JSON.stringify(errorRes.body)).not.toContain("database secret");
     });
 
     it("validates retry ids and requeues existing artist/audio items", async () => {

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -19,6 +19,7 @@ import {
     enrichmentFailureService,
     type EnrichmentFailure,
 } from "../services/enrichmentFailureService";
+import { sanitizeEnrichmentErrorSummary } from "../utils/enrichmentErrorSummary";
 import { musicBrainzService } from "../services/musicbrainz";
 import { coverArtService } from "../services/coverArt";
 import {
@@ -32,7 +33,7 @@ import { TRACK_VISIBLE_WHERE } from "../utils/librarySorting";
 import { config } from "../config";
 import { sendFeatureDisabled } from "../utils/featureGate";
 import { parseBoundedInt } from "../utils/queryParams";
-import { sendRouteError } from "./routeErrorResponse";
+import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
 import { updateAlbumMetadataWithOwnership } from "../services/albumMetadataPersistence";
 
@@ -50,8 +51,8 @@ function isValidMusicBrainzId(value: string): boolean {
 
 type ClientSafeEnrichmentFailure = Omit<
     EnrichmentFailure,
-    "errorMessage" | "errorCode" | "metadata"
->;
+    "errorMessage" | "metadata"
+> & { errorSummary: string | null };
 
 function toClientSafeEnrichmentFailure(
     failure: EnrichmentFailure,
@@ -61,6 +62,8 @@ function toClientSafeEnrichmentFailure(
         entityType: failure.entityType,
         entityId: failure.entityId,
         entityName: failure.entityName,
+        errorSummary: sanitizeEnrichmentErrorSummary(failure.errorMessage),
+        errorCode: failure.errorCode,
         retryCount: failure.retryCount,
         maxRetries: failure.maxRetries,
         firstFailedAt: failure.firstFailedAt,
@@ -1054,6 +1057,36 @@ router.get("/failures/counts", requireAdmin, async (req, res) => {
     } catch (error) {
         logger.error("Get failure counts error:", error);
         res.status(500).json({ error: "Failed to get failure counts" });
+    }
+});
+
+/**
+ * @openapi
+ * /api/enrichment/failures/reconcile:
+ *   post:
+ *     summary: Reconcile unresolved enrichment failures with live entity state
+ *     tags: [Enrichment]
+ *     security:
+ *       - apiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Number of failure rows checked and resolved
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Admin access required
+ */
+/**
+ * POST /enrichment/failures/reconcile
+ * Reconcile stale failure records with authoritative live state (admin only)
+ */
+router.post("/failures/reconcile", requireAdmin, async (_req, res) => {
+    try {
+        const result = await enrichmentFailureService.reconcileWithLiveState();
+        res.json(result);
+    } catch (error) {
+        logger.error("Reconcile enrichment failures error:", error);
+        sendInternalRouteError(res, "Failed to reconcile failures");
     }
 });
 

--- a/backend/src/services/__tests__/enrichmentFailureService.test.ts
+++ b/backend/src/services/__tests__/enrichmentFailureService.test.ts
@@ -18,10 +18,10 @@ const prisma = {
         deleteMany: jest.fn(),
     },
     artist: {
-        findUnique: jest.fn(),
+        findMany: jest.fn(),
     },
     track: {
-        findUnique: jest.fn(),
+        findMany: jest.fn(),
     },
 };
 
@@ -30,6 +30,104 @@ jest.mock("../../utils/db", () => ({
 }));
 
 import { enrichmentFailureService } from "../enrichmentFailureService";
+import { sanitizeEnrichmentErrorSummary } from "../../utils/enrichmentErrorSummary";
+
+describe("sanitizeEnrichmentErrorSummary", () => {
+    it("strips a Windows path with spaces without leaking suffix fragments", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "failed at C:\\Music\\Artist Name\\song.flac",
+            ),
+        ).toBe("failed at [path] [path]");
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "failed at C:\\Music\\Artist Name\\song.flac",
+            ),
+        ).not.toContain("song.flac");
+    });
+
+    it("strips a UNC path with spaces", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "failed at \\\\server\\share\\Artist Name\\song.flac",
+            ),
+        ).toBe("failed at [path] [path]");
+    });
+
+    it("strips a POSIX path with spaces", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "failed at /srv/music/Artist Name/song.flac",
+            ),
+        ).toBe("failed at [path] [path]");
+    });
+
+    it("sanitizes a message that contains only a path", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary("C:\\Music\\private\\song.flac"),
+        ).toBe("[path]");
+    });
+
+    it("keeps a URL host while stripping credentials and path", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "request to https://user:pass@example.test/jobs/1 failed",
+            ),
+        ).toBe("request to https://example.test/[...] failed");
+    });
+
+    it("keeps a URL host while stripping its path", () => {
+        expect(
+            sanitizeEnrichmentErrorSummary(
+                "request to https://example.test/jobs/1 failed",
+            ),
+        ).toBe("request to https://example.test/[...] failed");
+    });
+
+    it.each([
+        "data:,super-secret",
+        "data:text,super-secret",
+        "C:private.txt",
+        ":leading-secret",
+        "'data:,super-secret'",
+        "(data:,super-secret)",
+    ])("redacts colon-prefixed payload token %s", (token) => {
+        expect(sanitizeEnrichmentErrorSummary(token)).toBe("[redacted]");
+    });
+
+    it("retains a bare trailing-colon word", () => {
+        expect(sanitizeEnrichmentErrorSummary("Error:")).toBe("Error:");
+    });
+
+    it("collapses whitespace and caps the summary at 200 characters", () => {
+        const summary = sanitizeEnrichmentErrorSummary(
+            `  decoder\n\tfailed ${"x".repeat(300)}  `,
+        );
+
+        expect(summary).toHaveLength(200);
+        expect(summary?.startsWith("decoder failed ")).toBe(true);
+        expect(summary).not.toContain("\n");
+    });
+
+    it("caps summaries at 200 code points without splitting an emoji", () => {
+        const summary = sanitizeEnrichmentErrorSummary(
+            `${"a".repeat(199)}😀 trailing`,
+        );
+
+        expect(summary).toBe(`${"a".repeat(199)}😀`);
+        expect(Array.from(summary ?? "")).toHaveLength(200);
+    });
+
+    it("handles a long all-alphabetic message", () => {
+        expect(sanitizeEnrichmentErrorSummary("a".repeat(100_000))).toBe(
+            "a".repeat(200),
+        );
+    });
+
+    it("preserves null when no message was recorded", () => {
+        expect(sanitizeEnrichmentErrorSummary(null)).toBeNull();
+    });
+});
 
 describe("enrichmentFailureService", () => {
     beforeEach(() => {
@@ -130,6 +228,8 @@ describe("enrichmentFailureService", () => {
                     errorCode: "E_TIMEOUT",
                     retryCount: 3,
                     lastFailedAt: expect.any(Date),
+                    resolved: false,
+                    resolvedAt: null,
                     metadata: existingMetadata,
                 },
             });
@@ -138,6 +238,63 @@ describe("enrichmentFailureService", () => {
                     id: "failure-2",
                     retryCount: 3,
                     metadata: existingMetadata,
+                }),
+            );
+        });
+
+        it("reopens a resolved failure when the entity fails again", async () => {
+            let row: Record<string, unknown> | null = null;
+            prisma.enrichmentFailure.findUnique.mockImplementation(
+                async () => row,
+            );
+            prisma.enrichmentFailure.create.mockImplementation(
+                async ({ data }) => {
+                    row = {
+                        id: "failure-reopened",
+                        ...data,
+                        resolved: false,
+                        resolvedAt: null,
+                    };
+                    return row;
+                },
+            );
+            prisma.enrichmentFailure.updateMany.mockImplementation(
+                async ({ data }) => {
+                    row = row === null ? null : { ...row, ...data };
+                    return { count: row === null ? 0 : 1 };
+                },
+            );
+            prisma.enrichmentFailure.update.mockImplementation(
+                async ({ data }) => {
+                    row = row === null ? null : { ...row, ...data };
+                    return row;
+                },
+            );
+
+            const recorded = await enrichmentFailureService.recordFailure({
+                entityType: "audio",
+                entityId: "track-reopened",
+                errorMessage: "first failure",
+            });
+            await enrichmentFailureService.resolveFailures([recorded.id]);
+            expect(row).toEqual(
+                expect.objectContaining({
+                    resolved: true,
+                    resolvedAt: expect.any(Date),
+                }),
+            );
+
+            const rerecorded = await enrichmentFailureService.recordFailure({
+                entityType: "audio",
+                entityId: "track-reopened",
+                errorMessage: "failed again",
+            });
+
+            expect(rerecorded).toEqual(
+                expect.objectContaining({
+                    resolved: false,
+                    resolvedAt: null,
+                    lastFailedAt: expect.any(Date),
                 }),
             );
         });
@@ -517,66 +674,305 @@ describe("enrichmentFailureService", () => {
         });
     });
 
-    describe("cleanupOrphanedFailures", () => {
-        it("resolves orphaned artist/track/audio/vibe entries and returns counts", async () => {
+    describe("reconcileWithLiveState", () => {
+        it("resolves vibe failures when tracks recovered or disappeared and keeps live failures", async () => {
             prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
-                { id: "f1", entityType: "artist", entityId: "artist-1" },
-                { id: "f2", entityType: "track", entityId: "track-1" },
-                { id: "f3", entityType: "audio", entityId: "audio-1" },
-                { id: "f4", entityType: "vibe", entityId: "vibe-1" },
+                { id: "v-recovered", entityType: "vibe", entityId: "v-1" },
+                { id: "v-failed", entityType: "vibe", entityId: "v-2" },
+                { id: "v-missing", entityType: "vibe", entityId: "v-3" },
             ]);
-            prisma.artist.findUnique
-                .mockResolvedValueOnce({ id: "artist-1" })
-                .mockResolvedValueOnce(null);
-            prisma.track.findUnique
-                .mockResolvedValueOnce(null)
-                .mockResolvedValueOnce({ id: "track-audio-1" });
+            prisma.track.findMany.mockResolvedValueOnce([
+                { id: "v-1", vibeAnalysisStatus: "completed", removedAt: null },
+                { id: "v-2", vibeAnalysisStatus: "failed", removedAt: null },
+            ]);
             prisma.enrichmentFailure.updateMany.mockResolvedValueOnce({
                 count: 2,
             });
 
             const result =
-                await enrichmentFailureService.cleanupOrphanedFailures();
+                await enrichmentFailureService.reconcileWithLiveState();
 
-            expect(prisma.artist.findUnique).toHaveBeenCalledWith({
-                where: { id: "artist-1" },
-                select: { id: true },
-            });
-            expect(prisma.track.findUnique).toHaveBeenCalledWith({
-                where: { id: "track-1" },
-                select: { id: true },
-            });
-            expect(prisma.track.findUnique).toHaveBeenCalledWith({
-                where: { id: "audio-1" },
-                select: { id: true },
+            expect(prisma.track.findMany).toHaveBeenCalledWith({
+                where: { id: { in: ["v-1", "v-2", "v-3"] } },
+                select: { id: true, vibeAnalysisStatus: true, removedAt: true },
             });
             expect(prisma.enrichmentFailure.updateMany).toHaveBeenCalledWith({
                 where: {
-                    id: { in: ["f2", "f4"] },
+                    id: { in: ["v-recovered", "v-missing"] },
+                    resolved: false,
+                    skipped: false,
+                    lastFailedAt: { lt: expect.any(Date) },
                 },
                 data: {
                     resolved: true,
                     resolvedAt: expect.any(Date),
                 },
             });
-            expect(result).toEqual({ cleaned: 2, checked: 4 });
-            expect(logger.debug).toHaveBeenCalledWith(
-                "[Enrichment Failures] Cleaned up 2 orphaned failures",
+            expect(result).toEqual({ resolved: 2, checked: 3 });
+        });
+
+        it("does not resolve a row re-failed after reconciliation started", async () => {
+            const startedAt = new Date("2026-08-21T12:00:00.000Z");
+            const row = {
+                id: "v-raced",
+                resolved: false,
+                skipped: false,
+                lastFailedAt: new Date(startedAt.getTime() + 1),
+            };
+            jest.useFakeTimers().setSystemTime(startedAt);
+            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
+                { id: row.id, entityType: "vibe", entityId: "track-raced" },
+            ]);
+            prisma.track.findMany.mockResolvedValueOnce([
+                {
+                    id: "track-raced",
+                    vibeAnalysisStatus: "completed",
+                    removedAt: null,
+                },
+            ]);
+            prisma.enrichmentFailure.updateMany.mockImplementationOnce(
+                async ({ where, data }) => {
+                    const canResolve =
+                        !row.resolved &&
+                        !row.skipped &&
+                        row.lastFailedAt < where.lastFailedAt.lt;
+                    if (canResolve) Object.assign(row, data);
+                    return { count: canResolve ? 1 : 0 };
+                },
+            );
+
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState();
+
+            expect(row.resolved).toBe(false);
+            expect(result).toEqual({ resolved: 0, checked: 1 });
+            expect(prisma.enrichmentFailure.updateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        lastFailedAt: { lt: startedAt },
+                    }),
+                }),
             );
         });
 
-        it("returns zero counts and does not resolve when there are no orphans", async () => {
-            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([]);
+        it("resolves audio failures when tracks recovered or disappeared and keeps live failures", async () => {
+            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
+                { id: "a-recovered", entityType: "audio", entityId: "a-1" },
+                { id: "a-failed", entityType: "audio", entityId: "a-2" },
+                { id: "a-missing", entityType: "audio", entityId: "a-3" },
+            ]);
+            prisma.track.findMany.mockResolvedValueOnce([
+                { id: "a-1", analysisStatus: "completed", removedAt: null },
+                { id: "a-2", analysisStatus: "failed", removedAt: null },
+            ]);
             prisma.enrichmentFailure.updateMany.mockResolvedValueOnce({
-                count: 0,
+                count: 2,
             });
 
             const result =
-                await enrichmentFailureService.cleanupOrphanedFailures();
+                await enrichmentFailureService.reconcileWithLiveState();
 
+            expect(prisma.track.findMany).toHaveBeenCalledWith({
+                where: { id: { in: ["a-1", "a-2", "a-3"] } },
+                select: { id: true, analysisStatus: true, removedAt: true },
+            });
+            expect(prisma.enrichmentFailure.updateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        id: { in: ["a-recovered", "a-missing"] },
+                    }),
+                }),
+            );
+            expect(result).toEqual({ resolved: 2, checked: 3 });
+        });
+
+        it("resolves track failures after terminal tags or disappearance", async () => {
+            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
+                { id: "t-tagged", entityType: "track", entityId: "t-1" },
+                { id: "t-no-mood", entityType: "track", entityId: "t-2" },
+                { id: "t-not-found", entityType: "track", entityId: "t-3" },
+                { id: "t-empty", entityType: "track", entityId: "t-4" },
+                { id: "t-null", entityType: "track", entityId: "t-5" },
+                { id: "t-missing", entityType: "track", entityId: "t-6" },
+            ]);
+            prisma.track.findMany.mockResolvedValueOnce([
+                { id: "t-1", lastfmTags: ["dreamy"], removedAt: null },
+                { id: "t-2", lastfmTags: ["_no_mood_tags"], removedAt: null },
+                { id: "t-3", lastfmTags: ["_not_found"], removedAt: null },
+                { id: "t-4", lastfmTags: [], removedAt: null },
+                { id: "t-5", lastfmTags: null, removedAt: null },
+            ]);
+            prisma.enrichmentFailure.updateMany.mockResolvedValueOnce({
+                count: 4,
+            });
+
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState();
+
+            expect(prisma.track.findMany).toHaveBeenCalledWith({
+                where: {
+                    id: { in: ["t-1", "t-2", "t-3", "t-4", "t-5", "t-6"] },
+                },
+                select: { id: true, lastfmTags: true, removedAt: true },
+            });
+            expect(prisma.enrichmentFailure.updateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        id: {
+                            in: [
+                                "t-tagged",
+                                "t-no-mood",
+                                "t-not-found",
+                                "t-missing",
+                            ],
+                        },
+                    }),
+                }),
+            );
+            expect(result).toEqual({ resolved: 4, checked: 6 });
+        });
+
+        it("resolves artist failures when artists completed or disappeared", async () => {
+            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
+                {
+                    id: "artist-completed",
+                    entityType: "artist",
+                    entityId: "artist-1",
+                },
+                {
+                    id: "artist-failed",
+                    entityType: "artist",
+                    entityId: "artist-2",
+                },
+                {
+                    id: "artist-missing",
+                    entityType: "artist",
+                    entityId: "artist-3",
+                },
+            ]);
+            prisma.artist.findMany.mockResolvedValueOnce([
+                { id: "artist-1", enrichmentStatus: "completed" },
+                { id: "artist-2", enrichmentStatus: "failed" },
+            ]);
+            prisma.enrichmentFailure.updateMany.mockResolvedValueOnce({
+                count: 2,
+            });
+
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState();
+
+            expect(prisma.artist.findMany).toHaveBeenCalledWith({
+                where: {
+                    id: { in: ["artist-1", "artist-2", "artist-3"] },
+                },
+                select: { id: true, enrichmentStatus: true },
+            });
+            expect(prisma.enrichmentFailure.updateMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        id: { in: ["artist-completed", "artist-missing"] },
+                    }),
+                }),
+            );
+            expect(result).toEqual({ resolved: 2, checked: 3 });
+        });
+
+        it("keeps system-level artist failures for manual resolution", async () => {
+            prisma.enrichmentFailure.findMany.mockResolvedValueOnce([
+                {
+                    id: "artist-system",
+                    entityType: "artist",
+                    entityId: "system",
+                },
+            ]);
+
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState();
+
+            expect(prisma.artist.findMany).not.toHaveBeenCalled();
             expect(prisma.enrichmentFailure.updateMany).not.toHaveBeenCalled();
-            expect(result).toEqual({ cleaned: 0, checked: 0 });
-            expect(logger.debug).not.toHaveBeenCalled();
+            expect(result).toEqual({ resolved: 0, checked: 1 });
+        });
+
+        it("cursor-paginates the unresolved scan and bounds live-state lookups", async () => {
+            const failures = Array.from({ length: 5 }, (_, index) => ({
+                id: `failure-${index}`,
+                entityType: "vibe",
+                entityId: `track-${index}`,
+            }));
+            prisma.enrichmentFailure.findMany
+                .mockResolvedValueOnce(failures.slice(0, 2))
+                .mockResolvedValueOnce(failures.slice(2, 4))
+                .mockResolvedValueOnce(failures.slice(4));
+            prisma.track.findMany.mockImplementation(async ({ where }) =>
+                where.id.in.map((id: string) => ({
+                    id,
+                    vibeAnalysisStatus: "failed",
+                    removedAt: null,
+                })),
+            );
+
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState(2);
+
+            expect(prisma.enrichmentFailure.findMany).toHaveBeenCalledTimes(3);
+            expect(prisma.enrichmentFailure.findMany).toHaveBeenNthCalledWith(
+                1,
+                {
+                    where: {
+                        resolved: false,
+                        skipped: false,
+                        lastFailedAt: { lt: expect.any(Date) },
+                    },
+                    select: { id: true, entityType: true, entityId: true },
+                    orderBy: { id: "asc" },
+                    take: 2,
+                },
+            );
+            expect(prisma.enrichmentFailure.findMany).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({
+                    cursor: { id: "failure-1" },
+                    skip: 1,
+                    orderBy: { id: "asc" },
+                    take: 2,
+                }),
+            );
+            expect(prisma.enrichmentFailure.findMany).toHaveBeenNthCalledWith(
+                3,
+                expect.objectContaining({
+                    cursor: { id: "failure-3" },
+                    skip: 1,
+                    orderBy: { id: "asc" },
+                    take: 2,
+                }),
+            );
+            expect(prisma.track.findMany).toHaveBeenCalledTimes(3);
+            for (const [query] of prisma.track.findMany.mock.calls) {
+                expect(query.where.id.in.length).toBeLessThanOrEqual(2);
+            }
+            expect(prisma.enrichmentFailure.updateMany).not.toHaveBeenCalled();
+            expect(result).toEqual({ resolved: 0, checked: 5 });
+        });
+
+        it("shares one in-process reconciliation across concurrent callers", async () => {
+            let releaseFailures: ((value: never[]) => void) | undefined;
+            prisma.enrichmentFailure.findMany.mockImplementationOnce(
+                () =>
+                    new Promise<never[]>((resolve) => {
+                        releaseFailures = resolve;
+                    }),
+            );
+
+            const first = enrichmentFailureService.reconcileWithLiveState();
+            const second = enrichmentFailureService.reconcileWithLiveState();
+            releaseFailures?.([]);
+
+            await expect(Promise.all([first, second])).resolves.toEqual([
+                { resolved: 0, checked: 0 },
+                { resolved: 0, checked: 0 },
+            ]);
+            expect(prisma.enrichmentFailure.findMany).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/backend/src/services/enrichmentFailureService.ts
+++ b/backend/src/services/enrichmentFailureService.ts
@@ -8,6 +8,8 @@
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 
+const DEFAULT_RECONCILIATION_BATCH_SIZE = 500;
+
 export interface EnrichmentFailure {
     id: string;
     entityType: "artist" | "track" | "audio" | "vibe";
@@ -43,7 +45,196 @@ export interface GetFailuresOptions {
     offset?: number;
 }
 
+type FailureReference = Pick<
+    EnrichmentFailure,
+    "id" | "entityType" | "entityId"
+>;
+
+/** Counts returned after comparing unresolved failures with live entity state. */
+export interface ReconciliationResult {
+    resolved: number;
+    checked: number;
+}
+
+function chunkValues<T>(values: T[], batchSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let offset = 0; offset < values.length; offset += batchSize) {
+        chunks.push(values.slice(offset, offset + batchSize));
+    }
+    return chunks;
+}
+
+function failuresOfType(
+    failures: FailureReference[],
+    entityType: EnrichmentFailure["entityType"],
+): FailureReference[] {
+    return failures.filter((failure) => failure.entityType === entityType);
+}
+
+async function findVibeFailuresToResolve(
+    failures: FailureReference[],
+    batchSize: number,
+): Promise<string[]> {
+    const liveFailures = new Set<string>();
+    for (const batch of chunkValues(failures, batchSize)) {
+        const tracks = await prisma.track.findMany({
+            where: { id: { in: batch.map((failure) => failure.entityId) } },
+            select: { id: true, vibeAnalysisStatus: true, removedAt: true },
+        });
+        for (const track of tracks) {
+            // Soft-removed tracks are non-enrichable, so their rows resolve.
+            if (
+                track.removedAt === null &&
+                track.vibeAnalysisStatus === "failed"
+            ) {
+                liveFailures.add(track.id);
+            }
+        }
+    }
+    return failures
+        .filter((failure) => !liveFailures.has(failure.entityId))
+        .map((failure) => failure.id);
+}
+
+async function findAudioFailuresToResolve(
+    failures: FailureReference[],
+    batchSize: number,
+): Promise<string[]> {
+    const liveFailures = new Set<string>();
+    for (const batch of chunkValues(failures, batchSize)) {
+        const tracks = await prisma.track.findMany({
+            where: { id: { in: batch.map((failure) => failure.entityId) } },
+            select: { id: true, analysisStatus: true, removedAt: true },
+        });
+        for (const track of tracks) {
+            // Soft-removed tracks are non-enrichable, so their rows resolve.
+            if (track.removedAt === null && track.analysisStatus === "failed") {
+                liveFailures.add(track.id);
+            }
+        }
+    }
+    return failures
+        .filter((failure) => !liveFailures.has(failure.entityId))
+        .map((failure) => failure.id);
+}
+
+async function findTrackFailuresToResolve(
+    failures: FailureReference[],
+    batchSize: number,
+): Promise<string[]> {
+    const unfinishedIds = new Set<string>();
+    for (const batch of chunkValues(failures, batchSize)) {
+        const tracks = await prisma.track.findMany({
+            where: { id: { in: batch.map((failure) => failure.entityId) } },
+            select: { id: true, lastfmTags: true, removedAt: true },
+        });
+        for (const track of tracks) {
+            // Soft-removed tracks are non-enrichable, so their rows resolve.
+            if (
+                track.removedAt === null &&
+                (!Array.isArray(track.lastfmTags) ||
+                    track.lastfmTags.length === 0)
+            ) {
+                unfinishedIds.add(track.id);
+            }
+        }
+    }
+    return failures
+        .filter((failure) => !unfinishedIds.has(failure.entityId))
+        .map((failure) => failure.id);
+}
+
+async function findArtistFailuresToResolve(
+    failures: FailureReference[],
+    batchSize: number,
+): Promise<string[]> {
+    const reconcilableFailures = failures.filter(
+        (failure) => failure.entityId !== "system",
+    );
+    const unfinishedIds = new Set<string>();
+    for (const batch of chunkValues(reconcilableFailures, batchSize)) {
+        const artists = await prisma.artist.findMany({
+            where: { id: { in: batch.map((failure) => failure.entityId) } },
+            select: { id: true, enrichmentStatus: true },
+        });
+        for (const artist of artists) {
+            if (artist.enrichmentStatus !== "completed") {
+                unfinishedIds.add(artist.id);
+            }
+        }
+    }
+    return reconcilableFailures
+        .filter((failure) => !unfinishedIds.has(failure.entityId))
+        .map((failure) => failure.id);
+}
+
+async function findReconciliationPage(
+    batchSize: number,
+    startedAt: Date,
+    cursor?: string,
+): Promise<FailureReference[]> {
+    const failures = await prisma.enrichmentFailure.findMany({
+        where: {
+            resolved: false,
+            skipped: false,
+            // Fence the scan to the snapshot moment so sustained failure
+            // recording cannot keep feeding pages and stall the pass.
+            lastFailedAt: { lt: startedAt },
+        },
+        select: { id: true, entityType: true, entityId: true },
+        orderBy: { id: "asc" },
+        take: batchSize,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    return failures as FailureReference[];
+}
+
+async function findFailureIdsToResolve(
+    failures: FailureReference[],
+    batchSize: number,
+): Promise<string[]> {
+    const resolutionGroups = await Promise.all([
+        findVibeFailuresToResolve(failuresOfType(failures, "vibe"), batchSize),
+        findAudioFailuresToResolve(
+            failuresOfType(failures, "audio"),
+            batchSize,
+        ),
+        findTrackFailuresToResolve(
+            failuresOfType(failures, "track"),
+            batchSize,
+        ),
+        findArtistFailuresToResolve(
+            failuresOfType(failures, "artist"),
+            batchSize,
+        ),
+    ]);
+    return resolutionGroups.flat();
+}
+
+async function resolveFailureIds(
+    ids: string[],
+    batchSize: number,
+    startedAt: Date,
+): Promise<number> {
+    let resolved = 0;
+    for (const batch of chunkValues(ids, batchSize)) {
+        const result = await prisma.enrichmentFailure.updateMany({
+            where: {
+                id: { in: batch },
+                resolved: false,
+                skipped: false,
+                // Same-millisecond failures are kept for the next pass.
+                lastFailedAt: { lt: startedAt },
+            },
+            data: { resolved: true, resolvedAt: new Date() },
+        });
+        resolved += result.count;
+    }
+    return resolved;
+}
+
 class EnrichmentFailureService {
+    private reconciliationInFlight: Promise<ReconciliationResult> | null = null;
     /**
      * Record a failure (or increment retry count if already exists)
      */
@@ -81,6 +272,8 @@ class EnrichmentFailureService {
                     errorCode,
                     retryCount: newRetryCount,
                     lastFailedAt: new Date(),
+                    resolved: false,
+                    resolvedAt: null,
                     metadata: metadata
                         ? JSON.parse(JSON.stringify(metadata))
                         : existing.metadata,
@@ -340,55 +533,49 @@ class EnrichmentFailureService {
         });
     }
 
-    /**
-     * Clean up failures for entities that no longer exist in the database.
-     * This resolves orphaned failure records where the track/artist was deleted.
-     */
-    async cleanupOrphanedFailures(): Promise<{
-        cleaned: number;
-        checked: number;
-    }> {
-        // Get all unresolved failures
-        const failures = await prisma.enrichmentFailure.findMany({
-            where: { resolved: false, skipped: false },
-            select: { id: true, entityType: true, entityId: true },
-        });
+    private async reconcileOnce(
+        batchSize: number,
+    ): Promise<ReconciliationResult> {
+        const startedAt = new Date();
+        let failures = await findReconciliationPage(batchSize, startedAt);
+        let checked = 0;
+        let resolved = 0;
+        while (failures.length > 0) {
+            checked += failures.length;
+            const cursor = failures[failures.length - 1]?.id;
+            if (!cursor) throw new Error("Reconciliation page lacks a cursor");
+            const nextPage =
+                failures.length === batchSize
+                    ? await findReconciliationPage(batchSize, startedAt, cursor)
+                    : [];
+            const ids = await findFailureIdsToResolve(failures, batchSize);
+            resolved += await resolveFailureIds(ids, batchSize, startedAt);
+            failures = nextPage;
+        }
+        logger.debug(
+            `Reconciled ${resolved} of ${checked} unresolved enrichment failures`,
+        );
+        return { resolved, checked };
+    }
 
-        const toResolve: string[] = [];
-
-        for (const failure of failures) {
-            let exists = false;
-
-            if (failure.entityType === "artist") {
-                const artist = await prisma.artist.findUnique({
-                    where: { id: failure.entityId },
-                    select: { id: true },
-                });
-                exists = !!artist;
-            } else if (
-                failure.entityType === "track" ||
-                failure.entityType === "audio"
-            ) {
-                const track = await prisma.track.findUnique({
-                    where: { id: failure.entityId },
-                    select: { id: true },
-                });
-                exists = !!track;
-            }
-
-            if (!exists) {
-                toResolve.push(failure.id);
+    /** Resolve stale failure rows against the authoritative live entity state. */
+    async reconcileWithLiveState(
+        requestedBatchSize: number = DEFAULT_RECONCILIATION_BATCH_SIZE,
+    ): Promise<ReconciliationResult> {
+        if (this.reconciliationInFlight) return this.reconciliationInFlight;
+        const batchSize = Math.max(
+            1,
+            Math.min(DEFAULT_RECONCILIATION_BATCH_SIZE, requestedBatchSize),
+        );
+        const operation = this.reconcileOnce(batchSize);
+        this.reconciliationInFlight = operation;
+        try {
+            return await operation;
+        } finally {
+            if (this.reconciliationInFlight === operation) {
+                this.reconciliationInFlight = null;
             }
         }
-
-        if (toResolve.length > 0) {
-            await this.resolveFailures(toResolve);
-            logger.debug(
-                `[Enrichment Failures] Cleaned up ${toResolve.length} orphaned failures`,
-            );
-        }
-
-        return { cleaned: toResolve.length, checked: failures.length };
     }
 
     /**

--- a/backend/src/utils/enrichmentErrorSummary.ts
+++ b/backend/src/utils/enrichmentErrorSummary.ts
@@ -1,0 +1,53 @@
+const URL_TOKEN_PATTERN =
+    /^([a-z][a-z\d+.-]*:\/\/)(?:[^/?#@]*@)?([^/?#@]+)([/?#]\S*)?$/i;
+const DRIVE_PATH_TOKEN_PATTERN = /^[A-Za-z]:[\\/]/;
+const COLON_PAYLOAD_TOKEN_PATTERN = /^[A-Za-z\d+.-]*:\S/;
+const LEADING_PUNCTUATION_PATTERN = /^[("'[{<`,;]+/;
+const TRAILING_PUNCTUATION_PATTERN = /[)"'\]}>`.,;:!?]+$/;
+
+function sanitizeToken(token: string): string {
+    // Sensitive payloads often arrive wrapped in quotes or brackets; strip the
+    // wrapping before classifying so punctuation cannot defeat redaction, but
+    // rewrite the WHOLE token when the core matches.
+    const leading = LEADING_PUNCTUATION_PATTERN.exec(token)?.[0] ?? "";
+    const withoutLeading = token.slice(leading.length);
+    const trailing =
+        TRAILING_PUNCTUATION_PATTERN.exec(withoutLeading)?.[0] ?? "";
+    const core = withoutLeading.slice(
+        0,
+        withoutLeading.length - trailing.length,
+    );
+    const urlParts = URL_TOKEN_PATTERN.exec(core);
+    if (urlParts) {
+        const [, scheme, host, suffix] = urlParts;
+        return `${leading}${scheme}${host}${suffix ? "/[...]" : ""}${trailing}`;
+    }
+    if (
+        DRIVE_PATH_TOKEN_PATTERN.test(core) ||
+        core.includes("/") ||
+        core.includes("\\")
+    ) {
+        return "[path]";
+    }
+    if (COLON_PAYLOAD_TOKEN_PATTERN.test(core)) return "[redacted]";
+    return token;
+}
+
+/**
+ * Return a bounded client-safe summary of an internal enrichment error.
+ * A directory word surrounded by spaces can remain when that token contains
+ * no path separator, such as the middle word in "Artist Name Two".
+ * Pure so route tests that mock the failure service keep the real sanitizer.
+ */
+export function sanitizeEnrichmentErrorSummary(
+    message: string | null,
+): string | null {
+    if (message === null) return null;
+    const collapsed = message.replace(/\s+/g, " ");
+    const sanitized = collapsed
+        .split(" ")
+        .map((token) => sanitizeToken(token))
+        .join(" ")
+        .trim();
+    return Array.from(sanitized).slice(0, 200).join("");
+}

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -146,6 +146,10 @@ describe("unified enrichment runtime behavior", () => {
         const enrichmentFailureService = {
             clearAllFailures: jest.fn(async () => undefined),
             recordFailure: jest.fn(async () => undefined),
+            reconcileWithLiveState: jest.fn(async () => ({
+                resolved: 0,
+                checked: 0,
+            })),
         };
         const audioAnalysisCleanupService = {
             cleanupStaleProcessing: jest.fn(async () => ({
@@ -472,6 +476,9 @@ describe("unified enrichment runtime behavior", () => {
         });
 
         expect(enrichmentStateService.initializeState).toHaveBeenCalledTimes(1);
+        expect(
+            enrichmentFailureService.reconcileWithLiveState,
+        ).toHaveBeenCalledTimes(1);
         expect(enrichmentStateService.updateState).toHaveBeenCalledWith(
             expect.objectContaining({
                 pendingMoodBucketBackfill: true,

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -449,6 +449,19 @@ export async function runFullEnrichment(options?: {
 }> {
     log.debug("\n=== FULL ENRICHMENT: Re-enriching everything ===\n");
 
+    try {
+        const reconciliation =
+            await enrichmentFailureService.reconcileWithLiveState();
+        log.debug(
+            `Reconciled ${reconciliation.resolved} of ${reconciliation.checked} enrichment failures before full run`,
+        );
+    } catch (error) {
+        log.error(
+            "Failed to reconcile enrichment failures before full run:",
+            error,
+        );
+    }
+
     const forceVibeRebuild = options?.forceVibeRebuild === true;
     const forceMoodBucketBackfill = options?.forceMoodBucketBackfill === true;
 

--- a/frontend/components/EnrichmentFailuresModal.tsx
+++ b/frontend/components/EnrichmentFailuresModal.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { enrichmentApi } from "@/lib/enrichmentApi";
+import { createFrontendLogger } from "@/lib/logger";
 import { X, RefreshCw, SkipForward, Trash2, AlertCircle } from "lucide-react";
+
+const logger = createFrontendLogger("EnrichmentFailuresModal");
 
 interface EnrichmentFailuresModalProps {
     isOpen: boolean;
@@ -85,7 +88,7 @@ function RetryAllFailuresAction({
 
     return (
         <>
-            <div className="flex items-center justify-between gap-3 px-6 py-3 bg-white/5 border-b border-white/10">
+            <div className="shrink-0 flex items-center justify-between gap-3 px-6 py-3 bg-white/5 border-b border-white/10">
                 <div>
                     <p className="text-sm text-white/60">
                         Retry every failure in this tab. Work enters the
@@ -139,6 +142,28 @@ export function EnrichmentFailuresModal({
     const [showClearConfirm, setShowClearConfirm] = useState(false);
     const pageSize = 20;
     const queryClient = useQueryClient();
+    const wasOpenRef = useRef(false);
+
+    const invalidateFailureQueries = () => {
+        queryClient.invalidateQueries({
+            queryKey: ["enrichment-failures"],
+        });
+        queryClient.invalidateQueries({
+            queryKey: ["enrichment-failure-counts"],
+        });
+    };
+
+    const { mutate: reconcileFailures } = useMutation({
+        mutationFn: () => enrichmentApi.reconcileFailures(),
+        onSettled: invalidateFailureQueries,
+    });
+
+    useEffect(() => {
+        if (isOpen && !wasOpenRef.current) {
+            reconcileFailures();
+        }
+        wasOpenRef.current = isOpen;
+    }, [isOpen, reconcileFailures]);
 
     // Fetch failures
     const { data: failures, isLoading } = useQuery({
@@ -231,17 +256,19 @@ export function EnrichmentFailuresModal({
             entityType === "audio"
                 ? enrichmentApi.retryFailedAudioAnalysis()
                 : enrichmentApi.retryVibeEmbeddings(),
-        onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ["enrichment-failures"],
-            });
-            queryClient.invalidateQueries({
-                queryKey: ["enrichment-failure-counts"],
-            });
+        onSuccess: async () => {
+            invalidateFailureQueries();
             queryClient.invalidateQueries({
                 queryKey: ["enrichment-progress"],
             });
             setSelectedFailures(new Set());
+            try {
+                await enrichmentApi.reconcileFailures();
+            } catch (error) {
+                logger.error("Failed to reconcile retried failures", error);
+            } finally {
+                invalidateFailureQueries();
+            }
         },
     });
 
@@ -286,7 +313,7 @@ export function EnrichmentFailuresModal({
         <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
             <div className="bg-surface-hover rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col border border-white/10">
                 {/* Header */}
-                <div className="flex items-center justify-between p-6 border-b border-white/10">
+                <div className="shrink-0 flex items-center justify-between p-6 border-b border-white/10">
                     <div>
                         <h2 className="text-xl font-bold text-white">
                             Enrichment Failures
@@ -330,7 +357,7 @@ export function EnrichmentFailuresModal({
                 )}
 
                 {/* Filter Tabs */}
-                <div className="flex gap-3 px-6 py-4 border-b border-white/10 overflow-x-auto">
+                <div className="shrink-0 flex gap-3 px-6 py-4 border-b border-white/10 overflow-x-auto">
                     {[
                         {
                             key: "all" as const,
@@ -379,7 +406,7 @@ export function EnrichmentFailuresModal({
 
                 {/* Action Bar */}
                 {selectedFailures.size > 0 && (
-                    <div className="flex items-center gap-2 p-4 bg-white/5 border-b border-white/10">
+                    <div className="shrink-0 flex items-center gap-2 p-4 bg-white/5 border-b border-white/10">
                         <span className="text-sm text-white/70">
                             {selectedFailures.size} selected
                         </span>
@@ -470,8 +497,9 @@ export function EnrichmentFailuresModal({
                                             </span>
                                         </div>
                                         <p className="text-xs text-red-400 mt-1">
-                                            {failure.errorMessage ||
-                                                "Unknown error"}
+                                            {failure.errorSummary ||
+                                                failure.errorCode ||
+                                                "No error details recorded"}
                                         </p>
                                         <div className="flex items-center gap-3 mt-2 text-[10px] text-white/30">
                                             <span>
@@ -485,14 +513,6 @@ export function EnrichmentFailuresModal({
                                                     failure.lastFailedAt,
                                                 ).toLocaleString()}
                                             </span>
-                                            {failure.errorCode && (
-                                                <>
-                                                    <span>•</span>
-                                                    <span>
-                                                        {failure.errorCode}
-                                                    </span>
-                                                </>
-                                            )}
                                         </div>
                                     </div>
                                     <button
@@ -513,7 +533,7 @@ export function EnrichmentFailuresModal({
 
                 {/* Pagination */}
                 {totalPages > 1 && (
-                    <div className="flex items-center justify-between p-4 border-t border-white/10">
+                    <div className="shrink-0 flex items-center justify-between p-4 border-t border-white/10">
                         <button
                             onClick={() =>
                                 setCurrentPage((p) => Math.max(1, p - 1))

--- a/frontend/features/settings/components/sections/CacheSection.tsx
+++ b/frontend/features/settings/components/sections/CacheSection.tsx
@@ -62,6 +62,11 @@ function ProgressBar({
     );
 }
 
+/** Keep unfinished stages from presenting rounded completion as final. */
+export function displayProgress(progress: number, isSettled: boolean): number {
+    return !isSettled && progress === 100 ? 99 : progress;
+}
+
 /** Name the analysis still outstanding so the pill matches reality. */
 function backgroundAnalysisLabel(progress: {
     audioAnalysis: { pending: number; processing: number };
@@ -107,6 +112,7 @@ function EnrichmentStage({
     const isSettled = unresolved === 0 && processing === 0;
     const isComplete = isSettled && failed === 0;
     const settledWithFailures = isSettled && failed > 0;
+    const visibleProgress = displayProgress(progress, isSettled);
 
     return (
         <div className="flex items-start gap-3 py-2">
@@ -143,7 +149,7 @@ function EnrichmentStage({
                 <p className="text-xs text-white/40 mt-0.5">{description}</p>
                 <div className="flex items-center gap-2 mt-2">
                     <ProgressBar
-                        progress={progress}
+                        progress={visibleProgress}
                         color={
                             isComplete
                                 ? "bg-success"

--- a/frontend/lib/enrichmentApi.ts
+++ b/frontend/lib/enrichmentApi.ts
@@ -43,7 +43,7 @@ export interface EnrichmentFailure {
     entityType: "artist" | "track" | "audio" | "vibe";
     entityId: string;
     entityName: string | null;
-    errorMessage: string | null;
+    errorSummary: string | null;
     errorCode: string | null;
     retryCount: number;
     maxRetries: number;
@@ -53,7 +53,6 @@ export interface EnrichmentFailure {
     skippedAt: string | null;
     resolved: boolean;
     resolvedAt: string | null;
-    metadata: Record<string, unknown> | null;
 }
 
 export interface FailureCounts {
@@ -135,6 +134,14 @@ export const enrichmentApi = {
      */
     getFailureCounts: async (): Promise<FailureCounts> => {
         return api.get("/enrichment/failures/counts");
+    },
+
+    /** Reconcile stale failure-log rows with current entity state. */
+    reconcileFailures: async (): Promise<{
+        resolved: number;
+        checked: number;
+    }> => {
+        return api.post("/enrichment/failures/reconcile", {});
     },
 
     /**

--- a/frontend/tests/component/cacheSection.component.test.ts
+++ b/frontend/tests/component/cacheSection.component.test.ts
@@ -176,8 +176,5 @@ test("displays 99 percent when rounded progress is 100 but work remains", async 
         },
     });
 
-    assert.match(
-        html,
-        /Artist Metadata[\s\S]*?style="width:99%"[\s\S]*?99%/,
-    );
+    assert.match(html, /Artist Metadata[\s\S]*?style="width:99%"[\s\S]*?99%/);
 });

--- a/frontend/tests/component/cacheSection.component.test.ts
+++ b/frontend/tests/component/cacheSection.component.test.ts
@@ -93,12 +93,24 @@ const settings: SystemSettings = {
     showVersion: false,
 };
 
-async function renderCacheSection(): Promise<string> {
+async function renderCacheSection(options?: {
+    artistProgress?: {
+        completed: number;
+        total: number;
+        progress: number;
+        failed: number;
+    };
+}): Promise<string> {
     const { CacheSection } =
         await import("../../features/settings/components/sections/CacheSection");
     const queryClient = new QueryClient();
     queryClient.setQueryData(["enrichment-progress"], {
-        artists: { completed: 2, total: 2, progress: 100, failed: 0 },
+        artists: options?.artistProgress ?? {
+            completed: 2,
+            total: 2,
+            progress: 100,
+            failed: 0,
+        },
         trackTags: { completed: 2, total: 2, progress: 100, failed: 0 },
         audioAnalysis: {
             completed: 2,
@@ -152,4 +164,20 @@ test("hides migration progress when no migration is active", async () => {
 
     assert.doesNotMatch(html, /Embedding migration/);
     assert.doesNotMatch(html, /Target space family:/);
+});
+
+test("displays 99 percent when rounded progress is 100 but work remains", async () => {
+    const html = await renderCacheSection({
+        artistProgress: {
+            completed: 999,
+            total: 1000,
+            progress: 100,
+            failed: 0,
+        },
+    });
+
+    assert.match(
+        html,
+        /Artist Metadata[\s\S]*?style="width:99%"[\s\S]*?99%/,
+    );
 });

--- a/frontend/tests/component/enrichmentFailuresModal.component.test.ts
+++ b/frontend/tests/component/enrichmentFailuresModal.component.test.ts
@@ -195,11 +195,11 @@ test("renders sanitized summaries and accurate missing-detail fallbacks", async 
     const harness = await mountModal();
     t.after(harness.unmount);
 
-    assert.match(document.body.textContent ?? "", /Decoder rejected the stream/);
-    assert.match(document.body.textContent ?? "", /VIBE_EMBEDDING_FAILED/);
     assert.match(
         document.body.textContent ?? "",
-        /No error details recorded/,
+        /Decoder rejected the stream/,
     );
+    assert.match(document.body.textContent ?? "", /VIBE_EMBEDDING_FAILED/);
+    assert.match(document.body.textContent ?? "", /No error details recorded/);
     assert.doesNotMatch(document.body.textContent ?? "", /Unknown error/);
 });

--- a/frontend/tests/component/enrichmentFailuresModal.component.test.ts
+++ b/frontend/tests/component/enrichmentFailuresModal.component.test.ts
@@ -17,11 +17,27 @@ const retryVibeEmbeddings = mock.fn(async () => ({
     message: "reset",
     reset: 1204,
 }));
+const reconcileFailures = mock.fn(async () => ({ resolved: 0, checked: 0 }));
+let failureRows: Array<Record<string, unknown>> = [];
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        createFrontendLogger: () => ({
+            error: () => undefined,
+            warn: () => undefined,
+            info: () => undefined,
+            debug: () => undefined,
+        }),
+    },
+});
 
 mock.module("@/lib/enrichmentApi", {
     namedExports: {
         enrichmentApi: {
-            getFailures: async () => ({ failures: [], total: 0 }),
+            getFailures: async () => ({
+                failures: failureRows,
+                total: failureRows.length,
+            }),
             getFailureCounts: async () => ({
                 artist: 0,
                 track: 0,
@@ -35,6 +51,7 @@ mock.module("@/lib/enrichmentApi", {
             clearAllFailures: async () => ({ message: "", count: 0 }),
             retryFailedAudioAnalysis,
             retryVibeEmbeddings,
+            reconcileFailures,
         },
     },
 });
@@ -50,6 +67,8 @@ after(() => {
 beforeEach(() => {
     retryFailedAudioAnalysis.mock.resetCalls();
     retryVibeEmbeddings.mock.resetCalls();
+    reconcileFailures.mock.resetCalls();
+    failureRows = [];
     document.body.replaceChildren();
 });
 
@@ -66,6 +85,10 @@ async function mountModal() {
         audio: 7226,
         vibe: 1204,
         total: 8430,
+    });
+    queryClient.setQueryData(["enrichment-failures", "all", 1], {
+        failures: failureRows,
+        total: failureRows.length,
     });
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -111,12 +134,14 @@ async function click(button: HTMLButtonElement): Promise<void> {
         button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         await Promise.resolve();
         await Promise.resolve();
+        await new Promise<void>((resolve) => setImmediate(resolve));
     });
 }
 
 test("retries every audio failure instead of only the visible page", async (t) => {
     const harness = await mountModal();
     t.after(harness.unmount);
+    assert.equal(reconcileFailures.mock.callCount(), 1);
     await click(buttonWithText("Audio Analysis (7226)"));
     await click(buttonWithText("Retry all 7226"));
     assert.match(document.body.textContent ?? "", /bounded background queue/i);
@@ -127,4 +152,54 @@ test("retries every audio failure instead of only the visible page", async (t) =
     await click(buttonWithText("Retry all 1204"));
     await click(buttonWithText("Retry all"));
     assert.equal(retryVibeEmbeddings.mock.callCount(), 1);
+    assert.equal(reconcileFailures.mock.callCount(), 3);
+});
+
+test("renders sanitized summaries and accurate missing-detail fallbacks", async (t) => {
+    failureRows = [
+        {
+            id: "summary",
+            entityType: "audio",
+            entityId: "track-summary",
+            entityName: "Summary Track",
+            errorSummary: "Decoder rejected the stream",
+            errorCode: "AUDIO_DECODE_FAILED",
+            retryCount: 1,
+            maxRetries: 3,
+            lastFailedAt: "2026-08-20T12:00:00.000Z",
+        },
+        {
+            id: "code",
+            entityType: "vibe",
+            entityId: "track-code",
+            entityName: "Code Track",
+            errorSummary: null,
+            errorCode: "VIBE_EMBEDDING_FAILED",
+            retryCount: 1,
+            maxRetries: 3,
+            lastFailedAt: "2026-08-20T12:00:00.000Z",
+        },
+        {
+            id: "empty",
+            entityType: "track",
+            entityId: "track-empty",
+            entityName: "Empty Track",
+            errorSummary: null,
+            errorCode: null,
+            retryCount: 1,
+            maxRetries: 3,
+            lastFailedAt: "2026-08-20T12:00:00.000Z",
+        },
+    ];
+
+    const harness = await mountModal();
+    t.after(harness.unmount);
+
+    assert.match(document.body.textContent ?? "", /Decoder rejected the stream/);
+    assert.match(document.body.textContent ?? "", /VIBE_EMBEDDING_FAILED/);
+    assert.match(
+        document.body.textContent ?? "",
+        /No error details recorded/,
+    );
+    assert.doesNotMatch(document.body.textContent ?? "", /Unknown error/);
 });


### PR DESCRIPTION
Fixes the Library Enrichment admin UI inconsistencies reported after the 2.4.0 upgrade: the "View Failures (1398)" button disagreeing with the tiles (152 vibe failed live vs 1387 logged), "Retry all" not moving the modal's numbers, every failure row reading "Unknown error", an unfinished artist stage showing "100%" in blue, and the modal chrome getting crushed by long lists.

## Root cause

The summary tiles count **live state** (`Track.analysisStatus`/`vibeAnalysisStatus`, `Artist.enrichmentStatus`), while the failures dialog counts rows in the persistent `EnrichmentFailure` log. Rows only got resolved on success through one specific vibe job path, so tracks recovered through other lanes (embedding-space migration, bulk re-queues) left permanent zombie rows — and "Retry all" only flips track statuses, never touching the log.

## What this does

**Reconciliation.** `reconcileWithLiveState()` resolves unresolved rows whose entity has recovered: vibe/audio → track missing, soft-removed, or no longer `failed`; track (tags) → track missing, soft-removed, or terminal `lastfmTags` written (the tag phase writes sentinel arrays on every terminal outcome); artist → missing or `completed`, with `system` pseudo-rows excluded (no recovery signal). Cursor-paginated with a snapshot fence on both the scan and the resolving update, so sustained failure recording can neither stall the pass nor have a fresh failure wrongly resolved; single-flight; runs via a new admin endpoint when the dialog opens, after "Retry all", and at the start of every full enrichment run. Replaces the dead `cleanupOrphanedFailures` (never called, and it mishandled vibe rows). `recordFailure` now re-opens a resolved row on re-failure so nothing reconciled can fail invisibly later.

**Error detail restored safely.** 2.4.0's sanitization stripped `errorMessage`/`errorCode` from the API while the dialog still rendered them — every row said "Unknown error". The payload now carries `errorCode` plus `errorSummary` from a linear token-scan sanitizer: URLs keep scheme+host only (credentials/paths dropped), path-bearing and colon-payload tokens are redacted even when quote/bracket-wrapped, output capped at 200 code points (no split surrogates). Documented limitations: separator-free middle words of spaced directory names can survive; colon tokens are over-redacted in favor of safety.

**UI.** Dialog rows render `errorSummary` → `errorCode` → "No error details recorded". An unsettled stage that rounds to 100% displays 99% so the artist tile can't claim completion in blue. All non-scrolling dialog chrome is `shrink-0`.

## Review

Seven adversarial rounds to a zero-findings verdict. Beyond the initial design, the loop caught: re-failure invisibility after reconciliation, a check/update race, a quadratic-backtracking sanitizer regex (measured 459ms at 32k chars), surrogate-pair truncation, spaced-path and punctuation-wrapped leak vectors, an unbounded reconciliation scan two different ways, `system` pseudo-artist auto-resolution, and soft-removed-track divergence from the tiles' enrichable-only counting.

## Verification

- Full backend suite: 431 suites / 6,932 tests green (plus the touched suites re-run after every round; final: 152 tests across the 4 core suites).
- `tsc --noEmit` clean in backend and frontend; frontend lint at the existing warning budget.
- Frontend component tests 5/5 under the component harness.
- Prettier, `git diff --check`, file-size gate, and route-error canonicalization gate all clean.
- Sanitizer behavior verified empirically against the adversarial inputs from review, not just via mocks.

On deployments hit by this (like the reporting one), the first open of the failures dialog reconciles the backlog — the 1387 stale vibe rows collapse to the real count with no manual action.