### PR TITLE
fix(security): rate-limit metrics access; stop re-reading credentials in tokenInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
+- The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.
 - Album genres, label, and release year now populate during normal background enrichment instead of only via the admin per-album tool, and admin re-enrichment now applies the same rules as the background worker.
 - Search results now reflect library changes immediately after a scan or deletion; artist-page popular tracks and discography now recognize remasters and editions you own (#758).
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).

--- a/backend/src/metrics/__tests__/endpoint.test.ts
+++ b/backend/src/metrics/__tests__/endpoint.test.ts
@@ -4,6 +4,10 @@ import request from "supertest";
 import { createMetricsRouter } from "../endpoint";
 import { createVibeEmbedMetrics } from "../vibeEmbedMetrics";
 
+jest.mock("../../middleware/rateLimitStore", () => ({
+    createRedisRateLimitOptions: jest.fn(() => ({})),
+}));
+
 describe("metrics endpoint", () => {
     function createApp(options: { token?: string; publicAccess?: boolean }) {
         const registry = new Registry();
@@ -45,6 +49,30 @@ describe("metrics endpoint", () => {
         expect(response.text).toContain("soundspan_test_known_value 1");
     });
 
+    it("rate-limits failed access attempts without blocking authorized scrapes", async () => {
+        const app = createApp({ token: "scrape-token" });
+
+        await request(app)
+            .get("/metrics")
+            .set("Authorization", "Bearer scrape-token")
+            .expect(200);
+
+        const failedAttempts = await Promise.all(
+            Array.from({ length: 120 }, () =>
+                request(app)
+                    .get("/metrics")
+                    .set("Authorization", "Bearer wrong-token"),
+            ),
+        );
+        expect(failedAttempts).toHaveLength(120);
+        expect(failedAttempts.every(({ status }) => status === 401)).toBe(true);
+
+        await request(app)
+            .get("/metrics")
+            .set("Authorization", "Bearer wrong-token")
+            .expect(429);
+    });
+
     it("fails closed when no token is configured", async () => {
         await request(createApp({})).get("/metrics").expect(401);
     });
@@ -81,13 +109,13 @@ describe("metrics endpoint", () => {
             }),
         } as any;
         let authorized = false;
-        route.stack[0].handle(
+        route.stack[1].handle(
             { get: jest.fn() },
             response,
             () => (authorized = true),
         );
         expect(authorized).toBe(true);
-        await route.stack[1].handle({}, response, jest.fn());
+        await route.stack[2].handle({}, response, jest.fn());
 
         expect(response.send).toHaveBeenCalledTimes(1);
         expect(response.statusCode).toBe(200);
@@ -99,7 +127,7 @@ describe("metrics endpoint", () => {
                 nextResponse.body = body;
             }),
         } as any;
-        await route.stack[1].handle({}, nextResponse, jest.fn());
+        await route.stack[2].handle({}, nextResponse, jest.fn());
 
         expect(nextResponse.statusCode).toBe(200);
         expect(nextResponse.body).toMatch(

--- a/backend/src/metrics/endpoint.ts
+++ b/backend/src/metrics/endpoint.ts
@@ -5,7 +5,12 @@ import {
     type Request,
     type Response,
 } from "express";
+import rateLimit from "express-rate-limit";
 import type { Registry } from "prom-client";
+import { createRedisRateLimitOptions } from "../middleware/rateLimitStore";
+
+const METRICS_AUTH_RATE_LIMIT_MAX = 120;
+const METRICS_AUTH_RATE_LIMIT_WINDOW_MS = 60_000;
 
 /** Configuration for the Prometheus scrape route. */
 export interface MetricsEndpointOptions {
@@ -57,11 +62,28 @@ function createMetricsHandler(registry: Registry) {
     };
 }
 
+function createMetricsAccessLimiter() {
+    // A 120-attempt budget leaves 30x headroom for a 15-second scraper, while
+    // successful scrapes do not consume the failed-authentication budget.
+    return rateLimit({
+        windowMs: METRICS_AUTH_RATE_LIMIT_WINDOW_MS,
+        max: METRICS_AUTH_RATE_LIMIT_MAX,
+        skipSuccessfulRequests: true,
+        message: "Too many metrics access attempts. Please try again later.",
+        standardHeaders: true,
+        legacyHeaders: false,
+        ...createRedisRateLimitOptions("metrics-auth", {
+            fallback: "memory",
+        }),
+    });
+}
+
 /** Creates the isolated `/metrics` router with fail-closed bearer auth. */
 export function createMetricsRouter(options: MetricsEndpointOptions): Router {
     const router = Router();
     router.get(
         "/metrics",
+        createMetricsAccessLimiter(),
         requireMetricsAccess(options),
         createMetricsHandler(options.registry),
     );

--- a/backend/src/middleware/__tests__/subsonicAuth.test.ts
+++ b/backend/src/middleware/__tests__/subsonicAuth.test.ts
@@ -231,6 +231,7 @@ describe("requireSubsonicAuth", () => {
         });
         expect((req as any).subsonicClient).toBe("symfonium");
         expect((req as any).subsonicVersion).toBe("1.16.1");
+        expect((req as any).subsonicAuthType).toBe("password");
         expect(next).toHaveBeenCalled();
     });
 
@@ -310,6 +311,7 @@ describe("requireSubsonicAuth", () => {
             username: "alice",
             role: "admin",
         });
+        expect((req as any).subsonicAuthType).toBe("token");
         expect(next).toHaveBeenCalled();
     });
 
