### PR TITLE
fix(downloads): route album retries through the configured download source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retrying a failed album download now uses the configured download source instead of always routing to Lidarr.
+
 ## [2.5.0] - 2026-08-23
 
 ### Added

--- a/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsInteractiveCompat.test.ts
@@ -15,6 +15,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: () => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        }),
     },
 }));
 

--- a/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
+++ b/backend/src/routes/__tests__/downloadsReleasesCompat.test.ts
@@ -20,6 +20,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: () => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        }),
     },
 }));
 

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -48,8 +48,6 @@ jest.mock("../../services/soulseek", () => ({
 jest.mock("../../services/tidal", () => ({
     tidalService: {
         isAvailable: jest.fn(),
-        findAlbum: jest.fn(),
-        downloadAlbum: jest.fn(),
     },
 }));
 
@@ -59,8 +57,10 @@ jest.mock("../../services/youtubeDownload", () => ({
     },
 }));
 
-jest.mock("../../services/youtubeLibraryDownload", () => ({
-    processYoutubeDownload: jest.fn(),
+const mockDispatchAlbumDownload = jest.fn();
+jest.mock("../../services/downloadDispatcher", () => ({
+    dispatchAlbumDownload: (...args: unknown[]) =>
+        mockDispatchAlbumDownload(...args),
 }));
 
 jest.mock("../../services/musicbrainz", () => ({
@@ -79,21 +79,13 @@ jest.mock("../../services/lastfm", () => ({
 
 jest.mock("../../services/simpleDownloadManager", () => ({
     simpleDownloadManager: {
-        startDownload: jest.fn(),
         clearLidarrQueue: jest.fn(),
-    },
-}));
-
-jest.mock("../../workers/queues", () => ({
-    scanQueue: {
-        add: jest.fn(),
     },
 }));
 
 jest.mock("../../utils/db", () => ({
     prisma: {
         downloadJob: {
-            findUnique: jest.fn(),
             findMany: jest.fn(),
             findFirst: jest.fn(),
             update: jest.fn(),
@@ -123,11 +115,9 @@ import { lidarrService } from "../../services/lidarr";
 import { soulseekService } from "../../services/soulseek";
 import { tidalService } from "../../services/tidal";
 import { youtubeDownloadService } from "../../services/youtubeDownload";
-import { processYoutubeDownload } from "../../services/youtubeLibraryDownload";
 import { musicBrainzService } from "../../services/musicbrainz";
 import { lastFmService } from "../../services/lastfm";
 import { simpleDownloadManager } from "../../services/simpleDownloadManager";
-import { scanQueue } from "../../workers/queues";
 import { logger } from "../../utils/logger";
 
 const mockGetSystemSettings = getSystemSettings as jest.Mock;
@@ -139,22 +129,16 @@ const mockLidarrGrabRelease = lidarrService.grabRelease as jest.Mock;
 
 const mockSoulseekAvailable = soulseekService.isAvailable as jest.Mock;
 const mockTidalAvailable = tidalService.isAvailable as jest.Mock;
-const mockTidalFindAlbum = tidalService.findAlbum as jest.Mock;
-const mockTidalDownloadAlbum = tidalService.downloadAlbum as jest.Mock;
 const mockYoutubeAvailable = youtubeDownloadService.isAvailable as jest.Mock;
-const mockProcessYoutubeDownload = processYoutubeDownload as jest.Mock;
 
 const mockGetArtist = musicBrainzService.getArtist as jest.Mock;
 const mockGetReleaseGroups = musicBrainzService.getReleaseGroups as jest.Mock;
 const mockGetArtistCorrection = lastFmService.getArtistCorrection as jest.Mock;
 
-const mockStartDownload = simpleDownloadManager.startDownload as jest.Mock;
 const mockClearLidarrQueue =
     simpleDownloadManager.clearLidarrQueue as jest.Mock;
-const mockScanQueueAdd = scanQueue.add as jest.Mock;
 const mockLogger = logger as jest.Mocked<typeof logger>;
 
-const mockDownloadFindUnique = prisma.downloadJob.findUnique as jest.Mock;
 const mockDownloadFindMany = prisma.downloadJob.findMany as jest.Mock;
 const mockDownloadFindFirst = prisma.downloadJob.findFirst as jest.Mock;
 const mockDownloadUpdate = prisma.downloadJob.update as jest.Mock;
@@ -269,25 +253,12 @@ describe("downloads routes runtime", () => {
         mockSoulseekAvailable.mockResolvedValue(true);
         mockTidalAvailable.mockResolvedValue(false);
         mockYoutubeAvailable.mockResolvedValue(false);
-        mockProcessYoutubeDownload.mockResolvedValue(undefined);
-        mockTidalFindAlbum.mockResolvedValue(null);
-        mockTidalDownloadAlbum.mockResolvedValue({
-            downloaded: 0,
-            failed: 0,
-            total_tracks: 0,
-            artist: "",
-            album_title: "",
-        });
+        mockDispatchAlbumDownload.mockResolvedValue(undefined);
 
         mockGetArtist.mockResolvedValue(null);
         mockGetReleaseGroups.mockResolvedValue([]);
         mockGetArtistCorrection.mockResolvedValue(null);
 
-        mockDownloadFindUnique.mockResolvedValue({
-            id: "job-1",
-            userId: "user-1",
-            metadata: {},
-        });
         mockDownloadFindMany.mockResolvedValue([]);
         mockDownloadFindFirst.mockResolvedValue(null);
         mockDownloadUpdate.mockResolvedValue({});
@@ -305,9 +276,7 @@ describe("downloads routes runtime", () => {
 
         mockAlbumFindFirst.mockResolvedValue(null);
 
-        mockStartDownload.mockResolvedValue({ success: true });
         mockClearLidarrQueue.mockResolvedValue({ removed: 2, errors: [] });
-        mockScanQueueAdd.mockResolvedValue(undefined);
 
         mockTransaction.mockImplementation(async (callback: any) =>
             callback({
@@ -528,104 +497,6 @@ describe("downloads routes runtime", () => {
         });
     });
 
-    it("dispatches an available configured youtube source", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "youtube",
-            primaryFailureFallback: "none",
-            ytMusicEnabled: true,
-        });
-        mockYoutubeAvailable.mockResolvedValue(true);
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-youtube",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
-            "job-1",
-            "Artist",
-            "Album",
-            "user-1",
-        );
-        expect(mockStartDownload).not.toHaveBeenCalled();
-    });
-
-    it("uses youtube as an available fallback source", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "youtube",
-            ytMusicEnabled: true,
-        });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockYoutubeAvailable.mockResolvedValue(true);
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-youtube-fallback",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
-            "job-1",
-            "Artist",
-            "Album",
-            "user-1",
-        );
-    });
-
-    it("falls back from unavailable youtube to soulseek", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "youtube",
-            primaryFailureFallback: "soulseek",
-            ytMusicEnabled: true,
-        });
-        mockYoutubeAvailable.mockResolvedValue(false);
-        mockSoulseekAvailable.mockResolvedValue(true);
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-youtube-primary",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-1",
-            "Artist",
-            "Album",
-            "rg-youtube-primary",
-            "user-1",
-        );
-        expect(mockProcessYoutubeDownload).not.toHaveBeenCalled();
-    });
-
     it("returns duplicate details when album job already exists in transaction", async () => {
         mockTransaction.mockImplementationOnce(async (callback: any) =>
             callback({
@@ -667,7 +538,7 @@ describe("downloads routes runtime", () => {
         );
     });
 
-    it("creates an album job and triggers simple download manager", async () => {
+    it("creates an album job and wires it to the dispatcher", async () => {
         mockGetArtistCorrection.mockResolvedValueOnce({
             corrected: true,
             canonicalName: "Correct Artist",
@@ -683,11 +554,6 @@ describe("downloads routes runtime", () => {
                 },
             }),
         );
-
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-created",
-            userId: "user-1",
-        });
 
         const req = {
             body: {
@@ -712,155 +578,14 @@ describe("downloads routes runtime", () => {
                 message: "Download job created. Processing in background.",
             }),
         );
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-created",
-            "Correct Artist",
-            "Album",
-            "rg-1",
-            "user-1",
-        );
-    });
-
-    it("fails the job instead of rerouting when the primary source is unavailable and fallback is Skip", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "none",
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-created",
+            type: "album",
+            mbid: "rg-1",
+            subject: "Typo Artist - Album",
+            artistName: "Correct Artist",
+            albumTitle: "Album",
         });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockLidarrIsEnabled.mockResolvedValue(true);
-        mockSoulseekAvailable.mockResolvedValue(true);
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-skip",
-                subject: "Ella Langley - Hungover",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(res.statusCode).toBe(200);
-        expect(mockStartDownload).not.toHaveBeenCalled();
-        expect(mockTidalFindAlbum).not.toHaveBeenCalled();
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: expect.stringContaining("Skip"),
-                    metadata: expect.objectContaining({
-                        statusText: "tidal unavailable — skipped",
-                    }),
-                }),
-            }),
-        );
-    });
-
-    it("uses the explicitly configured fallback source when the primary is unavailable", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "lidarr",
-        });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockLidarrIsEnabled.mockResolvedValue(true);
-        mockSoulseekAvailable.mockResolvedValue(false);
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fb",
-                subject: "Artist - Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-1",
-            "Artist",
-            "Album",
-            "rg-fb",
-            "user-1",
-        );
-    });
-
-    it("fails the job when both the primary and its configured fallback are unavailable", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "lidarr",
-        });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockLidarrIsEnabled.mockResolvedValue(false);
-        mockSoulseekAvailable.mockResolvedValue(true);
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fb-down",
-                subject: "Artist - Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        // Soulseek being available must NOT rescue the job — the user chose lidarr
-        expect(mockStartDownload).not.toHaveBeenCalled();
-        expect(mockTidalFindAlbum).not.toHaveBeenCalled();
-        // The status text must say the fallback was unavailable — NOT "skipped",
-        // which would misrepresent a non-Skip failure in the UI
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: expect.stringContaining("unavailable"),
-                    metadata: expect.objectContaining({
-                        statusText: "tidal and fallback lidarr unavailable",
-                    }),
-                }),
-            }),
-        );
-    });
-
-    it("keeps legacy auto-detect rerouting when no fallback preference is stored", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-        });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockLidarrIsEnabled.mockResolvedValue(true);
-        mockSoulseekAvailable.mockResolvedValue(true);
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-legacy",
-                subject: "Artist - Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalled();
-        expect(mockDownloadUpdate).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: expect.objectContaining({ status: "failed" }),
-            }),
-        );
     });
 
     it("returns existing active job for P2002 race-condition collisions", async () => {
@@ -1607,12 +1332,6 @@ describe("downloads routes runtime", () => {
                     },
                 }),
             );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-new",
