### PR TITLE
chore: remove stray .venv pointer file and ignore the file form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.so
 .Python
 venv/
+.venv
 .venv/
 **/.venv/
 

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/home/josh/git/soundspan/.claude/worktrees/youtube-download-tidal-naming-033b4b/.venv


### PR DESCRIPTION
A one-line `.venv` file containing a local worktree path (`/home/josh/git/soundspan/.claude/worktrees/youtube-download-tidal-naming-033b4b/.venv`) was accidentally committed in the tidal-streamer rename (853a27c3, #703) — a Python tool wrote a venv pointer file in the working tree and a broad `git add` swept it in. No secrets, just a local path.

Why the ignore rules missed it: `.gitignore` had `venv/`, `.venv/`, and `**/.venv/` — all directory-only patterns. A `.venv` **file** matches none of them. This removes the tracked file and adds a bare `.venv` pattern covering both forms.

I also swept the tracked file list for other strays (`node_modules`, `dist`, `.env`, `__pycache__`, `.pyc`, `.DS_Store`, logs) and audited every file added in the last 20 merges to main — nothing else non-legitimate is tracked; `.env.example` is intentional.