### PR TITLE
fix(ytmusic): stop album downloads silently skipping colliding tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Two different TIDAL tracks whose names collapse to the same filename no longer overwrite each other; the second download is saved under a disambiguated name, while legacy files without embedded TIDAL identity still refresh in place at their planned path.
+- Album downloads from YouTube Music no longer silently skip a track when two song names collide into the same filename — the second track is saved under a disambiguated name.
 - Retrying a failed album download now uses the configured download source instead of always routing to Lidarr.
 - TIDAL downloads now convert tracks detected as lossless to real FLAC files. Tracks detected as AAC-only are saved as `.m4a` instead of mislabeled `.flac`; when codec detection is unavailable, the original file is kept as-is.
 - Max-quality (Hi-Res) TIDAL downloads are no longer saved as broken files missing their opening data.

--- a/services/ytmusic-streamer/tests/test_yt_album_collisions.py
+++ b/services/ytmusic-streamer/tests/test_yt_album_collisions.py
@@ -1,0 +1,423 @@
+"""Behavioral coverage for YouTube Music album filename collisions."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+
+class _FakeYoutubeDL:
+    """Write deterministic audio bytes to the configured yt-dlp output path."""
+
+    output_paths: ClassVar[list[Path]] = []
+
+    def __init__(self, options: dict[str, Any]) -> None:
+        self._options = options
+
+    def __enter__(self) -> _FakeYoutubeDL:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def extract_info(self, url: str, *, download: bool) -> dict[str, str]:
+        assert download is True
+        video_id = url.rsplit("=", maxsplit=1)[-1]
+        output_path = Path(str(self._options["outtmpl"]).replace("%(ext)s", "mp3"))
+        output_path.write_bytes(f"audio:{video_id}".encode())
+        self.output_paths.append(output_path)
+        return {"id": video_id}
+
+
+class _WriteThenRaiseYoutubeDL(_FakeYoutubeDL):
+    """Create owned yt-dlp artifacts before simulating extraction failure."""
+
+    def extract_info(self, url: str, *, download: bool) -> dict[str, str]:
+        super().extract_info(url, download=download)
+        output_template = str(self._options["outtmpl"])
+        Path(output_template.replace("%(ext)s", "webm")).write_bytes(b"source")
+        Path(output_template.replace("%(ext)s", "webm.part")).write_bytes(b"partial")
+        Path(output_template.replace("%(ext)s", "webp")).write_bytes(b"thumbnail")
+        raise RuntimeError("simulated extraction failure")
+
+
+class _WriteThenReturnNoInfoYoutubeDL(_FakeYoutubeDL):
+    """Create the expected temp output before returning no extraction info."""
+
+    def extract_info(self, url: str, *, download: bool) -> dict[str, str]:
+        super().extract_info(url, download=download)
+        return {}
+
+
+class _NoWaitPacer:
+    """Avoid provider pacing in deterministic local download tests."""
+
+    def wait(self) -> float:
+        return 0.0
+
+
+def _fake_embedded_video_id(path: Path) -> str | None:
+    """Read the test identity appended by the fake ffmpeg tagger."""
+    try:
+        marker = path.read_bytes().rsplit(b"|ytmusic:", maxsplit=1)
+    except OSError:
+        return None
+    return marker[1].decode() if len(marker) == 2 else None
+
+
+def _fake_stamp_audio_tags(filepath: str, tags: dict[str, str], _logger: object) -> None:
+    """Represent ffmpeg identity stamping without invoking a process."""
+    path = Path(filepath)
+    path.write_bytes(path.read_bytes() + b"|" + tags["comment"].encode())
+
+
+def _configure_fake_download(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Install deterministic yt-dlp, pacing, stamping, and reading seams."""
+    import app
+    import yt_dlp
+
+    _FakeYoutubeDL.output_paths = []
+    monkeypatch.setattr(yt_dlp, "YoutubeDL", _FakeYoutubeDL)
+    monkeypatch.setattr(app, "_extract_pacer", _NoWaitPacer())
+    monkeypatch.setattr(app, "_stamp_audio_tags", _fake_stamp_audio_tags)
+    monkeypatch.setattr(app, "_read_embedded_video_id", _fake_embedded_video_id)
+    return app
+
+
+def _download_track(app: Any, music_path: Path, video_id: str) -> str:
+    """Download one colliding fixture track through the production orchestration."""
+    result = app._download_album_track_sync(
+        job={"cancel_requested": False},
+        track={
+            "videoId": video_id,
+            "title": "Intro: Part 1",
+            "trackNumber": 1,
+            "artists": ["Artist"],
+        },
+        index=1,
+        album_title="Album",
+        album_artist="Artist",
+        year="2024",
+        audio_format="mp3",
+        quality="HIGH",
+        music_path=music_path,
+    )
+    assert isinstance(result, str)
+    return result
+
+
+def test_distinct_videos_with_colliding_names_are_both_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+
+    first_result = _download_track(app, tmp_path, "video000001")
+    second_result = _download_track(app, tmp_path, "video000002")
+
+    first = tmp_path / "Artist" / "Album" / "01. Intro_ Part 1.mp3"
+    second = tmp_path / "Artist" / "Album" / "01. Intro_ Part 1 [video000002].mp3"
+    assert Path(first_result) == first
+    assert Path(second_result) == second
+    assert first.is_file()
+    assert second.is_file()
+    assert app._read_embedded_video_id(first) == "video000001"
+    assert app._read_embedded_video_id(second) == "video000002"
+
+
+def test_resume_of_same_embedded_video_id_skips_redownload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+
+    first_result = _download_track(app, tmp_path, "video000001")
+    second_result = _download_track(app, tmp_path, "video000001")
+
+    assert second_result == first_result
+    assert len(_FakeYoutubeDL.output_paths) == 1
+
+
+def test_gap_before_same_id_candidate_resumes_without_downloading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+    resumed = tmp_path / "Artist" / "Album" / "01. Intro_ Part 1 [video000001].mp3"
+    resumed.parent.mkdir(parents=True)
+    resumed.write_bytes(b"audio|ytmusic:video000001")
+
+    result = _download_track(app, tmp_path, "video000001")
+
+    assert Path(result) == resumed
+    assert _FakeYoutubeDL.output_paths == []
+
+
+def test_concurrent_colliding_downloads_use_unique_temps_and_preserve_both(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+    extraction_barrier = threading.Barrier(2)
+    extract_info = _FakeYoutubeDL.extract_info
+
+    def synchronized_extract(
+        downloader: _FakeYoutubeDL, url: str, *, download: bool
+    ) -> dict[str, str]:
+        result = extract_info(downloader, url, download=download)
+        extraction_barrier.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(_FakeYoutubeDL, "extract_info", synchronized_extract)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(_download_track, app, tmp_path, video_id)
+            for video_id in ("video000001", "video000002")
+        ]
+        results = [Path(future.result(timeout=10)) for future in futures]
+
+    assert len(set(_FakeYoutubeDL.output_paths)) == 2
+    assert len(set(results)) == 2
+    assert {app._read_embedded_video_id(path) for path in results} == {
+        "video000001",
+        "video000002",
+    }
+
+
+def test_resolver_advances_past_foreign_planned_and_suffixed_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app
+
+    planned = tmp_path / "Track.mp3"
+    suffixed = tmp_path / "Track [video000008].mp3"
+    planned.write_bytes(b"first")
+    suffixed.write_bytes(b"second")
+    identities = {planned: "video000001", suffixed: "video000002"}
+    monkeypatch.setattr(app, "_read_embedded_video_id", identities.get)
+
+    resolved = app._resolve_album_track_path(planned, tmp_path, "video000008")
+
+    assert resolved == tmp_path / "Track [video000008-2].mp3"
+
+
+def test_resolver_advances_past_unknown_identity_at_suffixed_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app
+
+    planned = tmp_path / "Track.mp3"
+    suffixed = tmp_path / "Track [video000008].mp3"
+    planned.write_bytes(b"first")
+    suffixed.write_bytes(b"legacy-suffix")
+    monkeypatch.setattr(
+        app,
+        "_read_embedded_video_id",
+        lambda path: "video000001" if path == planned else None,
+    )
+
+    resolved = app._resolve_album_track_path(planned, tmp_path, "video000008")
+
+    assert resolved == tmp_path / "Track [video000008-2].mp3"
+
+
+def test_resolver_returns_same_id_at_suffixed_candidate_after_free_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app
+
+    planned = tmp_path / "Track.mp3"
+    same_id = tmp_path / "Track [video000008].mp3"
+    same_id.write_bytes(b"existing")
+    monkeypatch.setattr(
+        app,
+        "_read_embedded_video_id",
+        lambda path: "video000008" if path == same_id else None,
+    )
+
+    resolved = app._resolve_album_track_path(planned, tmp_path, "video000008")
+
+    assert resolved == same_id
+
+
+def test_resolver_raises_when_all_bounded_candidates_are_foreign(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app
+    from yt_download import _build_album_track_candidates
+
+    planned = tmp_path / "Track.mp3"
+    candidates = _build_album_track_candidates(planned, "video000008")
+    for candidate in candidates:
+        candidate.write_bytes(b"occupied")
+    monkeypatch.setattr(app, "_read_embedded_video_id", lambda _path: "another0001")
+
+    with pytest.raises(RuntimeError, match=r"video000008.*6 candidates"):
+        app._resolve_album_track_path(planned, tmp_path, "video000008")
+
+
+def test_resolver_rejects_suffixed_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app
+
+    music = tmp_path / "music"
+    outside = tmp_path / "outside"
+    music.mkdir()
+    outside.mkdir()
+    planned = music / "Track.mp3"
+    planned.write_bytes(b"foreign")
+    (music / "Track [video000008].mp3").symlink_to(outside / "escaped.mp3")
+    monkeypatch.setattr(app, "_read_embedded_video_id", lambda _path: "another0001")
+
+    with pytest.raises(ValueError, match="outside MUSIC_PATH"):
+        app._resolve_album_track_path(planned, music, "video000008")
+
+
+@pytest.mark.parametrize("suffix", [".mp3", ".opus", ".ogg", ".flac", ".m4a"])
+def test_embedded_video_id_reader_returns_none_for_missing_and_corrupt_files(
+    tmp_path: Path, suffix: str
+) -> None:
+    from yt_download import _read_embedded_video_id
+
+    missing = tmp_path / f"missing{suffix}"
+    corrupt = tmp_path / f"corrupt{suffix}"
+    corrupt.write_bytes(b"not audio")
+
+    assert _read_embedded_video_id(missing) is None
+    assert _read_embedded_video_id(corrupt) is None
+
+
+@pytest.mark.parametrize(("suffix", "reader_name"), [(".opus", "OggOpus"), (".flac", "FLAC")])
+def test_vorbis_identity_reader_checks_comment_after_foreign_description(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+    reader_name: str,
+) -> None:
+    import yt_download
+
+    tags = {"description": ["foreign yt-dlp description"], "comment": ["ytmusic:video000001"]}
+    monkeypatch.setattr(yt_download, reader_name, lambda _path: tags)
+
+    assert yt_download._read_embedded_video_id(tmp_path / f"track{suffix}") == "video000001"
+
+
+@pytest.mark.parametrize(
+    ("suffix", "uses_stream_identity"),
+    [
+        pytest.param(".mp3", False, id="mp3-global"),
+        pytest.param(".m4a", False, id="m4a-global"),
+        pytest.param(".flac", False, id="flac-global"),
+        pytest.param(".opus", True, id="opus-stream"),
+        pytest.param(".ogg", True, id="ogg-stream"),
+    ],
+)
+def test_tag_rewrite_command_scopes_identity_for_container(
+    suffix: str, uses_stream_identity: bool
+) -> None:
+    from yt_download import build_tag_rewrite_command
+
+    command = build_tag_rewrite_command(
+        f"source{suffix}", {"comment": "ytmusic:video000001"}, f"tagged{suffix}"
+    )
+
+    assert command[10:12] == ["-metadata", "comment=ytmusic:video000001"]
+    stream_comment = ["-metadata:s:a:0", "comment=ytmusic:video000001"]
+    stream_description = ["-metadata:s:a:0", "description="]
+    if uses_stream_identity:
+        assert stream_comment == command[12:14]
+        assert stream_description == command[14:16]
+    else:
+        assert "-metadata:s:a:0" not in command
+
+
+@pytest.mark.parametrize(
+    ("suffix", "codec", "sample_rate"),
+    [
+        pytest.param(".mp3", "libmp3lame", "44100", id="mp3-txxx-comment"),
+        pytest.param(".opus", "libopus", "48000", id="opus-description"),
+        pytest.param(".flac", "flac", "44100", id="flac-description"),
+        pytest.param(".m4a", "aac", "44100", id="m4a-copyright-comment"),
+    ],
+)
+def test_ffmpeg_identity_tag_round_trip_per_supported_container(
+    tmp_path: Path, suffix: str, codec: str, sample_rate: str
+) -> None:
+    from yt_download import _read_embedded_video_id, build_tag_rewrite_command
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        pytest.skip("ffmpeg is not installed")
+    source = tmp_path / f"source{suffix}"
+    tagged = tmp_path / f"tagged{suffix}"
+    generate = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        f"anullsrc=r={sample_rate}:cl=mono",
+        "-t",
+        "0.05",
+        "-c:a",
+        codec,
+    ]
+    metadata_scope = "-metadata:s:a:0" if suffix == ".opus" else "-metadata"
+    generate += [
+        metadata_scope,
+        "description=foreign yt-dlp description",
+        metadata_scope,
+        "comment=foreign yt-dlp comment",
+        str(source),
+    ]
+    subprocess.run(generate, check=True, timeout=10)  # noqa: S603 -- resolved ffmpeg binary
+    rewrite = build_tag_rewrite_command(
+        str(source), {"comment": "ytmusic:video000001"}, str(tagged)
+    )
+    rewrite[0] = ffmpeg
+
+    subprocess.run(rewrite, check=True, timeout=10)  # noqa: S603 -- resolved ffmpeg binary
+
+    assert _read_embedded_video_id(tagged) == "video000001"
+
+
+@pytest.mark.parametrize(
+    "downloader_type",
+    [_WriteThenRaiseYoutubeDL, _WriteThenReturnNoInfoYoutubeDL],
+    ids=["extract-raises", "no-info"],
+)
+def test_unsuccessful_extraction_removes_owned_temp_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    downloader_type: type[_FakeYoutubeDL],
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+    import yt_dlp
+
+    monkeypatch.setattr(yt_dlp, "YoutubeDL", downloader_type)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        _download_track(app, tmp_path, "video000001")
+
+    assert [path for path in tmp_path.rglob("*") if path.is_file()] == []
+
+
+def test_tag_stamp_failure_removes_temp_and_installs_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _configure_fake_download(monkeypatch)
+
+    def fail_stamp(_filepath: str, _tags: dict[str, str], _logger: object) -> None:
+        raise RuntimeError("simulated ffmpeg failure")
+
+    monkeypatch.setattr(app, "_stamp_audio_tags", fail_stamp)
+
+    with pytest.raises(RuntimeError, match="simulated ffmpeg failure"):
+        _download_track(app, tmp_path, "video000001")
+
+    assert [path for path in tmp_path.rglob("*") if path.is_file()] == []

