### PR TITLE
fix(library): include user-owned remote provider tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- User-owned TIDAL and YouTube Music tracks now appear in the default Library Artists and Songs views and in normal Library track search, with provider ownership scoped to the authenticated user's likes (#699).
+
 ### Security
 
 ## [2.4.1] - 2026-08-22

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -46,7 +46,7 @@ import {
 } from "../../utils/libraryDeletion";
 import { findRouteNameMatch } from "../artistRouteName";
 import { deleteArtistCatalogEntry } from "../../services/artistCatalogDeletion";
-import { buildRemoteOwnedArtistFilters } from "../../services/remoteOwnedLibrary";
+import { addRemoteOwnedArtists } from "../../services/remoteOwnedLibrary";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -150,12 +150,6 @@ export async function handleGetArtists(req: Request, res: Response) {
         if (!origin) {
             return sendRouteError(res, 400, "Invalid library origin filter");
         }
-        const userId = req.user?.id;
-        const remoteOwnedArtistFilters =
-            origin === "all" && userId
-                ? buildRemoteOwnedArtistFilters(userId)
-                : [];
-
         const browseTrackWhere = {
             ...TRACK_VISIBLE_WHERE,
             ...trackBrowseWhere(origin),
@@ -181,7 +175,6 @@ export async function handleGetArtists(req: Request, res: Response) {
                 where: { countsLastUpdated: { not: null } },
             })) > 0;
 
