### PR TITLE
chore(downloads): unify the tidal/youtube library-download processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- TIDAL and YouTube Music library downloads now run through one shared processor with per-source steps, so fixes apply to both sources at once.
 - Consolidated repeated backend error handling, download-job state transitions, availability probes, queue event wiring, and value parsing behind shared internal helpers.
 - The Python sidecars now share one hardened implementation of their path-safety and runtime helpers instead of maintaining copies.
 - The TIDAL playlist and mix explore pages now share one implementation, settings connection tests share one status hook, and dates and durations render through shared formatters. Album pages now show total length compactly (for example "2h 30m").

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -83,6 +83,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/importJobStore.ts` | Core |
 | `backend/src/services/itunes.ts` | Core |
 | `backend/src/services/lastfm.ts` | Core |
+| `backend/src/services/libraryDownloadProcessor.ts` | Shared provider-backed library album download orchestration and fallback handoff |
 | `backend/src/services/libraryRadioBuilder.ts` | Core |
 | `backend/src/services/libraryRadioStationSelection.ts` | Shared Quick Start, genre, and decade radio selection |
 | `backend/src/services/libraryRadioTrackResponse.ts` | Library-radio playback response mapping |

--- a/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
+++ b/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
@@ -1,0 +1,279 @@
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findUnique: jest.fn(),
+            update: jest.fn(),
+        },
+    },
+}));
+
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+}));
+
+jest.mock("../simpleDownloadManager", () => ({
+    simpleDownloadManager: { startDownload: jest.fn() },
+}));
+
+jest.mock("../coalescedLibraryScan", () => ({
+    requestCoalescedLibraryScan: jest.fn(),
+}));
+
+import { prisma } from "../../utils/db";
+import { getSystemSettings } from "../../utils/systemSettings";
+import { requestCoalescedLibraryScan } from "../coalescedLibraryScan";
+import {
+    type LibraryAlbumDownloadOptions,
+    type LibraryDownloadProcessorConfig,
+    runLibraryAlbumDownload,
+} from "../libraryDownloadProcessor";
+
+interface FakeMatch {
+    id: string;
+}
+
+interface FakeResult {
+    downloaded: number;
+}
+
+const mockFindUnique = prisma.downloadJob.findUnique as jest.Mock;
+const mockUpdate = prisma.downloadJob.update as jest.Mock;
+const mockSettings = getSystemSettings as jest.Mock;
+const mockScan = requestCoalescedLibraryScan as jest.Mock;
+const findMatch = jest.fn<Promise<FakeMatch | null>, [string, string]>();
+const download = jest.fn<Promise<FakeResult>, [FakeMatch, unknown]>();
+type PeerRunArgs = [
+    string,
+    string,
+    string,
+    string,
+    LibraryAlbumDownloadOptions & { isFallback: true },
+];
+const fallbackPeer = jest.fn<Promise<void>, PeerRunArgs>();
+
+const processorConfig: LibraryDownloadProcessorConfig<FakeMatch, FakeResult> = {
+    sourceKey: "fake",
+    sourceLabel: "Fake Music",
+    searchingStatusText: "Searching Fake Music...",
+    failedError: "Fake download failed",
+    failedStatusText: "Fake Music failed",
+    findMatch,
+    download,
+    resultSummary: (_match, result) => ({
+        statusText: `Fake Music ✓ ${result.downloaded} tracks`,
+        metadata: { fakeResult: { downloaded: result.downloaded } },
+    }),
+    fallbackPeer: {
+        sourceKey: "peer",
+        run: fallbackPeer,
+    },
+    fallbackOrder: "manager-first",
+    logFallbackSelection: false,
+    prefixManagerFailureLog: false,
+    scanSource: "fake-download",
+};
+
+describe("libraryDownloadProcessor", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindUnique.mockResolvedValue({
+            metadata: {
+                albumMbid: "rg-1",
+                queuedVia: "album-download-queue",
+                failedAt: "2026-08-24T10:00:00.000Z",
+            },
+        });
+        mockUpdate.mockResolvedValue({});
+        mockSettings.mockResolvedValue({ primaryFailureFallback: "none" });
+        findMatch.mockResolvedValue({ id: "match-1" });
+        download.mockResolvedValue({ downloaded: 3 });
+        fallbackPeer.mockResolvedValue(undefined);
+        mockScan.mockResolvedValue(undefined);
+    });
+
+    it("hands a search miss to the configured peer", async () => {
+        findMatch.mockResolvedValueOnce(null);
+        mockSettings.mockResolvedValueOnce({
+            primaryFailureFallback: "peer",
+        });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(fallbackPeer).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+            { isFallback: true },
+        );
+        expect(mockUpdate).toHaveBeenCalledWith({
+            where: { id: "job-1" },
+            data: {
+                metadata: {
+                    albumMbid: "rg-1",
+                    queuedVia: "album-download-queue",
+                    failedAt: "2026-08-24T10:00:00.000Z",
+                    currentSource: "peer",
+                    statusText: "Fake Music not found → peer",
+                },
+            },
+        });
+        expect(download).not.toHaveBeenCalled();
+    });
+
+    it("marks a forwarded peer attempt as fallback and stops after both providers miss", async () => {
+        const siblingFindMatch = jest
+            .fn<Promise<FakeMatch | null>, [string, string]>()
+            .mockResolvedValue(null);
+        const recursivePeer = jest
+            .fn<Promise<void>, PeerRunArgs>()
+            .mockResolvedValue(undefined);
+        const siblingConfig: LibraryDownloadProcessorConfig<
+            FakeMatch,
+            FakeResult
+        > = {
+            ...processorConfig,
+            sourceKey: "peer",
+            sourceLabel: "Peer Music",
+            findMatch: siblingFindMatch,
+            fallbackPeer: {
+                sourceKey: "peer",
+                run: recursivePeer,
+            },
+        };
+        const siblingProcessor = jest.fn(
+            async (...args: PeerRunArgs): Promise<void> => {
+                await runLibraryAlbumDownload(siblingConfig, ...args);
+            },
+        );
+        const primaryFindMatch = jest
+            .fn<Promise<FakeMatch | null>, [string, string]>()
+            .mockResolvedValue(null);
+        const forwardingConfig: LibraryDownloadProcessorConfig<
+            FakeMatch,
+            FakeResult
+        > = {
+            ...processorConfig,
+            findMatch: primaryFindMatch,
+            fallbackPeer: {
+                sourceKey: "peer",
+                run: (...args) => siblingProcessor(...args),
+            },
+        };
+        mockSettings.mockResolvedValue({ primaryFailureFallback: "peer" });
+
+        await runLibraryAlbumDownload(
+            forwardingConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(siblingProcessor).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+            { isFallback: true },
+        );
+        expect(primaryFindMatch).toHaveBeenCalledTimes(1);
+        expect(siblingFindMatch).toHaveBeenCalledTimes(1);
+        expect(recursivePeer).not.toHaveBeenCalled();
+    });
+
+    it("persists a sanitized failure when the provider download fails", async () => {
+        download.mockRejectedValueOnce(new Error("private dependency detail"));
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        const failedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "failed",
+        )?.[0];
+        expect(failedUpdate.data.error).toBe("Fake download failed");
+        expect(failedUpdate.data.metadata).toEqual(
+            expect.objectContaining({
+                queuedVia: "album-download-queue",
+                currentSource: "fake",
+                statusText: "Fake Music failed",
+                failedAt: expect.any(String),
+            }),
+        );
+        expect(JSON.stringify(failedUpdate)).not.toContain(
+            "private dependency detail",
+        );
+        expect(mockScan).not.toHaveBeenCalled();
+    });
+
+    it("completes the job and requests the configured library scan", async () => {
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        const completedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "completed",
+        )?.[0];
+        expect(completedUpdate.data.error).toBeNull();
+        expect(completedUpdate.data.metadata).toEqual(
+            expect.objectContaining({
+                queuedVia: "album-download-queue",
+                currentSource: "fake",
+                statusText: "Fake Music ✓ 3 tracks",
+                fakeResult: { downloaded: 3 },
+            }),
+        );
+        expect(completedUpdate.data.metadata).not.toHaveProperty("failedAt");
+        expect(mockScan).toHaveBeenCalledWith("user-1", "fake-download");
+    });
+
+    it("does not hand a fallback search miss back to the peer", async () => {
+        findMatch.mockResolvedValueOnce(null);
+        mockSettings.mockResolvedValueOnce({
+            primaryFailureFallback: "peer",
+        });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+            { isFallback: true },
+        );
+
+        expect(fallbackPeer).not.toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: "Fake download failed",
+                }),
+            }),
+        );
+    });
+});

--- a/backend/src/services/libraryDownloadProcessor.ts
+++ b/backend/src/services/libraryDownloadProcessor.ts
@@ -1,0 +1,322 @@
+/** Shared orchestration for provider-backed library album downloads. */
+
+import { logger } from "../utils/logger";
+import { prisma } from "../utils/db";
+import { asPlainObject } from "../utils/plainObject";
+import { getSystemSettings } from "../utils/systemSettings";
+import { requestCoalescedLibraryScan } from "./coalescedLibraryScan";
+import { simpleDownloadManager } from "./simpleDownloadManager";
+
+type DownloadMetadata = Record<string, unknown>;
+type ManagerFallback = "lidarr" | "soulseek";
+type PeerFallbackOptions = LibraryAlbumDownloadOptions & {
+    isFallback: true;
+};
+
+interface DownloadContext {
+    jobId: string;
+    metadata: DownloadMetadata;
+}
+
+interface ProcessorContext extends DownloadContext {
+    artistName: string;
+    albumTitle: string;
+    userId: string;
+    isFallback: boolean;
+}
+
+interface ResultSummary {
+    statusText: string;
+    metadata: DownloadMetadata;
+}
+
+/** Controls hand-off behavior when a processor is itself a fallback. */
+export interface LibraryAlbumDownloadOptions {
+    isFallback?: boolean;
+}
+
+/** Defines provider-specific steps and text for the shared processor. */
+export interface LibraryDownloadProcessorConfig<TMatch, TResult> {
+    sourceKey: string;
+    sourceLabel: string;
+    searchingStatusText: string;
+    failedError: string;
+    failedStatusText: string;
+    findMatch: (
+        artistName: string,
+        albumTitle: string,
+    ) => Promise<TMatch | null>;
+    download: (match: TMatch, context: DownloadContext) => Promise<TResult>;
+    resultSummary: (match: TMatch, result: TResult) => ResultSummary;
+    fallbackPeer: {
+        sourceKey: string;
+        run: (
+            jobId: string,
+            artistName: string,
+            albumTitle: string,
+            userId: string,
+            options: PeerFallbackOptions,
+        ) => Promise<void>;
+    };
+    fallbackOrder: "manager-first" | "peer-first";
+    logFallbackSelection: boolean;
+    prefixManagerFailureLog: boolean;
+    scanSource: string;
+    onScanQueued?: (result: TResult) => Promise<void> | void;
+}
+
+function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
+    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
+    return retainedMetadata;
+}
+
+function isManagerFallback(value: unknown): value is ManagerFallback {
+    return value === "lidarr" || value === "soulseek";
+}
+
+async function markSearching<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    metadata: DownloadMetadata,
+): Promise<void> {
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            status: "processing",
+            error: null,
+            metadata: {
+                ...metadata,
+                currentSource: config.sourceKey,
+                statusText: config.searchingStatusText,
+            },
+        },
+    });
+}
+
+async function markSearchMissHandOff<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    fallback: string,
+    metadata: DownloadMetadata,
+): Promise<void> {
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            metadata: {
+                ...metadata,
+                currentSource: fallback,
+                statusText: `${config.sourceLabel} not found → ${fallback}`,
+            },
+        },
+    });
+}
+
+async function handOffToManager<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    fallback: ManagerFallback,
+    context: ProcessorContext,
+): Promise<void> {
+    const result = await simpleDownloadManager.startDownload(
+        context.jobId,
+        context.artistName,
+        context.albumTitle,
+        typeof context.metadata.albumMbid === "string"
+            ? context.metadata.albumMbid
+            : "",
+        context.userId,
+    );
+    if (result.success) return;
+    const prefix = config.prefixManagerFailureLog
+        ? `[${config.sourceLabel}] `
+        : "";
+    logger.error(`${prefix}Fallback ${fallback} failed: ${result.error}`);
+}
+
+async function handOffToPeer<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    context: ProcessorContext,
+): Promise<void> {
+    const options: PeerFallbackOptions = { isFallback: true };
+    await config.fallbackPeer.run(
+        context.jobId,
+        context.artistName,
+        context.albumTitle,
+        context.userId,
+        options,
+    );
+}
+
+async function dispatchHandOff<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    fallback: string,
+    context: ProcessorContext,
+): Promise<void> {
+    const managerFallback = isManagerFallback(fallback);
+    if (config.fallbackOrder === "manager-first") {
+        if (managerFallback) {
+            await handOffToManager(config, fallback, context);
+            return;
+        }
+        await handOffToPeer(config, context);
+        return;
+    }
+    if (fallback === config.fallbackPeer.sourceKey) {
+        await handOffToPeer(config, context);
+        return;
+    }
+    if (managerFallback) {
+        await handOffToManager(config, fallback, context);
+    }
+}
+
+async function handOffSearchMiss<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    context: ProcessorContext,
+): Promise<boolean> {
+    const settings = await getSystemSettings();
+    const fallback: unknown = settings?.primaryFailureFallback;
+    const managerFallback = isManagerFallback(fallback);
+    if (
+        !managerFallback &&
+        (fallback !== config.fallbackPeer.sourceKey || context.isFallback)
+    ) {
+        return false;
+    }
+    const selectedFallback = managerFallback
+        ? fallback
+        : config.fallbackPeer.sourceKey;
+    if (config.logFallbackSelection) {
+        logger.debug(
+            `[${config.sourceLabel}] Album not found, falling back to ${selectedFallback}`,
+        );
+    }
+    await markSearchMissHandOff(
+        config,
+        context.jobId,
+        selectedFallback,
+        context.metadata,
+    );
+    await dispatchHandOff(config, selectedFallback, context);
+    return true;
+}
+
+async function completeJob<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    match: TMatch,
+    result: TResult,
+    metadata: DownloadMetadata,
+): Promise<void> {
+    const summary = config.resultSummary(match, result);
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            status: "completed",
+            completedAt: new Date(),
+            error: null,
+            metadata: {
+                ...withoutFailedAt(metadata),
+                currentSource: config.sourceKey,
+                statusText: summary.statusText,
+                ...summary.metadata,
+            },
+        },
+    });
+}
+
+async function failJob<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    metadata: DownloadMetadata,
+): Promise<void> {
+    await prisma.downloadJob.update({
+        where: { id: jobId },
+        data: {
+            status: "failed",
+            error: config.failedError,
+            completedAt: new Date(),
+            metadata: {
+                ...metadata,
+                currentSource: config.sourceKey,
+                statusText: config.failedStatusText,
+                failedAt: new Date().toISOString(),
+            },
+        },
+    });
+}
+
+async function runAttempt<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    context: ProcessorContext,
+): Promise<TResult | null> {
+    await markSearching(config, context.jobId, context.metadata);
+    const match = await config.findMatch(
+        context.artistName,
+        context.albumTitle,
+    );
+    if (!match) {
+        if (await handOffSearchMiss(config, context)) return null;
+        throw new Error(
+            `Album not found on ${config.sourceLabel}: ${context.artistName} - ${context.albumTitle}`,
+        );
+    }
+    const result = await config.download(match, {
+        jobId: context.jobId,
+        metadata: context.metadata,
+    });
+    await completeJob(config, context.jobId, match, result, context.metadata);
+    return result;
+}
+
+async function queueLibraryScanSafely<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    userId: string,
+    result: TResult,
+): Promise<void> {
+    try {
+        await requestCoalescedLibraryScan(userId, config.scanSource);
+        await config.onScanQueued?.(result);
+    } catch (error) {
+        logger.warn(
+            `${config.sourceLabel} library scan enqueue failed; download remains completed`,
+            { jobId, error },
+        );
+    }
+}
+
+/** Run one provider-backed library album search, download, and scan request. */
+export async function runLibraryAlbumDownload<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    artistName: string,
+    albumTitle: string,
+    userId: string,
+    options: LibraryAlbumDownloadOptions = {},
+): Promise<void> {
+    const existingJob = await prisma.downloadJob.findUnique({
+        where: { id: jobId },
+        select: { metadata: true },
+    });
+    const metadata = asPlainObject(existingJob?.metadata);
+    let result: TResult | null;
+    try {
+        result = await runAttempt(config, {
+            jobId,
+            artistName,
+            albumTitle,
+            userId,
+            metadata,
+            isFallback: options.isFallback === true,
+        });
+    } catch (error: unknown) {
+        logger.error(
+            `[${config.sourceLabel}] Download failed for job ${jobId}:`,
+            error instanceof Error ? error.message : error,
+        );
+        await failJob(config, jobId, metadata);
+        return;
+    }
+    if (result === null) return;
+    await queueLibraryScanSafely(config, jobId, userId, result);
+}

--- a/backend/src/services/tidalLibraryDownload.ts
+++ b/backend/src/services/tidalLibraryDownload.ts
@@ -2,13 +2,12 @@
 
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
-import { getSystemSettings } from "../utils/systemSettings";
-import { simpleDownloadManager } from "./simpleDownloadManager";
+import {
+    type LibraryDownloadProcessorConfig,
+    runLibraryAlbumDownload,
+} from "./libraryDownloadProcessor";
 import { tidalService, type TidalAlbumDownloadResult } from "./tidal";
-import { requestCoalescedLibraryScan } from "./coalescedLibraryScan";
-import { asPlainObject } from "../utils/plainObject";
 
-type DownloadMetadata = Record<string, unknown>;
 type TidalAlbumMatch = NonNullable<
     Awaited<ReturnType<typeof tidalService.findAlbum>>
 >;
@@ -18,212 +17,84 @@ export interface TidalLibraryDownloadOptions {
     isFallback?: boolean;
 }
 
-function asMetadata(value: unknown): DownloadMetadata {
-    return asPlainObject(value);
-}
-
-function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
-    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
-    return retainedMetadata;
-}
-
-async function markSearching(
-    jobId: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "processing",
-            error: null,
-            metadata: {
-                ...metadata,
-                currentSource: "tidal",
-                statusText: "Searching TIDAL...",
-            },
-        },
-    });
-}
-
-async function markSearchMissHandOff(
-    jobId: string,
-    fallback: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            metadata: {
-                ...metadata,
-                currentSource: fallback,
-                statusText: `TIDAL not found → ${fallback}`,
-            },
-        },
-    });
-}
-
-async function handOffToDownloadManager(
-    fallback: "lidarr" | "soulseek",
-    jobId: string,
-    artistName: string,
-    albumTitle: string,
-    userId: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    const result = await simpleDownloadManager.startDownload(
-        jobId,
-        artistName,
-        albumTitle,
-        typeof metadata.albumMbid === "string" ? metadata.albumMbid : "",
-        userId,
-    );
-    if (!result.success) {
-        logger.error(`Fallback ${fallback} failed: ${result.error}`);
-    }
-}
-
-async function handOffSearchMiss(
-    jobId: string,
-    artistName: string,
-    albumTitle: string,
-    userId: string,
-    metadata: DownloadMetadata,
-    isFallback: boolean,
-): Promise<boolean> {
-    const settings = await getSystemSettings();
-    const fallback = settings?.primaryFailureFallback;
-    const isManagerFallback = fallback === "lidarr" || fallback === "soulseek";
-    if (!isManagerFallback && (fallback !== "youtube" || isFallback)) {
-        return false;
-    }
-    logger.debug(`[TIDAL] Album not found, falling back to ${fallback}`);
-    await markSearchMissHandOff(jobId, fallback, metadata);
-    if (isManagerFallback) {
-        await handOffToDownloadManager(
-            fallback,
-            jobId,
-            artistName,
-            albumTitle,
-            userId,
-            metadata,
-        );
-        return true;
-    }
-    const { processYoutubeDownload } = await import("./youtubeLibraryDownload");
-    await processYoutubeDownload(jobId, artistName, albumTitle, userId, {
-        isFallback: true,
-    });
-    return true;
-}
-
-async function markDownloading(
-    jobId: string,
-    match: TidalAlbumMatch,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            metadata: {
-                ...metadata,
-                currentSource: "tidal",
-                statusText: `Downloading ${match.numberOfTracks} tracks...`,
-                tidalAlbumId: match.albumId,
-            },
-        },
-    });
-}
-
-async function downloadAlbum(
-    match: TidalAlbumMatch,
-): Promise<TidalAlbumDownloadResult> {
-    const result = await tidalService.downloadAlbum(match.albumId);
-    logger.debug(
-        `[TIDAL] Download complete: ${result.downloaded}/${result.total_tracks} tracks`,
-    );
-    if (result.downloaded === 0) {
-        throw new Error(`All ${result.total_tracks} tracks failed to download`);
-    }
-    return result;
-}
-
 function completedStatusText(result: TidalAlbumDownloadResult): string {
     return result.failed > 0
         ? `${result.downloaded}/${result.total_tracks} tracks (${result.failed} failed)`
         : `${result.downloaded} tracks`;
 }
 
-async function completeTidalJob(
-    jobId: string,
-    match: TidalAlbumMatch,
-    result: TidalAlbumDownloadResult,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "completed",
-            completedAt: new Date(),
-            error: null,
-            metadata: {
-                ...withoutFailedAt(metadata),
-                currentSource: "tidal",
-                statusText: `TIDAL ✓ ${completedStatusText(result)}`,
-                tidalAlbumId: match.albumId,
-                tidalResult: {
-                    downloaded: result.downloaded,
-                    failed: result.failed,
-                    totalTracks: result.total_tracks,
+const tidalLibraryDownloadConfig = {
+    sourceKey: "tidal",
+    sourceLabel: "TIDAL",
+    searchingStatusText: "Searching TIDAL...",
+    failedError: "TIDAL download failed",
+    failedStatusText: "TIDAL failed",
+    findMatch: (artistName, albumTitle) =>
+        tidalService.findAlbum(artistName, albumTitle),
+    download: async (match, { jobId, metadata }) => {
+        logger.debug(
+            `[TIDAL] Found album: "${match.title}" by ${match.artist} (ID: ${match.albumId}, ${match.numberOfTracks} tracks)`,
+        );
+        await prisma.downloadJob.update({
+            where: { id: jobId },
+            data: {
+                metadata: {
+                    ...metadata,
+                    currentSource: "tidal",
+                    statusText: `Downloading ${match.numberOfTracks} tracks...`,
+                    tidalAlbumId: match.albumId,
                 },
             },
-        },
-    });
-}
-
-async function queueLibraryScan(
-    userId: string,
-    result: TidalAlbumDownloadResult,
-): Promise<void> {
-    await requestCoalescedLibraryScan(userId, "tidal-download");
-    logger.debug(
-        `[TIDAL] Scan queued for: ${result.artist} - ${result.album_title}`,
-    );
-}
-
-async function queueLibraryScanSafely(
-    jobId: string,
-    userId: string,
-    result: TidalAlbumDownloadResult,
-): Promise<void> {
-    try {
-        await queueLibraryScan(userId, result);
-    } catch (error) {
-        logger.warn(
-            "TIDAL library scan enqueue failed; download remains completed",
-            { jobId, error },
+        });
+        const result = await tidalService.downloadAlbum(match.albumId);
+        logger.debug(
+            `[TIDAL] Download complete: ${result.downloaded}/${result.total_tracks} tracks`,
         );
-    }
-}
-
-async function failTidalJob(
-    jobId: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "failed",
-            error: "TIDAL download failed",
-            completedAt: new Date(),
-            metadata: {
-                ...metadata,
-                currentSource: "tidal",
-                statusText: "TIDAL failed",
-                failedAt: new Date().toISOString(),
+        if (result.downloaded === 0) {
+            throw new Error(
+                `All ${result.total_tracks} tracks failed to download`,
+            );
+        }
+        return result;
+    },
+    resultSummary: (match, result) => ({
+        statusText: `TIDAL ✓ ${completedStatusText(result)}`,
+        metadata: {
+            tidalAlbumId: match.albumId,
+            tidalResult: {
+                downloaded: result.downloaded,
+                failed: result.failed,
+                totalTracks: result.total_tracks,
             },
         },
-    });
-}
+    }),
+    fallbackPeer: {
+        sourceKey: "youtube",
+        run: async (jobId, artistName, albumTitle, userId, options) => {
+            const { processYoutubeDownload } =
+                await import("./youtubeLibraryDownload");
+            await processYoutubeDownload(
+                jobId,
+                artistName,
+                albumTitle,
+                userId,
+                options,
+            );
+        },
+    },
+    fallbackOrder: "manager-first",
+    logFallbackSelection: true,
+    prefixManagerFailureLog: false,
+    scanSource: "tidal-download",
+    onScanQueued: (result) => {
+        logger.debug(
+            `[TIDAL] Scan queued for: ${result.artist} - ${result.album_title}`,
+        );
+    },
+} satisfies LibraryDownloadProcessorConfig<
+    TidalAlbumMatch,
+    TidalAlbumDownloadResult
+>;
 
 /** Process one library album through TIDAL search and download. */
 export async function processTidalDownload(
@@ -233,43 +104,12 @@ export async function processTidalDownload(
     userId: string,
     options: TidalLibraryDownloadOptions = {},
 ): Promise<void> {
-    const existingJob = await prisma.downloadJob.findUnique({
-        where: { id: jobId },
-        select: { metadata: true },
-    });
-    const metadata = asMetadata(existingJob?.metadata);
-    let completedResult: TidalAlbumDownloadResult;
-    try {
-        await markSearching(jobId, metadata);
-        const match = await tidalService.findAlbum(artistName, albumTitle);
-        if (!match) {
-            const handedOff = await handOffSearchMiss(
-                jobId,
-                artistName,
-                albumTitle,
-                userId,
-                metadata,
-                options.isFallback === true,
-            );
-            if (handedOff) return;
-            throw new Error(
-                `Album not found on TIDAL: ${artistName} - ${albumTitle}`,
-            );
-        }
-        logger.debug(
-            `[TIDAL] Found album: "${match.title}" by ${match.artist} (ID: ${match.albumId}, ${match.numberOfTracks} tracks)`,
-        );
-        await markDownloading(jobId, match, metadata);
-        const result = await downloadAlbum(match);
-        await completeTidalJob(jobId, match, result, metadata);
-        completedResult = result;
-    } catch (error: unknown) {
-        logger.error(
-            `[TIDAL] Download failed for job ${jobId}:`,
-            error instanceof Error ? error.message : error,
-        );
-        await failTidalJob(jobId, metadata);
-        return;
-    }
-    await queueLibraryScanSafely(jobId, userId, completedResult);
+    await runLibraryAlbumDownload(
+        tidalLibraryDownloadConfig,
+        jobId,
+        artistName,
+        albumTitle,
+        userId,
+        options,
+    );
 }

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -1,18 +1,15 @@
 /** YouTube Music album search, sidecar job orchestration, and library scanning. */
 
-import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
-import { getSystemSettings } from "../utils/systemSettings";
-import { simpleDownloadManager } from "./simpleDownloadManager";
-import { requestCoalescedLibraryScan } from "./coalescedLibraryScan";
+import {
+    type LibraryDownloadProcessorConfig,
+    runLibraryAlbumDownload,
+} from "./libraryDownloadProcessor";
 import {
     type YtAlbumDownloadJobStatus,
     watchYouTubeDownloadJobUntilTerminal,
     youtubeDownloadService,
 } from "./youtubeDownload";
-import { asPlainObject } from "../utils/plainObject";
-
-type DownloadMetadata = Record<string, unknown>;
 
 interface AlbumSearchCandidate {
     browseId: string;
@@ -23,15 +20,6 @@ interface AlbumSearchCandidate {
 /** Controls hand-off behavior when this processor is itself a fallback. */
 export interface YoutubeLibraryDownloadOptions {
     isFallback?: boolean;
-}
-
-function asMetadata(value: unknown): DownloadMetadata {
-    return asPlainObject(value);
-}
-
-function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
-    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
-    return retainedMetadata;
 }
 
 function asAlbumSearchCandidate(value: unknown): AlbumSearchCandidate | null {
@@ -98,75 +86,11 @@ export async function findAlbumBrowseId(
     return selectAlbumBrowseId(candidates, artistName, albumTitle);
 }
 
-async function markSearching(
-    jobId: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "processing",
-            error: null,
-            metadata: {
-                ...metadata,
-                currentSource: "youtube",
-                statusText: "Searching YouTube Music...",
-            },
-        },
-    });
-}
-
-async function handOffSearchMiss(
-    jobId: string,
-    artistName: string,
-    albumTitle: string,
-    userId: string,
-    metadata: DownloadMetadata,
-    isFallback: boolean,
-): Promise<boolean> {
-    const settings = await getSystemSettings();
-    const fallback = settings?.primaryFailureFallback;
-    const isManagerFallback = fallback === "lidarr" || fallback === "soulseek";
-    if (!isManagerFallback && (fallback !== "tidal" || isFallback)) {
-        return false;
-    }
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            metadata: {
-                ...metadata,
-                currentSource: fallback,
-                statusText: `YouTube Music not found → ${fallback}`,
-            },
-        },
-    });
-    if (fallback === "tidal") {
-        const { processTidalDownload } = await import("./tidalLibraryDownload");
-        await processTidalDownload(jobId, artistName, albumTitle, userId, {
-            isFallback: true,
-        });
-        return true;
-    }
-    const result = await simpleDownloadManager.startDownload(
-        jobId,
-        artistName,
-        albumTitle,
-        typeof metadata.albumMbid === "string" ? metadata.albumMbid : "",
-        userId,
-    );
-    if (!result.success) {
-        logger.error(
-            `[YouTube Music] Fallback ${fallback} failed: ${result.error}`,
-        );
-    }
-    return true;
-}
-
 async function updateProgress(
     jobId: string,
     sidecarJobId: string,
     progressPct: number,
-    metadata: DownloadMetadata,
+    metadata: Record<string, unknown>,
 ): Promise<void> {
     await prisma.downloadJob.update({
         where: { id: jobId },
@@ -184,7 +108,7 @@ async function updateProgress(
 async function startAndWatchAlbum(
     jobId: string,
     browseId: string,
-    metadata: DownloadMetadata,
+    metadata: Record<string, unknown>,
 ): Promise<YtAlbumDownloadJobStatus> {
     const started = await youtubeDownloadService.startAlbumDownload(browseId);
     await prisma.downloadJob.update({
@@ -221,65 +145,52 @@ async function startAndWatchAlbum(
     return youtubeDownloadService.getAlbumDownloadJobStatus(started.jobId);
 }
 
-async function completeYoutubeJob(
-    jobId: string,
-    result: YtAlbumDownloadJobStatus,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "completed",
-            completedAt: new Date(),
-            error: null,
-            metadata: {
-                ...withoutFailedAt(metadata),
-                currentSource: "youtube",
-                statusText: `YouTube Music ✓ ${result.downloaded}/${result.totalTracks} tracks`,
-                youtubeAlbumJobId: result.jobId,
-                youtubeResult: {
-                    downloaded: result.downloaded,
-                    failed: result.failed,
-                    totalTracks: result.totalTracks,
-                },
+const youtubeLibraryDownloadConfig = {
+    sourceKey: "youtube",
+    sourceLabel: "YouTube Music",
+    searchingStatusText: "Searching YouTube Music...",
+    failedError: "YouTube download failed",
+    failedStatusText: "YouTube Music failed",
+    findMatch: findAlbumBrowseId,
+    download: async (browseId, { jobId, metadata }) => {
+        const result = await startAndWatchAlbum(jobId, browseId, metadata);
+        if (result.downloaded === 0) {
+            throw new Error(
+                `All ${result.totalTracks} tracks failed to download`,
+            );
+        }
+        return result;
+    },
+    resultSummary: (_browseId, result) => ({
+        statusText: `YouTube Music ✓ ${result.downloaded}/${result.totalTracks} tracks`,
+        metadata: {
+            youtubeAlbumJobId: result.jobId,
+            youtubeResult: {
+                downloaded: result.downloaded,
+                failed: result.failed,
+                totalTracks: result.totalTracks,
             },
         },
-    });
-}
-
-async function failYoutubeJob(
-    jobId: string,
-    metadata: DownloadMetadata,
-): Promise<void> {
-    await prisma.downloadJob.update({
-        where: { id: jobId },
-        data: {
-            status: "failed",
-            error: "YouTube download failed",
-            completedAt: new Date(),
-            metadata: {
-                ...metadata,
-                currentSource: "youtube",
-                statusText: "YouTube Music failed",
-                failedAt: new Date().toISOString(),
-            },
+    }),
+    fallbackPeer: {
+        sourceKey: "tidal",
+        run: async (jobId, artistName, albumTitle, userId, options) => {
+            const { processTidalDownload } =
+                await import("./tidalLibraryDownload");
+            await processTidalDownload(
+                jobId,
+                artistName,
+                albumTitle,
+                userId,
+                options,
+            );
         },
-    });
-}
-
-async function queueLibraryScanSafely(
-    jobId: string,
-    userId: string,
-): Promise<void> {
-    try {
-        await requestCoalescedLibraryScan(userId, "youtube-download");
-    } catch (error) {
-        logger.warn(
-            "YouTube Music library scan enqueue failed; download remains completed",
-            { jobId, error },
-        );
-    }
-}
+    },
+    fallbackOrder: "peer-first",
+    logFallbackSelection: false,
+    prefixManagerFailureLog: true,
+    scanSource: "youtube-download",
+} satisfies LibraryDownloadProcessorConfig<string, YtAlbumDownloadJobStatus>;
 
 /** Process a library album through public YouTube Music search and download. */
 export async function processYoutubeDownload(
@@ -289,44 +200,12 @@ export async function processYoutubeDownload(
     userId: string,
     options: YoutubeLibraryDownloadOptions = {},
 ): Promise<void> {
-    const existingJob = await prisma.downloadJob.findUnique({
-        where: { id: jobId },
-        select: { metadata: true },
-    });
-    const metadata = asMetadata(existingJob?.metadata);
-    try {
-        await markSearching(jobId, metadata);
-        const browseId = await findAlbumBrowseId(artistName, albumTitle);
-        if (!browseId) {
-            if (
-                await handOffSearchMiss(
-                    jobId,
-                    artistName,
-                    albumTitle,
-                    userId,
-                    metadata,
-                    options.isFallback === true,
-                )
-            )
-                return;
-            throw new Error(
-                `Album not found on YouTube Music: ${artistName} - ${albumTitle}`,
-            );
-        }
-        const result = await startAndWatchAlbum(jobId, browseId, metadata);
-        if (result.downloaded === 0) {
-            throw new Error(
-                `All ${result.totalTracks} tracks failed to download`,
-            );
-        }
-        await completeYoutubeJob(jobId, result, metadata);
-    } catch (error: unknown) {
-        logger.error(
-            `[YouTube Music] Download failed for job ${jobId}:`,
-            error instanceof Error ? error.message : error,
-        );
-        await failYoutubeJob(jobId, metadata);
-        return;
-    }
-    await queueLibraryScanSafely(jobId, userId);
+    await runLibraryAlbumDownload(
+        youtubeLibraryDownloadConfig,
+        jobId,
+        artistName,
+        albumTitle,
+        userId,
+        options,
+    );
 }


### PR DESCRIPTION
Closes #745

## What this is

The first of the two behavioral consolidation refactors. `tidalLibraryDownload.ts` and `youtubeLibraryDownload.ts` were structural mirrors (same skeleton: findUnique → markSearching → search → handoff-or-throw → download → complete → scan-enqueue → catch-fail). The shared `libraryDownloadProcessor` now owns that skeleton; each provider supplies its search/download/progress/result-metadata steps and its lazy sibling import via a typed config. The two files shrank by 417 lines.

What was deliberately preserved rather than unified:
- The two handoff bodies check manager-fallback vs sibling-processor in **different orders** and log with different prefixes — kept as strategy points, byte-equivalent to before.
- The album-queue lifecycle contract (retry clears error, `failedAt` omitted on success, `queuedVia` preserved through every metadata patch) is owned by the shared processor and pinned by tests.
- Sibling imports stay dynamic inside config thunks — no new static path from services into the queue module graph.

Review hardening (2 rounds → zero findings): the anti-bounce marker is now **structural** — the processor builds the peer-call options with `isFallback: true`, so a provider config cannot reintroduce search ping-pong (red-proven); the handoff test pins the complete metadata object so dropping the spread fails loudly.

## Verification

- Both existing provider suites pass **completely unchanged** (including the anti-bounce tests) — the strongest behavior-preservation signal available
- `tsc` clean; 8 related suites / 155 tests green; prettier; file-size + route-canon gates green