### PR TITLE
fix(federation): stop positional dedup from generating a per-track Album self-join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Federation sync positional dedup no longer generates a per-track Album self-join that could exhaust database memory on large sync pages (#713).
 - Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library (#710).
 
 ### Security

--- a/backend/src/workers/processors/__tests__/federationSyncProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/federationSyncProcessor.test.ts
@@ -135,6 +135,7 @@ jest.mock("../../../services/trackReplacement", () => ({
 }));
 
 import { processFederationSync } from "../federationSyncProcessor";
+import { loadDedupIndex } from "../federationSyncDedup";
 
 const peer = {
     id: "peer-1",
@@ -297,6 +298,102 @@ function legacyCatalogPageFor(type: string) {
               skippedInvalid: page.skippedInvalid,
           }
         : page;
+}
+
+const POSITION_DEDUP_CHUNK_SIZE = 100;
+
+function positionOnlyTrack(id: string, parentRef: string, trackNo: number) {
+    return {
+        ...track,
+        id,
+        mediaType: "track" as const,
+        parentRef,
+        attributes: {
+            ...track.attributes,
+            title: `Track ${trackNo}`,
+            discNo: 1,
+            trackNo,
+            audioHash: null,
+            recordingMbid: null,
+            isrc: null,
+            embedding: undefined,
+        },
+    };
+}
+
+type TestTrack = ReturnType<typeof positionOnlyTrack>;
+type TestAlbumRow = {
+    id: string;
+    remoteId: string;
+    rgMbid: string;
+    artistId: string;
+};
+type TestLocalAlbumRow = { id: string; rgMbid: string };
+type TestPositionRow = {
+    id: string;
+    albumId: string;
+    discNo: number;
+    trackNo: number;
+};
+type PositionQueryProbe = { inFlight: number; maxInFlight: number };
+
+async function observePositionQuery(
+    probe: PositionQueryProbe | undefined,
+): Promise<void> {
+    if (!probe) return;
+    probe.inFlight += 1;
+    probe.maxInFlight = Math.max(probe.maxInFlight, probe.inFlight);
+    await Promise.resolve();
+    probe.inFlight -= 1;
+}
+
+async function runIncrementalTrackPage(
+    items: readonly TestTrack[],
+    remoteAlbums: readonly TestAlbumRow[],
+    localAlbums: readonly TestLocalAlbumRow[],
+    positionRows: readonly TestPositionRow[] = [],
+    positionQueryProbe?: PositionQueryProbe,
+): Promise<void> {
+    prisma.federationPeer.findUnique.mockResolvedValue({
+        ...peer,
+        lastSyncCursor: "2026-08-15T12:10:00.000Z",
+    });
+    client.getCatalogDelta.mockResolvedValue({
+        kind: "ok",
+        changes: items,
+        tombstones: [],
+        nextCursor: null,
+        nextSince: "2026-08-15T12:12:00.000Z",
+        skippedInvalid: 0,
+    });
+    prisma.album.findMany.mockImplementation(async ({ where }) => {
+        if (where?.OR) return remoteAlbums;
+        if (where?.rgMbid?.in) return localAlbums;
+        return [];
+    });
+    prisma.track.findMany.mockImplementation(async ({ where }) => {
+        if (where?.peerId === "peer-1" && where?.remoteId) return [];
+        if (where?.origin === "FEDERATED") return [];
+        if (where?.origin !== "LOCAL" || !where?.OR) return [];
+        await observePositionQuery(positionQueryProbe);
+        return positionRows.filter((row) =>
+            where.OR.some(
+                (candidate: {
+                    albumId?: string;
+                    discNo: number;
+                    trackNo: number;
+                }) =>
+                    candidate.albumId === row.albumId &&
+                    candidate.discNo === row.discNo &&
+                    candidate.trackNo === row.trackNo,
+            ),
+        );
+    });
+    prisma.track.upsert.mockImplementation(async ({ where }) => ({
+        id: `fed:${where.peerId_remoteId.remoteId}`,
+    }));
+
+    await processFederationSync(job());
 }
 
 describe("federation sync processor", () => {
@@ -1104,6 +1201,226 @@ describe("federation sync processor", () => {
         );
     });
 
+    it("bounds full-page positional dedup with flat scalar tuple queries", async () => {
+        const items = Array.from({ length: 500 }, (_, index) =>
+            positionOnlyTrack(
+                `remote-track-${index}`,
+                `remote-album-${index}`,
+                index + 1,
+            ),
+        );
+        const remoteAlbums = items.map((item, index) => ({
+            id: `federated-album-${index}`,
+            peerId: "peer-1",
+            remoteId: item.parentRef,
+            rgMbid: `release-group-${index}`,
+            artistId: `artist-${index}`,
+        }));
+        const localAlbums = remoteAlbums.map((item, index) => ({
+            ...item,
+            id: `local-album-${index}`,
+            peerId: undefined,
+            remoteId: undefined,
+        }));
+        const positionQueryProbe = { inFlight: 0, maxInFlight: 0 };
+
+        await runIncrementalTrackPage(
+            items,
+            remoteAlbums,
+            localAlbums,
+            [],
+            positionQueryProbe,
+        );
+
+        const albumResolutionCalls = prisma.album.findMany.mock.calls.filter(
+            ([args]) => Boolean(args.where?.rgMbid?.in),
+        );
+        expect(albumResolutionCalls).toHaveLength(1);
+        expect(albumResolutionCalls[0][0]).toEqual({
+            where: {
+                rgMbid: {
+                    in: remoteAlbums.map((item) => item.rgMbid),
+                },
+                location: "LIBRARY",
+            },
+            select: { id: true, rgMbid: true },
+        });
+        const positionQueries = prisma.track.findMany.mock.calls.filter(
+            ([args]) => args.where?.origin === "LOCAL" && args.where?.OR,
+        );
+        expect(positionQueries).toHaveLength(
+            Math.ceil(items.length / POSITION_DEDUP_CHUNK_SIZE),
+        );
+        expect(positionQueryProbe.maxInFlight).toBe(1);
+        const collectKeysDeep = (value: unknown, keys: Set<string>): void => {
+            if (Array.isArray(value)) {
+                for (const entry of value) collectKeysDeep(entry, keys);
+                return;
+            }
+            if (value === null || typeof value !== "object") return;
+            for (const [key, nested] of Object.entries(value)) {
+                keys.add(key);
+                collectKeysDeep(nested, keys);
+            }
+        };
+        for (const [args] of positionQueries) {
+            expect(args.where).toEqual(
+                expect.objectContaining({
+                    origin: "LOCAL",
+                    removedAt: null,
+                }),
+            );
+            const whereKeys = new Set<string>();
+            collectKeysDeep(args.where, whereKeys);
+            expect(whereKeys.has("album")).toBe(false);
+            expect(args.where.OR.length).toBeLessThanOrEqual(
+                POSITION_DEDUP_CHUNK_SIZE,
+            );
+            for (const arm of args.where.OR) {
+                expect(Object.hasOwn(arm, "album")).toBe(false);
+                expect(Object.keys(arm).sort()).toEqual([
+                    "albumId",
+                    "discNo",
+                    "trackNo",
+                ]);
+            }
+            expect(args.select).toEqual({
+                id: true,
+                albumId: true,
+                discNo: true,
+                trackNo: true,
+            });
+        }
+    });
+
+    it("collapses duplicate positional tuples into one query arm", async () => {
+        const items = [
+            positionOnlyTrack("remote-track-1", "remote-album-1", 1),
+            positionOnlyTrack("remote-track-2", "remote-album-1", 1),
+        ];
+        const remoteAlbums = [
+            {
+                id: "federated-album-1",
+                peerId: "peer-1",
+                remoteId: "remote-album-1",
+                rgMbid: "release-group-1",
+                artistId: "artist-1",
+            },
+        ];
+        const localAlbums = [
+            {
+                ...remoteAlbums[0],
+                id: "local-album-1",
+                peerId: undefined,
+                remoteId: undefined,
+            },
+        ];
+
+        await runIncrementalTrackPage(items, remoteAlbums, localAlbums);
+
+        const positionQueries = prisma.track.findMany.mock.calls.filter(
+            ([args]) => args.where?.origin === "LOCAL" && args.where?.OR,
+        );
+        expect(positionQueries).toHaveLength(1);
+        expect(positionQueries[0][0].where.OR).toEqual([
+            { albumId: "local-album-1", discNo: 1, trackNo: 1 },
+        ]);
+    });
+
+    it("rebuilds positional keys and keeps the lowest-id match", async () => {
+        const items = [
+            positionOnlyTrack("remote-track-1", "remote-album-1", 1),
+            positionOnlyTrack("remote-track-2", "remote-album-2", 2),
+        ];
+        const remoteAlbums = items.map((item, index) => ({
+            id: `federated-album-${index + 1}`,
+            peerId: "peer-1",
+            remoteId: item.parentRef,
+            rgMbid: `release-group-${index + 1}`,
+            artistId: `artist-${index + 1}`,
+        }));
+        const localAlbums = remoteAlbums.map((item, index) => ({
+            ...item,
+            id: `local-album-${index + 1}`,
+            peerId: undefined,
+            remoteId: undefined,
+        }));
+        const positionRows = [
+            {
+                id: "local-track-001",
+                albumId: "local-album-1",
+                discNo: 1,
+                trackNo: 1,
+            },
+            {
+                id: "local-track-002",
+                albumId: "local-album-2",
+                discNo: 1,
+                trackNo: 2,
+            },
+            {
+                id: "local-track-009",
+                albumId: "local-album-1",
+                discNo: 1,
+                trackNo: 1,
+            },
+        ];
+
+        prisma.album.findMany.mockResolvedValue(localAlbums);
+        prisma.track.findMany.mockResolvedValue(positionRows);
+        const albums = new Map(
+            remoteAlbums.map<[string, TestAlbumRow]>((item, index) => [
+                items[index].parentRef,
+                item,
+            ]),
+        );
+        const index = await loadDedupIndex(items, albums);
+
+        expect(index.position).toEqual(
+            new Map([
+                [JSON.stringify(["release-group-1", 1, 1]), "local-track-001"],
+                [JSON.stringify(["release-group-2", 1, 2]), "local-track-002"],
+            ]),
+        );
+        const positionQuery = prisma.track.findMany.mock.calls.find(
+            ([args]) => args.where?.origin === "LOCAL" && args.where?.OR,
+        );
+        expect(positionQuery?.[0].orderBy).toEqual({ id: "asc" });
+    });
+
+    it("skips missing remote and unresolved local albums without error", async () => {
+        const items = [
+            positionOnlyTrack("remote-track-missing", "missing-album", 1),
+            positionOnlyTrack("remote-track-unmatched", "remote-album-1", 2),
+        ];
+        const remoteAlbums = [
+            {
+                id: "federated-album-1",
+                peerId: "peer-1",
+                remoteId: "remote-album-1",
+                rgMbid: "release-group-1",
+                artistId: "artist-1",
+            },
+        ];
+        client.getCatalogItem.mockRejectedValue(
+            new MockFederationHttpError(404),
+        );
+
+        await expect(
+            runIncrementalTrackPage(items, remoteAlbums, []),
+        ).resolves.toBeUndefined();
+
+        const positionQueries = prisma.track.findMany.mock.calls.filter(
+            ([args]) => args.where?.origin === "LOCAL" && args.where?.OR,
+        );
+        expect(positionQueries).toHaveLength(0);
+        expect(prisma.track.upsert).toHaveBeenCalledTimes(1);
+        expect(prisma.track.updateMany).toHaveBeenCalledWith({
+            where: { id: "fed:remote-track-unmatched", dedupPinned: false },
+            data: { dedupOfTrackId: null },
+        });
+    });
+
     it.each([
         [
             "audioHash",
@@ -1129,6 +1446,30 @@ describe("federation sync processor", () => {
         "records %s local-wins dedup through TrackMapping",
         async (_tier, identity, confidence) => {
             const local = { id: "local-track-1" };
+            if (_tier === "albumPosition") {
+                prisma.album.findMany.mockImplementation(async ({ where }) => {
+                    if (where?.rgMbid?.in) {
+                        return [
+                            {
+                                id: "local-album-1",
+                                rgMbid: "release-group-1",
+                            },
+                        ];
+                    }
+                    if (where?.OR) {
+                        return [
+                            {
+                                id: "album-local-row",
+                                peerId: "peer-1",
+                                remoteId: "remote-album-1",
+                                rgMbid: "release-group-1",
+                                artistId: "artist-local-row",
+                            },
+                        ];
+                    }
+                    return [];
+                });
+            }
             prisma.track.findMany.mockImplementation(async ({ where }) => {
                 if (where.peerId === "peer-1" && where.remoteId) {
                     return [
@@ -1167,9 +1508,9 @@ describe("federation sync processor", () => {
                     return [
                         {
                             ...local,
+                            albumId: "local-album-1",
                             discNo: 1,
                             trackNo: 2,
-                            album: { rgMbid: "release-group-1" },
                         },
                     ];
                 return [];
@@ -1269,7 +1610,7 @@ describe("federation sync processor", () => {
         await processFederationSync(job());
 
         expect(prisma.artist.findMany).toHaveBeenCalledTimes(1);
-        expect(prisma.album.findMany).toHaveBeenCalledTimes(1);
+        expect(prisma.album.findMany).toHaveBeenCalledTimes(2);
         expect(
             prisma.track.findMany.mock.calls.filter(
                 ([args]) =>

--- a/backend/src/workers/processors/federationSyncDedup.ts
+++ b/backend/src/workers/processors/federationSyncDedup.ts
@@ -1,0 +1,212 @@
+import { prisma } from "../../utils/db";
+import { chunkArray } from "../../utils/async";
+import { type RemoteAlbumRow, type TrackEnvelope } from "./federationSyncPage";
+
+const POSITION_DEDUP_CHUNK_SIZE = 100;
+const LOCAL_DEDUP_WHERE = { origin: "LOCAL" as const, removedAt: null };
+
+/** A local track selected by federation dedup, with its match confidence. */
+export type DedupMatch = { id: string; confidence: number };
+
+interface DedupIndex {
+    audioHash: Map<string, string>;
+    recordingMbid: Map<string, string>;
+    isrc: Map<string, string>;
+    position: Map<string, string>;
+}
+
+interface LocalAlbumLookup {
+    albumIdByRgMbid: ReadonlyMap<string, string>;
+    rgMbidByAlbumId: ReadonlyMap<string, string>;
+}
+
+interface PositionTuple {
+    albumId: string;
+    discNo: number;
+    trackNo: number;
+}
+
+function uniqueValues(values: Array<string | null>): string[] {
+    return [
+        ...new Set(values.filter((value): value is string => Boolean(value))),
+    ];
+}
+
+function setFirst(map: Map<string, string>, key: string, id: string): void {
+    if (!map.has(key)) map.set(key, id);
+}
+
+function positionKey(rgMbid: string, discNo: number, trackNo: number): string {
+    return JSON.stringify([rgMbid, discNo, trackNo]);
+}
+
+async function loadAudioDedupMatches(
+    tracks: readonly TrackEnvelope[],
+    target: Map<string, string>,
+): Promise<void> {
+    const values = uniqueValues(
+        tracks.map((item) => item.attributes.audioHash),
+    );
+    if (values.length === 0) return;
+    const rows = await prisma.track.findMany({
+        where: { ...LOCAL_DEDUP_WHERE, audioHash: { in: values } },
+        orderBy: { id: "asc" },
+        select: { id: true, audioHash: true },
+    });
+    for (const row of rows) {
+        if (row.audioHash) setFirst(target, row.audioHash, row.id);
+    }
+}
+
+async function loadRecordingDedupMatches(
+    tracks: readonly TrackEnvelope[],
+    target: Map<string, string>,
+): Promise<void> {
+    const values = uniqueValues(
+        tracks.map((item) => item.attributes.recordingMbid),
+    );
+    if (values.length === 0) return;
+    const rows = await prisma.track.findMany({
+        where: { ...LOCAL_DEDUP_WHERE, recordingMbid: { in: values } },
+        orderBy: { id: "asc" },
+        select: { id: true, recordingMbid: true },
+    });
+    for (const row of rows) {
+        if (row.recordingMbid) {
+            setFirst(target, row.recordingMbid, row.id);
+        }
+    }
+}
+
+async function loadIsrcDedupMatches(
+    tracks: readonly TrackEnvelope[],
+    target: Map<string, string>,
+): Promise<void> {
+    const values = uniqueValues(tracks.map((item) => item.attributes.isrc));
+    if (values.length === 0) return;
+    const rows = await prisma.track.findMany({
+        where: { ...LOCAL_DEDUP_WHERE, isrc: { in: values } },
+        orderBy: { id: "asc" },
+        select: { id: true, isrc: true },
+    });
+    for (const row of rows) {
+        if (row.isrc) setFirst(target, row.isrc, row.id);
+    }
+}
+
+function requestedAlbumRgMbids(
+    tracks: readonly TrackEnvelope[],
+    albums: ReadonlyMap<string, RemoteAlbumRow>,
+): string[] {
+    return uniqueValues(
+        tracks.map((item) => albums.get(item.parentRef)?.rgMbid ?? null),
+    );
+}
+
+async function loadLocalAlbums(rgMbids: string[]): Promise<LocalAlbumLookup> {
+    const rows = await prisma.album.findMany({
+        where: { rgMbid: { in: rgMbids }, location: "LIBRARY" },
+        select: { id: true, rgMbid: true },
+    });
+    const albumIdByRgMbid = new Map<string, string>();
+    const rgMbidByAlbumId = new Map<string, string>();
+    for (const row of rows) {
+        albumIdByRgMbid.set(row.rgMbid, row.id);
+        rgMbidByAlbumId.set(row.id, row.rgMbid);
+    }
+    return { albumIdByRgMbid, rgMbidByAlbumId };
+}
+
+function buildPositionTuples(
+    tracks: readonly TrackEnvelope[],
+    albums: ReadonlyMap<string, RemoteAlbumRow>,
+    albumIdByRgMbid: ReadonlyMap<string, string>,
+): PositionTuple[] {
+    const tuples = new Map<string, PositionTuple>();
+    for (const item of tracks) {
+        const rgMbid = albums.get(item.parentRef)?.rgMbid;
+        const albumId = rgMbid ? albumIdByRgMbid.get(rgMbid) : undefined;
+        if (!albumId) continue;
+        const tuple = {
+            albumId,
+            discNo: item.attributes.discNo,
+            trackNo: item.attributes.trackNo,
+        };
+        const key = positionKey(albumId, tuple.discNo, tuple.trackNo);
+        if (!tuples.has(key)) tuples.set(key, tuple);
+    }
+    return [...tuples.values()];
+}
+
+async function loadPositionChunk(
+    tuples: PositionTuple[],
+    rgMbidByAlbumId: ReadonlyMap<string, string>,
+    target: Map<string, string>,
+): Promise<void> {
+    const rows = await prisma.track.findMany({
+        where: { ...LOCAL_DEDUP_WHERE, OR: tuples },
+        orderBy: { id: "asc" },
+        select: { id: true, albumId: true, discNo: true, trackNo: true },
+    });
+    for (const row of rows) {
+        const rgMbid = rgMbidByAlbumId.get(row.albumId);
+        if (!rgMbid) continue;
+        const key = positionKey(rgMbid, row.discNo, row.trackNo);
+        setFirst(target, key, row.id);
+    }
+}
+
+async function loadPositionDedupMatches(
+    tracks: readonly TrackEnvelope[],
+    albums: ReadonlyMap<string, RemoteAlbumRow>,
+    target: Map<string, string>,
+): Promise<void> {
+    const rgMbids = requestedAlbumRgMbids(tracks, albums);
+    if (rgMbids.length === 0) return;
+    const lookup = await loadLocalAlbums(rgMbids);
+    const tuples = buildPositionTuples(tracks, albums, lookup.albumIdByRgMbid);
+    for (const chunk of chunkArray(tuples, POSITION_DEDUP_CHUNK_SIZE)) {
+        await loadPositionChunk(chunk, lookup.rgMbidByAlbumId, target);
+    }
+}
+
+/** Loads all local-track identity indexes used for one federation page. */
+export async function loadDedupIndex(
+    tracks: readonly TrackEnvelope[],
+    albums: ReadonlyMap<string, RemoteAlbumRow>,
+): Promise<DedupIndex> {
+    const index: DedupIndex = {
+        audioHash: new Map(),
+        recordingMbid: new Map(),
+        isrc: new Map(),
+        position: new Map(),
+    };
+    await loadAudioDedupMatches(tracks, index.audioHash);
+    await loadRecordingDedupMatches(tracks, index.recordingMbid);
+    await loadIsrcDedupMatches(tracks, index.isrc);
+    await loadPositionDedupMatches(tracks, albums, index.position);
+    return index;
+}
+
+/** Selects the highest-confidence local match from a loaded dedup index. */
+export function findDedupMatch(
+    index: DedupIndex,
+    item: TrackEnvelope,
+    albumRgMbid: string,
+): DedupMatch | null {
+    const attributes = item.attributes;
+    const audio = attributes.audioHash
+        ? index.audioHash.get(attributes.audioHash)
+        : undefined;
+    if (audio) return { id: audio, confidence: 1 };
+    const recording = attributes.recordingMbid
+        ? index.recordingMbid.get(attributes.recordingMbid)
+        : undefined;
+    if (recording) return { id: recording, confidence: 0.95 };
+    const isrc = attributes.isrc ? index.isrc.get(attributes.isrc) : undefined;
+    if (isrc) return { id: isrc, confidence: 0.9 };
+    const positional = index.position.get(
+        positionKey(albumRgMbid, attributes.discNo, attributes.trackNo),
+    );
+    return positional ? { id: positional, confidence: 0.8 } : null;
+}

--- a/backend/src/workers/processors/federationSyncProcessor.ts
+++ b/backend/src/workers/processors/federationSyncProcessor.ts
@@ -50,6 +50,11 @@ import {
 } from "./federationSyncEmbeddingOutcome";
 import { refreshFederationPresence } from "./federationSyncPresence";
 import { getAvailableFederationConsumerPeer } from "./federationSyncPeer";
+import {
+    findDedupMatch,
+    loadDedupIndex,
+    type DedupMatch,
+} from "./federationSyncDedup";
 
 const log = logger.child("FederationSyncProcessor");
 const OVERLAP_MS = 5 * 60 * 1_000;
@@ -377,157 +382,10 @@ async function ensureRemoteAlbum(
     };
 }
 
-type DedupMatch = { id: string; confidence: number };
-
-interface DedupIndex {
-    audioHash: Map<string, string>;
-    recordingMbid: Map<string, string>;
-    isrc: Map<string, string>;
-    position: Map<string, string>;
-}
-
 function uniqueValues(values: Array<string | null>): string[] {
     return [
         ...new Set(values.filter((value): value is string => Boolean(value))),
     ];
-}
-
-function setFirst(map: Map<string, string>, key: string, id: string): void {
-    if (!map.has(key)) map.set(key, id);
-}
-
-function positionKey(rgMbid: string, discNo: number, trackNo: number): string {
-    return JSON.stringify([rgMbid, discNo, trackNo]);
-}
-
-const LOCAL_DEDUP_WHERE = { origin: "LOCAL" as const, removedAt: null };
-
-async function loadAudioDedupMatches(
-    tracks: readonly TrackEnvelope[],
-    target: Map<string, string>,
-): Promise<void> {
-    const values = uniqueValues(
-        tracks.map((item) => item.attributes.audioHash),
-    );
-    if (values.length === 0) return;
-    const rows = await prisma.track.findMany({
-        where: { ...LOCAL_DEDUP_WHERE, audioHash: { in: values } },
-        orderBy: { id: "asc" },
-        select: { id: true, audioHash: true },
-    });
-    for (const row of rows) {
-        if (row.audioHash) setFirst(target, row.audioHash, row.id);
-    }
-}
-
-async function loadRecordingDedupMatches(
-    tracks: readonly TrackEnvelope[],
-    target: Map<string, string>,
-): Promise<void> {
-    const values = uniqueValues(
-        tracks.map((item) => item.attributes.recordingMbid),
-    );
-    if (values.length === 0) return;
-    const rows = await prisma.track.findMany({
-        where: { ...LOCAL_DEDUP_WHERE, recordingMbid: { in: values } },
-        orderBy: { id: "asc" },
-        select: { id: true, recordingMbid: true },
-    });
-    for (const row of rows) {
-        if (row.recordingMbid) setFirst(target, row.recordingMbid, row.id);
-    }
-}
-
-async function loadIsrcDedupMatches(
-    tracks: readonly TrackEnvelope[],
-    target: Map<string, string>,
-): Promise<void> {
-    const values = uniqueValues(tracks.map((item) => item.attributes.isrc));
-    if (values.length === 0) return;
-    const rows = await prisma.track.findMany({
-        where: { ...LOCAL_DEDUP_WHERE, isrc: { in: values } },
-        orderBy: { id: "asc" },
-        select: { id: true, isrc: true },
-    });
-    for (const row of rows) {
-        if (row.isrc) setFirst(target, row.isrc, row.id);
-    }
-}
-
-async function loadPositionDedupMatches(
-    tracks: readonly TrackEnvelope[],
-    albums: ReadonlyMap<string, RemoteAlbumRow>,
-    target: Map<string, string>,
-): Promise<void> {
-    const positional = tracks.flatMap((item) => {
-        const album = albums.get(item.parentRef);
-        return album
-            ? [
-                  {
-                      discNo: item.attributes.discNo,
-                      trackNo: item.attributes.trackNo,
-                      album: {
-                          rgMbid: album.rgMbid,
-                          location: "LIBRARY" as const,
-                      },
-                  },
-              ]
-            : [];
-    });
-    if (positional.length === 0) return;
-    const rows = await prisma.track.findMany({
-        where: { ...LOCAL_DEDUP_WHERE, OR: positional },
-        orderBy: { id: "asc" },
-        select: {
-            id: true,
-            discNo: true,
-            trackNo: true,
-            album: { select: { rgMbid: true } },
-        },
-    });
-    for (const row of rows) {
-        const key = positionKey(row.album.rgMbid, row.discNo, row.trackNo);
-        setFirst(target, key, row.id);
-    }
-}
-
-async function loadDedupIndex(
-    tracks: readonly TrackEnvelope[],
-    albums: ReadonlyMap<string, RemoteAlbumRow>,
-): Promise<DedupIndex> {
-    const index: DedupIndex = {
-        audioHash: new Map(),
-        recordingMbid: new Map(),
-        isrc: new Map(),
-        position: new Map(),
-    };
-    await loadAudioDedupMatches(tracks, index.audioHash);
-    await loadRecordingDedupMatches(tracks, index.recordingMbid);
-    await loadIsrcDedupMatches(tracks, index.isrc);
-    await loadPositionDedupMatches(tracks, albums, index.position);
-    return index;
-}
-
-function findDedupMatch(
-    index: DedupIndex,
-    item: TrackEnvelope,
-    albumRgMbid: string,
-): DedupMatch | null {
-    const attributes = item.attributes;
-    const audio = attributes.audioHash
-        ? index.audioHash.get(attributes.audioHash)
-        : undefined;
-    if (audio) return { id: audio, confidence: 1 };
-    const recording = attributes.recordingMbid
-        ? index.recordingMbid.get(attributes.recordingMbid)
-        : undefined;
-    if (recording) return { id: recording, confidence: 0.95 };
-    const isrc = attributes.isrc ? index.isrc.get(attributes.isrc) : undefined;
-    if (isrc) return { id: isrc, confidence: 0.9 };
-    const positional = index.position.get(
-        positionKey(albumRgMbid, attributes.discNo, attributes.trackNo),
-    );
-    return positional ? { id: positional, confidence: 0.8 } : null;
 }
 
 async function applyTrackDedup(

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -68,7 +68,6 @@ const BASELINE = Object.freeze({
     "backend/src/services/musicScanner.ts": 1573,
     "backend/src/services/simpleDownloadManager.ts": 2387,
     "backend/src/services/spotify.ts": 1624,
-    "backend/src/workers/processors/federationSyncProcessor.ts": 1508,
     "backend/src/workers/unifiedEnrichment.ts": 1990,
     "frontend/app/playlist/[id]/page.tsx": 1565,
     "frontend/app/vibe/page.tsx": 1528,


### PR DESCRIPTION
Fixes #713.

## Problem

Federation sync position dedup (`loadPositionDedupMatches`) built one Prisma `OR` arm per remote track, each carrying a nested `album: { rgMbid, location }` relation filter. Prisma compiles every such arm into its own `LEFT JOIN "Album"`, so a full 500-item sync page produced a ~500-way self-join of Album onto Track. PostgreSQL's planner/executor memory grows super-linearly with range table entries: each execution held 1–2 GB of backend memory, and with 2–3 pages in flight the database pod exceeded its 4 Gi limit ~30 s after every sync tick — OOM-killing the CNPG primary every 15 minutes for hours, forcing a failover and timeline bump per kill, and eventually wedging both replicas in a `pg_rewind` loop that required re-cloning them.

## Fix

- Resolve LIBRARY album ids first with a single flat query: `album.findMany({ where: { rgMbid: { in: [...] }, location: "LIBRARY" } })`. `Album.rgMbid` is globally unique, so this resolution is at most 1:1 and reproduces the old relation-filter semantics exactly.
- Match tracks on flat scalar tuples `{ albumId, discNo, trackNo }` — no relation filter anywhere, landing directly on the existing `(albumId, discNo, trackNo)` composite index.
- Chunk the OR arms at 100 per query (reusing the shared `chunkArray` util) and run chunks **sequentially**, keeping sync-time DB concurrency at 1 for this loader.
- Output semantics preserved: identical `positionKey(rgMbid, discNo, trackNo)` keys and first-match-wins by ascending track id. Tuples are deduplicated before chunking, so each key lives in exactly one chunk and cross-chunk ordering cannot change a winner.
- The dedup loaders move to a new `federationSyncDedup.ts` module; `federationSyncProcessor.ts` drops from 1,508 to 1,352 lines, below the 1,500 cap, so its file-size baseline entry is removed.

## Tests

New regression coverage at the 500-item page boundary:

- Album resolution runs as one flat `rgMbid IN` query filtered to `location: LIBRARY`.
- Every positional track query is asserted to carry `origin: LOCAL` and `removedAt: null`, contain **no `album` key at any nesting depth** of the where-clause (deep walk, so a nested relation filter under `AND`/`OR` also fails), and hold at most 100 flat scalar arms; the number of queries equals `ceil(items / 100)`.
- Sequential execution is pinned with an in-flight probe (max concurrency must be 1) — verified by mutation check: swapping the loop for `Promise.all` fails the test.
- Duplicate tuples collapse to one arm; unresolved albums are skipped; the lowest-id tie winner is preserved.

## Known trade-off

Album resolution and track matching are now two queries instead of one, so an album whose `rgMbid` is rewritten by enrichment *between* the two queries could briefly index a concurrently inserted track under the stale MBID. The window is milliseconds, the consequence is a single advisory dedup match at the lowest confidence tier (0.8), and closing it would mean reintroducing a join or serializable transactions. Accepted.

## Verification

- verify: `npx tsc --noEmit` — exit 0
- verify: `npx jest src/workers/processors/__tests__/federationSyncProcessor.test.ts` — exit 0, `Test Suites: 1 passed`, `Tests: 51 passed, 51 total`
- verify: `npm run format:check` — exit 0
- verify: `node scripts/ci/check-file-size.mjs` — exit 0 (1077 source files, 25 baseline files)
- verify: mutation checks — `Promise.all` swap fails the sequentiality test; restore passes