--- a/services/ytmusic-streamer/tests/test_yt_download_path_safety.py
+++ b/services/ytmusic-streamer/tests/test_yt_download_path_safety.py
@@ -1,6 +1,7 @@
 """Pure path and naming coverage for YouTube Music album downloads."""
 
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ if str(SIDECAR_ROOT) not in sys.path:
     sys.path.insert(0, str(SIDECAR_ROOT))
 
 from yt_download import (  # noqa: E402
+    _build_album_track_candidates,
     _require_contained_download_path,
     _sanitize_download_relative_path,
     _sanitize_path_component,
@@ -43,13 +45,22 @@ def test_containment_rejects_symlink_escape(tmp_path: Path) -> None:
         _require_contained_download_path(music / "linked" / "track.mp3", music.resolve())
 
 
-def test_album_track_paths_reject_temporary_symlink_escape(tmp_path: Path) -> None:
+def test_album_track_paths_reject_temporary_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yt_download
+
     music = tmp_path / "music"
     target_parent = music / "Artist" / "Album"
     target_parent.mkdir(parents=True)
     outside = tmp_path / "outside.mp3"
     outside.write_bytes(b"unchanged")
-    (target_parent / "01. Title.tmp.mp3").symlink_to(outside)
+    (target_parent / "01. Title.0123456789abcdef0123456789abcdef.tmp.mp3").symlink_to(outside)
+    monkeypatch.setattr(
+        yt_download,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex="0123456789abcdef0123456789abcdef"),
+    )
 
     with pytest.raises(ValueError, match="outside MUSIC_PATH"):
         build_album_track_paths(music, "Artist", "Album", 1, "Title", "mp3")