@@ -429,6 +431,7 @@ describe("requireSubsonicAuth", () => {
             username: "alice",
             role: "user",
         });
+        expect((req as any).subsonicAuthType).toBe("token");
         expect(next).toHaveBeenCalled();
     });
 
@@ -771,6 +774,7 @@ describe("requireSubsonicAuth", () => {
             username: "alice",
             role: "user",
         });
+        expect((req as any).subsonicAuthType).toBe("apiKey");
         expect(next).toHaveBeenCalled();
     });
 

--- a/backend/src/middleware/subsonicAuth.ts
+++ b/backend/src/middleware/subsonicAuth.ts
@@ -24,6 +24,7 @@ declare global {
         interface Request {
             subsonicClient?: string;
             subsonicVersion?: string;
+            subsonicAuthType?: "apiKey" | "token" | "password";
         }
     }
 }
@@ -420,6 +421,11 @@ function attachSubsonicContext(
     req.user = principal;
     req.subsonicClient = input.client;
     req.subsonicVersion = input.version;
+    req.subsonicAuthType = input.hasApiKeyAuth
+        ? "apiKey"
+        : input.hasTokenAuth
+          ? "token"
+          : "password";
 }
 
 /** Validates OpenSubsonic credentials and enriches request context for `/rest` handlers. */

