### PR TITLE
chore(release): stage 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-08-23
+
 ### Added
 
 - Non-admin users now see per-album Request badges on artist pages (mirroring the admin download badge), with a Requested state for albums they've already asked for. (#663)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-backend",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-backend",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^9.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-backend",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "engines": {
         "node": ">=24.0.0"
     },

--- a/charts/soundspan/Chart.yaml
+++ b/charts/soundspan/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: soundspan
 description: A self-hosted music server with TIDAL and YouTube Music streaming integration
 type: application
-version: 2.4.1
-appVersion: "2.4.1"
+version: 2.5.0
+appVersion: "2.5.0"
 home: https://github.com/soundspan/soundspan
 sources:
   - https://github.com/soundspan/soundspan

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -89,7 +89,7 @@ haMode:
 aio:
   image:
     repository: ghcr.io/soundspan/soundspan
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ aio:
 backend:
   image:
     repository: ghcr.io/soundspan/soundspan-backend
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -228,7 +228,7 @@ backendWorker:
   vibeEmbedConcurrency: null
   image:
     repository: ghcr.io/soundspan/soundspan-backend-worker
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -283,7 +283,7 @@ backendWorker:
 frontend:
   image:
     repository: ghcr.io/soundspan/soundspan-frontend
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -410,7 +410,7 @@ tidalSidecar:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-tidal-streamer
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -439,7 +439,7 @@ ytmusicStreamer:
   enabled: false
   image:
     repository: ghcr.io/soundspan/soundspan-ytmusic-streamer
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -514,7 +514,7 @@ audioAnalyzer:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-audio-analyzer
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always
@@ -579,7 +579,7 @@ vibeProviderDclap:
   replicas: 1
   image:
     repository: ghcr.io/soundspan/soundspan-vibe-provider-dclap
-    tag: 2.4.1
+    tag: 2.5.0
     # -- Immutable sha256 digest. When set, takes precedence over tag.
     digest: ""
     pullPolicy: Always

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -34,7 +34,7 @@ data volume while the container is stopped.
 
 | Upgrading across | Action needed? |
 | ---------------- | -------------- |
-| **Unreleased (next release)** | None — the TIDAL sidecar is renamed to `tidal-streamer`, but every old reference keeps working: the old image name still receives new versions, and the old in-network hostname still resolves. See the section below if you want to move your pins to the new name. |
+| **2.5.0** | Usually none — plain rolling update; database migrations apply automatically. **Heads-up on two default changes:** users who share online presence become visible to federated peer servers too (and public playlists are shared with peers) — turning off **Share online presence** or making a playlist private restores local-only behavior; and the new music-request feature is on by default (`FEATURE_REQUESTS=false` to disable). Federation pairing codes are removed — new peer connections use the host-credential flow, and both servers must be on versions that support it. The TIDAL sidecar is also renamed to `tidal-streamer`, but every old reference keeps working; see the section below. |
 | **2.4.1** | None — plain rolling update; no database migrations. Fixes Subsonic full syncs of large libraries (Symfonium and similar clients importing nothing) and the Library Enrichment failures view. If your server must federate through an egress proxy, the new `FEDERATION_ALLOW_PROXY=true` opt-in restores proxy support that 2.4.0 disabled. |
 | **2.4.0** | Usually none — plain rolling update; all database migrations apply automatically. **Exception:** federation now resolves peer hostnames and rejects private, loopback, and link-local addresses whether configured literally or returned by DNS — if any peer lives on a LAN or VPN, set `FEDERATION_ALLOW_PRIVATE_PEERS=true` before upgrading or that peer stops syncing. Federation traffic also no longer routes through `HTTP(S)_PROXY` egress proxies. Heads-up for very large libraries: two migrations do heavier work (track-mapping housekeeping and an album-ownership guard), so the first startup can take longer than usual. Also new: a daily cleanup removes stale, unliked, unplayable TIDAL/YouTube Music catalog rows after 30 days (`PROVIDER_TRACK_RETENTION_DAYS` to tune); liked, playlisted, recently played, and file-backed content is always kept. |
 | **2.3.3** | Usually none — plain rolling update; a small database change applies automatically. **Exception:** if a federation peer is configured by a literal private, loopback, or link-local IP address (LAN/VPN IPs, `127.x`, `169.254.x`) or by `localhost`, set `FEDERATION_ALLOW_PRIVATE_PEERS=true` first — outbound federation now rejects these by default (peers configured by a DNS hostname other than `localhost` are unaffected). If you are on 2.3.2, upgrade promptly: its audio-analyzer container could not start, so loudness measurement was paused until this release. |
