### PR TITLE
fix(discover): make legacy Discover Weekly acquisition admin-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Discover Weekly no longer downloads albums for non-admin users; legacy-mode acquisition is admin-only. (#663)
 - Federation sync positional dedup no longer generates a per-track Album self-join that could exhaust database memory on large sync pages (#713).
 - Admin-only full audiobook syncs now prune only stable, proven-complete Audiobookshelf listings, stop at cooperative lease deadlines, serialize against incremental syncs through the scheduler claim, protect federated and cover-filename ID collisions, and remove absent local books with their cached covers and listening state (#712).
 - Newly added Audiobookshelf books are now discovered automatically after the initial SoundSpan cache has been populated; a lightweight five-minute sync imports only missing local ABS books instead of reprocessing the full audiobook library (#710).

--- a/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
+++ b/backend/src/routes/__tests__/discoverLegacyRuntime.test.ts
@@ -1,6 +1,18 @@
 import { Request, Response } from "express";
 import fs from "fs";
 
+jest.mock("@prisma/client", () => ({
+    Prisma: {
+        PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {},
+        PrismaClientRustPanicError: class PrismaClientRustPanicError extends Error {},
+        PrismaClientUnknownRequestError: class PrismaClientUnknownRequestError extends Error {},
+        sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+            strings,
+            values,
+        }),
+    },
+}));
+
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),
@@ -376,7 +388,7 @@ describe("discover legacy-mode runtime behavior", () => {
             status: "scanning",
         });
 
-        const req = { user: { id: "user-1" } } as any;
+        const req = { user: { id: "user-1", role: "admin" } } as any;
         const res = createRes();
         await generateHandler(req, res);
 
@@ -393,7 +405,7 @@ describe("discover legacy-mode runtime behavior", () => {
             new Error("discovery unavailable"),
         );
 
-        const req = { user: { id: "user-1" } } as any;
+        const req = { user: { id: "user-1", role: "admin" } } as any;
         const res = createRes();
         await generateHandler(req, res);
 
@@ -409,7 +421,7 @@ describe("discover legacy-mode runtime behavior", () => {
         );
         discoverQueue.add.mockResolvedValueOnce({ id: "job-legacy-77" });
 
-        const req = { user: { id: "user-1" } } as any;
+        const req = { user: { id: "user-1", role: "admin" } } as any;
         const res = createRes();
         await generateHandler(req, res);
 
@@ -419,6 +431,20 @@ describe("discover legacy-mode runtime behavior", () => {
             message: "Discover Weekly generation started",
             jobId: "job-legacy-77",
         });
+    });
+
+    it("forbids non-admin legacy generation before lookup or queueing", async () => {
+        const req = { user: { id: "user-1", role: "user" } } as any;
+        const res = createRes();
+
+        await generateHandler(req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({
+            error: "Discover Weekly downloads are admin-only on this server",
+        });
+        expect(prisma.discoveryBatch.findFirst).not.toHaveBeenCalled();
+        expect(discoverQueue.add).not.toHaveBeenCalled();
     });
 
     it("returns empty current-week legacy playlist when no discovery data exists", async () => {

--- a/backend/src/routes/discover/index.ts
+++ b/backend/src/routes/discover/index.ts
@@ -76,6 +76,8 @@ router.get(
  *         description: Generation already in progress
  *       401:
  *         description: Not authenticated
+ *       403:
+ *         description: Legacy-mode generation is restricted to administrators
  */
 router.post(
     "/generate",

--- a/backend/src/routes/discover/legacy/generation.ts
+++ b/backend/src/routes/discover/legacy/generation.ts
@@ -2,7 +2,10 @@ import type { Request, Response } from "express";
 import { prisma } from "../../../utils/db";
 import { logger } from "../../../utils/logger";
 import { discoverQueue } from "../../../workers/queues";
-import { sendInternalRouteError } from "../../routeErrorResponse";
+import {
+    sendInternalRouteError,
+    sendRouteError,
+} from "../../routeErrorResponse";
 
 // Deprecated legacy discovery code is frozen: no fixes; removal is planned.
 
@@ -12,6 +15,14 @@ export async function handleLegacyGenerate(
     res: Response,
 ): Promise<Response | void> {
     try {
+        if (req.user?.role !== "admin") {
+            return sendRouteError(
+                res,
+                403,
+                "Discover Weekly downloads are admin-only on this server",
+            );
+        }
+
         const userId = req.user!.id;
         // Check for existing active batch
         const existingBatch = await prisma.discoveryBatch.findFirst({

--- a/backend/src/services/__tests__/discoverWeeklyModuleBoundariesRuntime.test.ts
+++ b/backend/src/services/__tests__/discoverWeeklyModuleBoundariesRuntime.test.ts
@@ -32,6 +32,7 @@ const prisma = {
     },
     play: { findMany: jest.fn(async () => []) },
     track: { findMany: jest.fn(async () => []) },
+    user: { findUnique: jest.fn(async () => ({ role: "admin" })) },
     userDiscoverConfig: { findUnique: jest.fn(async () => null) },
 };
 

--- a/backend/src/services/__tests__/discoverWeeklyRuntime.test.ts
+++ b/backend/src/services/__tests__/discoverWeeklyRuntime.test.ts
@@ -62,6 +62,9 @@ describe("discover weekly runtime behavior", () => {
                 }
                 return arg;
             }),
+            user: {
+                findUnique: jest.fn(async () => ({ role: "admin" })),
+            },
             discoveryBatch: {
                 findMany: jest.fn(async () => []),
                 findUnique: jest.fn(async () => null),
@@ -421,6 +424,31 @@ describe("discover weekly runtime behavior", () => {
         expect(discoveryLogger.end).toHaveBeenCalledWith(false, "Not enabled");
     });
 
+    it("rejects non-admin generation before creating a batch or acquiring albums", async () => {
+        const { prisma, tx, acquisitionService } = setupDiscoverWeeklyMocks();
+        (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+            role: "user",
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { discoverWeeklyService } = require("../discoverWeekly");
+
+        await expect(
+            discoverWeeklyService.generatePlaylist("user-1"),
+        ).rejects.toThrow(
+            "Discover Weekly downloads are admin-only on this server",
+        );
+
+        expect(prisma.user.findUnique).toHaveBeenCalledWith({
+            where: { id: "user-1" },
+            select: { role: true },
+        });
+        expect(prisma.userDiscoverConfig.findUnique).not.toHaveBeenCalled();
+        expect(tx.discoveryBatch.create).not.toHaveBeenCalled();
+        expect(tx.downloadJob.create).not.toHaveBeenCalled();
+        expect(acquisitionService.acquireAlbum).not.toHaveBeenCalled();
+    });
+
     it("returns early when buildFinalPlaylist receives a missing batch id", async () => {
         const { prisma } = setupDiscoverWeeklyMocks();
         (prisma.discoveryBatch.findUnique as jest.Mock).mockResolvedValueOnce(
@@ -603,8 +631,13 @@ describe("discover weekly runtime behavior", () => {
 
         const result = await discoverWeeklyService.generatePlaylist("user-1");
 
+        expect(prisma.user.findUnique).toHaveBeenCalledWith({
+            where: { id: "user-1" },
+            select: { role: true },
+        });
         expect(tx.discoveryBatch.create).toHaveBeenCalledTimes(1);
         expect(tx.downloadJob.create).toHaveBeenCalledTimes(2);
+        expect(acquisitionService.acquireAlbum).toHaveBeenCalledTimes(2);
         expect(prisma.downloadJob.update).toHaveBeenCalledTimes(2);
         expect(discoveryBatchLogger.info).toHaveBeenCalledWith(
             expect.any(String),

--- a/backend/src/services/discoverWeekly/generationService.ts
+++ b/backend/src/services/discoverWeekly/generationService.ts
@@ -29,6 +29,14 @@ import type { SeedArtist } from "./types";
 
 /** Represents the DiscoverWeeklyService class. */
 export class DiscoverWeeklyService extends BatchLifecycleService {
+    private async resolveCanAcquire(userId: string): Promise<boolean> {
+        const user = await discoverWeeklyPrisma.user.findUnique({
+            where: { id: userId },
+            select: { role: true },
+        });
+        return user?.role === "admin";
+    }
+
     /**
      * Main entry: Generate Discovery Weekly
      */
@@ -38,6 +46,12 @@ export class DiscoverWeeklyService extends BatchLifecycleService {
         discoveryLogger.info(`Log file: ${logPath}`);
 
         try {
+            if (!(await this.resolveCanAcquire(userId))) {
+                throw new Error(
+                    "Discover Weekly downloads are admin-only on this server",
+                );
+            }
+
             discoveryLogger.section("CONFIGURATION CHECK");
             const settings = await getSystemSettings();
 

--- a/backend/src/workers/__tests__/discoverCron.test.ts
+++ b/backend/src/workers/__tests__/discoverCron.test.ts
@@ -8,7 +8,7 @@ describe("discoverCron worker", () => {
         jest.clearAllMocks();
     });
 
-    function loadDiscoverCron() {
+    function loadDiscoverCron(mode = "recommendation") {
         process.env = { ...originalEnv };
 
         const logger = {
@@ -30,7 +30,7 @@ describe("discoverCron worker", () => {
         jest.doMock("../../utils/db", () => ({ prisma }));
         jest.doMock("../queues", () => ({ discoverQueue }));
         jest.doMock("../../config", () => ({
-            config: { discover: { mode: "strict" } },
+            config: { discover: { mode } },
         }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -65,6 +65,32 @@ describe("discoverCron worker", () => {
         expect(discoverQueue.add.mock.calls[0][2]).toEqual({
             jobId: "discover:cron:2026-02-16:u1",
         });
+    });
+
+    it("selects only admin users for legacy discover generation", async () => {
+        const { module, prisma, discoverQueue } = loadDiscoverCron("legacy");
+        prisma.userDiscoverConfig.findMany.mockResolvedValueOnce([
+            { userId: "admin-1", playlistSize: 25 },
+        ]);
+        discoverQueue.add.mockResolvedValue(undefined);
+
+        await module.processDiscoverCronTick();
+
+        expect(prisma.userDiscoverConfig.findMany).toHaveBeenCalledWith({
+            where: {
+                enabled: true,
+                user: { role: "admin" },
+            },
+            select: { userId: true, playlistSize: true },
+        });
+        expect(discoverQueue.add).toHaveBeenCalledTimes(1);
+        expect(discoverQueue.add).toHaveBeenCalledWith(
+            "discover-recommendation",
+            { userId: "admin-1" },
+            expect.objectContaining({
+                jobId: expect.stringContaining(":admin-1"),
+            }),
+        );
     });
 
     it("registers and removes repeatable cron scheduler with success/failure logging", async () => {

--- a/backend/src/workers/discoverCron.ts
+++ b/backend/src/workers/discoverCron.ts
@@ -31,6 +31,9 @@ export async function processDiscoverCronTick(): Promise<void> {
     const configs = await prisma.userDiscoverConfig.findMany({
         where: {
             enabled: true,
+            ...(config.discover.mode === "legacy"
+                ? { user: { role: "admin" } }
+                : {}),
         },
         select: {
             userId: true,


### PR DESCRIPTION
## Problem

Non-admin users could trigger real album downloads. `POST /api/discover/generate` is auth-only, and in **legacy** discovery mode (`DISCOVERY_MODE=legacy`) the generation service creates `DownloadJob` rows and dispatches `acquisitionService.acquireAlbum` for the calling user. The Sunday cron does the same for every user with discover enabled, regardless of role. With the request queue (#663) landing, the product invariant becomes "non-admins cannot acquire content" — this was the one hole.

## Why block generation instead of just skipping acquisition

Legacy discover playlists are meaningless without their downloads: candidate selection skips already-owned albums, the final playlist is built only from tracks the batch imported, and a batch with no imports is marked failed. Skipping the acquisition step for non-admins would leave them with permanently failed batches. So non-admin legacy generation is blocked outright, at three layers:

- The manual legacy route returns **403** ("Discover Weekly downloads are admin-only on this server") before any lookup or queueing.
- `generatePlaylist` resolves the requesting user's role and rejects non-admins before creating a batch — covering any stray queued job.
- The weekly cron joins on user role in legacy mode and only enqueues admins.

The default **recommendation** mode is untouched: it never created download jobs, and playlists keep generating for everyone.

## Verification

- `npx tsc --noEmit` exit 0
- Targeted jest: `Test Suites: 3 passed` / `Tests: 150 passed` (route 403 asserted before any DB/queue call; cron filter asserted per mode; service guard asserted before batch/job/acquisition; admin paths regression-pinned)
- `node scripts/ci/check-file-size.mjs`, `npm run check:error-canon`, `npm run format:check` all exit 0

Refs #663