### PR TITLE
chore(metadata): one album-cover resolver behind the facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Album covers now resolve through one provider ladder with unified caching, replacing six surface-specific implementations.
 - Artist images now resolve through one provider ladder with unified caching, instead of five surface-specific implementations.
 - Search now matches songs by artist and album name, tolerates typos, and ranks fallback results by similarity instead of alphabetically.
 - Download job metadata updates now flow through guarded helpers instead of ad-hoc merges scattered across the backend.

--- a/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
+++ b/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
@@ -16,6 +16,10 @@ var mockPrisma = {
     },
 };
 
+jest.mock("../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn().mockResolvedValue(null),
+}));
+
 jest.mock("../utils/db", () => ({
     prisma: mockPrisma,
 }));

--- a/backend/src/__tests__/artistsRouteAuthz.test.ts
+++ b/backend/src/__tests__/artistsRouteAuthz.test.ts
@@ -22,6 +22,10 @@ const mockRequireAuthOrToken = jest.fn(
     },
 );
 
+jest.mock("../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn().mockResolvedValue(null),
+}));
+
 jest.mock("../middleware/auth", () => ({
     requireAuthOrToken: (req: any, res: any, next: any) =>
         mockRequireAuthOrToken(req, res, next),

--- a/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
+++ b/backend/src/routes/__tests__/artistsPreviewYtMusic.test.ts
@@ -3,6 +3,10 @@ import { PassThrough } from "stream";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
+jest.mock("../../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn().mockResolvedValue(null),
+}));
+
 jest.mock("../../middleware/auth", () => ({
     requireAuthOrToken: (_req: Request, _res: Response, next: () => void) =>
         next(),

--- a/backend/src/routes/__tests__/artistsRuntime.test.ts
+++ b/backend/src/routes/__tests__/artistsRuntime.test.ts
@@ -34,7 +34,6 @@ jest.mock("../../services/youtubeMusic", () => ({
 
 const deezerService = {
     getTrackPreview: jest.fn(),
-    getAlbumCover: jest.fn(),
 };
 
 jest.mock("../../services/deezer", () => ({
@@ -68,6 +67,11 @@ jest.mock("../../services/metadata/artistImageResolver", () => ({
     resolveArtistImage: mockResolveArtistImage,
 }));
 
+const mockResolveAlbumCover = jest.fn();
+jest.mock("../../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: mockResolveAlbumCover,
+}));
+
 const redisClient = {
     get: jest.fn(),
     set: jest.fn(),
@@ -86,7 +90,6 @@ const mockLoggerError = logger.error as jest.Mock;
 
 const mockYtSearch = ytMusicService.search as jest.Mock;
 const mockGetTrackPreview = deezerService.getTrackPreview as jest.Mock;
-const mockGetAlbumCover = deezerService.getAlbumCover as jest.Mock;
 
 const mockSearchArtist = musicBrainzService.searchArtist as jest.Mock;
 const mockGetArtist = musicBrainzService.getArtist as jest.Mock;
@@ -152,7 +155,7 @@ describe("artists routes runtime", () => {
         mockGetSystemSettings.mockResolvedValue({ ytMusicEnabled: true });
         mockYtSearch.mockResolvedValue({ results: [], total: 0 });
         mockGetTrackPreview.mockResolvedValue(null);
-        mockGetAlbumCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
 
         mockSearchArtist.mockResolvedValue([]);
         mockGetArtist.mockResolvedValue(null);
@@ -648,13 +651,12 @@ describe("artists routes runtime", () => {
             },
         ]);
 
-        fetchMock
-            .mockResolvedValueOnce({ ok: false })
-            .mockResolvedValueOnce({ ok: true });
-
-        mockGetAlbumCover.mockResolvedValueOnce(
-            "https://deezer/covers/older.jpg",
-        );
+        mockResolveAlbumCover
+            .mockResolvedValueOnce({
+                url: "https://deezer/covers/older.jpg",
+                source: "deezer",
+            })
+            .mockResolvedValueOnce(null);
 
         const req = {
             params: { nameOrMbid: "The Artist" },
@@ -675,6 +677,17 @@ describe("artists routes runtime", () => {
             10,
         );
         expect(mockGetReleaseGroups).toHaveBeenCalledWith("artist-mbid-1");
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Resolved Artist",
+            albumTitle: "Older Album",
+            rgMbid: "rg-older",
+        });
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Resolved Artist",
+            albumTitle: "Newer EP",
+            rgMbid: "rg-newer",
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
         expect(mockResolveArtistImage).toHaveBeenCalledWith({
             artistName: "Resolved Artist",
             mbid: "artist-mbid-1",
@@ -856,10 +869,10 @@ describe("artists routes runtime", () => {
             tags: { tag: { name: "electronic" } },
         });
 
-        fetchMock.mockResolvedValueOnce({ ok: false });
-        mockGetAlbumCover.mockResolvedValueOnce(
-            "https://deezer/covers/rg-123.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://deezer/covers/rg-123.jpg",
+            source: "deezer",
+        });
 
         const req = {
             params: { mbid: "rg-123" },
@@ -871,6 +884,12 @@ describe("artists routes runtime", () => {
 
         expect(mockGetReleaseGroup).toHaveBeenCalledWith("rg-123");
         expect(mockGetRelease).toHaveBeenCalledWith("release-1");
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "RG Artist",
+            albumTitle: "Release Group Album",
+            rgMbid: "rg-123",
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
 
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual(
@@ -952,8 +971,6 @@ describe("artists routes runtime", () => {
                 },
             ],
         });
-
-        fetchMock.mockResolvedValueOnce({ ok: true });
 
         const req = {
             params: { mbid: "release-mbid-9" },
@@ -1039,8 +1056,6 @@ describe("artists routes runtime", () => {
         mockGetRelease.mockRejectedValueOnce(
             new Error("release tracks failed"),
         );
-        fetchMock.mockResolvedValueOnce({ ok: true });
-
         const req = {
             params: { mbid: "rg-album-fail" },
             query: { includeTracks: "1" },
@@ -1058,7 +1073,7 @@ describe("artists routes runtime", () => {
         );
     });
 
-    it("falls back to Cover Art Archive URL when album art HEAD request fails", async () => {
+    it("falls back to the Cover Art Archive URL when resolution misses", async () => {
         mockGetReleaseGroup.mockResolvedValueOnce({
             id: "rg-cover-fallback",
             title: "Cover Fallback Album",
@@ -1068,8 +1083,7 @@ describe("artists routes runtime", () => {
                 { name: "Fallback Artist", artist: { id: "artist-fallback" } },
             ],
         });
-        fetchMock.mockRejectedValueOnce(new Error("cover head check failed"));
-        mockGetAlbumCover.mockResolvedValueOnce(null);
+        mockResolveAlbumCover.mockResolvedValueOnce(null);
 
         const req = {
             params: { mbid: "rg-cover-fallback" },
@@ -1079,10 +1093,11 @@ describe("artists routes runtime", () => {
 
         await getAlbum(req, res);
 
-        expect(mockGetAlbumCover).toHaveBeenCalledWith(
-            "Fallback Artist",
-            "Cover Fallback Album",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Fallback Artist",
+            albumTitle: "Cover Fallback Album",
+            rgMbid: "rg-cover-fallback",
+        });
         expect(res.statusCode).toBe(200);
         expect(res.body.coverUrl).toBe(
             "https://coverartarchive.org/release-group/rg-cover-fallback/front-500",
@@ -1105,8 +1120,6 @@ describe("artists routes runtime", () => {
                 { name: "Cache Artist", artist: { id: "artist-cache" } },
             ],
         });
-        fetchMock.mockResolvedValueOnce({ ok: true });
-
         const req = {
             params: { mbid: "rg-cache-fail" },
             query: { includeTracks: "0" },

--- a/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistLookupCompat.test.ts
@@ -84,10 +84,8 @@ jest.mock("../../services/fanart", () => ({
     fanartService: {},
 }));
 
-jest.mock("../../services/deezer", () => ({
-    deezerService: {
-        getAlbumCover: jest.fn(),
-    },
+jest.mock("../../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn(),
 }));
 
 jest.mock("../../services/imageProvider", () => ({
@@ -166,7 +164,7 @@ import router from "../library";
 import { flattenLibraryRouteLayers } from "./libraryRouteTestUtils";
 import { prisma } from "../../utils/db";
 import { lastFmService } from "../../services/lastfm";
-import { deezerService } from "../../services/deezer";
+import { resolveAlbumCover } from "../../services/metadata/albumCoverResolver";
 import { dataCacheService } from "../../services/dataCache";
 import { musicBrainzService } from "../../services/musicbrainz";
 
@@ -174,7 +172,7 @@ const mockArtistFindFirst = prisma.artist.findFirst as jest.Mock;
 const mockPlayGroupBy = prisma.play.groupBy as jest.Mock;
 const mockLastFmGetArtistTopTracks =
     lastFmService.getArtistTopTracks as jest.Mock;
-const mockDeezerGetAlbumCover = deezerService.getAlbumCover as jest.Mock;
+const mockResolveAlbumCover = resolveAlbumCover as jest.Mock;
 const mockDataCacheGetArtistImage =
     dataCacheService.getArtistImage as jest.Mock;
 const mockMusicBrainzGetReleaseGroups =
@@ -227,7 +225,7 @@ describe("library artist lookup compatibility", () => {
         mockArtistFindFirst.mockResolvedValue(createMockArtist());
         mockPlayGroupBy.mockResolvedValue([]);
         mockLastFmGetArtistTopTracks.mockResolvedValue([]);
-        mockDeezerGetAlbumCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
         mockDataCacheGetArtistImage.mockResolvedValue(null);
         mockMusicBrainzGetReleaseGroups.mockResolvedValue([]);
     });
@@ -567,7 +565,7 @@ describe("library artist lookup compatibility", () => {
                     album: expect.objectContaining({ id: "album-1" }),
                 }),
             ]);
-            expect(mockDeezerGetAlbumCover).not.toHaveBeenCalled();
+            expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         },
     );
 
@@ -619,7 +617,7 @@ describe("library artist lookup compatibility", () => {
         expect(res.body.discographyComplete).toBe(true);
     });
 
-    it("hydrates unmatched Last.fm top tracks and skips Deezer lookup for unknown albums", async () => {
+    it("hydrates unmatched Last.fm top tracks and skips cover resolution for unknown albums", async () => {
         mockArtistFindFirst.mockResolvedValueOnce(createMockArtist());
         mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
             {
@@ -639,9 +637,10 @@ describe("library artist lookup compatibility", () => {
                 album: {},
             },
         ]);
-        mockDeezerGetAlbumCover.mockResolvedValueOnce(
-            "https://cdn.deezer.com/rare-ep.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://cdn.deezer.com/rare-ep.jpg",
+            source: "deezer",
+        });
 
         const req = {
             params: { id: "artist-local-id-123" },
@@ -662,11 +661,11 @@ describe("library artist lookup compatibility", () => {
             "AC/DC",
             10,
         );
-        expect(mockDeezerGetAlbumCover).toHaveBeenCalledTimes(1);
-        expect(mockDeezerGetAlbumCover).toHaveBeenCalledWith(
-            "AC/DC",
-            "Rare EP",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledTimes(1);
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "AC/DC",
+            albumTitle: "Rare EP",
+        });
         const unownedTrack = res.body.topTracks.find(
             (track: any) => track.title === "Unmatched With Cover",
         );
@@ -697,7 +696,7 @@ describe("library artist lookup compatibility", () => {
         );
     });
 
-    it("continues top-track hydration when a Deezer cover lookup rejects", async () => {
+    it("continues top-track hydration when cover resolution rejects", async () => {
         mockArtistFindFirst.mockResolvedValueOnce(createMockArtist());
         mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
             {
@@ -709,7 +708,7 @@ describe("library artist lookup compatibility", () => {
                 album: { "#text": "Broken Cover Album" },
             },
         ]);
-        mockDeezerGetAlbumCover.mockRejectedValueOnce(
+        mockResolveAlbumCover.mockRejectedValueOnce(
             new Error("deezer timeout"),
         );
 
@@ -738,7 +737,7 @@ describe("library artist lookup compatibility", () => {
         ]);
     });
 
-    it("skips Deezer batch lookups when Last.fm contributes no non-unknown unowned albums", async () => {
+    it("skips cover lookups when Last.fm contributes no non-unknown unowned albums", async () => {
         mockArtistFindFirst.mockResolvedValueOnce(createMockArtist());
         mockLastFmGetArtistTopTracks.mockResolvedValueOnce([
             {
@@ -765,7 +764,7 @@ describe("library artist lookup compatibility", () => {
         await artistHandler(req, res);
 
         expect(res.statusCode).toBe(200);
-        expect(mockDeezerGetAlbumCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         expect(res.body.topTracks).toEqual([
             expect.objectContaining({
                 title: "Unknown Album Track",

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -113,6 +113,10 @@ jest.mock("../../services/imageProvider", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn(),
+}));
+
 jest.mock("../../services/musicbrainz", () => ({
     isValidMbid: (value: unknown) =>
         typeof value === "string" &&
@@ -226,8 +230,7 @@ import { fetchExternalImage } from "../../services/imageProxy";
 import { MAX_EXTERNAL_IMAGE_BYTES } from "../../services/imageProxy";
 import { coverArtService } from "../../services/coverArt";
 import { prisma } from "../../utils/db";
-import { deezerService } from "../../services/deezer";
-import { imageProviderService } from "../../services/imageProvider";
+import { resolveAlbumCover } from "../../services/metadata/albumCoverResolver";
 import { downloadAndStoreImage } from "../../services/imageStorage";
 import { getSystemSettings } from "../../utils/systemSettings";
 import {
@@ -254,9 +257,7 @@ const mockAlbumFindMany = prisma.album.findMany as jest.Mock;
 const mockArtistFindMany = prisma.artist.findMany as jest.Mock;
 const mockArtistUpdateMany = prisma.artist.updateMany as jest.Mock;
 const mockQueryRaw = prisma.$queryRaw as jest.Mock;
-const mockDeezerCover = deezerService.getAlbumCover as jest.Mock;
-const mockImageProviderGetAlbumCover =
-    imageProviderService.getAlbumCover as jest.Mock;
+const mockResolveAlbumCover = resolveAlbumCover as jest.Mock;
 const mockDownloadAndStoreImage = downloadAndStoreImage as jest.Mock;
 const mockCoverArtGetCoverArt = coverArtService.getCoverArt as jest.Mock;
 const mockCoverArtClearNotFoundCache =
@@ -361,7 +362,7 @@ describe("library cover-art proxy compatibility", () => {
         mockDownloadAndStoreImage.mockResolvedValue(null);
         mockCoverArtGetCoverArt.mockResolvedValue(null);
         mockCoverArtClearNotFoundCache.mockResolvedValue(undefined);
-        mockImageProviderGetAlbumCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
         mockResizeCoverArt.mockImplementation(
             async ({
                 buffer,
@@ -745,7 +746,10 @@ describe("library cover-art proxy compatibility", () => {
             title: "Example Album",
             artist: { name: "Example Artist" },
         });
-        mockDeezerCover.mockResolvedValue("https://cdn.deezer.com/cover.jpg");
+        mockResolveAlbumCover.mockResolvedValue({
+            url: "https://cdn.deezer.com/cover.jpg",
+            source: "deezer",
+        });
         mockDownloadAndStoreImage.mockResolvedValue(
             "native:albums/album-123.jpg",
         );
@@ -774,10 +778,10 @@ describe("library cover-art proxy compatibility", () => {
                 },
             },
         });
-        expect(mockDeezerCover).toHaveBeenCalledWith(
-            "Example Artist",
-            "Example Album",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Example Artist",
+            albumTitle: "Example Album",
+        });
         expect(mockDownloadAndStoreImage).toHaveBeenCalledWith(
             "https://cdn.deezer.com/cover.jpg",
             "album-123",
@@ -802,10 +806,10 @@ describe("library cover-art proxy compatibility", () => {
             rgMbid: "44444444-4444-4444-8444-444444444444",
             artist: { name: "Fallback Artist" },
         });
-        mockCoverArtGetCoverArt.mockResolvedValue(
-            "https://coverartarchive.org/release-group/44444444-4444-4444-8444-444444444444/front.jpg",
-        );
-        mockDeezerCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue({
+            url: "https://coverartarchive.org/release-group/44444444-4444-4444-8444-444444444444/front.jpg",
+            source: "coverartarchive",
+        });
         mockDownloadAndStoreImage.mockResolvedValue(
             "native:albums/album-456.jpg",
         );
@@ -819,9 +823,11 @@ describe("library cover-art proxy compatibility", () => {
 
         await coverArtHandler(req, res);
 
-        expect(mockCoverArtGetCoverArt).toHaveBeenCalledWith(
-            "44444444-4444-4444-8444-444444444444",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Fallback Artist",
+            albumTitle: "Fallback Album",
+            rgMbid: "44444444-4444-4444-8444-444444444444",
+        });
         expect(mockDownloadAndStoreImage).toHaveBeenCalledWith(
             "https://coverartarchive.org/release-group/44444444-4444-4444-8444-444444444444/front.jpg",
             "album-456",
@@ -860,7 +866,7 @@ describe("library cover-art proxy compatibility", () => {
 
         await coverArtHandler(req, res);
 
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         expect(mockDownloadAndStoreImage).not.toHaveBeenCalled();
         expect(res.redirect).toHaveBeenCalledWith(
             "/api/library/cover-art?url=native%3Aalbums%2Falbum-123.jpg",
@@ -892,7 +898,7 @@ describe("library cover-art proxy compatibility", () => {
 
         await coverArtHandler(req, res);
 
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "missing-path" },
             data: { coverUrl: "native:albums/legacy-healed.jpg" },
@@ -916,7 +922,7 @@ describe("library cover-art proxy compatibility", () => {
 
         await coverArtHandler(req, res);
 
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(404);
         expect(res.body).toEqual({ error: "Cover art not found" });
 
@@ -930,7 +936,7 @@ describe("library cover-art proxy compatibility", () => {
             title: "Album Without Cover",
             artist: { name: "No Cover Artist" },
         });
-        mockDeezerCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
 
         const req = {
             query: { url: "native:albums/album-no-cover.jpg" },
@@ -994,9 +1000,10 @@ describe("library cover-art proxy compatibility", () => {
             title: "Album Title",
             artist: { name: "Artist Name" },
         });
-        mockDeezerCover.mockResolvedValue(
-            "https://cdn.deezer.com/album-789.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValue({
+            url: "https://cdn.deezer.com/album-789.jpg",
+            source: "deezer",
+        });
         mockDownloadAndStoreImage.mockResolvedValue(
             "native:albums/album-789.jpg",
         );
@@ -1573,7 +1580,7 @@ describe("library cover-art proxy compatibility", () => {
             "/api/library/cover-art?url=native%3Aalbums%2Falbum-native.jpg",
         );
         expect(mockCoverArtClearNotFoundCache).not.toHaveBeenCalled();
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it("redirects on-demand album ids directly when a remote coverUrl already exists", async () => {
@@ -1598,7 +1605,7 @@ describe("library cover-art proxy compatibility", () => {
             "https://images.example/album-remote.jpg",
         );
         expect(mockCoverArtClearNotFoundCache).not.toHaveBeenCalled();
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it.each(["album-100%", "album%2Fpart", "\u30a2\u30eb\u30d0\u30e0"])(
@@ -1692,10 +1699,11 @@ describe("library cover-art proxy compatibility", () => {
 
         await coverArtHandler(req, res);
 
-        expect(mockDeezerCover).toHaveBeenCalledWith(
-            "Stale Artist",
-            "Stale Native Album",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Stale Artist",
+            albumTitle: "Stale Native Album",
+            rgMbid: null,
+        });
         expect(res.statusCode).toBe(404);
         expect(res.redirect).not.toHaveBeenCalled();
         existsSpy.mockRestore();
@@ -1709,9 +1717,10 @@ describe("library cover-art proxy compatibility", () => {
             coverUrl: null,
             artist: { name: "Temp Artist" },
         });
-        mockDeezerCover.mockResolvedValueOnce(
-            "https://cdn.deezer.com/temp-rg.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://cdn.deezer.com/temp-rg.jpg",
+            source: "deezer",
+        });
         mockFetchExternalImage.mockResolvedValueOnce({
             ok: true,
             buffer: Buffer.from("temp-cover"),
@@ -1731,11 +1740,11 @@ describe("library cover-art proxy compatibility", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(mockCoverArtClearNotFoundCache).not.toHaveBeenCalled();
-        expect(mockCoverArtGetCoverArt).not.toHaveBeenCalled();
-        expect(mockDeezerCover).toHaveBeenCalledWith(
-            "Temp Artist",
-            "Temporary RG Album",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Temp Artist",
+            albumTitle: "Temporary RG Album",
+            rgMbid: "temp-rg-123",
+        });
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "album-temp-rg" },
             data: { coverUrl: "https://cdn.deezer.com/temp-rg.jpg" },
@@ -1752,9 +1761,10 @@ describe("library cover-art proxy compatibility", () => {
             coverUrl: null,
             artist: { name: "CAA Artist" },
         });
-        mockCoverArtGetCoverArt.mockResolvedValueOnce(
-            "https://coverartarchive.org/release-group/rg-caa-hit/front.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://coverartarchive.org/release-group/rg-caa-hit/front.jpg",
+            source: "coverartarchive",
+        });
         mockFetchExternalImage.mockResolvedValueOnce({
             ok: true,
             buffer: Buffer.from("caa-hit"),
@@ -1776,7 +1786,11 @@ describe("library cover-art proxy compatibility", () => {
         expect(mockCoverArtClearNotFoundCache).toHaveBeenCalledWith(
             "rg-caa-hit",
         );
-        expect(mockDeezerCover).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "CAA Artist",
+            albumTitle: "CAA Hit Album",
+            rgMbid: "rg-caa-hit",
+        });
         expect(res.statusCode).toBe(200);
         expect(res.send).toHaveBeenCalledWith(Buffer.from("caa-hit"));
     });
@@ -1789,8 +1803,9 @@ describe("library cover-art proxy compatibility", () => {
             coverUrl: null,
             artist: { name: "Error Artist" },
         });
-        mockCoverArtGetCoverArt.mockRejectedValueOnce(new Error("caa timeout"));
-        mockDeezerCover.mockRejectedValueOnce(new Error("deezer timeout"));
+        mockResolveAlbumCover.mockRejectedValueOnce(
+            new Error("resolver timeout"),
+        );
 
         const req = {
             query: {},
@@ -1813,9 +1828,10 @@ describe("library cover-art proxy compatibility", () => {
             coverUrl: null,
             artist: { name: "Persist Fail Artist" },
         });
-        mockDeezerCover.mockResolvedValueOnce(
-            "https://cdn.deezer.com/persist-fail.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://cdn.deezer.com/persist-fail.jpg",
+            source: "deezer",
+        });
         mockAlbumUpdate.mockRejectedValueOnce(new Error("persist failure"));
         mockFetchExternalImage.mockResolvedValueOnce({
             ok: true,
@@ -1885,8 +1901,7 @@ describe("library cover-art proxy compatibility", () => {
             coverUrl: null,
             artist: { name: "Retry Artist" },
         });
-        mockCoverArtGetCoverArt.mockResolvedValueOnce(null);
-        mockDeezerCover.mockResolvedValueOnce(null);
+        mockResolveAlbumCover.mockResolvedValueOnce(null);
 
         const req = {
             query: {},
@@ -1900,7 +1915,11 @@ describe("library cover-art proxy compatibility", () => {
         expect(mockCoverArtClearNotFoundCache).toHaveBeenCalledWith(
             "rg-clear-1",
         );
-        expect(mockCoverArtGetCoverArt).toHaveBeenCalledWith("rg-clear-1");
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Retry Artist",
+            albumTitle: "Retry Album",
+            rgMbid: "rg-clear-1",
+        });
         expect(res.statusCode).toBe(404);
         expect(res.body).toEqual({ error: "Cover art not found" });
     });

--- a/backend/src/routes/__tests__/libraryRuntime.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.test.ts
@@ -3274,7 +3274,18 @@ describe("library catalog list runtime coverage", () => {
                 id: "artist-cacheless",
                 coverArt: "hero-from-cacheless-cache",
                 discographyComplete: true,
-                topTracks: [],
+                // The cover-resolver miss no longer aborts the Last.fm merge,
+                // so the unowned top track survives with the page artist.
+                topTracks: [
+                    expect.objectContaining({
+                        title: "One-Track",
+                        playCount: 88,
+                        artist: { name: "Cacheless Artist" },
+                        album: expect.objectContaining({
+                            title: "Single Album",
+                        }),
+                    }),
+                ],
                 similarArtists: [
                     expect.objectContaining({
                         id: "Similar Cacheless",

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import { logger } from "../utils/logger";
 import { lastFmService } from "../services/lastfm";
 import { musicBrainzService } from "../services/musicbrainz";
-import { deezerService } from "../services/deezer";
+import { resolveAlbumCover } from "../services/metadata/albumCoverResolver";
 import { resolveArtistImage } from "../services/metadata/artistImageResolver";
 import { ytMusicService } from "../services/youtubeMusic";
 import { redisClient } from "../utils/redis";
@@ -497,56 +497,49 @@ router.get<{ nameOrMbid: string }>(
                         },
                     );
 
-                    // Process albums with Deezer fallback
+                    // Resolve covers for the bounded discovery subset.
                     albums = await Promise.all(
-                        filteredReleaseGroups.map(async (rg: any) => {
-                            // Default to Cover Art Archive URL
-                            let coverUrl = `https://coverartarchive.org/release-group/${rg.id}/front-500`;
+                        filteredReleaseGroups.map(
+                            async (rg: any, index: number) => {
+                                const archiveUrl = `https://coverartarchive.org/release-group/${rg.id}/front-500`;
+                                let coverUrl = archiveUrl;
 
-                            // For first 10 albums, try Deezer as fallback if Cover Art Archive doesn't have it
-                            // (to avoid too many requests)
-                            const index = filteredReleaseGroups.indexOf(rg);
-                            if (index < 10) {
-                                try {
-                                    const response = await fetch(coverUrl, {
-                                        method: "HEAD",
-                                        signal: AbortSignal.timeout(2000),
-                                    });
-                                    if (!response.ok) {
-                                        // Cover Art Archive doesn't have it, try Deezer
-                                        const deezerCover =
-                                            await deezerService.getAlbumCover(
+                                // Preserve the existing ten-album provider-work cap.
+                                if (index < 10) {
+                                    try {
+                                        const resolution =
+                                            await resolveAlbumCover({
                                                 artistName,
-                                                rg.title,
-                                            );
-                                        if (deezerCover) {
-                                            coverUrl = deezerCover;
-                                        }
+                                                albumTitle: rg.title,
+                                                rgMbid: rg.id,
+                                            });
+                                        coverUrl =
+                                            resolution?.url ?? archiveUrl;
+                                    } catch (error) {
+                                        // Keep the legacy archive URL fallback.
                                     }
-                                } catch (error) {
-                                    // Silently fail and keep Cover Art Archive URL
                                 }
-                            }
 
-                            return {
-                                id: rg.id, // MBID - used for linking
-                                rgMbid: rg.id, // Release group MBID - used for downloads
-                                mbid: rg.id, // Fallback MBID
-                                title: rg.title,
-                                type: rg["primary-type"],
-                                year: rg["first-release-date"]
-                                    ? parseInt(
-                                          rg["first-release-date"].substring(
-                                              0,
-                                              4,
-                                          ),
-                                      )
-                                    : null,
-                                releaseDate: rg["first-release-date"] || null,
-                                coverUrl,
-                                owned: false, // Discovery albums are never owned
-                            };
-                        }),
+                                return {
+                                    id: rg.id, // MBID - used for linking
+                                    rgMbid: rg.id, // Release group MBID - used for downloads
+                                    mbid: rg.id, // Fallback MBID
+                                    title: rg.title,
+                                    type: rg["primary-type"],
+                                    year: rg["first-release-date"]
+                                        ? parseInt(
+                                              rg[
+                                                  "first-release-date"
+                                              ].substring(0, 4),
+                                          )
+                                        : null,
+                                    releaseDate:
+                                        rg["first-release-date"] || null,
+                                    coverUrl,
+                                    owned: false, // Discovery albums are never owned
+                                };
+                            },
+                        ),
                     );
 
                     // Sort albums
@@ -799,54 +792,22 @@ router.get<{ mbid: string }>(
                 }
             }
 
-            // Get album cover art - try Cover Art Archive first
-            let coverUrl = null;
+            // Get album cover art through the canonical provider ladder.
             let coverArtUrl = `https://coverartarchive.org/release/${mbid}/front-500`;
             if (!release) {
                 coverArtUrl = `https://coverartarchive.org/release-group/${releaseGroupId}/front-500`;
             }
 
-            // Check if Cover Art Archive actually has the image
+            let coverUrl = coverArtUrl;
             try {
-                const response = await fetch(coverArtUrl, {
-                    method: "HEAD",
-                    signal: AbortSignal.timeout(2000),
+                const resolution = await resolveAlbumCover({
+                    artistName,
+                    albumTitle,
+                    rgMbid: releaseGroupId,
                 });
-                if (response.ok) {
-                    coverUrl = coverArtUrl;
-                    logger.debug(
-                        `Cover Art Archive has cover for ${albumTitle}`,
-                    );
-                } else {
-                    logger.debug(
-                        `✗ Cover Art Archive 404 for ${albumTitle}, trying Deezer...`,
-                    );
-                }
+                coverUrl = resolution?.url ?? coverArtUrl;
             } catch (error) {
-                logger.debug(
-                    `✗ Cover Art Archive check failed for ${albumTitle}, trying Deezer...`,
-                );
-            }
-
-            // Fallback to Deezer if Cover Art Archive doesn't have it
-            if (!coverUrl) {
-                try {
-                    const deezerCover = await deezerService.getAlbumCover(
-                        artistName,
-                        albumTitle,
-                    );
-                    if (deezerCover) {
-                        coverUrl = deezerCover;
-                        logger.debug(`Deezer has cover for ${albumTitle}`);
-                    } else {
-                        // Final fallback to Cover Art Archive URL (might 404, but better than nothing)
-                        coverUrl = coverArtUrl;
-                    }
-                } catch (error) {
-                    logger.debug(` Deezer lookup failed for ${albumTitle}`);
-                    // Final fallback to Cover Art Archive URL
-                    coverUrl = coverArtUrl;
-                }
+                logger.debug(`Album cover lookup failed for ${albumTitle}`);
             }
 
             // Format response

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -12,7 +12,7 @@ import { logger } from "../../utils/logger";
 import path from "path";
 import fs from "fs";
 import { config } from "../../config";
-import { deezerService } from "../../services/deezer";
+import { resolveAlbumCover } from "../../services/metadata/albumCoverResolver";
 import { musicBrainzService } from "../../services/musicbrainz";
 import { dataCacheService } from "../../services/dataCache";
 import {
@@ -945,19 +945,19 @@ export async function handleGetArtist(
                 }
             }
 
-            // Fetch Deezer covers for unowned tracks in parallel (cached 24h)
             if (unownedEntries.length > 0) {
                 const covers = await Promise.all(
                     unownedEntries.map((entry) =>
-                        deezerService
-                            .getAlbumCover(artist.name, entry.albumTitle)
-                            .catch(() => null),
+                        resolveAlbumCover({
+                            artistName: artist.name,
+                            albumTitle: entry.albumTitle,
+                        }).catch(() => null),
                     ),
                 );
                 for (let i = 0; i < unownedEntries.length; i++) {
                     if (covers[i]) {
                         combinedTracks[unownedEntries[i].index].album.coverArt =
-                            covers[i];
+                            covers[i]?.url ?? null;
                     }
                 }
             }

--- a/backend/src/routes/library/coverArt.ts
+++ b/backend/src/routes/library/coverArt.ts
@@ -5,8 +5,8 @@ import { redisClient } from "../../utils/redis";
 import { logger } from "../../utils/logger";
 import crypto from "crypto";
 import path from "path";
-import { deezerService } from "../../services/deezer";
 import { coverArtService } from "../../services/coverArt";
+import { resolveAlbumCover } from "../../services/metadata/albumCoverResolver";
 import { extractColorsFromImage } from "../../utils/colorExtractor";
 import {
     fetchExternalImage,
@@ -38,6 +38,7 @@ import {
     trySendResizedNativeCover,
 } from "../../utils/libraryCoverArt";
 import { normalizeRouteName } from "../routeParamName";
+import { rgMbidKind } from "../../utils/musicIds";
 
 const coverAlbumSelect = {
     id: true,
@@ -418,34 +419,26 @@ export async function handleGetCoverArt(
             const validRgMbid =
                 typeof album.rgMbid === "string" &&
                 album.rgMbid.length > 0 &&
-                !album.rgMbid.startsWith("temp-") &&
-                !album.rgMbid.startsWith("federation:")
+                rgMbidKind(album.rgMbid) === "musicbrainz"
                     ? album.rgMbid
                     : null;
 
             // Clear stale NOT_FOUND cache so retry uses improved matching
             if (validRgMbid) {
                 await coverArtService.clearNotFoundCache(validRgMbid);
-                try {
-                    fetchedCoverUrl =
-                        await coverArtService.getCoverArt(validRgMbid);
-                } catch (err) {
-                    logger.warn(
-                        `[COVER-ART] On-demand CAA fetch failed for ${validRgMbid}:`,
-                        err,
-                    );
-                }
             }
 
-            if (!fetchedCoverUrl && album.artist) {
+            if (album.artist) {
                 try {
-                    fetchedCoverUrl = await deezerService.getAlbumCover(
-                        album.artist.name,
-                        album.title,
-                    );
+                    const resolution = await resolveAlbumCover({
+                        artistName: album.artist.name,
+                        albumTitle: album.title,
+                        rgMbid: album.rgMbid,
+                    });
+                    fetchedCoverUrl = resolution?.url ?? null;
                 } catch (err) {
                     logger.warn(
-                        `[COVER-ART] On-demand Deezer fetch failed for ${album.artist.name} - ${album.title}:`,
+                        `[COVER-ART] On-demand cover resolution failed for ${album.artist.name} - ${album.title}:`,
                         err,
                     );
                 }

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -137,6 +137,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/listenTogetherUserQuiescence.ts` | Bounded per-group local mutation-tail barrier before administrative user cleanup |
 | `backend/src/services/lyrics.ts` | Core |
 | `backend/src/services/m3uParser.ts` | Core |
+| `backend/src/services/metadata/albumCoverResolver.ts` | Canonical bounded album-cover provider ladder, cache, and in-flight deduplication |
 | `backend/src/services/metadata/artistImageResolver.ts` | Canonical bounded artist-image provider ladder, cache, and in-flight deduplication |
 | `backend/src/services/moodBucketService.ts` | Core |
 | `backend/src/services/musicbrainz.ts` | Core |

--- a/backend/src/services/__tests__/coverArtService.test.ts
+++ b/backend/src/services/__tests__/coverArtService.test.ts
@@ -1,7 +1,5 @@
 import axios from "axios";
 import { redisClient } from "../../utils/redis";
-import { imageProviderService } from "../imageProvider";
-import { musicBrainzService } from "../musicbrainz";
 import { rateLimiter } from "../rateLimiter";
 import { coverArtService } from "../coverArt";
 
@@ -31,18 +29,8 @@ jest.mock("../rateLimiter", () => ({
     },
 }));
 
-jest.mock("../imageProvider", () => ({
-    imageProviderService: {
-        getAlbumCover: jest.fn(),
-    },
-}));
-
 jest.mock("../musicbrainz", () => ({
     isValidMbid: jest.requireActual("../musicbrainz").isValidMbid,
-    musicBrainzService: {
-        getReleaseGroup: jest.fn(),
-        extractPrimaryArtist: jest.fn(),
-    },
 }));
 
 const mockAxiosGet = axios.get as jest.Mock;
@@ -50,14 +38,9 @@ const mockRedisGet = redisClient.get as jest.Mock;
 const mockRedisSetEx = redisClient.setEx as jest.Mock;
 const mockRedisDel = redisClient.del as jest.Mock;
 const mockRateLimiterExecute = rateLimiter.execute as jest.Mock;
-const mockGetAlbumCover = imageProviderService.getAlbumCover as jest.Mock;
-const mockGetReleaseGroup = musicBrainzService.getReleaseGroup as jest.Mock;
-const mockExtractPrimaryArtist =
-    musicBrainzService.extractPrimaryArtist as jest.Mock;
 
 const CACHE_HIT_MBID = "11111111-1111-4111-8111-111111111111";
 const DEDUPE_MBID = "22222222-2222-4222-8222-222222222222";
-const FALLBACK_MBID = "33333333-3333-4333-8333-333333333333";
 const NOT_FOUND_MBID = "44444444-4444-4444-8444-444444444444";
 const TRANSIENT_ERROR_MBID = "55555555-5555-4555-8555-555555555555";
 
@@ -70,9 +53,6 @@ describe("coverArtService", () => {
             async (_bucket: string, requestFn: () => Promise<unknown>) =>
                 requestFn(),
         );
-        mockGetReleaseGroup.mockResolvedValue(null);
-        mockExtractPrimaryArtist.mockReturnValue("Unknown Artist");
-        mockGetAlbumCover.mockResolvedValue(null);
     });
 
     it("returns cached URL without making upstream calls", async () => {
@@ -90,8 +70,6 @@ describe("coverArtService", () => {
         expect(result).toBeNull();
         expect(mockRedisGet).not.toHaveBeenCalled();
         expect(mockRateLimiterExecute).not.toHaveBeenCalled();
-        expect(mockGetReleaseGroup).not.toHaveBeenCalled();
-        expect(mockGetAlbumCover).not.toHaveBeenCalled();
     });
 
     it("quietly rejects federation placeholders before cache or upstream access", async () => {
@@ -103,8 +81,6 @@ describe("coverArtService", () => {
         expect(mockRedisGet).not.toHaveBeenCalled();
         expect(mockAxiosGet).not.toHaveBeenCalled();
         expect(mockRateLimiterExecute).not.toHaveBeenCalled();
-        expect(mockGetReleaseGroup).not.toHaveBeenCalled();
-        expect(mockGetAlbumCover).not.toHaveBeenCalled();
         expect(mockRedisSetEx).not.toHaveBeenCalled();
     });
 
@@ -164,40 +140,7 @@ describe("coverArtService", () => {
         );
     });
 
-    it("falls back to provider chain when Cover Art Archive is not found", async () => {
-        mockAxiosGet.mockImplementation((url: string) => {
-            if (url.includes("coverartarchive.org")) {
-                return Promise.reject({ response: { status: 404 } });
-            }
-            throw new Error(`Unexpected URL: ${url}`);
-        });
-        mockGetReleaseGroup.mockResolvedValue({
-            title: "Fallback Album",
-            "artist-credit": [{ name: "Fallback Artist" }],
-        });
-        mockExtractPrimaryArtist.mockReturnValue("Fallback Artist");
-        mockGetAlbumCover.mockResolvedValue({
-            url: "https://deezer.example/fallback.jpg",
-            source: "deezer",
-        });
-
-        const result = await coverArtService.getCoverArt(FALLBACK_MBID);
-
-        expect(result).toBe("https://deezer.example/fallback.jpg");
-        expect(mockGetAlbumCover).toHaveBeenCalledWith(
-            "Fallback Artist",
-            "Fallback Album",
-            FALLBACK_MBID,
-            { timeout: 5000 },
-        );
-        expect(mockRedisSetEx).toHaveBeenCalledWith(
-            `caa:${FALLBACK_MBID}`,
-            365 * 24 * 60 * 60,
-            "https://deezer.example/fallback.jpg",
-        );
-    });
-
-    it("negative-caches not-found result when no fallback image exists", async () => {
+    it("negative-caches a Cover Art Archive not-found result", async () => {
         mockAxiosGet.mockImplementation((url: string) => {
             if (url.includes("coverartarchive.org")) {
                 return Promise.reject({ response: { status: 404 } });

--- a/backend/src/services/__tests__/dataCacheService.test.ts
+++ b/backend/src/services/__tests__/dataCacheService.test.ts
@@ -35,10 +35,8 @@ jest.mock("../metadata/artistImageResolver", () => ({
     resolveArtistImage: jest.fn(),
 }));
 
-jest.mock("../coverArt", () => ({
-    coverArtService: {
-        getCoverArt: jest.fn(),
-    },
+jest.mock("../metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn(),
 }));
 
 jest.mock("../imageStorage", () => ({
@@ -49,7 +47,7 @@ import { dataCacheService } from "../dataCache";
 import { prisma } from "../../utils/db";
 import { redisClient } from "../../utils/redis";
 import { resolveArtistImage } from "../metadata/artistImageResolver";
-import { coverArtService } from "../coverArt";
+import { resolveAlbumCover } from "../metadata/albumCoverResolver";
 import { downloadAndStoreImage } from "../imageStorage";
 import { logger } from "../../utils/logger";
 
@@ -66,7 +64,7 @@ const mockRedisMGet = redisClient.mGet as jest.Mock;
 const mockRedisMulti = redisClient.multi as jest.Mock;
 
 const mockResolveArtistImage = resolveArtistImage as jest.Mock;
-const mockCoverArtGet = coverArtService.getCoverArt as jest.Mock;
+const mockResolveAlbumCover = resolveAlbumCover as jest.Mock;
 const mockDownloadAndStoreImage = downloadAndStoreImage as jest.Mock;
 
 const mockWarn = logger.warn as jest.Mock;
@@ -99,7 +97,7 @@ describe("dataCacheService", () => {
         mockRedisMulti.mockImplementation(() => createRedisMulti());
 
         mockResolveArtistImage.mockResolvedValue(null);
-        mockCoverArtGet.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
         mockDownloadAndStoreImage.mockResolvedValue(null);
     });
 
@@ -253,6 +251,7 @@ describe("dataCacheService", () => {
             ONE_YEAR_SECONDS,
             "native:albums/from-db.jpg",
         );
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it("uses Redis album cover cache and syncs DB", async () => {
@@ -265,26 +264,53 @@ describe("dataCacheService", () => {
             where: { id: "album-2" },
             data: { coverUrl: "native:albums/from-redis.jpg" },
         });
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
-    it("fetches album cover from Cover Art service and persists", async () => {
-        mockCoverArtGet.mockResolvedValue("https://cover.art/cover.jpg");
+    it("resolves an album cover through the facade and persists it", async () => {
+        mockAlbumFindUnique.mockResolvedValue({
+            coverUrl: null,
+            location: "LIBRARY",
+            title: "Album Three",
+            artist: { name: "Artist Three" },
+        });
+        mockResolveAlbumCover.mockResolvedValue({
+            url: "https://cover.art/cover.jpg",
+            source: "deezer",
+        });
 
         const result = await dataCacheService.getAlbumCover("album-3", "rg-3");
 
         expect(result).toBe("https://cover.art/cover.jpg");
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Artist Three",
+            albumTitle: "Album Three",
+            rgMbid: "rg-3",
+        });
         expect(mockAlbumUpdate).toHaveBeenCalledWith({
             where: { id: "album-3" },
             data: { coverUrl: "https://cover.art/cover.jpg" },
         });
     });
 
-    it("stores negative cache for missing album cover", async () => {
-        mockCoverArtGet.mockResolvedValue(null);
+    it("stores negative cache when the album cover facade misses", async () => {
+        mockAlbumFindUnique.mockResolvedValue({
+            coverUrl: null,
+            location: "LIBRARY",
+            title: "Album Four",
+            artist: { name: "Artist Four" },
+        });
+        mockResolveAlbumCover.mockResolvedValue(null);
 
         const result = await dataCacheService.getAlbumCover("album-4", "rg-4");
 
         expect(result).toBeNull();
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Artist Four",
+            albumTitle: "Album Four",
+            rgMbid: "rg-4",
+        });
+        expect(mockAlbumUpdate).not.toHaveBeenCalled();
         expect(mockRedisSetEx).toHaveBeenCalledWith(
             "album-cover:album-4",
             NEGATIVE_CACHE_SECONDS,
@@ -304,7 +330,7 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBe("/api/library/cover-art/federated-album");
-        expect(mockCoverArtGet).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
         expect(mockRedisSetEx).not.toHaveBeenCalledWith(
             "album-cover:federated-album",
             NEGATIVE_CACHE_SECONDS,
@@ -312,7 +338,12 @@ describe("dataCacheService", () => {
         );
         expect(mockAlbumFindUnique).toHaveBeenCalledWith({
             where: { id: "federated-album" },
-            select: { coverUrl: true, location: true },
+            select: {
+                coverUrl: true,
+                location: true,
+                title: true,
+                artist: { select: { name: true } },
+            },
         });
     });
 
@@ -329,15 +360,25 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBe("native:albums/existing.jpg");
-        expect(mockCoverArtGet).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it("resolves rgMbid from album and delegates to album cover retrieval", async () => {
-        mockAlbumFindUnique.mockResolvedValue({
-            rgMbid: "rg-from-db",
-            coverUrl: null,
+        mockAlbumFindUnique
+            .mockResolvedValueOnce({
+                rgMbid: "rg-from-db",
+                coverUrl: null,
+            })
+            .mockResolvedValueOnce({
+                coverUrl: null,
+                location: "LIBRARY",
+                title: "Album Six",
+                artist: { name: "Artist Six" },
+            });
+        mockResolveAlbumCover.mockResolvedValue({
+            url: "https://cover.art/from-rg.jpg",
+            source: "coverartarchive",
         });
-        mockCoverArtGet.mockResolvedValue("https://cover.art/from-rg.jpg");
 
         const result = await dataCacheService.getTrackCover(
             "track-2",
@@ -346,7 +387,11 @@ describe("dataCacheService", () => {
         );
 
         expect(result).toBe("https://cover.art/from-rg.jpg");
-        expect(mockCoverArtGet).toHaveBeenCalledWith("rg-from-db");
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Artist Six",
+            albumTitle: "Album Six",
+            rgMbid: "rg-from-db",
+        });
     });
 
     it("returns null when track cover has no rgMbid source", async () => {

--- a/backend/src/services/__tests__/deezerService.test.ts
+++ b/backend/src/services/__tests__/deezerService.test.ts
@@ -1457,66 +1457,20 @@ describe("deezerService", () => {
         );
     });
 
-    it("logs release-group metadata lookup failures", async () => {
+    it("returns null on a CAA miss without consulting MusicBrainz", async () => {
         mockAxiosGet.mockResolvedValueOnce({
             data: {
                 images: [],
             },
         });
-        mockMusicBrainzGetReleaseGroup.mockRejectedValueOnce(
-            new Error("musicbrainz timeout"),
-        );
 
         await expect(
             coverArtService.getCoverArt("33333333-3333-4333-8333-333333333333"),
         ).resolves.toBeNull();
-        expect(mockLoggerWarn).toHaveBeenCalledWith(
-            "[CoverArt] Failed to resolve release-group metadata for 33333333-3333-4333-8333-333333333333:",
-            expect.any(Error),
-        );
-    });
-
-    it("logs fallback-provider failures and returns null", async () => {
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                images: [],
-            },
-        });
-        mockMusicBrainzGetReleaseGroup.mockResolvedValueOnce({
-            title: "Provider Album",
-            "artist-credit": [{ name: "Provider Artist" }],
-        });
-        mockMusicBrainzExtractPrimaryArtist.mockReturnValueOnce(
-            "Provider Artist",
-        );
-        mockImageProviderGetAlbumCover.mockRejectedValueOnce(
-            new Error("provider unavailable"),
-        );
-
-        await expect(
-            coverArtService.getCoverArt("44444444-4444-4444-8444-444444444444"),
-        ).resolves.toBeNull();
-        expect(mockLoggerWarn).toHaveBeenCalledWith(
-            "[CoverArt] Fallback providers failed for Provider Artist - Provider Album:",
-            expect.any(Error),
-        );
-    });
-
-    it("logs redis-set warnings when caching successful CAA covers fails", async () => {
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                images: [{ front: true, image: "https://img/caa-cache.jpg" }],
-            },
-        });
-        mockRedisSetEx.mockRejectedValueOnce(new Error("redis write failed"));
-
-        await expect(
-            coverArtService.getCoverArt("55555555-5555-4555-8555-555555555555"),
-        ).resolves.toBe("https://img/caa-cache.jpg");
-        expect(mockLoggerWarn).toHaveBeenCalledWith(
-            "Redis set error:",
-            expect.any(Error),
-        );
+        // The fallback ladder moved to the album-cover resolver; the CAA
+        // service no longer resolves release-group context on a miss.
+        expect(mockMusicBrainzGetReleaseGroup).not.toHaveBeenCalled();
+        expect(mockImageProviderGetAlbumCover).not.toHaveBeenCalled();
     });
 
     it("clears stale NOT_FOUND cache entries for release groups", async () => {

--- a/backend/src/services/__tests__/imageProviderService.test.ts
+++ b/backend/src/services/__tests__/imageProviderService.test.ts
@@ -1,71 +1,21 @@
-const logger = {
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-};
-jest.mock("../../utils/logger", () => ({ logger }));
-
-const mockConfig = {
-    secretsDbOnly: false,
-    fanart: {
-        get apiKey() {
-            return process.env.FANART_API_KEY;
-        },
-    },
-};
-jest.mock("../../config", () => ({ config: mockConfig }));
-
-const mockGetSystemSettings = jest.fn();
-jest.mock("../../utils/systemSettings", () => ({
-    getSystemSettings: (...args: unknown[]) => mockGetSystemSettings(...args),
-}));
-
-const rateLimiter = { execute: jest.fn() };
-jest.mock("../rateLimiter", () => ({ rateLimiter }));
-
-const mockAxiosGet = jest.fn();
-const mockAxiosIsAxiosError = jest.fn();
-jest.mock("axios", () => ({
-    __esModule: true,
-    default: {
-        get: (...args: unknown[]) => mockAxiosGet(...args),
-        isAxiosError: (...args: unknown[]) => mockAxiosIsAxiosError(...args),
-    },
-}));
-
-const mockDeezerGetAlbumCover = jest.fn();
-jest.mock("../deezer", () => ({
-    deezerService: {
-        getAlbumCover: (...args: unknown[]) => mockDeezerGetAlbumCover(...args),
-    },
-}));
-
 const mockResolveArtistImage = jest.fn();
+const mockResolveAlbumCover = jest.fn();
+
 jest.mock("../metadata/artistImageResolver", () => ({
-    resolveArtistImage: (...args: unknown[]) => mockResolveArtistImage(...args),
+    resolveArtistImage: mockResolveArtistImage,
+}));
+
+jest.mock("../metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: mockResolveAlbumCover,
 }));
 
 import { ImageProviderService } from "../imageProvider";
 
 describe("image provider service behavior", () => {
-    const originalFanartApiKey = process.env.FANART_API_KEY;
-
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env.FANART_API_KEY = originalFanartApiKey;
-        mockConfig.secretsDbOnly = false;
-        mockGetSystemSettings.mockResolvedValue(null);
         mockResolveArtistImage.mockResolvedValue(null);
-        mockDeezerGetAlbumCover.mockResolvedValue(null);
-        mockAxiosGet.mockResolvedValue({ data: {} });
-        mockAxiosIsAxiosError.mockReturnValue(false);
-        rateLimiter.execute.mockImplementation(
-            async (_bucket: string, run: () => Promise<unknown>) => run(),
-        );
-    });
-
-    afterAll(() => {
-        process.env.FANART_API_KEY = originalFanartApiKey;
+        mockResolveAlbumCover.mockResolvedValue(null);
     });
 
     it("delegates artist image resolution to the metadata facade", async () => {
@@ -87,134 +37,25 @@ describe("image provider service behavior", () => {
         });
     });
 
-    it("preserves the album-cover Deezer, MusicBrainz, Fanart order", async () => {
-        process.env.FANART_API_KEY = "fanart-key";
+    it("delegates album cover resolution to the metadata facade", async () => {
         const service = new ImageProviderService();
-        jest.spyOn(service as any, "getAlbumCoverFromDeezer")
-            .mockResolvedValueOnce(null)
-            .mockResolvedValueOnce(null);
-        jest.spyOn(service as any, "getAlbumCoverFromMusicBrainz")
-            .mockResolvedValueOnce({
-                url: "https://coverart/front.jpg",
-                source: "musicbrainz",
-            })
-            .mockResolvedValueOnce(null);
-        jest.spyOn(
-            service as any,
-            "getAlbumCoverFromFanart",
-        ).mockResolvedValueOnce({
-            url: "https://fanart/cover.jpg",
-            source: "fanart",
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://coverartarchive.example/front.jpg",
+            source: "coverartarchive",
         });
 
         await expect(
-            service.getAlbumCover("Artist A", "Album A", "rg-1"),
+            service.getAlbumCover("Artist Name", "Album Title", "rg-mbid", {
+                timeout: 1_000,
+            }),
         ).resolves.toEqual({
-            url: "https://coverart/front.jpg",
-            source: "musicbrainz",
+            url: "https://coverartarchive.example/front.jpg",
+            source: "coverartarchive",
         });
-        await expect(
-            service.getAlbumCover("Artist B", "Album B", "rg-2"),
-        ).resolves.toEqual({
-            url: "https://fanart/cover.jpg",
-            source: "fanart",
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Artist Name",
+            albumTitle: "Album Title",
+            rgMbid: "rg-mbid",
         });
-    });
-
-    it("delegates Deezer album matching to the Deezer service", async () => {
-        const service = new ImageProviderService();
-        mockDeezerGetAlbumCover.mockResolvedValueOnce(
-            "https://deezer/album-xl.jpg",
-        );
-
-        await expect(
-            (service as any).getAlbumCoverFromDeezer(
-                "Artist A",
-                "Album One",
-                3000,
-            ),
-        ).resolves.toEqual({
-            url: "https://deezer/album-xl.jpg",
-            source: "deezer",
-            size: "xl",
-        });
-        expect(mockDeezerGetAlbumCover).toHaveBeenCalledWith(
-            "Artist A",
-            "Album One",
-        );
-    });
-
-    it("uses the configured Fanart key for album covers", async () => {
-        process.env.FANART_API_KEY = "fanart-key";
-        const service = new ImageProviderService();
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                albums: {
-                    "rg-mbid": {
-                        albumcover: [{ url: "https://fanart/album-cover.jpg" }],
-                    },
-                },
-            },
-        });
-
-        await expect(
-            (service as any).getAlbumCoverFromFanart("rg-mbid", 2000),
-        ).resolves.toEqual({
-            url: "https://fanart/album-cover.jpg",
-            source: "fanart",
-        });
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://webservice.fanart.tv/v3/music/albums/rg-mbid",
-            {
-                params: { api_key: "fanart-key" },
-                timeout: 2000,
-            },
-        );
-    });
-
-    it("resolves the stored Fanart key in DB-only mode", async () => {
-        process.env.FANART_API_KEY = "env-key";
-        mockConfig.secretsDbOnly = true;
-        mockGetSystemSettings.mockResolvedValue({
-            fanartEnabled: true,
-            fanartApiKey: "db-key",
-        });
-        const service = new ImageProviderService();
-        mockAxiosGet.mockResolvedValueOnce({ data: {} });
-
-        await expect(
-            (service as any).getAlbumCoverFromFanart("rg-mbid", 2000),
-        ).resolves.toBeNull();
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-            "https://webservice.fanart.tv/v3/music/albums/rg-mbid",
-            expect.objectContaining({ params: { api_key: "db-key" } }),
-        );
-    });
-
-    it("handles Cover Art Archive success, 404, and unknown failures", async () => {
-        const service = new ImageProviderService();
-        mockAxiosGet.mockResolvedValueOnce({
-            data: {
-                images: [{ image: "https://coverart/front.jpg", front: true }],
-            },
-        });
-        await expect(
-            (service as any).getAlbumCoverFromMusicBrainz("rg-1", 1000),
-        ).resolves.toEqual({
-            url: "https://coverart/front.jpg",
-            source: "musicbrainz",
-        });
-
-        const notFoundError = { response: { status: 404 } };
-        rateLimiter.execute.mockRejectedValueOnce(notFoundError);
-        mockAxiosIsAxiosError.mockReturnValueOnce(true);
-        await expect(
-            (service as any).getAlbumCoverFromMusicBrainz("rg-2", 1000),
-        ).resolves.toBeNull();
-
-        rateLimiter.execute.mockRejectedValueOnce(new Error("timeout"));
-        await expect(
-            (service as any).getAlbumCoverFromMusicBrainz("rg-3", 1000),
-        ).rejects.toThrow("timeout");
     });
 });

--- a/backend/src/services/__tests__/musicScannerService.test.ts
+++ b/backend/src/services/__tests__/musicScannerService.test.ts
@@ -79,7 +79,7 @@ mockLogger.child.mockReturnValue(mockLogger);
 
 const mockUpdateArtistCountsInBatches = jest.fn();
 const mockComputeAudioStreamHash = jest.fn();
-const mockGetAlbumCover = jest.fn();
+const mockResolveAlbumCover = jest.fn();
 const mockNormalizeArtistName = jest.fn((name: string) =>
     name.trim().toLowerCase(),
 );
@@ -215,10 +215,8 @@ jest.mock("../coverArtExtractor", () => ({
     })),
 }));
 
-jest.mock("../deezer", () => ({
-    deezerService: {
-        getAlbumCover: mockGetAlbumCover,
-    },
+jest.mock("../metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: mockResolveAlbumCover,
 }));
 
 jest.mock("../../utils/artistNormalization", () => ({
@@ -437,7 +435,7 @@ describe("MusicScannerService.scanLibrary", () => {
             updated: 0,
             failed: 0,
         });
-        mockGetAlbumCover.mockResolvedValue(null);
+        mockResolveAlbumCover.mockResolvedValue(null);
         mockComputeAudioStreamHash.mockResolvedValue(
             "sha256:" + "ab".repeat(32),
         );
@@ -3976,15 +3974,16 @@ describe("MusicScannerService.processAudioFile artist fallbacks", () => {
         expect(mockPrisma.ownedAlbum.upsert).not.toHaveBeenCalled();
     });
 
-    it("falls back to Deezer cover when extractor returns no local art", async () => {
+    it("falls back to the album-cover resolver when extractor returns no local art", async () => {
         const scanner = new MusicScannerService(
             undefined,
             "/tmp/covers",
         ) as any;
         mockExtractCoverArt.mockResolvedValueOnce(null);
-        mockGetAlbumCover.mockResolvedValueOnce(
-            "https://example.com/cover.jpg",
-        );
+        mockResolveAlbumCover.mockResolvedValueOnce({
+            url: "https://example.com/cover.jpg",
+            source: "deezer",
+        });
 
         await scanner.processAudioFile(
             "/music/DiscFallback/Track.flac",
@@ -3996,10 +3995,11 @@ describe("MusicScannerService.processAudioFile artist fallbacks", () => {
             "/music/DiscFallback/Track.flac",
             "album-new",
         );
-        expect(mockGetAlbumCover).toHaveBeenCalledWith(
-            "DiscFallback",
-            "Album Name",
-        );
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "DiscFallback",
+            albumTitle: "Album Name",
+            rgMbid: undefined,
+        });
         expect(mockPrisma.album.update).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: { id: "album-new" },

--- a/backend/src/services/__tests__/nativeCoverHealing.test.ts
+++ b/backend/src/services/__tests__/nativeCoverHealing.test.ts
@@ -20,24 +20,8 @@ jest.mock("../../utils/logger", () => ({
     logger: { warn: jest.fn() },
 }));
 
-jest.mock("../coverArt", () => ({
-    coverArtService: { getCoverArt: jest.fn() },
-}));
-
-jest.mock("../imageProvider", () => ({
-    imageProviderService: { getAlbumCover: jest.fn() },
-}));
-
-jest.mock("../deezer", () => ({
-    deezerService: { getAlbumCover: jest.fn() },
-}));
-
-jest.mock("../musicbrainz", () => ({
-    isValidMbid: (value: unknown) =>
-        typeof value === "string" &&
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-            value,
-        ),
+jest.mock("../metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn(),
 }));
 
 jest.mock("../imageStorage", () => ({
@@ -45,9 +29,7 @@ jest.mock("../imageStorage", () => ({
 }));
 
 import { prisma } from "../../utils/db";
-import { coverArtService } from "../coverArt";
-import { deezerService } from "../deezer";
-import { imageProviderService } from "../imageProvider";
+import { resolveAlbumCover } from "../metadata/albumCoverResolver";
 import { downloadAndStoreImage } from "../imageStorage";
 import {
     nativeCoverHealInFlight,
@@ -57,9 +39,7 @@ import {
 const mockAlbumFindUnique = prisma.album.findUnique as jest.Mock;
 const mockAlbumUpdate = prisma.album.update as jest.Mock;
 const mockAlbumUpdateMany = prisma.album.updateMany as jest.Mock;
-const mockCoverArtGet = coverArtService.getCoverArt as jest.Mock;
-const mockProviderGet = imageProviderService.getAlbumCover as jest.Mock;
-const mockDeezerGet = deezerService.getAlbumCover as jest.Mock;
+const mockResolveAlbumCover = resolveAlbumCover as jest.Mock;
 const mockDownloadAndStoreImage = downloadAndStoreImage as jest.Mock;
 
 describe("native cover healing", () => {
@@ -91,9 +71,7 @@ describe("native cover healing", () => {
             data: { coverUrl: null },
         });
         expect(mockAlbumUpdate).not.toHaveBeenCalled();
-        expect(mockCoverArtGet).not.toHaveBeenCalled();
-        expect(mockProviderGet).not.toHaveBeenCalled();
-        expect(mockDeezerGet).not.toHaveBeenCalled();
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it("does not overwrite a cover changed after the stale native value was read", async () => {
@@ -119,7 +97,7 @@ describe("native cover healing", () => {
         expect(mockAlbumUpdate).not.toHaveBeenCalled();
     });
 
-    it("does not call image providers with a malformed release-group MBID", async () => {
+    it("delegates malformed release-group identity gating to the resolver", async () => {
         mockAlbumFindUnique.mockResolvedValue({
             id: "malformed-mbid-album",
             title: "Malformed MBID album",
@@ -131,12 +109,34 @@ describe("native cover healing", () => {
 
         await tryHealMissingNativeAlbumCover("albums/malformed-mbid-album.jpg");
 
-        expect(mockCoverArtGet).not.toHaveBeenCalled();
-        expect(mockProviderGet).not.toHaveBeenCalled();
-        expect(mockDeezerGet).toHaveBeenCalledWith(
-            "Local artist",
-            "Malformed MBID album",
+        expect(mockResolveAlbumCover).toHaveBeenCalledWith({
+            artistName: "Local artist",
+            albumTitle: "Malformed MBID album",
+            rgMbid: "not-a-musicbrainz-uuid",
+        });
+    });
+
+    it("uses a working persisted external URL before resolving providers", async () => {
+        mockAlbumFindUnique.mockResolvedValue({
+            id: "existing-cover-album",
+            title: "Existing Cover",
+            rgMbid: "11111111-1111-4111-8111-111111111111",
+            coverUrl: "https://images.example/existing.jpg",
+            location: "LIBRARY",
+            artist: { name: "Existing Artist" },
+        });
+        mockDownloadAndStoreImage.mockResolvedValue(
+            "native:albums/existing-cover-album.jpg",
         );
+
+        await tryHealMissingNativeAlbumCover("albums/existing-cover-album.jpg");
+
+        expect(mockDownloadAndStoreImage).toHaveBeenCalledWith(
+            "https://images.example/existing.jpg",
+            "existing-cover-album",
+            "album",
+        );
+        expect(mockResolveAlbumCover).not.toHaveBeenCalled();
     });
 
     it("removes settled heals so a later request can retry the same album", async () => {
@@ -148,9 +148,15 @@ describe("native cover healing", () => {
             location: "LIBRARY",
             artist: { name: "Local artist" },
         });
-        mockDeezerGet
-            .mockResolvedValueOnce("https://images.example/first.jpg")
-            .mockResolvedValueOnce("https://images.example/second.jpg");
+        mockResolveAlbumCover
+            .mockResolvedValueOnce({
+                url: "https://images.example/first.jpg",
+                source: "deezer",
+            })
+            .mockResolvedValueOnce({
+                url: "https://images.example/second.jpg",
+                source: "deezer",
+            });
         mockDownloadAndStoreImage
             .mockResolvedValueOnce("native:albums/retry-album-first.jpg")
             .mockResolvedValueOnce("native:albums/retry-album-second.jpg");

--- a/backend/src/services/coverArt.ts
+++ b/backend/src/services/coverArt.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
-import { imageProviderService } from "./imageProvider";
-import { isValidMbid, musicBrainzService } from "./musicbrainz";
+import { isValidMbid } from "./musicbrainz";
 import { rateLimiter } from "./rateLimiter";
 
 const COVER_ART_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60;
@@ -12,11 +11,6 @@ const COVER_ART_TIMEOUT_MS = 5000;
 interface CoverArtLookupResult {
     coverUrl: string | null;
     notFound: boolean;
-}
-
-interface ReleaseGroupLookupContext {
-    artistName: string;
-    albumTitle: string;
 }
 
 class CoverArtService {
@@ -64,19 +58,6 @@ class CoverArtService {
             return coverArtResult.coverUrl;
         }
 
-        const releaseGroupContext =
-            await this.resolveReleaseGroupContext(rgMbid);
-        if (releaseGroupContext) {
-            const fallbackCover = await this.fetchFromFallbackProviders(
-                releaseGroupContext,
-                rgMbid,
-            );
-            if (fallbackCover) {
-                await this.cacheCoverUrl(cacheKey, fallbackCover);
-                return fallbackCover;
-            }
-        }
-
         if (coverArtResult.notFound) {
             await this.cacheNotFound(cacheKey);
         }
@@ -114,59 +95,6 @@ class CoverArtService {
             }
             logger.error(`Cover art error for ${rgMbid}:`, error.message);
             return { coverUrl: null, notFound: false };
-        }
-    }
-
-    private async resolveReleaseGroupContext(
-        rgMbid: string,
-    ): Promise<ReleaseGroupLookupContext | null> {
-        try {
-            const releaseGroup =
-                await musicBrainzService.getReleaseGroup(rgMbid);
-            if (!releaseGroup || typeof releaseGroup.title !== "string") {
-                return null;
-            }
-
-            const artistCredits = Array.isArray(releaseGroup["artist-credit"])
-                ? releaseGroup["artist-credit"]
-                : [];
-            const artistName =
-                musicBrainzService.extractPrimaryArtist(artistCredits);
-            if (!artistName || artistName === "Unknown Artist") {
-                return null;
-            }
-
-            return {
-                artistName,
-                albumTitle: releaseGroup.title,
-            };
-        } catch (err) {
-            logger.warn(
-                `[CoverArt] Failed to resolve release-group metadata for ${rgMbid}:`,
-                err,
-            );
-            return null;
-        }
-    }
-
-    private async fetchFromFallbackProviders(
-        context: ReleaseGroupLookupContext,
-        rgMbid: string,
-    ): Promise<string | null> {
-        try {
-            const fallback = await imageProviderService.getAlbumCover(
-                context.artistName,
-                context.albumTitle,
-                rgMbid,
-                { timeout: COVER_ART_TIMEOUT_MS },
-            );
-            return fallback?.url ?? null;
-        } catch (err) {
-            logger.warn(
-                `[CoverArt] Fallback providers failed for ${context.artistName} - ${context.albumTitle}:`,
-                err,
-            );
-            return null;
         }
     }
 

--- a/backend/src/services/dataCache.ts
+++ b/backend/src/services/dataCache.ts
@@ -14,8 +14,8 @@ import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { redisClient } from "../utils/redis";
 import { buildFederatedCoverProxyPath } from "../utils/federationCover";
-import { coverArtService } from "./coverArt";
 import { downloadAndStoreImage } from "./imageStorage";
+import { resolveAlbumCover } from "./metadata/albumCoverResolver";
 import { resolveArtistImage } from "./metadata/artistImageResolver";
 
 // Cache TTLs
@@ -81,19 +81,26 @@ class DataCacheService {
 
     /**
      * Get album cover with unified caching
-     * Order: DB -> Redis -> Cover Art Archive -> save to both
+     * Order: DB -> Redis -> provider resolver -> save to both
      */
     async getAlbumCover(
         albumId: string,
         rgMbid: string,
     ): Promise<string | null> {
         const cacheKey = `album-cover:${albumId}`;
+        let albumTitle = "";
+        let artistName = "";
 
         // 1. Check DB first
         try {
             const album = await prisma.album.findUnique({
                 where: { id: albumId },
-                select: { coverUrl: true, location: true },
+                select: {
+                    coverUrl: true,
+                    location: true,
+                    title: true,
+                    artist: { select: { name: true } },
+                },
             });
             if (album?.coverUrl) {
                 this.setRedisCache(cacheKey, album.coverUrl, ALBUM_COVER_TTL);
@@ -102,6 +109,8 @@ class DataCacheService {
             if (album?.location === "FEDERATED") {
                 return buildFederatedCoverProxyPath(albumId);
             }
+            albumTitle = album?.title ?? "";
+            artistName = album?.artist.name ?? "";
         } catch (err) {
             logger.warn("[DataCache] DB lookup failed for album:", albumId);
         }
@@ -118,8 +127,13 @@ class DataCacheService {
             // Redis errors are non-critical
         }
 
-        // 3. Fetch from Cover Art Archive
-        const coverUrl = await coverArtService.getCoverArt(rgMbid);
+        // 3. Resolve through the canonical provider ladder
+        const resolution = await resolveAlbumCover({
+            artistName,
+            albumTitle,
+            rgMbid,
+        });
+        const coverUrl = resolution?.url ?? null;
 
         // 4. Save to both DB and Redis
         if (coverUrl) {

--- a/backend/src/services/imageProvider.ts
+++ b/backend/src/services/imageProvider.ts
@@ -1,15 +1,11 @@
 /**
  * Image Provider Service
  *
- * Preserves the legacy image-provider API. Artist images delegate to the
- * metadata facade; album covers retain their existing provider ladder.
+ * Preserves the legacy image-provider API while delegating artist images and
+ * album covers to the canonical metadata facade.
  */
 
-import { logger } from "../utils/logger";
-import axios from "axios";
-import { rateLimiter } from "./rateLimiter";
-import { config } from "../config";
-import { getSystemSettings } from "../utils/systemSettings";
+import { resolveAlbumCover } from "./metadata/albumCoverResolver";
 import { resolveArtistImage } from "./metadata/artistImageResolver";
 
 /** Legacy image search controls retained for caller compatibility. */
@@ -23,6 +19,7 @@ export interface ImageResult {
     url: string;
     source:
         | "wikidata"
+        | "coverartarchive"
         | "deezer"
         | "fanart"
         | "musicbrainz"
@@ -35,35 +32,6 @@ export interface ImageResult {
  * Represents the ImageProviderService class.
  */
 export class ImageProviderService {
-    private readonly FANART_API_KEY = config.fanart.apiKey;
-    private readonly FANART_API_URL = "https://webservice.fanart.tv/v3";
-    private fanartSettingsWarningShown = false;
-
-    private async resolveFanartApiKey(): Promise<string | undefined> {
-        if (!config.secretsDbOnly) {
-            return this.FANART_API_KEY;
-        }
-
-        try {
-            const settings = await getSystemSettings();
-            if (settings?.fanartEnabled && settings?.fanartApiKey) {
-                return settings.fanartApiKey;
-            }
-            this.warnFanartKeyUnavailable("key unavailable in system settings");
-        } catch {
-            this.warnFanartKeyUnavailable("system settings unreadable");
-        }
-        return undefined;
-    }
-
-    private warnFanartKeyUnavailable(reason: string): void {
-        if (this.fanartSettingsWarningShown) {
-            return;
-        }
-        logger.warn(`SECRETS_DB_ONLY: Fanart.tv ${reason} (no .env fallback)`);
-        this.fanartSettingsWarningShown = true;
-    }
-
     /**
      * Get an artist image through the canonical metadata facade.
      */
@@ -75,179 +43,14 @@ export class ImageProviderService {
         return resolveArtistImage({ artistName, mbid });
     }
 
-    /**
-     * Get album cover from multiple sources with fallback chain
-     */
+    /** Get an album cover through the canonical metadata facade. */
     async getAlbumCover(
         artistName: string,
         albumTitle: string,
         rgMbid?: string,
-        options: ImageSearchOptions = {},
+        _options: ImageSearchOptions = {},
     ): Promise<ImageResult | null> {
-        const { timeout = 5000 } = options;
-
-        logger.debug(
-            `[IMAGE] Searching for album cover: ${artistName} - ${albumTitle}`,
-        );
-
-        // Try Deezer first (most reliable)
-        try {
-            const deezerCover = await this.getAlbumCoverFromDeezer(
-                artistName,
-                albumTitle,
-                timeout,
-            );
-            if (deezerCover) {
-                logger.debug(`  Found cover from Deezer`);
-                return deezerCover;
-            }
-        } catch (error) {
-            logger.debug(
-                `    Deezer failed: ${
-                    error instanceof Error ? error.message : "Unknown error"
-                }`,
-            );
-        }
-
-        // Try MusicBrainz Cover Art Archive if we have MBID
-        if (rgMbid) {
-            try {
-                const mbCover = await this.getAlbumCoverFromMusicBrainz(
-                    rgMbid,
-                    timeout,
-                );
-                if (mbCover) {
-                    logger.debug(`  Found cover from MusicBrainz`);
-                    return mbCover;
-                }
-            } catch (error) {
-                logger.debug(
-                    `MusicBrainz failed: ${
-                        error instanceof Error ? error.message : "Unknown error"
-                    }`,
-                );
-            }
-        }
-
-        // Try Fanart.tv if we have API key and MBID
-        if ((await this.resolveFanartApiKey()) && rgMbid) {
-            try {
-                const fanartCover = await this.getAlbumCoverFromFanart(
-                    rgMbid,
-                    timeout,
-                );
-                if (fanartCover) {
-                    logger.debug(`  Found cover from Fanart.tv`);
-                    return fanartCover;
-                }
-            } catch (error) {
-                logger.debug(
-                    `Fanart.tv failed: ${
-                        error instanceof Error ? error.message : "Unknown error"
-                    }`,
-                );
-            }
-        }
-
-        logger.debug(` No album cover found from any source`);
-        return null;
-    }
-
-    /**
-     * Search Deezer for album cover
-     */
-    private async getAlbumCoverFromDeezer(
-        artistName: string,
-        albumTitle: string,
-        _timeout: number,
-    ): Promise<ImageResult | null> {
-        // Delegate to deezerService which has better matching logic:
-        // title variant generation, multi-query search with scoring, and 24h Redis caching.
-        // Dynamic import to avoid circular dependency (imageProvider ← coverArt ← deezer).
-        const { deezerService } = await import("./deezer");
-        const coverUrl = await deezerService.getAlbumCover(
-            artistName,
-            albumTitle,
-        );
-        if (coverUrl) {
-            return { url: coverUrl, source: "deezer", size: "xl" };
-        }
-        return null;
-    }
-
-    /**
-     * Get album cover from Fanart.tv
-     */
-    private async getAlbumCoverFromFanart(
-        rgMbid: string,
-        timeout: number,
-    ): Promise<ImageResult | null> {
-        const fanartApiKey = await this.resolveFanartApiKey();
-        if (!fanartApiKey) {
-            return null;
-        }
-
-        const response = await rateLimiter.execute("fanart", () =>
-            axios.get(`${this.FANART_API_URL}/music/albums/${rgMbid}`, {
-                params: { api_key: fanartApiKey },
-                timeout,
-            }),
-        );
-
-        // Prefer albumcover, fall back to cdart
-        const covers =
-            response.data.albums?.[rgMbid]?.albumcover ||
-            response.data.albums?.[rgMbid]?.cdart;
-
-        if (covers && covers.length > 0) {
-            return {
-                url: covers[0].url,
-                source: "fanart",
-            };
-        }
-
-        return null;
-    }
-
-    /**
-     * Get album cover from MusicBrainz Cover Art Archive
-     */
-    private async getAlbumCoverFromMusicBrainz(
-        rgMbid: string,
-        timeout: number,
-    ): Promise<ImageResult | null> {
-        try {
-            const response = await rateLimiter.execute("coverart", () =>
-                axios.get(
-                    `https://coverartarchive.org/release-group/${rgMbid}`,
-                    {
-                        timeout,
-                        validateStatus: (status) => status === 200,
-                    },
-                ),
-            );
-
-            if (response.data.images && response.data.images.length > 0) {
-                // Find front cover
-                const frontCover =
-                    response.data.images.find(
-                        (img: any) => img.front === true,
-                    ) || response.data.images[0];
-
-                return {
-                    url: frontCover.image,
-                    source: "musicbrainz",
-                };
-            }
-        } catch (error) {
-            // 404 is expected if no cover art exists
-            if (axios.isAxiosError(error) && error.response?.status === 404) {
-                return null;
-            }
-            throw error;
-        }
-
-        return null;
+        return resolveAlbumCover({ artistName, albumTitle, rgMbid });
     }
 }
 

--- a/backend/src/services/metadata/__tests__/albumCoverResolver.test.ts
+++ b/backend/src/services/metadata/__tests__/albumCoverResolver.test.ts
@@ -1,0 +1,217 @@
+const mockCoverArtGet = jest.fn();
+const mockDeezerAlbumCover = jest.fn();
+const mockFanartAlbumCover = jest.fn();
+const mockRedisGet = jest.fn();
+const mockRedisSetEx = jest.fn();
+
+jest.mock("../../coverArt", () => ({
+    coverArtService: { getCoverArt: mockCoverArtGet },
+}));
+
+jest.mock("../../deezer", () => ({
+    deezerService: { getAlbumCover: mockDeezerAlbumCover },
+}));
+
+jest.mock("../../fanart", () => ({
+    fanartService: { getAlbumCover: mockFanartAlbumCover },
+}));
+
+jest.mock("../../../utils/redis", () => ({
+    redisClient: {
+        get: mockRedisGet,
+        setEx: mockRedisSetEx,
+    },
+}));
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        child: jest.fn().mockReturnValue({
+            debug: jest.fn(),
+            warn: jest.fn(),
+        }),
+    },
+}));
+
+import { resolveAlbumCover } from "../albumCoverResolver";
+
+const REAL_RG_MBID = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3";
+const INPUT = {
+    artistName: "Radiohead",
+    albumTitle: "In Rainbows",
+    rgMbid: REAL_RG_MBID,
+};
+
+describe("resolveAlbumCover", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRedisGet.mockResolvedValue(null);
+        mockRedisSetEx.mockResolvedValue(undefined);
+        mockCoverArtGet.mockResolvedValue(null);
+        mockDeezerAlbumCover.mockResolvedValue(null);
+        mockFanartAlbumCover.mockResolvedValue(null);
+    });
+
+    it("runs the canonical ladder in order and short-circuits on Deezer", async () => {
+        const calls: string[] = [];
+        mockCoverArtGet.mockImplementation(async () => {
+            calls.push("coverartarchive");
+            return null;
+        });
+        mockDeezerAlbumCover.mockImplementation(async () => {
+            calls.push("deezer");
+            return "https://deezer.example/album.jpg";
+        });
+        mockFanartAlbumCover.mockImplementation(async () => {
+            calls.push("fanart");
+            return null;
+        });
+
+        await expect(resolveAlbumCover(INPUT)).resolves.toEqual({
+            url: "https://deezer.example/album.jpg",
+            source: "deezer",
+        });
+        expect(calls).toEqual(["coverartarchive", "deezer"]);
+        expect(mockCoverArtGet).toHaveBeenCalledWith(REAL_RG_MBID);
+        expect(mockDeezerAlbumCover).toHaveBeenCalledWith(
+            "Radiohead",
+            "In Rainbows",
+        );
+        expect(mockFanartAlbumCover).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        undefined,
+        null,
+        "temp-album",
+        "remote:deezer:123",
+        "federation:peer:album",
+    ])("skips release-group-gated rungs for %p", async (rgMbid) => {
+        mockDeezerAlbumCover.mockResolvedValue(
+            "https://deezer.example/no-mbid.jpg",
+        );
+
+        await expect(
+            resolveAlbumCover({
+                artistName: "No MBID",
+                albumTitle: "Album",
+                rgMbid,
+            }),
+        ).resolves.toEqual({
+            url: "https://deezer.example/no-mbid.jpg",
+            source: "deezer",
+        });
+        expect(mockCoverArtGet).not.toHaveBeenCalled();
+        expect(mockFanartAlbumCover).not.toHaveBeenCalled();
+    });
+
+    it("uses Fanart only after Cover Art Archive and Deezer miss", async () => {
+        mockFanartAlbumCover.mockResolvedValue(
+            "https://fanart.example/album.jpg",
+        );
+
+        await expect(resolveAlbumCover(INPUT)).resolves.toEqual({
+            url: "https://fanart.example/album.jpg",
+            source: "fanart",
+        });
+        expect(mockFanartAlbumCover).toHaveBeenCalledWith(REAL_RG_MBID);
+    });
+
+    it("uses a negative cache entry without re-hitting providers", async () => {
+        mockRedisGet
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(JSON.stringify({ status: "miss" }));
+
+        await expect(resolveAlbumCover(INPUT)).resolves.toBeNull();
+        await expect(resolveAlbumCover(INPUT)).resolves.toBeNull();
+
+        expect(mockCoverArtGet).toHaveBeenCalledTimes(1);
+        expect(mockDeezerAlbumCover).toHaveBeenCalledTimes(1);
+        expect(mockFanartAlbumCover).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches successful resolutions for seven days", async () => {
+        mockCoverArtGet.mockResolvedValue(
+            "https://coverartarchive.example/front.jpg",
+        );
+
+        await resolveAlbumCover(INPUT);
+
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            "metadata:album-cover:radiohead::in%20rainbows",
+            7 * 24 * 60 * 60,
+            JSON.stringify({
+                status: "hit",
+                value: {
+                    url: "https://coverartarchive.example/front.jpg",
+                    source: "coverartarchive",
+                },
+            }),
+        );
+    });
+
+    it("negative-caches permanent misses for one day", async () => {
+        await expect(resolveAlbumCover(INPUT)).resolves.toBeNull();
+
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            "metadata:album-cover:radiohead::in%20rainbows",
+            24 * 60 * 60,
+            JSON.stringify({ status: "miss" }),
+        );
+    });
+
+    it("stops later rungs when the shared budget expires", async () => {
+        jest.useFakeTimers();
+        mockCoverArtGet.mockReturnValue(new Promise(() => undefined));
+
+        try {
+            const pending = resolveAlbumCover(INPUT);
+            await jest.advanceTimersByTimeAsync(8_000);
+            await expect(pending).resolves.toBeNull();
+            expect(mockDeezerAlbumCover).not.toHaveBeenCalled();
+            expect(mockFanartAlbumCover).not.toHaveBeenCalled();
+            expect(mockRedisSetEx).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it("does not poison the negative cache after a transient provider error", async () => {
+        mockDeezerAlbumCover.mockRejectedValue(new Error("Deezer timeout"));
+
+        await expect(resolveAlbumCover(INPUT)).resolves.toBeNull();
+        await expect(resolveAlbumCover(INPUT)).resolves.toBeNull();
+
+        expect(mockDeezerAlbumCover).toHaveBeenCalledTimes(2);
+        expect(mockRedisSetEx).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates concurrent resolution for normalized album identity", async () => {
+        let finishCoverArt: ((value: string) => void) | undefined;
+        mockCoverArtGet.mockReturnValue(
+            new Promise((resolve) => {
+                finishCoverArt = resolve;
+            }),
+        );
+
+        const first = resolveAlbumCover(INPUT);
+        const second = resolveAlbumCover({
+            artistName: "  RADIOHEAD  ",
+            albumTitle: "  IN RAINBOWS  ",
+            rgMbid: REAL_RG_MBID,
+        });
+        await Promise.resolve();
+        finishCoverArt?.("https://coverartarchive.example/deduped.jpg");
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            {
+                url: "https://coverartarchive.example/deduped.jpg",
+                source: "coverartarchive",
+            },
+            {
+                url: "https://coverartarchive.example/deduped.jpg",
+                source: "coverartarchive",
+            },
+        ]);
+        expect(mockCoverArtGet).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/services/metadata/albumCoverResolver.ts
+++ b/backend/src/services/metadata/albumCoverResolver.ts
@@ -1,0 +1,264 @@
+import {
+    normalizeAlbumTitle,
+    normalizeArtistName,
+} from "../../utils/artistNormalization";
+import { logger } from "../../utils/logger";
+import { rgMbidKind } from "../../utils/musicIds";
+import { redisClient } from "../../utils/redis";
+import { coverArtService } from "../coverArt";
+import { deezerService } from "../deezer";
+import { fanartService } from "../fanart";
+
+const log = logger.child("AlbumCoverResolver");
+const OVERALL_BUDGET_MS = 8_000;
+const CACHE_OPERATION_BUDGET_MS = 250;
+const POSITIVE_TTL_SECONDS = 7 * 24 * 60 * 60;
+const NEGATIVE_TTL_SECONDS = 24 * 60 * 60;
+const CACHE_PREFIX = "metadata:album-cover:";
+const MAX_IN_FLIGHT = 1_000;
+
+/** Provider rung that produced an album cover. */
+export type AlbumCoverSource = "coverartarchive" | "deezer" | "fanart";
+
+/** Album identity accepted by the canonical cover resolver. */
+export interface AlbumCoverInput {
+    artistName: string;
+    albumTitle: string;
+    rgMbid?: string | null;
+}
+
+/** Canonical album cover and the provider that supplied it. */
+export interface AlbumCoverResolution {
+    url: string;
+    source: AlbumCoverSource;
+}
+
+type CacheLookup =
+    | { found: false }
+    | { found: true; value: AlbumCoverResolution | null };
+
+type RungResult =
+    | { status: "resolved"; value: AlbumCoverResolution }
+    | { status: "miss"; transient: boolean };
+
+type AlbumCoverRung = Readonly<{
+    source: AlbumCoverSource;
+    requiresMbid: boolean;
+    fetch: (
+        input: AlbumCoverInput,
+        mbid: string | null,
+    ) => Promise<string | null>;
+}>;
+
+class BudgetExpiredError extends Error {}
+
+function cacheKeyFor(artistName: string, albumTitle: string): string {
+    const artist = encodeURIComponent(normalizeArtistName(artistName));
+    const album = encodeURIComponent(normalizeAlbumTitle(albumTitle));
+    return `${CACHE_PREFIX}${artist}::${album}`;
+}
+
+function isResolution(value: unknown): value is AlbumCoverResolution {
+    if (!value || typeof value !== "object") return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+        typeof candidate.url === "string" &&
+        candidate.url.length > 0 &&
+        ["coverartarchive", "deezer", "fanart"].includes(
+            candidate.source as string,
+        )
+    );
+}
+
+async function withTimeout<T>(
+    operation: () => Promise<T>,
+    timeoutMs: number,
+): Promise<T> {
+    if (timeoutMs <= 0) throw new BudgetExpiredError("Budget expired");
+    let timer: NodeJS.Timeout | undefined;
+    try {
+        return await Promise.race([
+            operation(),
+            new Promise<never>((_resolve, reject) => {
+                timer = setTimeout(
+                    () => reject(new BudgetExpiredError("Budget expired")),
+                    timeoutMs,
+                );
+                timer.unref?.();
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+function remainingBudget(deadlineMs: number): number {
+    return Math.max(0, deadlineMs - Date.now());
+}
+
+async function readCache(
+    key: string,
+    deadlineMs: number,
+): Promise<CacheLookup> {
+    try {
+        const timeout = Math.min(
+            CACHE_OPERATION_BUDGET_MS,
+            remainingBudget(deadlineMs),
+        );
+        const raw = await withTimeout(() => redisClient.get(key), timeout);
+        if (!raw) return { found: false };
+        const parsed: unknown = JSON.parse(raw);
+        if ((parsed as { status?: unknown })?.status === "miss") {
+            return { found: true, value: null };
+        }
+        const value = (parsed as { value?: unknown })?.value;
+        return isResolution(value) ? { found: true, value } : { found: false };
+    } catch (error) {
+        log.debug("Album cover cache read failed", error);
+        return { found: false };
+    }
+}
+
+async function writeCache(
+    key: string,
+    value: AlbumCoverResolution | null,
+    deadlineMs: number,
+): Promise<void> {
+    const ttl = value ? POSITIVE_TTL_SECONDS : NEGATIVE_TTL_SECONDS;
+    const payload = value
+        ? JSON.stringify({ status: "hit", value })
+        : JSON.stringify({ status: "miss" });
+    try {
+        const timeout = Math.min(
+            CACHE_OPERATION_BUDGET_MS,
+            remainingBudget(deadlineMs),
+        );
+        await withTimeout(() => redisClient.setEx(key, ttl, payload), timeout);
+    } catch (error) {
+        log.debug("Album cover cache write failed", error);
+    }
+}
+
+const ALBUM_COVER_RUNGS: readonly AlbumCoverRung[] = [
+    {
+        source: "coverartarchive",
+        requiresMbid: true,
+        fetch: async (_input, mbid) => {
+            if (!mbid) return null;
+            return coverArtService.getCoverArt(mbid);
+        },
+    },
+    {
+        source: "deezer",
+        requiresMbid: false,
+        fetch: (input) =>
+            deezerService.getAlbumCover(input.artistName, input.albumTitle),
+    },
+    {
+        source: "fanart",
+        requiresMbid: true,
+        fetch: async (_input, mbid) => {
+            if (!mbid) return null;
+            return fanartService.getAlbumCover(mbid);
+        },
+    },
+];
+
+async function tryRung(
+    rung: AlbumCoverRung,
+    input: AlbumCoverInput,
+    realMbid: string | null,
+    deadlineMs: number,
+): Promise<RungResult> {
+    try {
+        const url = await withTimeout(
+            () => rung.fetch(input, realMbid),
+            remainingBudget(deadlineMs),
+        );
+        return url
+            ? { status: "resolved", value: { url, source: rung.source } }
+            : { status: "miss", transient: false };
+    } catch (error) {
+        if (error instanceof BudgetExpiredError) throw error;
+        log.debug(`Album cover lookup failed at ${rung.source}`, error);
+        return { status: "miss", transient: true };
+    }
+}
+
+function realReleaseGroupMbid(
+    rgMbid: string | null | undefined,
+): string | null {
+    if (!rgMbid || rgMbidKind(rgMbid) !== "musicbrainz") return null;
+    return rgMbid;
+}
+
+async function runLadder(
+    input: AlbumCoverInput,
+    deadlineMs: number,
+): Promise<RungResult> {
+    const realMbid = realReleaseGroupMbid(input.rgMbid);
+    let transient = false;
+    for (let index = 0; index < ALBUM_COVER_RUNGS.length; index += 1) {
+        const rung = ALBUM_COVER_RUNGS[index];
+        if (rung.requiresMbid && !realMbid) continue;
+        const result = await tryRung(rung, input, realMbid, deadlineMs);
+        if (result.status === "resolved") return result;
+        transient ||= result.transient;
+    }
+    return { status: "miss", transient };
+}
+
+async function resolveWithoutDedupe(
+    input: AlbumCoverInput,
+    cacheKey: string,
+): Promise<AlbumCoverResolution | null> {
+    const deadlineMs = Date.now() + OVERALL_BUDGET_MS;
+    const cached = await readCache(cacheKey, deadlineMs);
+    if (cached.found) return cached.value;
+
+    try {
+        const result = await runLadder(input, deadlineMs);
+        if (result.status === "resolved") {
+            await writeCache(cacheKey, result.value, deadlineMs);
+            return result.value;
+        }
+        if (!result.transient) await writeCache(cacheKey, null, deadlineMs);
+        return null;
+    } catch (error) {
+        if (error instanceof BudgetExpiredError) {
+            log.debug("Album cover resolution budget expired");
+            return null;
+        }
+        throw error;
+    }
+}
+
+const inFlight = new Map<string, Promise<AlbumCoverResolution | null>>();
+
+/** Resolve an album cover through the canonical bounded provider ladder. */
+export async function resolveAlbumCover(
+    input: AlbumCoverInput,
+): Promise<AlbumCoverResolution | null> {
+    if (
+        typeof input.artistName !== "string" ||
+        !input.artistName.trim() ||
+        typeof input.albumTitle !== "string" ||
+        !input.albumTitle.trim()
+    ) {
+        return null;
+    }
+    const cacheKey = cacheKeyFor(input.artistName, input.albumTitle);
+    const existing = inFlight.get(cacheKey);
+    if (existing) return existing;
+    if (inFlight.size >= MAX_IN_FLIGHT) {
+        return resolveWithoutDedupe(input, cacheKey);
+    }
+
+    const task = resolveWithoutDedupe(input, cacheKey);
+    inFlight.set(cacheKey, task);
+    try {
+        return await task;
+    } finally {
+        if (inFlight.get(cacheKey) === task) inFlight.delete(cacheKey);
+    }
+}

--- a/backend/src/services/musicScanner.ts
+++ b/backend/src/services/musicScanner.ts
@@ -6,7 +6,7 @@ import { parseFile } from "music-metadata";
 import { prisma } from "../utils/db";
 import PQueue from "p-queue";
 import { CoverArtExtractor } from "./coverArtExtractor";
-import { deezerService } from "./deezer";
+import { resolveAlbumCover } from "./metadata/albumCoverResolver";
 import {
     normalizeArtistName,
     canonicalizeVariousArtists,
@@ -1324,17 +1324,17 @@ export class MusicScannerService {
                             data: { coverUrl: `native:${coverPath}` },
                         });
                     } else {
-                        // No embedded art, try fetching from Deezer
+                        // No embedded art, use the canonical provider ladder.
                         try {
-                            const deezerCover =
-                                await deezerService.getAlbumCover(
-                                    artistName,
-                                    albumTitle,
-                                );
-                            if (deezerCover) {
+                            const resolution = await resolveAlbumCover({
+                                artistName,
+                                albumTitle,
+                                rgMbid: albumMbid,
+                            });
+                            if (resolution) {
                                 await prisma.album.update({
                                     where: { id: album.id },
-                                    data: { coverUrl: deezerCover },
+                                    data: { coverUrl: resolution.url },
                                 });
                             }
                         } catch (error) {

--- a/backend/src/services/nativeCoverHealing.ts
+++ b/backend/src/services/nativeCoverHealing.ts
@@ -6,15 +6,11 @@ import { prisma } from "../utils/db";
 import { redisClient } from "../utils/redis";
 import { logger } from "../utils/logger";
 import { buildFederatedCoverProxyPath } from "../utils/federationCover";
-import { coverArtService } from "./coverArt";
-import { imageProviderService } from "./imageProvider";
-import { deezerService } from "./deezer";
-import { isValidMbid } from "./musicbrainz";
 import { normalizeExternalImageUrl } from "./imageProxy";
 import { downloadAndStoreImage } from "./imageStorage";
+import { resolveAlbumCover } from "./metadata/albumCoverResolver";
 
 const ALBUM_COVER_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
-export const NATIVE_COVER_HEAL_TIMEOUT_MS = 5000;
 
 export const nativeCoverHealInFlight = new Map<
     string,
@@ -88,6 +84,20 @@ export const persistHealedAlbumCover = async (
         );
     }
 };
+
+async function storeHealedAlbumCover(
+    albumId: string,
+    coverUrl: string,
+): Promise<string | null> {
+    const localCoverPath = await downloadAndStoreImage(
+        coverUrl,
+        albumId,
+        "album",
+    );
+    if (!localCoverPath) return null;
+    await persistHealedAlbumCover(albumId, localCoverPath);
+    return buildNativeCoverProxyRedirectPath(localCoverPath);
+}
 
 export const tryHealMissingNativeAlbumCover = async (
     nativePath: string,
@@ -177,73 +187,45 @@ export const tryHealMissingNativeAlbumCover = async (
             }
         };
 
+        let persistedExternalCover: string | null = null;
         if (
             typeof album.coverUrl === "string" &&
             (album.coverUrl.startsWith("http://") ||
                 album.coverUrl.startsWith("https://"))
         ) {
-            addCandidateUrl(album.coverUrl);
-        }
-
-        const validRgMbid = isValidMbid(album.rgMbid) ? album.rgMbid : null;
-
-        if (validRgMbid) {
-            try {
-                const coverArtArchiveCover =
-                    await coverArtService.getCoverArt(validRgMbid);
-                addCandidateUrl(coverArtArchiveCover);
-            } catch (error) {
-                logger.warn(
-                    `[COVER-ART] Cover Art Archive recovery failed for ${validRgMbid}:`,
-                    error,
+            persistedExternalCover = normalizeExternalImageUrl(album.coverUrl);
+            if (persistedExternalCover) {
+                const storedCover = await storeHealedAlbumCover(
+                    album.id,
+                    persistedExternalCover,
                 );
-            }
-        }
-
-        if (validRgMbid) {
-            try {
-                const providerCover = await imageProviderService.getAlbumCover(
-                    album.artist.name,
-                    album.title,
-                    validRgMbid,
-                    { timeout: NATIVE_COVER_HEAL_TIMEOUT_MS },
-                );
-                addCandidateUrl(providerCover?.url);
-            } catch (error) {
-                logger.warn(
-                    `[COVER-ART] Provider-chain recovery failed for ${album.artist.name} - ${album.title}:`,
-                    error,
-                );
+                if (storedCover) return storedCover;
+                candidateUrls.add(persistedExternalCover);
             }
         }
 
         try {
-            const deezerCover = await deezerService.getAlbumCover(
-                album.artist.name,
-                album.title,
-            );
-            addCandidateUrl(deezerCover);
+            const resolution = await resolveAlbumCover({
+                artistName: album.artist.name,
+                albumTitle: album.title,
+                rgMbid: album.rgMbid,
+            });
+            addCandidateUrl(resolution?.url);
         } catch (error) {
             logger.warn(
-                `[COVER-ART] Deezer recovery failed for ${album.artist.name} - ${album.title}:`,
+                `[COVER-ART] Album-cover recovery failed for ${album.artist.name} - ${album.title}:`,
                 error,
             );
         }
 
         const orderedCandidateUrls = Array.from(candidateUrls);
         for (const candidateUrl of orderedCandidateUrls) {
-            const localCoverPath = await downloadAndStoreImage(
-                candidateUrl,
+            if (candidateUrl === persistedExternalCover) continue;
+            const storedCover = await storeHealedAlbumCover(
                 album.id,
-                "album",
+                candidateUrl,
             );
-
-            if (!localCoverPath) {
-                continue;
-            }
-
-            await persistHealedAlbumCover(album.id, localCoverPath);
-            return buildNativeCoverProxyRedirectPath(localCoverPath);
+            if (storedCover) return storedCover;
         }
 
         const fallbackExternalUrl = orderedCandidateUrls[0];

--- a/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
@@ -33,11 +33,11 @@ describe("artistEnrichment runtime", () => {
         const artistImageResolver = {
             resolveArtistImage: jest.fn().mockResolvedValue(null),
         };
+        const albumCoverResolver = {
+            resolveAlbumCover: jest.fn().mockResolvedValue(null),
+        };
         const musicBrainzService = {
             searchArtist: jest.fn().mockResolvedValue([]),
-        };
-        const coverArtService = {
-            getCoverArt: jest.fn().mockResolvedValue(null),
         };
         const redisClient = {
             setEx: jest.fn().mockResolvedValue(undefined),
@@ -55,6 +55,10 @@ describe("artistEnrichment runtime", () => {
             "../../services/metadata/artistImageResolver",
             () => artistImageResolver,
         );
+        jest.doMock(
+            "../../services/metadata/albumCoverResolver",
+            () => albumCoverResolver,
+        );
         jest.doMock("../../utils/musicIds", () => ({
             isRealArtistMbid: (value: unknown) =>
                 typeof value === "string" && !value.startsWith("temp-"),
@@ -70,7 +74,6 @@ describe("artistEnrichment runtime", () => {
         jest.doMock("../../services/musicbrainz", () => ({
             musicBrainzService,
         }));
-        jest.doMock("../../services/coverArt", () => ({ coverArtService }));
         jest.doMock("../../utils/redis", () => ({ redisClient }));
         jest.doMock("../../services/imageStorage", () => imageStorage);
 
@@ -85,8 +88,8 @@ describe("artistEnrichment runtime", () => {
             wikidataService,
             lastFmService,
             artistImageResolver,
+            albumCoverResolver,
             musicBrainzService,
-            coverArtService,
             redisClient,
             imageStorage,
         };
@@ -139,12 +142,23 @@ describe("artistEnrichment runtime", () => {
         );
 
         runtime.prisma.album.findMany.mockResolvedValueOnce([
-            { id: "album-1", rgMbid: "rg-1", title: "Album One" },
-            { id: "album-2", rgMbid: null, title: "Album Two" },
+            {
+                id: "album-1",
+                rgMbid: "rg-1",
+                title: "Album One",
+                artist: { name: "Artist One" },
+            },
+            {
+                id: "album-2",
+                rgMbid: null,
+                title: "Album Two",
+                artist: { name: "Artist One" },
+            },
         ]);
-        runtime.coverArtService.getCoverArt.mockResolvedValueOnce(
-            "https://covers/rg-1.jpg",
-        );
+        runtime.albumCoverResolver.resolveAlbumCover.mockResolvedValueOnce({
+            url: "https://covers/rg-1.jpg",
+            source: "coverartarchive",
+        });
 
         const artist = {
             id: "a1",
@@ -193,9 +207,13 @@ describe("artistEnrichment runtime", () => {
             where: { fromArtistId: "a1" },
         });
         expect(runtime.prisma.similarArtist.upsert).toHaveBeenCalledTimes(2);
-        expect(runtime.coverArtService.getCoverArt).toHaveBeenCalledWith(
-            "rg-1",
-        );
+        expect(
+            runtime.albumCoverResolver.resolveAlbumCover,
+        ).toHaveBeenCalledWith({
+            artistName: "Artist One",
+            albumTitle: "Album One",
+            rgMbid: "rg-1",
+        });
         expect(runtime.prisma.album.update).toHaveBeenCalledWith({
             where: { id: "album-1" },
             data: { coverUrl: "https://covers/rg-1.jpg" },
@@ -470,7 +488,7 @@ describe("artistEnrichment runtime", () => {
         expect(runtime.prisma.similarArtist.upsert).not.toHaveBeenCalled();
     });
 
-    it("continues when album cover lookup fails for an owned album", async () => {
+    it("skips album persistence when the album cover resolver misses", async () => {
         const runtime = setupRuntime();
 
         runtime.lastFmService.getArtistInfo.mockResolvedValueOnce({
@@ -485,10 +503,11 @@ describe("artistEnrichment runtime", () => {
                 id: "owned-album-1",
                 rgMbid: "rg-cover-miss",
                 title: "Missing cover",
+                artist: { name: "Album Cover Miss" },
             },
         ]);
-        runtime.coverArtService.getCoverArt.mockRejectedValueOnce(
-            new Error("cover lookup failed"),
+        runtime.albumCoverResolver.resolveAlbumCover.mockResolvedValueOnce(
+            null,
         );
 
         const artist = {
@@ -498,9 +517,13 @@ describe("artistEnrichment runtime", () => {
         } as any;
         await runtime.enrichSimilarArtist(artist);
 
-        expect(runtime.coverArtService.getCoverArt).toHaveBeenCalledWith(
-            "rg-cover-miss",
-        );
+        expect(
+            runtime.albumCoverResolver.resolveAlbumCover,
+        ).toHaveBeenCalledWith({
+            artistName: "Album Cover Miss",
+            albumTitle: "Missing cover",
+            rgMbid: "rg-cover-miss",
+        });
         expect(runtime.prisma.album.update).not.toHaveBeenCalled();
         const completed = runtime.prisma.artist.update.mock.calls
             .map((call: any[]) => call[0] as any)
@@ -510,10 +533,17 @@ describe("artistEnrichment runtime", () => {
         expect(completed.data.genres).toEqual(["rock"]);
     });
 
-    it("excludes federated albums with real release-group MBIDs from cover enrichment", async () => {
+    it("skips federation release-group placeholders during cover enrichment", async () => {
         const runtime = setupRuntime();
 
-        runtime.prisma.album.findMany.mockResolvedValueOnce([]);
+        runtime.prisma.album.findMany.mockResolvedValueOnce([
+            {
+                id: "federated-album",
+                rgMbid: "federation:peer:album",
+                title: "Federated Album",
+                artist: { name: "Federated Artist" },
+            },
+        ]);
 
         const artist = {
             id: "federated-artist",
@@ -532,9 +562,12 @@ describe("artistEnrichment runtime", () => {
                 id: true,
                 rgMbid: true,
                 title: true,
+                artist: { select: { name: true } },
             },
         });
-        expect(runtime.coverArtService.getCoverArt).not.toHaveBeenCalled();
+        expect(
+            runtime.albumCoverResolver.resolveAlbumCover,
+        ).not.toHaveBeenCalled();
         expect(runtime.prisma.album.update).not.toHaveBeenCalled();
     });
 

--- a/backend/src/workers/artistEnrichment.ts
+++ b/backend/src/workers/artistEnrichment.ts
@@ -5,9 +5,9 @@ import { wikidataService } from "../services/wikidata";
 import { lastFmService } from "../services/lastfm";
 import { musicBrainzService } from "../services/musicbrainz";
 import { normalizeArtistName } from "../utils/artistNormalization";
-import { coverArtService } from "../services/coverArt";
 import { redisClient } from "../utils/redis";
 import { downloadAndStoreImage, isNativePath } from "../services/imageStorage";
+import { resolveAlbumCover } from "../services/metadata/albumCoverResolver";
 import { resolveArtistImage } from "../services/metadata/artistImageResolver";
 import { isRealArtistMbid } from "../utils/musicIds";
 
@@ -362,7 +362,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
 
 /**
  * Enrich album covers for an artist
- * Fetches covers from Cover Art Archive for albums without covers
+ * Resolves covers through the canonical provider ladder for albums without covers
  */
 async function enrichAlbumCovers(
     artistId: string,
@@ -380,6 +380,7 @@ async function enrichAlbumCovers(
                 id: true,
                 rgMbid: true,
                 title: true,
+                artist: { select: { name: true } },
             },
         });
 
@@ -395,23 +396,23 @@ async function enrichAlbumCovers(
         let fetchedCount = 0;
         const BATCH_SIZE = 3; // Limit concurrent requests
 
-        // Process in batches to avoid overwhelming Cover Art Archive
+        // Process in batches to avoid overwhelming cover providers
         for (let i = 0; i < albumsWithoutCovers.length; i += BATCH_SIZE) {
             const batch = albumsWithoutCovers.slice(i, i + BATCH_SIZE);
 
             await Promise.all(
                 batch.map(async (album) => {
-                    if (
-                        !album.rgMbid ||
-                        album.rgMbid.startsWith("federation:")
-                    ) {
+                    if (album.rgMbid?.startsWith("federation:")) {
                         return;
                     }
 
                     try {
-                        const coverUrl = await coverArtService.getCoverArt(
-                            album.rgMbid,
-                        );
+                        const resolution = await resolveAlbumCover({
+                            artistName: album.artist.name,
+                            albumTitle: album.title,
+                            rgMbid: album.rgMbid,
+                        });
+                        const coverUrl = resolution?.url;
 
                         if (coverUrl) {
                             // Save to database


### PR DESCRIPTION
PR 2 of the #760 consolidation (after #772's artist-image resolver; bio/genre unification follows).

## What

- **`services/metadata/albumCoverResolver`** — same shape as the artist-image resolver: CAA (real MB rgMbid only, via the cached rate-limited `coverArt` service, gated by `rgMbidKind`) → Deezer (artist+title) → Fanart; 8s budget, 7d/24h positive/negative caching under `metadata:album-cover:*`, in-flight dedupe.
- **Recursion broken**: `coverArt` keeps the single CAA implementation (its internal MB-context → imageProvider fallback removed), `imageProvider.getAlbumCover` delegates to the resolver, and the resolver never calls back. The raw CAA fetch duplicate in imageProvider is gone.
- **Raw HEAD probes removed** from the discovery routes — the CAA rung answers existence through the cached service.
- **All cover call sites migrated**: native cover healing (persisted-URL short-circuit kept), on-demand cover route (NOT_FOUND-clear semantics kept), scanner (embedded-art first), discovery discography + album details, top-track cover backfill, plus the two out-of-scope callers a review pass caught relying on the deleted internal fallback: `dataCache.getAlbumCover` and the enrichment worker's cover pass — both now resolve with full artist/title context.
- **Behavioral fix shipped with it**: a throwing cover lookup used to abort the artist page's entire Last.fm top-tracks merge (a runtime test had pinned the empty result); resolver misses are contained and the merge survives — the pin now asserts the populated merge.

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass
- verify: backend jest — resolver + 9 migrated-call-site suites: `Test Suites: 10 passed`, `Tests: 282 passed`; full `libraryRuntime` (161), `enrichmentRuntime`, `enrichmentRepairCovers` pass unsandboxed; follow-up TDD ran red (2 failing suites) before green