### PR TITLE
feat(playback): source priority — library → peer libraries → TIDAL → YT Music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Federation administrators can set the instance display name advertised to peers. Peer health now exposes classified probe failures and the latest embedding federation outcome, including space-mismatch skips.
+- Playback source priority is now configurable through the `playbackSourceOrder` system setting, with the default owned-library → peer-library → TIDAL → YouTube Music order and strict provider validation. (#683)
 - YouTube Music is now a selectable library download source alongside Soulseek, Lidarr, and TIDAL. Pick **YouTube Music (Albums)** in Admin → Download Preferences (or as the "When Primary Source Fails" fallback) and album download jobs dispatch through the `ytmusic-streamer` sidecar the same way TIDAL jobs do: public album search, per-track downloads with TIDAL-style `Artist/Album/NN. Title` naming and scanner-compatible tags under the shared music volume, live progress on the job row, and an automatic library scan on completion. New sidecar env values `MUSIC_PATH` (default `/music`) and `YT_ALBUM_DOWNLOAD_CONCURRENCY` (default `1`). (#701)
 
 ### Changed
 
 - The TIDAL sidecar is renamed from `tidal-downloader` to `tidal-streamer`, matching the `ytmusic-streamer` naming: images now publish under `ghcr.io/soundspan/soundspan-tidal-streamer` (with the old `soundspan-tidal-downloader` name still published as an alias), the compose service and default container name follow (`tidal-streamer` / `soundspan_tidal_streamer`), and the old `tidal-downloader` in-network hostname remains as a network alias so custom `TIDAL_SIDECAR_URL` values keep working. No variable names, ports, APIs, Helm values keys, or TIDAL logins change — the rename requires no operator action. (#701)
 - Federation pairing now creates explicit one-way host and client links instead of attempting a reciprocal callback. Pairing codes last 30 minutes, retain up to five live codes per administrator without clobbering newer codes, and return distinct used, expired, and scope-mismatch errors; outbound peer setup also distinguishes unreachable, TLS, authorization, and invalid-peer failures. Existing bidirectional peer rows remain supported.
+- Federated tracks now identify playback as the first-class `peer` source, rank between owned files and streaming providers while their peer is online, and fall back at stream time to a hidden local dedup twin or an existing TIDAL/YouTube Music mapping before reporting `PEER_OFFLINE`; the same ladder applies to OpenSubsonic streams. Offline peers rank below provider copies. During mixed-version rollout, Listen Together snapshots retain legacy `local` source fields plus additive peer-origin metadata so previous pods can validate them while current pods restore the `peer` source. (#683)
 
 ### Fixed
 

--- a/backend/prisma/migrations/20260822120000_add_playback_source_order/migration.sql
+++ b/backend/prisma/migrations/20260822120000_add_playback_source_order/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "SystemSettings"
+ADD COLUMN "playbackSourceOrder" TEXT NOT NULL DEFAULT 'library,peers,tidal,ytmusic';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -254,6 +254,7 @@ model SystemSettings {
   downloadRetryAttempts       Int      @default(3)
   transcodeCacheMaxGb         Int      @default(10)
   downloadSource              String   @default("soulseek")
+  playbackSourceOrder         String   @default("library,peers,tidal,ytmusic")
   primaryFailureFallback      String   @default("none")
   updatedAt                   DateTime @updatedAt
   createdAt                   DateTime @default(now())

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -9,6 +9,10 @@ const mockParseFile = jest.fn();
 const mockLookup = jest.fn();
 const mockProxyFederatedTrackStream = jest.fn();
 const mockProxyFederatedCover = jest.fn();
+const mockLoadPeerPlaybackFallback = jest.fn();
+const mockServeMappedProviderStream = jest.fn();
+const mockTerminateCommittedStream = jest.fn((res: Response) => res.end());
+const mockGetYtMusicUserIdOrPublic = jest.fn();
 
 jest.mock("dns/promises", () => ({
     lookup: (...args: unknown[]) => mockLookup(...args),
@@ -108,6 +112,9 @@ jest.mock("../../utils/db", () => ({
         userSettings: {
             findUnique: jest.fn(),
         },
+        systemSettings: {
+            findUnique: jest.fn(),
+        },
         artist: {
             findMany: jest.fn(),
             findUnique: jest.fn(),
@@ -195,6 +202,30 @@ jest.mock("../../services/federationStreamProxy", () => ({
 jest.mock("../../services/federationCoverProxy", () => ({
     proxyFederatedCover: (...args: unknown[]) =>
         mockProxyFederatedCover(...args),
+}));
+jest.mock("../../services/peerPlaybackFallback", () => ({
+    loadPeerPlaybackFallback: (...args: unknown[]) =>
+        mockLoadPeerPlaybackFallback(...args),
+}));
+jest.mock("../../services/mappedProviderStream", () => ({
+    serveMappedProviderStream: (...args: unknown[]) =>
+        mockServeMappedProviderStream(...args),
+    terminateCommittedStream: (...args: [Response]) =>
+        mockTerminateCommittedStream(...args),
+    mappedProviderResponseState: (res: Response) => ({
+        headersSent: Boolean(res.headersSent),
+        destroyed: Boolean(res.destroyed),
+        writableEnded: Boolean(res.writableEnded),
+    }),
+    isMappedProviderResponseUnusable: (state: {
+        headersSent: boolean;
+        destroyed: boolean;
+        writableEnded: boolean;
+    }) => state.headersSent || state.destroyed || state.writableEnded,
+}));
+jest.mock("../youtubeMusic", () => ({
+    getUserIdOrPublic: (...args: unknown[]) =>
+        mockGetYtMusicUserIdOrPublic(...args),
 }));
 
 jest.mock("../../workers/queues", () => ({
@@ -1379,6 +1410,9 @@ describe("library stream runtime coverage", () => {
         mockStreamDestroy.mockImplementation(() => undefined);
         mockProxyFederatedTrackStream.mockResolvedValue(undefined);
         mockProxyFederatedCover.mockResolvedValue(true);
+        mockLoadPeerPlaybackFallback.mockResolvedValue([]);
+        mockServeMappedProviderStream.mockResolvedValue({ status: "served" });
+        mockGetYtMusicUserIdOrPublic.mockResolvedValue("user-1");
         mockFederationPeerFindUnique.mockResolvedValue({
             id: "peer-1",
             name: "Peer One",
@@ -1748,6 +1782,262 @@ describe("library stream runtime coverage", () => {
             });
             expect(mockPlayCreate).not.toHaveBeenCalled();
             expect(mockProxyFederatedTrackStream).not.toHaveBeenCalled();
+        },
+    );
+
+    it("streams the local dedup twin when the owning peer is offline", async () => {
+        mockTrackFindUnique
+            .mockResolvedValueOnce(
+                createNativeTrack({
+                    id: "fed-track-1",
+                    origin: "FEDERATED",
+                    peerId: "peer-1",
+                    remoteId: "remote-track-1",
+                    filePath: null,
+                }),
+            )
+            .mockResolvedValueOnce(createNativeTrack({ id: "local-twin-1" }));
+        mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "library", trackId: "local-twin-1" },
+        ]);
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValueOnce(true);
+        const res = createRes();
+
+        await streamHandler(
+            {
+                params: { id: "fed-track-1" },
+                query: { quality: "original" },
+                headers: {},
+                user: { id: "user-1" },
+            } as any,
+            res,
+        );
+
+        expect(mockLoadPeerPlaybackFallback).toHaveBeenCalledWith(
+            "fed-track-1",
+        );
+        expect(mockStreamWithRangeSupport).toHaveBeenCalled();
+        existsSpy.mockRestore();
+    });
+
+    it("serves an existing TIDAL mapping when an offline peer has no local twin", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({
+                id: "fed-track-1",
+                origin: "FEDERATED",
+                peerId: "peer-1",
+                remoteId: "remote-track-1",
+                filePath: null,
+            }),
+        );
+        mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+        ]);
+        const req = {
+            params: { id: "fed-track-1" },
+            query: {},
+            headers: {},
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledWith({
+            req,
+            res,
+            userId: "user-1",
+            youtubeUserId: undefined,
+            quality: "high",
+            trackId: "fed-track-1",
+            fallback: { source: "tidal", tidalTrackId: 42 },
+        });
+        expect(mockAudioStreamingCtor).not.toHaveBeenCalled();
+    });
+
+    it("advances from a pre-header TIDAL failure to YouTube", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({
+                id: "fed-track-1",
+                origin: "FEDERATED",
+                peerId: "peer-1",
+                remoteId: "remote-track-1",
+                filePath: null,
+            }),
+        );
+        mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        mockServeMappedProviderStream
+            .mockResolvedValueOnce({
+                status: "failed",
+                error: new Error("TIDAL unavailable"),
+                responseState: {
+                    headersSent: false,
+                    destroyed: false,
+                    writableEnded: false,
+                },
+            })
+            .mockResolvedValueOnce({ status: "served" });
+        const req = {
+            params: { id: "fed-track-1" },
+            query: {},
+            headers: {},
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await streamHandler(req, res);
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(2);
+        expect(mockServeMappedProviderStream).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                youtubeUserId: "user-1",
+                quality: "high",
+                fallback: {
+                    source: "ytmusic",
+                    youtubeVideoId: "video-1",
+                },
+            }),
+        );
+        expect(res.status).not.toHaveBeenCalledWith(503);
+    });
+
+    it("returns PEER_OFFLINE after every fallback rung fails", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({
+                id: "fed-track-1",
+                origin: "FEDERATED",
+                peerId: "peer-1",
+                remoteId: "remote-track-1",
+                filePath: null,
+            }),
+        );
+        mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        mockServeMappedProviderStream.mockResolvedValue({
+            status: "failed",
+            error: new Error("provider unavailable"),
+            responseState: {
+                headersSent: false,
+                destroyed: false,
+                writableEnded: false,
+            },
+        });
+        const res = createRes();
+
+        await streamHandler(
+            {
+                params: { id: "fed-track-1" },
+                query: {},
+                headers: {},
+                user: { id: "user-1" },
+            } as any,
+            res,
+        );
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(2);
+        expect(res.statusCode).toBe(503);
+        expect(res.body).toEqual({
+            error: "Federation peer is offline",
+            code: "PEER_OFFLINE",
+        });
+    });
+
+    it("does not advance after a mapped fallback commits headers", async () => {
+        mockTrackFindUnique.mockResolvedValueOnce(
+            createNativeTrack({
+                id: "fed-track-1",
+                origin: "FEDERATED",
+                peerId: "peer-1",
+                remoteId: "remote-track-1",
+                filePath: null,
+            }),
+        );
+        mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        const res = createRes();
+        res.headersSent = true;
+        res.writableEnded = false;
+        mockServeMappedProviderStream.mockResolvedValueOnce({
+            status: "failed",
+            error: new Error("stream reset"),
+            responseState: {
+                headersSent: true,
+                destroyed: false,
+                writableEnded: false,
+            },
+        });
+
+        await streamHandler(
+            {
+                params: { id: "fed-track-1" },
+                query: {},
+                headers: {},
+                user: { id: "user-1" },
+            } as any,
+            res,
+        );
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(1);
+        expect(res.end).toHaveBeenCalledTimes(1);
+        expect(res.status).not.toHaveBeenCalledWith(503);
+    });
+
+    it.each([
+        [false, false, true],
+        [true, false, true],
+    ])(
+        "stops after a mapped body failure with headersSent=%s writableEnded=%s destroyed=%s",
+        async (headersSent, writableEnded, destroyed) => {
+            mockTrackFindUnique.mockResolvedValueOnce(
+                createNativeTrack({
+                    id: "fed-track-1",
+                    origin: "FEDERATED",
+                    peerId: "peer-1",
+                    remoteId: "remote-track-1",
+                    filePath: null,
+                }),
+            );
+            mockFederationPeerFindUnique.mockResolvedValueOnce(null);
+            mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+                { source: "tidal", tidalTrackId: 42 },
+                { source: "ytmusic", youtubeVideoId: "video-1" },
+            ]);
+            mockServeMappedProviderStream.mockResolvedValueOnce({
+                status: "failed",
+                responseState: { headersSent, writableEnded, destroyed },
+                error: new Error("body failed"),
+            });
+            const res = createRes();
+
+            await streamHandler(
+                {
+                    params: { id: "fed-track-1" },
+                    query: {},
+                    headers: {},
+                    user: { id: "user-1" },
+                } as any,
+                res,
+            );
+
+            expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(1);
+            expect(res.status).not.toHaveBeenCalledWith(503);
+            expect(res.json).not.toHaveBeenCalled();
+            expect(res.end).not.toHaveBeenCalled();
         },
     );
 
@@ -4102,6 +4392,7 @@ describe("library catalog list runtime coverage", () => {
         expect(res.body).toMatchObject({
             id: "federated-track-1",
             source: "federated",
+            streamSource: "peer",
             peer: { id: "peer-1", name: "Peer One", online: true },
         });
     });

--- a/backend/src/routes/__tests__/playsCore.test.ts
+++ b/backend/src/routes/__tests__/playsCore.test.ts
@@ -171,6 +171,36 @@ describe("plays routes integration", () => {
                 trackYtMusic: null,
             },
             {
+                id: "play-peer",
+                playedAt: new Date("2026-03-01T11:00:00.000Z"),
+                source: "LIBRARY",
+                track: {
+                    id: "peer-track-1",
+                    title: "Peer Song",
+                    duration: 211,
+                    trackNumber: 8,
+                    filePath: null,
+                    origin: "FEDERATED",
+                    federationPeer: {
+                        id: "peer-1",
+                        name: "Peer One",
+                        outboundStatus: "ACTIVE",
+                    },
+                    album: {
+                        id: "peer-album-1",
+                        title: "Peer Album",
+                        coverUrl: null,
+                        artist: {
+                            id: "peer-artist-1",
+                            name: "Peer Artist",
+                            mbid: null,
+                        },
+                    },
+                },
+                trackTidal: null,
+                trackYtMusic: null,
+            },
+            {
                 id: "play-tidal",
                 playedAt: new Date("2026-03-02T10:00:00.000Z"),
                 source: "TIDAL",
@@ -251,7 +281,7 @@ describe("plays routes integration", () => {
                 trackYtMusic: true,
             },
         });
-        expect(res.body).toHaveLength(3);
+        expect(res.body).toHaveLength(4);
         expect(res.body).toEqual([
             {
                 id: "play-local",
@@ -284,6 +314,40 @@ describe("plays routes integration", () => {
                             name: "Local Artist",
                         },
                     },
+                },
+            },
+            {
+                id: "play-peer",
+                playedAt: "2026-03-01T11:00:00.000Z",
+                source: "LIBRARY",
+                track: {
+                    id: "peer-track-1",
+                    title: "Peer Song",
+                    displayTitle: null,
+                    duration: 211,
+                    trackNo: 8,
+                    source: "federated",
+                    provider: {
+                        tidalTrackId: null,
+                        youtubeVideoId: null,
+                    },
+                    filePath: null,
+                    artist: {
+                        id: "peer-artist-1",
+                        name: "Peer Artist",
+                    },
+                    album: {
+                        id: "peer-album-1",
+                        title: "Peer Album",
+                        coverArt: null,
+                        albumLoudnessLufs: null,
+                        albumTruePeakDb: null,
+                        artist: {
+                            id: "peer-artist-1",
+                            name: "Peer Artist",
+                        },
+                    },
+                    streamSource: "peer",
                 },
             },
             {

--- a/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
@@ -170,7 +170,11 @@ function buildRes(): Response {
         setHeader: jest.fn(),
         status: jest.fn(),
         send: jest.fn(),
+        end: jest.fn(),
+        destroy: jest.fn(),
         headersSent: false,
+        writableEnded: false,
+        destroyed: false,
     };
     (res.status as jest.Mock).mockReturnValue(res);
     return res as Response;

--- a/backend/src/routes/__tests__/subsonicMediaCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicMediaCompat.test.ts
@@ -111,6 +111,33 @@ describe("subsonic media compatibility handlers", () => {
         jest.restoreAllMocks();
     });
 
+    it("returns not found instead of a local file when a federated download's peer is unavailable", async () => {
+        mockTrackFindFirst.mockResolvedValue({
+            id: "track-2",
+            origin: "FEDERATED",
+            remoteId: "remote-2",
+            filePath: null,
+            federationPeer: {
+                id: "peer-1",
+                baseUrl: "https://peer.example",
+                outboundToken: "v2:tok",
+                outboundStatus: "OFFLINE",
+            },
+        });
+        const res = buildRes();
+
+        await handleDownload(buildReq({ id: "tr-track-2" }), res);
+
+        expect(res.download).not.toHaveBeenCalled();
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            70,
+            "Song not found",
+            expect.anything(),
+            undefined,
+        );
+    });
+
     it("returns not found when download track lookup fails", async () => {
         mockTrackFindFirst.mockResolvedValue(null);
 

--- a/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
+++ b/backend/src/routes/__tests__/subsonicStreamCoverArtHandlers.test.ts
@@ -8,6 +8,13 @@ const mockCleanupStreamFile = jest.fn();
 const mockLookup = jest.fn();
 const mockProxyFederatedTrackStream = jest.fn();
 const mockProxyFederatedCover = jest.fn();
+const mockLoadPeerPlaybackFallback = jest.fn();
+const mockServeMappedProviderStream = jest.fn();
+const mockTerminateCommittedStream = jest.fn((res: Response) => {
+    if (typeof res.destroy === "function") res.destroy();
+    else res.end();
+});
+const mockGetYtMusicUserIdOrPublic = jest.fn();
 const mockSubsonicLogger = {
     debug: jest.fn(),
     info: jest.fn(),
@@ -82,6 +89,27 @@ jest.mock("../../services/federationStreamProxy", () => ({
 }));
 jest.mock("../../services/federationCoverProxy", () => ({
     proxyFederatedCover: mockProxyFederatedCover,
+}));
+jest.mock("../../services/peerPlaybackFallback", () => ({
+    loadPeerPlaybackFallback: mockLoadPeerPlaybackFallback,
+}));
+jest.mock("../../services/mappedProviderStream", () => ({
+    serveMappedProviderStream: mockServeMappedProviderStream,
+    terminateCommittedStream: mockTerminateCommittedStream,
+    mappedProviderResponseState: (res: Response) => ({
+        headersSent: Boolean(res.headersSent),
+        destroyed: Boolean(res.destroyed),
+        writableEnded: Boolean(res.writableEnded),
+    }),
+    isMappedProviderResponseUnusable: (state: {
+        headersSent: boolean;
+        destroyed: boolean;
+        writableEnded: boolean;
+    }) => state.headersSent || state.destroyed || state.writableEnded,
+}));
+jest.mock("../youtubeMusic", () => ({
+    getUserIdOrPublic: (...args: unknown[]) =>
+        mockGetYtMusicUserIdOrPublic(...args),
 }));
 jest.mock("../../utils/logger", () => ({ logger: mockSubsonicLogger }));
 
@@ -175,6 +203,9 @@ beforeEach(() => {
     mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     mockProxyFederatedTrackStream.mockResolvedValue(undefined);
     mockProxyFederatedCover.mockResolvedValue(true);
+    mockLoadPeerPlaybackFallback.mockResolvedValue([]);
+    mockServeMappedProviderStream.mockResolvedValue({ status: "served" });
+    mockGetYtMusicUserIdOrPublic.mockResolvedValue("user-1");
 });
 
 afterEach(() => {
@@ -470,6 +501,247 @@ describe("handleStream", () => {
         );
         expect(mockProxyFederatedTrackStream).not.toHaveBeenCalled();
     });
+
+    it("streams the local dedup twin when a Subsonic peer is offline", async () => {
+        mockTrackFindFirst
+            .mockResolvedValueOnce({
+                id: "federated-track",
+                origin: "FEDERATED",
+                remoteId: "remote-track",
+                mime: "audio/flac",
+                filePath: null,
+                fileModified: new Date("2026-08-15T12:00:00Z"),
+                federationPeer: {
+                    id: "peer-1",
+                    baseUrl: "https://peer.example",
+                    outboundToken: "v2:encrypted-token",
+                    outboundStatus: "OFFLINE",
+                },
+            })
+            .mockResolvedValueOnce({
+                id: "local-track",
+                origin: "LOCAL",
+                remoteId: null,
+                mime: "audio/flac",
+                filePath: "Artist/Album/track.flac",
+                fileModified: new Date("2026-08-15T12:00:00Z"),
+                federationPeer: null,
+            });
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "library", trackId: "local-track" },
+        ]);
+        const existsSpy = jest
+            .spyOn(fs, "existsSync")
+            .mockReturnValueOnce(true);
+        mockGetStreamFilePath.mockResolvedValueOnce({
+            filePath: "/music/Artist/Album/track.flac",
+            mimeType: "audio/flac",
+        });
+
+        await handleStream(buildReq({ id: "tr-federated-track" }), buildRes());
+
+        expect(mockLoadPeerPlaybackFallback).toHaveBeenCalledWith(
+            "federated-track",
+        );
+        expect(mockStreamFileWithRangeSupport).toHaveBeenCalled();
+        expect(mockSendError).not.toHaveBeenCalled();
+        existsSpy.mockRestore();
+    });
+
+    it("serves an existing provider mapping for an offline Subsonic peer", async () => {
+        mockTrackFindFirst.mockResolvedValueOnce({
+            id: "federated-track",
+            origin: "FEDERATED",
+            remoteId: "remote-track",
+            mime: "audio/flac",
+            filePath: null,
+            fileModified: new Date("2026-08-15T12:00:00Z"),
+            federationPeer: {
+                id: "peer-1",
+                baseUrl: "https://peer.example",
+                outboundToken: "v2:encrypted-token",
+                outboundStatus: "OFFLINE",
+            },
+        });
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        const req = buildReq({ id: "tr-federated-track" });
+        const res = buildRes();
+
+        await handleStream(req, res);
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledWith({
+            req,
+            res,
+            userId: "user-1",
+            youtubeUserId: "user-1",
+            quality: "original",
+            fallback: { source: "ytmusic", youtubeVideoId: "video-1" },
+        });
+        expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it("advances from a pre-header TIDAL failure to YouTube", async () => {
+        mockTrackFindFirst.mockResolvedValueOnce({
+            id: "federated-track",
+            origin: "FEDERATED",
+            remoteId: "remote-track",
+            mime: "audio/flac",
+            filePath: null,
+            fileModified: new Date("2026-08-15T12:00:00Z"),
+            federationPeer: {
+                id: "peer-1",
+                baseUrl: "https://peer.example",
+                outboundToken: "v2:encrypted-token",
+                outboundStatus: "OFFLINE",
+            },
+        });
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        mockServeMappedProviderStream
+            .mockResolvedValueOnce({
+                status: "failed",
+                error: new Error("TIDAL unavailable"),
+                responseState: {
+                    headersSent: false,
+                    destroyed: false,
+                    writableEnded: false,
+                },
+            })
+            .mockResolvedValueOnce({ status: "served" });
+
+        await handleStream(buildReq({ id: "tr-federated-track" }), buildRes());
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(2);
+        expect(mockServeMappedProviderStream).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                youtubeUserId: "user-1",
+                quality: "original",
+                fallback: {
+                    source: "ytmusic",
+                    youtubeVideoId: "video-1",
+                },
+            }),
+        );
+        expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it("returns PEER_OFFLINE after all mapped provider rungs fail", async () => {
+        mockTrackFindFirst.mockResolvedValueOnce({
+            id: "federated-track",
+            origin: "FEDERATED",
+            remoteId: "remote-track",
+            mime: "audio/flac",
+            filePath: null,
+            fileModified: new Date("2026-08-15T12:00:00Z"),
+            federationPeer: null,
+        });
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        mockServeMappedProviderStream.mockResolvedValue({
+            status: "failed",
+            error: new Error("provider unavailable"),
+            responseState: {
+                headersSent: false,
+                destroyed: false,
+                writableEnded: false,
+            },
+        });
+
+        await handleStream(buildReq({ id: "tr-federated-track" }), buildRes());
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(2);
+        expect(mockSendError).toHaveBeenCalledWith(
+            expect.anything(),
+            SubsonicErrorCode.GENERIC,
+            "Federation peer is offline",
+            "json",
+            undefined,
+        );
+    });
+
+    it("destroys a committed mapped stream without advancing or writing an error", async () => {
+        mockTrackFindFirst.mockResolvedValueOnce({
+            id: "federated-track",
+            origin: "FEDERATED",
+            remoteId: "remote-track",
+            mime: "audio/flac",
+            filePath: null,
+            fileModified: new Date("2026-08-15T12:00:00Z"),
+            federationPeer: null,
+        });
+        mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+        const res = buildRes();
+        const destroy = jest.fn();
+        (res as Response & { destroy: jest.Mock }).destroy = destroy;
+        (res as Response & { headersSent: boolean }).headersSent = true;
+        mockServeMappedProviderStream.mockResolvedValueOnce({
+            status: "failed",
+            error: new Error("stream reset"),
+            responseState: {
+                headersSent: true,
+                destroyed: false,
+                writableEnded: false,
+            },
+        });
+
+        await expect(
+            handleStream(buildReq({ id: "tr-federated-track" }), res),
+        ).resolves.toBeUndefined();
+
+        expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(1);
+        expect(destroy).toHaveBeenCalledTimes(1);
+        expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it.each([false, true])(
+        "stops after a destroyed mapped body with headersSent=%s",
+        async (headersSent) => {
+            mockTrackFindFirst.mockResolvedValueOnce({
+                id: "federated-track",
+                origin: "FEDERATED",
+                remoteId: "remote-track",
+                mime: "audio/flac",
+                filePath: null,
+                fileModified: new Date("2026-08-15T12:00:00Z"),
+                federationPeer: null,
+            });
+            mockLoadPeerPlaybackFallback.mockResolvedValueOnce([
+                { source: "tidal", tidalTrackId: 42 },
+                { source: "ytmusic", youtubeVideoId: "video-1" },
+            ]);
+            mockServeMappedProviderStream.mockResolvedValueOnce({
+                status: "failed",
+                responseState: {
+                    headersSent,
+                    writableEnded: false,
+                    destroyed: true,
+                },
+                error: new Error("body failed"),
+            });
+            const res = buildRes();
+
+            await expect(
+                handleStream(
+                    buildReq({ id: "tr-federated-track", maxBitRate: "128" }),
+                    res,
+                ),
+            ).resolves.toBeUndefined();
+
+            expect(mockServeMappedProviderStream).toHaveBeenCalledTimes(1);
+            expect(mockSendError).not.toHaveBeenCalled();
+            expect(res.end).not.toHaveBeenCalled();
+        },
+    );
 
     it("returns not found instead of streaming a removed library track", async () => {
         mockTrackFindFirst.mockImplementationOnce(

--- a/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
+++ b/backend/src/routes/__tests__/systemSettingsRuntime.test.ts
@@ -68,6 +68,10 @@ jest.mock("../../utils/systemSettings", () => ({
     invalidateSystemSettingsCache: jest.fn(),
 }));
 
+jest.mock("../../services/listenTogetherResolution", () => ({
+    invalidateUserProviderProfileCache: jest.fn(),
+}));
+
 const mockSchedulerJobGetState = jest.fn();
 const mockSchedulerJobRemove = jest.fn();
 const mockSchedulerJob = {
@@ -154,6 +158,7 @@ import router from "../systemSettings";
 import { prisma } from "../../utils/db";
 import { writeEnvFile, EnvFileSyncSkippedError } from "../../utils/envWriter";
 import { invalidateSystemSettingsCache } from "../../utils/systemSettings";
+import { invalidateUserProviderProfileCache } from "../../services/listenTogetherResolution";
 import { decrypt } from "../../utils/encryption";
 import { lastFmService } from "../../services/lastfm";
 import { tidalService } from "../../services/tidal";
@@ -174,6 +179,8 @@ const mockAxiosPut = axios.put as jest.Mock;
 const mockWriteEnvFile = writeEnvFile as jest.Mock;
 const mockInvalidateSystemSettingsCache =
     invalidateSystemSettingsCache as jest.Mock;
+const mockInvalidateUserProviderProfileCache =
+    invalidateUserProviderProfileCache as jest.Mock;
 const mockDecrypt = decrypt as jest.Mock;
 const mockLastFmService = lastFmService as jest.Mocked<typeof lastFmService>;
 const mockTidalService = tidalService as jest.Mocked<typeof tidalService>;
@@ -521,6 +528,38 @@ describe("systemSettings runtime routes", () => {
         );
     });
 
+    it("accepts a closed playback source order", async () => {
+        const req = {
+            user: { id: "admin-1" },
+            body: { playbackSourceOrder: "peers,library,tidal,ytmusic" },
+        } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(mockSystemSettingsUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                update: expect.objectContaining({
+                    playbackSourceOrder: "peers,library,tidal,ytmusic",
+                }),
+            }),
+        );
+    });
+
+    it("rejects malformed playback source orders", async () => {
+        const req = {
+            user: { id: "admin-1" },
+            body: { playbackSourceOrder: "library,peers,spotify,ytmusic" },
+        } as any;
+        const res = createRes();
+
+        await postSettingsHandler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(mockSystemSettingsUpsert).not.toHaveBeenCalled();
+    });
+
     it("env sync and webhook config use stored secrets when the form round-trips empty strings", async () => {
         mockSystemSettingsUpsert.mockResolvedValueOnce({
             id: "default",
@@ -771,6 +810,7 @@ describe("systemSettings runtime routes", () => {
         expect(savedUpdate).not.toHaveProperty("tidalAccessToken");
         expect(savedUpdate).not.toHaveProperty("tidalRefreshToken");
         expect(mockInvalidateSystemSettingsCache).toHaveBeenCalled();
+        expect(mockInvalidateUserProviderProfileCache).toHaveBeenCalled();
         expect(mockWriteEnvFile).toHaveBeenCalled();
         expect(mockLastFmService.refreshApiKey).toHaveBeenCalled();
         expect(mockSoulseekService.disconnect).toHaveBeenCalled();

--- a/backend/src/routes/library/albums.ts
+++ b/backend/src/routes/library/albums.ts
@@ -421,6 +421,7 @@ function formatLocalAlbumTracks(album: AlbumWithTracks) {
         ...(track.origin === "FEDERATED" && federationPeer
             ? {
                   source: "federated" as const,
+                  streamSource: "peer" as const,
                   peer: {
                       id: federationPeer.id,
                       name: federationPeer.name,

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -46,6 +46,7 @@ import {
 } from "../../utils/libraryDeletion";
 import { findRouteNameMatch } from "../artistRouteName";
 import { deleteArtistCatalogEntry } from "../../services/artistCatalogDeletion";
+import { withFederatedTrackPlayback } from "../../services/federatedTrackPayload";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -344,6 +345,7 @@ export async function handleGetArtists(req: Request, res: Response) {
                 ...(artist.peerId && artist.federationPeer
                     ? {
                           source: "federated" as const,
+                          streamSource: "peer" as const,
                           peer: {
                               id: artist.federationPeer.id,
                               name: artist.federationPeer.name,
@@ -580,20 +582,9 @@ export async function handleGetArtist(
         .filter((album) => album.location !== "REMOTE")
         .map((album) => ({
             ...album,
-            tracks: album.tracks.map(({ federationPeer, ...track }) => ({
-                ...track,
-                ...(track.origin === "FEDERATED" && federationPeer
-                    ? {
-                          source: "federated" as const,
-                          peer: {
-                              id: federationPeer.id,
-                              name: federationPeer.name,
-                              online:
-                                  federationPeer.outboundStatus === "ACTIVE",
-                          },
-                      }
-                    : {}),
-            })),
+            tracks: album.tracks.map(({ federationPeer, ...track }) =>
+                withFederatedTrackPlayback(track, federationPeer),
+            ),
             owned:
                 album.location === "LIBRARY" || ownedRgMbids.has(album.rgMbid),
             coverArt: album.coverUrl,
@@ -812,20 +803,9 @@ export async function handleGetArtist(
     if (includeTopTracks) {
         // Extract top tracks from library first
         const allTracks = artist.albums.flatMap((album) =>
-            album.tracks.map(({ federationPeer, ...track }) => ({
-                ...track,
-                ...(track.origin === "FEDERATED" && federationPeer
-                    ? {
-                          source: "federated" as const,
-                          peer: {
-                              id: federationPeer.id,
-                              name: federationPeer.name,
-                              online:
-                                  federationPeer.outboundStatus === "ACTIVE",
-                          },
-                      }
-                    : {}),
-            })),
+            album.tracks.map(({ federationPeer, ...track }) =>
+                withFederatedTrackPlayback(track, federationPeer),
+            ),
         );
         topTracks = allTracks.slice(0, 10);
 

--- a/backend/src/routes/library/libraryNativeTrackStream.ts
+++ b/backend/src/routes/library/libraryNativeTrackStream.ts
@@ -7,7 +7,7 @@ import {
 import { config } from "../../config";
 import { safeResolvePath } from "../../utils/safeResolvePath";
 import { logger } from "../../utils/logger";
-import { sendRouteError } from "../routeErrorResponse";
+import { sendInternalRouteError, sendRouteError } from "../routeErrorResponse";
 
 const log = logger.child("LibraryNativeTrackStream");
 
@@ -86,7 +86,7 @@ export async function serveNativeLibraryTrack(input: {
         });
     } catch (error) {
         log.error("Native streaming failed", { error });
-        return input.res.status(500).json({ error: "Failed to stream track" });
+        return sendInternalRouteError(input.res, "Failed to stream track");
     } finally {
         service.destroy();
     }

--- a/backend/src/routes/library/libraryNativeTrackStream.ts
+++ b/backend/src/routes/library/libraryNativeTrackStream.ts
@@ -1,0 +1,93 @@
+import type { Request, Response } from "express";
+import type { Track } from "@prisma/client";
+import {
+    AudioStreamingService,
+    type Quality,
+} from "../../services/audioStreaming";
+import { config } from "../../config";
+import { safeResolvePath } from "../../utils/safeResolvePath";
+import { logger } from "../../utils/logger";
+import { sendRouteError } from "../routeErrorResponse";
+
+const log = logger.child("LibraryNativeTrackStream");
+
+async function streamNativeFile(input: {
+    req: Request;
+    res: Response;
+    track: Track;
+    quality: Quality;
+    absolutePath: string;
+    service: AudioStreamingService;
+}): Promise<void> {
+    try {
+        const streamFile = await input.service.getStreamFilePath(
+            input.track.id,
+            input.quality,
+            input.track.fileModified,
+            input.absolutePath,
+        );
+        await input.service.streamFileWithRangeSupport(
+            input.req,
+            input.res,
+            streamFile.filePath,
+            streamFile.mimeType,
+        );
+    } catch (error: any) {
+        if (error.code !== "FFMPEG_NOT_FOUND" || input.quality === "original") {
+            throw error;
+        }
+        const original = await input.service.getStreamFilePath(
+            input.track.id,
+            "original",
+            input.track.fileModified,
+            input.absolutePath,
+        );
+        await input.service.streamFileWithRangeSupport(
+            input.req,
+            input.res,
+            original.filePath,
+            original.mimeType,
+        );
+    }
+}
+
+/** Streams a local library file with bounded transcode fallback. */
+export async function serveNativeLibraryTrack(input: {
+    req: Request;
+    res: Response;
+    track: Track;
+    requestedQuality: string;
+}): Promise<Response | void> {
+    if (!input.track.filePath) {
+        return sendRouteError(input.res, 404, "Track not available");
+    }
+    const normalizedPath = input.track.filePath.replace(/\\/g, "/");
+    const absolutePath = safeResolvePath(
+        config.music.musicPath,
+        normalizedPath,
+    );
+    if (!absolutePath) {
+        log.warn("Rejected out-of-root stream path", {
+            trackId: input.track.id,
+        });
+        return sendRouteError(input.res, 404, "Track not available");
+    }
+    const service = new AudioStreamingService(
+        config.music.musicPath,
+        config.music.transcodeCachePath,
+        config.music.transcodeCacheMaxGb,
+    );
+    try {
+        await streamNativeFile({
+            ...input,
+            quality: input.requestedQuality as Quality,
+            absolutePath,
+            service,
+        });
+    } catch (error) {
+        log.error("Native streaming failed", { error });
+        return input.res.status(500).json({ error: "Failed to stream track" });
+    } finally {
+        service.destroy();
+    }
+}

--- a/backend/src/routes/library/libraryPeerStream.ts
+++ b/backend/src/routes/library/libraryPeerStream.ts
@@ -1,0 +1,113 @@
+import type { Request, Response } from "express";
+import { proxyFederatedTrackStream } from "../../services/federationStreamProxy";
+import { loadPeerPlaybackFallback } from "../../services/peerPlaybackFallback";
+import {
+    isMappedProviderResponseUnusable,
+    mappedProviderResponseState,
+    serveMappedProviderStream,
+    terminateCommittedStream,
+} from "../../services/mappedProviderStream";
+import { normalizeStreamingQuality } from "../../utils/libraryAudioInfo";
+import { TRACK_VISIBLE_WHERE } from "../../utils/librarySorting";
+import { logger } from "../../utils/logger";
+import { prisma } from "../../utils/db";
+import { sendRouteError } from "../routeErrorResponse";
+
+const log = logger.child("LibraryPeerStream");
+
+interface LibraryPeerStreamInput {
+    req: Request<{ id: string }>;
+    res: Response;
+    peer: {
+        id: string;
+        baseUrl: string;
+        outboundToken: string;
+    };
+    remoteId: string;
+    trackId: string;
+    sourceModified: Date;
+    sourceMime: string | null;
+    requestedQuality: string;
+}
+
+/** Proxies the peer stream and reports whether a response was completed. */
+export async function proxyLibraryPeerStream(
+    input: LibraryPeerStreamInput,
+): Promise<boolean> {
+    try {
+        await proxyFederatedTrackStream({
+            req: input.req,
+            res: input.res,
+            peer: input.peer,
+            remoteId: input.remoteId,
+            trackId: input.trackId,
+            sourceModified: input.sourceModified,
+            sourceMime: input.sourceMime,
+            quality:
+                normalizeStreamingQuality(input.requestedQuality) ?? "medium",
+        });
+        return true;
+    } catch (error) {
+        log.warn("Federated stream proxy failed", { error });
+        const state = mappedProviderResponseState(input.res);
+        if (!isMappedProviderResponseUnusable(state)) return false;
+        if (!state.destroyed && !state.writableEnded) {
+            terminateCommittedStream(input.res);
+        }
+        return true;
+    }
+}
+
+/** Applies the peer fallback policy, serving providers or returning a local twin. */
+export async function applyLibraryPeerFallback(input: {
+    req: Request<{ id: string }>;
+    res: Response;
+    userId: string;
+    trackId: string;
+    quality: string;
+}) {
+    const fallbacks = await loadPeerPlaybackFallback(input.trackId);
+    let youtubeUserId: string | undefined;
+    for (let index = 0; index < 3; index += 1) {
+        const fallback = fallbacks[index];
+        if (!fallback) break;
+        if (fallback.source === "library") {
+            const track = await prisma.track.findUnique({
+                where: { id: fallback.trackId, ...TRACK_VISIBLE_WHERE },
+            });
+            if (track) return track;
+            continue;
+        }
+        if (fallback.source === "ytmusic" && youtubeUserId === undefined) {
+            youtubeUserId = await import("../youtubeMusic").then((mod) =>
+                mod.getUserIdOrPublic(input.userId),
+            );
+        }
+        const result = await serveMappedProviderStream({
+            ...input,
+            youtubeUserId,
+            fallback,
+        });
+        if (result.status === "served") return null;
+        if (result.status !== "failed") continue;
+        log.warn("Mapped peer fallback failed", { error: result.error });
+        if (isMappedProviderResponseUnusable(result.responseState)) {
+            if (
+                !result.responseState.destroyed &&
+                !result.responseState.writableEnded
+            ) {
+                terminateCommittedStream(input.res);
+            }
+            return null;
+        }
+    }
+    const state = mappedProviderResponseState(input.res);
+    if (!isMappedProviderResponseUnusable(state)) sendPeerOffline(input.res);
+    return null;
+}
+
+function sendPeerOffline(res: Response): void {
+    sendRouteError(res, 503, "Federation peer is offline", {
+        code: "PEER_OFFLINE",
+    });
+}

--- a/backend/src/routes/library/libraryPeerStream.ts
+++ b/backend/src/routes/library/libraryPeerStream.ts
@@ -90,7 +90,7 @@ export async function applyLibraryPeerFallback(input: {
         });
         if (result.status === "served") return null;
         if (result.status !== "failed") continue;
-        log.warn("Mapped peer fallback failed", { error: result.error });
+        log.warn("Mapped peer fallback failed", { error: result.failure });
         if (isMappedProviderResponseUnusable(result.responseState)) {
             if (
                 !result.responseState.destroyed &&

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -7,15 +7,10 @@ import {
 import { asyncHandler } from "../../middleware/asyncHandler";
 import { prisma, Prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
-import path from "path";
 import fs from "fs";
 import { config } from "../../config";
-import {
-    AudioStreamingService,
-    type Quality as StreamingQuality,
-} from "../../services/audioStreaming";
+import { type Quality as StreamingQuality } from "../../services/audioStreaming";
 import { shuffleArray } from "../../utils/shuffle";
-import { safeResolvePath } from "../../utils/safeResolvePath";
 import {
     applyTrackPreferenceOrderBias,
     applyTrackPreferenceSimilarityBias,
@@ -38,10 +33,8 @@ import {
     normalizeTidalTrack,
     normalizeYtMusicTrack,
 } from "../../services/unifiedTrackResponse";
-import { proxyFederatedTrackStream } from "../../services/federationStreamProxy";
 import {
     buildFederatedAudioInfo,
-    normalizeStreamingQuality,
     resolveAudioInfoAbsolutePath,
 } from "../../utils/libraryAudioInfo";
 import {
@@ -76,6 +69,15 @@ import {
     libraryDeletionLogger,
 } from "../../utils/libraryDeletion";
 import { deleteTrackAndRecomputeAlbum } from "../../services/trackDeletion";
+import {
+    parsePlaybackSourceOrder,
+    rankPlaybackSource,
+} from "../../services/playbackSourcePriority";
+import {
+    applyLibraryPeerFallback,
+    proxyLibraryPeerStream,
+} from "./libraryPeerStream";
+import { serveNativeLibraryTrack } from "./libraryNativeTrackStream";
 
 /**
  * Router segment for tracks routes registered at this position.
@@ -237,6 +239,9 @@ export async function handleGetTracks(req: Request, res: Response) {
     const tracks = tracksData.map(({ federationPeer, ...track }) => ({
         ...track,
         source: track.origin === "FEDERATED" ? "federated" : "local",
+        ...(track.origin === "FEDERATED"
+            ? { streamSource: "peer" as const }
+            : {}),
         peer: federationPeer
             ? {
                   id: federationPeer.id,
@@ -395,38 +400,48 @@ export async function handleGetLikedTracks(req: Request, res: Response) {
                 }
               : { userId };
 
-    const [total, remoteTotal, userSettings, localEntries, remoteEntries] =
-        await Promise.all([
-            prisma.likedTrack.count({
-                where: { userId, track: TRACK_VISIBLE_WHERE },
-            }),
-            prisma.likedRemoteTrack.count({ where: { userId } }),
-            prisma.userSettings.findUnique({
-                where: { userId },
-                select: {
-                    tidalOAuthJson: true,
-                    ytMusicOAuthJson: true,
-                },
-            }),
-            prisma.likedTrack.findMany({
-                where: likedWhere,
-                select: {
-                    trackId: true,
-                    likedAt: true,
-                },
-                orderBy: [{ likedAt: "desc" }, { trackId: "asc" }],
-                take: fetchTake,
-            }),
-            prisma.likedRemoteTrack.findMany({
-                where: remoteWhere,
-                include: {
-                    trackTidal: true,
-                    trackYtMusic: true,
-                },
-                orderBy: [{ likedAt: "desc" }, { id: "asc" }],
-                take: fetchTake,
-            }),
-        ]);
+    const [
+        total,
+        remoteTotal,
+        userSettings,
+        localEntries,
+        remoteEntries,
+        systemSettings,
+    ] = await Promise.all([
+        prisma.likedTrack.count({
+            where: { userId, track: TRACK_VISIBLE_WHERE },
+        }),
+        prisma.likedRemoteTrack.count({ where: { userId } }),
+        prisma.userSettings.findUnique({
+            where: { userId },
+            select: {
+                tidalOAuthJson: true,
+                ytMusicOAuthJson: true,
+            },
+        }),
+        prisma.likedTrack.findMany({
+            where: likedWhere,
+            select: {
+                trackId: true,
+                likedAt: true,
+            },
+            orderBy: [{ likedAt: "desc" }, { trackId: "asc" }],
+            take: fetchTake,
+        }),
+        prisma.likedRemoteTrack.findMany({
+            where: remoteWhere,
+            include: {
+                trackTidal: true,
+                trackYtMusic: true,
+            },
+            orderBy: [{ likedAt: "desc" }, { id: "asc" }],
+            take: fetchTake,
+        }),
+        prisma.systemSettings.findUnique({
+            where: { id: "default" },
+            select: { playbackSourceOrder: true },
+        }),
+    ]);
 
     const hasTidal = hasConnectedProviderToken(userSettings?.tidalOAuthJson);
     const hasYtMusic = hasConnectedProviderToken(
@@ -638,10 +653,31 @@ export async function handleGetLikedTracks(req: Request, res: Response) {
         grouped.set(root, bucket);
     }
 
+    const sourceOrder = parsePlaybackSourceOrder(
+        (systemSettings as { playbackSourceOrder?: unknown } | null)
+            ?.playbackSourceOrder,
+    );
     const choosePriority = (entry: MergedEntry): number => {
-        if (entry.kind === "local") return 300;
-        if (entry.source === "tidal") return hasTidal ? 220 : 120;
-        return hasYtMusic ? 210 : 110;
+        if (entry.kind === "local") {
+            const track = localTrackById.get(entry.trackId);
+            const isPeer = track?.origin === "FEDERATED";
+            return rankPlaybackSource(
+                {
+                    source: isPeer ? "peers" : "library",
+                    available:
+                        !isPeer ||
+                        track?.federationPeer?.outboundStatus === "ACTIVE",
+                },
+                sourceOrder,
+            );
+        }
+        return rankPlaybackSource(
+            {
+                source: entry.source === "tidal" ? "tidal" : "ytmusic",
+                available: entry.source === "tidal" ? hasTidal : hasYtMusic,
+            },
+            sourceOrder,
+        );
     };
 
     const deduped = Array.from(grouped.values())
@@ -938,47 +974,6 @@ tracksBrowseRouter.get(
 /**
  * Handles GET /api/library/tracks/:id/stream.
  */
-async function streamFederatedTrack(
-    req: Request<{ id: string }>,
-    res: Response,
-    peer: {
-        id: string;
-        name: string;
-        baseUrl: string;
-        outboundToken: string;
-        outboundStatus: string | null;
-    },
-    remoteId: string,
-    trackId: string,
-    sourceModified: Date,
-    sourceMime: string | null,
-    requestedQuality: string,
-): Promise<Response | void> {
-    const quality = normalizeStreamingQuality(requestedQuality) ?? "medium";
-    try {
-        await proxyFederatedTrackStream({
-            req,
-            res,
-            peer,
-            remoteId,
-            trackId,
-            sourceModified,
-            sourceMime,
-            quality,
-        });
-        return undefined;
-    } catch (error: unknown) {
-        logger.warn("Federated stream proxy failed", { error });
-        if (res.headersSent) {
-            if (!res.writableEnded) res.end();
-            return undefined;
-        }
-        return sendRouteError(res, 503, "Federation peer is offline", {
-            code: "PEER_OFFLINE",
-        });
-    }
-}
-
 export async function handleStreamTrack(
     req: Request<{ id: string }>,
     res: Response,
@@ -993,7 +988,7 @@ export async function handleStreamTrack(
             return sendRouteError(res, 401, "Unauthorized");
         }
 
-        const track = await prisma.track.findUnique({
+        let track = await prisma.track.findUnique({
             where: { id: req.params.id, ...TRACK_VISIBLE_WHERE },
         });
 
@@ -1007,167 +1002,87 @@ export async function handleStreamTrack(
         const federationPeer = isFederatedTrack
             ? await loadActiveFederationStreamPeer(track.peerId)
             : null;
-        if (isFederatedTrack && (!federationPeer || !track.remoteId)) {
-            return sendRouteError(res, 503, "Federation peer is offline", {
-                code: "PEER_OFFLINE",
-            });
-        }
-
-        // Log play start - only if this is a new playback session
-        const recentPlay = await prisma.play.findFirst({
-            where: {
-                userId,
-                trackId: track.id,
-                playedAt: {
-                    gte: new Date(Date.now() - 30 * 1000),
-                },
-            },
-            orderBy: { playedAt: "desc" },
-        });
-
-        if (!recentPlay) {
-            await prisma.play.create({
-                data: {
-                    userId,
-                    trackId: track.id,
-                },
-            });
-            logger.debug("[STREAM] Logged new play for track:", track.title);
-        }
-
-        // Get user's quality preference
-        let requestedQuality: string = "medium";
-        if (quality) {
-            requestedQuality = quality as string;
-        } else {
-            const settings = await prisma.userSettings.findUnique({
-                where: { userId },
-            });
-            requestedQuality = settings?.playbackQuality || "medium";
-        }
-
-        const ext = track.filePath
-            ? path.extname(track.filePath).toLowerCase()
-            : "";
-        logger.debug(
-            `[STREAM] Quality: requested=${
-                quality || "default"
-            }, using=${requestedQuality}, format=${ext}`,
-        );
-
-        if (isFederatedTrack && federationPeer && track.remoteId) {
-            return streamFederatedTrack(
+        const canProxyPeer = Boolean(federationPeer && track.remoteId);
+        const requestedQuality = await resolveStreamQuality(userId, quality);
+        if (isFederatedTrack && !canProxyPeer) {
+            const fallbackTrack = await applyLibraryPeerFallback({
                 req,
                 res,
-                federationPeer,
-                track.remoteId,
-                track.id,
-                track.fileModified,
-                track.mime,
+                userId,
+                trackId: track.id,
+                quality: requestedQuality,
+            });
+            if (!fallbackTrack) return;
+            track = fallbackTrack;
+        }
+
+        await recordStreamPlay(userId, track.id, track.title);
+
+        if (canProxyPeer && federationPeer && track.remoteId) {
+            const served = await proxyLibraryPeerStream({
+                req,
+                res,
+                peer: federationPeer,
+                remoteId: track.remoteId,
+                trackId: track.id,
+                sourceModified: track.fileModified,
+                sourceMime: track.mime,
                 requestedQuality,
-            );
+            });
+            if (served) return;
         }
 
-        // === NATIVE FILE STREAMING ===
-        // Check if track has native file path
-        if (track.filePath && track.fileModified) {
-            const normalizedFilePath = track.filePath.replace(/\\/g, "/");
-            const absolutePath = safeResolvePath(
-                config.music.musicPath,
-                normalizedFilePath,
-            );
-            if (!absolutePath) {
-                logger.warn(
-                    `[STREAM] Rejected out-of-root file path for track ${track.id}`,
-                );
-                return sendRouteError(res, 404, "Track not available");
-            }
-
-            let streamingService: AudioStreamingService | null = null;
-
-            try {
-                // Initialize streaming service
-                streamingService = new AudioStreamingService(
-                    config.music.musicPath,
-                    config.music.transcodeCachePath,
-                    config.music.transcodeCacheMaxGb,
-                );
-
-                logger.debug(
-                    `[STREAM] Using native file: ${track.filePath} (${requestedQuality})`,
-                );
-
-                // Get stream file (either original or transcoded)
-                const { filePath, mimeType } =
-                    await streamingService.getStreamFilePath(
-                        track.id,
-                        requestedQuality as any,
-                        track.fileModified,
-                        absolutePath,
-                    );
-
-                // Stream file with range support
-                logger.debug(
-                    `[STREAM] Sending file: ${filePath}, mimeType: ${mimeType}`,
-                );
-
-                await streamingService.streamFileWithRangeSupport(
-                    req,
-                    res,
-                    filePath,
-                    mimeType,
-                );
-                logger.debug(
-                    `[STREAM] File sent successfully: ${path.basename(
-                        filePath,
-                    )}`,
-                );
-
-                return;
-            } catch (err: any) {
-                // If FFmpeg not found, try original quality instead
-                if (
-                    err.code === "FFMPEG_NOT_FOUND" &&
-                    requestedQuality !== "original" &&
-                    streamingService !== null
-                ) {
-                    logger.warn(
-                        `[STREAM] FFmpeg not available, falling back to original quality`,
-                    );
-
-                    const { filePath, mimeType } =
-                        await streamingService.getStreamFilePath(
-                            track.id,
-                            "original",
-                            track.fileModified,
-                            absolutePath,
-                        );
-
-                    await streamingService.streamFileWithRangeSupport(
-                        req,
-                        res,
-                        filePath,
-                        mimeType,
-                    );
-                    return;
-                }
-
-                logger.error("[STREAM] Native streaming failed:", err.message);
-                return res
-                    .status(500)
-                    .json({ error: "Failed to stream track" });
-            } finally {
-                streamingService?.destroy();
-            }
+        if (canProxyPeer) {
+            const fallbackTrack = await applyLibraryPeerFallback({
+                req,
+                res,
+                userId,
+                trackId: track.id,
+                quality: requestedQuality,
+            });
+            if (!fallbackTrack) return;
+            track = fallbackTrack;
         }
 
-        // No file path available
-        logger.debug("[STREAM] Track has no file path - unavailable");
-        return sendRouteError(res, 404, "Track not available");
+        return serveNativeLibraryTrack({
+            req,
+            res,
+            track,
+            requestedQuality,
+        });
     } catch (error) {
         logger.error("Stream track error:", error);
         sendInternalRouteError(res, "Failed to stream track");
     }
+}
+
+async function recordStreamPlay(
+    userId: string,
+    trackId: string,
+    title: string,
+): Promise<void> {
+    const recent = await prisma.play.findFirst({
+        where: {
+            userId,
+            trackId,
+            playedAt: { gte: new Date(Date.now() - 30 * 1000) },
+        },
+        orderBy: { playedAt: "desc" },
+    });
+    if (recent) return;
+    await prisma.play.create({ data: { userId, trackId } });
+    logger.debug("[STREAM] Logged new play for track:", title);
+}
+
+async function resolveStreamQuality(
+    userId: string,
+    requested: unknown,
+): Promise<string> {
+    if (typeof requested === "string") return requested;
+    const settings = await prisma.userSettings.findUnique({
+        where: { userId },
+    });
+    return settings?.playbackQuality || "medium";
 }
 
 tracksStreamRouter.get("/tracks/:id/stream", handleStreamTrack);
@@ -1496,6 +1411,9 @@ export async function handleGetTrack(
         loudnessLufs: track.loudnessLufs,
         truePeakDb: track.truePeakDb,
         source: normalizedTrack.source,
+        ...(normalizedTrack.source === "federated"
+            ? { streamSource: "peer" as const }
+            : {}),
         ...(normalizedTrack.peer ? { peer: normalizedTrack.peer } : {}),
     };
 

--- a/backend/src/routes/plays.ts
+++ b/backend/src/routes/plays.ts
@@ -564,5 +564,8 @@ const toHistoryTrackShape = (
             youtubeVideoId: normalized.provider.youtubeVideoId,
         };
     }
+    if (normalized.source === "federated") {
+        return { ...base, streamSource: "peer" as const };
+    }
     return base;
 };

--- a/backend/src/routes/subsonic/mediaRetrieval.ts
+++ b/backend/src/routes/subsonic/mediaRetrieval.ts
@@ -31,6 +31,13 @@ import {
     type ResponseFormat,
 } from "../../utils/subsonicResponse";
 import { AppError, ErrorCode } from "../../utils/errors";
+import { loadPeerPlaybackFallback } from "../../services/peerPlaybackFallback";
+import {
+    isMappedProviderResponseUnusable,
+    mappedProviderResponseState,
+    serveMappedProviderStream,
+    terminateCommittedStream,
+} from "../../services/mappedProviderStream";
 import {
     DEFAULT_SUBSONIC_AVATAR_PNG,
     fetchCoverArtBuffer,
@@ -481,9 +488,9 @@ async function proxySubsonicFederatedStream(input: {
     quality: Quality;
     format: ResponseFormat;
     callback?: string;
-}): Promise<boolean> {
+}): Promise<"not-peer" | "served" | "failed"> {
     const { track, res } = input;
-    if (track.origin !== "FEDERATED") return false;
+    if (track.origin !== "FEDERATED") return "not-peer";
     const peer = track.federationPeer;
     if (
         !track.remoteId ||
@@ -492,14 +499,7 @@ async function proxySubsonicFederatedStream(input: {
         !peer.baseUrl ||
         !peer.outboundToken
     ) {
-        sendSubsonicError(
-            res,
-            SubsonicErrorCode.GENERIC,
-            "Federation peer is offline",
-            input.format,
-            input.callback,
-        );
-        return true;
+        return "failed";
     }
     try {
         await proxyFederatedTrackStream({
@@ -512,21 +512,70 @@ async function proxySubsonicFederatedStream(input: {
             sourceMime: track.mime,
             quality: input.quality,
         });
+        return "served";
     } catch (error: unknown) {
         log.warn("Federated stream proxy failed", { error });
-        if (!res.headersSent) {
-            sendSubsonicError(
-                res,
-                SubsonicErrorCode.GENERIC,
-                "Federation peer is offline",
-                input.format,
-                input.callback,
+        const state = mappedProviderResponseState(res);
+        if (!isMappedProviderResponseUnusable(state)) {
+            return "failed";
+        }
+        if (!state.destroyed && !state.writableEnded) {
+            terminateCommittedStream(res);
+        }
+        return "served";
+    }
+}
+
+async function serveSubsonicPeerFallback(input: {
+    req: Request;
+    res: Response;
+    trackId: string;
+    quality: Quality;
+    timeOffsetSeconds: number;
+}): Promise<boolean> {
+    const fallbacks = await loadPeerPlaybackFallback(input.trackId);
+    let youtubeUserId: string | undefined;
+    for (let index = 0; index < 3; index += 1) {
+        const fallback = fallbacks[index];
+        if (!fallback) break;
+        if (fallback.source === "library") {
+            const localTrack = await loadSubsonicStreamTrack(fallback.trackId);
+            if (!localTrack) continue;
+            const result = await serveLocalSubsonicStream({
+                ...input,
+                track: localTrack,
+            });
+            if (result === "served") return true;
+            continue;
+        }
+        const userId = input.req.user!.id;
+        if (fallback.source === "ytmusic" && youtubeUserId === undefined) {
+            youtubeUserId = await import("../youtubeMusic").then((mod) =>
+                mod.getUserIdOrPublic(userId),
             );
-        } else if (!res.writableEnded) {
-            res.end();
+        }
+        const result = await serveMappedProviderStream({
+            req: input.req,
+            res: input.res,
+            userId,
+            youtubeUserId,
+            quality: input.quality,
+            fallback,
+        });
+        if (result.status === "served") return true;
+        if (result.status !== "failed") continue;
+        log.warn("Mapped peer fallback failed", { error: result.error });
+        if (isMappedProviderResponseUnusable(result.responseState)) {
+            if (
+                !result.responseState.destroyed &&
+                !result.responseState.writableEnded
+            ) {
+                terminateCommittedStream(input.res);
+            }
+            return true;
         }
     }
-    return true;
+    return false;
 }
 
 type StreamRequest = {
@@ -583,11 +632,11 @@ async function executeStreamRequest(
     }
 
     if (
-        await proxySubsonicFederatedStream({
+        await handleSubsonicPeerPlayback({
             req,
             res,
             track,
-            quality: request.quality,
+            request,
             format,
             callback,
         })
@@ -613,6 +662,56 @@ async function executeStreamRequest(
     }
 }
 
+async function handleSubsonicPeerPlayback(input: {
+    req: Request;
+    res: Response;
+    track: SubsonicStreamTrack;
+    request: StreamRequest;
+    format: ResponseFormat;
+    callback?: string;
+}): Promise<boolean> {
+    const peerResult = await proxySubsonicFederatedStream({
+        req: input.req,
+        res: input.res,
+        track: input.track,
+        quality: input.request.quality,
+        format: input.format,
+        callback: input.callback,
+    });
+    if (peerResult === "served") return true;
+    if (peerResult === "failed") {
+        try {
+            if (
+                await serveSubsonicPeerFallback({
+                    req: input.req,
+                    res: input.res,
+                    trackId: input.track.id,
+                    quality: input.request.quality,
+                    timeOffsetSeconds: input.request.timeOffsetSeconds,
+                })
+            ) {
+                return true;
+            }
+        } catch (error) {
+            log.warn("Peer fallback ladder failed", { error });
+        }
+        const state = mappedProviderResponseState(input.res);
+        if (!isMappedProviderResponseUnusable(state)) {
+            sendSubsonicError(
+                input.res,
+                SubsonicErrorCode.GENERIC,
+                "Federation peer is offline",
+                input.format,
+                input.callback,
+            );
+        } else if (!state.destroyed && !state.writableEnded) {
+            terminateCommittedStream(input.res);
+        }
+        return true;
+    }
+    return false;
+}
+
 /** Executes handleStream. */
 export async function handleStream(req: Request, res: Response): Promise<void> {
     const { format, callback } = getRequestContext(req);
@@ -629,6 +728,8 @@ export async function handleStream(req: Request, res: Response): Promise<void> {
                 format,
                 callback,
             );
+        } else {
+            terminateCommittedStream(res);
         }
     }
 }

--- a/backend/src/routes/subsonic/mediaRetrieval.ts
+++ b/backend/src/routes/subsonic/mediaRetrieval.ts
@@ -564,7 +564,7 @@ async function serveSubsonicPeerFallback(input: {
         });
         if (result.status === "served") return true;
         if (result.status !== "failed") continue;
-        log.warn("Mapped peer fallback failed", { error: result.error });
+        log.warn("Mapped peer fallback failed", { error: result.failure });
         if (isMappedProviderResponseUnusable(result.responseState)) {
             if (
                 !result.responseState.destroyed &&

--- a/backend/src/routes/subsonic/mediaRetrieval.ts
+++ b/backend/src/routes/subsonic/mediaRetrieval.ts
@@ -798,16 +798,25 @@ export async function handleDownload(
             return;
         }
 
-        if (
-            await proxySubsonicFederatedStream({
-                req,
+        const peerResult = await proxySubsonicFederatedStream({
+            req,
+            res,
+            track,
+            quality: "original",
+            format,
+            callback,
+        });
+        if (peerResult === "served") {
+            return;
+        }
+        if (peerResult === "failed") {
+            sendSubsonicError(
                 res,
-                track,
-                quality: "original",
+                SubsonicErrorCode.NOT_FOUND,
+                "Song not found",
                 format,
                 callback,
-            })
-        ) {
+            );
             return;
         }
 

--- a/backend/src/routes/systemSettings.ts
+++ b/backend/src/routes/systemSettings.ts
@@ -5,7 +5,6 @@ import { prisma } from "../utils/db";
 import { z } from "zod";
 import { EnvFileSyncSkippedError, writeEnvFile } from "../utils/envWriter";
 import { invalidateSystemSettingsCache } from "../utils/systemSettings";
-import { schedulerQueue } from "../workers/queues";
 import { encrypt, decrypt } from "../utils/encryption";
 import { ENCRYPTED_SETTINGS_COLUMNS } from "../utils/encryptedColumns";
 import { BRAND_NAME, BRAND_SLUG } from "../config/brand";
@@ -13,73 +12,22 @@ import { normalizeSafeOutboundUrl } from "../services/outboundUrlSafety";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import { config } from "../config";
 import { federationInstanceNameSchema } from "./systemSettingsFederationSchema";
+import { isPlaybackSourceOrder } from "../services/playbackSourcePriority";
+import { invalidateUserProviderProfileCache } from "../services/listenTogetherResolution";
+import {
+    cancelQueuedQueueCleanerWorkerJob,
+    enqueueQueueCleanerWorkerJob,
+    getQueueCleanerWorkerStatus,
+    idleQueueCleanerWorkerStatus,
+    loadQueueCleanerWorkerStatus,
+    queueCleanerLog,
+} from "../services/systemSettingsQueueCleaner";
 
 const router = Router();
 const WEBHOOK_NAME_ALIASES = [BRAND_NAME];
 const WEBHOOK_URL_ALIASES = [BRAND_SLUG];
-const QUEUE_CLEANER_JOB_NAME = "download-reconciliation-cycle";
-const QUEUE_CLEANER_JOB_ID = "scheduler:reconciliation:on-demand";
-const queueCleanerLog = logger.child("SystemSettingsQueueCleaner");
 // Shared validation message for admin outbound connection-test URLs.
 const ADMIN_TEST_URL_ERROR = "URL must be a valid public HTTP(S) URL";
-
-type QueueCleanerWorkerStatus = {
-    running: boolean;
-    queued: boolean;
-    state: string;
-    jobId: string | null;
-    workerOwned: true;
-};
-
-function idleQueueCleanerWorkerStatus(): QueueCleanerWorkerStatus {
-    return {
-        running: false,
-        queued: false,
-        state: "idle",
-        jobId: null,
-        workerOwned: true,
-    };
-}
-
-async function getQueueCleanerWorkerStatus(
-    job: Awaited<ReturnType<typeof schedulerQueue.getJob>>,
-): Promise<QueueCleanerWorkerStatus> {
-    if (!job) return idleQueueCleanerWorkerStatus();
-
-    const state = await job.getState();
-    return {
-        running: state === "active",
-        queued: ["waiting", "delayed", "paused"].includes(state),
-        state,
-        jobId: String(job.id),
-        workerOwned: true,
-    };
-}
-
-async function enqueueQueueCleanerWorkerJob() {
-    return schedulerQueue.add(
-        QUEUE_CLEANER_JOB_NAME,
-        { mode: "repeat", source: "system-settings" },
-        {
-            jobId: QUEUE_CLEANER_JOB_ID,
-            removeOnComplete: true,
-            removeOnFail: 10,
-        },
-    );
-}
-
-async function cancelQueuedQueueCleanerWorkerJob(): Promise<
-    "absent" | "active" | "cancelled"
-> {
-    const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
-    if (!job) return "absent";
-
-    const status = await getQueueCleanerWorkerStatus(job);
-    if (status.running) return "active";
-
-    await job.remove();
-    return "cancelled";
-}
 
 function normalizeAdminTestUrl(url: string): string | null {
     // Deliberately the STRING check only (no DNS resolution): admin connection
@@ -153,6 +101,10 @@ const systemSettingsSchema = z.object({
 
     downloadSource: z
         .enum(["soulseek", "lidarr", "tidal", "youtube"])
+        .optional(),
+    playbackSourceOrder: z
+        .string()
+        .refine(isPlaybackSourceOrder, "Invalid playback source order")
         .optional(),
     primaryFailureFallback: z
         .enum(["none", "lidarr", "soulseek", "tidal", "youtube"])
@@ -374,6 +326,7 @@ router.post("/", async (req, res) => {
         });
 
         invalidateSystemSettingsCache();
+        invalidateUserProviderProfileCache();
 
         // Effective plaintext secret after the no-change/clear semantics
         // above: a non-empty submitted value wins, an empty string falls
@@ -1377,8 +1330,7 @@ router.post("/tidal-auth/token", async (req, res) => {
 // Get queue cleaner worker-job status from the shared scheduler queue.
 router.get("/queue-cleaner-status", async (req, res) => {
     try {
-        const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
-        res.json(await getQueueCleanerWorkerStatus(job));
+        res.json(await loadQueueCleanerWorkerStatus());
     } catch (error) {
         queueCleanerLog.error(
             "Failed to read queue cleaner worker status",

--- a/backend/src/routes/youtubeMusic.ts
+++ b/backend/src/routes/youtubeMusic.ts
@@ -411,7 +411,7 @@ async function requireUserOAuth(
  * stream-info, stream) so the admin toggle alone unlocks all core YT Music
  * functionality.
  */
-async function getUserIdOrPublic(userId: string): Promise<string> {
+export async function getUserIdOrPublic(userId: string): Promise<string> {
     const hasOAuth = await ensureUserOAuth(userId);
     return hasOAuth ? userId : "__public__";
 }

--- a/backend/src/services/__tests__/federatedTrackPayload.test.ts
+++ b/backend/src/services/__tests__/federatedTrackPayload.test.ts
@@ -1,0 +1,22 @@
+import { withFederatedTrackPlayback } from "../federatedTrackPayload";
+
+describe("federated track playback payload", () => {
+    it("adds peer stream source and persisted health provenance", () => {
+        expect(
+            withFederatedTrackPlayback(
+                { id: "track-1", origin: "FEDERATED" },
+                {
+                    id: "peer-1",
+                    name: "Peer One",
+                    outboundStatus: "ACTIVE",
+                },
+            ),
+        ).toEqual({
+            id: "track-1",
+            origin: "FEDERATED",
+            source: "federated",
+            streamSource: "peer",
+            peer: { id: "peer-1", name: "Peer One", online: true },
+        });
+    });
+});

--- a/backend/src/services/__tests__/listenTogether.test.ts
+++ b/backend/src/services/__tests__/listenTogether.test.ts
@@ -41,6 +41,9 @@ describe("listenTogether service", () => {
             track: {
                 findMany: jest.fn(),
             },
+            trackMapping: {
+                findMany: jest.fn(async () => []),
+            },
             user: {
                 findUnique: jest.fn(),
                 updateMany: jest.fn(async () => ({ count: 1 })),
@@ -268,7 +271,6 @@ describe("listenTogether service", () => {
                 },
             },
         ]);
-
         const tx = {
             user: {
                 updateMany: jest.fn(async () => ({ count: 1 })),
@@ -366,6 +368,48 @@ describe("listenTogether service", () => {
             playback: {},
             members: [],
         });
+    });
+
+    it("serializes a federated queue row as peer media", async () => {
+        const { listenTogether, prisma } = loadService();
+        prisma.track.findMany.mockResolvedValueOnce([
+            {
+                id: "peer-track-1",
+                title: "Peer Track",
+                duration: 180,
+                filePath: null,
+                origin: "FEDERATED",
+                loudnessLufs: null,
+                truePeakDb: null,
+                federationPeer: { outboundStatus: "ACTIVE" },
+                album: {
+                    id: "album-1",
+                    title: "Album",
+                    coverUrl: null,
+                    albumLoudnessLufs: null,
+                    albumTruePeakDb: null,
+                    artist: { id: "artist-1", name: "Artist" },
+                },
+            },
+        ]);
+        prisma.trackMapping.findMany.mockResolvedValueOnce([
+            { id: "mapping-1", trackId: "peer-track-1" },
+        ]);
+
+        const queue = await listenTogether.validateQueueTracks([
+            { trackId: "peer-track-1" },
+        ]);
+
+        expect(JSON.parse(JSON.stringify(queue))).toEqual([
+            expect.objectContaining({
+                id: "peer-track-1",
+                mediaSource: "peer",
+                provider: { source: "peer" },
+                originSource: "peer",
+                peerOnline: true,
+                trackMappingId: "mapping-1",
+            }),
+        ]);
     });
 
     it("rejects group creation while the user is pending deletion", async () => {
@@ -2353,6 +2397,10 @@ describe("listenTogether service", () => {
                     id: "track-1",
                     title: "Track 1",
                     duration: 120,
+                    mediaSource: "peer",
+                    streamSource: "peer",
+                    originSource: "peer",
+                    peerOnline: true,
                     artist: { id: "artist-1", name: "Artist 1" },
                     album: {
                         id: "album-1",
@@ -2399,6 +2447,9 @@ describe("listenTogether service", () => {
                 queue: [
                     expect.objectContaining({
                         id: "track-1",
+                        mediaSource: "peer",
+                        originSource: "peer",
+                        peerOnline: true,
                     }),
                 ],
                 members: [

--- a/backend/src/services/__tests__/listenTogetherResolution.test.ts
+++ b/backend/src/services/__tests__/listenTogetherResolution.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../utils/db", () => ({
 
 import {
     getUserProviderProfile,
+    invalidateUserProviderProfileCache,
     resolveTrackForUser,
 } from "../listenTogetherResolution";
 import type { SyncQueueItem } from "../listenTogetherManager";
@@ -44,6 +45,7 @@ function queueItem(overrides: Partial<SyncQueueItem> = {}): SyncQueueItem {
 describe("listenTogetherResolution", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        invalidateUserProviderProfileCache();
         mockPrisma.systemSettings.findUnique.mockResolvedValue({
             ytMusicEnabled: true,
         });
@@ -102,6 +104,123 @@ describe("listenTogetherResolution", () => {
             source: "youtube",
             youtubeVideoId: "vid-1",
             trackYtMusicId: "yt-1",
+        });
+    });
+
+    it("ranks an offline peer below an available TIDAL mapping", async () => {
+        const profile = {
+            userId: "user-1",
+            hasLocal: true as const,
+            hasTidal: true,
+            hasYtMusic: true,
+        };
+        const mapping = {
+            id: "map-peer",
+            stale: false,
+            confidence: 0.92,
+            trackId: "peer-track-1",
+            track: {
+                origin: "FEDERATED" as const,
+                federationPeer: { outboundStatus: "OFFLINE" as const },
+            },
+            trackTidal: { id: "tt-1", tidalId: 123, duration: 180 },
+            trackYtMusic: { id: "yt-1", videoId: "vid-1", duration: 180 },
+        };
+
+        const resolved = await resolveTrackForUser(
+            queueItem({
+                localTrackId: "peer-track-1",
+                trackMappingId: "map-peer",
+                originSource: "peer",
+                peerOnline: false,
+            }),
+            profile,
+            { mappingsById: new Map([["map-peer", mapping]]) },
+        );
+
+        expect(resolved).toEqual({
+            available: true,
+            source: "tidal",
+            tidalTrackId: 123,
+            trackTidalId: "tt-1",
+        });
+    });
+
+    it("ranks an online peer above an available TIDAL mapping by default", async () => {
+        const profile = {
+            userId: "user-1",
+            hasLocal: true as const,
+            hasTidal: true,
+            hasYtMusic: true,
+        };
+        const mapping = {
+            id: "map-peer-online",
+            stale: false,
+            confidence: 0.92,
+            trackId: "peer-track-1",
+            track: {
+                origin: "FEDERATED" as const,
+                federationPeer: { outboundStatus: "ACTIVE" as const },
+            },
+            trackTidal: { id: "tt-1", tidalId: 123, duration: 180 },
+            trackYtMusic: null,
+        };
+
+        const resolved = await resolveTrackForUser(
+            queueItem({
+                localTrackId: "peer-track-1",
+                trackMappingId: "map-peer-online",
+                originSource: "peer",
+                peerOnline: true,
+            }),
+            profile,
+            { mappingsById: new Map([["map-peer-online", mapping]]) },
+        );
+
+        expect(resolved).toEqual({
+            available: true,
+            source: "local",
+            trackId: "peer-track-1",
+        });
+    });
+
+    it("honors the configured source order for mapped peer candidates", async () => {
+        const profile = {
+            userId: "user-1",
+            hasLocal: true as const,
+            hasTidal: true,
+            hasYtMusic: true,
+            playbackSourceOrder: "tidal,peers,library,ytmusic",
+        };
+        const mapping = {
+            id: "map-override",
+            stale: false,
+            confidence: 0.92,
+            trackId: "peer-track-1",
+            track: {
+                origin: "FEDERATED" as const,
+                federationPeer: { outboundStatus: "ACTIVE" as const },
+            },
+            trackTidal: { id: "tt-1", tidalId: 123, duration: 180 },
+            trackYtMusic: null,
+        };
+
+        const resolved = await resolveTrackForUser(
+            queueItem({
+                localTrackId: "peer-track-1",
+                trackMappingId: "map-override",
+                originSource: "peer",
+                peerOnline: true,
+            }),
+            profile,
+            { mappingsById: new Map([["map-override", mapping]]) },
+        );
+
+        expect(resolved).toEqual({
+            available: true,
+            source: "tidal",
+            tidalTrackId: 123,
+            trackTidalId: "tt-1",
         });
     });
 
@@ -314,5 +433,33 @@ describe("listenTogetherResolution", () => {
             hasTidal: true,
             hasYtMusic: false,
         });
+    });
+
+    it("reads an updated playback order immediately after invalidation", async () => {
+        mockPrisma.userSettings.findUnique.mockResolvedValue({
+            tidalOAuthJson: "tidal-token",
+        });
+        mockPrisma.systemSettings.findUnique
+            .mockResolvedValueOnce({
+                ytMusicEnabled: true,
+                playbackSourceOrder: "library,peers,tidal,ytmusic",
+            })
+            .mockResolvedValueOnce({
+                ytMusicEnabled: true,
+                playbackSourceOrder: "ytmusic,tidal,peers,library",
+            });
+
+        await expect(getUserProviderProfile("user-cache")).resolves.toEqual(
+            expect.objectContaining({
+                playbackSourceOrder: "library,peers,tidal,ytmusic",
+            }),
+        );
+        invalidateUserProviderProfileCache();
+        await expect(getUserProviderProfile("user-cache")).resolves.toEqual(
+            expect.objectContaining({
+                playbackSourceOrder: "ytmusic,tidal,peers,library",
+            }),
+        );
+        expect(mockPrisma.systemSettings.findUnique).toHaveBeenCalledTimes(2);
     });
 });

--- a/backend/src/services/__tests__/listenTogetherStateStore.test.ts
+++ b/backend/src/services/__tests__/listenTogetherStateStore.test.ts
@@ -1,5 +1,142 @@
 import { DeterministicRedisServer } from "./support/deterministicRedis";
 
+function previousIsRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function previousIsFiniteNumber(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value);
+}
+
+function previousIsOptionalString(value: unknown): boolean {
+    return value === undefined || typeof value === "string";
+}
+
+function previousIsOptionalNumberOrNull(value: unknown): boolean {
+    return (
+        value === undefined || value === null || previousIsFiniteNumber(value)
+    );
+}
+
+function previousIsMediaSource(value: unknown): boolean {
+    return (
+        value === "local" ||
+        value === "tidal" ||
+        value === "youtube" ||
+        value === "youtube-direct"
+    );
+}
+
+function previousAcceptsProvider(value: unknown): boolean {
+    if (value === undefined) return true;
+    if (!previousIsRecord(value) || !previousIsMediaSource(value.source)) {
+        return false;
+    }
+    return (
+        previousIsOptionalString(value.providerTrackId) &&
+        (value.tidalTrackId === undefined ||
+            previousIsFiniteNumber(value.tidalTrackId)) &&
+        previousIsOptionalString(value.youtubeVideoId) &&
+        (value.youtubeAudioFormat === undefined ||
+            value.youtubeAudioFormat === "mp4" ||
+            value.youtubeAudioFormat === "webm")
+    );
+}
+
+function previousReleaseAcceptsQueueItem(value: unknown): boolean {
+    if (
+        !previousIsRecord(value) ||
+        !previousIsRecord(value.artist) ||
+        !previousIsRecord(value.album)
+    ) {
+        return false;
+    }
+    const validSources =
+        (value.mediaSource === undefined ||
+            previousIsMediaSource(value.mediaSource)) &&
+        (value.streamSource === undefined ||
+            (previousIsMediaSource(value.streamSource) &&
+                value.streamSource !== "local")) &&
+        (value.originSource === undefined ||
+            value.originSource === "local" ||
+            value.originSource === "tidal" ||
+            value.originSource === "youtube");
+    return (
+        typeof value.id === "string" &&
+        typeof value.title === "string" &&
+        previousIsFiniteNumber(value.duration) &&
+        value.duration >= 0 &&
+        previousIsOptionalNumberOrNull(value.loudnessLufs) &&
+        previousIsOptionalNumberOrNull(value.truePeakDb) &&
+        typeof value.artist.id === "string" &&
+        typeof value.artist.name === "string" &&
+        typeof value.album.id === "string" &&
+        typeof value.album.title === "string" &&
+        (value.album.coverArt === null ||
+            typeof value.album.coverArt === "string") &&
+        previousIsOptionalNumberOrNull(value.album.albumLoudnessLufs) &&
+        previousIsOptionalNumberOrNull(value.album.albumTruePeakDb) &&
+        validSources &&
+        previousAcceptsProvider(value.provider) &&
+        previousIsOptionalString(value.localTrackId) &&
+        previousIsOptionalString(value.trackTidalId) &&
+        previousIsOptionalString(value.trackYtMusicId) &&
+        previousIsOptionalString(value.trackMappingId) &&
+        (value.tidalTrackId === undefined ||
+            previousIsFiniteNumber(value.tidalTrackId)) &&
+        previousIsOptionalString(value.youtubeVideoId) &&
+        (value.youtubeAudioFormat === undefined ||
+            value.youtubeAudioFormat === "mp4" ||
+            value.youtubeAudioFormat === "webm")
+    );
+}
+
+function previousReleaseAcceptsSnapshot(value: unknown): boolean {
+    if (!previousIsRecord(value) || !previousIsRecord(value.playback)) {
+        return false;
+    }
+    const playback = value.playback;
+    if (
+        !Array.isArray(playback.queue) ||
+        playback.queue.length > 500 ||
+        !playback.queue.every(previousReleaseAcceptsQueueItem)
+    ) {
+        return false;
+    }
+    const index = playback.currentIndex;
+    const validIndex =
+        Number.isSafeInteger(index) &&
+        (index as number) >= 0 &&
+        (playback.queue.length === 0
+            ? index === 0
+            : (index as number) < playback.queue.length);
+    return (
+        typeof value.id === "string" &&
+        typeof value.name === "string" &&
+        typeof value.joinCode === "string" &&
+        (value.groupType === "host-follower" ||
+            value.groupType === "collaborative") &&
+        (value.visibility === "public" || value.visibility === "private") &&
+        typeof value.isActive === "boolean" &&
+        typeof value.hostUserId === "string" &&
+        (value.syncState === "idle" ||
+            value.syncState === "waiting" ||
+            value.syncState === "playing" ||
+            value.syncState === "paused") &&
+        Array.isArray(value.members) &&
+        value.members.length <= 10_000 &&
+        validIndex &&
+        typeof playback.isPlaying === "boolean" &&
+        previousIsFiniteNumber(playback.positionMs) &&
+        playback.positionMs >= 0 &&
+        previousIsFiniteNumber(playback.serverTime) &&
+        playback.serverTime >= 0 &&
+        Number.isSafeInteger(playback.stateVersion) &&
+        (playback.stateVersion as number) >= 0 &&
+        (playback.trackId === null || typeof playback.trackId === "string")
+    );
+}
+
 describe("listenTogetherStateStore", () => {
     afterEach(() => {
         jest.resetModules();
@@ -131,6 +268,87 @@ describe("listenTogetherStateStore", () => {
             "34567",
             "17",
         ]);
+    });
+
+    it("accepts peer playback source metadata in persisted queue items", async () => {
+        const loaded = loadStateStore();
+        const value = snapshot();
+        value.playback.queue = [
+            {
+                id: "peer-track-1",
+                title: "Peer Song",
+                duration: 180,
+                artist: { id: "artist-1", name: "Artist" },
+                album: { id: "album-1", title: "Album", coverArt: null },
+                mediaSource: "peer",
+                streamSource: "peer",
+                originSource: "peer",
+                peerOnline: true,
+            } as never,
+        ];
+        loaded.server.write(
+            "listen-together:state:group-1",
+            JSON.stringify(value),
+        );
+
+        await expect(
+            loaded.listenTogetherStateStore.getSnapshot("group-1"),
+        ).resolves.toEqual(value);
+    });
+
+    it("writes peer snapshots in the previous release shape and restores peer origin", async () => {
+        const loaded = loadStateStore();
+        const value = snapshot();
+        value.playback.queue = [
+            {
+                id: "peer-track-1",
+                title: "Peer Song",
+                duration: 180,
+                artist: { id: "artist-1", name: "Artist" },
+                album: { id: "album-1", title: "Album", coverArt: null },
+                mediaSource: "peer",
+                provider: { source: "peer" },
+                streamSource: "peer",
+                originSource: "peer",
+                peerOnline: true,
+            } as never,
+        ];
+
+        await loaded.listenTogetherStateStore.setSnapshot(
+            "group-1",
+            value as never,
+        );
+
+        const write = loaded.server.commandLog.find(
+            (command) =>
+                command.name === "EVAL" &&
+                String(command.args[0]).includes(
+                    "listen-together:set-snapshot-if-current",
+                ),
+        );
+        const persisted = JSON.parse(String(write?.args[5])) as any;
+        expect(previousReleaseAcceptsSnapshot(persisted)).toBe(true);
+        expect(persisted.playback.queue[0]).toMatchObject({
+            mediaSource: "local",
+            provider: { source: "local" },
+            originSource: "local",
+            actualOriginSource: "peer",
+        });
+        expect(persisted.playback.queue[0].streamSource).toBeUndefined();
+        await expect(
+            loaded.listenTogetherStateStore.getSnapshot("group-1"),
+        ).resolves.toMatchObject({
+            playback: {
+                queue: [
+                    {
+                        mediaSource: "peer",
+                        provider: { source: "peer" },
+                        streamSource: "peer",
+                        originSource: "peer",
+                    },
+                ],
+            },
+        });
     });
 
     it("rejects malformed JSON as transient and suppresses repeat warnings", async () => {

--- a/backend/src/services/__tests__/mappedProviderStream.test.ts
+++ b/backend/src/services/__tests__/mappedProviderStream.test.ts
@@ -1,0 +1,106 @@
+import { Readable, Writable } from "node:stream";
+import type { Request, Response } from "express";
+
+const mockTidalStream = jest.fn();
+const mockYtMusicStream = jest.fn();
+
+jest.mock("../tidalStreaming", () => ({
+    tidalStreamingService: { getStreamProxy: mockTidalStream },
+}));
+jest.mock("../youtubeMusic", () => ({
+    ytMusicService: { getStreamProxy: mockYtMusicStream },
+}));
+
+import { serveMappedProviderStream } from "../mappedProviderStream";
+
+function responseSink(): Response {
+    const sink = new Writable({
+        write(_chunk, _encoding, callback) {
+            callback();
+        },
+    }) as Writable & Partial<Response>;
+    sink.headersSent = false;
+    sink.status = jest.fn(() => sink as unknown as Response);
+    sink.setHeader = jest.fn();
+    return sink as unknown as Response;
+}
+
+function failingBody(res: Response, afterBytes: boolean): Readable {
+    let read = false;
+    return new Readable({
+        read() {
+            if (read) return;
+            read = true;
+            if (afterBytes) {
+                (res as Response & { headersSent: boolean }).headersSent = true;
+                this.push(Buffer.from("audio"));
+            }
+            this.destroy(new Error("upstream body failed"));
+        },
+    });
+}
+
+describe("mapped provider stream", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it.each([false, true])(
+        "reports a destroyed response when the body fails afterBytes=%s",
+        async (afterBytes) => {
+            const res = responseSink();
+            mockTidalStream.mockResolvedValueOnce({
+                status: 200,
+                headers: { "content-type": "audio/flac" },
+                data: failingBody(res, afterBytes),
+            });
+
+            const result = await serveMappedProviderStream({
+                req: { headers: {} } as Request,
+                res,
+                userId: "user-1",
+                quality: "high",
+                fallback: { source: "tidal", tidalTrackId: 42 },
+            });
+
+            expect(result).toMatchObject({
+                status: "failed",
+                responseState: {
+                    headersSent: afterBytes,
+                    destroyed: true,
+                },
+            });
+            expect(mockTidalStream).toHaveBeenCalledWith(
+                "user-1",
+                42,
+                "high",
+                undefined,
+            );
+        },
+    );
+
+    it("passes the selected YouTube identity and quality", async () => {
+        const res = responseSink();
+        mockYtMusicStream.mockResolvedValueOnce({
+            status: 200,
+            headers: {},
+            data: Readable.from([Buffer.from("audio")]),
+        });
+
+        await serveMappedProviderStream({
+            req: { headers: { range: "bytes=0-99" } } as Request,
+            res,
+            userId: "user-1",
+            youtubeUserId: "oauth-user-1",
+            quality: "low",
+            fallback: { source: "ytmusic", youtubeVideoId: "video-1" },
+        });
+
+        expect(mockYtMusicStream).toHaveBeenCalledWith(
+            "oauth-user-1",
+            "video-1",
+            "low",
+            "bytes=0-99",
+        );
+    });
+});

--- a/backend/src/services/__tests__/peerPlaybackFallback.test.ts
+++ b/backend/src/services/__tests__/peerPlaybackFallback.test.ts
@@ -1,0 +1,113 @@
+const mockTrackFindUnique = jest.fn();
+const mockTrackMappingFindMany = jest.fn();
+const mockSystemSettingsFindUnique = jest.fn();
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: { findUnique: mockTrackFindUnique },
+        trackMapping: { findMany: mockTrackMappingFindMany },
+        systemSettings: { findUnique: mockSystemSettingsFindUnique },
+    },
+}));
+
+import {
+    choosePeerPlaybackFallback,
+    loadPeerPlaybackFallback,
+} from "../peerPlaybackFallback";
+
+describe("peer playback fallback ladder", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockTrackFindUnique.mockResolvedValue({
+            dedupOfTrackId: null,
+            duration: 180,
+        });
+        mockSystemSettingsFindUnique.mockResolvedValue({
+            playbackSourceOrder: "library,peers,tidal,ytmusic",
+        });
+    });
+
+    it("selects the local dedup twin before provider mappings", () => {
+        expect(
+            choosePeerPlaybackFallback({
+                localTwinId: "local-1",
+                tidalTrackId: 42,
+                youtubeVideoId: "video-1",
+            }),
+        ).toEqual([
+            { source: "library", trackId: "local-1" },
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+    });
+
+    it("selects an existing TIDAL mapping without a local twin", () => {
+        expect(
+            choosePeerPlaybackFallback({
+                localTwinId: null,
+                tidalTrackId: 42,
+                youtubeVideoId: "video-1",
+            }),
+        ).toEqual([
+            { source: "tidal", tidalTrackId: 42 },
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+        ]);
+    });
+
+    it("honors the configured order for provider rungs", () => {
+        expect(
+            choosePeerPlaybackFallback(
+                {
+                    localTwinId: null,
+                    tidalTrackId: 42,
+                    youtubeVideoId: "video-1",
+                },
+                "library,peers,ytmusic,tidal",
+            ),
+        ).toEqual([
+            { source: "ytmusic", youtubeVideoId: "video-1" },
+            { source: "tidal", tidalTrackId: 42 },
+        ]);
+    });
+
+    it("returns an empty ladder when no fallback exists", () => {
+        expect(
+            choosePeerPlaybackFallback({
+                localTwinId: null,
+                tidalTrackId: null,
+                youtubeVideoId: null,
+            }),
+        ).toEqual([]);
+    });
+
+    it.each([
+        ["low-confidence", 0.69, 180],
+        ["duration-mismatch", 0.9, 196],
+    ])("skips a %s provider mapping", async (_name, confidence, duration) => {
+        mockTrackMappingFindMany.mockResolvedValueOnce([
+            {
+                confidence,
+                trackTidal: { tidalId: 42, duration },
+                trackYtMusic: null,
+            },
+        ]);
+
+        await expect(loadPeerPlaybackFallback("peer-track")).resolves.toEqual(
+            [],
+        );
+    });
+
+    it("selects an eligible provider mapping", async () => {
+        mockTrackMappingFindMany.mockResolvedValueOnce([
+            {
+                confidence: 0.7,
+                trackTidal: { tidalId: 42, duration: 195 },
+                trackYtMusic: null,
+            },
+        ]);
+
+        await expect(loadPeerPlaybackFallback("peer-track")).resolves.toEqual([
+            { source: "tidal", tidalTrackId: 42 },
+        ]);
+    });
+});

--- a/backend/src/services/__tests__/playbackSourcePriority.test.ts
+++ b/backend/src/services/__tests__/playbackSourcePriority.test.ts
@@ -1,0 +1,38 @@
+import {
+    DEFAULT_PLAYBACK_SOURCE_ORDER,
+    parsePlaybackSourceOrder,
+    rankPlaybackSource,
+} from "../playbackSourcePriority";
+
+describe("playback source priority", () => {
+    it.each([
+        ["library", true, 500],
+        ["peers", true, 400],
+        ["tidal", true, 300],
+        ["ytmusic", true, 200],
+        ["peers", false, 100],
+    ] as const)("ranks %s availability=%s", (source, available, expected) => {
+        expect(
+            rankPlaybackSource(
+                { source, available },
+                DEFAULT_PLAYBACK_SOURCE_ORDER,
+            ),
+        ).toBe(expected);
+    });
+
+    it("honors a valid configured provider order", () => {
+        const order = parsePlaybackSourceOrder("ytmusic,tidal,peers,library");
+
+        expect(
+            rankPlaybackSource({ source: "ytmusic", available: true }, order),
+        ).toBeGreaterThan(
+            rankPlaybackSource({ source: "library", available: true }, order),
+        );
+    });
+
+    it("falls back to the default for malformed stored values", () => {
+        const order = parsePlaybackSourceOrder("library,unknown,tidal,ytmusic");
+
+        expect(order).toEqual(DEFAULT_PLAYBACK_SOURCE_ORDER);
+    });
+});

--- a/backend/src/services/__tests__/playlistTrackResolution.test.ts
+++ b/backend/src/services/__tests__/playlistTrackResolution.test.ts
@@ -273,6 +273,33 @@ describe("playlistTrackResolution", () => {
         ).toBeNull();
     });
 
+    it("threads federated origin and online state into queue resolution", () => {
+        const input = playlistTrackResolutionTestables.toResolutionInput(
+            playlistItem({
+                trackId: "peer-track-1",
+                track: localTrack({
+                    id: "peer-track-1",
+                    origin: "FEDERATED",
+                    federationPeer: {
+                        id: "peer-1",
+                        name: "Peer One",
+                        outboundStatus: "ACTIVE",
+                    },
+                }),
+            }),
+            "mapping-1",
+        );
+
+        expect(input).toEqual(
+            expect.objectContaining({
+                localTrackId: "peer-track-1",
+                trackMappingId: "mapping-1",
+                originSource: "peer",
+                peerOnline: true,
+            }),
+        );
+    });
+
     it("prefers local mappings over remote mappings", () => {
         const preferred =
             playlistTrackResolutionTestables.selectPreferredMappingForItem(
@@ -631,6 +658,13 @@ describe("playlistTrackResolution", () => {
         expect(mockPrisma.track.findMany).toHaveBeenCalledWith({
             where: { id: { in: ["missing-local"] } },
             include: {
+                federationPeer: {
+                    select: {
+                        id: true,
+                        name: true,
+                        outboundStatus: true,
+                    },
+                },
                 album: {
                     include: {
                         artist: {

--- a/backend/src/services/__tests__/unifiedTrackResponse.test.ts
+++ b/backend/src/services/__tests__/unifiedTrackResponse.test.ts
@@ -301,6 +301,7 @@ describe("unifiedTrackResponse", () => {
         });
         expect(result.track).toMatchObject({
             source: "federated",
+            streamSource: "peer",
             peer: { id: "peer-1", name: "Peer One", online: false },
         });
     });

--- a/backend/src/services/federatedTrackPayload.ts
+++ b/backend/src/services/federatedTrackPayload.ts
@@ -1,0 +1,23 @@
+interface FederatedPayloadPeer {
+    id: string;
+    name: string;
+    outboundStatus: string | null;
+}
+
+/** Adds playback-only peer provenance without changing federation envelopes. */
+export function withFederatedTrackPlayback<Track extends { origin: string }>(
+    track: Track,
+    peer: FederatedPayloadPeer | null,
+) {
+    if (track.origin !== "FEDERATED" || !peer) return track;
+    return {
+        ...track,
+        source: "federated" as const,
+        streamSource: "peer" as const,
+        peer: {
+            id: peer.id,
+            name: peer.name,
+            online: peer.outboundStatus === "ACTIVE",
+        },
+    };
+}

--- a/backend/src/services/libraryTrackPreferences.ts
+++ b/backend/src/services/libraryTrackPreferences.ts
@@ -82,6 +82,10 @@ export const toLikedResponseTrack = (
         };
     }
 
+    if (normalized.source === "federated") {
+        return { ...base, streamSource: "peer" as const };
+    }
+
     return base;
 };
 

--- a/backend/src/services/listenTogether.ts
+++ b/backend/src/services/listenTogether.ts
@@ -161,6 +161,23 @@ async function resolvePresentationName(
     return user?.username ?? fallbackUsername;
 }
 
+async function loadLocalQueueMappingIds(
+    trackIds: string[],
+): Promise<Map<string, string>> {
+    const mappings = await prisma.trackMapping.findMany({
+        where: { stale: false, trackId: { in: trackIds } },
+        select: { id: true, trackId: true },
+        orderBy: [{ confidence: "desc" }, { createdAt: "desc" }],
+    });
+    const mappingByTrackId = new Map<string, string>();
+    for (const mapping of mappings) {
+        if (mapping.trackId && !mappingByTrackId.has(mapping.trackId)) {
+            mappingByTrackId.set(mapping.trackId, mapping.id);
+        }
+    }
+    return mappingByTrackId;
+}
+
 /**
  * Validates and materializes mixed-source queue input into canonical queue items.
  */
@@ -230,8 +247,12 @@ export async function validateQueueTracks(
                 title: true,
                 duration: true,
                 filePath: true,
+                origin: true,
                 loudnessLufs: true,
                 truePeakDb: true,
+                federationPeer: {
+                    select: { outboundStatus: true },
+                },
                 album: {
                     select: {
                         id: true,
@@ -244,6 +265,7 @@ export async function validateQueueTracks(
                 },
             },
         });
+        const localMappingIds = await loadLocalQueueMappingIds(uniqueLocalIds);
         const localTrackMap = new Map(
             localTracks.map((track) => [track.id, track]),
         );
@@ -251,6 +273,7 @@ export async function validateQueueTracks(
         for (const entry of localInputs) {
             const track = localTrackMap.get(entry.trackId);
             if (!track) continue;
+            const isPeer = track.origin === "FEDERATED";
             queue.push({
                 id: track.id,
                 title: track.title,
@@ -268,10 +291,14 @@ export async function validateQueueTracks(
                     albumLoudnessLufs: track.album.albumLoudnessLufs,
                     albumTruePeakDb: track.album.albumTruePeakDb,
                 },
-                mediaSource: "local",
-                provider: { source: "local" },
+                mediaSource: isPeer ? "peer" : "local",
+                provider: { source: isPeer ? "peer" : "local" },
                 localTrackId: track.id,
-                originSource: "local",
+                trackMappingId: localMappingIds.get(track.id),
+                originSource: isPeer ? "peer" : "local",
+                peerOnline: isPeer
+                    ? track.federationPeer?.outboundStatus === "ACTIVE"
+                    : undefined,
             });
         }
     }
@@ -1426,9 +1453,14 @@ function parseQueueFromDb(raw: Prisma.JsonValue | null): SyncQueueItem[] {
                 originSource:
                     q.originSource === "tidal" ||
                     q.originSource === "youtube" ||
+                    q.originSource === "peer" ||
                     q.originSource === "local"
                         ? q.originSource
                         : "local",
+                peerOnline:
+                    typeof q.peerOnline === "boolean"
+                        ? q.peerOnline
+                        : undefined,
             });
         }
     }

--- a/backend/src/services/listenTogetherQueueItem.ts
+++ b/backend/src/services/listenTogetherQueueItem.ts
@@ -38,4 +38,6 @@ export interface SyncQueueItem {
     trackYtMusicId?: string;
     trackMappingId?: string;
     originSource?: ResolvedMediaSource;
+    /** Current owning-peer reachability captured when the queue item was built. */
+    peerOnline?: boolean;
 }

--- a/backend/src/services/listenTogetherResolution.ts
+++ b/backend/src/services/listenTogetherResolution.ts
@@ -1,6 +1,15 @@
 import type { ResolvedMediaSource } from "@soundspan/media-metadata-contract";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import {
+    parsePlaybackSourceOrder,
+    rankPlaybackSource,
+    type PlaybackSource,
+} from "./playbackSourcePriority";
+import {
+    isProviderMappingEligible,
+    MIN_PROVIDER_MAPPING_CONFIDENCE,
+} from "./providerMappingEligibility";
 
 const log = logger.child("ListenTogetherResolution");
 
@@ -33,6 +42,7 @@ export interface UserProviderProfile {
     hasLocal: true;
     hasTidal: boolean;
     hasYtMusic: boolean;
+    playbackSourceOrder?: string;
 }
 
 export interface TrackResolutionInput {
@@ -45,19 +55,23 @@ export interface TrackResolutionInput {
     tidalTrackId?: number;
     youtubeVideoId?: string;
     originSource?: ResolvedMediaSource;
+    peerOnline?: boolean;
 }
 
 type TidalTrack = { id: string; tidalId: number; duration: number };
 type YouTubeTrack = { id: string; videoId: string; duration: number };
 
 const PROFILE_CACHE_TTL_MS = 60_000;
-const DURATION_MISMATCH_THRESHOLD_SECONDS = 15;
-const MIN_MAPPING_CONFIDENCE = 0.7;
 
 const profileCache = new Map<
     string,
     { expiresAt: number; profile: UserProviderProfile }
 >();
+
+/** Invalidates cached provider profiles after system settings change. */
+export function invalidateUserProviderProfileCache(): void {
+    profileCache.clear();
+}
 
 interface ResolutionOptions {
     signal?: AbortSignal;
@@ -86,19 +100,6 @@ function hasToken(value: string | null | undefined): boolean {
     return typeof value === "string" && value.trim().length > 0;
 }
 
-function hasDurationMismatch(
-    expectedSeconds: number,
-    actualSeconds: number,
-): boolean {
-    if (!Number.isFinite(expectedSeconds) || !Number.isFinite(actualSeconds)) {
-        return false;
-    }
-    return (
-        Math.abs(Math.trunc(expectedSeconds) - Math.trunc(actualSeconds)) >
-        DURATION_MISMATCH_THRESHOLD_SECONDS
-    );
-}
-
 /**
  * Returns cached per-user provider connectivity flags used for queue resolution.
  */
@@ -122,7 +123,10 @@ export async function getUserProviderProfile(
             }),
             prisma.systemSettings.findUnique({
                 where: { id: "default" },
-                select: { ytMusicEnabled: true },
+                select: {
+                    ytMusicEnabled: true,
+                    playbackSourceOrder: true,
+                },
             }),
         ]),
         options.signal,
@@ -136,6 +140,9 @@ export async function getUserProviderProfile(
         // per-user OAuth connectivity to mark tracks playable. Still respect
         // global system-level YouTube enablement.
         hasYtMusic: systemSettings?.ytMusicEnabled !== false,
+        playbackSourceOrder: (
+            systemSettings as { playbackSourceOrder?: string } | null
+        )?.playbackSourceOrder,
     };
 
     profileCache.set(userId, {
@@ -150,6 +157,10 @@ type MappingWithTargets = {
     stale: boolean;
     confidence: number;
     trackId: string | null;
+    track?: {
+        origin: "LOCAL" | "FEDERATED";
+        federationPeer: { outboundStatus: string | null } | null;
+    } | null;
     trackTidal: { id: string; tidalId: number; duration: number } | null;
     trackYtMusic: { id: string; videoId: string; duration: number } | null;
 };
@@ -159,6 +170,99 @@ interface ResolveTrackContext {
     trackTidalById?: Map<string, TidalTrack>;
     signal?: AbortSignal;
     trackYtById?: Map<string, YouTubeTrack>;
+}
+
+type MappingCandidate = {
+    source: PlaybackSource;
+    available: boolean;
+    resolved: ResolvedSource;
+};
+
+function localMappingCandidate(
+    mapping: MappingWithTargets,
+): MappingCandidate | null {
+    if (!mapping.trackId) return null;
+    const isPeer = mapping.track?.origin === "FEDERATED";
+    return {
+        source: isPeer ? "peers" : "library",
+        available:
+            !isPeer ||
+            mapping.track?.federationPeer?.outboundStatus === "ACTIVE",
+        resolved: {
+            available: true,
+            source: "local",
+            trackId: mapping.trackId,
+        },
+    };
+}
+
+function tidalMappingCandidate(
+    mapping: MappingWithTargets,
+    item: TrackResolutionInput,
+    profile: UserProviderProfile,
+): MappingCandidate | null {
+    if (
+        !mapping.trackTidal ||
+        !isProviderMappingEligible({
+            confidence: mapping.confidence,
+            expectedDurationSeconds: item.duration,
+            actualDurationSeconds: mapping.trackTidal.duration,
+        })
+    ) {
+        return null;
+    }
+    return {
+        source: "tidal",
+        available: profile.hasTidal,
+        resolved: {
+            available: true,
+            source: "tidal",
+            tidalTrackId: mapping.trackTidal.tidalId,
+            trackTidalId: mapping.trackTidal.id,
+        },
+    };
+}
+
+function youtubeMappingCandidate(
+    mapping: MappingWithTargets,
+    item: TrackResolutionInput,
+    profile: UserProviderProfile,
+): MappingCandidate | null {
+    if (
+        !mapping.trackYtMusic ||
+        !isProviderMappingEligible({
+            confidence: mapping.confidence,
+            expectedDurationSeconds: item.duration,
+            actualDurationSeconds: mapping.trackYtMusic.duration,
+        })
+    ) {
+        return null;
+    }
+    return {
+        source: "ytmusic",
+        available: profile.hasYtMusic,
+        resolved: {
+            available: true,
+            source: "youtube",
+            youtubeVideoId: mapping.trackYtMusic.videoId,
+            trackYtMusicId: mapping.trackYtMusic.id,
+        },
+    };
+}
+
+function mappedCandidates(
+    mapping: MappingWithTargets,
+    item: TrackResolutionInput,
+    profile: UserProviderProfile,
+): MappingCandidate[] {
+    const candidates = [localMappingCandidate(mapping)];
+    candidates.push(
+        tidalMappingCandidate(mapping, item, profile),
+        youtubeMappingCandidate(mapping, item, profile),
+    );
+    return candidates.filter(
+        (candidate): candidate is MappingCandidate => candidate !== null,
+    );
 }
 
 async function loadMapping(
@@ -177,6 +281,12 @@ async function loadMapping(
                 stale: true,
                 confidence: true,
                 trackId: true,
+                track: {
+                    select: {
+                        origin: true,
+                        federationPeer: { select: { outboundStatus: true } },
+                    },
+                },
                 trackTidal: {
                     select: {
                         id: true,
@@ -206,36 +316,25 @@ async function resolveMappedTrack(
     const mapping = await loadMapping(item.trackMappingId!, context);
     if (!mapping) return { available: false, reason: "no-mapping" };
     if (mapping.stale) return { available: false, reason: "stale" };
-    if (mapping.trackId) {
-        return { available: true, source: "local", trackId: mapping.trackId };
-    }
-    if (!profile.hasTidal && !profile.hasYtMusic) {
-        return { available: false, reason: "no-provider" };
-    }
-    if (mapping.confidence < MIN_MAPPING_CONFIDENCE) {
+    const candidates = mappedCandidates(mapping, item, profile);
+    const order = parsePlaybackSourceOrder(profile.playbackSourceOrder);
+    const preferred = candidates
+        .filter((candidate) => candidate.available)
+        .sort(
+            (left, right) =>
+                rankPlaybackSource(right, order) -
+                rankPlaybackSource(left, order),
+        )[0];
+    if (preferred) return preferred.resolved;
+    if (
+        mapping.confidence < MIN_PROVIDER_MAPPING_CONFIDENCE &&
+        !mapping.trackId
+    ) {
         return { available: false, reason: "low-confidence" };
     }
-    if (mapping.trackTidal && profile.hasTidal) {
-        if (hasDurationMismatch(item.duration, mapping.trackTidal.duration)) {
-            return { available: false, reason: "duration-mismatch" };
-        }
-        return {
-            available: true,
-            source: "tidal",
-            tidalTrackId: mapping.trackTidal.tidalId,
-            trackTidalId: mapping.trackTidal.id,
-        };
-    }
-    if (mapping.trackYtMusic && profile.hasYtMusic) {
-        if (hasDurationMismatch(item.duration, mapping.trackYtMusic.duration)) {
-            return { available: false, reason: "duration-mismatch" };
-        }
-        return {
-            available: true,
-            source: "youtube",
-            youtubeVideoId: mapping.trackYtMusic.videoId,
-            trackYtMusicId: mapping.trackYtMusic.id,
-        };
+    const hasProviderTarget = mapping.trackTidal || mapping.trackYtMusic;
+    if (hasProviderTarget && candidates.length === 0) {
+        return { available: false, reason: "duration-mismatch" };
     }
     return { available: false, reason: "no-provider" };
 }
@@ -294,8 +393,11 @@ async function findYouTubeFallback(
     );
     if (
         !crossMapping?.trackYtMusic ||
-        crossMapping.confidence < MIN_MAPPING_CONFIDENCE ||
-        hasDurationMismatch(item.duration, crossMapping.trackYtMusic.duration)
+        !isProviderMappingEligible({
+            confidence: crossMapping.confidence,
+            expectedDurationSeconds: item.duration,
+            actualDurationSeconds: crossMapping.trackYtMusic.duration,
+        })
     ) {
         return null;
     }
@@ -390,8 +492,11 @@ async function findTidalFallback(
     );
     if (
         !crossMapping?.trackTidal ||
-        crossMapping.confidence < MIN_MAPPING_CONFIDENCE ||
-        hasDurationMismatch(item.duration, crossMapping.trackTidal.duration)
+        !isProviderMappingEligible({
+            confidence: crossMapping.confidence,
+            expectedDurationSeconds: item.duration,
+            actualDurationSeconds: crossMapping.trackTidal.duration,
+        })
     ) {
         return null;
     }
@@ -440,7 +545,7 @@ export async function resolveTrackForUser(
     const localTrackId =
         item.localTrackId ??
         (item.originSource === "local" ? item.id : undefined);
-    if (localTrackId) {
+    if (localTrackId && item.originSource !== "peer") {
         return { available: true, source: "local", trackId: localTrackId };
     }
 
@@ -454,6 +559,10 @@ export async function resolveTrackForUser(
 
     if (item.trackYtMusicId || typeof item.youtubeVideoId === "string") {
         return resolveYouTubeTrack(item, profile, context);
+    }
+
+    if (localTrackId && item.peerOnline) {
+        return { available: true, source: "local", trackId: localTrackId };
     }
 
     return { available: false, reason: "no-mapping" };
@@ -481,6 +590,12 @@ async function preloadMappings(ids: string[]): Promise<MappingWithTargets[]> {
             stale: true,
             confidence: true,
             trackId: true,
+            track: {
+                select: {
+                    origin: true,
+                    federationPeer: { select: { outboundStatus: true } },
+                },
+            },
             trackTidal: {
                 select: { id: true, tidalId: true, duration: true },
             },

--- a/backend/src/services/listenTogetherStateStore.ts
+++ b/backend/src/services/listenTogetherStateStore.ts
@@ -1,6 +1,7 @@
 import { logger } from "../utils/logger";
 import { createIORedisClient } from "../utils/ioredis";
 import type { GroupSnapshot } from "./listenTogetherManager";
+import type { SyncQueueItem } from "./listenTogetherQueueItem";
 import { config } from "../config";
 import { withListenTogetherDeadline } from "./listenTogetherDeadline";
 import type { FencedStateWriteResult } from "./listenTogetherLeaseFencing";
@@ -27,6 +28,61 @@ const MAX_SNAPSHOT_MEMBERS = 10_000;
 const MAX_SNAPSHOT_QUEUE_ITEMS = 500;
 const log = logger.child("ListenTogetherStateStore");
 
+type RolloutQueueItem = SyncQueueItem & {
+    actualOriginSource?: "peer";
+};
+
+function toRolloutQueueItem(item: SyncQueueItem): RolloutQueueItem {
+    const isPeer =
+        item.mediaSource === "peer" ||
+        item.provider?.source === "peer" ||
+        item.streamSource === "peer" ||
+        item.originSource === "peer";
+    if (!isPeer) return item;
+    const { streamSource: _streamSource, ...legacy } = item;
+    return {
+        ...legacy,
+        mediaSource: "local",
+        provider: { ...item.provider, source: "local" },
+        originSource: "local",
+        actualOriginSource: "peer",
+    };
+}
+
+function toRolloutSnapshot(snapshot: GroupSnapshot): GroupSnapshot {
+    return {
+        ...snapshot,
+        playback: {
+            ...snapshot.playback,
+            queue: snapshot.playback.queue.map(toRolloutQueueItem),
+        },
+    };
+}
+
+function restoreRolloutQueueItem(item: SyncQueueItem): SyncQueueItem {
+    const rolloutItem = item as RolloutQueueItem;
+    if (rolloutItem.actualOriginSource !== "peer") return item;
+    const { actualOriginSource: _actualOriginSource, ...restored } =
+        rolloutItem;
+    return {
+        ...restored,
+        mediaSource: "peer",
+        provider: { ...item.provider, source: "peer" },
+        streamSource: "peer",
+        originSource: "peer",
+    };
+}
+
+function restoreRolloutSnapshot(snapshot: GroupSnapshot): GroupSnapshot {
+    return {
+        ...snapshot,
+        playback: {
+            ...snapshot.playback,
+            queue: snapshot.playback.queue.map(restoreRolloutQueueItem),
+        },
+    };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -50,6 +106,7 @@ function isOptionalNumberOrNull(value: unknown): boolean {
 function isMediaSource(value: unknown): boolean {
     return (
         value === "local" ||
+        value === "peer" ||
         value === "tidal" ||
         value === "youtube" ||
         value === "youtube-direct"
@@ -81,6 +138,7 @@ function isQueueItem(value: unknown): boolean {
                 value.streamSource !== "local")) &&
         (value.originSource === undefined ||
             value.originSource === "local" ||
+            value.originSource === "peer" ||
             value.originSource === "tidal" ||
             value.originSource === "youtube");
     return (
@@ -104,6 +162,8 @@ function isQueueItem(value: unknown): boolean {
         isOptionalString(value.trackTidalId) &&
         isOptionalString(value.trackYtMusicId) &&
         isOptionalString(value.trackMappingId) &&
+        (value.peerOnline === undefined ||
+            typeof value.peerOnline === "boolean") &&
         (value.tidalTrackId === undefined ||
             isFiniteNumber(value.tidalTrackId)) &&
         isOptionalString(value.youtubeVideoId) &&
@@ -279,7 +339,7 @@ class ListenTogetherStateStore {
         if (parsed.id !== groupId) {
             return this.rejectInvalidSnapshot(groupId, "mismatched-group-id");
         }
-        return parsed;
+        return restoreRolloutSnapshot(parsed);
     }
 
     private rejectInvalidSnapshot(
@@ -329,7 +389,7 @@ class ListenTogetherStateStore {
                 this.key(groupId),
                 this.fenceKey(groupId),
                 this.fencingCounterKey(groupId),
-                JSON.stringify(snapshot),
+                JSON.stringify(toRolloutSnapshot(snapshot)),
                 `${LISTEN_TOGETHER_STATE_STORE_TTL_SECONDS}`,
                 `${ordering.stateVersion}`,
                 `${ordering.serverTime}`,

--- a/backend/src/services/mappedProviderStream.ts
+++ b/backend/src/services/mappedProviderStream.ts
@@ -1,0 +1,114 @@
+import { pipeline } from "node:stream/promises";
+import type { Request, Response } from "express";
+import type { PeerPlaybackFallback } from "./peerPlaybackFallback";
+
+const FORWARDED_STREAM_HEADERS = [
+    "content-type",
+    "content-length",
+    "content-range",
+    "accept-ranges",
+] as const;
+
+/** Observable response state after a mapped provider attempt. */
+export interface MappedProviderResponseState {
+    headersSent: boolean;
+    destroyed: boolean;
+    writableEnded: boolean;
+}
+
+/** Result of one mapped provider stream attempt. */
+export type MappedProviderStreamResult =
+    | { status: "served" }
+    | { status: "unavailable" }
+    | {
+          status: "failed";
+          error: unknown;
+          responseState: MappedProviderResponseState;
+      };
+
+/** Reports whether a response can still accept a fallback or error body. */
+export function mappedProviderResponseState(
+    res: Response,
+): MappedProviderResponseState {
+    return {
+        headersSent: res.headersSent,
+        destroyed: res.destroyed,
+        writableEnded: res.writableEnded,
+    };
+}
+
+/** Returns whether no further response write is safe. */
+export function isMappedProviderResponseUnusable(
+    state: MappedProviderResponseState,
+): boolean {
+    return state.headersSent || state.destroyed || state.writableEnded;
+}
+
+function forwardStreamHeaders(
+    res: Response,
+    headers: Record<string, unknown>,
+): void {
+    for (let index = 0; index < FORWARDED_STREAM_HEADERS.length; index += 1) {
+        const name = FORWARDED_STREAM_HEADERS[index];
+        const value = headers[name];
+        if (typeof value === "string" || typeof value === "number") {
+            res.setHeader(name, String(value));
+        }
+    }
+}
+
+/** Proxies one already-mapped provider fallback through its bounded sidecar call. */
+export async function serveMappedProviderStream(input: {
+    req: Request;
+    res: Response;
+    userId: string;
+    youtubeUserId?: string;
+    quality: string;
+    fallback: PeerPlaybackFallback;
+}): Promise<MappedProviderStreamResult> {
+    const range =
+        typeof input.req.headers.range === "string"
+            ? input.req.headers.range
+            : undefined;
+    try {
+        let response = null;
+        if (input.fallback.source === "tidal") {
+            const { tidalStreamingService } = await import("./tidalStreaming");
+            response = await tidalStreamingService.getStreamProxy(
+                input.userId,
+                input.fallback.tidalTrackId,
+                input.quality,
+                range,
+            );
+        } else if (input.fallback.source === "ytmusic") {
+            const { ytMusicService } = await import("./youtubeMusic");
+            response = await ytMusicService.getStreamProxy(
+                input.youtubeUserId ?? "__public__",
+                input.fallback.youtubeVideoId,
+                input.quality,
+                range,
+            );
+        }
+        if (!response) return { status: "unavailable" };
+        input.res.status(response.status);
+        forwardStreamHeaders(input.res, response.headers);
+        await pipeline(response.data, input.res);
+        return { status: "served" };
+    } catch (error) {
+        return {
+            status: "failed",
+            error,
+            responseState: mappedProviderResponseState(input.res),
+        };
+    }
+}
+
+/** Terminates a stream whose HTTP headers were already committed. */
+export function terminateCommittedStream(res: Response): void {
+    if (res.destroyed || res.writableEnded) return;
+    if (typeof res.destroy === "function") {
+        res.destroy();
+        return;
+    }
+    res.end();
+}

--- a/backend/src/services/mappedProviderStream.ts
+++ b/backend/src/services/mappedProviderStream.ts
@@ -22,7 +22,7 @@ export type MappedProviderStreamResult =
     | { status: "unavailable" }
     | {
           status: "failed";
-          error: unknown;
+          failure: unknown;
           responseState: MappedProviderResponseState;
       };
 
@@ -97,7 +97,7 @@ export async function serveMappedProviderStream(input: {
     } catch (error) {
         return {
             status: "failed",
-            error,
+            failure: error,
             responseState: mappedProviderResponseState(input.res),
         };
     }

--- a/backend/src/services/peerPlaybackFallback.ts
+++ b/backend/src/services/peerPlaybackFallback.ts
@@ -1,0 +1,108 @@
+import { prisma } from "../utils/db";
+import {
+    parsePlaybackSourceOrder,
+    rankPlaybackSource,
+} from "./playbackSourcePriority";
+import { isProviderMappingEligible } from "./providerMappingEligibility";
+
+/** One stream-time replacement rung for an unavailable peer track. */
+export type PeerPlaybackFallback =
+    | { source: "library"; trackId: string }
+    | { source: "tidal"; tidalTrackId: number }
+    | { source: "ytmusic"; youtubeVideoId: string };
+
+interface PeerFallbackCandidates {
+    localTwinId: string | null;
+    tidalTrackId: number | null;
+    youtubeVideoId: string | null;
+}
+
+/** Applies the bounded peer failure ladder without performing I/O. */
+export function choosePeerPlaybackFallback(
+    candidates: PeerFallbackCandidates,
+    playbackSourceOrder?: string,
+): PeerPlaybackFallback[] {
+    const ladder: PeerPlaybackFallback[] = [];
+    if (candidates.localTwinId) {
+        ladder.push({ source: "library", trackId: candidates.localTwinId });
+    }
+    const providers: PeerPlaybackFallback[] = [];
+    if (candidates.tidalTrackId) {
+        providers.push({
+            source: "tidal",
+            tidalTrackId: candidates.tidalTrackId,
+        });
+    }
+    if (candidates.youtubeVideoId) {
+        providers.push({
+            source: "ytmusic",
+            youtubeVideoId: candidates.youtubeVideoId,
+        });
+    }
+    const order = parsePlaybackSourceOrder(playbackSourceOrder);
+    providers.sort(
+        (left, right) =>
+            rankPlaybackSource(
+                { source: right.source, available: true },
+                order,
+            ) -
+            rankPlaybackSource({ source: left.source, available: true }, order),
+    );
+    return [...ladder, ...providers];
+}
+
+/** Loads the local dedup winner and existing provider mappings for one peer track. */
+export async function loadPeerPlaybackFallback(
+    trackId: string,
+): Promise<PeerPlaybackFallback[]> {
+    const [track, systemSettings] = await Promise.all([
+        prisma.track.findUnique({
+            where: { id: trackId },
+            select: { dedupOfTrackId: true, duration: true },
+        }),
+        prisma.systemSettings.findUnique({
+            where: { id: "default" },
+            select: { playbackSourceOrder: true },
+        }),
+    ]);
+    const linkedIds = [trackId, track?.dedupOfTrackId].filter(
+        (value): value is string => typeof value === "string",
+    );
+    const mappings = await prisma.trackMapping.findMany({
+        where: { stale: false, trackId: { in: linkedIds } },
+        select: {
+            confidence: true,
+            trackTidal: { select: { tidalId: true, duration: true } },
+            trackYtMusic: { select: { videoId: true, duration: true } },
+        },
+        orderBy: { confidence: "desc" },
+        take: 20,
+    });
+    const expectedDurationSeconds = track?.duration ?? Number.NaN;
+    const tidal = mappings.find(
+        (row) =>
+            row.trackTidal &&
+            isProviderMappingEligible({
+                confidence: row.confidence,
+                expectedDurationSeconds,
+                actualDurationSeconds: row.trackTidal.duration,
+            }),
+    )?.trackTidal;
+    const youtube = mappings.find(
+        (row) =>
+            row.trackYtMusic &&
+            isProviderMappingEligible({
+                confidence: row.confidence,
+                expectedDurationSeconds,
+                actualDurationSeconds: row.trackYtMusic.duration,
+            }),
+    )?.trackYtMusic;
+    return choosePeerPlaybackFallback(
+        {
+            localTwinId: track?.dedupOfTrackId ?? null,
+            tidalTrackId: tidal?.tidalId ?? null,
+            youtubeVideoId: youtube?.videoId ?? null,
+        },
+        systemSettings?.playbackSourceOrder,
+    );
+}

--- a/backend/src/services/playbackSourcePriority.ts
+++ b/backend/src/services/playbackSourcePriority.ts
@@ -1,0 +1,53 @@
+/** Providers accepted by the persisted playback source-order setting. */
+export const PLAYBACK_SOURCE_VALUES = [
+    "library",
+    "peers",
+    "tidal",
+    "ytmusic",
+] as const;
+
+/** One configurable tier in playback source selection. */
+export type PlaybackSource = (typeof PLAYBACK_SOURCE_VALUES)[number];
+/** A complete ordered permutation of playback source tiers. */
+export type PlaybackSourceOrder = readonly PlaybackSource[];
+
+/** Default playback order: owned library, online peers, TIDAL, then YT Music. */
+export const DEFAULT_PLAYBACK_SOURCE_ORDER: PlaybackSourceOrder =
+    PLAYBACK_SOURCE_VALUES;
+/** Persisted string representation of the default playback order. */
+export const DEFAULT_PLAYBACK_SOURCE_ORDER_VALUE =
+    PLAYBACK_SOURCE_VALUES.join(",");
+// Offline peers remain a last-resort identity at 100, below the lowest
+// available provider tier (200), regardless of the configured order.
+const UNAVAILABLE_SOURCE_PRIORITY = 100;
+
+/** Parses a stored source order and safely restores the default on drift. */
+export function parsePlaybackSourceOrder(value: unknown): PlaybackSourceOrder {
+    if (typeof value !== "string") return DEFAULT_PLAYBACK_SOURCE_ORDER;
+    const entries = value.split(",").map((entry) => entry.trim());
+    if (entries.length !== PLAYBACK_SOURCE_VALUES.length) {
+        return DEFAULT_PLAYBACK_SOURCE_ORDER;
+    }
+    const values = new Set(entries);
+    const valid = PLAYBACK_SOURCE_VALUES.every((source) => values.has(source));
+    return valid
+        ? (entries as PlaybackSource[])
+        : DEFAULT_PLAYBACK_SOURCE_ORDER;
+}
+
+/** Returns true only for a complete, duplicate-free provider permutation. */
+export function isPlaybackSourceOrder(value: string): boolean {
+    const parsed = parsePlaybackSourceOrder(value);
+    return parsed.join(",") === value;
+}
+
+/** Ranks a candidate. Offline/unavailable sources always remain below providers. */
+export function rankPlaybackSource(
+    candidate: { source: PlaybackSource; available: boolean },
+    order: PlaybackSourceOrder,
+): number {
+    if (!candidate.available) return UNAVAILABLE_SOURCE_PRIORITY;
+    const index = order.indexOf(candidate.source);
+    const normalizedIndex = index >= 0 ? index : order.length;
+    return (order.length - normalizedIndex + 1) * 100;
+}

--- a/backend/src/services/playlistTrackResolution.ts
+++ b/backend/src/services/playlistTrackResolution.ts
@@ -139,11 +139,17 @@ function toResolutionInput(
                 ? item.trackYtMusic.videoId.trim()
                 : undefined,
         originSource: item.track
-            ? "local"
+            ? item.track.origin === "FEDERATED"
+                ? "peer"
+                : "local"
             : item.trackTidal
               ? "tidal"
               : item.trackYtMusic
                 ? "youtube"
+                : undefined,
+        peerOnline:
+            item.track?.origin === "FEDERATED"
+                ? item.track.federationPeer?.outboundStatus === "ACTIVE"
                 : undefined,
     };
 }
@@ -297,6 +303,13 @@ export async function resolvePlaylistItemsForUser(
             ? prisma.track.findMany({
                   where: { id: { in: Array.from(missingLocalIds) } },
                   include: {
+                      federationPeer: {
+                          select: {
+                              id: true,
+                              name: true,
+                              outboundStatus: true,
+                          },
+                      },
                       album: {
                           include: {
                               artist: {

--- a/backend/src/services/providerMappingEligibility.ts
+++ b/backend/src/services/providerMappingEligibility.ts
@@ -1,0 +1,30 @@
+/** Minimum confidence accepted for automatic provider mapping playback. */
+export const MIN_PROVIDER_MAPPING_CONFIDENCE = 0.7;
+
+const DURATION_MISMATCH_THRESHOLD_SECONDS = 15;
+
+/** Returns whether a provider mapping is safe to use for playback. */
+export function isProviderMappingEligible(input: {
+    confidence: number;
+    expectedDurationSeconds: number;
+    actualDurationSeconds: number;
+}): boolean {
+    if (
+        !Number.isFinite(input.confidence) ||
+        input.confidence < MIN_PROVIDER_MAPPING_CONFIDENCE
+    ) {
+        return false;
+    }
+    if (
+        !Number.isFinite(input.expectedDurationSeconds) ||
+        !Number.isFinite(input.actualDurationSeconds)
+    ) {
+        return true;
+    }
+    return (
+        Math.abs(
+            Math.trunc(input.expectedDurationSeconds) -
+                Math.trunc(input.actualDurationSeconds),
+        ) <= DURATION_MISMATCH_THRESHOLD_SECONDS
+    );
+}

--- a/backend/src/services/systemSettingsQueueCleaner.ts
+++ b/backend/src/services/systemSettingsQueueCleaner.ts
@@ -1,0 +1,72 @@
+import { logger } from "../utils/logger";
+import { schedulerQueue } from "../workers/queues";
+
+const QUEUE_CLEANER_JOB_NAME = "download-reconciliation-cycle";
+const QUEUE_CLEANER_JOB_ID = "scheduler:reconciliation:on-demand";
+/** Scoped logger retained by the system-settings queue-cleaner routes. */
+export const queueCleanerLog = logger.child("SystemSettingsQueueCleaner");
+
+type QueueCleanerWorkerStatus = {
+    running: boolean;
+    queued: boolean;
+    state: string;
+    jobId: string | null;
+    workerOwned: true;
+};
+
+/** Builds the stable idle queue-cleaner status response. */
+export function idleQueueCleanerWorkerStatus(): QueueCleanerWorkerStatus {
+    return {
+        running: false,
+        queued: false,
+        state: "idle",
+        jobId: null,
+        workerOwned: true,
+    };
+}
+
+/** Maps one scheduler job to its public worker status. */
+export async function getQueueCleanerWorkerStatus(
+    job: Awaited<ReturnType<typeof schedulerQueue.getJob>>,
+): Promise<QueueCleanerWorkerStatus> {
+    if (!job) return idleQueueCleanerWorkerStatus();
+    const state = await job.getState();
+    return {
+        running: state === "active",
+        queued: ["waiting", "delayed", "paused"].includes(state),
+        state,
+        jobId: String(job.id),
+        workerOwned: true,
+    };
+}
+
+/** Loads current queue-cleaner status from the shared scheduler queue. */
+export async function loadQueueCleanerWorkerStatus() {
+    const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
+    return getQueueCleanerWorkerStatus(job);
+}
+
+/** Enqueues the coalesced queue-cleaner reconciliation job. */
+export async function enqueueQueueCleanerWorkerJob() {
+    return schedulerQueue.add(
+        QUEUE_CLEANER_JOB_NAME,
+        { mode: "repeat", source: "system-settings" },
+        {
+            jobId: QUEUE_CLEANER_JOB_ID,
+            removeOnComplete: true,
+            removeOnFail: 10,
+        },
+    );
+}
+
+/** Cancels an unclaimed queue-cleaner job without interrupting active work. */
+export async function cancelQueuedQueueCleanerWorkerJob(): Promise<
+    "absent" | "active" | "cancelled"
+> {
+    const job = await schedulerQueue.getJob(QUEUE_CLEANER_JOB_ID);
+    if (!job) return "absent";
+    const status = await getQueueCleanerWorkerStatus(job);
+    if (status.running) return "active";
+    await job.remove();
+    return "cancelled";
+}

--- a/backend/src/services/unifiedTrackResponse.ts
+++ b/backend/src/services/unifiedTrackResponse.ts
@@ -273,11 +273,11 @@ export function normalizeYtMusicTrack(
 function toLegacyCompatibleTrackShape(
     normalized: UnifiedTrackResponse,
 ): Record<string, unknown> {
+    const streamSource =
+        normalized.source === "federated" ? "peer" : normalized.source;
     return {
         ...normalized,
-        ...(normalized.source !== "local"
-            ? { streamSource: normalized.source }
-            : {}),
+        ...(normalized.source !== "local" ? { streamSource } : {}),
         ...(normalized.provider.tidalTrackId !== null
             ? { tidalTrackId: normalized.provider.tidalTrackId }
             : {}),

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -13,6 +13,7 @@ import { SettingsLayout, SidebarItem } from "@/features/settings/components/ui";
 import { useFeatures } from "@/lib/features-context";
 
 const baseSidebarItems: SidebarItem[] = [
+    { id: "playback-sources", label: "Playback Sources" },
     { id: "download-preferences", label: "Download Preferences" },
     { id: "download-services", label: "Download Services" },
     { id: "audiobookshelf", label: "Media Servers" },
@@ -38,6 +39,14 @@ const DownloadPreferencesSection = dynamic(
     () =>
         import("@/features/settings/components/sections/DownloadPreferencesSection").then(
             (mod) => mod.DownloadPreferencesSection,
+        ),
+    { loading: renderSectionFallback },
+);
+
+const PlaybackSourcesSection = dynamic(
+    () =>
+        import("@/features/settings/components/sections/PlaybackSourcesSection").then(
+            (mod) => mod.PlaybackSourcesSection,
         ),
     { loading: renderSectionFallback },
 );
@@ -273,6 +282,11 @@ export default function AdminPage() {
                 isAdmin={true}
                 title="Admin"
             >
+                <PlaybackSourcesSection
+                    settings={systemSettings}
+                    onUpdate={updateSystemSettings}
+                />
+
                 <DownloadPreferencesSection
                     settings={systemSettings}
                     onUpdate={updateSystemSettings}

--- a/frontend/app/artist/[id]/page.tsx
+++ b/frontend/app/artist/[id]/page.tsx
@@ -227,6 +227,9 @@ export default function ArtistPage() {
             streamSource: "youtube" as const,
             youtubeVideoId: t.youtubeVideoId,
         }),
+        ...(t.streamSource === "peer" && {
+            streamSource: "peer" as const,
+        }),
     });
 
     // Play track handler (for popular tracks)

--- a/frontend/app/my-history/page.tsx
+++ b/frontend/app/my-history/page.tsx
@@ -32,7 +32,7 @@ interface PlayHistoryTrack {
         tidalTrackId: number | null;
         youtubeVideoId: string | null;
     };
-    streamSource?: "tidal" | "youtube";
+    streamSource?: "peer" | "tidal" | "youtube";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     artist?: {

--- a/frontend/app/playlist/[id]/page.tsx
+++ b/frontend/app/playlist/[id]/page.tsx
@@ -17,12 +17,18 @@ import {
     useAudioState,
     usePlaybackStatus,
     useAudioControls,
-    Track as AudioTrack,
 } from "@/lib/audio-context";
 import { cn } from "@/utils/cn";
 import { shuffleArray } from "@/utils/shuffle";
 import { formatTime } from "@/utils/formatTime";
 import { usePlaylistQuery } from "@/hooks/useQueries";
+import {
+    getUnplayableMessage,
+    isLocalPlayableTrackItem,
+    isPlayableTrackItem,
+    toAudioTrack,
+    TRACK_REMOVED_TOOLTIP,
+} from "@/lib/playlistItemPlayback";
 import { TrackPreferenceButtons } from "@/components/player/TrackPreferenceButtons";
 import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
 import {
@@ -78,72 +84,6 @@ import { formatPlaylistDuration } from "./playlistDuration";
 
 type PlaylistItem = PlaylistDetailTrackItem;
 type PendingTrack = PlaylistPendingTrackItem;
-
-const TRACK_REMOVED_TOOLTIP =
-    "File removed from library — restore the file to bring it back";
-
-interface PlayablePlaylistItem extends PlaylistItem {
-    track: NonNullable<PlaylistItem["track"]>;
-}
-
-function isPlayableTrackItem(item: PlaylistItem): item is PlayablePlaylistItem {
-    return Boolean(item.track && item.playback?.isPlayable !== false);
-}
-
-function isLocalPlayableTrackItem(
-    item: PlaylistItem,
-): item is PlayablePlaylistItem {
-    if (!isPlayableTrackItem(item)) return false;
-    return (
-        item.track.source !== "federated" &&
-        (item.provider?.source || "local") === "local"
-    );
-}
-
-function getUnplayableMessage(item: PlaylistItem): string {
-    if (item.playback?.reason === "track_removed") {
-        return TRACK_REMOVED_TOOLTIP;
-    }
-    if (item.playback?.reason === "peer_offline") {
-        return "This peer is offline.";
-    }
-    return (
-        item.playback?.message ||
-        "Playback is unavailable for this track right now."
-    );
-}
-
-function toAudioTrack(item: PlayablePlaylistItem): AudioTrack {
-    const track = item.track;
-    return {
-        id: track.id,
-        title: track.title,
-        artist: {
-            name: track.album.artist.name,
-            id: track.album.artist.id,
-        },
-        album: {
-            title: track.album.title,
-            coverArt: track.album.coverArt || undefined,
-            id: track.album.id,
-        },
-        duration: track.duration,
-        source: track.source,
-        peer: track.peer,
-        ...(track.streamSource === "tidal"
-            ? {
-                  streamSource: "tidal" as const,
-                  tidalTrackId: track.tidalTrackId,
-              }
-            : {}),
-        ...(track.streamSource === "youtube"
-            ? {
-                  streamSource: "youtube" as const,
-                  youtubeVideoId: track.youtubeVideoId,
-              }
-            : {}),
-    };
-}
 
 /**
  * Renders the PlaylistDetailPage component.

--- a/frontend/app/queue/page.tsx
+++ b/frontend/app/queue/page.tsx
@@ -67,17 +67,22 @@ export default function QueuePage() {
 
     const resolveQueueSource = (
         index: number,
-        fallback?: "tidal" | "youtube" | "youtube-direct",
-    ): "local" | "tidal" | "youtube" => {
+        fallback?: "peer" | "tidal" | "youtube" | "youtube-direct",
+    ): "local" | "peer" | "tidal" | "youtube" => {
         const resolved = trackAvailability.get(index)?.source;
         if (
             resolved === "local" ||
+            resolved === "peer" ||
             resolved === "tidal" ||
             resolved === "youtube"
         ) {
             return resolved;
         }
-        if (fallback === "tidal" || fallback === "youtube") {
+        if (
+            fallback === "peer" ||
+            fallback === "tidal" ||
+            fallback === "youtube"
+        ) {
             return fallback;
         }
         if (fallback === "youtube-direct") {
@@ -766,8 +771,8 @@ function NextTrackRow({
     isInGroup: boolean;
     resolveQueueSource: (
         index: number,
-        fallback?: "tidal" | "youtube" | "youtube-direct",
-    ) => "local" | "tidal" | "youtube";
+        fallback?: "peer" | "tidal" | "youtube" | "youtube-direct",
+    ) => "local" | "peer" | "tidal" | "youtube";
     onMoveUp: (index: number) => void;
     onMoveDown: (index: number) => void;
     onPlay: (index: number) => void;
@@ -925,8 +930,8 @@ function PreviousTrackRow({
     isInGroup: boolean;
     resolveQueueSource: (
         index: number,
-        fallback?: "tidal" | "youtube" | "youtube-direct",
-    ) => "local" | "tidal" | "youtube";
+        fallback?: "peer" | "tidal" | "youtube" | "youtube-direct",
+    ) => "local" | "peer" | "tidal" | "youtube";
     trackAvailability: Map<number, AvailabilityItem>;
 }) {
     const availability = isInGroup ? trackAvailability.get(idx) : undefined;

--- a/frontend/components/player/AudioPlaybackOrchestrator.tsx
+++ b/frontend/components/player/AudioPlaybackOrchestrator.tsx
@@ -23,7 +23,7 @@ import {
     isAdvancePlayIntentFresh,
     resolveLoadAutoplayDecision,
     resolvePlaybackDuration,
-    resolveRemoteStreamFormat,
+    resolveTrackFormatHint,
     shouldAttemptRecoveryOnUnexpectedPause,
 } from "./audioPlaybackOrchestratorPolicy";
 import { readMigratingStorageItem } from "@/lib/storage-migration";
@@ -525,7 +525,6 @@ export const AudioPlaybackOrchestrator = memo(
                             );
                             if (nextTrack) {
                                 let preloadUrl: string;
-                                let preloadFormat: string | undefined = "mp3";
                                 if (
                                     nextTrack.streamSource === "tidal" &&
                                     nextTrack.tidalTrackId
@@ -533,8 +532,6 @@ export const AudioPlaybackOrchestrator = memo(
                                     preloadUrl = api.getTidalStreamUrl(
                                         nextTrack.tidalTrackId,
                                     );
-                                    preloadFormat =
-                                        resolveRemoteStreamFormat("tidal");
                                 } else if (
                                     nextTrack.streamSource === "youtube" &&
                                     nextTrack.youtubeVideoId
@@ -544,8 +541,6 @@ export const AudioPlaybackOrchestrator = memo(
                                         undefined,
                                         !ytMusicAuthenticatedRef.current,
                                     );
-                                    preloadFormat =
-                                        resolveRemoteStreamFormat("youtube");
                                 } else if (
                                     nextTrack.streamSource ===
                                         "youtube-direct" &&
@@ -554,24 +549,13 @@ export const AudioPlaybackOrchestrator = memo(
                                     preloadUrl = api.getYouTubeStreamUrl(
                                         nextTrack.youtubeVideoId,
                                     );
-                                    preloadFormat =
-                                        nextTrack.youtubeAudioFormat === "webm"
-                                            ? "webm"
-                                            : "mp4";
                                 } else {
+                                    // Local and peer tracks share the
+                                    // library stream route.
                                     preloadUrl = api.getStreamUrl(nextTrack.id);
-                                    const ext = (nextTrack.filePath || "")
-                                        .split(".")
-                                        .pop()
-                                        ?.toLowerCase();
-                                    if (ext === "flac") preloadFormat = "flac";
-                                    else if (ext === "m4a" || ext === "aac")
-                                        preloadFormat = "mp4";
-                                    else if (ext === "ogg" || ext === "opus")
-                                        preloadFormat = "webm";
-                                    else if (ext === "wav")
-                                        preloadFormat = "wav";
                                 }
+                                const preloadFormat =
+                                    resolveTrackFormatHint(nextTrack);
                                 audioEngine.preload(preloadUrl, {
                                     format: preloadFormat,
                                 });
@@ -1178,6 +1162,11 @@ export const AudioPlaybackOrchestrator = memo(
                     streamUrl = api.getYouTubeStreamUrl(
                         currentTrack.youtubeVideoId,
                     );
+                } else if (currentTrack.streamSource === "peer") {
+                    // Peer tracks stream through the consumer's library
+                    // route; the backend resolves the owning peer and
+                    // applies the stream-time fallback ladder.
+                    streamUrl = api.getStreamUrl(currentTrack.id);
                 } else {
                     streamUrl = api.getStreamUrl(currentTrack.id);
                 }
@@ -1247,33 +1236,7 @@ export const AudioPlaybackOrchestrator = memo(
                     0;
                 setDuration(fallbackDuration);
 
-                let format: string | undefined = "mp3";
-                if (currentTrack?.streamSource === "youtube-direct") {
-                    // Direct YouTube audio is opus-in-webm or AAC-in-mp4
-                    // depending on the source video; /api/youtube/info reports
-                    // the container as audioFormat.
-                    format =
-                        currentTrack.youtubeAudioFormat === "webm"
-                            ? "webm"
-                            : "mp4";
-                } else if (
-                    currentTrack?.streamSource === "tidal" ||
-                    currentTrack?.streamSource === "youtube"
-                ) {
-                    format = resolveRemoteStreamFormat(
-                        currentTrack.streamSource,
-                    );
-                } else {
-                    const filePath = currentTrack?.filePath || "";
-                    if (filePath) {
-                        const ext = filePath.split(".").pop()?.toLowerCase();
-                        if (ext === "flac") format = "flac";
-                        else if (ext === "m4a" || ext === "aac") format = "mp4";
-                        else if (ext === "ogg" || ext === "opus")
-                            format = "webm";
-                        else if (ext === "wav") format = "wav";
-                    }
-                }
+                const format = resolveTrackFormatHint(currentTrack ?? null);
 
                 if (playbackType === "track" && currentTrack) {
                     setStreamProfile({

--- a/frontend/components/player/audioPlaybackOrchestratorPolicy.ts
+++ b/frontend/components/player/audioPlaybackOrchestratorPolicy.ts
@@ -115,3 +115,38 @@ export function isAdvancePlayIntentFresh(
     const ageMs = nowMs - intentAtMs;
     return ageMs >= 0 && ageMs < ADVANCE_PLAY_INTENT_TTL_MS;
 }
+
+/**
+ * Resolves the engine format hint for a track load or preload.
+ *
+ * TIDAL/YT Music remote streams get the extensionless-URL hint; direct
+ * YouTube audio reports its container; peer streams get NO hint because
+ * the body may be the peer's original container or provider bytes from
+ * the stream-time fallback ladder, and the engine detects the container
+ * from Content-Type when the hint is absent; local tracks derive the
+ * hint from the file extension.
+ */
+export function resolveTrackFormatHint(
+    track: {
+        streamSource?: string | null;
+        youtubeAudioFormat?: "mp4" | "webm";
+        filePath?: string | null;
+    } | null,
+): string | undefined {
+    if (!track) return "mp3";
+    if (track.streamSource === "youtube-direct") {
+        return track.youtubeAudioFormat === "webm" ? "webm" : "mp4";
+    }
+    if (track.streamSource === "tidal" || track.streamSource === "youtube") {
+        return resolveRemoteStreamFormat(track.streamSource);
+    }
+    if (track.streamSource === "peer") {
+        return undefined;
+    }
+    const ext = (track.filePath || "").split(".").pop()?.toLowerCase();
+    if (ext === "flac") return "flac";
+    if (ext === "m4a" || ext === "aac") return "mp4";
+    if (ext === "ogg" || ext === "opus") return "webm";
+    if (ext === "wav") return "wav";
+    return "mp3";
+}

--- a/frontend/features/album/albumPlayback.ts
+++ b/frontend/features/album/albumPlayback.ts
@@ -34,5 +34,8 @@ export function toAlbumPlaybackTrack(track: Track, album: Album) {
             streamSource: "youtube" as const,
             youtubeVideoId: track.youtubeVideoId,
         }),
+        ...(track.streamSource === "peer" && {
+            streamSource: "peer" as const,
+        }),
     };
 }

--- a/frontend/features/album/types.ts
+++ b/frontend/features/album/types.ts
@@ -62,7 +62,7 @@ export interface Track {
     displayTrackNo?: number | null;
     hasUserOverrides?: boolean;
     // Streaming fields (gap-fill)
-    streamSource?: "local" | "tidal" | "youtube";
+    streamSource?: "local" | "peer" | "tidal" | "youtube";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     thumbnailUrl?: string;

--- a/frontend/features/artist/types.ts
+++ b/frontend/features/artist/types.ts
@@ -85,7 +85,7 @@ export interface Track {
     displayTrackNo?: number | null;
     hasUserOverrides?: boolean;
     // Streaming fields (gap-fill)
-    streamSource?: "local" | "tidal" | "youtube";
+    streamSource?: "local" | "peer" | "tidal" | "youtube";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     source?: UnifiedTrackSource;

--- a/frontend/features/settings/components/sections/PlaybackSourcesSection.tsx
+++ b/frontend/features/settings/components/sections/PlaybackSourcesSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { SettingsSection, SettingsRow, SettingsSelect } from "../ui";
+import { SystemSettings } from "../../types";
+
+const DEFAULT_ORDER = "library,peers,tidal,ytmusic";
+
+const orderOptions = [
+    {
+        value: DEFAULT_ORDER,
+        label: "Library → Peers → TIDAL → YT Music (Default)",
+    },
+    {
+        value: "library,peers,ytmusic,tidal",
+        label: "Library → Peers → YT Music → TIDAL",
+    },
+    {
+        value: "library,tidal,ytmusic,peers",
+        label: "Library → TIDAL → YT Music → Peers",
+    },
+    {
+        value: "library,ytmusic,tidal,peers",
+        label: "Library → YT Music → TIDAL → Peers",
+    },
+];
+
+/** Returns the preset list, appending the stored value when it is custom. */
+function resolveOrderOptions(stored: string) {
+    if (orderOptions.some((option) => option.value === stored)) {
+        return orderOptions;
+    }
+    return [...orderOptions, { value: stored, label: "Custom (current)" }];
+}
+
+interface PlaybackSourcesSectionProps {
+    settings: SystemSettings;
+    onUpdate: (updates: Partial<SystemSettings>) => void;
+}
+
+/**
+ * Renders the PlaybackSourcesSection component.
+ */
+export function PlaybackSourcesSection({
+    settings,
+    onUpdate,
+}: PlaybackSourcesSectionProps) {
+    const stored = settings.playbackSourceOrder || DEFAULT_ORDER;
+
+    return (
+        <SettingsSection
+            id="playback-sources"
+            title="Playback Sources"
+            description="Where tracks play from when more than one source can provide them"
+        >
+            <SettingsRow
+                label="Source priority"
+                description="Your own library always wins when it has the track. This order decides what is tried next: connected peer libraries, TIDAL, or YT Music."
+            >
+                <SettingsSelect
+                    value={stored}
+                    onChange={(v) => onUpdate({ playbackSourceOrder: v })}
+                    options={resolveOrderOptions(stored)}
+                />
+            </SettingsRow>
+        </SettingsSection>
+    );
+}

--- a/frontend/features/settings/hooks/useSystemSettings.ts
+++ b/frontend/features/settings/hooks/useSystemSettings.ts
@@ -41,6 +41,7 @@ const defaultSystemSettings: SystemSettings = {
     // Download preferences
     downloadSource: "soulseek",
     federationInstanceName: null,
+    playbackSourceOrder: "library,peers,tidal,ytmusic",
     primaryFailureFallback: "none",
     // YouTube Music streaming
     ytMusicEnabled: false,

--- a/frontend/features/settings/types.ts
+++ b/frontend/features/settings/types.ts
@@ -74,6 +74,8 @@ export interface SystemSettings {
     // Federation identity
     federationInstanceName: string | null;
     primaryFailureFallback: DownloadFallback;
+    // Playback source priority (comma-separated provider order)
+    playbackSourceOrder: string;
     // YouTube Music streaming (admin toggle + OAuth app credentials)
     ytMusicEnabled: boolean;
     ytMusicClientId: string;

--- a/frontend/hooks/useStreamBitrate.ts
+++ b/frontend/hooks/useStreamBitrate.ts
@@ -183,7 +183,7 @@ export function resolveEffectiveLocalPlaybackQuality(input: {
     playbackQuality: LocalTrackQuality | null;
     streamProfile: {
         mode: "direct";
-        sourceType: "local" | "tidal" | "ytmusic" | "unknown";
+        sourceType: "local" | "peer" | "tidal" | "ytmusic" | "unknown";
         codec: string | null;
         bitrateKbps: number | null;
     } | null;
@@ -301,6 +301,7 @@ export interface PlaybackQualityBadge {
 
 export type PlaybackStreamSource =
     | "local"
+    | "peer"
     | "tidal"
     | "youtube"
     | "youtube-direct";
@@ -452,11 +453,15 @@ export function useStreamBitrate(): {
     // ── Local track quality info ───────────────────────────────────
     useEffect(() => {
         // Local tracks have no streamSource (or streamSource === "local")
-        // and always have an id that isn't a synthetic lastfm-* id
+        // and always have an id that isn't a synthetic lastfm-* id.
+        // Peer tracks are library rows synced from a federation peer:
+        // their quality metadata lives on the local Track row, so they
+        // use the same metadata lookup as local tracks.
         const isLocal =
             playbackType === "track" &&
             currentTrack &&
-            !currentTrack.streamSource &&
+            (!currentTrack.streamSource ||
+                currentTrack.streamSource === "peer") &&
             currentTrack.id &&
             !currentTrack.id.startsWith("lastfm-");
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -155,7 +155,7 @@ export interface PlaylistDetailTrack {
     id: string;
     title: string;
     duration: number;
-    streamSource?: "tidal" | "youtube";
+    streamSource?: "peer" | "tidal" | "youtube";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     source?: "local" | "tidal" | "youtube" | "federated";

--- a/frontend/lib/audio-engine/audioPlaybackTrackPolicy.ts
+++ b/frontend/lib/audio-engine/audioPlaybackTrackPolicy.ts
@@ -1,6 +1,7 @@
 import {
     normalizeCanonicalMediaProviderIdentity,
     toAudioEngineSourceType,
+    type AudioEngineSourceType,
     type CanonicalMediaProviderIdentity,
     type CanonicalMediaSource,
 } from "@soundspan/media-metadata-contract";
@@ -9,7 +10,7 @@ import {
 export interface RuntimeProviderTrack {
     mediaSource?: CanonicalMediaSource;
     provider?: CanonicalMediaProviderIdentity;
-    streamSource?: "local" | "tidal" | "youtube" | "youtube-direct";
+    streamSource?: "local" | "peer" | "tidal" | "youtube" | "youtube-direct";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     youtubeAudioFormat?: "mp4" | "webm";
@@ -23,7 +24,12 @@ export function getNextTrackInfo(
         filePath?: string;
         mediaSource?: CanonicalMediaSource;
         provider?: CanonicalMediaProviderIdentity;
-        streamSource?: "local" | "tidal" | "youtube" | "youtube-direct";
+        streamSource?:
+            | "local"
+            | "peer"
+            | "tidal"
+            | "youtube"
+            | "youtube-direct";
         tidalTrackId?: number;
         youtubeVideoId?: string;
         youtubeAudioFormat?: "mp4" | "webm";
@@ -38,7 +44,7 @@ export function getNextTrackInfo(
     filePath?: string;
     mediaSource?: CanonicalMediaSource;
     provider?: CanonicalMediaProviderIdentity;
-    streamSource?: "local" | "tidal" | "youtube" | "youtube-direct";
+    streamSource?: "local" | "peer" | "tidal" | "youtube" | "youtube-direct";
     tidalTrackId?: number;
     youtubeVideoId?: string;
     youtubeAudioFormat?: "mp4" | "webm";
@@ -74,7 +80,7 @@ export function getNextTrackInfo(
 /** Resolves the direct engine source type from canonical provider metadata. */
 export function resolveDirectTrackSourceType(
     track: RuntimeProviderTrack,
-): "local" | "tidal" | "ytmusic" {
+): AudioEngineSourceType {
     const provider = normalizeCanonicalMediaProviderIdentity({
         mediaSource: track.mediaSource,
         providerTrackId: track.provider?.providerTrackId,

--- a/frontend/lib/audio-playback-context.tsx
+++ b/frontend/lib/audio-playback-context.tsx
@@ -44,7 +44,7 @@ import {
 
 export interface PlaybackStreamProfile {
     mode: "direct";
-    sourceType: "local" | "tidal" | "ytmusic" | "unknown";
+    sourceType: "local" | "peer" | "tidal" | "ytmusic" | "unknown";
     codec: string | null;
     bitrateKbps: number | null;
 }

--- a/frontend/lib/playlistItemPlayback.ts
+++ b/frontend/lib/playlistItemPlayback.ts
@@ -1,0 +1,78 @@
+import type { PlaylistDetailTrackItem } from "@/lib/api";
+import type { Track as AudioTrack } from "@/lib/audio-context";
+
+export const TRACK_REMOVED_TOOLTIP =
+    "File removed from library — restore the file to bring it back";
+
+/** Playlist row whose track is present and currently playable. */
+export interface PlayablePlaylistItem extends PlaylistDetailTrackItem {
+    track: NonNullable<PlaylistDetailTrackItem["track"]>;
+}
+
+/** Returns whether a playlist row can be played right now. */
+export function isPlayableTrackItem(
+    item: PlaylistDetailTrackItem,
+): item is PlayablePlaylistItem {
+    return Boolean(item.track && item.playback?.isPlayable !== false);
+}
+
+/** Returns whether a playlist row is a locally sourced playable track. */
+export function isLocalPlayableTrackItem(
+    item: PlaylistDetailTrackItem,
+): item is PlayablePlaylistItem {
+    if (!isPlayableTrackItem(item)) return false;
+    return (
+        item.track.source !== "federated" &&
+        (item.provider?.source || "local") === "local"
+    );
+}
+
+/** Explains why a playlist row cannot be played. */
+export function getUnplayableMessage(item: PlaylistDetailTrackItem): string {
+    if (item.playback?.reason === "track_removed") {
+        return TRACK_REMOVED_TOOLTIP;
+    }
+    if (item.playback?.reason === "peer_offline") {
+        return "This peer is offline.";
+    }
+    return (
+        item.playback?.message ||
+        "Playback is unavailable for this track right now."
+    );
+}
+
+/** Maps a playable playlist row onto the audio-context track shape. */
+export function toAudioTrack(item: PlayablePlaylistItem): AudioTrack {
+    const track = item.track;
+    return {
+        id: track.id,
+        title: track.title,
+        artist: {
+            name: track.album.artist.name,
+            id: track.album.artist.id,
+        },
+        album: {
+            title: track.album.title,
+            coverArt: track.album.coverArt || undefined,
+            id: track.album.id,
+        },
+        duration: track.duration,
+        source: track.source,
+        peer: track.peer,
+        ...(track.streamSource === "tidal"
+            ? {
+                  streamSource: "tidal" as const,
+                  tidalTrackId: track.tidalTrackId,
+              }
+            : {}),
+        ...(track.streamSource === "youtube"
+            ? {
+                  streamSource: "youtube" as const,
+                  youtubeVideoId: track.youtubeVideoId,
+              }
+            : {}),
+        ...(track.streamSource === "peer"
+            ? { streamSource: "peer" as const }
+            : {}),
+    };
+}

--- a/frontend/tests/component/cacheSection.component.test.ts
+++ b/frontend/tests/component/cacheSection.component.test.ts
@@ -87,6 +87,7 @@ const settings: SystemSettings = {
     soulseekConcurrentDownloads: 4,
     downloadSource: "soulseek",
     federationInstanceName: null,
+    playbackSourceOrder: "library,peers,tidal,ytmusic",
     primaryFailureFallback: "none",
     ytMusicEnabled: false,
     ytMusicClientId: "",

--- a/frontend/tests/component/downloadPreferencesSection.component.test.ts
+++ b/frontend/tests/component/downloadPreferencesSection.component.test.ts
@@ -44,6 +44,7 @@ const baseSettings: SystemSettings = {
     soulseekConcurrentDownloads: 4,
     downloadSource: "soulseek",
     federationInstanceName: null,
+    playbackSourceOrder: "library,peers,tidal,ytmusic",
     primaryFailureFallback: "none",
     ytMusicEnabled: false,
     ytMusicClientId: "",

--- a/frontend/tests/unit/audioPlaybackOrchestratorPolicy.test.ts
+++ b/frontend/tests/unit/audioPlaybackOrchestratorPolicy.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
     resolvePlaybackDuration,
     resolveRemoteStreamFormat,
+    resolveTrackFormatHint,
     shouldAttemptRecoveryOnUnexpectedPause,
 } from "../../components/player/audioPlaybackOrchestratorPolicy";
 
@@ -128,4 +129,32 @@ test("local stream uses low loaded duration when no metadata available", () => {
         }),
         4,
     );
+});
+
+test("format hint follows the source: remote hinted, peer detected, local by extension", () => {
+    assert.equal(resolveTrackFormatHint({ streamSource: "tidal" }), "mp4");
+    assert.equal(resolveTrackFormatHint({ streamSource: "youtube" }), "mp4");
+    assert.equal(
+        resolveTrackFormatHint({
+            streamSource: "youtube-direct",
+            youtubeAudioFormat: "webm",
+        }),
+        "webm",
+    );
+    // Peer bodies may be the original container or fallback provider
+    // bytes, so the engine must detect from Content-Type.
+    assert.equal(resolveTrackFormatHint({ streamSource: "peer" }), undefined);
+    assert.equal(
+        resolveTrackFormatHint({
+            streamSource: "peer",
+            filePath: "/music/a.flac",
+        }),
+        undefined,
+    );
+    assert.equal(resolveTrackFormatHint({ filePath: "/music/a.flac" }), "flac");
+    assert.equal(resolveTrackFormatHint({ filePath: "/music/a.m4a" }), "mp4");
+    assert.equal(resolveTrackFormatHint({ filePath: "/music/a.opus" }), "webm");
+    assert.equal(resolveTrackFormatHint({ filePath: "/music/a.wav" }), "wav");
+    assert.equal(resolveTrackFormatHint({}), "mp3");
+    assert.equal(resolveTrackFormatHint(null), "mp3");
 });

--- a/frontend/tests/unit/audioPlaybackTrackPolicy.test.ts
+++ b/frontend/tests/unit/audioPlaybackTrackPolicy.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
     getNextTrackInfo,
     isLikelyTransientStreamError,
+    resolveDirectTrackSourceType,
 } from "../../lib/audio-engine/audioPlaybackTrackPolicy";
 
 test("selects the next music track in queue order", () => {
@@ -44,5 +45,20 @@ test("classifies bounded transport failures as transient", () => {
     assert.equal(
         isLikelyTransientStreamError(new Error("decode failed")),
         false,
+    );
+});
+
+test("resolves peer tracks to the peer engine source type", () => {
+    assert.equal(
+        resolveDirectTrackSourceType({ streamSource: "peer" }),
+        "peer",
+    );
+    assert.equal(resolveDirectTrackSourceType({}), "local");
+    assert.equal(
+        resolveDirectTrackSourceType({
+            streamSource: "tidal",
+            tidalTrackId: 42,
+        }),
+        "tidal",
     );
 });

--- a/frontend/tests/unit/mediaSourceContract.test.ts
+++ b/frontend/tests/unit/mediaSourceContract.test.ts
@@ -34,6 +34,7 @@ void _sBad;
 test("CANONICAL_MEDIA_SOURCE_VALUES lists every canonical media source", () => {
     assert.deepEqual(CANONICAL_MEDIA_SOURCE_VALUES, [
         "local",
+        "peer",
         "tidal",
         "youtube",
         "youtube-direct",

--- a/packages/media-metadata-contract/package.json
+++ b/packages/media-metadata-contract/package.json
@@ -12,6 +12,7 @@
     ],
     "scripts": {
         "build": "tsc -p tsconfig.json",
+        "test": "node --test test/*.test.js",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/packages/media-metadata-contract/src/index.ts
+++ b/packages/media-metadata-contract/src/index.ts
@@ -4,6 +4,7 @@ export const CENTRAL_MEDIA_METADATA_CONTRACT_VERSION = "1.0.0";
 /** Complete runtime list of canonical media source identifiers. */
 export const CANONICAL_MEDIA_SOURCE_VALUES = [
     "local",
+    "peer",
     "tidal",
     "youtube",
     "youtube-direct",
@@ -23,7 +24,7 @@ export type ResolvedMediaSource = Exclude<
 >;
 
 /** Source identifiers accepted by the audio engine boundary. */
-export type AudioEngineSourceType = "local" | "tidal" | "ytmusic";
+export type AudioEngineSourceType = "local" | "peer" | "tidal" | "ytmusic";
 
 /** Canonical provider identity and optional provider-specific track metadata. */
 export interface CanonicalMediaProviderIdentity {
@@ -193,6 +194,7 @@ export const normalizeCanonicalMediaSource = (
 ): CanonicalMediaSource | null => {
     if (
         value === "local" ||
+        value === "peer" ||
         value === "tidal" ||
         value === "youtube" ||
         value === "youtube-direct"
@@ -275,6 +277,10 @@ export const normalizeCanonicalMediaProviderIdentity = (value: {
         };
     }
 
+    if (source === "peer") {
+        return { source, providerTrackId };
+    }
+
     return { source: "local" };
 };
 
@@ -290,6 +296,9 @@ export const toLegacyStreamFields = (
             streamSource: "tidal",
             tidalTrackId: provider.tidalTrackId,
         };
+    }
+    if (provider.source === "peer") {
+        return { streamSource: "peer" };
     }
     if (provider.source === "youtube") {
         return {

--- a/packages/media-metadata-contract/test/index.test.js
+++ b/packages/media-metadata-contract/test/index.test.js
@@ -1,0 +1,16 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const contract = require("../dist/index.js");
+
+test("peer is a canonical media source and audio-engine source", () => {
+    assert.equal(contract.CANONICAL_MEDIA_SOURCE_VALUES.includes("peer"), true);
+    assert.equal(contract.normalizeCanonicalMediaSource("peer"), "peer");
+    assert.equal(contract.toAudioEngineSourceType("peer"), "peer");
+});
+
+test("peer legacy stream fields remain a playback-only concern", () => {
+    assert.deepEqual(contract.toLegacyStreamFields({ source: "peer" }), {
+        streamSource: "peer",
+    });
+});


### PR DESCRIPTION
## Problem

Once peers exist, order-of-operations for where a track comes from was wrong. Source selection was a one-time dispatch decided at queue time: federated rows silently inherited local's ranking tier, peer-offline was a dead-end `503 PEER_OFFLINE`, playlist and Listen Together resolution returned any `localTrackId` immediately (bypassing ranking for federated rows entirely), and no provider-order configuration existed.

## What changed

**Peers are an explicit ranking tier.** `choosePriority` splits the local case on origin: local wins outright; online peers rank above TIDAL and YT Music; offline peers fall below every available provider. The order is configurable via a new `playbackSourceOrder` system setting (default `library,peers,tidal,ytmusic`, validated as a complete duplicate-free permutation, resolution caches invalidated on save) with a new admin **Playback Sources** section offering curated presets. The same tiering governs playlist and Listen Together resolution, which now thread origin and peer-online state instead of hardcoding local.

**Stream-time fallback is a real ladder.** Peer offline → local dedup twin → eligible provider mappings in configured order → only then `PEER_OFFLINE` — in both the API and Subsonic routes. Rungs advance only on pre-header failures; committed-header and destroyed-response guards prevent a second protocol body mid-stream. Fallback mappings honor the same eligibility rules as ranked resolution (confidence ≥ 0.7, duration match — shared predicate, single source of truth), and provider calls carry the primary route's quality and YouTube identity.

**`peer` is a first-class source type** in the media-metadata contract and the player: explicit orchestrator dispatch arm, format hints resolved by a pure tested policy (peer streams carry no hint — the engine detects the container from Content-Type, since the ladder can substitute provider bytes), quality badges preserved for peer tracks, and playlist/artist/album/history adapters keep `streamSource: "peer"` instead of dropping it. Search already places library sections (which contain peer rows) above external providers.

**Rolling-deploy safety.** Listen Together persisted snapshots write the legacy shape plus an additive `actualOriginSource` field: old pods still validate snapshots from new pods (proved by a behavioral fixture reconstructing the previous validator), and new readers restore peer semantics. Heavy provider services are lazily imported on the fallback path so the route module graph stays lean. The federation sync envelope is untouched.

## Verification

- Backend: 39 affected suites / 723 tests green outside the sandbox (including both cover-art compat suites twice for order-independence); tsc clean; format clean; route-error and file-size gates clean (ratchet respected by extracting `resolveTrackFormatHint` into the orchestrator policy and the playlist playable-item helpers into `lib/playlistItemPlayback.ts`)
- Frontend: tsc 0 errors, eslint at the exact 183-warning cap, Next build compiles, policy unit tests 16/16
- Post-rebase battery rerun after resolving `systemSettings.ts` overlap with the federation pairing PR: 31 suites / 630 tests green
- Four review rounds; every finding fixed test-first

Closes #683