@@ -57,7 +68,16 @@ def test_album_track_paths_reject_temporary_symlink_escape(tmp_path: Path) -> No
     assert outside.read_bytes() == b"unchanged"
 
 
-def test_album_track_naming_is_zero_padded_and_sanitized(tmp_path: Path) -> None:
+def test_album_track_naming_is_zero_padded_and_sanitized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yt_download
+
+    monkeypatch.setattr(
+        yt_download,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex="0123456789abcdef0123456789abcdef"),
+    )
     relative, final_path, tmp_pathname = build_album_track_paths(
         tmp_path,
         "Artist/Name",
@@ -69,4 +89,45 @@ def test_album_track_naming_is_zero_padded_and_sanitized(tmp_path: Path) -> None
 
     assert relative == Path("Artist_Name/Album_ Name/01. Title_.mp3")
     assert final_path == tmp_path / relative
-    assert tmp_pathname == tmp_path / "Artist_Name/Album_ Name/01. Title_.tmp.mp3"
+    assert tmp_pathname == (
+        tmp_path / "Artist_Name/Album_ Name/01. Title_.0123456789abcdef0123456789abcdef.tmp.mp3"
+    )
+
+
+def test_album_track_temp_names_use_full_unique_uuid_and_stay_byte_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yt_download
+
+    uuid_hexes = iter(
+        (
+            "0123456789abcdef0123456789abcdef",
+            "fedcba9876543210fedcba9876543210",
+        )
+    )
+    monkeypatch.setattr(
+        yt_download,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex=next(uuid_hexes)),
+    )
+    long_title = "é" * 200
+
+    first = build_album_track_paths(tmp_path, "Artist", "Album", 1, long_title, "mp3")[2]
+    second = build_album_track_paths(tmp_path, "Artist", "Album", 1, long_title, "mp3")[2]
+
+    assert first != second
+    assert first.name.endswith(".0123456789abcdef0123456789abcdef.tmp.mp3")
+    assert second.name.endswith(".fedcba9876543210fedcba9876543210.tmp.mp3")
+    assert len(first.name.encode()) <= 255
+    assert len(second.name.encode()) <= 255
+
+
+def test_album_collision_candidates_truncate_utf8_stems_to_255_bytes(tmp_path: Path) -> None:
+    planned = tmp_path / f"{'é' * 123}.mp3"
+
+    candidates = _build_album_track_candidates(planned, "video000001")
+
+    assert candidates[1].name.endswith(" [video000001].mp3")
+    assert candidates[5].name.endswith(" [video000001-5].mp3")
+    assert all(len(candidate.name.encode()) <= 255 for candidate in candidates)
+    assert all(candidate.name.encode().decode() == candidate.name for candidate in candidates)

