### PR TITLE
chore(changelog): add required empty subsection headings to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
 ## [2.5.0] - 2026-08-23
 
 ### Added


### PR DESCRIPTION
The release-tag validator requires `[Unreleased]` to carry `### Added` / `### Changed` / `### Fixed` even when empty. The 2.5.0 promotion left the section bare, which failed the release Image Builds run at the validate step. Same fix shape as 7f56ae67 after 2.4.1. After merge, the 2.5.0 tag and release get recreated on the new tip so validation passes.