### PR TITLE
feat(requests): per-album Request badges on artist pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Non-admin users now see per-album Request badges on artist pages (mirroring the admin download badge), with a Requested state for albums they've already asked for. (#663)
 - Music requests: non-admin users get a Request button on albums and Release Radar entries they can't download. Admins review the queue on a new Requests page (avatar menu), approve to start the download through the normal path, or decline; requesters get notifications when their request is approved, declined, fulfilled, or fails. One open request per album per user, with a daily per-user cap (`REQUESTS_PER_USER_PER_DAY`, default 10) and a feature switch (`FEATURE_REQUESTS`). (#663)
 - Local users can browse active peers' public playlists on demand, follow them with live availability, and copy resolvable tracks into caller-owned local playlists. Peer playlist export uses the existing `social:read` scope; it shares the owner's display name for attribution and never exposes private playlists, account ids, or emails.
 - Federation peers can receive privacy-filtered online presence through the new `social:read` scope. Phase 0 deliberately requires `library:read` with `social:read` because social exchange piggybacks on catalog sync; social-only peering is out of scope. Users must enable online presence before they appear to peers, and peer snapshots expire automatically when syncs stop.

--- a/frontend/app/artist/[id]/page.tsx
+++ b/frontend/app/artist/[id]/page.tsx
@@ -20,6 +20,7 @@ import { resolvePreferenceTrackId } from "@/lib/trackRef";
 
 // Hooks
 import { useArtistData } from "@/features/artist/hooks/useArtistData";
+import { useArtistAlbumRequests } from "@/features/artist/hooks/useArtistAlbumRequests";
 import { useArtistActions } from "@/features/artist/hooks/useArtistActions";
 import { useDownloadActions } from "@/features/artist/hooks/useDownloadActions";
 import { useYtMusicTopTracks } from "@/features/artist/hooks/useYtMusicTopTracks";
@@ -103,6 +104,15 @@ export default function ArtistPage() {
         setSortBy,
         reloadArtist,
     } = useArtistData();
