### PR TITLE
chore(downloads): claim the album-download throttle only for streaming sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Python sidecars now share one hardened implementation of their path-safety and runtime helpers instead of maintaining copies.
 - The TIDAL playlist and mix explore pages now share one implementation, settings connection tests share one status hook, and dates and durations render through shared formatters. Album pages now show total length compactly (for example "2h 30m").
 - Album downloads now use queued, serialized processing, one album at a time across the deployment, with renewable claims, restart recovery, and queue-owned lifecycle reconciliation.
+- Lidarr-routed album downloads no longer wait behind in-flight TIDAL/YouTube downloads; the one-at-a-time throttle now applies only to the streaming providers.
 - The DCLAP vibe provider now answers malformed requests with the same 422 response the other sidecars use (previously 400).
 - Library scans now process several files at once within a configurable bound, making large-library scans significantly faster.
 

--- a/backend/src/services/__tests__/downloadDispatcher.test.ts
+++ b/backend/src/services/__tests__/downloadDispatcher.test.ts
@@ -74,7 +74,11 @@ jest.mock("../simpleDownloadManager", () => ({
     },
 }));
 
-import { dispatchAlbumDownload } from "../downloadDispatcher";
+import {
+    dispatchAlbumDownload,
+    dispatchResolvedAlbumDownload,
+    resolveAlbumDownloadRouting,
+} from "../downloadDispatcher";
 
 const baseParams = {
     jobId: "job-1",
@@ -145,6 +149,24 @@ describe("dispatchAlbumDownload", () => {
         expect(mockSoulseekAvailable).toHaveBeenCalledTimes(1);
         expect(mockYoutubeAvailable).toHaveBeenCalledTimes(1);
         expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+
+    it("dispatches a resolved routing snapshot without probing sources twice", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "none",
+        });
+        mockTidalAvailable.mockResolvedValue(true);
+        const routing = await resolveAlbumDownloadRouting(baseParams);
+
+        await dispatchResolvedAlbumDownload(routing, baseParams);
+
+        expect(mockGetSystemSettings).toHaveBeenCalledTimes(1);
+        expect(mockTidalAvailable).toHaveBeenCalledTimes(1);
+        expect(mockLidarrAvailable).toHaveBeenCalledTimes(1);
+        expect(mockSoulseekAvailable).toHaveBeenCalledTimes(1);
+        expect(mockYoutubeAvailable).toHaveBeenCalledTimes(1);
+        expect(mockProcessTidalDownload).toHaveBeenCalledTimes(1);
     });
 
     it("uses YouTube as an available explicit fallback", async () => {

--- a/backend/src/services/downloadDispatcher.ts
+++ b/backend/src/services/downloadDispatcher.ts
@@ -1,9 +1,11 @@
+import type { DownloadJob } from "@prisma/client";
 import { logger as rootLogger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { getSystemSettings } from "../utils/systemSettings";
 import {
     type DownloadSource,
     type DownloadSourceAvailability,
+    type DownloadSourceResolution,
     probeDownloadSourceAvailability,
     resolveDownloadSource,
 } from "./downloadSourcePolicy";
@@ -30,6 +32,27 @@ interface AlbumNames {
     artist: string;
     album: string;
 }
+
+type FailedDownloadSourceResolution = Extract<
+    DownloadSourceResolution,
+    { kind: "fail" }
+> & { source: DownloadSource };
+
+/** Resolved album-download routing snapshot used by queue workers. */
+export type AlbumDownloadRouting =
+    | {
+          kind: "fail";
+          job: DownloadJob;
+          resolution: FailedDownloadSourceResolution;
+      }
+    | {
+          kind: "dispatch";
+          source: DownloadSource;
+          availability: DownloadSourceAvailability;
+          job: DownloadJob;
+          names: AlbumNames;
+          userId: string;
+      };
 
 function parseAlbumNames({
     subject,
@@ -119,21 +142,18 @@ async function dispatchResolvedSource(
     }
 }
 
-/**
- * Dispatch an existing album download job through the configured source and
- * fallback policy. Missing jobs and non-album types are left undispatched.
- */
-export async function dispatchAlbumDownload(
+/** Resolve one album download against a single settings and availability snapshot. */
+export async function resolveAlbumDownloadRouting(
     params: AlbumDownloadDispatchParams,
-): Promise<void> {
+): Promise<AlbumDownloadRouting | null> {
     const job = await prisma.downloadJob.findUnique({
         where: { id: params.jobId },
     });
     if (!job) {
         logger.error(`Job ${params.jobId} not found`);
-        return;
+        return null;
     }
-    if (params.type !== "album") return;
+    if (params.type !== "album") return null;
 
     const names = parseAlbumNames(params);
     logger.debug(`Parsed: Artist="${names.artist}", Album="${names.album}"`);
@@ -148,24 +168,62 @@ export async function dispatchAlbumDownload(
         availability,
     });
     if (resolution.kind === "fail") {
-        await failJobWithoutDispatch(
-            params.jobId,
-            job.metadata,
-            configuredSource,
-            resolution.error,
-            resolution.statusText,
-        );
-        return;
+        return {
+            kind: "fail",
+            job,
+            resolution: { ...resolution, source: configuredSource },
+        };
     }
 
     logger.debug(
         `Download source: configured=${configuredSource}, effective=${resolution.source}`,
     );
-    await dispatchResolvedSource(
-        resolution.source,
+    return {
+        kind: "dispatch",
+        source: resolution.source,
         availability,
-        params,
+        job,
         names,
-        job.userId,
+        userId: job.userId,
+    };
+}
+
+/**
+ * Dispatch a previously resolved routing snapshot without probing settings or
+ * availability again. Configuration changes after resolution affect later jobs.
+ */
+export async function dispatchResolvedAlbumDownload(
+    routing: AlbumDownloadRouting | null,
+    params: AlbumDownloadDispatchParams,
+): Promise<void> {
+    if (!routing) return;
+    if (routing.kind === "fail") {
+        await failJobWithoutDispatch(
+            params.jobId,
+            routing.job.metadata,
+            routing.resolution.source,
+            routing.resolution.error,
+            routing.resolution.statusText,
+        );
+        return;
+    }
+
+    await dispatchResolvedSource(
+        routing.source,
+        routing.availability,
+        params,
+        routing.names,
+        routing.userId,
     );
+}
+
+/**
+ * Dispatch an existing album download job through the configured source and
+ * fallback policy. Missing jobs and non-album types are left undispatched.
+ */
+export async function dispatchAlbumDownload(
+    params: AlbumDownloadDispatchParams,
+): Promise<void> {
+    const routing = await resolveAlbumDownloadRouting(params);
+    await dispatchResolvedAlbumDownload(routing, params);
 }

--- a/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
@@ -1,14 +1,28 @@
-const mockDispatchAlbumDownload = jest.fn();
+const mockResolveAlbumDownloadRouting = jest.fn();
 const mockDownloadJobFindUnique = jest.fn();
+const mockDownloadJobUpdate = jest.fn();
 const mockDownloadJobUpdateMany = jest.fn();
 const mockRunWithSchedulerClaim = jest.fn();
 const mockExtendSchedulerClaim = jest.fn();
 const mockLoggerInfo = jest.fn();
 const mockLoggerError = jest.fn();
+const mockProcessTidalDownload = jest.fn();
+const mockProcessYoutubeDownload = jest.fn();
+const mockStartDownload = jest.fn();
 
 jest.mock("../../../services/downloadDispatcher", () => ({
-    dispatchAlbumDownload: (...args: unknown[]) =>
-        mockDispatchAlbumDownload(...args),
+    ...jest.requireActual("../../../services/downloadDispatcher"),
+    resolveAlbumDownloadRouting: (...args: unknown[]) =>
+        mockResolveAlbumDownloadRouting(...args),
+}));
+
+jest.mock("../../../services/downloadSourcePolicy", () => ({
+    probeDownloadSourceAvailability: jest.fn(),
+    resolveDownloadSource: jest.fn(),
+}));
+
+jest.mock("../../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
 }));
 
 jest.mock("../../../utils/db", () => ({
@@ -16,6 +30,7 @@ jest.mock("../../../utils/db", () => ({
         downloadJob: {
             findUnique: (...args: unknown[]) =>
                 mockDownloadJobFindUnique(...args),
+            update: (...args: unknown[]) => mockDownloadJobUpdate(...args),
             updateMany: (...args: unknown[]) =>
                 mockDownloadJobUpdateMany(...args),
         },
@@ -38,6 +53,22 @@ jest.mock("../../../utils/logger", () => ({
     },
 }));
 
+jest.mock("../../../services/tidalLibraryDownload", () => ({
+    processTidalDownload: (...args: unknown[]) =>
+        mockProcessTidalDownload(...args),
+}));
+
+jest.mock("../../../services/youtubeLibraryDownload", () => ({
+    processYoutubeDownload: (...args: unknown[]) =>
+        mockProcessYoutubeDownload(...args),
+}));
+
+jest.mock("../../../services/simpleDownloadManager", () => ({
+    simpleDownloadManager: {
+        startDownload: (...args: unknown[]) => mockStartDownload(...args),
+    },
+}));
+
 import {
     AlbumDownloadFailedError,
     finalizeAlbumDownloadQueueFailure,
@@ -53,14 +84,42 @@ const payload = {
     albumTitle: "Album",
     artistMbid: "artist-mbid-1",
 } as const;
+const availability = {
+    tidal: true,
+    lidarr: true,
+    soulseek: true,
+    youtube: true,
+} as const;
+const routingJob = {
+    id: payload.jobId,
+    userId: "user-1",
+    metadata: { preserved: true },
+};
+
+function dispatchRouting(source: "tidal" | "youtube" | "lidarr") {
+    return {
+        kind: "dispatch" as const,
+        source,
+        availability,
+        job: routingJob,
+        names: { artist: "Artist", album: "Album" },
+        userId: "user-1",
+    };
+}
 
 describe("album download queue processor", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockDispatchAlbumDownload.mockResolvedValue(undefined);
+        mockResolveAlbumDownloadRouting.mockResolvedValue(
+            dispatchRouting("tidal"),
+        );
         mockDownloadJobFindUnique.mockResolvedValue({ status: "processing" });
+        mockDownloadJobUpdate.mockResolvedValue({});
         mockDownloadJobUpdateMany.mockResolvedValue({ count: 1 });
         mockExtendSchedulerClaim.mockResolvedValue(true);
+        mockProcessTidalDownload.mockResolvedValue(undefined);
+        mockProcessYoutubeDownload.mockResolvedValue(undefined);
+        mockStartDownload.mockResolvedValue({ success: true });
         mockRunWithSchedulerClaim.mockImplementation(
             async (
                 _claimKey: string,
@@ -75,7 +134,25 @@ describe("album download queue processor", () => {
         jest.useRealTimers();
     });
 
-    it("validates and dispatches an album while reporting progress", async () => {
+    it("acquires the claim before dispatching a TIDAL-routed album", async () => {
+        const ordering: string[] = [];
+        mockProcessTidalDownload.mockImplementationOnce(async () => {
+            ordering.push("dispatch");
+        });
+        mockRunWithSchedulerClaim.mockImplementationOnce(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: (claimToken: string) => Promise<void>,
+            ) => {
+                ordering.push("acquired");
+                return {
+                    acquired: true,
+                    value: await operation("claim-token"),
+                };
+            },
+        );
         const job = {
             data: payload,
             progress: jest.fn().mockResolvedValue(undefined),
@@ -83,15 +160,126 @@ describe("album download queue processor", () => {
 
         await processAlbumDownload(job);
 
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith(payload);
+        expect(mockResolveAlbumDownloadRouting).toHaveBeenCalledWith(payload);
         expect(mockRunWithSchedulerClaim).toHaveBeenCalledWith(
             "scheduler-claim:album-download",
             15 * 60_000,
             "album download",
             expect.any(Function),
         );
+        expect(mockProcessTidalDownload).toHaveBeenCalledWith(
+            payload.jobId,
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(ordering).toEqual(["acquired", "dispatch"]);
         expect(job.progress).toHaveBeenNthCalledWith(1, 0);
         expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+    });
+
+    it("acquires the claim before dispatching a YouTube-routed album", async () => {
+        const ordering: string[] = [];
+        mockResolveAlbumDownloadRouting.mockResolvedValueOnce(
+            dispatchRouting("youtube"),
+        );
+        mockProcessYoutubeDownload.mockImplementationOnce(async () => {
+            ordering.push("dispatch");
+        });
+        mockRunWithSchedulerClaim.mockImplementationOnce(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: (claimToken: string) => Promise<void>,
+            ) => {
+                ordering.push("acquired");
+                return {
+                    acquired: true,
+                    value: await operation("claim-token"),
+                };
+            },
+        );
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processAlbumDownload(job);
+
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledTimes(1);
+        expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
+            payload.jobId,
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(ordering).toEqual(["acquired", "dispatch"]);
+    });
+
+    it("dispatches a Lidarr-routed album through the manager without a claim", async () => {
+        mockResolveAlbumDownloadRouting.mockResolvedValueOnce(
+            dispatchRouting("lidarr"),
+        );
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processAlbumDownload(job);
+
+        expect(mockRunWithSchedulerClaim).not.toHaveBeenCalled();
+        expect(mockExtendSchedulerClaim).not.toHaveBeenCalled();
+        expect(mockStartDownload).toHaveBeenCalledWith(
+            payload.jobId,
+            "Artist",
+            "Album",
+            payload.mbid,
+            "user-1",
+            false,
+            payload.artistMbid,
+        );
+    });
+
+    it("persists a failed resolution without a claim", async () => {
+        mockResolveAlbumDownloadRouting.mockResolvedValueOnce({
+            kind: "fail",
+            job: routingJob,
+            resolution: {
+                kind: "fail",
+                source: "tidal",
+                error: "Download source unavailable",
+                statusText: "tidal unavailable — skipped",
+            },
+        });
+        mockDownloadJobFindUnique
+            .mockResolvedValueOnce({ status: "pending" })
+            .mockResolvedValueOnce({ status: "failed" });
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toBeInstanceOf(
+            AlbumDownloadFailedError,
+        );
+
+        expect(mockRunWithSchedulerClaim).not.toHaveBeenCalled();
+        expect(mockExtendSchedulerClaim).not.toHaveBeenCalled();
+        expect(mockDownloadJobUpdate).toHaveBeenCalledWith({
+            where: { id: payload.jobId },
+            data: {
+                status: "failed",
+                error: "Download source unavailable",
+                completedAt: expect.any(Date),
+                metadata: {
+                    preserved: true,
+                    currentSource: "tidal",
+                    statusText: "tidal unavailable — skipped",
+                    failedAt: expect.any(String),
+                },
+            },
+        });
     });
 
     it("drains a slow renewal before releasing and starts none post-release", async () => {
@@ -99,7 +287,7 @@ describe("album download queue processor", () => {
         let finishDispatch!: () => void;
         let finishRenewal!: () => void;
         const ordering: string[] = [];
-        mockDispatchAlbumDownload.mockImplementationOnce(
+        mockProcessTidalDownload.mockImplementationOnce(
             () =>
                 new Promise<void>((resolve) => {
                     finishDispatch = resolve;
@@ -167,7 +355,7 @@ describe("album download queue processor", () => {
 
         await expect(processAlbumDownload(job)).rejects.toThrow();
 
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockResolveAlbumDownloadRouting).not.toHaveBeenCalled();
         expect(job.progress).not.toHaveBeenCalled();
     });
 
@@ -179,13 +367,13 @@ describe("album download queue processor", () => {
 
         await expect(processAlbumDownload(job)).rejects.toThrow();
 
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockResolveAlbumDownloadRouting).not.toHaveBeenCalled();
         expect(job.progress).not.toHaveBeenCalled();
     });
 
     it("propagates dispatcher rejection without reporting completion", async () => {
         const error = new Error("sidecar unavailable");
-        mockDispatchAlbumDownload.mockRejectedValueOnce(error);
+        mockProcessTidalDownload.mockRejectedValueOnce(error);
         const job = {
             data: payload,
             progress: jest.fn().mockResolvedValue(undefined),
@@ -208,7 +396,8 @@ describe("album download queue processor", () => {
 
         await processAlbumDownload(job);
 
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockResolveAlbumDownloadRouting).not.toHaveBeenCalled();
+        expect(mockRunWithSchedulerClaim).not.toHaveBeenCalled();
         expect(mockDownloadJobFindUnique).toHaveBeenCalledTimes(1);
         expect(mockLoggerInfo).toHaveBeenCalledWith(
             "Skipping completed album download redelivery",
@@ -219,6 +408,7 @@ describe("album download queue processor", () => {
     it("throws a typed failure when dispatch persists failed status", async () => {
         mockDownloadJobFindUnique
             .mockResolvedValueOnce({ status: "pending" })
+            .mockResolvedValueOnce({ status: "processing" })
             .mockResolvedValueOnce({ status: "failed" });
         const job = {
             data: payload,
@@ -229,7 +419,7 @@ describe("album download queue processor", () => {
             AlbumDownloadFailedError,
         );
 
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledWith(payload);
+        expect(mockProcessTidalDownload).toHaveBeenCalledTimes(1);
         expect(job.progress).toHaveBeenCalledTimes(1);
     });
 
@@ -255,13 +445,13 @@ describe("album download queue processor", () => {
 
         const processing = processAlbumDownload(job);
         await Promise.resolve();
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockProcessTidalDownload).not.toHaveBeenCalled();
 
         await jest.advanceTimersByTimeAsync(15_000);
         await processing;
 
         expect(mockRunWithSchedulerClaim).toHaveBeenCalledTimes(2);
-        expect(mockDispatchAlbumDownload).toHaveBeenCalledTimes(1);
+        expect(mockProcessTidalDownload).toHaveBeenCalledTimes(1);
     });
 
     it("throws after the bounded deployment-claim wait is exhausted", async () => {
@@ -280,7 +470,7 @@ describe("album download queue processor", () => {
         await rejection;
 
         expect(mockRunWithSchedulerClaim).toHaveBeenCalledTimes(960);
-        expect(mockDispatchAlbumDownload).not.toHaveBeenCalled();
+        expect(mockProcessTidalDownload).not.toHaveBeenCalled();
     });
 
     it("finalizes an additive poison payload when it still carries a valid job id", async () => {

--- a/backend/src/workers/processors/albumDownloadProcessor.ts
+++ b/backend/src/workers/processors/albumDownloadProcessor.ts
@@ -1,6 +1,10 @@
 import type { Job } from "bull";
 import { z } from "zod";
-import { dispatchAlbumDownload } from "../../services/downloadDispatcher";
+import {
+    type AlbumDownloadRouting,
+    dispatchResolvedAlbumDownload,
+    resolveAlbumDownloadRouting,
+} from "../../services/downloadDispatcher";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
 import {
@@ -58,17 +62,21 @@ async function getPersistedStatus(jobId: string): Promise<string | null> {
     return persistedJob?.status ?? null;
 }
 
+async function skipCompletedRedelivery(
+    payload: AlbumDownloadPayload,
+): Promise<boolean> {
+    if ((await getPersistedStatus(payload.jobId)) !== "completed") return false;
+    log.info("Skipping completed album download redelivery", {
+        jobId: payload.jobId,
+    });
+    return true;
+}
+
 async function dispatchPersistedAlbumDownload(
     payload: AlbumDownloadPayload,
+    routing: AlbumDownloadRouting | null,
 ): Promise<void> {
-    if ((await getPersistedStatus(payload.jobId)) === "completed") {
-        log.info("Skipping completed album download redelivery", {
-            jobId: payload.jobId,
-        });
-        return;
-    }
-
-    await dispatchAlbumDownload(payload);
+    await dispatchResolvedAlbumDownload(routing, payload);
     if ((await getPersistedStatus(payload.jobId)) === "failed") {
         throw new AlbumDownloadFailedError(payload.jobId);
     }
@@ -94,6 +102,7 @@ async function renewAlbumDownloadClaim(
 
 async function dispatchWithClaimRenewal(
     payload: AlbumDownloadPayload,
+    routing: AlbumDownloadRouting,
     claimToken: string,
 ): Promise<void> {
     let renewalPromise: Promise<void> | null = null;
@@ -107,7 +116,9 @@ async function dispatchWithClaimRenewal(
     }, ALBUM_DOWNLOAD_CLAIM_RENEW_INTERVAL_MS);
     renewalTimer.unref();
     try {
-        await dispatchPersistedAlbumDownload(payload);
+        if (!(await skipCompletedRedelivery(payload))) {
+            await dispatchPersistedAlbumDownload(payload, routing);
+        }
     } finally {
         clearInterval(renewalTimer);
         if (renewalPromise) await renewalPromise;
@@ -116,13 +127,15 @@ async function dispatchWithClaimRenewal(
 
 async function waitForAlbumDownloadClaim(
     payload: AlbumDownloadPayload,
+    routing: AlbumDownloadRouting,
 ): Promise<void> {
     for (let poll = 0; poll < ALBUM_DOWNLOAD_CLAIM_MAX_POLLS; poll += 1) {
         const result = await runWithSchedulerClaim(
             ALBUM_DOWNLOAD_CLAIM_KEY,
             ALBUM_DOWNLOAD_CLAIM_TTL_MS,
             "album download",
-            (claimToken) => dispatchWithClaimRenewal(payload, claimToken),
+            (claimToken) =>
+                dispatchWithClaimRenewal(payload, routing, claimToken),
         );
         if (result.acquired) return;
         await new Promise<void>((resolve) =>
@@ -132,11 +145,30 @@ async function waitForAlbumDownloadClaim(
     throw new Error("Timed out waiting for the album download claim");
 }
 
+function requiresAlbumDownloadClaim(
+    routing: AlbumDownloadRouting | null,
+): routing is Extract<AlbumDownloadRouting, { kind: "dispatch" }> {
+    return (
+        routing?.kind === "dispatch" &&
+        (routing.source === "tidal" || routing.source === "youtube")
+    );
+}
+
 /** Validate and dispatch one queued album download. */
 export async function processAlbumDownload(job: Job<unknown>): Promise<void> {
     const payload = payloadSchema.parse(job.data);
     await job.progress(0);
-    await waitForAlbumDownloadClaim(payload);
+    if (await skipCompletedRedelivery(payload)) {
+        await job.progress(100);
+        return;
+    }
+
+    const routing = await resolveAlbumDownloadRouting(payload);
+    if (requiresAlbumDownloadClaim(routing)) {
+        await waitForAlbumDownloadClaim(payload, routing);
+    } else {
+        await dispatchPersistedAlbumDownload(payload, routing);
+    }
     await job.progress(100);
 }
 


### PR DESCRIPTION
Follow-up to #759 (flagged in the issue comment).

## Problem

The global album-download claim serializes ALL dispatches one-at-a-time. That's the intended throttle for TIDAL/YouTube (the whole download runs inline while holding it), but Lidarr-backed dispatch just fires an add-album request and returns in seconds — completion is webhook-driven; soundspan isn't the download manager there. In mixed-source setups a Lidarr handoff queued behind a multi-minute streaming hold, polling every 15s for up to 4 hours.

## Changes

- `downloadDispatcher` gains `resolveAlbumDownloadRouting` (job load + names + settings + availability + source resolution as a discriminated `fail`/`dispatch` union) and `dispatchResolvedAlbumDownload`; `dispatchAlbumDownload` composes them, behavior unchanged for all other callers.
- The worker resolves routing BEFORE any claim: TIDAL/YouTube → claim + renewal exactly as before; Lidarr/Soulseek-managed dispatch and `fail` routing proceed with no claim interaction. The completed-redelivery skip and failed-status recheck apply on both paths, and the routing snapshot passes through so settings/availability are probed once per job.
- Source flips between resolution and dispatch use the snapshot — identical semantics to today's inside-claim behavior.

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass
- verify: backend jest — albumDownloadProcessor, downloadDispatcher, albumDownloadQueueService, artistDownloadExpansionProcessor: `Test Suites: 4 passed`, `Tests: 57 passed`, exit 0 (claim ordering, Lidarr bypass, failure routing, completed redelivery, single-probe dispatch all covered)