--- a/services/ytmusic-streamer/yt_download.py
+++ b/services/ytmusic-streamer/yt_download.py
@@ -225,7 +225,7 @@ def _parse_ytmusic_identity(tag_values: object) -> str | None:
 def _read_mp3_video_id(path: Path) -> str | None:
     """Read ffmpeg's MP3 description/comment frames and conservative COMM variants."""
     # Mutagen 1.48.1 lacks complete annotations; ID3.getall owns these frame shapes.
-    tags = cast(_Id3Reader, ID3(path))  # type: ignore[no-untyped-call]
+    tags = cast(_Id3Reader, ID3(path))
     for raw_frame in tags.getall("TXXX")[:16]:
         frame = cast(_Id3UserTextFrame, raw_frame)
         if frame.desc.lower() not in {"description", "comment"}:
@@ -258,15 +258,15 @@ def _read_embedded_video_id(path: Path) -> str | None:
             return _read_mp3_video_id(path)
         if suffix in {".opus", ".ogg"}:
             # Mutagen 1.48.1 lacks complete annotations for Vorbis mapping access.
-            opus_tags = cast(_TagReader, OggOpus(path))  # type: ignore[no-untyped-call]
+            opus_tags = cast(_TagReader, OggOpus(path))
             return _read_mapping_video_id(opus_tags, ("description", "comment"))
         if suffix == ".flac":
             # Mutagen 1.48.1 lacks complete annotations for Vorbis mapping access.
