### PR TITLE
chore(db): match indexes to hot query shapes; drop 14 never-scanned scalar indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Backend Jest tests now use transpile-only TypeScript transforms, six workers, and smaller runtime suites for faster test runs.
+- Database indexes now match frequent embedding, library, radio, playlist, and notification queries, while unused single-column audio-feature indexes no longer add write overhead.
 - Album covers now resolve through one provider ladder with unified caching, replacing six surface-specific implementations.
 - Artist images now resolve through one provider ladder with unified caching, instead of five surface-specific implementations.
 - Search now matches songs by artist and album name, tolerates typos, and ranks fallback results by similarity instead of alphabetically.

--- a/backend/prisma/migrations/20260825140000_tune_track_and_hot_query_indexes/migration.sql
+++ b/backend/prisma/migrations/20260825140000_tune_track_and_hot_query_indexes/migration.sql
@@ -1,0 +1,66 @@
+-- Build indexes for recurring worker, library, radio, playlist, and
+-- notification query shapes. New indexes build CONCURRENTLY so writes are
+-- never blocked (this file must therefore remain free of explicit
+-- BEGIN/COMMIT statements, matching the Track_random_idx precedent).
+-- Drops are plain DROP INDEX: DROP INDEX CONCURRENTLY fails under
+-- prisma migrate deploy's statement runner (verified against a scratch
+-- database), and dropping a never-scanned ~3MB index holds its lock for
+-- only a moment.
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "Track_vibeAnalysisStatus_idx"
+ON "Track"("vibeAnalysisStatus");
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "LikedTrack_userId_likedAt_idx"
+ON "LikedTrack"("userId", "likedAt");
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "Track_analysisStatus_origin_removedAt_idx"
+ON "Track"("analysisStatus", "origin", "removedAt");
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "Notification_userId_cleared_createdAt_idx"
+ON "Notification"("userId", "cleared", "createdAt");
+
+-- DropIndex
+DROP INDEX "Track_acousticness_idx";
+
+-- DropIndex
+DROP INDEX "Track_arousal_idx";
+
+-- DropIndex
+DROP INDEX "Track_bpm_idx";
+
+-- DropIndex
+DROP INDEX "Track_danceability_idx";
+
+-- DropIndex
+DROP INDEX "Track_energy_idx";
+
+-- DropIndex
+DROP INDEX "Track_instrumentalness_idx";
+
+-- DropIndex
+DROP INDEX "Track_valence_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodAcoustic_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodAggressive_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodElectronic_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodHappy_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodParty_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodRelaxed_idx";
+
+-- DropIndex
+DROP INDEX "Track_moodSad_idx";

--- a/backend/prisma/migrations/20260825140000_tune_track_and_hot_query_indexes/migration.sql
+++ b/backend/prisma/migrations/20260825140000_tune_track_and_hot_query_indexes/migration.sql
@@ -7,60 +7,68 @@
 -- database), and dropping a never-scanned ~3MB index holds its lock for
 -- only a moment.
 
--- CreateIndex
+-- CreateIndex (re-runnable: a failed CONCURRENTLY build leaves an INVALID
+-- index under the target name; drop any leftover before rebuilding)
+DROP INDEX IF EXISTS "Track_vibeAnalysisStatus_idx";
 CREATE INDEX CONCURRENTLY "Track_vibeAnalysisStatus_idx"
 ON "Track"("vibeAnalysisStatus");
 
--- CreateIndex
+-- CreateIndex (re-runnable: a failed CONCURRENTLY build leaves an INVALID
+-- index under the target name; drop any leftover before rebuilding)
+DROP INDEX IF EXISTS "LikedTrack_userId_likedAt_idx";
 CREATE INDEX CONCURRENTLY "LikedTrack_userId_likedAt_idx"
 ON "LikedTrack"("userId", "likedAt");
 
--- CreateIndex
+-- CreateIndex (re-runnable: a failed CONCURRENTLY build leaves an INVALID
+-- index under the target name; drop any leftover before rebuilding)
+DROP INDEX IF EXISTS "Track_analysisStatus_origin_removedAt_idx";
 CREATE INDEX CONCURRENTLY "Track_analysisStatus_origin_removedAt_idx"
 ON "Track"("analysisStatus", "origin", "removedAt");
 
--- CreateIndex
+-- CreateIndex (re-runnable: a failed CONCURRENTLY build leaves an INVALID
+-- index under the target name; drop any leftover before rebuilding)
+DROP INDEX IF EXISTS "Notification_userId_cleared_createdAt_idx";
 CREATE INDEX CONCURRENTLY "Notification_userId_cleared_createdAt_idx"
 ON "Notification"("userId", "cleared", "createdAt");
 
 -- DropIndex
-DROP INDEX "Track_acousticness_idx";
+DROP INDEX IF EXISTS "Track_acousticness_idx";
 
 -- DropIndex
-DROP INDEX "Track_arousal_idx";
+DROP INDEX IF EXISTS "Track_arousal_idx";
 
 -- DropIndex
-DROP INDEX "Track_bpm_idx";
+DROP INDEX IF EXISTS "Track_bpm_idx";
 
 -- DropIndex