-            userId: "user-1",
-            metadata: {},
-        });
-
         const req = {
             body: {
                 type: "artist",
@@ -1633,13 +1352,14 @@ describe("downloads routes runtime", () => {
                 jobs: [{ id: "job-new", subject: "Artist Name - New Album" }],
             }),
         );
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-new",
-            "Artist Name",
-            "New Album",
-            "rg-new",
-            "user-1",
-        );
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-new",
+            type: "album",
+            mbid: "rg-new",
+            subject: "Artist Name - New Album",
+            artistName: "Artist Name",
+            albumTitle: "New Album",
+        });
     });
 
     it("skips recently failed artist albums without creating new jobs", async () => {
@@ -1684,7 +1404,7 @@ describe("downloads routes runtime", () => {
                 jobs: [],
             }),
         );
-        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
     });
 
     it("returns 500 when listing failed albums throws", async () => {
@@ -1720,166 +1440,6 @@ describe("downloads routes runtime", () => {
         expect(res.body).toEqual({ error: "Failed to delete failed album" });
     });
 
-    it("ignores background album processing when job lookup misses", async () => {
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-missing",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce(null);
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-missing-job",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(res.statusCode).toBe(200);
-        expect(mockStartDownload).not.toHaveBeenCalled();
-    });
-
-    it("parses artist/album from subject when album metadata is missing", async () => {
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-parse",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-parse",
-            userId: "user-1",
-            metadata: {},
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-parse",
-                subject: "SingleSubject",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-parse",
-            "SingleSubject",
-            "SingleSubject",
-            "rg-parse",
-            "user-1",
-        );
-    });
-
-    it("parses artist/album split from subject when delimiter is present", async () => {
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-parse-split",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-parse-split",
-            userId: "user-1",
-            metadata: {},
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-parse-split",
-                subject: "Split Artist - Split Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-parse-split",
-            "Split Artist",
-            "Split Album",
-            "rg-parse-split",
-            "user-1",
-        );
-    });
-
-    it("logs failed simple download starts without crashing create job flow", async () => {
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-simple-fail",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-simple-fail",
-            userId: "user-1",
-            metadata: {},
-        });
-        mockStartDownload.mockResolvedValueOnce({
-            success: false,
-            error: "unavailable indexer",
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-simple-fail",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(res.statusCode).toBe(200);
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-simple-fail",
-            "Artist",
-            "Album",
-            "rg-simple-fail",
-            "user-1",
-        );
-    });
-
     it("handles background processor rejections from single album jobs", async () => {
         mockTransaction.mockImplementationOnce(async (callback: any) =>
             callback({
@@ -1892,12 +1452,9 @@ describe("downloads routes runtime", () => {
                 },
             }),
         );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-throw",
-            userId: "user-1",
-            metadata: {},
-        });
-        mockStartDownload.mockRejectedValueOnce(new Error("start threw"));
+        mockDispatchAlbumDownload.mockRejectedValueOnce(
+            new Error("dispatch threw"),
+        );
 
         const req = {
             body: {
@@ -1915,6 +1472,10 @@ describe("downloads routes runtime", () => {
         await flushAsyncWork();
 
         expect(res.statusCode).toBe(200);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "Download processing failed for job job-throw:",
+            expect.any(Error),
+        );
     });
 
     it("uses LastFM artist correction for artist downloads when MusicBrainz lookup fails", async () => {
@@ -1986,12 +1547,9 @@ describe("downloads routes runtime", () => {
                 },
             }),
         );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-batch-1",
-            userId: "user-1",
-            metadata: {},
-        });
-        mockStartDownload.mockRejectedValueOnce(new Error("batch failure"));
+        mockDispatchAlbumDownload.mockRejectedValueOnce(
+            new Error("batch failure"),
+        );
 
         const req = {
             body: {
@@ -2007,535 +1565,14 @@ describe("downloads routes runtime", () => {
         await flushAsyncWork();
 
         expect(res.statusCode).toBe(200);
-        expect(mockStartDownload).toHaveBeenCalled();
-    });
-
-    it("falls back to soulseek when configured tidal source is unavailable", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "soulseek",
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-batch-1",
+            type: "album",
+            mbid: "rg-batch-1",
+            subject: "Batch Artist - Batch Album",
+            artistName: "Batch Artist",
+            albumTitle: "Batch Album",
         });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockSoulseekAvailable.mockResolvedValue(true);
-        mockLidarrIsEnabled.mockResolvedValue(true);
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-fallback-1",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-fallback-1",
-            userId: "user-1",
-            metadata: {},
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fallback-1",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-fallback-1",
-            "Artist",
-            "Album",
-            "rg-fallback-1",
-            "user-1",
-        );
-    });
-
-    it("falls back to tidal when configured soulseek source is unavailable", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "soulseek",
-            primaryFailureFallback: "tidal",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockSoulseekAvailable.mockResolvedValue(false);
-        mockLidarrIsEnabled.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce({
-            albumId: 789,
-            title: "Album",
-            artist: "Artist",
-            numberOfTracks: 6,
-        });
-        mockTidalDownloadAlbum.mockResolvedValueOnce({
-            downloaded: 6,
-            failed: 0,
-            total_tracks: 6,
-            artist: "Artist",
-            album_title: "Album",
-        });
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-fallback-3",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-fallback-3",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return {
-                metadata: { albumMbid: "rg-fallback-3" },
-            };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fallback-3",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockTidalFindAlbum).toHaveBeenCalledWith("Artist", "Album");
-    });
-
-    it("falls back to soulseek when configured lidarr source is unavailable", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "lidarr",
-            primaryFailureFallback: "soulseek",
-        });
-        mockTidalAvailable.mockResolvedValue(false);
-        mockSoulseekAvailable.mockResolvedValue(true);
-        mockLidarrIsEnabled.mockResolvedValue(false);
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-fallback-2",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockDownloadFindUnique.mockResolvedValueOnce({
-            id: "job-fallback-2",
-            userId: "user-1",
-            metadata: {},
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fallback-2",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-fallback-2",
-            "Artist",
-            "Album",
-            "rg-fallback-2",
-            "user-1",
-        );
-    });
-
-    it("completes tidal downloads and queues a library scan", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "none",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce({
-            albumId: 123,
-            title: "Album",
-            artist: "Artist",
-            numberOfTracks: 10,
-        });
-        mockTidalDownloadAlbum.mockResolvedValueOnce({
-            downloaded: 9,
-            failed: 1,
-            total_tracks: 10,
-            artist: "Artist",
-            album_title: "Album",
-        });
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-tidal",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-tidal",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return {
-                metadata: { albumMbid: "rg-tidal" },
-            };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-tidal",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockTidalFindAlbum).toHaveBeenCalledWith("Artist", "Album");
-        expect(mockTidalDownloadAlbum).toHaveBeenCalledWith(123);
-        expect(mockScanQueueAdd).toHaveBeenCalledWith(
-            "scan",
-            expect.objectContaining({
-                userId: "user-1",
-                source: "tidal-download",
-                artistName: "Artist",
-                albumTitle: "Album",
-            }),
-        );
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-tidal" },
-                data: expect.objectContaining({
-                    status: "completed",
-                }),
-            }),
-        );
-    });
-
-    it("persists a sanitized error when a tidal download throws", async () => {
-        const rawError =
-            "ECONNREFUSED http://tidal-internal:9999 token=secret123";
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "none",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce({
-            albumId: 321,
-            title: "Album",
-            artist: "Artist",
-            numberOfTracks: 10,
-        });
-        mockTidalDownloadAlbum.mockRejectedValueOnce(new Error(rawError));
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-tidal-error",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-tidal-error",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return { metadata: { albumMbid: "rg-tidal-error" } };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-tidal-error",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        const failedUpdate = mockDownloadUpdate.mock.calls.find(
-            ([call]) => call.data?.status === "failed",
-        )?.[0];
-        expect(failedUpdate).toEqual(
-            expect.objectContaining({
-                where: { id: "job-tidal-error" },
-                data: expect.objectContaining({
-                    error: "TIDAL download failed",
-                }),
-            }),
-        );
-        expect(JSON.stringify(failedUpdate)).not.toContain(rawError);
-    });
-
-    it("falls back when tidal cannot find album and reports fallback failures", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "soulseek",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce(null);
-        mockStartDownload.mockResolvedValueOnce({
-            success: false,
-            error: "fallback failed",
-        });
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-tidal-fallback",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-tidal-fallback",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return {
-                metadata: { albumMbid: "rg-fallback" },
-            };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-fallback",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockStartDownload).toHaveBeenCalledWith(
-            "job-tidal-fallback",
-            "Artist",
-            "Album",
-            "rg-fallback",
-            "user-1",
-        );
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-tidal-fallback" },
-                data: expect.objectContaining({
-                    metadata: expect.objectContaining({
-                        currentSource: "soulseek",
-                        statusText: "TIDAL not found → soulseek",
-                    }),
-                }),
-            }),
-        );
-    });
-
-    it("marks tidal jobs failed when album lookup misses and no fallback is configured", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "none",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce(null);
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-tidal-fail",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-tidal-fail",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return {
-                metadata: {},
-            };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-tidal-fail",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-tidal-fail" },
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: "TIDAL download failed",
-                }),
-            }),
-        );
-        expect(JSON.stringify(mockDownloadUpdate.mock.calls)).not.toContain(
-            "Album not found on TIDAL",
-        );
-    });
-
-    it("marks tidal jobs failed when zero tracks download", async () => {
-        mockGetSystemSettings.mockResolvedValue({
-            musicPath: "/music",
-            downloadSource: "tidal",
-            primaryFailureFallback: "none",
-        });
-        mockTidalAvailable.mockResolvedValue(true);
-        mockTidalFindAlbum.mockResolvedValueOnce({
-            albumId: 456,
-            title: "Album",
-            artist: "Artist",
-            numberOfTracks: 8,
-        });
-        mockTidalDownloadAlbum.mockResolvedValueOnce({
-            downloaded: 0,
-            failed: 8,
-            total_tracks: 8,
-            artist: "Artist",
-            album_title: "Album",
-        });
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest.fn().mockResolvedValue([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-tidal-zero",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        let findUniqueCall = 0;
-        mockDownloadFindUnique.mockImplementation(async () => {
-            findUniqueCall += 1;
-            if (findUniqueCall === 1) {
-                return {
-                    id: "job-tidal-zero",
-                    userId: "user-1",
-                    metadata: {},
-                };
-            }
-            return {
-                metadata: {},
-            };
-        });
-
-        const req = {
-            body: {
-                type: "album",
-                mbid: "rg-tidal-zero",
-                subject: "Artist - Album",
-                artistName: "Artist",
-                albumTitle: "Album",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(mockDownloadUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-tidal-zero" },
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: "TIDAL download failed",
-                }),
-            }),
-        );
-        expect(JSON.stringify(mockDownloadUpdate.mock.calls)).not.toContain(
-            "All 8 tracks failed to download",
-        );
     });
 
     it("returns 500 when fetching a job throws", async () => {

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -8,14 +8,13 @@ jest.mock("../../middleware/auth", () => ({
     },
 }));
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
-}));
+const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
 const notificationService = {
     getForUser: jest.fn(),
@@ -74,6 +73,12 @@ const simpleDownloadManager = {
 };
 jest.mock("../../services/simpleDownloadManager", () => ({
     simpleDownloadManager,
+}));
+
+const dispatchAlbumDownload = jest.fn();
+jest.mock("../../services/downloadDispatcher", () => ({
+    dispatchAlbumDownload: (...args: unknown[]) =>
+        dispatchAlbumDownload(...args),
 }));
 
 import router from "../notifications";
@@ -142,6 +147,46 @@ function createRes() {
 async function flushAsyncWork() {
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function captureUnhandledRejections(
+    run: () => Promise<void>,
+): Promise<unknown[]> {
+    const rejections: unknown[] = [];
+    const capture = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", capture);
+    try {
+        await run();
+        await flushAsyncWork();
+        return rejections;
+    } finally {
+        process.off("unhandledRejection", capture);
+    }
+}
+
+function prepareSpotifyImportFallback(id: string): void {
+    prisma.downloadJob.findFirst.mockResolvedValueOnce({
+        id: `job-${id}`,
+        userId: "u1",
+        subject: "Artist - Album",
+        type: "album",
+        targetMbid: `mbid-${id}`,
+        artistMbid: "artist-mbid",
+        metadata: {
+            downloadType: "spotify_import",
+            artistName: "Artist",
+            albumTitle: "Album",
+        },
+    });
+    prisma.downloadJob.create.mockResolvedValueOnce({
+        id: `job-new-${id}`,
+        metadata: {},
+    });
+    getSystemSettings.mockResolvedValueOnce({ musicPath: "/music" });
+    soulseekService.searchAndDownloadBatch.mockResolvedValueOnce({
+        successful: 0,
+        files: [],
+    });
 }
 
 describe("notifications route runtime", () => {
@@ -213,6 +258,7 @@ describe("notifications route runtime", () => {
             success: true,
             error: null,
         });
+        dispatchAlbumDownload.mockResolvedValue(undefined);
     });
 
     it("requires admin authorization for download retries", () => {
@@ -238,12 +284,13 @@ describe("notifications route runtime", () => {
         expect(soulseekService.downloadBestMatch).not.toHaveBeenCalled();
         expect(soulseekService.searchAndDownloadBatch).not.toHaveBeenCalled();
         expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
+        expect(dispatchAlbumDownload).not.toHaveBeenCalled();
         expect(prisma.downloadJob.updateMany).not.toHaveBeenCalled();
         expect(prisma.downloadJob.update).not.toHaveBeenCalled();
         expect(prisma.downloadJob.create).not.toHaveBeenCalled();
     });
 
-    it("allows admin download retries through the route stack", async () => {
+    it("routes an admin generic album retry through the dispatcher", async () => {
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
             id: "job-generic",
             userId: "u1",
@@ -257,13 +304,26 @@ describe("notifications route runtime", () => {
             id: "job-new-generic",
             metadata: {},
         });
+        let resolveDispatch!: () => void;
+        dispatchAlbumDownload.mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveDispatch = resolve;
+                }),
+        );
         const req = {
             user: { id: "u1", role: "admin" },
             params: { id: "job-generic" },
         } as any;
         const res = createRes();
 
-        await invokeRouteStack("/downloads/:id/retry", "post", req, res);
+        const retryPromise = invokeRouteStack(
+            "/downloads/:id/retry",
+            "post",
+            req,
+            res,
+        );
+        await flushAsyncWork();
 
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({
@@ -271,14 +331,145 @@ describe("notifications route runtime", () => {
             newJobId: "job-new-generic",
             error: null,
         });
+        expect(dispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-new-generic",
+            type: "album",
+            mbid: "album-mbid",
+            subject: "Artist - Album",
+            artistName: "Artist",
+            albumTitle: "Album",
+        });
+        resolveDispatch();
+        await retryPromise;
+        await flushAsyncWork();
+        expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
+    });
+
+    it("marks a scheduled generic album retry failed when dispatch rejects", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-generic-failed",
+            userId: "u1",
+            subject: "Artist - Album",
+            type: "album",
+            targetMbid: "album-mbid",
+            artistMbid: "artist-mbid",
+            metadata: { albumTitle: "Album" },
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-generic-failed",
+            metadata: {},
+        });
+        const dispatchError = new Error("provider token=dispatch-secret");
+        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
+        const req = {
+            user: { id: "u1", role: "admin" },
+            params: { id: "job-generic-failed" },
+        } as any;
+        const res = createRes();
+
+        await retryDownload(req, res);
+        await flushAsyncWork();
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-generic-failed",
+            error: null,
+        });
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith({
+            where: { id: "job-new-generic-failed" },
+            data: {
+                status: "failed",
+                error: "Download dispatch failed",
+                completedAt: expect.any(Date),
+            },
+        });
+        expect(
+            JSON.stringify(prisma.downloadJob.update.mock.calls),
+        ).not.toContain("dispatch-secret");
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Album dispatch error:",
+            dispatchError,
+        );
+        expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
+    });
+
+    it("logs when generic album dispatch failure persistence rejects", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-generic-persistence-failed",
+            userId: "u1",
+            subject: "Artist - Album",
+            type: "album",
+            targetMbid: "album-mbid",
+            artistMbid: "artist-mbid",
+            metadata: { albumTitle: "Album" },
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-generic-persistence-failed",
+            metadata: {},
+        });
+        const dispatchError = new Error("dispatch unavailable");
+        const persistenceError = new Error("database unavailable");
+        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
+        prisma.downloadJob.update
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(persistenceError);
+        const req = {
+            user: { id: "u1", role: "admin" },
+            params: { id: "job-generic-persistence-failed" },
+        } as any;
+        const res = createRes();
+
+        await retryDownload(req, res);
+        await flushAsyncWork();
+
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-generic-persistence-failed",
+            error: null,
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Failed to persist album dispatch failure:",
+            persistenceError,
+        );
+    });
+
+    it("keeps generic artist retries on the simple download manager", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-artist",
+            userId: "u1",
+            subject: "Artist Name",
+            type: "artist",
+            targetMbid: "artist-target-mbid",
+            artistMbid: "artist-mbid",
+            metadata: {},
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-artist",
+            metadata: {},
+        });
+        const req = {
+            user: { id: "u1", role: "admin" },
+            params: { id: "job-artist" },
+        } as any;
+        const res = createRes();
+
+        await retryDownload(req, res);
+
         expect(simpleDownloadManager.startDownload).toHaveBeenCalledWith(
-            "job-new-generic",
-            "Artist",
-            "Album",
-            "album-mbid",
+            "job-new-artist",
+            "Artist Name",
+            "Artist Name",
+            "artist-target-mbid",
             "u1",
             false,
         );
