### PR TITLE
chore(deps): bump @bull-board/api and @bull-board/express to 9.4.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,8 @@
             "version": "2.4.1",
             "license": "GPL-3.0",
             "dependencies": {
-                "@bull-board/api": "^8.6.1",
-                "@bull-board/express": "^8.6.1",
+                "@bull-board/api": "^9.4.0",
+                "@bull-board/express": "^9.4.0",
                 "@prisma/adapter-pg": "^7.9.1",
                 "@prisma/client": "^7.9.1",
                 "@socket.io/redis-adapter": "^8.3.0",
@@ -715,15 +715,15 @@
             }
         },
         "node_modules/@bull-board/api": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.6.1.tgz",
-            "integrity": "sha512-v5GLzMpss8e+3AnnKRGry+9PKlm6MKU2VFxveJCSoT5+/no7WZTM5zVyjPJSG29Xwgf6CujThche6v3j4ZrmrA==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-9.4.0.tgz",
+            "integrity": "sha512-poPku55iQd/VS65BUD8yn/uIHUruDwOVOiPEbThzjCd1nHAzEUEj/D+LWW1t9vzRsvN6xBr5jXlbJDapBnz7aw==",
             "license": "MIT",
             "dependencies": {
                 "redis-info": "^3.1.0"
             },
             "peerDependencies": {
-                "@bull-board/ui": "8.6.1",
+                "@bull-board/ui": "9.4.0",
                 "bull": "^4.16.5",
                 "bullmq": "^5.79.2 || ^6.0.0"
             },
@@ -737,24 +737,24 @@
             }
         },
         "node_modules/@bull-board/express": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-8.6.1.tgz",
-            "integrity": "sha512-nQii+RudZAdKF1I7K8rPQ/p7iURaHyhbNdgdDA1+PHKG1zuWlavSfM2e+229cZovagseBdF19DRZ++Y0edvESA==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-9.4.0.tgz",
+            "integrity": "sha512-VpK4kPqVJtF/Abc3Ajvc7E8jrRNSwRKjjIjkwrDXKF4on84hwoKUpKpnl8T394X5MiNOhchWIpvJ8xlFFNS4UQ==",
             "license": "MIT",
             "dependencies": {
-                "@bull-board/api": "8.6.1",
-                "@bull-board/ui": "8.6.1",
+                "@bull-board/api": "9.4.0",
+                "@bull-board/ui": "9.4.0",
                 "ejs": "^6.0.1",
                 "express": "^5.2.1"
             }
         },
         "node_modules/@bull-board/ui": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.6.1.tgz",
-            "integrity": "sha512-RV7oDopOJEUxzjmfKoqGcYDeHZGmpnpG+h/4DOVSSGYBtK87/8tlwAuLca9SPZqYTQjbviv7qOZ4jSjke/rUmQ==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-9.4.0.tgz",
+            "integrity": "sha512-oRuCjMawEdpwFpHWWT6tzZLVqaqP+sK7xs1C1AhvTGm4pViNyPKwV7chtSExFOdVZuXJnJOl74WTXsHRfKMF3A==",
             "license": "MIT",
             "dependencies": {
-                "@bull-board/api": "8.6.1"
+                "@bull-board/api": "9.4.0"
             }
         },
         "node_modules/@electric-sql/pglite": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,8 +39,8 @@
         "generate:vocabulary": "tsx scripts/generateVibeVocabulary.ts"
     },
     "dependencies": {
-        "@bull-board/api": "^8.6.1",
-        "@bull-board/express": "^8.6.1",
+        "@bull-board/api": "^9.4.0",
+        "@bull-board/express": "^9.4.0",
         "@prisma/adapter-pg": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "@socket.io/redis-adapter": "^8.3.0",


### PR DESCRIPTION
Combines the two Dependabot bull-board PRs (#696, #697) into one lockstep bump.

**Why one PR:** `@bull-board/api` and `@bull-board/express` share type contracts. Bumping either one alone fails Backend Typecheck — `ExpressAdapter` from one major is not assignable to `IServerAdapter` from the other. They have to move together.

**Version:** 9.4.0 (latest 9.x; Dependabot proposed 9.3.1 before 9.4.0 shipped). v9 is a UI refresh plus features — no adapter API removals; our usage surface (`ExpressAdapter`, `setBasePath`, `createBullBoard`, classic `BullAdapter`) is unchanged.

**Verification**
- `npx tsc --noEmit` — exit 0
- `jest apiEntrypointRuntime.test.ts` — Test Suites: 1 passed, Tests: 22 passed
- `npm run format:check` — clean

The admin queues dashboard at `/api/admin/queues` gets the v9 visual refresh; worth a quick eyeball after deploy.

Closes #696, closes #697.