### PR TITLE
fix(downloads): route artist downloads through the album queue and report progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).
 - Tracks you do not own on the artist page keep their row menu, so Go to artist and Go to album stay available (#757).
+- Artist-wide downloads now expand through the background album-download pipeline and no longer require Lidarr, allowing TIDAL- and YouTube-only deployments to queue the full discography.
+- Artist-wide download jobs now expose durable enumeration progress through the artist MBID instead of leaving the Download All button waiting on per-album rows.
+- Album and artist jobs rejected during Redis queue admission now remain pending for automatic recovery instead of becoming stranded failures.
 - Retrying a download no longer cuts off album titles that contain a dash.
 - The DCLAP vibe provider now refuses requests when its internal secret is missing or left at the default, instead of silently allowing them.
 - Finishing a batch of album downloads now triggers one combined library scan instead of one scan per album, which could crash the background worker.

--- a/backend/src/routes/__tests__/downloadsRuntime.test.ts
+++ b/backend/src/routes/__tests__/downloadsRuntime.test.ts
@@ -58,9 +58,12 @@ jest.mock("../../services/youtubeDownload", () => ({
 }));
 
 const mockEnqueueAlbumDownloadInBackground = jest.fn();
+const mockEnqueueArtistDownloadExpansionInBackground = jest.fn();
 jest.mock("../../services/albumDownloadQueueService", () => ({
     enqueueAlbumDownloadInBackground: (...args: unknown[]) =>
         mockEnqueueAlbumDownloadInBackground(...args),
+    enqueueArtistDownloadExpansionInBackground: (...args: unknown[]) =>
+        mockEnqueueArtistDownloadExpansionInBackground(...args),
 }));
 
 jest.mock("../../services/musicbrainz", () => ({
@@ -254,6 +257,9 @@ describe("downloads routes runtime", () => {
         mockTidalAvailable.mockResolvedValue(false);
         mockYoutubeAvailable.mockResolvedValue(false);
         mockEnqueueAlbumDownloadInBackground.mockReturnValue(undefined);
+        mockEnqueueArtistDownloadExpansionInBackground.mockReturnValue(
+            undefined,
+        );
 
         mockGetArtist.mockResolvedValue(null);
         mockGetReleaseGroups.mockResolvedValue([]);
@@ -562,6 +568,7 @@ describe("downloads routes runtime", () => {
                 mbid: "rg-1",
                 subject: "Typo Artist - Album",
                 artistName: "Typo Artist",
+                artistMbid: "artist-mbid-1",
                 albumTitle: "Album",
             },
             user: { id: "user-1" },
@@ -585,6 +592,7 @@ describe("downloads routes runtime", () => {
             mbid: "rg-1",
             subject: "Typo Artist - Album",
             artistName: "Correct Artist",
+            artistMbid: "artist-mbid-1",
             albumTitle: "Album",
         });
         expect(createAlbumJob).toHaveBeenCalledWith(
@@ -592,6 +600,7 @@ describe("downloads routes runtime", () => {
                 data: expect.objectContaining({
                     metadata: expect.objectContaining({
                         queuedVia: "album-download-queue",
+                        artistMbid: "artist-mbid-1",
                     }),
                 }),
             }),
@@ -626,9 +635,17 @@ describe("downloads routes runtime", () => {
         });
     });
 
-    it("creates artist batch response with discovery root folder", async () => {
-        mockGetArtist.mockResolvedValueOnce({ name: "Artist Canonical" });
-        mockGetReleaseGroups.mockResolvedValueOnce([]);
+    it("queues artist expansion without calling Lidarr or MusicBrainz", async () => {
+        const createArtistJob = jest.fn().mockResolvedValue({
+            id: "artist-job-1",
+            status: "pending",
+        });
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                $queryRaw: jest.fn().mockResolvedValue([]),
+                downloadJob: { create: createArtistJob },
+            }),
+        );
 
         const req = {
             body: {
@@ -643,25 +660,62 @@ describe("downloads routes runtime", () => {
 
         await createJobHandler(req, res);
 
-        expect(mockLidarrAddArtist).toHaveBeenCalledWith(
-            "artist-mbid-1",
-            "Artist Canonical",
-            "/music/discovery",
-        );
+        expect(mockLidarrAddArtist).not.toHaveBeenCalled();
+        expect(mockGetArtist).not.toHaveBeenCalled();
+        expect(mockGetReleaseGroups).not.toHaveBeenCalled();
+        expect(createArtistJob).toHaveBeenCalledWith({
+            data: {
+                userId: "user-1",
+                type: "artist",
+                targetMbid: "artist-mbid-1",
+                subject: "Alias Artist",
+                status: "pending",
+                metadata: {
+                    queuedVia: "artist-download-expansion",
+                    downloadType: "discovery",
+                    rootFolderPath: "/music/discovery",
+                    artistName: "Alias Artist",
+                    batchId: expect.any(String),
+                    statusText: "Queued",
+                },
+            },
+        });
+        expect(
+            mockEnqueueArtistDownloadExpansionInBackground,
+        ).toHaveBeenCalledWith({
+            jobId: "artist-job-1",
+            artistMbid: "artist-mbid-1",
+            artistName: "Alias Artist",
+            downloadType: "discovery",
+            rootFolderPath: "/music/discovery",
+            userId: "user-1",
+        });
         expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual(
-            expect.objectContaining({
-                status: "processing",
-                downloadType: "discovery",
-                rootFolderPath: "/music/discovery",
-                albumCount: 0,
-                jobs: [],
-            }),
-        );
+        expect(res.body).toEqual({
+            id: "artist-job-1",
+            status: "pending",
+            downloadType: "discovery",
+            rootFolderPath: "/music/discovery",
+            message: "Enumerating discography in the background",
+        });
     });
 
-    it("returns 500 when artist processing fails", async () => {
-        mockLidarrAddArtist.mockResolvedValueOnce(null);
+    it("returns an active duplicate instead of queueing artist expansion", async () => {
+        const createArtistJob = jest.fn();
+        mockTransaction.mockImplementationOnce(async (callback: any) =>
+            callback({
+                $queryRaw: jest.fn().mockResolvedValue([
+                    {
+                        id: "artist-job-existing",
+                        status: "processing",
+                        subject: "Artist Name",
+                        targetMbid: "artist-mbid-2",
+                        type: "artist",
+                    },
+                ]),
+                downloadJob: { create: createArtistJob },
+            }),
+        );
 
         const req = {
             body: {
@@ -675,8 +729,21 @@ describe("downloads routes runtime", () => {
 
         await createJobHandler(req, res);
 
-        expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({ error: "Failed to create download job" });
+        expect(createArtistJob).not.toHaveBeenCalled();
+        expect(
+            mockEnqueueArtistDownloadExpansionInBackground,
+        ).not.toHaveBeenCalled();
+        expect(mockLidarrAddArtist).not.toHaveBeenCalled();
+        expect(mockGetReleaseGroups).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            id: "artist-job-existing",
+            status: "processing",
+            downloadType: "library",
+            rootFolderPath: "/music",
+            message: "Download already in progress",
+            duplicate: true,
+        });
     });
 
     it("clears jobs for the current user with optional status filter", async () => {
@@ -1301,132 +1368,6 @@ describe("downloads routes runtime", () => {
         });
     });
 
-    it("creates artist batch jobs while skipping existing and queued albums", async () => {
-        mockGetArtist.mockResolvedValueOnce({ name: "Artist Name" });
-        mockGetReleaseGroups.mockResolvedValueOnce([
-            { id: "rg-existing", title: "Existing Album" },
-            { id: "rg-queued", title: "Queued Album" },
-            { id: "rg-new", title: "New Album" },
-        ]);
-        mockAlbumFindFirst
-            .mockResolvedValueOnce({ id: "existing-album" })
-            .mockResolvedValueOnce(null)
-            .mockResolvedValueOnce(null);
-        const createArtistAlbumJob = jest.fn().mockResolvedValue({
-            id: "job-new",
-            status: "pending",
-        });
-        mockTransaction
-            .mockImplementationOnce(async (callback: any) =>
-                callback({
-                    $queryRaw: jest.fn().mockResolvedValue([
-                        {
-                            id: "queued-job",
-                            status: "pending",
-                            subject: "Artist Name - Queued Album",
-                            createdAt: new Date(),
-                        },
-                    ]),
-                    downloadJob: {
-                        create: jest.fn(),
-                    },
-                }),
-            )
-            .mockImplementationOnce(async (callback: any) =>
-                callback({
-                    $queryRaw: jest
-                        .fn()
-                        .mockResolvedValueOnce([])
-                        .mockResolvedValueOnce([]),
-                    downloadJob: {
-                        create: createArtistAlbumJob,
-                    },
-                }),
-            );
-        const req = {
-            body: {
-                type: "artist",
-                mbid: "artist-mbid-3",
-                subject: "Artist Name",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual(
-            expect.objectContaining({
-                albumCount: 1,
-                jobs: [{ id: "job-new", subject: "Artist Name - New Album" }],
-            }),
-        );
-        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
-            jobId: "job-new",
-            type: "album",
-            mbid: "rg-new",
-            subject: "Artist Name - New Album",
-            artistName: "Artist Name",
-            albumTitle: "New Album",
-        });
-        expect(createArtistAlbumJob).toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: expect.objectContaining({
-                    metadata: expect.objectContaining({
-                        queuedVia: "album-download-queue",
-                    }),
-                }),
-            }),
-        );
-    });
-
-    it("skips recently failed artist albums without creating new jobs", async () => {
-        mockGetReleaseGroups.mockResolvedValueOnce([
-            { id: "rg-recent-fail", title: "Recently Failed" },
-        ]);
-        mockAlbumFindFirst.mockResolvedValueOnce(null);
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest
-                    .fn()
-                    .mockResolvedValueOnce([])
-                    .mockResolvedValueOnce([
-                        {
-                            id: "failed-job",
-                            status: "failed",
-                            completedAt: new Date(),
-                        },
-                    ]),
-                downloadJob: {
-                    create: jest.fn(),
-                },
-            }),
-        );
-
-        const req = {
-            body: {
-                type: "artist",
-                mbid: "artist-mbid-4",
-                subject: "Artist Name",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-
-        expect(res.statusCode).toBe(200);
-        expect(res.body).toEqual(
-            expect.objectContaining({
-                albumCount: 0,
-                jobs: [],
-            }),
-        );
-        expect(mockEnqueueAlbumDownloadInBackground).not.toHaveBeenCalled();
-    });
-
     it("returns 500 when listing failed albums throws", async () => {
         mockUnavailableFindMany.mockRejectedValueOnce(
             new Error("db unavailable"),
@@ -1495,101 +1436,6 @@ describe("downloads routes runtime", () => {
             subject: "Artist - Album",
             artistName: "Artist",
             albumTitle: "Album",
-        });
-    });
-
-    it("uses LastFM artist correction for artist downloads when MusicBrainz lookup fails", async () => {
-        mockGetArtist.mockRejectedValueOnce(new Error("mb down"));
-        mockGetArtistCorrection.mockResolvedValueOnce({
-            canonicalName: "Artist Canonical",
-        });
-        mockGetReleaseGroups.mockResolvedValueOnce([]);
-
-        const req = {
-            body: {
-                type: "artist",
-                mbid: "artist-fallback-1",
-                subject: "Alias Artist",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-
-        expect(mockLidarrAddArtist).toHaveBeenCalledWith(
-            "artist-fallback-1",
-            "Artist Canonical",
-            "/music",
-        );
-    });
-
-    it("keeps original artist name when MusicBrainz and LastFM corrections both fail", async () => {
-        mockGetArtist.mockRejectedValueOnce(new Error("mb down"));
-        mockGetArtistCorrection.mockRejectedValueOnce(new Error("lfm down"));
-        mockGetReleaseGroups.mockResolvedValueOnce([]);
-
-        const req = {
-            body: {
-                type: "artist",
-                mbid: "artist-fallback-2",
-                subject: "Alias Artist",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-
-        expect(mockLidarrAddArtist).toHaveBeenCalledWith(
-            "artist-fallback-2",
-            "Alias Artist",
-            "/music",
-        );
-    });
-
-    it("logs per-album background failures during artist batch processing", async () => {
-        mockGetReleaseGroups.mockResolvedValueOnce([
-            { id: "rg-batch-1", title: "Batch Album" },
-        ]);
-        mockAlbumFindFirst.mockResolvedValueOnce(null);
-        mockTransaction.mockImplementationOnce(async (callback: any) =>
-            callback({
-                $queryRaw: jest
-                    .fn()
-                    .mockResolvedValueOnce([])
-                    .mockResolvedValueOnce([]),
-                downloadJob: {
-                    create: jest.fn().mockResolvedValue({
-                        id: "job-batch-1",
-                        status: "pending",
-                    }),
-                },
-            }),
-        );
-        mockEnqueueAlbumDownloadInBackground.mockReturnValueOnce(undefined);
-
-        const req = {
-            body: {
-                type: "artist",
-                mbid: "artist-batch-fail",
-                subject: "Batch Artist",
-            },
-            user: { id: "user-1" },
-        } as any;
-        const res = createRes();
-
-        await createJobHandler(req, res);
-        await flushAsyncWork();
-
-        expect(res.statusCode).toBe(200);
-        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
-            jobId: "job-batch-1",
-            type: "album",
-            mbid: "rg-batch-1",
-            subject: "Batch Artist - Batch Album",
-            artistName: "Batch Artist",
-            albumTitle: "Batch Album",
         });
     });
 

--- a/backend/src/routes/__tests__/notificationsRuntime.test.ts
+++ b/backend/src/routes/__tests__/notificationsRuntime.test.ts
@@ -336,6 +336,7 @@ describe("notifications route runtime", () => {
             mbid: "album-mbid",
             subject: "Artist - Album",
             artistName: "Artist",
+            artistMbid: "artist-mbid",
             albumTitle: "Album",
         });
         expect(prisma.downloadJob.create).toHaveBeenCalledWith(
@@ -1119,6 +1120,7 @@ describe("notifications route runtime", () => {
             mbid: "mbid-dashed-album",
             subject: "Artist - Album - Deluxe Edition",
             artistName: "Artist",
+            artistMbid: "artist-mbid",
             albumTitle: "Album - Deluxe Edition",
         });
     });

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -7,18 +7,20 @@ import { config } from "../config";
 import { getSystemSettings } from "../utils/systemSettings";
 import { lidarrService } from "../services/lidarr";
 import { musicBrainzService } from "../services/musicbrainz";
-import { lastFmService } from "../services/lastfm";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
 import { mapInteractiveRelease } from "../services/releaseContracts";
 import { createAlbumDownloadJob } from "../services/albumDownloadJobs";
-import { enqueueAlbumDownloadInBackground } from "../services/albumDownloadQueueService";
+import {
+    enqueueAlbumDownloadInBackground,
+    enqueueArtistDownloadExpansionInBackground,
+} from "../services/albumDownloadQueueService";
 import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "../services/albumDownloadQueueOwnership";
+import { createArtistDownloadExpansionJob } from "../services/artistDownloadExpansionJobs";
 import {
     sendRouteFailure,
     sendInternalRouteError,
     sendRouteError,
 } from "./routeErrorResponse";
-import crypto from "crypto";
 import { probeDownloadSourceAvailability } from "../services/downloadSourcePolicy";
 import {
     ACTIVE_DOWNLOAD_JOB_STATUSES,
@@ -74,7 +76,7 @@ router.get("/availability", async (req, res) => {
  * /api/downloads:
  *   post:
  *     summary: Create a new download job for an artist or album
- *     description: Creates a persisted download job and queues album work for serialized background processing.
+ *     description: Creates a persisted download job and queues artist expansion or album work for background processing.
  *     tags: [Downloads]
  *     security:
  *       - apiKeyAuth: []
@@ -105,7 +107,7 @@ router.get("/availability", async (req, res) => {
  *                 default: library
  *     responses:
  *       200:
- *         description: Album jobs are created and queued for background processing, or an active duplicate is returned
+ *         description: Artist expansion or album work is queued for background processing, or an active duplicate is returned
  *       400:
  *         description: Missing required fields or no download service configured
  *       401:
@@ -121,6 +123,7 @@ router.post("/", requireAdmin, async (req, res) => {
             mbid,
             subject,
             artistName,
+            artistMbid,
             albumTitle,
             downloadType = "library",
         } = req.body;
@@ -167,23 +170,40 @@ router.post("/", requireAdmin, async (req, res) => {
                 : baseMusicPath;
 
         if (type === "artist") {
-            // For artist downloads, fetch albums and create individual jobs
-            const jobs = await processArtistDownload(
+            const jobResult = await createArtistDownloadExpansionJob({
                 userId,
-                mbid,
-                subject,
-                rootFolderPath,
+                artistMbid: mbid,
+                artistName: subject,
                 downloadType,
-            );
+                rootFolderPath,
+            });
+
+            if (jobResult.duplicate) {
+                return res.json({
+                    id: jobResult.job.id,
+                    status: jobResult.job.status,
+                    downloadType,
+                    rootFolderPath,
+                    message: "Download already in progress",
+                    duplicate: true,
+                });
+            }
+
+            enqueueArtistDownloadExpansionInBackground({
+                jobId: jobResult.job.id,
+                artistMbid: mbid,
+                artistName: subject,
+                downloadType,
+                rootFolderPath,
+                userId,
+            });
 
             return res.json({
-                id: jobs[0]?.id || null,
-                status: "processing",
+                id: jobResult.job.id,
+                status: "pending",
                 downloadType,
                 rootFolderPath,
-                message: `Creating download jobs for ${jobs.length} album(s)...`,
-                albumCount: jobs.length,
-                jobs: jobs.map((j) => ({ id: j.id, subject: j.subject })),
+                message: "Enumerating discography in the background",
             });
         }
 
@@ -192,6 +212,7 @@ router.post("/", requireAdmin, async (req, res) => {
             mbid,
             subject,
             artistName,
+            artistMbid,
             albumTitle,
             downloadType,
             rootFolderPath,
@@ -229,6 +250,7 @@ router.post("/", requireAdmin, async (req, res) => {
             mbid,
             subject,
             artistName: jobResult.verifiedArtistName,
+            artistMbid,
             albumTitle,
         });
 
@@ -244,223 +266,6 @@ router.post("/", requireAdmin, async (req, res) => {
         sendInternalRouteError(res, "Failed to create download job");
     }
 });
-
-/**
- * Process artist download by creating individual album jobs
- */
-async function processArtistDownload(
-    userId: string,
-    artistMbid: string,
-    artistName: string,
-    rootFolderPath: string,
-    downloadType: string,
-): Promise<{ id: string; subject: string }[]> {
-    logger.debug(`\n Processing artist download: ${artistName}`);
-    logger.debug(`   Artist MBID: ${artistMbid}`);
-
-    // Generate a batch ID to group all album downloads
-    const batchId = crypto.randomUUID();
-    logger.debug(`   Batch ID: ${batchId}`);
-
-    // CRITICAL FIX: Resolve canonical artist name from MusicBrainz
-    // Last.fm may return aliases (e.g., "blink" for "blink-182")
-    // Lidarr needs the official name to find the correct artist
-    let canonicalArtistName = artistName;
-    try {
-        logger.debug(`   Resolving canonical artist name from MusicBrainz...`);
-        const mbArtist = await musicBrainzService.getArtist(artistMbid);
-        if (mbArtist && mbArtist.name) {
-            canonicalArtistName = mbArtist.name;
-            if (canonicalArtistName !== artistName) {
-                logger.debug(
-                    `   ✓ Canonical name resolved: "${artistName}" → "${canonicalArtistName}"`,
-                );
-            } else {
-                logger.debug(
-                    `   ✓ Name matches canonical: "${canonicalArtistName}"`,
-                );
-            }
-        }
-    } catch (mbError: any) {
-        logger.warn(`   ⚠ MusicBrainz lookup failed: ${mbError.message}`);
-        // Fallback to LastFM correction
-        try {
-            const correction =
-                await lastFmService.getArtistCorrection(artistName);
-            if (correction?.canonicalName) {
-                canonicalArtistName = correction.canonicalName;
-                logger.debug(
-                    `   ✓ Name resolved via LastFM: "${artistName}" → "${canonicalArtistName}"`,
-                );
-            }
-        } catch (lfmError) {
-            logger.warn(
-                `   ⚠ LastFM correction also failed, using original name`,
-            );
-        }
-    }
-
-    try {
-        // First, add the artist to Lidarr (this monitors all albums)
-        const lidarrArtist = await lidarrService.addArtist(
-            artistMbid,
-            canonicalArtistName,
-            rootFolderPath,
-        );
-
-        if (!lidarrArtist) {
-            logger.debug(`   Failed to add artist to Lidarr`);
-            throw new Error("Failed to add artist to Lidarr");
-        }
-
-        logger.debug(`   Artist added to Lidarr (ID: ${lidarrArtist.id})`);
-
-        // Fetch albums from MusicBrainz
-        const releaseGroups = await musicBrainzService.getReleaseGroups(
-            artistMbid,
-            ["album", "ep"],
-            100,
-        );
-
-        logger.debug(
-            `   Found ${releaseGroups.length} albums/EPs from MusicBrainz`,
-        );
-
-        if (releaseGroups.length === 0) {
-            logger.debug(`   No albums found for artist`);
-            return [];
-        }
-
-        // Create individual album jobs
-        const jobs: { id: string; subject: string }[] = [];
-
-        for (const rg of releaseGroups) {
-            const albumMbid = rg.id;
-            const albumTitle = rg.title;
-            const albumSubject = `${artistName} - ${albumTitle}`;
-
-            // Check if we already have this album downloaded
-            const existingAlbum = await prisma.album.findFirst({
-                where: { rgMbid: albumMbid },
-            });
-
-            if (existingAlbum) {
-                logger.debug(
-                    `   Skipping "${albumTitle}" - already in library`,
-                );
-                continue;
-            }
-
-            // Use transaction with row-level locking to prevent race conditions
-            const jobResult = await prisma.$transaction(async (tx) => {
-                // Check for existing active job with FOR UPDATE SKIP LOCKED
-                // This prevents TOCTOU race conditions like in the single download case
-                const existingJobs = await tx.$queryRaw<
-                    Array<{
-                        id: string;
-                        status: string;
-                        subject: string;
-                        createdAt: Date;
-                    }>
-                >`
-                    SELECT id, status, subject, "createdAt"
-                    FROM "DownloadJob"
-                    WHERE "targetMbid" = ${albumMbid}
-                    AND status IN ('pending', 'processing')
-                    FOR UPDATE SKIP LOCKED
-                `;
-
-                if (existingJobs.length > 0) {
-                    return {
-                        skipped: true,
-                        job: existingJobs[0],
-                        reason: "already_queued",
-                    };
-                }
-
-                // Also check for recently failed job (within last 30 seconds) to prevent spam retries
-                const recentFailed = await tx.$queryRaw<
-                    Array<{
-                        id: string;
-                        status: string;
-                        completedAt: Date;
-                    }>
-                >`
-                    SELECT id, status, "completedAt"
-                    FROM "DownloadJob"
-                    WHERE "targetMbid" = ${albumMbid}
-                    AND status = 'failed'
-                    AND "completedAt" >= ${new Date(Date.now() - 30000)}
-                    FOR UPDATE SKIP LOCKED
-                `;
-
-                if (recentFailed.length > 0) {
-                    return {
-                        skipped: true,
-                        job: recentFailed[0],
-                        reason: "recently_failed",
-                    };
-                }
-
-                // Create new job inside transaction
-                const now = new Date();
-                const job = await tx.downloadJob.create({
-                    data: {
-                        userId,
-                        subject: albumSubject,
-                        type: "album",
-                        targetMbid: albumMbid,
-                        status: "pending",
-                        metadata: {
-                            queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER,
-                            downloadType,
-                            rootFolderPath,
-                            artistName,
-                            artistMbid,
-                            albumTitle,
-                            batchId, // Link all albums in this artist download
-                            statusText: "Queued",
-                            batchArtist: artistName,
-                            createdAt: now.toISOString(), // Track when job was created for timeout
-                        },
-                    },
-                });
-
-                return { skipped: false, job };
-            });
-
-            if (jobResult.skipped) {
-                logger.debug(
-                    `   Skipping "${albumTitle}" - ${
-                        jobResult.reason === "recently_failed"
-                            ? "recently failed"
-                            : "already in download queue"
-                    }`,
-                );
-                continue;
-            }
-
-            const job = jobResult.job;
-            jobs.push({ id: job.id, subject: albumSubject });
-            logger.debug(`   [JOB] Created job for: ${albumSubject}`);
-
-            enqueueAlbumDownloadInBackground({
-                jobId: job.id,
-                type: "album",
-                mbid: albumMbid,
-                subject: albumSubject,
-                artistName,
-                albumTitle,
-            });
-        }
-
-        logger.debug(`   Created ${jobs.length} album download jobs`);
-        return jobs;
-    } catch (error: any) {
-        logger.error(`   Failed to process artist download:`, error.message);
-        throw error;
-    }
-}
 
 /**
  * @openapi

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -907,6 +907,11 @@ router.post(
                     mbid: failedJob.targetMbid,
                     subject: failedJob.subject,
                     artistName,
+                    artistMbid:
+                        failedJob.artistMbid ??
+                        (typeof metadata?.artistMbid === "string"
+                            ? metadata.artistMbid
+                            : undefined),
                     albumTitle,
                 }).catch((error) => {
                     logger.error(`[Retry] Album enqueue error:`, error);

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -127,6 +127,7 @@ function dispatchApprovedDownload(dispatch: DownloadDispatch): void {
         mbid: dispatch.mbid,
         subject: dispatch.subject,
         artistName: dispatch.artistName,
+        artistMbid: dispatch.artistMbid,
         albumTitle: dispatch.albumTitle,
     });
 }

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -17,6 +17,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/albumDownloadJobs.ts` | Shared locked album download-job creation and active-job deduplication |
 | `backend/src/services/albumDownloadQueueOwnership.ts` | Persisted album-download queue ownership marker and metadata predicate |
 | `backend/src/services/albumDownloadQueueService.ts` | Durable album download queue admission and observed background enqueue failures |
+| `backend/src/services/artistDownloadExpansionJobs.ts` | Locked creation and active-job deduplication for durable artist discography expansion |
 | `backend/src/services/albumTitleGuards.ts` | Shared remote-album placeholder-title classification |
 | `backend/src/services/albumLoudness.ts` | Transactional active-track loudness rollups and per-album serialization |
 | `backend/src/services/artistCountsService.ts` | Core |
@@ -54,6 +55,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/discovery/index.ts` | Discovery |
 | `backend/src/services/discoveryLogger.ts` | Core |
 | `backend/src/services/downloadDispatcher.ts` | Configured-source album download dispatch (policy resolution and provider routing) |
+| `backend/src/services/downloadArtistMbid.ts` | Artist-MBID reuse and MusicBrainz fallback for manager-backed album downloads |
 | `backend/src/services/downloadJobStatus.ts` | Shared download-job status transitions and guarded metadata patch writes |
 | `backend/src/services/downloadQueue.ts` | Core |
 | `backend/src/services/embeddingSpaceLifecycle.ts` | Blue/green embedding-space cutover and retirement cleanup |

--- a/backend/src/services/__tests__/albumDownloadQueueService.test.ts
+++ b/backend/src/services/__tests__/albumDownloadQueueService.test.ts
@@ -1,6 +1,7 @@
 const mockQueueAdd = jest.fn();
 const mockQueueGetJob = jest.fn();
 const mockDownloadJobFindMany = jest.fn();
+const mockDownloadJobFindUnique = jest.fn();
 const mockDownloadJobUpdate = jest.fn();
 const mockDownloadJobUpdateMany = jest.fn();
 const mockLoggerDebug = jest.fn();
@@ -17,6 +18,8 @@ jest.mock("../../utils/db", () => ({
     prisma: {
         downloadJob: {
             findMany: (...args: unknown[]) => mockDownloadJobFindMany(...args),
+            findUnique: (...args: unknown[]) =>
+                mockDownloadJobFindUnique(...args),
             update: (...args: unknown[]) => mockDownloadJobUpdate(...args),
             updateMany: (...args: unknown[]) =>
                 mockDownloadJobUpdateMany(...args),
@@ -36,10 +39,13 @@ jest.mock("../../utils/logger", () => ({
 import {
     enqueueAlbumDownload,
     enqueueAlbumDownloadInBackground,
+    enqueueArtistDownloadExpansion,
+    recoverUnqueuedArtistDownloadExpansions,
     recoverUnqueuedAlbumDownloads,
 } from "../albumDownloadQueueService";
 import {
     ALBUM_DOWNLOAD_QUEUE_OWNER,
+    ARTIST_DOWNLOAD_EXPANSION_OWNER,
     isAlbumDownloadQueueOwned,
 } from "../albumDownloadQueueOwnership";
 
@@ -58,6 +64,9 @@ describe("album download queue service", () => {
         mockQueueAdd.mockResolvedValue({ id: "albumdl:download-job-1" });
         mockQueueGetJob.mockResolvedValue(null);
         mockDownloadJobFindMany.mockResolvedValue([]);
+        mockDownloadJobFindUnique.mockResolvedValue({
+            metadata: { preserved: true },
+        });
         mockDownloadJobUpdate.mockResolvedValue({});
         mockDownloadJobUpdateMany.mockResolvedValue({ count: 1 });
     });
@@ -84,7 +93,7 @@ describe("album download queue service", () => {
         });
     });
 
-    it("marks the persisted job failed with a static error and rethrows enqueue failure", async () => {
+    it("leaves the job pending with retry metadata and rethrows enqueue failure", async () => {
         const enqueueError = new Error("redis unavailable");
         mockQueueAdd.mockRejectedValueOnce(enqueueError);
 
@@ -93,9 +102,55 @@ describe("album download queue service", () => {
         expect(mockDownloadJobUpdate).toHaveBeenCalledWith({
             where: { id: payload.jobId },
             data: {
-                status: "failed",
-                error: "Download queue unavailable",
-                completedAt: expect.any(Date),
+                metadata: {
+                    preserved: true,
+                    statusText: "Queue admission failed — retrying",
+                },
+            },
+        });
+    });
+
+    it("enqueues artist expansion with its named job and stable id", async () => {
+        const artistPayload = {
+            jobId: "artist-job-1",
+            artistMbid: "artist-mbid-1",
+            artistName: "Artist",
+            downloadType: "library" as const,
+            rootFolderPath: "/music",
+            userId: "user-1",
+        };
+
+        await enqueueArtistDownloadExpansion(artistPayload);
+
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "artist-download-expand",
+            artistPayload,
+            { jobId: "artistdl:artist-job-1" },
+        );
+    });
+
+    it("keeps artist expansion pending when queue admission fails", async () => {
+        const enqueueError = new Error("redis unavailable");
+        mockQueueAdd.mockRejectedValueOnce(enqueueError);
+
+        await expect(
+            enqueueArtistDownloadExpansion({
+                jobId: "artist-job-1",
+                artistMbid: "artist-mbid-1",
+                artistName: "Artist",
+                downloadType: "library",
+                rootFolderPath: "/music",
+                userId: "user-1",
+            }),
+        ).rejects.toBe(enqueueError);
+
+        expect(mockDownloadJobUpdate).toHaveBeenCalledWith({
+            where: { id: "artist-job-1" },
+            data: {
+                metadata: {
+                    preserved: true,
+                    statusText: "Queue admission failed — retrying",
+                },
             },
         });
     });
@@ -266,6 +321,55 @@ describe("album download queue service", () => {
                 },
                 take: 20,
             }),
+        );
+    });
+
+    it("recovers stale pending artist expansion rows", async () => {
+        const now = new Date("2026-08-24T18:00:00.000Z");
+        mockDownloadJobFindMany.mockResolvedValueOnce([
+            {
+                id: "artist-job-1",
+                userId: "user-1",
+                targetMbid: "artist-mbid-1",
+                subject: "Artist",
+                metadata: {
+                    queuedVia: ARTIST_DOWNLOAD_EXPANSION_OWNER,
+                    artistName: "Artist",
+                    downloadType: "discovery",
+                    rootFolderPath: "/music/discovery",
+                },
+            },
+        ]);
+
+        await expect(
+            recoverUnqueuedArtistDownloadExpansions(now),
+        ).resolves.toBe(1);
+
+        expect(mockDownloadJobFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    type: "artist",
+                    status: "pending",
+                    cleared: false,
+                    metadata: {
+                        path: ["queuedVia"],
+                        equals: ARTIST_DOWNLOAD_EXPANSION_OWNER,
+                    },
+                }),
+                take: 20,
+            }),
+        );
+        expect(mockQueueAdd).toHaveBeenCalledWith(
+            "artist-download-expand",
+            {
+                jobId: "artist-job-1",
+                artistMbid: "artist-mbid-1",
+                artistName: "Artist",
+                downloadType: "discovery",
+                rootFolderPath: "/music/discovery",
+                userId: "user-1",
+            },
+            { jobId: "artistdl:artist-job-1" },
         );
     });
 

--- a/backend/src/services/__tests__/downloadDispatcher.test.ts
+++ b/backend/src/services/__tests__/downloadDispatcher.test.ts
@@ -199,6 +199,23 @@ describe("dispatchAlbumDownload", () => {
         );
     });
 
+    it("passes a supplied artist MBID to the manager-backed source", async () => {
+        await dispatchAlbumDownload({
+            ...baseParams,
+            artistMbid: "artist-mbid-1",
+        });
+
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "rg-1",
+            "user-1",
+            false,
+            "artist-mbid-1",
+        );
+    });
+
     it("uses the subject for both names when no delimiter or metadata exists", async () => {
         await dispatchAlbumDownload({
             ...baseParams,

--- a/backend/src/services/__tests__/musicRequestService.test.ts
+++ b/backend/src/services/__tests__/musicRequestService.test.ts
@@ -356,6 +356,7 @@ describe("musicRequestService", () => {
                 mbid: input.rgMbid,
                 subject: `${input.artistName} - ${input.albumTitle}`,
                 artistName: input.artistName,
+                artistMbid: input.artistMbid,
                 albumTitle: input.albumTitle,
                 downloadType: "library",
                 rootFolderPath: "/library",

--- a/backend/src/services/__tests__/simpleDownloadManager.test.ts
+++ b/backend/src/services/__tests__/simpleDownloadManager.test.ts
@@ -244,6 +244,9 @@ describe("simpleDownloadManager", () => {
 
         expect(result.success).toBe(true);
         expect(result.correlationId).toBeDefined();
+        expect(mockMusicBrainzService.getReleaseGroup).toHaveBeenCalledWith(
+            "album-mbid-1",
+        );
         expect(mockLidarrService.addAlbum).toHaveBeenCalledWith(
             "album-mbid-1",
             "Artist",
@@ -266,6 +269,29 @@ describe("simpleDownloadManager", () => {
                     }),
                 }),
             }),
+        );
+    });
+
+    it("uses a supplied artist MBID without querying the release group", async () => {
+        const result = await simpleDownloadManager.startDownload(
+            "job-known-artist",
+            "Artist",
+            "Album",
+            "album-mbid-1",
+            "user-1",
+            false,
+            "artist-mbid-known",
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockMusicBrainzService.getReleaseGroup).not.toHaveBeenCalled();
+        expect(mockLidarrService.addAlbum).toHaveBeenCalledWith(
+            "album-mbid-1",
+            "Artist",
+            "Album",
+            "/music",
+            "artist-mbid-known",
+            false,
         );
     });
 

--- a/backend/src/services/__tests__/tidalLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/tidalLibraryDownload.test.ts
@@ -196,6 +196,8 @@ describe("tidalLibraryDownload", () => {
             "Album",
             "rg-1",
             "user-1",
+            false,
+            undefined,
         );
         expect(mockUpdate).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -278,6 +278,8 @@ describe("youtubeLibraryDownload", () => {
             "Album",
             "rg-1",
             "user-1",
+            false,
+            undefined,
         );
         expect(mockStartAlbum).not.toHaveBeenCalled();
     });

--- a/backend/src/services/albumDownloadJobs.ts
+++ b/backend/src/services/albumDownloadJobs.ts
@@ -18,6 +18,7 @@ export interface CreateAlbumDownloadJobParams {
     mbid: string;
     subject: string;
     artistName?: string;
+    artistMbid?: string;
     albumTitle?: string;
     downloadType: "library" | "discovery";
     rootFolderPath: string;
@@ -100,6 +101,7 @@ async function createWithDatabase(
                 downloadType: params.downloadType,
                 rootFolderPath: params.rootFolderPath,
                 artistName: verifiedArtistName,
+                artistMbid: params.artistMbid,
                 albumTitle: params.albumTitle,
                 statusText: "Queued",
             },

--- a/backend/src/services/albumDownloadQueueOwnership.ts
+++ b/backend/src/services/albumDownloadQueueOwnership.ts
@@ -1,6 +1,10 @@
 /** Persisted owner value for rows managed by the album-download queue. */
 export const ALBUM_DOWNLOAD_QUEUE_OWNER = "album-download-queue" as const;
 
+/** Persisted owner value for artist rows expanded through the album queue. */
+export const ARTIST_DOWNLOAD_EXPANSION_OWNER =
+    "artist-download-expansion" as const;
+
 /** Return whether persisted metadata assigns lifecycle ownership to the queue. */
 export function isAlbumDownloadQueueOwned(metadata: unknown): boolean {
     if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {

--- a/backend/src/services/albumDownloadQueueService.ts
+++ b/backend/src/services/albumDownloadQueueService.ts
@@ -2,10 +2,18 @@ import type { AlbumDownloadDispatchParams } from "./downloadDispatcher";
 import { albumDownloadQueue } from "../workers/queues";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
-import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "./albumDownloadQueueOwnership";
+import {
+    ALBUM_DOWNLOAD_QUEUE_OWNER,
+    ARTIST_DOWNLOAD_EXPANSION_OWNER,
+} from "./albumDownloadQueueOwnership";
+import {
+    ACTIVE_DOWNLOAD_JOB_STATUSES,
+    patchDownloadJobMetadata,
+} from "./downloadJobStatus";
 
 const log = logger.child("AlbumDownloadQueueService");
 const ALBUM_DOWNLOAD_JOB_NAME = "album-download";
+export const ARTIST_DOWNLOAD_EXPANSION_JOB_NAME = "artist-download-expand";
 const ALBUM_DOWNLOAD_RECOVERY_AGE_MS = 5 * 60_000;
 const ALBUM_DOWNLOAD_RECOVERY_LIMIT = 20;
 
@@ -13,9 +21,18 @@ function albumDownloadQueueJobId(jobId: string): string {
     return `albumdl:${jobId}`;
 }
 
+function artistDownloadQueueJobId(jobId: string): string {
+    return `artistdl:${jobId}`;
+}
+
 function readMetadataString(
     metadata: unknown,
-    key: "artistName" | "albumTitle",
+    key:
+        | "artistName"
+        | "artistMbid"
+        | "albumTitle"
+        | "downloadType"
+        | "rootFolderPath",
 ): string | undefined {
     if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
         return undefined;
@@ -26,13 +43,25 @@ function readMetadataString(
 
 async function persistQueueAdmissionFailure(jobId: string): Promise<void> {
     try {
-        await failDownloadJob(jobId, "Download queue unavailable");
+        await patchDownloadJobMetadata(jobId, {
+            statusText: "Queue admission failed — retrying",
+        });
     } catch (error) {
         log.error("Failed to persist album download queue admission failure", {
             jobId,
             error,
         });
     }
+}
+
+/** Payload for one durable artist discography-expansion job. */
+export interface ArtistDownloadExpansionParams {
+    jobId: string;
+    artistMbid: string;
+    artistName: string;
+    downloadType: "library" | "discovery";
+    rootFolderPath: string;
+    userId: string;
 }
 
 /** Add one album download to the durable queue. */
@@ -45,6 +74,27 @@ export async function enqueueAlbumDownload(
             jobId: queueJobId,
         });
         log.debug("Album download queued", {
+            jobId: params.jobId,
+            queueJobId,
+        });
+    } catch (error) {
+        await persistQueueAdmissionFailure(params.jobId);
+        throw error;
+    }
+}
+
+/** Add one artist discography expansion to the album-download queue. */
+export async function enqueueArtistDownloadExpansion(
+    params: ArtistDownloadExpansionParams,
+): Promise<void> {
+    const queueJobId = artistDownloadQueueJobId(params.jobId);
+    try {
+        await albumDownloadQueue.add(
+            ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
+            params,
+            { jobId: queueJobId },
+        );
+        log.debug("Artist download expansion queued", {
             jobId: params.jobId,
             queueJobId,
         });
@@ -77,6 +127,60 @@ async function findRecoveryCandidates(now: Date) {
             metadata: true,
         },
     });
+}
+
+async function findArtistRecoveryCandidates(now: Date) {
+    return prisma.downloadJob.findMany({
+        where: {
+            type: "artist",
+            status: "pending",
+            cleared: false,
+            createdAt: {
+                lt: new Date(now.getTime() - ALBUM_DOWNLOAD_RECOVERY_AGE_MS),
+            },
+            metadata: {
+                path: ["queuedVia"],
+                equals: ARTIST_DOWNLOAD_EXPANSION_OWNER,
+            },
+        },
+        orderBy: { createdAt: "asc" },
+        take: ALBUM_DOWNLOAD_RECOVERY_LIMIT,
+        select: {
+            id: true,
+            userId: true,
+            targetMbid: true,
+            subject: true,
+            metadata: true,
+        },
+    });
+}
+
+type ArtistRecoveryCandidate = Awaited<
+    ReturnType<typeof findArtistRecoveryCandidates>
+>[number];
+
+function buildArtistRecoveryPayload(
+    job: ArtistRecoveryCandidate,
+): ArtistDownloadExpansionParams | null {
+    const rootFolderPath = readMetadataString(job.metadata, "rootFolderPath");
+    if (!rootFolderPath) {
+        log.error("Artist expansion recovery metadata is incomplete", {
+            jobId: job.id,
+        });
+        return null;
+    }
+    return {
+        jobId: job.id,
+        artistMbid: job.targetMbid,
+        artistName:
+            readMetadataString(job.metadata, "artistName") ?? job.subject,
+        downloadType:
+            readMetadataString(job.metadata, "downloadType") === "discovery"
+                ? "discovery"
+                : "library",
+        rootFolderPath,
+        userId: job.userId,
+    };
 }
 
 async function finalizeRecoveredQueueFailure(jobId: string): Promise<void> {
@@ -126,10 +230,9 @@ async function removeIncoherentQueueJob(
 
 async function retainedBullJobHandlesCandidate(
     jobId: string,
+    queueJobId: string,
 ): Promise<boolean> {
-    const queueJob = await albumDownloadQueue.getJob(
-        albumDownloadQueueJobId(jobId),
-    );
+    const queueJob = await albumDownloadQueue.getJob(queueJobId);
     if (!queueJob) return false;
     const state = await queueJob.getState();
     switch (state) {
@@ -156,15 +259,41 @@ export async function recoverUnqueuedAlbumDownloads(
     const staleJobs = await findRecoveryCandidates(now);
 
     for (const job of staleJobs) {
-        if (await retainedBullJobHandlesCandidate(job.id)) continue;
+        if (
+            await retainedBullJobHandlesCandidate(
+                job.id,
+                albumDownloadQueueJobId(job.id),
+            )
+        )
+            continue;
         await enqueueAlbumDownload({
             jobId: job.id,
             type: "album",
             mbid: job.targetMbid,
             subject: job.subject,
             artistName: readMetadataString(job.metadata, "artistName"),
+            artistMbid: readMetadataString(job.metadata, "artistMbid"),
             albumTitle: readMetadataString(job.metadata, "albumTitle"),
         });
+    }
+    return staleJobs.length;
+}
+
+/** Re-enqueue bounded stale artist-expansion jobs with lost Redis admission. */
+export async function recoverUnqueuedArtistDownloadExpansions(
+    now = new Date(),
+): Promise<number> {
+    const staleJobs = await findArtistRecoveryCandidates(now);
+    for (const job of staleJobs) {
+        if (
+            await retainedBullJobHandlesCandidate(
+                job.id,
+                artistDownloadQueueJobId(job.id),
+            )
+        )
+            continue;
+        const payload = buildArtistRecoveryPayload(job);
+        if (payload) await enqueueArtistDownloadExpansion(payload);
     }
     return staleJobs.length;
 }
@@ -180,7 +309,15 @@ export function enqueueAlbumDownloadInBackground(
         });
     });
 }
-import {
-    ACTIVE_DOWNLOAD_JOB_STATUSES,
-    failDownloadJob,
-} from "./downloadJobStatus";
+
+/** Supervise a fire-and-forget artist expansion enqueue operation. */
+export function enqueueArtistDownloadExpansionInBackground(
+    params: ArtistDownloadExpansionParams,
+): void {
+    void enqueueArtistDownloadExpansion(params).catch((error) => {
+        log.error("Artist download expansion enqueue failed", {
+            jobId: params.jobId,
+            error,
+        });
+    });
+}

--- a/backend/src/services/artistDownloadExpansionJobs.ts
+++ b/backend/src/services/artistDownloadExpansionJobs.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from "crypto";
+import type { DownloadJob, Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import { ARTIST_DOWNLOAD_EXPANSION_OWNER } from "./albumDownloadQueueOwnership";
+import { ACTIVE_DOWNLOAD_JOB_STATUSES } from "./downloadJobStatus";
+
+type ArtistExpansionDatabase = Pick<
+    Prisma.TransactionClient,
+    "$queryRaw" | "downloadJob"
+>;
+
+/** Input for one durable artist discography-expansion row. */
+export interface CreateArtistDownloadExpansionJobParams {
+    userId: string;
+    artistMbid: string;
+    artistName: string;
+    downloadType: "library" | "discovery";
+    rootFolderPath: string;
+}
+
+/** A newly created artist row or the active row that already owns expansion. */
+export interface ArtistDownloadExpansionJobResult {
+    job: DownloadJob;
+    duplicate: boolean;
+}
+
+function isP2002(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "P2002"
+    );
+}
+
+async function createWithDatabase(
+    database: ArtistExpansionDatabase,
+    params: CreateArtistDownloadExpansionJobParams,
+): Promise<ArtistDownloadExpansionJobResult> {
+    const existingJobs = await database.$queryRaw<DownloadJob[]>`
+        SELECT *
+        FROM "DownloadJob"
+        WHERE "targetMbid" = ${params.artistMbid}
+        AND type = 'artist'
+        AND status IN ('pending', 'processing')
+        FOR UPDATE SKIP LOCKED
+    `;
+    if (existingJobs.length > 0) {
+        return { job: existingJobs[0], duplicate: true };
+    }
+    const job = await database.downloadJob.create({
+        data: {
+            userId: params.userId,
+            type: "artist",
+            targetMbid: params.artistMbid,
+            subject: params.artistName,
+            status: "pending",
+            metadata: {
+                queuedVia: ARTIST_DOWNLOAD_EXPANSION_OWNER,
+                downloadType: params.downloadType,
+                rootFolderPath: params.rootFolderPath,
+                artistName: params.artistName,
+                batchId: randomUUID(),
+                statusText: "Queued",
+            },
+        },
+    });
+    return { job, duplicate: false };
+}
+
+async function findActiveArtistJob(
+    artistMbid: string,
+): Promise<DownloadJob | null> {
+    return prisma.downloadJob.findFirst({
+        where: {
+            targetMbid: artistMbid,
+            type: "artist",
+            status: { in: [...ACTIVE_DOWNLOAD_JOB_STATUSES] },
+        },
+        orderBy: { createdAt: "asc" },
+    });
+}
+
+/** Create or reuse the active artist expansion row under the lock fence. */
+export async function createArtistDownloadExpansionJob(
+    params: CreateArtistDownloadExpansionJobParams,
+): Promise<ArtistDownloadExpansionJobResult> {
+    try {
+        return await prisma.$transaction((transaction) =>
+            createWithDatabase(transaction, params),
+        );
+    } catch (error) {
+        if (!isP2002(error)) throw error;
+        const job = await findActiveArtistJob(params.artistMbid);
+        if (!job) throw error;
+        return { job, duplicate: true };
+    }
+}

--- a/backend/src/services/downloadArtistMbid.ts
+++ b/backend/src/services/downloadArtistMbid.ts
@@ -1,0 +1,32 @@
+import { logger } from "../utils/logger";
+import { musicBrainzService } from "./musicbrainz";
+
+const log = logger.child?.("DownloadArtistMbid") ?? logger;
+
+/** Return a known artist MBID or resolve it from an album release group. */
+export async function resolveDownloadArtistMbid(
+    albumMbid: string,
+    providedArtistMbid?: string,
+): Promise<string | undefined> {
+    if (providedArtistMbid) return providedArtistMbid;
+    try {
+        const releaseGroup =
+            await musicBrainzService.getReleaseGroup(albumMbid);
+        const artistMbid = releaseGroup?.["artist-credit"]?.[0]?.artist?.id;
+        if (artistMbid) {
+            log.debug("Resolved artist MBID for album download", {
+                albumMbid,
+                artistMbid,
+            });
+        } else {
+            log.warn("Release group has no artist MBID", { albumMbid });
+        }
+        return artistMbid;
+    } catch (error) {
+        log.error("Failed to resolve artist MBID for album download", {
+            albumMbid,
+            error,
+        });
+        return undefined;
+    }
+}

--- a/backend/src/services/downloadDispatcher.ts
+++ b/backend/src/services/downloadDispatcher.ts
@@ -22,6 +22,7 @@ export interface AlbumDownloadDispatchParams {
     mbid: string;
     subject: string;
     artistName?: string;
+    artistMbid?: string;
     albumTitle?: string;
 }
 
@@ -99,13 +100,20 @@ async function dispatchResolvedSource(
     // Lidarr-backed — there is no per-source dispatch below this point, so a
     // "soulseek" selection is executed by the Lidarr manager (pre-existing
     // pipeline limitation).
-    const result = await simpleDownloadManager.startDownload(
+    const managerParams = [
         params.jobId,
         names.artist,
         names.album,
         params.mbid,
         userId,
-    );
+    ] as const;
+    const result = params.artistMbid
+        ? await simpleDownloadManager.startDownload(
+              ...managerParams,
+              false,
+              params.artistMbid,
+          )
+        : await simpleDownloadManager.startDownload(...managerParams);
     if (!result.success) {
         logger.error(`Failed to start download: ${result.error}`);
     }

--- a/backend/src/services/libraryDownloadProcessor.ts
+++ b/backend/src/services/libraryDownloadProcessor.ts
@@ -116,6 +116,10 @@ async function handOffToManager<TMatch, TResult>(
             ? context.metadata.albumMbid
             : "",
         context.userId,
+        false,
+        typeof context.metadata.artistMbid === "string"
+            ? context.metadata.artistMbid
+            : undefined,
     );
     if (result.success) return;
     const prefix = config.prefixManagerFailureLog

--- a/backend/src/services/musicRequestService.ts
+++ b/backend/src/services/musicRequestService.ts
@@ -81,6 +81,7 @@ export interface DownloadDispatch {
     mbid: string;
     subject: string;
     artistName?: string;
+    artistMbid?: string;
     albumTitle?: string;
 }
 
@@ -399,6 +400,7 @@ function approvalJobParams(
         mbid: request.rgMbid,
         subject: `${request.artistName} - ${request.albumTitle}`,
         artistName: request.artistName,
+        artistMbid: request.artistMbid ?? undefined,
         albumTitle: request.albumTitle,
         downloadType: "library",
         rootFolderPath,
@@ -417,6 +419,7 @@ function approvalDispatch(
         mbid: request.rgMbid,
         subject: `${request.artistName} - ${request.albumTitle}`,
         artistName: jobResult.verifiedArtistName,
+        artistMbid: request.artistMbid ?? undefined,
         albumTitle: request.albumTitle,
     };
 }

--- a/backend/src/services/simpleDownloadManager.ts
+++ b/backend/src/services/simpleDownloadManager.ts
@@ -17,7 +17,7 @@ import {
     ReconciliationSnapshot,
 } from "./lidarr";
 import { yieldToEventLoop } from "../utils/async";
-import { musicBrainzService } from "./musicbrainz";
+import { resolveDownloadArtistMbid } from "./downloadArtistMbid";
 import { getSystemSettings } from "../utils/systemSettings";
 import { notificationService } from "./notificationService";
 import { notificationPolicyService } from "./notificationPolicyService";
@@ -187,6 +187,7 @@ class SimpleDownloadManager {
         albumMbid: string,
         userId: string,
         isDiscovery: boolean = false,
+        providedArtistMbid?: string,
     ): Promise<{
         success: boolean;
         correlationId?: string;
@@ -210,27 +211,10 @@ class SimpleDownloadManager {
             const settings = await getSystemSettings();
             const musicPath = settings?.musicPath || config.music.musicPath;
 
-            // Fetch artist MBID from MusicBrainz using the album MBID
-            let artistMbid: string | undefined;
-            try {
-                logger.debug(`   Fetching artist MBID from MusicBrainz...`);
-                const releaseGroup =
-                    await musicBrainzService.getReleaseGroup(albumMbid);
-
-                if (releaseGroup?.["artist-credit"]?.[0]?.artist?.id) {
-                    artistMbid = releaseGroup["artist-credit"][0].artist.id;
-                    logger.debug(`   Found artist MBID: ${artistMbid}`);
-                } else {
-                    logger.warn(
-                        `   Could not extract artist MBID from release group`,
-                    );
-                }
-            } catch (mbError) {
-                logger.error(
-                    `   Failed to fetch artist MBID from MusicBrainz:`,
-                    mbError,
-                );
-            }
+            const artistMbid = await resolveDownloadArtistMbid(
+                albumMbid,
+                providedArtistMbid,
+            );
 
             // Add album to Lidarr (with discovery tag if this is a discovery download)
             const result = await lidarrService.addAlbum(

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -85,10 +85,12 @@ describe("workers runtime behavior", () => {
             async () => undefined,
         );
         const processAlbumDownload = jest.fn(async () => undefined);
+        const processArtistDownloadExpansion = jest.fn(async () => undefined);
         const finalizeAlbumDownloadQueueFailure = jest.fn(
             async () => undefined,
         );
         const recoverUnqueuedAlbumDownloads = jest.fn(async () => 0);
+        const recoverUnqueuedArtistDownloadExpansions = jest.fn(async () => 0);
         const recordAlbumDownloadOutcome = jest.fn();
         const registerRecoveryJobs = jest.fn(async () => undefined);
         const registerFederationProcessors = jest.fn();
@@ -236,8 +238,13 @@ describe("workers runtime behavior", () => {
             processAlbumDownload,
             finalizeAlbumDownloadQueueFailure,
         }));
+        jest.doMock("../processors/artistDownloadExpansionProcessor", () => ({
+            processArtistDownloadExpansion,
+        }));
         jest.doMock("../../services/albumDownloadQueueService", () => ({
+            ARTIST_DOWNLOAD_EXPANSION_JOB_NAME: "artist-download-expand",
             recoverUnqueuedAlbumDownloads,
+            recoverUnqueuedArtistDownloadExpansions,
         }));
         jest.doMock("../../metrics", () => ({
             recordAlbumDownloadOutcome,
@@ -358,8 +365,10 @@ describe("workers runtime behavior", () => {
             processRequestFulfillmentBatch,
             finalizeGenericImportQueueFailure,
             processAlbumDownload,
+            processArtistDownloadExpansion,
             finalizeAlbumDownloadQueueFailure,
             recoverUnqueuedAlbumDownloads,
+            recoverUnqueuedArtistDownloadExpansions,
             recordAlbumDownloadOutcome,
             registerRecoveryJobs,
             registerFederationProcessors,
@@ -427,6 +436,11 @@ describe("workers runtime behavior", () => {
             "album-download",
             1,
             mocks.processAlbumDownload,
+        );
+        expect(mocks.albumDownloadQueue.process).toHaveBeenCalledWith(
+            "artist-download-expand",
+            1,
+            mocks.processArtistDownloadExpansion,
         );
         expect(mocks.registerRecoveryJobs).toHaveBeenCalledTimes(1);
         expect(mocks.registerFederationProcessors).not.toHaveBeenCalled();
@@ -1225,6 +1239,7 @@ describe("workers runtime behavior", () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
         mocks.recoverUnqueuedAlbumDownloads.mockResolvedValueOnce(3);
+        mocks.recoverUnqueuedArtistDownloadExpansions.mockResolvedValueOnce(2);
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         require("../index");
@@ -1247,8 +1262,14 @@ describe("workers runtime behavior", () => {
             "NX",
         );
         expect(mocks.recoverUnqueuedAlbumDownloads).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.recoverUnqueuedArtistDownloadExpansions,
+        ).toHaveBeenCalledTimes(1);
         expect(mocks.logger.info).toHaveBeenCalledWith(
             "Recovered 3 unqueued album downloads",
+        );
+        expect(mocks.logger.info).toHaveBeenCalledWith(
+            "Recovered 2 unqueued artist expansions",
         );
     });
 

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -30,8 +30,13 @@ import {
     finalizeAlbumDownloadQueueFailure,
     processAlbumDownload,
 } from "./processors/albumDownloadProcessor";
+import { processArtistDownloadExpansion } from "./processors/artistDownloadExpansionProcessor";
 import { recordAlbumDownloadOutcome } from "../metrics";
-import { recoverUnqueuedAlbumDownloads } from "../services/albumDownloadQueueService";
+import {
+    ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
+    recoverUnqueuedAlbumDownloads,
+    recoverUnqueuedArtistDownloadExpansions,
+} from "../services/albumDownloadQueueService";
 import {
     startUnifiedEnrichmentWorker,
     stopUnifiedEnrichmentWorker,
@@ -313,6 +318,13 @@ async function processAlbumDownloadRecoveryJob(): Promise<void> {
             const recovered = await recoverUnqueuedAlbumDownloads();
             if (recovered > 0) {
                 log.info(`Recovered ${recovered} unqueued album downloads`);
+            }
+            const recoveredArtists =
+                await recoverUnqueuedArtistDownloadExpansions();
+            if (recoveredArtists > 0) {
+                log.info(
+                    `Recovered ${recoveredArtists} unqueued artist expansions`,
+                );
             }
         },
     );
@@ -641,6 +653,11 @@ albumDownloadQueue.process(
     ALBUM_DOWNLOAD_JOB_NAME,
     ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
     processAlbumDownload,
+);
+albumDownloadQueue.process(
+    ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
+    ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
+    processArtistDownloadExpansion,
 );
 if (config.features.federation) {
     registerFederationProcessors();

--- a/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
@@ -51,6 +51,7 @@ const payload = {
     subject: "Artist - Album",
     artistName: "Artist",
     albumTitle: "Album",
+    artistMbid: "artist-mbid-1",
 } as const;
 
 describe("album download queue processor", () => {
@@ -316,6 +317,34 @@ describe("album download queue processor", () => {
         expect(mockDownloadJobUpdateMany).toHaveBeenCalledWith({
             where: {
                 id: payload.jobId,
+                status: { in: ["pending", "processing"] },
+            },
+            data: {
+                status: "failed",
+                error: "Download failed",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("marks an artist expansion row failed after Bull exhausts retries", async () => {
+        const job = {
+            data: {
+                jobId: "artist-job-1",
+                artistMbid: "artist-mbid-1",
+                artistName: "Artist",
+                downloadType: "library",
+                rootFolderPath: "/music",
+                userId: "user-1",
+            },
+            getState: jest.fn().mockResolvedValue("failed"),
+        } as any;
+
+        await finalizeAlbumDownloadQueueFailure(job, new Error("raw failure"));
+
+        expect(mockDownloadJobUpdateMany).toHaveBeenCalledWith({
+            where: {
+                id: "artist-job-1",
                 status: { in: ["pending", "processing"] },
             },
             data: {

--- a/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
@@ -1,0 +1,271 @@
+const mockDownloadJobFindUnique = jest.fn();
+const mockDownloadJobUpdate = jest.fn();
+const mockAlbumFindFirst = jest.fn();
+const mockTransaction = jest.fn();
+const mockGetArtist = jest.fn();
+const mockGetReleaseGroups = jest.fn();
+const mockGetArtistCorrection = jest.fn();
+const mockEnqueueAlbumDownloadInBackground = jest.fn();
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findUnique: (...args: unknown[]) =>
+                mockDownloadJobFindUnique(...args),
+            update: (...args: unknown[]) => mockDownloadJobUpdate(...args),
+        },
+        album: {
+            findFirst: (...args: unknown[]) => mockAlbumFindFirst(...args),
+        },
+        $transaction: (...args: unknown[]) => mockTransaction(...args),
+    },
+}));
+
+jest.mock("../../../services/musicbrainz", () => ({
+    musicBrainzService: {
+        getArtist: (...args: unknown[]) => mockGetArtist(...args),
+        getReleaseGroups: (...args: unknown[]) => mockGetReleaseGroups(...args),
+    },
+}));
+
+jest.mock("../../../services/lastfm", () => ({
+    lastFmService: {
+        getArtistCorrection: (...args: unknown[]) =>
+            mockGetArtistCorrection(...args),
+    },
+}));
+
+jest.mock("../../../services/albumDownloadQueueService", () => ({
+    enqueueAlbumDownloadInBackground: (...args: unknown[]) =>
+        mockEnqueueAlbumDownloadInBackground(...args),
+}));
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        child: () => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        }),
+    },
+}));
+
+import { processArtistDownloadExpansion } from "../artistDownloadExpansionProcessor";
+
+const payload = {
+    jobId: "artist-job-1",
+    artistMbid: "artist-mbid-1",
+    artistName: "Alias Artist",
+    downloadType: "library",
+    rootFolderPath: "/music",
+    userId: "user-1",
+} as const;
+
+function createJob() {
+    return {
+        data: payload,
+        progress: jest.fn().mockResolvedValue(undefined),
+    } as any;
+}
+
+function transactionResult(
+    active: unknown[],
+    recentFailed: unknown[],
+    createdId?: string,
+) {
+    return async (operation: (transaction: any) => Promise<unknown>) =>
+        operation({
+            $queryRaw: jest
+                .fn()
+                .mockResolvedValueOnce(active)
+                .mockResolvedValueOnce(recentFailed),
+            downloadJob: {
+                create: jest.fn(async ({ data }) => ({
+                    id: createdId,
+                    ...data,
+                })),
+            },
+        });
+}
+
+describe("artist download expansion processor", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockDownloadJobFindUnique.mockResolvedValue({
+            metadata: { batchId: "batch-1", preserved: true },
+        });
+        mockDownloadJobUpdate.mockResolvedValue({});
+        mockGetArtist.mockResolvedValue({ name: "Canonical Artist" });
+        mockGetReleaseGroups.mockResolvedValue([]);
+        mockGetArtistCorrection.mockResolvedValue(null);
+        mockAlbumFindFirst.mockResolvedValue(null);
+        mockEnqueueAlbumDownloadInBackground.mockReturnValue(undefined);
+    });
+
+    it("skips local albums, keeps remote catalog albums, and records expansion counts", async () => {
+        mockGetReleaseGroups.mockResolvedValue([
+            { id: "rg-local", title: "Local Album" },
+            { id: "rg-remote", title: "Remote Album" },
+            { id: "rg-queued", title: "Queued Album" },
+            { id: "rg-recent", title: "Recent Failure" },
+            { id: "rg-new", title: "New Album" },
+        ]);
+        mockAlbumFindFirst.mockImplementation(({ where }) => {
+            expect(where.location).toBe("LIBRARY");
+            return Promise.resolve(
+                where.rgMbid === "rg-local" ? { id: "local-album" } : null,
+            );
+        });
+        mockTransaction
+            .mockImplementationOnce(transactionResult([], [], "job-remote"))
+            .mockImplementationOnce(
+                transactionResult([{ id: "queued-job" }], []),
+            )
+            .mockImplementationOnce(
+                transactionResult([], [{ id: "failed-job" }]),
+            )
+            .mockImplementationOnce(transactionResult([], [], "job-new"));
+
+        const job = createJob();
+        await processArtistDownloadExpansion(job);
+
+        expect(mockGetReleaseGroups).toHaveBeenCalledWith(
+            "artist-mbid-1",
+            ["album", "ep"],
+            100,
+        );
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledTimes(2);
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
+            jobId: "job-remote",
+            type: "album",
+            mbid: "rg-remote",
+            subject: "Canonical Artist - Remote Album",
+            artistName: "Canonical Artist",
+            artistMbid: "artist-mbid-1",
+            albumTitle: "Remote Album",
+        });
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
+            jobId: "job-new",
+            type: "album",
+            mbid: "rg-new",
+            subject: "Canonical Artist - New Album",
+            artistName: "Canonical Artist",
+            artistMbid: "artist-mbid-1",
+            albumTitle: "New Album",
+        });
+        expect(mockDownloadJobUpdate).toHaveBeenLastCalledWith({
+            where: { id: "artist-job-1" },
+            data: {
+                status: "completed",
+                completedAt: expect.any(Date),
+                metadata: {
+                    batchId: "batch-1",
+                    preserved: true,
+                    albumCount: 2,
+                    skippedInLibrary: 1,
+                    skippedQueued: 1,
+                    skippedRecentlyFailed: 1,
+                    statusText: "Queued 2 albums",
+                },
+            },
+        });
+        expect(job.progress).toHaveBeenNthCalledWith(1, 0);
+        expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+    });
+
+    it("persists batch metadata on each created album job", async () => {
+        mockGetReleaseGroups.mockResolvedValue([
+            { id: "rg-new", title: "New Album" },
+        ]);
+        const create = jest.fn().mockResolvedValue({ id: "job-new" });
+        mockTransaction.mockImplementationOnce(async (operation: any) =>
+            operation({
+                $queryRaw: jest
+                    .fn()
+                    .mockResolvedValueOnce([])
+                    .mockResolvedValueOnce([]),
+                downloadJob: { create },
+            }),
+        );
+
+        await processArtistDownloadExpansion(createJob());
+
+        expect(create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                type: "album",
+                targetMbid: "rg-new",
+                metadata: expect.objectContaining({
+                    queuedVia: "album-download-queue",
+                    artistMbid: "artist-mbid-1",
+                    batchId: "batch-1",
+                    batchArtist: "Canonical Artist",
+                }),
+            }),
+        });
+    });
+
+    it("marks the artist row failed when discography enumeration fails", async () => {
+        const error = new Error("MusicBrainz unavailable");
+        mockGetReleaseGroups.mockRejectedValueOnce(error);
+
+        await expect(processArtistDownloadExpansion(createJob())).rejects.toBe(
+            error,
+        );
+
+        expect(mockDownloadJobUpdate).toHaveBeenLastCalledWith({
+            where: { id: "artist-job-1" },
+            data: {
+                status: "failed",
+                error: "MusicBrainz unavailable",
+                completedAt: expect.any(Date),
+                metadata: {
+                    batchId: "batch-1",
+                    preserved: true,
+                    statusText: "MusicBrainz unavailable",
+                },
+            },
+        });
+    });
+
+    it("completes with zero albums when no release groups are missing", async () => {
+        await processArtistDownloadExpansion(createJob());
+
+        expect(mockEnqueueAlbumDownloadInBackground).not.toHaveBeenCalled();
+        expect(mockDownloadJobUpdate).toHaveBeenLastCalledWith({
+            where: { id: "artist-job-1" },
+            data: {
+                status: "completed",
+                completedAt: expect.any(Date),
+                metadata: {
+                    batchId: "batch-1",
+                    preserved: true,
+                    albumCount: 0,
+                    skippedInLibrary: 0,
+                    skippedQueued: 0,
+                    skippedRecentlyFailed: 0,
+                    statusText: "No missing albums to download",
+                },
+            },
+        });
+    });
+
+    it("uses Last.fm correction when canonical MusicBrainz lookup fails", async () => {
+        mockGetArtist.mockRejectedValueOnce(new Error("lookup failed"));
+        mockGetArtistCorrection.mockResolvedValueOnce({
+            canonicalName: "Corrected Artist",
+        });
+        mockGetReleaseGroups.mockResolvedValue([
+            { id: "rg-new", title: "Album" },
+        ]);
+        mockTransaction.mockImplementationOnce(
+            transactionResult([], [], "job-new"),
+        );
+
+        await processArtistDownloadExpansion(createJob());
+
+        expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith(
+            expect.objectContaining({ artistName: "Corrected Artist" }),
+        );
+    });
+});

--- a/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
@@ -217,12 +217,12 @@ describe("artist download expansion processor", () => {
             where: { id: "artist-job-1" },
             data: {
                 status: "failed",
-                error: "MusicBrainz unavailable",
+                error: "Artist expansion failed — see server logs",
                 completedAt: expect.any(Date),
                 metadata: {
                     batchId: "batch-1",
                     preserved: true,
-                    statusText: "MusicBrainz unavailable",
+                    statusText: "Artist expansion failed — see server logs",
                 },
             },
         });

--- a/backend/src/workers/processors/albumDownloadProcessor.ts
+++ b/backend/src/workers/processors/albumDownloadProcessor.ts
@@ -16,6 +16,7 @@ const payloadSchema = z
         mbid: z.string(),
         subject: z.string(),
         artistName: z.string().optional(),
+        artistMbid: z.string().optional(),
         albumTitle: z.string().optional(),
     })
     .strict();

--- a/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
+++ b/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
@@ -45,9 +45,11 @@ interface ArtistAlbumJobInput {
     batchId: string;
 }
 
-function errorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : "Artist expansion failed";
-}
+/**
+ * Persisted failure text is code-owned: the stored job error is returned to
+ * clients via GET /api/downloads, so raw error detail stays in server logs.
+ */
+const EXPANSION_FAILED_TEXT = "Artist expansion failed — see server logs";
 
 async function resolveCanonicalArtistName(
     artistMbid: string,
@@ -267,12 +269,16 @@ async function completeExpansion(
 }
 
 async function failExpansion(jobId: string, error: unknown): Promise<void> {
-    const message = errorMessage(error);
+    log.error("Artist expansion failed", { jobId, error });
     try {
         await patchDownloadJobMetadata(
             jobId,
-            { statusText: message },
-            { status: "failed", error: message, completedAt: new Date() },
+            { statusText: EXPANSION_FAILED_TEXT },
+            {
+                status: "failed",
+                error: EXPANSION_FAILED_TEXT,
+                completedAt: new Date(),
+            },
         );
     } catch (persistenceError) {
         log.error("Failed to persist artist expansion failure", {

--- a/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
+++ b/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
@@ -1,0 +1,315 @@
+import type { Job } from "bull";
+import type { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { ALBUM_DOWNLOAD_QUEUE_OWNER } from "../../services/albumDownloadQueueOwnership";
+import { enqueueAlbumDownloadInBackground } from "../../services/albumDownloadQueueService";
+import { patchDownloadJobMetadata } from "../../services/downloadJobStatus";
+import { lastFmService } from "../../services/lastfm";
+import { musicBrainzService } from "../../services/musicbrainz";
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import { asPlainObject } from "../../utils/plainObject";
+
+const log = logger.child("ArtistDownloadExpansionProcessor");
+const payloadSchema = z
+    .object({
+        jobId: z.string(),
+        artistMbid: z.string(),
+        artistName: z.string(),
+        downloadType: z.enum(["library", "discovery"]),
+        rootFolderPath: z.string(),
+        userId: z.string(),
+    })
+    .strict();
+const MAX_RELEASE_GROUPS = 100;
+const RECENT_FAILURE_AGE_MS = 30_000;
+
+type ArtistExpansionPayload = z.infer<typeof payloadSchema>;
+type ArtistAlbumCreateResult =
+    | { kind: "created"; jobId: string; subject: string }
+    | { kind: "already_queued" | "recently_failed" };
+type ReleaseGroupResult = ArtistAlbumCreateResult | { kind: "in_library" };
+
+interface ExpansionCounts {
+    albumCount: number;
+    skippedInLibrary: number;
+    skippedQueued: number;
+    skippedRecentlyFailed: number;
+}
+
+interface ArtistAlbumJobInput {
+    payload: ArtistExpansionPayload;
+    artistName: string;
+    albumMbid: string;
+    albumTitle: string;
+    batchId: string;
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : "Artist expansion failed";
+}
+
+async function resolveCanonicalArtistName(
+    artistMbid: string,
+    artistName: string,
+): Promise<string> {
+    try {
+        const artist = await musicBrainzService.getArtist(artistMbid);
+        return artist?.name || artistName;
+    } catch (error) {
+        log.warn("MusicBrainz artist lookup failed", { artistMbid, error });
+    }
+    try {
+        const correction = await lastFmService.getArtistCorrection(artistName);
+        return correction?.canonicalName || artistName;
+    } catch (error) {
+        log.warn("Last.fm artist correction failed", { artistMbid, error });
+        return artistName;
+    }
+}
+
+async function readBatchId(jobId: string): Promise<string> {
+    const job = await prisma.downloadJob.findUnique({
+        where: { id: jobId },
+        select: { metadata: true },
+    });
+    const batchId = asPlainObject(job?.metadata).batchId;
+    if (typeof batchId !== "string" || !batchId) {
+        throw new Error("Artist expansion batch metadata is missing");
+    }
+    return batchId;
+}
+
+async function findAlbumSkipReason(
+    transaction: Prisma.TransactionClient,
+    albumMbid: string,
+): Promise<"already_queued" | "recently_failed" | null> {
+    const active = await transaction.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "DownloadJob"
+        WHERE "targetMbid" = ${albumMbid}
+        AND status IN ('pending', 'processing')
+        FOR UPDATE SKIP LOCKED
+    `;
+    if (active.length > 0) return "already_queued";
+    const recentFailed = await transaction.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "DownloadJob"
+        WHERE "targetMbid" = ${albumMbid}
+        AND status = 'failed'
+        AND "completedAt" >= ${new Date(Date.now() - RECENT_FAILURE_AGE_MS)}
+        FOR UPDATE SKIP LOCKED
+    `;
+    return recentFailed.length > 0 ? "recently_failed" : null;
+}
+
+async function createArtistAlbumRow(
+    transaction: Prisma.TransactionClient,
+    input: ArtistAlbumJobInput,
+): Promise<ArtistAlbumCreateResult> {
+    const { payload, artistName, albumMbid, albumTitle, batchId } = input;
+    const subject = `${artistName} - ${albumTitle}`;
+    const createdAt = new Date();
+    const job = await transaction.downloadJob.create({
+        data: {
+            userId: payload.userId,
+            subject,
+            type: "album",
+            targetMbid: albumMbid,
+            status: "pending",
+            metadata: {
+                queuedVia: ALBUM_DOWNLOAD_QUEUE_OWNER,
+                downloadType: payload.downloadType,
+                rootFolderPath: payload.rootFolderPath,
+                artistName,
+                artistMbid: payload.artistMbid,
+                albumTitle,
+                batchId,
+                statusText: "Queued",
+                batchArtist: artistName,
+                createdAt: createdAt.toISOString(),
+            },
+        },
+    });
+    return { kind: "created", jobId: job.id, subject };
+}
+
+async function createAlbumJobInTransaction(
+    transaction: Prisma.TransactionClient,
+    input: ArtistAlbumJobInput,
+): Promise<ArtistAlbumCreateResult> {
+    const skipReason = await findAlbumSkipReason(transaction, input.albumMbid);
+    if (skipReason) return { kind: skipReason };
+    return createArtistAlbumRow(transaction, input);
+}
+
+async function createArtistAlbumJob(
+    payload: ArtistExpansionPayload,
+    artistName: string,
+    albumMbid: string,
+    albumTitle: string,
+    batchId: string,
+): Promise<ArtistAlbumCreateResult> {
+    return prisma.$transaction((transaction) =>
+        createAlbumJobInTransaction(transaction, {
+            payload,
+            artistName,
+            albumMbid,
+            albumTitle,
+            batchId,
+        }),
+    );
+}
+
+function recordAlbumResult(
+    result: ReleaseGroupResult,
+    counts: ExpansionCounts,
+): void {
+    if (result.kind === "created") counts.albumCount += 1;
+    if (result.kind === "in_library") counts.skippedInLibrary += 1;
+    if (result.kind === "already_queued") counts.skippedQueued += 1;
+    if (result.kind === "recently_failed") counts.skippedRecentlyFailed += 1;
+}
+
+async function processReleaseGroup(
+    payload: ArtistExpansionPayload,
+    artistName: string,
+    batchId: string,
+    releaseGroup: { id: string; title: string },
+): Promise<ReleaseGroupResult> {
+    const localAlbum = await prisma.album.findFirst({
+        where: { rgMbid: releaseGroup.id, location: "LIBRARY" },
+        select: { id: true },
+    });
+    if (localAlbum) return { kind: "in_library" };
+    const result = await createArtistAlbumJob(
+        payload,
+        artistName,
+        releaseGroup.id,
+        releaseGroup.title,
+        batchId,
+    );
+    enqueueCreatedAlbum(
+        result,
+        payload,
+        artistName,
+        releaseGroup.id,
+        releaseGroup.title,
+    );
+    return result;
+}
+
+function enqueueCreatedAlbum(
+    result: ArtistAlbumCreateResult,
+    payload: ArtistExpansionPayload,
+    artistName: string,
+    albumMbid: string,
+    albumTitle: string,
+): void {
+    if (result.kind !== "created") return;
+    enqueueAlbumDownloadInBackground({
+        jobId: result.jobId,
+        type: "album",
+        mbid: albumMbid,
+        subject: result.subject,
+        artistName,
+        artistMbid: payload.artistMbid,
+        albumTitle,
+    });
+}
+
+async function expandReleaseGroups(
+    payload: ArtistExpansionPayload,
+    artistName: string,
+    batchId: string,
+): Promise<ExpansionCounts> {
+    const releaseGroups = await musicBrainzService.getReleaseGroups(
+        payload.artistMbid,
+        ["album", "ep"],
+        MAX_RELEASE_GROUPS,
+    );
+    const counts: ExpansionCounts = {
+        albumCount: 0,
+        skippedInLibrary: 0,
+        skippedQueued: 0,
+        skippedRecentlyFailed: 0,
+    };
+    for (
+        let index = 0;
+        index < releaseGroups.length && index < MAX_RELEASE_GROUPS;
+        index += 1
+    ) {
+        const releaseGroup = releaseGroups[index];
+        const result = await processReleaseGroup(
+            payload,
+            artistName,
+            batchId,
+            releaseGroup,
+        );
+        recordAlbumResult(result, counts);
+    }
+    return counts;
+}
+
+async function completeExpansion(
+    jobId: string,
+    counts: ExpansionCounts,
+): Promise<void> {
+    const statusText =
+        counts.albumCount === 0
+            ? "No missing albums to download"
+            : `Queued ${counts.albumCount} albums`;
+    await patchDownloadJobMetadata(
+        jobId,
+        { ...counts, statusText },
+        { status: "completed", completedAt: new Date() },
+    );
+}
+
+async function failExpansion(jobId: string, error: unknown): Promise<void> {
+    const message = errorMessage(error);
+    try {
+        await patchDownloadJobMetadata(
+            jobId,
+            { statusText: message },
+            { status: "failed", error: message, completedAt: new Date() },
+        );
+    } catch (persistenceError) {
+        log.error("Failed to persist artist expansion failure", {
+            jobId,
+            error: persistenceError,
+        });
+    }
+}
+
+/** Validate and expand one queued artist into durable album jobs. */
+export async function processArtistDownloadExpansion(
+    job: Job<unknown>,
+): Promise<void> {
+    const payload = payloadSchema.parse(job.data);
+    await job.progress(0);
+    try {
+        const batchId = await readBatchId(payload.jobId);
+        await patchDownloadJobMetadata(
+            payload.jobId,
+            {
+                statusText: "Enumerating discography",
+            },
+            {
+                status: "processing",
+                startedAt: new Date(),
+                error: null,
+            },
+        );
+        const artistName = await resolveCanonicalArtistName(
+            payload.artistMbid,
+            payload.artistName,
+        );
+        const counts = await expandReleaseGroups(payload, artistName, batchId);
+        await job.progress(100);
+        await completeExpansion(payload.jobId, counts);
+    } catch (error) {
+        await failExpansion(payload.jobId, error);
+        throw error;
+    }
+}

--- a/frontend/features/artist/components/ArtistActionBar.tsx
+++ b/frontend/features/artist/components/ArtistActionBar.tsx
@@ -196,8 +196,8 @@ export function ArtistActionBar({
                         )}
                         title={
                             isPendingDownload
-                                ? "Downloading all tracks"
-                                : "Download all tracks"
+                                ? "Queueing missing albums"
+                                : "Download all missing albums"
                         }
                     >
                         {isPendingDownload ? (

--- a/frontend/features/artist/hooks/useDownloadActions.ts
+++ b/frontend/features/artist/hooks/useDownloadActions.ts
@@ -9,7 +9,8 @@ import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
  * Executes useDownloadActions.
  */
 export function useDownloadActions() {
-    const { addPendingDownload, isPendingByMbid } = useDownloadContext();
+    const { addPendingDownload, removePendingByMbid, isPendingByMbid } =
+        useDownloadContext();
 
     const downloadArtist = useCallback(
         async (artist: Artist | null) => {
@@ -25,7 +26,9 @@ export function useDownloadActions() {
 
             // Check if already downloading
             if (isPendingByMbid(artist.mbid)) {
-                toast.info(`${artist.name} is already being downloaded`);
+                toast.info(
+                    `Missing albums for ${artist.name} are already being queued`,
+                );
                 return;
             }
 
@@ -34,19 +37,23 @@ export function useDownloadActions() {
                 addPendingDownload("artist", artist.name, artist.mbid);
 
                 // Show immediate feedback
-                toast.loading(`Preparing download: "${artist.name}"...`, {
+                toast.loading(`Checking discography for "${artist.name}"...`, {
                     id: `download-${artist.mbid}`,
                 });
 
-                // Trigger download
+                // Trigger background enumeration of missing albums
                 await api.downloadArtist(artist.name, artist.mbid);
 
                 // Update the loading toast to success
-                toast.success(`Downloading ${artist.name}`, {
+                toast.success(`Queueing missing albums for ${artist.name}`, {
                     id: `download-${artist.mbid}`,
                 });
             } catch (error: unknown) {
                 sharedFrontendLogger.error("Failed to download artist:", error);
+                // The request never became a job, so clear the local pending
+                // entry — otherwise the button stays disabled until the stale
+                // sweep runs.
+                removePendingByMbid(artist.mbid);
                 toast.error(
                     error instanceof Error
                         ? error.message
@@ -57,7 +64,7 @@ export function useDownloadActions() {
                 );
             }
         },
-        [addPendingDownload, isPendingByMbid],
+        [addPendingDownload, removePendingByMbid, isPendingByMbid],
     );
 
     const downloadAlbum = useCallback(
@@ -101,6 +108,10 @@ export function useDownloadActions() {
                 });
             } catch (error: unknown) {
                 sharedFrontendLogger.error("Failed to download album:", error);
+                // The request never became a job, so clear the local pending
+                // entry — otherwise the button stays disabled until the stale
+                // sweep runs.
+                removePendingByMbid(mbid);
                 toast.error(
                     error instanceof Error
                         ? error.message
@@ -111,7 +122,7 @@ export function useDownloadActions() {
                 );
             }
         },
-        [addPendingDownload, isPendingByMbid],
+        [addPendingDownload, removePendingByMbid, isPendingByMbid],
     );
 
     return {

--- a/frontend/tests/component/artistActionBar.component.test.ts
+++ b/frontend/tests/component/artistActionBar.component.test.ts
@@ -95,8 +95,22 @@ test("ArtistActionBar renders canonical button set for library artist", async ()
     assert.match(html, /title="Add all to queue"/);
     assert.match(html, /title="Add all to playlist"/);
     assert.match(html, /title="Like all tracks"/);
-    assert.match(html, /title="Download all tracks"/);
+    assert.match(html, /title="Download all missing albums"/);
     assert.match(html, /title="Start artist radio"/);
+});
+
+test("ArtistActionBar shows queueing state on the download button while pending", async () => {
+    const { ArtistActionBar } =
+        await import("../../features/artist/components/ArtistActionBar");
+    const html = renderToStaticMarkup(
+        React.createElement(ArtistActionBar, {
+            ...baseProps,
+            isPendingDownload: true,
+        }),
+    );
+
+    assert.match(html, /title="Queueing missing albums"/);
+    assert.doesNotMatch(html, /title="Download all missing albums"/);
 });
 
 test("ArtistActionBar hides Add to Queue when callback is not provided", async () => {
@@ -191,7 +205,7 @@ test("ArtistActionBar hides download button when downloadsEnabled is false", asy
         }),
     );
 
-    assert.doesNotMatch(html, /title="Download all tracks"/);
+    assert.doesNotMatch(html, /title="Download all missing albums"/);
 });
 
 test("ArtistActionBar shows Listen Together locked state", async () => {

--- a/frontend/tests/component/useDownloadActions.component.test.ts
+++ b/frontend/tests/component/useDownloadActions.component.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const apiState: {
+    downloadArtist: (name: string, mbid: string) => Promise<unknown>;
+    downloadAlbum: (
+        artistName: string,
+        albumTitle: string,
+        rgMbid?: string,
+    ) => Promise<unknown>;
+} = {
+    downloadArtist: async () => ({ id: "job-1", status: "pending" }),
+    downloadAlbum: async () => ({ id: "job-2", status: "pending" }),
+};
+
+const contextCalls: {
+    added: Array<{ type: string; subject: string; mbid: string }>;
+    removedByMbid: string[];
+    pendingMbids: Set<string>;
+} = { added: [], removedByMbid: [], pendingMbids: new Set() };
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: {
+            downloadArtist: (name: string, mbid: string) =>
+                apiState.downloadArtist(name, mbid),
+            downloadAlbum: (
+                artistName: string,
+                albumTitle: string,
+                rgMbid?: string,
+            ) => apiState.downloadAlbum(artistName, albumTitle, rgMbid),
+        },
+    },
+});
+
+mock.module("sonner", {
+    namedExports: {
+        toast: {
+            loading: () => undefined,
+            success: () => undefined,
+            error: () => undefined,
+            info: () => undefined,
+        },
+    },
+});
+
+mock.module("@/lib/download-context", {
+    namedExports: {
+        useDownloadContext: () => ({
+            addPendingDownload: (
+                type: string,
+                subject: string,
+                mbid: string,
+            ) => {
+                contextCalls.added.push({ type, subject, mbid });
+                return "pending-id";
+            },
+            removePendingByMbid: (mbid: string) => {
+                contextCalls.removedByMbid.push(mbid);
+            },
+            isPendingByMbid: (mbid: string) =>
+                contextCalls.pendingMbids.has(mbid),
+        }),
+    },
+});
+
+mock.module("@/lib/logger", {
+    namedExports: {
+        frontendLogger: { error: () => undefined },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    apiState.downloadArtist = async () => ({ id: "job-1", status: "pending" });
+    apiState.downloadAlbum = async () => ({ id: "job-2", status: "pending" });
+    contextCalls.added.length = 0;
+    contextCalls.removedByMbid.length = 0;
+    contextCalls.pendingMbids.clear();
+});
+
+type DownloadArtistFn = (
+    artist: { name: string; mbid: string } | null,
+) => Promise<void>;
+type DownloadAlbumFn = (
+    album: { title: string; rgMbid?: string; mbid?: string },
+    artistName: string,
+    e: { preventDefault: () => void; stopPropagation: () => void },
+) => Promise<void>;
+
+interface CapturedActions {
+    downloadArtist: DownloadArtistFn;
+    downloadAlbum: DownloadAlbumFn;
+}
+
+async function renderDownloadActions(): Promise<CapturedActions> {
+    const { useDownloadActions } =
+        await import("../../features/artist/hooks/useDownloadActions");
+    const { createRoot } = await import("react-dom/client");
+
+    let captured: CapturedActions | null = null;
+    function Harness() {
+        captured = useDownloadActions() as unknown as CapturedActions;
+        return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    await React.act(async () => {
+        createRoot(container).render(React.createElement(Harness));
+    });
+    assert.ok(captured, "download actions were not captured");
+    return captured!;
+}
+
+const clickEvent = {
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+};
+
+test("downloadArtist clears the pending entry when the request fails", async () => {
+    apiState.downloadArtist = async () => {
+        throw new Error("Request timed out after 15000ms");
+    };
+    const { downloadArtist } = await renderDownloadActions();
+
+    await React.act(async () => {
+        await downloadArtist({ name: "Trace Adkins", mbid: "mbid-1" });
+    });
+
+    assert.deepEqual(contextCalls.removedByMbid, ["mbid-1"]);
+});
+
+test("downloadArtist keeps the pending entry on success", async () => {
+    const { downloadArtist } = await renderDownloadActions();
+
+    await React.act(async () => {
+        await downloadArtist({ name: "Trace Adkins", mbid: "mbid-1" });
+    });
+
+    assert.deepEqual(contextCalls.removedByMbid, []);
+    assert.deepEqual(contextCalls.added, [
+        { type: "artist", subject: "Trace Adkins", mbid: "mbid-1" },
+    ]);
+});
+
+test("downloadArtist short-circuits when the artist is already pending", async () => {
+    contextCalls.pendingMbids.add("mbid-1");
+    let apiCalled = false;
+    apiState.downloadArtist = async () => {
+        apiCalled = true;
+        return { id: "job-1", status: "pending" };
+    };
+    const { downloadArtist } = await renderDownloadActions();
+
+    await React.act(async () => {
+        await downloadArtist({ name: "Trace Adkins", mbid: "mbid-1" });
+    });
+
+    assert.equal(apiCalled, false);
+    assert.deepEqual(contextCalls.added, []);
+});
+
+test("downloadAlbum clears the pending entry when the request fails", async () => {
+    apiState.downloadAlbum = async () => {
+        throw new Error("Request timed out after 15000ms");
+    };
+    const { downloadAlbum } = await renderDownloadActions();
+
+    await React.act(async () => {
+        await downloadAlbum(
+            { title: "Dreamin' Out Loud", rgMbid: "rg-1" },
+            "Trace Adkins",
+            clickEvent,
+        );
+    });
+
+    assert.deepEqual(contextCalls.removedByMbid, ["rg-1"]);
+});
+
+test("downloadAlbum keeps the pending entry on success", async () => {
+    const { downloadAlbum } = await renderDownloadActions();
+
+    await React.act(async () => {
+        await downloadAlbum(
+            { title: "Dreamin' Out Loud", rgMbid: "rg-1" },
+            "Trace Adkins",
+            clickEvent,
+        );
+    });
+
+    assert.deepEqual(contextCalls.removedByMbid, []);
+    assert.deepEqual(contextCalls.added, [
+        {
+            type: "album",
+            subject: "Trace Adkins - Dreamin' Out Loud",
+            mbid: "rg-1",
+        },
+    ]);
+});


### PR DESCRIPTION
Closes #759.

## Problem

The artist-page "download all" button ran the entire discography enumeration inline in the HTTP request, and the path hard-required a successful Lidarr add-artist before the per-album source router was ever consulted. Consequences (all hit in production, see the issue for logs):

- TIDAL/YT-only deployments — or any Lidarr/SkyHook flakiness — 500'd with **zero** jobs queued.
- Large discographies outlived the 15-second client timeout even when the server would have succeeded.
- No job ever carried the artist MBID the frontend spinner is keyed on, so the spinner could only clear via a 2-minute stale sweep — even on success.
- Redis admission failures marked jobs `failed`, which the recovery sweep (pending-only) never retried.

## Changes

**Backend**
- `POST /api/downloads` (type=artist) now creates a durable **artist tracking job** (`targetMbid` = artist MBID) and returns immediately; a new `artist-download-expand` worker on the existing album-download queue does the enumeration: canonical-name resolution (MB → Last.fm fallback), release-group fetch, per-album transactional dedup identical to the album button, and per-album dispatch through the configured source router. **No unconditional Lidarr add-artist.**
- The "already in library" skip now matches only `location: "LIBRARY"` albums — remote catalog rows no longer masquerade as owned.
- The tracking job finishes with counts (`albumCount`, skipped in-library/queued/recently-failed) and a human statusText ("Queued N albums" / "No missing albums to download"), and fails with the real error. Bull-exhaustion finalization and a dedicated recovery sweep for stale artist rows are wired in.
- Queue-admission failures now leave rows `pending` (with a statusText marker) so the 5-minute recovery sweep re-enqueues them.
- Known artist MBIDs thread through album dispatch (`AlbumDownloadDispatchParams.artistMbid` → `simpleDownloadManager.startDownload`), eliminating a throttled MusicBrainz `getReleaseGroup` lookup per Lidarr dispatch. Request approval, retry, and library-download fallback paths forward it too.

**Frontend**
- Button/tooltip renamed to **"Download all missing albums"** ("Queueing missing albums" while pending).
- The pending spinner entry clears on request failure (both artist and album download hooks — previously both leaked until the stale sweep) and otherwise resolves through the artist tracking job's lifecycle via the existing `targetMbid` sync.

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size guardrail passed
- verify: backend jest — 9 touched suites: `Test Suites: 9 passed`, `Tests: 269 passed`, exit 0 (downloadsRuntime, notificationsRuntime, albumDownloadQueueService, downloadDispatcher, musicRequestService, simpleDownloadManager, workers indexRuntime, albumDownloadProcessor, artistDownloadExpansionProcessor)
- verify: frontend `tsc --noEmit` exit 0; lint 0 errors at the 183 cap (no new warnings); component tests 14/14 pass on Node 24 (artistActionBar + new useDownloadActions suite)

Follow-up (tracked in the issue comment): split the global album-download claim per source class so Lidarr handoffs don't queue behind in-flight TIDAL/YT holds.