### PR TITLE
chore(metadata): one artist-image resolver behind a facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Artist images now resolve through one provider ladder with unified caching, instead of five surface-specific implementations.
 - Search now matches songs by artist and album name, tolerates typos, and ranks fallback results by similarity instead of alphabetically.
 - Download job metadata updates now flow through guarded helpers instead of ad-hoc merges scattered across the backend.
 - TIDAL and YouTube Music library downloads now run through one shared processor with per-source steps, so fixes apply to both sources at once.

--- a/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
+++ b/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
@@ -40,16 +40,14 @@ jest.mock("../services/lastfm", () => ({
     },
 }));
 
-jest.mock("../services/fanart", () => ({
-    fanartService: {
-        getArtistImage: jest.fn().mockResolvedValue(null),
-    },
+jest.mock("../services/metadata/artistImageResolver", () => ({
+    resolveArtistImage: jest.fn().mockResolvedValue(null),
 }));
 
-jest.mock("../services/deezer", () => ({
-    deezerService: {
-        getArtistImage: jest.fn().mockResolvedValue(null),
-    },
+jest.mock("../utils/musicIds", () => ({
+    isRealArtistMbid: (value: unknown) =>
+        typeof value === "string" && !value.startsWith("temp-"),
+    rgMbidKind: () => "musicbrainz",
 }));
 
 jest.mock("../services/musicbrainz", () => ({

--- a/backend/src/__tests__/artistsRouteAuthz.test.ts
+++ b/backend/src/__tests__/artistsRouteAuthz.test.ts
@@ -80,6 +80,12 @@ jest.mock("../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
+++ b/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
@@ -14,6 +14,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/artistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/artistsRuntime.test.ts
@@ -34,7 +34,6 @@ jest.mock("../../services/youtubeMusic", () => ({
 
 const deezerService = {
     getTrackPreview: jest.fn(),
-    getArtistImage: jest.fn(),
     getAlbumCover: jest.fn(),
 };
 
@@ -57,7 +56,6 @@ jest.mock("../../services/musicbrainz", () => ({
 const lastFmService = {
     getArtistInfo: jest.fn(),
     getArtistTopTracks: jest.fn(),
-    getBestImage: jest.fn(),
     getAlbumInfo: jest.fn(),
 };
 
@@ -65,12 +63,9 @@ jest.mock("../../services/lastfm", () => ({
     lastFmService,
 }));
 
-const fanartService = {
-    getArtistImage: jest.fn(),
-};
-
-jest.mock("../../services/fanart", () => ({
-    fanartService,
+const mockResolveArtistImage = jest.fn();
+jest.mock("../../services/metadata/artistImageResolver", () => ({
+    resolveArtistImage: mockResolveArtistImage,
 }));
 
 const redisClient = {
@@ -91,7 +86,6 @@ const mockLoggerError = logger.error as jest.Mock;
 
 const mockYtSearch = ytMusicService.search as jest.Mock;
 const mockGetTrackPreview = deezerService.getTrackPreview as jest.Mock;
-const mockGetArtistImage = deezerService.getArtistImage as jest.Mock;
 const mockGetAlbumCover = deezerService.getAlbumCover as jest.Mock;
 
 const mockSearchArtist = musicBrainzService.searchArtist as jest.Mock;
@@ -102,10 +96,7 @@ const mockGetRelease = musicBrainzService.getRelease as jest.Mock;
 
 const mockGetArtistInfo = lastFmService.getArtistInfo as jest.Mock;
 const mockGetArtistTopTracks = lastFmService.getArtistTopTracks as jest.Mock;
-const mockGetBestImage = lastFmService.getBestImage as jest.Mock;
 const mockGetAlbumInfo = lastFmService.getAlbumInfo as jest.Mock;
-
-const mockFanartArtistImage = fanartService.getArtistImage as jest.Mock;
 
 const mockRedisGet = redisClient.get as jest.Mock;
 const mockRedisSetEx = redisClient.setEx as jest.Mock;
@@ -161,7 +152,6 @@ describe("artists routes runtime", () => {
         mockGetSystemSettings.mockResolvedValue({ ytMusicEnabled: true });
         mockYtSearch.mockResolvedValue({ results: [], total: 0 });
         mockGetTrackPreview.mockResolvedValue(null);
-        mockGetArtistImage.mockResolvedValue(null);
         mockGetAlbumCover.mockResolvedValue(null);
 
         mockSearchArtist.mockResolvedValue([]);
@@ -178,10 +168,8 @@ describe("artists routes runtime", () => {
             similar: { artist: [] },
         });
         mockGetArtistTopTracks.mockResolvedValue([]);
-        mockGetBestImage.mockReturnValue(null);
         mockGetAlbumInfo.mockResolvedValue(null);
-
-        mockFanartArtistImage.mockResolvedValue(null);
+        mockResolveArtistImage.mockResolvedValue(null);
 
         mockRedisGet.mockResolvedValue(null);
         mockRedisSetEx.mockResolvedValue("OK");
@@ -607,10 +595,6 @@ describe("artists routes runtime", () => {
             url: "https://last.fm/resolved-artist",
         });
 
-        mockGetBestImage.mockReturnValueOnce(
-            "https://last.fm/images/resolved-artist.jpg",
-        );
-
         mockGetArtistTopTracks.mockResolvedValueOnce([
             {
                 name: "Hit Song",
@@ -622,13 +606,22 @@ describe("artists routes runtime", () => {
             },
         ]);
 
-        mockFanartArtistImage.mockImplementation(async (_mbid: string) => null);
-
-        mockGetArtistImage.mockImplementation(async (artistName: string) => {
-            if (artistName === "Similar Two") {
-                return "https://deezer/images/sim-2.jpg";
-            }
-            return null;
+        mockResolveArtistImage.mockImplementation(async ({ artistName }) => {
+            const images: Record<string, { url: string; source: string }> = {
+                "Resolved Artist": {
+                    url: "https://last.fm/images/resolved-artist.jpg",
+                    source: "lastfm",
+                },
+                "Similar One": {
+                    url: "https://last.fm/images/sim-1.jpg",
+                    source: "lastfm",
+                },
+                "Similar Two": {
+                    url: "https://deezer/images/sim-2.jpg",
+                    source: "deezer",
+                },
+            };
+            return images[artistName] ?? null;
         });
 
         mockGetReleaseGroups.mockResolvedValueOnce([
@@ -682,6 +675,18 @@ describe("artists routes runtime", () => {
             10,
         );
         expect(mockGetReleaseGroups).toHaveBeenCalledWith("artist-mbid-1");
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Resolved Artist",
+            mbid: "artist-mbid-1",
+        });
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Similar One",
+            mbid: "sim-1",
+        });
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Similar Two",
+            mbid: null,
+        });
 
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual(

--- a/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -84,6 +90,7 @@ jest.mock("../../utils/redis", () => ({
 jest.mock("../../config", () => ({
     config: {
         fanart: { apiKey: undefined },
+        lastfm: { apiKey: "test-lastfm-key" },
         features: {
             audioAnalysis: true,
             discovery: true,

--- a/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
@@ -12,6 +12,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -85,6 +91,7 @@ jest.mock("../../utils/redis", () => ({
 jest.mock("../../config", () => ({
     config: {
         fanart: { apiKey: undefined },
+        lastfm: { apiKey: "test-lastfm-key" },
         features: {
             audioAnalysis: true,
             discovery: true,

--- a/backend/src/routes/__tests__/enrichmentFullOptionsCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFullOptionsCompat.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -105,6 +111,7 @@ jest.mock("../../utils/db", () => ({
 jest.mock("../../config", () => ({
     config: {
         fanart: { apiKey: undefined },
+        lastfm: { apiKey: "test-lastfm-key" },
         features: {
             audioAnalysis: true,
             discovery: true,

--- a/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -100,6 +106,7 @@ jest.mock("../../utils/db", () => ({
 jest.mock("../../config", () => ({
     config: {
         fanart: { apiKey: undefined },
+        lastfm: { apiKey: "test-lastfm-key" },
         features: {
             audioAnalysis: true,
             discovery: true,

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -85,6 +91,7 @@ jest.mock("../../utils/redis", () => ({
 jest.mock("../../config", () => ({
     config: {
         fanart: { apiKey: undefined },
+        lastfm: { apiKey: "test-lastfm-key" },
         features: {
             audioAnalysis: true,
             discovery: true,

--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -210,7 +210,7 @@ function createMockArtist(name = "AC/DC") {
     return {
         id: "artist-1",
         name,
-        mbid: "mbid-artist-1",
+        mbid: "11111111-1111-4111-8111-111111111111",
         heroUrl: null,
         userHeroUrl: null,
         albums: [],
@@ -455,7 +455,7 @@ describe("library artist lookup compatibility", () => {
                                 artist: {
                                     id: "artist-1",
                                     name: "AC/DC",
-                                    mbid: "mbid-artist-1",
+                                    mbid: "11111111-1111-4111-8111-111111111111",
                                 },
                             },
                         },
@@ -494,7 +494,7 @@ describe("library artist lookup compatibility", () => {
                 artist: {
                     id: "artist-1",
                     name: "AC/DC",
-                    mbid: "mbid-artist-1",
+                    mbid: "11111111-1111-4111-8111-111111111111",
                 },
             }),
         ]);
@@ -658,7 +658,7 @@ describe("library artist lookup compatibility", () => {
 
         expect(res.statusCode).toBe(200);
         expect(mockLastFmGetArtistTopTracks).toHaveBeenCalledWith(
-            "mbid-artist-1",
+            "11111111-1111-4111-8111-111111111111",
             "AC/DC",
             10,
         );

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -259,7 +259,6 @@ jest.mock("../../services/fanart", () => ({
 jest.mock("../../services/deezer", () => ({
     deezerService: {
         getAlbumCover: jest.fn(),
-        getArtistImage: jest.fn(),
     },
 }));
 
@@ -279,6 +278,19 @@ jest.mock("../../services/musicbrainz", () => ({
         searchArtist: jest.fn(),
         getReleaseGroups: jest.fn(),
     },
+}));
+
+jest.mock("../../utils/musicIds", () => ({
+    isRealArtistMbid: (value: unknown) =>
+        typeof value === "string" && !value.startsWith("temp-"),
+    rgMbidKind: (value: string) =>
+        value.startsWith("federation:")
+            ? "federation"
+            : value.startsWith("remote:")
+              ? "remote"
+              : value.startsWith("temp-")
+                ? "temp"
+                : "musicbrainz",
 }));
 
 jest.mock("../../services/coverArt", () => ({
@@ -305,6 +317,11 @@ jest.mock("../../services/dataCache", () => ({
         getArtistImagesBatch: jest.fn(),
         getArtistImage: jest.fn(),
     },
+}));
+
+const mockResolveArtistImage = jest.fn();
+jest.mock("../../services/metadata/artistImageResolver", () => ({
+    resolveArtistImage: mockResolveArtistImage,
 }));
 
 jest.mock("../../services/artistCountsService", () => ({
@@ -524,7 +541,6 @@ const mockLastFmGetArtistTopTracks =
     lastFmService.getArtistTopTracks as jest.Mock;
 const mockLastFmGetSimilarArtists =
     lastFmService.getSimilarArtists as jest.Mock;
-const mockDeezerGetArtistImage = deezerService.getArtistImage as jest.Mock;
 const mockImageProviderGetAlbumCover =
     imageProviderService.getAlbumCover as jest.Mock;
 const mockMusicBrainzSearchArtist =
@@ -2271,7 +2287,7 @@ describe("library catalog list runtime coverage", () => {
         mockGetArtistImage.mockResolvedValue(null);
         mockLastFmGetArtistTopTracks.mockResolvedValue([]);
         mockLastFmGetSimilarArtists.mockResolvedValue([]);
-        mockDeezerGetArtistImage.mockResolvedValue(null);
+        mockResolveArtistImage.mockResolvedValue(null);
         mockImageProviderGetAlbumCover.mockResolvedValue(null);
         mockMusicBrainzSearchArtist.mockResolvedValue([]);
         mockMusicBrainzGetReleaseGroups.mockResolvedValue([]);
@@ -2853,7 +2869,10 @@ describe("library catalog list runtime coverage", () => {
                 _count: { albums: 3 },
             },
         ]);
-        mockDeezerGetArtistImage.mockResolvedValueOnce("similar-two.jpg");
+        mockResolveArtistImage.mockResolvedValueOnce({
+            url: "similar-two.jpg",
+            source: "deezer",
+        });
         mockGetArtistImage.mockResolvedValueOnce("hero-fetched.jpg");
         mockRedisGet.mockImplementation(async (key: string) => {
             if (key === "discography:artist-real-mbid") {
@@ -2898,6 +2917,10 @@ describe("library catalog list runtime coverage", () => {
             24 * 60 * 60,
             expect.any(String),
         );
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Similar Two",
+            mbid: null,
+        });
         expect(mockRedisSetEx).toHaveBeenCalledWith(
             "top-tracks:artist-1",
             24 * 60 * 60,
@@ -3226,9 +3249,10 @@ describe("library catalog list runtime coverage", () => {
                 match: 0.91,
             },
         ]);
-        mockDeezerGetArtistImage.mockResolvedValueOnce(
-            "https://images.example/similar-cacheless.jpg",
-        );
+        mockResolveArtistImage.mockResolvedValueOnce({
+            url: "https://images.example/similar-cacheless.jpg",
+            source: "deezer",
+        });
 
         const req = {
             params: { id: "artist-cacheless" },
@@ -3240,6 +3264,10 @@ describe("library catalog list runtime coverage", () => {
         await artistByIdHandler(req, res);
 
         expect(mockMusicBrainzGetReleaseGroups).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Similar Cacheless",
+            mbid: "sim-cacheless",
+        });
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual(
             expect.objectContaining({

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from "express";
 import { logger } from "../utils/logger";
 import { lastFmService } from "../services/lastfm";
 import { musicBrainzService } from "../services/musicbrainz";
-import { fanartService } from "../services/fanart";
 import { deezerService } from "../services/deezer";
+import { resolveArtistImage } from "../services/metadata/artistImageResolver";
 import { ytMusicService } from "../services/youtubeMusic";
 import { redisClient } from "../utils/redis";
 import { normalizeToArray } from "../utils/normalize";
@@ -456,53 +456,11 @@ router.get<{ nameOrMbid: string }>(
                 }
             }
 
-            // Get artist image
-            let image = null;
-
-            // Try Fanart.tv first (if we have MBID)
-            if (mbid) {
-                try {
-                    image = await fanartService.getArtistImage(mbid);
-                    logger.debug(`Fanart.tv image for ${artistName}`);
-                } catch (error) {
-                    logger.debug(
-                        `✗ Failed to get Fanart.tv image for ${artistName}`,
-                    );
-                }
-            }
-
-            // Fallback to Deezer
-            if (!image) {
-                try {
-                    image = await deezerService.getArtistImage(artistName);
-                    if (image) {
-                        logger.debug(`Deezer image for ${artistName}`);
-                    }
-                } catch (error) {
-                    logger.debug(
-                        ` Failed to get Deezer image for ${artistName}`,
-                    );
-                }
-            }
-
-            // Fallback to Last.fm (but filter placeholders)
-            // NORMALIZATION: lastFmInfo.image could be a single object or array
-            if (!image && lastFmInfo?.image) {
-                const images = normalizeToArray(lastFmInfo.image);
-                const lastFmImage = lastFmService.getBestImage(images);
-                // Filter out Last.fm placeholder
-                if (
-                    lastFmImage &&
-                    !lastFmImage.includes("2a96cbd8b46e442fc41c2b86b821562f")
-                ) {
-                    image = lastFmImage;
-                    logger.debug(`Last.fm image for ${artistName}`);
-                } else {
-                    logger.debug(
-                        ` Last.fm returned placeholder for ${artistName}`,
-                    );
-                }
-            }
+            const artistImage = await resolveArtistImage({
+                artistName,
+                mbid,
+            });
+            const image = artistImage?.url ?? null;
 
             // Get discography from MusicBrainz
             let albums: any[] = [];
@@ -616,57 +574,17 @@ router.get<{ nameOrMbid: string }>(
                 );
                 similarArtists = await Promise.all(
                     similarArtistsRaw.slice(0, 10).map(async (artist: any) => {
-                        // NORMALIZATION: artist.image could be a single object or array
-                        const images = normalizeToArray(artist.image);
-                        const similarImage = images.find(
-                            (img: any) => img.size === "large",
-                        )?.[" #text"];
-
-                        let image = null;
-
-                        // Try Fanart.tv first (if we have MBID)
-                        if (artist.mbid) {
-                            try {
-                                image = await fanartService.getArtistImage(
-                                    artist.mbid,
-                                );
-                            } catch (error) {
-                                // Silently fail
-                            }
-                        }
-
-                        // Fallback to Deezer
-                        if (!image) {
-                            try {
-                                const deezerImage =
-                                    await deezerService.getArtistImage(
-                                        artist.name,
-                                    );
-                                if (deezerImage) {
-                                    image = deezerImage;
-                                }
-                            } catch (error) {
-                                // Silently fail
-                            }
-                        }
-
-                        // Last fallback to Last.fm (but filter placeholders)
-                        if (
-                            !image &&
-                            similarImage &&
-                            !similarImage.includes(
-                                "2a96cbd8b46e442fc41c2b86b821562f",
-                            )
-                        ) {
-                            image = similarImage;
-                        }
+                        const resolvedImage = await resolveArtistImage({
+                            artistName: artist.name,
+                            mbid: artist.mbid || null,
+                        });
 
                         return {
                             id: artist.mbid || artist.name,
                             name: artist.name,
                             mbid: artist.mbid || null,
                             url: artist.url,
-                            image,
+                            image: resolvedImage?.url ?? null,
                         };
                     }),
                 );

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -53,6 +53,8 @@ import {
     filterDistinctDiscographyAlbums,
     findArtistTrackByTitle,
 } from "./artistPageMatching";
+import { resolveArtistImage } from "../../services/metadata/artistImageResolver";
+import { isRealArtistMbid } from "../../utils/musicIds";
 
 /**
  * Router segments for artists routes registered at their mount positions.
@@ -529,10 +531,7 @@ export async function handleGetArtist(
 
     // If artist has temp MBID, try to find real MBID by searching MusicBrainz
     let effectiveMbid = artist.mbid;
-    if (
-        shouldResolveMbid &&
-        (!effectiveMbid || effectiveMbid.startsWith("temp-"))
-    ) {
+    if (shouldResolveMbid && !isRealArtistMbid(effectiveMbid)) {
         logger.debug(
             ` Artist has temp/no MBID, searching MusicBrainz for ${artist.name}...`,
         );
@@ -621,8 +620,7 @@ export async function handleGetArtist(
         albumsWithOwnership = dbAlbums;
     } else {
         // Always fetch discography if we have a valid MBID - users need to see what's available
-        const shouldFetchDiscography =
-            effectiveMbid && !effectiveMbid.startsWith("temp-");
+        const shouldFetchDiscography = isRealArtistMbid(effectiveMbid);
 
         if (shouldFetchDiscography) {
             const discoCacheKey = `discography:${effectiveMbid}`;
@@ -854,10 +852,9 @@ export async function handleGetArtist(
                 );
             } else {
                 // Cache miss - fetch from Last.fm
-                const validMbid =
-                    effectiveMbid && !effectiveMbid.startsWith("temp-")
-                        ? effectiveMbid
-                        : "";
+                const validMbid = isRealArtistMbid(effectiveMbid)
+                    ? effectiveMbid
+                    : "";
                 lastfmTopTracks = await lastFmService.getArtistTopTracks(
                     validMbid,
                     artist.name,
@@ -1059,7 +1056,7 @@ export async function handleGetArtist(
                 libraryMatches.filter((a) => a.mbid).map((a) => [a.mbid!, a]),
             );
 
-            // Fetch images in parallel from Deezer (cached in Redis)
+            // Fetch missing images in parallel through the canonical facade.
             const similarWithImages = await Promise.all(
                 enrichedSimilar.slice(0, 10).map(async (s) => {
                     // Check if this artist is in our library
@@ -1069,28 +1066,16 @@ export async function handleGetArtist(
 
                     let image = libraryArtist?.heroUrl || null;
 
-                    // If no library image, try Deezer
+                    // Persisted library images remain the first choice.
                     if (!image) {
                         try {
-                            // Check Redis cache first
-                            const cacheKey = `deezer-artist-image:${s.name}`;
-                            const cached = await redisClient.get(cacheKey);
-                            if (cached && cached !== "NOT_FOUND") {
-                                image = cached;
-                            } else {
-                                image = await deezerService.getArtistImage(
-                                    s.name,
-                                );
-                                if (image) {
-                                    await redisClient.setEx(
-                                        cacheKey,
-                                        24 * 60 * 60,
-                                        image,
-                                    );
-                                }
-                            }
+                            const resolved = await resolveArtistImage({
+                                artistName: s.name,
+                                mbid: s.mbid,
+                            });
+                            image = resolved?.url ?? null;
                         } catch (err) {
-                            // Deezer failed, leave null
+                            // Image resolution failed, leave null.
                         }
                     }
 
@@ -1118,10 +1103,9 @@ export async function handleGetArtist(
             logger.debug(`[Artist] Fetching similar artists from Last.fm...`);
 
             try {
-                const validMbid =
-                    effectiveMbid && !effectiveMbid.startsWith("temp-")
-                        ? effectiveMbid
-                        : "";
+                const validMbid = isRealArtistMbid(effectiveMbid)
+                    ? effectiveMbid
+                    : "";
                 const lastfmSimilar = await lastFmService.getSimilarArtists(
                     validMbid,
                     artist.name,
@@ -1176,7 +1160,7 @@ export async function handleGetArtist(
                         .map((a) => [a.mbid!, a]),
                 );
 
-                // Fetch images in parallel (Deezer only - fastest source)
+                // Fetch missing images in parallel through the canonical facade.
                 const similarWithImages = await Promise.all(
                     lastfmSimilar.map(async (s: any) => {
                         const libraryArtist =
@@ -1187,11 +1171,13 @@ export async function handleGetArtist(
 
                         if (!image) {
                             try {
-                                image = await deezerService.getArtistImage(
-                                    s.name,
-                                );
+                                const resolved = await resolveArtistImage({
+                                    artistName: s.name,
+                                    mbid: s.mbid || null,
+                                });
+                                image = resolved?.url ?? null;
                             } catch (err) {
-                                // Deezer failed, leave null
+                                // Image resolution failed, leave null.
                             }
                         }
 
@@ -1474,7 +1460,7 @@ export async function handleDeleteArtist(
         // Delete from Lidarr if connected and artist has MBID
         let lidarrDeleted = false;
         let lidarrError: string | null = null;
-        if (artist.mbid && !artist.mbid.startsWith("temp-")) {
+        if (isRealArtistMbid(artist.mbid)) {
             try {
                 const { lidarrService } = await import("../../services/lidarr");
                 const lidarrResult = await lidarrService.deleteArtist(

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -137,6 +137,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/listenTogetherUserQuiescence.ts` | Bounded per-group local mutation-tail barrier before administrative user cleanup |
 | `backend/src/services/lyrics.ts` | Core |
 | `backend/src/services/m3uParser.ts` | Core |
+| `backend/src/services/metadata/artistImageResolver.ts` | Canonical bounded artist-image provider ladder, cache, and in-flight deduplication |
 | `backend/src/services/moodBucketService.ts` | Core |
 | `backend/src/services/musicbrainz.ts` | Core |
 | `backend/src/services/musicScanner.ts` | Core |

--- a/backend/src/services/__tests__/dataCacheService.test.ts
+++ b/backend/src/services/__tests__/dataCacheService.test.ts
@@ -31,22 +31,8 @@ jest.mock("../../utils/redis", () => ({
     },
 }));
 
-jest.mock("../fanart", () => ({
-    fanartService: {
-        getArtistImage: jest.fn(),
-    },
-}));
-
-jest.mock("../deezer", () => ({
-    deezerService: {
-        getArtistImage: jest.fn(),
-    },
-}));
-
-jest.mock("../lastfm", () => ({
-    lastFmService: {
-        getArtistInfo: jest.fn(),
-    },
+jest.mock("../metadata/artistImageResolver", () => ({
+    resolveArtistImage: jest.fn(),
 }));
 
 jest.mock("../coverArt", () => ({
@@ -62,9 +48,7 @@ jest.mock("../imageStorage", () => ({
 import { dataCacheService } from "../dataCache";
 import { prisma } from "../../utils/db";
 import { redisClient } from "../../utils/redis";
-import { fanartService } from "../fanart";
-import { deezerService } from "../deezer";
-import { lastFmService } from "../lastfm";
+import { resolveArtistImage } from "../metadata/artistImageResolver";
 import { coverArtService } from "../coverArt";
 import { downloadAndStoreImage } from "../imageStorage";
 import { logger } from "../../utils/logger";
@@ -81,9 +65,7 @@ const mockRedisSetEx = redisClient.setEx as jest.Mock;
 const mockRedisMGet = redisClient.mGet as jest.Mock;
 const mockRedisMulti = redisClient.multi as jest.Mock;
 
-const mockFanartGetArtistImage = fanartService.getArtistImage as jest.Mock;
-const mockDeezerGetArtistImage = deezerService.getArtistImage as jest.Mock;
-const mockLastfmGetArtistInfo = lastFmService.getArtistInfo as jest.Mock;
+const mockResolveArtistImage = resolveArtistImage as jest.Mock;
 const mockCoverArtGet = coverArtService.getCoverArt as jest.Mock;
 const mockDownloadAndStoreImage = downloadAndStoreImage as jest.Mock;
 
@@ -116,9 +98,7 @@ describe("dataCacheService", () => {
         mockRedisMGet.mockResolvedValue([]);
         mockRedisMulti.mockImplementation(() => createRedisMulti());
 
-        mockFanartGetArtistImage.mockResolvedValue(null);
-        mockDeezerGetArtistImage.mockResolvedValue(null);
-        mockLastfmGetArtistInfo.mockResolvedValue(null);
+        mockResolveArtistImage.mockResolvedValue(null);
         mockCoverArtGet.mockResolvedValue(null);
         mockDownloadAndStoreImage.mockResolvedValue(null);
     });
@@ -142,7 +122,7 @@ describe("dataCacheService", () => {
             "native:artists/custom.jpg",
         );
         expect(mockRedisGet).not.toHaveBeenCalled();
-        expect(mockFanartGetArtistImage).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).not.toHaveBeenCalled();
     });
 
     it("uses Redis artist cache and syncs back to DB when DB misses", async () => {
@@ -158,7 +138,7 @@ describe("dataCacheService", () => {
             where: { id: "artist-2" },
             data: { heroUrl: "native:artists/from-redis.jpg" },
         });
-        expect(mockFanartGetArtistImage).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).not.toHaveBeenCalled();
     });
 
     it("returns null on negative Redis artist cache hit", async () => {
@@ -170,13 +150,14 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBeNull();
-        expect(mockFanartGetArtistImage).not.toHaveBeenCalled();
-        expect(mockDeezerGetArtistImage).not.toHaveBeenCalled();
-        expect(mockLastfmGetArtistInfo).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).not.toHaveBeenCalled();
     });
 
-    it("fetches artist image from Fanart, stores local path, and persists", async () => {
-        mockFanartGetArtistImage.mockResolvedValue("https://fanart/image.jpg");
+    it("resolves an artist image through the facade, stores it locally, and persists it", async () => {
+        mockResolveArtistImage.mockResolvedValue({
+            url: "https://fanart/image.jpg",
+            source: "fanart",
+        });
         mockDownloadAndStoreImage.mockResolvedValue("native:artists/a1.jpg");
 
         const result = await dataCacheService.getArtistImage(
@@ -186,6 +167,10 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBe("native:artists/a1.jpg");
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Artist Four",
+            mbid: "mbid-4",
+        });
         expect(mockArtistUpdate).toHaveBeenCalledWith({
             where: { id: "artist-4" },
             data: { heroUrl: "native:artists/a1.jpg" },
@@ -197,8 +182,11 @@ describe("dataCacheService", () => {
         );
     });
 
-    it("skips Fanart for temp MBID, uses Deezer, and falls back to external URL when local download fails", async () => {
-        mockDeezerGetArtistImage.mockResolvedValue("https://deezer/image.jpg");
+    it("passes a synthetic MBID to the facade and falls back to the external URL when local download fails", async () => {
+        mockResolveArtistImage.mockResolvedValue({
+            url: "https://deezer/image.jpg",
+            source: "deezer",
+        });
         mockDownloadAndStoreImage.mockResolvedValue(null);
 
         const result = await dataCacheService.getArtistImage(
@@ -208,24 +196,17 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBe("https://deezer/image.jpg");
-        expect(mockFanartGetArtistImage).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Artist Five",
+            mbid: "temp-artist-5",
+        });
         expect(mockArtistUpdate).toHaveBeenCalledWith({
             where: { id: "artist-5" },
             data: { heroUrl: "https://deezer/image.jpg" },
         });
     });
 
-    it("ignores Last.fm placeholder image and stores a negative cache entry", async () => {
-        mockLastfmGetArtistInfo.mockResolvedValue({
-            image: [
-                {
-                    size: "extralarge",
-                    "#text":
-                        "https://lastfm/2a96cbd8b46e442fc41c2b86b821562f.png",
-                },
-            ],
-        });
-
+    it("stores its existing negative cache entry when the facade misses", async () => {
         const result = await dataCacheService.getArtistImage(
             "artist-6",
             "Artist Six",
@@ -233,6 +214,10 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBeNull();
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Artist Six",
+            mbid: "mbid-6",
+        });
         expect(mockRedisSetEx).toHaveBeenCalledWith(
             "hero:artist-6",
             NEGATIVE_CACHE_SECONDS,

--- a/backend/src/services/__tests__/fanart.test.ts
+++ b/backend/src/services/__tests__/fanart.test.ts
@@ -166,6 +166,42 @@ describe("fanart service", () => {
         );
     });
 
+    it("uses thumb, banner, then logo order for square artist images", async () => {
+        mockGetSystemSettings.mockResolvedValueOnce({
+            fanartEnabled: true,
+            fanartApiKey: "db-key",
+        });
+        mockAxiosGet
+            .mockResolvedValueOnce({
+                data: {
+                    artistbackground: [{ url: "https://cdn/background.jpg" }],
+                    artistthumb: [{ url: "https://cdn/thumb.jpg" }],
+                    musicbanner: [{ url: "https://cdn/banner.jpg" }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    artistbackground: [{ url: "https://cdn/background.jpg" }],
+                    artistthumb: [],
+                    musicbanner: [{ url: "banner-file.jpg" }],
+                    hdmusiclogo: [{ url: "https://cdn/logo.png" }],
+                },
+            });
+
+        await expect(
+            fanartService.getArtistImage("mbid-square-thumb", {
+                preference: "square",
+            }),
+        ).resolves.toBe("https://cdn/thumb.jpg");
+        await expect(
+            fanartService.getArtistImage("mbid-square-banner", {
+                preference: "square",
+            }),
+        ).resolves.toBe(
+            "https://assets.fanart.tv/fanart/music/mbid-square-banner/musicbanner/banner-file.jpg",
+        );
+    });
+
     it("returns null for 404 and logs non-404 artist-image errors", async () => {
         mockGetSystemSettings.mockResolvedValueOnce({
             fanartEnabled: true,

--- a/backend/src/services/__tests__/imageProviderService.test.ts
+++ b/backend/src/services/__tests__/imageProviderService.test.ts
@@ -3,9 +3,7 @@ const logger = {
     warn: jest.fn(),
     error: jest.fn(),
 };
-jest.mock("../../utils/logger", () => ({
-    logger,
-}));
+jest.mock("../../utils/logger", () => ({ logger }));
 
 const mockConfig = {
     secretsDbOnly: false,
@@ -22,44 +20,29 @@ jest.mock("../../utils/systemSettings", () => ({
     getSystemSettings: (...args: unknown[]) => mockGetSystemSettings(...args),
 }));
 
-const mockNormalizeQuotes = jest.fn((value: string) => value);
-const mockNormalizeFullwidth = jest.fn((value: string) => value);
-jest.mock("../../utils/stringNormalization", () => ({
-    normalizeQuotes: (value: string) => mockNormalizeQuotes(value),
-    normalizeFullwidth: (value: string) => mockNormalizeFullwidth(value),
-}));
-
-const rateLimiter = {
-    execute: jest.fn(),
-};
-jest.mock("../rateLimiter", () => ({
-    rateLimiter,
-}));
+const rateLimiter = { execute: jest.fn() };
+jest.mock("../rateLimiter", () => ({ rateLimiter }));
 
 const mockAxiosGet = jest.fn();
 const mockAxiosIsAxiosError = jest.fn();
 jest.mock("axios", () => ({
     __esModule: true,
     default: {
-        get: (...args: any[]) => mockAxiosGet(...args),
-        isAxiosError: (...args: any[]) => mockAxiosIsAxiosError(...args),
+        get: (...args: unknown[]) => mockAxiosGet(...args),
+        isAxiosError: (...args: unknown[]) => mockAxiosIsAxiosError(...args),
     },
-    get: (...args: any[]) => mockAxiosGet(...args),
-    isAxiosError: (...args: any[]) => mockAxiosIsAxiosError(...args),
-}));
-
-const lastFmService = {
-    getArtistInfo: jest.fn(),
-};
-jest.mock("../lastfm", () => ({
-    lastFmService,
 }));
 
 const mockDeezerGetAlbumCover = jest.fn();
 jest.mock("../deezer", () => ({
     deezerService: {
-        getAlbumCover: (...args: any[]) => mockDeezerGetAlbumCover(...args),
+        getAlbumCover: (...args: unknown[]) => mockDeezerGetAlbumCover(...args),
     },
+}));
+
+const mockResolveArtistImage = jest.fn();
+jest.mock("../metadata/artistImageResolver", () => ({
+    resolveArtistImage: (...args: unknown[]) => mockResolveArtistImage(...args),
 }));
 
 import { ImageProviderService } from "../imageProvider";
@@ -70,192 +53,44 @@ describe("image provider service behavior", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         process.env.FANART_API_KEY = originalFanartApiKey;
-
-        rateLimiter.execute.mockImplementation(
-            async (_bucket: string, fn: () => Promise<unknown>) => fn(),
-        );
-
-        mockAxiosGet.mockResolvedValue({ data: {} });
-        mockAxiosIsAxiosError.mockReturnValue(false);
-        lastFmService.getArtistInfo.mockResolvedValue(null);
         mockConfig.secretsDbOnly = false;
         mockGetSystemSettings.mockResolvedValue(null);
-
-        mockNormalizeQuotes.mockImplementation((value: string) => value);
-        mockNormalizeFullwidth.mockImplementation((value: string) => value);
+        mockResolveArtistImage.mockResolvedValue(null);
+        mockDeezerGetAlbumCover.mockResolvedValue(null);
+        mockAxiosGet.mockResolvedValue({ data: {} });
+        mockAxiosIsAxiosError.mockReturnValue(false);
+        rateLimiter.execute.mockImplementation(
+            async (_bucket: string, run: () => Promise<unknown>) => run(),
+        );
     });
 
     afterAll(() => {
         process.env.FANART_API_KEY = originalFanartApiKey;
     });
 
-    it("returns Deezer artist image first and short-circuits fallback chain", async () => {
-        process.env.FANART_API_KEY = "fanart-key";
+    it("delegates artist image resolution to the metadata facade", async () => {
         const service = new ImageProviderService();
-
-        const deezerSpy = jest
-            .spyOn(service as any, "getArtistImageFromDeezer")
-            .mockResolvedValueOnce({
-                url: "https://deezer/artist-xl.jpg",
-                source: "deezer",
-                size: "xl",
-            });
-        const fanartSpy = jest.spyOn(
-            service as any,
-            "getArtistImageFromFanart",
-        );
-        const mbSpy = jest.spyOn(
-            service as any,
-            "getArtistImageFromMusicBrainz",
-        );
+        mockResolveArtistImage.mockResolvedValueOnce({
+            url: "https://wikidata/artist.jpg",
+            source: "wikidata",
+        });
 
         await expect(
             service.getArtistImage("Artist Name", "artist-mbid"),
         ).resolves.toEqual({
-            url: "https://deezer/artist-xl.jpg",
-            source: "deezer",
-            size: "xl",
+            url: "https://wikidata/artist.jpg",
+            source: "wikidata",
         });
-
-        expect(deezerSpy).toHaveBeenCalledWith("Artist Name", 5000);
-        expect(fanartSpy).not.toHaveBeenCalled();
-        expect(mbSpy).not.toHaveBeenCalled();
+        expect(mockResolveArtistImage).toHaveBeenCalledWith({
+            artistName: "Artist Name",
+            mbid: "artist-mbid",
+        });
     });
 
-    it("falls back artist image Deezer -> Fanart -> MusicBrainz and then null", async () => {
+    it("preserves the album-cover Deezer, MusicBrainz, Fanart order", async () => {
         process.env.FANART_API_KEY = "fanart-key";
         const service = new ImageProviderService();
-
-        jest.spyOn(service as any, "getArtistImageFromDeezer")
-            .mockRejectedValueOnce(new Error("deezer down"))
-            .mockResolvedValueOnce(null)
-            .mockResolvedValueOnce(null);
-        jest.spyOn(service as any, "getArtistImageFromFanart")
-            .mockResolvedValueOnce({
-                url: "https://fanart/artist.jpg",
-                source: "fanart",
-            })
-            .mockResolvedValueOnce(null);
-        jest.spyOn(service as any, "getArtistImageFromMusicBrainz")
-            .mockResolvedValueOnce({
-                url: "https://coverart/artist.jpg",
-                source: "musicbrainz",
-            })
-            .mockResolvedValueOnce(null);
-
-        await expect(
-            service.getArtistImage("Artist One", "mbid-1"),
-        ).resolves.toEqual({
-            url: "https://fanart/artist.jpg",
-            source: "fanart",
-        });
-
-        await expect(
-            service.getArtistImage("Artist Two", "mbid-2"),
-        ).resolves.toEqual({
-            url: "https://coverart/artist.jpg",
-            source: "musicbrainz",
-        });
-
-        await expect(
-            service.getArtistImage("Artist Three", "mbid-3"),
-        ).resolves.toBeNull();
-    });
-
-    it("skips fanart without API key and returns null when no artist sources resolve", async () => {
-        delete process.env.FANART_API_KEY;
-        const service = new ImageProviderService();
-
-        const fanartSpy = jest.spyOn(
-            service as any,
-            "getArtistImageFromFanart",
-        );
-        jest.spyOn(
-            service as any,
-            "getArtistImageFromDeezer",
-        ).mockResolvedValue(null);
-        jest.spyOn(
-            service as any,
-            "getArtistImageFromMusicBrainz",
-        ).mockResolvedValue(null);
-
-        await expect(
-            service.getArtistImage("No Key Artist", "mbid"),
-        ).resolves.toBeNull();
-        expect(fanartSpy).not.toHaveBeenCalled();
-    });
-
-    it("uses the env Fanart key when DB-only mode is off", async () => {
-        process.env.FANART_API_KEY = "env-key-456";
-        const service = new ImageProviderService();
-        jest.spyOn(
-            service as any,
-            "getArtistImageFromDeezer",
-        ).mockResolvedValue(null);
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                artistthumb: [{ url: "https://fanart/env-artist.jpg" }],
-            },
-        });
-
-        await expect(
-            service.getArtistImage("Env Artist", "env-mbid"),
-        ).resolves.toEqual({
-            url: "https://fanart/env-artist.jpg",
-            source: "fanart",
-        });
-        expect(mockGetSystemSettings).not.toHaveBeenCalled();
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://webservice.fanart.tv/v3/music/env-mbid",
-            expect.objectContaining({
-                params: { api_key: "env-key-456" },
-            }),
-        );
-    });
-
-    it("resolves the stored Fanart key in DB-only mode", async () => {
-        process.env.FANART_API_KEY = "env-key-456";
-        mockConfig.secretsDbOnly = true;
-        mockGetSystemSettings.mockResolvedValue({
-            fanartEnabled: true,
-            fanartApiKey: "db-key-123",
-        });
-        const service = new ImageProviderService();
-        jest.spyOn(
-            service as any,
-            "getArtistImageFromDeezer",
-        ).mockResolvedValue(null);
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                artistthumb: [{ url: "https://fanart/db-artist.jpg" }],
-            },
-        });
-
-        await expect(
-            service.getArtistImage("DB Artist", "db-mbid"),
-        ).resolves.toEqual({
-            url: "https://fanart/db-artist.jpg",
-            source: "fanart",
-        });
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://webservice.fanart.tv/v3/music/db-mbid",
-            expect.objectContaining({
-                params: { api_key: "db-key-123" },
-            }),
-        );
-    });
-
-    it("resolves album covers with Deezer-first ordering and fallbacks", async () => {
-        process.env.FANART_API_KEY = "fanart-key";
-        const service = new ImageProviderService();
-
-        const deezerSpy = jest
-            .spyOn(service as any, "getAlbumCoverFromDeezer")
-            .mockResolvedValueOnce({
-                url: "https://deezer/cover-xl.jpg",
-                source: "deezer",
-                size: "xl",
-            })
+        jest.spyOn(service as any, "getAlbumCoverFromDeezer")
             .mockResolvedValueOnce(null)
             .mockResolvedValueOnce(null);
         jest.spyOn(service as any, "getAlbumCoverFromMusicBrainz")
@@ -264,83 +99,38 @@ describe("image provider service behavior", () => {
                 source: "musicbrainz",
             })
             .mockResolvedValueOnce(null);
-        jest.spyOn(service as any, "getAlbumCoverFromFanart")
-            .mockResolvedValueOnce({
-                url: "https://fanart/cover.jpg",
-                source: "fanart",
-            })
-            .mockResolvedValueOnce(null);
-
-        await expect(
-            service.getAlbumCover("Artist A", "Album A", "rg-1"),
-        ).resolves.toEqual({
-            url: "https://deezer/cover-xl.jpg",
-            source: "deezer",
-            size: "xl",
-        });
-
-        await expect(
-            service.getAlbumCover("Artist B", "Album B", "rg-2"),
-        ).resolves.toEqual({
-            url: "https://coverart/front.jpg",
-            source: "musicbrainz",
-        });
-
-        await expect(
-            service.getAlbumCover("Artist C", "Album C", "rg-3"),
-        ).resolves.toEqual({
+        jest.spyOn(
+            service as any,
+            "getAlbumCoverFromFanart",
+        ).mockResolvedValueOnce({
             url: "https://fanart/cover.jpg",
             source: "fanart",
         });
 
-        expect(deezerSpy).toHaveBeenCalledTimes(3);
+        await expect(
+            service.getAlbumCover("Artist A", "Album A", "rg-1"),
+        ).resolves.toEqual({
+            url: "https://coverart/front.jpg",
+            source: "musicbrainz",
+        });
+        await expect(
+            service.getAlbumCover("Artist B", "Album B", "rg-2"),
+        ).resolves.toEqual({
+            url: "https://fanart/cover.jpg",
+            source: "fanart",
+        });
     });
 
-    it("normalizes lookup values and maps Deezer artist/album responses", async () => {
+    it("delegates Deezer album matching to the Deezer service", async () => {
         const service = new ImageProviderService();
-        mockNormalizeQuotes.mockImplementation((value: string) =>
-            value.replace(/[“”]/g, '"'),
-        );
-        mockNormalizeFullwidth.mockImplementation((value: string) =>
-            value.replace("Ａ", "A"),
-        );
-
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                data: [
-                    {
-                        picture: "https://deezer/artist.jpg",
-                        picture_big: "https://deezer/artist-big.jpg",
-                        picture_xl: "https://deezer/artist-xl.jpg",
-                    },
-                ],
-            },
-        });
-
-        await expect(
-            (service as any).getArtistImageFromDeezer("Ａrtist “Name”", 2500),
-        ).resolves.toEqual({
-            url: "https://deezer/artist-xl.jpg",
-            source: "deezer",
-            size: "xl",
-        });
-
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://api.deezer.com/search/artist",
-            {
-                params: { q: 'Artist "Name"', limit: 1 },
-                timeout: 2500,
-            },
-        );
-
-        // getAlbumCoverFromDeezer now delegates to deezerService.getAlbumCover()
         mockDeezerGetAlbumCover.mockResolvedValueOnce(
             "https://deezer/album-xl.jpg",
         );
+
         await expect(
             (service as any).getAlbumCoverFromDeezer(
-                "Ａrtist A",
-                "Album “One”",
+                "Artist A",
+                "Album One",
                 3000,
             ),
         ).resolves.toEqual({
@@ -349,45 +139,14 @@ describe("image provider service behavior", () => {
             size: "xl",
         });
         expect(mockDeezerGetAlbumCover).toHaveBeenCalledWith(
-            "Ａrtist A",
-            "Album “One”",
+            "Artist A",
+            "Album One",
         );
-
-        mockDeezerGetAlbumCover.mockResolvedValueOnce(null);
-        await expect(
-            (service as any).getAlbumCoverFromDeezer(
-                "No Match",
-                "No Match",
-                3000,
-            ),
-        ).resolves.toBeNull();
     });
 
-    it("maps fanart artist/album responses and handles missing API key", async () => {
-        delete process.env.FANART_API_KEY;
-        const noKeyService = new ImageProviderService();
-        await expect(
-            (noKeyService as any).getArtistImageFromFanart("mbid", 1000),
-        ).resolves.toBeNull();
-        await expect(
-            (noKeyService as any).getAlbumCoverFromFanart("rg-mbid", 1000),
-        ).resolves.toBeNull();
-
+    it("uses the configured Fanart key for album covers", async () => {
         process.env.FANART_API_KEY = "fanart-key";
         const service = new ImageProviderService();
-
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                artistthumb: [{ url: "https://fanart/artist-thumb.jpg" }],
-            },
-        });
-        await expect(
-            (service as any).getArtistImageFromFanart("artist-mbid", 2000),
-        ).resolves.toEqual({
-            url: "https://fanart/artist-thumb.jpg",
-            source: "fanart",
-        });
-
         mockAxiosGet.mockResolvedValueOnce({
             data: {
                 albums: {
@@ -397,23 +156,46 @@ describe("image provider service behavior", () => {
                 },
             },
         });
+
         await expect(
             (service as any).getAlbumCoverFromFanart("rg-mbid", 2000),
         ).resolves.toEqual({
             url: "https://fanart/album-cover.jpg",
             source: "fanart",
         });
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            "https://webservice.fanart.tv/v3/music/albums/rg-mbid",
+            {
+                params: { api_key: "fanart-key" },
+                timeout: 2000,
+            },
+        );
     });
 
-    it("handles cover art archive lookup including 404 and unknown failures", async () => {
+    it("resolves the stored Fanart key in DB-only mode", async () => {
+        process.env.FANART_API_KEY = "env-key";
+        mockConfig.secretsDbOnly = true;
+        mockGetSystemSettings.mockResolvedValue({
+            fanartEnabled: true,
+            fanartApiKey: "db-key",
+        });
         const service = new ImageProviderService();
+        mockAxiosGet.mockResolvedValueOnce({ data: {} });
 
+        await expect(
+            (service as any).getAlbumCoverFromFanart("rg-mbid", 2000),
+        ).resolves.toBeNull();
+        expect(mockAxiosGet).toHaveBeenCalledWith(
+            "https://webservice.fanart.tv/v3/music/albums/rg-mbid",
+            expect.objectContaining({ params: { api_key: "db-key" } }),
+        );
+    });
+
+    it("handles Cover Art Archive success, 404, and unknown failures", async () => {
+        const service = new ImageProviderService();
         mockAxiosGet.mockResolvedValueOnce({
             data: {
-                images: [
-                    { image: "https://coverart/front.jpg", front: true },
-                    { image: "https://coverart/other.jpg", front: false },
-                ],
+                images: [{ image: "https://coverart/front.jpg", front: true }],
             },
         });
         await expect(
@@ -430,53 +212,9 @@ describe("image provider service behavior", () => {
             (service as any).getAlbumCoverFromMusicBrainz("rg-2", 1000),
         ).resolves.toBeNull();
 
-        const unknownError = new Error("coverart timeout");
-        rateLimiter.execute.mockRejectedValueOnce(unknownError);
-        mockAxiosIsAxiosError.mockReturnValueOnce(false);
+        rateLimiter.execute.mockRejectedValueOnce(new Error("timeout"));
         await expect(
             (service as any).getAlbumCoverFromMusicBrainz("rg-3", 1000),
-        ).rejects.toThrow("coverart timeout");
-    });
-
-    it("returns null for placeholder MusicBrainz artist image lookup", async () => {
-        const service = new ImageProviderService();
-        await expect(
-            (service as any).getArtistImageFromMusicBrainz("artist-mbid", 1000),
-        ).resolves.toBeNull();
-    });
-
-    it("maps Last.fm artist images and handles Last.fm failures", async () => {
-        const service = new ImageProviderService();
-
-        lastFmService.getArtistInfo.mockResolvedValueOnce({
-            image: [
-                { size: "small", "#text": "https://lastfm/small.jpg" },
-                { size: "mega", "#text": "https://lastfm/mega.jpg" },
-            ],
-        });
-        await expect(
-            service.getArtistImageFromLastFm("Artist", "mbid-1"),
-        ).resolves.toEqual({
-            url: "https://lastfm/mega.jpg",
-            source: "lastfm",
-            size: "mega",
-        });
-
-        lastFmService.getArtistInfo.mockResolvedValueOnce({
-            image: [{ size: "extralarge", "#text": "" }],
-        });
-        await expect(
-            service.getArtistImageFromLastFm("Artist"),
-        ).resolves.toBeNull();
-
-        lastFmService.getArtistInfo.mockRejectedValueOnce(
-            new Error("lastfm down"),
-        );
-        await expect(
-            service.getArtistImageFromLastFm("Artist"),
-        ).resolves.toBeNull();
-        expect(logger.debug).toHaveBeenCalledWith(
-            expect.stringContaining("Last.fm failed:"),
-        );
+        ).rejects.toThrow("timeout");
     });
 });

--- a/backend/src/services/dataCache.ts
+++ b/backend/src/services/dataCache.ts
@@ -14,11 +14,9 @@ import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { redisClient } from "../utils/redis";
 import { buildFederatedCoverProxyPath } from "../utils/federationCover";
-import { fanartService } from "./fanart";
-import { deezerService } from "./deezer";
-import { lastFmService } from "./lastfm";
 import { coverArtService } from "./coverArt";
 import { downloadAndStoreImage } from "./imageStorage";
+import { resolveArtistImage } from "./metadata/artistImageResolver";
 
 // Cache TTLs
 const ARTIST_IMAGE_TTL = 365 * 24 * 60 * 60; // 1 year
@@ -241,7 +239,6 @@ class DataCacheService {
 
     /**
      * Fetch artist image from external APIs and store locally
-     * Order: Fanart.tv (if MBID) -> Deezer -> Last.fm
      * Returns native path (e.g., "native:artists/{id}.jpg") or null
      */
     private async fetchArtistImage(
@@ -249,80 +246,17 @@ class DataCacheService {
         artistName: string,
         mbid?: string | null,
     ): Promise<string | null> {
-        let externalUrl: string | null = null;
-        let source = "";
-
-        // Try Fanart.tv first if we have a valid MBID
-        if (mbid && !mbid.startsWith("temp-")) {
-            try {
-                externalUrl = await fanartService.getArtistImage(mbid);
-                if (externalUrl) {
-                    source = "Fanart.tv";
-                }
-            } catch (err) {
-                // Fanart.tv failed, continue
-            }
-        }
-
-        // Try Deezer
-        if (!externalUrl) {
-            try {
-                externalUrl = await deezerService.getArtistImage(artistName);
-                if (externalUrl) {
-                    source = "Deezer";
-                }
-            } catch (err) {
-                // Deezer failed, continue
-            }
-        }
-
-        // Try Last.fm
-        if (!externalUrl) {
-            try {
-                const validMbid =
-                    mbid && !mbid.startsWith("temp-") ? mbid : undefined;
-                const lastfmInfo = await lastFmService.getArtistInfo(
-                    artistName,
-                    validMbid,
-                );
-
-                if (lastfmInfo?.image && Array.isArray(lastfmInfo.image)) {
-                    const largestImage =
-                        lastfmInfo.image.find(
-                            (img: any) =>
-                                img.size === "extralarge" ||
-                                img.size === "mega",
-                        ) || lastfmInfo.image[lastfmInfo.image.length - 1];
-
-                    if (largestImage && largestImage["#text"]) {
-                        const imageUrl = largestImage["#text"];
-                        // Filter out Last.fm placeholder images
-                        if (
-                            !imageUrl.includes(
-                                "2a96cbd8b46e442fc41c2b86b821562f",
-                            )
-                        ) {
-                            externalUrl = imageUrl;
-                            source = "Last.fm";
-                        }
-                    }
-                }
-            } catch (err) {
-                // Last.fm failed
-            }
-        }
-
-        if (!externalUrl) {
+        const resolved = await resolveArtistImage({ artistName, mbid });
+        if (!resolved) {
             logger.debug(`[DataCache] No image found for ${artistName}`);
             return null;
         }
 
-        // Download and store locally
         logger.debug(
-            `[DataCache] Got image from ${source} for ${artistName}, downloading...`,
+            `[DataCache] Got image from ${resolved.source} for ${artistName}, downloading...`,
         );
         const localPath = await downloadAndStoreImage(
-            externalUrl,
+            resolved.url,
             artistId,
             "artist",
         );
@@ -338,7 +272,7 @@ class DataCacheService {
         logger.debug(
             `[DataCache] Download failed, using external URL for ${artistName}`,
         );
-        return externalUrl;
+        return resolved.url;
     }
 
     /**

--- a/backend/src/services/fanart.ts
+++ b/backend/src/services/fanart.ts
@@ -5,6 +5,53 @@ import { getSystemSettings } from "../utils/systemSettings";
 import { BRAND_USER_AGENT } from "../config/brand";
 import { config } from "../config";
 
+type ArtistImagePreference = "background" | "square";
+
+/** Options for selecting an artist image from Fanart.tv image sets. */
+export interface FanartArtistImageOptions {
+    preference?: ArtistImagePreference;
+}
+
+type FanartArtistImageKind =
+    | "artistbackground"
+    | "artistthumb"
+    | "musicbanner"
+    | "hdmusiclogo";
+
+const BACKGROUND_FIRST: readonly FanartArtistImageKind[] = [
+    "artistbackground",
+    "artistthumb",
+    "hdmusiclogo",
+];
+const SQUARE_FIRST: readonly FanartArtistImageKind[] = [
+    "artistthumb",
+    "musicbanner",
+    "hdmusiclogo",
+];
+
+function selectArtistImage(
+    data: Record<string, unknown>,
+    preference: ArtistImagePreference,
+): { kind: FanartArtistImageKind; url: string } | null {
+    const order = preference === "square" ? SQUARE_FIRST : BACKGROUND_FIRST;
+    for (let index = 0; index < order.length; index += 1) {
+        const kind = order[index];
+        const images = data[kind];
+        if (!Array.isArray(images) || images.length === 0) continue;
+        const url = (images[0] as { url?: unknown })?.url;
+        if (typeof url === "string" && url.length > 0) return { kind, url };
+    }
+    return null;
+}
+
+function expandArtistImageUrl(
+    mbid: string,
+    image: { kind: FanartArtistImageKind; url: string },
+): string {
+    if (image.url.startsWith("http")) return image.url;
+    return `https://assets.fanart.tv/fanart/music/${mbid}/${image.kind}/${image.url}`;
+}
+
 /**
  * Fanart.tv API Service
  *
@@ -80,7 +127,10 @@ class FanartService {
      * Get artist images (background, thumbnail, logo)
      * Returns the highest quality artist image available
      */
-    async getArtistImage(mbid: string): Promise<string | null> {
+    async getArtistImage(
+        mbid: string,
+        options: FanartArtistImageOptions = {},
+    ): Promise<string | null> {
         await this.ensureInitialized();
 
         // Early exit if no API key - don't log every time (reduces log spam)
@@ -89,7 +139,11 @@ class FanartService {
         }
 
         // Check cache first
-        const cacheKey = `fanart:artist:${mbid}`;
+        const preference = options.preference ?? "background";
+        const cacheKey =
+            preference === "square"
+                ? `fanart:artist:square:${mbid}`
+                : `fanart:artist:${mbid}`;
         try {
             if (redisClient.isOpen) {
                 const cached = await redisClient.get(cacheKey);
@@ -108,51 +162,10 @@ class FanartService {
                 params: { api_key: this.apiKey },
             });
 
-            const data = response.data;
-
-            // Priority: artistbackground > artistthumb > hdmusiclogo
-            let imageUrl: string | null = null;
-
-            if (data.artistbackground && data.artistbackground.length > 0) {
-                let rawUrl = data.artistbackground[0].url;
-
-                // If it's just a filename, construct the full URL
-                if (rawUrl && !rawUrl.startsWith("http")) {
-                    rawUrl = `https://assets.fanart.tv/fanart/music/${mbid}/artistbackground/${rawUrl}`;
-                    logger.debug(
-                        `  Fanart.tv: Constructed full URL from filename`,
-                    );
-                }
-
-                imageUrl = rawUrl;
-                logger.debug(`  Fanart.tv: Found artist background`);
-            } else if (data.artistthumb && data.artistthumb.length > 0) {
-                let rawUrl = data.artistthumb[0].url;
-
-                // If it's just a filename, construct the full URL
-                if (rawUrl && !rawUrl.startsWith("http")) {
-                    rawUrl = `https://assets.fanart.tv/fanart/music/${mbid}/artistthumb/${rawUrl}`;
-                    logger.debug(
-                        `  Fanart.tv: Constructed full URL from filename`,
-                    );
-                }
-
-                imageUrl = rawUrl;
-                logger.debug(`  Fanart.tv: Found artist thumbnail`);
-            } else if (data.hdmusiclogo && data.hdmusiclogo.length > 0) {
-                let rawUrl = data.hdmusiclogo[0].url;
-
-                // If it's just a filename, construct the full URL
-                if (rawUrl && !rawUrl.startsWith("http")) {
-                    rawUrl = `https://assets.fanart.tv/fanart/music/${mbid}/hdmusiclogo/${rawUrl}`;
-                    logger.debug(
-                        `  Fanart.tv: Constructed full URL from filename`,
-                    );
-                }
-
-                imageUrl = rawUrl;
-                logger.debug(`  Fanart.tv: Found HD logo`);
-            }
+            const selected = selectArtistImage(response.data, preference);
+            const imageUrl = selected
+                ? expandArtistImageUrl(mbid, selected)
+                : null;
 
             // Cache for 7 days
             if (imageUrl && redisClient.isOpen) {

--- a/backend/src/services/imageProvider.ts
+++ b/backend/src/services/imageProvider.ts
@@ -1,31 +1,33 @@
 /**
  * Image Provider Service
  *
- * Tries multiple sources for high-quality artist/album artwork:
- * 1. Deezer (most reliable, high quality)
- * 2. Fanart.tv (excellent quality, requires API key)
- * 3. MusicBrainz Cover Art Archive (good quality)
- * 4. Last.fm (fallback, often missing)
+ * Preserves the legacy image-provider API. Artist images delegate to the
+ * metadata facade; album covers retain their existing provider ladder.
  */
 
 import { logger } from "../utils/logger";
 import axios from "axios";
 import { rateLimiter } from "./rateLimiter";
-import {
-    normalizeFullwidth,
-    normalizeQuotes,
-} from "../utils/stringNormalization";
 import { config } from "../config";
 import { getSystemSettings } from "../utils/systemSettings";
+import { resolveArtistImage } from "./metadata/artistImageResolver";
 
+/** Legacy image search controls retained for caller compatibility. */
 export interface ImageSearchOptions {
     preferredSize?: "small" | "medium" | "large" | "extralarge" | "mega";
     timeout?: number;
 }
 
+/** Image URL and provider provenance returned to legacy callers. */
 export interface ImageResult {
     url: string;
-    source: "deezer" | "fanart" | "musicbrainz" | "lastfm" | "spotify";
+    source:
+        | "wikidata"
+        | "deezer"
+        | "fanart"
+        | "musicbrainz"
+        | "lastfm"
+        | "spotify";
     size?: string;
 }
 
@@ -34,13 +36,8 @@ export interface ImageResult {
  */
 export class ImageProviderService {
     private readonly FANART_API_KEY = config.fanart.apiKey;
-    private readonly DEEZER_API_URL = "https://api.deezer.com";
     private readonly FANART_API_URL = "https://webservice.fanart.tv/v3";
     private fanartSettingsWarningShown = false;
-
-    private normalizeLookupValue(value: string): string {
-        return normalizeFullwidth(normalizeQuotes(value));
-    }
 
     private async resolveFanartApiKey(): Promise<string | undefined> {
         if (!config.secretsDbOnly) {
@@ -68,77 +65,14 @@ export class ImageProviderService {
     }
 
     /**
-     * Get artist image from multiple sources with fallback chain
+     * Get an artist image through the canonical metadata facade.
      */
     async getArtistImage(
         artistName: string,
         mbid?: string,
-        options: ImageSearchOptions = {},
+        _options: ImageSearchOptions = {},
     ): Promise<ImageResult | null> {
-        const { timeout = 5000 } = options;
-
-        logger.debug(`[IMAGE] Searching for artist image: ${artistName}`);
-
-        // Try Deezer first (most reliable)
-        try {
-            const deezerImage = await this.getArtistImageFromDeezer(
-                artistName,
-                timeout,
-            );
-            if (deezerImage) {
-                logger.debug(`  Found image from Deezer`);
-                return deezerImage;
-            }
-        } catch (error) {
-            logger.debug(
-                `    Deezer failed: ${
-                    error instanceof Error ? error.message : "Unknown error"
-                }`,
-            );
-        }
-
-        // Try Fanart.tv if we have API key and MBID
-        if ((await this.resolveFanartApiKey()) && mbid) {
-            try {
-                const fanartImage = await this.getArtistImageFromFanart(
-                    mbid,
-                    timeout,
-                );
-                if (fanartImage) {
-                    logger.debug(`  Found image from Fanart.tv`);
-                    return fanartImage;
-                }
-            } catch (error) {
-                logger.debug(
-                    `Fanart.tv failed: ${
-                        error instanceof Error ? error.message : "Unknown error"
-                    }`,
-                );
-            }
-        }
-
-        // Try MusicBrainz/Cover Art Archive if we have MBID
-        if (mbid) {
-            try {
-                const mbImage = await this.getArtistImageFromMusicBrainz(
-                    mbid,
-                    timeout,
-                );
-                if (mbImage) {
-                    logger.debug(`  Found image from MusicBrainz`);
-                    return mbImage;
-                }
-            } catch (error) {
-                logger.debug(
-                    `MusicBrainz failed: ${
-                        error instanceof Error ? error.message : "Unknown error"
-                    }`,
-                );
-            }
-        }
-
-        logger.debug(` No artist image found from any source`);
-        return null;
+        return resolveArtistImage({ artistName, mbid });
     }
 
     /**
@@ -220,38 +154,6 @@ export class ImageProviderService {
     }
 
     /**
-     * Search Deezer for artist image
-     */
-    private async getArtistImageFromDeezer(
-        artistName: string,
-        timeout: number,
-    ): Promise<ImageResult | null> {
-        const normalizedName = this.normalizeLookupValue(artistName);
-        const response = await rateLimiter.execute("deezer", () =>
-            axios.get(`${this.DEEZER_API_URL}/search/artist`, {
-                params: { q: normalizedName, limit: 1 },
-                timeout,
-            }),
-        );
-
-        if (response.data.data && response.data.data.length > 0) {
-            const artist = response.data.data[0];
-            // Deezer provides: picture, picture_small, picture_medium, picture_big, picture_xl
-            const imageUrl =
-                artist.picture_xl || artist.picture_big || artist.picture;
-            if (imageUrl) {
-                return {
-                    url: imageUrl,
-                    source: "deezer",
-                    size: "xl",
-                };
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Search Deezer for album cover
      */
     private async getAlbumCoverFromDeezer(
@@ -270,40 +172,6 @@ export class ImageProviderService {
         if (coverUrl) {
             return { url: coverUrl, source: "deezer", size: "xl" };
         }
-        return null;
-    }
-
-    /**
-     * Get artist image from Fanart.tv
-     */
-    private async getArtistImageFromFanart(
-        mbid: string,
-        timeout: number,
-    ): Promise<ImageResult | null> {
-        const fanartApiKey = await this.resolveFanartApiKey();
-        if (!fanartApiKey) {
-            return null;
-        }
-
-        const response = await rateLimiter.execute("fanart", () =>
-            axios.get(`${this.FANART_API_URL}/music/${mbid}`, {
-                params: { api_key: fanartApiKey },
-                timeout,
-            }),
-        );
-
-        // Fanart.tv provides multiple image types, prefer artistthumb
-        const images =
-            response.data.artistthumb ||
-            response.data.musicbanner ||
-            response.data.hdmusiclogo;
-        if (images && images.length > 0) {
-            return {
-                url: images[0].url,
-                source: "fanart",
-            };
-        }
-
         return null;
     }
 
@@ -338,18 +206,6 @@ export class ImageProviderService {
             };
         }
 
-        return null;
-    }
-
-    /**
-     * Get artist image from MusicBrainz (via relationships)
-     */
-    private async getArtistImageFromMusicBrainz(
-        mbid: string,
-        timeout: number,
-    ): Promise<ImageResult | null> {
-        // MusicBrainz doesn't have direct artist images, but we can check for image relationships
-        // This is a placeholder - in practice, we'd need to parse relationships
         return null;
     }
 
@@ -389,48 +245,6 @@ export class ImageProviderService {
                 return null;
             }
             throw error;
-        }
-
-        return null;
-    }
-
-    /**
-     * Get artist image from Last.fm (fallback only - often unreliable)
-     */
-    async getArtistImageFromLastFm(
-        artistName: string,
-        mbid?: string,
-    ): Promise<ImageResult | null> {
-        try {
-            const { lastFmService } = await import("./lastfm");
-            const artistInfo = await lastFmService.getArtistInfo(
-                artistName,
-                mbid,
-            );
-
-            if (artistInfo?.image) {
-                const megaImage = artistInfo.image.find(
-                    (img: any) => img.size === "mega",
-                );
-                const largeImage = artistInfo.image.find(
-                    (img: any) => img.size === "extralarge",
-                );
-                const image = megaImage || largeImage;
-
-                if (image?.["#text"]) {
-                    return {
-                        url: image["#text"],
-                        source: "lastfm",
-                        size: image.size,
-                    };
-                }
-            }
-        } catch (error) {
-            logger.debug(
-                `Last.fm failed: ${
-                    error instanceof Error ? error.message : "Unknown error"
-                }`,
-            );
         }
 
         return null;

--- a/backend/src/services/metadata/__tests__/artistImageResolver.test.ts
+++ b/backend/src/services/metadata/__tests__/artistImageResolver.test.ts
@@ -1,0 +1,218 @@
+const mockWikidataArtistInfo = jest.fn();
+const mockFanartArtistImage = jest.fn();
+const mockDeezerArtistImage = jest.fn();
+const mockLastFmArtistInfo = jest.fn();
+const mockRedisGet = jest.fn();
+const mockRedisSetEx = jest.fn();
+
+jest.mock("../../wikidata", () => ({
+    wikidataService: { getArtistInfo: mockWikidataArtistInfo },
+}));
+
+jest.mock("../../fanart", () => ({
+    fanartService: { getArtistImage: mockFanartArtistImage },
+}));
+
+jest.mock("../../deezer", () => ({
+    deezerService: { getArtistImage: mockDeezerArtistImage },
+}));
+
+jest.mock("../../lastfm", () => ({
+    lastFmService: { getArtistInfo: mockLastFmArtistInfo },
+}));
+
+jest.mock("../../../utils/redis", () => ({
+    redisClient: {
+        get: mockRedisGet,
+        setEx: mockRedisSetEx,
+    },
+}));
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        child: jest.fn().mockReturnValue({
+            debug: jest.fn(),
+            warn: jest.fn(),
+        }),
+    },
+}));
+
+import { resolveArtistImage } from "../artistImageResolver";
+
+const REAL_MBID = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3";
+const INPUT = { artistName: "Radiohead", mbid: REAL_MBID };
+
+describe("resolveArtistImage", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRedisGet.mockResolvedValue(null);
+        mockRedisSetEx.mockResolvedValue(undefined);
+        mockWikidataArtistInfo.mockResolvedValue({});
+        mockFanartArtistImage.mockResolvedValue(null);
+        mockDeezerArtistImage.mockResolvedValue(null);
+        mockLastFmArtistInfo.mockResolvedValue(null);
+    });
+
+    it("runs the canonical ladder in order and short-circuits on Deezer", async () => {
+        const calls: string[] = [];
+        mockWikidataArtistInfo.mockImplementation(async () => {
+            calls.push("wikidata");
+            return {};
+        });
+        mockFanartArtistImage.mockImplementation(async () => {
+            calls.push("fanart");
+            return null;
+        });
+        mockDeezerArtistImage.mockImplementation(async () => {
+            calls.push("deezer");
+            return "https://deezer.example/artist.jpg";
+        });
+        mockLastFmArtistInfo.mockImplementation(async () => {
+            calls.push("lastfm");
+            return null;
+        });
+
+        await expect(resolveArtistImage(INPUT)).resolves.toEqual({
+            url: "https://deezer.example/artist.jpg",
+            source: "deezer",
+        });
+        expect(calls).toEqual(["wikidata", "fanart", "deezer"]);
+        expect(mockFanartArtistImage).toHaveBeenCalledWith(REAL_MBID, {
+            preference: "square",
+        });
+        expect(mockLastFmArtistInfo).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, null, "temp-artist", "invalid-mbid"])(
+        "skips MBID-gated rungs for %p",
+        async (mbid) => {
+            mockLastFmArtistInfo.mockResolvedValue({
+                image: [
+                    {
+                        size: "extralarge",
+                        "#text": "https://lastfm.example/artist.jpg",
+                    },
+                ],
+            });
+
+            await expect(
+                resolveArtistImage({ artistName: "No MBID", mbid }),
+            ).resolves.toEqual({
+                url: "https://lastfm.example/artist.jpg",
+                source: "lastfm",
+            });
+            expect(mockWikidataArtistInfo).not.toHaveBeenCalled();
+            expect(mockFanartArtistImage).not.toHaveBeenCalled();
+            expect(mockDeezerArtistImage).toHaveBeenCalledWith("No MBID");
+        },
+    );
+
+    it("filters the Last.fm placeholder hash in the resolver", async () => {
+        mockLastFmArtistInfo.mockResolvedValue({
+            image: [
+                {
+                    size: "extralarge",
+                    "#text":
+                        "https://lastfm.example/2a96cbd8b46e442fc41c2b86b821562f.png",
+                },
+            ],
+        });
+
+        await expect(resolveArtistImage(INPUT)).resolves.toBeNull();
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            "metadata:artist-image:radiohead",
+            24 * 60 * 60,
+            JSON.stringify({ status: "miss" }),
+        );
+    });
+
+    it("uses a negative cache entry without re-hitting providers", async () => {
+        mockRedisGet
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(JSON.stringify({ status: "miss" }));
+
+        await expect(resolveArtistImage(INPUT)).resolves.toBeNull();
+        await expect(resolveArtistImage(INPUT)).resolves.toBeNull();
+
+        expect(mockWikidataArtistInfo).toHaveBeenCalledTimes(1);
+        expect(mockFanartArtistImage).toHaveBeenCalledTimes(1);
+        expect(mockDeezerArtistImage).toHaveBeenCalledTimes(1);
+        expect(mockLastFmArtistInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches successful resolutions for seven days", async () => {
+        mockWikidataArtistInfo.mockResolvedValue({
+            heroUrl: "https://wikidata.example/artist.jpg",
+        });
+
+        await resolveArtistImage(INPUT);
+
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            "metadata:artist-image:radiohead",
+            7 * 24 * 60 * 60,
+            JSON.stringify({
+                status: "hit",
+                value: {
+                    url: "https://wikidata.example/artist.jpg",
+                    source: "wikidata",
+                },
+            }),
+        );
+    });
+
+    it("stops later rungs when the shared budget expires", async () => {
+        jest.useFakeTimers();
+        mockWikidataArtistInfo.mockReturnValue(new Promise(() => undefined));
+
+        try {
+            const pending = resolveArtistImage(INPUT);
+            await jest.advanceTimersByTimeAsync(8_000);
+            await expect(pending).resolves.toBeNull();
+            expect(mockFanartArtistImage).not.toHaveBeenCalled();
+            expect(mockDeezerArtistImage).not.toHaveBeenCalled();
+            expect(mockLastFmArtistInfo).not.toHaveBeenCalled();
+            expect(mockRedisSetEx).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it("does not poison the negative cache after a transient provider error", async () => {
+        mockDeezerArtistImage.mockRejectedValue(new Error("Deezer timeout"));
+
+        await expect(resolveArtistImage(INPUT)).resolves.toBeNull();
+        await expect(resolveArtistImage(INPUT)).resolves.toBeNull();
+
+        expect(mockDeezerArtistImage).toHaveBeenCalledTimes(2);
+        expect(mockRedisSetEx).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates concurrent resolution for the same normalized artist", async () => {
+        let finishWikidata: ((value: { heroUrl: string }) => void) | undefined;
+        mockWikidataArtistInfo.mockReturnValue(
+            new Promise((resolve) => {
+                finishWikidata = resolve;
+            }),
+        );
+
+        const first = resolveArtistImage(INPUT);
+        const second = resolveArtistImage({
+            artistName: "  RADIOHEAD  ",
+            mbid: REAL_MBID,
+        });
+        await Promise.resolve();
+        finishWikidata?.({ heroUrl: "https://wikidata.example/deduped.jpg" });
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            {
+                url: "https://wikidata.example/deduped.jpg",
+                source: "wikidata",
+            },
+            {
+                url: "https://wikidata.example/deduped.jpg",
+                source: "wikidata",
+            },
+        ]);
+        expect(mockWikidataArtistInfo).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/services/metadata/artistImageResolver.ts
+++ b/backend/src/services/metadata/artistImageResolver.ts
@@ -1,0 +1,286 @@
+import { logger } from "../../utils/logger";
+import { isRealArtistMbid } from "../../utils/musicIds";
+import { redisClient } from "../../utils/redis";
+import { normalizeArtistName } from "../../utils/artistNormalization";
+import { deezerService } from "../deezer";
+import { fanartService } from "../fanart";
+import { lastFmService } from "../lastfm";
+import { wikidataService } from "../wikidata";
+
+const log = logger.child("ArtistImageResolver");
+const OVERALL_BUDGET_MS = 8_000;
+const CACHE_OPERATION_BUDGET_MS = 250;
+const POSITIVE_TTL_SECONDS = 7 * 24 * 60 * 60;
+const NEGATIVE_TTL_SECONDS = 24 * 60 * 60;
+const CACHE_PREFIX = "metadata:artist-image:";
+const LASTFM_PLACEHOLDER_HASH = "2a96cbd8b46e442fc41c2b86b821562f";
+const MAX_IN_FLIGHT = 1_000;
+
+/** Provider rung that produced an artist image. */
+export type ArtistImageSource = "wikidata" | "fanart" | "deezer" | "lastfm";
+
+/** Artist identity accepted by the canonical image resolver. */
+export interface ArtistImageInput {
+    artistName: string;
+    mbid?: string | null;
+}
+
+/** Canonical artist image and the provider that supplied it. */
+export interface ArtistImageResolution {
+    url: string;
+    source: ArtistImageSource;
+}
+
+type CacheLookup =
+    | { found: false }
+    | { found: true; value: ArtistImageResolution | null };
+
+type RungResult =
+    | { status: "resolved"; value: ArtistImageResolution }
+    | { status: "miss"; transient: boolean };
+
+type ArtistImageRung = Readonly<{
+    source: ArtistImageSource;
+    requiresMbid: boolean;
+    fetch: (
+        input: ArtistImageInput,
+        mbid: string | null,
+    ) => Promise<string | null>;
+}>;
+
+class BudgetExpiredError extends Error {}
+
+function cacheKeyFor(artistName: string): string {
+    return `${CACHE_PREFIX}${encodeURIComponent(normalizeArtistName(artistName))}`;
+}
+
+function isResolution(value: unknown): value is ArtistImageResolution {
+    if (!value || typeof value !== "object") return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+        typeof candidate.url === "string" &&
+        candidate.url.length > 0 &&
+        ["wikidata", "fanart", "deezer", "lastfm"].includes(
+            candidate.source as string,
+        )
+    );
+}
+
+async function withTimeout<T>(
+    operation: () => Promise<T>,
+    timeoutMs: number,
+): Promise<T> {
+    if (timeoutMs <= 0) throw new BudgetExpiredError("Budget expired");
+    let timer: NodeJS.Timeout | undefined;
+    try {
+        // Provider adapters do not expose abort signals. This bounds caller
+        // wait time, although timed-out provider work may settle afterward.
+        return await Promise.race([
+            operation(),
+            new Promise<never>((_resolve, reject) => {
+                timer = setTimeout(
+                    () => reject(new BudgetExpiredError("Budget expired")),
+                    timeoutMs,
+                );
+                timer.unref?.();
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+function remainingBudget(deadlineMs: number): number {
+    return Math.max(0, deadlineMs - Date.now());
+}
+
+async function readCache(
+    key: string,
+    deadlineMs: number,
+): Promise<CacheLookup> {
+    try {
+        const timeout = Math.min(
+            CACHE_OPERATION_BUDGET_MS,
+            remainingBudget(deadlineMs),
+        );
+        const raw = await withTimeout(() => redisClient.get(key), timeout);
+        if (!raw) return { found: false };
+        const parsed: unknown = JSON.parse(raw);
+        if ((parsed as { status?: unknown })?.status === "miss") {
+            return { found: true, value: null };
+        }
+        const value = (parsed as { value?: unknown })?.value;
+        return isResolution(value) ? { found: true, value } : { found: false };
+    } catch (error) {
+        log.debug("Artist image cache read failed", error);
+        return { found: false };
+    }
+}
+
+async function writeCache(
+    key: string,
+    value: ArtistImageResolution | null,
+    deadlineMs: number,
+): Promise<void> {
+    const ttl = value ? POSITIVE_TTL_SECONDS : NEGATIVE_TTL_SECONDS;
+    const payload = value
+        ? JSON.stringify({ status: "hit", value })
+        : JSON.stringify({ status: "miss" });
+    try {
+        const timeout = Math.min(
+            CACHE_OPERATION_BUDGET_MS,
+            remainingBudget(deadlineMs),
+        );
+        await withTimeout(() => redisClient.setEx(key, ttl, payload), timeout);
+    } catch (error) {
+        log.debug("Artist image cache write failed", error);
+    }
+}
+
+function selectLastFmImage(info: unknown): string | null {
+    if (!info || typeof info !== "object") return null;
+    const rawImages = (info as { image?: unknown }).image;
+    const images = Array.isArray(rawImages)
+        ? rawImages
+        : rawImages
+          ? [rawImages]
+          : [];
+    const sizes = ["extralarge", "mega", "large", "medium", "small"];
+    for (let index = 0; index < sizes.length; index += 1) {
+        const entry = images.find(
+            (image) =>
+                image &&
+                typeof image === "object" &&
+                (image as { size?: unknown }).size === sizes[index],
+        ) as { "#text"?: unknown } | undefined;
+        const url = entry?.["#text"];
+        if (typeof url !== "string" || url.length === 0) continue;
+        if (!url.includes(LASTFM_PLACEHOLDER_HASH)) return url;
+    }
+    return null;
+}
+
+const ARTIST_IMAGE_RUNGS: readonly ArtistImageRung[] = [
+    {
+        source: "wikidata",
+        requiresMbid: true,
+        fetch: async (input, mbid) => {
+            if (!mbid) return null;
+            const info = await wikidataService.getArtistInfo(
+                input.artistName,
+                mbid,
+            );
+            return info.heroUrl ?? null;
+        },
+    },
+    {
+        source: "fanart",
+        requiresMbid: true,
+        fetch: async (_input, mbid) => {
+            if (!mbid) return null;
+            return fanartService.getArtistImage(mbid, {
+                preference: "square",
+            });
+        },
+    },
+    {
+        source: "deezer",
+        requiresMbid: false,
+        fetch: (input) => deezerService.getArtistImage(input.artistName),
+    },
+    {
+        source: "lastfm",
+        requiresMbid: false,
+        fetch: async (input) =>
+            selectLastFmImage(
+                await lastFmService.getArtistInfo(input.artistName),
+            ),
+    },
+];
+
+async function tryRung(
+    rung: ArtistImageRung,
+    input: ArtistImageInput,
+    realMbid: string | null,
+    deadlineMs: number,
+): Promise<RungResult> {
+    try {
+        const url = await withTimeout(
+            () => rung.fetch(input, realMbid),
+            remainingBudget(deadlineMs),
+        );
+        return url
+            ? { status: "resolved", value: { url, source: rung.source } }
+            : { status: "miss", transient: false };
+    } catch (error) {
+        if (error instanceof BudgetExpiredError) throw error;
+        log.debug(`Artist image lookup failed at ${rung.source}`, error);
+        return { status: "miss", transient: true };
+    }
+}
+
+async function runLadder(
+    input: ArtistImageInput,
+    deadlineMs: number,
+): Promise<RungResult> {
+    const realMbid = isRealArtistMbid(input.mbid) ? input.mbid! : null;
+    let transient = false;
+    for (let index = 0; index < ARTIST_IMAGE_RUNGS.length; index += 1) {
+        const rung = ARTIST_IMAGE_RUNGS[index];
+        if (rung.requiresMbid && !realMbid) continue;
+        const result = await tryRung(rung, input, realMbid, deadlineMs);
+        if (result.status === "resolved") return result;
+        transient ||= result.transient;
+    }
+    return { status: "miss", transient };
+}
+
+async function resolveWithoutDedupe(
+    input: ArtistImageInput,
+    cacheKey: string,
+): Promise<ArtistImageResolution | null> {
+    const deadlineMs = Date.now() + OVERALL_BUDGET_MS;
+    const cached = await readCache(cacheKey, deadlineMs);
+    if (cached.found) return cached.value;
+
+    try {
+        const result = await runLadder(input, deadlineMs);
+        if (result.status === "resolved") {
+            await writeCache(cacheKey, result.value, deadlineMs);
+            return result.value;
+        }
+        if (!result.transient) await writeCache(cacheKey, null, deadlineMs);
+        return null;
+    } catch (error) {
+        if (error instanceof BudgetExpiredError) {
+            log.debug("Artist image resolution budget expired");
+            return null;
+        }
+        throw error;
+    }
+}
+
+const inFlight = new Map<string, Promise<ArtistImageResolution | null>>();
+
+/** Resolve an artist image through the canonical bounded provider ladder. */
+export async function resolveArtistImage(
+    input: ArtistImageInput,
+): Promise<ArtistImageResolution | null> {
+    if (typeof input.artistName !== "string" || !input.artistName.trim()) {
+        return null;
+    }
+    const cacheKey = cacheKeyFor(input.artistName);
+    const existing = inFlight.get(cacheKey);
+    if (existing) return existing;
+    if (inFlight.size >= MAX_IN_FLIGHT) {
+        return resolveWithoutDedupe(input, cacheKey);
+    }
+
+    const task = resolveWithoutDedupe(input, cacheKey);
+    inFlight.set(cacheKey, task);
+    try {
+        return await task;
+    } finally {
+        if (inFlight.get(cacheKey) === task) inFlight.delete(cacheKey);
+    }
+}

--- a/backend/src/services/musicbrainz.ts
+++ b/backend/src/services/musicbrainz.ts
@@ -7,16 +7,11 @@ import {
     normalizeQuotes,
 } from "../utils/stringNormalization";
 import { BRAND_USER_AGENT } from "../config/brand";
+import { isValidMbid } from "../utils/musicIds";
 
-const MBID_PATTERN =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export { isValidMbid } from "../utils/musicIds";
 
 type MbidEntity = "artist" | "release group" | "release";
-
-/** Returns whether a value has the UUID shape required for MusicBrainz IDs. */
-export function isValidMbid(value: unknown): value is string {
-    return typeof value === "string" && MBID_PATTERN.test(value);
-}
 
 function validateMbid(value: unknown, entity: MbidEntity): string {
     if (!isValidMbid(value)) {

--- a/backend/src/utils/__tests__/musicIds.test.ts
+++ b/backend/src/utils/__tests__/musicIds.test.ts
@@ -1,0 +1,37 @@
+import { isRealArtistMbid, rgMbidKind } from "../musicIds";
+
+describe("music ID helpers", () => {
+    describe("isRealArtistMbid", () => {
+        it.each([
+            "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+            "0383DADF-2A4E-4D10-A46A-E9E041DA8EB3",
+        ])("accepts a syntactically valid MusicBrainz artist ID", (mbid) => {
+            expect(isRealArtistMbid(mbid)).toBe(true);
+        });
+
+        it.each([
+            null,
+            undefined,
+            "",
+            "not-an-mbid",
+            "temp-artist-1",
+            "temp-remote-artist-1",
+            "remote:artist-1",
+            "federation:artist-1",
+        ])("rejects non-MusicBrainz artist identity %p", (mbid) => {
+            expect(isRealArtistMbid(mbid)).toBe(false);
+        });
+    });
+
+    describe("rgMbidKind", () => {
+        it.each([
+            ["0383dadf-2a4e-4d10-a46a-e9e041da8eb3", "musicbrainz"],
+            ["remote:album-123", "remote"],
+            ["federation:peer:album-123", "federation"],
+            ["temp-album-123", "temp"],
+            ["temp-remote-album-123", "temp"],
+        ] as const)("classifies %s as %s", (rgMbid, expected) => {
+            expect(rgMbidKind(rgMbid)).toBe(expected);
+        });
+    });
+});

--- a/backend/src/utils/musicIds.ts
+++ b/backend/src/utils/musicIds.ts
@@ -1,0 +1,23 @@
+const MBID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Return whether a value has the UUID shape required for MusicBrainz IDs. */
+export function isValidMbid(value: unknown): value is string {
+    return typeof value === "string" && MBID_PATTERN.test(value);
+}
+
+/** Return whether an artist ID is a real MusicBrainz ID, not a synthetic ID. */
+export function isRealArtistMbid(mbid: string | null | undefined): boolean {
+    if (!isValidMbid(mbid)) return false;
+    return !mbid.startsWith("temp-") && !mbid.startsWith("temp-remote-");
+}
+
+/** Classify a persisted release-group identity by its namespace shape. */
+export function rgMbidKind(
+    rgMbid: string,
+): "musicbrainz" | "remote" | "federation" | "temp" {
+    if (rgMbid.startsWith("remote:")) return "remote";
+    if (rgMbid.startsWith("federation:")) return "federation";
+    if (rgMbid.startsWith("temp-")) return "temp";
+    return "musicbrainz";
+}

--- a/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
@@ -30,11 +30,8 @@ describe("artistEnrichment runtime", () => {
             getArtistInfo: jest.fn().mockResolvedValue(null),
             getSimilarArtists: jest.fn().mockResolvedValue([]),
         };
-        const fanartService = {
-            getArtistImage: jest.fn().mockResolvedValue(null),
-        };
-        const deezerService = {
-            getArtistImage: jest.fn().mockResolvedValue(null),
+        const artistImageResolver = {
+            resolveArtistImage: jest.fn().mockResolvedValue(null),
         };
         const musicBrainzService = {
             searchArtist: jest.fn().mockResolvedValue([]),
@@ -54,8 +51,22 @@ describe("artistEnrichment runtime", () => {
         jest.doMock("../../utils/logger", () => ({ logger }));
         jest.doMock("../../services/wikidata", () => ({ wikidataService }));
         jest.doMock("../../services/lastfm", () => ({ lastFmService }));
-        jest.doMock("../../services/fanart", () => ({ fanartService }));
-        jest.doMock("../../services/deezer", () => ({ deezerService }));
+        jest.doMock(
+            "../../services/metadata/artistImageResolver",
+            () => artistImageResolver,
+        );
+        jest.doMock("../../utils/musicIds", () => ({
+            isRealArtistMbid: (value: unknown) =>
+                typeof value === "string" && !value.startsWith("temp-"),
+            rgMbidKind: (value: string) =>
+                value.startsWith("federation:")
+                    ? "federation"
+                    : value.startsWith("remote:")
+                      ? "remote"
+                      : value.startsWith("temp-")
+                        ? "temp"
+                        : "musicbrainz",
+        }));
         jest.doMock("../../services/musicbrainz", () => ({
             musicBrainzService,
         }));
@@ -73,8 +84,7 @@ describe("artistEnrichment runtime", () => {
             logger,
             wikidataService,
             lastFmService,
-            fanartService,
-            deezerService,
+            artistImageResolver,
             musicBrainzService,
             coverArtService,
             redisClient,
@@ -107,6 +117,10 @@ describe("artistEnrichment runtime", () => {
         runtime.wikidataService.getArtistInfo.mockResolvedValueOnce({
             summary: "Wiki summary",
             heroUrl: "https://wiki/images/artist.jpg",
+        });
+        runtime.artistImageResolver.resolveArtistImage.mockResolvedValueOnce({
+            url: "https://wiki/images/artist.jpg",
+            source: "wikidata",
         });
         runtime.lastFmService.getArtistInfo.mockResolvedValueOnce({
             tags: {
@@ -191,6 +205,12 @@ describe("artistEnrichment runtime", () => {
             7 * 24 * 60 * 60,
             "/images/artists/a1.jpg",
         );
+        expect(
+            runtime.artistImageResolver.resolveArtistImage,
+        ).toHaveBeenCalledWith({
+            artistName: "Artist One",
+            mbid: "real-mbid-1",
+        });
     });
 
     it("uses a native hero path without attempting local download", async () => {
@@ -199,6 +219,10 @@ describe("artistEnrichment runtime", () => {
         runtime.wikidataService.getArtistInfo.mockResolvedValueOnce({
             summary: "Native hero from wikidata",
             heroUrl: "/assets/artist/native-cover.jpg",
+        });
+        runtime.artistImageResolver.resolveArtistImage.mockResolvedValueOnce({
+            url: "/assets/artist/native-cover.jpg",
+            source: "wikidata",
         });
         runtime.lastFmService.getArtistInfo.mockResolvedValueOnce({
             tags: { tag: [{ name: "ambient" }] },
@@ -330,10 +354,10 @@ describe("artistEnrichment runtime", () => {
                 },
             ],
         });
-        runtime.fanartService.getArtistImage.mockResolvedValueOnce(null);
-        runtime.deezerService.getArtistImage.mockResolvedValueOnce(
-            "https://deezer/images/artist.jpg",
-        );
+        runtime.artistImageResolver.resolveArtistImage.mockResolvedValueOnce({
+            url: "https://deezer/images/artist.jpg",
+            source: "deezer",
+        });
         runtime.imageStorage.isNativePath.mockReturnValue(false);
         runtime.imageStorage.downloadAndStoreImage.mockResolvedValueOnce(null);
 
@@ -344,12 +368,12 @@ describe("artistEnrichment runtime", () => {
         } as any;
         await runtime.enrichSimilarArtist(artist);
 
-        expect(runtime.fanartService.getArtistImage).toHaveBeenCalledWith(
-            "real-artist-mbid",
-        );
-        expect(runtime.deezerService.getArtistImage).toHaveBeenCalledWith(
-            "Artist Three",
-        );
+        expect(
+            runtime.artistImageResolver.resolveArtistImage,
+        ).toHaveBeenCalledWith({
+            artistName: "Artist Three",
+            mbid: "real-artist-mbid",
+        });
         expect(runtime.imageStorage.downloadAndStoreImage).toHaveBeenCalledWith(
             "https://deezer/images/artist.jpg",
             "a3",
@@ -520,6 +544,10 @@ describe("artistEnrichment runtime", () => {
         runtime.wikidataService.getArtistInfo.mockResolvedValueOnce({
             summary: "Cache resilient summary",
             heroUrl: "https://images.example.com/artist-hero.jpg",
+        });
+        runtime.artistImageResolver.resolveArtistImage.mockResolvedValueOnce({
+            url: "https://images.example.com/artist-hero.jpg",
+            source: "wikidata",
         });
         runtime.lastFmService.getArtistInfo.mockResolvedValueOnce(null);
         runtime.imageStorage.isNativePath.mockReturnValue(false);

--- a/backend/src/workers/artistEnrichment.ts
+++ b/backend/src/workers/artistEnrichment.ts
@@ -3,13 +3,13 @@ import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { wikidataService } from "../services/wikidata";
 import { lastFmService } from "../services/lastfm";
-import { fanartService } from "../services/fanart";
-import { deezerService } from "../services/deezer";
 import { musicBrainzService } from "../services/musicbrainz";
 import { normalizeArtistName } from "../utils/artistNormalization";
 import { coverArtService } from "../services/coverArt";
 import { redisClient } from "../utils/redis";
 import { downloadAndStoreImage, isNativePath } from "../services/imageStorage";
+import { resolveArtistImage } from "../services/metadata/artistImageResolver";
+import { isRealArtistMbid } from "../utils/musicIds";
 
 function isMbidUniqueConstraintError(error: unknown): boolean {
     if (!error || typeof error !== "object") return false;
@@ -46,7 +46,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
 
     try {
         // If artist has a temp MBID, try to get the real one from MusicBrainz
-        if (artist.mbid.startsWith("temp-")) {
+        if (!isRealArtistMbid(artist.mbid)) {
             logger.debug(
                 `${logPrefix} Temp MBID detected, searching MusicBrainz...`,
             );
@@ -55,7 +55,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
                     artist.name,
                     1,
                 );
-                if (mbResults.length > 0 && mbResults[0].id) {
+                if (mbResults.length > 0 && isRealArtistMbid(mbResults[0].id)) {
                     const realMbid = mbResults[0].id;
                     logger.debug(
                         `${logPrefix} MusicBrainz: Found real MBID: ${realMbid}`,
@@ -109,7 +109,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
         let heroUrl = null;
         let genres: string[] = [];
 
-        if (!artist.mbid.startsWith("temp-")) {
+        if (isRealArtistMbid(artist.mbid)) {
             logger.debug(
                 `${logPrefix} Wikidata: Fetching for MBID ${artist.mbid}...`,
             );
@@ -120,13 +120,9 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
                 );
                 if (wikidataInfo) {
                     summary = wikidataInfo.summary;
-                    heroUrl = wikidataInfo.heroUrl;
                     if (summary) summarySource = "wikidata";
-                    if (heroUrl) imageSource = "wikidata";
                     logger.debug(
-                        `${logPrefix} Wikidata: SUCCESS (image: ${
-                            heroUrl ? "yes" : "no"
-                        }, summary: ${summary ? "yes" : "no"})`,
+                        `${logPrefix} Wikidata: SUCCESS (summary: ${summary ? "yes" : "no"})`,
                     );
                 } else {
                     logger.debug(`${logPrefix} Wikidata: No data returned`);
@@ -140,15 +136,15 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
             logger.debug(`${logPrefix} Wikidata: Skipped (temp MBID)`);
         }
 
-        // Fetch from Last.fm if we need summary/heroUrl or always try for genres
-        if (!summary || !heroUrl || genres.length === 0) {
+        // Fetch from Last.fm if we need summary or genres.
+        if (!summary || genres.length === 0) {
             logger.debug(
-                `${logPrefix} Last.fm: Fetching (need summary: ${!summary}, need image: ${!heroUrl})...`,
+                `${logPrefix} Last.fm: Fetching (need summary: ${!summary})...`,
             );
             try {
-                const validMbid = artist.mbid.startsWith("temp-")
-                    ? undefined
-                    : artist.mbid;
+                const validMbid = isRealArtistMbid(artist.mbid)
+                    ? artist.mbid
+                    : undefined;
                 const lastfmInfo = await lastFmService.getArtistInfo(
                     artist.name,
                     validMbid,
@@ -179,102 +175,6 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
                             );
                         }
                     }
-
-                    // Try Fanart.tv for image (only with real MBID)
-                    if (!heroUrl && !artist.mbid.startsWith("temp-")) {
-                        logger.debug(
-                            `${logPrefix} Fanart.tv: Fetching for MBID ${artist.mbid}...`,
-                        );
-                        try {
-                            heroUrl = await fanartService.getArtistImage(
-                                artist.mbid,
-                            );
-                            if (heroUrl) {
-                                imageSource = "fanart.tv";
-                                logger.debug(
-                                    `${logPrefix} Fanart.tv: SUCCESS - ${heroUrl.substring(
-                                        0,
-                                        60,
-                                    )}...`,
-                                );
-                            } else {
-                                logger.debug(
-                                    `${logPrefix} Fanart.tv: No image found`,
-                                );
-                            }
-                        } catch (error: any) {
-                            logger.debug(
-                                `${logPrefix} Fanart.tv: FAILED - ${
-                                    error?.message || error
-                                }`,
-                            );
-                        }
-                    }
-
-                    // Fallback to Deezer
-                    if (!heroUrl) {
-                        logger.debug(
-                            `${logPrefix} Deezer: Fetching for "${artist.name}"...`,
-                        );
-                        try {
-                            heroUrl = await deezerService.getArtistImage(
-                                artist.name,
-                            );
-                            if (heroUrl) {
-                                imageSource = "deezer";
-                                logger.debug(
-                                    `${logPrefix} Deezer: SUCCESS - ${heroUrl.substring(
-                                        0,
-                                        60,
-                                    )}...`,
-                                );
-                            } else {
-                                logger.debug(
-                                    `${logPrefix} Deezer: No image found`,
-                                );
-                            }
-                        } catch (error: any) {
-                            logger.debug(
-                                `${logPrefix} Deezer: FAILED - ${
-                                    error?.message || error
-                                }`,
-                            );
-                        }
-                    }
-
-                    // Last fallback to Last.fm's own image
-                    if (!heroUrl && lastfmInfo.image) {
-                        const imageArray = lastfmInfo.image as any[];
-                        if (Array.isArray(imageArray)) {
-                            const bestImage =
-                                imageArray.find(
-                                    (img) => img.size === "extralarge",
-                                )?.["#text"] ||
-                                imageArray.find(
-                                    (img) => img.size === "large",
-                                )?.["#text"] ||
-                                imageArray.find(
-                                    (img) => img.size === "medium",
-                                )?.["#text"];
-                            // Filter out Last.fm's placeholder images
-                            if (
-                                bestImage &&
-                                !bestImage.includes(
-                                    "2a96cbd8b46e442fc41c2b86b821562f",
-                                )
-                            ) {
-                                heroUrl = bestImage;
-                                imageSource = "lastfm";
-                                logger.debug(
-                                    `${logPrefix} Last.fm image: SUCCESS`,
-                                );
-                            } else {
-                                logger.debug(
-                                    `${logPrefix} Last.fm image: Placeholder/none`,
-                                );
-                            }
-                        }
-                    }
                 } else {
                     logger.debug(`${logPrefix} Last.fm: No data returned`);
                 }
@@ -285,6 +185,17 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
             }
         }
 
+        try {
+            const image = await resolveArtistImage({
+                artistName: artist.name,
+                mbid: artist.mbid,
+            });
+            heroUrl = image?.url ?? null;
+            imageSource = image?.source ?? "none";
+        } catch (error) {
+            logger.debug(`${logPrefix} Artist image resolution failed`, error);
+        }
+
         // Get similar artists from Last.fm
         let similarArtists: Array<{
             name: string;
@@ -293,9 +204,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
         }> = [];
         try {
             // Filter out temp MBIDs
-            const validMbid = artist.mbid.startsWith("temp-")
-                ? ""
-                : artist.mbid;
+            const validMbid = isRealArtistMbid(artist.mbid) ? artist.mbid : "";
             similarArtists = await lastFmService.getSimilarArtists(
                 validMbid,
                 artist.name,

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -55,7 +55,7 @@ const FIXED_SCAN_ROOTS = Object.freeze([
 const BASELINE = Object.freeze({
     "backend/src/routes/browse.ts": 1540,
     "backend/src/routes/enrichment.ts": 2277,
-    "backend/src/routes/library/artists.ts": 1553,
+    "backend/src/routes/library/artists.ts": 1531,
     "backend/src/routes/library/radio.ts": 1661,
     "backend/src/routes/library/tracks.ts": 1769,
     "backend/src/routes/playlists.ts": 2262,


### PR DESCRIPTION
PR 1 of the #760 consolidation (album covers, then bio/genre unification follow).

## What

Five independently written artist-image ladders (imageProvider, dataCache, enrichment worker, discovery artist route, library similar-artist thumbnails) become one facade resolver.

- **`services/metadata/artistImageResolver`** — shaped like `trackAlbumResolution`: typed source union, explicit rung list, shared 8s budget with per-rung guards, 7d positive / 24h negative Redis caching under one `metadata:artist-image:*` key family, bounded in-flight dedupe, transient-vs-permanent miss handling.
- **Canonical ladder**: Wikidata (real MBID only) → Fanart (real MBID + key, square-first: thumb → banner → logo) → Deezer (name) → Last.fm (name, placeholder-hash filtered here, once).
- All five call sites delegate; response shapes unchanged (payload-pinning suites updated for module boundaries only). The dead MusicBrainz artist-image rung is gone.
- **`utils/musicIds`**: `isRealArtistMbid` / `rgMbidKind` replace ad-hoc `startsWith("temp-")` checks in the touched files; the MBID regex now has one home (re-exported through `musicbrainz.ts`).
- Behavioral tightening (intended): provider lookups keyed by MBID now require a syntactically valid MBID instead of any non-`temp-` string — malformed stored values no longer get sent to Last.fm/Fanart.
- File-size baseline for `routes/library/artists.ts` tightened 1553 → 1531 (the gate's ratchet-down rule).

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass (post-rebase onto #771)
- verify: backend jest post-rebase — libraryArtistLookupCompat, FULL libraryRuntime (161), artistsRuntime, artistImageResolver: `Test Suites: 4 passed`, `Tests: 217 passed`; earlier in-worktree: musicIds, fanart, imageProvider, dataCache, artistEnrichmentRuntime, artistEnrichmentMbidConflict, musicbrainzService all green