-            flac_tags = cast(_TagReader, FLAC(path))  # type: ignore[no-untyped-call]
+            flac_tags = cast(_TagReader, FLAC(path))
             return _read_mapping_video_id(flac_tags, ("description", "comment"))
         if suffix == ".m4a":
             # Mutagen 1.48.1 lacks complete annotations for MP4 tag access.
-            mp4_audio = cast(_Mp4Reader, MP4(path))  # type: ignore[no-untyped-call]
+            mp4_audio = cast(_Mp4Reader, MP4(path))
             if mp4_audio.tags is None:
                 return None
             return _read_mapping_video_id(mp4_audio.tags, ("desc", "\xa9des", "\xa9cmt"))

--- a/services/ytmusic-streamer/yt_download.py
+++ b/services/ytmusic-streamer/yt_download.py
@@ -14,7 +14,13 @@ import re
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
+from uuid import uuid4
+
+from mutagen.flac import FLAC
+from mutagen.id3 import ID3
+from mutagen.mp4 import MP4
+from mutagen.oggopus import OggOpus
 
 # Audio file extensions produced by the download postprocessors (plus raw
 # bestaudio containers in case postprocessing is skipped).
@@ -22,6 +28,9 @@ AUDIO_EXTENSIONS = {".mp3", ".opus", ".flac", ".m4a", ".ogg", ".webm"}
 
 # Download-job states that mean a download is still in flight.
 ACTIVE_DOWNLOAD_STATUSES = {"queued", "downloading", "processing"}
