### PR TITLE
fix(audiobooks): remove Audiobookshelf-deleted books from the cache on full sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Federation sync positional dedup no longer generates a per-track Album self-join that could exhaust database memory on large sync pages (#713).
+- Admin-only full audiobook syncs now prune only stable, proven-complete Audiobookshelf listings, stop at cooperative lease deadlines, serialize against incremental syncs through the scheduler claim, protect federated and cover-filename ID collisions, and remove absent local books with their cached covers and listening state (#712).
 - Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library (#710).
 
 ### Security

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -268,6 +268,7 @@ describe("api entrypoint runtime behavior", () => {
         const shutdownWorkers = jest.fn(
             shutdownWorkersImpl || (async () => undefined),
         );
+        const shutdownSchedulerClaimRedis = jest.fn(async () => undefined);
         const shutdownUmapProjection = jest.fn(async () => undefined);
 
         jest.doMock("express", () => expressFn);
@@ -346,6 +347,9 @@ describe("api entrypoint runtime behavior", () => {
         jest.doMock("../workers", () => ({
             shutdownWorkers,
         }));
+        jest.doMock("../utils/schedulerClaim", () => ({
+            shutdownSchedulerClaimRedis,
+        }));
         jest.doMock("../services/umapProjection", () => ({
             shutdownUmapProjection,
         }));
@@ -380,6 +384,7 @@ describe("api entrypoint runtime behavior", () => {
             requireAuth,
             requireAdmin,
             shutdownWorkers,
+            shutdownSchedulerClaimRedis,
             shutdownUmapProjection,
             compressionMiddleware,
             compressionFilter,
@@ -1176,6 +1181,35 @@ describe("api entrypoint runtime behavior", () => {
         expect(mocks.logger.debug).toHaveBeenCalledWith(
             "Shutdown already in progress...",
         );
+    });
+
+    it("closes scheduler claim Redis during API-only shutdown", async () => {
+        process.env = {
+            ...originalEnv,
+            BACKEND_PROCESS_ROLE: "api",
+        };
+        const processOnSpy = jest
+            .spyOn(process, "on")
+            .mockImplementation(() => process as any);
+        jest.spyOn(global, "setInterval").mockImplementation(
+            () => 1 as unknown as NodeJS.Timeout,
+        );
+        process.exit = jest.fn() as any;
+        const mocks = setupApiEntrypointMocks();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+        const sigtermHandler = getProcessHandler(processOnSpy, "SIGTERM");
+        await sigtermHandler();
+        await flushPromises();
+
+        expect(mocks.shutdownWorkers).not.toHaveBeenCalled();
+        expect(mocks.shutdownSchedulerClaimRedis).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.shutdownSchedulerClaimRedis.mock.invocationCallOrder[0],
+        ).toBeLessThan(mocks.redisClient.close.mock.invocationCallOrder[0]);
+        expect(process.exit).toHaveBeenCalledWith(0);
     });
 
     it("logs shutdown cleanup errors and exits non-zero", async () => {

--- a/backend/src/__tests__/audiobooksCoverAuthz.test.ts
+++ b/backend/src/__tests__/audiobooksCoverAuthz.test.ts
@@ -24,6 +24,7 @@ const mockRequireAuthOrToken = jest.fn(
 jest.mock("../middleware/auth", () => ({
     requireAuthOrToken: (req: any, res: any, next: any) =>
         mockRequireAuthOrToken(req, res, next),
+    requireAdmin: (_req: any, _res: any, next: any) => next(),
 }));
 
 jest.mock("../middleware/rateLimiter", () => ({

--- a/backend/src/__tests__/config.test.ts
+++ b/backend/src/__tests__/config.test.ts
@@ -1046,6 +1046,7 @@ describe("config module", () => {
         expect(config.playlistLogDir).toBe("/tmp/playlist-logs");
         expect(config.workers).toEqual({
             moodBucketClaimTtlMs: 120_001,
+            schedulerClaimSkipWarnThreshold: 3,
             enrichmentClaimTtlMs: 900_001,
             trackReconciliationMaxRows: 10_001,
             trackReconciliationTimeoutMs: 600_001,
@@ -1093,6 +1094,7 @@ describe("config module", () => {
         expect(config.playlistLogDir).toBeUndefined();
         expect(config.workers).toEqual({
             moodBucketClaimTtlMs: 120_000,
+            schedulerClaimSkipWarnThreshold: 3,
             enrichmentClaimTtlMs: 900_000,
             trackReconciliationMaxRows: 10_000,
             trackReconciliationTimeoutMs: 10 * 60 * 1000,

--- a/backend/src/__tests__/workerSchedulerClaimContract.test.ts
+++ b/backend/src/__tests__/workerSchedulerClaimContract.test.ts
@@ -2,32 +2,6 @@ import fs from "fs";
 import path from "path";
 
 describe("worker scheduler claim contract", () => {
-    it("uses Redis-backed claim helper for recurring scheduler loops", () => {
-        const workersPath = path.resolve(__dirname, "../workers/index.ts");
-        const workersSource = fs.readFileSync(workersPath, "utf8");
-
-        expect(workersSource).toMatch(
-            /let schedulerLockRedis: Redis = createIORedisClient\(\s*"worker-scheduler-locks",\s*jestLazyConnectOverride,?\s*\)/,
-        );
-        expect(workersSource).toContain(
-            "async function runWithSchedulerClaim(",
-        );
-        expect(workersSource).toContain(
-            "async function withSchedulerClaimRedisRetry<",
-        );
-        expect(workersSource).toContain(
-            "failed due to Redis connection closure (attempt",
-        );
-        expect(workersSource).toContain(
-            '"scheduler-claim:reconciliation-cycle"',
-        );
-        expect(workersSource).toContain(
-            '"scheduler-claim:lidarr-cleanup-cycle"',
-        );
-        expect(workersSource).toContain('"scheduler-claim:data-integrity"');
-        expect(workersSource).toContain("SCHEDULER_CLAIM_SKIP_WARN_THRESHOLD");
-    });
-
     it("registers queue-backed repeatable scheduler jobs", () => {
         const workersPath = path.resolve(__dirname, "../workers/index.ts");
         const workersSource = fs.readFileSync(workersPath, "utf8");

--- a/backend/src/__tests__/workerShutdownResilienceContract.test.ts
+++ b/backend/src/__tests__/workerShutdownResilienceContract.test.ts
@@ -11,7 +11,7 @@ describe("worker shutdown resilience contract", () => {
     const workersSource = fs.readFileSync(workersPath, "utf8");
     const unifiedSource = fs.readFileSync(unifiedPath, "utf8");
 
-    it("awaits enrichment worker stop and keeps queue processing alive until queue close", () => {
+    it("awaits enrichment worker stop and keeps enrichment state alive until queue close", () => {
         expect(workersSource).toContain("await stopUnifiedEnrichmentWorker()");
 
         const queueCloseIndex = workersSource.indexOf(
@@ -20,13 +20,9 @@ describe("worker shutdown resilience contract", () => {
         const enrichmentDisconnectIndex = workersSource.indexOf(
             "await enrichmentStateService.disconnect()",
         );
-        const schedulerLockDisconnectIndex = workersSource.indexOf(
-            "await schedulerLockRedis.quit()",
-        );
 
         expect(queueCloseIndex).toBeGreaterThan(-1);
         expect(enrichmentDisconnectIndex).toBeGreaterThan(queueCloseIndex);
-        expect(schedulerLockDisconnectIndex).toBeGreaterThan(queueCloseIndex);
     });
 
     it("waits for active enrichment cycle and updates state before local redis teardown", () => {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -632,6 +632,8 @@ export const config = {
         30_000,
     ),
     nodeEnv: process.env.NODE_ENV || "development",
+    // Jest worker detection for code that must skip live connections in tests.
+    underJest: process.env.JEST_WORKER_ID !== undefined,
     get appVersion(): string {
         return process.env.npm_package_version || "unknown";
     },
@@ -996,6 +998,12 @@ export const config = {
         trackRemovalRetentionDays,
         federationTombstoneRetentionDays,
         federationSyncIntervalMinutes,
+        get schedulerClaimSkipWarnThreshold(): number {
+            return positiveIntEnvOr(
+                process.env.SCHEDULER_CLAIM_SKIP_WARN_THRESHOLD,
+                3,
+            );
+        },
         get moodBucketClaimTtlMs(): number {
             return positiveIntEnvOr(
                 process.env.MOOD_BUCKET_CLAIM_TTL_MS,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -773,6 +773,10 @@ async function gracefulShutdown(signal: string) {
         if (workersInitialized) {
             const { shutdownWorkers } = await import("./workers");
             await shutdownWorkers();
+        } else if (runApiRole) {
+            const { shutdownSchedulerClaimRedis } =
+                await import("./utils/schedulerClaim");
+            await shutdownSchedulerClaimRedis();
         }
 
         // Close Redis connection (node-redis v5+ replaced quit() with close())

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -99,6 +99,7 @@ route file is intentionally incremental (per touched file), not a big-bang.
 | `backend/src/routes/podcasts.ts`           | `/api/podcasts`                                                                                       |
 | `backend/src/routes/recommendations.ts`    | `/api/recommendations`                                                                                |
 | `backend/src/routes/releases.ts`           | `/api/releases`                                                                                       |
+| `backend/src/routes/audiobookRouteResponses.ts` | Audiobook response serializers; not a router                                                          |
 | `backend/src/routes/routeErrorResponse.ts` | Shared response helper; not a router                                                                  |
 | `backend/src/routes/search.ts`             | `/api/search`                                                                                         |
 | `backend/src/routes/settings.ts`           | `/api/settings`                                                                                       |

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -6,6 +6,7 @@ import { isOriginAllowed } from "../../utils/cors";
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
+    requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
 }));
 
 jest.mock("../../middleware/rateLimiter", () => ({

--- a/backend/src/routes/__tests__/audiobooksRateLimitWiring.test.ts
+++ b/backend/src/routes/__tests__/audiobooksRateLimitWiring.test.ts
@@ -38,6 +38,13 @@ jest.mock("../../middleware/auth", () => ({
         req.user = { id: "user-1", username: "test" } as Request["user"];
         next();
     },
+    requireAdmin: function requireAdmin(
+        _req: Request,
+        _res: Response,
+        next: NextFunction,
+    ) {
+        next();
+    },
 }));
 
 jest.mock("../../middleware/rateLimiter", () => ({

--- a/backend/src/routes/__tests__/audiobooksRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksRuntime.test.ts
@@ -7,8 +7,20 @@ jest.mock("dns/promises", () => ({
 }));
 
 jest.mock("../../middleware/auth", () => ({
-    requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
-        next(),
+    requireAuthOrToken: (req: Request, _res: Response, next: () => void) => {
+        req.user = {
+            id: "authenticated-user",
+            username: "authenticated-user",
+            role: req.headers["x-test-role"] === "admin" ? "admin" : "user",
+        };
+        next();
+    },
+    requireAdmin: (req: Request, res: Response, next: () => void) => {
+        if (req.user?.role !== "admin") {
+            return res.status(403).json({ error: "Admin access required" });
+        }
+        next();
+    },
 }));
 
 jest.mock("../../middleware/rateLimiter", () => ({
@@ -93,6 +105,8 @@ jest.mock("../../utils/db", () => ({
 
 import router from "../audiobooks";
 
+const MAX_ROUTE_HANDLERS = 4;
+
 function getHandler(path: string, method: "get" | "post") {
     const layer = (router as any).stack.find(
         (entry: any) =>
@@ -102,6 +116,31 @@ function getHandler(path: string, method: "get" | "post") {
         throw new Error(`${method.toUpperCase()} route not found: ${path}`);
     }
     return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+async function invokeRouteStack(
+    path: string,
+    method: "get" | "post",
+    req: any,
+    res: any,
+) {
+    const layer = (router as any).stack.find(
+        (entry: any) =>
+            entry.route?.path === path && entry.route?.methods?.[method],
+    );
+    const stack = layer?.route?.stack ?? [];
+    if (stack.length > MAX_ROUTE_HANDLERS) {
+        throw new Error(`Too many route handlers: ${stack.length}`);
+    }
+    for (let index = 0; index < MAX_ROUTE_HANDLERS; index += 1) {
+        const entry = stack[index];
+        if (!entry) return;
+        let nextCalled = false;
+        await entry.handle(req, res, () => {
+            nextCalled = true;
+        });
+        if (!nextCalled) return;
+    }
 }
 
 function createRes() {
@@ -239,8 +278,26 @@ describe("audiobooks route runtime", () => {
         expect(audiobookCacheService.syncAll).not.toHaveBeenCalled();
     });
 
+    it("rejects an authenticated non-admin sync request", async () => {
+        const req = { headers: { "x-test-role": "user" } } as any;
+        const res = createRes();
+
+        await invokeRouteStack("/sync", "post", req, res);
+
+        expect(req.user).toEqual(expect.objectContaining({ role: "user" }));
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: "Admin access required" });
+        expect(audiobookCacheService.syncAll).not.toHaveBeenCalled();
+    });
+
     it("syncs audiobooks and notifies the current user", async () => {
-        audiobookCacheService.syncAll.mockResolvedValueOnce({ synced: 7 });
+        audiobookCacheService.syncAll.mockResolvedValueOnce({
+            synced: 7,
+            failed: 0,
+            skipped: 1,
+            deleted: 2,
+            errors: [],
+        });
         prisma.audiobook.count.mockResolvedValueOnce(3);
 
         const req = { user: { id: "user-42" } } as any;
@@ -250,7 +307,13 @@ describe("audiobooks route runtime", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
             success: true,
-            result: { synced: 7 },
+            result: {
+                synced: 7,
+                failed: 0,
+                skipped: 1,
+                deleted: 2,
+                errors: [],
+            },
         });
         expect(notificationService.notifySystem).toHaveBeenCalledWith(
             "user-42",
@@ -290,6 +353,21 @@ describe("audiobooks route runtime", () => {
         });
     });
 
+    it("surfaces an already-running audiobook sync error", async () => {
+        audiobookCacheService.syncAll.mockRejectedValueOnce(
+            new Error("audiobook sync already running"),
+        );
+
+        const req = { user: { id: "user-1" } } as any;
+        const res = createRes();
+        await syncHandler(req, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({
+            error: "audiobook sync already running",
+        });
+    });
+
     it("rejects an unsafe cached ABS cover path before proxy fetch", async () => {
         const existsSpy = jest.spyOn(require("fs"), "existsSync");
         existsSpy.mockReturnValue(false);
@@ -312,6 +390,27 @@ describe("audiobooks route runtime", () => {
         expect(res.statusCode).toBe(404);
         expect(res.body).toEqual({ error: "Cover not found" });
         expect(fetchMock).not.toHaveBeenCalled();
+        existsSpy.mockRestore();
+    });
+
+    it("does not probe a fallback cover filename for an unsafe local id", async () => {
+        const existsSpy = jest.spyOn(require("fs"), "existsSync");
+        existsSpy.mockReturnValue(true);
+        prisma.audiobook.findUnique.mockResolvedValueOnce({
+            localCoverPath: null,
+            coverUrl: null,
+            peerId: null,
+        });
+
+        const req = { params: { id: "victim:cover" } } as any;
+        const res = createRes();
+
+        await coverHandler(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({ error: "Cover not found" });
+        expect(existsSpy).not.toHaveBeenCalled();
+        expect(prisma.audiobook.update).not.toHaveBeenCalled();
         existsSpy.mockRestore();
     });
 

--- a/backend/src/routes/__tests__/audiobooksRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksRuntime.test.ts
@@ -353,7 +353,7 @@ describe("audiobooks route runtime", () => {
         });
     });
 
-    it("surfaces an already-running audiobook sync error", async () => {
+    it("surfaces an already-running audiobook sync as a conflict", async () => {
         audiobookCacheService.syncAll.mockRejectedValueOnce(
             new Error("audiobook sync already running"),
         );
@@ -362,7 +362,7 @@ describe("audiobooks route runtime", () => {
         const res = createRes();
         await syncHandler(req, res);
 
-        expect(res.statusCode).toBe(500);
+        expect(res.statusCode).toBe(409);
         expect(res.body).toEqual({
             error: "audiobook sync already running",
         });

--- a/backend/src/routes/audiobookRouteResponses.ts
+++ b/backend/src/routes/audiobookRouteResponses.ts
@@ -1,0 +1,72 @@
+import type {
+    Audiobook,
+    AudiobookProgress,
+    FederationPeer,
+} from "@prisma/client";
+
+/** Audiobook row shape consumed by the audiobook route serializers. */
+export type AudiobookRow = Audiobook & {
+    federationPeer?: Pick<
+        FederationPeer,
+        "id" | "name" | "outboundStatus" | "baseUrl" | "outboundToken"
+    > | null;
+};
+
+/** Progress fields the audiobook list/detail responses consume. */
+export type ProgressRow = Pick<
+    AudiobookProgress,
+    "currentTime" | "duration" | "isFinished" | "lastPlayedAt"
+>;
+
+/** Federated origin fields for a peer-mirrored audiobook row. */
+export function federatedSource(book: AudiobookRow) {
+    if (!book.peerId || !book.federationPeer) return {};
+    return {
+        source: "federated" as const,
+        peer: {
+            id: book.federationPeer.id,
+            name: book.federationPeer.name,
+            online: book.federationPeer.outboundStatus === "ACTIVE",
+        },
+    };
+}
+
+/** Serializes a progress row into the API progress payload. */
+export function progressResponse(progress: ProgressRow | null | undefined) {
+    if (!progress) return null;
+    return {
+        currentTime: progress.currentTime,
+        progress:
+            progress.duration > 0
+                ? (progress.currentTime / progress.duration) * 100
+                : 0,
+        isFinished: progress.isFinished,
+        lastPlayedAt: progress.lastPlayedAt,
+    };
+}
+
+/** Serializes an audiobook row into the list response payload. */
+export function audiobookListResponse(
+    book: AudiobookRow,
+    progress: ProgressRow | null | undefined,
+) {
+    return {
+        id: book.id,
+        title: book.title,
+        author: book.author || "Unknown Author",
+        narrator: book.narrator,
+        description: book.description,
+        coverUrl:
+            book.localCoverPath || book.coverUrl
+                ? `/audiobooks/${book.id}/cover`
+                : null,
+        duration: book.duration || 0,
+        libraryId: book.libraryId,
+        series: book.series
+            ? { name: book.series, sequence: book.seriesSequence || "1" }
+            : null,
+        genres: book.genres || [],
+        progress: progressResponse(progress),
+        ...federatedSource(book),
+    };
+}

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -1,9 +1,5 @@
 import { Router, type Request, type Response } from "express";
-import type {
-    Audiobook,
-    AudiobookProgress,
-    FederationPeer,
-} from "@prisma/client";
+import type { Audiobook } from "@prisma/client";
 import { z } from "zod";
 import { logger } from "../utils/logger";
 import { audiobookshelfService } from "../services/audiobookshelf";
@@ -36,6 +32,11 @@ import {
     type AudiobookSections,
 } from "../services/audiobookSections";
 import { findRouteNameMatch } from "./routeParamName";
+import {
+    audiobookListResponse,
+    federatedSource,
+    type AudiobookRow,
+} from "./audiobookRouteResponses";
 
 const router = Router();
 const audiobookSyncAuth = [requireAuthOrToken, requireAdmin] as const;
@@ -64,68 +65,6 @@ const audiobookProgressMetadataSelect = {
     localCoverPath: true,
     peerId: true,
 } as const;
-
-type AudiobookRow = Audiobook & {
-    federationPeer?: Pick<
-        FederationPeer,
-        "id" | "name" | "outboundStatus" | "baseUrl" | "outboundToken"
-    > | null;
-};
-
-type ProgressRow = Pick<
-    AudiobookProgress,
-    "currentTime" | "duration" | "isFinished" | "lastPlayedAt"
->;
-
-function federatedSource(book: AudiobookRow) {
-    if (!book.peerId || !book.federationPeer) return {};
-    return {
-        source: "federated" as const,
-        peer: {
-            id: book.federationPeer.id,
-            name: book.federationPeer.name,
-            online: book.federationPeer.outboundStatus === "ACTIVE",
-        },
-    };
-}
-
-function progressResponse(progress: ProgressRow | null | undefined) {
-    if (!progress) return null;
-    return {
-        currentTime: progress.currentTime,
-        progress:
-            progress.duration > 0
-                ? (progress.currentTime / progress.duration) * 100
-                : 0,
-        isFinished: progress.isFinished,
-        lastPlayedAt: progress.lastPlayedAt,
-    };
-}
-
-function audiobookListResponse(
-    book: AudiobookRow,
-    progress: ProgressRow | null | undefined,
-) {
-    return {
-        id: book.id,
-        title: book.title,
-        author: book.author || "Unknown Author",
-        narrator: book.narrator,
-        description: book.description,
-        coverUrl:
-            book.localCoverPath || book.coverUrl
-                ? `/audiobooks/${book.id}/cover`
-                : null,
-        duration: book.duration || 0,
-        libraryId: book.libraryId,
-        series: book.series
-            ? { name: book.series, sequence: book.seriesSequence || "1" }
-            : null,
-        genres: book.genres || [],
-        progress: progressResponse(progress),
-        ...federatedSource(book),
-    };
-}
 
 function sectionsArePlayable(cachedSections: AudiobookSections): boolean {
     return cachedSections.kind !== "none";

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -24,7 +24,7 @@ import {
     MAX_EXTERNAL_IMAGE_BYTES,
     readResponseBodyWithByteCap,
 } from "../services/imageProxy";
-import { sendRouteError } from "./routeErrorResponse";
+import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import { sendFileFromRoot } from "../utils/sendFileFromRoot";
 import { config } from "../config";
 import {
@@ -250,11 +250,12 @@ router.post("/sync", apiLimiter, ...audiobookSyncAuth, async (req, res) => {
             result,
         });
     } catch (error: any) {
-        const syncError = error.message;
         logger.error("Audiobook sync failed:", error);
-        res.status(500).json({
-            error: syncError === SYNC_RUNNING_ERROR ? syncError : "Sync failed",
-        });
+        if (error.message === SYNC_RUNNING_ERROR) {
+            sendRouteError(res, 409, SYNC_RUNNING_ERROR);
+            return;
+        }
+        sendInternalRouteError(res, "Sync failed");
     }
 });
 

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -9,14 +9,17 @@ import { logger } from "../utils/logger";
 import { audiobookshelfService } from "../services/audiobookshelf";
 import { audiobookCacheService } from "../services/audiobookCache";
 import { prisma } from "../utils/db";
-import { requireAuthOrToken } from "../middleware/auth";
+import { requireAdmin, requireAuthOrToken } from "../middleware/auth";
 import {
     apiLimiter,
     coverArtLimiter,
     streamingLimiter,
 } from "../middleware/rateLimiter";
 import { safeResolvePath } from "../utils/safeResolvePath";
-import { buildSafeAudiobookCoverUrl } from "../services/audiobookCoverProxy";
+import {
+    buildSafeAudiobookCoverUrl,
+    safeCoverFilename,
+} from "../services/audiobookCoverProxy";
 import {
     MAX_EXTERNAL_IMAGE_BYTES,
     readResponseBodyWithByteCap,
@@ -35,6 +38,8 @@ import {
 import { findRouteNameMatch } from "./routeParamName";
 
 const router = Router();
+const audiobookSyncAuth = [requireAuthOrToken, requireAdmin] as const;
+const SYNC_RUNNING_ERROR = "audiobook sync already running";
 
 const federationPeerInclude = {
     federationPeer: {
@@ -202,23 +207,12 @@ router.get(
  * /api/audiobooks/sync:
  *   post:
  *     summary: Manually trigger audiobook sync from Audiobookshelf
+ *     description: Requires administrator access. Destructively reconciles the local audiobook cache with the complete Audiobookshelf listing, including deleting absent local books and related state.
  *     tags: [Audiobooks]
- *     security:
- *       - apiKeyAuth: []
- *     responses:
- *       200:
- *         description: Sync completed successfully
- *       400:
- *         description: Audiobookshelf not enabled
- *       401:
- *         description: Not authenticated
+ *     security: [{ apiKeyAuth: [] }]
+ *     responses: { 200: { description: Sync completed successfully, content: { application/json: { schema: { type: object, required: [success, result], properties: { success: { type: boolean }, result: { type: object, required: [synced, failed, skipped, deleted, errors], properties: { synced: { type: integer }, failed: { type: integer }, skipped: { type: integer }, deleted: { type: integer }, errors: { type: array, items: { type: string } } } } } } } } }, 400: { description: Audiobookshelf not enabled }, 401: { description: Not authenticated }, 403: { description: Administrator access required } }
  */
-/**
- * POST /audiobooks/sync
- * Manually trigger audiobook sync from Audiobookshelf
- * Fetches all audiobooks and caches metadata + cover images locally
- */
-router.post("/sync", apiLimiter, requireAuthOrToken, async (req, res) => {
+router.post("/sync", apiLimiter, ...audiobookSyncAuth, async (req, res) => {
     try {
         const { getSystemSettings } = await import("../utils/systemSettings");
         const { notificationService } =
@@ -256,9 +250,10 @@ router.post("/sync", apiLimiter, requireAuthOrToken, async (req, res) => {
             result,
         });
     } catch (error: any) {
+        const syncError = error.message;
         logger.error("Audiobook sync failed:", error);
         res.status(500).json({
-            error: "Sync failed",
+            error: syncError === SYNC_RUNNING_ERROR ? syncError : "Sync failed",
         });
     }
 });
@@ -732,7 +727,12 @@ async function resolveAudiobookCoverPath(
 ): Promise<string | null | undefined> {
     if (storedPath) return storedPath;
     const fs = await import("fs");
-    const fallbackPath = safeResolvePath(coverDir, `${id}.jpg`);
+    const fallbackFilename = safeCoverFilename(id);
+    if (!fallbackFilename) {
+        logger.warn("Skipped unsafe audiobook cover id", { audiobookId: id });
+        return null;
+    }
+    const fallbackPath = safeResolvePath(coverDir, fallbackFilename);
     if (!fallbackPath || !fs.existsSync(fallbackPath)) return null;
     try {
         await prisma.audiobook.update({

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -2,10 +2,13 @@ import path from "path";
 import { Prisma } from "@prisma/client";
 
 const mockGetAllAudiobooks = jest.fn();
+const mockGetAudiobookListing = jest.fn();
 const mockGetAudiobook = jest.fn();
 jest.mock("../audiobookshelf", () => ({
     audiobookshelfService: {
         getAllAudiobooks: (...args: any[]) => mockGetAllAudiobooks(...args),
+        getAudiobookListing: (...args: any[]) =>
+            mockGetAudiobookListing(...args),
         getAudiobook: (...args: any[]) => mockGetAudiobook(...args),
     },
 }));
@@ -14,7 +17,9 @@ const logger = {
     debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    child: jest.fn(),
 };
+logger.child.mockReturnValue(logger);
 jest.mock("../../utils/logger", () => ({
     logger,
 }));
@@ -24,10 +29,46 @@ const prisma = {
         upsert: jest.fn(),
         findUnique: jest.fn(),
         findMany: jest.fn(),
+        count: jest.fn(),
+        deleteMany: jest.fn(),
+    },
+    audiobookProgress: {
+        deleteMany: jest.fn(),
+    },
+    playbackState: {
+        updateMany: jest.fn(),
+    },
+    federationTombstone: {
+        createMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+};
+const transactionClient = {
+    audiobook: {
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
+    },
+    audiobookProgress: {
+        deleteMany: jest.fn(),
+    },
+    playbackState: {
+        updateMany: jest.fn(),
+    },
+    federationTombstone: {
+        createMany: jest.fn(),
     },
 };
 jest.mock("../../utils/db", () => ({
     prisma,
+}));
+
+const mockRunWithSchedulerClaim = jest.fn();
+jest.mock("../../utils/schedulerClaim", () => ({
+    AUDIOBOOK_SYNC_CLAIM_KEY: "scheduler-claim:audiobook-auto-sync",
+    AUDIOBOOK_SYNC_CLAIM_TTL_MS: 2 * 60 * 60 * 1000,
+    AUDIOBOOK_SYNC_WORK_TIMEOUT_MS: 2 * 60 * 60 * 1000 - 10 * 60_000,
+    runWithSchedulerClaim: (...args: any[]) =>
+        mockRunWithSchedulerClaim(...args),
 }));
 
 const fsPromises = {
@@ -46,13 +87,15 @@ jest.mock("../../utils/systemSettings", () => ({
     getSystemSettings: (...args: any[]) => mockGetSystemSettings(...args),
 }));
 
-jest.mock("../../config", () => ({
-    config: {
-        music: {
-            musicPath: "/srv/music",
-        },
+const mockConfig = {
+    music: {
+        musicPath: "/srv/music",
     },
-}));
+    features: {
+        federation: false,
+    },
+};
+jest.mock("../../config", () => ({ config: mockConfig }));
 
 import { AudiobookCacheService } from "../audiobookCache";
 import { MAX_EXTERNAL_IMAGE_BYTES } from "../imageProxy";
@@ -92,15 +135,102 @@ function buildBook(overrides: Record<string, any> = {}) {
     };
 }
 
+function createDeferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+type AudiobookFixtureRow = {
+    id: string;
+    localCoverPath?: string | null;
+    lastSyncedAt?: Date;
+    libraryId?: string | null;
+    peerId?: string | null;
+};
+
+function fixtureValue<T extends keyof AudiobookFixtureRow>(
+    row: AudiobookFixtureRow,
+    key: T,
+    fallback: AudiobookFixtureRow[T],
+): AudiobookFixtureRow[T] {
+    return Object.prototype.hasOwnProperty.call(row, key) ? row[key] : fallback;
+}
+
+function matchesAudiobookWhere(
+    row: AudiobookFixtureRow,
+    where: Record<string, any>,
+): boolean {
+    const peerId = fixtureValue(row, "peerId", null);
+    const libraryId = fixtureValue(row, "libraryId", "library-1");
+    const lastSyncedAt = fixtureValue(row, "lastSyncedAt", new Date(0)) as Date;
+    if (where.peerId === null && peerId !== null) return false;
+    if (where.peerId?.not === null && peerId === null) return false;
+    if (where.id?.in && !where.id.in.includes(row.id)) return false;
+    if (where.lastSyncedAt?.lt && lastSyncedAt >= where.lastSyncedAt.lt) {
+        return false;
+    }
+    if (where.libraryId?.in && !where.libraryId.in.includes(libraryId)) {
+        return false;
+    }
+    if (typeof where.libraryId === "string" && libraryId !== where.libraryId) {
+        return false;
+    }
+    if (where.libraryId?.not === null && libraryId === null) return false;
+    if (where.libraryId?.notIn?.includes(libraryId)) return false;
+    if (where.libraryId === null && libraryId !== null) return false;
+    return true;
+}
+
+function mockAudiobookQueries({
+    federatedRows = [],
+    pruneRows = [],
+    cachedRows = [],
+}: {
+    federatedRows?: any[];
+    pruneRows?: any[];
+    cachedRows?: any[];
+} = {}) {
+    const rows = [...federatedRows, ...pruneRows, ...cachedRows];
+    prisma.audiobook.findMany.mockImplementation(async ({ where }) => {
+        return rows.filter((row) => matchesAudiobookWhere(row, where ?? {}));
+    });
+    prisma.audiobook.count.mockImplementation(
+        async ({ where }) =>
+            rows.filter((row) => matchesAudiobookWhere(row, where ?? {}))
+                .length,
+    );
+}
+
 describe("audiobook cache service behavior", () => {
     const fetchMock = jest.fn();
 
     beforeEach(() => {
-        jest.clearAllMocks();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        jest.resetAllMocks();
+        logger.child.mockReturnValue(logger);
 
         (global as any).fetch = fetchMock;
 
         mockGetAllAudiobooks.mockResolvedValue([]);
+        mockGetAudiobookListing.mockImplementation(async () => {
+            const books = await mockGetAllAudiobooks();
+            return {
+                books,
+                verifiedCompleteLibraryIds: new Set(
+                    books
+                        .map((book: any) => book.libraryId)
+                        .filter(
+                            (libraryId: unknown): libraryId is string =>
+                                typeof libraryId === "string" &&
+                                libraryId.length > 0,
+                        ),
+                ),
+            };
+        });
         mockGetAudiobook.mockResolvedValue(null);
 
         fsPromises.mkdir.mockResolvedValue(undefined);
@@ -110,7 +240,38 @@ describe("audiobook cache service behavior", () => {
 
         prisma.audiobook.upsert.mockResolvedValue({});
         prisma.audiobook.findUnique.mockResolvedValue(null);
-        prisma.audiobook.findMany.mockResolvedValue([]);
+        mockAudiobookQueries();
+        transactionClient.audiobook.findMany.mockResolvedValue([]);
+        transactionClient.audiobook.deleteMany.mockImplementation(
+            async ({ where }: { where: { id: { in: string[] } } }) => ({
+                count: where.id.in.length,
+            }),
+        );
+        transactionClient.audiobookProgress.deleteMany.mockResolvedValue({
+            count: 0,
+        });
+        transactionClient.playbackState.updateMany.mockResolvedValue({
+            count: 0,
+        });
+        transactionClient.federationTombstone.createMany.mockResolvedValue({
+            count: 0,
+        });
+        prisma.$transaction.mockImplementation(
+            async (
+                operation: (
+                    transaction: typeof transactionClient,
+                ) => Promise<any>,
+            ) => operation(transactionClient),
+        );
+        mockRunWithSchedulerClaim.mockImplementation(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: () => Promise<unknown>,
+            ) => ({ acquired: true, value: await operation() }),
+        );
+        mockConfig.features.federation = false;
 
         mockGetSystemSettings.mockResolvedValue({
             audiobookshelfUrl: "http://abs.local",
@@ -147,6 +308,7 @@ describe("audiobook cache service behavior", () => {
             synced: 1,
             failed: 1,
             skipped: 0,
+            deleted: 0,
             errors: [expect.stringContaining("Failed to sync Broken Book")],
         });
         expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(2);
@@ -160,6 +322,7 @@ describe("audiobook cache service behavior", () => {
                 author: "Author A",
                 series: "Saga",
                 seriesSequence: "2",
+                libraryId: "library-1",
                 coverUrl: "items/book-1/cover",
                 localCoverPath: path.join(
                     "/srv/music",
@@ -183,6 +346,7 @@ describe("audiobook cache service behavior", () => {
         expect(firstUpsertArg.update.sections).toEqual(
             firstUpsertArg.create.sections,
         );
+        expect(firstUpsertArg.update.libraryId).toBe("library-1");
 
         expect(fetchMock).toHaveBeenCalledWith(
             "http://abs.local/api/items/book-1/cover",
@@ -195,6 +359,813 @@ describe("audiobook cache service behavior", () => {
         );
     });
 
+    it("throws when another audiobook sync holds the scheduler claim", async () => {
+        const service = new AudiobookCacheService();
+        mockRunWithSchedulerClaim.mockResolvedValueOnce({ acquired: false });
+
+        await expect(service.syncAll()).rejects.toThrow(
+            "audiobook sync already running",
+        );
+        expect(mockGetAllAudiobooks).not.toHaveBeenCalled();
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledWith(
+            "scheduler-claim:audiobook-auto-sync",
+            2 * 60 * 60 * 1000,
+            "full audiobook sync",
+            expect.any(Function),
+        );
+    });
+
+    it("skips syncMissing when another audiobook sync holds the scheduler claim", async () => {
+        const service = new AudiobookCacheService();
+        mockRunWithSchedulerClaim.mockResolvedValueOnce({ acquired: false });
+
+        await expect(service.syncMissing()).resolves.toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 0,
+            deleted: 0,
+            errors: [],
+        });
+        expect(mockGetAllAudiobooks).not.toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith(
+            "Skipped incremental audiobook sync because another audiobook sync is running",
+        );
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledWith(
+            "scheduler-claim:audiobook-auto-sync",
+            2 * 60 * 60 * 1000,
+            "incremental audiobook sync",
+            expect.any(Function),
+        );
+    });
+
+    it("releases the scheduler claim after a successful sync", async () => {
+        const service = new AudiobookCacheService();
+        let lockHeld = false;
+        mockRunWithSchedulerClaim.mockImplementation(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: () => Promise<unknown>,
+            ) => {
+                if (lockHeld) return { acquired: false };
+                lockHeld = true;
+                try {
+                    return { acquired: true, value: await operation() };
+                } finally {
+                    lockHeld = false;
+                }
+            },
+        );
+
+        await expect(service.syncAll()).resolves.toEqual(
+            expect.objectContaining({ deleted: 0 }),
+        );
+        expect(lockHeld).toBe(false);
+        await expect(service.syncMissing()).resolves.toEqual(
+            expect.objectContaining({ synced: 0 }),
+        );
+    });
+
+    it("releases the scheduler claim after a failed sync", async () => {
+        const service = new AudiobookCacheService();
+        let lockHeld = false;
+        mockRunWithSchedulerClaim.mockImplementation(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: () => Promise<unknown>,
+            ) => {
+                if (lockHeld) return { acquired: false };
+                lockHeld = true;
+                try {
+                    return { acquired: true, value: await operation() };
+                } finally {
+                    lockHeld = false;
+                }
+            },
+        );
+        mockGetAudiobookListing.mockRejectedValueOnce(new Error("sync failed"));
+
+        await expect(service.syncAll()).rejects.toThrow("sync failed");
+        expect(lockHeld).toBe(false);
+
+        await expect(service.syncAll()).resolves.toEqual(
+            expect.objectContaining({ deleted: 0 }),
+        );
+    });
+
+    it("keeps the claim until timed-out full sync work actually settles", async () => {
+        jest.useFakeTimers();
+        const service = new AudiobookCacheService();
+        const listingRequested = createDeferred();
+        const releaseListing = createDeferred();
+        const bodySettled = createDeferred();
+        let lockHeld = false;
+        mockGetAudiobookListing.mockImplementationOnce(async () => {
+            listingRequested.resolve();
+            await releaseListing.promise;
+            return { books: [], verifiedCompleteLibraryIds: new Set() };
+        });
+        mockRunWithSchedulerClaim.mockImplementationOnce(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: () => Promise<unknown>,
+            ) => {
+                lockHeld = true;
+                try {
+                    return { acquired: true, value: await operation() };
+                } finally {
+                    lockHeld = false;
+                    bodySettled.resolve();
+                }
+            },
+        );
+
+        const sync = service.syncAll();
+        await listingRequested.promise;
+        const rejection = expect(sync).rejects.toThrow(
+            "Full audiobook sync timed out after 6600000ms",
+        );
+        await jest.advanceTimersByTimeAsync(2 * 60 * 60 * 1000 - 10 * 60_000);
+        await rejection;
+        expect(lockHeld).toBe(true);
+
+        releaseListing.resolve();
+        await bodySettled.promise;
+        expect(lockHeld).toBe(false);
+    });
+
+    it("does not overwrite a federated audiobook whose id collides with ABS", async () => {
+        const service = new AudiobookCacheService();
+        const federatedRow = {
+            id: "colliding-book",
+            peerId: "peer-1",
+            title: "Federated Title",
+            localCoverPath: "/federated/cover.jpg",
+        };
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "colliding-book" }),
+        ]);
+        mockAudiobookQueries({ federatedRows: [federatedRow] });
+
+        const result = await service.syncAll();
+
+        expect(prisma.audiobook.upsert).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 1,
+            deleted: 0,
+            errors: [],
+        });
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Skipped ABS book whose id collides with a federated audiobook",
+            { audiobookId: "colliding-book" },
+        );
+    });
+
+    it("prunes local audiobooks missing from a full ABS listing", async () => {
+        const service = new AudiobookCacheService();
+        const coverPath = path.join(
+            "/srv/music",
+            "cover-cache",
+            "audiobooks",
+            "stale-cover.jpg",
+        );
+
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: coverPath }],
+        });
+
+        const result = await service.syncAll();
+
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-1"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["stale-book"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(
+            transactionClient.audiobookProgress.deleteMany,
+        ).toHaveBeenCalledWith({
+            where: { audiobookshelfId: { in: ["stale-book"] } },
+        });
+        expect(transactionClient.playbackState.updateMany).toHaveBeenCalledWith(
+            {
+                where: { audiobookId: { in: ["stale-book"] } },
+                data: { audiobookId: null },
+            },
+        );
+        expect(
+            transactionClient.federationTombstone.createMany,
+        ).not.toHaveBeenCalled();
+        expect(prisma.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.audiobookProgress.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.playbackState.updateMany).not.toHaveBeenCalled();
+        expect(prisma.federationTombstone.createMany).not.toHaveBeenCalled();
+        expect(fsPromises.unlink).toHaveBeenCalledWith(coverPath);
+        expect(result.deleted).toBe(1);
+    });
+
+    it("prunes only rows from libraries with verified-complete listings", async () => {
+        const service = new AudiobookCacheService();
+        const libraryABook = buildBook({
+            id: "library-a-current",
+            libraryId: "library-a",
+        });
+        mockGetAllAudiobooks.mockResolvedValue([libraryABook]);
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [libraryABook],
+            verifiedCompleteLibraryIds: new Set(["library-a"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "library-a-stale",
+                    libraryId: "library-a",
+                    localCoverPath: null,
+                },
+                {
+                    id: "library-b-stale",
+                    libraryId: "library-b",
+                    localCoverPath: null,
+                },
+            ],
+        });
+
+        const result = await service.syncAll();
+
+        expect(result.deleted).toBe(1);
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["library-a-stale"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-a"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(logger.debug).toHaveBeenCalledWith(
+            "Skipped 1 audiobooks from libraries without verified-complete listings during prune",
+        );
+    });
+
+    it("spares a verified library with a bogus-empty listing", async () => {
+        const service = new AudiobookCacheService();
+        const libraryABook = buildBook({
+            id: "library-a-current",
+            libraryId: "library-a",
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [libraryABook],
+            verifiedCompleteLibraryIds: new Set(["library-a", "library-b"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "library-a-stale",
+                    libraryId: "library-a",
+                    localCoverPath: null,
+                },
+                {
+                    id: "library-b-stale",
+                    libraryId: "library-b",
+                    localCoverPath: null,
+                },
+            ],
+        });
+
+        const result = await service.syncAll();
+
+        expect(result.deleted).toBe(1);
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["library-a-stale"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-a"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Skipped pruning audiobook library library-b because Audiobookshelf returned an empty listing while 1 local rows exist",
+        );
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("never prunes rows with an unknown library and warns once with the count", async () => {
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({
+            id: "library-a-current",
+            libraryId: "library-a",
+        });
+        mockGetAllAudiobooks.mockResolvedValue([currentBook]);
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-a"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "unknown-library-book",
+                    libraryId: null,
+                    localCoverPath: null,
+                },
+            ],
+        });
+
+        const result = await service.syncAll();
+
+        expect(result.deleted).toBe(0);
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+            "skipped 1 audiobooks with unknown library during prune",
+        );
+    });
+
+    it("syncs books from an unverified listing without pruning that library", async () => {
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({
+            id: "unverified-current",
+            libraryId: "unverified-library",
+        });
+        mockGetAllAudiobooks.mockResolvedValue([currentBook]);
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(),
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "unverified-stale",
+                    libraryId: "unverified-library",
+                    localCoverPath: null,
+                },
+            ],
+        });
+
+        const result = await service.syncAll();
+
+        expect(result.synced).toBe(1);
+        expect(result.deleted).toBe(0);
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith(
+            "Skipped 1 audiobooks from libraries without verified-complete listings during prune",
+        );
+    });
+
+    it("does not select or prune federated audiobook mirrors", async () => {
+        const service = new AudiobookCacheService();
+        const federatedRow = {
+            id: "federated-book",
+            peerId: "peer-1",
+            localCoverPath: null,
+        };
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({ federatedRows: [federatedRow] });
+
+        const result = await service.syncAll();
+
+        expect(result.deleted).toBe(0);
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-1"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+    });
+
+    it("skips pruning when the ABS listing contains an item without an id", async () => {
+        const service = new AudiobookCacheService();
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+            {},
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+        });
+
+        const result = await service.syncAll();
+
+        expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(1);
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Skipped pruning audiobooks because Audiobookshelf returned a malformed listing",
+            ),
+        );
+        expect(result.deleted).toBe(0);
+    });
+
+    it("skips pruning when ABS returns an empty listing but local books exist", async () => {
+        const service = new AudiobookCacheService();
+        mockAudiobookQueries({
+            pruneRows: [{ id: "local-book", localCoverPath: null }],
+        });
+
+        const result = await service.syncAll();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(
+            transactionClient.audiobookProgress.deleteMany,
+        ).not.toHaveBeenCalled();
+        expect(
+            transactionClient.playbackState.updateMany,
+        ).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Skipped pruning audiobooks because Audiobookshelf returned an empty listing",
+            ),
+        );
+        expect(result).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 0,
+            deleted: 0,
+            errors: [],
+        });
+    });
+
+    it("completes an empty full sync when no local books exist", async () => {
+        const service = new AudiobookCacheService();
+
+        const result = await service.syncAll();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining("Skipped pruning audiobooks"),
+        );
+        expect(result.deleted).toBe(0);
+    });
+
+    it("writes audiobook tombstones for pruned rows when federation is enabled", async () => {
+        const service = new AudiobookCacheService();
+        mockConfig.features.federation = true;
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [
+                { id: "stale-1", localCoverPath: null },
+                { id: "stale-2", localCoverPath: null },
+            ],
+        });
+
+        const result = await service.syncAll();
+
+        expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+        expect(
+            transactionClient.federationTombstone.createMany,
+        ).toHaveBeenCalledWith({
+            data: [
+                { entityType: "audiobook", entityId: "stale-1" },
+                { entityType: "audiobook", entityId: "stale-2" },
+            ],
+        });
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledTimes(1);
+        expect(
+            transactionClient.audiobookProgress.deleteMany,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            transactionClient.playbackState.updateMany,
+        ).toHaveBeenCalledTimes(1);
+        expect(prisma.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.audiobookProgress.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.playbackState.updateMany).not.toHaveBeenCalled();
+        expect(prisma.federationTombstone.createMany).not.toHaveBeenCalled();
+        expect(result.deleted).toBe(2);
+    });
+
+    it("tolerates missing and failed cover cleanup after pruning", async () => {
+        const service = new AudiobookCacheService();
+        const missingError = Object.assign(new Error("missing"), {
+            code: "ENOENT",
+        });
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [
+                { id: "stale-missing", localCoverPath: null },
+                { id: "stale-denied", localCoverPath: null },
+            ],
+        });
+        fsPromises.unlink
+            .mockRejectedValueOnce(missingError)
+            .mockRejectedValueOnce(new Error("EACCES"));
+
+        await expect(service.syncAll()).resolves.toEqual(
+            expect.objectContaining({ deleted: 2 }),
+        );
+        expect(fsPromises.unlink).toHaveBeenNthCalledWith(
+            1,
+            path.join(
+                "/srv/music",
+                "cover-cache",
+                "audiobooks",
+                "stale-missing.jpg",
+            ),
+        );
+        expect(fsPromises.unlink).toHaveBeenNthCalledWith(
+            2,
+            path.join(
+                "/srv/music",
+                "cover-cache",
+                "audiobooks",
+                "stale-denied.jpg",
+            ),
+        );
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("Failed to delete audiobook cover"),
+            expect.objectContaining({ audiobookId: "stale-denied" }),
+        );
+    });
+
+    it("prunes a row with an unsafe stored cover path without unlinking that path", async () => {
+        const service = new AudiobookCacheService();
+        const unsafePath = "/srv/music/Albums/song.flac";
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: unsafePath }],
+        });
+
+        const result = await service.syncAll();
+
+        expect(result.deleted).toBe(1);
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledTimes(1);
+        expect(fsPromises.unlink).not.toHaveBeenCalledWith(unsafePath);
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Skipped unsafe audiobook cover path",
+            { audiobookId: "stale-book" },
+        );
+    });
+
+    it("spares a row refreshed after the prune cutoff", async () => {
+        const service = new AudiobookCacheService();
+        let pruneCutoff: Date | undefined;
+        let refreshedAt: Date | undefined;
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        prisma.audiobook.findMany.mockImplementation(async ({ where }) => {
+            if (where?.peerId?.not === null) return [];
+            if (where?.peerId === null && where?.lastSyncedAt) {
+                const selectedCutoff = where.lastSyncedAt.lt as Date;
+                pruneCutoff = selectedCutoff;
+                refreshedAt = new Date(selectedCutoff.getTime() + 1_000);
+                return [
+                    {
+                        id: "concurrently-refreshed-book",
+                        localCoverPath: null,
+                        lastSyncedAt: refreshedAt,
+                    },
+                ];
+            }
+            if (where?.id?.in) {
+                return [{ id: "concurrently-refreshed-book" }];
+            }
+            return [];
+        });
+        transactionClient.audiobook.deleteMany.mockImplementationOnce(
+            async ({ where }) => {
+                const deleteCutoff = where.lastSyncedAt?.lt;
+                const isProtected =
+                    deleteCutoff instanceof Date &&
+                    refreshedAt instanceof Date &&
+                    refreshedAt >= deleteCutoff;
+                return { count: isProtected ? 0 : 1 };
+            },
+        );
+        transactionClient.audiobook.findMany.mockResolvedValueOnce([
+            { id: "concurrently-refreshed-book" },
+        ]);
+
+        const result = await service.syncAll();
+
+        expect(pruneCutoff).toBeInstanceOf(Date);
+        expect(refreshedAt!.getTime()).toBeGreaterThan(pruneCutoff!.getTime());
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["concurrently-refreshed-book"] },
+                peerId: null,
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+        });
+        expect(result.deleted).toBe(0);
+        expect(fsPromises.unlink).not.toHaveBeenCalled();
+    });
+
+    it("prunes stale audiobooks in batches of at most 100", async () => {
+        const service = new AudiobookCacheService();
+        const staleRows = Array.from({ length: 101 }, (_, index) => ({
+            id: `stale-${index}`,
+            localCoverPath: null,
+        }));
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({ pruneRows: staleRows });
+
+        const result = await service.syncAll();
+
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledTimes(2);
+        for (const [args] of transactionClient.audiobook.deleteMany.mock
+            .calls) {
+            expect(args.where.id.in.length).toBeLessThanOrEqual(100);
+        }
+        expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+        expect(result.deleted).toBe(101);
+    });
+
+    it("surfaces an expired deadline before opening a prune transaction", async () => {
+        const service = new AudiobookCacheService();
+
+        await expect(
+            (service as any).pruneAudiobookBatches(
+                [{ id: "stale-book", localCoverPath: null }],
+                new Date(),
+                Date.now() - 1,
+            ),
+        ).rejects.toMatchObject({
+            name: "AudiobookSyncTimeoutError",
+            message: "Full audiobook sync timed out after 6600000ms",
+        });
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("cleans a committed prune batch before surfacing an expired deadline", async () => {
+        const service = new AudiobookCacheService();
+        const staleRows = Array.from({ length: 101 }, (_, index) => ({
+            id: `stale-${index}`,
+            localCoverPath: null,
+        }));
+        let now = 99;
+        jest.spyOn(Date, "now").mockImplementation(() => now);
+        prisma.$transaction.mockImplementationOnce(
+            async (
+                operation: (
+                    transaction: typeof transactionClient,
+                ) => Promise<any>,
+            ) => {
+                const deletedRows = await operation(transactionClient);
+                now = 100;
+                return deletedRows;
+            },
+        );
+
+        await expect(
+            (service as any).pruneAudiobookBatches(staleRows, new Date(), 100),
+        ).rejects.toMatchObject({ name: "AudiobookSyncTimeoutError" });
+
+        expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+        expect(fsPromises.unlink).toHaveBeenCalledTimes(100);
+        expect(fsPromises.unlink).not.toHaveBeenCalledWith(
+            path.join(
+                "/srv/music",
+                "cover-cache",
+                "audiobooks",
+                "stale-100.jpg",
+            ),
+        );
+    });
+
+    it("stops syncing at the next book boundary when the deadline expires", async () => {
+        const service = new AudiobookCacheService();
+        jest.spyOn(Date, "now").mockReturnValueOnce(99).mockReturnValue(100);
+        const result = {
+            synced: 0,
+            failed: 0,
+            skipped: 0,
+            deleted: 0,
+            errors: [],
+        };
+
+        await expect(
+            (service as any).syncBooks(
+                [buildBook({ id: "book-1" }), buildBook({ id: "book-2" })],
+                result,
+                { logEachBook: false },
+                100,
+            ),
+        ).rejects.toMatchObject({ name: "AudiobookSyncTimeoutError" });
+        expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(1);
+        expect(prisma.audiobook.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: "book-1" } }),
+        );
+    });
+
+    it("surfaces a second prune batch failure after cleaning only the first batch covers", async () => {
+        const service = new AudiobookCacheService();
+        const staleRows = Array.from({ length: 101 }, (_, index) => ({
+            id: `stale-${index}`,
+            localCoverPath: null,
+        }));
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({ pruneRows: staleRows });
+        prisma.$transaction
+            .mockImplementationOnce(
+                async (
+                    operation: (
+                        transaction: typeof transactionClient,
+                    ) => Promise<any>,
+                ) => operation(transactionClient),
+            )
+            .mockRejectedValueOnce(new Error("second batch failed"));
+
+        await expect(service.syncAll()).rejects.toThrow("second batch failed");
+
+        expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledTimes(1);
+        expect(
+            transactionClient.audiobook.deleteMany.mock.calls[0][0].where.id.in,
+        ).toHaveLength(100);
+        expect(fsPromises.unlink).toHaveBeenCalledTimes(100);
+        expect(fsPromises.unlink).not.toHaveBeenCalledWith(
+            path.join(
+                "/srv/music",
+                "cover-cache",
+                "audiobooks",
+                "stale-100.jpg",
+            ),
+        );
+    });
+
+    it("waits for a batch transaction to resolve before unlinking its covers", async () => {
+        const service = new AudiobookCacheService();
+        const transactionStarted = createDeferred();
+        const releaseTransaction = createDeferred();
+        mockGetAllAudiobooks.mockResolvedValue([
+            buildBook({ id: "current-book" }),
+        ]);
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+        });
+        prisma.$transaction.mockImplementationOnce(
+            async (
+                operation: (
+                    transaction: typeof transactionClient,
+                ) => Promise<any>,
+            ) => {
+                const deletedRows = await operation(transactionClient);
+                transactionStarted.resolve();
+                await releaseTransaction.promise;
+                return deletedRows;
+            },
+        );
+
+        const sync = service.syncAll();
+        await transactionStarted.promise;
+
+        expect(fsPromises.unlink).not.toHaveBeenCalled();
+        releaseTransaction.resolve();
+        await expect(sync).resolves.toEqual(
+            expect.objectContaining({ deleted: 1 }),
+        );
+        expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
+    });
+
     it("syncs only audiobooks missing from the local ABS cache", async () => {
         const service = new AudiobookCacheService();
 
@@ -202,7 +1173,7 @@ describe("audiobook cache service behavior", () => {
             buildBook({ id: "book-1" }),
             buildBook({ id: "book-2" }),
         ]);
-        prisma.audiobook.findMany.mockResolvedValueOnce([{ id: "book-1" }]);
+        mockAudiobookQueries({ cachedRows: [{ id: "book-1" }] });
 
         const result = await service.syncMissing();
 
@@ -214,6 +1185,7 @@ describe("audiobook cache service behavior", () => {
             synced: 1,
             failed: 0,
             skipped: 1,
+            deleted: 0,
             errors: [],
         });
         expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(1);
@@ -222,6 +1194,16 @@ describe("audiobook cache service behavior", () => {
                 where: { id: "book-2" },
             }),
         );
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(
+            transactionClient.audiobookProgress.deleteMany,
+        ).not.toHaveBeenCalled();
+        expect(
+            transactionClient.playbackState.updateMany,
+        ).not.toHaveBeenCalled();
+        expect(
+            transactionClient.federationTombstone.createMany,
+        ).not.toHaveBeenCalled();
     });
 
     it("records the error message when a missing audiobook fails to sync", async () => {
@@ -376,6 +1358,7 @@ describe("audiobook cache service behavior", () => {
             synced: 1,
             failed: 0,
             skipped: 0,
+            deleted: 0,
             errors: [],
         });
         expect(fetchMock).not.toHaveBeenCalled();
@@ -388,6 +1371,78 @@ describe("audiobook cache service behavior", () => {
                 }),
             }),
         );
+    });
+
+    it.each(["./victim", "..%2Fx"])(
+        "does not write a cover for unsafe audiobook id %s",
+        async (audiobookId) => {
+            const service = new AudiobookCacheService();
+            (service as any).coverCacheAvailable = true;
+
+            await expect(
+                (service as any).downloadCover(
+                    audiobookId,
+                    "http://abs.local/cover.jpg",
+                ),
+            ).resolves.toBeNull();
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(fsPromises.writeFile).not.toHaveBeenCalled();
+            expect(logger.warn).toHaveBeenCalledWith(
+                "Skipped audiobook cover operation for unsafe audiobook id",
+                { audiobookId },
+            );
+        },
+    );
+
+    it.each(["./victim", "..%2Fx"])(
+        "does not unlink a fallback cover for unsafe audiobook id %s",
+        async (audiobookId) => {
+            const service = new AudiobookCacheService();
+            mockGetAllAudiobooks.mockResolvedValue([
+                buildBook({ id: "current-book" }),
+            ]);
+            mockAudiobookQueries({
+                pruneRows: [{ id: audiobookId, localCoverPath: null }],
+            });
+
+            await expect(service.syncAll()).resolves.toEqual(
+                expect.objectContaining({ deleted: 1 }),
+            );
+            expect(fsPromises.unlink).not.toHaveBeenCalled();
+            expect(logger.warn).toHaveBeenCalledWith(
+                "Skipped audiobook cover operation for unsafe audiobook id",
+                { audiobookId },
+            );
+        },
+    );
+
+    it("round-trips a normal ABS id through cover write and unlink fallback", async () => {
+        const service = new AudiobookCacheService();
+        const audiobookId = "abs_book-1.2";
+        const expectedPath = path.join(
+            "/srv/music",
+            "cover-cache",
+            "audiobooks",
+            `${audiobookId}.jpg`,
+        );
+        (service as any).coverCacheAvailable = true;
+
+        await expect(
+            (service as any).downloadCover(
+                audiobookId,
+                "http://abs.local/cover.jpg",
+            ),
+        ).resolves.toBe(expectedPath);
+        await (service as any).unlinkAudiobookCover({
+            id: audiobookId,
+            localCoverPath: null,
+        });
+
+        expect(fsPromises.writeFile).toHaveBeenCalledWith(
+            expectedPath,
+            expect.any(Buffer),
+        );
+        expect(fsPromises.unlink).toHaveBeenCalledWith(expectedPath);
     });
 
     it("handles cover downloads for unavailable cache, HTTP failures, and success", async () => {

--- a/backend/src/services/__tests__/audiobookshelfService.test.ts
+++ b/backend/src/services/__tests__/audiobookshelfService.test.ts
@@ -236,6 +236,367 @@ describe("audiobookshelf service behavior", () => {
         );
     });
 
+    it("assembles every page from a paginated library response", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-2" }],
+                    total: 2,
+                    limit: 1,
+                    page: 1,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getLibraryItems("book-lib"),
+        ).resolves.toEqual([{ id: "book-1" }, { id: "book-2" }]);
+        expect(client.get).toHaveBeenNthCalledWith(
+            1,
+            "/api/libraries/book-lib/items",
+            { params: { limit: 0 } },
+        );
+        expect(client.get).toHaveBeenNthCalledWith(
+            2,
+            "/api/libraries/book-lib/items",
+            { params: { limit: 1, page: 1 } },
+        );
+        expect(client.get).toHaveBeenNthCalledWith(
+            3,
+            "/api/libraries/book-lib/items",
+            { params: { limit: 1, page: 0 } },
+        );
+    });
+
+    it("marks a single-response limit=0 listing verified", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 1,
+                    limit: 0,
+                    page: 0,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).resolves.toEqual({
+            books: [{ id: "book-1", libraryId: "book-lib" }],
+            verifiedCompleteLibraryIds: new Set(["book-lib"]),
+        });
+        expect(client.get).toHaveBeenNthCalledWith(
+            2,
+            "/api/libraries/book-lib/items",
+            { params: { limit: 0 } },
+        );
+    });
+
+    it("marks a multi-page listing unverified when the stability total drifts", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-2", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 1,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 3,
+                    limit: 1,
+                    page: 0,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).resolves.toEqual({
+            books: [
+                { id: "book-1", libraryId: "book-lib" },
+                { id: "book-2", libraryId: "book-lib" },
+            ],
+            verifiedCompleteLibraryIds: new Set(),
+        });
+    });
+
+    it("marks a stable multi-page listing verified after rechecking page zero", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-2", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 1,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).resolves.toEqual({
+            books: [
+                { id: "book-1", libraryId: "book-lib" },
+                { id: "book-2", libraryId: "book-lib" },
+            ],
+            verifiedCompleteLibraryIds: new Set(["book-lib"]),
+        });
+        expect(client.get).toHaveBeenLastCalledWith(
+            "/api/libraries/book-lib/items",
+            { params: { limit: 1, page: 0 } },
+        );
+    });
+
+    it("rejects a library listing whose unique id count is below total", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 10,
+                    page: 0,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).rejects.toThrow(
+            "Audiobookshelf returned an incomplete library items response",
+        );
+    });
+
+    it("deduplicates page items by id and rejects when duplicates hide a missing item", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 0,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                    total: 2,
+                    limit: 1,
+                    page: 1,
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).rejects.toThrow(
+            "Audiobookshelf returned an incomplete library items response",
+        );
+    });
+
+    it("syncs an unpaginated listing without total but excludes it from pruning", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    libraries: [{ id: "book-lib", mediaType: "book" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    results: [{ id: "book-1", libraryId: "book-lib" }],
+                },
+            });
+
+        await expect(
+            audiobookshelfService.getAudiobookListing(),
+        ).resolves.toEqual({
+            books: [{ id: "book-1", libraryId: "book-lib" }],
+            verifiedCompleteLibraryIds: new Set(),
+        });
+    });
+
+    it("rejects an incomplete listing that has no usable page limit", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get.mockResolvedValueOnce({
+            data: {
+                results: [{ id: "book-1" }],
+                total: 2,
+                limit: 0,
+                page: 0,
+            },
+        });
+
+        await expect(
+            audiobookshelfService.getLibraryItems("book-lib"),
+        ).rejects.toThrow(
+            "Audiobookshelf returned an incomplete library items response",
+        );
+        expect(client.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a complete single-page library response unchanged", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get.mockResolvedValueOnce({
+            data: {
+                results: [{ id: "book-1" }],
+                total: 1,
+                limit: 10,
+                page: 0,
+            },
+        });
+
+        await expect(
+            audiobookshelfService.getLibraryItems("book-lib"),
+        ).resolves.toEqual([{ id: "book-1" }]);
+        expect(client.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a malformed libraries response", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get.mockResolvedValueOnce({ data: {} });
+
+        await expect(audiobookshelfService.getLibraries()).rejects.toThrow(
+            "Audiobookshelf returned a malformed libraries response",
+        );
+    });
+
+    it("rejects a malformed item response while aggregating book libraries", async () => {
+        const client = createClient();
+        const svc = audiobookshelfService as any;
+        svc.client = client;
+        svc.baseUrl = "http://abs.local";
+        svc.initialized = true;
+        client.get.mockImplementation(async (url: string) => {
+            if (url === "/api/libraries") {
+                return {
+                    data: {
+                        libraries: [
+                            { id: "healthy-lib", mediaType: "book" },
+                            { id: "malformed-lib", mediaType: "book" },
+                        ],
+                    },
+                };
+            }
+            if (url === "/api/libraries/healthy-lib/items") {
+                return { data: { results: [{ id: "healthy-book" }] } };
+            }
+            return { data: {} };
+        });
+
+        await expect(audiobookshelfService.getAllAudiobooks()).rejects.toThrow(
+            "Audiobookshelf returned a malformed library items response",
+        );
+    });
+
     it("caches podcast responses and tolerates failed podcast libraries", async () => {
         const client = createClient();
         const svc = audiobookshelfService as any;

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -6,8 +6,19 @@ import path from "path";
 import { Prisma } from "@prisma/client";
 import { config } from "../config";
 import { buildCachePath, isPastStaleWindow } from "./cacheHelpers";
-import { buildSafeAudiobookCoverUrl } from "./audiobookCoverProxy";
+import { safeResolvePath } from "../utils/safeResolvePath";
+import {
+    buildSafeAudiobookCoverUrl,
+    safeCoverFilename,
+} from "./audiobookCoverProxy";
 import { buildSectionsWhenPresent } from "./audiobookSections";
+import {
+    AUDIOBOOK_SYNC_CLAIM_KEY,
+    AUDIOBOOK_SYNC_CLAIM_TTL_MS,
+    AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+    runWithSchedulerClaim,
+} from "../utils/schedulerClaim";
+import { withTimeout } from "../utils/withTimeout";
 import {
     MAX_EXTERNAL_IMAGE_BYTES,
     readResponseBodyWithByteCap,
@@ -23,10 +34,44 @@ interface SyncResult {
     synced: number;
     failed: number;
     skipped: number;
+    deleted: number;
     errors: string[];
 }
 
 const AUDIOBOOK_CACHE_STALE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const AUDIOBOOK_PRUNE_BATCH_SIZE = 100;
+const audiobookCacheLogger = logger.child("AudiobookCache");
+const AUDIOBOOK_SYNC_TIMEOUT_MESSAGE = `Full audiobook sync timed out after ${AUDIOBOOK_SYNC_WORK_TIMEOUT_MS}ms`;
+
+type LocalAudiobookRow = {
+    id: string;
+    localCoverPath: string | null;
+};
+
+function hasNonEmptyAudiobookId(book: any): boolean {
+    return typeof book?.id === "string" && book.id.trim().length > 0;
+}
+
+function createSyncResult(): SyncResult {
+    return {
+        synced: 0,
+        failed: 0,
+        skipped: 0,
+        deleted: 0,
+        errors: [],
+    };
+}
+
+class AudiobookSyncTimeoutError extends Error {
+    constructor() {
+        super(AUDIOBOOK_SYNC_TIMEOUT_MESSAGE);
+        this.name = "AudiobookSyncTimeoutError";
+    }
+}
+
+function throwIfSyncDeadlineExpired(deadlineMs: number): void {
+    if (Date.now() >= deadlineMs) throw new AudiobookSyncTimeoutError();
+}
 
 /**
  * Represents the AudiobookCacheService class.
@@ -66,46 +111,74 @@ export class AudiobookCacheService {
     }
 
     /**
-     * Sync all audiobooks from Audiobookshelf to our database
+     * Sync all Audiobookshelf books and destructively reconcile the local cache.
+     * Removes absent local rows, cached covers, progress, and playback references,
+     * and writes federation tombstones when enabled. Empty or malformed listings
+     * skip pruning.
      */
     async syncAll(): Promise<SyncResult> {
-        const result: SyncResult = {
-            synced: 0,
-            failed: 0,
-            skipped: 0,
-            errors: [],
-        };
-
         try {
-            logger.debug(" Starting audiobook sync from Audiobookshelf...");
-
-            // Try to ensure cover cache directory exists (non-fatal if it fails)
-            await this.ensureCoverCacheDir();
-
-            // Fetch all audiobooks from Audiobookshelf
-            const audiobooks = await audiobookshelfService.getAllAudiobooks();
-
-            logger.debug(
-                `[AUDIOBOOK] Found ${audiobooks.length} audiobooks in Audiobookshelf`,
+            const locked = await withTimeout(
+                () =>
+                    runWithSchedulerClaim(
+                        AUDIOBOOK_SYNC_CLAIM_KEY,
+                        AUDIOBOOK_SYNC_CLAIM_TTL_MS,
+                        "full audiobook sync",
+                        () =>
+                            this.syncAllLocked(
+                                Date.now() + AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+                            ),
+                    ),
+                AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+                "full audiobook sync",
+                audiobookCacheLogger,
             );
-
-            await this.syncBooks(audiobooks, result, { logEachBook: true });
-
-            logger.debug("\nSync Summary:");
-            logger.debug(`  Synced: ${result.synced}`);
-            logger.debug(`   Failed: ${result.failed}`);
-            logger.debug(`    Skipped: ${result.skipped}`);
-
-            if (result.errors.length > 0) {
-                logger.debug("\n[ERRORS]:");
-                result.errors.forEach((err) => logger.debug(`  - ${err}`));
+            if (!locked) throw new AudiobookSyncTimeoutError();
+            if (!locked.acquired) {
+                throw new Error("audiobook sync already running");
             }
-
-            return result;
+            return locked.value;
         } catch (error: any) {
             logger.error(" Audiobook sync failed:", error);
             throw error;
         }
+    }
+
+    private async syncAllLocked(deadlineMs: number): Promise<SyncResult> {
+        const result = createSyncResult();
+        logger.debug(" Starting audiobook sync from Audiobookshelf...");
+        await this.ensureCoverCacheDir();
+        const pruneCutoff = new Date();
+        const listing = await audiobookshelfService.getAudiobookListing();
+        const audiobooks = listing.books;
+        logger.debug(
+            `[AUDIOBOOK] Found ${audiobooks.length} audiobooks in Audiobookshelf`,
+        );
+        await this.syncBooks(
+            audiobooks,
+            result,
+            { logEachBook: true },
+            deadlineMs,
+        );
+        result.deleted = await this.pruneMissingAudiobooks(
+            audiobooks,
+            listing.verifiedCompleteLibraryIds,
+            pruneCutoff,
+            deadlineMs,
+        );
+        this.logSyncSummary(result);
+        return result;
+    }
+
+    private logSyncSummary(result: SyncResult): void {
+        logger.debug("\nSync Summary:");
+        logger.debug(`  Synced: ${result.synced}`);
+        logger.debug(`   Failed: ${result.failed}`);
+        logger.debug(`    Skipped: ${result.skipped}`);
+        logger.debug(`    Deleted: ${result.deleted}`);
+        if (result.errors.length === 0) return;
+        logger.debug("\n[ERRORS]:");
+        result.errors.forEach((error) => logger.debug(`  - ${error}`));
     }
 
     /**
@@ -114,60 +187,95 @@ export class AudiobookCacheService {
      * It is lighter than syncAll because cached books skip upserts and cover work.
      */
     async syncMissing(): Promise<SyncResult> {
-        const result: SyncResult = {
-            synced: 0,
-            failed: 0,
-            skipped: 0,
-            errors: [],
-        };
-
         try {
-            const audiobooks = await audiobookshelfService.getAllAudiobooks();
-
-            if (audiobooks.length === 0) {
-                return result;
+            const locked = await runWithSchedulerClaim(
+                AUDIOBOOK_SYNC_CLAIM_KEY,
+                AUDIOBOOK_SYNC_CLAIM_TTL_MS,
+                "incremental audiobook sync",
+                () =>
+                    this.syncMissingLocked(
+                        Date.now() + AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+                    ),
+            );
+            if (!locked.acquired) {
+                audiobookCacheLogger.debug(
+                    "Skipped incremental audiobook sync because another audiobook sync is running",
+                );
+                return createSyncResult();
             }
-
-            const cachedAudiobooks = await prisma.audiobook.findMany({
-                where: { peerId: null },
-                select: { id: true },
-            });
-            const cachedIds = new Set(
-                cachedAudiobooks.map((audiobook) => audiobook.id),
-            );
-            const missingAudiobooks = audiobooks.filter(
-                (audiobook) => !cachedIds.has(audiobook.id),
-            );
-
-            result.skipped = audiobooks.length - missingAudiobooks.length;
-
-            if (missingAudiobooks.length === 0) {
-                return result;
-            }
-
-            await this.ensureCoverCacheDir();
-
-            await this.syncBooks(missingAudiobooks, result, {
-                logEachBook: false,
-            });
-
-            logger.debug(
-                `[AUDIOBOOK] Incremental sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
-            );
-
-            return result;
+            return locked.value;
         } catch (error: any) {
             logger.error(" Audiobook incremental sync failed:", error);
             throw error;
         }
     }
 
+    private async syncMissingLocked(deadlineMs: number): Promise<SyncResult> {
+        const result = createSyncResult();
+        const audiobooks = await audiobookshelfService.getAllAudiobooks();
+        if (audiobooks.length === 0) return result;
+        const cachedAudiobooks = await prisma.audiobook.findMany({
+            where: { peerId: null },
+            select: { id: true },
+        });
+        const cachedIds = new Set(
+            cachedAudiobooks.map((audiobook) => audiobook.id),
+        );
+        const missingAudiobooks = audiobooks.filter(
+            (audiobook) => !cachedIds.has(audiobook.id),
+        );
+        result.skipped = audiobooks.length - missingAudiobooks.length;
+        if (missingAudiobooks.length === 0) return result;
+        await this.ensureCoverCacheDir();
+        await this.syncBooks(
+            missingAudiobooks,
+            result,
+            {
+                logEachBook: false,
+            },
+            deadlineMs,
+        );
+        logger.debug(
+            `[AUDIOBOOK] Incremental sync complete: ${result.synced} new, ${result.skipped} already cached or skipped, ${result.failed} failed`,
+        );
+        return result;
+    }
+
+    private async findFederatedCollisionIds(
+        books: any[],
+    ): Promise<Set<string>> {
+        const ids = books
+            .filter(hasNonEmptyAudiobookId)
+            .map((book) => book.id as string);
+        if (ids.length === 0) return new Set();
+        const rows = await prisma.audiobook.findMany({
+            where: {
+                id: { in: ids },
+                peerId: { not: null },
+            },
+            select: { id: true },
+        });
+        return new Set(rows.map((row) => row.id));
+    }
+
     private async syncBooks(
         books: any[],
         result: SyncResult,
         options: { logEachBook: boolean },
+        deadlineMs: number,
     ): Promise<void> {
+        const federatedCollisionIds =
+            await this.findFederatedCollisionIds(books);
         for (const book of books) {
+            throwIfSyncDeadlineExpired(deadlineMs);
+            if (federatedCollisionIds.has(book.id)) {
+                result.skipped++;
+                audiobookCacheLogger.warn(
+                    "Skipped ABS book whose id collides with a federated audiobook",
+                    { audiobookId: book.id },
+                );
+                continue;
+            }
             const metadata = book.media?.metadata || book;
             const title = metadata.title || book.title || "Unknown Title";
             const author =
@@ -189,6 +297,263 @@ export class AudiobookCacheService {
                 logger.error(` ${errorMsg}`, error);
             }
         }
+    }
+
+    private async pruneMissingAudiobooks(
+        books: any[],
+        verifiedCompleteLibraryIds: ReadonlySet<string>,
+        pruneCutoff: Date,
+        deadlineMs: number,
+    ): Promise<number> {
+        if (!books.every(hasNonEmptyAudiobookId)) {
+            audiobookCacheLogger.warn(
+                "Skipped pruning audiobooks because Audiobookshelf returned a malformed listing",
+            );
+            return 0;
+        }
+
+        const localRowCount = await prisma.audiobook.count({
+            where: {
+                peerId: null,
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+        });
+
+        if (books.length === 0 && localRowCount > 0) {
+            audiobookCacheLogger.warn(
+                "Skipped pruning audiobooks because Audiobookshelf returned an empty listing; the configured library may be unavailable",
+            );
+            return 0;
+        }
+
+        const verifiedLibraryIds = await this.getPrunableLibraryIds(
+            books,
+            verifiedCompleteLibraryIds,
+        );
+        await this.logSkippedPruneRows(verifiedLibraryIds, pruneCutoff);
+        const localRows = await prisma.audiobook.findMany({
+            where: {
+                peerId: null,
+                libraryId: { in: verifiedLibraryIds },
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        const listedIds = new Set(books.map((book) => book.id));
+        const staleRows = localRows.filter((row) => !listedIds.has(row.id));
+        return this.pruneAudiobookBatches(staleRows, pruneCutoff, deadlineMs);
+    }
+
+    private async getPrunableLibraryIds(
+        books: any[],
+        verifiedLibraryIds: ReadonlySet<string>,
+    ): Promise<string[]> {
+        const listedLibraryIds = new Set(
+            books
+                .map((book) => book.libraryId)
+                .filter(
+                    (libraryId): libraryId is string =>
+                        typeof libraryId === "string" && libraryId.length > 0,
+                ),
+        );
+        const prunableLibraryIds: string[] = [];
+        for (const libraryId of verifiedLibraryIds) {
+            if (listedLibraryIds.has(libraryId)) {
+                prunableLibraryIds.push(libraryId);
+                continue;
+            }
+            const localRowCount = await prisma.audiobook.count({
+                where: { peerId: null, libraryId },
+            });
+            if (localRowCount === 0) {
+                prunableLibraryIds.push(libraryId);
+                continue;
+            }
+            audiobookCacheLogger.warn(
+                `Skipped pruning audiobook library ${libraryId} because Audiobookshelf returned an empty listing while ${localRowCount} local rows exist`,
+            );
+        }
+        return prunableLibraryIds;
+    }
+
+    private async logSkippedPruneRows(
+        verifiedLibraryIds: string[],
+        pruneCutoff: Date,
+    ): Promise<void> {
+        const baseWhere = {
+            peerId: null,
+            lastSyncedAt: { lt: pruneCutoff },
+        } as const;
+        const [unknownLibraryCount, unverifiedLibraryCount] = await Promise.all(
+            [
+                prisma.audiobook.count({
+                    where: { ...baseWhere, libraryId: null },
+                }),
+                prisma.audiobook.count({
+                    where: {
+                        ...baseWhere,
+                        libraryId: {
+                            not: null,
+                            notIn: verifiedLibraryIds,
+                        },
+                    },
+                }),
+            ],
+        );
+        if (unknownLibraryCount > 0) {
+            audiobookCacheLogger.warn(
+                `skipped ${unknownLibraryCount} audiobooks with unknown library during prune`,
+            );
+        }
+        if (unverifiedLibraryCount > 0) {
+            audiobookCacheLogger.debug(
+                `Skipped ${unverifiedLibraryCount} audiobooks from libraries without verified-complete listings during prune`,
+            );
+        }
+    }
+
+    private async pruneAudiobookBatches(
+        staleRows: LocalAudiobookRow[],
+        pruneCutoff: Date,
+        deadlineMs: number,
+    ): Promise<number> {
+        let deleted = 0;
+        for (
+            let offset = 0;
+            offset < staleRows.length;
+            offset += AUDIOBOOK_PRUNE_BATCH_SIZE
+        ) {
+            throwIfSyncDeadlineExpired(deadlineMs);
+            const batch = staleRows.slice(
+                offset,
+                offset + AUDIOBOOK_PRUNE_BATCH_SIZE,
+            );
+            const deletedRows = await this.deleteAudiobookBatch(
+                batch,
+                pruneCutoff,
+            );
+            deleted += deletedRows.length;
+            await this.unlinkAudiobookCovers(deletedRows);
+        }
+        return deleted;
+    }
+
+    private async deleteAudiobookBatch(
+        batch: LocalAudiobookRow[],
+        pruneCutoff: Date,
+    ): Promise<LocalAudiobookRow[]> {
+        const ids = batch.map((row) => row.id);
+        return prisma.$transaction(async (transaction) => {
+            const result = await transaction.audiobook.deleteMany({
+                where: {
+                    id: { in: ids },
+                    peerId: null,
+                    lastSyncedAt: { lt: pruneCutoff },
+                },
+            });
+            const deletedRows = await this.resolveDeletedAudiobooks(
+                transaction,
+                batch,
+                result.count,
+            );
+            const deletedIds = deletedRows.map((row) => row.id);
+            await this.deleteAudiobookUserState(transaction, deletedIds);
+            await this.writeAudiobookTombstones(transaction, deletedIds);
+            return deletedRows;
+        });
+    }
+
+    private async resolveDeletedAudiobooks(
+        transaction: Prisma.TransactionClient,
+        selected: LocalAudiobookRow[],
+        deletedCount: number,
+    ): Promise<LocalAudiobookRow[]> {
+        if (deletedCount === selected.length) return selected;
+        const remaining = await transaction.audiobook.findMany({
+            where: { id: { in: selected.map((row) => row.id) } },
+            select: { id: true },
+        });
+        const remainingIds = new Set(remaining.map((row) => row.id));
+        const deletedRows = selected.filter((row) => !remainingIds.has(row.id));
+        if (deletedRows.length !== deletedCount) {
+            throw new Error(
+                "Audiobook deletion count changed during prune cleanup",
+            );
+        }
+        return deletedRows;
+    }
+
+    private async deleteAudiobookUserState(
+        transaction: Prisma.TransactionClient,
+        audiobookIds: string[],
+    ): Promise<void> {
+        if (audiobookIds.length === 0) return;
+        await transaction.audiobookProgress.deleteMany({
+            where: { audiobookshelfId: { in: audiobookIds } },
+        });
+        await transaction.playbackState.updateMany({
+            where: { audiobookId: { in: audiobookIds } },
+            data: { audiobookId: null },
+        });
+    }
+
+    private async writeAudiobookTombstones(
+        transaction: Prisma.TransactionClient,
+        audiobookIds: string[],
+    ): Promise<void> {
+        if (!config.features.federation || audiobookIds.length === 0) return;
+        await transaction.federationTombstone.createMany({
+            data: audiobookIds.map((entityId) => ({
+                entityType: "audiobook",
+                entityId,
+            })),
+        });
+    }
+
+    private async unlinkAudiobookCovers(
+        deletedRows: LocalAudiobookRow[],
+    ): Promise<void> {
+        for (const row of deletedRows) {
+            await this.unlinkAudiobookCover(row);
+        }
+    }
+
+    private async unlinkAudiobookCover(row: LocalAudiobookRow): Promise<void> {
+        const coverPath = this.resolveAudiobookCoverPath(row);
+        if (!coverPath) return;
+        try {
+            await fs.unlink(coverPath);
+        } catch (error: unknown) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+            audiobookCacheLogger.warn("Failed to delete audiobook cover", {
+                audiobookId: row.id,
+                coverPath,
+                error,
+            });
+        }
+    }
+
+    private resolveAudiobookCoverPath(row: LocalAudiobookRow): string | null {
+        const cacheDir = path.resolve(this.coverCacheDir);
+        const relativeCoverPath =
+            row.localCoverPath ?? safeCoverFilename(row.id);
+        if (!relativeCoverPath) {
+            this.warnUnsafeCoverId(row.id);
+            return null;
+        }
+        const coverPath = safeResolvePath(cacheDir, relativeCoverPath);
+        if (coverPath) return coverPath;
+        audiobookCacheLogger.warn("Skipped unsafe audiobook cover path", {
+            audiobookId: row.id,
+        });
+        return null;
+    }
+
+    private warnUnsafeCoverId(audiobookId: string): void {
+        audiobookCacheLogger.warn(
+            "Skipped audiobook cover operation for unsafe audiobook id",
+            { audiobookId },
+        );
     }
 
     /**
@@ -396,6 +761,11 @@ export class AudiobookCacheService {
         if (!this.coverCacheAvailable) {
             return null;
         }
+        const fileName = safeCoverFilename(audiobookId);
+        if (!fileName) {
+            this.warnUnsafeCoverId(audiobookId);
+            return null;
+        }
 
         try {
             // Get API key for authentication
@@ -428,7 +798,6 @@ export class AudiobookCacheService {
             if (!bodyResult.ok) {
                 return null;
             }
-            const fileName = `${audiobookId}.jpg`;
             const filePath = path.join(this.coverCacheDir, fileName);
 
             await fs.writeFile(filePath, bodyResult.buffer);

--- a/backend/src/services/audiobookCoverProxy.ts
+++ b/backend/src/services/audiobookCoverProxy.ts
@@ -6,6 +6,18 @@
  * past the literal `..` check below.
  */
 const AUDIOBOOK_COVER_PATH_RE = /^items\/[A-Za-z0-9_\-./]+$/;
+const SAFE_COVER_FILENAME_ID_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]*$/;
+
+/**
+ * Builds a cache filename only for conservative, non-hidden audiobook IDs.
+ * Slash, backslash, percent-encoded traversal prefixes, and leading dots are
+ * rejected so normalization cannot alias another audiobook's cover file.
+ */
+export function safeCoverFilename(audiobookId: string): string | null {
+    return SAFE_COVER_FILENAME_ID_RE.test(audiobookId)
+        ? `${audiobookId}.jpg`
+        : null;
+}
 
 /**
  * Returns true only when `coverPath` stays within the confined Audiobookshelf

--- a/backend/src/services/audiobookshelf.ts
+++ b/backend/src/services/audiobookshelf.ts
@@ -18,6 +18,7 @@ const STREAM_HEADER_TIMEOUT_MS = 30_000;
 const AUDIOBOOK_STREAM_MAP_CACHE_TTL_MS = 15 * 60 * 1000;
 const AUDIOBOOK_STREAM_MAP_CACHE_MAX_ITEMS = 256;
 const MAX_AUDIOBOOK_TRACKS = 10_000;
+const MAX_LIBRARY_ITEM_PAGE_REQUESTS = 1_000;
 const UNSAFE_AUDIO_TRACK_URL_ERROR =
     "Audiobookshelf returned an unsafe audio track URL";
 
@@ -102,6 +103,136 @@ type StreamSlicesInput = Readonly<{
     signal: AbortSignal;
     detachDisconnect(): void;
 }>;
+
+type LibraryItemsPage = Readonly<{
+    items: any[];
+    total?: number;
+    limit?: number;
+    page?: number;
+}>;
+
+type LibraryItemListing = Readonly<{
+    items: any[];
+    verifiedComplete: boolean;
+}>;
+
+/** Audiobook items plus libraries whose listings were proven complete. */
+export type AudiobookListing = Readonly<{
+    books: any[];
+    verifiedCompleteLibraryIds: ReadonlySet<string>;
+}>;
+
+function hasNonEmptyItemId(item: any): item is { id: string } {
+    return typeof item?.id === "string" && item.id.trim().length > 0;
+}
+
+function deduplicateLibraryItems(items: any[]): Readonly<{
+    items: any[];
+    uniqueIdCount: number;
+    allHaveIds: boolean;
+}> {
+    const seenIds = new Set<string>();
+    const uniqueItems: any[] = [];
+    let allHaveIds = true;
+    for (const item of items) {
+        if (!hasNonEmptyItemId(item)) {
+            allHaveIds = false;
+            uniqueItems.push(item);
+            continue;
+        }
+        if (seenIds.has(item.id)) continue;
+        seenIds.add(item.id);
+        uniqueItems.push(item);
+    }
+    return {
+        items: uniqueItems,
+        uniqueIdCount: seenIds.size,
+        allHaveIds,
+    };
+}
+
+function completeLibraryItemListing(
+    items: any[],
+    total: number | undefined,
+): LibraryItemListing {
+    const deduplicated = deduplicateLibraryItems(items);
+    if (total !== undefined && deduplicated.uniqueIdCount !== total) {
+        throw incompleteLibraryItemsError();
+    }
+    return {
+        items: deduplicated.items,
+        verifiedComplete: total !== undefined && deduplicated.allHaveIds,
+    };
+}
+
+function parseLibraryItemsPage(payload: unknown): LibraryItemsPage {
+    const data = payload as Record<string, unknown> | null;
+    if (!data || !Array.isArray(data.results)) {
+        throw new Error(
+            "Audiobookshelf returned a malformed library items response",
+        );
+    }
+    return {
+        items: data.results,
+        ...(typeof data.total === "number" ? { total: data.total } : {}),
+        ...(typeof data.limit === "number" ? { limit: data.limit } : {}),
+        ...(typeof data.page === "number" ? { page: data.page } : {}),
+    };
+}
+
+function incompleteLibraryItemsError(): Error {
+    return new Error(
+        "Audiobookshelf returned an incomplete library items response",
+    );
+}
+
+function hasRemainingLibraryItemPages(firstPage: LibraryItemsPage): boolean {
+    if (firstPage.limit === undefined) {
+        if (firstPage.page !== undefined) throw incompleteLibraryItemsError();
+        return false;
+    }
+    const initialPage = firstPage.page ?? 0;
+    if (
+        !Number.isSafeInteger(firstPage.limit) ||
+        firstPage.limit <= 0 ||
+        !Number.isSafeInteger(initialPage) ||
+        initialPage !== 0
+    ) {
+        throw incompleteLibraryItemsError();
+    }
+    return Math.ceil((firstPage.total ?? 0) / firstPage.limit) > 1;
+}
+
+function libraryItemIdSet(items: any[]): Set<string> | null {
+    const ids = new Set<string>();
+    for (const item of items) {
+        if (!hasNonEmptyItemId(item) || ids.has(item.id)) return null;
+        ids.add(item.id);
+    }
+    return ids;
+}
+
+function pageZeroSampleIsStable(
+    firstPage: LibraryItemsPage,
+    recheckPage: LibraryItemsPage,
+    assembledItems: any[],
+): boolean {
+    if (
+        recheckPage.total !== firstPage.total ||
+        recheckPage.limit !== firstPage.limit ||
+        (recheckPage.page ?? 0) !== 0
+    ) {
+        return false;
+    }
+    const firstIds = libraryItemIdSet(firstPage.items);
+    const recheckIds = libraryItemIdSet(recheckPage.items);
+    const assembledIds = libraryItemIdSet(assembledItems);
+    if (!firstIds || !recheckIds || !assembledIds) return false;
+    if (firstIds.size !== recheckIds.size) return false;
+    return [...recheckIds].every(
+        (id) => firstIds.has(id) && assembledIds.has(id),
+    );
+}
 
 function resolveStreamContentPath(
     contentUrl: unknown,
@@ -432,32 +563,155 @@ class AudiobookshelfService {
     async getLibraries() {
         await this.ensureInitialized();
         const response = await this.client!.get("/api/libraries");
-        return response.data.libraries || [];
+        const libraries = response.data?.libraries;
+        if (!Array.isArray(libraries)) {
+            throw new Error(
+                "Audiobookshelf returned a malformed libraries response",
+            );
+        }
+        return libraries;
     }
 
     /**
      * Get all audiobooks from a specific library
      */
     async getLibraryItems(libraryId: string) {
+        const listing = await this.getLibraryItemListing(libraryId);
+        return listing.items;
+    }
+
+    private async getLibraryItemListing(
+        libraryId: string,
+    ): Promise<LibraryItemListing> {
         await this.ensureInitialized();
-        const response = await this.client!.get(
-            `/api/libraries/${libraryId}/items`,
+        const path = `/api/libraries/${libraryId}/items`;
+        const response = await this.client!.get(path, {
+            params: { limit: 0 },
+        });
+        const firstPage = parseLibraryItemsPage(response.data);
+        if (firstPage.total === undefined) {
+            if (firstPage.limit !== undefined || firstPage.page !== undefined) {
+                throw incompleteLibraryItemsError();
+            }
+            return completeLibraryItemListing(firstPage.items, undefined);
+        }
+        if (!Number.isSafeInteger(firstPage.total) || firstPage.total < 0) {
+            throw incompleteLibraryItemsError();
+        }
+        if (firstPage.items.length >= firstPage.total) {
+            return completeLibraryItemListing(firstPage.items, firstPage.total);
+        }
+        if (!hasRemainingLibraryItemPages(firstPage)) {
+            return completeLibraryItemListing(firstPage.items, firstPage.total);
+        }
+        return this.getRemainingLibraryItemPages(path, firstPage);
+    }
+
+    private async getRemainingLibraryItemPages(
+        path: string,
+        firstPage: LibraryItemsPage,
+    ): Promise<LibraryItemListing> {
+        const { total, limit } = firstPage;
+        const initialPage = firstPage.page ?? 0;
+        if (
+            total === undefined ||
+            limit === undefined ||
+            !Number.isSafeInteger(limit) ||
+            limit <= 0 ||
+            !Number.isSafeInteger(initialPage) ||
+            initialPage !== 0
+        ) {
+            throw incompleteLibraryItemsError();
+        }
+
+        const pageCount = Math.ceil(total / limit);
+        if (pageCount - 1 > MAX_LIBRARY_ITEM_PAGE_REQUESTS) {
+            throw incompleteLibraryItemsError();
+        }
+
+        const items = [...firstPage.items];
+        for (
+            let page = 1;
+            page <= MAX_LIBRARY_ITEM_PAGE_REQUESTS && page < pageCount;
+            page += 1
+        ) {
+            const response = await this.client!.get(path, {
+                params: { limit, page },
+            });
+            const nextPage = parseLibraryItemsPage(response.data);
+            if (nextPage.page !== undefined && nextPage.page !== page) {
+                throw incompleteLibraryItemsError();
+            }
+            if (nextPage.total !== undefined && nextPage.total !== total) {
+                throw incompleteLibraryItemsError();
+            }
+            items.push(...nextPage.items);
+        }
+        if (items.length < total) throw incompleteLibraryItemsError();
+        const listing = completeLibraryItemListing(items, total);
+        const stable = await this.recheckLibraryItemAssembly(
+            path,
+            firstPage,
+            listing.items,
         );
-        return response.data.results || [];
+        // Residual accepted window: an equal-total replacement outside page 0
+        // can still evade this multi-page check. The ABS book returns on the next
+        // incremental sync, but its local listening progress may have been lost.
+        return {
+            items: listing.items,
+            verifiedComplete: listing.verifiedComplete && stable,
+        };
+    }
+
+    private async recheckLibraryItemAssembly(
+        path: string,
+        firstPage: LibraryItemsPage,
+        assembledItems: any[],
+    ): Promise<boolean> {
+        try {
+            const response = await this.client!.get(path, {
+                params: { limit: firstPage.limit, page: 0 },
+            });
+            const recheckPage = parseLibraryItemsPage(response.data);
+            return pageZeroSampleIsStable(
+                firstPage,
+                recheckPage,
+                assembledItems,
+            );
+        } catch (error: unknown) {
+            logger.warn(
+                "Audiobookshelf library listing stability recheck failed; pruning is disabled for this library",
+                { error },
+            );
+            return false;
+        }
     }
 
     /**
      * Get all audiobooks from all libraries
      */
     async getAllAudiobooks() {
+        const listing = await this.getAudiobookListing();
+        return listing.books;
+    }
+
+    /**
+     * Get all audiobooks and record which per-library listings are complete.
+     */
+    async getAudiobookListing(): Promise<AudiobookListing> {
         await this.ensureInitialized();
         const libraries = await this.getLibraries();
 
         const allBooks: any[] = [];
+        const verifiedCompleteLibraryIds = new Set<string>();
         for (const library of libraries) {
             if (library.mediaType === "book") {
                 // Only get audiobook libraries
-                const items = await this.getLibraryItems(library.id);
+                const listing = await this.getLibraryItemListing(library.id);
+                const items = listing.items;
+                if (listing.verifiedComplete) {
+                    verifiedCompleteLibraryIds.add(library.id);
+                }
 
                 // DEBUG: Log the structure of the first item with series
                 if (items.length > 0) {
@@ -490,7 +744,7 @@ class AudiobookshelfService {
             }
         }
 
-        return allBooks;
+        return { books: allBooks, verifiedCompleteLibraryIds };
     }
 
     /**

--- a/backend/src/utils/schedulerClaim.ts
+++ b/backend/src/utils/schedulerClaim.ts
@@ -1,0 +1,237 @@
+import { randomUUID } from "crypto";
+import type Redis from "ioredis";
+import { createIORedisClient } from "./ioredis";
+import { logger } from "./logger";
+
+const claimLog = logger.child("WorkerScheduler").child("SchedulerClaim");
+const claimObservabilityLog = claimLog.child("Observability");
+const SCHEDULER_CLAIM_RETRY_ATTEMPTS = 3;
+const OBSERVABILITY_LOG_EVERY = 25;
+const DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD = 3;
+const parsedSchedulerSkipWarnThreshold = Number.parseInt(
+    process.env.SCHEDULER_CLAIM_SKIP_WARN_THRESHOLD ||
+        `${DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD}`,
+    10,
+);
+const SCHEDULER_SKIP_WARN_THRESHOLD =
+    Number.isFinite(parsedSchedulerSkipWarnThreshold) &&
+    parsedSchedulerSkipWarnThreshold > 0
+        ? parsedSchedulerSkipWarnThreshold
+        : DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD;
+const jestLazyConnectOverride =
+    process.env.JEST_WORKER_ID !== undefined ? { lazyConnect: true } : {};
+
+/** Shared scheduler-claim key for full and incremental audiobook syncs. */
+export const AUDIOBOOK_SYNC_CLAIM_KEY = "scheduler-claim:audiobook-auto-sync";
+/** Existing two-hour lease duration for an audiobook sync. */
+export const AUDIOBOOK_SYNC_CLAIM_TTL_MS = 2 * 60 * 60 * 1000;
+const AUDIOBOOK_SYNC_LEASE_SAFETY_MARGIN_MS = 10 * 60_000;
+/** Sync work must finish before its serialization lease can expire. */
+export const AUDIOBOOK_SYNC_WORK_TIMEOUT_MS =
+    AUDIOBOOK_SYNC_CLAIM_TTL_MS - AUDIOBOOK_SYNC_LEASE_SAFETY_MARGIN_MS;
+const SCHEDULER_CLAIM_PROCESS_ID = randomUUID();
+/** Process-scoped owner identifier used in scheduler claim diagnostics. */
+export const SCHEDULER_CLAIM_OWNER_ID = `${SCHEDULER_CLAIM_PROCESS_ID}:scheduler-claims`;
+
+/** Outcome from a non-blocking scheduler claim attempt. */
+export type SchedulerClaimResult<T> =
+    | Readonly<{ acquired: false }>
+    | Readonly<{ acquired: true; value: T }>;
+
+type RedisOperation<T> = (client: Redis) => Promise<T>;
+
+const schedulerClaimSkipCounts = new Map<string, number>();
+const schedulerClaimCounters = {
+    acquired: 0,
+    skipped: 0,
+    failedAcquire: 0,
+    failedRelease: 0,
+    retryRecoveries: 0,
+};
+let schedulerLockRedis: Redis = createIORedisClient(
+    "worker-scheduler-locks",
+    jestLazyConnectOverride,
+);
+let schedulerClaimRedisClosed = false;
+
+function logSchedulerClaimObservability(context: string): void {
+    const counters = schedulerClaimCounters;
+    claimObservabilityLog.info(
+        `context=${context} workerId=${SCHEDULER_CLAIM_PROCESS_ID} owner=${SCHEDULER_CLAIM_OWNER_ID} acquired=${counters.acquired} skipped=${counters.skipped} failedAcquire=${counters.failedAcquire} failedRelease=${counters.failedRelease} retryRecoveries=${counters.retryRecoveries}`,
+    );
+}
+
+function maybeLogSchedulerClaimObservability(context: string): void {
+    const counters = schedulerClaimCounters;
+    const totalEvents =
+        counters.acquired +
+        counters.skipped +
+        counters.failedAcquire +
+        counters.failedRelease;
+    if (totalEvents > 0 && totalEvents % OBSERVABILITY_LOG_EVERY === 0) {
+        logSchedulerClaimObservability(context);
+    }
+}
+
+function isRetryableSchedulerClaimError(error: unknown): boolean {
+    const message =
+        error instanceof Error ? error.message : String(error ?? "");
+    return (
+        message.includes("Connection is closed") ||
+        message.includes("Connection is in closing state") ||
+        message.includes("ECONNRESET") ||
+        message.includes("ETIMEDOUT") ||
+        message.includes("EPIPE")
+    );
+}
+
+function recreateSchedulerLockRedisClient(): void {
+    try {
+        schedulerLockRedis.disconnect();
+    } catch {
+        // The failed client is already unusable.
+    }
+    schedulerLockRedis = createIORedisClient(
+        "worker-scheduler-locks",
+        jestLazyConnectOverride,
+    );
+}
+
+/** Runs one scheduler Redis operation with bounded connection recovery. */
+export async function withSchedulerClaimRedisRetry<T>(
+    operationName: string,
+    operation: RedisOperation<T>,
+): Promise<T> {
+    for (
+        let attempt = 1;
+        attempt <= SCHEDULER_CLAIM_RETRY_ATTEMPTS;
+        attempt += 1
+    ) {
+        try {
+            return await operation(schedulerLockRedis);
+        } catch (error) {
+            if (
+                !isRetryableSchedulerClaimError(error) ||
+                attempt === SCHEDULER_CLAIM_RETRY_ATTEMPTS
+            ) {
+                throw error;
+            }
+            claimLog.warn(
+                `${operationName} failed due to Redis connection closure (attempt ${attempt}/${SCHEDULER_CLAIM_RETRY_ATTEMPTS}); recreating client and retrying`,
+                error,
+            );
+            schedulerClaimCounters.retryRecoveries += 1;
+            recreateSchedulerLockRedisClient();
+            await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+        }
+    }
+    throw new Error("Scheduler claim Redis retry limit was not enforced");
+}
+
+function recordSkippedClaim(claimKey: string, operationName: string): void {
+    const skippedCount = (schedulerClaimSkipCounts.get(claimKey) ?? 0) + 1;
+    schedulerClaimSkipCounts.set(claimKey, skippedCount);
+    schedulerClaimCounters.skipped += 1;
+    const message =
+        skippedCount >= SCHEDULER_SKIP_WARN_THRESHOLD
+            ? `${operationName} skipped ${skippedCount} consecutive time(s); claim held by another worker (owner=${SCHEDULER_CLAIM_OWNER_ID})`
+            : `Skipping ${operationName}; claim is held by another worker (owner=${SCHEDULER_CLAIM_OWNER_ID})`;
+    if (skippedCount >= SCHEDULER_SKIP_WARN_THRESHOLD) {
+        claimLog.warn(message);
+    } else {
+        claimLog.debug(message);
+    }
+    maybeLogSchedulerClaimObservability("skip");
+}
+
+async function acquireSchedulerClaim(
+    claimKey: string,
+    ttlMs: number,
+    operationName: string,
+): Promise<string | null> {
+    const claimToken = `${SCHEDULER_CLAIM_OWNER_ID}:${randomUUID()}`;
+    const ttlSeconds = Math.max(1, Math.ceil(ttlMs / 1000));
+    const acquired = await withSchedulerClaimRedisRetry(
+        `claim acquire for ${operationName}`,
+        (client) => client.set(claimKey, claimToken, "EX", ttlSeconds, "NX"),
+    );
+    if (acquired !== "OK") {
+        recordSkippedClaim(claimKey, operationName);
+        return null;
+    }
+    schedulerClaimSkipCounts.delete(claimKey);
+    schedulerClaimCounters.acquired += 1;
+    claimLog.debug(
+        `Acquired claim for ${operationName} (claimKey=${claimKey}, owner=${SCHEDULER_CLAIM_OWNER_ID})`,
+    );
+    maybeLogSchedulerClaimObservability("acquire");
+    return claimToken;
+}
+
+function recordClaimFailure(operationName: string, error: unknown): void {
+    schedulerClaimCounters.failedAcquire += 1;
+    claimLog.error(
+        `Failed to claim ${operationName}; skipping cycle (owner=${SCHEDULER_CLAIM_OWNER_ID})`,
+        error,
+    );
+    maybeLogSchedulerClaimObservability("failed-acquire");
+}
+
+async function releaseSchedulerClaim(
+    claimKey: string,
+    claimToken: string,
+    operationName: string,
+): Promise<void> {
+    try {
+        await withSchedulerClaimRedisRetry(
+            `claim release for ${operationName}`,
+            (client) =>
+                client.eval(
+                    "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+                    1,
+                    claimKey,
+                    claimToken,
+                ),
+        );
+    } catch (error) {
+        schedulerClaimCounters.failedRelease += 1;
+        claimLog.warn(
+            `Failed to release claim for ${operationName} (owner=${SCHEDULER_CLAIM_OWNER_ID})`,
+            error,
+        );
+        maybeLogSchedulerClaimObservability("failed-release");
+    }
+}
+
+/** Runs an operation under the Redis lease used by scheduled worker claims. */
+export async function runWithSchedulerClaim<T>(
+    claimKey: string,
+    ttlMs: number,
+    operationName: string,
+    operation: () => Promise<T>,
+): Promise<SchedulerClaimResult<T>> {
+    let claimToken: string | null;
+    try {
+        claimToken = await acquireSchedulerClaim(
+            claimKey,
+            ttlMs,
+            operationName,
+        );
+    } catch (error) {
+        recordClaimFailure(operationName, error);
+        return { acquired: false };
+    }
+    if (!claimToken) return { acquired: false };
+    try {
+        return { acquired: true, value: await operation() };
+    } finally {
+        await releaseSchedulerClaim(claimKey, claimToken, operationName);
+    }
+}
+
+/** Closes the shared Redis client used by scheduler claims and cursors. */
+export async function shutdownSchedulerClaimRedis(): Promise<void> {
+    if (schedulerClaimRedisClosed) return;
+    await schedulerLockRedis.quit();
+    schedulerClaimRedisClosed = true;
+}

--- a/backend/src/utils/schedulerClaim.ts
+++ b/backend/src/utils/schedulerClaim.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import type Redis from "ioredis";
+import { config } from "../config";
 import { createIORedisClient } from "./ioredis";
 import { logger } from "./logger";
 
@@ -7,19 +8,10 @@ const claimLog = logger.child("WorkerScheduler").child("SchedulerClaim");
 const claimObservabilityLog = claimLog.child("Observability");
 const SCHEDULER_CLAIM_RETRY_ATTEMPTS = 3;
 const OBSERVABILITY_LOG_EVERY = 25;
-const DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD = 3;
-const parsedSchedulerSkipWarnThreshold = Number.parseInt(
-    process.env.SCHEDULER_CLAIM_SKIP_WARN_THRESHOLD ||
-        `${DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD}`,
-    10,
-);
+// Optional access keeps partial config mocks in tests from failing at import.
 const SCHEDULER_SKIP_WARN_THRESHOLD =
-    Number.isFinite(parsedSchedulerSkipWarnThreshold) &&
-    parsedSchedulerSkipWarnThreshold > 0
-        ? parsedSchedulerSkipWarnThreshold
-        : DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD;
-const jestLazyConnectOverride =
-    process.env.JEST_WORKER_ID !== undefined ? { lazyConnect: true } : {};
+    config.workers?.schedulerClaimSkipWarnThreshold ?? 3;
+const jestLazyConnectOverride = config.underJest ? { lazyConnect: true } : {};
 
 /** Shared scheduler-claim key for full and incremental audiobook syncs. */
 export const AUDIOBOOK_SYNC_CLAIM_KEY = "scheduler-claim:audiobook-auto-sync";

--- a/backend/src/utils/withTimeout.ts
+++ b/backend/src/utils/withTimeout.ts
@@ -1,0 +1,27 @@
+import { logger } from "./logger";
+
+type TimeoutLogger = Pick<typeof logger, "warn">;
+
+/** Runs an operation until its deadline and returns undefined on timeout. */
+export async function withTimeout<T>(
+    operation: () => Promise<T>,
+    timeoutMs: number,
+    operationName: string,
+    timeoutLogger: TimeoutLogger = logger,
+): Promise<T | undefined> {
+    let timeoutId: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<undefined>((resolve) => {
+        timeoutId = setTimeout(() => {
+            timeoutLogger.warn(
+                `Operation timed out after ${timeoutMs}ms: ${operationName}`,
+            );
+            resolve(undefined);
+        }, timeoutMs);
+    });
+
+    try {
+        return await Promise.race([operation(), timeoutPromise]);
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+    }
+}

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -476,6 +476,15 @@ describe("workers runtime behavior", () => {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         require("../index");
         await flushPromises();
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const {
+            AUDIOBOOK_SYNC_CLAIM_TTL_MS,
+            AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+        } = require("../../utils/schedulerClaim");
+
+        expect(AUDIOBOOK_SYNC_WORK_TIMEOUT_MS).toBe(
+            AUDIOBOOK_SYNC_CLAIM_TTL_MS - 10 * 60_000,
+        );
 
         const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
             (call) => call[0] === "*",
@@ -779,6 +788,11 @@ describe("workers runtime behavior", () => {
         );
         expect(mocks.shutdownDiscoverProcessor).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerLockRedis.quit).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.schedulerLockRedis.quit.mock.invocationCallOrder[0],
+        ).toBeGreaterThan(
+            mocks.schedulerQueue.close.mock.invocationCallOrder[0],
+        );
     });
 
     it("executes scheduler wildcard data-integrity job when claim is acquired", async () => {
@@ -1826,6 +1840,11 @@ describe("workers runtime behavior", () => {
             name: "image-backfill-startup",
             data: { mode: "startup" },
         });
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(
+            expect.any(Function),
+            2 * 60 * 60 * 1000 - 10 * 60_000,
+        );
         setTimeoutSpy.mockRestore();
 
         expect(mocks.logger.debug).not.toHaveBeenCalledWith(

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -250,6 +250,8 @@ describe("workers runtime behavior", () => {
             config: {
                 vibeProviderUrl,
                 vibeEmbedConcurrency: 1,
+                underJest: true,
+                workers: { schedulerClaimSkipWarnThreshold: 3 },
                 features: {
                     audioAnalysis: true,
                     discovery: true,

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -2,7 +2,6 @@ import { logger } from "../utils/logger";
 import { randomUUID } from "crypto";
 import { trackJobStart, trackJobEnd } from "../services/workerEventLoopMonitor";
 import type Bull from "bull";
-import type Redis from "ioredis";
 import {
     scanQueue,
     discoverQueue,
@@ -49,7 +48,6 @@ import { runDataIntegrityCheck } from "./dataIntegrity";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
 import { queueCleaner } from "../jobs/queueCleaner";
 import { enrichmentStateService } from "../services/enrichmentState";
-import { createIORedisClient } from "../utils/ioredis";
 import { dataCacheService } from "../services/dataCache";
 import { genericImportJobRunner } from "../services/genericImportJobRunner";
 import type { ReconciliationCursor } from "../services/trackReconciliation";
@@ -66,67 +64,29 @@ import {
     ONE_MINUTE_MS,
     SCHEDULER_JOB_TYPES,
 } from "./schedulerJobRegistry";
+import {
+    AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+    runWithSchedulerClaim,
+    SCHEDULER_CLAIM_OWNER_ID,
+    shutdownSchedulerClaimRedis,
+    withSchedulerClaimRedisRetry,
+} from "../utils/schedulerClaim";
+import { withTimeout } from "../utils/withTimeout";
 
 const log = logger.child("WorkerScheduler");
-const claimLog = log.child("SchedulerClaim");
-const claimObservabilityLog = claimLog.child("Observability");
 const queueProcessorLog = log.child("QueueProcessor");
 const startupLog = log.child("Startup");
 
 const WORKER_PROCESSOR_ID = randomUUID();
-const jestLazyConnectOverride =
-    process.env.JEST_WORKER_ID !== undefined ? { lazyConnect: true } : {};
-let schedulerLockRedis: Redis = createIORedisClient(
-    "worker-scheduler-locks",
-    jestLazyConnectOverride,
-);
-const schedulerLockOwnerId = `${WORKER_PROCESSOR_ID}:scheduler-claims`;
 const TRACK_RECONCILIATION_CURSOR_KEY =
     "scheduler:cursor:track-mapping-reconcile";
 const MAX_RECONCILIATION_CURSOR_BYTES = 512;
-const SCHEDULER_CLAIM_RETRY_ATTEMPTS = 3;
 const OBSERVABILITY_LOG_EVERY = 25;
-const DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD = 3;
-const parsedSchedulerSkipWarnThreshold = Number.parseInt(
-    process.env.SCHEDULER_CLAIM_SKIP_WARN_THRESHOLD ||
-        `${DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD}`,
-    10,
-);
-const SCHEDULER_SKIP_WARN_THRESHOLD =
-    Number.isFinite(parsedSchedulerSkipWarnThreshold) &&
-    parsedSchedulerSkipWarnThreshold > 0
-        ? parsedSchedulerSkipWarnThreshold
-        : DEFAULT_SCHEDULER_SKIP_WARN_THRESHOLD;
-const schedulerClaimSkipCounts = new Map<string, number>();
-const schedulerClaimCounters = {
-    acquired: 0,
-    skipped: 0,
-    failedAcquire: 0,
-    failedRelease: 0,
-    retryRecoveries: 0,
-};
 const queueProcessorCounters = {
     active: 0,
     completed: 0,
     failed: 0,
 };
-
-function logSchedulerClaimObservability(context: string): void {
-    claimObservabilityLog.info(
-        `context=${context} workerId=${WORKER_PROCESSOR_ID} owner=${schedulerLockOwnerId} acquired=${schedulerClaimCounters.acquired} skipped=${schedulerClaimCounters.skipped} failedAcquire=${schedulerClaimCounters.failedAcquire} failedRelease=${schedulerClaimCounters.failedRelease} retryRecoveries=${schedulerClaimCounters.retryRecoveries}`,
-    );
-}
-
-function maybeLogSchedulerClaimObservability(context: string): void {
-    const totalEvents =
-        schedulerClaimCounters.acquired +
-        schedulerClaimCounters.skipped +
-        schedulerClaimCounters.failedAcquire +
-        schedulerClaimCounters.failedRelease;
-    if (totalEvents > 0 && totalEvents % OBSERVABILITY_LOG_EVERY === 0) {
-        logSchedulerClaimObservability(context);
-    }
-}
 
 function recordQueueProcessorEvent(
     queueName: string,
@@ -164,58 +124,6 @@ function recordQueueProcessorEvent(
     }
 }
 
-function isRetryableSchedulerClaimError(error: unknown): boolean {
-    const message =
-        error instanceof Error ? error.message : String(error ?? "");
-    return (
-        message.includes("Connection is closed") ||
-        message.includes("Connection is in closing state") ||
-        message.includes("ECONNRESET") ||
-        message.includes("ETIMEDOUT") ||
-        message.includes("EPIPE")
-    );
-}
-
-function recreateSchedulerLockRedisClient(): void {
-    try {
-        schedulerLockRedis.disconnect();
-    } catch {
-        // no-op
-    }
-
-    schedulerLockRedis = createIORedisClient(
-        "worker-scheduler-locks",
-        jestLazyConnectOverride,
-    );
-}
-
-async function withSchedulerClaimRedisRetry<T>(
-    operationName: string,
-    operation: () => Promise<T>,
-): Promise<T> {
-    for (let attempt = 1; ; attempt += 1) {
-        try {
-            return await operation();
-        } catch (error) {
-            if (
-                !isRetryableSchedulerClaimError(error) ||
-                attempt === SCHEDULER_CLAIM_RETRY_ATTEMPTS
-            ) {
-                throw error;
-            }
-
-            claimLog.warn(
-                `${operationName} failed due to Redis connection closure (attempt ${attempt}/${SCHEDULER_CLAIM_RETRY_ATTEMPTS}); recreating client and retrying`,
-                error,
-            );
-            schedulerClaimCounters.retryRecoveries += 1;
-
-            recreateSchedulerLockRedisClient();
-            await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
-        }
-    }
-}
-
 function parseReconciliationCursor(value: string): ReconciliationCursor | null {
     if (value.length > MAX_RECONCILIATION_CURSOR_BYTES) return null;
 
@@ -247,7 +155,7 @@ async function loadReconciliationCursor(): Promise<
 > {
     const stored = await withSchedulerClaimRedisRetry(
         "track reconciliation cursor load",
-        () => schedulerLockRedis.get(TRACK_RECONCILIATION_CURSOR_KEY),
+        (client) => client.get(TRACK_RECONCILIATION_CURSOR_KEY),
     );
     if (!stored) return undefined;
 
@@ -257,7 +165,7 @@ async function loadReconciliationCursor(): Promise<
     log.warn("Discarding invalid persisted track reconciliation cursor");
     await withSchedulerClaimRedisRetry(
         "invalid track reconciliation cursor removal",
-        () => schedulerLockRedis.del(TRACK_RECONCILIATION_CURSOR_KEY),
+        (client) => client.del(TRACK_RECONCILIATION_CURSOR_KEY),
     );
     return undefined;
 }
@@ -268,7 +176,7 @@ async function saveReconciliationCursor(
     if (!cursor) {
         await withSchedulerClaimRedisRetry(
             "track reconciliation cursor clear",
-            () => schedulerLockRedis.del(TRACK_RECONCILIATION_CURSOR_KEY),
+            (client) => client.del(TRACK_RECONCILIATION_CURSOR_KEY),
         );
         return;
     }
@@ -277,126 +185,10 @@ async function saveReconciliationCursor(
         id: cursor.id,
         createdAt: cursor.createdAt.toISOString(),
     });
-    await withSchedulerClaimRedisRetry("track reconciliation cursor save", () =>
-        schedulerLockRedis.set(TRACK_RECONCILIATION_CURSOR_KEY, stored),
+    await withSchedulerClaimRedisRetry(
+        "track reconciliation cursor save",
+        (client) => client.set(TRACK_RECONCILIATION_CURSOR_KEY, stored),
     );
-}
-
-async function runWithSchedulerClaim(
-    claimKey: string,
-    ttlMs: number,
-    operationName: string,
-    operation: () => Promise<void>,
-): Promise<void> {
-    const claimToken = `${schedulerLockOwnerId}:${Date.now()}:${Math.random()}`;
-    const ttlSeconds = Math.max(1, Math.ceil(ttlMs / 1000));
-
-    try {
-        const acquired = await withSchedulerClaimRedisRetry(
-            `claim acquire for ${operationName}`,
-            () =>
-                schedulerLockRedis.set(
-                    claimKey,
-                    claimToken,
-                    "EX",
-                    ttlSeconds,
-                    "NX",
-                ),
-        );
-
-        if (acquired !== "OK") {
-            const skippedCount =
-                (schedulerClaimSkipCounts.get(claimKey) ?? 0) + 1;
-            schedulerClaimSkipCounts.set(claimKey, skippedCount);
-
-            if (skippedCount >= SCHEDULER_SKIP_WARN_THRESHOLD) {
-                schedulerClaimCounters.skipped += 1;
-                claimLog.warn(
-                    `${operationName} skipped ${skippedCount} consecutive time(s); claim held by another worker (owner=${schedulerLockOwnerId}, workerId=${WORKER_PROCESSOR_ID})`,
-                );
-            } else {
-                schedulerClaimCounters.skipped += 1;
-                claimLog.debug(
-                    `Skipping ${operationName}; claim is held by another worker (owner=${schedulerLockOwnerId}, workerId=${WORKER_PROCESSOR_ID})`,
-                );
-            }
-            maybeLogSchedulerClaimObservability("skip");
-            return;
-        }
-
-        schedulerClaimSkipCounts.delete(claimKey);
-        schedulerClaimCounters.acquired += 1;
-        claimLog.debug(
-            `Acquired claim for ${operationName} (claimKey=${claimKey}, owner=${schedulerLockOwnerId}, workerId=${WORKER_PROCESSOR_ID})`,
-        );
-        maybeLogSchedulerClaimObservability("acquire");
-    } catch (err) {
-        schedulerClaimCounters.failedAcquire += 1;
-        claimLog.error(
-            `Failed to claim ${operationName}; skipping cycle (owner=${schedulerLockOwnerId}, workerId=${WORKER_PROCESSOR_ID})`,
-            err,
-        );
-        maybeLogSchedulerClaimObservability("failed-acquire");
-        return;
-    }
-
-    try {
-        await operation();
-    } finally {
-        try {
-            await withSchedulerClaimRedisRetry(
-                `claim release for ${operationName}`,
-                () =>
-                    schedulerLockRedis.eval(
-                        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
-                        1,
-                        claimKey,
-                        claimToken,
-                    ),
-            );
-        } catch (err) {
-            schedulerClaimCounters.failedRelease += 1;
-            claimLog.warn(
-                `Failed to release claim for ${operationName} (owner=${schedulerLockOwnerId}, workerId=${WORKER_PROCESSOR_ID})`,
-                err,
-            );
-            maybeLogSchedulerClaimObservability("failed-release");
-        }
-    }
-}
-
-/**
- * Wrap an async operation with a timeout to prevent indefinite hangs
- * Returns undefined if the operation times out (does not throw)
- */
-async function withTimeout<T>(
-    operation: () => Promise<T>,
-    timeoutMs: number,
-    operationName: string,
-): Promise<T | undefined> {
-    let timeoutId: NodeJS.Timeout | undefined;
-    let timedOut = false;
-
-    const timeoutPromise = new Promise<undefined>((resolve) => {
-        timeoutId = setTimeout(() => {
-            timedOut = true;
-            log.warn(
-                `Operation timed out after ${timeoutMs}ms: ${operationName}`,
-            );
-            resolve(undefined);
-        }, timeoutMs);
-    });
-
-    try {
-        const result = await Promise.race([operation(), timeoutPromise]);
-        if (!timedOut && timeoutId) {
-            clearTimeout(timeoutId);
-        }
-        return result;
-    } catch (error) {
-        clearTimeout(timeoutId);
-        throw error;
-    }
 }
 
 async function processDataIntegrityJob(): Promise<void> {
@@ -551,62 +343,47 @@ let lastAudiobookRepeatFailureWarnAt = 0;
 async function processAudiobookAutoSyncJob(
     mode: "startup" | "repeat",
 ): Promise<void> {
-    await runWithSchedulerClaim(
-        "scheduler-claim:audiobook-auto-sync",
-        2 * ONE_HOUR_MS,
-        `${mode} audiobook auto-sync`,
-        async () => {
-            const { getSystemSettings } =
-                await import("../utils/systemSettings");
-            const settings = await getSystemSettings();
-            if (
-                !settings?.audiobookshelfEnabled ||
-                !settings?.audiobookshelfUrl
-            ) {
-                if (mode === "startup") {
-                    startupLog.debug(
-                        "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
-                    );
-                }
-                return;
-            }
-            const { audiobookCacheService } =
-                await import("../services/audiobookCache");
-            let result;
-            try {
-                result = await withTimeout(
-                    () => audiobookCacheService.syncMissing(),
-                    2 * ONE_HOUR_MS,
-                    "audiobookCacheService.syncMissing",
-                );
-            } catch (error) {
-                if (mode === "startup") {
-                    throw error;
-                }
-                const now = Date.now();
-                const message =
-                    "Repeat audiobook auto-sync failed; will retry on the next cycle";
-                if (
-                    now - lastAudiobookRepeatFailureWarnAt >=
-                    REPEAT_SYNC_FAILURE_WARN_INTERVAL_MS
-                ) {
-                    lastAudiobookRepeatFailureWarnAt = now;
-                    startupLog.warn(message, error);
-                } else {
-                    startupLog.debug(message, error);
-                }
-                return;
-            }
-            if (
-                result &&
-                (mode === "startup" || result.synced || result.failed)
-            ) {
-                startupLog.debug(
-                    `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
-                );
-            }
-        },
-    );
+    const { getSystemSettings } = await import("../utils/systemSettings");
+    const settings = await getSystemSettings();
+    if (!settings?.audiobookshelfEnabled || !settings?.audiobookshelfUrl) {
+        if (mode === "startup") {
+            startupLog.debug(
+                "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
+            );
+        }
+        return;
+    }
+    const { audiobookCacheService } =
+        await import("../services/audiobookCache");
+    let result;
+    try {
+        result = await withTimeout(
+            () => audiobookCacheService.syncMissing(),
+            AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+            "audiobookCacheService.syncMissing",
+            log,
+        );
+    } catch (error) {
+        if (mode === "startup") throw error;
+        const now = Date.now();
+        const message =
+            "Repeat audiobook auto-sync failed; will retry on the next cycle";
+        if (
+            now - lastAudiobookRepeatFailureWarnAt >=
+            REPEAT_SYNC_FAILURE_WARN_INTERVAL_MS
+        ) {
+            lastAudiobookRepeatFailureWarnAt = now;
+            startupLog.warn(message, error);
+        } else {
+            startupLog.debug(message, error);
+        }
+        return;
+    }
+    if (result && (mode === "startup" || result.synced || result.failed)) {
+        startupLog.debug(
+            `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
+        );
+    }
 }
 
 async function processDownloadQueueReconcileJob(): Promise<void> {
@@ -773,7 +550,7 @@ async function registerSchedulerJobs(): Promise<void> {
 
 // Register processors with named job types
 queueProcessorLog.info(
-    `workerId=${WORKER_PROCESSOR_ID} owner=${schedulerLockOwnerId} hostname=${process.env.HOSTNAME ?? "unknown"} pid=${process.pid}`,
+    `workerId=${WORKER_PROCESSOR_ID} owner=${SCHEDULER_CLAIM_OWNER_ID} hostname=${process.env.HOSTNAME ?? "unknown"} pid=${process.pid}`,
 );
 scanQueue.process("scan", processScan);
 if (config.features.discovery) {
@@ -1209,7 +986,7 @@ export async function shutdownWorkers(): Promise<void> {
 
     // Disconnect worker scheduler lock Redis connection
     try {
-        await schedulerLockRedis.quit();
+        await shutdownSchedulerClaimRedis();
         log.debug("Worker scheduler lock Redis disconnected");
     } catch (err) {
         log.error("Failed to disconnect worker scheduler lock Redis:", err);

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -53,7 +53,6 @@ const FIXED_SCAN_ROOTS = Object.freeze([
 ]);
 
 const BASELINE = Object.freeze({
-    "backend/src/routes/audiobooks.ts": 1555,
     "backend/src/routes/browse.ts": 1540,
     "backend/src/routes/downloads.ts": 1591,
     "backend/src/routes/enrichment.ts": 2277,


### PR DESCRIPTION
Fixes #712.

Books removed from Audiobookshelf lingered in soundspan forever — rows, cached covers under `cover-cache/audiobooks/`, and listening progress — because neither `syncAll` nor the incremental `syncMissing` (#711) ever deleted anything.

## What full sync does now

- **Reconciles**: local rows (`peerId: null` only — federated mirrors are never touched, and the predicate is repeated inside every `deleteMany` as a belt) absent from the ABS listing are deleted in batched transactions of 100, together with their `AudiobookProgress` rows (no FK cascade exists), `PlaybackState.audiobookId` references nulled, federation tombstones written when federation is enabled so peers drop their mirrors, and cached covers unlinked after each batch commits. The 5-minute incremental pass stays add-only, per the issue.

## Trust boundaries (the bulk of the review rounds)

An external listing must prove itself before anything gets deleted:

- Listings request ABS's documented `limit=0` for one atomic response. Paged fallbacks dedup by id, must match the declared `total` by **unique** count, fetch every declared page (bounded), and re-check stability afterward; malformed payloads (`{}` coerced arrays, items without ids) now **throw** instead of silently emptying, and drift marks a library add-only.
- Prune eligibility is **per-library**: only libraries whose listings verified complete participate. An empty-but-verified library with local rows is skipped with a warning (the same conservative posture the issue mandated globally — lingering beats wrongly deleting). Rows with unknown/null `libraryId` are never pruned.
- A pre-listing `lastSyncedAt` cutoff spares rows written by concurrent work; `syncAll`/`syncMissing` serialize under the shared Redis scheduler claim (`syncAll` errors when already running, `syncMissing` skips its tick); work is deadline-bounded below the claim lease with cooperative cancellation at book/batch boundaries, and a committed batch always finishes its cover cleanup before the deadline can fire.
- `POST /api/audiobooks/sync` is now **admin-only** (both UI callers are admin surfaces); stored cover paths and id-derived fallbacks are containment-checked (`./victim`-style ids can no longer redirect a write or unlink); ABS ids colliding with federated rows are skipped with a warning.

## Review loop

Six adversarial rounds to convergence; every fix carries a mutation check proving its test bites (pagination completeness, library scoping, `peerId` scoping, cutoff, sequential claim, tx atomicity via a distinct tx-client mock, deadline/cover ordering, cover-filename guard). Accepted residuals, documented in code comments: a concurrent equal-total replace during a *multi-page* assembly can still slip one book through (self-heals next sync; loss is that book's progress); the on-demand detail-refresh race needs a user opening a book at the exact prune instant and also self-heals; the candidate query's three-field select is unbounded but tiny at audiobook cardinality; `syncAudiobook` remains over the 60-line gate — pre-existing shape, only marginally touched here.

## Verification

- verify: `npx tsc --noEmit` — exit 0 (post-rebase onto current main, client regenerated)
- verify: `npx jest audiobookCacheService audiobookshelfService audiobooksRuntime indexRuntime` — `Test Suites: 4 passed`, `Tests: 154 passed, 154 total`, exit 0
- verify: `npm run format:check` — exit 0; `node scripts/ci/check-file-size.mjs` — exit 0