-DROP INDEX "Track_danceability_idx";
+DROP INDEX IF EXISTS "Track_danceability_idx";
 
 -- DropIndex
-DROP INDEX "Track_energy_idx";
+DROP INDEX IF EXISTS "Track_energy_idx";
 
 -- DropIndex
-DROP INDEX "Track_instrumentalness_idx";
+DROP INDEX IF EXISTS "Track_instrumentalness_idx";
 
 -- DropIndex
-DROP INDEX "Track_valence_idx";
+DROP INDEX IF EXISTS "Track_valence_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodAcoustic_idx";
+DROP INDEX IF EXISTS "Track_moodAcoustic_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodAggressive_idx";
+DROP INDEX IF EXISTS "Track_moodAggressive_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodElectronic_idx";
+DROP INDEX IF EXISTS "Track_moodElectronic_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodHappy_idx";
+DROP INDEX IF EXISTS "Track_moodHappy_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodParty_idx";
+DROP INDEX IF EXISTS "Track_moodParty_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodRelaxed_idx";
+DROP INDEX IF EXISTS "Track_moodRelaxed_idx";
 
 -- DropIndex
-DROP INDEX "Track_moodSad_idx";
+DROP INDEX IF EXISTS "Track_moodSad_idx";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -475,21 +475,9 @@ model Track {
   @@index([title])
   @@index([searchVector], type: Gin)
   @@index([analysisStatus])
+  @@index([analysisStatus, origin, removedAt])
   @@index([analysisMode])
-  @@index([bpm])
-  @@index([energy])
-  @@index([valence])
-  @@index([danceability])
-  @@index([moodHappy])
-  @@index([moodSad])
-  @@index([moodRelaxed])
-  @@index([moodAggressive])
-  @@index([moodParty])
-  @@index([moodAcoustic])
-  @@index([moodElectronic])
-  @@index([arousal])
-  @@index([acousticness])
-  @@index([instrumentalness])
+  @@index([vibeAnalysisStatus])
   @@index([hasUserOverrides])
   @@index([random])
   @@index([audioHash])
@@ -950,6 +938,7 @@ model LikedTrack {
   @@id([userId, trackId])
   @@index([userId])
   @@index([likedAt])
+  @@index([userId, likedAt])
 }
 
 model TrackRating {
@@ -1328,6 +1317,7 @@ model Notification {
 
   @@index([userId, cleared])
   @@index([userId, read])
+  @@index([userId, cleared, createdAt])
   @@index([createdAt])
 }
 


### PR DESCRIPTION
## Problem (#782)

Four recurring query shapes had no matching index:

| Query shape | Call sites | Gap |
|---|---|---|
| `vibeAnalysisStatus in {…}` + `embeddings: none` | vibe-embed worker poll | no index on `vibeAnalysisStatus` at all — steady-state poll walked the whole table via the `fileModified` index, forever |
| `{ userId }` orderBy `likedAt desc, trackId` | library + subsonic liked lists | no `(userId, likedAt)` composite |
| `analysisStatus + origin + removedAt` | radio + programmatic playlists | single-column `analysisStatus` only |
| `{ userId, cleared, read }` orderBy `createdAt` | notification list | no `(userId, cleared, createdAt)` |

Separately, Track carried 27 single-column indexes; the 14 audio-feature/mood scalars were speculative.

## Change

- **Adds** `Track(vibeAnalysisStatus)`, `Track(analysisStatus, origin, removedAt)`, `LikedTrack(userId, likedAt)`, `Notification(userId, cleared, createdAt)` — built `CONCURRENTLY` per the `Track_random_idx` precedent, so production writes are never blocked.
- **Drops** the 14 never-scanned scalar indexes (`bpm`, `energy`, `valence`, `danceability`, `acousticness`, `instrumentalness`, `arousal`, 7× `mood*`).

## Evidence for the drops

2.5 days of `pg_stat_user_indexes` on the production primary (postmaster start 2026-08-23, sampled 2026-08-25): all 14 show **idx_scan = 0** while the same workload drove `Track_pkey` 1.87M, `albumId` 1.64M, `analysisStatus` 156k scans. The columns are still referenced in where-predicates (programmatic mixes, radio predicates, hybridSimilarity) — the planner simply never chooses these single-column value indexes for those multi-predicate range filters. ~46MB reclaimed and 14 fewer index maintenances per scanner upsert. Kept pending a longer observation window: `title`, `title_trgm`, `random`, `analysisMode`, `hasUserOverrides`, `albumId_discNo_trackNo`.

A partial index over the not-completed vibe set was considered and rejected: Prisma's schema DSL can't express it, and a plain btree already makes the steady-state probe an empty index lookup.

## Verification

- `verify:` full migration chain applied to a scratch pgvector Postgres via `prisma migrate deploy` — "All migrations have been successfully applied"; final index state confirmed via `pg_indexes` (adds present, drops gone). First attempt used `DROP INDEX CONCURRENTLY`, which fails under prisma's statement runner — switched to plain drops (instant on ~3MB dead indexes) and re-verified.
- `verify: prisma validate` ✓, `backend tsc --noEmit` exit 0, `format:check` clean, `check-file-size` pass
- `verify:` targeted suites: `prismaBinaryTargetContract`, `embeddingSpaceMigration` — pass

Closes #782