### PR TITLE
fix(search): invalidate caches on library changes and match editions you own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Search results now reflect library changes immediately after a scan or deletion; artist-page popular tracks and discography now recognize remasters and editions you own (#758).
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).
 - Tracks you do not own on the artist page keep their row menu, so Go to artist and Go to album stay available (#757).
 - Artist-wide downloads now expand through the background album-download pipeline and no longer require Lidarr, allowing TIDAL- and YouTube-only deployments to queue the full discography.

--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -95,7 +95,9 @@ jest.mock("../../services/imageProvider", () => ({
 }));
 
 jest.mock("../../services/musicbrainz", () => ({
-    musicBrainzService: {},
+    musicBrainzService: {
+        getReleaseGroups: jest.fn(),
+    },
 }));
 
 jest.mock("../../services/coverArt", () => ({
@@ -166,6 +168,7 @@ import { prisma } from "../../utils/db";
 import { lastFmService } from "../../services/lastfm";
 import { deezerService } from "../../services/deezer";
 import { dataCacheService } from "../../services/dataCache";
+import { musicBrainzService } from "../../services/musicbrainz";
 
 const mockArtistFindFirst = prisma.artist.findFirst as jest.Mock;
 const mockPlayGroupBy = prisma.play.groupBy as jest.Mock;
@@ -174,6 +177,8 @@ const mockLastFmGetArtistTopTracks =
 const mockDeezerGetAlbumCover = deezerService.getAlbumCover as jest.Mock;
 const mockDataCacheGetArtistImage =
     dataCacheService.getArtistImage as jest.Mock;
+const mockMusicBrainzGetReleaseGroups =
+    musicBrainzService.getReleaseGroups as jest.Mock;
 
 function getGetHandler(path: string, stackIndex = 0) {
     const layer = flattenLibraryRouteLayers(router).find(
@@ -224,6 +229,7 @@ describe("library artist lookup compatibility", () => {
         mockLastFmGetArtistTopTracks.mockResolvedValue([]);
         mockDeezerGetAlbumCover.mockResolvedValue(null);
         mockDataCacheGetArtistImage.mockResolvedValue(null);
+        mockMusicBrainzGetReleaseGroups.mockResolvedValue([]);
     });
 
     it.each([
@@ -492,6 +498,125 @@ describe("library artist lookup compatibility", () => {
                 },
             }),
         ]);
+    });
+
+    it.each([
+        ["Song Title (2011 Remaster)", "Song Title"],
+        ["Song Title (feat. Guest)", "Song Title"],
+        ["Song: Title!", "Song Title"],
+    ])(
+        "matches normalized library title %p to Last.fm title %p",
+        async (libraryTitle, lastFmTitle) => {
+            mockArtistFindFirst.mockResolvedValueOnce({
+                ...createMockArtist(),
+                albums: [
+                    {
+                        id: "album-1",
+                        title: "Owned Album",
+                        rgMbid: "rg-owned",
+                        coverUrl: "owned-cover.jpg",
+                        tracks: [
+                            {
+                                id: "track-remaster",
+                                title: libraryTitle,
+                                album: {
+                                    id: "album-1",
+                                    title: "Owned Album",
+                                    coverUrl: "owned-cover.jpg",
+                                    albumLoudnessLufs: null,
+                                    albumTruePeakDb: null,
+                                    artist: {
+                                        id: "artist-1",
+                                        name: "AC/DC",
+                                        mbid: "mbid-artist-1",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+            mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
+                {
+                    name: lastFmTitle,
+                    playcount: "12",
+                    listeners: "34",
+                    duration: "245",
+                    url: "https://last.fm/track/song-title",
+                    album: { "#text": "Owned Album" },
+                },
+            ]);
+            const req = {
+                params: { id: "artist-local-id-123" },
+                query: {
+                    includeDiscography: "false",
+                    includeTopTracks: "true",
+                    includeSimilarArtists: "false",
+                },
+                user: { id: "user-1" },
+            } as any;
+            const res = createRes();
+
+            await artistHandler(req, res);
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body.topTracks).toEqual([
+                expect.objectContaining({
+                    id: "track-remaster",
+                    title: libraryTitle,
+                    album: expect.objectContaining({ id: "album-1" }),
+                }),
+            ]);
+            expect(mockDeezerGetAlbumCover).not.toHaveBeenCalled();
+        },
+    );
+
+    it("folds a MusicBrainz base album into its owned deluxe edition", async () => {
+        mockArtistFindFirst.mockResolvedValueOnce({
+            ...createMockArtist(),
+            albums: [
+                {
+                    id: "album-deluxe",
+                    title: "Album (Deluxe Edition)",
+                    rgMbid: "rg-owned-deluxe",
+                    coverUrl: "owned-cover.jpg",
+                    location: "LIBRARY",
+                    tracks: [],
+                },
+            ],
+        });
+        mockMusicBrainzGetReleaseGroups.mockResolvedValueOnce([
+            {
+                id: "rg-mb-base",
+                title: "Album",
+                "first-release-date": "2011-01-01",
+                "primary-type": "Album",
+                "secondary-types": [],
+            },
+        ]);
+        const req = {
+            params: { id: "artist-local-id-123" },
+            query: {
+                includeDiscography: "true",
+                includeTopTracks: "false",
+                includeSimilarArtists: "false",
+            },
+            user: { id: "user-1" },
+        } as any;
+        const res = createRes();
+
+        await artistHandler(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.albums).toEqual([
+            expect.objectContaining({
+                id: "album-deluxe",
+                title: "Album (Deluxe Edition)",
+                owned: true,
+                source: "database",
+            }),
+        ]);
+        expect(res.body.discographyComplete).toBe(true);
     });
 
     it("hydrates unmatched Last.fm top tracks and skips Deezer lookup for unknown albums", async () => {

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -13,6 +13,7 @@ const mockLoadPeerPlaybackFallback = jest.fn();
 const mockServeMappedProviderStream = jest.fn();
 const mockTerminateCommittedStream = jest.fn((res: Response) => res.end());
 const mockGetYtMusicUserIdOrPublic = jest.fn();
+const mockBumpSearchCacheVersion = jest.fn().mockResolvedValue(undefined);
 
 jest.mock("dns/promises", () => ({
     lookup: (...args: unknown[]) => mockLookup(...args),
@@ -353,6 +354,10 @@ jest.mock("../../services/imageProxy", () => ({
 
 jest.mock("../../services/imageStorage", () => ({
     downloadAndStoreImage: jest.fn(),
+}));
+
+jest.mock("../../services/searchCacheVersion", () => ({
+    bumpSearchCacheVersion: mockBumpSearchCacheVersion,
 }));
 
 const mockLidarrDeleteArtist = jest.fn();
@@ -5160,6 +5165,7 @@ describe("library catalog list runtime coverage", () => {
             lidarrDeleted: false,
             lidarrError: null,
         });
+        expect(mockBumpSearchCacheVersion).toHaveBeenCalledTimes(3);
         artistFsSpy.mockRestore();
     });
 

--- a/backend/src/routes/library/albums.ts
+++ b/backend/src/routes/library/albums.ts
@@ -50,6 +50,7 @@ import {
     isSafeRecursiveDeletionTarget,
     libraryDeletionLogger,
 } from "../../utils/libraryDeletion";
+import { bumpSearchCacheVersion } from "../../services/searchCacheVersion";
 
 /**
  * Router segment for albums routes registered at this position.
@@ -808,6 +809,7 @@ export async function handleDeleteAlbum(
             where: { id: album.id },
         });
     });
+    await bumpSearchCacheVersion();
 
     // Delete track files only after the database transaction commits.
     let deletedFiles = 0;

--- a/backend/src/routes/library/artistPageMatching.ts
+++ b/backend/src/routes/library/artistPageMatching.ts
@@ -1,0 +1,75 @@
+import {
+    normalizeTrackTitle,
+    stripTrackSuffix,
+} from "../../utils/trackMatching";
+import {
+    normalizeAlbumTitle,
+    stripAlbumEdition,
+} from "../../utils/artistNormalization";
+import { stripDelimitedSegments } from "../../utils/stripDelimitedSegments";
+
+type Titled = Readonly<{ title: string }>;
+const FEATURE_SUFFIX = /^(?:feat\.?|ft\.?|featuring)\b/i;
+
+function stripFeatureSuffix(title: string): string {
+    return stripDelimitedSegments(
+        stripTrackSuffix(title),
+        "(",
+        ")",
+        (segment) => FEATURE_SUFFIX.test(segment.trim()),
+        " ",
+    );
+}
+
+function trackTitleKeys(title: string): readonly string[] {
+    const rawFallback = title.toLowerCase();
+    const normalizedTitle = normalizeTrackTitle(title) || rawFallback;
+    const normalizedWithoutSuffix =
+        normalizeTrackTitle(stripFeatureSuffix(title)) || rawFallback;
+    return normalizedTitle === normalizedWithoutSuffix
+        ? [normalizedTitle]
+        : [normalizedTitle, normalizedWithoutSuffix];
+}
+
+/** Builds a first-writer-wins lookup for normalized artist-page track titles. */
+export function buildArtistTrackTitleIndex<T extends Titled>(
+    tracks: readonly T[],
+): ReadonlyMap<string, T> {
+    const tracksByTitle = new Map<string, T>();
+    for (const track of tracks) {
+        for (const key of trackTitleKeys(track.title)) {
+            if (!tracksByTitle.has(key)) tracksByTitle.set(key, track);
+        }
+    }
+    return tracksByTitle;
+}
+
+/** Finds a library track through the same normalized title variants. */
+export function findArtistTrackByTitle<T extends Titled>(
+    tracksByTitle: ReadonlyMap<string, T>,
+    title: string,
+): T | undefined {
+    for (const key of trackTitleKeys(title)) {
+        const track = tracksByTitle.get(key);
+        if (track) return track;
+    }
+    return undefined;
+}
+
+function normalizeDiscographyAlbumTitle(title: string): string {
+    return normalizeAlbumTitle(stripAlbumEdition(title));
+}
+
+/** Removes remote discography rows that match an owned album edition. */
+export function filterDistinctDiscographyAlbums<
+    TOwned extends Titled,
+    TRemote extends Titled,
+>(ownedAlbums: readonly TOwned[], remoteAlbums: readonly TRemote[]): TRemote[] {
+    const ownedTitles = new Set(
+        ownedAlbums.map((album) => normalizeDiscographyAlbumTitle(album.title)),
+    );
+    return remoteAlbums.filter(
+        (album) =>
+            !ownedTitles.has(normalizeDiscographyAlbumTitle(album.title)),
+    );
+}

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -47,6 +47,12 @@ import {
 import { findRouteNameMatch } from "../artistRouteName";
 import { deleteArtistCatalogEntry } from "../../services/artistCatalogDeletion";
 import { withFederatedTrackPlayback } from "../../services/federatedTrackPayload";
+import { bumpSearchCacheVersion } from "../../services/searchCacheVersion";
+import {
+    buildArtistTrackTitleIndex,
+    filterDistinctDiscographyAlbums,
+    findArtistTrackByTitle,
+} from "./artistPageMatching";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -728,11 +734,9 @@ export async function handleGetArtist(
 
                 // Merge database albums with MusicBrainz albums
                 // Database albums take precedence (they have actual files!)
-                const dbAlbumTitles = new Set(
-                    dbAlbums.map((a) => a.title.toLowerCase()),
-                );
-                const mbAlbumsFiltered = mbAlbums.filter(
-                    (a) => !dbAlbumTitles.has(a.title.toLowerCase()),
+                const mbAlbumsFiltered = filterDistinctDiscographyAlbums(
+                    dbAlbums,
+                    mbAlbums,
                 );
 
                 albumsWithOwnership = [...dbAlbums, ...mbAlbumsFiltered];
@@ -871,13 +875,7 @@ export async function handleGetArtist(
             }
 
             // Build lookup map for O(1) matching instead of O(n*m)
-            const tracksByTitle = new Map<string, (typeof allTracks)[0]>();
-            for (const track of allTracks) {
-                const key = track.title.toLowerCase();
-                if (!tracksByTitle.has(key)) {
-                    tracksByTitle.set(key, track);
-                }
-            }
+            const tracksByTitle = buildArtistTrackTitleIndex(allTracks);
 
             // For each Last.fm track, try to match with library track or add as unowned
             const combinedTracks: any[] = [];
@@ -890,9 +888,10 @@ export async function handleGetArtist(
             }> = [];
 
             for (const lfmTrack of lastfmTopTracks) {
-                // O(1) lookup instead of O(n) find
-                const key = lfmTrack.name.toLowerCase();
-                const matchedTrack = tracksByTitle.get(key);
+                const matchedTrack = findArtistTrackByTitle(
+                    tracksByTitle,
+                    lfmTrack.name,
+                );
 
                 if (matchedTrack) {
                     // Track exists in library - include user play count
@@ -1514,6 +1513,7 @@ export async function handleDeleteArtist(
             `[DELETE] Deleting artist from database: ${artist.name} (${artist.id})`,
         );
         await deleteArtistCatalogEntry(artist.id);
+        await bumpSearchCacheVersion();
 
         logger.debug(
             `[DELETE] Successfully deleted artist: ${

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -78,6 +78,7 @@ import {
     proxyLibraryPeerStream,
 } from "./libraryPeerStream";
 import { serveNativeLibraryTrack } from "./libraryNativeTrackStream";
+import { bumpSearchCacheVersion } from "../../services/searchCacheVersion";
 
 /**
  * Router segment for tracks routes registered at this position.
@@ -1637,6 +1638,7 @@ export async function handleDeleteTrack(
 
     // Delete from database (cascade will handle related records)
     await deleteTrackAndRecomputeAlbum(track.id, track.albumId);
+    await bumpSearchCacheVersion();
 
     logger.debug(`[DELETE] Deleted track: ${track.title}`);
 

--- a/backend/src/services/__tests__/libraryOrphanCleanup.test.ts
+++ b/backend/src/services/__tests__/libraryOrphanCleanup.test.ts
@@ -5,6 +5,7 @@ describe("cleanupOrphanedLibraryEntities", () => {
     });
 
     function loadCleanup(federationEnabled = false) {
+        const bumpSearchCacheVersion = jest.fn().mockResolvedValue(undefined);
         const logger = {
             info: jest.fn(),
             error: jest.fn(),
@@ -55,14 +56,23 @@ describe("cleanupOrphanedLibraryEntities", () => {
                 workers: { providerTrackRetentionDays: 30 },
             },
         }));
+        jest.doMock("../searchCacheVersion", () => ({
+            bumpSearchCacheVersion,
+        }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const module = require("../libraryOrphanCleanup");
-        return { logger, module, operations, prisma };
+        return {
+            bumpSearchCacheVersion,
+            logger,
+            module,
+            operations,
+            prisma,
+        };
     }
 
     it("deletes only peerless orphaned albums and artists", async () => {
-        const { module, prisma } = loadCleanup();
+        const { bumpSearchCacheVersion, module, prisma } = loadCleanup();
 
         await expect(module.cleanupOrphanedLibraryEntities()).resolves.toEqual({
             albumsDeleted: 1,
@@ -129,10 +139,11 @@ describe("cleanupOrphanedLibraryEntities", () => {
             { maxWait: 2000, timeout: 15000 },
         );
         expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(bumpSearchCacheVersion).toHaveBeenCalledTimes(1);
     });
 
     it("leaves peer-owned entities untouched during an empty sync window", async () => {
-        const { module, prisma } = loadCleanup();
+        const { bumpSearchCacheVersion, module, prisma } = loadCleanup();
         prisma.album.findMany.mockImplementationOnce(async (args: any) => {
             return args.where?.peerId === null
                 ? []
@@ -161,6 +172,7 @@ describe("cleanupOrphanedLibraryEntities", () => {
         );
         expect(prisma.album.deleteMany).not.toHaveBeenCalled();
         expect(prisma.artist.deleteMany).not.toHaveBeenCalled();
+        expect(bumpSearchCacheVersion).not.toHaveBeenCalled();
     });
 
     it("writes album and artist tombstones in the deletion transaction when federation is enabled", async () => {

--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -92,6 +92,7 @@ const mockParseArtistFromPath = jest.fn((name: string) => name);
 const mockExtractCoverArt = jest.fn();
 const mockCreateMapping = jest.fn();
 const mockRecomputeAlbumLoudness = jest.fn();
+const mockBumpSearchCacheVersion = jest.fn();
 const mockConfig = {
     music: { transcodeCachePath: "/cache/transcodes" },
     scanFileConcurrency: 2,
@@ -242,6 +243,10 @@ jest.mock("../trackMappingService", () => ({
 
 jest.mock("../albumLoudness", () => ({
     recomputeAlbumLoudness: mockRecomputeAlbumLoudness,
+}));
+
+jest.mock("../searchCacheVersion", () => ({
+    bumpSearchCacheVersion: mockBumpSearchCacheVersion,
 }));
 
 jest.mock("../../config", () => ({
@@ -437,11 +442,21 @@ describe("MusicScannerService.scanLibrary", () => {
             "sha256:" + "ab".repeat(32),
         );
         mockCreateMapping.mockResolvedValue({ id: "mapping-1" });
+        mockBumpSearchCacheVersion.mockResolvedValue(undefined);
     });
 
     afterEach(() => {
         jest.useRealTimers();
         jest.restoreAllMocks();
+    });
+
+    it("bumps the search cache version once after a completed scan", async () => {
+        const scanner = new MusicScannerService();
+        jest.spyOn(scanner as any, "findAudioFiles").mockResolvedValue([]);
+
+        await scanner.scanLibrary("/music");
+
+        expect(mockBumpSearchCacheVersion).toHaveBeenCalledTimes(1);
     });
 
     it("starts multiple per-file tasks before the first one completes", async () => {

--- a/backend/src/services/__tests__/searchCacheVersion.test.ts
+++ b/backend/src/services/__tests__/searchCacheVersion.test.ts
@@ -1,0 +1,86 @@
+const redisClient = {
+    get: jest.fn(),
+    incr: jest.fn(),
+    set: jest.fn(),
+};
+
+const versionLogger = {
+    warn: jest.fn(),
+};
+const logger = {
+    child: jest.fn(() => versionLogger),
+};
+
+jest.mock("../../utils/redis", () => ({ redisClient }));
+jest.mock("../../utils/logger", () => ({ logger }));
+
+import {
+    bumpSearchCacheVersion,
+    getSearchCacheVersion,
+} from "../searchCacheVersion";
+
+describe("search cache version", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        redisClient.get.mockResolvedValue(null);
+        redisClient.incr.mockResolvedValue(2);
+        redisClient.set.mockResolvedValue("OK");
+    });
+
+    it("reads the current Redis version and defaults a missing value to one", async () => {
+        redisClient.get.mockResolvedValueOnce("7").mockResolvedValueOnce(null);
+
+        await expect(getSearchCacheVersion()).resolves.toBe(7);
+        await expect(getSearchCacheVersion()).resolves.toBe(1);
+
+        expect(redisClient.get).toHaveBeenNthCalledWith(1, "search:version");
+        expect(redisClient.get).toHaveBeenNthCalledWith(2, "search:version");
+        expect(redisClient.set).toHaveBeenCalledWith("search:version", "1", {
+            NX: true,
+        });
+    });
+
+    it.each(["", "not-a-number", "0", "-1", "1.5"])(
+        "falls back to one for invalid Redis version %p",
+        async (storedVersion) => {
+            redisClient.get.mockResolvedValueOnce(storedVersion);
+
+            await expect(getSearchCacheVersion()).resolves.toBe(1);
+
+            expect(versionLogger.warn).toHaveBeenCalledWith(
+                "Invalid search cache version; using fallback",
+                { storedVersion },
+            );
+        },
+    );
+
+    it("falls back to one when Redis reads fail", async () => {
+        const error = new Error("redis unavailable");
+        redisClient.get.mockRejectedValueOnce(error);
+
+        await expect(getSearchCacheVersion()).resolves.toBe(1);
+
+        expect(versionLogger.warn).toHaveBeenCalledWith(
+            "Search cache version read failed; using fallback",
+            { error },
+        );
+    });
+
+    it("increments the shared Redis version", async () => {
+        await expect(bumpSearchCacheVersion()).resolves.toBeUndefined();
+
+        expect(redisClient.incr).toHaveBeenCalledWith("search:version");
+    });
+
+    it("logs and swallows Redis increment failures", async () => {
+        const error = new Error("redis unavailable");
+        redisClient.incr.mockRejectedValueOnce(error);
+
+        await expect(bumpSearchCacheVersion()).resolves.toBeUndefined();
+
+        expect(versionLogger.warn).toHaveBeenCalledWith(
+            "Search cache version bump failed",
+            { error },
+        );
+    });
+});

--- a/backend/src/services/__tests__/searchService.test.ts
+++ b/backend/src/services/__tests__/searchService.test.ts
@@ -30,6 +30,7 @@ const logger = {
     warn: jest.fn(),
     error: jest.fn(),
 };
+const getSearchCacheVersion = jest.fn();
 const MAX_SQL_FRAGMENT_VALUES = 128;
 
 interface SqlFragment {
@@ -86,6 +87,8 @@ jest.mock("../../utils/logger", () => ({
     logger,
 }));
 
+jest.mock("../searchCacheVersion", () => ({ getSearchCacheVersion }));
+
 import { normalizeCacheQuery, searchService } from "../search";
 
 describe("search service", () => {
@@ -101,6 +104,7 @@ describe("search service", () => {
         prisma.audiobook.findMany.mockResolvedValue([]);
         redisClient.get.mockResolvedValue(null);
         redisClient.setEx.mockResolvedValue("OK");
+        getSearchCacheVersion.mockResolvedValue(1);
     });
 
     it("normalizes cache queries", () => {
@@ -768,6 +772,9 @@ describe("search service", () => {
             query: "book",
             limit: 4,
         });
+        expect(redisClient.get).toHaveBeenCalledWith(
+            "search:all:v1:book:4::all",
+        );
         expect(cacheHit.audiobooks).toEqual([
             expect.objectContaining({
                 id: "book-9",
@@ -1022,13 +1029,56 @@ describe("search service", () => {
             offset: 40,
         });
 
-        const cacheKey = "search:artists:radiohead:10:40::all";
+        const cacheKey = "search:artists:v1:radiohead:10:40::all";
         expect(redisClient.get).toHaveBeenCalledWith(cacheKey);
         expect(redisClient.setEx).toHaveBeenCalledWith(
             cacheKey,
             120,
             expect.any(String),
         );
+    });
+
+    it("misses an old type-scoped cache entry after the version changes", async () => {
+        const oldResults = {
+            artists: [{ id: "artist-old" }],
+            albums: [],
+            tracks: [],
+            podcasts: [],
+            audiobooks: [],
+            episodes: [],
+        };
+        getSearchCacheVersion.mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+        redisClient.get.mockImplementation(async (key: string) =>
+            key === "search:artists:v1:radiohead:20:0::all"
+                ? JSON.stringify(oldResults)
+                : null,
+        );
+        const searchArtists = jest
+            .spyOn(searchService, "searchArtists")
+            .mockResolvedValueOnce([]);
+
+        await expect(
+            searchService.searchByType({
+                query: "Radiohead",
+                type: "artists",
+            }),
+        ).resolves.toEqual(oldResults);
+        await expect(
+            searchService.searchByType({
+                query: "Radiohead",
+                type: "artists",
+            }),
+        ).resolves.toEqual(expect.objectContaining({ artists: [] }));
+
+        expect(redisClient.get).toHaveBeenNthCalledWith(
+            1,
+            "search:artists:v1:radiohead:20:0::all",
+        );
+        expect(redisClient.get).toHaveBeenNthCalledWith(
+            2,
+            "search:artists:v2:radiohead:20:0::all",
+        );
+        expect(searchArtists).toHaveBeenCalledTimes(1);
     });
 
     it("searchAudiobooksFTS falls back to local search when full-text results are empty", async () => {

--- a/backend/src/services/__tests__/searchStopWordFallback.test.ts
+++ b/backend/src/services/__tests__/searchStopWordFallback.test.ts
@@ -22,6 +22,7 @@ const logger = {
     warn: jest.fn(),
     error: jest.fn(),
 };
+(logger as { child?: unknown }).child = jest.fn(() => logger);
 
 jest.mock("../../utils/db", () => ({
     prisma,

--- a/backend/src/services/libraryOrphanCleanup.ts
+++ b/backend/src/services/libraryOrphanCleanup.ts
@@ -7,6 +7,7 @@ import {
     artistOrphanRetentionGuardWhere,
     providerTrackRetentionCutoff,
 } from "./providerTrackRetention";
+import { bumpSearchCacheVersion } from "./searchCacheVersion";
 
 const cleanupLogger = logger.child("LibraryOrphanCleanup");
 /** Keeps each deletion transaction near the provider GC's 100-row write cost. */
@@ -267,6 +268,7 @@ export async function cleanupOrphanedLibraryEntities(
     const artistsDeleted = await cleanupArtistBatches(writeTombstones, cutoff);
 
     if (albumsDeleted > 0 || artistsDeleted > 0) {
+        await bumpSearchCacheVersion();
         cleanupLogger.info(
             `Deleted ${albumsDeleted} orphaned albums and ${artistsDeleted} orphaned artists`,
         );

--- a/backend/src/services/musicScanner.ts
+++ b/backend/src/services/musicScanner.ts
@@ -34,6 +34,7 @@ import {
     resolveScannerAlbum,
     resolveScannerArtist,
 } from "./musicScannerIdentity";
+import { bumpSearchCacheVersion } from "./searchCacheVersion";
 
 const scanLogger = logger.child("MusicScannerService");
 const TRACK_IDENTITY_SELECT = {
@@ -694,6 +695,8 @@ export class MusicScannerService {
                 logger.error("[Scan] Artist counts update failed:", err);
             });
         }
+
+        await bumpSearchCacheVersion();
 
         return result;
     }

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/librarySorting";
 import { trackBrowseSql } from "../utils/libraryRadioPredicates";
 import { escapeLikePattern } from "../utils/likePattern";
+import { getSearchCacheVersion } from "./searchCacheVersion";
 
 const MAX_TRACK_SEARCH_TERMS = 6;
 
@@ -873,7 +874,8 @@ export class SearchService {
         }
 
         // Check Redis cache first
-        const cacheKey = `search:all:${normalizeCacheQuery(query)}:${limit}:${genre || ""}:${source}`;
+        const cacheVersion = await getSearchCacheVersion();
+        const cacheKey = `search:all:v${cacheVersion}:${normalizeCacheQuery(query)}:${limit}:${genre || ""}:${source}`;
         try {
             const cached = await redisClient.get(cacheKey);
             if (cached) {
@@ -988,7 +990,8 @@ export class SearchService {
         }
 
         // Check cache
-        const cacheKey = `search:${type}:${normalizeCacheQuery(query)}:${limit}:${offset}:${genre || ""}:${source}`;
+        const cacheVersion = await getSearchCacheVersion();
+        const cacheKey = `search:${type}:v${cacheVersion}:${normalizeCacheQuery(query)}:${limit}:${offset}:${genre || ""}:${source}`;
         try {
             const cached = await redisClient.get(cacheKey);
             if (cached) {

--- a/backend/src/services/searchCacheVersion.ts
+++ b/backend/src/services/searchCacheVersion.ts
@@ -1,0 +1,41 @@
+import { redisClient } from "../utils/redis";
+import { logger } from "../utils/logger";
+
+const SEARCH_CACHE_VERSION_KEY = "search:version";
+const searchCacheVersionLogger = logger.child("SearchCacheVersion");
+
+/** Returns the shared search-cache namespace version. */
+export async function getSearchCacheVersion(): Promise<number> {
+    try {
+        const storedVersion = await redisClient.get(SEARCH_CACHE_VERSION_KEY);
+        if (storedVersion === null) {
+            await redisClient.set(SEARCH_CACHE_VERSION_KEY, "1", { NX: true });
+            return 1;
+        }
+
+        const version = Number(storedVersion);
+        if (Number.isSafeInteger(version) && version > 0) return version;
+
+        searchCacheVersionLogger.warn(
+            "Invalid search cache version; using fallback",
+            { storedVersion },
+        );
+    } catch (error) {
+        searchCacheVersionLogger.warn(
+            "Search cache version read failed; using fallback",
+            { error },
+        );
+    }
+    return 1;
+}
+
+/** Advances the shared search-cache namespace without failing the mutation. */
+export async function bumpSearchCacheVersion(): Promise<void> {
+    try {
+        await redisClient.incr(SEARCH_CACHE_VERSION_KEY);
+    } catch (error) {
+        searchCacheVersionLogger.warn("Search cache version bump failed", {
+            error,
+        });
+    }
+}


### PR DESCRIPTION
PR B of 2 for #758 (PR A was #767). Closes #758.

## Problems

- Search Redis caches (`search:all:*` 300s, `search:<type>:*` 120s) were never invalidated on library mutation — new scans invisible for up to 5 minutes, deletions lingering.
- Artist-page top-track matching and discography dedup used exact lowercase title equality — remasters, `(feat. X)` variants, and deluxe editions you own rendered as unowned duplicates.

## Changes

- **Version-stamped cache namespace**: new `searchCacheVersion` service (Redis `search:version`, NX-initialized, INCR bumps, graceful degradation — reads fall back to 1, bumps log and swallow). Keys become `search:all:v<N>:...` / `search:<type>:v<N>:...`.
- **Bump sites** (one per user-visible mutation, each after its transaction commits): scan completion, track deletion, album deletion, artist catalog deletion, and orphan cleanup (only when something was actually deleted). Remote-entity resolution intentionally does not bump.
- **Normalized artist-page matching**: new `artistPageMatching` module builds a first-writer-wins index over the shared `normalizeTrackTitle`/suffix-stripped/feature-stripped variants, and discography dedup folds `stripAlbumEdition` + `normalizeAlbumTitle` matches (owned entry wins). `artists.ts` stayed at 1,545 lines — logic extracted, not grown.

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass
- verify: backend jest — searchCacheVersion, searchService, musicScannerService, libraryOrphanCleanup, libraryArtistLookupCompat: `Test Suites: 5 passed`, `Tests: 174 passed`, exit 0; full `libraryRuntime` suite: `Tests: 161 passed`, exit 0 (run outside the local socket sandbox)