+
+    const artistAlbumRequests = useArtistAlbumRequests(artist?.name || "");
+    const albumRequestControls = {
+        enabled: artistAlbumRequests.requestsEnabled,
+        isRequestable: artistAlbumRequests.isRequestableAlbum,
+        isRequested: artistAlbumRequests.isRequestedAlbum,
+        isSubmitting: artistAlbumRequests.isSubmittingRequest,
+        request: (album: Album) => void artistAlbumRequests.requestAlbum(album),
+    };
 
     // Action hooks
     const {
@@ -461,6 +471,7 @@ export default function ArtistPage() {
                             onSearchAlbum={handleSearchAlbum}
                             isPendingDownload={isPendingByMbid}
                             downloadsEnabled={downloadsEnabled}
+                            requestControls={albumRequestControls}
                         />
                     ) : (
                         showProgressivePlaceholders && (

--- a/frontend/components/ui/PlayableCard.tsx
+++ b/frontend/components/ui/PlayableCard.tsx
@@ -2,7 +2,15 @@
 
 import { ReactNode, memo, useMemo } from "react";
 import Link from "next/link";
-import { Play, Pause, Check, Download, Loader2, Search } from "lucide-react";
+import {
+    Play,
+    Pause,
+    Check,
+    Download,
+    Loader2,
+    Search,
+    Send,
+} from "lucide-react";
 import { Card, CardProps } from "./Card";
 import { cn } from "@/utils/cn";
 import type { ColorPalette } from "@/hooks/useImageColor";
@@ -22,10 +30,12 @@ export interface PlayableCardProps extends Omit<CardProps, "onPlay"> {
     onPlay?: (e: React.MouseEvent) => void;
     onDownload?: (e: React.MouseEvent) => void;
     onSearch?: (e: React.MouseEvent) => void;
+    onRequest?: (e: React.MouseEvent) => void;
     showPlayButton?: boolean;
     circular?: boolean;
-    badge?: "owned" | "download" | ReactNode | null;
+    badge?: "owned" | "download" | "request" | "requested" | ReactNode | null;
     isDownloading?: boolean;
+    isRequesting?: boolean;
     colors?: ColorPalette | null;
     tvCardIndex?: number;
 }
@@ -40,10 +50,12 @@ const PlayableCard = memo(function PlayableCard({
     onPlay,
     onDownload,
     onSearch,
+    onRequest,
     showPlayButton = true,
     circular = false,
     badge = null,
     isDownloading = false,
+    isRequesting = false,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     colors = null,
     className,
@@ -191,6 +203,50 @@ const PlayableCard = memo(function PlayableCard({
                                     Search
                                 </button>
                             )}
+                        </span>
+                    )}
+                    {badge === "request" && (
+                        <button
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                e.nativeEvent.stopImmediatePropagation();
+                                if (!isRequesting && onRequest) {
+                                    onRequest(e);
+                                }
+                            }}
+                            onMouseDown={(e) => {
+                                e.stopPropagation();
+                            }}
+                            disabled={isRequesting}
+                            className={cn(
+                                "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors",
+                                isRequesting
+                                    ? "bg-gray-500/20 border border-gray-500/30 text-gray-400 cursor-not-allowed"
+                                    : "bg-brand/20 hover:bg-brand/30 border border-brand/30 hover:border-brand/50 text-brand",
+                            )}
+                            title={
+                                isRequesting
+                                    ? "Requesting..."
+                                    : "Ask an admin to add this album"
+                            }
+                        >
+                            <Send
+                                className={cn(
+                                    "w-3 h-3",
+                                    isRequesting && "animate-pulse",
+                                )}
+                            />
+                            {isRequesting ? "Requesting..." : "Request"}
+                        </button>
+                    )}
+                    {badge === "requested" && (
+                        <span
+                            className="inline-flex items-center gap-1 px-2 py-0.5 bg-brand/10 border border-brand/20 rounded-full text-xs font-medium text-brand/80"
+                            title="You already have an open request for this album"
+                        >
+                            <Check className="w-3 h-3" />
+                            Requested
                         </span>
                     )}
                     {typeof badge !== "string" && badge}

--- a/frontend/features/artist/components/AvailableAlbums.tsx
+++ b/frontend/features/artist/components/AvailableAlbums.tsx
@@ -8,6 +8,15 @@ import { Disc3 } from "lucide-react";
 import { api } from "@/lib/api";
 import { PeerBadge } from "@/components/ui/PeerBadge";
 
+/** Request-flow controls threaded into the album grids for non-admins. */
+export interface AlbumRequestControls {
+    enabled: boolean;
+    isRequestable: (album: Album) => boolean;
+    isRequested: (album: Album) => boolean;
+    isSubmitting: boolean;
+    request: (album: Album) => void;
+}
+
 interface AvailableAlbumsProps {
     albums: Album[];
     artistName: string;
@@ -17,6 +26,7 @@ interface AvailableAlbumsProps {
     onSearchAlbum?: (album: Album, e: React.MouseEvent) => void;
     isPendingDownload: (mbid: string) => boolean;
     downloadsEnabled?: boolean;
+    requestControls?: AlbumRequestControls;
 }
 
 const COVER_PREFETCH_ROOT_MARGIN = "320px 0px";
@@ -44,6 +54,7 @@ function LazyAlbumCard({
     isPendingDownload,
     index,
     downloadsEnabled = true,
+    requestControls,
 }: {
     album: Album;
     source: ArtistSource;
@@ -53,6 +64,7 @@ function LazyAlbumCard({
     isPendingDownload: (mbid: string) => boolean;
     index: number;
     downloadsEnabled?: boolean;
+    requestControls?: AlbumRequestControls;
 }) {
     const [coverArt, setCoverArt] = useState<string | null>(() =>
         resolveAlbumCoverUrl(album, source),
@@ -157,15 +169,28 @@ function LazyAlbumCard({
                         />
                     ) : downloadsEnabled ? (
                         "download"
+                    ) : requestControls?.enabled &&
+                      requestControls.isRequestable(album) ? (
+                        requestControls.isRequested(album) ? (
+                            "requested"
+                        ) : (
+                            "request"
+                        )
                     ) : null
                 }
                 showPlayButton={false}
                 colors={colors}
                 isDownloading={isPendingDownload(albumMbid)}
+                isRequesting={requestControls?.isSubmitting ?? false}
                 onDownload={
                     album.provenanceSource === "federated"
                         ? undefined
                         : (e) => onDownloadAlbum(album, e)
+                }
+                onRequest={
+                    requestControls
+                        ? () => requestControls.request(album)
+                        : undefined
                 }
                 onSearch={
                     onSearchAlbum ? (e) => onSearchAlbum(album, e) : undefined
@@ -184,6 +209,7 @@ function AlbumGrid({
     onSearchAlbum,
     isPendingDownload,
     downloadsEnabled,
+    requestControls,
 }: Omit<AvailableAlbumsProps, "artistName">) {
     return (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
@@ -198,6 +224,7 @@ function AlbumGrid({
                     isPendingDownload={isPendingDownload}
                     index={index}
                     downloadsEnabled={downloadsEnabled}
+                    requestControls={requestControls}
                 />
             ))}
         </div>
@@ -216,6 +243,7 @@ export function AvailableAlbums({
     onSearchAlbum,
     isPendingDownload,
     downloadsEnabled = true,
+    requestControls,
 }: AvailableAlbumsProps) {
     if (!albums || albums.length === 0) {
         return null;
@@ -244,6 +272,7 @@ export function AvailableAlbums({
                             onSearchAlbum={onSearchAlbum}
                             isPendingDownload={isPendingDownload}
                             downloadsEnabled={downloadsEnabled}
+                            requestControls={requestControls}
                         />
                     </div>
                 </section>
@@ -262,6 +291,7 @@ export function AvailableAlbums({
                             onSearchAlbum={onSearchAlbum}
                             isPendingDownload={isPendingDownload}
                             downloadsEnabled={downloadsEnabled}
+                            requestControls={requestControls}
                         />
                     </div>
                 </section>

--- a/frontend/features/artist/hooks/useArtistAlbumRequests.ts
+++ b/frontend/features/artist/hooks/useArtistAlbumRequests.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { toast } from "sonner";
+import {
+    openRequestRgMbids,
+    useCreateMusicRequest,
+    useMyMusicRequests,
+    useRequestsGate,
+} from "@/hooks/useMusicRequests";
+import { isRequestableMbid } from "@/lib/musicRequests";
+import type { Album } from "../types";
+
+/**
+ * Request-flow state for the artist page's album grids: which albums the
+ * caller may request, which already carry an open request, and a
+ * toast-wrapped submit. Closed for admins and anonymous viewers.
+ */
+export function useArtistAlbumRequests(artistName: string) {
+    const { requestsEnabled } = useRequestsGate();
+    const myRequests = useMyMusicRequests(requestsEnabled);
+    const create = useCreateMusicRequest();
+    const openRgMbids = openRequestRgMbids(myRequests.data);
+
+    const albumRgMbid = (album: Album): string | null => {
+        const candidate = album.rgMbid || album.mbid || null;
+        return isRequestableMbid(candidate) ? candidate : null;
+    };
+
+    const isRequestedAlbum = (album: Album): boolean => {
+        const rgMbid = albumRgMbid(album);
+        return Boolean(rgMbid && openRgMbids.has(rgMbid.toLowerCase()));
+    };
+
+    const requestAlbum = async (album: Album): Promise<void> => {
+        const rgMbid = albumRgMbid(album);
+        if (!rgMbid || create.isPending) return;
+        const toastId = `music-request-${rgMbid}`;
+        toast.loading(`Requesting ${album.title}...`, { id: toastId });
+        try {
+            await create.mutateAsync({
+                artistName,
+                albumTitle: album.title,
+                rgMbid,
+            });
+            toast.success(
+                `Requested ${album.title} — an admin will review it`,
+                { id: toastId },
+            );
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to submit the request",
+                { id: toastId },
+            );
+        }
+    };
+
+    return {
+        requestsEnabled,
+        isRequestableAlbum: (album: Album) => albumRgMbid(album) !== null,
+        isRequestedAlbum,
+        isSubmittingRequest: create.isPending,
+        requestAlbum,
+    };
+}

--- a/frontend/lib/musicRequests.ts
+++ b/frontend/lib/musicRequests.ts
@@ -110,3 +110,15 @@ export function canReviewRequest(
 export function isOpenRequestStatus(status: string): boolean {
     return status === "pending" || status === "approved";
 }
+
+const MBID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Only real MusicBrainz release-group ids are requestable; the scanner's
+ * synthetic ids (temp-*, remote:*, federation:*) would be rejected by the
+ * API's MBID validation.
+ */
+export function isRequestableMbid(value: string | null | undefined): boolean {
+    return Boolean(value && MBID_PATTERN.test(value));
+}

--- a/frontend/tests/component/availableAlbums.component.test.ts
+++ b/frontend/tests/component/availableAlbums.component.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const icon = (name: string) => {
+    const MockIcon = (props: Record<string, unknown> = {}) =>
+        React.createElement("svg", { ...props, "data-icon": name });
+    MockIcon.displayName = `MockIcon${name}`;
+    return MockIcon;
+};
+
+mock.module("lucide-react", {
+    namedExports: {
+        Play: icon("play"),
+        Pause: icon("pause"),
+        Check: icon("check"),
+        Download: icon("download"),
+        Loader2: icon("loader2"),
+        Search: icon("search"),
+        Send: icon("send"),
+        Disc3: icon("disc3"),
+    },
+});
+
+mock.module("@/utils/cn", {
+    namedExports: {
+        cn: (...values: Array<string | false | null | undefined>) =>
+            values.filter(Boolean).join(" "),
+    },
+});
+
+mock.module("next/link", {
+    defaultExport: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & Record<string, unknown>) =>
+        React.createElement("a", { href, ...rest }, children),
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getCoverArtUrl: (url: string) => url,
+            request: async () => ({ coverUrl: null }),
+        },
+    },
+});
+
+mock.module("@/components/ui/CachedImage", {
+    namedExports: {
+        CachedImage: ({ src, alt }: { src: string; alt: string }) =>
+            React.createElement("img", { src, alt }),
+    },
+});
+
+mock.module("@/hooks/usePlayButtonFeedback", {
+    namedExports: {
+        usePlayButtonFeedback: () => ({
+            showSpinner: false,
+            trigger: () => undefined,
+        }),
+    },
+});
+
+const noop = () => undefined;
+
+const REAL_MBID = "0befee0f-2b0b-4b52-9d41-38f0f1f74ea5";
+
+const album = (overrides: Record<string, unknown> = {}) => ({
+    id: "album-1",
+    title: "Geogaddi",
+    type: "album",
+    rgMbid: REAL_MBID,
+    ...overrides,
+});
+
+const requestControls = (overrides: Record<string, unknown> = {}) => ({
+    enabled: true,
+    isRequestable: (candidate: { rgMbid?: string }) =>
+        Boolean(candidate.rgMbid?.startsWith("0befee0f")),
+    isRequested: () => false,
+    isSubmitting: false,
+    request: noop,
+    ...overrides,
+});
+
+const baseProps = {
+    artistName: "Boards of Canada",
+    source: "library" as const,
+    colors: null,
+    onDownloadAlbum: noop,
+    onSearchAlbum: noop,
+    isPendingDownload: () => false,
+};
+
+test("admins keep the download badge even when request controls exist", async () => {
+    const { AvailableAlbums } =
+        await import("../../features/artist/components/AvailableAlbums");
+    const html = renderToStaticMarkup(
+        React.createElement(AvailableAlbums, {
+            ...baseProps,
+            albums: [album()],
+            downloadsEnabled: true,
+            requestControls: requestControls(),
+        }),
+    );
+    assert.match(html, />Download</);
+    assert.doesNotMatch(html, />Request</);
+});
+
+test("non-admins with the gate open see the Request badge", async () => {
+    const { AvailableAlbums } =
+        await import("../../features/artist/components/AvailableAlbums");
+    const html = renderToStaticMarkup(
+        React.createElement(AvailableAlbums, {
+            ...baseProps,
+            albums: [album()],
+            downloadsEnabled: false,
+            requestControls: requestControls(),
+        }),
+    );
+    assert.match(html, />Request</);
+    assert.doesNotMatch(html, />Download</);
+});
+
+test("albums with an open request render the Requested state", async () => {
+    const { AvailableAlbums } =
+        await import("../../features/artist/components/AvailableAlbums");
+    const html = renderToStaticMarkup(
+        React.createElement(AvailableAlbums, {
+            ...baseProps,
+            albums: [album()],
+            downloadsEnabled: false,
+            requestControls: requestControls({ isRequested: () => true }),
+        }),
+    );
+    assert.match(html, />Requested</);
+    assert.doesNotMatch(html, />Request</);
+});
+
+test("synthetic release-group ids never show a request affordance", async () => {
+    const { AvailableAlbums } =
+        await import("../../features/artist/components/AvailableAlbums");
+    const html = renderToStaticMarkup(
+        React.createElement(AvailableAlbums, {
+            ...baseProps,
+            albums: [album({ rgMbid: "temp-172444-0.5" })],
+            downloadsEnabled: false,
+            requestControls: requestControls(),
+        }),
+    );
+    assert.doesNotMatch(html, />Request</);
+    assert.doesNotMatch(html, />Requested</);
+});
+
+test("closed gate renders no acquisition badge at all", async () => {
+    const { AvailableAlbums } =
+        await import("../../features/artist/components/AvailableAlbums");
+    const html = renderToStaticMarkup(
+        React.createElement(AvailableAlbums, {
+            ...baseProps,
+            albums: [album()],
+            downloadsEnabled: false,
+            requestControls: requestControls({ enabled: false }),
+        }),
+    );
+    assert.doesNotMatch(html, />Request</);
+    assert.doesNotMatch(html, />Download</);
+});

--- a/frontend/tests/component/streamingRoutes.component.test.ts
+++ b/frontend/tests/component/streamingRoutes.component.test.ts
@@ -343,6 +343,18 @@ mock.module("@/features/album/components/SimilarAlbums", {
     },
 });
 
+mock.module("@/features/artist/hooks/useArtistAlbumRequests", {
+    exports: {
+        useArtistAlbumRequests: () => ({
+            requestsEnabled: false,
+            isRequestableAlbum: () => false,
+            isRequestedAlbum: () => false,
+            isSubmittingRequest: false,
+            requestAlbum: async () => undefined,
+        }),
+    },
+});
+
 mock.module("@/features/artist/hooks/useArtistData", {
     exports: {
         useArtistData: () => ({

--- a/frontend/tests/unit/musicRequests.test.ts
+++ b/frontend/tests/unit/musicRequests.test.ts
@@ -6,6 +6,7 @@ import {
     canReviewRequest,
     filterRequestRows,
     isOpenRequestStatus,
+    isRequestableMbid,
     requestStatusBadgeVariant,
     requestStatusLabel,
     toMusicRequestStatus,
@@ -70,6 +71,23 @@ test("isOpenRequestStatus treats pending and approved as open", () => {
     assert.equal(isOpenRequestStatus("fulfilled"), false);
     assert.equal(isOpenRequestStatus("denied"), false);
     assert.equal(isOpenRequestStatus("cancelled"), false);
+});
+
+test("isRequestableMbid accepts real MBIDs and rejects synthetic ids", () => {
+    assert.equal(
+        isRequestableMbid("0befee0f-2b0b-4b52-9d41-38f0f1f74ea5"),
+        true,
+    );
+    assert.equal(
+        isRequestableMbid("0BEFEE0F-2B0B-4B52-9D41-38F0F1F74EA5"),
+        true,
+    );
+    assert.equal(isRequestableMbid("temp-1724448000-0.123"), false);
+    assert.equal(isRequestableMbid("remote:generated-hash"), false);
+    assert.equal(isRequestableMbid("federation:peer:album"), false);
+    assert.equal(isRequestableMbid(""), false);
+    assert.equal(isRequestableMbid(null), false);
+    assert.equal(isRequestableMbid(undefined), false);
 });
 
 test("filter options start with all and cover the reviewable states", () => {


### PR DESCRIPTION
Follow-up to #729. Non-admins could only request from inside an album page; the artist page's "Albums Available" grid — where admins get hover download badges — showed them nothing.

## What changes

- Artist-page album cards now show a **Request** badge for non-admins exactly where admins see Download, flipping to a passive **Requested** chip for albums with an open request. Peer badges still win for federated albums; admin behavior is untouched.
- `PlayableCard` gains `request`/`requested` badge variants + `onRequest`/`isRequesting`, mirroring the download badge's event handling (click doesn't navigate the card link).
- New pure helper `isRequestableMbid` gates out synthetic release-group ids (`temp-`, `remote:`, `federation:`) the API would reject.
- New `useArtistAlbumRequests` hook reuses the existing request gate/open-request/create machinery with the same toast flow as the album page.

Artist-level "request discography" remains phase 3 (#726) — this is album-scope only.

## Verification

- tsc 0, eslint at the exact 183-warning cap, prettier clean.
- Unit `1023 passed` (new `isRequestableMbid` coverage), component `699 passed` (new `availableAlbums.component.test.ts`: admin-precedence, request badge, requested state, synthetic-id suppression, closed-gate cases).

Refs #663