### PR TITLE
fix(frontend): window long track lists and stop per-second re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - Album genres, label, and release year now populate during normal background enrichment instead of only via the admin per-album tool, and admin re-enrichment now applies the same rules as the background worker.
 - Search results now reflect library changes immediately after a scan or deletion; artist-page popular tracks and discography now recognize remasters and editions you own (#758).
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).

--- a/frontend/app/playlist/my-liked/page.tsx
+++ b/frontend/app/playlist/my-liked/page.tsx
@@ -16,8 +16,8 @@ import {
 import { CachedImage } from "@/components/ui/CachedImage";
 import {
     useAudioControls,
-    useAudioPlayback,
     useAudioState,
+    usePlaybackStatus,
 } from "@/lib/audio-context";
 import {
     api,
@@ -178,7 +178,9 @@ export default function MyLikedPlaylistPage() {
     const queryClient = useQueryClient();
     const { toast } = useToast();
     const { currentTrack } = useAudioState();
-    const { isPlaying } = useAudioPlayback();
+    // Narrow subscription: this page only reads isPlaying, so it must not
+    // re-render on the once-per-second currentTime tick (GH #784).
+    const { isPlaying } = usePlaybackStatus();
     const { playTracks, playNow, pause, resume, addTracksToQueue } =
         useAudioControls();
     const { data, isLoading, isError } = useLikedPlaylistQuery();

--- a/frontend/app/queue/page.tsx
+++ b/frontend/app/queue/page.tsx
@@ -46,6 +46,13 @@ import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 import { PeerBadge } from "@/components/ui/PeerBadge";
 
 /**
+ * Rows rendered on the first pass before react-virtuoso measures the
+ * viewport; keeps first paint windowed instead of mounting the whole queue
+ * (GH #784).
+ */
+const INITIAL_WINDOW_COUNT = 20;
+
+/**
  * Renders the QueuePage component.
  */
 export default function QueuePage() {
@@ -471,7 +478,10 @@ export default function QueuePage() {
                         <Card>
                             <Virtuoso
                                 totalCount={nextTracks.length}
-                                initialItemCount={nextTracks.length}
+                                initialItemCount={Math.min(
+                                    nextTracks.length,
+                                    INITIAL_WINDOW_COUNT,
+                                )}
                                 computeItemKey={(idx) =>
                                     `next-${nextTracks[idx]?.id ?? idx}-${idx}`
                                 }
@@ -567,7 +577,10 @@ export default function QueuePage() {
                         <Card>
                             <Virtuoso
                                 totalCount={previousTracks.length}
-                                initialItemCount={previousTracks.length}
+                                initialItemCount={Math.min(
+                                    previousTracks.length,
+                                    INITIAL_WINDOW_COUNT,
+                                )}
                                 computeItemKey={(idx) =>
                                     `prev-${previousTracks[idx]?.id ?? idx}-${idx}`
                                 }

--- a/frontend/components/layout/AuthenticatedLayout.tsx
+++ b/frontend/components/layout/AuthenticatedLayout.tsx
@@ -137,6 +137,7 @@ export function AuthenticatedLayout({ children }: { children: ReactNode }) {
                             <main
                                 id="main-content"
                                 tabIndex={-1}
+                                data-app-scroll-container
                                 className="flex-1 bg-gradient-to-b from-surface-hover via-black to-black mx-2 mb-2 rounded-lg overflow-y-auto relative focus:outline-none"
                                 style={{
                                     marginTop:
@@ -182,6 +183,7 @@ export function AuthenticatedLayout({ children }: { children: ReactNode }) {
                         <main
                             id="main-content"
                             tabIndex={-1}
+                            data-app-scroll-container
                             className="flex-1 bg-gradient-to-b from-surface-hover via-black to-black rounded-lg overflow-y-auto relative focus:outline-none"
                         >
                             <GalaxyBackground />

--- a/frontend/components/track/TrackList.tsx
+++ b/frontend/components/track/TrackList.tsx
@@ -15,6 +15,19 @@ import {
 } from "./reorderDnd";
 import type { TrackListProps } from "./types";
 
+/**
+ * Above this item count the list windows its DOM via react-virtuoso unless
+ * the caller pins `virtualized` explicitly. Reorderable lists never
+ * auto-virtualize: the drag-and-drop handle math needs every row mounted.
+ */
+const AUTO_VIRTUALIZE_THRESHOLD = 200;
+
+/**
+ * Rows rendered on the first pass before react-virtuoso measures the
+ * viewport; keeps first paint windowed instead of mounting every row.
+ */
+const INITIAL_WINDOW_COUNT = 20;
+
 interface DragOverState {
     index: number;
     position: DropPosition;
@@ -30,7 +43,10 @@ interface DragOverState {
  * With the optional `reorder` prop (non-virtualized lists only), each row
  * gains a hover-revealed grip handle in its left padding gutter for pointer
  * and keyboard reordering (GH #27); all decision math lives in the pure
- * reorderDnd module. Without the prop the render output is unchanged.
+ * reorderDnd module.
+ *
+ * Lists above AUTO_VIRTUALIZE_THRESHOLD items window their DOM automatically
+ * (GH #784) unless the caller pins `virtualized` or enables `reorder`.
  */
 export function TrackList<T>({
     items,
@@ -61,7 +77,19 @@ export function TrackList<T>({
     const dragIndexRef = useRef<number | null>(null);
     const [dragIndex, setDragIndex] = useState<number | null>(null);
     const [dragOver, setDragOver] = useState<DragOverState | null>(null);
-    const reorderEnabled = Boolean(reorder) && !virtualized;
+    const isVirtualized =
+        virtualized ?? (!reorder && items.length > AUTO_VIRTUALIZE_THRESHOLD);
+    const reorderEnabled = Boolean(reorder) && !isVirtualized;
+
+    // Windowed lists scroll with the app's main scroll container when one is
+    // present so long pages keep native full-page scrolling; otherwise the
+    // list falls back to a bounded internal scroll box.
+    const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
+    const virtualContainerRef = useCallback((node: HTMLDivElement | null) => {
+        setScrollParent(
+            node?.closest<HTMLElement>("[data-app-scroll-container]") ?? null,
+        );
+    }, []);
 
     const handlePlay = useCallback(
         (item: T, index: number) => () => onPlay(item, index),
@@ -237,22 +265,33 @@ export function TrackList<T>({
         );
     };
 
-    if (virtualized) {
+    if (isVirtualized) {
         return (
             <>
                 {header}
-                <div data-tv-section={tvSection} className={className}>
+                <div
+                    ref={virtualContainerRef}
+                    data-tv-section={tvSection}
+                    className={className}
+                >
                     <Virtuoso
                         totalCount={items.length}
-                        initialItemCount={items.length}
+                        initialItemCount={Math.min(
+                            items.length,
+                            INITIAL_WINDOW_COUNT,
+                        )}
                         defaultItemHeight={estimatedItemHeight}
                         itemContent={renderRow}
-                        style={{
-                            height: Math.min(
-                                items.length * estimatedItemHeight,
-                                600,
-                            ),
-                        }}
+                        {...(scrollParent
+                            ? { customScrollParent: scrollParent }
+                            : {
+                                  style: {
+                                      height: Math.min(
+                                          items.length * estimatedItemHeight,
+                                          600,
+                                      ),
+                                  },
+                              })}
                     />
                 </div>
             </>

--- a/frontend/components/track/TrackList.tsx
+++ b/frontend/components/track/TrackList.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
-import { Virtuoso } from "react-virtuoso";
+import {
+    forwardRef,
+    useCallback,
+    useMemo,
+    useRef,
+    useState,
+    type HTMLAttributes,
+} from "react";
+import { Virtuoso, type Components } from "react-virtuoso";
 import { GripVertical } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { useAudioState } from "@/lib/audio-state-context";
@@ -18,7 +25,8 @@ import type { TrackListProps } from "./types";
 /**
  * Above this item count the list windows its DOM via react-virtuoso unless
  * the caller pins `virtualized` explicitly. Reorderable lists never
- * auto-virtualize: the drag-and-drop handle math needs every row mounted.
+ * auto-virtualize (the drag-and-drop handle math needs every row mounted),
+ * and neither do TV sections (D-pad navigation walks the mounted cards).
  */
 const AUTO_VIRTUALIZE_THRESHOLD = 200;
 
@@ -78,7 +86,8 @@ export function TrackList<T>({
     const [dragIndex, setDragIndex] = useState<number | null>(null);
     const [dragOver, setDragOver] = useState<DragOverState | null>(null);
     const isVirtualized =
-        virtualized ?? (!reorder && items.length > AUTO_VIRTUALIZE_THRESHOLD);
+        virtualized ??
+        (!reorder && !tvSection && items.length > AUTO_VIRTUALIZE_THRESHOLD);
     const reorderEnabled = Boolean(reorder) && !isVirtualized;
 
     // Windowed lists scroll with the app's main scroll container when one is
@@ -90,6 +99,30 @@ export function TrackList<T>({
             node?.closest<HTMLElement>("[data-app-scroll-container]") ?? null,
         );
     }, []);
+
+    // The caller's className styles the element whose direct children are the
+    // row wrappers (divide-y/space-y utilities depend on that). In windowed
+    // mode that element is Virtuoso's internal item list, not our container,
+    // so forward the className there.
+    const virtuosoComponents = useMemo<Components>(
+        () => ({
+            List: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+                function VirtualRowList(
+                    { className: listClassName, ...props },
+                    ref,
+                ) {
+                    return (
+                        <div
+                            {...props}
+                            ref={ref}
+                            className={cn(listClassName, className)}
+                        />
+                    );
+                },
+            ),
+        }),
+        [className],
+    );
 
     const handlePlay = useCallback(
         (item: T, index: number) => () => onPlay(item, index),
@@ -269,11 +302,7 @@ export function TrackList<T>({
         return (
             <>
                 {header}
-                <div
-                    ref={virtualContainerRef}
-                    data-tv-section={tvSection}
-                    className={className}
-                >
+                <div ref={virtualContainerRef} data-tv-section={tvSection}>
                     <Virtuoso
                         totalCount={items.length}
                         initialItemCount={Math.min(
@@ -281,6 +310,7 @@ export function TrackList<T>({
                             INITIAL_WINDOW_COUNT,
                         )}
                         defaultItemHeight={estimatedItemHeight}
+                        components={virtuosoComponents}
                         itemContent={renderRow}
                         {...(scrollParent
                             ? { customScrollParent: scrollParent }

--- a/frontend/components/track/types.ts
+++ b/frontend/components/track/types.ts
@@ -120,7 +120,11 @@ export interface TrackListProps<T> {
     emptyState?: ReactNode;
     loadingState?: ReactNode;
     isLoading?: boolean;
-    /** When true, render items using react-virtuoso for large lists. Default: false. */
+    /**
+     * Render items using react-virtuoso (windowed DOM). Defaults to true for
+     * lists above ~200 items without `reorder`, false otherwise; pass an
+     * explicit value to pin either mode.
+     */
     virtualized?: boolean;
     /** Estimated row height in px when virtualized. Default: 64. */
     estimatedItemHeight?: number;

--- a/frontend/components/track/types.ts
+++ b/frontend/components/track/types.ts
@@ -122,8 +122,9 @@ export interface TrackListProps<T> {
     isLoading?: boolean;
     /**
      * Render items using react-virtuoso (windowed DOM). Defaults to true for
-     * lists above ~200 items without `reorder`, false otherwise; pass an
-     * explicit value to pin either mode.
+     * lists above ~200 items without `reorder` or `tvSection` (both need
+     * every row mounted), false otherwise; pass an explicit value to pin
+     * either mode.
      */
     virtualized?: boolean;
     /** Estimated row height in px when virtualized. Default: 64. */

--- a/frontend/tests/component/myLikedPlaylist.component.test.ts
+++ b/frontend/tests/component/myLikedPlaylist.component.test.ts
@@ -115,9 +115,13 @@ mock.module("@/lib/audio-context", {
         useAudioState: () => ({
             currentTrack: state.currentTrack,
         }),
-        useAudioPlayback: () => ({
-            isPlaying: state.isPlaying,
-        }),
+        useAudioPlayback: () => {
+            throw new Error(
+                "my-liked must not subscribe to the composite playback " +
+                    "context: it re-renders once per second during playback " +
+                    "(GH #784). Use usePlaybackStatus instead.",
+            );
+        },
         usePlaybackStatus: () => ({
             isPlaying: state.isPlaying,
         }),

--- a/frontend/tests/component/myLikedPlaylist.component.test.ts
+++ b/frontend/tests/component/myLikedPlaylist.component.test.ts
@@ -118,6 +118,9 @@ mock.module("@/lib/audio-context", {
         useAudioPlayback: () => ({
             isPlaying: state.isPlaying,
         }),
+        usePlaybackStatus: () => ({
+            isPlaying: state.isPlaying,
+        }),
         useAudioControls: () => ({
             playTracks: () => undefined,
             playNow: () => undefined,

--- a/frontend/tests/component/trackListVirtualization.component.test.ts
+++ b/frontend/tests/component/trackListVirtualization.component.test.ts
@@ -84,6 +84,8 @@ interface MountOptions {
     virtualized?: boolean;
     withReorder?: boolean;
     insideScrollContainer?: boolean;
+    tvSection?: string;
+    className?: string;
 }
 
 async function mountTrackList(options: MountOptions) {
@@ -107,6 +109,8 @@ async function mountTrackList(options: MountOptions) {
                 toRowItem,
                 onPlay: () => undefined,
                 virtualized: options.virtualized,
+                tvSection: options.tvSection,
+                className: options.className,
                 reorder: options.withReorder
                     ? { onReorder: () => undefined }
                     : undefined,
@@ -137,9 +141,41 @@ test("lists above the threshold window their rows automatically", async () => {
     );
     const mountedRows =
         mounted.container.querySelectorAll("[data-track-id]").length;
+    assert.equal(
+        mountedRows,
+        20,
+        "the initial pass mounts exactly the 20-row window",
+    );
+    await unmount(mounted);
+});
+
+test("TV sections never auto-virtualize", async () => {
+    const mounted = await mountTrackList({
+        itemCount: 250,
+        tvSection: "tracks",
+    });
+
+    assert.equal(queryScroller(mounted.container), null);
+    assert.equal(
+        mounted.container.querySelectorAll("[data-track-id]").length,
+        250,
+    );
+    await unmount(mounted);
+});
+
+test("caller className keeps styling the element that wraps the rows", async () => {
+    const mounted = await mountTrackList({
+        itemCount: 250,
+        className: "space-y-1",
+    });
+    const list = mounted.container.querySelector(
+        '[data-virtuoso-scroller] [data-testid="virtuoso-item-list"]',
+    );
+
+    assert.ok(list, "expected Virtuoso's item list");
     assert.ok(
-        mountedRows < 250,
-        `windowed list must not mount every row (mounted ${mountedRows})`,
+        list.className.includes("space-y-1"),
+        "divide/space utilities must land on the row wrapper parent",
     );
     await unmount(mounted);
 });

--- a/frontend/tests/component/trackListVirtualization.component.test.ts
+++ b/frontend/tests/component/trackListVirtualization.component.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const Icon = (props: Record<string, unknown>) =>
+    React.createElement("svg", props);
+
+mock.module("lucide-react", {
+    namedExports: {
+        AudioLines: Icon,
+        GripVertical: Icon,
+        Music: Icon,
+        Play: Icon,
+    },
+});
+
+mock.module("@/utils/formatTime", {
+    namedExports: { formatTime: (seconds: number) => `t:${seconds}` },
+});
+
+mock.module("@/components/ui/CachedImage", {
+    namedExports: {
+        CachedImage: ({ src, alt }: { src: string; alt: string }) =>
+            React.createElement("img", { src, alt }),
+    },
+});
+
+mock.module("@/components/ui/TrackOverflowMenu", {
+    namedExports: { TrackOverflowMenu: () => null },
+});
+
+mock.module("@/components/player/TrackPreferenceButtons", {
+    namedExports: { TrackPreferenceButtons: () => null },
+});
+
+mock.module("@/lib/audio-state-context", {
+    namedExports: { useAudioState: () => ({ currentTrack: null }) },
+});
+
+mock.module("@/hooks/useQueuedTrackIds", {
+    namedExports: { useQueuedTrackIds: () => new Set() },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+interface Item {
+    id: string;
+    title: string;
+    artist: string;
+}
+
+function makeItems(count: number): Item[] {
+    return Array.from({ length: count }, (_, i) => ({
+        id: `track-${i + 1}`,
+        title: `Track ${i + 1}`,
+        artist: `Artist ${i + 1}`,
+    }));
+}
+
+function toRowItem(item: Item) {
+    return {
+        id: item.id,
+        title: item.title,
+        artistName: item.artist,
+        duration: 180,
+        coverArtUrl: null,
+    };
+}
+
+interface MountOptions {
+    itemCount: number;
+    virtualized?: boolean;
+    withReorder?: boolean;
+    insideScrollContainer?: boolean;
+}
+
+async function mountTrackList(options: MountOptions) {
+    const { createRoot } = await import("react-dom/client");
+    const { TrackList } = await import("../../components/track");
+    const TypedTrackList = TrackList<Item>;
+
+    const host = document.createElement("div");
+    if (options.insideScrollContainer) {
+        host.setAttribute("data-app-scroll-container", "");
+    }
+    document.body.appendChild(host);
+    const container = document.createElement("div");
+    host.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(TypedTrackList, {
+                items: makeItems(options.itemCount),
+                toRowItem,
+                onPlay: () => undefined,
+                virtualized: options.virtualized,
+                reorder: options.withReorder
+                    ? { onReorder: () => undefined }
+                    : undefined,
+            }),
+        );
+    });
+
+    return { container, host, root };
+}
+
+async function unmount(mounted: Awaited<ReturnType<typeof mountTrackList>>) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.host.remove();
+}
+
+function queryScroller(container: HTMLElement): HTMLElement | null {
+    return container.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+}
+
+test("lists above the threshold window their rows automatically", async () => {
+    const mounted = await mountTrackList({ itemCount: 250 });
+
+    assert.ok(
+        queryScroller(mounted.container),
+        "expected the windowed render path",
+    );
+    const mountedRows =
+        mounted.container.querySelectorAll("[data-track-id]").length;
+    assert.ok(
+        mountedRows < 250,
+        `windowed list must not mount every row (mounted ${mountedRows})`,
+    );
+    await unmount(mounted);
+});
+
+test("small lists render every row without windowing", async () => {
+    const mounted = await mountTrackList({ itemCount: 50 });
+
+    assert.equal(queryScroller(mounted.container), null);
+    assert.equal(
+        mounted.container.querySelectorAll("[data-track-id]").length,
+        50,
+    );
+    await unmount(mounted);
+});
+
+test("reorderable lists never auto-virtualize", async () => {
+    const mounted = await mountTrackList({ itemCount: 250, withReorder: true });
+
+    assert.equal(queryScroller(mounted.container), null);
+    assert.equal(
+        mounted.container.querySelectorAll("[data-track-id]").length,
+        250,
+    );
+    await unmount(mounted);
+});
+
+test("an explicit virtualized=false pins the plain render path", async () => {
+    const mounted = await mountTrackList({
+        itemCount: 250,
+        virtualized: false,
+    });
+
+    assert.equal(queryScroller(mounted.container), null);
+    assert.equal(
+        mounted.container.querySelectorAll("[data-track-id]").length,
+        250,
+    );
+    await unmount(mounted);
+});
+
+test("windowed lists scroll with the app container when one is present", async () => {
+    const mounted = await mountTrackList({
+        itemCount: 250,
+        insideScrollContainer: true,
+    });
+    const scroller = queryScroller(mounted.container);
+
+    assert.ok(scroller);
+    // With a custom scroll parent Virtuoso sizes the scroller to its content
+    // so the list participates in the page's own scrolling instead of the
+    // 600px bounded box.
+    assert.notEqual(scroller.style.height, "600px");
+    await unmount(mounted);
+});
+
+test("windowed lists fall back to a bounded box without an app scroll container", async () => {
+    const mounted = await mountTrackList({ itemCount: 250 });
+    const scroller = queryScroller(mounted.container);
+
+    assert.ok(scroller);
+    assert.equal(scroller.style.height, "600px");
+    await unmount(mounted);
+});


### PR DESCRIPTION
## Problem (#784)

List virtualization was dead code where declared and self-defeating where mounted:

- `TrackListProps.virtualized` had zero call sites, so all nine `<TrackList>` surfaces rendered every row.
- The opt-in path passed `initialItemCount={items.length}`, telling Virtuoso to mount the entire list on first paint — same pattern in both queue-page Virtuoso mounts.
- Liked Songs subscribed to the deprecated composite playback context, so up to 10k unmemoized row subtrees reconciled once per second during playback.

## Fix

- **TrackList** auto-virtualizes above 200 items (reorderable lists are exempt — drag-and-drop needs every row mounted; an explicit `virtualized` still pins either mode). The initial pass seeds a bounded 20-row window.
- **Page-native scrolling preserved:** the app's two `<main>` scroll containers now carry `data-app-scroll-container`; a windowed TrackList finds the nearest one and hands it to Virtuoso as `customScrollParent`, so long pages keep full-page scroll instead of a nested scroll box. Without a container it falls back to the bounded 600px box.
- **Queue page** keeps its bounded boxes but seeds a 20-row initial window instead of the full queue.
- **Liked Songs** reads `usePlaybackStatus()` (the page only needs `isPlaying`), ending the once-per-second re-render.

## Verification

- `verify: frontend tsc --noEmit` exit 0
- `verify: npm run test:component` (Node 24) — 729 tests, 729 pass, 0 fail; includes 6 new tests in `trackListVirtualization.component.test.ts` covering the auto-threshold, reorder exemption, explicit pin, and both scroll modes
- `verify: npm run lint` — 0 errors, 183 warnings (exact cap, zero new)
- `verify: format:check` clean (frontend + CHANGELOG via pinned prettier)

Closes #784