### PR TITLE
fix(requests): admin-owned approval downloads and linkable request rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Music request entries now link to matching local artist and album pages.
+- Approving a music request now shows the download in the approving admin's activity panel instead of running invisibly under the requester's account. (#663)
 - Discover Weekly no longer downloads albums for non-admin users; legacy-mode acquisition is admin-only. (#663)
 - Federation sync positional dedup no longer generates a per-track Album self-join that could exhaust database memory on large sync pages (#713).
 - Admin-only full audiobook syncs now prune only stable, proven-complete Audiobookshelf listings, stop at cooperative lease deadlines, serialize against incremental syncs through the scheduler claim, protect federated and cover-filename ID collisions, and remove absent local books with their cached covers and listening state (#712).

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -245,7 +245,7 @@ router.post("/", asyncHandler(handleCreate));
  *     security:
  *       - apiKeyAuth: []
  *     responses:
- *       200: { description: Newest-first request history }
+ *       200: { description: Newest-first request history with nullable albumId and artistId local link fields }
  *       401: { description: Not authenticated }
  */
 router.get("/mine", asyncHandler(handleMine));
@@ -286,7 +286,7 @@ router.delete("/:id", asyncHandler(handleCancel));
  *           type: string
  *           enum: [pending, approved, denied, fulfilled, failed, cancelled]
  *     responses:
- *       200: { description: Bounded newest-first request list }
+ *       200: { description: Bounded newest-first request list with nullable albumId and artistId local link fields }
  *       400: { description: Invalid status filter }
  *       401: { description: Not authenticated }
  *       403: { description: Admin access required }

--- a/backend/src/services/__tests__/musicRequestService.test.ts
+++ b/backend/src/services/__tests__/musicRequestService.test.ts
@@ -8,7 +8,8 @@ const mockNotifyRequestDenied = jest.fn();
 const mockNotifyRequestFulfilled = jest.fn();
 
 const prisma = {
-    album: { findFirst: jest.fn() },
+    album: { findFirst: jest.fn(), findMany: jest.fn() },
+    artist: { findMany: jest.fn() },
     downloadJob: { findFirst: jest.fn() },
     musicRequest: {
         count: jest.fn(),
@@ -71,6 +72,8 @@ import {
     cancelOwnRequest,
     createRequest,
     denyRequest,
+    listAllRequests,
+    listRequestsForUser,
     MusicRequestServiceError,
 } from "../musicRequestService";
 
@@ -104,6 +107,8 @@ describe("musicRequestService", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         prisma.album.findFirst.mockResolvedValue(null);
+        prisma.album.findMany.mockResolvedValue([]);
+        prisma.artist.findMany.mockResolvedValue([]);
         prisma.musicRequest.findFirst.mockResolvedValue(null);
         prisma.downloadJob.findFirst.mockResolvedValue(null);
         prisma.musicRequest.count.mockResolvedValue(0);
@@ -213,6 +218,87 @@ describe("musicRequestService", () => {
         );
     });
 
+    it("batches album links and prefers the library row", async () => {
+        const secondRequest = { ...pendingRequest, id: "request-2" };
+        prisma.musicRequest.findMany.mockResolvedValueOnce([
+            pendingRequest,
+            secondRequest,
+        ]);
+        prisma.album.findMany.mockResolvedValueOnce([
+            {
+                id: "album-discovery",
+                rgMbid: input.rgMbid,
+                location: "DISCOVER",
+                artistId: "artist-discovery",
+            },
+            {
+                id: "album-library",
+                rgMbid: input.rgMbid,
+                location: "LIBRARY",
+                artistId: "artist-library",
+            },
+        ]);
+
+        const result = await listRequestsForUser("user-1");
+
+        expect(result).toEqual([
+            {
+                ...pendingRequest,
+                albumId: "album-library",
+                artistId: "artist-library",
+            },
+            {
+                ...secondRequest,
+                albumId: "album-library",
+                artistId: "artist-library",
+            },
+        ]);
+        expect(prisma.album.findMany).toHaveBeenCalledTimes(1);
+        expect(prisma.album.findMany).toHaveBeenCalledWith({
+            where: { rgMbid: { in: [input.rgMbid] } },
+            select: {
+                id: true,
+                rgMbid: true,
+                location: true,
+                artistId: true,
+            },
+        });
+        expect(prisma.artist.findMany).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the artist MBID for administrator request rows", async () => {
+        const adminRequest = {
+            ...pendingRequest,
+            user: { id: "user-1", username: "listener" },
+        };
+        prisma.musicRequest.findMany.mockResolvedValueOnce([adminRequest]);
+        prisma.artist.findMany.mockResolvedValueOnce([
+            { id: "artist-local", mbid: input.artistMbid },
+        ]);
+
+        const result = await listAllRequests("pending");
+
+        expect(result).toEqual([
+            {
+                ...adminRequest,
+                albumId: null,
+                artistId: "artist-local",
+            },
+        ]);
+        expect(prisma.artist.findMany).toHaveBeenCalledWith({
+            where: { mbid: { in: [input.artistMbid] } },
+            select: { id: true, mbid: true },
+        });
+    });
+
+    it("returns null links when neither album nor artist resolves", async () => {
+        prisma.musicRequest.findMany.mockResolvedValueOnce([pendingRequest]);
+
+        await expect(listRequestsForUser("user-1")).resolves.toEqual([
+            { ...pendingRequest, albumId: null, artistId: null },
+        ]);
+    });
+
     it("does not reveal another user's request during cancellation", async () => {
         prisma.musicRequest.updateMany.mockResolvedValueOnce({ count: 0 });
         prisma.musicRequest.findFirst.mockResolvedValueOnce(null);
@@ -259,6 +345,28 @@ describe("musicRequestService", () => {
             kind: "conflict",
         });
         expect(mockCreateAlbumDownloadJob).not.toHaveBeenCalled();
+    });
+
+    it("creates the approval job for the admin and notifies the requester", async () => {
+        await approveRequest("admin-1", "request-1");
+
+        expect(mockCreateAlbumDownloadJob).toHaveBeenCalledWith(
+            {
+                userId: "admin-1",
+                mbid: input.rgMbid,
+                subject: `${input.artistName} - ${input.albumTitle}`,
+                artistName: input.artistName,
+                albumTitle: input.albumTitle,
+                downloadType: "library",
+                rootFolderPath: "/library",
+            },
+            prisma,
+            input.artistName,
+        );
+        expect(mockNotifyRequestApproved).toHaveBeenCalledWith(
+            "user-1",
+            expect.objectContaining({ requestId: "request-1" }),
+        );
     });
 
     it("links an existing active job without producing dispatch work", async () => {

--- a/backend/src/services/musicRequestService.ts
+++ b/backend/src/services/musicRequestService.ts
@@ -1,4 +1,4 @@
-import type { DownloadJob, MusicRequest } from "@prisma/client";
+import type { Album, DownloadJob, MusicRequest } from "@prisma/client";
 import { config } from "../config";
 import { recordMusicRequestAction } from "../metrics";
 import { prisma } from "../utils/db";
@@ -20,6 +20,13 @@ const MAX_ADMIN_NOTIFICATIONS = 200;
 const MAX_REQUEST_LIST_SIZE = 200;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const OPEN_REQUEST_STATUSES = ["pending", "approved"] as const;
+
+type RequestLibraryLinks = {
+    albumId: string | null;
+    artistId: string | null;
+};
+type LinkableRequest = Pick<MusicRequest, "rgMbid" | "artistMbid">;
+type AlbumLink = Pick<Album, "id" | "rgMbid" | "location" | "artistId">;
 
 /** Stable persisted status vocabulary for the request queue. */
 export const MUSIC_REQUEST_STATUSES = [
@@ -246,15 +253,84 @@ export async function createRequest(
     return request;
 }
 
+function mapPreferredAlbums(albums: AlbumLink[]): Map<string, AlbumLink> {
+    const preferred = new Map<string, AlbumLink>();
+    for (const album of albums) {
+        const current = preferred.get(album.rgMbid);
+        if (
+            !current ||
+            (current.location !== "LIBRARY" && album.location === "LIBRARY")
+        ) {
+            preferred.set(album.rgMbid, album);
+        }
+    }
+    return preferred;
+}
+
+async function attachLibraryLinks<T extends LinkableRequest>(
+    rows: T[],
+): Promise<Array<T & RequestLibraryLinks>> {
+    if (rows.length === 0) return [];
+    const rgMbids = [...new Set(rows.map((row) => row.rgMbid))];
+    const albums = await prisma.album.findMany({
+        where: { rgMbid: { in: rgMbids } },
+        select: { id: true, rgMbid: true, location: true, artistId: true },
+    });
+    const albumsByMbid = mapPreferredAlbums(albums);
+    const artistsByMbid = await resolveFallbackArtists(rows, albumsByMbid);
+    return addLibraryLinks(rows, albumsByMbid, artistsByMbid);
+}
+
+async function resolveFallbackArtists<T extends LinkableRequest>(
+    rows: T[],
+    albumsByMbid: Map<string, AlbumLink>,
+): Promise<Map<string, string>> {
+    const fallbackMbids = [
+        ...new Set(
+            rows
+                .filter((row) => !albumsByMbid.has(row.rgMbid))
+                .map((row) => row.artistMbid)
+                .filter((mbid): mbid is string => mbid !== null),
+        ),
+    ];
+    const artists = fallbackMbids.length
+        ? await prisma.artist.findMany({
+              where: { mbid: { in: fallbackMbids } },
+              select: { id: true, mbid: true },
+          })
+        : [];
+    return new Map(artists.map((artist) => [artist.mbid, artist.id]));
+}
+
+function addLibraryLinks<T extends LinkableRequest>(
+    rows: T[],
+    albumsByMbid: Map<string, AlbumLink>,
+    artistsByMbid: Map<string, string>,
+): Array<T & RequestLibraryLinks> {
+    return rows.map((row) => {
+        const album = albumsByMbid.get(row.rgMbid);
+        return {
+            ...row,
+            albumId: album?.id ?? null,
+            artistId:
+                album?.artistId ??
+                (row.artistMbid
+                    ? (artistsByMbid.get(row.artistMbid) ?? null)
+                    : null),
+        };
+    });
+}
+
 /** List the caller's request history newest first. */
 export async function listRequestsForUser(
     userId: string,
-): Promise<MusicRequest[]> {
-    return prisma.musicRequest.findMany({
+): Promise<Array<MusicRequest & RequestLibraryLinks>> {
+    const rows = await prisma.musicRequest.findMany({
         where: { userId },
         orderBy: { createdAt: "desc" },
         take: MAX_REQUEST_LIST_SIZE,
     });
+    return attachLibraryLinks(rows);
 }
 
 /** Return current feature availability and the rolling 24-hour allowance. */
@@ -298,21 +374,28 @@ export async function cancelOwnRequest(
 /** List the bounded administrator queue with requester identity. */
 export async function listAllRequests(
     status?: MusicRequestStatus,
-): Promise<Array<MusicRequest & { user: { id: string; username: string } }>> {
-    return prisma.musicRequest.findMany({
+): Promise<
+    Array<
+        MusicRequest &
+            RequestLibraryLinks & { user: { id: string; username: string } }
+    >
+> {
+    const rows = await prisma.musicRequest.findMany({
         where: status ? { status } : undefined,
         include: { user: { select: { id: true, username: true } } },
         orderBy: { createdAt: "desc" },
         take: MAX_REQUEST_LIST_SIZE,
     });
+    return attachLibraryLinks(rows);
 }
 
 function approvalJobParams(
     request: MusicRequest,
+    adminId: string,
     rootFolderPath: string,
 ): CreateAlbumDownloadJobParams {
     return {
-        userId: request.userId,
+        userId: adminId,
         mbid: request.rgMbid,
         subject: `${request.artistName} - ${request.albumTitle}`,
         artistName: request.artistName,
@@ -353,7 +436,7 @@ async function approveWithJob(
         });
         if (changed.count === 0) return { kind: "conflict" } as const;
         const jobResult = await createAlbumDownloadJob(
-            approvalJobParams(request, rootFolderPath),
+            approvalJobParams(request, adminId, rootFolderPath),
             transaction,
             verifiedArtistName,
         );

--- a/frontend/app/requests/page.tsx
+++ b/frontend/app/requests/page.tsx
@@ -26,6 +26,20 @@ import {
     useReviewMusicRequest,
 } from "@/hooks/useMusicRequests";
 
+/** Deep link for a request's artist: local page when resolved, search otherwise. */
+function requestArtistHref(request: MusicRequest): string {
+    if (request.artistId) return `/artist/${request.artistId}`;
+    return `/search?q=${encodeURIComponent(request.artistName)}`;
+}
+
+/** Deep link for a request's album: local page when resolved, search otherwise. */
+function requestAlbumHref(request: MusicRequest): string {
+    if (request.albumId) return `/album/${request.albumId}`;
+    return `/search?q=${encodeURIComponent(
+        `${request.artistName} ${request.albumTitle}`,
+    )}`;
+}
+
 function formatRequestDate(value: string): string {
     const parsed = new Date(value);
     if (Number.isNaN(parsed.getTime())) return "";
@@ -108,7 +122,19 @@ function RequestRow(props: {
         <li className="flex flex-wrap items-center gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3">
             <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-white">
-                    {request.artistName} — {request.albumTitle}
+                    <Link
+                        href={requestArtistHref(request)}
+                        className="hover:underline"
+                    >
+                        {request.artistName}
+                    </Link>{" "}
+                    —{" "}
+                    <Link
+                        href={requestAlbumHref(request)}
+                        className="hover:underline"
+                    >
+                        {request.albumTitle}
+                    </Link>
                 </p>
                 <p className="truncate text-xs text-gray-400">
                     {props.isAdmin && request.user

--- a/frontend/lib/api/requests.ts
+++ b/frontend/lib/api/requests.ts
@@ -14,6 +14,8 @@ export interface MusicRequest {
     deniedReason: string | null;
     reviewedAt: string | null;
     downloadJobId: string | null;
+    albumId?: string | null;
+    artistId?: string | null;
     createdAt: string;
     updatedAt: string;
     user?: {

--- a/frontend/tests/component/requestsPage.component.test.ts
+++ b/frontend/tests/component/requestsPage.component.test.ts
@@ -118,7 +118,8 @@ test("admin view lists requests with requester and review actions", async () => 
     const html = renderToStaticMarkup(React.createElement(RequestsPage));
 
     assert.match(html, />Requests</);
-    assert.match(html, /Boards of Canada — Geogaddi/);
+    assert.match(html, />Boards of Canada</);
+    assert.match(html, />Geogaddi</);
     assert.match(html, /Requested by alice/);
     assert.match(html, />Approve</);
     assert.match(html, />Decline</);
@@ -159,6 +160,37 @@ test("non-admin view shows own requests with cancel for pending", async () => {
     assert.match(html, />Declined</);
     assert.doesNotMatch(html, />Approve</);
     assert.doesNotMatch(html, /Requested by/);
+});
+
+test("request rows link to resolved artist and album pages", async () => {
+    state.auth = {
+        user: { id: "admin-1", role: "admin" },
+        isAuthenticated: true,
+        isLoading: false,
+    };
+    state.adminQuery = {
+        data: [requestRow({ artistId: "artist-9", albumId: "album-9" })],
+        isLoading: false,
+    };
+
+    const { default: RequestsPage } = await import("../../app/requests/page");
+    const html = renderToStaticMarkup(React.createElement(RequestsPage));
+
+    assert.match(html, /href="\/artist\/artist-9"/);
+    assert.match(html, /href="\/album\/album-9"/);
+});
+
+test("unresolved request rows fall back to search links", async () => {
+    state.adminQuery = {
+        data: [requestRow({ artistId: null, albumId: null })],
+        isLoading: false,
+    };
+
+    const { default: RequestsPage } = await import("../../app/requests/page");
+    const html = renderToStaticMarkup(React.createElement(RequestsPage));
+
+    assert.match(html, /href="\/search\?q=Boards%20of%20Canada"/);
+    assert.match(html, /href="\/search\?q=Boards%20of%20Canada%20Geogaddi"/);
 });
 
 test("empty state guides users toward the library", async () => {


### PR DESCRIPTION
Two fixes from live testing of the request queue (#729):

## 1. Approved downloads were invisible

Approving a request created the `DownloadJob` under the **requester's** account. The Activity panel's Active tab only lists your own jobs — and non-admins don't get an Active tab at all — so an approved download ran with no visible progress anywhere. Confirmed in production: the job completed successfully without ever appearing in the approving admin's sidebar.

Approval jobs now belong to the **approving admin**: the download appears in their Active list and they get the completion notification, exactly like a download they triggered directly. The requester's experience is unchanged — `request_approved` / `request_fulfilled` / `request_failed` notifications key off the request row, and the reconciler links by job id, not owner. Side benefit: a requester can no longer delete the job from their own downloads list and strand their request.

## 2. Request rows now link to the artist and album

The requests page rendered "Artist — Album" as plain text. Both list endpoints now batch-resolve local `albumId`/`artistId` from the stored release-group MBID (one `findMany` per page; library rows win over discovery duplicates; artist-MBID fallback when no album row exists), and the page renders both names as links — falling back to a prefilled `/search?q=` when nothing resolves locally.

## Verification

- Backend: tsc 0; request service/route/reconciler suites `50 passed` (admin-owned job payload pinned; requester notification target pinned; LIBRARY-preference, artist-fallback, unresolved-null, and batching all asserted).
- Frontend: tsc 0; unit `1022 passed`; component `696 passed` incl. new link/fallback cases; eslint at the exact cap; prettier clean.
- `check-file-size`, `check:error-canon` green.

Refs #663