### PR TITLE
fix(web): resolve empty-body success responses instead of failing JSON parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The web client no longer fails successful API calls that return `204 No Content` or an otherwise empty body. The shared request path parsed every success response as JSON, so endpoints such as federation peer deletion reported a parse error ("The string did not match the expected pattern" on Safari/WebKit, "Unexpected end of JSON input" on Chromium) even though the server had completed the operation. Empty bodies now resolve as successful void results.
 - The Library Enrichment failures view no longer disagrees with the summary tiles: stale failure-log rows whose track, artist, audio analysis, or vibe embedding has since recovered (for example after a bulk re-queue or an embedding-space migration) are now reconciled against live state when the failures dialog opens, after "Retry all", and at the start of every full enrichment run, so the "View Failures" count converges to what is actually failed. Failure rows also show a sanitized error summary and error code again instead of "Unknown error" (the 2.4.0 sanitization had stripped the detail the dialog rendered), an unfinished enrichment stage no longer rounds up to a misleading "100%", and the dialog's header, tabs, and action bars keep their size instead of being crushed by a long failure list.
 
 ### Security

--- a/frontend/lib/api/core.ts
+++ b/frontend/lib/api/core.ts
@@ -709,8 +709,16 @@ export abstract class ApiClientCore {
                 throw requestError;
             }
 
-            const data = await response.json();
-            return data;
+            // 204/205 and other empty bodies have nothing to parse; WebKit
+            // rejects response.json() on them even when the request succeeded.
+            if (response.status === 204 || response.status === 205) {
+                return undefined as T;
+            }
+            const rawBody = await response.text();
+            if (rawBody === "") {
+                return undefined as T;
+            }
+            return JSON.parse(rawBody) as T;
         };
 
         if (!inFlightGetKey) {

--- a/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
+++ b/frontend/tests/component/apiRefreshSingleFlight.component.test.ts
@@ -42,14 +42,12 @@ test("shares one token refresh across concurrent 401 responses", async () => {
             refreshCount += 1;
             return new Promise<Response>((resolve) => {
                 setTimeout(() => {
-                    resolve({
-                        ok: true,
-                        status: 200,
-                        json: async () => ({
+                    resolve(
+                        Response.json({
                             token: "access-new",
                             refreshToken: "refresh-new",
                         }),
-                    } as Response);
+                    );
                 }, 5);
             });
         }
@@ -67,11 +65,7 @@ test("shares one token refresh across concurrent 401 responses", async () => {
             } as Response;
         }
         if (authorization === "Bearer access-new") {
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({ ok: true }),
-            } as Response;
+            return Response.json({ ok: true });
         }
 
         throw new Error(`Unexpected Authorization header for ${url}`);
@@ -214,23 +208,15 @@ test("refreshes a second time after one spurious post-refresh 401", async () => 
                 (init as RequestInit & { priority?: string }).priority,
                 "high",
             );
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({
-                    token: `access-${refreshCount}`,
-                    refreshToken: `refresh-${refreshCount}`,
-                }),
-            } as Response;
+            return Response.json({
+                token: `access-${refreshCount}`,
+                refreshToken: `refresh-${refreshCount}`,
+            });
         }
 
         const authorization = new Headers(init?.headers).get("Authorization");
         if (authorization === "Bearer access-2") {
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({ ok: true }),
-            } as Response;
+            return Response.json({ ok: true });
         }
         return {
             ok: false,
@@ -266,14 +252,10 @@ test("logs out when the second refresh is rejected", async () => {
         if (String(input).endsWith("/api/auth/refresh")) {
             refreshCount += 1;
             if (refreshCount === 1) {
-                return {
-                    ok: true,
-                    status: 200,
-                    json: async () => ({
-                        token: "access-1",
-                        refreshToken: "refresh-1",
-                    }),
-                } as Response;
+                return Response.json({
+                    token: "access-1",
+                    refreshToken: "refresh-1",
+                });
             }
             return {
                 ok: false,

--- a/frontend/tests/unit/apiEmptyBodyResponse.test.ts
+++ b/frontend/tests/unit/apiEmptyBodyResponse.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test, { after, beforeEach, type TestContext } from "node:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { ApiClientCore } from "../../lib/api/core";
+
+GlobalRegistrator.register();
+
+class TestApiClient extends ApiClientCore {}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+after(() => {
+    if (originalFetch) {
+        globalThis.fetch = originalFetch;
+    } else {
+        Reflect.deleteProperty(globalThis, "fetch");
+    }
+    GlobalRegistrator.unregister();
+});
+
+function mockFetch(
+    testContext: TestContext,
+    responder: (url: string, init?: RequestInit) => Response,
+) {
+    return testContext.mock.method(
+        globalThis,
+        "fetch",
+        async (input: string | URL | Request, init?: RequestInit) =>
+            responder(String(input), init),
+    );
+}
+
+test("resolves a 204 No Content response without parsing a body", async (testContext) => {
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access", "refresh");
+    const fetchMock = mockFetch(
+        testContext,
+        () => new Response(null, { status: 204 }),
+    );
+
+    const result = await client.delete("/federation/admin/peers/peer-1");
+
+    assert.equal(result, undefined);
+    assert.equal(fetchMock.mock.callCount(), 1);
+});
+
+test("resolves a 200 response with an empty body as undefined", async (testContext) => {
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access", "refresh");
+    mockFetch(testContext, () => new Response("", { status: 200 }));
+
+    const result = await client.get("/library/empty");
+
+    assert.equal(result, undefined);
+});
+
+test("still parses a JSON body on success", async (testContext) => {
+    const client = new TestApiClient("http://soundspan.test");
+    client.setToken("access", "refresh");
+    mockFetch(testContext, () =>
+        Response.json({ success: true }, { status: 200 }),
+    );
+
+    const result = await client.get<{ success: boolean }>("/library/ok");
+
+    assert.deepEqual(result, { success: true });
+});

--- a/frontend/tests/unit/onboardingApiBoundary.test.ts
+++ b/frontend/tests/unit/onboardingApiBoundary.test.ts
@@ -9,14 +9,10 @@ test("getOnboardingStatus requests the onboarding status endpoint", async () => 
 
     globalThis.fetch = (async (input: string | URL | Request) => {
         calledUrl = String(input);
-        return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-                needsOnboarding: false,
-                hasAccount: true,
-            }),
-        } as Response;
+        return Response.json({
+            needsOnboarding: false,
+            hasAccount: true,
+        });
     }) as typeof fetch;
 
     try {


### PR DESCRIPTION
## Problem

Deleting a federation peer from the admin panel reports an error even though the deletion succeeds. On Safari/WebKit the message is "The string did not match the expected pattern"; on Chromium it's "Unexpected end of JSON input".

## Cause

The shared client request path (`frontend/lib/api/core.ts`) called `response.json()` unconditionally on every successful response. `DELETE /api/federation/admin/peers/:id` returns `204 No Content`, so the parse of the empty body throws and the UI shows a failure for an operation that completed.

## Fix

Successful `204`/`205` responses and empty bodies now resolve as void results; JSON is parsed only when a body is present. Existing JSON success and error paths are unchanged.

The onboarding boundary test stubbed fetch with an object that only implemented `json()`; it now returns a real `Response` so the body read works.

## Verification

- `npm run test:unit`: 987 pass, 0 fail (new `apiEmptyBodyResponse.test.ts` covers 204, empty 200, and JSON-body regression; the 204/empty cases failed before the fix)
- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors, 183 warnings (exactly at cap, none new)
- `node scripts/ci/check-file-size.mjs`: pass
- Prettier clean on all touched files including CHANGELOG.md