### PR TITLE
fix(tidal): never let colliding track names overwrite another track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Two different TIDAL tracks whose names collapse to the same filename no longer overwrite each other; the second download is saved under a disambiguated name, while legacy files without embedded TIDAL identity still refresh in place at their planned path.
 - Retrying a failed album download now uses the configured download source instead of always routing to Lidarr.
 - TIDAL downloads now convert tracks detected as lossless to real FLAC files. Tracks detected as AAC-only are saved as `.m4a` instead of mislabeled `.flac`; when codec detection is unavailable, the original file is kept as-is.
 - Max-quality (Hi-Res) TIDAL downloads are no longer saved as broken files missing their opening data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ module = ["tiddl", "tiddl.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+# Mutagen 1.48.1 marks itself typed, but its file loaders and tag mappings remain untyped.
+module = ["mutagen", "mutagen.*"]
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
 # yt-dlp 2026.7.4 does not publish PEP 561 type information (2 import diagnostics).
 module = ["yt_dlp", "yt_dlp.*"]
 ignore_missing_imports = true

--- a/services/tidal-streamer/tests/test_download_collisions.py
+++ b/services/tidal-streamer/tests/test_download_collisions.py
@@ -1,0 +1,522 @@
+"""Behavioral coverage for TIDAL download filename collision handling."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import types
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _FakeDownloadApi:
+    """Provide track-specific titles and the minimal download API surface."""
+
+    def __init__(self, titles: dict[int, str], *, cover: str | None = None) -> None:
+        self._titles = titles
+        self._cover = cover
+
+    def get_track(self, track_id: int) -> Any:
+        return types.SimpleNamespace(
+            id=track_id,
+            title=self._titles[track_id],
+            album=types.SimpleNamespace(id=22),
+            artists=[types.SimpleNamespace(name="Artist")],
+        )
+
+    def get_album(self, _album_id: int) -> Any:
+        return types.SimpleNamespace(title="Album", cover=self._cover, releaseDate=None)
+
+    def get_track_stream(self, *, track_id: int, quality: str) -> Any:
+        return types.SimpleNamespace(audioQuality=quality, track_id=track_id)
+
+
+class _TaggedAudio:
+    """Expose path-keyed fake Mutagen tags through the mapping API."""
+
+    def __init__(self, path: Path, tags: dict[Path, dict[str, list[str]]]) -> None:
+        if path.read_bytes() == b"corrupted":
+            raise ValueError("corrupted audio")
+        self._tags = tags.get(path, {})
+
+    def get(self, key: str) -> list[str] | None:
+        return self._tags.get(key)
+
+
+def _configure_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tidal_downloads: Any,
+    payload_for_track: Callable[[int], bytes],
+) -> dict[Path, dict[str, list[str]]]:
+    """Install deterministic provider, metadata, and Mutagen seams."""
+    download_module = types.ModuleType("tiddl.core.utils.download")
+    download_module.__dict__["download"] = lambda urls: payload_for_track(int(urls[0]))
+    monkeypatch.setitem(sys.modules, "tiddl.core.utils.download", download_module)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "format_template",
+        lambda **kwargs: f"Artist/Album/{kwargs['item'].title}",
+    )
+    monkeypatch.setattr(
+        tidal_downloads,
+        "parse_track_stream",
+        lambda stream: ([str(stream.track_id)], ".m4a"),
+    )
+
+    tags: dict[Path, dict[str, list[str]]] = {}
+
+    def add_metadata(*, path: Path, comment: str, **_kwargs: Any) -> None:
+        tags[path] = {"comment": [comment]}
+
+    monkeypatch.setattr(tidal_downloads, "add_track_metadata", add_metadata)
+    monkeypatch.setattr(tidal_downloads, "EasyMP4", lambda path: _TaggedAudio(path, tags))
+    monkeypatch.setattr(tidal_downloads, "FLAC", lambda path: _TaggedAudio(path, tags))
+    return tags
+
+
+def test_distinct_tracks_with_colliding_names_are_both_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    _configure_download(monkeypatch, tidal_downloads, lambda track_id: f"audio-{track_id}".encode())
+    api = _FakeDownloadApi({101: "Intro: Part 1", 202: "Intro? Part 1"})
+    destination = tmp_path / "music"
+
+    first = tidal_downloads._download_track_sync(api, 101, "HIGH", "ignored", destination)
+    second = tidal_downloads._download_track_sync(api, 202, "HIGH", "ignored", destination)
+
+    first_path = destination / "Artist" / "Album" / "Intro_ Part 1.m4a"
+    second_path = destination / "Artist" / "Album" / "Intro_ Part 1 [tidal-202].m4a"
+    assert first_path.read_bytes() == b"audio-101"
+    assert second_path.read_bytes() == b"audio-202"
+    assert tidal_downloads._read_embedded_tidal_id(first_path) == 101
+    assert tidal_downloads._read_embedded_tidal_id(second_path) == 202
+    assert Path(first["file_path"]) == first_path
+    assert Path(second["file_path"]) == second_path
+    assert second["relative_path"] == "Artist/Album/Intro_ Part 1 [tidal-202].m4a"
+
+
+def test_redownload_of_same_track_overwrites_without_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    payloads = iter((b"old-audio", b"refreshed-audio"))
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: next(payloads))
+    api = _FakeDownloadApi({303: "Track"})
+    destination = tmp_path / "music"
+
+    tidal_downloads._download_track_sync(api, 303, "HIGH", "ignored", destination)
+    result = tidal_downloads._download_track_sync(api, 303, "HIGH", "ignored", destination)
+
+    expected = destination / "Artist" / "Album" / "Track.m4a"
+    assert expected.read_bytes() == b"refreshed-audio"
+    assert list(expected.parent.glob("Track*.m4a")) == [expected]
+    assert Path(result["file_path"]) == expected
+    assert tidal_downloads._read_embedded_tidal_id(expected) == 303
+
+
+def test_legacy_file_without_identity_is_refreshed_at_planned_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import tidal_downloads
+
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"new-audio")
+    destination = tmp_path / "music"
+    existing = destination / "Artist" / "Album" / "Track.m4a"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"unidentified-audio")
+
+    with caplog.at_level(logging.DEBUG, logger="tidal-streamer"):
+        result = tidal_downloads._download_track_sync(
+            _FakeDownloadApi({404: "Track"}), 404, "HIGH", "ignored", destination
+        )
+
+    assert existing.read_bytes() == b"new-audio"
+    assert list(existing.parent.glob("Track*.m4a")) == [existing]
+    assert Path(result["file_path"]) == existing
+    assert tidal_downloads._read_embedded_tidal_id(existing) == 404
+    assert "Refreshing unidentified legacy file at planned path" in caplog.text
+
+
+def test_allocator_skips_planned_and_suffixed_paths_owned_by_other_tracks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    suffixed = tmp_path / "Track [tidal-8].m4a"
+    expected = tmp_path / "Track [tidal-8-2].m4a"
+    planned.write_bytes(b"track-one")
+    suffixed.write_bytes(b"track-two")
+    embedded_ids = {planned: 1, suffixed: 2}
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: embedded_ids.get(path),
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved == expected
+    assert planned.read_bytes() == b"track-one"
+    assert suffixed.read_bytes() == b"track-two"
+
+
+def test_allocator_raises_when_every_bounded_candidate_is_occupied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    candidates = [
+        planned,
+        tmp_path / "Track [tidal-8].m4a",
+        *(tmp_path / f"Track [tidal-8-{counter}].m4a" for counter in range(2, 6)),
+    ]
+    for candidate in candidates:
+        candidate.write_bytes(b"occupied")
+    embedded_ids = {candidate: index for index, candidate in enumerate(candidates, start=20)}
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: embedded_ids.get(path),
+    )
+
+    with pytest.raises(RuntimeError, match=r"track 8.*6 candidates"):
+        tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+
+def test_download_allocator_exhaustion_removes_uuid_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    destination = tmp_path / "music"
+    parent = destination / "Artist" / "Album"
+    parent.mkdir(parents=True)
+    planned = parent / "Track.m4a"
+    candidates = tidal_downloads._build_download_candidates(planned, 8)
+    for candidate in candidates:
+        candidate.write_bytes(b"occupied")
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"new-audio")
+    monkeypatch.setattr(tidal_downloads, "_read_embedded_tidal_id", lambda _path: 999)
+
+    with pytest.raises(RuntimeError, match=r"track 8.*6 candidates"):
+        tidal_downloads._download_track_sync(
+            _FakeDownloadApi({8: "Track"}), 8, "HIGH", "ignored", destination
+        )
+
+    assert list(parent.glob("*.tmp")) == []
+    assert {path.read_bytes() for path in candidates} == {b"occupied"}
+
+
+def test_allocator_reuses_same_track_at_suffixed_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    suffixed = tmp_path / "Track [tidal-8].m4a"
+    planned.write_bytes(b"other-track")
+    suffixed.write_bytes(b"old-current-track")
+    embedded_ids = {planned: 7, suffixed: 8}
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: embedded_ids.get(path),
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved == suffixed
+
+
+def test_allocator_skips_unidentified_suffixed_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    suffixed = tmp_path / "Track [tidal-8].m4a"
+    expected = tmp_path / "Track [tidal-8-2].m4a"
+    planned.write_bytes(b"other-track")
+    suffixed.write_bytes(b"legacy-suffixed-file")
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 7 if path == planned else None,
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved == expected
+    assert planned.read_bytes() == b"other-track"
+    assert suffixed.read_bytes() == b"legacy-suffixed-file"
+
+
+def test_allocator_truncates_utf8_stem_for_maximum_counter_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    stem = ("é" * 120) + ("a" * 10)
+    planned = tmp_path / f"{stem}.m4a"
+    planned.write_bytes(b"occupied")
+    occupied = [planned]
+    for counter in range(1, 5):
+        identity_suffix = " [tidal-8]" if counter == 1 else f" [tidal-8-{counter}]"
+        stem_budget = 255 - len(f"{identity_suffix}.m4a".encode())
+        bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
+        candidate = tmp_path / f"{bounded_stem}{identity_suffix}.m4a"
+        candidate.write_bytes(b"occupied")
+        occupied.append(candidate)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 99 if path in occupied else None,
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved.name.endswith(" [tidal-8-5].m4a")
+    assert len(resolved.name.encode()) <= 255
+    assert resolved.name.encode().decode() == resolved.name
+
+
+def test_concurrent_colliding_downloads_use_unique_temps_and_preserve_both_tracks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    _configure_download(monkeypatch, tidal_downloads, lambda track_id: f"audio-{track_id}".encode())
+    api = _FakeDownloadApi({101: "Track", 202: "Track"})
+    destination = tmp_path / "music"
+    write_barrier = threading.Barrier(2)
+    original_write_bytes = Path.write_bytes
+    temporary_paths: list[Path] = []
+    failures: list[BaseException] = []
+
+    def synchronized_write(path: Path, payload: bytes) -> int:
+        written = original_write_bytes(path, payload)
+        if path.suffix == ".tmp":
+            temporary_paths.append(path)
+            write_barrier.wait(timeout=5)
+        return written
+
+    def download(track_id: int) -> None:
+        try:
+            tidal_downloads._download_track_sync(api, track_id, "HIGH", "ignored", destination)
+        except BaseException as error:
+            failures.append(error)
+
+    monkeypatch.setattr(Path, "write_bytes", synchronized_write)
+    threads = [
+        threading.Thread(target=download, args=(track_id,), daemon=True) for track_id in (101, 202)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert failures == []
+    assert len(temporary_paths) == 2
+    assert len({path.name for path in temporary_paths}) == 2
+    installed = sorted((destination / "Artist" / "Album").glob("Track*.m4a"))
+    assert len(installed) == 2
+    assert {tidal_downloads._read_embedded_tidal_id(path) for path in installed} == {101, 202}
+    for path in installed:
+        embedded_id = tidal_downloads._read_embedded_tidal_id(path)
+        assert path.read_bytes() == f"audio-{embedded_id}".encode()
+
+
+def test_partial_temp_write_failure_removes_uuid_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"audio")
+    destination = tmp_path / "music"
+    original_write_bytes = Path.write_bytes
+    temporary_paths: list[Path] = []
+
+    def fail_after_partial_write(path: Path, payload: bytes) -> int:
+        if path.suffix != ".tmp":
+            return original_write_bytes(path, payload)
+        temporary_paths.append(path)
+        original_write_bytes(path, payload[:2])
+        raise OSError("partial write")
+
+    monkeypatch.setattr(Path, "write_bytes", fail_after_partial_write)
+
+    with pytest.raises(OSError, match="partial write"):
+        tidal_downloads._download_track_sync(
+            _FakeDownloadApi({8: "Track"}), 8, "HIGH", "ignored", destination
+        )
+
+    assert len(temporary_paths) == 1
+    assert not temporary_paths[0].exists()
+
+
+def test_non_flac_move_failure_removes_uuid_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    fixed_uuid = "0123456789abcdef0123456789abcdef"
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"audio")
+    monkeypatch.setattr(
+        tidal_downloads,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex=fixed_uuid),
+    )
+
+    def fail_move(_source: str, _destination: str) -> None:
+        raise OSError("move")
+
+    monkeypatch.setattr("tidal_downloads.shutil.move", fail_move)
+    destination = tmp_path / "music"
+    temporary = destination / "Artist" / "Album" / f"Track.{fixed_uuid}.tmp"
+
+    with pytest.raises(OSError, match="move"):
+        tidal_downloads._download_track_sync(
+            _FakeDownloadApi({8: "Track"}), 8, "HIGH", "ignored", destination
+        )
+
+    assert not temporary.exists()
+
+
+def test_cover_fetch_runs_before_install_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    cover_lock_states: list[bool] = []
+    embedded_covers: list[bytes | None] = []
+    api = _FakeDownloadApi({8: "Track"}, cover="cover-id")
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"audio")
+
+    def fetch_cover() -> bytes:
+        cover_lock_states.append(tidal_downloads._DOWNLOAD_INSTALL_LOCK.locked())
+        return b"cover"
+
+    monkeypatch.setattr(
+        tidal_downloads,
+        "Cover",
+        lambda _cover_id: types.SimpleNamespace(fetch_data=fetch_cover),
+    )
+    monkeypatch.setattr(
+        tidal_downloads,
+        "add_track_metadata",
+        lambda *, cover_data, **_kwargs: embedded_covers.append(cover_data),
+    )
+
+    tidal_downloads._download_track_sync(api, 8, "HIGH", "ignored", tmp_path / "music")
+
+    assert cover_lock_states == [False]
+    assert embedded_covers == [b"cover"]
+
+
+def test_temp_name_uses_full_uuid4_hex_and_33_byte_infix_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    fixed_uuid = "0123456789abcdef0123456789abcdef"
+    stem = "a" * 218
+    monkeypatch.setattr(
+        tidal_downloads,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex=fixed_uuid),
+    )
+
+    _relative, _planned, temporary = tidal_downloads._build_download_file_path(
+        Path(stem), ".m4a", tmp_path
+    )
+
+    assert temporary.name == f"{stem}.{fixed_uuid}.tmp"
+    assert len(temporary.name.encode()) == 255
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload", "tags"),
+    [
+        pytest.param("broken.flac", b"corrupted", {}, id="corrupted"),
+        pytest.param("track.mp3", b"audio", {}, id="unsupported-suffix"),
+        pytest.param("untagged.m4a", b"audio", {}, id="absent-tag"),
+        pytest.param(
+            "malformed.m4a",
+            b"audio",
+            {"comment": ["not-a-tidal-id"]},
+            id="unparseable-tag",
+        ),
+    ],
+)
+def test_embedded_tidal_id_reader_returns_none_for_unreadable_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    payload: bytes,
+    tags: dict[str, list[str]],
+) -> None:
+    import tidal_downloads
+
+    path = tmp_path / filename
+    path.write_bytes(payload)
+    tags_by_path = {path: tags}
+    monkeypatch.setattr(tidal_downloads, "EasyMP4", lambda item: _TaggedAudio(item, tags_by_path))
+    monkeypatch.setattr(tidal_downloads, "FLAC", lambda item: _TaggedAudio(item, tags_by_path))
+
+    assert tidal_downloads._read_embedded_tidal_id(path) is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "tag_key"),
+    [
+        pytest.param("track.flac", "COMMENT", id="flac-vorbis-comment"),
+        pytest.param("track.m4a", "comment", id="easy-mp4-comment"),
+    ],
+)
+def test_embedded_tidal_id_reader_uses_tiddl_comment_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    tag_key: str,
+) -> None:
+    import tidal_downloads
+
+    path = tmp_path / filename
+    path.write_bytes(b"audio")
+    tags_by_path = {path: {tag_key: ["tidal:606"]}}
+    monkeypatch.setattr(tidal_downloads, "EasyMP4", lambda item: _TaggedAudio(item, tags_by_path))
+    monkeypatch.setattr(tidal_downloads, "FLAC", lambda item: _TaggedAudio(item, tags_by_path))
+
+    assert tidal_downloads._read_embedded_tidal_id(path) == 606
+
+
+def test_metadata_embed_receives_tidal_identity_comment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    comments: list[str] = []
+    _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"audio")
+    monkeypatch.setattr(
+        tidal_downloads,
+        "add_track_metadata",
+        lambda *, comment, **_kwargs: comments.append(comment),
+    )
+
+    tidal_downloads._download_track_sync(
+        _FakeDownloadApi({505: "Track"}), 505, "HIGH", "ignored", tmp_path / "music"
+    )
+
+    assert comments == ["tidal:505"]

--- a/services/tidal-streamer/tests/test_download_flac_extraction.py
+++ b/services/tidal-streamer/tests/test_download_flac_extraction.py
@@ -76,9 +76,12 @@ def test_flac_extraction_uses_one_path_and_moves_converted_file(
     )
 
     expected = destination / "Artist" / "Album" / "01. Track.flac"
-    temporary = expected.with_suffix(".flac.tmp")
+    temporary = calls[0][0]
     intermediate = temporary.with_suffix(".flac")
     assert calls == [(temporary,)]
+    assert temporary.parent == expected.parent
+    assert temporary.name.startswith("01. Track.")
+    assert temporary.name.endswith(".tmp")
     assert expected.read_bytes() == b"audio"
     assert not temporary.exists()
     assert not intermediate.exists()
@@ -93,8 +96,10 @@ def test_aac_detection_uses_m4a_final_path_and_metadata_path(
     import tidal_downloads
 
     metadata_paths: list[Path] = []
+    temporary_paths: list[Path] = []
 
     def extract_flac(source: Path) -> Path:
+        temporary_paths.append(source)
         converted = source.with_suffix(".m4a")
         source.replace(converted)
         return converted
@@ -113,7 +118,7 @@ def test_aac_detection_uses_m4a_final_path_and_metadata_path(
 
     planned = destination / "Artist" / "Album" / "01. Track.flac"
     expected = planned.with_suffix(".m4a")
-    temporary = planned.with_suffix(".flac.tmp")
+    temporary = temporary_paths[0]
     intermediate = temporary.with_suffix(".m4a")
     assert expected.read_bytes() == b"audio"
     assert Path(result["file_path"]).resolve() == expected.resolve()
@@ -125,6 +130,38 @@ def test_aac_detection_uses_m4a_final_path_and_metadata_path(
     assert result["file_size"] == len(b"audio")
 
 
+def test_aac_detection_disambiguates_existing_m4a_for_different_track(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    def extract_flac(source: Path) -> Path:
+        converted = source.with_suffix(".m4a")
+        source.replace(converted)
+        return converted
+
+    destination = tmp_path / "music"
+    existing = destination / "Artist" / "Album" / "01. Track.m4a"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"different-track")
+    _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 700 if path == existing else None,
+    )
+
+    result = tidal_downloads._download_track_sync(
+        _FakeDownloadApi(), 8, "LOSSLESS", "ignored", destination
+    )
+
+    disambiguated = existing.with_name("01. Track [tidal-8].m4a")
+    assert existing.read_bytes() == b"different-track"
+    assert disambiguated.read_bytes() == b"audio"
+    assert Path(result["file_path"]) == disambiguated
+    assert result["relative_path"] == "Artist/Album/01. Track [tidal-8].m4a"
+
+
 def test_ffmpeg_error_logs_warning_and_falls_back_to_planned_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -132,7 +169,10 @@ def test_ffmpeg_error_logs_warning_and_falls_back_to_planned_path(
 ) -> None:
     import tidal_downloads
 
+    temporary_paths: list[Path] = []
+
     def extract_flac(source: Path) -> Path:
+        temporary_paths.append(source)
         source.with_suffix(".tmp.flac").write_bytes(b"partial-flac")
         raise _FakeFFmpegError("ffmpeg failed")
 
@@ -145,7 +185,7 @@ def test_ffmpeg_error_logs_warning_and_falls_back_to_planned_path(
         )
 
     expected = destination / "Artist" / "Album" / "01. Track.flac"
-    temporary = expected.with_suffix(".flac.tmp")
+    temporary = temporary_paths[0]
     intermediate = temporary.with_suffix(".tmp.flac")
     assert expected.read_bytes() == b"audio"
     assert not temporary.exists()
@@ -170,6 +210,11 @@ def test_flac_to_m4a_transition_removes_stale_flac_sibling(
     planned.parent.mkdir(parents=True)
     planned.write_bytes(b"old-flac")
     _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 4 if path == planned else None,
+    )
 
     result = tidal_downloads._download_track_sync(
         _FakeDownloadApi(), 4, "LOSSLESS", "ignored", destination
@@ -197,6 +242,11 @@ def test_m4a_to_flac_transition_removes_stale_m4a_sibling(
     stale_m4a.parent.mkdir(parents=True)
     stale_m4a.write_bytes(b"old-m4a")
     _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 5 if path == stale_m4a else None,
+    )
 
     result = tidal_downloads._download_track_sync(
         _FakeDownloadApi(), 5, "LOSSLESS", "ignored", destination
@@ -205,6 +255,79 @@ def test_m4a_to_flac_transition_removes_stale_m4a_sibling(
     assert planned.read_bytes() == b"audio"
     assert set(planned.parent.iterdir()) == {planned}
     assert Path(result["file_path"]) == planned
+
+
+@pytest.mark.parametrize(
+    "embedded_id",
+    [pytest.param(None, id="unknown"), pytest.param(999, id="different-track")],
+)
+def test_codec_transition_preserves_sibling_not_owned_by_current_track(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    embedded_id: int | None,
+) -> None:
+    import tidal_downloads
+
+    def extract_flac(source: Path) -> Path:
+        converted = source.with_suffix(".flac")
+        source.replace(converted)
+        return converted
+
+    destination = tmp_path / "music"
+    planned = destination / "Artist" / "Album" / "01. Track.flac"
+    sibling = planned.with_suffix(".m4a")
+    sibling.parent.mkdir(parents=True)
+    sibling.write_bytes(b"different-track")
+    _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: embedded_id if path == sibling else None,
+    )
+
+    result = tidal_downloads._download_track_sync(
+        _FakeDownloadApi(), 6, "LOSSLESS", "ignored", destination
+    )
+
+    assert planned.read_bytes() == b"audio"
+    assert sibling.read_bytes() == b"different-track"
+    assert set(planned.parent.iterdir()) == {planned, sibling}
+    assert Path(result["file_path"]) == planned
+
+
+def test_disambiguated_codec_switch_cleans_owned_planned_stem_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    def extract_flac(source: Path) -> Path:
+        converted = source.with_suffix(".m4a")
+        source.replace(converted)
+        return converted
+
+    destination = tmp_path / "music"
+    planned = destination / "Artist" / "Album" / "01. Track.flac"
+    occupied_m4a = planned.with_suffix(".m4a")
+    planned.parent.mkdir(parents=True)
+    planned.write_bytes(b"old-current-track")
+    occupied_m4a.write_bytes(b"different-track")
+    _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 8 if path == planned else 700 if path == occupied_m4a else None,
+    )
+
+    result = tidal_downloads._download_track_sync(
+        _FakeDownloadApi(), 8, "LOSSLESS", "ignored", destination
+    )
+
+    installed = occupied_m4a.with_name("01. Track [tidal-8].m4a")
+    assert not planned.exists()
+    assert occupied_m4a.read_bytes() == b"different-track"
+    assert installed.read_bytes() == b"audio"
+    assert set(installed.parent.iterdir()) == {occupied_m4a, installed}
+    assert Path(result["file_path"]) == installed
 
 
 def test_outside_converted_path_warns_and_falls_back_without_touching_outside_file(
@@ -235,7 +358,7 @@ def test_outside_converted_path_warns_and_falls_back_without_touching_outside_fi
     assert "outside MUSIC_PATH" in caplog.text
 
 
-def test_unexpected_final_move_failure_preserves_one_recoverable_file(
+def test_unexpected_final_move_failure_removes_all_staged_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import tidal_downloads
@@ -243,7 +366,7 @@ def test_unexpected_final_move_failure_preserves_one_recoverable_file(
     destination = tmp_path / "music"
     destination.mkdir()
     planned = destination / "Track.flac"
-    temporary = planned.with_suffix(".flac.tmp")
+    temporary = destination / "Track.0123456789abcdef0123456789abcdef.tmp"
     temporary.write_bytes(b"source-audio")
     converted = temporary.with_suffix(".flac")
 
@@ -260,6 +383,36 @@ def test_unexpected_final_move_failure_preserves_one_recoverable_file(
     with pytest.raises(OSError, match="move"):
         tidal_downloads._finalize_flac_download(temporary, planned, destination.resolve(), 7)
 
-    assert temporary.read_bytes() == b"source-audio"
+    assert not temporary.exists()
     assert not converted.exists()
-    assert set(destination.iterdir()) == {temporary}
+    assert list(destination.iterdir()) == []
+
+
+def test_ffmpeg_fallback_move_failure_removes_all_staged_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tidal_downloads
+
+    destination = tmp_path / "music"
+    destination.mkdir()
+    planned = destination / "Track.flac"
+    temporary = destination / "Track.0123456789abcdef0123456789abcdef.tmp"
+    temporary.write_bytes(b"source-audio")
+    intermediate = temporary.with_suffix(".tmp.flac")
+
+    def extract_flac(_source: Path) -> Path:
+        intermediate.write_bytes(b"partial-flac")
+        raise _FakeFFmpegError("ffmpeg failed")
+
+    def fail_move(_source: str, _destination: str) -> None:
+        raise OSError("move")
+
+    _configure_flac_download(monkeypatch, tidal_downloads, extract_flac)
+    monkeypatch.setattr("tidal_downloads.shutil.move", fail_move)
+
+    with pytest.raises(OSError, match="move"):
+        tidal_downloads._finalize_flac_download(temporary, planned, destination.resolve(), 7)
+
+    assert not temporary.exists()
+    assert not intermediate.exists()
+    assert list(destination.iterdir()) == []

--- a/services/tidal-streamer/tests/test_download_path_safety.py
+++ b/services/tidal-streamer/tests/test_download_path_safety.py
@@ -82,8 +82,14 @@ def test_download_rejects_temporary_file_symlink_escape(
     outside_file = tmp_path / "outside.m4a.tmp"
     target_parent.mkdir(parents=True)
     outside_file.write_bytes(b"unchanged")
-    (target_parent / "01. Track.m4a.tmp").symlink_to(outside_file)
+    fixed_uuid = "0123456789abcdef0123456789abcdef"
+    (target_parent / f"01. Track.{fixed_uuid}.tmp").symlink_to(outside_file)
     _configure_download(monkeypatch, tidal_downloads, "Artist/Album/01. Track", b"replacement")
+    monkeypatch.setattr(
+        tidal_downloads,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex=fixed_uuid),
+    )
 
     with pytest.raises(ValueError, match="outside MUSIC_PATH"):
         tidal_downloads._download_track_sync(_FakeDownloadApi(), 1, "HIGH", "ignored", destination)

--- a/services/tidal-streamer/tests/test_tiddl_metadata_roundtrip.py
+++ b/services/tidal-streamer/tests/test_tiddl_metadata_roundtrip.py
@@ -1,0 +1,83 @@
+"""Round-trip coverage for real tiddl metadata and production identity reads."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FFMPEG_PATH = shutil.which("ffmpeg")
+_REAL_TIDDL_METADATA_PROBE = """
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+from tiddl.core.metadata import add_track_metadata
+
+track = SimpleNamespace(
+    title="Identity Round Trip",
+    version=None,
+    trackNumber=1,
+    volumeNumber=1,
+    copyright="",
+    artists=[SimpleNamespace(name="Artist")],
+    album=SimpleNamespace(title="Album"),
+    isrc="",
+    bpm=None,
+)
+add_track_metadata(Path(sys.argv[1]), track, comment="tidal:8675309")
+"""
+
+
+def _generate_silent_audio(path: Path) -> None:
+    """Generate a short valid audio file using the requested container codec."""
+    assert _FFMPEG_PATH is not None
+    codec = "flac" if path.suffix == ".flac" else "aac"
+    result = subprocess.run(  # noqa: S603 -- resolved ffmpeg path and code-owned arguments
+        [
+            _FFMPEG_PATH,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=stereo",
+            "-t",
+            "0.2",
+            "-c:a",
+            codec,
+            str(path),
+        ],
+        check=False,
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
+
+
+def _write_real_tiddl_metadata(path: Path) -> None:
+    """Run real tiddl outside the pytest process that owns the suite stub."""
+    result = subprocess.run(  # noqa: S603 -- fixed interpreter executes a code-owned probe
+        [sys.executable, "-c", _REAL_TIDDL_METADATA_PROBE, str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(_FFMPEG_PATH is None, reason="ffmpeg is required for real audio fixtures")
+@pytest.mark.parametrize("extension", [pytest.param(".flac"), pytest.param(".m4a")])
+def test_real_tiddl_metadata_round_trips_through_production_reader(
+    tmp_path: Path, extension: str
+) -> None:
+    import tidal_downloads
+
+    audio_path = tmp_path / f"identity{extension}"
+    _generate_silent_audio(audio_path)
+    _write_real_tiddl_metadata(audio_path)
+
+    assert tidal_downloads._read_embedded_tidal_id(audio_path) == 8675309

--- a/services/tidal-streamer/tidal_downloads.py
+++ b/services/tidal-streamer/tidal_downloads.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
+import threading
 from base64 import b64decode
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
+from uuid import uuid4
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import fromstring as xml_fromstring
 
 from common.sidecar_runtime_utils import env_float
+from mutagen.easymp4 import EasyMP4
+from mutagen.flac import FLAC
 from tiddl.core.metadata import Cover, add_track_metadata
 from tiddl.core.utils import parse_track_stream
 from tiddl.core.utils.format import format_template
@@ -34,6 +38,11 @@ __all__ = (
 
 JsonObject = dict[str, Any]
 log = logging.getLogger("tidal-streamer")
+
+_MAX_FILENAME_BYTES = 255
+_MAX_COLLISION_COUNTER = 5
+# Backend queue claims serialize downloads across replicas; this lock closes in-process races.
+_DOWNLOAD_INSTALL_LOCK = threading.Lock()
 
 
 class TrackDownloadAPIProtocol(Protocol):
@@ -110,18 +119,118 @@ def _build_download_file_path(
     file_extension: str,
     dest_base: Path,
 ) -> tuple[Path, Path, Path]:
-    """Build contained final and temporary paths from a rendered template."""
+    """Build a final path and a ``<stem>.<32 lowercase uuid4 hex>.tmp`` path."""
     relative_file = relative_stem.parent / f"{relative_stem.name}{file_extension}"
     destination_root = dest_base.resolve()
     file_path = _require_contained_download_path(
         destination_root / relative_file,
         destination_root,
     )
+    temporary_name = _build_bounded_filename(
+        file_path.stem,
+        f".{uuid4().hex}",
+        ".tmp",
+    )
     tmp_path = _require_contained_download_path(
-        file_path.with_suffix(file_path.suffix + ".tmp"),
+        file_path.with_name(temporary_name),
         destination_root,
     )
     return relative_file, file_path, tmp_path
+
+
+def _build_bounded_filename(stem: str, suffix: str, extension: str) -> str:
+    """Build one UTF-8 filename component within the common 255-byte limit."""
+    reserved_bytes = len(f"{suffix}{extension}".encode())
+    stem_budget = _MAX_FILENAME_BYTES - reserved_bytes
+    if stem_budget < 1:
+        raise ValueError("Download filename suffix exceeds the 255-byte component limit")
+    bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
+    if not bounded_stem:
+        raise ValueError("Download filename has no stem within the 255-byte component limit")
+    return f"{bounded_stem}{suffix}{extension}"
+
+
+def _parse_tidal_comment(tag_values: object) -> int | None:
+    """Parse the single identity value written by tiddl's comment metadata."""
+    if not isinstance(tag_values, list) or not tag_values:
+        return None
+    comment = tag_values[0]
+    if not isinstance(comment, str) or not comment.startswith("tidal:"):
+        return None
+    track_id = comment.removeprefix("tidal:")
+    if not track_id.isdigit():
+        return None
+    return int(track_id)
+
+
+def _read_embedded_tidal_id(path: Path) -> int | None:
+    """Read a tiddl-written track identity, returning None for every failure."""
+    try:
+        if path.suffix.lower() == ".flac":
+            return _parse_tidal_comment(FLAC(path).get("COMMENT"))
+        if path.suffix.lower() == ".m4a":
+            return _parse_tidal_comment(EasyMP4(path).get("comment"))
+    except Exception:
+        return None
+    return None
+
+
+def _resolve_final_download_path(
+    planned_path: Path,
+    destination_root: Path,
+    track_id: int,
+) -> Path:
+    """Reuse planned legacy files but require identity for occupied suffixes."""
+    candidates = _build_download_candidates(planned_path, track_id)
+    for candidate_index, candidate in enumerate(candidates):
+        contained_candidate = _require_contained_download_path(candidate, destination_root)
+        if not contained_candidate.exists():
+            if contained_candidate != planned_path:
+                log.info(
+                    "Download path collision at %s; saving track %s to %s",
+                    planned_path,
+                    track_id,
+                    contained_candidate,
+                )
+            return contained_candidate
+        embedded_id = _read_embedded_tidal_id(contained_candidate)
+        if embedded_id == track_id:
+            if contained_candidate != planned_path:
+                log.info(
+                    "Download path collision at %s; saving track %s to %s",
+                    planned_path,
+                    track_id,
+                    contained_candidate,
+                )
+            return contained_candidate
+        if candidate_index == 0 and embedded_id is None:
+            log.debug(
+                "Refreshing unidentified legacy file at planned path %s for track %s",
+                contained_candidate,
+                track_id,
+            )
+            return contained_candidate
+
+    raise RuntimeError(
+        f"No safe download path for TIDAL track {track_id}; all {len(candidates)} candidates "
+        "are occupied by other or unidentified files"
+    )
+
+
+def _build_download_candidates(planned_path: Path, track_id: int) -> tuple[Path, ...]:
+    """Build the planned path and five byte-bounded identity alternatives."""
+    candidates = [planned_path]
+    for counter in range(1, _MAX_COLLISION_COUNTER + 1):
+        identity_suffix = (
+            f" [tidal-{track_id}]" if counter == 1 else f" [tidal-{track_id}-{counter}]"
+        )
+        candidate_name = _build_bounded_filename(
+            planned_path.stem,
+            identity_suffix,
+            planned_path.suffix,
+        )
+        candidates.append(planned_path.with_name(candidate_name))
+    return tuple(candidates)
 
 
 def _finalize_flac_download(
@@ -134,35 +243,50 @@ def _finalize_flac_download(
     from tiddl.core.utils.ffmpeg import FFmpegError, extract_flac
 
     try:
-        converted_path = extract_flac(tmp_path)
-    except (FFmpegError, FileNotFoundError) as error:
-        log.warning(
-            "FLAC extraction failed for track %s: %s; saving original download",
-            track_id,
-            error,
-        )
-        return _fallback_flac_download(tmp_path, planned_file_path, destination_root)
+        try:
+            converted_path = extract_flac(tmp_path)
+        except (FFmpegError, FileNotFoundError) as error:
+            log.warning(
+                "FLAC extraction failed for track %s: %s; saving original download",
+                track_id,
+                error,
+            )
+            return _fallback_flac_download(
+                tmp_path,
+                planned_file_path,
+                destination_root,
+                track_id,
+            )
 
-    try:
-        trusted_converted_path = _require_regular_converted_path(
-            converted_path,
+        try:
+            trusted_converted_path = _require_regular_converted_path(
+                converted_path,
+                destination_root,
+            )
+        except ValueError as error:
+            log.warning(
+                "FLAC extraction returned an unsafe path for track %s: %s; "
+                "saving original download",
+                track_id,
+                error,
+            )
+            return _fallback_flac_download(
+                tmp_path,
+                planned_file_path,
+                destination_root,
+                track_id,
+            )
+
+        return _install_converted_flac_download(
+            tmp_path,
+            trusted_converted_path,
+            planned_file_path,
             destination_root,
-        )
-    except ValueError as error:
-        log.warning(
-            "FLAC extraction returned an unsafe path for track %s: %s; saving original download",
             track_id,
-            error,
         )
-        return _fallback_flac_download(tmp_path, planned_file_path, destination_root)
-
-    return _install_converted_flac_download(
-        tmp_path,
-        trusted_converted_path,
-        planned_file_path,
-        destination_root,
-        track_id,
-    )
+    except Exception:
+        _cleanup_staged_download(tmp_path, track_id)
+        raise
 
 
 def _require_regular_converted_path(converted_path: Path, destination_root: Path) -> Path:
@@ -177,56 +301,111 @@ def _fallback_flac_download(
     tmp_path: Path,
     planned_file_path: Path,
     destination_root: Path,
+    track_id: int,
 ) -> Path:
     """Remove ffmpeg output and retain the original download at its planned path."""
-    tmp_path.with_suffix(".tmp.flac").unlink(missing_ok=True)
-    shutil.move(str(tmp_path), str(planned_file_path))
-    _remove_stale_codec_sibling(planned_file_path, destination_root)
-    return planned_file_path
+    _cleanup_extractor_intermediates(tmp_path, track_id, None)
+    final_path = _resolve_final_download_path(planned_file_path, destination_root, track_id)
+    shutil.move(str(tmp_path), str(final_path))
+    return final_path
 
 
-def _remove_stale_codec_sibling(final_path: Path, destination_root: Path) -> None:
-    """Remove only the opposite known codec sibling beside a completed download."""
+def _remove_stale_codec_siblings(
+    planned_path: Path,
+    final_path: Path,
+    destination_root: Path,
+    track_id: int,
+) -> None:
+    """Remove current-track codec siblings for both planned and resolved stems."""
+    contained_planned_path = _require_contained_download_path(planned_path, destination_root)
     contained_final_path = _require_contained_download_path(final_path, destination_root)
-    if contained_final_path.suffix == ".flac":
-        sibling_extension = ".m4a"
-    elif contained_final_path.suffix == ".m4a":
-        sibling_extension = ".flac"
-    else:
+    sibling_extension = _opposite_codec_extension(contained_final_path)
+    if sibling_extension is None:
         return
-    sibling_path = contained_final_path.with_suffix(sibling_extension)
-    _require_contained_download_path(sibling_path, destination_root)
-    sibling_path.unlink(missing_ok=True)
+    sibling_paths = {
+        contained_planned_path.with_suffix(sibling_extension),
+        contained_final_path.with_suffix(sibling_extension),
+    }
+    for sibling_path in sibling_paths:
+        _remove_owned_codec_sibling(sibling_path, destination_root, track_id)
+
+
+def _opposite_codec_extension(path: Path) -> str | None:
+    """Return the other supported library codec extension."""
+    if path.suffix == ".flac":
+        return ".m4a"
+    if path.suffix == ".m4a":
+        return ".flac"
+    return None
+
+
+def _remove_owned_codec_sibling(
+    sibling_path: Path,
+    destination_root: Path,
+    track_id: int,
+) -> None:
+    """Remove one sibling only when its embedded identity matches the download."""
+    contained_sibling_path = _require_contained_download_path(sibling_path, destination_root)
+    if not contained_sibling_path.exists():
+        return
+    sibling_track_id = _read_embedded_tidal_id(contained_sibling_path)
+    # Planned UNKNOWN files may be refreshed, but deletion requires positive ownership proof.
+    if sibling_track_id != track_id:
+        log.debug(
+            "Keeping codec sibling %s for track %s because its embedded TIDAL id is %s",
+            contained_sibling_path,
+            track_id,
+            sibling_track_id,
+        )
+        return
+    contained_sibling_path.unlink()
 
 
 def _cleanup_failed_flac_install(
     tmp_path: Path,
     converted_path: Path,
-    final_path: Path,
     track_id: int,
 ) -> None:
-    """Best-effort cleanup that retains one recoverable copy after install failure."""
-    if final_path.is_file() and not final_path.is_symlink():
-        preserved_path = final_path
-    elif tmp_path.is_file() and not tmp_path.is_symlink():
-        preserved_path = tmp_path
-    else:
-        preserved_path = converted_path
-    if converted_path != preserved_path:
-        _unlink_failed_flac_path(converted_path, track_id)
-    if tmp_path != preserved_path:
-        _unlink_failed_flac_path(tmp_path, track_id)
-    ffmpeg_path = tmp_path.with_suffix(".tmp.flac")
-    if ffmpeg_path != preserved_path:
-        _unlink_failed_flac_path(ffmpeg_path, track_id)
+    """Remove UUID staging and a validated extractor result after failure."""
+    _cleanup_staged_download(tmp_path, track_id)
+    if converted_path not in _extractor_intermediate_paths(tmp_path):
+        _unlink_staged_path(converted_path, track_id)
 
 
-def _unlink_failed_flac_path(path: Path, track_id: int) -> None:
-    """Remove a failed-install artifact without replacing the active exception."""
+def _extractor_intermediate_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Return every filename shape the FLAC extractor can derive from UUID staging."""
+    return (
+        tmp_path.with_suffix(".flac"),
+        tmp_path.with_suffix(".m4a"),
+        tmp_path.with_suffix(".tmp.flac"),
+    )
+
+
+def _cleanup_extractor_intermediates(
+    tmp_path: Path,
+    track_id: int,
+    additional_path: Path | None,
+) -> None:
+    """Best-effort remove bounded extractor intermediates for one staged download."""
+    intermediate_paths = _extractor_intermediate_paths(tmp_path)
+    for intermediate_path in intermediate_paths:
+        _unlink_staged_path(intermediate_path, track_id)
+    if additional_path is not None and additional_path not in intermediate_paths:
+        _unlink_staged_path(additional_path, track_id)
+
+
+def _cleanup_staged_download(tmp_path: Path, track_id: int) -> None:
+    """Best-effort remove the exact UUID temp and its known extractor outputs."""
+    _unlink_staged_path(tmp_path, track_id)
+    _cleanup_extractor_intermediates(tmp_path, track_id, None)
+
+
+def _unlink_staged_path(path: Path, track_id: int) -> None:
+    """Remove a staged artifact without replacing the active exception."""
     try:
         path.unlink(missing_ok=True)
     except OSError as error:
-        log.warning("Could not clean FLAC artifact for track %s: %s", track_id, error)
+        log.warning("Could not clean staged artifact for track %s: %s", track_id, error)
 
 
 def _install_converted_flac_download(
@@ -239,15 +418,120 @@ def _install_converted_flac_download(
     """Install a validated extractor result and remove temporary codec siblings."""
     final_path = planned_file_path.with_suffix(converted_path.suffix)
     try:
-        final_path = _require_contained_download_path(final_path, destination_root)
+        final_path = _resolve_final_download_path(final_path, destination_root, track_id)
         shutil.move(str(converted_path), str(final_path))
-        tmp_path.unlink(missing_ok=True)
-        tmp_path.with_suffix(".tmp.flac").unlink(missing_ok=True)
-        _remove_stale_codec_sibling(final_path, destination_root)
     except Exception:
-        _cleanup_failed_flac_install(tmp_path, converted_path, final_path, track_id)
+        _cleanup_failed_flac_install(tmp_path, converted_path, track_id)
         raise
+    _cleanup_staged_download(tmp_path, track_id)
     return final_path
+
+
+def _install_staged_download(
+    tmp_path: Path,
+    planned_file_path: Path,
+    file_extension: str,
+    destination_root: Path,
+    track_id: int,
+) -> Path:
+    """Move one staged download into its identity-checked final candidate."""
+    if file_extension == ".flac":
+        return _finalize_flac_download(
+            tmp_path,
+            planned_file_path,
+            destination_root,
+            track_id,
+        )
+    final_path = _resolve_final_download_path(
+        planned_file_path,
+        destination_root,
+        track_id,
+    )
+    shutil.move(str(tmp_path), str(final_path))
+    return final_path
+
+
+def _fetch_download_cover(album: Any, track_id: int) -> tuple[bool, bytes | None]:
+    """Fetch optional cover bytes before installation without failing the audio download."""
+    if not album.cover:
+        return True, None
+    try:
+        return True, cast(bytes, Cover(album.cover).fetch_data())
+    except Exception as error:
+        log.warning("Failed to embed metadata for track %s: %s", track_id, error)
+        return False, None
+
+
+def _embed_download_metadata(
+    path: Path,
+    track: Any,
+    album: Any,
+    track_id: int,
+    cover_data: bytes | None,
+) -> None:
+    """Embed metadata and retain the completed audio when tagging fails."""
+    try:
+        add_track_metadata(
+            path=path,
+            track=track,
+            album_artist=track.artists[0].name if track.artists else "",
+            date=str(album.releaseDate.date()) if album.releaseDate else "",
+            cover_data=cover_data,
+            comment=f"tidal:{track_id}",
+        )
+    except Exception as error:
+        log.warning("Failed to embed metadata for track %s: %s", track_id, error)
+
+
+def _install_download_with_metadata(
+    tmp_path: Path,
+    planned_file_path: Path,
+    file_extension: str,
+    destination_root: Path,
+    track_id: int,
+    track: Any,
+    album: Any,
+) -> Path:
+    """Serialize candidate allocation, installation, tagging, and codec cleanup."""
+    cover_fetched, cover_data = _fetch_download_cover(album, track_id)
+    with _DOWNLOAD_INSTALL_LOCK:
+        final_path = _install_staged_download(
+            tmp_path,
+            planned_file_path,
+            file_extension,
+            destination_root,
+            track_id,
+        )
+        if cover_fetched:
+            _embed_download_metadata(final_path, track, album, track_id, cover_data)
+        _remove_stale_codec_siblings(
+            planned_file_path,
+            final_path,
+            destination_root,
+            track_id,
+        )
+    return final_path
+
+
+def _build_download_result(
+    track: Any,
+    album: Any,
+    stream: Any,
+    track_id: int,
+    file_path: Path,
+    relative_file: Path,
+) -> JsonObject:
+    """Describe one installed track for the download API response."""
+    return {
+        "track_id": track_id,
+        "title": track.title,
+        "artist": track.artists[0].name if track.artists else "Unknown",
+        "album": album.title,
+        "quality": stream.audioQuality,
+        "file_path": str(file_path),
+        "relative_path": relative_file.as_posix(),
+        "file_size": file_path.stat().st_size,
+    }
 
 
 def _download_track_sync(
@@ -280,7 +564,7 @@ def _download_track_sync(
     urls, file_extension = parse_track_stream(stream)
     urls = _prepend_dash_init_segment(stream, urls, track_id)
 
-    relative_file, file_path, tmp_path = _build_download_file_path(
+    _relative_file, planned_file_path, tmp_path = _build_download_file_path(
         relative_stem,
         file_extension,
         dest_base,
@@ -292,50 +576,28 @@ def _download_track_sync(
     stream_data = download_bytes(urls)
 
     # 4. Write to disk
-    file_path.parent.mkdir(parents=True, exist_ok=True)
+    planned_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write to temp file first, then move (atomic-ish)
-    tmp_path.write_bytes(stream_data)
-
-    # 5. If FLAC, ffmpeg extraction may be needed
-    if file_extension == ".flac":
-        file_path = _finalize_flac_download(
-            tmp_path,
-            file_path,
-            dest_base.resolve(),
-            track_id,
-        )
-        relative_file = relative_file.with_suffix(file_path.suffix)
-    else:
-        shutil.move(str(tmp_path), str(file_path))
-
-    # 6. Embed metadata
     try:
-        # Fetch cover
-        cover = None
-        if album.cover:
-            cover = Cover(album.cover)
+        # The 33-byte ``.<uuid4 hex>`` infix is included in the 255-byte name budget.
+        tmp_path.write_bytes(stream_data)
 
-        add_track_metadata(
-            path=file_path,
-            track=track,
-            album_artist=track.artists[0].name if track.artists else "",
-            date=str(album.releaseDate.date()) if album.releaseDate else "",
-            cover_data=cover.fetch_data() if cover else None,
+        # 5-6. Install, embed identity, then clean only same-track codec siblings.
+        destination_root = dest_base.resolve()
+        file_path = _install_download_with_metadata(
+            tmp_path,
+            planned_file_path,
+            file_extension,
+            destination_root,
+            track_id,
+            track,
+            album,
         )
-    except Exception as error:
-        log.warning("Failed to embed metadata for track %s: %s", track_id, error)
-
-    return {
-        "track_id": track_id,
-        "title": track.title,
-        "artist": track.artists[0].name if track.artists else "Unknown",
-        "album": album.title,
-        "quality": stream.audioQuality,
-        "file_path": str(file_path),
-        "relative_path": relative_file.as_posix(),
-        "file_size": file_path.stat().st_size,
-    }
+    except Exception:
+        _cleanup_staged_download(tmp_path, track_id)
+        raise
+    relative_file = file_path.relative_to(destination_root)
+    return _build_download_result(track, album, stream, track_id, file_path, relative_file)
 
 
 # Maximum decoded manifest size we're willing to parse (1 MiB).


### PR DESCRIPTION
## Problem

Sanitization is many-to-one: `Intro: Part 1` and `Intro? Part 1` both become `Intro Part 1`, and the tmp→final move silently overwrote the earlier track — one file, wrong audio, scanner indexes the lie. Surfaced during the #735 review; policy decision (preserve-and-disambiguate) approved.

## Fix

- **Identity embedded at write time**: `comment = tidal:<track_id>` rides the existing tiddl metadata write (FLAC `COMMENT` / M4A `©cmt`); a read-only mutagen checker never raises.
- **Bounded identity-checked allocation**: planned path → ` [tidal-<id>]` → ` [tidal-<id>-N]` (N≤5), each candidate containment-validated. Same id → refresh in place. Different id → next candidate. All taken → the download fails loudly. Data is never destroyed.
- **Legacy libraries keep refresh semantics**: an id-less file at the planned path (everything downloaded before this change) is overwritten in place exactly as before — no duplicate-album surprise on re-download — and the new write embeds an id, making the future collision-safe.
- **Codec-switch sibling cleanup is identity-gated** (both planned and resolved stems considered): only a same-id sibling is retired; unknown or different ids are left alone. Deleting is held to a stricter standard than overwriting.
- Unique per-download temp names (full uuid4 hex) cleaned on every failure path; per-process install lock around resolve→move→embed (cross-replica serialization already comes from the album queue claim); cover art fetched outside the lock; byte-aware stem truncation against the 255-byte component limit.
- Real tiddl+mutagen round-trip test (skipif no ffmpeg) pins the tag mapping against dependency drift, alongside 20+ behavioral collision tests.

## Verification

- verify: full tidal-streamer pytest suite — 168 passed, exit 0
- verify: ruff check + format (pinned 0.16.2) clean, strict mypy (pinned 2.3.0) clean — exit 0
- verify: file-size ratchet exit 0; CHANGELOG prettier-clean

Review process: full adversarial round + focused delta round, findings driven to zero (companion ytmusic fix follows separately).