--- a/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
+++ b/backend/src/routes/__tests__/subsonicBranchCoverage.test.ts
@@ -157,6 +157,7 @@ function buildReq(query: Record<string, unknown>): Request {
     return {
         query,
         headers: {},
+        subsonicAuthType: "password",
         user: {
             id: "user-1",
             username: "alice",
@@ -271,8 +272,10 @@ describe("subsonic branch coverage focused handlers", () => {
         );
     });
 
-    it("uses token auth type when t is present", () => {
-        handleTokenInfo(buildReq({ t: "abcdef" }), buildRes());
+    it("uses the middleware-stamped token auth type", () => {
+        const req = buildReq({});
+        req.subsonicAuthType = "token";
+        handleTokenInfo(req, buildRes());
 
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),

--- a/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicCoreCompat.test.ts
@@ -94,10 +94,12 @@ function buildReq(
         username: "alice",
         role: "user",
     },
+    subsonicAuthType: "apiKey" | "token" | "password" = "password",
 ): Request {
     return {
         query,
         user,
+        subsonicAuthType,
     } as unknown as Request;
 }
 
@@ -985,12 +987,7 @@ describe("subsonic core compatibility handlers", () => {
     });
 
     it("returns tokenInfo with authType derived from apiKey auth", () => {
-        handleTokenInfo(
-            buildReq({
-                apiKey: "api-key-1",
-            }),
-            buildRes(),
-        );
+        handleTokenInfo(buildReq({}, undefined, "apiKey"), buildRes());
 
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -122,9 +122,13 @@ import {
     handleTokenInfo,
 } from "../subsonic";
 
-function buildReq(query: Record<string, unknown>): Request {
+function buildReq(
+    query: Record<string, unknown>,
+    subsonicAuthType: "apiKey" | "token" | "password" = "password",
+): Request {
     return {
         query,
+        subsonicAuthType,
         user: {
             id: "user-1",
             username: "alice",
@@ -2090,11 +2094,14 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
-    it("returns token-based authType for tokenInfo when apiKey is supplied", async () => {
+    it("returns middleware-stamped apiKey authType for tokenInfo", async () => {
         await handleTokenInfo(
-            buildReq({
-                apiKey: "key-123",
-            }),
+            buildReq(
+                {
+                    t: "handler-must-ignore-this-token",
+                },
+                "apiKey",
+            ),
             buildRes(),
         );
 
@@ -2112,11 +2119,14 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
-    it("returns token-based authType for tokenInfo when token is supplied", async () => {
+    it("returns middleware-stamped token authType for tokenInfo", async () => {
         await handleTokenInfo(
-            buildReq({
-                t: "token-123",
-            }),
+            buildReq(
+                {
+                    apiKey: "handler-must-ignore-this-key",
+                },
+                "token",
+            ),
             buildRes(),
         );
 
@@ -2134,8 +2144,17 @@ describe("subsonic Tier B handlers", () => {
         );
     });
 
-    it("returns password-based authType for tokenInfo without credentials", async () => {
-        await handleTokenInfo(buildReq({}), buildRes());
+    it("returns middleware-stamped password authType for tokenInfo", async () => {
+        await handleTokenInfo(
+            buildReq(
+                {
+                    apiKey: "handler-must-ignore-this-key",
+                    t: "handler-must-ignore-this-token",
+                },
+                "password",
+            ),
+            buildRes(),
+        );
 
         expect(mockSendSuccess).toHaveBeenCalledWith(
             expect.anything(),

--- a/backend/src/routes/subsonic/system.ts
+++ b/backend/src/routes/subsonic/system.ts
@@ -84,9 +84,6 @@ export function handleGetNewestPodcasts(req: Request, res: Response): void {
  */
 export function handleTokenInfo(req: Request, res: Response): void {
     const { format, callback } = getRequestContext(req);
-    const hasApiKey =
-        typeof req.query.apiKey === "string" && req.query.apiKey.length > 0;
-    const hasToken = typeof req.query.t === "string" && req.query.t.length > 0;
 
     sendSubsonicSuccess(
         res,
@@ -94,11 +91,7 @@ export function handleTokenInfo(req: Request, res: Response): void {
             tokenInfo: {
                 valid: true,
                 username: req.user?.username,
-                authType: hasApiKey
-                    ? "apiKey"
-                    : hasToken
-                      ? "token"
-                      : "password",
+                authType: req.subsonicAuthType ?? "password",
             },
         },
         format,


### PR DESCRIPTION
Resolves the three open code-scanning alerts (the full set).

## Alert 1266 (high) — missing rate limiting on `/metrics`

The isolated metrics router has fail-closed bearer auth but no ceiling on failed attempts. It now runs the repo's Redis-backed limiter (bounded-memory fallback, same `createRedisRateLimitOptions` pattern as the existing auth limiters) **before** authentication: 120/min per IP, `skipSuccessfulRequests: true` so legitimate scrapers never consume budget — a 15s Prometheus interval keeps 30× headroom while brute force hits the wall.

## Alerts 1264 + 1265 (medium) — sensitive data read from GET query

`handleTokenInfo` re-read `req.query.apiKey` / `req.query.t` only to report which auth type was in use. The subsonic auth middleware already derives this, so it now stamps `subsonicAuthType` on the request context it attaches, and the handler reads the stamp with the original `"password"` fallback. **Credential transport is untouched** — the protocol's query auth works exactly as before, and `/rest` response shapes are byte-identical (compat suites pin all three authType values).

## Verification

- `verify: backend tsc --noEmit` exit 0
- `verify:` metrics endpoint suite: 1 suite, 6 tests, pass (includes over-limit → 429 and under-limit authorized → 200)
- `verify:` subsonic auth + tierB + branch-coverage + core-compat suites: 4 suites, 160 tests, pass
- `verify: format:check` clean (backend + CHANGELOG)
- `verify: check-file-size` pass