### PR TITLE
feat(downloads): durable album download queue, one album at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Album downloads now use queued, serialized processing, one album at a time across the deployment, with renewable claims, restart recovery, and queue-owned lifecycle reconciliation.
+
 ### Fixed
 
 - Retrying a failed album download now uses the configured download source instead of always routing to Lidarr.
@@ -59,8 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.1] - 2026-08-22
 
 ### Added
-
-### Changed
 
 ### Fixed
 

--- a/backend/src/metrics/albumDownloadMetrics.ts
+++ b/backend/src/metrics/albumDownloadMetrics.ts
@@ -1,0 +1,23 @@
+import { Counter, type Registry } from "prom-client";
+
+/** Closed result vocabulary for queued album download attempts. */
+export const ALBUM_DOWNLOAD_OUTCOMES = [
+    "completed",
+    "failed",
+    "retried",
+] as const;
+
+/** Final or retry outcome for one album download queue attempt. */
+export type AlbumDownloadOutcome = (typeof ALBUM_DOWNLOAD_OUTCOMES)[number];
+
+/** Create album download queue metrics in the provided registry. */
+export function createAlbumDownloadMetrics(registry: Registry) {
+    return {
+        downloads: new Counter({
+            name: "soundspan_album_downloads_total",
+            help: "Album download queue attempts by outcome",
+            labelNames: ["outcome"] as const,
+            registers: [registry],
+        }),
+    };
+}

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -58,6 +58,10 @@ import {
     createRequestMetrics,
     type MusicRequestAction,
 } from "./requestMetrics";