@@ -49,7 +49,26 @@ Anything not listed: drop-in.
 
 ---
 
-## Unreleased (next release): TIDAL sidecar renamed to `tidal-streamer`
+## 2.5.0: sharing defaults, pairing codes, and the TIDAL sidecar rename
+
+**Sharing defaults.** After the upgrade, **Share online presence** controls a
+user's visibility everywhere, including federated peer servers, and every
+public playlist is visible to connected peers. The old per-user "share with
+trusted peers" toggles are gone. Users who want to stay local-only should turn
+off **Share online presence** or make the playlist private before or after the
+upgrade — nothing else is required.
+
+**Music requests.** Non-admin users get Request buttons and admins get a
+Requests page (avatar menu). The feature is on by default; set
+`FEATURE_REQUESTS=false` to turn it off, and `REQUESTS_PER_USER_PER_DAY`
+(default 10) to tune the per-user daily cap.
+
+**Pairing codes removed.** New federation connections are made with a host
+credential issued by the hosting server's admin. A peer running a version that
+only supports pairing codes must upgrade before it can pair. Established
+connections keep working.
+
+### TIDAL sidecar renamed to `tidal-streamer`
 
 The TIDAL sidecar now matches the YouTube sidecar's naming. It streams and
 downloads, so it is named for its primary role, like `ytmusic-streamer`.