+
+_MAX_FILENAME_BYTES = 255
+_MAX_COLLISION_COUNTER = 5
 
 
 def find_active_download_job(
@@ -71,6 +80,36 @@ class _WarningLogger(Protocol):
     def warning(self, message: str) -> None: ...
 
 
+class _TagReader(Protocol):
+    """Typed view of Mutagen's untyped mapping-like tag containers."""
+
+    def get(self, key: str) -> object: ...
+
+
+class _Id3Reader(Protocol):
+    """Typed view of the ID3 frame lookup used by the identity reader."""
+
+    def getall(self, key: str) -> list[object]: ...
+
+
+class _Id3TextFrame(Protocol):
+    """Typed view shared by Mutagen TXXX and COMM text frames."""
+
+    text: list[str]
+
+
+class _Id3UserTextFrame(_Id3TextFrame, Protocol):
+    """Typed view of Mutagen's TXXX description field."""
+
+    desc: str
+
+
+class _Mp4Reader(Protocol):
+    """Typed view of Mutagen's optional MP4 tag container."""
+
+    tags: _TagReader | None
+
+
 def _sanitize_path_component(name: str) -> str:
     """Replace filesystem-reserved characters and trim unsafe suffixes."""
     for char in '<>:"/\\|?*':
@@ -99,6 +138,45 @@ def _require_contained_download_path(path: Path, destination_root: Path) -> Path
     return resolved_path
 
 
+def _build_bounded_filename(stem: str, suffix: str, extension: str) -> str:
+    """Build one UTF-8 filename component within the common 255-byte limit."""
+    reserved_bytes = len(f"{suffix}{extension}".encode())
+    stem_budget = _MAX_FILENAME_BYTES - reserved_bytes
+    if stem_budget < 1:
+        raise ValueError("Download filename suffix exceeds the 255-byte component limit")
+    bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
+    if not bounded_stem:
+        raise ValueError("Download filename has no stem within the 255-byte component limit")
+    return f"{bounded_stem}{suffix}{extension}"
+
+
+def _build_album_track_candidates(planned_path: Path, video_id: str) -> tuple[Path, ...]:
+    """Build the planned album path and five byte-bounded identity alternatives."""
+    candidates = [planned_path]
+    for counter in range(1, _MAX_COLLISION_COUNTER + 1):
+        identity_suffix = f" [{video_id}]" if counter == 1 else f" [{video_id}-{counter}]"
+        candidate_name = _build_bounded_filename(
+            planned_path.stem,
+            identity_suffix,
+            planned_path.suffix,
+        )
+        candidates.append(planned_path.with_name(candidate_name))
+    return tuple(candidates)
+
+
+def _build_album_track_tmp_path(final_path: Path, destination_root: Path) -> Path:
+    """Build a contained, byte-bounded temporary path unique to one invocation."""
+    temporary_name = _build_bounded_filename(
+        final_path.stem,
+        f".{uuid4().hex}.tmp",
+        final_path.suffix,
+    )
+    return _require_contained_download_path(
+        final_path.with_name(temporary_name),
+        destination_root,
+    )
+
+
 def build_album_track_paths(
     music_path: Path,
     album_artist: str,
@@ -107,7 +185,7 @@ def build_album_track_paths(
     track_title: str,
     audio_format: str,
 ) -> tuple[Path, Path, Path]:
-    """Build deterministic contained paths for one album track and its temp file."""
+    """Build a deterministic album path and a unique contained temporary path."""
     if track_number < 1:
         raise ValueError("Track number must be positive")
     components = (
@@ -117,13 +195,84 @@ def build_album_track_paths(
     )
     relative_stem = _sanitize_download_relative_path("/".join(components))
     extension = audio_format.lstrip(".")
-    relative_path = relative_stem.parent / f"{relative_stem.name}.{extension}"
+    filename = _build_bounded_filename(relative_stem.name, "", f".{extension}")
+    relative_path = relative_stem.parent / filename
     destination_root = music_path.resolve()
     final_path = _require_contained_download_path(
         destination_root / relative_path, destination_root
     )
-    tmp_path = final_path.with_name(f"{final_path.stem}.tmp{final_path.suffix}")
-    return relative_path, final_path, _require_contained_download_path(tmp_path, destination_root)
+    tmp_path = _build_album_track_tmp_path(final_path, destination_root)
+    return relative_path, final_path, tmp_path
+
+
+def _parse_ytmusic_identity(tag_values: object) -> str | None:
+    """Parse one ffmpeg-written YouTube Music identity metadata value."""
+    if isinstance(tag_values, str):
+        values = [tag_values]
+    elif isinstance(tag_values, list):
+        values = tag_values[:16]
+    else:
+        return None
+    for value in values:
+        if not isinstance(value, str) or not value.startswith("ytmusic:"):
+            continue
+        video_id = value.removeprefix("ytmusic:")
+        if video_id:
+            return video_id
+    return None
+
+
+def _read_mp3_video_id(path: Path) -> str | None:
+    """Read ffmpeg's MP3 description/comment frames and conservative COMM variants."""
+    # Mutagen 1.48.1 lacks complete annotations; ID3.getall owns these frame shapes.
+    tags = cast(_Id3Reader, ID3(path))  # type: ignore[no-untyped-call]
+    for raw_frame in tags.getall("TXXX")[:16]:
+        frame = cast(_Id3UserTextFrame, raw_frame)
+        if frame.desc.lower() not in {"description", "comment"}:
+            continue
+        video_id = _parse_ytmusic_identity(frame.text)
+        if video_id is not None:
+            return video_id
+    for raw_frame in tags.getall("COMM")[:16]:
+        comment_frame = cast(_Id3TextFrame, raw_frame)
+        video_id = _parse_ytmusic_identity(comment_frame.text)
+        if video_id is not None:
+            return video_id
+    return None
+
+
+def _read_mapping_video_id(tags: _TagReader, keys: tuple[str, ...]) -> str | None:
+    """Read every supported metadata key independently until identity is found."""
+    for key in keys:
+        video_id = _parse_ytmusic_identity(tags.get(key))
+        if video_id is not None:
+            return video_id
+    return None
+
+
+def _read_embedded_video_id(path: Path) -> str | None:
+    """Read an ffmpeg-written album identity, returning None for every failure."""
+    try:
+        suffix = path.suffix.lower()
+        if suffix == ".mp3":
+            return _read_mp3_video_id(path)
+        if suffix in {".opus", ".ogg"}:
+            # Mutagen 1.48.1 lacks complete annotations for Vorbis mapping access.
+            opus_tags = cast(_TagReader, OggOpus(path))  # type: ignore[no-untyped-call]
+            return _read_mapping_video_id(opus_tags, ("description", "comment"))
+        if suffix == ".flac":
+            # Mutagen 1.48.1 lacks complete annotations for Vorbis mapping access.
+            flac_tags = cast(_TagReader, FLAC(path))  # type: ignore[no-untyped-call]
+            return _read_mapping_video_id(flac_tags, ("description", "comment"))
+        if suffix == ".m4a":
+            # Mutagen 1.48.1 lacks complete annotations for MP4 tag access.
+            mp4_audio = cast(_Mp4Reader, MP4(path))  # type: ignore[no-untyped-call]
+            if mp4_audio.tags is None:
+                return None
+            return _read_mapping_video_id(mp4_audio.tags, ("desc", "\xa9des", "\xa9cmt"))
+    except Exception:
+        return None
+    return None
 
 
 def build_audio_download_opts(
@@ -424,6 +573,9 @@ def build_tag_rewrite_command(filepath: str, tags: dict[str, Any], tmp_path: str
     ]
     for key, value in tags.items():
         cmd += ["-metadata", f"{key}={value}"]
+    if Path(tmp_path).suffix.lower() in {".opus", ".ogg"} and "comment" in tags:
+        cmd += ["-metadata:s:a:0", f"comment={tags['comment']}"]
+        cmd += ["-metadata:s:a:0", f"description={tags.get('description', '')}"]
     cmd.append(tmp_path)
     return cmd
 

--- a/services/ytmusic-streamer/ytmusic_album_downloads.py
+++ b/services/ytmusic-streamer/ytmusic_album_downloads.py
@@ -1,17 +1,24 @@
 """YouTube Music album download jobs and HTTP routes."""
 
 import asyncio
+import glob
 import os
+import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
 from common.sidecar_runtime_utils import env_int
 from fastapi import HTTPException, Query
 from yt_download import (
+    _build_album_track_candidates,
+    _build_album_track_tmp_path,
+    _read_embedded_video_id,
+    _require_contained_download_path,
     _stamp_audio_tags,
     build_album_track_paths,
     build_audio_download_opts,
@@ -32,6 +39,8 @@ _yt_album_download_executor = ThreadPoolExecutor(
 )
 _yt_album_download_jobs: dict[str, JsonObject] = {}
 _yt_album_download_tasks: set[asyncio.Task[None]] = set()
+_album_track_install_lock = threading.Lock()
+_MAX_OWNED_TEMP_ARTIFACTS = 64
 
 
 def _album_search_artists(value: object) -> list[str]:
@@ -163,7 +172,7 @@ def _album_track_tags(
     track: JsonObject, index: int, album_title: str, album_artist: str, year: str
 ) -> dict[str, str]:
     """Build scanner-compatible tags for one album track."""
-    _video_id, title, track_number, artists = _track_details(track, index)
+    video_id, title, track_number, artists = _track_details(track, index)
     return {
         "artist": ", ".join(artists) or album_artist,
         "album_artist": album_artist,
@@ -171,7 +180,64 @@ def _album_track_tags(
         "title": title,
         "track": str(track_number),
         "date": year,
+        "comment": f"ytmusic:{video_id}",
     }
+
+
+def _resolve_album_track_path(
+    planned_path: Path,
+    destination_root: Path,
+    video_id: str,
+) -> Path:
+    """Resolve one bounded identity-checked album path without overwriting files."""
+    candidates = _build_album_track_candidates(planned_path, video_id)
+    first_free: Path | None = None
+    for index, candidate in enumerate(candidates):
+        contained = _require_contained_download_path(candidate, destination_root)
+        if not contained.exists():
+            if first_free is None:
+                first_free = contained
+            continue
+        if not contained.is_file():
+            continue
+        embedded_id = _read_embedded_video_id(contained)
+        if embedded_id == video_id:
+            return contained
+        if embedded_id is None and index == 0:
+            log.debug(
+                "Keeping legacy YouTube Music album track without embedded identity at %s",
+                contained,
+            )
+            return contained
+    if first_free is not None:
+        return first_free
+    raise RuntimeError(
+        f"No safe download path for YouTube Music video {video_id}; all {len(candidates)} "
+        "candidates are occupied by other or unidentified files"
+    )
+
+
+def _install_album_track(
+    tmp_path: Path,
+    planned_path: Path,
+    destination_root: Path,
+    video_id: str,
+) -> Path:
+    """Atomically install a tagged temp file into a race-safe resolved candidate."""
+    with _album_track_install_lock:
+        final_path = _resolve_album_track_path(planned_path, destination_root, video_id)
+        if final_path.is_file():
+            tmp_path.unlink()
+            return final_path
+        if final_path != planned_path:
+            log.info(
+                "Album path collision at %s; saving YouTube Music video %s to %s",
+                planned_path,
+                video_id,
+                final_path,
+            )
+        os.replace(tmp_path, final_path)
+        return final_path
 
 
 def _album_progress_hook(job: JsonObject, download_cancelled: type[Exception]) -> Any:
@@ -186,28 +252,43 @@ def _album_progress_hook(job: JsonObject, download_cancelled: type[Exception]) -
     return update
 
 
-def _download_album_track_sync(
+def _select_album_track_paths(
     *,
-    job: JsonObject,
-    track: JsonObject,
-    index: int,
-    album_title: str,
-    album_artist: str,
-    year: str,
-    audio_format: str,
-    quality: str,
     music_path: Path,
-) -> str:
-    """Download, tag, and atomically place one album track."""
-    import yt_dlp
-
-    video_id, title, track_number, _artists = _track_details(track, index)
-    _relative, final_path, tmp_path = build_album_track_paths(
+    album_artist: str,
+    album_title: str,
+    track_number: int,
+    title: str,
+    audio_format: str,
+    video_id: str,
+) -> tuple[Path, Path | None]:
+    """Return an existing resume target or planned and unique temporary paths."""
+    _relative, planned_path, planned_tmp_path = build_album_track_paths(
         music_path, album_artist, album_title, track_number, title, audio_format
     )
+    destination_root = music_path.resolve()
+    final_path = _resolve_album_track_path(planned_path, destination_root, video_id)
     if final_path.is_file():
-        return str(final_path)
+        return final_path, None
+    tmp_path = (
+        planned_tmp_path
+        if final_path == planned_path
+        else _build_album_track_tmp_path(final_path, destination_root)
+    )
     final_path.parent.mkdir(parents=True, exist_ok=True)
+    return planned_path, tmp_path
+
+
+def _extract_album_track(
+    job: JsonObject,
+    video_id: str,
+    tmp_path: Path,
+    audio_format: str,
+    quality: str,
+) -> None:
+    """Run one bounded yt-dlp extraction into a unique temporary path."""
+    import yt_dlp
+
     _extract_pacer.wait()
     hook = _album_progress_hook(job, yt_dlp.utils.DownloadCancelled)
     options = build_audio_download_opts(
@@ -224,13 +305,90 @@ def _download_album_track_sync(
         info = ydl.extract_info(f"https://www.youtube.com/watch?v={video_id}", download=True)
     if not info or not tmp_path.is_file():
         raise ValueError("Track download completed without an output file")
+
+
+def _tag_album_track(
+    tmp_path: Path,
+    track: JsonObject,
+    index: int,
+    album_title: str,
+    album_artist: str,
+    year: str,
+    video_id: str,
+) -> None:
+    """Stamp scanner-compatible tags and require readable track identity."""
     _stamp_audio_tags(
         str(tmp_path),
         _album_track_tags(track, index, album_title, album_artist, year),
         log,
     )
-    os.replace(tmp_path, final_path)
-    return str(final_path)
+    if _read_embedded_video_id(tmp_path) == video_id:
+        return
+    raise ValueError("Track identity metadata could not be embedded")
+
+
+def _cleanup_album_track_temp(tmp_path: Path) -> None:
+    """Remove bounded yt-dlp artifacts owned by one UUID temporary stem."""
+    owned_pattern = f"{glob.escape(str(tmp_path.with_suffix('')))}.*"
+    artifact_names = islice(glob.iglob(owned_pattern), _MAX_OWNED_TEMP_ARTIFACTS)
+    for artifact_name in artifact_names:
+        artifact = Path(artifact_name)
+        try:
+            artifact.unlink(missing_ok=True)
+        except OSError as error:
+            log.warning(
+                "Could not remove YouTube Music album temp artifact %s: %s", artifact, error
+            )
+
+
+def _download_album_track_sync(
+    *,
+    job: JsonObject,
+    track: JsonObject,
+    index: int,
+    album_title: str,
+    album_artist: str,
+    year: str,
+    audio_format: str,
+    quality: str,
+    music_path: Path,
+) -> str:
+    """Download, tag, and atomically place one album track."""
+    video_id, title, track_number, _artists = _track_details(track, index)
+    planned_path, tmp_path = _select_album_track_paths(
+        music_path=music_path,
+        album_artist=album_artist,
+        album_title=album_title,
+        track_number=track_number,
+        title=title,
+        audio_format=audio_format,
+        video_id=video_id,
+    )
+    if tmp_path is None:
+        return str(planned_path)
+    succeeded = False
+    try:
+        _extract_album_track(job, video_id, tmp_path, audio_format, quality)
+        _tag_album_track(
+            tmp_path,
+            track,
+            index,
+            album_title,
+            album_artist,
+            year,
+            video_id,
+        )
+        installed_path = _install_album_track(
+            tmp_path,
+            planned_path,
+            music_path.resolve(),
+            video_id,
+        )
+        succeeded = True
+        return str(installed_path)
+    finally:
+        if not succeeded:
+            _cleanup_album_track_temp(tmp_path)
 
 
 def _record_track_failure(job: JsonObject, track: JsonObject, error: Exception) -> None:


### PR DESCRIPTION
## Problem

Companion to #737, same collision class with a different failure mode: album track paths are `NN. Title.<ext>` with no video ID, and `final_path.is_file()` meant "already downloaded." Two songs whose sanitized names collide → the second is silently skipped and missing from the library. (The single-track path was already immune via yt-dlp's `[%(id)s]` outtmpl.)

## Fix

- **Identity via the ffmpeg tag rewrite** (not mutagen writes, which break the backend scanner): `comment=ytmusic:<video_id>`. For Opus/Ogg the tags are **stream-scoped** (`-metadata:s:a:0`) because yt-dlp pre-embeds a stream-level comment that global `-metadata` does not replace — this was caught in review with a live ffmpeg probe; global-only tagging would have failed identity verification for every Opus download. Read-back covers mp3 (TXXX/COMM), vorbis (DESCRIPTION/COMMENT), and m4a (©cmt), checking each key independently.
- **Bounded identity-checked candidates** with resume-correct scanning: the full candidate set is scanned for an existing same-ID file *first* (so a deleted planned file with a surviving suffixed copy resumes instead of duplicating), then the first free candidate is used; exhaustion fails loudly. ID-less files at the planned path keep the legacy skip.
- **Temp lifecycle ownership**: unique full-uuid temp names, try/finally cleanup on every unsuccessful outcome (previously a failed extraction could leave scanner-visible temp audio that a completed-album scan would index), tag verification before installation.
- Byte-aware truncation for near-limit filenames; real ffmpeg round-trip tests seeded with yt-dlp-like pre-existing tags for every reachable audio format.

## Verification

- verify: full ytmusic-streamer pytest suite — 306 passed, exit 0
- verify: ruff check + format clean, strict mypy clean (29 source files) — exit 0
- verify: file-size ratchet exit 0

Review: full adversarial round (5 findings, incl. the Opus blocker) driven to zero.