+        expect(dispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-artist",
+            error: null,
+        });
     });
 
     it("handles notification listing/read/clear endpoints", async () => {
@@ -813,7 +1004,60 @@ describe("notifications route runtime", () => {
         ).not.toContain(pendingRawError);
     });
 
-    it("validates spotify_import retries and generic retries", async () => {
+    it("logs when pending-track failure persistence rejects", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-pending-persistence-failed",
+            userId: "u1",
+            subject: "Artist - Title",
+            type: "track",
+            targetMbid: "target-pending-persistence-failed",
+            artistMbid: null,
+            metadata: {
+                downloadType: "pending-track-retry",
+                playlistId: "pl-1",
+                pendingTrackId: "pt-1",
+            },
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-pending-persistence-failed",
+            metadata: {},
+        });
+        getSystemSettings.mockResolvedValueOnce({
+            musicPath: "/music",
+            soulseekUsername: "user",
+            soulseekPassword: "pass",
+        });
+        soulseekService.searchTrack.mockResolvedValueOnce({
+            found: true,
+            allMatches: [{ id: "m1" }],
+        });
+        soulseekService.downloadBestMatch.mockRejectedValueOnce(
+            new Error("download unavailable"),
+        );
+        const persistenceError = new Error("database unavailable");
+        prisma.downloadJob.update
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(persistenceError);
+        const req = {
+            user: { id: "u1" },
+            params: { id: "job-pending-persistence-failed" },
+        } as any;
+        const res = createRes();
+
+        await retryDownload(req, res);
+        await flushAsyncWork();
+
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-pending-persistence-failed",
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Failed to persist download exception:",
+            persistenceError,
+        );
+    });
+
+    it("validates spotify_import retries and generic retry MBIDs", async () => {
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
             id: "job-spotify-1",
             userId: "u1",
@@ -875,69 +1119,6 @@ describe("notifications route runtime", () => {
         await retryDownload(noMbidReq, noMbidRes);
         expect(noMbidRes.statusCode).toBe(400);
         expect(noMbidRes.body.error).toBe("Cannot retry: missing album MBID");
-
-        prisma.downloadJob.findFirst.mockResolvedValueOnce({
-            id: "job-generic",
-            userId: "u1",
-            subject: "Artist - Album",
-            type: "album",
-            targetMbid: "mbid-generic",
-            artistMbid: "artist-mbid",
-            metadata: { albumTitle: "Album" },
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "job-new-generic",
-            metadata: {},
-        });
-        simpleDownloadManager.startDownload.mockResolvedValueOnce({
-            success: true,
-            error: null,
-        });
-        const genericReq = {
-            user: { id: "u1" },
-            params: { id: "job-generic" },
-        } as any;
-        const genericRes = createRes();
-        await retryDownload(genericReq, genericRes);
-        expect(genericRes.statusCode).toBe(200);
-        expect(genericRes.body).toEqual({
-            success: true,
-            newJobId: "job-new-generic",
-            error: null,
-        });
-
-        prisma.downloadJob.findFirst.mockResolvedValueOnce({
-            id: "job-generic-failed",
-            userId: "u1",
-            subject: "Artist - Album",
-            type: "album",
-            targetMbid: "mbid-generic-failed",
-            artistMbid: "artist-mbid",
-            metadata: { albumTitle: "Album" },
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "job-new-generic-failed",
-            metadata: {},
-        });
-        simpleDownloadManager.startDownload.mockResolvedValueOnce({
-            success: false,
-            error: "raw lidarr detail xyz",
-        });
-        const genericFailedReq = {
-            user: { id: "u1" },
-            params: { id: "job-generic-failed" },
-        } as any;
-        const genericFailedRes = createRes();
-        await retryDownload(genericFailedReq, genericFailedRes);
-        expect(genericFailedRes.statusCode).toBe(200);
-        expect(genericFailedRes.body).toEqual({
-            success: false,
-            newJobId: "job-new-generic-failed",
-            error: "Download failed (details in server log)",
-        });
-        expect(JSON.stringify(genericFailedRes.body)).not.toContain(
-            "raw lidarr detail",
-        );
     });
 
     it("handles spotify_import retry async success/fallback/catch branches", async () => {
@@ -1015,11 +1196,6 @@ describe("notifications route runtime", () => {
             successful: 0,
             files: [],
         });
-        simpleDownloadManager.startDownload.mockResolvedValueOnce({
-            success: false,
-            error: "lidarr failed",
-        });
-
         const lidarrFailReq = {
             user: { id: "u1" },
             params: { id: "job-spotify-lidarr-fail" },
@@ -1028,15 +1204,15 @@ describe("notifications route runtime", () => {
         await retryDownload(lidarrFailReq, lidarrFailRes);
         await flushAsyncWork();
         expect(lidarrFailRes.statusCode).toBe(200);
-        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-new-spotify-lidarr-fail" },
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: "lidarr failed",
-                }),
-            }),
-        );
+        expect(dispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-new-spotify-lidarr-fail",
+            type: "album",
+            mbid: "mbid-spotify-lidarr-fail",
+            subject: "Artist - Album",
+            artistName: "Artist",
+            albumTitle: "Album",
+        });
+        expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
 
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
             id: "job-spotify-no-mbid",
@@ -1123,6 +1299,116 @@ describe("notifications route runtime", () => {
         expect(
             JSON.stringify(prisma.downloadJob.update.mock.calls),
         ).not.toContain(spotifyRawError);
+    });
+
+    it("attributes spotify_import fallback dispatch rejection to dispatch", async () => {
+        prepareSpotifyImportFallback("spotify-dispatch-failed");
+        const dispatchError = new Error("configured source unavailable");
+        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
+        const req = {
+            user: { id: "u1" },
+            params: { id: "job-spotify-dispatch-failed" },
+        } as any;
+        const res = createRes();
+
+        const unhandledRejections = await captureUnhandledRejections(
+            async () => {
+                await retryDownload(req, res);
+            },
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith({
+            where: { id: "job-new-spotify-dispatch-failed" },
+            data: {
+                status: "failed",
+                error: "Download dispatch failed",
+                completedAt: expect.any(Date),
+            },
+        });
+        expect(prisma.downloadJob.update).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ error: "Soulseek error" }),
+            }),
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Album dispatch error:",
+            dispatchError,
+        );
+        expect(unhandledRejections).toEqual([]);
+    });
+
+    it("observes spotify_import fallback failure-persistence rejection", async () => {
+        prepareSpotifyImportFallback("spotify-dispatch-persistence-failed");
+        const persistenceError = new Error("database unavailable");
+        dispatchAlbumDownload.mockRejectedValueOnce(
+            new Error("configured source unavailable"),
+        );
+        prisma.downloadJob.update
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(persistenceError);
+        const req = {
+            user: { id: "u1" },
+            params: { id: "job-spotify-dispatch-persistence-failed" },
+        } as any;
+        const res = createRes();
+
+        const unhandledRejections = await captureUnhandledRejections(
+            async () => {
+                await retryDownload(req, res);
+            },
+        );
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Failed to persist album dispatch failure:",
+            persistenceError,
+        );
+        expect(unhandledRejections).toEqual([]);
+    });
+
+    it("logs when spotify_import failure persistence rejects", async () => {
+        prisma.downloadJob.findFirst.mockResolvedValueOnce({
+            id: "job-spotify-persistence-failed",
+            userId: "u1",
+            subject: "Artist - Album",
+            type: "album",
+            targetMbid: "mbid-spotify-persistence-failed",
+            artistMbid: "artist-mbid",
+            metadata: {
+                downloadType: "spotify_import",
+                artistName: "Artist",
+                albumTitle: "Album",
+            },
+        });
+        prisma.downloadJob.create.mockResolvedValueOnce({
+            id: "job-new-spotify-persistence-failed",
+            metadata: {},
+        });
+        getSystemSettings.mockResolvedValueOnce({ musicPath: "/music" });
+        soulseekService.searchAndDownloadBatch.mockRejectedValueOnce(
+            new Error("soulseek unavailable"),
+        );
+        const persistenceError = new Error("database unavailable");
+        prisma.downloadJob.update
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(persistenceError);
+        const req = {
+            user: { id: "u1" },
+            params: { id: "job-spotify-persistence-failed" },
+        } as any;
+        const res = createRes();
+
+        await retryDownload(req, res);
+        await flushAsyncWork();
+
+        expect(res.body).toEqual({
+            success: true,
+            newJobId: "job-new-spotify-persistence-failed",
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "[Retry] Failed to persist Soulseek error:",
+            persistenceError,
+        );
     });
 
     it("returns 500 when retry handler throws unexpectedly", async () => {

--- a/backend/src/routes/__tests__/requestsRuntime.test.ts
+++ b/backend/src/routes/__tests__/requestsRuntime.test.ts
@@ -5,7 +5,7 @@ const mockListAllRequests = jest.fn();
 const mockApproveRequest = jest.fn();
 const mockDenyRequest = jest.fn();
 const mockGetRequestAvailability = jest.fn();
-const mockProcessDownload = jest.fn();
+const mockDispatchAlbumDownload = jest.fn();
 
 class MockMusicRequestServiceError extends Error {
     constructor(
@@ -50,10 +50,9 @@ jest.mock("../../services/musicRequestService", () => ({
     getRequestAvailability: (...args: unknown[]) =>
         mockGetRequestAvailability(...args),
 }));
-jest.mock("../downloads", () => ({
-    __esModule: true,
-    default: {},
-    processDownload: (...args: unknown[]) => mockProcessDownload(...args),
+jest.mock("../../services/downloadDispatcher", () => ({
+    dispatchAlbumDownload: (...args: unknown[]) =>
+        mockDispatchAlbumDownload(...args),
 }));
 jest.mock("../../utils/logger", () => ({
     logger: {
@@ -149,7 +148,7 @@ describe("requests route runtime", () => {
             remainingToday: 9,
             dailyCap: 10,
         });
-        mockProcessDownload.mockResolvedValue(undefined);
+        mockDispatchAlbumDownload.mockResolvedValue(undefined);
     });
 
     it("requires an interactive authenticated session for the router", async () => {
@@ -344,7 +343,6 @@ describe("requests route runtime", () => {
                 type: "album",
                 mbid: validBody.rgMbid,
                 subject: "Massive Attack - Mezzanine",
-                rootFolderPath: "/music",
                 artistName: "Massive Attack",
                 albumTitle: "Mezzanine",
             },
@@ -358,15 +356,14 @@ describe("requests route runtime", () => {
         );
 
         expect(res.body).toEqual({ id: "request-1", status: "approved" });
-        expect(mockProcessDownload).toHaveBeenCalledWith(
-            "job-1",
-            "album",
-            validBody.rgMbid,
-            "Massive Attack - Mezzanine",
-            "/music",
-            "Massive Attack",
-            "Mezzanine",
-        );
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+            jobId: "job-1",
+            type: "album",
+            mbid: validBody.rgMbid,
+            subject: "Massive Attack - Mezzanine",
+            artistName: "Massive Attack",
+            albumTitle: "Mezzanine",
+        });
     });
 
     it("does not dispatch a duplicate approval job", async () => {
@@ -378,7 +375,7 @@ describe("requests route runtime", () => {
         );
 
         expect(res.statusCode).toBe(200);
-        expect(mockProcessDownload).not.toHaveBeenCalled();
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
     });
 
     it("rejects invalid admin status filters", async () => {

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -8,18 +8,13 @@ import { getSystemSettings } from "../utils/systemSettings";
 import { lidarrService } from "../services/lidarr";
 import { soulseekService } from "../services/soulseek";
 import { tidalService } from "../services/tidal";
-import { processTidalDownload } from "../services/tidalLibraryDownload";
 import { youtubeDownloadService } from "../services/youtubeDownload";
-import { processYoutubeDownload } from "../services/youtubeLibraryDownload";
-import {
-    type DownloadSource,
-    resolveDownloadSource,
-} from "../services/downloadSourcePolicy";
 import { musicBrainzService } from "../services/musicbrainz";
 import { lastFmService } from "../services/lastfm";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
 import { mapInteractiveRelease } from "../services/releaseContracts";
 import { createAlbumDownloadJob } from "../services/albumDownloadJobs";
+import { dispatchAlbumDownload } from "../services/downloadDispatcher";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import crypto from "crypto";
 
@@ -240,15 +235,14 @@ router.post("/", requireAdmin, async (req, res) => {
         );
 
         // Process in background
-        processDownload(
-            job.id,
+        dispatchAlbumDownload({
+            jobId: job.id,
             type,
             mbid,
             subject,
-            rootFolderPath,
-            jobResult.verifiedArtistName,
+            artistName: jobResult.verifiedArtistName,
             albumTitle,
-        ).catch((error) => {
+        }).catch((error) => {
             logger.error(
                 `Download processing failed for job ${job.id}:`,
                 error,
@@ -466,15 +460,14 @@ async function processArtistDownload(
             logger.debug(`   [JOB] Created job for: ${albumSubject}`);
 
             // Start the download in background
-            processDownload(
-                job.id,
-                "album",
-                albumMbid,
-                albumSubject,
-                rootFolderPath,
+            dispatchAlbumDownload({
+                jobId: job.id,
+                type: "album",
+                mbid: albumMbid,
+                subject: albumSubject,
                 artistName,
                 albumTitle,
-            ).catch((error) => {
+            }).catch((error) => {
                 logger.error(`Download failed for ${albumSubject}:`, error);
             });
         }
@@ -484,155 +477,6 @@ async function processArtistDownload(
     } catch (error: any) {
         logger.error(`   Failed to process artist download:`, error.message);
         throw error;
-    }
-}
-
-/**
- * Mark a download job failed before any source was contacted — used when
- * the configured source is unavailable and the fallback setting forbids
- * rerouting. Mirrors the failure shape of processTidalDownload's catch.
- */
-async function failJobWithoutDispatch(
-    jobId: string,
-    jobMetadata: unknown,
-    source: string,
-    message: string,
-    statusText: string,
-) {
-    logger.error(`[Downloads] ${message} — job ${jobId} not dispatched`);
-
-    // metadata is a Prisma Json column, so it can legally hold a string,
-    // array, or scalar — spreading those would corrupt the shape
-    // (e.g. "abc" → {0:"a",1:"b",2:"c"}). Only spread plain objects.
-    const baseMetadata =
-        jobMetadata &&
-        typeof jobMetadata === "object" &&
-        !Array.isArray(jobMetadata)
-            ? (jobMetadata as Record<string, unknown>)
-            : {};
-
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "failed",
-            error: message,
-            completedAt: new Date(),
-            metadata: {
-                ...baseMetadata,
-                currentSource: source,
-                statusText,
-                failedAt: new Date().toISOString(),
-            },
-        },
-    });
-}
-
-/** Dispatch one album download through the configured source and fallback chain. */
-export async function processDownload(
-    jobId: string,
-    type: string,
-    mbid: string,
-    subject: string,
-    rootFolderPath: string,
-    artistName?: string,
-    albumTitle?: string,
-) {
-    const job = await prisma.downloadJob.findUnique({ where: { id: jobId } });
-    if (!job) {
-        logger.error(`Job ${jobId} not found`);
-        return;
-    }
-
-    if (type === "album") {
-        let parsedArtist = artistName;
-        let parsedAlbum = albumTitle;
-
-        if (!parsedArtist || !parsedAlbum) {
-            const parts = subject.split(" - ");
-            if (parts.length >= 2) {
-                parsedArtist = parts[0].trim();
-                parsedAlbum = parts.slice(1).join(" - ").trim();
-            } else {
-                parsedArtist = subject;
-                parsedAlbum = subject;
-            }
-        }
-
-        logger.debug(
-            `Parsed: Artist="${parsedArtist}", Album="${parsedAlbum}"`,
-        );
-
-        // Check configured download source and service availability
-        const settings = await getSystemSettings();
-        const configuredSource = (settings?.downloadSource ||
-            "soulseek") as DownloadSource;
-
-        const [tidalAvail, lidarrAvail, soulseekAvail, youtubeAvail] =
-            await Promise.all([
-                tidalService.isAvailable(),
-                lidarrService.isEnabled(),
-                soulseekService.isAvailable(),
-                youtubeDownloadService.isAvailable(),
-            ]);
-        const availability = {
-            tidal: tidalAvail,
-            lidarr: lidarrAvail,
-            soulseek: soulseekAvail,
-            youtube: youtubeAvail,
-        };
-
-        const resolution = resolveDownloadSource({
-            configuredSource,
-            fallback: settings?.primaryFailureFallback,
-            availability,
-        });
-        if (resolution.kind === "fail") {
-            await failJobWithoutDispatch(
-                jobId,
-                job.metadata,
-                configuredSource,
-                resolution.error,
-                resolution.statusText,
-            );
-            return;
-        }
-        const effectiveSource = resolution.source;
-
-        logger.debug(
-            `Download source: configured=${configuredSource}, effective=${effectiveSource}`,
-        );
-
-        if (effectiveSource === "tidal" && tidalAvail) {
-            await processTidalDownload(
-                jobId,
-                parsedArtist,
-                parsedAlbum,
-                job.userId,
-            );
-        } else if (effectiveSource === "youtube" && youtubeAvail) {
-            await processYoutubeDownload(
-                jobId,
-                parsedArtist,
-                parsedAlbum,
-                job.userId,
-            );
-        } else {
-            // Non-TIDAL dispatch goes through simpleDownloadManager, which
-            // is Lidarr-backed — there is no per-source dispatch below this
-            // point, so a "soulseek" selection is executed by the Lidarr
-            // manager (pre-existing pipeline limitation).
-            const result = await simpleDownloadManager.startDownload(
-                jobId,
-                parsedArtist,
-                parsedAlbum,
-                mbid,
-                job.userId,
-            );
-
-            if (!result.success) {
-                logger.error(`Failed to start download: ${result.error}`);
-            }
-        }
     }
 }
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -4,6 +4,7 @@ import { notificationService } from "../services/notificationService";
 import { requireAdmin, requireAuth } from "../middleware/auth";
 import { asyncHandler } from "../middleware/asyncHandler";
 import { prisma } from "../utils/db";
+import { dispatchAlbumDownload } from "../services/downloadDispatcher";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
@@ -443,7 +444,7 @@ router.post(
  * /api/notifications/downloads/{id}/retry:
  *   post:
  *     summary: Retry a failed download (admin only)
- *     description: Retries a failed or exhausted download job. Supports pending-track-retry (Soulseek), spotify_import (Soulseek then Lidarr fallback), and generic album retry via Lidarr.
+ *     description: Retries a failed or exhausted download job. The generic album case schedules the retry through the configured download source. Validation failures, artist retries, and pending-track or spotify_import preconditions can still return a domain result with success false.
  *     tags: [Notifications]
  *     security:
  *       - apiKeyAuth: []
@@ -464,6 +465,7 @@ router.post(
  *               properties:
  *                 success:
  *                   type: boolean
+ *                   description: For generic album retries, true means the retry was scheduled rather than completed.
  *                 newJobId:
  *                   type: string
  *                   description: ID of the new download job created for the retry
@@ -708,6 +710,12 @@ router.post(
                                 completedAt: new Date(),
                             },
                         });
+                    })
+                    .catch((persistenceError) => {
+                        logger.error(
+                            `[Retry] Failed to persist download exception:`,
+                            persistenceError,
+                        );
                     });
 
                 return res.json({ success: true, newJobId: newJobRecord.id });
@@ -826,39 +834,43 @@ router.post(
                                 source: "retry-spotify-import",
                             });
                         } else {
-                            // Soulseek failed, try Lidarr if we have an MBID
+                            // Soulseek failed, try the configured source if we have an MBID
                             logger.debug(
-                                `[Retry] Soulseek failed, trying Lidarr for ${artistName} - ${albumTitle}`,
+                                `[Retry] Soulseek failed, trying configured source for ${artistName} - ${albumTitle}`,
                             );
 
                             if (
                                 failedJob.targetMbid &&
                                 !failedJob.targetMbid.startsWith("retry_")
                             ) {
-                                const { simpleDownloadManager } =
-                                    await import("../services/simpleDownloadManager");
-                                const lidarrResult =
-                                    await simpleDownloadManager.startDownload(
-                                        newJobRecord.id,
-                                        artistName,
-                                        albumTitle,
-                                        failedJob.targetMbid,
-                                        req.user!.id,
-                                        false,
+                                await dispatchAlbumDownload({
+                                    jobId: newJobRecord.id,
+                                    type: "album",
+                                    mbid: failedJob.targetMbid,
+                                    subject: `${artistName} - ${albumTitle}`,
+                                    artistName,
+                                    albumTitle,
+                                }).catch((error) => {
+                                    logger.error(
+                                        `[Retry] Album dispatch error:`,
+                                        error,
                                     );
-
-                                if (!lidarrResult.success) {
-                                    await prisma.downloadJob.update({
-                                        where: { id: newJobRecord.id },
-                                        data: {
-                                            status: "failed",
-                                            error:
-                                                lidarrResult.error ||
-                                                "Both Soulseek and Lidarr failed",
-                                            completedAt: new Date(),
-                                        },
-                                    });
-                                }
+                                    return prisma.downloadJob
+                                        .update({
+                                            where: { id: newJobRecord.id },
+                                            data: {
+                                                status: "failed",
+                                                error: "Download dispatch failed",
+                                                completedAt: new Date(),
+                                            },
+                                        })
+                                        .catch((persistenceError) => {
+                                            logger.error(
+                                                `[Retry] Failed to persist album dispatch failure:`,
+                                                persistenceError,
+                                            );
+                                        });
+                                });
                             } else {
                                 await prisma.downloadJob.update({
                                     where: { id: newJobRecord.id },
@@ -882,6 +894,12 @@ router.post(
                                 completedAt: new Date(),
                             },
                         });
+                    })
+                    .catch((persistenceError) => {
+                        logger.error(
+                            `[Retry] Failed to persist Soulseek error:`,
+                            persistenceError,
+                        );
                     });
 
                 return res.json({ success: true, newJobId: newJobRecord.id });
@@ -924,21 +942,51 @@ router.post(
                 },
             });
 
-            // Import the download manager dynamically to avoid circular deps
+            if (failedJob.type === "album") {
+                dispatchAlbumDownload({
+                    jobId: newJobRecord.id,
+                    type: failedJob.type,
+                    mbid: failedJob.targetMbid,
+                    subject: failedJob.subject,
+                    artistName,
+                    albumTitle,
+                }).catch((error) => {
+                    logger.error(`[Retry] Album dispatch error:`, error);
+                    return prisma.downloadJob
+                        .update({
+                            where: { id: newJobRecord.id },
+                            data: {
+                                status: "failed",
+                                error: "Download dispatch failed",
+                                completedAt: new Date(),
+                            },
+                        })
+                        .catch((persistenceError) => {
+                            logger.error(
+                                `[Retry] Failed to persist album dispatch failure:`,
+                                persistenceError,
+                            );
+                        });
+                });
+
+                return res.json({
+                    success: true,
+                    newJobId: newJobRecord.id,
+                    error: null,
+                });
+            }
+
+            // Artist retries preserve the existing Lidarr-backed path.
             const { simpleDownloadManager } =
                 await import("../services/simpleDownloadManager");
-
-            // Start download with the correct positional arguments
-            // startDownload(jobId, artistName, albumTitle, albumMbid, userId, isDiscovery)
             const result = await simpleDownloadManager.startDownload(
                 newJobRecord.id,
                 artistName,
                 albumTitle,
                 failedJob.targetMbid,
                 req.user!.id,
-                false, // isDiscovery
+                false,
             );
-
             if (!result.success) {
                 logger.warn(
                     `[Retry] Download failed for job ${newJobRecord.id}: ${result.error}`,
@@ -947,7 +995,6 @@ router.post(
             res.json({
                 success: result.success,
                 newJobId: newJobRecord.id,
-                // startDownload result.error carries raw downstream error text; return a static message (raw detail in server log).
                 error: result.success
                     ? null
                     : "Download failed (details in server log)",

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -14,8 +14,8 @@ import {
     MUSIC_REQUEST_STATUSES,
     MusicRequestServiceError,
 } from "../services/musicRequestService";
+import { dispatchAlbumDownload } from "../services/downloadDispatcher";
 import { logger } from "../utils/logger";
-import { processDownload } from "./downloads";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 
 const router = Router();
@@ -121,15 +121,14 @@ async function handleListAll(req: Request, res: Response) {
 }
 
 function dispatchApprovedDownload(dispatch: DownloadDispatch): void {
-    processDownload(
-        dispatch.jobId,
-        dispatch.type,
-        dispatch.mbid,
-        dispatch.subject,
-        dispatch.rootFolderPath,
-        dispatch.artistName,
-        dispatch.albumTitle,
-    ).catch((error) => {
+    dispatchAlbumDownload({
+        jobId: dispatch.jobId,
+        type: dispatch.type,
+        mbid: dispatch.mbid,
+        subject: dispatch.subject,
+        artistName: dispatch.artistName,
+        albumTitle: dispatch.albumTitle,
+    }).catch((error) => {
         log.error(
             `Download processing failed for job ${dispatch.jobId}:`,
             error,

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -50,6 +50,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/discovery/discoverySeeding.ts` | Discovery |
 | `backend/src/services/discovery/index.ts` | Discovery |
 | `backend/src/services/discoveryLogger.ts` | Core |
+| `backend/src/services/downloadDispatcher.ts` | Configured-source album download dispatch (policy resolution and provider routing) |
 | `backend/src/services/downloadQueue.ts` | Core |
 | `backend/src/services/embeddingSpaceLifecycle.ts` | Blue/green embedding-space cutover and retirement cleanup |
 | `backend/src/services/embeddingSpaces.ts` | Provider-space registry resolution, active cache, and worker target |

--- a/backend/src/services/__tests__/downloadDispatcher.test.ts
+++ b/backend/src/services/__tests__/downloadDispatcher.test.ts
@@ -1,0 +1,335 @@
+const mockLog = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        child: jest.fn(() => mockLog),
+    },
+}));
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findUnique: (...args: unknown[]) => mockFindUnique(...args),
+            update: (...args: unknown[]) => mockUpdate(...args),
+        },
+    },
+}));
+
+const mockGetSystemSettings = jest.fn();
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: (...args: unknown[]) => mockGetSystemSettings(...args),
+}));
+
+const mockLidarrAvailable = jest.fn();
+jest.mock("../lidarr", () => ({
+    lidarrService: {
+        isEnabled: (...args: unknown[]) => mockLidarrAvailable(...args),
+    },
+}));
+
+const mockSoulseekAvailable = jest.fn();
+jest.mock("../soulseek", () => ({
+    soulseekService: {
+        isAvailable: (...args: unknown[]) => mockSoulseekAvailable(...args),
+    },
+}));
+
+const mockTidalAvailable = jest.fn();
+jest.mock("../tidal", () => ({
+    tidalService: {
+        isAvailable: (...args: unknown[]) => mockTidalAvailable(...args),
+    },
+}));
+
+const mockYoutubeAvailable = jest.fn();
+jest.mock("../youtubeDownload", () => ({
+    youtubeDownloadService: {
+        isAvailable: (...args: unknown[]) => mockYoutubeAvailable(...args),
+    },
+}));
+
+const mockProcessTidalDownload = jest.fn();
+jest.mock("../tidalLibraryDownload", () => ({
+    processTidalDownload: (...args: unknown[]) =>
+        mockProcessTidalDownload(...args),
+}));
+
+const mockProcessYoutubeDownload = jest.fn();
+jest.mock("../youtubeLibraryDownload", () => ({
+    processYoutubeDownload: (...args: unknown[]) =>
+        mockProcessYoutubeDownload(...args),
+}));
+
+const mockStartDownload = jest.fn();
+jest.mock("../simpleDownloadManager", () => ({
+    simpleDownloadManager: {
+        startDownload: (...args: unknown[]) => mockStartDownload(...args),
+    },
+}));
+
+import { dispatchAlbumDownload } from "../downloadDispatcher";
+
+const baseParams = {
+    jobId: "job-1",
+    type: "album",
+    mbid: "rg-1",
+    subject: "Artist - Album",
+    artistName: "Artist",
+    albumTitle: "Album",
+};
+
+describe("dispatchAlbumDownload", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindUnique.mockResolvedValue({
+            id: "job-1",
+            userId: "user-1",
+            metadata: { preserved: true },
+        });
+        mockUpdate.mockResolvedValue({});
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "soulseek",
+            primaryFailureFallback: "none",
+        });
+        mockTidalAvailable.mockResolvedValue(false);
+        mockLidarrAvailable.mockResolvedValue(true);
+        mockSoulseekAvailable.mockResolvedValue(true);
+        mockYoutubeAvailable.mockResolvedValue(false);
+        mockProcessTidalDownload.mockResolvedValue(undefined);
+        mockProcessYoutubeDownload.mockResolvedValue(undefined);
+        mockStartDownload.mockResolvedValue({ success: true });
+    });
+
+    it("dispatches an available configured YouTube source", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "youtube",
+            primaryFailureFallback: "none",
+        });
+        mockYoutubeAvailable.mockResolvedValue(true);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+
+    it("dispatches an available configured TIDAL source", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "none",
+        });
+        mockTidalAvailable.mockResolvedValue(true);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockProcessTidalDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(mockTidalAvailable).toHaveBeenCalledTimes(1);
+        expect(mockLidarrAvailable).toHaveBeenCalledTimes(1);
+        expect(mockSoulseekAvailable).toHaveBeenCalledTimes(1);
+        expect(mockYoutubeAvailable).toHaveBeenCalledTimes(1);
+        expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+
+    it("uses YouTube as an available explicit fallback", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "youtube",
+        });
+        mockYoutubeAvailable.mockResolvedValue(true);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+    });
+
+    it("falls back from unavailable YouTube to the manager-backed Soulseek path", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "youtube",
+            primaryFailureFallback: "soulseek",
+        });
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-1",
+            "user-1",
+        );
+        expect(mockProcessYoutubeDownload).not.toHaveBeenCalled();
+    });
+
+    it("uses the manager for an available configured Soulseek source", async () => {
+        await dispatchAlbumDownload({
+            ...baseParams,
+            artistName: undefined,
+            albumTitle: undefined,
+            subject: "Split Artist - Split - Album",
+        });
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Split Artist",
+            "Split - Album",
+            "rg-1",
+            "user-1",
+        );
+    });
+
+    it("uses the subject for both names when no delimiter or metadata exists", async () => {
+        await dispatchAlbumDownload({
+            ...baseParams,
+            artistName: undefined,
+            albumTitle: undefined,
+            subject: "SingleSubject",
+        });
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "SingleSubject",
+            "SingleSubject",
+            "rg-1",
+            "user-1",
+        );
+    });
+
+    it("logs unsuccessful manager starts without throwing", async () => {
+        mockStartDownload.mockResolvedValueOnce({
+            success: false,
+            error: "unavailable indexer",
+        });
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockLog.error).toHaveBeenCalledWith(
+            "Failed to start download: unavailable indexer",
+        );
+    });
+
+    it("fails without dispatch when the unavailable primary uses Skip", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "none",
+        });
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockProcessTidalDownload).not.toHaveBeenCalled();
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledWith({
+            where: { id: "job-1" },
+            data: {
+                status: "failed",
+                error: 'tidal is unavailable and "When primary source fails" is set to Skip',
+                completedAt: expect.any(Date),
+                metadata: {
+                    preserved: true,
+                    currentSource: "tidal",
+                    statusText: "tidal unavailable — skipped",
+                    failedAt: expect.any(String),
+                },
+            },
+        });
+    });
+
+    it("uses the explicitly configured manager fallback", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "lidarr",
+        });
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-1",
+            "user-1",
+        );
+    });
+
+    it("fails when both the primary and configured fallback are unavailable", async () => {
+        mockFindUnique.mockResolvedValueOnce({
+            id: "job-1",
+            userId: "user-1",
+            metadata: "scalar metadata",
+        });
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "lidarr",
+        });
+        mockLidarrAvailable.mockResolvedValue(false);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledWith({
+            where: { id: "job-1" },
+            data: {
+                status: "failed",
+                error: "tidal is unavailable and the configured fallback (lidarr) is also unavailable",
+                completedAt: expect.any(Date),
+                metadata: {
+                    currentSource: "tidal",
+                    statusText: "tidal and fallback lidarr unavailable",
+                    failedAt: expect.any(String),
+                },
+            },
+        });
+    });
+
+    it("preserves the legacy availability ladder when fallback is absent", async () => {
+        mockGetSystemSettings.mockResolvedValue({ downloadSource: "tidal" });
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-1",
+            "user-1",
+        );
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("returns without probing sources when the job no longer exists", async () => {
+        mockFindUnique.mockResolvedValueOnce(null);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockGetSystemSettings).not.toHaveBeenCalled();
+        expect(mockLog.error).toHaveBeenCalledWith("Job job-1 not found");
+    });
+
+    it("leaves non-album jobs undispatched", async () => {
+        await dispatchAlbumDownload({ ...baseParams, type: "artist" });
+
+        expect(mockGetSystemSettings).not.toHaveBeenCalled();
+        expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/services/__tests__/tidalLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/tidalLibraryDownload.test.ts
@@ -138,6 +138,106 @@ describe("tidalLibraryDownload", () => {
         expect(mockDownloadAlbum).not.toHaveBeenCalled();
     });
 
+    it("hands a search miss to a manager fallback and records the hand-off", async () => {
+        mockFindAlbum.mockResolvedValueOnce(null);
+        mockSettings.mockResolvedValueOnce({
+            primaryFailureFallback: "soulseek",
+        });
+        mockFallback.mockResolvedValueOnce({
+            success: false,
+            error: "fallback failed",
+        });
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(mockFallback).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-1",
+            "user-1",
+        );
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-1" },
+                data: expect.objectContaining({
+                    metadata: expect.objectContaining({
+                        currentSource: "soulseek",
+                        statusText: "TIDAL not found → soulseek",
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it("persists a sanitized failure when a TIDAL download throws", async () => {
+        const rawError =
+            "ECONNREFUSED http://tidal-internal:9999 token=secret123";
+        mockDownloadAlbum.mockRejectedValueOnce(new Error(rawError));
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        const failedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "failed",
+        )?.[0];
+        expect(failedUpdate).toEqual(
+            expect.objectContaining({
+                where: { id: "job-1" },
+                data: expect.objectContaining({
+                    error: "TIDAL download failed",
+                }),
+            }),
+        );
+        expect(JSON.stringify(failedUpdate)).not.toContain(rawError);
+    });
+
+    it("marks a search miss failed when no fallback is configured", async () => {
+        mockFindAlbum.mockResolvedValueOnce(null);
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-1" },
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: "TIDAL download failed",
+                }),
+            }),
+        );
+        expect(JSON.stringify(mockUpdate.mock.calls)).not.toContain(
+            "Album not found on TIDAL",
+        );
+    });
+
+    it("marks the job failed when TIDAL downloads zero tracks", async () => {
+        mockDownloadAlbum.mockResolvedValueOnce({
+            album_id: 123,
+            album_title: "Album",
+            artist: "Artist",
+            total_tracks: 10,
+            downloaded: 0,
+            failed: 10,
+            tracks: [],
+            errors: [],
+        });
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-1" },
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: "TIDAL download failed",
+                }),
+            }),
+        );
+        expect(JSON.stringify(mockUpdate.mock.calls)).not.toContain(
+            "All 10 tracks failed to download",
+        );
+    });
+
     it("does not hand a youtube fallback back to youtube on another search miss", async () => {
         mockFindAlbum.mockResolvedValueOnce(null);
         mockSettings.mockResolvedValueOnce({

--- a/backend/src/services/downloadDispatcher.ts
+++ b/backend/src/services/downloadDispatcher.ts
@@ -1,0 +1,190 @@
+import { logger as rootLogger } from "../utils/logger";
+import { prisma } from "../utils/db";
+import { getSystemSettings } from "../utils/systemSettings";
+import {
+    type DownloadSource,
+    type DownloadSourceAvailability,
+    resolveDownloadSource,
+} from "./downloadSourcePolicy";
+import { lidarrService } from "./lidarr";
+import { simpleDownloadManager } from "./simpleDownloadManager";
+import { soulseekService } from "./soulseek";
+import { tidalService } from "./tidal";
+import { processTidalDownload } from "./tidalLibraryDownload";
+import { youtubeDownloadService } from "./youtubeDownload";
+import { processYoutubeDownload } from "./youtubeLibraryDownload";
+
+const logger = rootLogger.child("DownloadDispatcher");
+
+/** Parameters required to dispatch one existing album download job. */
+export interface AlbumDownloadDispatchParams {
+    jobId: string;
+    type: string;
+    mbid: string;
+    subject: string;
+    artistName?: string;
+    albumTitle?: string;
+}
+
+interface AlbumNames {
+    artist: string;
+    album: string;
+}
+
+function parseAlbumNames({
+    subject,
+    artistName,
+    albumTitle,
+}: Pick<
+    AlbumDownloadDispatchParams,
+    "subject" | "artistName" | "albumTitle"
+>): AlbumNames {
+    if (artistName && albumTitle) {
+        return { artist: artistName, album: albumTitle };
+    }
+    const parts = subject.split(" - ");
+    if (parts.length >= 2) {
+        return {
+            artist: parts[0].trim(),
+            album: parts.slice(1).join(" - ").trim(),
+        };
+    }
+    return { artist: subject, album: subject };
+}
+
+async function getDownloadSourceAvailability(): Promise<DownloadSourceAvailability> {
+    const [tidal, lidarr, soulseek, youtube] = await Promise.all([
+        tidalService.isAvailable(),
+        lidarrService.isEnabled(),
+        soulseekService.isAvailable(),
+        youtubeDownloadService.isAvailable(),
+    ]);
+    return { tidal, lidarr, soulseek, youtube };
+}
+
+async function failJobWithoutDispatch(
+    jobId: string,
+    jobMetadata: unknown,
+    source: string,
+    message: string,
+    statusText: string,
+): Promise<void> {
+    logger.error(`${message} — job ${jobId} not dispatched`);
+
+    // Metadata is a Prisma Json column and may contain a scalar. Only plain
+    // objects can be spread without corrupting the stored metadata shape.
+    const baseMetadata =
+        jobMetadata &&
+        typeof jobMetadata === "object" &&
+        !Array.isArray(jobMetadata)
+            ? (jobMetadata as Record<string, unknown>)
+            : {};
+
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            status: "failed",
+            error: message,
+            completedAt: new Date(),
+            metadata: {
+                ...baseMetadata,
+                currentSource: source,
+                statusText,
+                failedAt: new Date().toISOString(),
+            },
+        },
+    });
+}
+
+async function dispatchResolvedSource(
+    source: DownloadSource,
+    availability: DownloadSourceAvailability,
+    params: AlbumDownloadDispatchParams,
+    names: AlbumNames,
+    userId: string,
+): Promise<void> {
+    if (source === "tidal" && availability.tidal) {
+        await processTidalDownload(
+            params.jobId,
+            names.artist,
+            names.album,
+            userId,
+        );
+        return;
+    }
+    if (source === "youtube" && availability.youtube) {
+        await processYoutubeDownload(
+            params.jobId,
+            names.artist,
+            names.album,
+            userId,
+        );
+        return;
+    }
+
+    // Non-TIDAL dispatch goes through simpleDownloadManager, which is
+    // Lidarr-backed — there is no per-source dispatch below this point, so a
+    // "soulseek" selection is executed by the Lidarr manager (pre-existing
+    // pipeline limitation).
+    const result = await simpleDownloadManager.startDownload(
+        params.jobId,
+        names.artist,
+        names.album,
+        params.mbid,
+        userId,
+    );
+    if (!result.success) {
+        logger.error(`Failed to start download: ${result.error}`);
+    }
+}
+
+/**
+ * Dispatch an existing album download job through the configured source and
+ * fallback policy. Missing jobs and non-album types are left undispatched.
+ */
+export async function dispatchAlbumDownload(
+    params: AlbumDownloadDispatchParams,
+): Promise<void> {
+    const job = await prisma.downloadJob.findUnique({
+        where: { id: params.jobId },
+    });
+    if (!job) {
+        logger.error(`Job ${params.jobId} not found`);
+        return;
+    }
+    if (params.type !== "album") return;
+
+    const names = parseAlbumNames(params);
+    logger.debug(`Parsed: Artist="${names.artist}", Album="${names.album}"`);
+
+    const settings = await getSystemSettings();
+    const configuredSource = (settings?.downloadSource ||
+        "soulseek") as DownloadSource;
+    const availability = await getDownloadSourceAvailability();
+    const resolution = resolveDownloadSource({
+        configuredSource,
+        fallback: settings?.primaryFailureFallback,
+        availability,
+    });
+    if (resolution.kind === "fail") {
+        await failJobWithoutDispatch(
+            params.jobId,
+            job.metadata,
+            configuredSource,
+            resolution.error,
+            resolution.statusText,
+        );
+        return;
+    }
+
+    logger.debug(
+        `Download source: configured=${configuredSource}, effective=${resolution.source}`,
+    );
+    await dispatchResolvedSource(
+        resolution.source,
+        availability,
+        params,
+        names,
+        job.userId,
+    );
+}

--- a/backend/src/services/musicRequestService.ts
+++ b/backend/src/services/musicRequestService.ts
@@ -73,13 +73,12 @@ export type RequestTransitionResult =
     | { kind: "conflict" }
     | { kind: "updated"; request: MusicRequest };
 
-/** Positional download processor input returned only for a fresh approval job. */
+/** Dispatcher input returned only for a fresh approval job. */
 export interface DownloadDispatch {
     jobId: string;
     type: "album";
     mbid: string;
     subject: string;
-    rootFolderPath: string;
     artistName?: string;
     albumTitle?: string;
 }
@@ -407,7 +406,6 @@ function approvalJobParams(
 
 function approvalDispatch(
     request: MusicRequest,
-    rootFolderPath: string,
     jobResult: AlbumDownloadJobResult,
 ): DownloadDispatch | null {
     if (jobResult.duplicate) return null;
@@ -416,7 +414,6 @@ function approvalDispatch(
         type: "album",
         mbid: request.rgMbid,
         subject: `${request.artistName} - ${request.albumTitle}`,
-        rootFolderPath,
         artistName: jobResult.verifiedArtistName,
         albumTitle: request.albumTitle,
     };
@@ -448,7 +445,7 @@ async function approveWithJob(
             kind: "updated",
             request: updated,
             duplicate: jobResult.duplicate,
-            dispatch: approvalDispatch(request, rootFolderPath, jobResult),
+            dispatch: approvalDispatch(request, jobResult),
         } as const;
     });
 }

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -70,8 +70,8 @@ const LEAK_BASELINE = Object.freeze({
     // library/artists.ts remaining 1: admin-only Lidarr deletion diagnostics (lidarrError = err?.message) returned to the initiating admin, not a general-user 500 leak.
     "backend/src/routes/library/artists.ts": 1,
     "backend/src/routes/listenTogether.ts": 1,
-    // notifications.ts remaining 2: stored downloadJob.error strings from the soulseek retry result (~L702) and Lidarr fallback (~L864); stored-then-returned to the owning user via GET /api/downloads — client-reachable, flagged for follow-up sanitization under the slice-J scope guard (the POST retry response leak itself was sanitized).
-    "backend/src/routes/notifications.ts": 2,
+    // notifications.ts remaining 1: stored downloadJob.error from the soulseek retry result (~L702), returned to the owning user via GET /api/downloads — client-reachable and flagged for follow-up sanitization under the slice-J scope guard.
+    "backend/src/routes/notifications.ts": 1,
     "backend/src/routes/playbackState.ts": 0,
     // playlistImport.ts remaining 2: substring-guarded 400 echoes of playlistImportService's own thrown validation messages (~L434 preview, ~L516 "Invalid track reference" execute); code-owned text, not raw transport errors.
     "backend/src/routes/playlistImport.ts": 2,


### PR DESCRIPTION
## Problem

Clicking Retry on a failed album download always routed to the Lidarr-backed manager, regardless of the configured download source. With TIDAL configured (and Lidarr not selected), every retry failed with `Failed to add album to Lidarr - album not found`. The spotify_import retry fallback had the same hardcoded path.

## Cause

Download dispatch (configured source + availability probe + fallback policy) lived inside the downloads route module. The retry endpoint never used it — it called `simpleDownloadManager.startDownload` directly, so retries were Lidarr-only by construction.

## Fix

- New `backend/src/services/downloadDispatcher.ts`: the source-resolution dispatch extracted verbatim from the downloads route (same guards, parsing, policy resolution, and failure bookkeeping), decomposed into small single-purpose functions under a `DownloadDispatcher` logger scope.
- Every album entrypoint now goes through it: create route, artist-batch route, request-approval flow, generic album retry, and the spotify_import retry fallback. The route→route import from requests.ts is gone.
- Album retries schedule dispatch in the background and respond immediately (previously the new code path would have held the HTTP request open for the entire album download). Dispatch failures mark the job failed with a static sanitized error; the persistence write is itself observed so no rejection goes unhandled.
- Artist retries deliberately keep the existing Lidarr-backed path — no behavior change there.
- Dropped the dead `rootFolderPath` field from the dispatch contract (`DownloadDispatch`).

## Tests

- Dispatch-behavior matrix relocated from `downloadsRuntime.test.ts` into the new `downloadDispatcher.test.ts` (14 cases, superset of the old 8), plus route-level wiring tests.
- New negative coverage: dispatcher rejection → terminal job failure with static error; failure-persistence rejection → logged, no unhandled rejection; spotify fallback error attribution (dispatch failures no longer masquerade as "Soulseek error"); artist-retry regression lock.
- Raw-error-leak baseline for notifications.ts tightened 2→1 (the Lidarr fallback no longer persists raw downstream error text).

## Verification

- verify: `tsc --noEmit` exit 0
- verify: 8 targeted Jest suites, 170 tests passed, exit 0
- verify: `format:check`, `check-file-size.mjs`, `check-route-error-canon.mjs` all exit 0

## Notes

Known divergence left as-is on purpose: `acquisitionService` (discovery/spotify acquisition) keeps its own soulseek/lidarr matrix — unifying it would change which providers discovery uses, which is a product decision, not a bug fix. Follow-up: a queued album-download pipeline (one album at a time) building on this dispatcher.