### PR TITLE
feat(playback): track deep links — ?track= autoplay on the album page and Copy link to song

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Songs now have shareable links: "Copy link to song" in a track's menu copies a link that opens the album with that song highlighted and starts playing it (browsers may require a tap first on brand-new devices) (#756).
+
 - Popular tracks on the artist page now show the album name as a clickable link, including for tracks that are not in your library (#757).
 
 ### Changed

--- a/frontend/app/album/[id]/page.tsx
+++ b/frontend/app/album/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
     useAlbumLikedState,
 } from "@/features/album/hooks/useAlbumActions";
 import { useAlbumRequest } from "@/features/album/hooks/useAlbumRequest";
+import { useTrackDeepLink } from "@/features/album/hooks/useTrackDeepLink";
 import { useYtMusicGapFill } from "@/features/album/hooks/useYtMusicGapFill";
 import { useTidalGapFill } from "@/features/album/hooks/useTidalGapFill";
 import { useTrackPreview } from "@/hooks/useTrackPreview";
@@ -128,6 +129,11 @@ export default function AlbumPage({ params }: AlbumPageProps) {
         isYtMatching;
     const hasTracks = Boolean(album?.tracks && album.tracks.length > 0);
     const showTrackPlaceholder = detailsLoading && !hasTracks;
+    const { highlightTrackId } = useTrackDeepLink(
+        album,
+        (track) => playTrackNow(track, album!),
+        hasTracks,
+    );
 
     // Get cover URL for display and color extraction
     // Proxy through API to handle native: URLs and CORS
@@ -309,6 +315,7 @@ export default function AlbumPage({ params }: AlbumPageProps) {
                                 )
                             }
                             isProviderMatching={isProviderMatching}
+                            highlightTrackId={highlightTrackId}
                         />
                     )}
                     {showTrackPlaceholder && <AlbumTracksSkeleton />}

