### PR TITLE
feat(artist): album links and real metadata for popular and unowned track rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Popular tracks on the artist page now show the album name as a clickable link, including for tracks that are not in your library (#757).
+
 ### Changed
 
 - Download job metadata updates now flow through guarded helpers instead of ad-hoc merges scattered across the backend.
@@ -22,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).
+- Tracks you do not own on the artist page keep their row menu, so Go to artist and Go to album stay available (#757).
 - Retrying a download no longer cuts off album titles that contain a dash.
 - The DCLAP vibe provider now refuses requests when its internal secret is missing or left at the default, instead of silently allowing them.
 - Finishing a batch of album downloads now triggers one combined library scan instead of one scan per album, which could crash the background worker.

--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -427,6 +427,73 @@ describe("library artist lookup compatibility", () => {
         );
     });
 
+    it("exposes the album artist on matched Last.fm top tracks", async () => {
+        mockArtistFindFirst.mockResolvedValueOnce({
+            ...createMockArtist(),
+            albums: [
+                {
+                    id: "album-1",
+                    title: "Owned Album",
+                    rgMbid: "rg-owned",
+                    coverUrl: "owned-cover.jpg",
+                    tracks: [
+                        {
+                            id: "track-1",
+                            title: "Owned Track",
+                            album: {
+                                id: "album-1",
+                                title: "Owned Album",
+                                coverUrl: "owned-cover.jpg",
+                                albumLoudnessLufs: null,
+                                albumTruePeakDb: null,
+                                artist: {
+                                    id: "artist-1",
+                                    name: "AC/DC",
+                                    mbid: "mbid-artist-1",
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+        mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
+            {
+                name: "Owned Track",
+                playcount: "12",
+                listeners: "34",
+                duration: "245",
+                url: "https://last.fm/track/owned",
+                album: { "#text": "Owned Album" },
+            },
+        ]);
+
+        const req = {
+            params: { id: "artist-local-id-123" },
+            query: {
+                includeDiscography: "false",
+                includeTopTracks: "true",
+                includeSimilarArtists: "false",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await artistHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.topTracks).toEqual([
+            expect.objectContaining({
+                id: "track-1",
+                artist: {
+                    id: "artist-1",
+                    name: "AC/DC",
+                    mbid: "mbid-artist-1",
+                },
+            }),
+        ]);
+    });
+
     it("hydrates unmatched Last.fm top tracks and skips Deezer lookup for unknown albums", async () => {
         mockArtistFindFirst.mockResolvedValueOnce(createMockArtist());
         mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
@@ -434,7 +501,7 @@ describe("library artist lookup compatibility", () => {
                 name: "Unmatched With Cover",
                 playcount: "12",
                 listeners: "34",
-                duration: "250000",
+                duration: "245",
                 url: "https://last.fm/track/1",
                 album: { "#text": "Rare EP" },
             },
@@ -442,7 +509,7 @@ describe("library artist lookup compatibility", () => {
                 name: "Unmatched Unknown Album",
                 playcount: "7",
                 listeners: "11",
-                duration: "210000",
+                duration: "210",
                 url: "https://last.fm/track/2",
                 album: {},
             },
@@ -475,6 +542,16 @@ describe("library artist lookup compatibility", () => {
             "AC/DC",
             "Rare EP",
         );
+        const unownedTrack = res.body.topTracks.find(
+            (track: any) => track.title === "Unmatched With Cover",
+        );
+        expect(unownedTrack).toEqual(
+            expect.objectContaining({
+                artist: { name: "AC/DC" },
+                duration: 245,
+            }),
+        );
+        expect(unownedTrack.album).not.toHaveProperty("id");
         expect(res.body.topTracks).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -502,7 +579,7 @@ describe("library artist lookup compatibility", () => {
                 name: "Rejected Cover Lookup",
                 playcount: "5",
                 listeners: "9",
-                duration: "180000",
+                duration: "180",
                 url: "https://last.fm/track/rejected",
                 album: { "#text": "Broken Cover Album" },
             },
@@ -543,7 +620,7 @@ describe("library artist lookup compatibility", () => {
                 name: "Unknown Album Track",
                 playcount: "3",
                 listeners: "6",
-                duration: "160000",
+                duration: "160",
                 url: "https://last.fm/track/unknown",
                 album: {},
             },

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -479,6 +479,13 @@ export async function handleGetArtist(
                                 coverUrl: true,
                                 albumLoudnessLufs: true,
                                 albumTruePeakDb: true,
+                                artist: {
+                                    select: {
+                                        id: true,
+                                        name: true,
+                                        mbid: true,
+                                    },
+                                },
                             },
                         },
                     },
@@ -807,7 +814,10 @@ export async function handleGetArtist(
                 withFederatedTrackPlayback(track, federationPeer),
             ),
         );
-        topTracks = allTracks.slice(0, 10);
+        topTracks = allTracks.slice(0, 10).map((track) => ({
+            ...track,
+            artist: track.album.artist,
+        }));
 
         // Get user play counts for all tracks
         const userId = req.user!.id;
@@ -888,6 +898,7 @@ export async function handleGetArtist(
                     // Track exists in library - include user play count
                     combinedTracks.push({
                         ...matchedTrack,
+                        artist: matchedTrack.album.artist,
                         playCount: lfmTrack.playcount
                             ? parseInt(lfmTrack.playcount)
                             : 0,
@@ -917,9 +928,10 @@ export async function handleGetArtist(
                             ? parseInt(lfmTrack.listeners)
                             : 0,
                         duration: lfmTrack.duration
-                            ? Math.floor(parseInt(lfmTrack.duration) / 1000)
+                            ? Math.floor(parseInt(lfmTrack.duration))
                             : 0,
                         url: lfmTrack.url,
+                        artist: { name: artist.name },
                         album: {
                             title: albumTitle,
                             coverArt: null,
@@ -963,6 +975,7 @@ export async function handleGetArtist(
             // If Last.fm fails, add user play counts to library tracks
             topTracks = topTracks.map((t) => ({
                 ...t,
+                artist: t.album.artist,
                 userPlayCount: userPlayCounts.get(t.id) || 0,
                 album: {
                     ...t.album,

--- a/frontend/features/artist/components/PopularTracks.tsx
+++ b/frontend/features/artist/components/PopularTracks.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Play, Plus, ChevronDown, ChevronUp } from "lucide-react";
 import Link from "next/link";
 import { api } from "@/lib/api";
@@ -15,6 +15,7 @@ import { TrackOverflowMenu } from "@/components/ui/TrackOverflowMenu";
 import { TrackPreferenceButtons } from "@/components/player/TrackPreferenceButtons";
 import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
 import { resolvePreferenceTrackId } from "@/lib/trackRef";
+import { useTrackAlbumResolutions } from "../hooks/useTrackAlbumResolutions";
 
 /** Default number of popular tracks shown in collapsed state. */
 export const POPULAR_COLLAPSED_COUNT = 5;
@@ -60,9 +61,14 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
 }) => {
     const [expanded, setExpanded] = useState(false);
     const canExpand = tracks.length > POPULAR_COLLAPSED_COUNT;
-    const visibleTracks = expanded
-        ? tracks
-        : tracks.slice(0, POPULAR_COLLAPSED_COUNT);
+    const visibleTracks = useMemo(
+        () => (expanded ? tracks : tracks.slice(0, POPULAR_COLLAPSED_COUNT)),
+        [tracks, expanded],
+    );
+    const albumResolutions = useTrackAlbumResolutions(
+        visibleTracks,
+        artist.name,
+    );
 
     const handlePlay = useCallback(
         (track: Track) => {
@@ -115,6 +121,17 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                 hasLocalFile,
             });
 
+            const resolution = track.album?.id
+                ? undefined
+                : albumResolutions.get(track.id);
+            const albumId = track.album?.id || resolution?.rgMbid;
+            const localAlbumTitle =
+                track.album?.title && track.album.title !== "Unknown Album"
+                    ? track.album.title
+                    : undefined;
+            const albumTitle = localAlbumTitle ?? resolution?.albumTitle;
+            const albumHref = albumId ? `/album/${albumId}` : null;
+
             return {
                 titleBadges: (
                     <>
@@ -130,10 +147,25 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                     </>
                 ),
                 middleColumns: (
-                    <div className="hidden md:flex items-center text-sm text-gray-400">
+                    <div className="hidden md:flex items-center gap-3 min-w-0 text-sm text-gray-400">
+                        {albumTitle &&
+                            (albumHref ? (
+                                <Link
+                                    href={albumHref}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="truncate hover:text-white hover:underline"
+                                    title={albumTitle}
+                                >
+                                    {albumTitle}
+                                </Link>
+                            ) : (
+                                <span className="truncate" title={albumTitle}>
+                                    {albumTitle}
+                                </span>
+                            ))}
                         {track.playCount !== undefined &&
                             track.playCount > 0 && (
-                                <span className="flex items-center gap-1">
+                                <span className="flex shrink-0 items-center gap-1">
                                     <Play className="w-3 h-3" />
                                     {formatNumber(track.playCount)}
                                 </span>
@@ -160,33 +192,34 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                                 id: preferenceTrackId,
                             })}
                         />
-                        {isPlayable && (
-                            <TrackOverflowMenu
-                                track={{
-                                    id: track.id,
-                                    title: track.displayTitle ?? track.title,
-                                    artist: {
-                                        name: track.artist?.name ?? artist.name,
-                                        id: track.artist?.id ?? artist.id,
-                                    },
-                                    album: track.album
-                                        ? {
-                                              title: track.album.title ?? "",
-                                              id: track.album.id,
-                                              coverArt: track.album.coverArt,
-                                          }
-                                        : { title: "" },
-                                    duration: track.duration,
-                                    streamSource:
-                                        track.streamSource === "tidal" ||
-                                        track.streamSource === "youtube"
-                                            ? track.streamSource
-                                            : undefined,
-                                    source: track.source,
-                                    peer: track.peer,
-                                }}
-                            />
-                        )}
+                        <TrackOverflowMenu
+                            track={{
+                                id: track.id,
+                                title: track.displayTitle ?? track.title,
+                                artist: {
+                                    name: track.artist?.name ?? artist.name,
+                                    id: track.artist?.id ?? artist.id,
+                                },
+                                album: {
+                                    title: albumTitle ?? "",
+                                    id: albumId || undefined,
+                                    coverArt: track.album?.coverArt,
+                                },
+                                duration: track.duration,
+                                streamSource:
+                                    track.streamSource === "tidal" ||
+                                    track.streamSource === "youtube"
+                                        ? track.streamSource
+                                        : undefined,
+                                source: track.source,
+                                peer: track.peer,
+                            }}
+                            showPlayNext={isPlayable}
+                            showAddToQueue={isPlayable}
+                            showAddToPlaylist={isPlayable}
+                            showMatchVibe={isPlayable}
+                            showVibeMap={isPlayable}
+                        />
                     </div>
                 ),
                 rowClassName:
@@ -195,7 +228,7 @@ export const PopularTracks: React.FC<PopularTracksProps> = ({
                         : undefined,
             };
         },
-        [artist, isProviderMatching],
+        [artist, isProviderMatching, albumResolutions],
     );
 
     return (

--- a/frontend/features/artist/hooks/useTrackAlbumResolutions.ts
+++ b/frontend/features/artist/hooks/useTrackAlbumResolutions.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import type { TrackAlbumResolution } from "@/lib/api/metadata";
+import type { Track } from "../types";
+
+/**
+ * Module-level cache so repeat visits (and expand/collapse cycles) never
+ * re-resolve the same artist/title pair. `null` records a resolution miss.
+ */
+const resolutionCache = new Map<string, TrackAlbumResolution | null>();
+
+function cacheKey(artistName: string, title: string): string {
+    return `${artistName.toLowerCase()}::${title.toLowerCase()}`;
+}
+
+function albumHint(track: Track): string | undefined {
+    const title = track.album?.title;
+    if (!title || title === "Unknown Album") return undefined;
+    return title;
+}
+
+async function resolveTrack(
+    artistName: string,
+    track: Track,
+): Promise<TrackAlbumResolution | null> {
+    const key = cacheKey(artistName, track.title);
+    const cached = resolutionCache.get(key);
+    if (cached !== undefined) return cached;
+
+    let resolution: TrackAlbumResolution | null = null;
+    try {
+        resolution = await api.getTrackAlbum(
+            artistName,
+            track.title,
+            albumHint(track),
+        );
+    } catch {
+        // Misses and transport failures both render as "no album link";
+        // the server distinguishes and caches them on its side.
+        resolution = null;
+    }
+    resolutionCache.set(key, resolution);
+    return resolution;
+}
+
+/**
+ * Resolve canonical album identity (rgMbid + title) for tracks that carry no
+ * local album id, via the cached `/api/metadata/track-album` ladder. Returns
+ * a map keyed by track id containing only successful resolutions.
+ */
+export function useTrackAlbumResolutions(
+    tracks: Track[],
+    artistName: string,
+): Map<string, TrackAlbumResolution> {
+    const [resolutions, setResolutions] = useState<
+        Map<string, TrackAlbumResolution>
+    >(() => new Map());
+
+    useEffect(() => {
+        const targets = tracks.filter((track) => !track.album?.id);
+        if (targets.length === 0 || !artistName) return;
+
+        let cancelled = false;
+        const run = async () => {
+            for (const track of targets) {
+                const resolution = await resolveTrack(artistName, track);
+                if (cancelled) return;
+                if (!resolution) continue;
+                setResolutions((prev) => {
+                    if (prev.get(track.id) === resolution) return prev;
+                    const next = new Map(prev);
+                    next.set(track.id, resolution);
+                    return next;
+                });
+            }
+        };
+        void run();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [tracks, artistName]);
+
+    return resolutions;
+}

--- a/frontend/tests/component/popularTracksAlbumColumn.component.test.ts
+++ b/frontend/tests/component/popularTracksAlbumColumn.component.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+    installTrackOverflowHarness,
+    trackOverflowIcon,
+} from "../trackOverflowHarness";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const metadataState: {
+    calls: Array<{ artist: string; title: string; album?: string }>;
+    resolve: (
+        artist: string,
+        title: string,
+    ) => Promise<{ albumTitle: string; rgMbid: string }>;
+} = {
+    calls: [],
+    resolve: async () => ({ albumTitle: "Resolved Album", rgMbid: "rg-123" }),
+};
+
+mock.module("lucide-react", {
+    namedExports: {
+        Play: trackOverflowIcon,
+        Pause: trackOverflowIcon,
+        Volume2: trackOverflowIcon,
+        Music: trackOverflowIcon,
+        ListPlus: trackOverflowIcon,
+        EllipsisVertical: trackOverflowIcon,
+        ListEnd: trackOverflowIcon,
+        Plus: trackOverflowIcon,
+        User: trackOverflowIcon,
+        Disc3: trackOverflowIcon,
+        AudioWaveform: trackOverflowIcon,
+        Link: trackOverflowIcon,
+        ChevronDown: trackOverflowIcon,
+        ChevronUp: trackOverflowIcon,
+    },
+});
+
+mock.module("@/utils/formatTime", {
+    namedExports: { formatTime: (s: number) => String(s) },
+});
+mock.module("@/utils/formatNumber", {
+    namedExports: { formatNumber: (n: number) => String(n) },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            getCoverArtUrl: (url: string) => url,
+            addTrackToPlaylist: async () => undefined,
+            getTrackAlbum: (artist: string, title: string, album?: string) => {
+                metadataState.calls.push({ artist, title, album });
+                return metadataState.resolve(artist, title);
+            },
+        },
+    },
+});
+
+installTrackOverflowHarness(mock, {
+    useAudioControls: () => ({
+        playNext: () => undefined,
+        addToQueue: () => undefined,
+        playTrack: () => undefined,
+        playTracks: () => undefined,
+        startVibeMode: async () => ({ success: true, trackCount: 10 }),
+    }),
+    useAudioState: () => ({
+        playbackType: "track",
+        currentTrack: null,
+    }),
+});
+
+mock.module("next/image", {
+    defaultExport: (props: Record<string, unknown>) =>
+        React.createElement("img", {
+            src: props.src as string,
+            alt: props.alt as string,
+        }),
+});
+
+mock.module("next/link", {
+    defaultExport: ({
+        children,
+        href,
+        ...props
+    }: {
+        children: React.ReactNode;
+        href: string;
+        [key: string]: unknown;
+    }) => React.createElement("a", { href, ...props }, children),
+});
+
+mock.module("@/components/ui/TidalBadge", {
+    namedExports: {
+        TidalBadge: () => React.createElement("span", null, "TIDAL"),
+    },
+});
+mock.module("@/hooks/useQueuedTrackIds", {
+    namedExports: { useQueuedTrackIds: () => new Set<string>() },
+});
+mock.module("@tanstack/react-query", {
+    namedExports: {
+        useQueryClient: () => ({
+            invalidateQueries: async () => undefined,
+            setQueryData: () => undefined,
+        }),
+    },
+});
+mock.module("@/hooks/useTrackPreference", {
+    namedExports: {
+        buildPreferenceMetadata: () => undefined,
+        useTrackPreference: () => ({
+            signal: null,
+            isSaving: false,
+            toggleLike: async () => undefined,
+        }),
+    },
+});
+mock.module("@/components/player/TrackPreferenceButtons", {
+    namedExports: {
+        TrackPreferenceButtons: () =>
+            React.createElement("div", {
+                "data-testid": "track-preference-buttons",
+            }),
+    },
+});
+mock.module("next/navigation", {
+    namedExports: { useRouter: () => ({ push: () => undefined }) },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    metadataState.calls.length = 0;
+    metadataState.resolve = async () => ({
+        albumTitle: "Resolved Album",
+        rgMbid: "rg-123",
+    });
+});
+
+const artist = { id: "artist-1", name: "Test Artist" };
+
+async function renderPopular(
+    tracks: unknown[],
+): Promise<{ container: HTMLElement; unmount: () => void }> {
+    const { PopularTracks } =
+        await import("../../features/artist/components/PopularTracks");
+    const { createRoot } = await import("react-dom/client");
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(
+            React.createElement(PopularTracks, {
+                tracks: tracks as never,
+                artist: artist as never,
+                currentTrackId: undefined,
+                colors: null,
+                onPlayTrack: () => undefined,
+            }),
+        );
+    });
+    // Drain the resolution effect's async continuations inside act so the
+    // state updates are tracked and nothing leaks past the test boundary.
+    await React.act(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+    return {
+        container,
+        unmount: () => {
+            void React.act(() => {
+                root.unmount();
+            });
+        },
+    };
+}
+
+test("owned popular rows link the album column to the local album", async () => {
+    const { container, unmount } = await renderPopular([
+        {
+            id: "pt1",
+            title: "Owned Track",
+            duration: 200,
+            album: { id: "al1", title: "Album One", coverArt: null },
+            artist: { id: "artist-1", name: "Test Artist" },
+            filePath: "/music/track1.flac",
+            playCount: 42,
+        },
+    ]);
+
+    const link = container.querySelector('a[href="/album/al1"]');
+    assert.ok(link, "expected an album link for the owned row");
+    assert.equal(link!.textContent, "Album One");
+    assert.equal(metadataState.calls.length, 0);
+    unmount();
+});
+
+test("unowned popular rows resolve album identity and link to /album/<rgMbid>", async () => {
+    const { container, unmount } = await renderPopular([
+        {
+            id: "pt2",
+            title: "Unowned Track",
+            duration: 180,
+            album: { id: "", title: "Unknown Album", coverArt: null },
+            artist: { id: "artist-1", name: "Test Artist" },
+        },
+    ]);
+
+    assert.deepEqual(metadataState.calls, [
+        { artist: "Test Artist", title: "Unowned Track", album: undefined },
+    ]);
+    const link = container.querySelector('a[href="/album/rg-123"]');
+    assert.ok(link, "expected a resolved album link for the unowned row");
+    assert.equal(link!.textContent, "Resolved Album");
+    unmount();
+});
+
+test("unowned rows without a resolution render no album link", async () => {
+    metadataState.resolve = async () => {
+        throw new Error("resolution unavailable");
+    };
+    const { container, unmount } = await renderPopular([
+        {
+            id: "pt3",
+            title: "Unresolvable Track",
+            duration: 120,
+            album: { id: "", title: "Unknown Album", coverArt: null },
+            artist: { id: "artist-1", name: "Test Artist" },
+        },
+    ]);
+
+    assert.equal(container.querySelector('a[href^="/album/"]'), null);
+    unmount();
+});

--- a/frontend/tests/component/remainingViewsOverflowMenu.component.test.ts
+++ b/frontend/tests/component/remainingViewsOverflowMenu.component.test.ts
@@ -233,7 +233,7 @@ test("PopularTracks overflow menu renders for playable track", async () => {
     assert.match(html, /Track actions/, "Should render overflow menu");
 });
 
-test("PopularTracks hides overflow menu for unplayable tracks", async () => {
+test("PopularTracks keeps a navigation-only overflow menu for unplayable tracks", async () => {
     const { PopularTracks } =
         await import("../../features/artist/components/PopularTracks");
 
@@ -258,11 +258,12 @@ test("PopularTracks hides overflow menu for unplayable tracks", async () => {
         }),
     );
 
-    // Unmatched track should NOT have overflow menu
-    assert.doesNotMatch(
+    // Unmatched tracks keep the overflow menu so Go to artist/album stay
+    // reachable; playback-dependent entries are gated off inside the menu.
+    assert.match(
         html,
         /Track actions/,
-        "Should not render overflow menu for unplayable track",
+        "Should render overflow menu for unplayable track",
     );
     // Should be dimmed
     assert.match(html, /opacity-50/, "Unplayable track row should be dimmed");


### PR DESCRIPTION
Closes #757.

## Problem

Tracks not in the library were dead rows on the artist page: no overflow menu at all (so "Go to artist" / "Go to album" were unreachable), no album shown in the Popular section, a blank artist line on every popular row, and unowned durations rendered as 0.

## Changes

**Backend** (`GET /api/library/artists/:id` top tracks):
- Select the album's artist and surface a top-level `artist` object on every top-tracks row (owned rows get id/name/mbid from the album artist; unowned Last.fm rows get the page artist's name).
- Keep Last.fm durations as seconds — the old code divided by 1000, so unowned tracks always showed 0:00. This now matches the discovery route.

**Frontend** (Popular section):
- The overflow menu now renders for every row; only the playback-dependent entries (queue, play next, playlist, vibe) are gated on playability. Navigation stays available for unowned tracks.
- New album column: owned rows link to `/album/<id>`; unowned rows resolve album identity lazily through the existing `/api/metadata/track-album` ladder (server-cached 7 days) and link to `/album/<rgMbid>`, which the album page already resolves via its discovery fallback. Resolution is limited to visible rows and cached client-side, so expand/collapse and repeat visits cost nothing.

## Verification

- verify: backend `npx jest libraryArtistLookupCompat libraryRuntime artistsRuntime` — Test Suites: 3 passed, Tests: 202 passed, exit 0
- verify: backend `tsc --noEmit` exit 0; `format:check` exit 0; file-size guardrail passed (artists.ts 1545 < 1553 baseline)
- verify: frontend `tsc --noEmit` exit 0; lint 0 errors at the 183-warning cap (no new warnings); component tests: 3 new album-column tests + rewritten unplayable-menu test all pass on Node 24
- Pre-existing local failures in `streamingRoutes` / `providerTrackLists` component suites reproduce identically on clean main (environmental); CI is the arbiter.