--- a/docs/release-notes/RELEASE_NOTES_2.5.0.md
+++ b/docs/release-notes/RELEASE_NOTES_2.5.0.md
@@ -1,0 +1,107 @@
+# [2.5.0] Release Notes - 2026-08-23
+
+## Release Summary
+
+2.5.0 introduces **music requests**: users who can't download music directly can now ask for it. A Request button appears on albums that aren't in the library, admins approve or decline from a new Requests page, and the requester gets notified when their music arrives. This first version is deliberately an MVP — album requests only, with a simple approve/decline flow — and it will grow in future releases.
+
+Federation sharing also gets simpler. Presence and public playlists now follow one rule each: **Share online presence** controls whether people can see you (locally and on peer servers), and public playlists are visible to connected peers — no separate per-peer toggles to manage. Peer playlists now appear alongside your own in the sidebar and Playlists page, badged with the server they come from.
+
+Rounding it out: a configurable playback source priority, YouTube Music as a download source, and important stability fixes for federation sync and audiobook libraries.
+
+## Before you upgrade
+
+**Warning:** If you run a version earlier than 2.0.0, do not upgrade directly
+to 2.5.0. Complete the 2.0.0 breaking changes first. See
+[Upgrading from an earlier version](#upgrading-from-an-earlier-version).
+
+- If you already run 2.0.x or later, this is a plain rolling update. Database migrations run automatically on startup.
+- Two behavior changes to know about before you upgrade:
+  - **Presence now extends to peers automatically.** Users who have **Share online presence** turned on become visible to federated peer servers too, and every public playlist is shared with connected peers. Anyone who wants to stay local-only should turn off **Share online presence** or make playlists private.
+  - **Music requests are on by default.** Non-admin users will see Request buttons after the upgrade. Turn the feature off with `FEATURE_REQUESTS=false` if you don't want it.
+
+## Fixed
+
+- Approving a music request now shows the download in the approving admin's activity panel instead of running invisibly under the requester's account. (#663)
+- Entries on the Requests page link to their artist and album pages.
+- Discover Weekly no longer downloads albums for non-admin users; acquiring new music is admin-only or request-mediated. (#663)
+- Fixed a federation sync query that could exhaust database memory on servers syncing large peer libraries. (#713)
+- Audiobook libraries now stay in step with Audiobookshelf in both directions: newly added books appear within about five minutes, and books deleted from Audiobookshelf are removed from soundspan (covers and listening state included) on the next full sync — with careful safeguards so a flaky or partial Audiobookshelf response never deletes anything. (#710, #712)
+
+## Added
+
+- **Music requests (MVP).** Non-admin users get a Request button on albums and Release Radar entries they can't download, plus per-album Request badges on artist pages. Admins review the queue on a new Requests page (open it from your avatar menu), where artist and album names link straight to their pages; approving starts the download through the server's normal download path. Requesters get notifications when a request is approved, declined, fulfilled, or fails. Limits: one open request per album per user and a daily cap per user (`REQUESTS_PER_USER_PER_DAY`, default 10). Kill switch: `FEATURE_REQUESTS=false`. This is the first slice of the request system — artist-level requests, auto-approval for trusted users, and per-user quotas are planned follow-ups. (#663)
+- **Peer playlists you can actually use.** Browse a connected peer's public playlists, follow them with live availability, or copy the playable tracks into a playlist of your own. Sharing uses the existing federation connection; private playlists, account ids, and emails are never exposed.
+- **Presence across servers.** Users who share their online presence now appear in the Social tab of federated peer servers, with the same privacy controls as local presence. Snapshots expire automatically if servers stop syncing.
+- **Configurable playback source priority.** Choose the order soundspan tries sources when playing a track: the default is your library → peer libraries → TIDAL → YouTube Music. (#683)
+- **YouTube Music album downloads.** Pick **YouTube Music (Albums)** as a download source (or fallback) in Admin → Download Preferences; albums download through the `ytmusic-streamer` sidecar with proper file naming and tags, then trigger a library scan. (#701)
+- Federation admins can set the instance display name shown to peers, and the peer health panel now classifies connection failures and reports embedding-sync outcomes.
+
+## Changed
+
+- **One switch for presence, one rule for playlists.** The per-user "share with trusted peers" toggles and the admin "Show user status from peers" toggle are gone. **Share online presence** controls your visibility everywhere; **Share listening status** still controls whether people see what you're playing; public playlists are public, including to peers.
+- Peer playlists appear alongside local playlists in the sidebar and on the Playlists page, badged with their server. Both surfaces gain a Local/Peers filter (only shown when federation is enabled).
+- **Federation pairing is simpler**: the host admin issues a credential, the other server connects with it. The old pairing-code flow is removed. Setup errors now say what actually went wrong (unreachable, TLS, authorization, or invalid peer). Existing peer connections keep working unchanged. (#708)
+- Tracks streamed from peers are now a first-class playback source: they rank between your own files and streaming providers while the peer is online, and fall back to a provider copy instead of failing when the peer goes offline. (#683)
+- The TIDAL sidecar is renamed `tidal-downloader` → `tidal-streamer`. Old image names and network hostnames keep working as aliases — no action needed. (#701)
+
+## Deprecated
+
+- None documented in this release.
+
+## Removed
+
+- Federation pairing codes. Servers running versions that only support pairing codes can no longer pair against an upgraded server; upgrade both sides or use a host credential. In-flight codes stop working on upgrade. (#708)
+- The old unimplemented release-radar download endpoint (it always returned an error); the Release Radar page now uses the real download and request flows. (#663)
+
+## Accessibility
+
+- No accessibility improvements documented in this release.
+
+## Admin/Operations
+
+- New environment knobs: `FEATURE_REQUESTS` (default `true`) and `REQUESTS_PER_USER_PER_DAY` (default `10`). Both are plumbed through docker-compose and the AIO image.
+- A lightweight background job (every 5 minutes) settles approved requests when their download finishes and notifies the requester.
+- Non-admin users can no longer trigger downloads through any path, including the deprecated legacy Discover mode; requests are the only way non-admins bring new music in.
+- New request metrics: `soundspan_music_requests_total{action}`.
+- Node runtime images no longer ship npm/npx/corepack, removing a recurring source of CVE scan findings. (#671, #717)
+
+## Deployment and Distribution
+
+- Docker image: `ghcr.io/soundspan/soundspan`
+- Helm chart repository: `https://soundspan.github.io/soundspan`
+- Helm chart name: `soundspan`
+- Helm chart reference: `soundspan/soundspan`
+
+```bash
+helm repo add soundspan https://soundspan.github.io/soundspan
+helm repo update
+helm upgrade --install soundspan soundspan/soundspan --version 2.5.0
+```
+
+## Breaking Changes
+
+- Federation pairing codes are removed. A peer that only knows how to pair with codes must upgrade before it can pair with a 2.5.0 server. Existing established peer connections are unaffected. (#708)
+- The per-user peer-sharing opt-outs are removed. Users who kept presence or public playlists local-only through those toggles are now shared with peers; the remedy is turning off **Share online presence** or making the playlist private. (See "Before you upgrade".)
+
+## Known Issues
+
+- The admin Requests page shows the newest 200 requests without pagination; filtering is client-side. Fine at typical scale, and pagination is planned with the request-system follow-ups (#725).
+
+## Compatibility and Migration
+
+- Database migrations run automatically on startup: the new music-request table is added, and the removed per-user and admin peer-sharing settings columns are dropped. No manual steps.
+- Federation wire compatibility: 2.5.0 servers interoperate with 2.4.x peers for library sync and streaming. Pairing *new* connections requires the credential flow on both sides.
+
+## Upgrading from an earlier version
+
+If you are upgrading from a version earlier than 2.0.0, you must complete the
+2.0.0 upgrade before you install 2.5.0. The 2.0.0 release contains breaking
+changes that later releases depend on. Read the
+[2.0.0 release notes](https://github.com/soundspan/soundspan/blob/2.0.0/docs/release-notes/RELEASE_NOTES_2.0.0.md)
+and complete the
+[2.0.0 upgrade guide](https://github.com/soundspan/soundspan/blob/2.0.0/docs/UPGRADING_TO_2.0.0.md).
+
+## Full Changelog
+
+- Compare changes: [2.4.1...2.5.0](https://github.com/soundspan/soundspan/compare/2.4.1...2.5.0)
+- Full changelog: https://github.com/soundspan/soundspan/blob/2.5.0/CHANGELOG.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundspan-frontend",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@soundspan/media-metadata-contract": "file:../packages/media-metadata-contract",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "soundspan-frontend",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "engines": {
         "node": ">=24.0.0"
     },


### PR DESCRIPTION
Stages the 2.5.0 minor release. **Merging this PR is the release decision** — after merge I tag the merge commit and publish the GitHub release, which triggers the versioned image builds and the helm-chart publish.

## Scope (everything on main since 2.4.1)

- **Music requests (MVP)** — request button → admin approval queue → normal download path → requester notifications, with artist-page badges, a role-aware Requests page, admin-owned approval downloads, and linked request rows (#663, #729–#731). Framed as an MVP in the notes; follow-ups tracked in #725/#726/#727.
- **Social simplification** — one presence switch spanning peers, public playlists shared with peers, unified playlist surfaces, credential-only pairing (pairing codes removed), always-on peer presence display (#708, #714, #718, #721–#723).
- **Playback source priority** (#709) and **YouTube Music album downloads** (#701), TIDAL sidecar rename with full aliasing (#701).
- **Fixes**: federation sync dedup OOM (#713, #716), audiobook cache two-way sync (#710, #711, #712, #724), non-admin Discover acquisition lockdown (#728), runtime image npm removal (#719).

## Release mechanics in this PR

- Version bumps: backend + frontend packages/lockfiles, chart `version`/`appVersion`, all 8 values.yaml image-tag defaults.
- CHANGELOG promoted to `## [2.5.0] - 2026-08-23` with a fresh empty Unreleased above.
- `docs/release-notes/RELEASE_NOTES_2.5.0.md` — plain-language, MVP framing on requests, both default-behavior changes (presence-to-peers, requests-on-by-default) called out in "Before you upgrade".
- `docs/UPGRADING.md` — 2.5.0 row + section (sharing defaults, `FEATURE_REQUESTS`, pairing codes, TIDAL rename folded in from the former Unreleased section).

## Verification

- `npm run verify:helm` exit 0 (chart lints and renders at 2.5.0).
- `npm run verify:gates` exit 0 (release-helper tests + repo-wide prettier + ratchets).
- Prettier clean on CHANGELOG, release notes, UPGRADING.
- Scale-smoke runs on this branch push — blocking if red.

Not in this release: #700 (still open) ships whenever it merges.