### PR TITLE
feat(search): artist/album-aware track matching, typo-tolerant ranked fallback, offset pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Popular tracks on the artist page now show the album name as a clickable link, including for tracks that are not in your library (#757).
+- Search API supports offset pagination for type-scoped searches.
 
 ### Changed
 
+- Search now matches songs by artist and album name, tolerates typos, and ranks fallback results by similarity instead of alphabetically.
 - Download job metadata updates now flow through guarded helpers instead of ad-hoc merges scattered across the backend.
 - TIDAL and YouTube Music library downloads now run through one shared processor with per-source steps, so fixes apply to both sources at once.
 - Consolidated repeated backend error handling, download-job state transitions, availability probes, queue event wiring, and value parsing behind shared internal helpers.

--- a/backend/prisma/migrations/20260825120000_add_search_trigram_indexes/migration.sql
+++ b/backend/prisma/migrations/20260825120000_add_search_trigram_indexes/migration.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS "Track_title_trgm_idx"
+    ON "Track" USING GIN (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Album_title_trgm_idx"
+    ON "Album" USING GIN (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Artist_name_trgm_idx"
+    ON "Artist" USING GIN (name gin_trgm_ops);

--- a/backend/src/routes/__tests__/searchRuntime.test.ts
+++ b/backend/src/routes/__tests__/searchRuntime.test.ts
@@ -204,6 +204,7 @@ describe("search route runtime behavior", () => {
                 q: "  radiohead ",
                 type: "all",
                 limit: "999",
+                offset: "50",
                 genre: "alt",
             },
         } as any;
@@ -272,10 +273,45 @@ describe("search route runtime behavior", () => {
             query: "dj",
             type: "artists",
             limit: 1,
+            offset: 0,
             genre: undefined,
         });
         expect(res.statusCode).toBe(200);
     });
+
+    it("passes a validated offset to type-scoped search", async () => {
+        const req = {
+            query: { q: "creep", type: "tracks", offset: "25" },
+        } as any;
+        const res = createRes();
+
+        await rootHandler(req, res);
+
+        expect(mockSearchByType).toHaveBeenCalledWith({
+            query: "creep",
+            type: "tracks",
+            limit: 20,
+            offset: 25,
+            genre: undefined,
+        });
+        expect(res.statusCode).toBe(200);
+    });
+
+    it.each(["-1", "10001", "1.5", "not-a-number"])(
+        "rejects invalid offset %s",
+        async (offset) => {
+            const req = {
+                query: { q: "creep", type: "tracks", offset },
+            } as any;
+            const res = createRes();
+
+            await rootHandler(req, res);
+
+            expect(mockSearchByType).not.toHaveBeenCalled();
+            expect(res.statusCode).toBe(400);
+            expect(res.body).toEqual({ error: "Invalid search query" });
+        },
+    );
 
     it("passes a validated peers source filter to the search service", async () => {
         const req = {
@@ -289,6 +325,7 @@ describe("search route runtime behavior", () => {
             query: "shared",
             type: "tracks",
             limit: 20,
+            offset: 0,
             genre: undefined,
             source: "peers",
         });
@@ -325,6 +362,7 @@ describe("search route runtime behavior", () => {
             query: "shared",
             type: "tracks",
             limit: 20,
+            offset: 0,
             genre: undefined,
         });
     });
@@ -354,6 +392,7 @@ describe("search route runtime behavior", () => {
             query: "jazz",
             type: "albums",
             limit: 20,
+            offset: 0,
             genre: undefined,
         });
         expect(res.statusCode).toBe(500);

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -33,6 +33,7 @@ const searchQuerySchema = z.object({
         const parsed = Number.parseInt(String(value ?? "20"), 10);
         return Number.isNaN(parsed) ? 20 : Math.min(Math.max(parsed, 1), 100);
     }, z.number().int()),
+    offset: z.coerce.number().int().min(0).max(10_000).default(0),
     source: z.enum(LIBRARY_ORIGIN_VALUES).default("all"),
 });
 
@@ -265,6 +266,14 @@ router.use(requireAuth);
  *           maximum: 100
  *         description: Maximum number of results per type
  *         default: 20
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *           maximum: 10000
+ *           default: 0
+ *         description: Zero-based result offset for type-scoped searches; ignored when type is all
  *     responses:
  *       200:
  *         description: Search results
