### PR TITLE
feat(security): strip npm toolchain from runtime images and honor Trivy severity policy in SARIF

### DIFF
--- a/.github/workflows/image-security-scanning.yml
+++ b/.github/workflows/image-security-scanning.yml
@@ -90,6 +90,7 @@ jobs:
           image-ref: ${{ steps.check.outputs.image_ref }}
           scanners: vuln
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           trivyignores: .trivyignore
           exit-code: "0"

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -49,6 +49,7 @@ jobs:
           scan-ref: .
           scanners: vuln # secret scanning is owned by the dedicated gitleaks job below
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           trivyignores: .trivyignore
           exit-code: "0"

--- a/.trivyignore
+++ b/.trivyignore
@@ -49,3 +49,19 @@
 #
 # Syntax: one CVE-ID / GHSA-ID per line, optional trailing comment. See
 # https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#trivyignore
+
+# --- Reviewed ML dependency deferrals (2026-08-23, #671 / #717) -----------
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2025-12060
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2025-9906
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2026-1462
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2026-11816
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2026-12481
+# keras 2.15.0: fixes need keras 3.x/TF 2.16+, but TF 2.15.x is locked to Essentia's newest CPython 3.11 wheel; no first-party keras import, only image-bundled frozen .pb loads via Essentia (#671; defer #717).
+CVE-2026-12484
+# protobuf 4.25.9: the fix requires 5.29.6+, outside TF 2.15's protobuf<5 constraint; defer the companion dependency upgrade from #671 to #717.
+CVE-2026-0994

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to soundspan are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library (#710).
 
 ### Security
+
+- Removed npm, npx, and corepack from all Node runtime images to eliminate package-installer and npm-vendored CVE exposure, limited Trivy SARIF uploads to CRITICAL/HIGH findings, and documented the reviewed keras/protobuf deferrals pending the companion dependency upgrade (#671, #717).
 
 ## [2.4.1] - 2026-08-22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,7 +227,7 @@ RUN npm run build
 
 # Prune backend dev dependencies after build (typescript, jest, tsx, etc.),
 # then reinstall the prisma CLI locally: the startup script needs
-# `npx prisma migrate deploy`, and Prisma 7's prisma.config.ts imports
+# `./node_modules/.bin/prisma migrate deploy`, and Prisma 7's prisma.config.ts imports
 # "prisma/config", which must resolve from the app's own node_modules —
 # a globally-installed CLI cannot satisfy that import after prune.
 RUN PRISMA_VERSION=$(node -p "require('./node_modules/prisma/package.json').version") && \
@@ -284,7 +284,8 @@ RUN apt-get purge -y --auto-remove build-essential python3-dev 2>/dev/null || tr
     rm -f /usr/bin/curl /bin/curl 2>/dev/null || true && \
     rm -f /usr/bin/nc /bin/nc /usr/bin/ncat /usr/bin/netcat 2>/dev/null || true && \
     rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
 
 # ============================================
 # CONFIGURATION
@@ -343,7 +344,7 @@ directory=/app/backend
 priority=30
 
 [program:frontend]
-command=/bin/bash -c "cd /app/frontend && npm start"
+command=/bin/bash -c "cd /app/frontend && node server.js"
 user=soundspan
 autostart=true
 autorestart=true
@@ -606,7 +607,7 @@ fi
 if [ "$MIGRATIONS_EXIST" = "t" ]; then
     # Normal migration flow - migrations table exists
     echo "Migration history found, running migrate deploy..."
-    if ! npx prisma migrate deploy 2>&1; then
+    if ! ./node_modules/.bin/prisma migrate deploy 2>&1; then
         echo "FATAL: Database migration failed! Check logs above."
         exit 1
     fi
@@ -615,16 +616,16 @@ elif [ "$USER_TABLE_EXIST" = "t" ]; then
     echo "Existing database detected without migration history."
     echo "Creating baseline from current schema..."
     # Mark the init migration as already applied (baseline)
-    npx prisma migrate resolve --applied 20241130000000_init 2>&1 || true
+    ./node_modules/.bin/prisma migrate resolve --applied 20241130000000_init 2>&1 || true
     # Now run any subsequent migrations
-    if ! npx prisma migrate deploy 2>&1; then
+    if ! ./node_modules/.bin/prisma migrate deploy 2>&1; then
         echo "FATAL: Migration after baseline failed!"
         exit 1
     fi
 else
     # Fresh database - run migrations normally
     echo "Fresh database detected, running initial migrations..."
-    if ! npx prisma migrate deploy 2>&1; then
+    if ! ./node_modules/.bin/prisma migrate deploy 2>&1; then
         echo "FATAL: Initial migration failed. Check database connection and schema."
         exit 1
     fi

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -69,7 +69,8 @@ RUN mkdir -p /app/cache /app/logs && \
     chown -R node:node /app/cache /app/logs && \
     rm -f /usr/bin/wget /usr/bin/curl /bin/wget /bin/curl 2>/dev/null || true && \
     rm -f /usr/bin/nc /bin/nc /usr/bin/ncat /usr/bin/netcat 2>/dev/null || true && \
-    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true
+    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true && \
+    rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
 
 USER node
 
@@ -77,7 +78,7 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "dist/worker.js"]
 
 # Stage: prune to prod deps but keep a working Prisma CLI for the entrypoint's
-# `npx prisma migrate deploy`. Prisma 7's prisma.config.ts imports
+# `./node_modules/.bin/prisma migrate deploy`. Prisma 7's prisma.config.ts imports
 # "prisma/config", which must resolve from the app's own node_modules, so the
 # CLI is reinstalled locally after prune (a global CLI cannot satisfy it).
 FROM build AS api-deps
@@ -116,7 +117,8 @@ RUN mkdir -p /app/cache/covers /app/cache/transcodes /app/logs && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     rm -f /usr/bin/wget /usr/bin/curl /bin/wget /bin/curl 2>/dev/null || true && \
     rm -f /usr/bin/nc /bin/nc /usr/bin/ncat /usr/bin/netcat 2>/dev/null || true && \
-    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true
+    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true && \
+    rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
 
 USER node
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -79,7 +79,7 @@ run_prisma_migrations_with_retry() {
     echo "[DB] Running database migrations (attempt ${attempt}/${max_attempts})..."
 
     set +e
-    migrate_output=$(npx prisma migrate deploy 2>&1)
+    migrate_output=$(./node_modules/.bin/prisma migrate deploy 2>&1)
     migrate_exit_code=$?
     set -e
 
@@ -124,7 +124,7 @@ fi
 # Runtime images already include generated clients from build stage.
 if [ "${PRISMA_GENERATE_ON_STARTUP:-false}" = "true" ]; then
   echo "[DB] Generating Prisma client..."
-  npx prisma generate
+  ./node_modules/.bin/prisma generate
 else
   echo "[DB] Skipping Prisma client generation (PRISMA_GENERATE_ON_STARTUP=false)"
 fi

--- a/backend/src/__tests__/apiEntrypointDbResilienceContract.test.ts
+++ b/backend/src/__tests__/apiEntrypointDbResilienceContract.test.ts
@@ -14,7 +14,9 @@ describe("api entrypoint db resilience contract", () => {
             "PRISMA_MIGRATE_RETRY_DELAY_SECONDS",
         );
         expect(entrypointSource).toContain("too many clients already");
-        expect(entrypointSource).toContain("npx prisma migrate deploy");
+        expect(entrypointSource).toContain(
+            "./node_modules/.bin/prisma migrate deploy",
+        );
     });
 
     it("allows operators to disable startup migration/generate hooks explicitly", () => {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -69,13 +69,14 @@ COPY --chown=node:node healthcheck.js ./
 COPY docker-entrypoint.sh /usr/local/bin/
 
 # Fix line endings, set entrypoint permissions, then remove dangerous tools
-# NOTE: We keep /bin/sh because npm requires it to spawn processes
+# NOTE: We keep /bin/sh because the runtime entrypoint script requires it
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     # Remove download/network utilities (prevents downloading malware)
     rm -f /usr/bin/wget /usr/bin/curl /bin/wget /bin/curl 2>/dev/null || true && \
     rm -f /usr/bin/nc /bin/nc /usr/bin/ncat /usr/bin/netcat 2>/dev/null || true && \
-    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true
+    rm -f /usr/bin/ftp /usr/bin/tftp /usr/bin/telnet 2>/dev/null || true && \
+    rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
 
 USER node
 
@@ -87,4 +88,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 
 # Use tini for proper signal handling, with entrypoint script
 ENTRYPOINT ["/usr/bin/tini", "--", "docker-entrypoint.sh"]
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/scripts/ci/dockerfile-hygiene.test.mjs
+++ b/scripts/ci/dockerfile-hygiene.test.mjs
@@ -63,6 +63,8 @@ const baseImageFamilyBinaries = [
 ];
 
 const probeNames = ["livenessProbe", "readinessProbe"];
+const npmToolchainRemovalPattern =
+    /rm -rf\s+\/usr\/local\/lib\/node_modules\s+\/usr\/local\/bin\/npm\s+\/usr\/local\/bin\/npx\s+\/usr\/local\/bin\/corepack\b/;
 
 function readRepoFile(relativePath) {
     return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
@@ -279,7 +281,24 @@ function stageRunsPrisma(stage) {
         .split(/\r?\n/)
         .filter((line) => !line.trimStart().startsWith("#"))
         .join("\n");
-    return /\bnpx\s+prisma\s+(?:generate|migrate)\b/i.test(commands);
+    return /(?:^|\s)\.\/node_modules\/\.bin\/prisma\s+(?:generate|migrate)\b/i.test(
+        commands,
+    );
+}
+
+function runtimeCommandLinesAfterToolchainRemoval(stage) {
+    const removalIndex = stage.search(npmToolchainRemovalPattern);
+    assert.notEqual(
+        removalIndex,
+        -1,
+        "runtime stage must remove npm toolchain",
+    );
+
+    return stage
+        .slice(removalIndex)
+        .split(/\r?\n/)
+        .filter((line) => /^\s*(?:CMD|ENTRYPOINT)\b|^\s*command=/i.test(line))
+        .join("\n");
 }
 
 function effectiveStageCopies(stages) {
@@ -730,4 +749,40 @@ test("14. sidecar images copy every top-level Python module", () => {
         [],
         `Dockerfile COPY instructions omit top-level sidecar modules:\n${missingFiles.join("\n")}`,
     );
+});
+
+test("15. final Node runtime stages remove npm tooling", () => {
+    const backendStages = dockerfileStages(readRepoFile("backend/Dockerfile"));
+    const frontendStages = dockerfileStages(
+        readRepoFile("frontend/Dockerfile"),
+    );
+    const runtimeStages = [
+        [
+            "backend/Dockerfile worker-runtime",
+            backendStages.find((stage) => stage.name === "worker-runtime"),
+        ],
+        [
+            "backend/Dockerfile api-runtime",
+            backendStages.find((stage) => stage.name === "api-runtime"),
+        ],
+        ["frontend/Dockerfile final stage", frontendStages.at(-1)],
+        [
+            "Dockerfile AIO stage",
+            dockerfileStages(readRepoFile("Dockerfile")).at(-1),
+        ],
+    ];
+
+    for (const [label, stage] of runtimeStages) {
+        assert.ok(stage, `${label}: runtime stage must exist`);
+        assert.match(
+            stage.text,
+            npmToolchainRemovalPattern,
+            `${label}: npm toolchain must be removed`,
+        );
+        assert.doesNotMatch(
+            runtimeCommandLinesAfterToolchainRemoval(stage.text),
+            /\b(?:npm|npx)(?=["'\s,])/i,
+            `${label}: runtime commands must not invoke npm or npx`,
+        );
+    }
 });


### PR DESCRIPTION
Part of #671 — the remaining actionable slice of the Trivy image-CVE backlog after the base-digest refresh (#675).

## Problem

Three separate things kept the backlog alive:

1. **npm's vendored dependencies ship in every Node runtime image.** The `node:24-bookworm-slim` base bundles npm, and npm bundles its own `node_modules` (tar, undici, ip-address, brace-expansion). Those accounted for all 18 remaining non-Python findings, and they re-appear with every new CVE against those packages no matter how fresh our base digest is. Nothing in any runtime image actually needs npm: the frontend `start` script is just `node server.js`, prisma is deliberately installed into the app's local `node_modules` (so `node_modules/.bin/prisma` resolves identically to `npx prisma`), and the worker never touches it.
2. **The trivy-action severity filter silently doesn't apply to SARIF.** `severity: CRITICAL,HIGH` only filters table output; SARIF uploads carried every medium/low finding into the security tab unless `limit-severities-for-sarif: true` is set. That's where most of the OS-package noise came from.
3. **The keras/protobuf chain is unfixable in place.** All keras fixes land in keras 3.x (needs TF 2.16+); the protobuf fix (5.29.6) is outside TF 2.15's `<5` pin. TF 2.15.x is the validated companion of `essentia-tensorflow 2.1b6.dev1389`, the newest CPython 3.11 wheel. No first-party code imports keras, and the analyzers only load image-bundled frozen `.pb` graphs — the untrusted-model-deserialization surface those CVEs need does not exist in these images.

## Fix

- Remove npm, npx, and corepack from every final runtime filesystem (backend api, backend worker, frontend, AIO). Production containers don't need a package installer — this is the same reasoning as the existing curl/wget/nc stripping, and it eliminates the npm-vendored CVE class permanently rather than chasing individual bumps. Entry points now call `node server.js` and `node_modules/.bin/prisma` directly.
- Add `limit-severities-for-sarif: true` to both Trivy workflows so the SARIF uploads honor the CRITICAL/HIGH policy that was already configured.
- Defer the seven blocked keras/protobuf HIGHs in `.trivyignore`, each with the rationale the file's policy header requires, pointing at #717 (the essentia CPython 3.14 migration path, which is the real fix).

## Tests

- `scripts/ci/dockerfile-hygiene.test.mjs`: the pinned prisma-invocation contract is updated to the `.bin/prisma` form, and a new test asserts every Node runtime stage strips the npm toolchain and that no CMD/ENTRYPOINT/supervisord program invokes npm/npx.
- `backend/src/__tests__/dockerEntrypointSecrets.test.ts`: pinned entrypoint expectations updated for the `.bin/prisma` change.

## Bookkeeping done alongside (no code)

- Deleted the frozen analyses of the two retired scan categories (`trivy-image-tidal-downloader`, renamed in #703; `trivy-image-audio-analyzer-clap`, image deleted in #560). Their last uploads kept 76 alerts open forever for images that no longer exist.
- Fresh post-#675 scan confirmed the digest refresh: dclap and ytmusic categories are at zero.