+import {
+    createAlbumDownloadMetrics,
+    type AlbumDownloadOutcome,
+} from "./albumDownloadMetrics";
 
 export type {
     FederationAuthFailureReason,
@@ -85,6 +89,7 @@ const libraryHealthMetrics = createLibraryHealthMetrics(metricsRegistry);
 const providerMetrics = createProviderMetrics(metricsRegistry);
 const providerTrackGcMetrics = createProviderTrackGcMetrics(metricsRegistry);
 const requestMetrics = createRequestMetrics(metricsRegistry);
+const albumDownloadMetrics = createAlbumDownloadMetrics(metricsRegistry);
 createLoudnessMetrics(metricsRegistry, prisma, {
     getBackfillOutcomes: async () => {
         const { redisClient } = await import("../utils/redis");
@@ -140,6 +145,13 @@ export function recordBrowseImageCacheResult(result: "hit" | "miss"): void {
 /** Records one bounded music request state or rejection action. */
 export function recordMusicRequestAction(action: MusicRequestAction): void {
     requestMetrics.requests.inc({ action });
+}
+
+/** Records one bounded album download queue outcome. */
+export function recordAlbumDownloadOutcome(
+    outcome: AlbumDownloadOutcome,
+): void {
+    albumDownloadMetrics.downloads.inc({ outcome });
 }
 
 /** Records one Library Health panel cache outcome. */

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -57,10 +57,10 @@ jest.mock("../../services/youtubeDownload", () => ({
     },
 }));
 
-const mockDispatchAlbumDownload = jest.fn();
-jest.mock("../../services/downloadDispatcher", () => ({
-    dispatchAlbumDownload: (...args: unknown[]) =>
-        mockDispatchAlbumDownload(...args),
+const mockEnqueueAlbumDownloadInBackground = jest.fn();
+jest.mock("../../services/albumDownloadQueueService", () => ({
+    enqueueAlbumDownloadInBackground: (...args: unknown[]) =>
+        mockEnqueueAlbumDownloadInBackground(...args),
 }));
 
 jest.mock("../../services/musicbrainz", () => ({
@@ -253,7 +253,7 @@ describe("downloads routes runtime", () => {
         mockSoulseekAvailable.mockResolvedValue(true);
         mockTidalAvailable.mockResolvedValue(false);
         mockYoutubeAvailable.mockResolvedValue(false);
-        mockDispatchAlbumDownload.mockResolvedValue(undefined);
+        mockEnqueueAlbumDownloadInBackground.mockReturnValue(undefined);
 
         mockGetArtist.mockResolvedValue(null);
         mockGetReleaseGroups.mockResolvedValue([]);
@@ -546,11 +546,12 @@ describe("downloads routes runtime", () => {
 
         const createdJob = { id: "job-created", status: "pending" };
 
+        const createAlbumJob = jest.fn().mockResolvedValue(createdJob);
         mockTransaction.mockImplementationOnce(async (callback: any) =>
             callback({
                 $queryRaw: jest.fn().mockResolvedValue([]),
                 downloadJob: {
-                    create: jest.fn().mockResolvedValue(createdJob),
+                    create: createAlbumJob,
                 },
             }),
         );
@@ -578,7 +579,7 @@ describe("downloads routes runtime", () => {
                 message: "Download job created. Processing in background.",
             }),
         );
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
             jobId: "job-created",
             type: "album",
             mbid: "rg-1",
@@ -586,6 +587,15 @@ describe("downloads routes runtime", () => {
             artistName: "Correct Artist",
             albumTitle: "Album",
         });
+        expect(createAlbumJob).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    metadata: expect.objectContaining({
+                        queuedVia: "album-download-queue",
+                    }),
+                }),
+            }),
+        );
     });
 
     it("returns existing active job for P2002 race-condition collisions", async () => {
@@ -1302,6 +1312,10 @@ describe("downloads routes runtime", () => {
             .mockResolvedValueOnce({ id: "existing-album" })
             .mockResolvedValueOnce(null)
             .mockResolvedValueOnce(null);
+        const createArtistAlbumJob = jest.fn().mockResolvedValue({
+            id: "job-new",
+            status: "pending",
+        });
         mockTransaction
             .mockImplementationOnce(async (callback: any) =>
                 callback({
@@ -1325,10 +1339,7 @@ describe("downloads routes runtime", () => {
                         .mockResolvedValueOnce([])
                         .mockResolvedValueOnce([]),
                     downloadJob: {
-                        create: jest.fn().mockResolvedValue({
-                            id: "job-new",
-                            status: "pending",
-                        }),
+                        create: createArtistAlbumJob,
                     },
                 }),
             );
@@ -1352,7 +1363,7 @@ describe("downloads routes runtime", () => {
                 jobs: [{ id: "job-new", subject: "Artist Name - New Album" }],
             }),
         );
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
             jobId: "job-new",
             type: "album",
             mbid: "rg-new",
@@ -1360,6 +1371,15 @@ describe("downloads routes runtime", () => {
             artistName: "Artist Name",
             albumTitle: "New Album",
         });
+        expect(createArtistAlbumJob).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    metadata: expect.objectContaining({
+                        queuedVia: "album-download-queue",
+                    }),
+                }),
+            }),
+        );
     });
 
     it("skips recently failed artist albums without creating new jobs", async () => {
@@ -1404,7 +1424,7 @@ describe("downloads routes runtime", () => {
                 jobs: [],
             }),
         );
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockEnqueueAlbumDownloadInBackground).not.toHaveBeenCalled();
     });
 
     it("returns 500 when listing failed albums throws", async () => {
@@ -1440,7 +1460,7 @@ describe("downloads routes runtime", () => {
         expect(res.body).toEqual({ error: "Failed to delete failed album" });
     });
 
-    it("handles background processor rejections from single album jobs", async () => {
+    it("schedules single album jobs through the durable queue", async () => {
         mockTransaction.mockImplementationOnce(async (callback: any) =>
             callback({
                 $queryRaw: jest.fn().mockResolvedValue([]),
@@ -1452,10 +1472,6 @@ describe("downloads routes runtime", () => {
                 },
             }),
         );
-        mockDispatchAlbumDownload.mockRejectedValueOnce(
-            new Error("dispatch threw"),
-        );
-
         const req = {
             body: {
                 type: "album",
@@ -1472,10 +1488,14 @@ describe("downloads routes runtime", () => {
         await flushAsyncWork();
 
         expect(res.statusCode).toBe(200);
-        expect(mockLogger.error).toHaveBeenCalledWith(
-            "Download processing failed for job job-throw:",
-            expect.any(Error),
-        );
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
+            jobId: "job-throw",
+            type: "album",
+            mbid: "rg-throw",
+            subject: "Artist - Album",
+            artistName: "Artist",
+            albumTitle: "Album",
+        });
     });
 
     it("uses LastFM artist correction for artist downloads when MusicBrainz lookup fails", async () => {
@@ -1547,9 +1567,7 @@ describe("downloads routes runtime", () => {
                 },
             }),
         );
-        mockDispatchAlbumDownload.mockRejectedValueOnce(
-            new Error("batch failure"),
-        );
+        mockEnqueueAlbumDownloadInBackground.mockReturnValueOnce(undefined);
 
         const req = {
             body: {
@@ -1565,7 +1583,7 @@ describe("downloads routes runtime", () => {
         await flushAsyncWork();
 
         expect(res.statusCode).toBe(200);
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
             jobId: "job-batch-1",
             type: "album",
             mbid: "rg-batch-1",

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -75,10 +75,9 @@ jest.mock("../../services/simpleDownloadManager", () => ({
     simpleDownloadManager,
 }));
 
-const dispatchAlbumDownload = jest.fn();
-jest.mock("../../services/downloadDispatcher", () => ({
-    dispatchAlbumDownload: (...args: unknown[]) =>
-        dispatchAlbumDownload(...args),
+const enqueueAlbumDownload = jest.fn();
+jest.mock("../../services/albumDownloadQueueService", () => ({
+    enqueueAlbumDownload: (...args: unknown[]) => enqueueAlbumDownload(...args),
 }));
 
 import router from "../notifications";
@@ -258,7 +257,7 @@ describe("notifications route runtime", () => {
             success: true,
             error: null,
         });
-        dispatchAlbumDownload.mockResolvedValue(undefined);
+        enqueueAlbumDownload.mockResolvedValue(undefined);
     });
 
     it("requires admin authorization for download retries", () => {
@@ -284,13 +283,13 @@ describe("notifications route runtime", () => {
         expect(soulseekService.downloadBestMatch).not.toHaveBeenCalled();
         expect(soulseekService.searchAndDownloadBatch).not.toHaveBeenCalled();
         expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
-        expect(dispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(enqueueAlbumDownload).not.toHaveBeenCalled();
         expect(prisma.downloadJob.updateMany).not.toHaveBeenCalled();
         expect(prisma.downloadJob.update).not.toHaveBeenCalled();
         expect(prisma.downloadJob.create).not.toHaveBeenCalled();
     });
 
-    it("routes an admin generic album retry through the dispatcher", async () => {
+    it("routes an admin generic album retry through the durable queue", async () => {
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
             id: "job-generic",
             userId: "u1",
@@ -305,7 +304,7 @@ describe("notifications route runtime", () => {
             metadata: {},
         });
         let resolveDispatch!: () => void;
-        dispatchAlbumDownload.mockImplementationOnce(
+        enqueueAlbumDownload.mockImplementationOnce(
             () =>
                 new Promise<void>((resolve) => {
                     resolveDispatch = resolve;
@@ -331,7 +330,7 @@ describe("notifications route runtime", () => {
             newJobId: "job-new-generic",
             error: null,
         });
-        expect(dispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(enqueueAlbumDownload).toHaveBeenCalledWith({
             jobId: "job-new-generic",
             type: "album",
             mbid: "album-mbid",
@@ -339,13 +338,22 @@ describe("notifications route runtime", () => {
             artistName: "Artist",
             albumTitle: "Album",
         });
+        expect(prisma.downloadJob.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    metadata: expect.objectContaining({
+                        queuedVia: "album-download-queue",
+                    }),
+                }),
+            }),
+        );
         resolveDispatch();
         await retryPromise;
         await flushAsyncWork();
         expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
     });
 
-    it("marks a scheduled generic album retry failed when dispatch rejects", async () => {
+    it("observes a generic album queue admission rejection", async () => {
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
             id: "job-generic-failed",
             userId: "u1",
@@ -359,8 +367,8 @@ describe("notifications route runtime", () => {
             id: "job-new-generic-failed",
             metadata: {},
         });
-        const dispatchError = new Error("provider token=dispatch-secret");
-        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
+        const enqueueError = new Error("provider token=queue-secret");
+        enqueueAlbumDownload.mockRejectedValueOnce(enqueueError);
         const req = {
             user: { id: "u1", role: "admin" },
             params: { id: "job-generic-failed" },
@@ -376,62 +384,16 @@ describe("notifications route runtime", () => {
             newJobId: "job-new-generic-failed",
             error: null,
         });
-        expect(prisma.downloadJob.update).toHaveBeenCalledWith({
-            where: { id: "job-new-generic-failed" },
-            data: {
-                status: "failed",
-                error: "Download dispatch failed",
-                completedAt: expect.any(Date),
-            },
-        });
-        expect(
-            JSON.stringify(prisma.downloadJob.update.mock.calls),
-        ).not.toContain("dispatch-secret");
+        expect(prisma.downloadJob.update).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-new-generic-failed" },
+            }),
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
-            "[Retry] Album dispatch error:",
-            dispatchError,
+            "[Retry] Album enqueue error:",
+            enqueueError,
         );
         expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
-    });
-
-    it("logs when generic album dispatch failure persistence rejects", async () => {
-        prisma.downloadJob.findFirst.mockResolvedValueOnce({
-            id: "job-generic-persistence-failed",
-            userId: "u1",
-            subject: "Artist - Album",
-            type: "album",
-            targetMbid: "album-mbid",
-            artistMbid: "artist-mbid",
-            metadata: { albumTitle: "Album" },
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "job-new-generic-persistence-failed",
-            metadata: {},
-        });
-        const dispatchError = new Error("dispatch unavailable");
-        const persistenceError = new Error("database unavailable");
-        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
-        prisma.downloadJob.update
-            .mockResolvedValueOnce({})
-            .mockRejectedValueOnce(persistenceError);
-        const req = {
-            user: { id: "u1", role: "admin" },
-            params: { id: "job-generic-persistence-failed" },
-        } as any;
-        const res = createRes();
-
-        await retryDownload(req, res);
-        await flushAsyncWork();
-
-        expect(res.body).toEqual({
-            success: true,
-            newJobId: "job-new-generic-persistence-failed",
-            error: null,
-        });
-        expect(mockLogger.error).toHaveBeenCalledWith(
-            "[Retry] Failed to persist album dispatch failure:",
-            persistenceError,
-        );
     });
 
     it("keeps generic artist retries on the simple download manager", async () => {
@@ -464,7 +426,7 @@ describe("notifications route runtime", () => {
             "u1",
             false,
         );
-        expect(dispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(enqueueAlbumDownload).not.toHaveBeenCalled();
         expect(res.body).toEqual({
             success: true,
             newJobId: "job-new-artist",
@@ -1204,7 +1166,7 @@ describe("notifications route runtime", () => {
         await retryDownload(lidarrFailReq, lidarrFailRes);
         await flushAsyncWork();
         expect(lidarrFailRes.statusCode).toBe(200);
-        expect(dispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(enqueueAlbumDownload).toHaveBeenCalledWith({
             jobId: "job-new-spotify-lidarr-fail",
             type: "album",
             mbid: "mbid-spotify-lidarr-fail",
@@ -1212,6 +1174,18 @@ describe("notifications route runtime", () => {
             artistName: "Artist",
             albumTitle: "Album",
         });
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-new-spotify-lidarr-fail" },
+                data: expect.objectContaining({
+                    status: "pending",
+                    metadata: expect.objectContaining({
+                        queuedVia: "album-download-queue",
+                        statusText: "Queued",
+                    }),
+                }),
+            }),
+        );
         expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
 
         prisma.downloadJob.findFirst.mockResolvedValueOnce({
@@ -1301,10 +1275,10 @@ describe("notifications route runtime", () => {
         ).not.toContain(spotifyRawError);
     });
 
-    it("attributes spotify_import fallback dispatch rejection to dispatch", async () => {
+    it("attributes spotify_import fallback admission rejection to the queue", async () => {
         prepareSpotifyImportFallback("spotify-dispatch-failed");
-        const dispatchError = new Error("configured source unavailable");
-        dispatchAlbumDownload.mockRejectedValueOnce(dispatchError);
+        const enqueueError = new Error("queue unavailable");
+        enqueueAlbumDownload.mockRejectedValueOnce(enqueueError);
         const req = {
             user: { id: "u1" },
             params: { id: "job-spotify-dispatch-failed" },
@@ -1318,50 +1292,15 @@ describe("notifications route runtime", () => {
         );
 
         expect(res.statusCode).toBe(200);
-        expect(prisma.downloadJob.update).toHaveBeenCalledWith({
-            where: { id: "job-new-spotify-dispatch-failed" },
-            data: {
-                status: "failed",
-                error: "Download dispatch failed",
-                completedAt: expect.any(Date),
-            },
-        });
         expect(prisma.downloadJob.update).not.toHaveBeenCalledWith(
             expect.objectContaining({
-                data: expect.objectContaining({ error: "Soulseek error" }),
+                where: { id: "job-new-spotify-dispatch-failed" },
+                data: expect.objectContaining({ status: "failed" }),
             }),
         );
         expect(mockLogger.error).toHaveBeenCalledWith(
-            "[Retry] Album dispatch error:",
-            dispatchError,
-        );
-        expect(unhandledRejections).toEqual([]);
-    });
-
-    it("observes spotify_import fallback failure-persistence rejection", async () => {
-        prepareSpotifyImportFallback("spotify-dispatch-persistence-failed");
-        const persistenceError = new Error("database unavailable");
-        dispatchAlbumDownload.mockRejectedValueOnce(
-            new Error("configured source unavailable"),
-        );
-        prisma.downloadJob.update
-            .mockResolvedValueOnce({})
-            .mockRejectedValueOnce(persistenceError);
-        const req = {
-            user: { id: "u1" },
-            params: { id: "job-spotify-dispatch-persistence-failed" },
-        } as any;
-        const res = createRes();
-
-        const unhandledRejections = await captureUnhandledRejections(
-            async () => {
-                await retryDownload(req, res);
-            },
-        );
-
-        expect(mockLogger.error).toHaveBeenCalledWith(
-            "[Retry] Failed to persist album dispatch failure:",
-            persistenceError,
+            "[Retry] Album enqueue error:",
+            enqueueError,
         );
         expect(unhandledRejections).toEqual([]);
     });

--- a/backend/src/routes/__tests__/requestsRuntime.test.ts
+++ b/backend/src/routes/__tests__/requestsRuntime.test.ts
@@ -5,7 +5,7 @@ const mockListAllRequests = jest.fn();
 const mockApproveRequest = jest.fn();
 const mockDenyRequest = jest.fn();
 const mockGetRequestAvailability = jest.fn();
-const mockDispatchAlbumDownload = jest.fn();
+const mockEnqueueAlbumDownloadInBackground = jest.fn();
 
 class MockMusicRequestServiceError extends Error {
     constructor(
@@ -50,9 +50,9 @@ jest.mock("../../services/musicRequestService", () => ({
     getRequestAvailability: (...args: unknown[]) =>
         mockGetRequestAvailability(...args),
 }));
-jest.mock("../../services/downloadDispatcher", () => ({
-    dispatchAlbumDownload: (...args: unknown[]) =>
-        mockDispatchAlbumDownload(...args),
+jest.mock("../../services/albumDownloadQueueService", () => ({
+    enqueueAlbumDownloadInBackground: (...args: unknown[]) =>
+        mockEnqueueAlbumDownloadInBackground(...args),
 }));
 jest.mock("../../utils/logger", () => ({
     logger: {
@@ -148,7 +148,7 @@ describe("requests route runtime", () => {
             remainingToday: 9,
             dailyCap: 10,
         });
-        mockDispatchAlbumDownload.mockResolvedValue(undefined);
+        mockEnqueueAlbumDownloadInBackground.mockReturnValue(undefined);
     });
 
     it("requires an interactive authenticated session for the router", async () => {
@@ -356,7 +356,7 @@ describe("requests route runtime", () => {
         );
 
         expect(res.body).toEqual({ id: "request-1", status: "approved" });
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith({
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
             jobId: "job-1",
             type: "album",
             mbid: validBody.rgMbid,
@@ -375,7 +375,7 @@ describe("requests route runtime", () => {
         );
 
         expect(res.statusCode).toBe(200);
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockEnqueueAlbumDownloadInBackground).not.toHaveBeenCalled();
     });
 
     it("rejects invalid admin status filters", async () => {

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -14,7 +14,8 @@ import { lastFmService } from "../services/lastfm";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
 import { mapInteractiveRelease } from "../services/releaseContracts";
 import { createAlbumDownloadJob } from "../services/albumDownloadJobs";
-import { dispatchAlbumDownload } from "../services/downloadDispatcher";
+import { enqueueAlbumDownloadInBackground } from "../services/albumDownloadQueueService";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "../services/albumDownloadQueueOwnership";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import crypto from "crypto";
 
@@ -77,6 +78,7 @@ router.get("/availability", async (req, res) => {
  * /api/downloads:
  *   post:
  *     summary: Create a new download job for an artist or album
+ *     description: Creates a persisted download job and queues album work for serialized background processing.
  *     tags: [Downloads]
  *     security:
  *       - apiKeyAuth: []
@@ -107,7 +109,7 @@ router.get("/availability", async (req, res) => {
  *                 default: library
  *     responses:
  *       200:
- *         description: Download job created or duplicate found
+ *         description: Album jobs are created and queued for background processing, or an active duplicate is returned
  *       400:
  *         description: Missing required fields or no download service configured
  *       401:
@@ -207,6 +209,7 @@ router.post("/", requireAdmin, async (req, res) => {
             albumTitle,
             downloadType,
             rootFolderPath,
+            metadata: { queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER },
         });
 
         if (jobResult.duplicate) {
@@ -234,19 +237,13 @@ router.post("/", requireAdmin, async (req, res) => {
             `[DOWNLOAD] Triggering Lidarr: ${type} "${subject}" -> ${rootFolderPath}`,
         );
 
-        // Process in background
-        dispatchAlbumDownload({
+        enqueueAlbumDownloadInBackground({
             jobId: job.id,
             type,
             mbid,
             subject,
             artistName: jobResult.verifiedArtistName,
             albumTitle,
-        }).catch((error) => {
-            logger.error(
-                `Download processing failed for job ${job.id}:`,
-                error,
-            );
         });
 
         res.json({
@@ -429,12 +426,14 @@ async function processArtistDownload(
                         targetMbid: albumMbid,
                         status: "pending",
                         metadata: {
+                            queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER,
                             downloadType,
                             rootFolderPath,
                             artistName,
                             artistMbid,
                             albumTitle,
                             batchId, // Link all albums in this artist download
+                            statusText: "Queued",
                             batchArtist: artistName,
                             createdAt: now.toISOString(), // Track when job was created for timeout
                         },
@@ -459,16 +458,13 @@ async function processArtistDownload(
             jobs.push({ id: job.id, subject: albumSubject });
             logger.debug(`   [JOB] Created job for: ${albumSubject}`);
 
-            // Start the download in background
-            dispatchAlbumDownload({
+            enqueueAlbumDownloadInBackground({
                 jobId: job.id,
                 type: "album",
                 mbid: albumMbid,
                 subject: albumSubject,
                 artistName,
                 albumTitle,
-            }).catch((error) => {
-                logger.error(`Download failed for ${albumSubject}:`, error);
             });
         }
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -4,7 +4,8 @@ import { notificationService } from "../services/notificationService";
 import { requireAdmin, requireAuth } from "../middleware/auth";
 import { asyncHandler } from "../middleware/asyncHandler";
 import { prisma } from "../utils/db";
-import { dispatchAlbumDownload } from "../services/downloadDispatcher";
+import { enqueueAlbumDownload } from "../services/albumDownloadQueueService";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "../services/albumDownloadQueueOwnership";
 import { sendRouteError, sendInternalRouteError } from "./routeErrorResponse";
 
 const router = Router();
@@ -444,7 +445,7 @@ router.post(
  * /api/notifications/downloads/{id}/retry:
  *   post:
  *     summary: Retry a failed download (admin only)
- *     description: Retries a failed or exhausted download job. The generic album case schedules the retry through the configured download source. Validation failures, artist retries, and pending-track or spotify_import preconditions can still return a domain result with success false.
+ *     description: Retries a failed or exhausted download job. Generic album work is queued for serialized background processing through the configured download source. Validation failures, artist retries, and pending-track or spotify_import preconditions can still return a domain result with success false.
  *     tags: [Notifications]
  *     security:
  *       - apiKeyAuth: []
@@ -843,7 +844,22 @@ router.post(
                                 failedJob.targetMbid &&
                                 !failedJob.targetMbid.startsWith("retry_")
                             ) {
-                                await dispatchAlbumDownload({
+                                await prisma.downloadJob.update({
+                                    where: { id: newJobRecord.id },
+                                    data: {
+                                        status: "pending",
+                                        metadata: {
+                                            ...(newJobRecord.metadata as Record<
+                                                string,
+                                                unknown
+                                            >),
+                                            queuedVia:
+                                                ALBUM_DOWNLOAD_QUEUE_OWNER,
+                                            statusText: "Queued",
+                                        },
+                                    },
+                                });
+                                await enqueueAlbumDownload({
                                     jobId: newJobRecord.id,
                                     type: "album",
                                     mbid: failedJob.targetMbid,
@@ -852,24 +868,9 @@ router.post(
                                     albumTitle,
                                 }).catch((error) => {
                                     logger.error(
-                                        `[Retry] Album dispatch error:`,
+                                        `[Retry] Album enqueue error:`,
                                         error,
                                     );
-                                    return prisma.downloadJob
-                                        .update({
-                                            where: { id: newJobRecord.id },
-                                            data: {
-                                                status: "failed",
-                                                error: "Download dispatch failed",
-                                                completedAt: new Date(),
-                                            },
-                                        })
-                                        .catch((persistenceError) => {
-                                            logger.error(
-                                                `[Retry] Failed to persist album dispatch failure:`,
-                                                persistenceError,
-                                            );
-                                        });
                                 });
                             } else {
                                 await prisma.downloadJob.update({
@@ -938,12 +939,18 @@ router.post(
                     artistMbid: failedJob.artistMbid,
                     subject: failedJob.subject,
                     status: "pending",
-                    metadata: (metadata || {}) as any,
+                    metadata: {
+                        ...(metadata || {}),
+                        ...(failedJob.type === "album"
+                            ? { queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER }
+                            : {}),
+                        statusText: "Queued",
+                    } as any,
                 },
             });
 
             if (failedJob.type === "album") {
-                dispatchAlbumDownload({
+                enqueueAlbumDownload({
                     jobId: newJobRecord.id,
                     type: failedJob.type,
                     mbid: failedJob.targetMbid,
@@ -951,22 +958,7 @@ router.post(
                     artistName,
                     albumTitle,
                 }).catch((error) => {
-                    logger.error(`[Retry] Album dispatch error:`, error);
-                    return prisma.downloadJob
-                        .update({
-                            where: { id: newJobRecord.id },
-                            data: {
-                                status: "failed",
-                                error: "Download dispatch failed",
-                                completedAt: new Date(),
-                            },
-                        })
-                        .catch((persistenceError) => {
-                            logger.error(
-                                `[Retry] Failed to persist album dispatch failure:`,
-                                persistenceError,
-                            );
-                        });
+                    logger.error(`[Retry] Album enqueue error:`, error);
                 });
 
                 return res.json({

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -14,7 +14,7 @@ import {
     MUSIC_REQUEST_STATUSES,
     MusicRequestServiceError,
 } from "../services/musicRequestService";
-import { dispatchAlbumDownload } from "../services/downloadDispatcher";
+import { enqueueAlbumDownloadInBackground } from "../services/albumDownloadQueueService";
 import { logger } from "../utils/logger";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 
@@ -121,18 +121,13 @@ async function handleListAll(req: Request, res: Response) {
 }
 
 function dispatchApprovedDownload(dispatch: DownloadDispatch): void {
-    dispatchAlbumDownload({
+    enqueueAlbumDownloadInBackground({
         jobId: dispatch.jobId,
         type: dispatch.type,
         mbid: dispatch.mbid,
         subject: dispatch.subject,
         artistName: dispatch.artistName,
         albumTitle: dispatch.albumTitle,
-    }).catch((error) => {
-        log.error(
-            `Download processing failed for job ${dispatch.jobId}:`,
-            error,
-        );
     });
 }
 
@@ -296,7 +291,7 @@ router.get("/", requireAdmin, asyncHandler(handleListAll));
  * @openapi
  * /api/requests/{id}/approve:
  *   post:
- *     summary: Approve a pending request and start its album download
+ *     summary: Approve a pending request and queue its album download
  *     tags: [Music Requests]
  *     security:
  *       - apiKeyAuth: []

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -15,6 +15,8 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/acquisitionService.ts` | Core |
 | `backend/src/services/albumResolutionService.ts` | Core |
 | `backend/src/services/albumDownloadJobs.ts` | Shared locked album download-job creation and active-job deduplication |
+| `backend/src/services/albumDownloadQueueOwnership.ts` | Persisted album-download queue ownership marker and metadata predicate |
+| `backend/src/services/albumDownloadQueueService.ts` | Durable album download queue admission and observed background enqueue failures |
 | `backend/src/services/albumTitleGuards.ts` | Shared remote-album placeholder-title classification |
 | `backend/src/services/albumLoudness.ts` | Transactional active-track loudness rollups and per-album serialization |
 | `backend/src/services/artistCountsService.ts` | Core |

--- a/backend/src/services/__tests__/albumDownloadQueueService.test.ts
+++ b/backend/src/services/__tests__/albumDownloadQueueService.test.ts
@@ -1,0 +1,413 @@
+const mockQueueAdd = jest.fn();
+const mockQueueGetJob = jest.fn();
+const mockDownloadJobFindMany = jest.fn();
+const mockDownloadJobUpdate = jest.fn();
+const mockDownloadJobUpdateMany = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.mock("../../workers/queues", () => ({
+    albumDownloadQueue: {
+        add: (...args: unknown[]) => mockQueueAdd(...args),
+        getJob: (...args: unknown[]) => mockQueueGetJob(...args),
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findMany: (...args: unknown[]) => mockDownloadJobFindMany(...args),
+            update: (...args: unknown[]) => mockDownloadJobUpdate(...args),
+            updateMany: (...args: unknown[]) =>
+                mockDownloadJobUpdateMany(...args),
+        },
+    },
+}));
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        child: () => ({
+            debug: mockLoggerDebug,
+            error: mockLoggerError,
+        }),
+    },
+}));
+
+import {
+    enqueueAlbumDownload,
+    enqueueAlbumDownloadInBackground,
+    recoverUnqueuedAlbumDownloads,
+} from "../albumDownloadQueueService";
+import {
+    ALBUM_DOWNLOAD_QUEUE_OWNER,
+    isAlbumDownloadQueueOwned,
+} from "../albumDownloadQueueOwnership";
+
+const payload = {
+    jobId: "download-job-1",
+    type: "album",
+    mbid: "release-group-1",
+    subject: "Artist - Album",
+    artistName: "Artist",
+    albumTitle: "Album",
+} as const;
+
+describe("album download queue service", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockQueueAdd.mockResolvedValue({ id: "albumdl:download-job-1" });
+        mockQueueGetJob.mockResolvedValue(null);
+        mockDownloadJobFindMany.mockResolvedValue([]);
+        mockDownloadJobUpdate.mockResolvedValue({});
+        mockDownloadJobUpdateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it("recognizes only the album-download queue ownership marker", () => {
+        expect(
+            isAlbumDownloadQueueOwned({
+                queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER,
+            }),
+        ).toBe(true);
+        expect(isAlbumDownloadQueueOwned({ queuedVia: "legacy" })).toBe(false);
+        expect(isAlbumDownloadQueueOwned(null)).toBe(false);
+    });
+
+    it("enqueues the payload with a stable Bull deduplication id", async () => {
+        await enqueueAlbumDownload(payload);
+
+        expect(mockQueueAdd).toHaveBeenCalledWith("album-download", payload, {
+            jobId: "albumdl:download-job-1",
+        });
+        expect(mockLoggerDebug).toHaveBeenCalledWith("Album download queued", {
+            jobId: payload.jobId,
+            queueJobId: "albumdl:download-job-1",
+        });
+    });
+
+    it("marks the persisted job failed with a static error and rethrows enqueue failure", async () => {
+        const enqueueError = new Error("redis unavailable");
+        mockQueueAdd.mockRejectedValueOnce(enqueueError);
+
+        await expect(enqueueAlbumDownload(payload)).rejects.toBe(enqueueError);
+
+        expect(mockDownloadJobUpdate).toHaveBeenCalledWith({
+            where: { id: payload.jobId },
+            data: {
+                status: "failed",
+                error: "Download queue unavailable",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("observes failure-persistence rejection and still rethrows enqueue failure", async () => {
+        const enqueueError = new Error("redis unavailable");
+        const persistenceError = new Error("database unavailable");
+        mockQueueAdd.mockRejectedValueOnce(enqueueError);
+        mockDownloadJobUpdate.mockRejectedValueOnce(persistenceError);
+
+        await expect(enqueueAlbumDownload(payload)).rejects.toBe(enqueueError);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Failed to persist album download queue admission failure",
+            { jobId: payload.jobId, error: persistenceError },
+        );
+    });
+
+    it("swallows background enqueue rejection after final logging", async () => {
+        const enqueueError = new Error("redis unavailable");
+        mockQueueAdd.mockRejectedValueOnce(enqueueError);
+
+        enqueueAlbumDownloadInBackground(payload);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Album download enqueue failed",
+            { jobId: payload.jobId, error: enqueueError },
+        );
+    });
+
+    it("recovers only the first twenty stale pending uncleared album jobs", async () => {
+        const now = new Date("2026-08-24T18:00:00.000Z");
+        const candidates = [
+            ...Array.from({ length: 22 }, (_, index) => ({
+                id: `stale-${index}`,
+                type: "album",
+                status: "pending",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 6 * 60_000 - index),
+                targetMbid: `rg-${index}`,
+                subject: `Artist ${index} - Album ${index}`,
+                metadata: {
+                    artistName: `Artist ${index}`,
+                    albumTitle: `Album ${index}`,
+                    queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER,
+                },
+            })),
+            {
+                id: "fresh",
+                type: "album",
+                status: "pending",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 4 * 60_000),
+                targetMbid: "rg-fresh",
+                subject: "Fresh",
+                metadata: { queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER },
+            },
+            {
+                id: "legacy-album",
+                type: "album",
+                status: "pending",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 20 * 60_000),
+                targetMbid: "legacy-album-mbid",
+                subject: "Legacy Album",
+                metadata: {},
+            },
+            {
+                id: "artist",
+                type: "artist",
+                status: "pending",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 20 * 60_000),
+                targetMbid: "artist-mbid",
+                subject: "Artist",
+                metadata: {},
+            },
+            {
+                id: "processing",
+                type: "album",
+                status: "processing",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 20 * 60_000),
+                targetMbid: "rg-processing",
+                subject: "Processing",
+                metadata: {},
+            },
+            {
+                id: "terminal",
+                type: "album",
+                status: "failed",
+                cleared: false,
+                createdAt: new Date(now.getTime() - 20 * 60_000),
+                targetMbid: "rg-terminal",
+                subject: "Terminal",
+                metadata: {},
+            },
+            {
+                id: "cleared",
+                type: "album",
+                status: "pending",
+                cleared: true,
+                createdAt: new Date(now.getTime() - 20 * 60_000),
+                targetMbid: "rg-cleared",
+                subject: "Cleared",
+                metadata: {},
+            },
+        ];
+        mockDownloadJobFindMany.mockImplementationOnce((args) =>
+            candidates
+                .filter(
+                    (candidate) =>
+                        candidate.type === args.where.type &&
+                        candidate.status === args.where.status &&
+                        candidate.cleared === args.where.cleared &&
+                        candidate.createdAt < args.where.createdAt.lt &&
+                        candidate.metadata.queuedVia ===
+                            args.where.metadata.equals,
+                )
+                .sort(
+                    (left, right) =>
+                        left.createdAt.getTime() - right.createdAt.getTime(),
+                )
+                .slice(0, args.take),
+        );
+
+        const recovered = await recoverUnqueuedAlbumDownloads(now);
+
+        expect(recovered).toBe(20);
+        expect(mockQueueAdd).toHaveBeenCalledTimes(20);
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ jobId: "fresh" }),
+            expect.anything(),
+        );
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ jobId: "legacy-album" }),
+            expect.anything(),
+        );
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ jobId: "artist" }),
+            expect.anything(),
+        );
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ jobId: "processing" }),
+            expect.anything(),
+        );
+        expect(mockQueueAdd).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ jobId: "terminal" }),
+            expect.anything(),
+        );
+        expect(mockDownloadJobFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    type: "album",
+                    status: "pending",
+                    cleared: false,
+                    createdAt: { lt: new Date("2026-08-24T17:55:00.000Z") },
+                    metadata: {
+                        path: ["queuedVia"],
+                        equals: ALBUM_DOWNLOAD_QUEUE_OWNER,
+                    },
+                },
+                take: 20,
+            }),
+        );
+    });
+
+    it.each<[string, "skip" | "finalize-and-remove" | "remove-and-re-enqueue"]>(
+        [
+            ["waiting", "skip"],
+            ["active", "skip"],
+            ["delayed", "skip"],
+            ["paused", "skip"],
+            ["failed", "finalize-and-remove"],
+            ["completed", "remove-and-re-enqueue"],
+            ["stuck", "remove-and-re-enqueue"],
+        ],
+    )("handles Bull state %s with %s", async (state, expectedAction) => {
+        const remove = jest.fn().mockResolvedValue(undefined);
+        mockDownloadJobFindMany.mockResolvedValueOnce([
+            {
+                id: "existing-job",
+                targetMbid: "rg-existing",
+                subject: "Artist - Album",
+                metadata: {},
+            },
+        ]);
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue(state),
+            remove,
+        });
+
+        await recoverUnqueuedAlbumDownloads();
+
+        if (expectedAction === "skip") {
+            expect(mockQueueAdd).not.toHaveBeenCalled();
+            expect(mockDownloadJobUpdateMany).not.toHaveBeenCalled();
+            expect(remove).not.toHaveBeenCalled();
+            return;
+        }
+
+        if (expectedAction === "finalize-and-remove") {
+            expect(mockDownloadJobUpdateMany).toHaveBeenCalledWith({
+                where: {
+                    id: "existing-job",
+                    status: { in: ["pending", "processing"] },
+                },
+                data: {
+                    status: "failed",
+                    error: "Download failed",
+                    completedAt: expect.any(Date),
+                },
+            });
+            expect(remove).toHaveBeenCalledTimes(1);
+            expect(
+                mockDownloadJobUpdateMany.mock.invocationCallOrder[0],
+            ).toBeLessThan(remove.mock.invocationCallOrder[0]);
+            expect(mockQueueAdd).not.toHaveBeenCalled();
+            return;
+        }
+
+        expect(mockDownloadJobUpdateMany).not.toHaveBeenCalled();
+        expect(remove).toHaveBeenCalledTimes(1);
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "album-download",
+            expect.objectContaining({ jobId: "existing-job" }),
+            { jobId: "albumdl:existing-job" },
+        );
+        expect(remove.mock.invocationCallOrder[0]).toBeLessThan(
+            mockQueueAdd.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("removes and re-enqueues a recovered row with an unknown Bull state", async () => {
+        const remove = jest.fn().mockResolvedValue(undefined);
+        mockDownloadJobFindMany.mockResolvedValueOnce([
+            {
+                id: "unknown-state-job",
+                targetMbid: "rg-unknown",
+                subject: "Artist - Album",
+                metadata: {},
+            },
+        ]);
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("unknown"),
+            remove,
+        });
+
+        await recoverUnqueuedAlbumDownloads();
+
+        expect(remove).toHaveBeenCalledTimes(1);
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "album-download",
+            expect.objectContaining({ jobId: "unknown-state-job" }),
+            { jobId: "albumdl:unknown-state-job" },
+        );
+    });
+
+    it("logs orphan cleanup errors and still attempts re-enqueue", async () => {
+        const cleanupError = new Error("remove failed");
+        mockDownloadJobFindMany.mockResolvedValueOnce([
+            {
+                id: "completed-job",
+                targetMbid: "rg-completed",
+                subject: "Artist - Album",
+                metadata: {},
+            },
+        ]);
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("completed"),
+            remove: jest.fn().mockRejectedValue(cleanupError),
+        });
+
+        await expect(recoverUnqueuedAlbumDownloads()).resolves.toBe(1);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Failed to remove incoherent album download queue job",
+            { jobId: "completed-job", error: cleanupError },
+        );
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "album-download",
+            expect.objectContaining({ jobId: "completed-job" }),
+            { jobId: "albumdl:completed-job" },
+        );
+    });
+
+    it("logs retained failed Bull job cleanup errors and continues", async () => {
+        const cleanupError = new Error("remove failed");
+        mockDownloadJobFindMany.mockResolvedValueOnce([
+            {
+                id: "failed-job",
+                targetMbid: "rg-failed",
+                subject: "Artist - Album",
+                metadata: {},
+            },
+        ]);
+        mockQueueGetJob.mockResolvedValueOnce({
+            getState: jest.fn().mockResolvedValue("failed"),
+            remove: jest.fn().mockRejectedValue(cleanupError),
+        });
+
+        await expect(recoverUnqueuedAlbumDownloads()).resolves.toBe(1);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Failed to finalize retained album download queue failure",
+            { jobId: "failed-job", error: cleanupError },
+        );
+    });
+});

--- a/backend/src/services/__tests__/musicRequestService.test.ts
+++ b/backend/src/services/__tests__/musicRequestService.test.ts
@@ -359,6 +359,7 @@ describe("musicRequestService", () => {
                 albumTitle: input.albumTitle,
                 downloadType: "library",
                 rootFolderPath: "/library",
+                metadata: { queuedVia: "album-download-queue" },
             },
             prisma,
             input.artistName,

--- a/backend/src/services/__tests__/simpleDownloadManager.test.ts
+++ b/backend/src/services/__tests__/simpleDownloadManager.test.ts
@@ -975,6 +975,12 @@ describe("simpleDownloadManager", () => {
                 status: "pending",
                 createdAt: freshDate,
             },
+            {
+                id: "pending-queue-owned",
+                status: "pending",
+                createdAt: staleDate,
+                metadata: { queuedVia: "album-download-queue" },
+            },
         ]);
         mockPrisma.downloadJob.updateMany.mockResolvedValueOnce({ count: 1 });
 

--- a/backend/src/services/__tests__/tidalLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/tidalLibraryDownload.test.ts
@@ -1,8 +1,10 @@
+const mockLoggerWarn = jest.fn();
+
 jest.mock("../../utils/logger", () => ({
     logger: {
         debug: jest.fn(),
         info: jest.fn(),
-        warn: jest.fn(),
+        warn: mockLoggerWarn,
         error: jest.fn(),
     },
 }));
@@ -107,6 +109,49 @@ describe("tidalLibraryDownload", () => {
             artistName: "Artist",
             albumTitle: "Album",
         });
+    });
+
+    it("clears the first-attempt failure state after a successful retry", async () => {
+        mockFindUnique.mockResolvedValueOnce({
+            metadata: {
+                albumMbid: "rg-1",
+                retained: true,
+                failedAt: "2026-08-24T10:00:00.000Z",
+            },
+        });
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        const searchingUpdate = mockUpdate.mock.calls.find(
+            ([call]) =>
+                call.data?.metadata?.statusText === "Searching TIDAL...",
+        )?.[0];
+        const completedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "completed",
+        )?.[0];
+        expect(searchingUpdate.data.error).toBeNull();
+        expect(completedUpdate.data.error).toBeNull();
+        expect(completedUpdate.data.metadata).toEqual(
+            expect.objectContaining({ retained: true }),
+        );
+        expect(completedUpdate.data.metadata).not.toHaveProperty("failedAt");
+    });
+
+    it("keeps a completed download completed when scan admission fails", async () => {
+        const scanError = new Error("scan queue unavailable");
+        mockScan.mockRejectedValueOnce(scanError);
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(
+            mockUpdate.mock.calls.some(
+                ([call]) => call.data?.status === "failed",
+            ),
+        ).toBe(false);
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "TIDAL library scan enqueue failed; download remains completed",
+            { jobId: "job-1", error: scanError },
+        );
     });
 
     it("hands a search miss to a configured youtube fallback", async () => {

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -1,8 +1,10 @@
+const mockLoggerWarn = jest.fn();
+
 jest.mock("../../utils/logger", () => ({
     logger: {
         debug: jest.fn(),
         info: jest.fn(),
-        warn: jest.fn(),
+        warn: mockLoggerWarn,
         error: jest.fn(),
     },
 }));
@@ -198,6 +200,50 @@ describe("youtubeLibraryDownload", () => {
             artistName: "Artist",
             albumTitle: "Album",
         });
+    });
+
+    it("clears the first-attempt failure state after a successful retry", async () => {
+        mockFindUnique.mockResolvedValueOnce({
+            metadata: {
+                albumMbid: "rg-1",
+                retained: true,
+                failedAt: "2026-08-24T10:00:00.000Z",
+            },
+        });
+
+        await processYoutubeDownload("job-1", "Artist", "Album", "user-1");
+
+        const searchingUpdate = mockUpdate.mock.calls.find(
+            ([call]) =>
+                call.data?.metadata?.statusText ===
+                "Searching YouTube Music...",
+        )?.[0];
+        const completedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "completed",
+        )?.[0];
+        expect(searchingUpdate.data.error).toBeNull();
+        expect(completedUpdate.data.error).toBeNull();
+        expect(completedUpdate.data.metadata).toEqual(
+            expect.objectContaining({ retained: true }),
+        );
+        expect(completedUpdate.data.metadata).not.toHaveProperty("failedAt");
+    });
+
+    it("keeps a completed download completed when scan admission fails", async () => {
+        const scanError = new Error("scan queue unavailable");
+        mockScan.mockRejectedValueOnce(scanError);
+
+        await processYoutubeDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(
+            mockUpdate.mock.calls.some(
+                ([call]) => call.data?.status === "failed",
+            ),
+        ).toBe(false);
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "YouTube Music library scan enqueue failed; download remains completed",
+            { jobId: "job-1", error: scanError },
+        );
     });
 
     it("persists progress only when the reported percentage changes", async () => {

--- a/backend/src/services/albumDownloadJobs.ts
+++ b/backend/src/services/albumDownloadJobs.ts
@@ -2,6 +2,7 @@ import type { DownloadJob, Prisma } from "@prisma/client";
 import { lastFmService } from "./lastfm";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "./albumDownloadQueueOwnership";
 
 const log = logger.child?.("AlbumDownloadJobs") ?? logger;
 const ACTIVE_DOWNLOAD_STATUSES = ["pending", "processing"] as const;
@@ -20,6 +21,7 @@ export interface CreateAlbumDownloadJobParams {
     albumTitle?: string;
     downloadType: "library" | "discovery";
     rootFolderPath: string;
+    metadata: Readonly<{ queuedVia: typeof ALBUM_DOWNLOAD_QUEUE_OWNER }>;
 }
 
 /** A newly created job or the active job that already owns the album. */
@@ -94,10 +96,12 @@ async function createWithDatabase(
             targetMbid: params.mbid,
             status: "pending",
             metadata: {
+                ...params.metadata,
                 downloadType: params.downloadType,
                 rootFolderPath: params.rootFolderPath,
                 artistName: verifiedArtistName,
                 albumTitle: params.albumTitle,
+                statusText: "Queued",
             },
         },
     });

--- a/backend/src/services/albumDownloadQueueOwnership.ts
+++ b/backend/src/services/albumDownloadQueueOwnership.ts
@@ -1,0 +1,13 @@
+/** Persisted owner value for rows managed by the album-download queue. */
+export const ALBUM_DOWNLOAD_QUEUE_OWNER = "album-download-queue" as const;
+
+/** Return whether persisted metadata assigns lifecycle ownership to the queue. */
+export function isAlbumDownloadQueueOwned(metadata: unknown): boolean {
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+        return false;
+    }
+    return (
+        (metadata as Record<string, unknown>).queuedVia ===
+        ALBUM_DOWNLOAD_QUEUE_OWNER
+    );
+}

--- a/backend/src/services/albumDownloadQueueService.ts
+++ b/backend/src/services/albumDownloadQueueService.ts
@@ -1,0 +1,189 @@
+import type { AlbumDownloadDispatchParams } from "./downloadDispatcher";
+import { albumDownloadQueue } from "../workers/queues";
+import { prisma } from "../utils/db";
+import { logger } from "../utils/logger";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "./albumDownloadQueueOwnership";
+
+const log = logger.child("AlbumDownloadQueueService");
+const ALBUM_DOWNLOAD_JOB_NAME = "album-download";
+const ALBUM_DOWNLOAD_RECOVERY_AGE_MS = 5 * 60_000;
+const ALBUM_DOWNLOAD_RECOVERY_LIMIT = 20;
+
+function albumDownloadQueueJobId(jobId: string): string {
+    return `albumdl:${jobId}`;
+}
+
+function readMetadataString(
+    metadata: unknown,
+    key: "artistName" | "albumTitle",
+): string | undefined {
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+        return undefined;
+    }
+    const value = (metadata as Record<string, unknown>)[key];
+    return typeof value === "string" ? value : undefined;
+}
+
+async function persistQueueAdmissionFailure(jobId: string): Promise<void> {
+    try {
+        await prisma.downloadJob.update({
+            where: { id: jobId },
+            data: {
+                status: "failed",
+                error: "Download queue unavailable",
+                completedAt: new Date(),
+            },
+        });
+    } catch (error) {
+        log.error("Failed to persist album download queue admission failure", {
+            jobId,
+            error,
+        });
+    }
+}
+
+/** Add one album download to the durable queue. */
+export async function enqueueAlbumDownload(
+    params: AlbumDownloadDispatchParams,
+): Promise<void> {
+    const queueJobId = albumDownloadQueueJobId(params.jobId);
+    try {
+        await albumDownloadQueue.add(ALBUM_DOWNLOAD_JOB_NAME, params, {
+            jobId: queueJobId,
+        });
+        log.debug("Album download queued", {
+            jobId: params.jobId,
+            queueJobId,
+        });
+    } catch (error) {
+        await persistQueueAdmissionFailure(params.jobId);
+        throw error;
+    }
+}
+
+async function findRecoveryCandidates(now: Date) {
+    return prisma.downloadJob.findMany({
+        where: {
+            type: "album",
+            status: "pending",
+            cleared: false,
+            createdAt: {
+                lt: new Date(now.getTime() - ALBUM_DOWNLOAD_RECOVERY_AGE_MS),
+            },
+            metadata: {
+                path: ["queuedVia"],
+                equals: ALBUM_DOWNLOAD_QUEUE_OWNER,
+            },
+        },
+        orderBy: { createdAt: "asc" },
+        take: ALBUM_DOWNLOAD_RECOVERY_LIMIT,
+        select: {
+            id: true,
+            targetMbid: true,
+            subject: true,
+            metadata: true,
+        },
+    });
+}
+
+async function finalizeRecoveredQueueFailure(jobId: string): Promise<void> {
+    await prisma.downloadJob.updateMany({
+        where: {
+            id: jobId,
+            status: { in: ["pending", "processing"] },
+        },
+        data: {
+            status: "failed",
+            error: "Download failed",
+            completedAt: new Date(),
+        },
+    });
+}
+
+type RemovableQueueJob = Readonly<{ remove: () => Promise<void> }>;
+
+async function finalizeRetainedFailedQueueJob(
+    jobId: string,
+    queueJob: RemovableQueueJob,
+): Promise<void> {
+    try {
+        await finalizeRecoveredQueueFailure(jobId);
+        await queueJob.remove();
+    } catch (error) {
+        log.error("Failed to finalize retained album download queue failure", {
+            jobId,
+            error,
+        });
+    }
+}
+
+async function removeIncoherentQueueJob(
+    jobId: string,
+    queueJob: RemovableQueueJob,
+): Promise<void> {
+    try {
+        await queueJob.remove();
+    } catch (error) {
+        log.error("Failed to remove incoherent album download queue job", {
+            jobId,
+            error,
+        });
+    }
+}
+
+async function retainedBullJobHandlesCandidate(
+    jobId: string,
+): Promise<boolean> {
+    const queueJob = await albumDownloadQueue.getJob(
+        albumDownloadQueueJobId(jobId),
+    );
+    if (!queueJob) return false;
+    const state = await queueJob.getState();
+    switch (state) {
+        case "waiting":
+        case "active":
+        case "delayed":
+        case "paused":
+            return true;
+        case "failed":
+            await finalizeRetainedFailedQueueJob(jobId, queueJob);
+            return true;
+        case "completed":
+        case "stuck":
+        default:
+            await removeIncoherentQueueJob(jobId, queueJob);
+            return false;
+    }
+}
+
+/** Re-enqueue bounded stale queue-owned jobs whose Redis admission was lost. */
+export async function recoverUnqueuedAlbumDownloads(
+    now = new Date(),
+): Promise<number> {
+    const staleJobs = await findRecoveryCandidates(now);
+
+    for (const job of staleJobs) {
+        if (await retainedBullJobHandlesCandidate(job.id)) continue;
+        await enqueueAlbumDownload({
+            jobId: job.id,
+            type: "album",
+            mbid: job.targetMbid,
+            subject: job.subject,
+            artistName: readMetadataString(job.metadata, "artistName"),
+            albumTitle: readMetadataString(job.metadata, "albumTitle"),
+        });
+    }
+    return staleJobs.length;
+}
+
+/** Supervise a fire-and-forget album download enqueue operation. */
+export function enqueueAlbumDownloadInBackground(
+    params: AlbumDownloadDispatchParams,
+): void {
+    void enqueueAlbumDownload(params).catch((error) => {
+        log.error("Album download enqueue failed", {
+            jobId: params.jobId,
+            error,
+        });
+    });
+}

--- a/backend/src/services/musicRequestService.ts
+++ b/backend/src/services/musicRequestService.ts
@@ -10,6 +10,7 @@ import {
     type AlbumDownloadJobResult,
     type CreateAlbumDownloadJobParams,
 } from "./albumDownloadJobs";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "./albumDownloadQueueOwnership";
 import {
     notificationService,
     type RequestNotificationMetadata,
@@ -401,6 +402,7 @@ function approvalJobParams(
         albumTitle: request.albumTitle,
         downloadType: "library",
         rootFolderPath,
+        metadata: { queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER },
     };
 }
 

--- a/backend/src/services/simpleDownloadManager.ts
+++ b/backend/src/services/simpleDownloadManager.ts
@@ -25,6 +25,7 @@ import { sessionLog } from "../utils/playlistLogger";
 import { config } from "../config";
 import axios from "axios";
 import * as crypto from "crypto";
+import { isAlbumDownloadQueueOwned } from "./albumDownloadQueueOwnership";
 
 // Type for transactional prisma client
 type TransactionClient = Omit<
@@ -1369,9 +1370,7 @@ class SimpleDownloadManager {
 
     /**
      * Mark stale jobs as failed (called by cleanup job)
-     * - Pending jobs (never started) timeout after 3 minutes = "download never started"
-     * - Processing jobs with no lidarrRef (never grabbed) timeout after 2 minutes = "no sources found"
-     * - Processing jobs with lidarrRef (grabbed but not imported) timeout after 5 minutes = "import failed"
+     * Applies the configured pending, no-source, and import timeouts to legacy-owned jobs.
      * Optionally accepts a pre-fetched snapshot to avoid duplicate API calls.
      */
     async markStaleJobsAsFailed(
@@ -1407,9 +1406,10 @@ class SimpleDownloadManager {
 
         // Handle old pending jobs - batch update instead of individual updates
         const stalePendingJobs = pendingJobs.filter(
-            (job) => job.createdAt < pendingCutoff,
+            (job) =>
+                !isAlbumDownloadQueueOwned(job.metadata) &&
+                job.createdAt < pendingCutoff,
         );
-
         const pendingDiscoveryBatchIds = new Set<string>();
 
         if (stalePendingJobs.length > 0) {

--- a/backend/src/services/tidalLibraryDownload.ts
+++ b/backend/src/services/tidalLibraryDownload.ts
@@ -22,6 +22,11 @@ function asMetadata(value: unknown): DownloadMetadata {
         : {};
 }
 
+function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
+    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
+    return retainedMetadata;
+}
+
 async function markSearching(
     jobId: string,
     metadata: DownloadMetadata,
@@ -30,6 +35,7 @@ async function markSearching(
         where: { id: jobId },
         data: {
             status: "processing",
+            error: null,
             metadata: {
                 ...metadata,
                 currentSource: "tidal",
@@ -158,8 +164,9 @@ async function completeTidalJob(
         data: {
             status: "completed",
             completedAt: new Date(),
+            error: null,
             metadata: {
-                ...metadata,
+                ...withoutFailedAt(metadata),
                 currentSource: "tidal",
                 statusText: `TIDAL ✓ ${completedStatusText(result)}`,
                 tidalAlbumId: match.albumId,
@@ -187,6 +194,21 @@ async function queueLibraryScan(
     logger.debug(
         `[TIDAL] Scan queued for: ${result.artist} - ${result.album_title}`,
     );
+}
+
+async function queueLibraryScanSafely(
+    jobId: string,
+    userId: string,
+    result: TidalAlbumDownloadResult,
+): Promise<void> {
+    try {
+        await queueLibraryScan(userId, result);
+    } catch (error) {
+        logger.warn(
+            "TIDAL library scan enqueue failed; download remains completed",
+            { jobId, error },
+        );
+    }
 }
 
 async function failTidalJob(
@@ -222,6 +244,7 @@ export async function processTidalDownload(
         select: { metadata: true },
     });
     const metadata = asMetadata(existingJob?.metadata);
+    let completedResult: TidalAlbumDownloadResult;
     try {
         await markSearching(jobId, metadata);
         const match = await tidalService.findAlbum(artistName, albumTitle);
@@ -245,12 +268,14 @@ export async function processTidalDownload(
         await markDownloading(jobId, match, metadata);
         const result = await downloadAlbum(match);
         await completeTidalJob(jobId, match, result, metadata);
-        await queueLibraryScan(userId, result);
+        completedResult = result;
     } catch (error: unknown) {
         logger.error(
             `[TIDAL] Download failed for job ${jobId}:`,
             error instanceof Error ? error.message : error,
         );
         await failTidalJob(jobId, metadata);
+        return;
     }
+    await queueLibraryScanSafely(jobId, userId, completedResult);
 }

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -29,6 +29,11 @@ function asMetadata(value: unknown): DownloadMetadata {
         : {};
 }
 
+function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
+    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
+    return retainedMetadata;
+}
+
 function asAlbumSearchCandidate(value: unknown): AlbumSearchCandidate | null {
     if (!value || typeof value !== "object") return null;
     const candidate = value as Record<string, unknown>;
@@ -101,6 +106,7 @@ async function markSearching(
         where: { id: jobId },
         data: {
             status: "processing",
+            error: null,
             metadata: {
                 ...metadata,
                 currentSource: "youtube",
@@ -225,8 +231,9 @@ async function completeYoutubeJob(
         data: {
             status: "completed",
             completedAt: new Date(),
+            error: null,
             metadata: {
-                ...metadata,
+                ...withoutFailedAt(metadata),
                 currentSource: "youtube",
                 statusText: `YouTube Music ✓ ${result.downloaded}/${result.totalTracks} tracks`,
                 youtubeAlbumJobId: result.jobId,
@@ -258,6 +265,28 @@ async function failYoutubeJob(
             },
         },
     });
+}
+
+async function queueLibraryScanSafely(
+    jobId: string,
+    userId: string,
+    artistName: string,
+    albumTitle: string,
+): Promise<void> {
+    try {
+        const { scanQueue } = await import("../workers/queues");
+        await scanQueue.add("scan", {
+            userId,
+            source: "youtube-download",
+            artistName,
+            albumTitle,
+        });
+    } catch (error) {
+        logger.warn(
+            "YouTube Music library scan enqueue failed; download remains completed",
+            { jobId, error },
+        );
+    }
 }
 
 /** Process a library album through public YouTube Music search and download. */
@@ -299,18 +328,13 @@ export async function processYoutubeDownload(
             );
         }
         await completeYoutubeJob(jobId, result, metadata);
-        const { scanQueue } = await import("../workers/queues");
-        await scanQueue.add("scan", {
-            userId,
-            source: "youtube-download",
-            artistName,
-            albumTitle,
-        });
     } catch (error: unknown) {
         logger.error(
             `[YouTube Music] Download failed for job ${jobId}:`,
             error instanceof Error ? error.message : error,
         );
         await failYoutubeJob(jobId, metadata);
+        return;
     }
+    await queueLibraryScanSafely(jobId, userId, artistName, albumTitle);
 }

--- a/backend/src/utils/schedulerClaim.ts
+++ b/backend/src/utils/schedulerClaim.ts
@@ -38,6 +38,8 @@ const schedulerClaimCounters = {
     skipped: 0,
     failedAcquire: 0,
     failedRelease: 0,
+    extended: 0,
+    failedExtend: 0,
     retryRecoveries: 0,
 };
 let schedulerLockRedis: Redis = createIORedisClient(
@@ -49,7 +51,7 @@ let schedulerClaimRedisClosed = false;
 function logSchedulerClaimObservability(context: string): void {
     const counters = schedulerClaimCounters;
     claimObservabilityLog.info(
-        `context=${context} workerId=${SCHEDULER_CLAIM_PROCESS_ID} owner=${SCHEDULER_CLAIM_OWNER_ID} acquired=${counters.acquired} skipped=${counters.skipped} failedAcquire=${counters.failedAcquire} failedRelease=${counters.failedRelease} retryRecoveries=${counters.retryRecoveries}`,
+        `context=${context} workerId=${SCHEDULER_CLAIM_PROCESS_ID} owner=${SCHEDULER_CLAIM_OWNER_ID} acquired=${counters.acquired} skipped=${counters.skipped} failedAcquire=${counters.failedAcquire} failedRelease=${counters.failedRelease} extended=${counters.extended} failedExtend=${counters.failedExtend} retryRecoveries=${counters.retryRecoveries}`,
     );
 }
 
@@ -59,7 +61,9 @@ function maybeLogSchedulerClaimObservability(context: string): void {
         counters.acquired +
         counters.skipped +
         counters.failedAcquire +
-        counters.failedRelease;
+        counters.failedRelease +
+        counters.extended +
+        counters.failedExtend;
     if (totalEvents > 0 && totalEvents % OBSERVABILITY_LOG_EVERY === 0) {
         logSchedulerClaimObservability(context);
     }
@@ -195,12 +199,44 @@ async function releaseSchedulerClaim(
     }
 }
 
+function recordClaimExtension(extended: boolean): void {
+    schedulerClaimCounters[extended ? "extended" : "failedExtend"] += 1;
+    maybeLogSchedulerClaimObservability(extended ? "extend" : "failed-extend");
+}
+
+/** Extend a scheduler claim when the caller still owns its token. */
+export async function extendSchedulerClaim(
+    claimKey: string,
+    claimToken: string,
+    ttlMs: number,
+): Promise<boolean> {
+    try {
+        const ttlMilliseconds = Math.max(1, Math.ceil(ttlMs));
+        const extended = await withSchedulerClaimRedisRetry(
+            "claim extension",
+            (client) =>
+                client.eval(
+                    "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+                    1,
+                    claimKey,
+                    claimToken,
+                    ttlMilliseconds,
+                ),
+        );
+        recordClaimExtension(extended === 1);
+        return extended === 1;
+    } catch (error) {
+        recordClaimExtension(false);
+        throw error;
+    }
+}
+
 /** Runs an operation under the Redis lease used by scheduled worker claims. */
 export async function runWithSchedulerClaim<T>(
     claimKey: string,
     ttlMs: number,
     operationName: string,
-    operation: () => Promise<T>,
+    operation: (claimToken: string) => Promise<T>,
 ): Promise<SchedulerClaimResult<T>> {
     let claimToken: string | null;
     try {
@@ -215,7 +251,7 @@ export async function runWithSchedulerClaim<T>(
     }
     if (!claimToken) return { acquired: false };
     try {
-        return { acquired: true, value: await operation() };
+        return { acquired: true, value: await operation(claimToken) };
     } finally {
         await releaseSchedulerClaim(claimKey, claimToken, operationName);
     }

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -41,6 +41,7 @@ describe("workers runtime behavior", () => {
         const schedulerQueue = createQueueMock();
         const genericImportQueue = createQueueMock();
         const federationQueue = createQueueMock();
+        const albumDownloadQueue = createQueueMock();
 
         const logger = {
             debug: jest.fn(),
@@ -83,6 +84,12 @@ describe("workers runtime behavior", () => {
         const finalizeGenericImportQueueFailure = jest.fn(
             async () => undefined,
         );
+        const processAlbumDownload = jest.fn(async () => undefined);
+        const finalizeAlbumDownloadQueueFailure = jest.fn(
+            async () => undefined,
+        );
+        const recoverUnqueuedAlbumDownloads = jest.fn(async () => 0);
+        const recordAlbumDownloadOutcome = jest.fn();
         const registerRecoveryJobs = jest.fn(async () => undefined);
         const registerFederationProcessors = jest.fn();
         const registerFederationSchedules = jest.fn(async () => undefined);
@@ -144,6 +151,7 @@ describe("workers runtime behavior", () => {
             set: jest.fn(async () => "OK"),
             del: jest.fn(async () => 1),
             eval: jest.fn(async () => 1),
+            expire: jest.fn(async () => 1),
             quit: jest.fn(async () => "OK"),
             disconnect: jest.fn(),
         };
@@ -185,6 +193,7 @@ describe("workers runtime behavior", () => {
             schedulerQueue,
             genericImportQueue,
             federationQueue,
+            albumDownloadQueue,
         }));
         jest.doMock("../federationJobs", () => ({
             registerFederationProcessors,
@@ -218,6 +227,18 @@ describe("workers runtime behavior", () => {
             processGenericImport,
             finalizeGenericImportQueueFailure,
             GENERIC_IMPORT_WORKER_CONCURRENCY: 2,
+        }));
+        jest.doMock("../processors/albumDownloadProcessor", () => ({
+            ALBUM_DOWNLOAD_JOB_NAME: "album-download",
+            ALBUM_DOWNLOAD_WORKER_CONCURRENCY: 1,
+            processAlbumDownload,
+            finalizeAlbumDownloadQueueFailure,
+        }));
+        jest.doMock("../../services/albumDownloadQueueService", () => ({
+            recoverUnqueuedAlbumDownloads,
+        }));
+        jest.doMock("../../metrics", () => ({
+            recordAlbumDownloadOutcome,
         }));
         jest.doMock("../processors/trackRemovalPurgeProcessor", () => ({
             TRACK_REMOVAL_PURGE_JOB_NAME: "track-removal-purge",
@@ -314,6 +335,7 @@ describe("workers runtime behavior", () => {
             schedulerQueue,
             genericImportQueue,
             federationQueue,
+            albumDownloadQueue,
             logger,
             startUnifiedEnrichmentWorker,
             stopUnifiedEnrichmentWorker,
@@ -328,6 +350,10 @@ describe("workers runtime behavior", () => {
             processLoudnessBackfill,
             processRequestFulfillmentBatch,
             finalizeGenericImportQueueFailure,
+            processAlbumDownload,
+            finalizeAlbumDownloadQueueFailure,
+            recoverUnqueuedAlbumDownloads,
+            recordAlbumDownloadOutcome,
             registerRecoveryJobs,
             registerFederationProcessors,
             registerFederationSchedules,
@@ -388,6 +414,11 @@ describe("workers runtime behavior", () => {
             2,
             mocks.processGenericImport,
         );
+        expect(mocks.albumDownloadQueue.process).toHaveBeenCalledWith(
+            "album-download",
+            1,
+            mocks.processAlbumDownload,
+        );
         expect(mocks.registerRecoveryJobs).toHaveBeenCalledTimes(1);
         expect(mocks.registerFederationProcessors).not.toHaveBeenCalled();
         expect(mocks.registerFederationSchedules).not.toHaveBeenCalled();
@@ -398,6 +429,26 @@ describe("workers runtime behavior", () => {
         expect(mocks.stopDiscoverWeeklyCron).not.toHaveBeenCalled();
         expect(mocks.schedulerQueue.isReady).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.add).toHaveBeenCalled();
+        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+            "album-download-recovery-cycle",
+            { mode: "startup" },
+            {
+                jobId: "scheduler:album-download-recovery:startup",
+                delay: 60_000,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
+        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+            "album-download-recovery-cycle",
+            { mode: "repeat" },
+            {
+                jobId: "scheduler:album-download-recovery:repeat",
+                repeat: { every: 5 * 60_000 },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        );
         expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
             "audiobook-auto-sync-startup",
             { mode: "repeat" },
@@ -807,6 +858,7 @@ describe("workers runtime behavior", () => {
         expect(workers.validationQueue).toBe(mocks.validationQueue);
         expect(workers.schedulerQueue).toBe(mocks.schedulerQueue);
         expect(workers.genericImportQueue).toBe(mocks.genericImportQueue);
+        expect(workers.albumDownloadQueue).toBe(mocks.albumDownloadQueue);
     });
 
     it("shuts down workers and queue resources cleanly", async () => {
@@ -827,8 +879,18 @@ describe("workers runtime behavior", () => {
         expect(
             mocks.genericImportQueue.removeAllListeners,
         ).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.albumDownloadQueue.removeAllListeners,
+        ).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.genericImportQueue.close).toHaveBeenCalledTimes(1);
+        expect(mocks.albumDownloadQueue.close).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.albumDownloadQueue.close.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            mocks.albumDownloadQueue.removeAllListeners.mock
+                .invocationCallOrder[0],
+        );
         expect(mocks.enrichmentStateService.disconnect).toHaveBeenCalledTimes(
             1,
         );
@@ -1067,6 +1129,37 @@ describe("workers runtime behavior", () => {
         ).toHaveBeenCalled();
         expect(mocks.backfillAllArtistCounts).toHaveBeenCalled();
         expect(mocks.backfillAllImages).toHaveBeenCalled();
+    });
+
+    it("runs the album-download recovery scheduler cycle under its claim", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        mocks.recoverUnqueuedAlbumDownloads.mockResolvedValueOnce(3);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+        await schedulerHandler({
+            id: "album-recovery-1",
+            name: "album-download-recovery-cycle",
+            data: { mode: "repeat" },
+        });
+
+        expect(mocks.schedulerLockRedis.set).toHaveBeenCalledWith(
+            "scheduler-claim:album-download-recovery",
+            expect.any(String),
+            "EX",
+            300,
+            "NX",
+        );
+        expect(mocks.recoverUnqueuedAlbumDownloads).toHaveBeenCalledTimes(1);
+        expect(mocks.logger.info).toHaveBeenCalledWith(
+            "Recovered 3 unqueued album downloads",
+        );
     });
 
     it("runs track-mapping reconcile job including YT->TIDAL upgrade pass", async () => {
@@ -1480,6 +1573,66 @@ describe("workers runtime behavior", () => {
         );
     });
 
+    it("atomically extends a scheduler claim only while its token still owns the key", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        mocks.schedulerLockRedis.eval
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(0)
+            .mockResolvedValue(1);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { extendSchedulerClaim } = require("../../utils/schedulerClaim");
+
+        await expect(
+            extendSchedulerClaim(
+                "scheduler-claim:test",
+                "claim-token",
+                900_000,
+            ),
+        ).resolves.toBe(true);
+
+        expect(mocks.schedulerLockRedis.eval).toHaveBeenNthCalledWith(
+            1,
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+            1,
+            "scheduler-claim:test",
+            "claim-token",
+            900_000,
+        );
+
+        await expect(
+            extendSchedulerClaim(
+                "scheduler-claim:test",
+                "claim-token",
+                900_000,
+            ),
+        ).resolves.toBe(false);
+        expect(mocks.schedulerLockRedis.eval).toHaveBeenNthCalledWith(
+            2,
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+            1,
+            "scheduler-claim:test",
+            "claim-token",
+            900_000,
+        );
+        expect(mocks.schedulerLockRedis.get).not.toHaveBeenCalled();
+        expect(mocks.schedulerLockRedis.expire).not.toHaveBeenCalled();
+
+        await Promise.all(
+            Array.from({ length: 23 }, () =>
+                extendSchedulerClaim(
+                    "scheduler-claim:test",
+                    "claim-token",
+                    900_000,
+                ),
+            ),
+        );
+        expect(mocks.logger.info).toHaveBeenCalledWith(
+            expect.stringContaining("extended=24 failedExtend=1"),
+        );
+    });
+
     it("registers queue event handlers and logs event activity", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
@@ -1536,6 +1689,30 @@ describe("workers runtime behavior", () => {
         getHandler(mocks.genericImportQueue, "completed")(job);
         const genericImportError = new Error("import-retries-exhausted");
         getHandler(mocks.genericImportQueue, "failed")(job, genericImportError);
+        getHandler(mocks.albumDownloadQueue, "active")(job);
+        getHandler(mocks.albumDownloadQueue, "completed")(job);
+        getHandler(mocks.albumDownloadQueue, "stalled")(job);
+        const albumDownloadError = new Error("album-download-failed");
+        const finalAlbumJob = {
+            ...job,
+            attemptsMade: 0,
+            opts: { attempts: 2 },
+            getState: jest.fn().mockResolvedValue("failed"),
+        };
+        const retriedAlbumJob = {
+            ...job,
+            attemptsMade: 2,
+            opts: { attempts: 2 },
+            getState: jest.fn().mockResolvedValue("delayed"),
+        };
+        getHandler(mocks.albumDownloadQueue, "failed")(
+            finalAlbumJob,
+            albumDownloadError,
+        );
+        getHandler(mocks.albumDownloadQueue, "failed")(
+            retriedAlbumJob,
+            new Error("album-download-retrying"),
+        );
         await flushPromises();
 
         getHandler(
@@ -1562,10 +1739,37 @@ describe("workers runtime behavior", () => {
                 /workerId=.* event=failed queue=worker-scheduler count=\d+/,
             ),
         );
+        expect(mocks.logger.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "job-start queue=album-download jobId=job-1 jobName=n1",
+            ),
+        );
         expect(mocks.finalizeGenericImportQueueFailure).toHaveBeenCalledWith(
             job,
             genericImportError,
         );
+        expect(mocks.finalizeAlbumDownloadQueueFailure).toHaveBeenCalledWith(
+            finalAlbumJob,
+            albumDownloadError,
+            "failed",
+        );
+        expect(mocks.finalizeAlbumDownloadQueueFailure).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(finalAlbumJob.getState).toHaveBeenCalledTimes(1);
+        expect(retriedAlbumJob.getState).toHaveBeenCalledTimes(1);
+        expect(mocks.recordAlbumDownloadOutcome).toHaveBeenCalledWith(
+            "completed",
+        );
+        expect(mocks.recordAlbumDownloadOutcome).toHaveBeenCalledWith("failed");
+        expect(mocks.recordAlbumDownloadOutcome).toHaveBeenCalledWith(
+            "retried",
+        );
+        expect(
+            mocks.recordAlbumDownloadOutcome.mock.calls.filter(
+                ([outcome]) => outcome === "retried",
+            ),
+        ).toHaveLength(2);
     });
 
     it("handles scheduler failed/completed event logs when job identity is missing", async () => {

--- a/backend/src/workers/__tests__/queues.test.ts
+++ b/backend/src/workers/__tests__/queues.test.ts
@@ -50,7 +50,7 @@ describe("workers/queues", () => {
             "rediss://user:pass@cache.example:6381/2",
         );
 
-        expect(bullCtor).toHaveBeenCalledTimes(8);
+        expect(bullCtor).toHaveBeenCalledTimes(9);
         const firstCallArgs = bullCtor.mock.calls[0];
         const firstQueueOptions = firstCallArgs[1];
 
@@ -65,7 +65,7 @@ describe("workers/queues", () => {
                 tls: {},
             }),
         );
-        expect(queuesModule.queues).toHaveLength(8);
+        expect(queuesModule.queues).toHaveLength(9);
         expect(bullCtor.mock.calls.map((call) => call[0])).toEqual([
             "library-scan",
             "discover-weekly",
@@ -75,6 +75,7 @@ describe("workers/queues", () => {
             "worker-scheduler",
             "generic-import",
             "federation-sync",
+            "album-download",
         ]);
         expect(logger.debug).toHaveBeenCalledWith(
             expect.stringContaining("Redis config resolved"),
@@ -129,6 +130,28 @@ describe("workers/queues", () => {
         expect(importCall![1].defaultJobOptions).toEqual({
             attempts: 3,
             backoff: { type: "exponential", delay: 5_000 },
+            removeOnComplete: 100,
+            removeOnFail: 200,
+        });
+    });
+
+    it("bounds album download retries, stalled recovery, and Redis retention", () => {
+        const { bullCtor } = loadQueues("redis://cache.example:6379/0");
+        const albumDownloadCall = bullCtor.mock.calls.find(
+            (call: any[]) => call[0] === "album-download",
+        );
+
+        expect(albumDownloadCall).toBeDefined();
+        expect(albumDownloadCall![1].settings).toEqual(
+            expect.objectContaining({
+                stalledInterval: 30_000,
+                lockDuration: 30_000,
+                maxStalledCount: 1,
+            }),
+        );
+        expect(albumDownloadCall![1].defaultJobOptions).toEqual({
+            attempts: 2,
+            backoff: { type: "exponential", delay: 60_000 },
             removeOnComplete: 100,
             removeOnFail: 200,
         });

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -10,6 +10,7 @@ import {
     schedulerQueue,
     genericImportQueue,
     federationQueue,
+    albumDownloadQueue,
 } from "./queues";
 import { processScan } from "./processors/scanProcessor";
 import {
@@ -23,6 +24,14 @@ import {
     GENERIC_IMPORT_WORKER_CONCURRENCY,
     processGenericImport,
 } from "./processors/genericImportProcessor";
+import {
+    ALBUM_DOWNLOAD_JOB_NAME,
+    ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
+    finalizeAlbumDownloadQueueFailure,
+    processAlbumDownload,
+} from "./processors/albumDownloadProcessor";
+import { recordAlbumDownloadOutcome } from "../metrics";
+import { recoverUnqueuedAlbumDownloads } from "../services/albumDownloadQueueService";
 import {
     startUnifiedEnrichmentWorker,
     stopUnifiedEnrichmentWorker,
@@ -110,9 +119,13 @@ function recordQueueProcessorEvent(
         // Unconditional start breadcrumb for the heavy queues: a job that
         // pegs the loop until the kubelet kills the process never lets the
         // watchdog interval fire, so the last log line before death must
-        // already name the culprit. Scheduler cycles and library scans are
-        // the known stall suspects; other queues stay on sampled logging.
-        if (queueName === "worker-scheduler" || queueName === "library-scan") {
+        // already name the culprit. Scheduler cycles, library scans, and
+        // long-running album downloads need this; other queues stay sampled.
+        if (
+            queueName === "worker-scheduler" ||
+            queueName === "library-scan" ||
+            queueName === "album-download"
+        ) {
             queueProcessorLog.info(
                 `job-start queue=${queueName} jobId=${jobId} jobName=${jobName}`,
             );
@@ -264,6 +277,20 @@ async function processReconciliationJob(): Promise<void> {
                 log.debug(
                     `Periodic sync: ${syncResult.cancelled} job(s) synced with Lidarr queue`,
                 );
+            }
+        },
+    );
+}
+
+async function processAlbumDownloadRecoveryJob(): Promise<void> {
+    await runWithSchedulerClaim(
+        "scheduler-claim:album-download-recovery",
+        5 * ONE_MINUTE_MS,
+        "album download recovery",
+        async () => {
+            const recovered = await recoverUnqueuedAlbumDownloads();
+            if (recovered > 0) {
+                log.info(`Recovered ${recovered} unqueued album downloads`);
             }
         },
     );
@@ -588,6 +615,11 @@ genericImportQueue.process(
     GENERIC_IMPORT_WORKER_CONCURRENCY,
     processGenericImport,
 );
+albumDownloadQueue.process(
+    ALBUM_DOWNLOAD_JOB_NAME,
+    ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
+    processAlbumDownload,
+);
 if (config.features.federation) {
     registerFederationProcessors();
 } else {
@@ -604,6 +636,9 @@ async function processSchedulerJob(job: Bull.Job<any>): Promise<void> {
             break;
         case SCHEDULER_JOB_TYPES.reconciliation:
             await processReconciliationJob();
+            break;
+        case SCHEDULER_JOB_TYPES.albumDownloadRecovery:
+            await processAlbumDownloadRecoveryJob();
             break;
         case SCHEDULER_JOB_TYPES.lidarrCleanup:
             await processLidarrCleanupJob(mode);
@@ -875,6 +910,50 @@ genericImportQueue.on("failed", (job, error) => {
     );
 });
 
+albumDownloadQueue.on("active", (job) => {
+    recordQueueProcessorEvent("album-download", "active", job);
+});
+
+albumDownloadQueue.on("completed", (job) => {
+    recordQueueProcessorEvent("album-download", "completed", job);
+    recordAlbumDownloadOutcome("completed");
+});
+
+albumDownloadQueue.on("stalled", () => {
+    recordAlbumDownloadOutcome("retried");
+});
+
+async function handleAlbumDownloadQueueFailure(
+    job: Bull.Job<any>,
+    error: Error,
+): Promise<void> {
+    const state = await job.getState();
+    if (state !== "failed") {
+        recordAlbumDownloadOutcome("retried");
+        return;
+    }
+    recordAlbumDownloadOutcome("failed");
+    await finalizeAlbumDownloadQueueFailure(job, error, state);
+}
+
+albumDownloadQueue.on("failed", (job, error) => {
+    if (!job) {
+        queueProcessorLog.error("Album download queue failure had no job", {
+            error,
+        });
+        return;
+    }
+    recordQueueProcessorEvent("album-download", "failed", job);
+    void handleAlbumDownloadQueueFailure(job, error).catch(
+        (finalizationError) => {
+            queueProcessorLog.error(
+                "Failed to classify or finalize album download queue failure",
+                { jobId: job.id, error: finalizationError },
+            );
+        },
+    );
+});
+
 // The scheduler queue runs the heavy maintenance cycles (metadata refresh,
 // reconciliation, artist-count backfills) — the primary stall suspects — so
 // it MUST feed the event-loop watchdog's attribution registry.
@@ -971,6 +1050,9 @@ export async function shutdownWorkers(): Promise<void> {
     // Shutdown download queue manager
     downloadQueueManager.shutdown();
 
+    // Drain the album processor while its finalizer listener is still active.
+    await albumDownloadQueue.close();
+
     // Remove all event listeners to prevent memory leaks
     scanQueue.removeAllListeners();
     discoverQueue.removeAllListeners();
@@ -979,6 +1061,7 @@ export async function shutdownWorkers(): Promise<void> {
     schedulerQueue.removeAllListeners();
     genericImportQueue.removeAllListeners();
     federationQueue.removeAllListeners();
+    albumDownloadQueue.removeAllListeners();
 
     // Close all queues gracefully
     await Promise.all([
@@ -1027,4 +1110,5 @@ export {
     schedulerQueue,
     genericImportQueue,
     federationQueue,
+    albumDownloadQueue,
 };

--- a/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
@@ -1,0 +1,373 @@
+const mockDispatchAlbumDownload = jest.fn();
+const mockDownloadJobFindUnique = jest.fn();
+const mockDownloadJobUpdateMany = jest.fn();
+const mockRunWithSchedulerClaim = jest.fn();
+const mockExtendSchedulerClaim = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.mock("../../../services/downloadDispatcher", () => ({
+    dispatchAlbumDownload: (...args: unknown[]) =>
+        mockDispatchAlbumDownload(...args),
+}));
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findUnique: (...args: unknown[]) =>
+                mockDownloadJobFindUnique(...args),
+            updateMany: (...args: unknown[]) =>
+                mockDownloadJobUpdateMany(...args),
+        },
+    },
+}));
+
+jest.mock("../../../utils/schedulerClaim", () => ({
+    extendSchedulerClaim: (...args: unknown[]) =>
+        mockExtendSchedulerClaim(...args),
+    runWithSchedulerClaim: (...args: unknown[]) =>
+        mockRunWithSchedulerClaim(...args),
+}));
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        child: () => ({
+            info: mockLoggerInfo,
+            error: mockLoggerError,
+        }),
+    },
+}));
+
+import {
+    AlbumDownloadFailedError,
+    finalizeAlbumDownloadQueueFailure,
+    processAlbumDownload,
+} from "../albumDownloadProcessor";
+
+const payload = {
+    jobId: "download-job-1",
+    type: "album",
+    mbid: "release-group-1",
+    subject: "Artist - Album",
+    artistName: "Artist",
+    albumTitle: "Album",
+} as const;
+
+describe("album download queue processor", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockDispatchAlbumDownload.mockResolvedValue(undefined);
+        mockDownloadJobFindUnique.mockResolvedValue({ status: "processing" });
+        mockDownloadJobUpdateMany.mockResolvedValue({ count: 1 });
+        mockExtendSchedulerClaim.mockResolvedValue(true);
+        mockRunWithSchedulerClaim.mockImplementation(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: (claimToken: string) => Promise<void>,
+            ) => ({ acquired: true, value: await operation("claim-token") }),
+        );
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("validates and dispatches an album while reporting progress", async () => {
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processAlbumDownload(job);
+
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith(payload);
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledWith(
+            "scheduler-claim:album-download",
+            15 * 60_000,
+            "album download",
+            expect.any(Function),
+        );
+        expect(job.progress).toHaveBeenNthCalledWith(1, 0);
+        expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+    });
+
+    it("drains a slow renewal before releasing and starts none post-release", async () => {
+        jest.useFakeTimers();
+        let finishDispatch!: () => void;
+        let finishRenewal!: () => void;
+        const ordering: string[] = [];
+        mockDispatchAlbumDownload.mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    finishDispatch = resolve;
+                }),
+        );
+        mockExtendSchedulerClaim.mockImplementationOnce(
+            () =>
+                new Promise<boolean>((resolve) => {
+                    ordering.push("renewal-started");
+                    finishRenewal = () => {
+                        ordering.push("renewal-finished");
+                        resolve(true);
+                    };
+                }),
+        );
+        mockRunWithSchedulerClaim.mockImplementationOnce(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: (claimToken: string) => Promise<void>,
+            ) => {
+                await operation("claim-token");
+                ordering.push("release");
+                return { acquired: true, value: undefined };
+            },
+        );
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const processing = processAlbumDownload(job);
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(5 * 60_000);
+
+        expect(mockExtendSchedulerClaim).toHaveBeenCalledWith(
+            "scheduler-claim:album-download",
+            "claim-token",
+            15 * 60_000,
+        );
+
+        finishDispatch();
+        await jest.advanceTimersByTimeAsync(0);
+        expect(ordering).toEqual(["renewal-started"]);
+        expect(job.progress).toHaveBeenCalledTimes(1);
+
+        finishRenewal();
+        await processing;
+        expect(ordering).toEqual([
+            "renewal-started",
+            "renewal-finished",
+            "release",
+        ]);
+
+        await jest.advanceTimersByTimeAsync(5 * 60_000);
+        expect(mockExtendSchedulerClaim).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects poison payloads before invoking dispatch", async () => {
+        const job = {
+            data: { ...payload, type: "artist", unexpected: true },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toThrow();
+
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(job.progress).not.toHaveBeenCalled();
+    });
+
+    it("rejects poison payloads before dispatch", async () => {
+        const job = {
+            data: { ...payload, unexpected: true },
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toThrow();
+
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(job.progress).not.toHaveBeenCalled();
+    });
+
+    it("propagates dispatcher rejection without reporting completion", async () => {
+        const error = new Error("sidecar unavailable");
+        mockDispatchAlbumDownload.mockRejectedValueOnce(error);
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toBe(error);
+
+        expect(job.progress).toHaveBeenCalledTimes(1);
+        expect(job.progress).toHaveBeenCalledWith(0);
+    });
+
+    it("skips dispatch when a stalled redelivery finds a completed row", async () => {
+        mockDownloadJobFindUnique.mockResolvedValueOnce({
+            status: "completed",
+        });
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processAlbumDownload(job);
+
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockDownloadJobFindUnique).toHaveBeenCalledTimes(1);
+        expect(mockLoggerInfo).toHaveBeenCalledWith(
+            "Skipping completed album download redelivery",
+            { jobId: payload.jobId },
+        );
+    });
+
+    it("throws a typed failure when dispatch persists failed status", async () => {
+        mockDownloadJobFindUnique
+            .mockResolvedValueOnce({ status: "pending" })
+            .mockResolvedValueOnce({ status: "failed" });
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toBeInstanceOf(
+            AlbumDownloadFailedError,
+        );
+
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith(payload);
+        expect(job.progress).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits for a busy deployment claim and dispatches after acquisition", async () => {
+        jest.useFakeTimers();
+        mockRunWithSchedulerClaim
+            .mockResolvedValueOnce({ acquired: false })
+            .mockImplementationOnce(
+                async (
+                    _claimKey: string,
+                    _ttlMs: number,
+                    _operationName: string,
+                    operation: (claimToken: string) => Promise<void>,
+                ) => ({
+                    acquired: true,
+                    value: await operation("claim-token"),
+                }),
+            );
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const processing = processAlbumDownload(job);
+        await Promise.resolve();
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(15_000);
+        await processing;
+
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledTimes(2);
+        expect(mockDispatchAlbumDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws after the bounded deployment-claim wait is exhausted", async () => {
+        jest.useFakeTimers();
+        mockRunWithSchedulerClaim.mockResolvedValue({ acquired: false });
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const processing = processAlbumDownload(job);
+        const rejection = expect(processing).rejects.toThrow(
+            "Timed out waiting for the album download claim",
+        );
+        await jest.runAllTimersAsync();
+        await rejection;
+
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledTimes(960);
+        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+    });
+
+    it("finalizes an additive poison payload when it still carries a valid job id", async () => {
+        const job = {
+            data: {
+                jobId: payload.jobId,
+                type: "future-album-version",
+                additiveField: true,
+            },
+        } as any;
+
+        await finalizeAlbumDownloadQueueFailure(
+            job,
+            new Error("poison payload"),
+            "failed",
+        );
+
+        expect(mockDownloadJobUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ id: payload.jobId }),
+            }),
+        );
+    });
+
+    it("marks a non-terminal persisted job failed after Bull exhausts retries", async () => {
+        const job = {
+            data: payload,
+            getState: jest.fn().mockResolvedValue("failed"),
+        } as any;
+
+        await finalizeAlbumDownloadQueueFailure(job, new Error("raw failure"));
+
+        expect(job.getState).toHaveBeenCalledTimes(1);
+        expect(mockDownloadJobUpdateMany).toHaveBeenCalledWith({
+            where: {
+                id: payload.jobId,
+                status: { in: ["pending", "processing"] },
+            },
+            data: {
+                status: "failed",
+                error: "Download failed",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("leaves a terminal persisted job unchanged", async () => {
+        mockDownloadJobUpdateMany.mockResolvedValueOnce({ count: 0 });
+        const job = {
+            data: payload,
+            getState: jest.fn().mockResolvedValue("failed"),
+        } as any;
+
+        await expect(
+            finalizeAlbumDownloadQueueFailure(job, new Error("raw failure")),
+        ).resolves.toBeUndefined();
+
+        expect(mockDownloadJobUpdateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-checks Bull state and skips jobs that are still retrying", async () => {
+        const job = {
+            data: payload,
+            getState: jest.fn().mockResolvedValue("delayed"),
+        } as any;
+
+        await finalizeAlbumDownloadQueueFailure(job, new Error("retrying"));
+
+        expect(job.getState).toHaveBeenCalledTimes(1);
+        expect(mockDownloadJobUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it("logs and survives persistence rejection", async () => {
+        const persistenceError = new Error("database unavailable");
+        mockDownloadJobUpdateMany.mockRejectedValueOnce(persistenceError);
+        const job = {
+            id: "bull-job-1",
+            data: payload,
+            getState: jest.fn().mockResolvedValue("failed"),
+        } as any;
+
+        await expect(
+            finalizeAlbumDownloadQueueFailure(job, new Error("raw failure")),
+        ).resolves.toBeUndefined();
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            "Failed to persist exhausted album download queue failure",
+            { jobId: payload.jobId, error: persistenceError },
+        );
+    });
+});

--- a/backend/src/workers/processors/albumDownloadProcessor.ts
+++ b/backend/src/workers/processors/albumDownloadProcessor.ts
@@ -1,0 +1,170 @@
+import type { Job } from "bull";
+import { z } from "zod";
+import { dispatchAlbumDownload } from "../../services/downloadDispatcher";
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import {
+    extendSchedulerClaim,
+    runWithSchedulerClaim,
+} from "../../utils/schedulerClaim";
+
+const log = logger.child("AlbumDownloadProcessor");
+const payloadSchema = z
+    .object({
+        jobId: z.string(),
+        type: z.literal("album"),
+        mbid: z.string(),
+        subject: z.string(),
+        artistName: z.string().optional(),
+        albumTitle: z.string().optional(),
+    })
+    .strict();
+const finalizerPayloadSchema = z
+    .object({
+        jobId: z.string(),
+    })
+    .passthrough();
+const ALBUM_DOWNLOAD_CLAIM_KEY = "scheduler-claim:album-download";
+const ALBUM_DOWNLOAD_CLAIM_TTL_MS = 15 * 60_000;
+const ALBUM_DOWNLOAD_CLAIM_RENEW_INTERVAL_MS = 5 * 60_000;
+const ALBUM_DOWNLOAD_CLAIM_POLL_INTERVAL_MS = 15_000;
+const ALBUM_DOWNLOAD_CLAIM_MAX_POLLS = 960;
+
+type AlbumDownloadPayload = z.infer<typeof payloadSchema>;
+
+/** Bull job name used for durable album downloads. */
+export const ALBUM_DOWNLOAD_JOB_NAME = "album-download";
+
+/** Fixed owner-selected album download concurrency per worker process. */
+export const ALBUM_DOWNLOAD_WORKER_CONCURRENCY = 1;
+
+/** Typed failure raised when a provider persists a failed download outcome. */
+export class AlbumDownloadFailedError extends Error {
+    readonly jobId: string;
+
+    constructor(jobId: string) {
+        super(`Album download ${jobId} failed`);
+        this.name = "AlbumDownloadFailedError";
+        this.jobId = jobId;
+    }
+}
+
+async function getPersistedStatus(jobId: string): Promise<string | null> {
+    const persistedJob = await prisma.downloadJob.findUnique({
+        where: { id: jobId },
+        select: { status: true },
+    });
+    return persistedJob?.status ?? null;
+}
+
+async function dispatchPersistedAlbumDownload(
+    payload: AlbumDownloadPayload,
+): Promise<void> {
+    if ((await getPersistedStatus(payload.jobId)) === "completed") {
+        log.info("Skipping completed album download redelivery", {
+            jobId: payload.jobId,
+        });
+        return;
+    }
+
+    await dispatchAlbumDownload(payload);
+    if ((await getPersistedStatus(payload.jobId)) === "failed") {
+        throw new AlbumDownloadFailedError(payload.jobId);
+    }
+}
+
+async function renewAlbumDownloadClaim(
+    payload: AlbumDownloadPayload,
+    claimToken: string,
+): Promise<void> {
+    try {
+        await extendSchedulerClaim(
+            ALBUM_DOWNLOAD_CLAIM_KEY,
+            claimToken,
+            ALBUM_DOWNLOAD_CLAIM_TTL_MS,
+        );
+    } catch (error) {
+        log.warn("Album download claim renewal failed", {
+            jobId: payload.jobId,
+            error,
+        });
+    }
+}
+
+async function dispatchWithClaimRenewal(
+    payload: AlbumDownloadPayload,
+    claimToken: string,
+): Promise<void> {
+    let renewalPromise: Promise<void> | null = null;
+    const renewalTimer = setInterval(() => {
+        if (renewalPromise) return;
+        renewalPromise = renewAlbumDownloadClaim(payload, claimToken).then(
+            () => {
+                renewalPromise = null;
+            },
+        );
+    }, ALBUM_DOWNLOAD_CLAIM_RENEW_INTERVAL_MS);
+    renewalTimer.unref();
+    try {
+        await dispatchPersistedAlbumDownload(payload);
+    } finally {
+        clearInterval(renewalTimer);
+        if (renewalPromise) await renewalPromise;
+    }
+}
+
+async function waitForAlbumDownloadClaim(
+    payload: AlbumDownloadPayload,
+): Promise<void> {
+    for (let poll = 0; poll < ALBUM_DOWNLOAD_CLAIM_MAX_POLLS; poll += 1) {
+        const result = await runWithSchedulerClaim(
+            ALBUM_DOWNLOAD_CLAIM_KEY,
+            ALBUM_DOWNLOAD_CLAIM_TTL_MS,
+            "album download",
+            (claimToken) => dispatchWithClaimRenewal(payload, claimToken),
+        );
+        if (result.acquired) return;
+        await new Promise<void>((resolve) =>
+            setTimeout(resolve, ALBUM_DOWNLOAD_CLAIM_POLL_INTERVAL_MS),
+        );
+    }
+    throw new Error("Timed out waiting for the album download claim");
+}
+
+/** Validate and dispatch one queued album download. */
+export async function processAlbumDownload(job: Job<unknown>): Promise<void> {
+    const payload = payloadSchema.parse(job.data);
+    await job.progress(0);
+    await waitForAlbumDownloadClaim(payload);
+    await job.progress(100);
+}
+
+/** Finalize persisted state after Bull exhausts album-download recovery. */
+export async function finalizeAlbumDownloadQueueFailure(
+    job: Job<unknown>,
+    _error: unknown,
+    knownState?: string,
+): Promise<void> {
+    const parsed = finalizerPayloadSchema.safeParse(job.data);
+    const state = knownState ?? (await job.getState());
+    if (!parsed.success || state !== "failed") return;
+
+    try {
+        await prisma.downloadJob.updateMany({
+            where: {
+                id: parsed.data.jobId,
+                status: { in: ["pending", "processing"] },
+            },
+            data: {
+                status: "failed",
+                error: "Download failed",
+                completedAt: new Date(),
+            },
+        });
+    } catch (error) {
+        log.error("Failed to persist exhausted album download queue failure", {
+            jobId: parsed.data.jobId,
+            error,
+        });
+    }
+}

--- a/backend/src/workers/queues.ts
+++ b/backend/src/workers/queues.ts
@@ -143,6 +143,18 @@ export const federationQueue = new Bull("federation-sync", {
     },
 });
 
+/** Durable queue for serialized album downloads. */
+export const albumDownloadQueue = new Bull("album-download", {
+    redis: redisConfig,
+    defaultJobOptions: {
+        attempts: 2,
+        backoff: { type: "exponential", delay: 60000 },
+        removeOnComplete: 100,
+        removeOnFail: 200,
+    },
+    settings: defaultQueueSettings,
+});
+
 // Export all queues for monitoring
 export const queues = [
     scanQueue,
@@ -153,6 +165,7 @@ export const queues = [
     schedulerQueue,
     genericImportQueue,
     federationQueue,
+    albumDownloadQueue,
 ];
 
 // Add error handlers to all queues to prevent unhandled exceptions

--- a/backend/src/workers/schedulerJobRegistry.ts
+++ b/backend/src/workers/schedulerJobRegistry.ts
@@ -14,6 +14,7 @@ export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 export const SCHEDULER_JOB_TYPES = {
     dataIntegrity: "data-integrity-check",
     reconciliation: "download-reconciliation-cycle",
+    albumDownloadRecovery: "album-download-recovery-cycle",
     lidarrCleanup: "lidarr-cleanup-cycle",
     cacheWarmup: "cache-warmup-startup",
     podcastCleanup: "podcast-cache-cleanup",
@@ -34,6 +35,8 @@ export const SCHEDULER_JOB_IDS = {
     dataIntegrityRepeat: "scheduler:data-integrity:repeat",
     reconciliationStartup: "scheduler:reconciliation:startup",
     reconciliationRepeat: "scheduler:reconciliation:repeat",
+    albumDownloadRecoveryStartup: "scheduler:album-download-recovery:startup",
+    albumDownloadRecoveryRepeat: "scheduler:album-download-recovery:repeat",
     lidarrCleanupStartup: "scheduler:lidarr-cleanup:startup",
     lidarrCleanupRepeat: "scheduler:lidarr-cleanup:repeat",
     cacheWarmupStartup: "scheduler:cache-warmup:startup",
@@ -120,6 +123,26 @@ export function buildSchedulerJobs(): SchedulerRegistration[] {
             opts: {
                 jobId: SCHEDULER_JOB_IDS.reconciliationRepeat,
                 repeat: { every: 2 * ONE_MINUTE_MS },
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.albumDownloadRecovery,
+            data: { mode: "startup" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.albumDownloadRecoveryStartup,
+                delay: ONE_MINUTE_MS,
+                removeOnComplete: true,
+                removeOnFail: 10,
+            },
+        },
+        {
+            type: SCHEDULER_JOB_TYPES.albumDownloadRecovery,
+            data: { mode: "repeat" },
+            opts: {
+                jobId: SCHEDULER_JOB_IDS.albumDownloadRecoveryRepeat,
+                repeat: { every: 5 * ONE_MINUTE_MS },
                 removeOnComplete: true,
                 removeOnFail: 10,
             },


### PR DESCRIPTION
## Problem

Album downloads ran fire-and-forget inside the API pods with unbounded concurrency. Yesterday a ten-album batch drove the TIDAL sidecar past its memory limit; the OOM kill failed every in-flight download with "socket hang up", and nothing survived a restart. Follow-up to #734.

## What changed

**Queue**: new `album-download` Bull queue (attempts 2, exponential backoff, dedup by deterministic `albumdl:<jobId>` Bull id). Producers — create route, artist batch, request approval, retry endpoint — enqueue instead of dispatching; jobs persist in Valkey across restarts. The worker-pod processor is now the *only* production caller of `dispatchAlbumDownload` (grep-verified).

**Global serialization**: per-process concurrency 1 plus a renewable distributed claim (15-min TTL, 5-min atomic compare-and-expire renewal via Lua) — one album at a time across all worker replicas. Waiting jobs poll the claim (bounded, 4h) without consuming retry attempts.

**Real retries**: providers persist failure and resolve, which would make Bull mark failed attempts as completed. The processor now re-reads the job row after dispatch and throws a typed error on failure, so transient sidecar crashes actually retry, completed rows are never re-dispatched, and outcome metrics are truthful.

**Lifecycle coherence**:
- Queue-owned rows carry `metadata.queuedVia = "album-download-queue"` (written at every creation site through a shared ownership module). The reconciliation cycle's 10-minute stale-pending timeout *exempts* them — with serialization, long pending waits are normal, and reconciliation was going to false-fail every queued backlog row.
- A 5-minute recovery cycle (scheduler claim, bounded batch) re-enqueues owned rows whose enqueue was lost mid-crash, finalizes rows whose Bull record terminally failed (durable-finalizer backstop), and clears incoherent terminal Bull records. Full Bull state table handled and tested.
- Successful retries clear first-attempt `error`/`failedAt`; a library-scan enqueue failure no longer flips a completed album back to failed (which would have triggered a full re-download).
- The album queue drains before its failure-listener teardown during shutdown.

**Observability**: `soundspan_album_downloads_total{outcome}` (completed / retried incl. stall recoveries / failed) via the metrics-factory convention; queue joins the shared depth gauge and unconditional job-start logging.

## Review process

Four adversarial review rounds to zero findings (10 → 7 → 2 → 0). Deferred with rationale: api-only-role misconfiguration guards (pre-existing class affecting all queues), full shutdown re-architecture, provider-level idempotency tokens.

## Verification

- verify: `tsc --noEmit` exit 0 (pre- and post-rebase)
- verify: 18 targeted Jest suites, 360 tests, exit 0
- verify: `format:check`, file-size ratchet (`simpleDownloadManager.ts` held at exactly its frozen 2387), route-error canon — all exit 0

## Deploy note

No chart changes needed — worker-role registration routes processing to worker pods automatically. Downloads move from API pods to worker pods with this release.