@@ -306,7 +315,7 @@ router.get("/", async (req, res) => {
         if (!parsed.success) {
             return res.status(400).json({ error: "Invalid search query" });
         }
-        const { type, genre, source } = parsed.data;
+        const { type, genre, offset, source } = parsed.data;
         const query = parsed.data.q.trim();
         const searchLimit = parsed.data.limit;
         const sourceOption = req.query.source === undefined ? {} : { source };
@@ -339,6 +348,7 @@ router.get("/", async (req, res) => {
             query,
             type: type as string,
             limit: searchLimit,
+            offset,
             genre: genre as string | undefined,
             ...sourceOption,
         });

--- a/backend/src/services/__tests__/searchService.test.ts
+++ b/backend/src/services/__tests__/searchService.test.ts
@@ -30,6 +30,49 @@ const logger = {
     warn: jest.fn(),
     error: jest.fn(),
 };
+const MAX_SQL_FRAGMENT_VALUES = 128;
+
+interface SqlFragment {
+    strings: readonly string[];
+    values: readonly unknown[];
+}
+
+function isSqlFragment(value: unknown): value is SqlFragment {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        Array.isArray((value as Partial<SqlFragment>).strings) &&
+        Array.isArray((value as Partial<SqlFragment>).values)
+    );
+}
+
+function collectSql(fragment: SqlFragment): {
+    text: string;
+    values: unknown[];
+} {
+    const pending: unknown[] = [fragment];
+    const values: unknown[] = [];
+    let text = "";
+    for (
+        let index = 0;
+        index < pending.length && index < MAX_SQL_FRAGMENT_VALUES;
+        index += 1
+    ) {
+        const value = pending[index];
+        if (isSqlFragment(value)) {
+            text += value.strings.join("");
+            pending.push(...value.values);
+        } else if (Array.isArray(value)) {
+            pending.push(...value);
+        } else {
+            values.push(value);
+        }
+    }
+    if (pending.length > MAX_SQL_FRAGMENT_VALUES) {
+        throw new Error("SQL fragment exceeded the test inspection bound");
+    }
+    return { text, values };
+}
 
 jest.mock("../../utils/db", () => ({
     prisma,
@@ -126,12 +169,13 @@ describe("search service", () => {
             expect.objectContaining({ id: "artist-1", rank: 0.91 }),
         ]);
 
-        prisma.artist.findMany.mockResolvedValueOnce([
+        prisma.$queryRaw.mockResolvedValueOnce([
             {
                 id: "artist-2",
                 name: "Fallback Artist",
                 mbid: "mbid-2",
                 heroUrl: "https://hero",
+                rank: 0.72,
             },
         ]);
         await expect(
@@ -142,19 +186,21 @@ describe("search service", () => {
                 name: "Fallback Artist",
                 mbid: "mbid-2",
                 heroUrl: "https://hero",
-                rank: 0,
+                rank: 0.72,
             },
         ]);
 
-        prisma.$queryRaw.mockRejectedValueOnce(new Error("artist fts failed"));
-        prisma.artist.findMany.mockResolvedValueOnce([
-            {
-                id: "artist-3",
-                name: "Recovered Artist",
-                mbid: "mbid-3",
-                heroUrl: null,
-            },
-        ]);
+        prisma.$queryRaw
+            .mockRejectedValueOnce(new Error("artist fts failed"))
+            .mockResolvedValueOnce([
+                {
+                    id: "artist-3",
+                    name: "Recovered Artist",
+                    mbid: "mbid-3",
+                    heroUrl: null,
+                    rank: 0.64,
+                },
+            ]);
         await expect(
             searchService.searchArtists({
                 query: "recovered",
@@ -167,7 +213,7 @@ describe("search service", () => {
                 name: "Recovered Artist",
                 mbid: "mbid-3",
                 heroUrl: null,
-                rank: 0,
+                rank: 0.64,
             },
         ]);
         expect(logger.error).toHaveBeenCalled();
@@ -219,17 +265,19 @@ describe("search service", () => {
             }),
         ]);
 
-        prisma.$queryRaw.mockRejectedValueOnce(new Error("album fts failed"));
-        prisma.album.findMany.mockResolvedValueOnce([
-            {
-                id: "album-2",
-                title: "Album Fallback",
-                artistId: "artist-2",
-                year: null,
-                coverUrl: null,
-                artist: { name: "Artist 2" },
-            },
-        ]);
+        prisma.$queryRaw
+            .mockRejectedValueOnce(new Error("album fts failed"))
+            .mockResolvedValueOnce([
+                {
+                    id: "album-2",
+                    title: "Album Fallback",
+                    artistId: "artist-2",
+                    artistName: "Artist 2",
+                    year: null,
+                    coverUrl: null,
+                    rank: 0.58,
+                },
+            ]);
         await expect(
             searchService.searchAlbums({
                 query: "fallback",
@@ -244,25 +292,24 @@ describe("search service", () => {
                 artistName: "Artist 2",
                 year: null,
                 coverUrl: null,
-                rank: 0,
+                rank: 0.58,
             },
         ]);
 
-        prisma.track.findMany.mockResolvedValueOnce([
+        prisma.$queryRaw.mockResolvedValueOnce([
             {
                 id: "track-2",
                 title: "Track Fallback",
                 albumId: "album-2",
+                albumTitle: "Album Fallback",
+                artistId: "artist-2",
+                artistName: "Artist 2",
                 duration: 180,
                 loudnessLufs: null,
                 truePeakDb: null,
-                album: {
-                    title: "Album Fallback",
-                    artistId: "artist-2",
-                    albumLoudnessLufs: null,
-                    albumTruePeakDb: null,
-                    artist: { name: "Artist 2" },
-                },
+                albumLoudnessLufs: null,
+                albumTruePeakDb: null,
+                rank: 0.81,
             },
         ]);
         await expect(
@@ -280,60 +327,141 @@ describe("search service", () => {
                 truePeakDb: null,
                 albumLoudnessLufs: null,
                 albumTruePeakDb: null,
-                rank: 0,
+                rank: 0.81,
             },
         ]);
     });
 
+    it.each([
+        [
+            "artists",
+            () => searchService.searchArtists({ query: "radiahead" }),
+            {
+                id: "artist-fuzzy",
+                name: "Radiohead",
+                mbid: "mbid-fuzzy",
+                heroUrl: null,
+                rank: 0.73,
+            },
+        ],
+        [
+            "albums",
+            () => searchService.searchAlbums({ query: "pablo hony" }),
+            {
+                id: "album-fuzzy",
+                title: "Pablo Honey",
+                artistId: "artist-fuzzy",
+                artistName: "Radiohead",
+                year: 1993,
+                coverUrl: null,
+                rank: 0.68,
+            },
+        ],
+        [
+            "tracks",
+            () => searchService.searchTracks({ query: "crepe" }),
+            {
+                id: "track-fuzzy",
+                title: "Creep",
+                albumId: "album-fuzzy",
+                albumTitle: "Pablo Honey",
+                artistId: "artist-fuzzy",
+                artistName: "Radiohead",
+                duration: 238,
+                loudnessLufs: null,
+                truePeakDb: null,
+                albumLoudnessLufs: null,
+                albumTruePeakDb: null,
+                rank: 0.61,
+            },
+        ],
+    ])(
+        "uses ranked raw SQL for %s fallback results",
+        async (_type, run, row) => {
+            prisma.$queryRaw
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([row]);
+
+            await expect(run()).resolves.toEqual([row]);
+
+            expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+            expect(prisma.artist.findMany).not.toHaveBeenCalled();
+            expect(prisma.album.findMany).not.toHaveBeenCalled();
+            expect(prisma.track.findMany).not.toHaveBeenCalled();
+        },
+    );
+
+    it("caps cross-column track FTS at six terms", async () => {
+        prisma.$queryRaw.mockResolvedValueOnce([
+            {
+                id: "track-six-terms",
+                title: "Six Terms",
+                albumId: "album-six-terms",
+                albumTitle: "Six Terms Album",
+                artistId: "artist-six-terms",
+                artistName: "Six Terms Artist",
+                duration: 180,
+                rank: 1,
+            },
+        ]);
+
+        await searchService.searchTracks({
+            query: "one two three four five six seven eight",
+        });
+
+        expect(logger.debug).toHaveBeenCalledWith(
+            "[SEARCH] Dropped 2 track search terms after the 6-term limit",
+        );
+    });
+
+    it.each([
+        [
+            "artists",
+            () =>
+                searchService.searchArtists({ query: "***", source: "peers" }),
+        ],
+        [
+            "albums",
+            () => searchService.searchAlbums({ query: "***", source: "peers" }),
+        ],
+        [
+            "tracks",
+            () => searchService.searchTracks({ query: "***", source: "peers" }),
+        ],
+    ])(
+        "preserves peers-only visibility in %s fallback SQL",
+        async (_type, run) => {
+            await run();
+
+            const [strings, ...values] = prisma.$queryRaw.mock.calls[0];
+            const query = collectSql({ strings: [...strings], values });
+            expect(query.values).toContain("FEDERATED");
+            expect(query.values).not.toContain("LOCAL");
+            expect(query.text).toContain('"dedupOfTrackId" IS NULL');
+        },
+    );
+
     it("keeps remote-only albums, hides removed-only albums, and keeps mixed albums", async () => {
-        prisma.album.findMany.mockImplementationOnce(async (args) => {
-            expect(args.where.AND[0]).toEqual({
-                OR: [
-                    { tracks: { none: {} } },
-                    {
-                        tracks: {
-                            some: {
-                                removedAt: null,
-                                OR: [
-                                    { origin: "LOCAL" },
-                                    {
-                                        origin: "FEDERATED",
-                                        OR: [
-                                            { dedupOfTrackId: null },
-                                            {
-                                                federationPeer: {
-                                                    showDedupedCopies: true,
-                                                },
-                                            },
-                                            {
-                                                dedupOfTrack: {
-                                                    removedAt: { not: null },
-                                                },
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                ],
-            });
+        prisma.$queryRaw.mockImplementationOnce(async (strings: string[]) => {
+            expect(strings.join(" ")).toContain('t."removedAt" IS NULL AND');
             return [
                 {
                     id: "album-remote",
                     title: "Remote Album",
                     artistId: "artist-1",
+                    artistName: "Remote Artist",
                     year: 2026,
                     coverUrl: null,
-                    artist: { name: "Remote Artist" },
+                    rank: 0.8,
                 },
                 {
                     id: "album-mixed",
                     title: "Mixed Album",
                     artistId: "artist-2",
+                    artistName: "Mixed Artist",
                     year: 2025,
                     coverUrl: null,
-                    artist: { name: "Mixed Artist" },
+                    rank: 0.7,
                 },
             ];
         });
@@ -390,33 +518,18 @@ describe("search service", () => {
                       },
                   ],
         );
-        prisma.track.findMany.mockResolvedValueOnce([]);
-
         await expect(
             searchService.searchTracks({ query: "removed" }),
         ).resolves.toEqual([]);
 
-        prisma.track.findMany.mockImplementationOnce(
-            async ({ where }: { where: { removedAt?: null } }) =>
-                where.removedAt === null
-                    ? []
-                    : [
-                          {
-                              id: "removed-ilike",
-                              title: "Removed ILIKE",
-                              albumId: "album-1",
-                              duration: 180,
-                              album: {
-                                  title: "Album",
-                                  artistId: "artist-1",
-                                  artist: { name: "Artist" },
-                              },
-                          },
-                      ],
-        );
         await expect(
             searchService.searchTracks({ query: "***" }),
         ).resolves.toEqual([]);
+        expect(
+            prisma.$queryRaw.mock.calls.every(([strings]) =>
+                strings.join(" ").includes('t."removedAt" IS NULL'),
+            ),
+        ).toBe(true);
     });
 
     it("searches podcasts, episodes, and audiobooks with fallback behavior", async () => {
@@ -899,6 +1012,25 @@ describe("search service", () => {
         expect(redisClient.setEx).toHaveBeenCalled();
     });
 
+    it("separates type-scoped cache entries by offset", async () => {
+        jest.spyOn(searchService, "searchArtists").mockResolvedValueOnce([]);
+
+        await searchService.searchByType({
+            query: "Radiohead",
+            type: "artists",
+            limit: 10,
+            offset: 40,
+        });
+
+        const cacheKey = "search:artists:radiohead:10:40::all";
+        expect(redisClient.get).toHaveBeenCalledWith(cacheKey);
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+            cacheKey,
+            120,
+            expect.any(String),
+        );
+    });
+
     it("searchAudiobooksFTS falls back to local search when full-text results are empty", async () => {
         prisma.$queryRaw.mockResolvedValueOnce([]);
         prisma.audiobook.findMany.mockResolvedValueOnce([
@@ -931,12 +1063,13 @@ describe("search service", () => {
     });
 
     it("searchArtistsFallback includes remote-only artists via OR condition", async () => {
-        prisma.artist.findMany.mockResolvedValueOnce([
+        prisma.$queryRaw.mockResolvedValueOnce([
             {
                 id: "artist-remote",
                 name: "Remote Only Artist",
                 mbid: "mbid-remote",
                 heroUrl: null,
+                rank: 0.76,
             },
         ]);
 
@@ -952,59 +1085,16 @@ describe("search service", () => {
                 name: "Remote Only Artist",
                 mbid: "mbid-remote",
                 heroUrl: null,
-                rank: 0,
+                rank: 0.76,
             },
         ]);
 
-        expect(prisma.artist.findMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    OR: [
-                        {
-                            albums: {
-                                some: {
-                                    tracks: {
-                                        some: {
-                                            removedAt: null,
-                                            OR: [
-                                                { origin: "LOCAL" },
-                                                {
-                                                    origin: "FEDERATED",
-                                                    OR: [
-                                                        {
-                                                            dedupOfTrackId:
-                                                                null,
-                                                        },
-                                                        {
-                                                            federationPeer: {
-                                                                showDedupedCopies: true,
-                                                            },
-                                                        },
-                                                        {
-                                                            dedupOfTrack: {
-                                                                removedAt: {
-                                                                    not: null,
-                                                                },
-                                                            },
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                        { remoteTrackCount: { gt: 0 } },
-                    ],
-                }),
-            }),
-        );
+        const [strings, ...values] = prisma.$queryRaw.mock.calls[0];
+        expect(strings.join(" ")).toContain('a."remoteTrackCount" > 0');
+        expect(values).toContain(true);
     });
 
     it("searchArtistsFallback excludes artists with no albums and zero remoteTrackCount", async () => {
-        prisma.artist.findMany.mockResolvedValueOnce([]);
-
         const results = await searchService.searchArtists({
             query: "###",
             limit: 5,
@@ -1015,50 +1105,9 @@ describe("search service", () => {
 
         // Verify the OR filter is passed so Prisma excludes artists
         // that have neither albums nor remote tracks
-        expect(prisma.artist.findMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    OR: [
-                        {
-                            albums: {
-                                some: {
-                                    tracks: {
-                                        some: {
-                                            removedAt: null,
-                                            OR: [
-                                                { origin: "LOCAL" },
-                                                {
-                                                    origin: "FEDERATED",
-                                                    OR: [
-                                                        {
-                                                            dedupOfTrackId:
-                                                                null,
-                                                        },
-                                                        {
-                                                            federationPeer: {
-                                                                showDedupedCopies: true,
-                                                            },
-                                                        },
-                                                        {
-                                                            dedupOfTrack: {
-                                                                removedAt: {
-                                                                    not: null,
-                                                                },
-                                                            },
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                        { remoteTrackCount: { gt: 0 } },
-                    ],
-                }),
-            }),
-        );
+        const [strings, ...values] = prisma.$queryRaw.mock.calls[0];
+        expect(strings.join(" ")).toContain('a."remoteTrackCount" > 0');
+        expect(values).toContain(true);
     });
 
     it("searchArtists FTS SQL includes remoteTrackCount condition", async () => {

--- a/backend/src/services/__tests__/searchStopWordFallback.test.ts
+++ b/backend/src/services/__tests__/searchStopWordFallback.test.ts
@@ -46,13 +46,14 @@ describe("search stop-word fallback", () => {
         prisma.track.findMany.mockResolvedValue([]);
     });
 
-    it("falls back to ILIKE when artist FTS returns zero rows", async () => {
-        prisma.artist.findMany.mockResolvedValueOnce([
+    it("falls back to trigram-ranked SQL when artist FTS returns zero rows", async () => {
+        prisma.$queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([
             {
                 id: "artist-1",
                 name: "The Artist",
                 mbid: "mbid-1",
                 heroUrl: null,
+                rank: 0.77,
             },
         ]);
 
@@ -64,12 +65,21 @@ describe("search stop-word fallback", () => {
                 name: "The Artist",
                 mbid: "mbid-1",
                 heroUrl: null,
-                rank: 0,
+                rank: 0.77,
             },
         ]);
         expect(logger.debug).toHaveBeenCalledWith(
             '[SEARCH] FTS returned 0 results for "the", falling back to ILIKE',
         );
-        expect(prisma.artist.findMany).toHaveBeenCalled();
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+        expect(prisma.artist.findMany).not.toHaveBeenCalled();
+    });
+
+    it("binds an escaped literal ILIKE pattern for fallback search", async () => {
+        prisma.$queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+        await searchService.searchArtists({ query: "50%_r\\ock" });
+
+        expect(prisma.$queryRaw.mock.calls[1]).toContain("%50\\%\\_r\\\\ock%");
     });
 });

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -4,10 +4,12 @@ import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
 import {
     type LibraryOriginFilter,
-    trackBrowseWhere,
     TRACK_VISIBLE_WHERE,
 } from "../utils/librarySorting";
 import { trackBrowseSql } from "../utils/libraryRadioPredicates";
+import { escapeLikePattern } from "../utils/likePattern";
+
+const MAX_TRACK_SEARCH_TERMS = 6;
 
 /**
  * Executes normalizeCacheQuery.
@@ -112,10 +114,6 @@ export interface SearchByTypeOptions {
     source?: LibraryOriginFilter;
 }
 
-function visibleBrowseTracks(source: LibraryOriginFilter) {
-    return { ...TRACK_VISIBLE_WHERE, ...trackBrowseWhere(source) };
-}
-
 function trackSourceSql(source: LibraryOriginFilter): Prisma.Sql {
     return trackBrowseSql("t", source);
 }
@@ -139,18 +137,22 @@ export interface SearchResults {
  * Represents the SearchService class.
  */
 export class SearchService {
+    private queryToTerms(query: string): string[] {
+        return query
+            .trim()
+            .replace(/&/g, " and ")
+            .split(/\s+/)
+            .map((term) => term.replace(/[^\w]/g, ""))
+            .filter((term) => term.length > 0);
+    }
+
     /**
      * Convert user query to PostgreSQL tsquery format
      * Splits on whitespace and adds prefix matching (:*)
      * Example: "radio head" -> "radio:* & head:*"
      */
     private queryToTsquery(query: string): string {
-        const terms = query
-            .trim()
-            .replace(/&/g, " and ")
-            .split(/\s+/)
-            .map((term) => term.replace(/[^\w]/g, ""))
-            .filter((term) => term.length > 0);
+        const terms = this.queryToTerms(query);
 
         if (terms.length === 0) return "";
 
@@ -163,59 +165,40 @@ export class SearchService {
         offset = 0,
         source = "all",
     }: SearchOptions): Promise<ArtistSearchResult[]> {
-        const trackWhere = visibleBrowseTracks(source);
-        const results = await prisma.artist.findMany({
-            where: {
-                name: {
-                    contains: query,
-                    mode: "insensitive",
-                },
-                ...(source === "all"
-                    ? {
-                          OR: [
-                              {
-                                  albums: {
-                                      some: { tracks: { some: trackWhere } },
-                                  },
-                              },
-                              { remoteTrackCount: { gt: 0 } },
-                          ],
-                      }
-                    : {
-                          albums: {
-                              some: { tracks: { some: trackWhere } },
-                          },
-                      }),
-            },
-            select: {
-                id: true,
-                name: true,
-                mbid: true,
-                heroUrl: true,
-                peerId: true,
-                federationPeer: {
-                    select: { id: true, name: true, outboundStatus: true },
-                },
-            },
-            take: limit,
-            skip: offset,
-            orderBy: {
-                name: "asc",
-            },
-        });
-
-        return results.map(({ federationPeer, peerId, ...result }) => ({
-            ...result,
-            rank: 0,
-            ...(peerId && federationPeer
-                ? {
-                      source: "federated" as const,
-                      peer: {
-                          id: federationPeer.id,
-                          name: federationPeer.name,
-                          online: federationPeer.outboundStatus === "ACTIVE",
-                      },
-                  }
+        const pattern = `%${escapeLikePattern(query)}%`;
+        const sourceSql = trackSourceSql(source);
+        const peerSql = peerProjectionSql("a");
+        const rows = await prisma.$queryRaw<
+            Array<
+                ArtistSearchResult & {
+                    source: "federated" | null;
+                    peer: SearchPeerResult | null;
+                }
+            >
+        >`
+            SELECT a.id, a.name, a.mbid, a."heroUrl",
+                   CASE WHEN a."peerId" IS NOT NULL THEN 'federated' END AS source,
+                   ${peerSql} AS peer,
+                   similarity(a.name, ${query}) AS rank
+            FROM "Artist" a
+            LEFT JOIN "FederationPeer" fp ON fp.id = a."peerId"
+            WHERE (a.name ILIKE ${pattern} ESCAPE '\\' OR a.name % ${query})
+              AND (
+                EXISTS (
+                  SELECT 1 FROM "Album" alb
+                  JOIN "Track" t ON t."albumId" = alb.id
+                  WHERE alb."artistId" = a.id AND t."removedAt" IS NULL AND ${sourceSql}
+                )
+                OR (${source === "all"} AND a."remoteTrackCount" > 0)
+              )
+            ORDER BY rank DESC, a.name ASC
+            LIMIT ${limit}
+            OFFSET ${offset}
+        `;
+        return rows.map(({ source: rowSource, peer, ...row }) => ({
+            ...row,
+            ...(rowSource === "federated" && peer
+                ? { source: rowSource, peer }
                 : {}),
         }));
     }
@@ -289,78 +272,42 @@ export class SearchService {
         offset = 0,
         source = "all",
     }: SearchOptions): Promise<AlbumSearchResult[]> {
-        const trackWhere = visibleBrowseTracks(source);
-        const results = await prisma.album.findMany({
-            where: {
-                AND: [
-                    {
-                        OR: [
-                            ...(source === "peers"
-                                ? []
-                                : [{ tracks: { none: {} } }]),
-                            { tracks: { some: trackWhere } },
-                        ],
-                    },
-                    {
-                        OR: [
-                            {
-                                title: {
-                                    contains: query,
-                                    mode: "insensitive",
-                                },
-                            },
-                            {
-                                artist: {
-                                    name: {
-                                        contains: query,
-                                        mode: "insensitive",
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                ],
-            },
-            select: {
-                id: true,
-                title: true,
-                artistId: true,
-                year: true,
-                coverUrl: true,
-                artist: {
-                    select: {
-                        name: true,
-                    },
-                },
-                peerId: true,
-                federationPeer: {
-                    select: { id: true, name: true, outboundStatus: true },
-                },
-            },
-            take: limit,
-            skip: offset,
-            orderBy: {
-                title: "asc",
-            },
-        });
-
-        return results.map((r) => ({
-            id: r.id,
-            title: r.title,
-            artistId: r.artistId,
-            artistName: r.artist.name,
-            year: r.year,
-            coverUrl: r.coverUrl,
-            rank: 0,
-            ...(r.peerId && r.federationPeer
-                ? {
-                      source: "federated" as const,
-                      peer: {
-                          id: r.federationPeer.id,
-                          name: r.federationPeer.name,
-                          online: r.federationPeer.outboundStatus === "ACTIVE",
-                      },
-                  }
+        const pattern = `%${escapeLikePattern(query)}%`;
+        const sourceSql = trackSourceSql(source);
+        const peerSql = peerProjectionSql("a");
+        const includeEmpty = source !== "peers";
+        const rows = await prisma.$queryRaw<
+            Array<
+                AlbumSearchResult & {
+                    source: "federated" | null;
+                    peer: SearchPeerResult | null;
+                }
+            >
+        >`
+            SELECT a.id, a.title, a."artistId", ar.name AS "artistName",
+                   a.year, a."coverUrl",
+                   CASE WHEN a."peerId" IS NOT NULL THEN 'federated' END AS source,
+                   ${peerSql} AS peer,
+                   similarity(a.title, ${query}) AS rank
+            FROM "Album" a
+            INNER JOIN "Artist" ar ON ar.id = a."artistId"
+            LEFT JOIN "FederationPeer" fp ON fp.id = a."peerId"
+            WHERE (a.title ILIKE ${pattern} ESCAPE '\\' OR a.title % ${query})
+              AND (
+                (${includeEmpty} AND NOT EXISTS (SELECT 1 FROM "Track" t WHERE t."albumId" = a.id))
+                OR EXISTS (
+                  SELECT 1 FROM "Track" t
+                  WHERE t."albumId" = a.id AND t."removedAt" IS NULL AND ${sourceSql}
+                )
+              )
+            ORDER BY rank DESC, a.title ASC
+            LIMIT ${limit}
+            OFFSET ${offset}
+        `;
+        return rows.map(({ source: rowSource, peer, ...row }) => ({
+            ...row,
+            ...(rowSource === "federated" && peer
+                ? { source: rowSource, peer }
                 : {}),
         }));
     }
@@ -460,69 +407,39 @@ export class SearchService {
         offset = 0,
         source = "all",
     }: SearchOptions): Promise<TrackSearchResult[]> {
-        const results = await prisma.track.findMany({
-            where: {
-                ...TRACK_VISIBLE_WHERE,
-                ...trackBrowseWhere(source),
-                title: {
-                    contains: query,
-                    mode: "insensitive",
-                },
-            },
-            select: {
-                id: true,
-                title: true,
-                albumId: true,
-                duration: true,
-                loudnessLufs: true,
-                truePeakDb: true,
-                album: {
-                    select: {
-                        title: true,
-                        artistId: true,
-                        albumLoudnessLufs: true,
-                        albumTruePeakDb: true,
-                        artist: {
-                            select: {
-                                name: true,
-                            },
-                        },
-                    },
-                },
-                origin: true,
-                federationPeer: {
-                    select: { id: true, name: true, outboundStatus: true },
-                },
-            },
-            take: limit,
-            skip: offset,
-            orderBy: {
-                title: "asc",
-            },
-        });
-
-        return results.map((r) => ({
-            id: r.id,
-            title: r.title,
-            albumId: r.albumId,
-            albumTitle: r.album.title,
-            artistId: r.album.artistId,
-            artistName: r.album.artist.name,
-            duration: r.duration,
-            loudnessLufs: r.loudnessLufs,
-            truePeakDb: r.truePeakDb,
-            albumLoudnessLufs: r.album.albumLoudnessLufs,
-            albumTruePeakDb: r.album.albumTruePeakDb,
-            rank: 0,
-            ...(r.origin === "FEDERATED" && r.federationPeer
-                ? {
-                      source: "federated" as const,
-                      peer: {
-                          id: r.federationPeer.id,
-                          name: r.federationPeer.name,
-                          online: r.federationPeer.outboundStatus === "ACTIVE",
-                      },
-                  }
+        const pattern = `%${escapeLikePattern(query)}%`;
+        const sourceSql = trackSourceSql(source);
+        const peerSql = peerProjectionSql("t");
+        const rows = await prisma.$queryRaw<
+            Array<
+                TrackSearchResult & {
+                    source: "federated" | null;
+                    peer: SearchPeerResult | null;
+                }
+            >
+        >`
+            SELECT t.id, t.title, t."albumId", t.duration,
+                   t."loudnessLufs", t."truePeakDb",
+                   a.title AS "albumTitle", a."albumLoudnessLufs",
+                   a."albumTruePeakDb", a."artistId", ar.name AS "artistName",
+                   CASE WHEN t.origin = ${"FEDERATED"}::"TrackOrigin" THEN 'federated' END AS source,
+                   ${peerSql} AS peer,
+                   similarity(t.title, ${query}) AS rank
+            FROM "Track" t
+            LEFT JOIN "Album" a ON a.id = t."albumId"
+            LEFT JOIN "Artist" ar ON ar.id = a."artistId"
+            LEFT JOIN "FederationPeer" fp ON fp.id = t."peerId"
+            WHERE t."removedAt" IS NULL
+              AND ${sourceSql}
+              AND (t.title ILIKE ${pattern} ESCAPE '\\' OR t.title % ${query})
+            ORDER BY rank DESC, t.title ASC
+            LIMIT ${limit}
+            OFFSET ${offset}
+        `;
+        return rows.map(({ source: rowSource, peer, ...row }) => ({
+            ...row,
+            ...(rowSource === "federated" && peer
+                ? { source: rowSource, peer }
                 : {}),
         }));
     }
@@ -537,10 +454,29 @@ export class SearchService {
             return [];
         }
 
-        const tsquery = this.queryToTsquery(query);
-        if (!tsquery) {
+        const queryTerms = this.queryToTerms(query);
+        if (queryTerms.length === 0) {
             return this.searchTracksFallback({ query, limit, offset, source });
         }
+
+        const terms = queryTerms.slice(0, MAX_TRACK_SEARCH_TERMS);
+        if (queryTerms.length > terms.length) {
+            logger.debug(
+                `[SEARCH] Dropped ${queryTerms.length - terms.length} track search terms after the 6-term limit`,
+            );
+        }
+        const termQueries = terms.map((term) => `${term}:*`);
+        const orQuery = termQueries.join(" | ");
+        const termConditions = Prisma.join(
+            termQueries.map(
+                (term) => Prisma.sql`(
+                    t."searchVector" @@ to_tsquery('english', ${term})
+                    OR a."searchVector" @@ to_tsquery('english', ${term})
+                    OR ar."searchVector" @@ to_tsquery('english', ${term})
+                )`,
+            ),
+            " AND ",
+        );
 
         try {
             const sourceSql = trackSourceSql(source);
@@ -560,14 +496,16 @@ export class SearchService {
           ar.name as "artistName",
           CASE WHEN t.origin = ${"FEDERATED"}::"TrackOrigin" THEN 'federated' ELSE 'local' END AS source,
           ${peerSql} AS peer,
-          ts_rank(t."searchVector", to_tsquery('english', ${tsquery})) AS rank
+          ts_rank(t."searchVector", to_tsquery('english', ${orQuery})) * 2
+            + ts_rank(COALESCE(a."searchVector", ''::tsvector), to_tsquery('english', ${orQuery}))
+            + ts_rank(COALESCE(ar."searchVector", ''::tsvector), to_tsquery('english', ${orQuery})) AS rank
         FROM "Track" t
         LEFT JOIN "Album" a ON t."albumId" = a.id
         LEFT JOIN "Artist" ar ON a."artistId" = ar.id
         LEFT JOIN "FederationPeer" fp ON fp.id = t."peerId"
         WHERE t."removedAt" IS NULL
           AND ${sourceSql}
-          AND t."searchVector" @@ to_tsquery('english', ${tsquery})
+          AND ${termConditions}
         ORDER BY rank DESC, t.title ASC
         LIMIT ${limit}
         OFFSET ${offset}
@@ -1050,7 +988,7 @@ export class SearchService {
         }
 
         // Check cache
-        const cacheKey = `search:${type}:${normalizeCacheQuery(query)}:${limit}:${genre || ""}:${source}`;
+        const cacheKey = `search:${type}:${normalizeCacheQuery(query)}:${limit}:${offset}:${genre || ""}:${source}`;
         try {
             const cached = await redisClient.get(cacheKey);
             if (cached) {

--- a/backend/tests-integration/searchPostgres.integration.test.ts
+++ b/backend/tests-integration/searchPostgres.integration.test.ts
@@ -1,0 +1,112 @@
+import type { Client } from "pg";
+import { searchService } from "../src/services/search";
+import { prisma } from "../src/utils/db";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+
+const ARTIST_ID = "search-relevance-artist";
+const ALBUM_ID = "search-relevance-album";
+
+async function seedTrack(
+    id: string,
+    title: string,
+    trackNo: number,
+): Promise<void> {
+    await prisma.track.create({
+        data: {
+            id,
+            albumId: ALBUM_ID,
+            title,
+            trackNo,
+            duration: 240,
+            fileModified: new Date("2026-08-25T00:00:00.000Z"),
+            fileSize: 1_000,
+        },
+    });
+}
+
+describeWithPostgres("search relevance PostgreSQL behavior", () => {
+    let admin: Client | undefined;
+
+    beforeAll(async () => {
+        if (!integrationDatabaseUrl || !databaseName) {
+            throw new Error("PostgreSQL integration environment is missing");
+        }
+        admin = await createScaleDatabase(integrationDatabaseUrl, databaseName);
+        const runtimeDatabaseUrl = process.env.DATABASE_URL;
+        if (!runtimeDatabaseUrl) {
+            throw new Error("Integration database URL was not initialized");
+        }
+        await applyScaleMigrations(runtimeDatabaseUrl);
+        await prisma.artist.create({
+            data: {
+                id: ARTIST_ID,
+                mbid: "search-relevance-artist-mbid",
+                name: "Radiohead",
+            },
+        });
+        await prisma.album.create({
+            data: {
+                id: ALBUM_ID,
+                rgMbid: "search-relevance-album-mbid",
+                artistId: ARTIST_ID,
+                title: "Pablo Honey",
+                primaryType: "Album",
+            },
+        });
+        await seedTrack("search-creep", "Creep", 1);
+        await seedTrack("search-acdc", "AC/DC", 2);
+        await seedTrack("search-acdc-tribute", "A Tribute to AC/DC", 3);
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+        if (admin && databaseName) {
+            await dropScaleDatabase(admin, databaseName);
+        }
+    });
+
+    it("matches a track across artist and title full-text columns", async () => {
+        const results = await searchService.searchTracks({
+            query: "radiohead creep",
+        });
+
+        expect(results).toContainEqual(
+            expect.objectContaining({ id: "search-creep" }),
+        );
+    });
+
+    it("finds a typo through trigram fallback with a positive rank", async () => {
+        const results = await searchService.searchTracks({ query: "crepe" });
+
+        expect(results).toContainEqual(
+            expect.objectContaining({
+                id: "search-creep",
+                rank: expect.any(Number),
+            }),
+        );
+        expect(results[0]?.rank).toBeGreaterThan(0);
+    });
+
+    it("orders fallback matches by similarity before title", async () => {
+        const results = await searchService.searchTracks({ query: "AC/DC" });
+
+        expect(results.slice(0, 2).map((track) => track.id)).toEqual([
+            "search-acdc",
+            "search-acdc-tribute",
+        ]);
+        const [exactMatch, tributeMatch] = results;
+        if (!exactMatch || !tributeMatch) {
+            throw new Error("Expected two fallback search results");
+        }
+        expect(exactMatch.rank).toBeGreaterThan(tributeMatch.rank);
+    });
+});


### PR DESCRIPTION
Part of #758 (PR A of 2 — relevance and fallback; cache invalidation + artist-page matching normalization follow separately).

## Problems

1. **Track FTS was title-only** — "radiohead creep" matched zero tracks via full-text and silently fell back to unranked ILIKE (albums had a UNION arm compensating; tracks didn't).
2. **The fallback destroyed ranking** — `rank: 0`, alphabetical order, no typo tolerance anywhere (`AC/DC` → tsquery `acdc` → nothing).
3. **Pagination existed in the service but was never exposed** by the route schema.

## Changes

- **Cross-column track FTS**: each query term (capped at 6) must match the track title, album title, or artist name tsvector; rank is `ts_rank` summed across the three vectors with title weighted 2×. Query-side only — no trigger/backfill migration, rename-safe by construction.
- **Trigram-ranked fallbacks** for tracks, albums, and artists: new migration enables `pg_trgm` (same pattern as the pgvector migration) and adds GIN trigram indexes; fallbacks return `similarity()` as rank, ordered by it, with the `%` operator adding typo tolerance alongside escaped ILIKE containment (existing `escapeLikePattern` + `ESCAPE '\\'` idiom).
- **Offset pagination**: route schema accepts `offset` (0–10000) for type-scoped searches, passed through and included in the Redis cache key (previously pages would have collided); `type=all` ignores it, documented in OpenAPI.
- Real-PostgreSQL integration suite covers multi-term artist+title FTS hits, typo'd-title trigram recovery with rank > 0, and similarity ordering.

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass
- verify: backend jest — searchService (31), searchStopWordFallback (2), searchRuntime (28): `Test Suites: 3 passed`, `Tests: 61 passed`, exit 0
- Integration suite skips locally (no `INTEGRATION_DATABASE_URL`); the Backend PostgreSQL Integration CI job is the arbiter.