### PR TITLE
chore(metadata): one enrichment rule set — album fields join the background worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Album genres, label, and release year now populate during normal background enrichment instead of only via the admin per-album tool, and admin re-enrichment now applies the same rules as the background worker.
 - Search results now reflect library changes immediately after a scan or deletion; artist-page popular tracks and discography now recognize remasters and editions you own (#758).
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).
 - Tracks you do not own on the artist page keep their row menu, so Go to artist and Go to album stay available (#757).

--- a/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
+++ b/backend/src/__tests__/artistEnrichmentMbidConflict.test.ts
@@ -28,6 +28,10 @@ jest.mock("../utils/logger", () => ({
     logger: {
         debug: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/__tests__/enrichmentRouteAuthz.test.ts
+++ b/backend/src/__tests__/enrichmentRouteAuthz.test.ts
@@ -69,6 +69,15 @@ jest.mock("../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: mockEnrichArtist,
+    applyArtistEnrichmentFields: mockApplyArtistEnrichment,
+}));
+jest.mock("../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: mockEnrichAlbum,
+    applyAlbumEnrichmentFields: mockApplyAlbumEnrichment,
+}));
+
 jest.mock("../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(async () => ({})),
     runFullEnrichment: mockRunFullEnrichment,

--- a/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
+++ b/backend/src/routes/__tests__/enrichmentErrorLeak.test.ts
@@ -31,6 +31,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn(),

--- a/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFailuresBoundedQuery.test.ts
@@ -32,6 +32,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn(),

--- a/backend/src/routes/__tests__/enrichmentFullOptionsCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentFullOptionsCompat.test.ts
@@ -31,6 +31,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn().mockResolvedValue({

--- a/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
@@ -31,6 +31,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn(),

--- a/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
@@ -25,6 +25,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn(),

--- a/backend/src/routes/__tests__/enrichmentRepairCovers.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRepairCovers.test.ts
@@ -39,6 +39,15 @@ jest.mock("../../services/enrichment", () => ({
     },
 }));
 
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
+}));
+
 jest.mock("../../workers/unifiedEnrichment", () => ({
     getEnrichmentProgress: jest.fn(),
     runFullEnrichment: jest.fn(),

--- a/backend/src/routes/__tests__/enrichmentRuntime.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRuntime.test.ts
@@ -24,11 +24,17 @@ jest.mock("../../services/enrichment", () => ({
     enrichmentService: {
         getSettings: jest.fn(),
         updateSettings: jest.fn(),
-        enrichArtist: jest.fn(),
-        applyArtistEnrichment: jest.fn(),
-        enrichAlbum: jest.fn(),
-        applyAlbumEnrichment: jest.fn(),
     },
+}));
+
+jest.mock("../../services/metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+
+jest.mock("../../services/metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
 }));
 
 jest.mock("../../workers/unifiedEnrichment", () => ({
@@ -144,6 +150,14 @@ jest.mock("../../utils/db", () => ({
 import router from "../enrichment";
 import { enrichmentService } from "../../services/enrichment";
 import {
+    applyArtistEnrichmentFields,
+    enrichArtistFields,
+} from "../../services/metadata/artistEnrichmentFields";
+import {
+    applyAlbumEnrichmentFields,
+    enrichAlbumFields,
+} from "../../services/metadata/albumEnrichmentFields";
+import {
     getEnrichmentProgress,
     runFullEnrichment,
     reRunArtistsOnly,
@@ -183,12 +197,10 @@ const mockMusicBrainzSearchReleaseGroups =
 
 const mockGetSettings = enrichmentService.getSettings as jest.Mock;
 const mockUpdateSettings = enrichmentService.updateSettings as jest.Mock;
-const mockEnrichArtist = enrichmentService.enrichArtist as jest.Mock;
-const mockApplyArtistEnrichment =
-    enrichmentService.applyArtistEnrichment as jest.Mock;
-const mockEnrichAlbum = enrichmentService.enrichAlbum as jest.Mock;
-const mockApplyAlbumEnrichment =
-    enrichmentService.applyAlbumEnrichment as jest.Mock;
+const mockEnrichArtist = enrichArtistFields as jest.Mock;
+const mockApplyArtistEnrichment = applyArtistEnrichmentFields as jest.Mock;
+const mockEnrichAlbum = enrichAlbumFields as jest.Mock;
+const mockApplyAlbumEnrichment = applyAlbumEnrichmentFields as jest.Mock;
 
 const mockGetFailures = enrichmentFailureService.getFailures as jest.Mock;
 const mockGetFailureCounts =
@@ -849,7 +861,7 @@ describe("enrichment route runtime behavior", () => {
         expect(res.body).toEqual({ error: "Failed to update settings" });
     });
 
-    it("gates artist enrichment by settings and confidence", async () => {
+    it("gates artist enrichment by settings and preserves low-confidence response payloads", async () => {
         mockGetSettings.mockResolvedValueOnce({ enabled: false });
         const disabledRes = createRes();
         await enrichArtistHandler(
@@ -878,7 +890,10 @@ describe("enrichment route runtime behavior", () => {
             { user: { id: "user-1" }, params: { id: "artist-low" } } as any,
             lowConfidenceRes,
         );
-        expect(mockApplyArtistEnrichment).not.toHaveBeenCalled();
+        expect(mockApplyArtistEnrichment).toHaveBeenCalledWith("artist-low", {
+            confidence: 0.2,
+            foo: "bar",
+        });
         expect(lowConfidenceRes.statusCode).toBe(200);
         expect(lowConfidenceRes.body).toEqual({
             success: true,
@@ -931,7 +946,7 @@ describe("enrichment route runtime behavior", () => {
         );
     });
 
-    it("applies album enrichment only above confidence threshold", async () => {
+    it("applies album enrichment through the shared field module without changing payloads", async () => {
         mockGetSettings.mockResolvedValueOnce({ enabled: true });
         mockEnrichAlbum.mockResolvedValueOnce({ confidence: 0.9, score: 9 });
 
@@ -953,6 +968,10 @@ describe("enrichment route runtime behavior", () => {
             { user: { id: "user-1" }, params: { id: "album-2" } } as any,
             lowConfidenceRes,
         );
+        expect(mockApplyAlbumEnrichment).toHaveBeenCalledWith("album-2", {
+            confidence: 0.1,
+            score: 1,
+        });
         expect(lowConfidenceRes.statusCode).toBe(200);
         expect(lowConfidenceRes.body).toEqual({
             success: true,

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -36,6 +36,14 @@ import { parseBoundedInt } from "../utils/queryParams";
 import { sendInternalRouteError, sendRouteError } from "./routeErrorResponse";
 import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
 import { updateAlbumMetadataWithOwnership } from "../services/albumMetadataPersistence";
+import {
+    applyArtistEnrichmentFields,
+    enrichArtistFields,
+} from "../services/metadata/artistEnrichmentFields";
+import {
+    applyAlbumEnrichmentFields,
+    enrichAlbumFields,
+} from "../services/metadata/albumEnrichmentFields";
 
 const router = Router();
 
@@ -663,21 +671,13 @@ router.post<{ id: string }>("/artist/:id", requireAdmin, async (req, res) => {
             return res.status(400).json({ error: "Enrichment is not enabled" });
         }
 
-        const enrichmentData = await enrichmentService.enrichArtist(
-            req.params.id,
-            settings,
-        );
+        const enrichmentData = await enrichArtistFields(req.params.id);
 
         if (!enrichmentData) {
             return res.status(404).json({ error: "No enrichment data found" });
         }
 
-        if (enrichmentData.confidence > 0.3) {
-            await enrichmentService.applyArtistEnrichment(
-                req.params.id,
-                enrichmentData,
-            );
-        }
+        await applyArtistEnrichmentFields(req.params.id, enrichmentData);
 
         res.json({
             success: true,
@@ -733,21 +733,13 @@ router.post<{ id: string }>("/album/:id", requireAdmin, async (req, res) => {
             return res.status(400).json({ error: "Enrichment is not enabled" });
         }
 
-        const enrichmentData = await enrichmentService.enrichAlbum(
-            req.params.id,
-            settings,
-        );
+        const enrichmentData = await enrichAlbumFields(req.params.id);
 
         if (!enrichmentData) {
             return res.status(404).json({ error: "No enrichment data found" });
         }
 
-        if (enrichmentData.confidence > 0.3) {
-            await enrichmentService.applyAlbumEnrichment(
-                req.params.id,
-                enrichmentData,
-            );
-        }
+        await applyAlbumEnrichmentFields(req.params.id, enrichmentData);
 
         res.json({
             success: true,

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -60,7 +60,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/downloadQueue.ts` | Core |
 | `backend/src/services/embeddingSpaceLifecycle.ts` | Blue/green embedding-space cutover and retirement cleanup |
 | `backend/src/services/embeddingSpaces.ts` | Provider-space registry resolution, active cache, and worker target |
-| `backend/src/services/enrichment.ts` | Core |
+| `backend/src/services/enrichment.ts` | Enrichment settings and compatibility facade over shared metadata field rules |
 | `backend/src/services/enrichmentFailureService.ts` | Core |
 | `backend/src/services/enrichmentState.ts` | Core |
 | `backend/src/services/fanart.ts` | Core |
@@ -138,6 +138,8 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/lyrics.ts` | Core |
 | `backend/src/services/m3uParser.ts` | Core |
 | `backend/src/services/metadata/albumCoverResolver.ts` | Canonical bounded album-cover provider ladder, cache, and in-flight deduplication |
+| `backend/src/services/metadata/albumEnrichmentFields.ts` | Shared MusicBrainz, Last.fm, cover, and album-column enrichment rules |
+| `backend/src/services/metadata/artistEnrichmentFields.ts` | Shared Wikidata-first bio, Last.fm genre, image, and artist-column enrichment rules |
 | `backend/src/services/metadata/artistImageResolver.ts` | Canonical bounded artist-image provider ladder, cache, and in-flight deduplication |
 | `backend/src/services/moodBucketService.ts` | Core |
 | `backend/src/services/musicbrainz.ts` | Core |

--- a/backend/src/services/__tests__/enrichmentBranchCoverage.test.ts
+++ b/backend/src/services/__tests__/enrichmentBranchCoverage.test.ts
@@ -1,275 +1,70 @@
-const logger = {
-    debug: jest.fn(),
-    error: jest.fn(),
-};
-jest.mock("../../utils/logger", () => ({ logger }));
-
 const prisma = {
-    user: { findUnique: jest.fn(), update: jest.fn() },
-    artist: { findUnique: jest.fn(), update: jest.fn() },
-    album: { findUnique: jest.fn(), update: jest.fn() },
-    ownedAlbum: { upsert: jest.fn() },
+    user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+    },
 };
+
 jest.mock("../../utils/db", () => ({ prisma }));
-
-const lastFmService = {
-    getArtistInfo: jest.fn(),
-    getSimilarArtists: jest.fn(),
-    getAlbumInfo: jest.fn(),
-};
-jest.mock("../lastfm", () => ({ lastFmService }));
-
-const musicBrainzService = {
-    searchArtist: jest.fn(),
-    getReleaseGroups: jest.fn(),
-    getReleaseGroup: jest.fn(),
-    getRelease: jest.fn(),
-};
-jest.mock("../musicbrainz", () => ({ musicBrainzService }));
-
-const imageProviderService = {
-    getArtistImage: jest.fn(),
-    getAlbumCover: jest.fn(),
-};
-jest.mock("../imageProvider", () => ({ imageProviderService }));
-
-const mockDownloadAndStoreImage = jest.fn();
-const mockIsNativePath = jest.fn();
-jest.mock("../imageStorage", () => ({
-    downloadAndStoreImage: (...args: unknown[]) =>
-        mockDownloadAndStoreImage(...args),
-    isNativePath: (...args: unknown[]) => mockIsNativePath(...args),
+jest.mock("../metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields: jest.fn(),
+    applyArtistEnrichmentFields: jest.fn(),
+}));
+jest.mock("../metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields: jest.fn(),
+    applyAlbumEnrichmentFields: jest.fn(),
 }));
 
 import { EnrichmentService } from "../enrichment";
 
-const enabledConfig = {
-    enabled: true,
-    autoEnrichOnScan: false,
-    sources: {
-        musicbrainz: true,
-        lastfm: true,
-        coverArtArchive: true,
-    },
-    rateLimit: {
-        maxRequestsPerMinute: 30,
-        respectApiLimits: true,
-    },
-    overwriteExisting: false,
-    matchingConfidence: "moderate" as const,
-};
-
-describe("enrichment branch coverage", () => {
+describe("enrichment settings normalization", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-
         prisma.user.findUnique.mockResolvedValue(null);
         prisma.user.update.mockResolvedValue({});
-        prisma.artist.findUnique.mockResolvedValue(null);
-        prisma.artist.update.mockResolvedValue({});
-        prisma.album.findUnique.mockResolvedValue(null);
-        prisma.album.update.mockResolvedValue({});
-        prisma.ownedAlbum.upsert.mockResolvedValue({});
-
-        musicBrainzService.searchArtist.mockResolvedValue([]);
-        musicBrainzService.getReleaseGroups.mockResolvedValue([]);
-        musicBrainzService.getReleaseGroup.mockResolvedValue(null);
-        musicBrainzService.getRelease.mockResolvedValue(null);
-
-        lastFmService.getArtistInfo.mockResolvedValue(null);
-        lastFmService.getSimilarArtists.mockResolvedValue([]);
-        lastFmService.getAlbumInfo.mockResolvedValue(null);
-
-        imageProviderService.getArtistImage.mockResolvedValue(null);
-        imageProviderService.getAlbumCover.mockResolvedValue(null);
-
-        mockDownloadAndStoreImage.mockResolvedValue(null);
-        mockIsNativePath.mockReturnValue(false);
     });
 
-    it("getSettings returns defaults and deeply merges partial nested object settings", async () => {
+    it("returns independent defaults when no persisted settings exist", async () => {
         const service = new EnrichmentService();
+        const first = await service.getSettings("user-1");
+        const second = await service.getSettings("user-2");
 
-        await expect(service.getSettings("u0")).resolves.toEqual(
+        expect(first).toEqual(second);
+        expect(first).not.toBe(second);
+        expect(first).toEqual(
             expect.objectContaining({
                 enabled: false,
-                sources: expect.any(Object),
+                sources: expect.objectContaining({ lastfm: true }),
             }),
         );
+    });
 
+    it("falls back safely for invalid persisted field types", async () => {
         prisma.user.findUnique.mockResolvedValueOnce({
             enrichmentSettings: {
-                enabled: true,
-                sources: { lastfm: false },
-                rateLimit: { respectApiLimits: false },
+                enabled: "yes",
+                sources: null,
+                rateLimit: { maxRequestsPerMinute: "fast" },
+                matchingConfidence: "unknown",
             },
         });
 
-        await expect(service.getSettings("u1")).resolves.toEqual(
+        await expect(
+            new EnrichmentService().getSettings("user-1"),
+        ).resolves.toEqual(
             expect.objectContaining({
-                enabled: true,
+                enabled: false,
+                matchingConfidence: "moderate",
                 sources: {
                     musicbrainz: true,
-                    lastfm: false,
+                    lastfm: true,
                     coverArtArchive: true,
                 },
                 rateLimit: {
                     maxRequestsPerMinute: 30,
-                    respectApiLimits: false,
+                    respectApiLimits: true,
                 },
             }),
         );
-    });
-
-    it("enrichArtist skips musicbrainz on stable mbid and handles lastfm/image failures", async () => {
-        const service = new EnrichmentService();
-
-        prisma.artist.findUnique.mockResolvedValueOnce({
-            id: "artist-1",
-            name: "Artist One",
-            mbid: "mbid-stable",
-        });
-        lastFmService.getArtistInfo.mockRejectedValueOnce(
-            new Error("lastfm timeout"),
-        );
-        imageProviderService.getArtistImage.mockRejectedValueOnce(
-            new Error("image provider timeout"),
-        );
-
-        const result = await service.enrichArtist("artist-1", enabledConfig);
-        expect(result).toEqual({ confidence: 0 });
-        expect(musicBrainzService.searchArtist).not.toHaveBeenCalled();
-        expect(lastFmService.getArtistInfo).toHaveBeenCalledWith(
-            "Artist One",
-            "mbid-stable",
-        );
-    });
-
-    it("enrichArtist uses undefined/empty fallback for temp mbids and maps minimal lastfm data", async () => {
-        const service = new EnrichmentService();
-
-        prisma.artist.findUnique.mockResolvedValueOnce({
-            id: "artist-2",
-            name: "Artist Temp",
-            mbid: "temp-artist",
-        });
-        musicBrainzService.searchArtist.mockResolvedValueOnce([]);
-        lastFmService.getArtistInfo.mockResolvedValueOnce({
-            bio: {},
-            tags: undefined,
-        });
-        lastFmService.getSimilarArtists.mockResolvedValueOnce([]);
-
-        const result = await service.enrichArtist("artist-2", enabledConfig);
-        expect(result).toEqual({
-            bio: undefined,
-            tags: [],
-            genres: [],
-            similarArtists: [],
-            confidence: 0.3,
-        });
-        expect(lastFmService.getArtistInfo).toHaveBeenCalledWith(
-            "Artist Temp",
-            undefined,
-        );
-        expect(lastFmService.getSimilarArtists).toHaveBeenCalledWith(
-            "",
-            "Artist Temp",
-            10,
-        );
-    });
-
-    it("enrichAlbum handles title normalization match, label lookup failure, and cover failure", async () => {
-        const service = new EnrichmentService();
-
-        prisma.album.findUnique.mockResolvedValueOnce({
-            id: "album-1",
-            title: "My Album!",
-            artist: { name: "Artist A", mbid: "artist-mbid" },
-        });
-        musicBrainzService.getReleaseGroups.mockResolvedValueOnce([
-            {
-                id: "rg-1",
-                title: "My Album",
-                "primary-type": "Album",
-                "first-release-date": "2000-01-02",
-            },
-        ]);
-        musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
-            releases: [{ id: "release-1" }],
-        });
-        musicBrainzService.getRelease.mockRejectedValueOnce(
-            new Error("release fetch failed"),
-        );
-        lastFmService.getAlbumInfo.mockResolvedValueOnce({
-            tags: undefined,
-            tracks: undefined,
-        });
-        imageProviderService.getAlbumCover.mockRejectedValueOnce(
-            new Error("cover timeout"),
-        );
-
-        const result = await service.enrichAlbum("album-1", enabledConfig);
-        expect(result).toEqual({
-            rgMbid: "rg-1",
-            albumType: "Album",
-            releaseDate: new Date("2000-01-02"),
-            tags: [],
-            genres: [],
-            trackCount: undefined,
-            confidence: 0.8,
-        });
-    });
-
-    it("applyArtistEnrichment skips update for empty payload and falls back to remote hero when download fails", async () => {
-        const service = new EnrichmentService();
-
-        await service.applyArtistEnrichment("artist-a", { confidence: 0.1 });
-        expect(prisma.artist.update).not.toHaveBeenCalled();
-
-        prisma.artist.findUnique.mockResolvedValueOnce(null);
-        mockIsNativePath.mockReturnValueOnce(false);
-        mockDownloadAndStoreImage.mockResolvedValueOnce(null);
-
-        await service.applyArtistEnrichment("artist-a", {
-            mbid: "unique-mbid",
-            heroUrl: "https://remote/hero.jpg",
-            genres: [],
-            confidence: 0.9,
-        });
-
-        expect(prisma.artist.update).toHaveBeenCalledWith({
-            where: { id: "artist-a" },
-            data: {
-                mbid: "unique-mbid",
-                heroUrl: "https://remote/hero.jpg",
-            },
-        });
-    });
-
-    it("applyAlbumEnrichment respects native cover paths and skips ownedAlbum upsert when album missing", async () => {
-        const service = new EnrichmentService();
-        mockIsNativePath.mockReturnValueOnce(true);
-        prisma.album.findUnique.mockResolvedValueOnce(null);
-
-        await service.applyAlbumEnrichment("album-x", {
-            rgMbid: "rg-x",
-            coverUrl: "/native/cover.jpg",
-            releaseDate: new Date("1998-09-10"),
-            genres: ["electronic"],
-            confidence: 1,
-        });
-
-        expect(prisma.album.update).toHaveBeenCalledWith({
-            where: { id: "album-x" },
-            data: {
-                rgMbid: "rg-x",
-                coverUrl: "/native/cover.jpg",
-                originalYear: 1998,
-                year: 1998,
-                genres: ["electronic"],
-            },
-        });
-        expect(prisma.ownedAlbum.upsert).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/services/__tests__/enrichmentService.test.ts
+++ b/backend/src/services/__tests__/enrichmentService.test.ts
@@ -1,98 +1,53 @@
-const logger = {
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-};
-jest.mock("../../utils/logger", () => ({
-    logger,
-}));
-
 const prisma = {
     user: {
         findUnique: jest.fn(),
         update: jest.fn(),
     },
-    artist: {
-        findUnique: jest.fn(),
-        update: jest.fn(),
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+const enrichArtistFields = jest.fn();
+const applyArtistEnrichmentFields = jest.fn();
+const enrichAlbumFields = jest.fn();
+const applyAlbumEnrichmentFields = jest.fn();
+
+jest.mock("../metadata/artistEnrichmentFields", () => ({
+    enrichArtistFields,
+    applyArtistEnrichmentFields,
+}));
+jest.mock("../metadata/albumEnrichmentFields", () => ({
+    enrichAlbumFields,
+    applyAlbumEnrichmentFields,
+}));
+
+import { EnrichmentService, type EnrichmentSettings } from "../enrichment";
+
+const enabledSettings: EnrichmentSettings = {
+    enabled: true,
+    autoEnrichOnScan: false,
+    sources: {
+        musicbrainz: true,
+        lastfm: true,
+        coverArtArchive: true,
     },
-    album: {
-        findUnique: jest.fn(),
-        update: jest.fn(),
+    rateLimit: {
+        maxRequestsPerMinute: 30,
+        respectApiLimits: true,
     },
-    ownedAlbum: {
-        upsert: jest.fn(),
-    },
+    overwriteExisting: false,
+    matchingConfidence: "moderate",
 };
-jest.mock("../../utils/db", () => ({
-    prisma,
-}));
 
-const lastFmService = {
-    getArtistInfo: jest.fn(),
-    getSimilarArtists: jest.fn(),
-    getAlbumInfo: jest.fn(),
-};
-jest.mock("../lastfm", () => ({
-    lastFmService,
-}));
-
-const musicBrainzService = {
-    searchArtist: jest.fn(),
-    getReleaseGroups: jest.fn(),
-    getReleaseGroup: jest.fn(),
-    getRelease: jest.fn(),
-};
-jest.mock("../musicbrainz", () => ({
-    musicBrainzService,
-}));
-
-const imageProviderService = {
-    getArtistImage: jest.fn(),
-    getAlbumCover: jest.fn(),
-};
-jest.mock("../imageProvider", () => ({
-    imageProviderService,
-}));
-
-const mockDownloadAndStoreImage = jest.fn();
-const mockIsNativePath = jest.fn();
-jest.mock("../imageStorage", () => ({
-    downloadAndStoreImage: (...args: any[]) =>
-        mockDownloadAndStoreImage(...args),
-    isNativePath: (...args: any[]) => mockIsNativePath(...args),
-}));
-
-import { EnrichmentService } from "../enrichment";
-
-describe("enrichment service behavior", () => {
+describe("enrichment service compatibility facade", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-
         prisma.user.findUnique.mockResolvedValue(null);
         prisma.user.update.mockResolvedValue({});
-
-        prisma.artist.findUnique.mockResolvedValue(null);
-        prisma.artist.update.mockResolvedValue({});
-
-        prisma.album.findUnique.mockResolvedValue(null);
-        prisma.album.update.mockResolvedValue({});
-        prisma.ownedAlbum.upsert.mockResolvedValue({});
-
-        musicBrainzService.searchArtist.mockResolvedValue([]);
-        musicBrainzService.getReleaseGroups.mockResolvedValue([]);
-        musicBrainzService.getReleaseGroup.mockResolvedValue(null);
-        musicBrainzService.getRelease.mockResolvedValue(null);
-
-        lastFmService.getArtistInfo.mockResolvedValue(null);
-        lastFmService.getSimilarArtists.mockResolvedValue([]);
-        lastFmService.getAlbumInfo.mockResolvedValue(null);
-
-        imageProviderService.getArtistImage.mockResolvedValue(null);
-        imageProviderService.getAlbumCover.mockResolvedValue(null);
-
-        mockDownloadAndStoreImage.mockResolvedValue(null);
-        mockIsNativePath.mockReturnValue(false);
+        enrichArtistFields.mockResolvedValue({ confidence: 0.8 });
+        enrichAlbumFields.mockResolvedValue({ confidence: 0.7 });
+        applyArtistEnrichmentFields.mockResolvedValue(undefined);
+        applyAlbumEnrichmentFields.mockResolvedValue(undefined);
     });
 
     it("merges persisted settings with defaults and updates settings payloads", async () => {
@@ -106,8 +61,7 @@ describe("enrichment service behavior", () => {
             }),
         });
 
-        const settings = await service.getSettings("user-1");
-        expect(settings).toEqual({
+        await expect(service.getSettings("user-1")).resolves.toEqual({
             enabled: true,
             autoEnrichOnScan: false,
             sources: {
@@ -124,312 +78,50 @@ describe("enrichment service behavior", () => {
         });
 
         prisma.user.findUnique.mockResolvedValueOnce({
-            enrichmentSettings: {
-                enabled: false,
-                sources: { coverArtArchive: false },
-                rateLimit: { respectApiLimits: false },
-            },
+            enrichmentSettings: enabledSettings,
         });
         const updated = await service.updateSettings("user-1", {
-            enabled: true,
-            autoEnrichOnScan: true,
+            enabled: false,
         });
 
-        expect(updated).toEqual(
-            expect.objectContaining({
-                enabled: true,
-                autoEnrichOnScan: true,
-                sources: expect.objectContaining({
-                    coverArtArchive: false,
-                }),
-                rateLimit: expect.objectContaining({
-                    respectApiLimits: false,
-                }),
-            }),
-        );
+        expect(updated.enabled).toBe(false);
         expect(prisma.user.update).toHaveBeenCalledWith({
             where: { id: "user-1" },
-            data: {
-                enrichmentSettings: expect.any(String),
-            },
+            data: { enrichmentSettings: JSON.stringify(updated) },
         });
     });
 
-    it("enriches artist metadata with MusicBrainz, Last.fm, and image provider data", async () => {
+    it("delegates enabled artist and album enrichment to shared field modules", async () => {
         const service = new EnrichmentService();
-        prisma.artist.findUnique.mockResolvedValueOnce({
-            id: "artist-1",
-            name: "Artist A",
-            mbid: "temp-artist-a",
-        });
-        musicBrainzService.searchArtist.mockResolvedValueOnce([
-            { id: "mbid-artist-a" },
-        ]);
-        lastFmService.getArtistInfo.mockResolvedValueOnce({
-            bio: { summary: "Bio Summary" },
-            tags: {
-                tag: [
-                    { name: "rock" },
-                    { name: "alternative" },
-                    { name: "indie" },
-                    { name: "extra" },
-                ],
-            },
-        });
-        lastFmService.getSimilarArtists.mockResolvedValueOnce([
-            { name: "Similar 1" },
-            { name: "Similar 2" },
-        ]);
-        imageProviderService.getArtistImage.mockResolvedValueOnce({
-            url: "https://images/artist-a.jpg",
-            source: "deezer",
-        });
 
-        const result = await service.enrichArtist("artist-1", {
-            enabled: true,
-            autoEnrichOnScan: true,
-            sources: {
-                musicbrainz: true,
-                lastfm: true,
-                coverArtArchive: true,
-            },
-            rateLimit: {
-                maxRequestsPerMinute: 30,
-                respectApiLimits: true,
-            },
-            overwriteExisting: false,
-            matchingConfidence: "moderate",
-        });
+        await expect(
+            service.enrichArtist("artist-1", enabledSettings),
+        ).resolves.toEqual({ confidence: 0.8 });
+        await expect(
+            service.enrichAlbum("album-1", enabledSettings),
+        ).resolves.toEqual({ confidence: 0.7 });
 
-        expect(result).toEqual(
-            expect.objectContaining({
-                mbid: "mbid-artist-a",
-                bio: "Bio Summary",
-                tags: ["rock", "alternative", "indie", "extra"],
-                genres: ["rock", "alternative", "indie"],
-                similarArtists: ["Similar 1", "Similar 2"],
-                heroUrl: "https://images/artist-a.jpg",
-            }),
-        );
-        expect(result?.confidence).toBeCloseTo(0.9, 5);
+        expect(enrichArtistFields).toHaveBeenCalledWith("artist-1");
+        expect(enrichAlbumFields).toHaveBeenCalledWith("album-1");
     });
 
-    it("returns null for disabled artist enrichment and throws when artist is missing", async () => {
+    it("preserves disabled enrichment and delegates compatibility writes", async () => {
         const service = new EnrichmentService();
-
         await expect(service.enrichArtist("artist-1")).resolves.toBeNull();
-
-        prisma.artist.findUnique.mockResolvedValueOnce(null);
-        await expect(
-            service.enrichArtist("missing-artist", {
-                enabled: true,
-                autoEnrichOnScan: false,
-                sources: {
-                    musicbrainz: true,
-                    lastfm: true,
-                    coverArtArchive: true,
-                },
-                rateLimit: {
-                    maxRequestsPerMinute: 30,
-                    respectApiLimits: true,
-                },
-                overwriteExisting: false,
-                matchingConfidence: "moderate",
-            }),
-        ).rejects.toThrow("Artist missing-artist not found");
-    });
-
-    it("handles artist enrichment source failures without aborting", async () => {
-        const service = new EnrichmentService();
-        prisma.artist.findUnique.mockResolvedValueOnce({
-            id: "artist-2",
-            name: "Artist B",
-            mbid: "mbid-existing",
-        });
-        lastFmService.getArtistInfo.mockRejectedValueOnce(
-            new Error("lastfm down"),
-        );
-        imageProviderService.getArtistImage.mockRejectedValueOnce(
-            new Error("image down"),
-        );
-
-        await expect(
-            service.enrichArtist("artist-2", {
-                enabled: true,
-                autoEnrichOnScan: false,
-                sources: {
-                    musicbrainz: false,
-                    lastfm: true,
-                    coverArtArchive: true,
-                },
-                rateLimit: {
-                    maxRequestsPerMinute: 30,
-                    respectApiLimits: true,
-                },
-                overwriteExisting: false,
-                matchingConfidence: "moderate",
-            }),
-        ).resolves.toEqual({ confidence: 0 });
-    });
-
-    it("enriches album metadata including MBID, labels, tags, and cover art", async () => {
-        const service = new EnrichmentService();
-        prisma.album.findUnique.mockResolvedValueOnce({
-            id: "album-1",
-            title: "My Album",
-            artist: {
-                name: "Artist A",
-                mbid: "artist-mbid",
-            },
-        });
-        musicBrainzService.getReleaseGroups.mockResolvedValueOnce([
-            {
-                id: "rg-1",
-                title: "My Album!",
-                "primary-type": "Album",
-                "first-release-date": "2001-02-03",
-            },
-        ]);
-        musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
-            releases: [{ id: "release-1" }],
-        });
-        musicBrainzService.getRelease.mockResolvedValueOnce({
-            "label-info": [{ label: { name: "Label A" } }],
-        });
-        lastFmService.getAlbumInfo.mockResolvedValueOnce({
-            tags: { tag: [{ name: "metal" }, { name: "progressive" }] },
-            tracks: { track: [{}, {}, {}] },
-        });
-        imageProviderService.getAlbumCover.mockResolvedValueOnce({
-            url: "https://images/album-a.jpg",
-            source: "musicbrainz",
-        });
-
-        const result = await service.enrichAlbum("album-1", {
-            enabled: true,
-            autoEnrichOnScan: true,
-            sources: {
-                musicbrainz: true,
-                lastfm: true,
-                coverArtArchive: true,
-            },
-            rateLimit: {
-                maxRequestsPerMinute: 30,
-                respectApiLimits: true,
-            },
-            overwriteExisting: false,
-            matchingConfidence: "moderate",
-        });
-
-        expect(result).toEqual({
-            rgMbid: "rg-1",
-            albumType: "Album",
-            releaseDate: new Date("2001-02-03"),
-            label: "Label A",
-            tags: ["metal", "progressive"],
-            genres: ["metal", "progressive"],
-            trackCount: 3,
-            coverUrl: "https://images/album-a.jpg",
-            confidence: 1,
-        });
-    });
-
-    it("returns null for disabled album enrichment and throws when album is missing", async () => {
-        const service = new EnrichmentService();
-
         await expect(service.enrichAlbum("album-1")).resolves.toBeNull();
 
-        prisma.album.findUnique.mockResolvedValueOnce(null);
-        await expect(
-            service.enrichAlbum("missing-album", {
-                enabled: true,
-                autoEnrichOnScan: false,
-                sources: {
-                    musicbrainz: true,
-                    lastfm: true,
-                    coverArtArchive: true,
-                },
-                rateLimit: {
-                    maxRequestsPerMinute: 30,
-                    respectApiLimits: true,
-                },
-                overwriteExisting: false,
-                matchingConfidence: "moderate",
-            }),
-        ).rejects.toThrow("Album missing-album not found");
-    });
+        const artistData = { confidence: 0.2, genres: ["rock"] };
+        const albumData = { confidence: 0.2, genres: ["jazz"] };
+        await service.applyArtistEnrichment("artist-1", artistData);
+        await service.applyAlbumEnrichment("album-1", albumData);
 
-    it("applies artist enrichment while handling MBID conflicts and native/external hero urls", async () => {
-        const service = new EnrichmentService();
-        prisma.artist.findUnique.mockResolvedValueOnce({
-            id: "artist-other",
-            name: "Other Artist",
-        });
-        mockIsNativePath.mockReturnValueOnce(false).mockReturnValueOnce(true);
-        mockDownloadAndStoreImage.mockResolvedValueOnce("/covers/artist-1.jpg");
-
-        await service.applyArtistEnrichment("artist-1", {
-            mbid: "mbid-dup",
-            bio: "Artist Bio",
-            heroUrl: "https://images/external.jpg",
-            genres: ["rock", "indie"],
-            confidence: 0.8,
-        });
-
-        expect(prisma.artist.update).toHaveBeenCalledWith({
-            where: { id: "artist-1" },
-            data: {
-                summary: "Artist Bio",
-                heroUrl: "/covers/artist-1.jpg",
-                genres: ["rock", "indie"],
-            },
-        });
-
-        await service.applyArtistEnrichment("artist-1", {
-            heroUrl: "/local/native/path.jpg",
-            confidence: 0.2,
-        });
-        expect(prisma.artist.update).toHaveBeenLastCalledWith({
-            where: { id: "artist-1" },
-            data: {
-                heroUrl: "/local/native/path.jpg",
-            },
-        });
-    });
-
-    it("applies album enrichment without creating ownership and skips empty updates", async () => {
-        const service = new EnrichmentService();
-        mockIsNativePath.mockReturnValue(false);
-        mockDownloadAndStoreImage.mockResolvedValueOnce(null);
-        prisma.album.findUnique.mockResolvedValueOnce({
-            artistId: "artist-1",
-        });
-
-        await service.applyAlbumEnrichment("album-1", {
-            rgMbid: "rg-1",
-            coverUrl: "https://images/external-cover.jpg",
-            releaseDate: new Date("1999-05-06"),
-            label: "Label Z",
-            genres: ["jazz"],
-            confidence: 0.9,
-        });
-
-        expect(prisma.album.update).toHaveBeenCalledWith({
-            where: { id: "album-1" },
-            data: {
-                rgMbid: "rg-1",
-                coverUrl: "https://images/external-cover.jpg",
-                originalYear: 1999,
-                year: 1999,
-                label: "Label Z",
-                genres: ["jazz"],
-            },
-        });
-        expect(prisma.ownedAlbum.upsert).not.toHaveBeenCalled();
-
-        await service.applyAlbumEnrichment("album-2", {
-            confidence: 0.1,
-        });
-        expect(prisma.album.update).toHaveBeenCalledTimes(1);
+        expect(applyArtistEnrichmentFields).toHaveBeenCalledWith(
+            "artist-1",
+            artistData,
+        );
+        expect(applyAlbumEnrichmentFields).toHaveBeenCalledWith(
+            "album-1",
+            albumData,
+        );
     });
 });

--- a/backend/src/services/enrichment.ts
+++ b/backend/src/services/enrichment.ts
@@ -1,26 +1,18 @@
-/**
- * Metadata Enrichment Service
- *
- * Enriches artist/album/track metadata using multiple sources:
- * - MusicBrainz: MBIDs, release dates, track info
- * - Last.fm: Genres, tags, similar artists, bio
- * - Cover Art Archive: Album artwork
- * - Discogs: Additional metadata (optional)
- *
- * Features:
- * - Optional/opt-in (bandwidth intensive)
- * - Rate limiting to respect API limits
- * - Confidence scoring for matches
- * - Manual override support
- */
-
-import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
-import { lastFmService } from "./lastfm";
-import { musicBrainzService } from "./musicbrainz";
-import { imageProviderService } from "./imageProvider";
-import { downloadAndStoreImage, isNativePath } from "./imageStorage";
+import {
+    applyAlbumEnrichmentFields,
+    enrichAlbumFields,
+    type AlbumEnrichmentData,
+} from "./metadata/albumEnrichmentFields";
+import {
+    applyArtistEnrichmentFields,
+    enrichArtistFields,
+    type ArtistEnrichmentData,
+} from "./metadata/artistEnrichmentFields";
 
+export type { AlbumEnrichmentData, ArtistEnrichmentData };
+
+/** Persisted per-user controls for manual metadata enrichment. */
 export interface EnrichmentSettings {
     enabled: boolean;
     autoEnrichOnScan: boolean;
@@ -37,487 +29,167 @@ export interface EnrichmentSettings {
     matchingConfidence: "strict" | "moderate" | "loose";
 }
 
-export interface ArtistEnrichmentData {
-    mbid?: string;
-    bio?: string;
-    genres?: string[];
-    tags?: string[];
-    similarArtists?: string[];
-    heroUrl?: string;
-    formed?: number;
-    confidence: number;
+const DEFAULT_SETTINGS: EnrichmentSettings = {
+    enabled: false,
+    autoEnrichOnScan: false,
+    sources: {
+        musicbrainz: true,
+        lastfm: true,
+        coverArtArchive: true,
+    },
+    rateLimit: {
+        maxRequestsPerMinute: 30,
+        respectApiLimits: true,
+    },
+    overwriteExisting: false,
+    matchingConfidence: "moderate",
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : {};
 }
 
-export interface AlbumEnrichmentData {
-    rgMbid?: string;
-    releaseDate?: Date;
-    albumType?: string;
-    genres?: string[];
-    tags?: string[];
-    label?: string;
-    coverUrl?: string;
-    trackCount?: number;
-    confidence: number;
+function parsedSettings(value: unknown): Record<string, unknown> {
+    if (typeof value !== "string") return asRecord(value);
+    return asRecord(JSON.parse(value) as unknown);
 }
 
-/**
- * Represents the EnrichmentService class.
- */
-export class EnrichmentService {
-    private defaultSettings: EnrichmentSettings = {
-        enabled: false, // Opt-in by default
-        autoEnrichOnScan: false,
-        sources: {
-            musicbrainz: true,
-            lastfm: true,
-            coverArtArchive: true,
-        },
-        rateLimit: {
-            maxRequestsPerMinute: 30,
-            respectApiLimits: true,
-        },
-        overwriteExisting: false,
-        matchingConfidence: "moderate",
+function booleanSetting(value: unknown, fallback: boolean): boolean {
+    return typeof value === "boolean" ? value : fallback;
+}
+
+function numberSetting(value: unknown, fallback: number): number {
+    return typeof value === "number" && Number.isFinite(value)
+        ? value
+        : fallback;
+}
+
+function matchingConfidence(
+    value: unknown,
+): EnrichmentSettings["matchingConfidence"] {
+    return value === "strict" || value === "loose" || value === "moderate"
+        ? value
+        : DEFAULT_SETTINGS.matchingConfidence;
+}
+
+function mergedSources(value: unknown): EnrichmentSettings["sources"] {
+    const sources = asRecord(value);
+    return {
+        musicbrainz: booleanSetting(
+            sources.musicbrainz,
+            DEFAULT_SETTINGS.sources.musicbrainz,
+        ),
+        lastfm: booleanSetting(sources.lastfm, DEFAULT_SETTINGS.sources.lastfm),
+        coverArtArchive: booleanSetting(
+            sources.coverArtArchive,
+            DEFAULT_SETTINGS.sources.coverArtArchive,
+        ),
     };
+}
 
-    /**
-     * Get enrichment settings for a user
-     */
+function mergedRateLimit(value: unknown): EnrichmentSettings["rateLimit"] {
+    const rateLimit = asRecord(value);
+    return {
+        maxRequestsPerMinute: numberSetting(
+            rateLimit.maxRequestsPerMinute,
+            DEFAULT_SETTINGS.rateLimit.maxRequestsPerMinute,
+        ),
+        respectApiLimits: booleanSetting(
+            rateLimit.respectApiLimits,
+            DEFAULT_SETTINGS.rateLimit.respectApiLimits,
+        ),
+    };
+}
+
+function mergeSettings(value: unknown): EnrichmentSettings {
+    const settings = parsedSettings(value);
+    return {
+        enabled: booleanSetting(settings.enabled, DEFAULT_SETTINGS.enabled),
+        autoEnrichOnScan: booleanSetting(
+            settings.autoEnrichOnScan,
+            DEFAULT_SETTINGS.autoEnrichOnScan,
+        ),
+        sources: mergedSources(settings.sources),
+        rateLimit: mergedRateLimit(settings.rateLimit),
+        overwriteExisting: booleanSetting(
+            settings.overwriteExisting,
+            DEFAULT_SETTINGS.overwriteExisting,
+        ),
+        matchingConfidence: matchingConfidence(settings.matchingConfidence),
+    };
+}
+
+function applySettingsPatch(
+    current: EnrichmentSettings,
+    patch: Partial<EnrichmentSettings>,
+): EnrichmentSettings {
+    return mergeSettings({
+        ...current,
+        ...patch,
+        sources: { ...current.sources, ...patch.sources },
+        rateLimit: { ...current.rateLimit, ...patch.rateLimit },
+    });
+}
+
+/** Compatibility facade for settings and shared metadata field modules. */
+export class EnrichmentService {
+    /** Return per-user enrichment settings merged with stable defaults. */
     async getSettings(userId: string): Promise<EnrichmentSettings> {
         const user = await prisma.user.findUnique({
             where: { id: userId },
             select: { enrichmentSettings: true },
         });
-
-        if (user?.enrichmentSettings) {
-            // enrichmentSettings is already a JSON object from Prisma
-            let userSettings: any;
-            if (typeof user.enrichmentSettings === "string") {
-                userSettings = JSON.parse(user.enrichmentSettings);
-            } else {
-                userSettings = user.enrichmentSettings;
-            }
-
-            // IMPORTANT: Always merge with defaults to ensure all fields exist
-            return {
-                ...this.defaultSettings,
-                ...userSettings,
-                sources: {
-                    ...this.defaultSettings.sources,
-                    ...(userSettings.sources || {}),
-                },
-                rateLimit: {
-                    ...this.defaultSettings.rateLimit,
-                    ...(userSettings.rateLimit || {}),
-                },
-            };
-        }
-
-        return this.defaultSettings;
+        return user?.enrichmentSettings
+            ? mergeSettings(user.enrichmentSettings)
+            : { ...DEFAULT_SETTINGS };
     }
 
-    /**
-     * Update enrichment settings for a user
-     */
+    /** Persist a partial settings update after merging current values. */
     async updateSettings(
         userId: string,
         settings: Partial<EnrichmentSettings>,
     ): Promise<EnrichmentSettings> {
         const current = await this.getSettings(userId);
-        const updated = { ...current, ...settings };
-
+        const updated = applySettingsPatch(current, settings);
         await prisma.user.update({
             where: { id: userId },
-            data: {
-                enrichmentSettings: JSON.stringify(updated) as any,
-            },
+            data: { enrichmentSettings: JSON.stringify(updated) },
         });
-
         return updated;
     }
 
-    /**
-     * Enrich a single artist with metadata from multiple sources
-     */
+    /** Delegate artist resolution to the shared worker-owned field rules. */
     async enrichArtist(
         artistId: string,
-        settings?: EnrichmentSettings,
+        settings: EnrichmentSettings = DEFAULT_SETTINGS,
     ): Promise<ArtistEnrichmentData | null> {
-        const config = settings || this.defaultSettings;
-        if (!config.enabled) {
-            return null;
-        }
-
-        const artist = await prisma.artist.findUnique({
-            where: { id: artistId },
-            select: { id: true, name: true, mbid: true },
-        });
-
-        if (!artist) {
-            throw new Error(`Artist ${artistId} not found`);
-        }
-
-        logger.debug(`Enriching artist: ${artist.name}`);
-
-        const enrichmentData: ArtistEnrichmentData = {
-            confidence: 0,
-        };
-
-        // Step 1: Get/verify MBID from MusicBrainz
-        if (
-            config.sources.musicbrainz &&
-            (!artist.mbid || artist.mbid.startsWith("temp-"))
-        ) {
-            try {
-                const mbResults = await musicBrainzService.searchArtist(
-                    artist.name,
-                    1,
-                );
-                if (mbResults.length > 0) {
-                    enrichmentData.mbid = mbResults[0].id;
-                    enrichmentData.confidence += 0.4;
-                    logger.debug(`  Found MBID: ${enrichmentData.mbid}`);
-                }
-            } catch (error) {
-                logger.error(` MusicBrainz lookup failed:`, error);
-            }
-        }
-
-        // Step 2: Get artist info from Last.fm
-        if (config.sources.lastfm) {
-            try {
-                const artistMbid = enrichmentData.mbid || artist.mbid;
-                const lastfmInfo = await lastFmService.getArtistInfo(
-                    artist.name,
-                    artistMbid && !artistMbid.startsWith("temp-")
-                        ? artistMbid
-                        : undefined,
-                );
-
-                if (lastfmInfo) {
-                    enrichmentData.bio = lastfmInfo.bio?.summary;
-                    enrichmentData.tags =
-                        lastfmInfo.tags?.tag?.map((t: any) => t.name) || [];
-                    enrichmentData.genres = enrichmentData.tags?.slice(0, 3); // Top 3 tags as genres
-                    enrichmentData.confidence += 0.3;
-                    logger.debug(
-                        `  Found Last.fm data: ${
-                            enrichmentData.tags?.length || 0
-                        } tags`,
-                    );
-
-                    // Get similar artists
-                    const artistMbidForSimilar =
-                        enrichmentData.mbid || artist.mbid;
-                    const similar = await lastFmService.getSimilarArtists(
-                        artistMbidForSimilar &&
-                            !artistMbidForSimilar.startsWith("temp-")
-                            ? artistMbidForSimilar
-                            : "",
-                        artist.name,
-                        10,
-                    );
-                    enrichmentData.similarArtists = similar.map(
-                        (a: any) => a.name,
-                    );
-                    logger.debug(`  Found ${similar.length} similar artists`);
-                }
-            } catch (error) {
-                logger.error(
-                    `  ✗ Last.fm lookup failed:`,
-                    error instanceof Error ? error.message : error,
-                );
-            }
-        }
-
-        // Step 3: Get artist image from multiple sources (Deezer → Fanart → MusicBrainz → Last.fm)
-        try {
-            const artistMbid = enrichmentData.mbid || artist.mbid;
-            const imageResult = await imageProviderService.getArtistImage(
-                artist.name,
-                artistMbid && !artistMbid.startsWith("temp-")
-                    ? artistMbid
-                    : undefined,
-            );
-
-            if (imageResult) {
-                enrichmentData.heroUrl = imageResult.url;
-                enrichmentData.confidence += 0.2;
-                logger.debug(`  Found artist image from ${imageResult.source}`);
-            }
-        } catch (error) {
-            logger.error(
-                `  ✗ Artist image lookup failed:`,
-                error instanceof Error ? error.message : error,
-            );
-        }
-
-        logger.debug(
-            `  Enrichment confidence: ${(
-                enrichmentData.confidence * 100
-            ).toFixed(0)}%`,
-        );
-
-        return enrichmentData;
+        return settings.enabled ? enrichArtistFields(artistId) : null;
     }
 
-    /**
-     * Enrich a single album with metadata from multiple sources
-     */
-    async enrichAlbum(
-        albumId: string,
-        settings?: EnrichmentSettings,
-    ): Promise<AlbumEnrichmentData | null> {
-        const config = settings || this.defaultSettings;
-        if (!config.enabled) {
-            return null;
-        }
-
-        const album = await prisma.album.findUnique({
-            where: { id: albumId },
-            include: {
-                artist: {
-                    select: { name: true, mbid: true },
-                },
-            },
-        });
-
-        if (!album) {
-            throw new Error(`Album ${albumId} not found`);
-        }
-
-        logger.debug(
-            `[Enrichment] Processing album: ${album.artist.name} - ${album.title}`,
-        );
-
-        const enrichmentData: AlbumEnrichmentData = {
-            confidence: 0,
-        };
-
-        // Step 1: Try to find MBID
-        if (config.sources.musicbrainz) {
-            try {
-                // If artist has MBID, search their discography
-                if (
-                    album.artist.mbid &&
-                    !album.artist.mbid.startsWith("temp-")
-                ) {
-                    const releaseGroups =
-                        await musicBrainzService.getReleaseGroups(
-                            album.artist.mbid,
-                            ["album", "ep"],
-                            50,
-                        );
-
-                    // Try to match by title
-                    const match = releaseGroups.find(
-                        (rg: any) =>
-                            rg.title.toLowerCase() ===
-                                album.title.toLowerCase() ||
-                            rg.title.toLowerCase().replace(/[^a-z0-9]/g, "") ===
-                                album.title
-                                    .toLowerCase()
-                                    .replace(/[^a-z0-9]/g, ""),
-                    );
-
-                    if (match) {
-                        enrichmentData.rgMbid = match.id;
-                        enrichmentData.albumType = match["primary-type"];
-                        enrichmentData.releaseDate = match["first-release-date"]
-                            ? new Date(match["first-release-date"])
-                            : undefined;
-                        enrichmentData.confidence += 0.5;
-                        logger.debug(`  Found MBID: ${enrichmentData.rgMbid}`);
-
-                        // Try to get label info from first release
-                        try {
-                            const rgDetails =
-                                await musicBrainzService.getReleaseGroup(
-                                    match.id,
-                                );
-                            if (rgDetails?.releases?.[0]?.id) {
-                                const releaseId = rgDetails.releases[0].id;
-                                const releaseInfo =
-                                    await musicBrainzService.getRelease(
-                                        releaseId,
-                                    );
-                                if (
-                                    releaseInfo?.["label-info"]?.[0]?.label
-                                        ?.name
-                                ) {
-                                    enrichmentData.label =
-                                        releaseInfo["label-info"][0].label.name;
-                                    logger.debug(
-                                        `  Found label: ${enrichmentData.label}`,
-                                    );
-                                }
-                            }
-                        } catch (error) {
-                            logger.debug(`Could not fetch label info`);
-                        }
-                    }
-                }
-            } catch (error) {
-                logger.error(` MusicBrainz lookup failed:`, error);
-            }
-        }
-
-        // Step 2: Get album info from Last.fm
-        if (config.sources.lastfm) {
-            try {
-                const lastfmInfo = await lastFmService.getAlbumInfo(
-                    album.artist.name,
-                    album.title,
-                );
-
-                if (lastfmInfo) {
-                    enrichmentData.tags =
-                        lastfmInfo.tags?.tag?.map((t: any) => t.name) || [];
-                    enrichmentData.genres = enrichmentData.tags?.slice(0, 3);
-                    enrichmentData.trackCount =
-                        lastfmInfo.tracks?.track?.length;
-                    enrichmentData.confidence += 0.3;
-                    logger.debug(
-                        `  Found Last.fm data: ${
-                            enrichmentData.tags?.length || 0
-                        } tags`,
-                    );
-                }
-            } catch (error) {
-                logger.error(` Last.fm lookup failed:`, error);
-            }
-        }
-
-        // Step 3: Get cover art from multiple sources (Deezer → MusicBrainz → Fanart)
-        try {
-            const coverResult = await imageProviderService.getAlbumCover(
-                album.artist.name,
-                album.title,
-                enrichmentData.rgMbid,
-            );
-
-            if (coverResult) {
-                enrichmentData.coverUrl = coverResult.url;
-                enrichmentData.confidence += 0.2;
-                logger.debug(`  Found cover art from ${coverResult.source}`);
-            }
-        } catch (error) {
-            logger.error(
-                `  ✗ Cover art lookup failed:`,
-                error instanceof Error ? error.message : error,
-            );
-        }
-
-        logger.debug(
-            `  Enrichment confidence: ${(
-                enrichmentData.confidence * 100
-            ).toFixed(0)}%`,
-        );
-
-        return enrichmentData;
-    }
-
-    /**
-     * Apply enrichment data to an artist in the database
-     */
+    /** Delegate artist persistence to the shared worker-owned field rules. */
     async applyArtistEnrichment(
         artistId: string,
         data: ArtistEnrichmentData,
     ): Promise<void> {
-        const updateData: any = {};
-
-        // Check if MBID is already in use by another artist
-        if (data.mbid) {
-            const existingArtist = await prisma.artist.findUnique({
-                where: { mbid: data.mbid },
-                select: { id: true, name: true },
-            });
-
-            if (existingArtist && existingArtist.id !== artistId) {
-                logger.debug(
-                    `MBID ${data.mbid} already used by "${existingArtist.name}", skipping MBID update`,
-                );
-            } else {
-                updateData.mbid = data.mbid;
-            }
-        }
-
-        if (data.bio) updateData.summary = data.bio;
-        if (data.heroUrl) {
-            // Download image locally if it's an external URL
-            if (!isNativePath(data.heroUrl)) {
-                const localPath = await downloadAndStoreImage(
-                    data.heroUrl,
-                    artistId,
-                    "artist",
-                );
-                updateData.heroUrl = localPath || data.heroUrl;
-            } else {
-                updateData.heroUrl = data.heroUrl;
-            }
-        }
-        if (data.genres && data.genres.length > 0) {
-            updateData.genres = data.genres;
-        }
-
-        if (Object.keys(updateData).length > 0) {
-            await prisma.artist.update({
-                where: { id: artistId },
-                data: updateData,
-            });
-            logger.debug(
-                `   Saved ${data.genres?.length || 0} genres for artist`,
-            );
-        }
+        await applyArtistEnrichmentFields(artistId, data);
     }
 
-    /**
-     * Apply enrichment data to an album in the database
-     */
+    /** Delegate album resolution to the scheduled-worker field rules. */
+    async enrichAlbum(
+        albumId: string,
+        settings: EnrichmentSettings = DEFAULT_SETTINGS,
+    ): Promise<AlbumEnrichmentData | null> {
+        return settings.enabled ? enrichAlbumFields(albumId) : null;
+    }
+
+    /** Delegate album persistence to the scheduled-worker field rules. */
     async applyAlbumEnrichment(
         albumId: string,
         data: AlbumEnrichmentData,
     ): Promise<void> {
-        const updateData: any = {};
-
-        if (data.rgMbid) updateData.rgMbid = data.rgMbid;
-        if (data.coverUrl) {
-            // Download cover locally if it's an external URL
-            if (!isNativePath(data.coverUrl)) {
-                const localPath = await downloadAndStoreImage(
-                    data.coverUrl,
-                    albumId,
-                    "album",
-                );
-                updateData.coverUrl = localPath || data.coverUrl;
-            } else {
-                updateData.coverUrl = data.coverUrl;
-            }
-        }
-        if (data.releaseDate) {
-            // Store original release date in dedicated field
-            updateData.originalYear = data.releaseDate.getFullYear();
-            // Also update year for backward compatibility (but originalYear takes precedence)
-            updateData.year = data.releaseDate.getFullYear();
-        }
-        if (data.label) updateData.label = data.label;
-        if (data.genres && data.genres.length > 0) {
-            updateData.genres = data.genres;
-        }
-
-        // The album FK cascade preserves existing ownership across MBID edits.
-        // Enrichment must not recreate ownership removed by an unlike.
-        if (Object.keys(updateData).length > 0) {
-            await prisma.album.update({
-                where: { id: albumId },
-                data: updateData,
-            });
-            logger.debug(
-                `   Saved album data: ${
-                    data.genres?.length || 0
-                } genres, label: ${data.label || "none"}`,
-            );
-        }
+        await applyAlbumEnrichmentFields(albumId, data);
     }
 }
 

--- a/backend/src/services/metadata/__tests__/albumEnrichmentFields.test.ts
+++ b/backend/src/services/metadata/__tests__/albumEnrichmentFields.test.ts
@@ -1,0 +1,228 @@
+const log = {
+    debug: jest.fn(),
+    error: jest.fn(),
+};
+
+jest.mock("../../../utils/logger", () => ({
+    logger: { child: jest.fn(() => log) },
+}));
+
+const prisma = {
+    album: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+    },
+};
+
+jest.mock("../../../utils/db", () => ({ prisma }));
+
+const musicBrainzService = {
+    getReleaseGroups: jest.fn(),
+    getReleaseGroup: jest.fn(),
+    getRelease: jest.fn(),
+};
+
+jest.mock("../../musicbrainz", () => ({ musicBrainzService }));
+
+const lastFmService = {
+    getAlbumInfo: jest.fn(),
+};
+
+jest.mock("../../lastfm", () => ({ lastFmService }));
+
+const resolveAlbumCover = jest.fn();
+
+jest.mock("../albumCoverResolver", () => ({ resolveAlbumCover }));
+
+const downloadAndStoreImage = jest.fn();
+const isNativePath = jest.fn();
+
+jest.mock("../../imageStorage", () => ({
+    downloadAndStoreImage,
+    isNativePath,
+}));
+
+import {
+    applyAlbumEnrichmentFields,
+    enrichAlbumFields,
+    resolveAlbumEnrichmentFields,
+} from "../albumEnrichmentFields";
+
+const ARTIST_MBID = "11111111-1111-4111-8111-111111111111";
+const RELEASE_GROUP_MBID = "22222222-2222-4222-8222-222222222222";
+const RELEASE_MBID = "33333333-3333-4333-8333-333333333333";
+
+describe("album enrichment fields", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        prisma.album.findUnique.mockResolvedValue(null);
+        prisma.album.update.mockResolvedValue({});
+        musicBrainzService.getReleaseGroups.mockResolvedValue([]);
+        musicBrainzService.getReleaseGroup.mockResolvedValue(null);
+        musicBrainzService.getRelease.mockResolvedValue(null);
+        lastFmService.getAlbumInfo.mockResolvedValue(null);
+        resolveAlbumCover.mockResolvedValue(null);
+        downloadAndStoreImage.mockResolvedValue(null);
+        isNativePath.mockReturnValue(false);
+    });
+
+    it("resolves a missing release-group MBID, year, label, and five Last.fm genres", async () => {
+        musicBrainzService.getReleaseGroups.mockResolvedValueOnce([
+            {
+                id: RELEASE_GROUP_MBID,
+                title: "Album One!",
+                "primary-type": "Album",
+                "first-release-date": "2001-02-03",
+            },
+        ]);
+        musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
+            releases: [{ id: RELEASE_MBID }],
+        });
+        musicBrainzService.getRelease.mockResolvedValueOnce({
+            "label-info": [{ label: { name: "Label One" } }],
+        });
+        lastFmService.getAlbumInfo.mockResolvedValueOnce({
+            tags: {
+                tag: [
+                    { name: "one" },
+                    { name: "two" },
+                    { name: "three" },
+                    { name: "four" },
+                    { name: "five" },
+                    { name: "six" },
+                ],
+            },
+            tracks: { track: [{}, {}] },
+        });
+        resolveAlbumCover.mockResolvedValueOnce({
+            url: "https://images.example/album.jpg",
+            source: "coverartarchive",
+        });
+
+        const result = await resolveAlbumEnrichmentFields({
+            id: "album-1",
+            title: "Album One",
+            rgMbid: null,
+            artist: { name: "Artist One", mbid: ARTIST_MBID },
+        });
+
+        expect(result).toEqual({
+            rgMbid: RELEASE_GROUP_MBID,
+            albumType: "Album",
+            releaseDate: new Date("2001-02-03"),
+            label: "Label One",
+            tags: ["one", "two", "three", "four", "five", "six"],
+            genres: ["one", "two", "three", "four", "five"],
+            trackCount: 2,
+            coverUrl: "https://images.example/album.jpg",
+            confidence: 1,
+        });
+    });
+
+    it("extracts the first release date and label for an existing MusicBrainz release group", async () => {
+        musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
+            "first-release-date": "1994-09-19",
+            releases: [{ id: RELEASE_MBID }],
+        });
+        musicBrainzService.getRelease.mockResolvedValueOnce({
+            "label-info": [{ label: { name: "Existing Label" } }],
+        });
+
+        const result = await resolveAlbumEnrichmentFields({
+            id: "album-2",
+            title: "Existing Album",
+            rgMbid: RELEASE_GROUP_MBID,
+            artist: { name: "Artist Two", mbid: ARTIST_MBID },
+        });
+
+        expect(musicBrainzService.getReleaseGroups).not.toHaveBeenCalled();
+        expect(result.releaseDate).toEqual(new Date("1994-09-19"));
+        expect(result.label).toBe("Existing Label");
+    });
+
+    it("does not send remote or federation identifiers to MusicBrainz", async () => {
+        for (const rgMbid of ["remote:album-1", "federation:peer:album-1"]) {
+            await resolveAlbumEnrichmentFields({
+                id: rgMbid,
+                title: "Remote Album",
+                rgMbid,
+                artist: { name: "Remote Artist", mbid: ARTIST_MBID },
+            });
+        }
+
+        expect(musicBrainzService.getReleaseGroups).not.toHaveBeenCalled();
+        expect(musicBrainzService.getReleaseGroup).not.toHaveBeenCalled();
+        expect(musicBrainzService.getRelease).not.toHaveBeenCalled();
+    });
+
+    it("tolerates missing and failing providers", async () => {
+        musicBrainzService.getReleaseGroups.mockRejectedValueOnce(
+            new Error("musicbrainz unavailable"),
+        );
+        lastFmService.getAlbumInfo.mockRejectedValueOnce(
+            new Error("lastfm unavailable"),
+        );
+        resolveAlbumCover.mockRejectedValueOnce(
+            new Error("covers unavailable"),
+        );
+
+        await expect(
+            resolveAlbumEnrichmentFields({
+                id: "album-3",
+                title: "Album Three",
+                rgMbid: null,
+                artist: { name: "Artist Three", mbid: ARTIST_MBID },
+            }),
+        ).resolves.toEqual({ confidence: 0 });
+    });
+
+    it("loads admin enrichment and applies year, label, genres, and localized cover", async () => {
+        prisma.album.findUnique.mockResolvedValueOnce({
+            id: "album-4",
+            title: "Album Four",
+            rgMbid: RELEASE_GROUP_MBID,
+            artist: { name: "Artist Four", mbid: ARTIST_MBID },
+        });
+        musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
+            "first-release-date": "1988-04-05",
+            releases: [{ id: RELEASE_MBID }],
+        });
+        musicBrainzService.getRelease.mockResolvedValueOnce({
+            "label-info": [{ label: { name: "Label Four" } }],
+        });
+        lastFmService.getAlbumInfo.mockResolvedValueOnce({
+            tags: { tag: [{ name: "jazz" }] },
+        });
+        resolveAlbumCover.mockResolvedValueOnce({
+            url: "https://images.example/four.jpg",
+            source: "deezer",
+        });
+        downloadAndStoreImage.mockResolvedValueOnce("/images/album-4.jpg");
+
+        const data = await enrichAlbumFields("album-4");
+        await applyAlbumEnrichmentFields("album-4", data);
+
+        expect(prisma.album.update).toHaveBeenCalledWith({
+            where: { id: "album-4" },
+            data: {
+                coverUrl: "/images/album-4.jpg",
+                originalYear: 1988,
+                year: 1988,
+                label: "Label Four",
+                genres: ["jazz"],
+            },
+        });
+    });
+
+    it("persists a year-only MusicBrainz date without local-time rollover", async () => {
+        await applyAlbumEnrichmentFields("album-year", {
+            releaseDate: new Date("2001"),
+            confidence: 0.5,
+        });
+
+        expect(prisma.album.update).toHaveBeenCalledWith({
+            where: { id: "album-year" },
+            data: { originalYear: 2001, year: 2001 },
+        });
+    });
+});

--- a/backend/src/services/metadata/__tests__/artistEnrichmentFields.test.ts
+++ b/backend/src/services/metadata/__tests__/artistEnrichmentFields.test.ts
@@ -1,0 +1,195 @@
+const log = {
+    debug: jest.fn(),
+    error: jest.fn(),
+};
+
+jest.mock("../../../utils/logger", () => ({
+    logger: { child: jest.fn(() => log) },
+}));
+
+const prisma = {
+    artist: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+    },
+};
+
+jest.mock("../../../utils/db", () => ({ prisma }));
+
+const musicBrainzService = {
+    searchArtist: jest.fn(),
+};
+
+jest.mock("../../musicbrainz", () => ({ musicBrainzService }));
+
+const wikidataService = {
+    getArtistInfo: jest.fn(),
+};
+
+jest.mock("../../wikidata", () => ({ wikidataService }));
+
+const lastFmService = {
+    getArtistInfo: jest.fn(),
+    getSimilarArtists: jest.fn(),
+};
+
+jest.mock("../../lastfm", () => ({ lastFmService }));
+
+const resolveArtistImage = jest.fn();
+
+jest.mock("../artistImageResolver", () => ({ resolveArtistImage }));
+
+const downloadAndStoreImage = jest.fn();
+const isNativePath = jest.fn();
+
+jest.mock("../../imageStorage", () => ({
+    downloadAndStoreImage,
+    isNativePath,
+}));
+
+import {
+    applyArtistEnrichmentFields,
+    enrichArtistFields,
+    resolveArtistEnrichmentFields,
+} from "../artistEnrichmentFields";
+
+const ARTIST_MBID = "11111111-1111-4111-8111-111111111111";
+
+describe("artist enrichment fields", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        prisma.artist.findUnique.mockResolvedValue(null);
+        prisma.artist.update.mockResolvedValue({});
+        musicBrainzService.searchArtist.mockResolvedValue([]);
+        wikidataService.getArtistInfo.mockResolvedValue({});
+        lastFmService.getArtistInfo.mockResolvedValue(null);
+        lastFmService.getSimilarArtists.mockResolvedValue([]);
+        resolveArtistImage.mockResolvedValue(null);
+        downloadAndStoreImage.mockResolvedValue(null);
+        isNativePath.mockReturnValue(false);
+    });
+
+    it("prefers Wikidata summary and keeps the top five Last.fm genres", async () => {
+        wikidataService.getArtistInfo.mockResolvedValueOnce({
+            summary: "Wikidata summary",
+        });
+        lastFmService.getArtistInfo.mockResolvedValueOnce({
+            bio: { summary: "Last.fm summary" },
+            tags: {
+                tag: [
+                    { name: "rock" },
+                    { name: "indie" },
+                    { name: "alternative" },
+                    { name: "shoegaze" },
+                    { name: "dream pop" },
+                    { name: "sixth" },
+                ],
+            },
+        });
+        resolveArtistImage.mockResolvedValueOnce({
+            url: "https://images.example/artist.jpg",
+            source: "wikidata",
+        });
+
+        const result = await resolveArtistEnrichmentFields({
+            id: "artist-1",
+            name: "Artist One",
+            mbid: ARTIST_MBID,
+        });
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                bio: "Wikidata summary",
+                tags: [
+                    "rock",
+                    "indie",
+                    "alternative",
+                    "shoegaze",
+                    "dream pop",
+                    "sixth",
+                ],
+                genres: [
+                    "rock",
+                    "indie",
+                    "alternative",
+                    "shoegaze",
+                    "dream pop",
+                ],
+                heroUrl: "https://images.example/artist.jpg",
+            }),
+        );
+        expect(lastFmService.getArtistInfo).toHaveBeenCalledWith(
+            "Artist One",
+            ARTIST_MBID,
+        );
+    });
+
+    it("falls back from Wikidata to Last.fm bio content", async () => {
+        wikidataService.getArtistInfo.mockResolvedValueOnce({});
+        lastFmService.getArtistInfo.mockResolvedValueOnce({
+            bio: { content: "Last.fm content" },
+            tags: { tag: [] },
+        });
+
+        const result = await resolveArtistEnrichmentFields({
+            id: "artist-2",
+            name: "Artist Two",
+            mbid: ARTIST_MBID,
+        });
+
+        expect(result.bio).toBe("Last.fm content");
+    });
+
+    it("tolerates missing and failing providers", async () => {
+        wikidataService.getArtistInfo.mockRejectedValueOnce(
+            new Error("wikidata unavailable"),
+        );
+        lastFmService.getArtistInfo.mockRejectedValueOnce(
+            new Error("lastfm unavailable"),
+        );
+        resolveArtistImage.mockRejectedValueOnce(
+            new Error("images unavailable"),
+        );
+
+        await expect(
+            resolveArtistEnrichmentFields({
+                id: "artist-3",
+                name: "Artist Three",
+                mbid: ARTIST_MBID,
+            }),
+        ).resolves.toEqual({ confidence: 0 });
+    });
+
+    it("loads admin enrichment and applies the worker-owned column mapping", async () => {
+        prisma.artist.findUnique
+            .mockResolvedValueOnce({
+                id: "artist-4",
+                name: "Artist Four",
+                mbid: ARTIST_MBID,
+            })
+            .mockResolvedValueOnce(null);
+        wikidataService.getArtistInfo.mockResolvedValueOnce({
+            summary: "Shared summary",
+        });
+        lastFmService.getArtistInfo.mockResolvedValueOnce({
+            tags: { tag: [{ name: "ambient" }] },
+        });
+        resolveArtistImage.mockResolvedValueOnce({
+            url: "https://images.example/shared.jpg",
+            source: "deezer",
+        });
+        downloadAndStoreImage.mockResolvedValueOnce("/images/artist-4.jpg");
+
+        const data = await enrichArtistFields("artist-4");
+        await applyArtistEnrichmentFields("artist-4", data);
+
+        expect(prisma.artist.update).toHaveBeenCalledWith({
+            where: { id: "artist-4" },
+            data: {
+                summary: "Shared summary",
+                heroUrl: "/images/artist-4.jpg",
+                genres: ["ambient"],
+            },
+        });
+    });
+});

--- a/backend/src/services/metadata/albumEnrichmentFields.ts
+++ b/backend/src/services/metadata/albumEnrichmentFields.ts
@@ -1,0 +1,329 @@
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import { isRealArtistMbid, rgMbidKind } from "../../utils/musicIds";
+import { downloadAndStoreImage, isNativePath } from "../imageStorage";
+import { lastFmService } from "../lastfm";
+import { musicBrainzService } from "../musicbrainz";
+import { resolveAlbumCover } from "./albumCoverResolver";
+
+const log = logger.child("AlbumEnrichmentFields");
+const MAX_RELEASE_GROUPS = 50;
+const MAX_ALBUM_TAGS = 5;
+
+/** Album identity used to resolve canonical enrichment fields. */
+export interface AlbumEnrichmentInput {
+    id: string;
+    title: string;
+    rgMbid: string | null;
+    artist: {
+        name: string;
+        mbid: string | null;
+    };
+}
+
+/** Compatibility payload returned by manual album enrichment. */
+export interface AlbumEnrichmentData {
+    rgMbid?: string;
+    releaseDate?: Date;
+    albumType?: string;
+    genres?: string[];
+    tags?: string[];
+    label?: string;
+    coverUrl?: string;
+    trackCount?: number;
+    confidence: number;
+}
+
+/** Prisma album-column values owned by the shared enrichment rules. */
+export interface AlbumEnrichmentWrite {
+    rgMbid?: string;
+    coverUrl?: string;
+    originalYear?: number;
+    year?: number;
+    label?: string;
+    genres?: string[];
+}
+
+/** Provider groups needed for one album enrichment resolution. */
+export interface AlbumEnrichmentOptions {
+    musicBrainz?: boolean;
+    lastFm?: boolean;
+    cover?: boolean;
+}
+
+interface ReleaseGroupResolution {
+    lookupMbid: string | null;
+    data: Pick<
+        AlbumEnrichmentData,
+        "rgMbid" | "releaseDate" | "albumType" | "label"
+    >;
+    found: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizedTitle(value: string): string {
+    return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function matchingReleaseGroup(results: unknown, title: string): unknown {
+    if (!Array.isArray(results)) return undefined;
+    const target = normalizedTitle(title);
+    return results.slice(0, MAX_RELEASE_GROUPS).find((candidate) => {
+        const candidateTitle = nonEmptyString(asRecord(candidate)?.title);
+        return candidateTitle
+            ? normalizedTitle(candidateTitle) === target
+            : false;
+    });
+}
+
+function releaseDate(value: unknown): Date | undefined {
+    const raw = nonEmptyString(value);
+    if (!raw) return undefined;
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function firstReleaseId(details: unknown): string | undefined {
+    const releases = asRecord(details)?.releases;
+    if (!Array.isArray(releases)) return undefined;
+    return nonEmptyString(asRecord(releases[0])?.id);
+}
+
+function firstLabelName(release: unknown): string | undefined {
+    const labelInfo = asRecord(release)?.["label-info"];
+    if (!Array.isArray(labelInfo)) return undefined;
+    return nonEmptyString(asRecord(asRecord(labelInfo[0])?.label)?.name);
+}
+
+async function loadReleaseGroupDetails(rgMbid: string): Promise<unknown> {
+    try {
+        return await musicBrainzService.getReleaseGroup(rgMbid);
+    } catch (error) {
+        log.debug("MusicBrainz release-group lookup failed", error);
+        return null;
+    }
+}
+
+async function loadReleaseLabel(details: unknown): Promise<string | undefined> {
+    const releaseId = firstReleaseId(details);
+    if (!releaseId) return undefined;
+    try {
+        return firstLabelName(await musicBrainzService.getRelease(releaseId));
+    } catch (error) {
+        log.debug("MusicBrainz release lookup failed", error);
+        return undefined;
+    }
+}
+
+async function existingReleaseGroup(
+    rgMbid: string,
+): Promise<ReleaseGroupResolution> {
+    const details = await loadReleaseGroupDetails(rgMbid);
+    return {
+        lookupMbid: rgMbid,
+        data: {
+            releaseDate: releaseDate(asRecord(details)?.["first-release-date"]),
+            label: await loadReleaseLabel(details),
+        },
+        found: true,
+    };
+}
+
+function searchedReleaseData(
+    match: Record<string, unknown>,
+    details: unknown,
+    rgMbid: string,
+    label: string | undefined,
+): ReleaseGroupResolution["data"] {
+    return {
+        rgMbid,
+        albumType: nonEmptyString(match["primary-type"]),
+        releaseDate:
+            releaseDate(match["first-release-date"]) ??
+            releaseDate(asRecord(details)?.["first-release-date"]),
+        label,
+    };
+}
+
+async function searchedReleaseGroup(
+    input: AlbumEnrichmentInput,
+): Promise<ReleaseGroupResolution> {
+    const artistMbid = input.artist.mbid;
+    if (!artistMbid || !isRealArtistMbid(artistMbid)) {
+        return { lookupMbid: null, data: {}, found: false };
+    }
+    try {
+        const groups = await musicBrainzService.getReleaseGroups(
+            artistMbid,
+            ["album", "ep"],
+            MAX_RELEASE_GROUPS,
+        );
+        const match = asRecord(matchingReleaseGroup(groups, input.title));
+        const rgMbid = nonEmptyString(match?.id);
+        if (!match || !rgMbid) {
+            return { lookupMbid: null, data: {}, found: false };
+        }
+        const details = await loadReleaseGroupDetails(rgMbid);
+        const label = await loadReleaseLabel(details);
+        return {
+            lookupMbid: rgMbid,
+            data: searchedReleaseData(match, details, rgMbid, label),
+            found: true,
+        };
+    } catch (error) {
+        log.debug("MusicBrainz album search failed", error);
+        return { lookupMbid: null, data: {}, found: false };
+    }
+}
+
+async function resolveReleaseGroup(
+    input: AlbumEnrichmentInput,
+): Promise<ReleaseGroupResolution> {
+    if (input.rgMbid) {
+        const kind = rgMbidKind(input.rgMbid);
+        if (kind === "musicbrainz") {
+            return existingReleaseGroup(input.rgMbid);
+        }
+        if (kind === "remote" || kind === "federation") {
+            return { lookupMbid: null, data: {}, found: false };
+        }
+    }
+    return searchedReleaseGroup(input);
+}
+
+function albumTags(info: unknown): string[] {
+    const rawTags = asRecord(asRecord(info)?.tags)?.tag;
+    if (!Array.isArray(rawTags)) return [];
+    return rawTags
+        .slice(0, 100)
+        .map((tag) => nonEmptyString(asRecord(tag)?.name))
+        .filter((name): name is string => name !== undefined);
+}
+
+function albumTrackCount(info: unknown): number | undefined {
+    const tracks = asRecord(asRecord(info)?.tracks)?.track;
+    return Array.isArray(tracks) ? tracks.length : undefined;
+}
+
+async function addLastFmFields(
+    input: AlbumEnrichmentInput,
+    data: AlbumEnrichmentData,
+): Promise<void> {
+    try {
+        const info = await lastFmService.getAlbumInfo(
+            input.artist.name,
+            input.title,
+        );
+        if (!info) return;
+        const tags = albumTags(info);
+        data.tags = tags;
+        data.genres = tags.slice(0, MAX_ALBUM_TAGS);
+        data.trackCount = albumTrackCount(info);
+        data.confidence += 0.3;
+    } catch (error) {
+        log.debug("Last.fm album lookup failed", error);
+    }
+}
+
+async function addCoverField(
+    input: AlbumEnrichmentInput,
+    rgMbid: string | null,
+    data: AlbumEnrichmentData,
+): Promise<void> {
+    try {
+        const resolution = await resolveAlbumCover({
+            artistName: input.artist.name,
+            albumTitle: input.title,
+            rgMbid: rgMbid ?? input.rgMbid,
+        });
+        if (!resolution) return;
+        data.coverUrl = resolution.url;
+        data.confidence += 0.2;
+    } catch (error) {
+        log.debug("Album cover resolution failed", error);
+    }
+}
+
+/** Resolve MusicBrainz album fields, five Last.fm genres, and canonical cover. */
+export async function resolveAlbumEnrichmentFields(
+    input: AlbumEnrichmentInput,
+    options: AlbumEnrichmentOptions = {},
+): Promise<AlbumEnrichmentData> {
+    const data: AlbumEnrichmentData = { confidence: 0 };
+    const releaseGroup =
+        options.musicBrainz === false
+            ? { lookupMbid: null, data: {}, found: false }
+            : await resolveReleaseGroup(input);
+    Object.assign(data, releaseGroup.data);
+    if (releaseGroup.found) data.confidence += 0.5;
+    if (options.lastFm !== false) await addLastFmFields(input, data);
+    if (options.cover !== false) {
+        await addCoverField(input, releaseGroup.lookupMbid, data);
+    }
+    return data;
+}
+
+/** Load an album and resolve the compatibility payload for the admin route. */
+export async function enrichAlbumFields(
+    albumId: string,
+): Promise<AlbumEnrichmentData> {
+    const album = await prisma.album.findUnique({
+        where: { id: albumId },
+        select: {
+            id: true,
+            title: true,
+            rgMbid: true,
+            artist: { select: { name: true, mbid: true } },
+        },
+    });
+    if (!album) throw new Error(`Album ${albumId} not found`);
+    return resolveAlbumEnrichmentFields(album);
+}
+
+async function localAlbumCover(
+    albumId: string,
+    coverUrl: string | undefined,
+): Promise<string | undefined> {
+    if (!coverUrl || isNativePath(coverUrl)) return coverUrl;
+    return (
+        (await downloadAndStoreImage(coverUrl, albumId, "album")) ?? coverUrl
+    );
+}
+
+/** Prepare the exact album columns shared by worker and admin persistence. */
+export async function prepareAlbumEnrichmentWrite(
+    albumId: string,
+    data: AlbumEnrichmentData,
+): Promise<AlbumEnrichmentWrite> {
+    const write: AlbumEnrichmentWrite = {};
+    if (data.rgMbid) write.rgMbid = data.rgMbid;
+    const coverUrl = await localAlbumCover(albumId, data.coverUrl);
+    if (coverUrl) write.coverUrl = coverUrl;
+    if (data.releaseDate) {
+        const year = data.releaseDate.getUTCFullYear();
+        write.originalYear = year;
+        write.year = year;
+    }
+    if (data.label) write.label = data.label;
+    if (data.genres && data.genres.length > 0) write.genres = data.genres;
+    return write;
+}
+
+/** Persist album enrichment using the scheduled-worker field mapping. */
+export async function applyAlbumEnrichmentFields(
+    albumId: string,
+    data: AlbumEnrichmentData,
+): Promise<void> {
+    const write = await prepareAlbumEnrichmentWrite(albumId, data);
+    if (Object.keys(write).length === 0) return;
+    await prisma.album.update({ where: { id: albumId }, data: write });
+}

--- a/backend/src/services/metadata/artistEnrichmentFields.ts
+++ b/backend/src/services/metadata/artistEnrichmentFields.ts
@@ -1,0 +1,264 @@
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import { isRealArtistMbid } from "../../utils/musicIds";
+import { downloadAndStoreImage, isNativePath } from "../imageStorage";
+import { lastFmService } from "../lastfm";
+import { musicBrainzService } from "../musicbrainz";
+import { wikidataService } from "../wikidata";
+import { resolveArtistImage } from "./artistImageResolver";
+
+const log = logger.child("ArtistEnrichmentFields");
+const MAX_ARTIST_TAGS = 5;
+
+/** Artist identity used to resolve canonical enrichment fields. */
+export interface ArtistEnrichmentInput {
+    id: string;
+    name: string;
+    mbid: string | null;
+}
+
+/** Compatibility payload returned by manual artist enrichment. */
+export interface ArtistEnrichmentData {
+    mbid?: string;
+    bio?: string;
+    genres?: string[];
+    tags?: string[];
+    similarArtists?: string[];
+    heroUrl?: string;
+    formed?: number;
+    confidence: number;
+}
+
+/** Prisma artist-column values owned by the shared enrichment rules. */
+export interface ArtistEnrichmentWrite {
+    mbid?: string;
+    summary: string | null;
+    heroUrl: string | null;
+    genres?: string[];
+}
+
+interface ArtistResolveOptions {
+    includeSimilarArtists?: boolean;
+}
+
+interface ArtistMetadata {
+    bio?: string;
+    tags?: string[];
+    genres?: string[];
+    found: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function artistBio(info: unknown): string | undefined {
+    const bio = asRecord(asRecord(info)?.bio);
+    return nonEmptyString(bio?.summary) ?? nonEmptyString(bio?.content);
+}
+
+function artistTags(info: unknown): string[] {
+    const rawTags = asRecord(asRecord(info)?.tags)?.tag;
+    if (!Array.isArray(rawTags)) return [];
+    return rawTags
+        .slice(0, 100)
+        .map((tag) => nonEmptyString(asRecord(tag)?.name))
+        .filter((name): name is string => name !== undefined);
+}
+
+function firstArtistMbid(results: unknown): string | null {
+    if (!Array.isArray(results)) return null;
+    const first = asRecord(results[0]);
+    const mbid = nonEmptyString(first?.id);
+    return mbid && isRealArtistMbid(mbid) ? mbid : null;
+}
+
+/** Resolve the real artist MBID used by every enrichment caller. */
+export async function resolveArtistMbid(
+    input: ArtistEnrichmentInput,
+): Promise<string | null> {
+    if (isRealArtistMbid(input.mbid)) return input.mbid;
+    try {
+        const results = await musicBrainzService.searchArtist(input.name, 1);
+        return firstArtistMbid(results);
+    } catch (error) {
+        log.debug("MusicBrainz artist lookup failed", error);
+        return null;
+    }
+}
+
+async function wikidataSummary(
+    input: ArtistEnrichmentInput,
+    mbid: string | null,
+): Promise<string | undefined> {
+    if (!mbid) return undefined;
+    try {
+        const info = await wikidataService.getArtistInfo(input.name, mbid);
+        return nonEmptyString(asRecord(info)?.summary);
+    } catch (error) {
+        log.debug("Wikidata artist lookup failed", error);
+        return undefined;
+    }
+}
+
+async function resolveArtistMetadata(
+    input: ArtistEnrichmentInput,
+    mbid: string | null,
+): Promise<ArtistMetadata> {
+    const preferredBio = await wikidataSummary(input, mbid);
+    try {
+        const info = await lastFmService.getArtistInfo(
+            input.name,
+            mbid ?? undefined,
+        );
+        if (!info) return { bio: preferredBio, found: Boolean(preferredBio) };
+        const tags = artistTags(info);
+        return {
+            bio: preferredBio ?? artistBio(info),
+            tags,
+            genres: tags.slice(0, MAX_ARTIST_TAGS),
+            found: true,
+        };
+    } catch (error) {
+        log.debug("Last.fm artist lookup failed", error);
+        return { bio: preferredBio, found: Boolean(preferredBio) };
+    }
+}
+
+async function resolveHeroUrl(
+    input: ArtistEnrichmentInput,
+    mbid: string | null,
+): Promise<string | undefined> {
+    try {
+        const image = await resolveArtistImage({
+            artistName: input.name,
+            mbid,
+        });
+        return image?.url;
+    } catch (error) {
+        log.debug("Artist image resolution failed", error);
+        return undefined;
+    }
+}
+
+async function resolveSimilarArtistNames(
+    input: ArtistEnrichmentInput,
+    mbid: string | null,
+): Promise<string[]> {
+    try {
+        const similar = await lastFmService.getSimilarArtists(
+            mbid ?? "",
+            input.name,
+            10,
+        );
+        return similar.slice(0, 10).map((artist) => artist.name);
+    } catch (error) {
+        log.debug("Last.fm similar-artist lookup failed", error);
+        return [];
+    }
+}
+
+function addMetadata(
+    data: ArtistEnrichmentData,
+    metadata: ArtistMetadata,
+): void {
+    if (metadata.bio !== undefined) data.bio = metadata.bio;
+    if (metadata.tags !== undefined) data.tags = metadata.tags;
+    if (metadata.genres !== undefined) data.genres = metadata.genres;
+    if (metadata.found) data.confidence += 0.3;
+}
+
+/** Resolve artist fields with Wikidata-first bio and five Last.fm genres. */
+export async function resolveArtistEnrichmentFields(
+    input: ArtistEnrichmentInput,
+    options: ArtistResolveOptions = {},
+): Promise<ArtistEnrichmentData> {
+    const data: ArtistEnrichmentData = { confidence: 0 };
+    const resolvedMbid = await resolveArtistMbid(input);
+    if (resolvedMbid && resolvedMbid !== input.mbid) {
+        data.mbid = resolvedMbid;
+        data.confidence += 0.4;
+    }
+
+    const metadata = await resolveArtistMetadata(input, resolvedMbid);
+    addMetadata(data, metadata);
+    const heroUrl = await resolveHeroUrl(input, resolvedMbid);
+    if (heroUrl) {
+        data.heroUrl = heroUrl;
+        data.confidence += 0.2;
+    }
+    if (options.includeSimilarArtists && metadata.found) {
+        data.similarArtists = await resolveSimilarArtistNames(
+            input,
+            resolvedMbid,
+        );
+    }
+    return data;
+}
+
+/** Load an artist and resolve the compatibility payload for the admin route. */
+export async function enrichArtistFields(
+    artistId: string,
+): Promise<ArtistEnrichmentData> {
+    const artist = await prisma.artist.findUnique({
+        where: { id: artistId },
+        select: { id: true, name: true, mbid: true },
+    });
+    if (!artist) throw new Error(`Artist ${artistId} not found`);
+    return resolveArtistEnrichmentFields(artist, {
+        includeSimilarArtists: true,
+    });
+}
+
+async function resolvedWriteMbid(
+    artistId: string,
+    mbid: string | undefined,
+): Promise<string | undefined> {
+    if (!mbid) return undefined;
+    const existing = await prisma.artist.findUnique({
+        where: { mbid },
+        select: { id: true },
+    });
+    return !existing || existing.id === artistId ? mbid : undefined;
+}
+
+async function localArtistHero(
+    artistId: string,
+    heroUrl: string | undefined,
+): Promise<string | null> {
+    if (!heroUrl) return null;
+    if (isNativePath(heroUrl)) return heroUrl;
+    return (
+        (await downloadAndStoreImage(heroUrl, artistId, "artist")) ?? heroUrl
+    );
+}
+
+/** Prepare the exact artist columns shared by worker and admin persistence. */
+export async function prepareArtistEnrichmentWrite(
+    artistId: string,
+    data: ArtistEnrichmentData,
+): Promise<ArtistEnrichmentWrite> {
+    const write: ArtistEnrichmentWrite = {
+        summary: data.bio ?? null,
+        heroUrl: await localArtistHero(artistId, data.heroUrl),
+    };
+    const mbid = await resolvedWriteMbid(artistId, data.mbid);
+    if (mbid) write.mbid = mbid;
+    if (data.genres && data.genres.length > 0) write.genres = data.genres;
+    return write;
+}
+
+/** Persist artist enrichment using the worker-owned field mapping. */
+export async function applyArtistEnrichmentFields(
+    artistId: string,
+    data: ArtistEnrichmentData,
+): Promise<void> {
+    const write = await prepareArtistEnrichmentWrite(artistId, data);
+    await prisma.artist.update({ where: { id: artistId }, data: write });
+}

--- a/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/artistEnrichmentRuntime.test.ts
@@ -1,3 +1,5 @@
+import { Prisma } from "@prisma/client";
+
 describe("artistEnrichment runtime", () => {
     function setupRuntime() {
         jest.resetModules();
@@ -21,7 +23,9 @@ describe("artistEnrichment runtime", () => {
         const logger = {
             debug: jest.fn(),
             error: jest.fn(),
+            child: jest.fn(),
         };
+        logger.child.mockReturnValue(logger);
 
         const wikidataService = {
             getArtistInfo: jest.fn().mockResolvedValue(null),
@@ -29,6 +33,7 @@ describe("artistEnrichment runtime", () => {
         const lastFmService = {
             getArtistInfo: jest.fn().mockResolvedValue(null),
             getSimilarArtists: jest.fn().mockResolvedValue([]),
+            getAlbumInfo: jest.fn().mockResolvedValue(null),
         };
         const artistImageResolver = {
             resolveArtistImage: jest.fn().mockResolvedValue(null),
@@ -38,6 +43,9 @@ describe("artistEnrichment runtime", () => {
         };
         const musicBrainzService = {
             searchArtist: jest.fn().mockResolvedValue([]),
+            getReleaseGroups: jest.fn().mockResolvedValue([]),
+            getReleaseGroup: jest.fn().mockResolvedValue(null),
+            getRelease: jest.fn().mockResolvedValue(null),
         };
         const redisClient = {
             setEx: jest.fn().mockResolvedValue(undefined),
@@ -146,19 +154,34 @@ describe("artistEnrichment runtime", () => {
                 id: "album-1",
                 rgMbid: "rg-1",
                 title: "Album One",
+                coverUrl: null,
+                genres: [],
+                label: "Existing Label",
+                year: 2000,
+                originalYear: 2000,
                 artist: { name: "Artist One" },
             },
             {
                 id: "album-2",
                 rgMbid: null,
                 title: "Album Two",
+                coverUrl: null,
+                genres: [],
+                label: "Existing Label",
+                year: 2000,
+                originalYear: 2000,
                 artist: { name: "Artist One" },
             },
         ]);
-        runtime.albumCoverResolver.resolveAlbumCover.mockResolvedValueOnce({
-            url: "https://covers/rg-1.jpg",
-            source: "coverartarchive",
-        });
+        runtime.albumCoverResolver.resolveAlbumCover.mockImplementation(
+            async ({ albumTitle }: { albumTitle: string }) =>
+                albumTitle === "Album One"
+                    ? {
+                          url: "https://covers/rg-1.jpg",
+                          source: "coverartarchive",
+                      }
+                    : null,
+        );
 
         const artist = {
             id: "a1",
@@ -483,7 +506,7 @@ describe("artistEnrichment runtime", () => {
             .find((call) => call?.data?.enrichmentStatus === "completed");
         expect(completed).toBeDefined();
         expect(completed.data.summary).toBe("Artist bio summary");
-        expect(completed.data.similarArtistsJson).toBeNull();
+        expect(completed.data.similarArtistsJson).toEqual(Prisma.DbNull);
         expect(runtime.prisma.similarArtist.deleteMany).not.toHaveBeenCalled();
         expect(runtime.prisma.similarArtist.upsert).not.toHaveBeenCalled();
     });
@@ -533,6 +556,141 @@ describe("artistEnrichment runtime", () => {
         expect(completed.data.genres).toEqual(["rock"]);
     });
 
+    it("persists album genres, label, and release years during the scheduled album pass", async () => {
+        const runtime = setupRuntime();
+
+        runtime.prisma.album.findMany.mockResolvedValueOnce([
+            {
+                id: "album-fields-1",
+                rgMbid: null,
+                title: "Album Fields",
+                coverUrl: null,
+                genres: null,
+                label: null,
+                year: null,
+                originalYear: null,
+                artist: {
+                    name: "Album Fields Artist",
+                    mbid: "11111111-1111-4111-8111-111111111111",
+                },
+            },
+        ]);
+        runtime.musicBrainzService.getReleaseGroups.mockResolvedValueOnce([
+            {
+                id: "22222222-2222-4222-8222-222222222222",
+                title: "Album Fields",
+                "primary-type": "Album",
+                "first-release-date": "2004-03-02",
+            },
+        ]);
+        runtime.musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
+            releases: [{ id: "33333333-3333-4333-8333-333333333333" }],
+        });
+        runtime.musicBrainzService.getRelease.mockResolvedValueOnce({
+            "label-info": [{ label: { name: "Scheduled Label" } }],
+        });
+        runtime.lastFmService.getAlbumInfo.mockResolvedValueOnce({
+            tags: {
+                tag: [
+                    { name: "one" },
+                    { name: "two" },
+                    { name: "three" },
+                    { name: "four" },
+                    { name: "five" },
+                    { name: "six" },
+                ],
+            },
+        });
+
+        const artist = {
+            id: "artist-fields-1",
+            name: "Album Fields Artist",
+            mbid: "11111111-1111-4111-8111-111111111111",
+        } as any;
+        await runtime.enrichSimilarArtist(artist);
+
+        expect(runtime.prisma.album.update).toHaveBeenCalledWith({
+            where: { id: "album-fields-1" },
+            data: expect.objectContaining({
+                rgMbid: "22222222-2222-4222-8222-222222222222",
+                genres: ["one", "two", "three", "four", "five"],
+                label: "Scheduled Label",
+                year: 2004,
+                originalYear: 2004,
+            }),
+        });
+    });
+
+    it("keeps scheduled album provider work within three-item batches", async () => {
+        const runtime = setupRuntime();
+        runtime.prisma.album.findMany.mockResolvedValueOnce(
+            ["one", "two", "three", "four"].map((suffix) => ({
+                id: `album-${suffix}`,
+                rgMbid: `remote:${suffix}`,
+                title: `Album ${suffix}`,
+                coverUrl: null,
+                genres: null,
+                label: null,
+                year: null,
+                originalYear: null,
+                artist: {
+                    name: "Batch Artist",
+                    mbid: "11111111-1111-4111-8111-111111111111",
+                },
+            })),
+        );
+
+        let signalFirstBatch: (() => void) | undefined;
+        let signalSecondBatch: (() => void) | undefined;
+        const firstBatchStarted = new Promise<void>((resolve) => {
+            signalFirstBatch = resolve;
+        });
+        const secondBatchStarted = new Promise<void>((resolve) => {
+            signalSecondBatch = resolve;
+        });
+        const releases: Array<() => void> = [];
+        let active = 0;
+        let maximumActive = 0;
+        runtime.lastFmService.getAlbumInfo.mockImplementation(
+            () =>
+                new Promise<null>((resolve) => {
+                    active += 1;
+                    maximumActive = Math.max(maximumActive, active);
+                    releases.push(() => {
+                        active -= 1;
+                        resolve(null);
+                    });
+                    if (releases.length === 3) signalFirstBatch?.();
+                    if (releases.length === 4) signalSecondBatch?.();
+                }),
+        );
+
+        const artist = {
+            id: "batch-artist",
+            name: "Batch Artist",
+            mbid: "11111111-1111-4111-8111-111111111111",
+        } as any;
+        const enrichment = runtime.enrichSimilarArtist(artist);
+
+        await firstBatchStarted;
+        expect(runtime.lastFmService.getAlbumInfo).toHaveBeenCalledTimes(3);
+        expect(maximumActive).toBe(3);
+        releases.slice(0, 3).forEach((release) => release());
+
+        await secondBatchStarted;
+        expect(runtime.lastFmService.getAlbumInfo).toHaveBeenCalledTimes(4);
+        expect(maximumActive).toBe(3);
+        releases[3]();
+        await enrichment;
+        expect(
+            runtime.musicBrainzService.getReleaseGroups,
+        ).not.toHaveBeenCalled();
+        expect(
+            runtime.musicBrainzService.getReleaseGroup,
+        ).not.toHaveBeenCalled();
+        expect(runtime.musicBrainzService.getRelease).not.toHaveBeenCalled();
+    });
+
     it("skips federation release-group placeholders during cover enrichment", async () => {
         const runtime = setupRuntime();
 
@@ -552,21 +710,24 @@ describe("artistEnrichment runtime", () => {
         } as any;
         await runtime.enrichSimilarArtist(artist);
 
-        expect(runtime.prisma.album.findMany).toHaveBeenCalledWith({
-            where: {
-                artistId: "federated-artist",
-                OR: [{ coverUrl: null }, { coverUrl: "" }],
-                location: { not: "FEDERATED" },
-            },
-            select: {
-                id: true,
-                rgMbid: true,
-                title: true,
-                artist: { select: { name: true } },
-            },
-        });
+        expect(runtime.prisma.album.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    artistId: "federated-artist",
+                    location: { not: "FEDERATED" },
+                }),
+                select: expect.objectContaining({
+                    id: true,
+                    rgMbid: true,
+                    title: true,
+                }),
+            }),
+        );
         expect(
             runtime.albumCoverResolver.resolveAlbumCover,
+        ).not.toHaveBeenCalled();
+        expect(
+            runtime.musicBrainzService.getReleaseGroup,
         ).not.toHaveBeenCalled();
         expect(runtime.prisma.album.update).not.toHaveBeenCalled();
     });
@@ -634,8 +795,8 @@ describe("artistEnrichment runtime", () => {
             data: { enrichmentStatus: "failed" },
         });
         expect(runtime.logger.error).toHaveBeenCalledWith(
-            "[ENRICH Artist Four] ENRICHMENT FAILED:",
-            "final write failed",
+            "Artist enrichment failed for Artist Four",
+            expect.objectContaining({ message: "final write failed" }),
         );
     });
 });

--- a/backend/src/workers/artistEnrichment.ts
+++ b/backend/src/workers/artistEnrichment.ts
@@ -1,454 +1,300 @@
-import { Artist } from "@prisma/client";
-import { logger } from "../utils/logger";
+import { Artist, Prisma } from "@prisma/client";
 import { prisma } from "../utils/db";
-import { wikidataService } from "../services/wikidata";
-import { lastFmService } from "../services/lastfm";
-import { musicBrainzService } from "../services/musicbrainz";
+import { logger } from "../utils/logger";
 import { normalizeArtistName } from "../utils/artistNormalization";
 import { redisClient } from "../utils/redis";
-import { downloadAndStoreImage, isNativePath } from "../services/imageStorage";
-import { resolveAlbumCover } from "../services/metadata/albumCoverResolver";
-import { resolveArtistImage } from "../services/metadata/artistImageResolver";
-import { isRealArtistMbid } from "../utils/musicIds";
+import { lastFmService } from "../services/lastfm";
+import {
+    prepareAlbumEnrichmentWrite,
+    resolveAlbumEnrichmentFields,
+    type AlbumEnrichmentWrite,
+} from "../services/metadata/albumEnrichmentFields";
+import {
+    prepareArtistEnrichmentWrite,
+    resolveArtistEnrichmentFields,
+    resolveArtistMbid,
+} from "../services/metadata/artistEnrichmentFields";
+import { rgMbidKind } from "../utils/musicIds";
+
+const log = logger.child("ArtistEnrichmentWorker");
+const ALBUM_BATCH_SIZE = 3;
+const MAX_ALBUMS_PER_ARTIST = 1_000;
+const MAX_SIMILAR_ARTISTS = 30;
+
+interface SimilarArtistResult {
+    name: string;
+    mbid?: string;
+    match: number;
+}
+
+interface AlbumForEnrichment {
+    id: string;
+    rgMbid: string | null;
+    title: string;
+    coverUrl: string | null;
+    genres: Prisma.JsonValue;
+    label: string | null;
+    year: number | null;
+    originalYear: number | null;
+    artist: { name: string; mbid: string | null };
+}
 
 function isMbidUniqueConstraintError(error: unknown): boolean {
     if (!error || typeof error !== "object") return false;
-    const maybeError = error as { code?: unknown; message?: unknown };
-    if (maybeError.code === "P2002") return true;
-    if (typeof maybeError.message === "string") {
-        return (
-            maybeError.message.includes("Unique constraint failed") &&
-            maybeError.message.includes("`mbid`")
-        );
-    }
-    return false;
+    return (error as { code?: unknown }).code === "P2002";
 }
 
-/**
- * Enriches an artist with metadata from Wikidata and Last.fm
- * - Fetches artist bio/summary and hero image from Wikidata
- * - Falls back to Last.fm if Wikidata fails
- * - Fetches similar artists from Last.fm
- */
-export async function enrichSimilarArtist(artist: Artist): Promise<void> {
-    const logPrefix = `[ENRICH ${artist.name}]`;
-    logger.debug(`${logPrefix} Starting enrichment (MBID: ${artist.mbid})`);
+async function upgradeArtistMbid(artist: Artist): Promise<void> {
+    const resolvedMbid = await resolveArtistMbid(artist);
+    if (!resolvedMbid || resolvedMbid === artist.mbid) return;
+    const existing = await prisma.artist.findUnique({
+        where: { mbid: resolvedMbid },
+        select: { id: true },
+    });
+    if (!existing || existing.id === artist.id) {
+        try {
+            await prisma.artist.update({
+                where: { id: artist.id },
+                data: { mbid: resolvedMbid },
+            });
+        } catch (error) {
+            if (!isMbidUniqueConstraintError(error)) throw error;
+        }
+    }
+    artist.mbid = resolvedMbid;
+}
 
-    // Mark as enriching
+async function loadSimilarArtists(
+    artist: Artist,
+): Promise<SimilarArtistResult[]> {
+    try {
+        const similar = await lastFmService.getSimilarArtists(
+            artist.mbid,
+            artist.name,
+        );
+        return similar.slice(0, MAX_SIMILAR_ARTISTS);
+    } catch (error) {
+        log.debug("Similar artist lookup failed", error);
+        return [];
+    }
+}
+
+async function findLocalSimilarArtist(similar: SimilarArtistResult) {
+    if (similar.mbid) {
+        const byMbid = await prisma.artist.findUnique({
+            where: { mbid: similar.mbid },
+        });
+        if (byMbid) return byMbid;
+    }
+    return prisma.artist.findFirst({
+        where: { normalizedName: normalizeArtistName(similar.name) },
+    });
+}
+
+async function upsertSimilarRelationship(
+    artistId: string,
+    similar: SimilarArtistResult,
+): Promise<void> {
+    const target = await findLocalSimilarArtist(similar);
+    if (!target) return;
+    await prisma.similarArtist.upsert({
+        where: {
+            fromArtistId_toArtistId: {
+                fromArtistId: artistId,
+                toArtistId: target.id,
+            },
+        },
+        create: {
+            fromArtistId: artistId,
+            toArtistId: target.id,
+            weight: similar.match,
+        },
+        update: { weight: similar.match },
+    });
+}
+
+async function persistSimilarArtists(
+    artistId: string,
+    similarArtists: SimilarArtistResult[],
+): Promise<void> {
+    if (similarArtists.length === 0) return;
+    await prisma.similarArtist.deleteMany({
+        where: { fromArtistId: artistId },
+    });
+    for (let index = 0; index < MAX_SIMILAR_ARTISTS; index += 1) {
+        const similar = similarArtists[index];
+        if (!similar) return;
+        await upsertSimilarRelationship(artistId, similar);
+    }
+}
+
+function similarArtistsJson(
+    similarArtists: SimilarArtistResult[],
+): Array<{ name: string; mbid: string | null; match: number }> | null {
+    if (similarArtists.length === 0) return null;
+    return similarArtists.map((similar) => ({
+        name: similar.name,
+        mbid: similar.mbid ?? null,
+        match: similar.match,
+    }));
+}
+
+async function cacheArtistHero(
+    artistId: string,
+    heroUrl: string | null,
+): Promise<void> {
+    if (!heroUrl) return;
+    try {
+        await redisClient.setEx(`hero:${artistId}`, 7 * 24 * 60 * 60, heroUrl);
+    } catch (error) {
+        log.debug("Artist hero cache write failed", error);
+    }
+}
+
+/** Enrich an artist and its albums through the shared metadata field rules. */
+export async function enrichSimilarArtist(artist: Artist): Promise<void> {
     await prisma.artist.update({
         where: { id: artist.id },
         data: { enrichmentStatus: "enriching" },
     });
-
-    // Track which source provided data
-    let imageSource = "none";
-    let summarySource = "none";
-
     try {
-        // If artist has a temp MBID, try to get the real one from MusicBrainz
-        if (!isRealArtistMbid(artist.mbid)) {
-            logger.debug(
-                `${logPrefix} Temp MBID detected, searching MusicBrainz...`,
-            );
-            try {
-                const mbResults = await musicBrainzService.searchArtist(
-                    artist.name,
-                    1,
-                );
-                if (mbResults.length > 0 && isRealArtistMbid(mbResults[0].id)) {
-                    const realMbid = mbResults[0].id;
-                    logger.debug(
-                        `${logPrefix} MusicBrainz: Found real MBID: ${realMbid}`,
-                    );
-
-                    const existingArtist = await prisma.artist.findUnique({
-                        where: { mbid: realMbid },
-                        select: { id: true },
-                    });
-                    if (existingArtist && existingArtist.id !== artist.id) {
-                        logger.debug(
-                            `${logPrefix} MusicBrainz: MBID ${realMbid} already exists on another artist, skipping DB MBID update`,
-                        );
-                    } else {
-                        // Update artist with real MBID. If a concurrent writer claims
-                        // it between lookup and update, swallow unique conflicts.
-                        try {
-                            await prisma.artist.update({
-                                where: { id: artist.id },
-                                data: { mbid: realMbid },
-                            });
-                        } catch (updateError) {
-                            if (isMbidUniqueConstraintError(updateError)) {
-                                logger.debug(
-                                    `${logPrefix} MusicBrainz: MBID ${realMbid} was claimed concurrently, skipping DB MBID update`,
-                                );
-                            } else {
-                                throw updateError;
-                            }
-                        }
-                    }
-
-                    // Update the local artist object for downstream lookups.
-                    artist.mbid = realMbid;
-                } else {
-                    logger.debug(
-                        `${logPrefix} MusicBrainz: No match found, keeping temp MBID`,
-                    );
-                }
-            } catch (error: any) {
-                logger.debug(
-                    `${logPrefix} MusicBrainz: FAILED - ${
-                        error?.message || error
-                    }`,
-                );
-            }
-        }
-
-        // Try Wikidata first (only if we have a real MBID)
-        let summary = null;
-        let heroUrl = null;
-        let genres: string[] = [];
-
-        if (isRealArtistMbid(artist.mbid)) {
-            logger.debug(
-                `${logPrefix} Wikidata: Fetching for MBID ${artist.mbid}...`,
-            );
-            try {
-                const wikidataInfo = await wikidataService.getArtistInfo(
-                    artist.name,
-                    artist.mbid,
-                );
-                if (wikidataInfo) {
-                    summary = wikidataInfo.summary;
-                    if (summary) summarySource = "wikidata";
-                    logger.debug(
-                        `${logPrefix} Wikidata: SUCCESS (summary: ${summary ? "yes" : "no"})`,
-                    );
-                } else {
-                    logger.debug(`${logPrefix} Wikidata: No data returned`);
-                }
-            } catch (error: any) {
-                logger.debug(
-                    `${logPrefix} Wikidata: FAILED - ${error?.message || error}`,
-                );
-            }
-        } else {
-            logger.debug(`${logPrefix} Wikidata: Skipped (temp MBID)`);
-        }
-
-        // Fetch from Last.fm if we need summary or genres.
-        if (!summary || genres.length === 0) {
-            logger.debug(
-                `${logPrefix} Last.fm: Fetching (need summary: ${!summary})...`,
-            );
-            try {
-                const validMbid = isRealArtistMbid(artist.mbid)
-                    ? artist.mbid
-                    : undefined;
-                const lastfmInfo = await lastFmService.getArtistInfo(
-                    artist.name,
-                    validMbid,
-                );
-                if (lastfmInfo) {
-                    // Extract text from bio object (bio.summary or bio.content)
-                    if (!summary && lastfmInfo.bio) {
-                        const bio = lastfmInfo.bio as any;
-                        summary = bio.summary || bio.content || null;
-                        if (summary) {
-                            summarySource = "lastfm";
-                            logger.debug(`${logPrefix} Last.fm: Got summary`);
-                        }
-                    }
-
-                    // Extract genres from Last.fm tags
-                    if (
-                        lastfmInfo.tags?.tag &&
-                        Array.isArray(lastfmInfo.tags.tag)
-                    ) {
-                        genres = lastfmInfo.tags.tag
-                            .slice(0, 5) // Top 5 tags as genres
-                            .map((t: any) => t.name)
-                            .filter(Boolean);
-                        if (genres.length > 0) {
-                            logger.debug(
-                                `${logPrefix} Extracted ${genres.length} genres: ${genres.join(", ")}`,
-                            );
-                        }
-                    }
-                } else {
-                    logger.debug(`${logPrefix} Last.fm: No data returned`);
-                }
-            } catch (error: any) {
-                logger.debug(
-                    `${logPrefix} Last.fm: FAILED - ${error?.message || error}`,
-                );
-            }
-        }
-
-        try {
-            const image = await resolveArtistImage({
-                artistName: artist.name,
-                mbid: artist.mbid,
-            });
-            heroUrl = image?.url ?? null;
-            imageSource = image?.source ?? "none";
-        } catch (error) {
-            logger.debug(`${logPrefix} Artist image resolution failed`, error);
-        }
-
-        // Get similar artists from Last.fm
-        let similarArtists: Array<{
-            name: string;
-            mbid?: string;
-            match: number;
-        }> = [];
-        try {
-            // Filter out temp MBIDs
-            const validMbid = isRealArtistMbid(artist.mbid) ? artist.mbid : "";
-            similarArtists = await lastFmService.getSimilarArtists(
-                validMbid,
-                artist.name,
-            );
-            logger.debug(
-                `${logPrefix} Similar artists: Found ${similarArtists.length}`,
-            );
-        } catch (error: any) {
-            logger.debug(
-                `${logPrefix} Similar artists: FAILED - ${
-                    error?.message || error
-                }`,
-            );
-        }
-
-        // Log enrichment summary
-        logger.debug(
-            `${logPrefix} SUMMARY: image=${imageSource}, summary=${summarySource}, heroUrl=${
-                heroUrl ? "set" : "null"
-            }`,
-        );
-
-        // Download image locally if we have an external URL
-        let localHeroUrl: string | null = null;
-        if (heroUrl && !isNativePath(heroUrl)) {
-            logger.debug(`${logPrefix} Downloading image locally...`);
-            localHeroUrl = await downloadAndStoreImage(
-                heroUrl,
-                artist.id,
-                "artist",
-            );
-            if (localHeroUrl) {
-                logger.debug(
-                    `${logPrefix} Image saved locally: ${localHeroUrl}`,
-                );
-            } else {
-                logger.debug(
-                    `${logPrefix} Failed to download image, keeping external URL`,
-                );
-                localHeroUrl = heroUrl; // Fallback to external URL if download fails
-            }
-        } else if (heroUrl) {
-            localHeroUrl = heroUrl; // Already a native path
-        }
-
-        // Prepare similar artists JSON for storage (full Last.fm data)
-        const similarArtistsJson: any =
-            similarArtists.length > 0
-                ? similarArtists.map((s) => ({
-                      name: s.name,
-                      mbid: s.mbid || null,
-                      match: s.match,
-                  }))
-                : null;
-
-        // Update artist with enriched data
+        await upgradeArtistMbid(artist);
+        const fields = await resolveArtistEnrichmentFields(artist);
+        const similarArtists = await loadSimilarArtists(artist);
+        const write = await prepareArtistEnrichmentWrite(artist.id, fields);
         await prisma.artist.update({
             where: { id: artist.id },
             data: {
-                summary,
-                heroUrl: localHeroUrl,
-                similarArtistsJson,
-                genres: genres.length > 0 ? genres : undefined,
+                ...write,
+                similarArtistsJson:
+                    similarArtistsJson(similarArtists) ?? Prisma.DbNull,
                 lastEnriched: new Date(),
                 enrichmentStatus: "completed",
             },
         });
-
-        // Store similar artists
-        if (similarArtists.length > 0) {
-            // Delete existing similar artist relationships
-            await prisma.similarArtist.deleteMany({
-                where: { fromArtistId: artist.id },
-            });
-
-            // Create new relationships
-            for (const similar of similarArtists) {
-                // Find existing similar artist (don't create new ones)
-                let similarArtistRecord = null;
-
-                if (similar.mbid) {
-                    // Try to find by MBID first
-                    similarArtistRecord = await prisma.artist.findUnique({
-                        where: { mbid: similar.mbid },
-                    });
-                }
-
-                if (!similarArtistRecord) {
-                    // Try to find by normalized name (case-insensitive)
-                    const normalizedSimilarName = normalizeArtistName(
-                        similar.name,
-                    );
-                    similarArtistRecord = await prisma.artist.findFirst({
-                        where: { normalizedName: normalizedSimilarName },
-                    });
-                }
-
-                // Only create similarity relationship if the similar artist already exists in our database
-                // This prevents endless crawling of similar artists
-                if (similarArtistRecord) {
-                    await prisma.similarArtist.upsert({
-                        where: {
-                            fromArtistId_toArtistId: {
-                                fromArtistId: artist.id,
-                                toArtistId: similarArtistRecord.id,
-                            },
-                        },
-                        create: {
-                            fromArtistId: artist.id,
-                            toArtistId: similarArtistRecord.id,
-                            weight: similar.match,
-                        },
-                        update: {
-                            weight: similar.match,
-                        },
-                    });
-                }
-            }
-
-            logger.debug(
-                `${logPrefix} Stored ${similarArtists.length} similar artist relationships`,
-            );
-        }
-
-        // Fetch covers for all albums belonging to this artist that don't have covers yet
-        await enrichAlbumCovers(artist.id, localHeroUrl);
-
-        // Cache artist image path in Redis for faster access
-        if (localHeroUrl) {
-            try {
-                await redisClient.setEx(
-                    `hero:${artist.id}`,
-                    7 * 24 * 60 * 60,
-                    localHeroUrl,
-                );
-            } catch (err) {
-                // Redis errors are non-critical
-            }
-        }
-    } catch (error: any) {
-        logger.error(
-            `${logPrefix} ENRICHMENT FAILED:`,
-            error?.message || error,
-        );
-
-        // Mark as failed
+        await persistSimilarArtists(artist.id, similarArtists);
+        await enrichAlbums(artist.id);
+        await cacheArtistHero(artist.id, write.heroUrl);
+    } catch (error) {
+        log.error(`Artist enrichment failed for ${artist.name}`, error);
         await prisma.artist.update({
             where: { id: artist.id },
             data: { enrichmentStatus: "failed" },
         });
-
         throw error;
     }
 }
 
-/**
- * Enrich album covers for an artist
- * Resolves covers through the canonical provider ladder for albums without covers
- */
-async function enrichAlbumCovers(
-    artistId: string,
-    artistHeroUrl: string | null,
+function needsGenres(value: Prisma.JsonValue): boolean {
+    return value === null || (Array.isArray(value) && value.length === 0);
+}
+
+function needsReleaseFields(album: AlbumForEnrichment): boolean {
+    if (!album.rgMbid || rgMbidKind(album.rgMbid) === "temp") return true;
+    return !album.label || album.year === null || album.originalYear === null;
+}
+
+function missingAlbumFields(
+    album: AlbumForEnrichment,
+    resolved: AlbumEnrichmentWrite,
+): AlbumEnrichmentWrite {
+    const write: AlbumEnrichmentWrite = {};
+    if (!album.coverUrl && resolved.coverUrl)
+        write.coverUrl = resolved.coverUrl;
+    if (needsGenres(album.genres) && resolved.genres) {
+        write.genres = resolved.genres;
+    }
+    if (!album.label && resolved.label) write.label = resolved.label;
+    if (album.year === null && resolved.year) write.year = resolved.year;
+    if (album.originalYear === null && resolved.originalYear) {
+        write.originalYear = resolved.originalYear;
+    }
+    if (
+        resolved.rgMbid &&
+        (!album.rgMbid || rgMbidKind(album.rgMbid) === "temp")
+    ) {
+        write.rgMbid = resolved.rgMbid;
+    }
+    return write;
+}
+
+async function cacheAlbumCover(
+    albumId: string,
+    coverUrl: string | undefined,
 ): Promise<void> {
+    if (!coverUrl) return;
     try {
-        // Find albums for this artist that don't have cover art
-        const albumsWithoutCovers = await prisma.album.findMany({
-            where: {
-                artistId,
-                OR: [{ coverUrl: null }, { coverUrl: "" }],
-                location: { not: "FEDERATED" },
-            },
-            select: {
-                id: true,
-                rgMbid: true,
-                title: true,
-                artist: { select: { name: true } },
-            },
-        });
-
-        if (albumsWithoutCovers.length === 0) {
-            logger.debug(`    All albums already have covers`);
-            return;
-        }
-
-        logger.debug(
-            `    Fetching covers for ${albumsWithoutCovers.length} albums...`,
-        );
-
-        let fetchedCount = 0;
-        const BATCH_SIZE = 3; // Limit concurrent requests
-
-        // Process in batches to avoid overwhelming cover providers
-        for (let i = 0; i < albumsWithoutCovers.length; i += BATCH_SIZE) {
-            const batch = albumsWithoutCovers.slice(i, i + BATCH_SIZE);
-
-            await Promise.all(
-                batch.map(async (album) => {
-                    if (album.rgMbid?.startsWith("federation:")) {
-                        return;
-                    }
-
-                    try {
-                        const resolution = await resolveAlbumCover({
-                            artistName: album.artist.name,
-                            albumTitle: album.title,
-                            rgMbid: album.rgMbid,
-                        });
-                        const coverUrl = resolution?.url;
-
-                        if (coverUrl) {
-                            // Save to database
-                            await prisma.album.update({
-                                where: { id: album.id },
-                                data: { coverUrl },
-                            });
-
-                            // Cache in Redis
-                            try {
-                                await redisClient.setEx(
-                                    `album-cover:${album.id}`,
-                                    30 * 24 * 60 * 60, // 30 days
-                                    coverUrl,
-                                );
-                            } catch (err) {
-                                // Redis errors are non-critical
-                            }
-
-                            fetchedCount++;
-                        }
-                    } catch (err) {
-                        // Cover art fetch failed, continue with next album
-                        logger.debug(
-                            `      No cover found for: ${album.title}`,
-                        );
-                    }
-                }),
-            );
-        }
-
-        logger.debug(
-            `    Fetched ${fetchedCount}/${albumsWithoutCovers.length} album covers`,
+        await redisClient.setEx(
+            `album-cover:${albumId}`,
+            30 * 24 * 60 * 60,
+            coverUrl,
         );
     } catch (error) {
-        logger.error(`    Failed to enrich album covers:`, error);
-        // Don't throw - album cover failures shouldn't fail the entire enrichment
+        log.debug("Album cover cache write failed", error);
     }
+}
+
+async function enrichAlbum(album: AlbumForEnrichment): Promise<boolean> {
+    if (album.rgMbid && rgMbidKind(album.rgMbid) === "federation") {
+        return false;
+    }
+    try {
+        const fields = await resolveAlbumEnrichmentFields(album, {
+            musicBrainz: needsReleaseFields(album),
+            lastFm: needsGenres(album.genres),
+            cover: !album.coverUrl,
+        });
+        const resolved = await prepareAlbumEnrichmentWrite(album.id, fields);
+        const write = missingAlbumFields(album, resolved);
+        if (Object.keys(write).length === 0) return false;
+        await prisma.album.update({ where: { id: album.id }, data: write });
+        await cacheAlbumCover(album.id, write.coverUrl);
+        return true;
+    } catch (error) {
+        log.debug(`Album enrichment failed for ${album.title}`, error);
+        return false;
+    }
+}
+
+async function enrichAlbums(artistId: string): Promise<void> {
+    const albums = await prisma.album.findMany({
+        where: {
+            artistId,
+            location: { not: "FEDERATED" },
+            OR: [
+                { coverUrl: null },
+                { coverUrl: "" },
+                { genres: { equals: Prisma.DbNull } },
+                { genres: { equals: [] } },
+                { label: null },
+                { label: "" },
+                { year: null },
+                { originalYear: null },
+            ],
+        },
+        select: {
+            id: true,
+            rgMbid: true,
+            title: true,
+            coverUrl: true,
+            genres: true,
+            label: true,
+            year: true,
+            originalYear: true,
+            artist: { select: { name: true, mbid: true } },
+        },
+        take: MAX_ALBUMS_PER_ARTIST,
+    });
+    let enrichedCount = 0;
+    for (
+        let index = 0;
+        index < MAX_ALBUMS_PER_ARTIST;
+        index += ALBUM_BATCH_SIZE
+    ) {
+        const batch = albums.slice(index, index + ALBUM_BATCH_SIZE);
+        if (batch.length === 0) break;
+        const results = await Promise.all(batch.map(enrichAlbum));
+        enrichedCount += results.filter(Boolean).length;
+    }
+    log.debug(`Enriched ${enrichedCount}/${albums.length} albums`);
 }

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -54,7 +54,7 @@ const FIXED_SCAN_ROOTS = Object.freeze([
 
 const BASELINE = Object.freeze({
     "backend/src/routes/browse.ts": 1540,
-    "backend/src/routes/enrichment.ts": 2277,
+    "backend/src/routes/enrichment.ts": 2261,
     "backend/src/routes/library/artists.ts": 1531,
     "backend/src/routes/library/radio.ts": 1661,
     "backend/src/routes/library/tracks.ts": 1769,


### PR DESCRIPTION
PR 3 of the #760 consolidation (after #772 artist images and #773 album covers). The remaining #760 work is the catalog-persistence feature, shipping separately per the locked design on the issue.

## What

- **One rule set** under `services/metadata/`: `artistEnrichmentFields` (MBID resolution, Wikidata-first bio with Last.fm fallback, top-5 genres, canonical image via #772's resolver) and `albumEnrichmentFields` (release-group resolution, MB first-release-date + label, top-5 Last.fm album tags, canonical cover via #773's resolver).
- **Album fields finally populate on normal installs**: the worker's album pass now fills missing cover/genres/label/year/originalYear with its existing 3-item batch pacing, never sending `remote:`/`federation:` identifiers to MusicBrainz (`rgMbidKind` gated).
- **Admin per-entity endpoints delegate to the same modules** — response shapes unchanged. One deliberate behavior change: explicit admin re-enrichment applies what it resolves instead of gating on the deleted implementation's `confidence > 0.3` heuristic (confidence is still computed and returned; the MBID-conflict guards live in the shared resolution). An admin clicking "re-enrich" gets an enrichment.
- `services/enrichment.ts` drops from ~700 lines of duplicated provider rules to a 179-line settings/compat facade; its stale Discogs claim dies with it. Enrichment-route file-size baseline tightened 2277 → 2261.
- Every enrichment-route suite now mocks the shared modules at the boundary (the partial-config/logger-child/p-queue import-graph traps from #772/#773, fixed proactively).

## Verification

- verify: backend `tsc --noEmit` exit 0; `format:check` clean; file-size + route-error-canon gates pass
- verify: backend jest — shared-module suites + 12 enrichment/worker suites: `Test Suites: 14 passed`, `Tests: 146 passed`; socket-bound `enrichmentRouteAuthz` + `enrichmentFailuresBoundedQuery` pass outside the local sandbox: `Test Suites: 2 passed`, `Tests: 21 passed`