### PR TITLE
feat(search): unified Songs section — owned and external results together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Search now shows one Songs section: songs you own and songs you don't sit together (external matches carry provider badges and skip anything already in your library) instead of being split across distant "Songs in Your Library" and "Songs to Discover" sections (#756).
+
 - Songs now have shareable links: "Copy link to song" in a track's menu copies a link that opens the album with that song highlighted and starts playing it (browsers may require a tap first on brand-new devices) (#756).
 - Songs in search results now have the full row menu and like/dislike buttons, and external "Songs to Discover" play right from the results when a streaming provider match exists (with TIDAL/YouTube badges) instead of only linking to the artist page (#756).
 

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { SearchIcon } from "lucide-react";
 import { useSearchData } from "@/features/search/hooks/useSearchData";
+import { dedupeDiscoverTracks } from "@/features/search/songDedup";
 import { useSoulseekSearch } from "@/features/search/hooks/useSoulseekSearch";
 import { useYouTubeUrl } from "@/features/search/hooks/useYouTubeUrl";
 import { YouTubePreviewCard } from "@/features/search/components/YouTubePreviewCard";
@@ -166,10 +167,18 @@ export default function SearchPage() {
     const libraryPodcasts = libraryResults?.podcasts ?? [];
     const hasPodcastResults =
         libraryPodcasts.length > 0 || discoverPodcastResults.length > 0;
+    // One Songs section: external matches continue the owned list, minus
+    // songs the library results already cover.
+    const unownedDiscoverTracks = showDiscover
+        ? dedupeDiscoverTracks(discoverTracks, libraryTracks)
+        : [];
 
     // Determine if we should show the 2-column layout
     const hasTopResult = visibleLibraryTopArtist || topArtist;
-    const hasTracks = libraryTracks.length > 0 || soulseekResults.length > 0;
+    const hasTracks =
+        libraryTracks.length > 0 ||
+        soulseekResults.length > 0 ||
+        unownedDiscoverTracks.length > 0;
     const show2ColumnLayout =
         hasSearched &&
         hasTopResult &&
@@ -364,7 +373,7 @@ export default function SearchPage() {
                                         href={sectionViewLinks.tracks}
                                         className="hover:underline"
                                     >
-                                        Songs in Your Library
+                                        Songs
                                     </Link>
                                 )}
                             </h2>
@@ -390,12 +399,23 @@ export default function SearchPage() {
                                         </div>
                                     ))}
                                 </div>
-                            ) : showLibrary && libraryTracks.length > 0 ? (
-                                <LibraryTracksList
-                                    tracks={libraryTracks}
-                                    limit={isTracksView ? null : 10}
-                                />
-                            ) : null}
+                            ) : (
+                                <>
+                                    {showLibrary &&
+                                        libraryTracks.length > 0 && (
+                                            <LibraryTracksList
+                                                tracks={libraryTracks}
+                                                limit={isTracksView ? null : 10}
+                                            />
+                                        )}
+                                    {unownedDiscoverTracks.length > 0 && (
+                                        <DiscoverTracksList
+                                            tracks={unownedDiscoverTracks}
+                                            limit={5}
+                                        />
+                                    )}
+                                </>
+                            )}
                         </div>
                     </div>
                 ) : (
@@ -472,25 +492,34 @@ export default function SearchPage() {
                                 </section>
                             )}
 
-                        {/* Library Songs */}
+                        {/* Songs — owned results with unowned continuation */}
                         {hasSearched &&
-                            showLibrary &&
                             !isPodcastTab &&
                             (sectionView === null || isTracksView) &&
-                            libraryTracks.length > 0 && (
+                            ((showLibrary && libraryTracks.length > 0) ||
+                                unownedDiscoverTracks.length > 0) && (
                                 <section>
                                     <h2 className="text-2xl font-bold text-white mb-6">
                                         <Link
                                             href={sectionViewLinks.tracks}
                                             className="hover:underline"
                                         >
-                                            Songs in Your Library
+                                            Songs
                                         </Link>
                                     </h2>
-                                    <LibraryTracksList
-                                        tracks={libraryTracks}
-                                        limit={isTracksView ? null : 10}
-                                    />
+                                    {showLibrary &&
+                                        libraryTracks.length > 0 && (
+                                            <LibraryTracksList
+                                                tracks={libraryTracks}
+                                                limit={isTracksView ? null : 10}
+                                            />
+                                        )}
+                                    {unownedDiscoverTracks.length > 0 && (
+                                        <DiscoverTracksList
+                                            tracks={unownedDiscoverTracks}
+                                            limit={isTracksView ? null : 5}
+                                        />
+                                    )}
                                 </section>
                             )}
                     </>
@@ -579,19 +608,9 @@ export default function SearchPage() {
                         />
                     )}
 
