### PR TITLE
chore(sidecars): move duplicated path-safety and runtime helpers to common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Consolidated repeated backend error handling, download-job state transitions, availability probes, queue event wiring, and value parsing behind shared internal helpers.
+- The Python sidecars now share one hardened implementation of their path-safety and runtime helpers instead of maintaining copies.
 - Album downloads now use queued, serialized processing, one album at a time across the deployment, with renewable claims, restart recovery, and queue-owned lifecycle reconciliation.
 - The DCLAP vibe provider now answers malformed requests with the same 422 response the other sidecars use (previously 400).
 - Library scans now process several files at once within a configurable bound, making large-library scans significantly faster.

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -73,8 +73,8 @@ const BASELINE = Object.freeze({
     "frontend/hooks/useQueries.ts": 1551,
     "frontend/lib/audio-controls-context.tsx": 2311,
     "frontend/lib/listen-together-context.tsx": 2073,
-    "services/audio-analyzer/analyzer.py": 2266,
-    "services/tidal-streamer/app.py": 1907,
+    "services/audio-analyzer/analyzer.py": 2248,
+    "services/tidal-streamer/app.py": 1865,
 });
 
 function packageScanRoots(repoRoot) {

--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -35,13 +35,13 @@ from model_paths import MODEL_DIR, MODELS
 from services.common.analyzer_env import (
     configure_thread_env,
     get_blocking_socket_timeout,
-    get_int_env,
 )
 from services.common.database_url import resolve_database_url
+from services.common.environment import env_float, env_int
 from services.common.logging_utils import configure_service_logger
 
 # Get thread configuration from environment (default to 1 for safety)
-THREADS_PER_WORKER = get_int_env("THREADS_PER_WORKER", 1)
+THREADS_PER_WORKER = env_int("THREADS_PER_WORKER", 1)
 
 # Configure TensorFlow and BLAS/OpenMP threading before TensorFlow/Essentia imports.
 configure_thread_env(THREADS_PER_WORKER, configure_tensorflow=True)
@@ -134,13 +134,13 @@ TensorflowPredictMusiCNN = None  # Loaded in worker processes
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 DATABASE_URL = resolve_database_url(os.environ)
 MUSIC_PATH = os.getenv("MUSIC_PATH", "/music")
-BATCH_SIZE = get_int_env("BATCH_SIZE", 10)
-SLEEP_INTERVAL = get_int_env("SLEEP_INTERVAL", 5)
+BATCH_SIZE = env_int("BATCH_SIZE", 10)
+SLEEP_INTERVAL = env_int("SLEEP_INTERVAL", 5)
 
 # BRPOP timeout: how long to block waiting for work (seconds)
 # Also serves as the DB reconciliation interval
 # Uses SLEEP_INTERVAL for backward compatibility, minimum 5s
-BRPOP_TIMEOUT = max(5, get_int_env("BRPOP_TIMEOUT", SLEEP_INTERVAL))
+BRPOP_TIMEOUT = max(5, env_int("BRPOP_TIMEOUT", SLEEP_INTERVAL))
 REDIS_SOCKET_TIMEOUT = get_blocking_socket_timeout(
     "AUDIO_REDIS_SOCKET_TIMEOUT",
     BRPOP_TIMEOUT + 5,
@@ -150,20 +150,20 @@ REDIS_SOCKET_TIMEOUT = get_blocking_socket_timeout(
 # DB reconciliation cadence (adaptive backoff while idle)
 DB_RECONCILE_MIN_INTERVAL_SECONDS = max(
     BRPOP_TIMEOUT,
-    get_int_env("DB_RECONCILE_MIN_INTERVAL_SECONDS", BRPOP_TIMEOUT),
+    env_int("DB_RECONCILE_MIN_INTERVAL_SECONDS", BRPOP_TIMEOUT),
 )
 DB_RECONCILE_MAX_INTERVAL_SECONDS = max(
     DB_RECONCILE_MIN_INTERVAL_SECONDS,
-    get_int_env("DB_RECONCILE_MAX_INTERVAL_SECONDS", max(BRPOP_TIMEOUT * 12, 60)),
+    env_int("DB_RECONCILE_MAX_INTERVAL_SECONDS", max(BRPOP_TIMEOUT * 12, 60)),
 )
 DB_RECONCILE_BACKOFF_MULTIPLIER = max(
     1.0,
-    float(os.getenv("DB_RECONCILE_BACKOFF_MULTIPLIER", "2.0")),
+    env_float("DB_RECONCILE_BACKOFF_MULTIPLIER", 2.0),
 )
 
 # Idle timeout before unloading ML models from memory (seconds)
 # Models are reloaded automatically when new work arrives
-MODEL_IDLE_TIMEOUT = get_int_env("MODEL_IDLE_TIMEOUT", 300)
+MODEL_IDLE_TIMEOUT = env_int("MODEL_IDLE_TIMEOUT", 300)
 
 # Debounce delay for worker resize (seconds) -- prevents pool churn when user drags a slider
 RESIZE_DEBOUNCE_SECONDS = 5
@@ -172,10 +172,10 @@ RESIZE_DEBOUNCE_SECONDS = 5
 # Oversized files are permanently failed to avoid repeated timeout loops.
 # Set to 0 to disable file-size guardrail.
 # Default is tuned for FLAC-heavy libraries with larger hi-res tracks.
-MAX_FILE_SIZE_MB = get_int_env("MAX_FILE_SIZE_MB", 500)
+MAX_FILE_SIZE_MB = env_int("MAX_FILE_SIZE_MB", 500)
 # Hard timeout for an entire analysis batch. Never-started tracks are requeued
 # without retry cost; in-flight tracks fail non-permanently and consume one retry.
-BATCH_ANALYSIS_TIMEOUT_SECONDS = get_int_env("BATCH_ANALYSIS_TIMEOUT_SECONDS", 900)
+BATCH_ANALYSIS_TIMEOUT_SECONDS = env_int("BATCH_ANALYSIS_TIMEOUT_SECONDS", 900)
 
 
 def _resolve_music_path(file_path: str) -> str | None:
@@ -216,23 +216,23 @@ def _get_workers_from_db() -> int:
             logger.info(f"Loaded worker count from database: {workers}")
             return workers
         logger.info("No worker count found in database, using env var or default")
-        return get_int_env("NUM_WORKERS", DEFAULT_WORKERS)
+        return env_int("NUM_WORKERS", DEFAULT_WORKERS)
 
     except Exception as e:
         logger.warning(f"Failed to fetch worker count from database: {e}")
         logger.info("Falling back to env var or default")
-        return get_int_env("NUM_WORKERS", DEFAULT_WORKERS)
+        return env_int("NUM_WORKERS", DEFAULT_WORKERS)
 
 
 # Conservative default: 2 workers (stable on any system)
 # Previous default used auto-scaling which could cause OOM on memory-constrained systems
 DEFAULT_WORKERS = 2
-NUM_WORKERS = get_int_env("NUM_WORKERS", DEFAULT_WORKERS)
+NUM_WORKERS = env_int("NUM_WORKERS", DEFAULT_WORKERS)
 ESSENTIA_VERSION = "2.1b6-enhanced-v3"
 
 # Retry configuration
-MAX_RETRIES = get_int_env("MAX_RETRIES", 3)  # Max retry attempts per track
-STALE_PROCESSING_MINUTES = get_int_env(
+MAX_RETRIES = env_int("MAX_RETRIES", 3)  # Max retry attempts per track
+STALE_PROCESSING_MINUTES = env_int(
     "STALE_PROCESSING_MINUTES", 15
 )  # Reset tracks stuck in 'processing' (synchronized with backend)
 
@@ -602,7 +602,7 @@ class AudioAnalyzer:
             result["_error"] = "Essentia library not installed"
             return result
 
-        MAX_ANALYZE_SECONDS = get_int_env("MAX_ANALYZE_SECONDS", 90)
+        MAX_ANALYZE_SECONDS = env_int("MAX_ANALYZE_SECONDS", 90)
         audio_44k = None
         try:
             audio_44k = self.load_audio(file_path, max_duration=MAX_ANALYZE_SECONDS)

--- a/services/audio-analyzer/audio_paths.py
+++ b/services/audio-analyzer/audio_paths.py
@@ -2,25 +2,9 @@
 
 from __future__ import annotations
 
-import os
+from services.common.music_path import resolve_contained_music_path
 
 
 def resolve_music_path(music_path: str, file_path: str) -> str | None:
     """Resolve one relative queue path beneath the configured music library."""
-    if not isinstance(file_path, str) or "\x00" in file_path:
-        return None
-
-    normalized_path = file_path.replace("\\", "/")
-    if os.path.isabs(normalized_path):
-        return None
-    if any(segment in {".", ".."} for segment in normalized_path.split("/")):
-        return None
-
-    try:
-        music_root = os.path.realpath(music_path)
-        resolved_path = os.path.realpath(os.path.join(music_root, normalized_path))
-        if os.path.commonpath((music_root, resolved_path)) != music_root:
-            return None
-    except (OSError, ValueError):
-        return None
-    return resolved_path
+    return resolve_contained_music_path(music_path, file_path)

--- a/services/audio-analyzer/tests/test_audio_analyzer_env.py
+++ b/services/audio-analyzer/tests/test_audio_analyzer_env.py
@@ -10,8 +10,8 @@ import pytest
 from services.common.analyzer_env import (
     configure_thread_env,
     get_blocking_socket_timeout,
-    get_int_env,
 )
+from services.common.environment import env_float, env_int
 
 THREAD_ENV_KEYS = [
     "OMP_NUM_THREADS",
@@ -86,17 +86,22 @@ def _load_analyzer_with_recording_redis(
     return module
 
 
-def test_get_int_env_uses_default_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_int_uses_integer_default_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MVR12_TEST_MISSING_INT", raising=False)
-    assert get_int_env("MVR12_TEST_MISSING_INT", 11) == 11
+    assert env_int("MVR12_TEST_MISSING_INT", 11) == 11
 
 
-def test_get_int_env_raises_value_error_for_invalid_value(
+def test_env_int_raises_value_error_for_invalid_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("MVR12_TEST_INVALID_INT", "not-a-number")
     with pytest.raises(ValueError):
-        get_int_env("MVR12_TEST_INVALID_INT", 3)
+        env_int("MVR12_TEST_INVALID_INT", 3)
+
+
+def test_env_float_accepts_float_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MVR12_TEST_MISSING_FLOAT", raising=False)
+    assert env_float("MVR12_TEST_MISSING_FLOAT", 2.5) == 2.5
 
 
 def test_audio_blocking_socket_timeout_exceeds_brpop_timeout(

--- a/services/audio-analyzer/tests/test_music_path_containment.py
+++ b/services/audio-analyzer/tests/test_music_path_containment.py
@@ -8,6 +8,9 @@ from types import ModuleType
 from typing import Any
 
 import pytest
+from audio_paths import resolve_music_path
+
+from services.common.music_path import resolve_contained_music_path
 
 
 class RecordingAnalyzer:
@@ -20,6 +23,47 @@ class RecordingAnalyzer:
         """Record the resolved path and return a successful result."""
         self.paths.append(file_path)
         return {"bpm": 120.0}
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "../outside.flac",
+        "artist/../outside.flac",
+        "artist/./track.flac",
+        "/etc/passwd",
+        "bad\x00.flac",
+    ],
+)
+def test_common_music_path_rejects_unsafe_paths(tmp_path: Path, file_path: str) -> None:
+    """Reject NUL, absolute, and explicit dot-segment paths in the shared boundary."""
+    assert resolve_contained_music_path(str(tmp_path), file_path) is None
+
+
+def test_common_music_path_normalizes_backslashes(tmp_path: Path) -> None:
+    """Normalize Windows-style separators before resolving a contained path."""
+    track_path = tmp_path / "artist" / "track.flac"
+    track_path.parent.mkdir()
+    track_path.touch()
+
+    assert resolve_contained_music_path(str(tmp_path), "artist\\track.flac") == str(
+        track_path.resolve()
+    )
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "../outside.flac",
+        "artist/../outside.flac",
+        "artist/./track.flac",
+        "/etc/passwd",
+        "bad\x00.flac",
+    ],
+)
+def test_audio_path_wrapper_rejects_unsafe_paths(tmp_path: Path, file_path: str) -> None:
+    """Keep every shared rejection active through the analyzer wrapper."""
+    assert resolve_music_path(str(tmp_path), file_path) is None
 
 
 def _analyze_queued_path(

--- a/services/common/analyzer_env.py
+++ b/services/common/analyzer_env.py
@@ -2,10 +2,7 @@
 
 import os
 
-
-def get_int_env(name: str, default: int | str) -> int:
-    """Read an integer env var with the same semantics as int(os.getenv(...))."""
-    return int(os.getenv(name, str(default)))
+from .environment import env_int
 
 
 def get_blocking_socket_timeout(
@@ -19,7 +16,7 @@ def get_blocking_socket_timeout(
     if blocking_timeout <= 0 or safety_margin <= 0:
         raise ValueError("blocking timeout and safety margin must be positive")
 
-    configured_timeout = get_int_env(name, default)
+    configured_timeout = env_int(name, default)
     if configured_timeout <= 0:
         raise ValueError(f"{name} must be positive")
 

--- a/services/common/download_paths.py
+++ b/services/common/download_paths.py
@@ -1,0 +1,33 @@
+"""Shared sanitization and containment for sidecar download paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def sanitize_path_component(name: str) -> str:
+    """Replace filesystem-reserved characters and trim unsafe suffixes."""
+    for character in '<>:"/\\|?*':
+        name = name.replace(character, "_")
+    return name.strip(". ")
+
+
+def sanitize_download_relative_path(rendered_path: str) -> Path:
+    """Validate and sanitize every component of a relative download path."""
+    sanitized_parts: list[str] = []
+    for component in rendered_path.split("/"):
+        sanitized = sanitize_path_component(component)
+        if not sanitized or sanitized in {".", ".."} or Path(sanitized).is_absolute():
+            raise ValueError("Invalid output template path component")
+        sanitized_parts.append(sanitized)
+    return Path(*sanitized_parts)
+
+
+def require_contained_download_path(path: Path, destination_root: Path) -> Path:
+    """Resolve a path and reject targets outside the resolved destination root."""
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(destination_root.resolve())
+    except ValueError:
+        raise ValueError("Download path resolves outside MUSIC_PATH") from None
+    return resolved_path

--- a/services/common/environment.py
+++ b/services/common/environment.py
@@ -1,0 +1,15 @@
+"""Shared environment-value parsing for Python sidecars."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_int(name: str, default: int | str) -> int:
+    """Parse an integer env var using an integer or string default value."""
+    return int(os.getenv(name, str(default)))
+
+
+def env_float(name: str, default: float | int | str) -> float:
+    """Parse a float env var using a numeric or string default value."""
+    return float(os.getenv(name, str(default)))

--- a/services/common/music_path.py
+++ b/services/common/music_path.py
@@ -1,0 +1,26 @@
+"""Shared music-library path containment for Python sidecars."""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_contained_music_path(music_root: str, relative: str) -> str | None:
+    """Resolve one relative path beneath a configured music-library root."""
+    if not isinstance(relative, str) or "\x00" in relative:
+        return None
+
+    normalized_path = relative.replace("\\", "/")
+    if os.path.isabs(normalized_path):
+        return None
+    if any(segment in {".", ".."} for segment in normalized_path.split("/")):
+        return None
+
+    try:
+        resolved_root = os.path.realpath(music_root)
+        resolved_path = os.path.realpath(os.path.join(resolved_root, normalized_path))
+        if os.path.commonpath((resolved_root, resolved_path)) != resolved_root:
+            return None
+    except (OSError, ValueError):
+        return None
+    return resolved_path

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -40,7 +40,10 @@ class _ThrottlePoolFullWarning(logging.Filter):
 
     def __init__(self) -> None:
         super().__init__()
-        self._last_emit_at = 0.0
+        # None = never emitted. A 0.0 sentinel would wrongly suppress the
+        # FIRST warning on hosts whose monotonic clock is younger than the
+        # suppression window (fresh VMs boot with time.monotonic() < 300s).
+        self._last_emit_at: float | None = None
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Rewrite the first pool-full warning and suppress repeats for five minutes."""
@@ -49,7 +52,10 @@ class _ThrottlePoolFullWarning(logging.Filter):
             return True
 
         now = time.monotonic()
-        if (now - self._last_emit_at) < _POOL_WARNING_SUPPRESSION_SECONDS:
+        if (
+            self._last_emit_at is not None
+            and (now - self._last_emit_at) < _POOL_WARNING_SUPPRESSION_SECONDS
+        ):
             return False
 
         self._last_emit_at = now

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -18,6 +18,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
 
+from . import environment as _environment
+
 DEFAULT_STREAM_CONNECT_TIMEOUT = 30.0
 DEFAULT_STREAM_READ_TIMEOUT = 300.0
 _KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me"  # noqa: S105 -- known insecure sentinel rejected at runtime
@@ -25,6 +27,47 @@ _KNOWN_DEFAULT_SECRET = "soundspan-internal-secret-change-me"  # noqa: S105 -- k
 # Prisma cuids (the only user_id the backend ever sends) are alphanumeric;
 # this also rejects any `/`, `.`, or `%` that could escape DATA_PATH.
 _USER_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+_POOL_FULL_WARNING = "Connection pool is full, discarding connection"
+_POOL_WARNING_SUPPRESSION_SECONDS = 300
+_POOL_WARNING_REPLACEMENT = (
+    "urllib3 connection pool saturated; suppressing repeated pool-full "
+    "warnings for 300s. Increase upstream pool size if this persists."
+)
+
+
+class _ThrottlePoolFullWarning(logging.Filter):
+    """Throttle noisy urllib3 pool-full warnings while preserving signal."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._last_emit_at = 0.0
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Rewrite the first pool-full warning and suppress repeats for five minutes."""
+        message = record.getMessage()
+        if _POOL_FULL_WARNING not in message:
+            return True
+
+        now = time.monotonic()
+        if (now - self._last_emit_at) < _POOL_WARNING_SUPPRESSION_SECONDS:
+            return False
+
+        self._last_emit_at = now
+        record.msg = _POOL_WARNING_REPLACEMENT
+        record.args = ()
+        return True
+
+
+def install_urllib3_pool_warning_throttle() -> None:
+    """Install the shared five-minute urllib3 pool-full warning throttle.
+
+    Idempotent: module reimports (test harnesses reload consumer modules in
+    one process) must not stack duplicate filters on the shared logger.
+    """
+    pool_logger = logging.getLogger("urllib3.connectionpool")
+    if any(isinstance(f, _ThrottlePoolFullWarning) for f in pool_logger.filters):
+        return
+    pool_logger.addFilter(_ThrottlePoolFullWarning())
 
 
 class ThreadSafeRatePacer:
@@ -108,6 +151,23 @@ def register_error_handlers(app: FastAPI, logger: logging.Logger) -> None:
         )
 
 
+def sanitized_http_error(
+    logger: logging.Logger,
+    operation: str,
+    exc: Exception,
+    status: int,
+    detail: str,
+) -> HTTPException:
+    """Log full exception detail and return a generic client-facing error."""
+    logger.error(
+        "%s failed: %s",
+        operation,
+        exc,
+        exc_info=True,  # noqa: LOG014 -- callers invoke this from active exception handlers
+    )
+    return HTTPException(status_code=status, detail=detail)
+
+
 def require_internal_secret(request: Request) -> None:
     """FastAPI dependency: authenticate machine-to-machine sidecar calls.
 
@@ -139,14 +199,14 @@ def validate_user_id(user_id: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid user_id")
 
 
-def env_int(name: str, default: str) -> int:
-    """Parse an integer env var using a string default value."""
-    return int(os.getenv(name, default))
+def env_int(name: str, default: int | str) -> int:
+    """Parse an integer environment value through the lightweight shared boundary."""
+    return _environment.env_int(name, default)
 
 
-def env_float(name: str, default: str) -> float:
-    """Parse a float env var using a string default value."""
-    return float(os.getenv(name, default))
+def env_float(name: str, default: float | int | str) -> float:
+    """Parse a float environment value through the lightweight shared boundary."""
+    return _environment.env_float(name, default)
 
 
 def stream_proxy_timeout() -> httpx.Timeout:

--- a/services/tidal-streamer/app.py
+++ b/services/tidal-streamer/app.py
@@ -13,13 +13,13 @@ query-parameter support retained for one release.
 """
 
 import asyncio as asyncio
-import logging
 import os
 import sys
 import threading
 import time as time
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
+from functools import partial
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, Protocol, cast
 
@@ -37,8 +37,10 @@ if str(SERVICES_ROOT) not in sys.path:
 from common.logging_utils import configure_service_logger
 from common.sidecar_runtime_utils import (
     build_stream_proxy_client,
+    install_urllib3_pool_warning_throttle,
     register_error_handlers,
     require_internal_secret,
+    sanitized_http_error,
 )
 from tidal_downloads import (
     _DASH_MANIFEST_MIME_TYPE,
@@ -70,36 +72,8 @@ class TidalAPIProtocol(TrackDownloadAPIProtocol, AlbumAPIProtocol, Protocol):
 
 # ── Logging ─────────────────────────────────────────────────────────
 log = configure_service_logger("tidal-streamer")
-
-
-class _ThrottlePoolFullWarning(logging.Filter):
-    """Throttle noisy urllib3 pool-full warnings while preserving signal."""
-
-    _SUPPRESSION_WINDOW_SECONDS = 300
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._last_emit_at = 0.0
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        message = record.getMessage()
-        if "Connection pool is full, discarding connection" not in message:
-            return True
-
-        now = time.monotonic()
-        if (now - self._last_emit_at) < self._SUPPRESSION_WINDOW_SECONDS:
-            return False
-
-        self._last_emit_at = now
-        record.msg = (
-            "urllib3 connection pool saturated; suppressing repeated pool-full "
-            "warnings for 300s. Increase upstream pool size if this persists."
-        )
-        record.args = ()
-        return True
-
-
-logging.getLogger("urllib3.connectionpool").addFilter(_ThrottlePoolFullWarning())
+install_urllib3_pool_warning_throttle()
+_sanitized_http_error = partial(sanitized_http_error, log)
 
 
 async def _run_stream_cache_cleanup() -> None:
@@ -365,22 +339,6 @@ def require_admin_credentials(
         "Bearer — query support will be removed next release"
     )
     return AdminCredentials(access_token, user_id, country_code)
-
-
-def _sanitized_http_error(
-    operation: str,
-    exc: Exception,
-    status_code: int,
-    detail: str,
-) -> HTTPException:
-    """Log full exception detail; return a generic client-facing HTTPException."""
-    log.error(
-        "%s failed: %s",
-        operation,
-        exc,
-        exc_info=True,  # noqa: LOG014 -- callers invoke this helper from active exception handlers
-    )
-    return HTTPException(status_code=status_code, detail=detail)
 
 
 def _is_playlist_not_found_error(error: Exception) -> bool:

--- a/services/tidal-streamer/tests/test_download_path_safety.py
+++ b/services/tidal-streamer/tests/test_download_path_safety.py
@@ -29,6 +29,32 @@ class _FakeDownloadApi:
         return types.SimpleNamespace(audioQuality=quality)
 
 
+@pytest.mark.parametrize("component", ["", ".", "..", "   ", "..."])
+def test_common_sanitizer_rejects_invalid_components(component: str) -> None:
+    """Reject components that become empty or retain dot-segment meaning."""
+    from common.download_paths import sanitize_download_relative_path
+
+    with pytest.raises(ValueError, match="output template path"):
+        sanitize_download_relative_path(f"Artist/{component}/Track")
+
+
+def test_common_sanitizer_replaces_reserved_characters() -> None:
+    """Replace the established cross-platform reserved-character set."""
+    from common.download_paths import sanitize_path_component
+
+    assert sanitize_path_component('A<>:"/\\|?*B') == "A_________B"
+
+
+def test_common_containment_resolves_the_destination_root(tmp_path: Path) -> None:
+    """Resolve an unresolved destination root before checking containment."""
+    from common.download_paths import require_contained_download_path
+
+    music = tmp_path / "parent" / ".." / "music"
+    expected = tmp_path / "music" / "track.m4a"
+
+    assert require_contained_download_path(expected, music) == expected.resolve()
+
+
 def _configure_download(
     monkeypatch: pytest.MonkeyPatch, app: Any, rendered_path: str, payload: bytes = b"audio"
 ) -> None:

--- a/services/tidal-streamer/tests/test_error_sanitization.py
+++ b/services/tidal-streamer/tests/test_error_sanitization.py
@@ -12,6 +12,47 @@ from httpx import AsyncClient
 MARKER = "sekrit-token-abc123"
 
 
+def test_shared_http_error_logs_detail_and_returns_generic_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keep provider details in logs while returning only the stable client detail."""
+    from common.sidecar_runtime_utils import sanitized_http_error
+
+    logger = logging.getLogger("tidal-shared-error-test")
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        try:
+            raise RuntimeError(MARKER)
+        except RuntimeError as error:
+            result = sanitized_http_error(logger, "shared operation", error, 502, "Safe detail")
+
+    assert result.status_code == 502
+    assert result.detail == "Safe detail"
+    assert MARKER in caplog.text
+
+
+def test_shared_pool_warning_filter_throttles_repeated_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Install the shared throttle in TIDAL and suppress repeated warnings."""
+    pool_logger = logging.getLogger("urllib3.connectionpool")
+    previous_filters = list(pool_logger.filters)
+    pool_logger.filters.clear()
+    try:
+        import app  # noqa: F401 -- importing the runtime installs the shared filter
+
+        with caplog.at_level(logging.WARNING, logger=pool_logger.name):
+            pool_logger.warning("Connection pool is full, discarding connection: one")
+            pool_logger.warning("Connection pool is full, discarding connection: two")
+    finally:
+        pool_logger.filters[:] = previous_filters
+
+    messages = [record.getMessage() for record in caplog.records if record.name == pool_logger.name]
+    assert messages == [
+        "urllib3 connection pool saturated; suppressing repeated pool-full warnings for 300s. "
+        "Increase upstream pool size if this persists."
+    ]
+
+
 @pytest.mark.anyio
 async def test_auth_device_error_sanitized(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/services/tidal-streamer/tidal_downloads.py
+++ b/services/tidal-streamer/tidal_downloads.py
@@ -13,6 +13,12 @@ from uuid import uuid4
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import fromstring as xml_fromstring
 
+from common.download_paths import (
+    require_contained_download_path as _require_contained_download_path,
+)
+from common.download_paths import (
+    sanitize_download_relative_path as _sanitize_download_relative_path,
+)
 from common.sidecar_runtime_utils import env_float
 from mutagen.easymp4 import EasyMP4
 from mutagen.flac import FLAC
@@ -84,34 +90,6 @@ class _TrackDownloaderProtocol(Protocol):
         output_template: str,
         dest_base: Path,
     ) -> JsonObject: ...
-
-
-def _sanitize_path_component(name: str) -> str:
-    """Remove or replace chars that are invalid on most filesystems."""
-    for ch in '<>:"/\\|?*':
-        name = name.replace(ch, "_")
-    return name.strip(". ")
-
-
-def _sanitize_download_relative_path(rendered_path: str) -> Path:
-    """Validate and sanitize every rendered download-path component."""
-    sanitized_parts = []
-    for component in rendered_path.split("/"):
-        sanitized = _sanitize_path_component(component)
-        if not sanitized or sanitized in {".", ".."} or Path(sanitized).is_absolute():
-            raise ValueError("Invalid output template path component")
-        sanitized_parts.append(sanitized)
-    return Path(*sanitized_parts)
-
-
-def _require_contained_download_path(path: Path, destination_root: Path) -> Path:
-    """Resolve a download path and reject targets outside the destination root."""
-    resolved_path = path.resolve()
-    try:
-        resolved_path.relative_to(destination_root)
-    except ValueError:
-        raise ValueError("Download path resolves outside MUSIC_PATH") from None
-    return resolved_path
 
 
 def _build_download_file_path(

--- a/services/vibe-provider-dclap/music_path.py
+++ b/services/vibe-provider-dclap/music_path.py
@@ -4,25 +4,11 @@ from __future__ import annotations
 
 import os
 
+from services.common.music_path import resolve_contained_music_path
+
 MUSIC_PATH = os.getenv("MUSIC_PATH", "/music")
 
 
 def resolve_music_path(track_ref: str) -> str | None:
     """Resolve a relative track reference beneath the real music root."""
-    if not isinstance(track_ref, str) or "\x00" in track_ref:
-        return None
-
-    normalized_path = track_ref.replace("\\", "/")
-    if os.path.isabs(normalized_path):
-        return None
-    if any(segment in {".", ".."} for segment in normalized_path.split("/")):
-        return None
-
-    try:
-        music_root = os.path.realpath(MUSIC_PATH)
-        resolved_path = os.path.realpath(os.path.join(music_root, normalized_path))
-        if os.path.commonpath((music_root, resolved_path)) != music_root:
-            return None
-    except (OSError, ValueError):
-        return None
-    return resolved_path
+    return resolve_contained_music_path(MUSIC_PATH, track_ref)

--- a/services/vibe-provider-dclap/settings.py
+++ b/services/vibe-provider-dclap/settings.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 
-from services.common.analyzer_env import configure_thread_env, get_int_env
+from services.common.analyzer_env import configure_thread_env
+from services.common.environment import env_int
 from services.common.logging_utils import configure_service_logger
 
 logger = configure_service_logger("vibe-provider-dclap")
@@ -18,9 +19,9 @@ DCLAP_TEXT_TOWER_HASH = "200d48f3905ff1f272af5006dd9851f94071a7dde4eafd9c07bc09c
 EMBEDDING_CHECKPOINT_HASH = "c892c7a8666dfa5adec5f0b76ecdd9b5394f5afa925d1362750309b6b9b96639"
 EMBEDDING_DIM = 512
 SAMPLE_RATE_HZ = 48000
-HTTP_PORT = get_int_env("DCLAP_HTTP_PORT", 8092)
-MODEL_IDLE_TIMEOUT = get_int_env("MODEL_IDLE_TIMEOUT", 300)
-ONNX_INTRA_OP_THREADS = get_int_env("DCLAP_ONNX_INTRA_OP_THREADS", 1)
+HTTP_PORT = env_int("DCLAP_HTTP_PORT", 8092)
+MODEL_IDLE_TIMEOUT = env_int("MODEL_IDLE_TIMEOUT", 300)
+ONNX_INTRA_OP_THREADS = env_int("DCLAP_ONNX_INTRA_OP_THREADS", 1)
 MODEL_DIRECTORY = os.getenv("DCLAP_MODEL_PATH", "/app/models")
 TOKENIZER_DIRECTORY = os.getenv("DCLAP_TOKENIZER_PATH", "/app/tokenizer")
 # This undeclared cap is part of the de-facto preprocessing contract. Changing

--- a/services/vibe-provider-dclap/tests/test_music_path.py
+++ b/services/vibe-provider-dclap/tests/test_music_path.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import music_path
 import pytest
 
+from services.common.music_path import resolve_contained_music_path
+
 
 @pytest.mark.parametrize(
     "track_ref",
@@ -56,3 +58,25 @@ def test_resolve_music_path_returns_real_in_library_path(
     monkeypatch.setattr(music_path, "MUSIC_PATH", str(tmp_path))
 
     assert music_path.resolve_music_path("artist/track.flac") == str(track.resolve())
+
+
+def test_common_music_path_normalizes_backslashes(tmp_path: Path) -> None:
+    """Normalize Windows-style separators in the shared containment boundary."""
+    track = tmp_path / "artist" / "track.flac"
+    track.parent.mkdir()
+    track.touch()
+
+    assert resolve_contained_music_path(str(tmp_path), "artist\\track.flac") == str(track.resolve())
+
+
+def test_resolve_music_path_normalizes_backslashes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep separator normalization active through the environment-bound wrapper."""
+    track = tmp_path / "artist" / "track.flac"
+    track.parent.mkdir()
+    track.touch()
+    monkeypatch.setattr(music_path, "MUSIC_PATH", str(tmp_path))
+
+    assert music_path.resolve_music_path("artist\\track.flac") == str(track.resolve())

--- a/services/ytmusic-streamer/tests/test_error_sanitization.py
+++ b/services/ytmusic-streamer/tests/test_error_sanitization.py
@@ -16,6 +16,69 @@ MARKER = "sekrit-yt-abc123"
 LOGGER_NAME = "ytmusic-streamer"
 
 
+def test_shared_http_error_logs_detail_and_returns_generic_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keep provider details in logs while returning only the stable client detail."""
+    import app  # noqa: F401 -- the runtime bootstraps the shared module path
+    from common.sidecar_runtime_utils import sanitized_http_error
+
+    logger = logging.getLogger("ytmusic-shared-error-test")
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        try:
+            raise RuntimeError(MARKER)
+        except RuntimeError as error:
+            result = sanitized_http_error(logger, "shared operation", error, 502, "Safe detail")
+
+    assert result.status_code == 502
+    assert result.detail == "Safe detail"
+    assert MARKER in caplog.text
+
+
+def test_shared_pool_warning_filter_throttles_repeated_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Install the shared throttle in YouTube Music and suppress repeated warnings."""
+    pool_logger = logging.getLogger("urllib3.connectionpool")
+    previous_filters = list(pool_logger.filters)
+    pool_logger.filters.clear()
+    try:
+        import app  # noqa: F401 -- importing the runtime installs the shared filter
+
+        with caplog.at_level(logging.WARNING, logger=pool_logger.name):
+            pool_logger.warning("Connection pool is full, discarding connection: one")
+            pool_logger.warning("Connection pool is full, discarding connection: two")
+    finally:
+        pool_logger.filters[:] = previous_filters
+
+    messages = [record.getMessage() for record in caplog.records if record.name == pool_logger.name]
+    assert messages == [
+        "urllib3 connection pool saturated; suppressing repeated pool-full warnings for 300s. "
+        "Increase upstream pool size if this persists."
+    ]
+
+
+def test_shared_pool_warning_filter_installs_once() -> None:
+    """Repeated installs (module reimports) must not stack duplicate filters."""
+    from common.sidecar_runtime_utils import (
+        _ThrottlePoolFullWarning,
+        install_urllib3_pool_warning_throttle,
+    )
+
+    pool_logger = logging.getLogger("urllib3.connectionpool")
+    previous_filters = list(pool_logger.filters)
+    pool_logger.filters.clear()
+    try:
+        install_urllib3_pool_warning_throttle()
+        install_urllib3_pool_warning_throttle()
+        throttle_filters = [
+            f for f in pool_logger.filters if isinstance(f, _ThrottlePoolFullWarning)
+        ]
+        assert len(throttle_filters) == 1
+    finally:
+        pool_logger.filters[:] = previous_filters
+
+
 @pytest.mark.anyio
 async def test_auth_status_reason_sanitized(
     client: AsyncClient,

--- a/services/ytmusic-streamer/tests/test_yt_download_path_safety.py
+++ b/services/ytmusic-streamer/tests/test_yt_download_path_safety.py
@@ -7,14 +7,21 @@ from pathlib import Path
 import pytest
 
 SIDECAR_ROOT = Path(__file__).resolve().parents[1]
+SERVICES_ROOT = SIDECAR_ROOT.parent
+if str(SERVICES_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICES_ROOT))
+
+from common.download_paths import (  # noqa: E402
+    require_contained_download_path,
+    sanitize_download_relative_path,
+    sanitize_path_component,
+)
+
 if str(SIDECAR_ROOT) not in sys.path:
     sys.path.insert(0, str(SIDECAR_ROOT))
 
 from yt_download import (  # noqa: E402
     _build_album_track_candidates,
-    _require_contained_download_path,
-    _sanitize_download_relative_path,
-    _sanitize_path_component,
     build_album_track_paths,
 )
 
@@ -22,16 +29,16 @@ from yt_download import (  # noqa: E402
 @pytest.mark.parametrize("component", ["", ".", "..", "   ", "..."])
 def test_sanitize_relative_path_rejects_invalid_components(component: str) -> None:
     with pytest.raises(ValueError, match="output template path"):
-        _sanitize_download_relative_path(f"Artist/{component}/Track")
+        sanitize_download_relative_path(f"Artist/{component}/Track")
 
 
 def test_sanitize_relative_path_rejects_absolute_path() -> None:
     with pytest.raises(ValueError, match="output template path"):
-        _sanitize_download_relative_path("/outside/Track")
+        sanitize_download_relative_path("/outside/Track")
 
 
 def test_sanitize_path_component_replaces_reserved_characters() -> None:
-    assert _sanitize_path_component('A<>:"/\\|?*B') == "A_________B"
+    assert sanitize_path_component('A<>:"/\\|?*B') == "A_________B"
 
 
 def test_containment_rejects_symlink_escape(tmp_path: Path) -> None:
@@ -42,7 +49,7 @@ def test_containment_rejects_symlink_escape(tmp_path: Path) -> None:
     (music / "linked").symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(ValueError, match="outside MUSIC_PATH"):
-        _require_contained_download_path(music / "linked" / "track.mp3", music.resolve())
+        require_contained_download_path(music / "linked" / "track.mp3", music.resolve())
 
 
 def test_album_track_paths_reject_temporary_symlink_escape(

--- a/services/ytmusic-streamer/yt_download.py
+++ b/services/ytmusic-streamer/yt_download.py
@@ -17,6 +17,13 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 from uuid import uuid4
 
+from common.download_paths import (
+    require_contained_download_path as _require_contained_download_path,
+)
+from common.download_paths import (
+    sanitize_download_relative_path as _sanitize_download_relative_path,
+)
+from common.download_paths import sanitize_path_component as _sanitize_path_component
 from mutagen.flac import FLAC
 from mutagen.id3 import ID3
 from mutagen.mp4 import MP4
@@ -108,34 +115,6 @@ class _Mp4Reader(Protocol):
     """Typed view of Mutagen's optional MP4 tag container."""
 
     tags: _TagReader | None
-
-
-def _sanitize_path_component(name: str) -> str:
-    """Replace filesystem-reserved characters and trim unsafe suffixes."""
-    for char in '<>:"/\\|?*':
-        name = name.replace(char, "_")
-    return name.strip(". ")
-
-
-def _sanitize_download_relative_path(rendered_path: str) -> Path:
-    """Validate and sanitize every component of a relative download path."""
-    sanitized_parts: list[str] = []
-    for component in rendered_path.split("/"):
-        sanitized = _sanitize_path_component(component)
-        if not sanitized or sanitized in {".", ".."} or Path(sanitized).is_absolute():
-            raise ValueError("Invalid output template path component")
-        sanitized_parts.append(sanitized)
-    return Path(*sanitized_parts)
-
-
-def _require_contained_download_path(path: Path, destination_root: Path) -> Path:
-    """Resolve a path and reject targets outside the configured music root."""
-    resolved_path = path.resolve()
-    try:
-        resolved_path.relative_to(destination_root.resolve())
-    except ValueError:
-        raise ValueError("Download path resolves outside MUSIC_PATH") from None
-    return resolved_path
 
 
 def _build_bounded_filename(stem: str, suffix: str, extension: str) -> str:

--- a/services/ytmusic-streamer/ytmusic_album_downloads.py
+++ b/services/ytmusic-streamer/ytmusic_album_downloads.py
@@ -12,13 +12,15 @@ from itertools import islice
 from pathlib import Path
 from typing import Any
 
+from common.download_paths import (
+    require_contained_download_path as _require_contained_download_path,
+)
 from common.sidecar_runtime_utils import env_int
 from fastapi import HTTPException, Query
 from yt_download import (
     _build_album_track_candidates,
     _build_album_track_tmp_path,
     _read_embedded_video_id,
-    _require_contained_download_path,
     _stamp_audio_tags,
     build_album_track_paths,
     build_audio_download_opts,

--- a/services/ytmusic-streamer/ytmusic_runtime.py
+++ b/services/ytmusic-streamer/ytmusic_runtime.py
@@ -2,23 +2,31 @@
 
 import os
 import sys
+from functools import partial
 from pathlib import Path
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 
 SERVICES_ROOT = Path(__file__).resolve().parents[1]
 if str(SERVICES_ROOT) not in sys.path:
     sys.path.append(str(SERVICES_ROOT))
 
 from common.logging_utils import configure_service_logger
-from common.sidecar_runtime_utils import register_error_handlers, require_internal_secret
+from common.sidecar_runtime_utils import (
+    install_urllib3_pool_warning_throttle,
+    register_error_handlers,
+    require_internal_secret,
+    sanitized_http_error,
+)
 
 JsonObject = dict[str, Any]
 JsonList = list[JsonObject]
 
 # ── Logging ─────────────────────────────────────────────────────────
 log = configure_service_logger("ytmusic-streamer")
+install_urllib3_pool_warning_throttle()
+_sanitized_http_error = partial(sanitized_http_error, log)
 
 # ── FastAPI app ─────────────────────────────────────────────────────
 app = FastAPI(
@@ -49,19 +57,3 @@ def _bound_cache(cache: dict[str, JsonObject], max_size: int) -> None:
     """Evict oldest entries; callers must hold the owning cache's lock."""
     while len(cache) > max_size:
         cache.pop(next(iter(cache)))
-
-
-def _sanitized_http_error(
-    operation: str,
-    exc: Exception,
-    status_code: int,
-    detail: str,
-) -> HTTPException:
-    """Log full exception detail; return a generic client-facing HTTPException."""
-    log.error(
-        "%s failed: %s",
-        operation,
-        exc,
-        exc_info=True,  # noqa: LOG014 -- callers invoke this helper from active exception handlers
-    )
-    return HTTPException(status_code=status_code, detail=detail)


### PR DESCRIPTION
Closes #743

## What this is

The Python-sidecar half of the consolidation audit. The security-sensitive helpers each sidecar maintained as its own copy now live once in `services/common`:

- **`resolve_contained_music_path`** (`common/music_path.py`) — the 18-line path-traversal guard formerly byte-identical in audio-analyzer and dclap (NUL reject, backslash normalize, absolute/dot-segment reject, realpath+commonpath containment). Both sidecars keep thin wrappers; both suites still exercise every rejection case, so the boundary is proven per consumer, not just in common.
- **`common/download_paths.py`** — the sanitizer trio twinned between tidal-streamer and ytmusic-streamer. The only real divergence was root resolution (tidal expected a pre-resolved root, ytmusic resolved internally); unified on resolve-internally after verifying every tidal caller already passed resolved roots.
- **`sanitized_http_error`** — verbatim twin, now beside `register_error_handlers`; each sidecar binds its logger with `partial`, call sites unchanged.
- **env helpers** — `get_int_env` deleted; `env_int`/`env_float` moved to a lightweight `common/environment.py` (re-exported from `sidecar_runtime_utils`) so the audio-analyzer image doesn't import FastAPI/httpx it doesn't ship; the one raw `DB_RECONCILE_BACKOFF_MULTIPLIER` cast now uses `env_float`.
- **urllib3 pool-warning throttle** — moved to common, made idempotent under module reimport (review finding, with a repeated-install test), and ytmusic-streamer now gets the same 5-minute suppression tidal had.

No Dockerfile changes needed — all four images already `COPY services/common` wholesale. `analyzer.py` (2248) and tidal `app.py` (1865) ratchet baselines tightened.

## Verification

- pytest: tidal 177, ytmusic 309, analyzer 110+1 skipped, dclap 71, root contract 43 — all green
- ruff check + format clean (pinned 0.16.2); every exact `verify:python-quality` mypy set green (pinned 2.3.0 strict), including the new common modules via the root config
- file-size gate green; CHANGELOG prettier-clean
- Adversarial review round produced one Low (throttle idempotence), fixed with a test