### PR TITLE
fix(audiobooks): discover new Audiobookshelf books automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library.
+
 ### Security
 
 ## [2.4.1] - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library.
+- Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library (#710).
 
 ### Security
 

--- a/backend/src/__tests__/workerSchedulerClaimContract.test.ts
+++ b/backend/src/__tests__/workerSchedulerClaimContract.test.ts
@@ -31,11 +31,21 @@ describe("worker scheduler claim contract", () => {
     it("registers queue-backed repeatable scheduler jobs", () => {
         const workersPath = path.resolve(__dirname, "../workers/index.ts");
         const workersSource = fs.readFileSync(workersPath, "utf8");
+        const registryPath = path.resolve(
+            __dirname,
+            "../workers/schedulerJobRegistry.ts",
+        );
+        const registrySource = fs.readFileSync(registryPath, "utf8");
 
         expect(workersSource).toContain("schedulerQueue.add(");
-        expect(workersSource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
-        expect(workersSource).toContain("repeat: { every: 2 * ONE_MINUTE_MS }");
-        expect(workersSource).toContain("repeat: { every: 5 * ONE_MINUTE_MS }");
+        expect(workersSource).toContain("buildSchedulerJobs()");
+        expect(registrySource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
+        expect(registrySource).toContain(
+            "repeat: { every: 2 * ONE_MINUTE_MS }",
+        );
+        expect(registrySource).toContain(
+            "repeat: { every: 5 * ONE_MINUTE_MS }",
+        );
         expect(workersSource).toContain(
             'schedulerQueue.process("*", async (job: Bull.Job<any>) =>',
         );

--- a/backend/src/__tests__/workerStartupMaintenanceQueueContract.test.ts
+++ b/backend/src/__tests__/workerStartupMaintenanceQueueContract.test.ts
@@ -3,10 +3,15 @@ import path from "path";
 
 describe("worker startup maintenance queue contract", () => {
     const workersPath = path.resolve(__dirname, "../workers/index.ts");
+    const registryPath = path.resolve(
+        __dirname,
+        "../workers/schedulerJobRegistry.ts",
+    );
     const indexPath = path.resolve(__dirname, "../index.ts");
     const workerPath = path.resolve(__dirname, "../worker.ts");
 
     const workersSource = fs.readFileSync(workersPath, "utf8");
+    const registrySource = fs.readFileSync(registryPath, "utf8");
     const indexSource = fs.readFileSync(indexPath, "utf8");
     const workerSource = fs.readFileSync(workerPath, "utf8");
 
@@ -17,7 +22,8 @@ describe("worker startup maintenance queue contract", () => {
         expect(workersSource).toContain("downloadQueueReconcile");
         expect(workersSource).toContain("artistCountsBackfill");
         expect(workersSource).toContain("imageBackfill");
-        expect(workersSource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
+        expect(workersSource).toContain("buildSchedulerJobs()");
+        expect(registrySource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
     });
 
     it("removes direct startup side-effects from api and worker entrypoints", () => {

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -224,6 +224,29 @@ describe("audiobook cache service behavior", () => {
         );
     });
 
+    it("records the error message when a missing audiobook fails to sync", async () => {
+        const service = new AudiobookCacheService();
+
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({
+                id: "book-broken",
+                media: {
+                    metadata: { title: "Broken Book" },
+                },
+            }),
+        ]);
+        prisma.audiobook.upsert.mockRejectedValueOnce(
+            new Error("db write failed"),
+        );
+
+        const result = await service.syncMissing();
+
+        expect(result.failed).toBe(1);
+        expect(result.errors[0]).toBe(
+            "Failed to sync Broken Book: db write failed",
+        );
+    });
+
     it("preserves stored sections on minified updates and creates them as unknown", async () => {
         const service = new AudiobookCacheService();
         mockGetAllAudiobooks.mockResolvedValue([

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -195,6 +195,35 @@ describe("audiobook cache service behavior", () => {
         );
     });
 
+    it("syncs only audiobooks missing from the local ABS cache", async () => {
+        const service = new AudiobookCacheService();
+
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "book-1" }),
+            buildBook({ id: "book-2" }),
+        ]);
+        prisma.audiobook.findMany.mockResolvedValueOnce([{ id: "book-1" }]);
+
+        const result = await service.syncMissing();
+
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: { peerId: null },
+            select: { id: true },
+        });
+        expect(result).toEqual({
+            synced: 1,
+            failed: 0,
+            skipped: 1,
+            errors: [],
+        });
+        expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(1);
+        expect(prisma.audiobook.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "book-2" },
+            }),
+        );
+    });
+
     it("preserves stored sections on minified updates and creates them as unknown", async () => {
         const service = new AudiobookCacheService();
         mockGetAllAudiobooks.mockResolvedValue([

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -89,30 +89,7 @@ export class AudiobookCacheService {
                 `[AUDIOBOOK] Found ${audiobooks.length} audiobooks in Audiobookshelf`,
             );
 
-            for (const book of audiobooks) {
-                try {
-                    await this.syncAudiobook(book);
-                    result.synced++;
-                    // Extract title and author from nested structure for logging
-                    const metadata = book.media?.metadata || book;
-                    const title =
-                        metadata.title || book.title || "Unknown Title";
-                    const author =
-                        metadata.authorName ||
-                        metadata.author ||
-                        book.author ||
-                        "Unknown Author";
-                    logger.debug(`  Synced: ${title} by ${author}`);
-                } catch (error: any) {
-                    result.failed++;
-                    const metadata = book.media?.metadata || book;
-                    const title =
-                        metadata.title || book.title || "Unknown Title";
-                    const errorMsg = `Failed to sync ${title}: ${error.message}`;
-                    result.errors.push(errorMsg);
-                    logger.error(` ${errorMsg}`);
-                }
-            }
+            await this.syncBooks(audiobooks, result, { logEachBook: true });
 
             logger.debug("\nSync Summary:");
             logger.debug(`  Synced: ${result.synced}`);
@@ -133,7 +110,8 @@ export class AudiobookCacheService {
 
     /**
      * Sync audiobooks that exist in Audiobookshelf but are not cached locally.
-     * Intended for lightweight periodic discovery of newly-added books.
+     * This fetches the full item listing because Audiobookshelf has no delta API.
+     * It is lighter than syncAll because cached books skip upserts and cover work.
      */
     async syncMissing(): Promise<SyncResult> {
         const result: SyncResult = {
@@ -169,20 +147,9 @@ export class AudiobookCacheService {
 
             await this.ensureCoverCacheDir();
 
-            for (const book of missingAudiobooks) {
-                try {
-                    await this.syncAudiobook(book);
-                    result.synced++;
-                } catch (error: any) {
-                    result.failed++;
-                    const metadata = book.media?.metadata || book;
-                    const title =
-                        metadata.title || book.title || "Unknown Title";
-                    const errorMsg = `Failed to sync ${title}`;
-                    result.errors.push(errorMsg);
-                    logger.error(` ${errorMsg}`, error);
-                }
-            }
+            await this.syncBooks(missingAudiobooks, result, {
+                logEachBook: false,
+            });
 
             logger.debug(
                 `[AUDIOBOOK] Incremental sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
@@ -192,6 +159,35 @@ export class AudiobookCacheService {
         } catch (error: any) {
             logger.error(" Audiobook incremental sync failed:", error);
             throw error;
+        }
+    }
+
+    private async syncBooks(
+        books: any[],
+        result: SyncResult,
+        options: { logEachBook: boolean },
+    ): Promise<void> {
+        for (const book of books) {
+            const metadata = book.media?.metadata || book;
+            const title = metadata.title || book.title || "Unknown Title";
+            const author =
+                metadata.authorName ||
+                metadata.author ||
+                book.author ||
+                "Unknown Author";
+
+            try {
+                await this.syncAudiobook(book);
+                result.synced++;
+                if (options.logEachBook) {
+                    logger.debug(`  Synced: ${title} by ${author}`);
+                }
+            } catch (error: any) {
+                result.failed++;
+                const errorMsg = `Failed to sync ${title}: ${error.message}`;
+                result.errors.push(errorMsg);
+                logger.error(` ${errorMsg}`, error);
+            }
         }
     }
 

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -132,6 +132,70 @@ export class AudiobookCacheService {
     }
 
     /**
+     * Sync audiobooks that exist in Audiobookshelf but are not cached locally.
+     * Intended for lightweight periodic discovery of newly-added books.
+     */
+    async syncMissing(): Promise<SyncResult> {
+        const result: SyncResult = {
+            synced: 0,
+            failed: 0,
+            skipped: 0,
+            errors: [],
+        };
+
+        try {
+            const audiobooks = await audiobookshelfService.getAllAudiobooks();
+
+            if (audiobooks.length === 0) {
+                return result;
+            }
+
+            const cachedAudiobooks = await prisma.audiobook.findMany({
+                where: { peerId: null },
+                select: { id: true },
+            });
+            const cachedIds = new Set(
+                cachedAudiobooks.map((audiobook) => audiobook.id),
+            );
+            const missingAudiobooks = audiobooks.filter(
+                (audiobook) => !cachedIds.has(audiobook.id),
+            );
+
+            result.skipped = audiobooks.length - missingAudiobooks.length;
+
+            if (missingAudiobooks.length === 0) {
+                return result;
+            }
+
+            await this.ensureCoverCacheDir();
+
+            for (const book of missingAudiobooks) {
+                try {
+                    await this.syncAudiobook(book);
+                    result.synced++;
+                } catch (error: any) {
+                    result.failed++;
+                    const metadata = book.media?.metadata || book;
+                    const title =
+                        metadata.title || book.title || "Unknown Title";
+                    const errorMsg = `Failed to sync ${title}`;
+                    result.errors.push(errorMsg);
+                    logger.error(` ${errorMsg}`, error);
+                }
+            }
+
+            logger.debug(
+                `[AUDIOBOOK] Incremental sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
+            );
+
+            return result;
+        } catch (error: any) {
+            logger.error(" Audiobook incremental sync failed:", error);
+            throw error;
+        }
+    }
+
+    /**
      * Sync a single audiobook
      */
     private async syncAudiobook(book: any): Promise<void> {

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -88,6 +88,12 @@ describe("workers runtime behavior", () => {
         }));
         const audiobookCacheService = {
             syncAll: jest.fn(async () => ({ synced: 0 })),
+            syncMissing: jest.fn(async () => ({
+                synced: 0,
+                failed: 0,
+                skipped: 0,
+                errors: [] as string[],
+            })),
         };
         const isBackfillNeeded = jest.fn(async () => false);
         const backfillAllArtistCounts = jest.fn(async () => ({
@@ -379,6 +385,16 @@ describe("workers runtime behavior", () => {
         expect(mocks.schedulerQueue.isReady).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.add).toHaveBeenCalled();
         expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+            "audiobook-auto-sync-startup",
+            { mode: "repeat" },
+            {
+                jobId: "scheduler:audiobook-auto-sync:repeat",
+                repeat: { every: 5 * 60 * 1000 },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
+        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
             "track-audio-hash-backfill",
             {
                 mode: "startup",
@@ -447,6 +463,34 @@ describe("workers runtime behavior", () => {
 
         expect(mocks.registerFederationProcessors).toHaveBeenCalledTimes(1);
         expect(mocks.registerFederationSchedules).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs incremental audiobook sync for scheduled repeat jobs", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
+            audiobookshelfEnabled: true,
+            audiobookshelfUrl: "http://abs.local",
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+
+        await schedulerHandler({
+            id: "audiobook-sync-1",
+            name: "audiobook-auto-sync-startup",
+            data: { mode: "repeat" },
+        });
+
+        expect(mocks.audiobookCacheService.syncMissing).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(mocks.audiobookCacheService.syncAll).not.toHaveBeenCalled();
     });
 
     it("dispatches track-removal purge jobs through the scheduler", async () => {
@@ -789,9 +833,12 @@ describe("workers runtime behavior", () => {
             audiobookshelfEnabled: true,
             audiobookshelfUrl: "http://audiobookshelf",
         });
-        const prisma = require("../../utils/db").prisma;
-        prisma.audiobook.count.mockResolvedValue(0);
-        mocks.audiobookCacheService.syncAll.mockResolvedValue({ synced: 4 });
+        mocks.audiobookCacheService.syncMissing.mockResolvedValue({
+            synced: 4,
+            failed: 0,
+            skipped: 0,
+            errors: [],
+        });
         mocks.isBackfillNeeded.mockResolvedValue(true);
         mocks.backfillAllArtistCounts.mockResolvedValue({
             processed: 10,
@@ -856,7 +903,7 @@ describe("workers runtime behavior", () => {
         });
 
         expect(mocks.cleanupExpiredCache).toHaveBeenCalled();
-        expect(mocks.audiobookCacheService.syncAll).toHaveBeenCalled();
+        expect(mocks.audiobookCacheService.syncMissing).toHaveBeenCalled();
         expect(
             mocks.downloadQueueManager.reconcileOnStartup,
         ).toHaveBeenCalled();
@@ -1006,25 +1053,29 @@ describe("workers runtime behavior", () => {
         await schedulerHandler({
             id: "audiobook-skip-disabled",
             name: "audiobook-auto-sync-startup",
-            data: {},
+            data: { mode: "startup" },
         });
 
         expect(mocks.logger.debug).toHaveBeenCalledWith(
             "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
         );
-        expect(mocks.audiobookCacheService.syncAll).not.toHaveBeenCalled();
+        expect(mocks.audiobookCacheService.syncMissing).not.toHaveBeenCalled();
     });
 
-    it("skips audiobook startup sync when cache is already populated", async () => {
+    it("checks for missing audiobooks even when the cache is already populated", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
-        const prisma = require("../../utils/db").prisma;
 
         (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
             audiobookshelfEnabled: true,
             audiobookshelfUrl: "http://audiobookshelf",
         });
-        prisma.audiobook.count.mockResolvedValueOnce(3);
+        mocks.audiobookCacheService.syncMissing.mockResolvedValueOnce({
+            synced: 1,
+            failed: 0,
+            skipped: 3,
+            errors: [],
+        });
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         require("../index");
@@ -1036,15 +1087,17 @@ describe("workers runtime behavior", () => {
         expect(schedulerHandler).toBeTruthy();
 
         await schedulerHandler({
-            id: "audiobook-skip-cached",
+            id: "audiobook-check-cached",
             name: "audiobook-auto-sync-startup",
-            data: {},
+            data: { mode: "startup" },
         });
 
-        expect(mocks.logger.debug).toHaveBeenCalledWith(
-            "Audiobook cache has 3 entries - skipping auto-sync",
+        expect(mocks.audiobookCacheService.syncMissing).toHaveBeenCalledTimes(
+            1,
         );
-        expect(mocks.audiobookCacheService.syncAll).not.toHaveBeenCalled();
+        expect(mocks.logger.debug).toHaveBeenCalledWith(
+            "Audiobook auto-sync complete: 1 new, 3 already cached, 0 failed",
+        );
     });
 
     it("skips startup backfills when artist counts and local images are already complete", async () => {
@@ -1601,9 +1654,13 @@ describe("workers runtime behavior", () => {
     it("times out startup maintenance tasks and skips completion logs when timed out", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
-        const prisma = require("../../utils/db").prisma;
-        const neverSyncAll = () =>
-            new Promise<{ synced: number }>(() => undefined);
+        const neverSyncMissing = () =>
+            new Promise<{
+                synced: number;
+                failed: number;
+                skipped: number;
+                errors: string[];
+            }>(() => undefined);
         const neverReconcileOnStartup = () =>
             new Promise<{ loaded: number; failed: number }>(() => undefined);
         const neverBackfillArtistCounts = () =>
@@ -1621,9 +1678,8 @@ describe("workers runtime behavior", () => {
             audiobookshelfEnabled: true,
             audiobookshelfUrl: "http://audiobookshelf",
         });
-        prisma.audiobook.count.mockResolvedValueOnce(0);
-        mocks.audiobookCacheService.syncAll.mockImplementationOnce(
-            neverSyncAll,
+        mocks.audiobookCacheService.syncMissing.mockImplementationOnce(
+            neverSyncMissing,
         );
         mocks.downloadQueueManager.reconcileOnStartup.mockImplementationOnce(
             neverReconcileOnStartup,

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -493,6 +493,104 @@ describe("workers runtime behavior", () => {
         expect(mocks.audiobookCacheService.syncAll).not.toHaveBeenCalled();
     });
 
+    it("resolves repeat audiobook sync failures and warns", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
+            audiobookshelfEnabled: true,
+            audiobookshelfUrl: "http://abs.local",
+        });
+        mocks.audiobookCacheService.syncMissing.mockRejectedValueOnce(
+            new Error("abs down"),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+
+        await expect(
+            schedulerHandler({
+                id: "audiobook-sync-failure",
+                name: "audiobook-auto-sync-startup",
+                data: { mode: "repeat" },
+            }),
+        ).resolves.toBeUndefined();
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            "Repeat audiobook auto-sync failed; will retry on the next cycle",
+            expect.objectContaining({ message: "abs down" }),
+        );
+    });
+
+    it("debounces repeat audiobook sync failure warnings without rejecting", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
+            audiobookshelfEnabled: true,
+            audiobookshelfUrl: "http://abs.local",
+        });
+        mocks.audiobookCacheService.syncMissing
+            .mockRejectedValueOnce(new Error("abs down"))
+            .mockRejectedValueOnce(new Error("abs down"));
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+        const repeatJob = {
+            id: "audiobook-sync-failure",
+            name: "audiobook-auto-sync-startup",
+            data: { mode: "repeat" },
+        };
+
+        await expect(schedulerHandler(repeatJob)).resolves.toBeUndefined();
+        await expect(schedulerHandler(repeatJob)).resolves.toBeUndefined();
+
+        expect(mocks.logger.warn).toHaveBeenCalledTimes(1);
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            "Repeat audiobook auto-sync failed; will retry on the next cycle",
+            expect.objectContaining({ message: "abs down" }),
+        );
+        expect(mocks.logger.debug).toHaveBeenCalledWith(
+            "Repeat audiobook auto-sync failed; will retry on the next cycle",
+            expect.objectContaining({ message: "abs down" }),
+        );
+    });
+
+    it("propagates startup audiobook sync failures", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
+            audiobookshelfEnabled: true,
+            audiobookshelfUrl: "http://abs.local",
+        });
+        mocks.audiobookCacheService.syncMissing.mockRejectedValueOnce(
+            new Error("abs down"),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+
+        await expect(
+            schedulerHandler({
+                id: "audiobook-startup-failure",
+                name: "audiobook-auto-sync-startup",
+                data: { mode: "startup" },
+            }),
+        ).rejects.toThrow("abs down");
+    });
+
     it("dispatches track-removal purge jobs through the scheduler", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -53,23 +53,19 @@ import { createIORedisClient } from "../utils/ioredis";
 import { dataCacheService } from "../services/dataCache";
 import { genericImportJobRunner } from "../services/genericImportJobRunner";
 import type { ReconciliationCursor } from "../services/trackReconciliation";
-import {
-    AUDIO_HASH_BACKFILL_JOB_NAME,
-    processAudioHashBackfill,
-} from "./processors/audioHashBackfillProcessor";
-import {
-    LOUDNESS_BACKFILL_JOB_NAME,
-    processLoudnessBackfill,
-} from "./processors/loudnessBackfillProcessor";
-import { loudnessBackfillRepeatSchedule } from "./loudnessBackfillSchedule";
-import {
-    processTrackRemovalPurge,
-    TRACK_REMOVAL_PURGE_JOB_NAME,
-} from "./processors/trackRemovalPurgeProcessor";
+import { processAudioHashBackfill } from "./processors/audioHashBackfillProcessor";
+import { processLoudnessBackfill } from "./processors/loudnessBackfillProcessor";
+import { processTrackRemovalPurge } from "./processors/trackRemovalPurgeProcessor";
 import {
     registerFederationProcessors,
     registerFederationSchedules,
 } from "./federationJobs";
+import {
+    buildSchedulerJobs,
+    ONE_HOUR_MS,
+    ONE_MINUTE_MS,
+    SCHEDULER_JOB_TYPES,
+} from "./schedulerJobRegistry";
 
 const log = logger.child("WorkerScheduler");
 const claimLog = log.child("SchedulerClaim");
@@ -85,8 +81,6 @@ let schedulerLockRedis: Redis = createIORedisClient(
     jestLazyConnectOverride,
 );
 const schedulerLockOwnerId = `${WORKER_PROCESSOR_ID}:scheduler-claims`;
-const ONE_MINUTE_MS = 60_000;
-const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const TRACK_RECONCILIATION_CURSOR_KEY =
     "scheduler:cursor:track-mapping-reconcile";
 const MAX_RECONCILIATION_CURSOR_BYTES = 512;
@@ -287,50 +281,6 @@ async function saveReconciliationCursor(
         schedulerLockRedis.set(TRACK_RECONCILIATION_CURSOR_KEY, stored),
     );
 }
-
-const SCHEDULER_JOB_TYPES = {
-    dataIntegrity: "data-integrity-check",
-    reconciliation: "download-reconciliation-cycle",
-    lidarrCleanup: "lidarr-cleanup-cycle",
-    cacheWarmup: "cache-warmup-startup",
-    podcastCleanup: "podcast-cache-cleanup",
-    audiobookAutoSync: "audiobook-auto-sync-startup",
-    downloadQueueReconcile: "download-queue-reconcile-startup",
-    artistCountsBackfill: "artist-counts-backfill-startup",
-    imageBackfill: "image-backfill-startup",
-    audioHashBackfill: AUDIO_HASH_BACKFILL_JOB_NAME,
-    loudnessBackfill: LOUDNESS_BACKFILL_JOB_NAME,
-    trackRemovalPurge: TRACK_REMOVAL_PURGE_JOB_NAME,
-    trackMappingReconcile: "track-mapping-reconcile",
-    remoteTrackMetadataRefresh: "remote-track-metadata-refresh",
-} as const;
-
-const SCHEDULER_JOB_IDS = {
-    dataIntegrityStartup: "scheduler:data-integrity:startup",
-    dataIntegrityRepeat: "scheduler:data-integrity:repeat",
-    reconciliationStartup: "scheduler:reconciliation:startup",
-    reconciliationRepeat: "scheduler:reconciliation:repeat",
-    lidarrCleanupStartup: "scheduler:lidarr-cleanup:startup",
-    lidarrCleanupRepeat: "scheduler:lidarr-cleanup:repeat",
-    cacheWarmupStartup: "scheduler:cache-warmup:startup",
-    podcastCleanupStartup: "scheduler:podcast-cleanup:startup",
-    podcastCleanupRepeat: "scheduler:podcast-cleanup:repeat",
-    audiobookAutoSyncStartup: "scheduler:audiobook-auto-sync:startup",
-    audiobookAutoSyncRepeat: "scheduler:audiobook-auto-sync:repeat",
-    downloadQueueReconcileStartup: "scheduler:download-queue-reconcile:startup",
-    artistCountsBackfillStartup: "scheduler:artist-counts-backfill:startup",
-    imageBackfillStartup: "scheduler:image-backfill:startup",
-    audioHashBackfillStartup: "scheduler:audio-hash-backfill:startup",
-    loudnessBackfillStartup: "scheduler:loudness-backfill:startup",
-    trackRemovalPurgeStartup: "scheduler:track-removal-purge:startup",
-    trackRemovalPurgeRepeat: "scheduler:track-removal-purge:repeat",
-    trackMappingReconcileStartup: "scheduler:track-mapping-reconcile:startup",
-    trackMappingReconcileRepeat: "scheduler:track-mapping-reconcile:repeat",
-    remoteTrackMetadataRefreshStartup:
-        "scheduler:remote-track-metadata-refresh:startup",
-    remoteTrackMetadataRefreshRepeat:
-        "scheduler:remote-track-metadata-refresh:repeat",
-} as const;
 
 async function runWithSchedulerClaim(
     claimKey: string,
@@ -595,6 +545,9 @@ async function processPodcastCleanupJob(
     );
 }
 
+const REPEAT_SYNC_FAILURE_WARN_INTERVAL_MS = ONE_HOUR_MS;
+let lastAudiobookRepeatFailureWarnAt = 0;
+
 async function processAudiobookAutoSyncJob(
     mode: "startup" | "repeat",
 ): Promise<void> {
@@ -619,11 +572,31 @@ async function processAudiobookAutoSyncJob(
             }
             const { audiobookCacheService } =
                 await import("../services/audiobookCache");
-            const result = await withTimeout(
-                () => audiobookCacheService.syncMissing(),
-                2 * ONE_HOUR_MS,
-                "audiobookCacheService.syncMissing",
-            );
+            let result;
+            try {
+                result = await withTimeout(
+                    () => audiobookCacheService.syncMissing(),
+                    2 * ONE_HOUR_MS,
+                    "audiobookCacheService.syncMissing",
+                );
+            } catch (error) {
+                if (mode === "startup") {
+                    throw error;
+                }
+                const now = Date.now();
+                const message =
+                    "Repeat audiobook auto-sync failed; will retry on the next cycle";
+                if (
+                    now - lastAudiobookRepeatFailureWarnAt >=
+                    REPEAT_SYNC_FAILURE_WARN_INTERVAL_MS
+                ) {
+                    lastAudiobookRepeatFailureWarnAt = now;
+                    startupLog.warn(message, error);
+                } else {
+                    startupLog.debug(message, error);
+                }
+                return;
+            }
             if (
                 result &&
                 (mode === "startup" || result.synced || result.failed)
@@ -788,253 +761,10 @@ async function processRemoteTrackMetadataRefreshJob(): Promise<void> {
     );
 }
 
-type SchedulerRegistration = {
-    type: (typeof SCHEDULER_JOB_TYPES)[keyof typeof SCHEDULER_JOB_TYPES];
-    data: { mode: "startup" | "repeat"; sweepStartedAt?: string };
-    opts: Bull.JobOptions;
-};
-
-function analysisBackfillStartupJob(
-    type: SchedulerRegistration["type"],
-    jobId: string,
-    delay: number,
-): SchedulerRegistration {
-    return {
-        type,
-        data: { mode: "startup", sweepStartedAt: new Date().toISOString() },
-        opts: {
-            jobId,
-            delay,
-            attempts: 3,
-            backoff: { type: "exponential", delay: 5_000 },
-            removeOnComplete: true,
-            removeOnFail: 10,
-        },
-    };
-}
-
-// Cohesion exception: this pre-existing function is one declarative schedule
-// registry. Analysis backfill construction is extracted above for reviewability.
 async function registerSchedulerJobs(): Promise<void> {
     await schedulerQueue.isReady();
 
-    const schedulerJobs: SchedulerRegistration[] = [
-        {
-            type: SCHEDULER_JOB_TYPES.dataIntegrity,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.dataIntegrityStartup,
-                delay: 10_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.dataIntegrity,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.dataIntegrityRepeat,
-                repeat: { every: 24 * ONE_HOUR_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.reconciliation,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.reconciliationStartup,
-                delay: 2 * ONE_MINUTE_MS,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.reconciliation,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.reconciliationRepeat,
-                repeat: { every: 2 * ONE_MINUTE_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.lidarrCleanup,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.lidarrCleanupStartup,
-                delay: 30_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.lidarrCleanup,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.lidarrCleanupRepeat,
-                repeat: { every: 5 * ONE_MINUTE_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.cacheWarmup,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.cacheWarmupStartup,
-                delay: 5_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.podcastCleanup,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.podcastCleanupStartup,
-                delay: 15_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.podcastCleanup,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.podcastCleanupRepeat,
-                repeat: { every: 24 * ONE_HOUR_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncStartup,
-                delay: 20_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncRepeat,
-                repeat: { every: 5 * ONE_MINUTE_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.downloadQueueReconcile,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.downloadQueueReconcileStartup,
-                delay: 25_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.artistCountsBackfill,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.artistCountsBackfillStartup,
-                delay: 30_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.imageBackfill,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.imageBackfillStartup,
-                delay: 40_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        analysisBackfillStartupJob(
-            SCHEDULER_JOB_TYPES.audioHashBackfill,
-            SCHEDULER_JOB_IDS.audioHashBackfillStartup,
-            50_000,
-        ),
-        analysisBackfillStartupJob(
-            SCHEDULER_JOB_TYPES.loudnessBackfill,
-            SCHEDULER_JOB_IDS.loudnessBackfillStartup,
-            55_000,
-        ),
-        loudnessBackfillRepeatSchedule,
-        {
-            type: SCHEDULER_JOB_TYPES.trackRemovalPurge,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.trackRemovalPurgeStartup,
-                delay: ONE_MINUTE_MS,
-                attempts: 3,
-                backoff: { type: "exponential", delay: 5_000 },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.trackRemovalPurge,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.trackRemovalPurgeRepeat,
-                repeat: { every: 24 * ONE_HOUR_MS },
-                attempts: 3,
-                backoff: { type: "exponential", delay: 5_000 },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.trackMappingReconcile,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.trackMappingReconcileStartup,
-                delay: 45_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.trackMappingReconcile,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.trackMappingReconcileRepeat,
-                repeat: { every: 6 * ONE_HOUR_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh,
-            data: { mode: "startup" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.remoteTrackMetadataRefreshStartup,
-                delay: 90_000,
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-        {
-            type: SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh,
-            data: { mode: "repeat" },
-            opts: {
-                jobId: SCHEDULER_JOB_IDS.remoteTrackMetadataRefreshRepeat,
-                repeat: { every: 12 * ONE_HOUR_MS },
-                removeOnComplete: true,
-                removeOnFail: 10,
-            },
-        },
-    ];
+    const schedulerJobs = buildSchedulerJobs();
 
     for (const job of schedulerJobs) {
         await schedulerQueue.add(job.type, job.data, job.opts);

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -316,6 +316,7 @@ const SCHEDULER_JOB_IDS = {
     podcastCleanupStartup: "scheduler:podcast-cleanup:startup",
     podcastCleanupRepeat: "scheduler:podcast-cleanup:repeat",
     audiobookAutoSyncStartup: "scheduler:audiobook-auto-sync:startup",
+    audiobookAutoSyncRepeat: "scheduler:audiobook-auto-sync:repeat",
     downloadQueueReconcileStartup: "scheduler:download-queue-reconcile:startup",
     artistCountsBackfillStartup: "scheduler:artist-counts-backfill:startup",
     imageBackfillStartup: "scheduler:image-backfill:startup",
@@ -594,49 +595,41 @@ async function processPodcastCleanupJob(
     );
 }
 
-async function processAudiobookAutoSyncJob(): Promise<void> {
+async function processAudiobookAutoSyncJob(
+    mode: "startup" | "repeat",
+): Promise<void> {
     await runWithSchedulerClaim(
-        "scheduler-claim:audiobook-auto-sync-startup",
+        "scheduler-claim:audiobook-auto-sync",
         2 * ONE_HOUR_MS,
-        "startup audiobook auto-sync",
+        `${mode} audiobook auto-sync`,
         async () => {
             const { getSystemSettings } =
                 await import("../utils/systemSettings");
             const settings = await getSystemSettings();
-
             if (
                 !settings?.audiobookshelfEnabled ||
                 !settings?.audiobookshelfUrl
             ) {
-                startupLog.debug(
-                    "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
-                );
+                if (mode === "startup") {
+                    startupLog.debug(
+                        "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
+                    );
+                }
                 return;
             }
-
-            const cachedCount = await prisma.audiobook.count();
-            if (cachedCount > 0) {
-                startupLog.debug(
-                    `Audiobook cache has ${cachedCount} entries - skipping auto-sync`,
-                );
-                return;
-            }
-
-            startupLog.debug(
-                "Audiobook cache is empty - auto-syncing from Audiobookshelf...",
-            );
-
             const { audiobookCacheService } =
                 await import("../services/audiobookCache");
             const result = await withTimeout(
-                () => audiobookCacheService.syncAll(),
+                () => audiobookCacheService.syncMissing(),
                 2 * ONE_HOUR_MS,
-                "audiobookCacheService.syncAll",
+                "audiobookCacheService.syncMissing",
             );
-
-            if (result) {
+            if (
+                result &&
+                (mode === "startup" || result.synced || result.failed)
+            ) {
                 startupLog.debug(
-                    `Audiobook auto-sync complete: ${result.synced} audiobooks cached`,
+                    `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
                 );
             }
         },
@@ -927,6 +920,16 @@ async function registerSchedulerJobs(): Promise<void> {
             },
         },
         {
+            type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncRepeat,
+                repeat: { every: 5 * ONE_MINUTE_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
             type: SCHEDULER_JOB_TYPES.downloadQueueReconcile,
             data: { mode: "startup" },
             opts: {
@@ -1089,7 +1092,7 @@ async function processSchedulerJob(job: Bull.Job<any>): Promise<void> {
             break;
         case SCHEDULER_JOB_TYPES.audiobookAutoSync:
         case "audiobook-auto-sync":
-            await processAudiobookAutoSyncJob();
+            await processAudiobookAutoSyncJob(mode);
             break;
         case SCHEDULER_JOB_TYPES.downloadQueueReconcile:
         case "download-queue-reconcile":

--- a/backend/src/workers/schedulerJobRegistry.ts
+++ b/backend/src/workers/schedulerJobRegistry.ts
@@ -1,0 +1,303 @@
+import type Bull from "bull";
+import { loudnessBackfillRepeatSchedule } from "./loudnessBackfillSchedule";
+import { AUDIO_HASH_BACKFILL_JOB_NAME } from "./processors/audioHashBackfillProcessor";
+import { LOUDNESS_BACKFILL_JOB_NAME } from "./processors/loudnessBackfillProcessor";
+import { TRACK_REMOVAL_PURGE_JOB_NAME } from "./processors/trackRemovalPurgeProcessor";
+
+/** Milliseconds in one minute for scheduler intervals and timeouts. */
+export const ONE_MINUTE_MS = 60_000;
+
+/** Milliseconds in one hour for scheduler intervals and timeouts. */
+export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+
+/** Bull job names handled by the worker scheduler. */
+export const SCHEDULER_JOB_TYPES = {
+    dataIntegrity: "data-integrity-check",
+    reconciliation: "download-reconciliation-cycle",
+    lidarrCleanup: "lidarr-cleanup-cycle",
+    cacheWarmup: "cache-warmup-startup",
+    podcastCleanup: "podcast-cache-cleanup",
+    audiobookAutoSync: "audiobook-auto-sync-startup",
+    downloadQueueReconcile: "download-queue-reconcile-startup",
+    artistCountsBackfill: "artist-counts-backfill-startup",
+    imageBackfill: "image-backfill-startup",
+    audioHashBackfill: AUDIO_HASH_BACKFILL_JOB_NAME,
+    loudnessBackfill: LOUDNESS_BACKFILL_JOB_NAME,
+    trackRemovalPurge: TRACK_REMOVAL_PURGE_JOB_NAME,
+    trackMappingReconcile: "track-mapping-reconcile",
+    remoteTrackMetadataRefresh: "remote-track-metadata-refresh",
+} as const;
+
+/** Stable Bull job IDs used to deduplicate scheduler registrations. */
+export const SCHEDULER_JOB_IDS = {
+    dataIntegrityStartup: "scheduler:data-integrity:startup",
+    dataIntegrityRepeat: "scheduler:data-integrity:repeat",
+    reconciliationStartup: "scheduler:reconciliation:startup",
+    reconciliationRepeat: "scheduler:reconciliation:repeat",
+    lidarrCleanupStartup: "scheduler:lidarr-cleanup:startup",
+    lidarrCleanupRepeat: "scheduler:lidarr-cleanup:repeat",
+    cacheWarmupStartup: "scheduler:cache-warmup:startup",
+    podcastCleanupStartup: "scheduler:podcast-cleanup:startup",
+    podcastCleanupRepeat: "scheduler:podcast-cleanup:repeat",
+    audiobookAutoSyncStartup: "scheduler:audiobook-auto-sync:startup",
+    audiobookAutoSyncRepeat: "scheduler:audiobook-auto-sync:repeat",
+    downloadQueueReconcileStartup: "scheduler:download-queue-reconcile:startup",
+    artistCountsBackfillStartup: "scheduler:artist-counts-backfill:startup",
+    imageBackfillStartup: "scheduler:image-backfill:startup",
+    audioHashBackfillStartup: "scheduler:audio-hash-backfill:startup",
+    loudnessBackfillStartup: "scheduler:loudness-backfill:startup",
+    trackRemovalPurgeStartup: "scheduler:track-removal-purge:startup",
+    trackRemovalPurgeRepeat: "scheduler:track-removal-purge:repeat",
+    trackMappingReconcileStartup: "scheduler:track-mapping-reconcile:startup",
+    trackMappingReconcileRepeat: "scheduler:track-mapping-reconcile:repeat",
+    remoteTrackMetadataRefreshStartup:
+        "scheduler:remote-track-metadata-refresh:startup",
+    remoteTrackMetadataRefreshRepeat:
+        "scheduler:remote-track-metadata-refresh:repeat",
+} as const;
+
+type SchedulerRegistration = {
+    type: (typeof SCHEDULER_JOB_TYPES)[keyof typeof SCHEDULER_JOB_TYPES];
+    data: { mode: "startup" | "repeat"; sweepStartedAt?: string };
+    opts: Bull.JobOptions;
+};
+
+function analysisBackfillStartupJob(
+    type: SchedulerRegistration["type"],
+    jobId: string,
+    delay: number,
+): SchedulerRegistration {
+    return {
+        type,
+        data: { mode: "startup", sweepStartedAt: new Date().toISOString() },
+        opts: {
+            jobId,
+            delay,
+            attempts: 3,
+            backoff: { type: "exponential", delay: 5_000 },
+            removeOnComplete: true,
+            removeOnFail: 10,
+        },
+    };
+}
+
+/** Build scheduler registrations in their required Bull enqueue order. */
+export function buildSchedulerJobs(): SchedulerRegistration[] {
+    return [
+        {
+            type: SCHEDULER_JOB_TYPES.dataIntegrity,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.dataIntegrityStartup,
+                delay: 10_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.dataIntegrity,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.dataIntegrityRepeat,
+                repeat: { every: 24 * ONE_HOUR_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.reconciliation,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.reconciliationStartup,
+                delay: 2 * ONE_MINUTE_MS,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.reconciliation,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.reconciliationRepeat,
+                repeat: { every: 2 * ONE_MINUTE_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.lidarrCleanup,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.lidarrCleanupStartup,
+                delay: 30_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.lidarrCleanup,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.lidarrCleanupRepeat,
+                repeat: { every: 5 * ONE_MINUTE_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.cacheWarmup,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.cacheWarmupStartup,
+                delay: 5_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.podcastCleanup,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.podcastCleanupStartup,
+                delay: 15_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.podcastCleanup,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.podcastCleanupRepeat,
+                repeat: { every: 24 * ONE_HOUR_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncStartup,
+                delay: 20_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncRepeat,
+                repeat: { every: 5 * ONE_MINUTE_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.downloadQueueReconcile,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.downloadQueueReconcileStartup,
+                delay: 25_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.artistCountsBackfill,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.artistCountsBackfillStartup,
+                delay: 30_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.imageBackfill,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.imageBackfillStartup,
+                delay: 40_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        analysisBackfillStartupJob(
+            SCHEDULER_JOB_TYPES.audioHashBackfill,
+            SCHEDULER_JOB_IDS.audioHashBackfillStartup,
+            50_000,
+        ),
+        analysisBackfillStartupJob(
+            SCHEDULER_JOB_TYPES.loudnessBackfill,
+            SCHEDULER_JOB_IDS.loudnessBackfillStartup,
+            55_000,
+        ),
+        loudnessBackfillRepeatSchedule,
+        {
+            type: SCHEDULER_JOB_TYPES.trackRemovalPurge,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.trackRemovalPurgeStartup,
+                delay: ONE_MINUTE_MS,
+                attempts: 3,
+                backoff: { type: "exponential", delay: 5_000 },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.trackRemovalPurge,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.trackRemovalPurgeRepeat,
+                repeat: { every: 24 * ONE_HOUR_MS },
+                attempts: 3,
+                backoff: { type: "exponential", delay: 5_000 },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.trackMappingReconcile,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.trackMappingReconcileStartup,
+                delay: 45_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.trackMappingReconcile,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.trackMappingReconcileRepeat,
+                repeat: { every: 6 * ONE_HOUR_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.remoteTrackMetadataRefreshStartup,
+                delay: 90_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.remoteTrackMetadataRefreshRepeat,
+                repeat: { every: 12 * ONE_HOUR_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+    ];
+}


### PR DESCRIPTION
## Summary

- add lightweight incremental Audiobookshelf cache reconciliation
- sync only books missing from the local SoundSpan cache
- schedule reconciliation every five minutes
- use the same incremental path during startup
- preserve the existing manual/full sync for metadata refreshes
- add service and worker regression coverage

## Why

Once SoundSpan's audiobook cache contained any rows, the startup auto-sync skipped synchronization completely and there was no repeating sync job. New books subsequently added to Audiobookshelf therefore remained invisible until a manual sync.

## Testing

- 59 focused Jest tests passed
- TypeScript passed
- Prettier passed
- file-size guard passed
- git diff check passed
- built successfully against SoundSpan 2.4.1
- real-world test with a populated ABS cache: a newly scanned audiobook appeared in SoundSpan automatically without a manual SoundSpan sync or restart

Fixes #710