-                {/* Songs to Discover — external track matches */}
-                {hasSearched &&
-                    showDiscover &&
-                    !isPodcastTab &&
-                    !isSectionView &&
-                    discoverTracks.length > 0 && (
-                        <section>
-                            <h2 className="text-2xl font-bold text-white mb-6">
-                                Songs to Discover
-                            </h2>
-                            <DiscoverTracksList tracks={discoverTracks} />
-                        </section>
-                    )}
+                {/* Songs to Discover merged into the unified Songs section
+                    above; external rows continue the owned list with badges
+                    instead of living four sections away. */}
 
                 {/* Related Artists */}
                 {hasSearched &&

--- a/frontend/features/search/songDedup.ts
+++ b/frontend/features/search/songDedup.ts
@@ -1,0 +1,41 @@
+import type { DiscoverResult, LibraryTrack } from "./types";
+
+/**
+ * Normalize an artist/title pair for owned-vs-external song comparison:
+ * lowercase, strip trailing parenthetical/bracketed qualifiers (remaster,
+ * feat., live, ...), then drop punctuation AND spacing so "T.N.T.", "TNT",
+ * and "AC/DC" vs "AC DC" all compare equal.
+ */
+export function normalizeSongKey(artist: string, title: string): string {
+    const normalizePart = (value: string): string =>
+        value
+            .toLowerCase()
+            .replace(/\s*[([][^)\]]*[)\]]\s*$/g, "")
+            .replace(/[^\p{L}\p{N}]+/gu, "");
+    return `${normalizePart(artist)}::${normalizePart(title)}`;
+}
+
+/**
+ * Drop external track results that duplicate a song already present in the
+ * library results, so the unified Songs section never shows the same song
+ * twice. External rows without an artist cannot be safely compared and are
+ * kept.
+ */
+export function dedupeDiscoverTracks(
+    discoverTracks: DiscoverResult[],
+    libraryTracks: LibraryTrack[],
+): DiscoverResult[] {
+    if (discoverTracks.length === 0 || libraryTracks.length === 0) {
+        return discoverTracks;
+    }
+    const ownedKeys = new Set(
+        libraryTracks.map((track) =>
+            normalizeSongKey(track.album.artist.name, track.title),
+        ),
+    );
+    return discoverTracks.filter(
+        (track) =>
+            !track.artist ||
+            !ownedKeys.has(normalizeSongKey(track.artist, track.name)),
+    );
+}

--- a/frontend/tests/unit/songDedup.test.ts
+++ b/frontend/tests/unit/songDedup.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    dedupeDiscoverTracks,
+    normalizeSongKey,
+} from "../../features/search/songDedup";
+import type { DiscoverResult, LibraryTrack } from "../../features/search/types";
+
+function libraryTrack(artist: string, title: string): LibraryTrack {
+    return {
+        id: `lib-${artist}-${title}`,
+        title,
+        duration: 200,
+        album: {
+            id: "al1",
+            title: "Album",
+            coverUrl: null,
+            artist: { id: "ar1", name: artist },
+        },
+    } as unknown as LibraryTrack;
+}
+
+function discoverTrack(artist: string, name: string): DiscoverResult {
+    return { type: "track", name, artist };
+}
+
+test("normalizeSongKey folds case, punctuation, and trailing qualifiers", () => {
+    assert.equal(
+        normalizeSongKey("AC/DC", "T.N.T. (Live)"),
+        normalizeSongKey("ac dc", "TNT"),
+    );
+    assert.equal(
+        normalizeSongKey(
+            "Trace Adkins",
+            "Every Light In The House (2003 Remaster)",
+        ),
+        normalizeSongKey("trace adkins", "every light in the house"),
+    );
+    assert.notEqual(
+        normalizeSongKey("Trace Adkins", "Songs About Me"),
+        normalizeSongKey("Trace Adkins", "Chrome"),
+    );
+});
+
+test("dedupeDiscoverTracks drops external rows that duplicate owned songs", () => {
+    const deduped = dedupeDiscoverTracks(
+        [
+            discoverTrack("Trace Adkins", "Chrome"),
+            discoverTrack("Trace Adkins", "Songs About Me"),
+        ],
+        [libraryTrack("Trace Adkins", "Chrome (2011 Remaster)")],
+    );
+    assert.deepEqual(
+        deduped.map((track) => track.name),
+        ["Songs About Me"],
+    );
+});
+
+test("dedupeDiscoverTracks keeps artist-less rows and everything when either side is empty", () => {
+    const artistless: DiscoverResult = { type: "track", name: "Mystery" };
+    assert.deepEqual(
+        dedupeDiscoverTracks([artistless], [libraryTrack("A", "Mystery")]),
+        [artistless],
+    );
+    const all = [discoverTrack("A", "B")];
+    assert.deepEqual(dedupeDiscoverTracks(all, []), all);
+    assert.deepEqual(dedupeDiscoverTracks([], [libraryTrack("A", "B")]), []);
+});


### PR DESCRIPTION
Final slice of #756 (after #766 deep links and #768 playable rows). Closes #756.

## What

- One **Songs** section in both search layouts: library results first, external matches continuing the same list (with the provider badges/playability from #768) instead of a separate "Songs to Discover" section four blocks away.
- External rows are **deduped against library results** via a normalized artist/title key (`features/search/songDedup.ts`, pure + unit-tested): case, punctuation, spacing, and trailing parenthetical qualifiers (remaster/live/feat) fold together, so an owned "Chrome (2011 Remaster)" suppresses the external "Chrome".
- A song-title query with no library hits now qualifies for the two-column Top Result + Songs layout — previously external-only matches were excluded from `hasTracks` and sank to the bottom of the page.

## Verification

- verify: frontend `tsc --noEmit` exit 0; lint 0 errors at exactly the 183-warning cap; prettier clean
- verify: unit `songDedup.test.ts` 3/3 pass; component suites searchExternalDiscovery + searchFiltersFederation + searchRowActions 9/9 pass on Node 24