-        // Build WHERE clause
         const where: Prisma.ArtistWhereInput = {};
 
         if (origin === "peers") {
@@ -194,7 +187,6 @@ export async function handleGetArtists(req: Request, res: Response) {
                 where.OR = [
                     { libraryAlbumCount: { gt: 0 } },
                     { ownedAlbums: { some: {} } },
-                    ...remoteOwnedArtistFilters,
                     ...(origin === "all" ? [{ peerId: { not: null } }] : []),
                 ];
             } else if (filter === "discovery") {
@@ -226,7 +218,6 @@ export async function handleGetArtists(req: Request, res: Response) {
                         },
                     },
                     { ownedAlbums: { some: {} } },
-                    ...remoteOwnedArtistFilters,
                 ];
                 if (origin === "all") {
                     where.OR.push({
@@ -277,7 +268,8 @@ export async function handleGetArtists(req: Request, res: Response) {
             }
         }
 
-        // Add search query if provided
+        addRemoteOwnedArtists(where, req.user?.id, origin, filter);
+
         if (query) {
             where.name = { contains: query as string, mode: "insensitive" };
         }

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -46,6 +46,7 @@ import {
 } from "../../utils/libraryDeletion";
 import { findRouteNameMatch } from "../artistRouteName";
 import { deleteArtistCatalogEntry } from "../../services/artistCatalogDeletion";
+import { buildRemoteOwnedArtistFilters } from "../../services/remoteOwnedLibrary";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -149,6 +150,12 @@ export async function handleGetArtists(req: Request, res: Response) {
         if (!origin) {
             return sendRouteError(res, 400, "Invalid library origin filter");
         }
+        const userId = req.user?.id;
+        const remoteOwnedArtistFilters =
+            origin === "all" && userId
+                ? buildRemoteOwnedArtistFilters(userId)
+                : [];
+
         const browseTrackWhere = {
             ...TRACK_VISIBLE_WHERE,
             ...trackBrowseWhere(origin),
@@ -187,6 +194,7 @@ export async function handleGetArtists(req: Request, res: Response) {
                 where.OR = [
                     { libraryAlbumCount: { gt: 0 } },
                     { ownedAlbums: { some: {} } },
+                    ...remoteOwnedArtistFilters,
                     ...(origin === "all" ? [{ peerId: { not: null } }] : []),
                 ];
             } else if (filter === "discovery") {
@@ -218,6 +226,7 @@ export async function handleGetArtists(req: Request, res: Response) {
                         },
                     },
                     { ownedAlbums: { some: {} } },
+                    ...remoteOwnedArtistFilters,
                 ];
                 if (origin === "all") {
                     where.OR.push({

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -38,6 +38,11 @@ import {
     normalizeTidalTrack,
     normalizeYtMusicTrack,
 } from "../../services/unifiedTrackResponse";
+import {
+    countRemoteOwnedTracksForUser,
+    loadRemoteOwnedTracksForUser,
+    toLibraryRemoteTrack,
+} from "../../services/remoteOwnedLibrary";
 import { proxyFederatedTrackStream } from "../../services/federationStreamProxy";
 import {
     buildFederatedAudioInfo,
@@ -188,6 +193,11 @@ export async function handleGetTracks(req: Request, res: Response) {
         MAX_LIMIT,
     );
     const offset = parseInt(offsetParam as string, 10) || 0;
+    const userId = req.user?.id;
+    const includeRemoteOwned = !albumId && origin === "all" && Boolean(userId);
+    const remoteSort = sortBy === "name-desc" ? "desc" : "asc";
+    const persistedSkip = includeRemoteOwned ? 0 : offset;
+    const persistedTake = includeRemoteOwned ? offset + limit : limit;
 
     let orderBy:
         | Prisma.TrackOrderByWithRelationInput
@@ -208,33 +218,43 @@ export async function handleGetTracks(req: Request, res: Response) {
         where.albumId = albumId as string;
     }
 
-    const [tracksData, total] = await Promise.all([
-        prisma.track.findMany({
-            where,
-            skip: offset,
-            take: limit,
-            orderBy,
-            include: {
-                album: {
-                    include: {
-                        artist: {
-                            select: {
-                                id: true,
-                                name: true,
+    const [tracksData, persistedTotal, remoteOwnedTracks, remoteOwnedTotal] =
+        await Promise.all([
+            prisma.track.findMany({
+                where,
+                skip: persistedSkip,
+                take: persistedTake,
+                orderBy,
+                include: {
+                    album: {
+                        include: {
+                            artist: {
+                                select: {
+                                    id: true,
+                                    name: true,
+                                },
                             },
                         },
                     },
+                    federationPeer: {
+                        select: { id: true, name: true, outboundStatus: true },
+                    },
                 },
-                federationPeer: {
-                    select: { id: true, name: true, outboundStatus: true },
-                },
-            },
-        }),
-        prisma.track.count({ where }),
-    ]);
+            }),
+            prisma.track.count({ where }),
+            includeRemoteOwned && userId
+                ? loadRemoteOwnedTracksForUser(userId, {
+                      take: offset + limit,
+                      sort: remoteSort,
+                  })
+                : Promise.resolve([]),
+            includeRemoteOwned && userId
+                ? countRemoteOwnedTracksForUser(userId)
+                : Promise.resolve(0),
+        ]);
 
     // Add coverArt field to albums
-    const tracks = tracksData.map(({ federationPeer, ...track }) => ({
+    const localTracks = tracksData.map(({ federationPeer, ...track }) => ({
         ...track,
         source: track.origin === "FEDERATED" ? "federated" : "local",
         peer: federationPeer
@@ -249,6 +269,22 @@ export async function handleGetTracks(req: Request, res: Response) {
             coverArt: track.album.coverUrl,
         },
     }));
+
+    let total = persistedTotal;
+
+    const tracks = includeRemoteOwned
+        ? [...localTracks, ...remoteOwnedTracks.map(toLibraryRemoteTrack)]
+              .sort((left, right) =>
+                  remoteSort === "desc"
+                      ? right.title.localeCompare(left.title)
+                      : left.title.localeCompare(right.title),
+              )
+              .slice(offset, offset + limit)
+        : localTracks;
+
+    if (includeRemoteOwned) {
+        total += remoteOwnedTotal;
+    }
 
     res.json({ tracks, total, offset, limit });
 }

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -12,6 +12,10 @@ import axios from "axios";
 import { redisClient } from "../utils/redis";
 import { z } from "zod";
 import { LIBRARY_ORIGIN_VALUES } from "../utils/librarySorting";
+import {
+    loadRemoteOwnedTracksForUser,
+    toLibraryRemoteTrack,
+} from "../services/remoteOwnedLibrary";
 
 const router = Router();
 
@@ -219,6 +223,49 @@ function transformSearchResults(serviceResults: SearchResults) {
     };
 }
 
+async function transformSearchResultsForUser(
+    serviceResults: SearchResults,
+    options: {
+        userId?: string;
+        query: string;
+        type: string;
+        limit: number;
+        source: string;
+    },
+) {
+    const transformed = transformSearchResults(serviceResults);
+
+    if (
+        !options.userId ||
+        options.source !== "all" ||
+        (options.type !== "all" && options.type !== "tracks")
+    ) {
+        return transformed;
+    }
+
+    const remoteTracks = (
+        await loadRemoteOwnedTracksForUser(options.userId, {
+            query: options.query,
+            take: options.limit,
+            sort: "asc",
+            match: "title",
+        })
+    ).map(toLibraryRemoteTrack);
+
+    // Prefer explicit user-owned provider results, then retain the normal
+    // ranked library results without duplicating an identical canonical ID.
+    const seen = new Set(remoteTracks.map((track) => track.id));
+    const tracks = [
+        ...remoteTracks,
+        ...transformed.tracks.filter((track) => !seen.has(track.id)),
+    ].slice(0, options.limit);
+
+    return {
+        ...transformed,
+        tracks,
+    };
+}
+
 router.use(requireAuth);
 
 /**
@@ -331,7 +378,15 @@ router.get("/", async (req, res) => {
                 ...sourceOption,
             });
 
-            return res.json(transformSearchResults(serviceResults));
+            return res.json(
+                await transformSearchResultsForUser(serviceResults, {
+                    userId: req.user?.id,
+                    query,
+                    type,
+                    limit: searchLimit,
+                    source,
+                }),
+            );
         }
 
         // Single-type search (service handles caching)
@@ -343,7 +398,15 @@ router.get("/", async (req, res) => {
             ...sourceOption,
         });
 
-        res.json(transformSearchResults(serviceResults));
+        res.json(
+            await transformSearchResultsForUser(serviceResults, {
+                userId: req.user?.id,
+                query,
+                type,
+                limit: searchLimit,
+                source,
+            }),
+        );
     } catch (error) {
         logger.error("Search error:", error);
         res.status(500).json({ error: "Search failed" });

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -248,7 +248,7 @@ async function transformSearchResultsForUser(
             query: options.query,
             take: options.limit,
             sort: "asc",
-            match: "title",
+            match: "any",
         })
     ).map(toLibraryRemoteTrack);
 

--- a/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
+++ b/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
@@ -1,0 +1,200 @@
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        trackTidal: {
+            findMany: jest.fn(),
+            count: jest.fn(),
+        },
+        trackYtMusic: {
+            findMany: jest.fn(),
+            count: jest.fn(),
+        },
+    },
+}));
+
+import { prisma } from "../../utils/db";
+import {
+    buildRemoteOwnedArtistFilters,
+    countRemoteOwnedTracksForUser,
+    loadRemoteOwnedTracksForUser,
+    toLibraryRemoteTrack,
+} from "../remoteOwnedLibrary";
+
+const mockTidalFindMany = prisma.trackTidal.findMany as jest.Mock;
+const mockTidalCount = prisma.trackTidal.count as jest.Mock;
+const mockYtMusicFindMany = prisma.trackYtMusic.findMany as jest.Mock;
+const mockYtMusicCount = prisma.trackYtMusic.count as jest.Mock;
+
+describe("remote owned library", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockTidalFindMany.mockResolvedValue([]);
+        mockYtMusicFindMany.mockResolvedValue([]);
+        mockTidalCount.mockResolvedValue(0);
+        mockYtMusicCount.mockResolvedValue(0);
+    });
+
+    it("builds artist ownership predicates scoped to one user's provider likes", () => {
+        expect(buildRemoteOwnedArtistFilters("user-1")).toEqual([
+            {
+                tracksTidal: {
+                    some: {
+                        likedBy: {
+                            some: { userId: "user-1" },
+                        },
+                    },
+                },
+            },
+            {
+                tracksYtMusic: {
+                    some: {
+                        likedBy: {
+                            some: { userId: "user-1" },
+                        },
+                    },
+                },
+            },
+        ]);
+    });
+
+    it("loads only user-owned provider tracks with canonical playback IDs", async () => {
+        mockTidalFindMany.mockResolvedValueOnce([
+            {
+                id: "tidal-row-1",
+                tidalId: 9001,
+                title: "Zulu",
+                artist: "TIDAL Artist",
+                album: "TIDAL Album",
+                duration: 200,
+                artistId: "artist-tidal",
+                albumId: "album-tidal",
+            },
+        ]);
+        mockYtMusicFindMany.mockResolvedValueOnce([
+            {
+                id: "yt-row-1",
+                videoId: "yt-video-1",
+                title: "Alpha",
+                artist: "YouTube Artist",
+                album: "YouTube Album",
+                duration: 180,
+                thumbnailUrl: "https://example.test/thumb.jpg",
+                artistId: "artist-youtube",
+                albumId: "album-youtube",
+            },
+        ]);
+
+        const tracks = await loadRemoteOwnedTracksForUser("user-1", {
+            take: 10,
+            sort: "asc",
+        });
+
+        expect(mockTidalFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    likedBy: {
+                        some: { userId: "user-1" },
+                    },
+                },
+                orderBy: { title: "asc" },
+                take: 10,
+            }),
+        );
+        expect(mockYtMusicFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    likedBy: {
+                        some: { userId: "user-1" },
+                    },
+                },
+                orderBy: { title: "asc" },
+                take: 10,
+            }),
+        );
+
+        expect(tracks.map((track) => track.id)).toEqual([
+            "yt:yt-video-1",
+            "tidal:9001",
+        ]);
+        expect(tracks.map((track) => track.source)).toEqual([
+            "youtube",
+            "tidal",
+        ]);
+
+        const tidalLibraryTrack = toLibraryRemoteTrack(tracks[1]);
+        expect(tidalLibraryTrack).toEqual(
+            expect.objectContaining({
+                id: "tidal:9001",
+                source: "tidal",
+                streamSource: "tidal",
+                tidalTrackId: 9001,
+                albumId: "album-tidal",
+                album: expect.objectContaining({
+                    id: "album-tidal",
+                    artist: {
+                        id: "artist-tidal",
+                        name: "TIDAL Artist",
+                    },
+                }),
+            }),
+        );
+    });
+
+    it("uses a title-only user-scoped provider query for normal track search", async () => {
+        await loadRemoteOwnedTracksForUser("user-search", {
+            query: "paranoid",
+            take: 20,
+            match: "title",
+        });
+
+        expect(mockTidalFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    likedBy: {
+                        some: { userId: "user-search" },
+                    },
+                    title: {
+                        contains: "paranoid",
+                        mode: "insensitive",
+                    },
+                },
+            }),
+        );
+        expect(mockYtMusicFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    likedBy: {
+                        some: { userId: "user-search" },
+                    },
+                    title: {
+                        contains: "paranoid",
+                        mode: "insensitive",
+                    },
+                },
+            }),
+        );
+    });
+
+    it("counts only the authenticated user's provider likes", async () => {
+        mockTidalCount.mockResolvedValueOnce(4);
+        mockYtMusicCount.mockResolvedValueOnce(3);
+
+        await expect(
+            countRemoteOwnedTracksForUser("user-count"),
+        ).resolves.toBe(7);
+
+        expect(mockTidalCount).toHaveBeenCalledWith({
+            where: {
+                likedBy: {
+                    some: { userId: "user-count" },
+                },
+            },
+        });
+        expect(mockYtMusicCount).toHaveBeenCalledWith({
+            where: {
+                likedBy: {
+                    some: { userId: "user-count" },
+                },
+            },
+        });
+    });
+});

--- a/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
+++ b/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
@@ -139,11 +139,11 @@ describe("remote owned library", () => {
         );
     });
 
-    it("uses a title-only user-scoped provider query for normal track search", async () => {
+    it("matches user-owned provider search by title, artist, or album", async () => {
         await loadRemoteOwnedTracksForUser("user-search", {
             query: "paranoid",
             take: 20,
-            match: "title",
+            match: "any",
         });
 
         expect(mockTidalFindMany).toHaveBeenCalledWith(
@@ -152,10 +152,26 @@ describe("remote owned library", () => {
                     likedBy: {
                         some: { userId: "user-search" },
                     },
-                    title: {
-                        contains: "paranoid",
-                        mode: "insensitive",
-                    },
+                    OR: [
+                        {
+                            title: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            artist: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            album: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                    ],
                 },
             }),
         );
@@ -165,10 +181,26 @@ describe("remote owned library", () => {
                     likedBy: {
                         some: { userId: "user-search" },
                     },
-                    title: {
-                        contains: "paranoid",
-                        mode: "insensitive",
-                    },
+                    OR: [
+                        {
+                            title: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            artist: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                        {
+                            album: {
+                                contains: "paranoid",
+                                mode: "insensitive",
+                            },
+                        },
+                    ],
                 },
             }),
         );
@@ -178,9 +210,9 @@ describe("remote owned library", () => {
         mockTidalCount.mockResolvedValueOnce(4);
         mockYtMusicCount.mockResolvedValueOnce(3);
 
-        await expect(
-            countRemoteOwnedTracksForUser("user-count"),
-        ).resolves.toBe(7);
+        await expect(countRemoteOwnedTracksForUser("user-count")).resolves.toBe(
+            7,
+        );
 
         expect(mockTidalCount).toHaveBeenCalledWith({
             where: {

--- a/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
+++ b/backend/src/services/__tests__/remoteOwnedLibrary.test.ts
@@ -13,6 +13,7 @@ jest.mock("../../utils/db", () => ({
 
 import { prisma } from "../../utils/db";
 import {
+    addRemoteOwnedArtists,
     buildRemoteOwnedArtistFilters,
     countRemoteOwnedTracksForUser,
     loadRemoteOwnedTracksForUser,
@@ -53,6 +54,19 @@ describe("remote owned library", () => {
                     },
                 },
             },
+        ]);
+    });
+
+    it("adds remote ownership to the owned all-origin artist filter", () => {
+        const where: any = {
+            OR: [{ libraryAlbumCount: { gt: 0 } }],
+        };
+
+        addRemoteOwnedArtists(where, "user-1", "all", "owned");
+
+        expect(where.OR).toEqual([
+            { libraryAlbumCount: { gt: 0 } },
+            ...buildRemoteOwnedArtistFilters("user-1"),
         ]);
     });
 

--- a/backend/src/services/remoteOwnedLibrary.ts
+++ b/backend/src/services/remoteOwnedLibrary.ts
@@ -105,6 +105,25 @@ export function buildRemoteOwnedArtistFilters(
     ];
 }
 
+export function addRemoteOwnedArtists(
+    where: Prisma.ArtistWhereInput,
+    userId: string | undefined,
+    origin: "all" | "local" | "peers",
+    filter: unknown,
+): void {
+    if (filter !== "owned" || origin !== "all" || !userId) {
+        return;
+    }
+
+    const existing = Array.isArray(where.OR)
+        ? where.OR
+        : where.OR
+          ? [where.OR]
+          : [];
+
+    where.OR = [...existing, ...buildRemoteOwnedArtistFilters(userId)];
+}
+
 /**
  * Load the authenticated user's liked provider tracks and normalize them
  * through the same canonical identities used by playback and My Liked.

--- a/backend/src/services/remoteOwnedLibrary.ts
+++ b/backend/src/services/remoteOwnedLibrary.ts
@@ -1,0 +1,187 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import {
+    normalizeTidalTrack,
+    normalizeYtMusicTrack,
+    type UnifiedTrackResponse,
+} from "./unifiedTrackResponse";
+
+export type RemoteOwnedTrackSort = "asc" | "desc";
+
+interface LoadRemoteOwnedTracksOptions {
+    query?: string;
+    take?: number;
+    sort?: RemoteOwnedTrackSort;
+    match?: "any" | "title";
+}
+
+function buildTidalWhere(
+    userId: string,
+    query: string,
+    match: "any" | "title",
+): Prisma.TrackTidalWhereInput {
+    const where: Prisma.TrackTidalWhereInput = {
+        likedBy: { some: { userId } },
+    };
+
+    if (!query) {
+        return where;
+    }
+
+    if (match === "title") {
+        where.title = {
+            contains: query,
+            mode: "insensitive",
+        };
+        return where;
+    }
+
+    where.OR = [
+        { title: { contains: query, mode: "insensitive" } },
+        { artist: { contains: query, mode: "insensitive" } },
+        { album: { contains: query, mode: "insensitive" } },
+    ];
+    return where;
+}
+
+function buildYtMusicWhere(
+    userId: string,
+    query: string,
+    match: "any" | "title",
+): Prisma.TrackYtMusicWhereInput {
+    const where: Prisma.TrackYtMusicWhereInput = {
+        likedBy: { some: { userId } },
+    };
+
+    if (!query) {
+        return where;
+    }
+
+    if (match === "title") {
+        where.title = {
+            contains: query,
+            mode: "insensitive",
+        };
+        return where;
+    }
+
+    where.OR = [
+        { title: { contains: query, mode: "insensitive" } },
+        { artist: { contains: query, mode: "insensitive" } },
+        { album: { contains: query, mode: "insensitive" } },
+    ];
+    return where;
+}
+
+/**
+ * Artist ownership predicates for provider tracks liked by one user.
+ *
+ * These deliberately key off LikedRemoteTrack rather than the global
+ * remoteTrackCount so one user's provider library never grants ownership
+ * to another user.
+ */
+export function buildRemoteOwnedArtistFilters(
+    userId: string,
+): Prisma.ArtistWhereInput[] {
+    return [
+        {
+            tracksTidal: {
+                some: {
+                    likedBy: {
+                        some: { userId },
+                    },
+                },
+            },
+        },
+        {
+            tracksYtMusic: {
+                some: {
+                    likedBy: {
+                        some: { userId },
+                    },
+                },
+            },
+        },
+    ];
+}
+
+/**
+ * Load the authenticated user's liked provider tracks and normalize them
+ * through the same canonical identities used by playback and My Liked.
+ */
+export async function loadRemoteOwnedTracksForUser(
+    userId: string,
+    options: LoadRemoteOwnedTracksOptions = {},
+): Promise<UnifiedTrackResponse[]> {
+    const query = (options.query ?? "").trim();
+    const take = Math.max(1, options.take ?? 100);
+    const sort = options.sort ?? "asc";
+    const match = options.match ?? "any";
+
+    const [tidalTracks, ytMusicTracks] = await Promise.all([
+        prisma.trackTidal.findMany({
+            where: buildTidalWhere(userId, query, match),
+            orderBy: { title: sort },
+            take,
+        }),
+        prisma.trackYtMusic.findMany({
+            where: buildYtMusicWhere(userId, query, match),
+            orderBy: { title: sort },
+            take,
+        }),
+    ]);
+
+    const tracks = [
+        ...tidalTracks.map(normalizeTidalTrack),
+        ...ytMusicTracks.map(normalizeYtMusicTrack),
+    ];
+
+    tracks.sort((left, right) =>
+        sort === "desc"
+            ? right.title.localeCompare(left.title)
+            : left.title.localeCompare(right.title),
+    );
+
+    return tracks.slice(0, take);
+}
+
+export async function countRemoteOwnedTracksForUser(
+    userId: string,
+): Promise<number> {
+    const [tidalCount, ytMusicCount] = await Promise.all([
+        prisma.trackTidal.count({
+            where: { likedBy: { some: { userId } } },
+        }),
+        prisma.trackYtMusic.count({
+            where: { likedBy: { some: { userId } } },
+        }),
+    ]);
+
+    return tidalCount + ytMusicCount;
+}
+
+/**
+ * Adapt a normalized provider track to the legacy-compatible Library/Search
+ * response shape expected by existing frontend consumers.
+ */
+export function toLibraryRemoteTrack(track: UnifiedTrackResponse) {
+    return {
+        ...track,
+        albumId: track.album.id,
+        artistId: track.artist.id,
+        trackNumber: track.trackNo,
+        streamSource: track.source,
+        ...(track.provider.tidalTrackId !== null
+            ? { tidalTrackId: track.provider.tidalTrackId }
+            : {}),
+        ...(track.provider.youtubeVideoId !== null
+            ? { youtubeVideoId: track.provider.youtubeVideoId }
+            : {}),
+        album: {
+            ...track.album,
+            artistId: track.artist.id,
+            coverUrl: track.album.coverArt,
+            artist: track.artist,
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- include artists referenced by the authenticated user's liked TIDAL / YouTube Music tracks in the default owned Library view
- merge user-owned provider tracks into `GET /api/library/tracks` without exposing unrelated materialized provider rows
- include the same user-scoped remote tracks in normal Library search, matching title, artist, or album metadata
- reuse SoundSpan's canonical TIDAL / YouTube track normalizers so playback/provider IDs stay consistent with existing My Liked behavior
- add focused regression coverage and an Unreleased changelog entry

## Why

Provider-backed libraries can legitimately have no local `Track` rows while ownership exists through `LikedRemoteTrack -> TrackTidal / TrackYtMusic`.

The existing Artists, Songs, and normal Library search paths therefore omit music the authenticated user actually owns/likes.

The new queries deliberately scope provider ownership through the current user's `LikedRemoteTrack` relationships rather than global provider/cache rows.

## Testing

- focused Library, Search, and remote-owned-library Jest suites pass
- final remote-search/helper regression suites pass after the metadata-match update
- backend TypeScript `tsc --noEmit` passes
- locally verified against a provider-backed library with 45 artists and 60 songs (58 TIDAL, 2 YouTube Music), including successful playback from the resulting library entries

Fixes #699