### PR TITLE
chore(changelog): add required empty Added/Changed headings to the 2.4.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.1] - 2026-08-22
 
+### Added
+
+### Changed
+
 ### Fixed
 
 - Deployments behind a mandatory egress proxy can restore federation proxy support with the new `FEDERATION_ALLOW_PROXY` administrator opt-in; the 2.4.0 DNS-pinning hardening had disabled `HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` handling on federation egress unconditionally (federation egress is HTTPS-only, so `HTTP_PROXY` never applies). Per-attempt peer address resolution and private-range validation still run and fail closed; only connection pinning is relinquished — proxied requests are connected by the proxy, and `NO_PROXY`-exempt requests connect directly without a pin. Default behavior is unchanged (#673).


### PR DESCRIPTION
The release-triggered Image Builds run for the 2.4.1 tag failed at `Validate release tag`: the validator requires every release section to contain the standard Added/Changed/Fixed headings even when empty, and the staged 2.4.1 section carried only Fixed and Security. This adds the two empty headings; `assertChangelogPreparedForRelease` now passes locally for 2.4.1.

After merge I re-point the 2.4.1 tag and release at the corrected commit and the release pipelines rerun.