--- a/frontend/components/track/TrackRow.tsx
+++ b/frontend/components/track/TrackRow.tsx
@@ -50,6 +50,7 @@ export function TrackRow({
         <div
             data-tv-card
             data-tv-card-index={index}
+            data-track-id={item.id}
             onClick={onPlay}
             role="button"
             aria-disabled={item.isPlayable === false ? true : undefined}

--- a/frontend/components/ui/TrackOverflowMenu.tsx
+++ b/frontend/components/ui/TrackOverflowMenu.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     EllipsisVertical,
+    Link as LinkIcon,
     ListEnd,
     ListPlus,
     Map as MapIcon,
@@ -105,6 +106,14 @@ export function TrackOverflowMenu({
     // Album href
     const albumHref = track.album?.id ? `/album/${track.album.id}` : null;
 
+    // Song deep link — the album page consumes ?track= by scrolling to the
+    // row and starting playback. Only local tracks with album identity have
+    // a stable URL to hand out.
+    const trackLinkPath =
+        !isRemote && track.album?.id
+            ? `/album/${track.album.id}?track=${encodeURIComponent(track.id)}`
+            : null;
+
     // Outside click and escape handlers
     useEffect(() => {
         if (!isOpen) return;
@@ -182,6 +191,20 @@ export function TrackOverflowMenu({
             toast.success(`Added "${track.title}" to playlist`);
         },
         [track],
+    );
+
+    const handleCopyTrackLink = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            closeMenu();
+            if (!trackLinkPath) return;
+            const url = `${window.location.origin}${trackLinkPath}`;
+            void navigator.clipboard.writeText(url).then(
+                () => toast.success("Song link copied"),
+                () => toast.error("Could not copy the song link"),
+            );
+        },
+        [trackLinkPath, closeMenu],
     );
 
     const handleGoToArtist = useCallback(
@@ -349,6 +372,14 @@ export function TrackOverflowMenu({
                                 onClick={handleShare}
                                 icon={<Share2 className="h-4 w-4" />}
                                 label="Share"
+                            />
+                        )}
+
+                        {trackLinkPath && (
+                            <MenuButton
+                                onClick={handleCopyTrackLink}
+                                icon={<LinkIcon className="h-4 w-4" />}
+                                label="Copy link to song"
                             />
                         )}
 

--- a/frontend/features/album/components/TrackList.tsx
+++ b/frontend/features/album/components/TrackList.tsx
@@ -30,6 +30,8 @@ interface TrackListProps {
     previewPlaying: boolean;
     onPreview: (track: Track, e: React.MouseEvent) => void;
     isProviderMatching?: boolean;
+    /** Track id to visually highlight (e.g. from a ?track= deep link). */
+    highlightTrackId?: string | null;
 }
 
 export const TrackList = memo(function TrackList({
@@ -43,6 +45,7 @@ export const TrackList = memo(function TrackList({
     previewPlaying,
     onPreview,
     isProviderMatching = false,
+    highlightTrackId = null,
 }: TrackListProps) {
     const isOwned = source === "library";
 
@@ -243,6 +246,8 @@ export const TrackList = memo(function TrackList({
                     state.isPlaying && "bg-surface-hover border-l-2",
                     isPreviewOnly && "opacity-70 hover:opacity-90",
                     isFederated && !track.peer?.online && "opacity-50",
+                    highlightTrackId === track.id &&
+                        "bg-brand/[0.12] ring-1 ring-inset ring-brand/50",
                 ),
             };
         },
@@ -253,6 +258,7 @@ export const TrackList = memo(function TrackList({
             previewTrack,
             previewPlaying,
             onPreview,
+            highlightTrackId,
         ],
     );
 

--- a/frontend/features/album/hooks/useTrackDeepLink.ts
+++ b/frontend/features/album/hooks/useTrackDeepLink.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { Album, Track } from "../types";
+
+function escapeAttributeValue(value: string): string {
+    if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+        return CSS.escape(value);
+    }
+    return value.replace(/["\\]/g, "\\$&");
+}
+
+function scrollTrackIntoView(trackId: string): void {
+    const row = document.querySelector(
+        `[data-track-id="${escapeAttributeValue(trackId)}"]`,
+    );
+    row?.scrollIntoView({ block: "center", behavior: "smooth" });
+}
+
+/**
+ * Consume a `?track=<id>` deep link on the album page: once the track list is
+ * ready, scroll the row into view, highlight it, and attempt playback. The
+ * browser may block unmuted autoplay without a prior gesture — the audio
+ * engine then leaves the track loaded and paused, which is the intended
+ * fallback.
+ */
+export function useTrackDeepLink(
+    album: Album | null,
+    playTrack: (track: Track, index: number) => void,
+    ready: boolean,
+): { highlightTrackId: string | null } {
+    const consumedRef = useRef(false);
+
+    const requestedTrackId = useMemo(() => {
+        if (typeof window === "undefined") return null;
+        return new URLSearchParams(window.location.search).get("track");
+    }, []);
+
+    const highlightTrackId = useMemo(() => {
+        if (!requestedTrackId || !ready) return null;
+        const tracks = album?.tracks;
+        if (!tracks?.some((track) => track.id === requestedTrackId)) {
+            return null;
+        }
+        return requestedTrackId;
+    }, [requestedTrackId, album, ready]);
+
+    useEffect(() => {
+        if (!highlightTrackId || consumedRef.current) return;
+        consumedRef.current = true;
+
+        scrollTrackIntoView(highlightTrackId);
+        const tracks = album?.tracks ?? [];
+        const index = tracks.findIndex(
+            (track) => track.id === highlightTrackId,
+        );
+        if (index >= 0) playTrack(tracks[index], index);
+    }, [highlightTrackId, album, playTrack]);
+
+    return { highlightTrackId };
+}

--- a/frontend/tests/component/trackCopyLink.component.test.ts
+++ b/frontend/tests/component/trackCopyLink.component.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+    installTrackOverflowHarness,
+    trackOverflowIcon,
+} from "../trackOverflowHarness";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const copied: string[] = [];
+
+mock.module("lucide-react", {
+    namedExports: {
+        EllipsisVertical: trackOverflowIcon,
+        Link: trackOverflowIcon,
+        ListEnd: trackOverflowIcon,
+        ListPlus: trackOverflowIcon,
+        Map: trackOverflowIcon,
+        Plus: trackOverflowIcon,
+        Share2: trackOverflowIcon,
+        User: trackOverflowIcon,
+        Disc3: trackOverflowIcon,
+        AudioWaveform: trackOverflowIcon,
+        Radio: trackOverflowIcon,
+    },
+});
+
+installTrackOverflowHarness(mock, {
+    useAudioControls: () => ({
+        playNext: () => undefined,
+        addToQueue: () => undefined,
+        playTrack: () => undefined,
+        startVibeMode: async () => ({ success: true, trackCount: 10 }),
+    }),
+    useAudioState: () => ({ playbackType: "track", currentTrack: null }),
+});
+
+mock.module("next/navigation", {
+    namedExports: { useRouter: () => ({ push: () => undefined }) },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: { addTrackToPlaylist: async () => undefined },
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    copied.length = 0;
+    Object.defineProperty(window.navigator, "clipboard", {
+        configurable: true,
+        value: {
+            writeText: (text: string) => {
+                copied.push(text);
+                return Promise.resolve();
+            },
+        },
+    });
+    window.location.href = "http://localhost/search";
+});
+
+const localTrack = {
+    id: "track-1",
+    title: "Test Track",
+    artist: { name: "Test Artist", id: "artist-1" },
+    album: { title: "Test Album", id: "album-1" },
+    duration: 240,
+};
+
+async function renderMenu(track: unknown): Promise<{
+    container: HTMLElement;
+    unmount: () => void;
+}> {
+    const { TrackOverflowMenu } =
+        await import("../../components/ui/TrackOverflowMenu");
+    const { createRoot } = await import("react-dom/client");
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(
+            React.createElement(TrackOverflowMenu, { track: track as never }),
+        );
+    });
+    // Open the menu.
+    const trigger = container.querySelector('[aria-haspopup="menu"]');
+    assert.ok(trigger, "menu trigger not found");
+    await React.act(async () => {
+        (trigger as HTMLElement).click();
+    });
+    return {
+        container,
+        unmount: () => {
+            void React.act(() => {
+                root.unmount();
+            });
+        },
+    };
+}
+
+function findMenuItem(
+    container: HTMLElement,
+    label: string,
+): HTMLElement | null {
+    const buttons = Array.from(container.querySelectorAll("button"));
+    return (
+        (buttons.find((button) =>
+            button.textContent?.includes(label),
+        ) as HTMLElement) ?? null
+    );
+}
+
+test("copies an /album?track= link for a local track", async () => {
+    const { container, unmount } = await renderMenu(localTrack);
+
+    const item = findMenuItem(container, "Copy link to song");
+    assert.ok(item, "Copy link to song item not found");
+    await React.act(async () => {
+        item!.click();
+    });
+
+    assert.deepEqual(copied, ["http://localhost/album/album-1?track=track-1"]);
+    unmount();
+});
+
+test("hides the copy item for remote provider tracks", async () => {
+    const { container, unmount } = await renderMenu({
+        ...localTrack,
+        streamSource: "youtube",
+    });
+
+    assert.equal(findMenuItem(container, "Copy link to song"), null);
+    unmount();
+});
+
+test("hides the copy item when the track has no album id", async () => {
+    const { container, unmount } = await renderMenu({
+        ...localTrack,
+        album: { title: "Test Album" },
+    });
+
+    assert.equal(findMenuItem(container, "Copy link to song"), null);
+    unmount();
+});

--- a/frontend/tests/component/trackDeepLink.component.test.ts
+++ b/frontend/tests/component/trackDeepLink.component.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // Best-effort teardown.
+    }
+});
+
+beforeEach(() => {
+    window.location.href = "http://localhost/album/al1";
+});
+
+const albumTracks = [
+    { id: "t1", title: "One" },
+    { id: "t2", title: "Two" },
+    { id: "t3", title: "Three" },
+];
+
+type HookResult = { highlightTrackId: string | null };
+
+async function renderHook(
+    playSpy: (track: { id: string }, index: number) => void,
+    ready = true,
+): Promise<{ result: () => HookResult; unmount: () => void }> {
+    const { useTrackDeepLink } =
+        await import("../../features/album/hooks/useTrackDeepLink");
+    const { createRoot } = await import("react-dom/client");
+
+    let latest: HookResult = { highlightTrackId: null };
+    function Harness() {
+        latest = useTrackDeepLink(
+            { tracks: albumTracks } as never,
+            playSpy as never,
+            ready,
+        );
+        return null;
+    }
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await React.act(async () => {
+        root.render(React.createElement(Harness));
+    });
+    return {
+        result: () => latest,
+        unmount: () => {
+            void React.act(() => {
+                root.unmount();
+            });
+        },
+    };
+}
+
+test("plays and highlights the track named in the ?track param", async () => {
+    window.location.href = "http://localhost/album/al1?track=t2";
+    const played: Array<{ id: string; index: number }> = [];
+    const { result, unmount } = await renderHook((track, index) =>
+        played.push({ id: track.id, index }),
+    );
+
+    assert.deepEqual(played, [{ id: "t2", index: 1 }]);
+    assert.equal(result().highlightTrackId, "t2");
+    unmount();
+});
+
+test("does nothing without a ?track param", async () => {
+    const played: unknown[] = [];
+    const { result, unmount } = await renderHook((track) => played.push(track));
+
+    assert.deepEqual(played, []);
+    assert.equal(result().highlightTrackId, null);
+    unmount();
+});
+
+test("ignores a ?track id that is not in the album", async () => {
+    window.location.href = "http://localhost/album/al1?track=missing";
+    const played: unknown[] = [];
+    const { result, unmount } = await renderHook((track) => played.push(track));
+
+    assert.deepEqual(played, []);
+    assert.equal(result().highlightTrackId, null);
+    unmount();
+});
+
+test("consumes the param once, not on every render", async () => {
+    window.location.href = "http://localhost/album/al1?track=t1";
+    const played: unknown[] = [];
+    const { unmount } = await renderHook((track) => played.push(track));
+
+    // A second hook mount in the same document simulates a re-render cycle;
+    // the ref guard means the first mount already consumed the param, and a
+    // fresh mount plays again by design (new page visit). Within one mount,
+    // strict-mode double effects must not double-play.
+    assert.equal(played.length, 1);
+    unmount();
+});


### PR DESCRIPTION
Part of #756 (first slice: playback deep links).

## What

There was no URL that identified a single track — songs couldn't be linked, shared, or bookmarked. Modeled on YouTube Music, where a song URL is just a player URL:

- `/album/<albumId>?track=<trackId>` now scrolls the track's row into view, highlights it, and attempts playback. When the browser blocks unmuted autoplay (no prior gesture on the site), the track is left loaded and paused — the intended fallback.
- The track overflow menu gains **"Copy link to song"** for local tracks with album identity (hidden for provider-remote tracks and tracks without an album id).

## How

- New `useTrackDeepLink` hook on the album page: reads `?track=` once per visit (ref-guarded against strict-mode double effects), derives the highlight id purely (no setState-in-effect), scrolls via a new `data-track-id` attribute on the shared `TrackRow`, and plays through the existing `playTrackNow` path.
- Album `TrackList` accepts `highlightTrackId` and rings the matching row.
- Menu item copies `origin + /album/<id>?track=<id>` via the clipboard API with success/failure toasts.

## Verification

- verify: frontend `tsc --noEmit` exit 0; lint 0 errors at exactly the 183-warning cap (no new warnings); prettier clean on all changed files
- verify: component tests on Node 24 — 4 new deep-link hook tests + 3 new copy-link menu tests, plus the 4 pre-existing overflow-menu suites (19 tests) all pass