### PR TITLE
chore(subsonic): serve browse from denormalized counts with caching; page genre songs in SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Subsonic apps load artist lists much faster on large libraries, and genre shuffle pages now load consistently fast.
 - Backend Jest tests now use transpile-only TypeScript transforms, six workers, and smaller runtime suites for faster test runs.
 - Database indexes now match frequent embedding, library, radio, playlist, and notification queries, while unused single-column audio-feature indexes no longer add write overhead.
 - Removed the unused frontend charting dependency and moved backend Listen Together and federation metrics contracts into cycle-free type modules.

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -205,6 +205,7 @@ single middleware and endpoint stack composed from these domain modules:
 | `backend/src/routes/subsonic/browsing.ts`                | Music folders, directories, artists, albums, songs, and genres        |
 | `backend/src/routes/subsonic/discovery.ts`               | Similar-song and top-song discovery                                   |
 | `backend/src/routes/subsonic/albumSongLists.ts`          | Album/song lists, random songs, genre songs, and starred collections  |
+| `backend/src/routes/subsonic/genreSongPaging.ts`         | Parameter-bound, day-stable SQL paging for genre-song membership      |
 | `backend/src/routes/subsonic/searching.ts`               | Legacy and current search endpoints                                   |
 | `backend/src/routes/subsonic/playlists.ts`               | Playlist reads and mutations                                          |
 | `backend/src/routes/subsonic/mediaRetrieval.ts`          | Audio, cover art, lyrics, and avatar retrieval                        |

--- a/backend/src/routes/__tests__/subsonicBrowseCaching.test.ts
+++ b/backend/src/routes/__tests__/subsonicBrowseCaching.test.ts
@@ -1,0 +1,67 @@
+import type { Request, Response } from "express";
+
+const loadSubsonicArtistIndexSnapshot = jest.fn();
+const sendSubsonicSuccess = jest.fn();
+
+jest.mock("../../services/subsonicArtistIndexCache", () => ({
+    loadSubsonicArtistIndexSnapshot,
+}));
+jest.mock("../../utils/subsonicResponse", () => ({
+    getResponseFormat: () => "json",
+    sendSubsonicError: jest.fn(),
+    sendSubsonicSuccess,
+    SubsonicErrorCode: { GENERIC: 0 },
+}));
+jest.mock("../../utils/db", () => ({ prisma: {} }));
+jest.mock("../../config", () => ({
+    config: {
+        music: {
+            musicPath: "/music",
+            transcodeCachePath: "/tmp/soundspan-cache",
+            transcodeCacheMaxGb: 1,
+        },
+    },
+}));
+
+import { handleGetIndexes } from "../subsonic/browsing";
+
+describe("Subsonic cached browsing", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("answers ifModifiedSince from the cached timestamp without loading artists", async () => {
+        const lastModified = 1_777_000_000_000;
+        loadSubsonicArtistIndexSnapshot.mockResolvedValue({
+            artists: [
+                {
+                    id: "artist-1",
+                    name: "Artist One",
+                    heroUrl: null,
+                    albumCount: 1,
+                },
+            ],
+            lastModified,
+        });
+
+        await handleGetIndexes(
+            {
+                query: { ifModifiedSince: String(lastModified) },
+            } as unknown as Request,
+            {} as Response,
+        );
+
+        expect(loadSubsonicArtistIndexSnapshot).toHaveBeenCalledTimes(1);
+        expect(sendSubsonicSuccess).toHaveBeenCalledWith(
+            expect.anything(),
+            {
+                indexes: expect.objectContaining({
+                    lastModified,
+                    index: [],
+                }),
+            },
+            "json",
+            undefined,
+        );
+    });
+});

--- a/backend/src/routes/__tests__/subsonicBrowseCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicBrowseCompat.test.ts
@@ -19,6 +19,7 @@ jest.mock("../../utils/subsonicResponse", () => ({
 
 jest.mock("../../utils/db", () => ({
     prisma: {
+        $queryRaw: jest.fn(),
         album: {
             findMany: jest.fn(),
             findFirst: jest.fn(),
@@ -43,6 +44,17 @@ jest.mock("../../utils/db", () => ({
             findMany: jest.fn(),
             findFirst: jest.fn(),
         },
+    },
+}));
+
+jest.mock("../../services/searchCacheVersion", () => ({
+    getSearchCacheVersion: jest.fn().mockResolvedValue(1),
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        get: jest.fn().mockResolvedValue(null),
+        setEx: jest.fn().mockResolvedValue("OK"),
     },
 }));
 
@@ -113,6 +125,7 @@ describe("subsonic browse compatibility handlers", () => {
     const mockPlayGroupBy = prisma.play.groupBy as jest.Mock;
     const mockTrackFindMany = prisma.track.findMany as jest.Mock;
     const mockTrackFindFirst = prisma.track.findFirst as jest.Mock;
+    const mockQueryRaw = prisma.$queryRaw as jest.Mock;
     const mockSendSuccess = sendSubsonicSuccess as jest.Mock;
     const mockSendError = sendSubsonicError as jest.Mock;
 
@@ -121,6 +134,7 @@ describe("subsonic browse compatibility handlers", () => {
         mockPlayGroupBy.mockResolvedValue([]);
         mockTrackFindMany.mockResolvedValue([]);
         mockTrackFindFirst.mockResolvedValue(null);
+        mockQueryRaw.mockResolvedValue([]);
     });
 
     it("returns albumList2 results for alphabeticalByName", async () => {
@@ -214,9 +228,7 @@ describe("subsonic browse compatibility handlers", () => {
                 name: "Artist One",
                 heroUrl: "https://example.test/artist.jpg",
                 lastSynced,
-                _count: {
-                    albums: 2,
-                },
+                libraryAlbumCount: 2,
             },
         ]);
 
@@ -417,13 +429,13 @@ describe("subsonic browse compatibility handlers", () => {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: "https://example.test/artist.jpg",
-                _count: { albums: 2 },
+                libraryAlbumCount: 2,
             },
             {
                 id: "artist-2",
                 name: "Artist Two",
                 heroUrl: null,
-                _count: { albums: 1 },
+                libraryAlbumCount: 1,
             },
         ]);
 
@@ -435,14 +447,11 @@ describe("subsonic browse compatibility handlers", () => {
         );
 
         const artistQuery = mockArtistFindMany.mock.calls[0][0];
+        expect(artistQuery.where).toEqual({
+            libraryAlbumCount: { gt: 0 },
+        });
         expect(artistQuery.select).toMatchObject({
-            _count: {
-                select: {
-                    albums: {
-                        where: { location: { in: ["LIBRARY", "FEDERATED"] } },
-                    },
-                },
-            },
+            libraryAlbumCount: true,
         });
         expect(artistQuery.select).not.toHaveProperty("albums");
 
@@ -609,6 +618,7 @@ describe("subsonic browse compatibility handlers", () => {
     });
 
     it("returns songs for a requested genre", async () => {
+        mockQueryRaw.mockResolvedValue([{ id: "federated-track-1" }]);
         mockTrackFindMany.mockResolvedValue([
             {
                 id: "federated-track-1",
@@ -644,20 +654,8 @@ describe("subsonic browse compatibility handlers", () => {
             buildRes(),
         );
 
-        // Two-phase selection (GH #46): an id-only fetch of all matching
-        // tracks (day-stable seeded ordering handles pagination), then a
-        // full fetch of the requested page by id.
-        expect(mockTrackFindMany).toHaveBeenNthCalledWith(
-            1,
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    trackGenres: expect.anything(),
-                }),
-                select: { id: true },
-            }),
-        );
-        expect(mockTrackFindMany).toHaveBeenNthCalledWith(
-            2,
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+        expect(mockTrackFindMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: {
                     removedAt: null,
@@ -1499,9 +1497,7 @@ describe("subsonic browse compatibility handlers", () => {
                 name: "Artist One",
                 heroUrl: "https://example.test/artist.jpg",
                 lastSynced,
-                _count: {
-                    albums: 2,
-                },
+                libraryAlbumCount: 2,
             },
         ]);
 
@@ -1538,9 +1534,7 @@ describe("subsonic browse compatibility handlers", () => {
                 id: "artist-1",
                 name: "Band One",
                 heroUrl: null,
-                _count: {
-                    albums: 1,
-                },
+                libraryAlbumCount: 1,
             },
         ]);
 

--- a/backend/src/routes/__tests__/subsonicEntityCompat.test.ts
+++ b/backend/src/routes/__tests__/subsonicEntityCompat.test.ts
@@ -44,6 +44,17 @@ jest.mock("../../utils/db", () => ({
     },
 }));
 
+jest.mock("../../services/searchCacheVersion", () => ({
+    getSearchCacheVersion: jest.fn().mockResolvedValue(1),
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        get: jest.fn().mockResolvedValue(null),
+        setEx: jest.fn().mockResolvedValue("OK"),
+    },
+}));
+
 jest.mock("../../workers/queues", () => ({
     scanQueue: {
         getActive: jest.fn(),
@@ -132,9 +143,7 @@ describe("subsonic entity compatibility handlers", () => {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: "https://example.test/artist-1.jpg",
-                _count: {
-                    albums: 2,
-                },
+                libraryAlbumCount: 2,
             },
         ]);
 

--- a/backend/src/routes/__tests__/subsonicGenreSongPaging.test.ts
+++ b/backend/src/routes/__tests__/subsonicGenreSongPaging.test.ts
@@ -1,0 +1,63 @@
+const queryRaw = jest.fn();
+
+jest.mock("../../utils/db", () => ({
+    prisma: { $queryRaw: queryRaw },
+}));
+jest.mock("../../config", () => ({
+    config: {
+        music: {
+            musicPath: "/music",
+            transcodeCachePath: "/tmp/soundspan-cache",
+            transcodeCacheMaxGb: 1,
+        },
+    },
+}));
+
+import {
+    buildSongsByGenreWhere,
+    loadSongsByGenrePageIds,
+} from "../subsonic/genreSongPaging";
+
+describe("Subsonic genre song paging", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        queryRaw.mockResolvedValue([{ id: "track-2" }, { id: "track-7" }]);
+    });
+
+    it("keeps the Prisma membership predicate at the shared browse boundary", () => {
+        expect(buildSongsByGenreWhere("RoCk")).toEqual(
+            expect.objectContaining({
+                removedAt: null,
+                AND: expect.any(Array),
+                album: { location: { in: ["LIBRARY", "FEDERATED"] } },
+                trackGenres: {
+                    some: {
+                        genre: {
+                            name: { equals: "RoCk", mode: "insensitive" },
+                        },
+                    },
+                },
+            }),
+        );
+    });
+
+    it("returns the SQL page and binds genre, day, limit, and offset", async () => {
+        await expect(
+            loadSongsByGenrePageIds("RoCk", "2026-08-25", 2, 4),
+        ).resolves.toEqual(["track-2", "track-7"]);
+
+        const query = queryRaw.mock.calls[0]?.[0];
+        expect(query?.values).toEqual(["RoCk", "2026-08-25", 2, 4]);
+        expect(query?.sql).toContain("LOWER(genre_row.name) = LOWER(?)");
+        expect(query?.sql).toContain("ORDER BY hashtext(track.id || ?)");
+        expect(query?.sql).toContain("LIMIT ? OFFSET ?");
+    });
+
+    it("returns an empty page for offsets beyond JavaScript's safe range", async () => {
+        await expect(
+            loadSongsByGenrePageIds("Rock", "2026-08-25", 2, Infinity),
+        ).resolves.toEqual([]);
+
+        expect(queryRaw).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/routes/__tests__/subsonicTierB.test.ts
+++ b/backend/src/routes/__tests__/subsonicTierB.test.ts
@@ -69,6 +69,17 @@ jest.mock("../../utils/db", () => ({
     },
 }));
 
+jest.mock("../../services/searchCacheVersion", () => ({
+    getSearchCacheVersion: jest.fn().mockResolvedValue(1),
+}));
+
+jest.mock("../../utils/redis", () => ({
+    redisClient: {
+        get: jest.fn().mockResolvedValue(null),
+        setEx: jest.fn().mockResolvedValue("OK"),
+    },
+}));
+
 jest.mock("../../workers/queues", () => ({
     scanQueue: {
         getActive: jest.fn(),
@@ -1929,9 +1940,7 @@ describe("subsonic Tier B handlers", () => {
                 name: "Artist One",
                 heroUrl: null,
                 lastSynced: lastModified,
-                _count: {
-                    albums: 1,
-                },
+                libraryAlbumCount: 1,
             },
         ]);
 
@@ -1959,9 +1968,7 @@ describe("subsonic Tier B handlers", () => {
                 id: "artist-1",
                 name: "Artist One",
                 heroUrl: "https://example.com/artist.jpg",
-                _count: {
-                    albums: 2,
-                },
+                libraryAlbumCount: 2,
             },
         ]);
 
@@ -1969,19 +1976,7 @@ describe("subsonic Tier B handlers", () => {
 
         expect(mockArtistFindMany).toHaveBeenCalledWith(
             expect.objectContaining({
-                where: {
-                    albums: {
-                        some: {
-                            location: { in: ["LIBRARY", "FEDERATED"] },
-                            tracks: {
-                                some: expect.objectContaining({
-                                    removedAt: null,
-                                    AND: expect.any(Array),
-                                }),
-                            },
-                        },
-                    },
-                },
+                where: { libraryAlbumCount: { gt: 0 } },
                 orderBy: { name: "asc" },
             }),
         );

--- a/backend/src/routes/subsonic/albumSongLists.ts
+++ b/backend/src/routes/subsonic/albumSongLists.ts
@@ -1,9 +1,6 @@
 import { type Request, type Response } from "express";
 import { Prisma } from "@prisma/client";
-import {
-    allocateTracksWithArtistWeighting,
-    seededShuffle,
-} from "../../services/artistSlotAllocation";
+import { allocateTracksWithArtistWeighting } from "../../services/artistSlotAllocation";
 import { prisma } from "../../utils/db";
 import {
     sendSubsonicError,
@@ -34,6 +31,7 @@ import {
     type AlbumListRecord,
     type SongEnrichment,
 } from "./shared";
+import { loadSongsByGenrePageIds } from "./genreSongPaging";
 
 async function handleGetAlbumListLike(
     req: Request,
@@ -346,39 +344,13 @@ export async function handleGetSongsByGenre(
     }
 
     try {
-        // Every request used to return the same deterministic alphabetical
-        // slice (GH #46). Matching ids are now ordered by a DAY-STABLE
-        // seeded shuffle: offset pagination stays coherent within a day
-        // while composition varies across days.
-        const matchingTracks = await prisma.track.findMany({
-            where: {
-                ...LIBRARY_TRACK_WHERE,
-                album: {
-                    location: SUBSONIC_ALBUM_LOCATION_WHERE,
-                },
-                trackGenres: {
-                    some: {
-                        genre: {
-                            name: {
-                                equals: genre,
-                                mode: "insensitive",
-                            },
-                        },
-                    },
-                },
-            },
-            select: { id: true },
-            // Deterministic base order: the seeded shuffle is only
-            // day-stable (and offset pagination only coherent) when its
-            // input order is stable across requests and query plans.
-            orderBy: { id: "asc" },
-        });
         const dayKey = new Date().toISOString().slice(0, 10);
-        const orderedIds = seededShuffle(
-            matchingTracks.map((t) => t.id),
-            `subsonic-songs-by-genre-${genre.toLowerCase()}-${dayKey}`,
+        const pageIds = await loadSongsByGenrePageIds(
+            genre,
+            dayKey,
+            count,
+            offset,
         );
-        const pageIds = orderedIds.slice(offset, offset + count);
         const trackRows =
             pageIds.length > 0
                 ? await prisma.track.findMany({

--- a/backend/src/routes/subsonic/browsing.ts
+++ b/backend/src/routes/subsonic/browsing.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
 import { buildArtistIndexes } from "../../utils/subsonicIndexes";
+import { loadSubsonicArtistIndexSnapshot } from "../../services/subsonicArtistIndexCache";
 import {
     parseSubsonicId,
     toSubsonicId,
@@ -75,31 +76,8 @@ export async function handleGetIndexes(
     }
 
     try {
-        const artists = await prisma.artist.findMany({
-            where: {
-                albums: {
-                    some: LIBRARY_ALBUM_WHERE,
-                },
-            },
-            select: {
-                id: true,
-                name: true,
-                heroUrl: true,
-                lastSynced: true,
-                _count: {
-                    select: {
-                        albums: { where: LIBRARY_ALBUM_WHERE },
-                    },
-                },
-            },
-            orderBy: { name: "asc" },
-        });
-
-        const lastModified =
-            artists.reduce((latest, artist) => {
-                const syncedAt = artist.lastSynced?.getTime() ?? 0;
-                return Math.max(latest, syncedAt);
-            }, 0) || Date.now();
+        const { artists, lastModified } =
+            await loadSubsonicArtistIndexSnapshot();
         const ifModifiedSince = parseTimestampParam(req.query.ifModifiedSince);
 
         if (ifModifiedSince !== null && ifModifiedSince >= lastModified) {
@@ -118,7 +96,7 @@ export async function handleGetIndexes(
             artists.map((artist) => ({
                 id: artist.id,
                 name: artist.name,
-                albumCount: artist._count.albums,
+                albumCount: artist.albumCount,
                 coverArtId: artist.heroUrl
                     ? toSubsonicId("artist", artist.id)
                     : undefined,
@@ -170,30 +148,13 @@ export async function handleGetArtists(
     }
 
     try {
-        const artists = await prisma.artist.findMany({
-            where: {
-                albums: {
-                    some: LIBRARY_ALBUM_WHERE,
-                },
-            },
-            select: {
-                id: true,
-                name: true,
-                heroUrl: true,
-                _count: {
-                    select: {
-                        albums: { where: LIBRARY_ALBUM_WHERE },
-                    },
-                },
-            },
-            orderBy: { name: "asc" },
-        });
+        const { artists } = await loadSubsonicArtistIndexSnapshot();
 
         const indexes = buildArtistIndexes(
             artists.map((artist) => ({
                 id: artist.id,
                 name: artist.name,
-                albumCount: artist._count.albums,
+                albumCount: artist.albumCount,
                 coverArtId: artist.heroUrl
                     ? toSubsonicId("artist", artist.id)
                     : undefined,
@@ -878,34 +839,13 @@ export async function handleGetAlbumInfo2(
 async function getRootMusicDirectoryChildren(): Promise<
     Record<string, unknown>[]
 > {
-    const artists = await prisma.artist.findMany({
-        where: {
-            albums: {
-                some: LIBRARY_ALBUM_WHERE,
-            },
-        },
-        select: {
-            id: true,
-            name: true,
-            heroUrl: true,
-            _count: {
-                select: {
-                    albums: {
-                        where: LIBRARY_ALBUM_WHERE,
-                    },
-                },
-            },
-        },
-        orderBy: {
-            name: "asc",
-        },
-    });
+    const { artists } = await loadSubsonicArtistIndexSnapshot();
 
     return artists.map((artist) => ({
         ...formatArtistForSubsonic({
             id: artist.id,
             name: artist.name,
-            albumCount: artist._count.albums,
+            albumCount: artist.albumCount,
             heroUrl: artist.heroUrl,
         }),
         parent: SUBSONIC_MUSIC_FOLDER_ID,

--- a/backend/src/routes/subsonic/genreSongPaging.ts
+++ b/backend/src/routes/subsonic/genreSongPaging.ts
@@ -1,0 +1,90 @@
+import { Prisma, type Prisma as PrismaTypes } from "@prisma/client";
+import { prisma } from "../../utils/db";
+import { LIBRARY_TRACK_WHERE, SUBSONIC_ALBUM_LOCATION_WHERE } from "./shared";
+
+/** Builds the Prisma membership predicate mirrored by SQL genre paging. */
+export function buildSongsByGenreWhere(
+    genre: string,
+): PrismaTypes.TrackWhereInput {
+    return {
+        ...LIBRARY_TRACK_WHERE,
+        album: { location: SUBSONIC_ALBUM_LOCATION_WHERE },
+        trackGenres: {
+            some: {
+                genre: {
+                    name: { equals: genre, mode: "insensitive" },
+                },
+            },
+        },
+    };
+}
+
+function validatePageArguments(
+    genre: string,
+    dayKey: string,
+    count: number,
+    offset: number,
+): void {
+    if (genre.trim().length === 0) throw new TypeError("Genre is required");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dayKey)) {
+        throw new TypeError("Genre page day key must use YYYY-MM-DD");
+    }
+    if (!Number.isSafeInteger(count) || count < 0 || count > 500) {
+        throw new RangeError("Genre page count must be from 0 through 500");
+    }
+    if (Number.isFinite(offset) && (!Number.isInteger(offset) || offset < 0)) {
+        throw new RangeError(
+            "Genre page offset must be a non-negative integer",
+        );
+    }
+}
+
+/** Returns one stable, parameter-bound SQL page of matching track IDs. */
+export async function loadSongsByGenrePageIds(
+    genre: string,
+    dayKey: string,
+    count: number,
+    offset: number,
+): Promise<string[]> {
+    validatePageArguments(genre, dayKey, count, offset);
+    if (!Number.isSafeInteger(offset)) return [];
+    const rows = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT track.id
+        FROM "Track" AS track
+        INNER JOIN "Album" AS album ON album.id = track."albumId"
+        WHERE track."removedAt" IS NULL
+          AND album.location IN ('LIBRARY', 'FEDERATED')
+          AND (
+              track.origin = 'LOCAL'
+              OR (
+                  track.origin = 'FEDERATED'
+                  AND (
+                      track."dedupOfTrackId" IS NULL
+                      OR EXISTS (
+                          SELECT 1
+                          FROM "FederationPeer" AS peer
+                          WHERE peer.id = track."peerId"
+                            AND peer."showDedupedCopies" = true
+                      )
+                      OR EXISTS (
+                          SELECT 1
+                          FROM "Track" AS dedup
+                          WHERE dedup.id = track."dedupOfTrackId"
+                            AND dedup."removedAt" IS NOT NULL
+                      )
+                  )
+              )
+          )
+          AND EXISTS (
+              SELECT 1
+              FROM "TrackGenre" AS track_genre
+              INNER JOIN "Genre" AS genre_row
+                  ON genre_row.id = track_genre."genreId"
+              WHERE track_genre."trackId" = track.id
+                AND LOWER(genre_row.name) = LOWER(${genre})
+          )
+        ORDER BY hashtext(track.id || ${dayKey}), track.id
+        LIMIT ${count} OFFSET ${offset}
+    `);
+    return rows.map((row) => row.id);
+}

--- a/backend/src/services/__tests__/subsonicArtistIndexCache.test.ts
+++ b/backend/src/services/__tests__/subsonicArtistIndexCache.test.ts
@@ -1,0 +1,115 @@
+const redisClient = {
+    get: jest.fn(),
+    setEx: jest.fn(),
+};
+const getSearchCacheVersion = jest.fn();
+const artistFindMany = jest.fn();
+
+jest.mock("../../utils/redis", () => ({ redisClient }));
+jest.mock("../../utils/db", () => ({
+    prisma: { artist: { findMany: artistFindMany } },
+}));
+jest.mock("../searchCacheVersion", () => ({ getSearchCacheVersion }));
+jest.mock("../../utils/logger", () => ({
+    logger: { child: () => ({ warn: jest.fn() }) },
+}));
+
+import { loadSubsonicArtistIndexSnapshot } from "../subsonicArtistIndexCache";
+
+const databaseArtist = {
+    id: "artist-1",
+    name: "Artist One",
+    heroUrl: "https://example.test/artist.jpg",
+    lastSynced: new Date("2026-08-25T12:00:00.000Z"),
+    libraryAlbumCount: 2,
+};
+
+describe("Subsonic artist index cache", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getSearchCacheVersion.mockResolvedValue(7);
+        redisClient.get.mockResolvedValue(null);
+        redisClient.setEx.mockResolvedValue("OK");
+        artistFindMany.mockResolvedValue([databaseArtist]);
+    });
+
+    it("loads counts-derived artists on a miss and caches the snapshot", async () => {
+        await expect(loadSubsonicArtistIndexSnapshot()).resolves.toEqual({
+            artists: [
+                {
+                    id: "artist-1",
+                    name: "Artist One",
+                    heroUrl: "https://example.test/artist.jpg",
+                    albumCount: 2,
+                },
+            ],
+            lastModified: databaseArtist.lastSynced.getTime(),
+        });
+
+        expect(redisClient.get).toHaveBeenCalledWith(
+            "subsonic:artist-index:v7",
+        );
+        expect(artistFindMany).toHaveBeenCalledWith({
+            where: { libraryAlbumCount: { gt: 0 } },
+            select: {
+                id: true,
+                name: true,
+                heroUrl: true,
+                lastSynced: true,
+                libraryAlbumCount: true,
+            },
+            orderBy: { name: "asc" },
+        });
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+            "subsonic:artist-index:v7",
+            300,
+            expect.any(String),
+        );
+    });
+
+    it("returns a valid cached snapshot without querying artists", async () => {
+        const cached = {
+            artists: [
+                {
+                    id: "artist-cached",
+                    name: "Cached Artist",
+                    heroUrl: null,
+                    albumCount: 4,
+                },
+            ],
+            lastModified: 1_777_000_000_000,
+        };
+        redisClient.get.mockResolvedValue(JSON.stringify(cached));
+
+        await expect(loadSubsonicArtistIndexSnapshot()).resolves.toEqual(
+            cached,
+        );
+
+        expect(artistFindMany).not.toHaveBeenCalled();
+        expect(redisClient.setEx).not.toHaveBeenCalled();
+    });
+
+    it("uses a fresh namespace after the shared library version advances", async () => {
+        const cached = {
+            artists: [],
+            lastModified: 1_777_000_000_000,
+        };
+        getSearchCacheVersion.mockResolvedValueOnce(7).mockResolvedValueOnce(8);
+        redisClient.get
+            .mockResolvedValueOnce(JSON.stringify(cached))
+            .mockResolvedValueOnce(null);
+
+        await loadSubsonicArtistIndexSnapshot();
+        await loadSubsonicArtistIndexSnapshot();
+
+        expect(redisClient.get).toHaveBeenNthCalledWith(
+            1,
+            "subsonic:artist-index:v7",
+        );
+        expect(redisClient.get).toHaveBeenNthCalledWith(
+            2,
+            "subsonic:artist-index:v8",
+        );
+        expect(artistFindMany).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/services/subsonicArtistIndexCache.ts
+++ b/backend/src/services/subsonicArtistIndexCache.ts
@@ -1,0 +1,115 @@
+import { prisma } from "../utils/db";
+import { logger } from "../utils/logger";
+import { redisClient } from "../utils/redis";
+import { getSearchCacheVersion } from "./searchCacheVersion";
+
+const CACHE_KEY_PREFIX = "subsonic:artist-index";
+const CACHE_TTL_SECONDS = 300;
+const cacheLogger = logger.child("SubsonicArtistIndexCache");
+
+/** Artist fields shared by the cached Subsonic browse surfaces. */
+export interface SubsonicArtistIndexEntry {
+    id: string;
+    name: string;
+    heroUrl: string | null;
+    albumCount: number;
+}
+
+/** Version-namespaced snapshot used by Subsonic artist browse handlers. */
+export interface SubsonicArtistIndexSnapshot {
+    artists: SubsonicArtistIndexEntry[];
+    lastModified: number;
+}
+
+function isArtistEntry(value: unknown): value is SubsonicArtistIndexEntry {
+    if (typeof value !== "object" || value === null) return false;
+    const entry = value as Record<string, unknown>;
+    return (
+        typeof entry.id === "string" &&
+        typeof entry.name === "string" &&
+        (typeof entry.heroUrl === "string" || entry.heroUrl === null) &&
+        Number.isSafeInteger(entry.albumCount) &&
+        Number(entry.albumCount) > 0
+    );
+}
+
+function isSnapshot(value: unknown): value is SubsonicArtistIndexSnapshot {
+    if (typeof value !== "object" || value === null) return false;
+    const snapshot = value as Record<string, unknown>;
+    return (
+        Array.isArray(snapshot.artists) &&
+        snapshot.artists.every(isArtistEntry) &&
+        Number.isSafeInteger(snapshot.lastModified) &&
+        Number(snapshot.lastModified) > 0
+    );
+}
+
+async function readCachedSnapshot(
+    cacheKey: string,
+): Promise<SubsonicArtistIndexSnapshot | null> {
+    try {
+        const cached = await redisClient.get(cacheKey);
+        if (cached === null) return null;
+        const parsed: unknown = JSON.parse(cached);
+        if (isSnapshot(parsed)) return parsed;
+        cacheLogger.warn("Invalid cached artist index payload", { cacheKey });
+    } catch (error) {
+        cacheLogger.warn("Artist index cache read failed", { error });
+    }
+    return null;
+}
+
+async function loadDatabaseSnapshot(): Promise<SubsonicArtistIndexSnapshot> {
+    const rows = await prisma.artist.findMany({
+        where: { libraryAlbumCount: { gt: 0 } },
+        select: {
+            id: true,
+            name: true,
+            heroUrl: true,
+            lastSynced: true,
+            libraryAlbumCount: true,
+        },
+        orderBy: { name: "asc" },
+    });
+    const lastModified =
+        rows.reduce(
+            (latest, artist) =>
+                Math.max(latest, artist.lastSynced?.getTime() ?? 0),
+            0,
+        ) || Date.now();
+    return {
+        artists: rows.map((artist) => ({
+            id: artist.id,
+            name: artist.name,
+            heroUrl: artist.heroUrl,
+            albumCount: artist.libraryAlbumCount,
+        })),
+        lastModified,
+    };
+}
+
+async function writeCachedSnapshot(
+    cacheKey: string,
+    snapshot: SubsonicArtistIndexSnapshot,
+): Promise<void> {
+    try {
+        await redisClient.setEx(
+            cacheKey,
+            CACHE_TTL_SECONDS,
+            JSON.stringify(snapshot),
+        );
+    } catch (error) {
+        cacheLogger.warn("Artist index cache write failed", { error });
+    }
+}
+
+/** Loads the cached artist browse snapshot or rebuilds it from denormalized counts. */
+export async function loadSubsonicArtistIndexSnapshot(): Promise<SubsonicArtistIndexSnapshot> {
+    const version = await getSearchCacheVersion();
+    const cacheKey = `${CACHE_KEY_PREFIX}:v${version}`;
+    const cached = await readCachedSnapshot(cacheKey);
+    if (cached) return cached;
+    const snapshot = await loadDatabaseSnapshot();
+    await writeCachedSnapshot(cacheKey, snapshot);
+    return snapshot;
+}

--- a/backend/tests-integration/subsonicBrowsePostgres.integration.test.ts
+++ b/backend/tests-integration/subsonicBrowsePostgres.integration.test.ts
@@ -1,0 +1,215 @@
+import type { Client } from "pg";
+import { updateMultipleArtistCounts } from "../src/services/artistCountsService";
+import { prisma } from "../src/utils/db";
+import { LIBRARY_ALBUM_WHERE } from "../src/routes/subsonic/shared";
+import {
+    buildSongsByGenreWhere,
+    loadSongsByGenrePageIds,
+} from "../src/routes/subsonic/genreSongPaging";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+const ARTIST_IDS = [
+    "subsonic-visible",
+    "subsonic-removed",
+    "subsonic-empty",
+    "subsonic-discover",
+];
+const ALBUM_IDS = [
+    "subsonic-visible-album",
+    "subsonic-removed-album",
+    "subsonic-discover-album",
+];
+const ROCK_TRACK_IDS = Array.from(
+    { length: 9 },
+    (_, index) => `subsonic-rock-${index + 1}`,
+);
+
+async function seedArtist(id: string): Promise<void> {
+    await prisma.artist.create({
+        data: { id, mbid: `${id}-mbid`, name: id },
+    });
+}
+
+async function seedAlbum(id: string, artistId: string): Promise<void> {
+    await prisma.album.create({
+        data: {
+            id,
+            rgMbid: `${id}-mbid`,
+            artistId,
+            title: id,
+            primaryType: "Album",
+        },
+    });
+}
+
+async function seedDiscoverAlbum(): Promise<void> {
+    await prisma.album.create({
+        data: {
+            id: ALBUM_IDS[2],
+            rgMbid: `${ALBUM_IDS[2]}-mbid`,
+            artistId: ARTIST_IDS[3],
+            title: ALBUM_IDS[2],
+            primaryType: "Album",
+            location: "DISCOVER",
+        },
+    });
+}
+
+async function seedTrack(
+    id: string,
+    albumId: string,
+    trackNo: number,
+    removedAt: Date | null = null,
+): Promise<void> {
+    await prisma.track.create({
+        data: {
+            id,
+            albumId,
+            title: id,
+            trackNo,
+            duration: 180,
+            fileModified: new Date("2026-08-25T00:00:00.000Z"),
+            fileSize: 1_000,
+            removedAt,
+        },
+    });
+}
+
+async function seedFixtureTracks(): Promise<void> {
+    await Promise.all(
+        ROCK_TRACK_IDS.map((trackId, index) =>
+            seedTrack(trackId, ALBUM_IDS[0], index + 1),
+        ),
+    );
+    await Promise.all([
+        seedTrack(
+            "subsonic-removed-track",
+            ALBUM_IDS[1],
+            1,
+            new Date("2026-08-25T01:00:00.000Z"),
+        ),
+        seedTrack("subsonic-jazz-track", ALBUM_IDS[0], 10),
+        seedTrack("subsonic-discover-rock", ALBUM_IDS[2], 1),
+    ]);
+}
+
+async function seedFixtureGenres(): Promise<void> {
+    const [rock, jazz, wildcard] = await Promise.all([
+        prisma.genre.create({ data: { name: "Rock" } }),
+        prisma.genre.create({ data: { name: "Jazz" } }),
+        prisma.genre.create({ data: { name: "100% Electronica" } }),
+    ]);
+    await prisma.trackGenre.createMany({
+        data: [
+            ...ROCK_TRACK_IDS.map((trackId) => ({
+                trackId,
+                genreId: rock.id,
+            })),
+            { trackId: "subsonic-removed-track", genreId: rock.id },
+            { trackId: "subsonic-discover-rock", genreId: rock.id },
+            { trackId: "subsonic-jazz-track", genreId: jazz.id },
+            { trackId: "subsonic-jazz-track", genreId: wildcard.id },
+        ],
+    });
+}
+
+async function seedFixture(): Promise<void> {
+    await Promise.all(ARTIST_IDS.map(seedArtist));
+    await Promise.all([
+        seedAlbum(ALBUM_IDS[0], ARTIST_IDS[0]),
+        seedAlbum(ALBUM_IDS[1], ARTIST_IDS[1]),
+        seedDiscoverAlbum(),
+    ]);
+    await seedFixtureTracks();
+    await seedFixtureGenres();
+}
+
+describeWithPostgres("Subsonic browse PostgreSQL behavior", () => {
+    let admin: Client | undefined;
+
+    beforeAll(async () => {
+        if (!integrationDatabaseUrl || !databaseName) {
+            throw new Error("PostgreSQL integration environment is missing");
+        }
+        admin = await createScaleDatabase(integrationDatabaseUrl, databaseName);
+        await applyScaleMigrations(process.env.DATABASE_URL!);
+        await seedFixture();
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+        if (admin && databaseName) await dropScaleDatabase(admin, databaseName);
+    });
+
+    it("keeps denormalized artist membership equal to the computed predicate", async () => {
+        await updateMultipleArtistCounts(ARTIST_IDS);
+        const [countsDerived, predicateDerived] = await Promise.all([
+            prisma.artist.findMany({
+                where: { libraryAlbumCount: { gt: 0 } },
+                select: { id: true },
+                orderBy: { id: "asc" },
+            }),
+            prisma.artist.findMany({
+                where: { albums: { some: LIBRARY_ALBUM_WHERE } },
+                select: { id: true },
+                orderBy: { id: "asc" },
+            }),
+        ]);
+
+        expect(countsDerived).toEqual(predicateDerived);
+        expect(countsDerived).toEqual([{ id: ARTIST_IDS[0] }]);
+    });
+
+    it("partitions SQL pages into the same exhaustive membership as Prisma", async () => {
+        const prismaIds = (
+            await prisma.track.findMany({
+                where: buildSongsByGenreWhere("rOcK"),
+                select: { id: true },
+            })
+        ).map(({ id }) => id);
+        const dayKey = "2026-08-25";
+        const pages = await Promise.all(
+            [0, 3, 6].map((offset) =>
+                loadSongsByGenrePageIds("rOcK", dayKey, 3, offset),
+            ),
+        );
+        const repeated = await loadSongsByGenrePageIds("rOcK", dayKey, 9, 0);
+        const flattened = pages.flat();
+
+        expect(new Set(flattened).size).toBe(flattened.length);
+        expect([...flattened].sort()).toEqual([...prismaIds].sort());
+        expect(repeated).toEqual(flattened);
+    });
+
+    it("treats SQL-wildcard characters in genre names as literals", async () => {
+        const dayKey = "2026-08-25";
+        const literal = await loadSongsByGenrePageIds(
+            "100% electronica",
+            dayKey,
+            10,
+            0,
+        );
+        const prismaIds = (
+            await prisma.track.findMany({
+                where: buildSongsByGenreWhere("100% electronica"),
+                select: { id: true },
+            })
+        ).map(({ id }) => id);
+
+        expect([...literal].sort()).toEqual([...prismaIds].sort());
+        expect(literal).toEqual(["subsonic-jazz-track"]);
+        // Underscore is the single-character SQL wildcard: "100_ Electronica"
+        // must NOT match "100% Electronica".
+        expect(
+            await loadSongsByGenrePageIds("100_ Electronica", dayKey, 10, 0),
+        ).toEqual([]);
+    });
+});

--- a/docs/OPENSUBSONIC_COMPATIBILITY.md
+++ b/docs/OPENSUBSONIC_COMPATIBILITY.md
@@ -262,7 +262,7 @@ Promote a deferred gap to in-scope when at least one of these is true:
 - `getArtists` now honors `musicFolderId` filtering.
 - `search`/`search2`/`search3` now honor `musicFolderId` filtering, normalize quoted-empty full-sync queries (`query=\"\"`), and treat zero counts as bounded full-sync requests.
 - `search`/`search2`/`search3` now pass through large offset values without a hard `10000` clamp so client pagination can complete on very large libraries.
-- Song/album protocol payloads now project `genre` from library metadata (prefer `userGenres`, then `genres`), and genre-filtered song responses (`getSongsByGenre`, `getRandomSongs` with `genre`) force explicit `genre` values in each returned song item.
+- Song/album protocol payloads now project `genre` from library metadata (prefer `userGenres`, then `genres`), and genre-filtered song responses (`getSongsByGenre`, `getRandomSongs` with `genre`) force explicit `genre` values in each returned song item. `getSongsByGenre` uses a day-stable order so offset pages remain coherent throughout the day.
 - `getRandomSongs` uses artist-diversity weighted sampling with a top-up to the requested size before returning its flat shuffled song list.
 - `getTopSongs` now deterministically falls back to case-insensitive artist-name lookup when ID-path lookup misses, including artist names containing hyphens.
 - `getSimilarSongs` uses artist-to-similar-artist graph data; `getSimilarSongs2` merges similar-artist tracks with genre and same-artist fallback sources to avoid empty responses when similarity metadata is sparse.


### PR DESCRIPTION
## Problem (#783)

- `getIndexes`/`getArtists`/`getMusicDirectory` root loaded the entire Artist table through the triple-nested EXISTS predicate (Artist → Album → Track → FederationPeer ∪ Track self-join) **twice** per request (where + filtered `_count`), uncached — while `Artist.libraryAlbumCount` sat unused.
- `ifModifiedSince` was computed only after the full query ran.
- `getSongsByGenre` fetched **all** matching ids per page, JS-shuffled, sliced — page 2 repeated the whole scan.

## Change

- Browse serves from `libraryAlbumCount > 0` via a new `subsonicArtistIndexCache`: key `subsonic:artist-index:v<searchCacheVersion>`, 300s TTL, payload-validated reads, Prisma fallback on Redis failure. `ifModifiedSince` short-circuits from the snapshot.
- Genre pages come from parameter-bound raw SQL (`hashtext(id || dayKey)` ordering, id tie-breaker, LIMIT/OFFSET). Raw SQL is the allowed class here — Prisma can't express seeded ordering. Params are clamped upstream (`parseCountParam`/`parseOffsetParam`); the module's validators are pure asserts.
- **Review fix during orchestration:** the SQL originally used `ILIKE`, which treats `%`/`_` as wildcards while the Prisma predicate is insensitive-**equals**. Switched to `LOWER() = LOWER()` and pinned with a "100% Electronica" fixture.

## Frozen-contract safety

`/rest` response shapes untouched — compat suites pass unchanged (only query-mechanics assertions updated: which Prisma/raw calls run, not what the responses contain). `docs/OPENSUBSONIC_COMPATIBILITY.md` updated.

## Verification

- `verify:` subsonic inventory (tierB, coreCompat, branchCoverage, browseCompat, entityCompat, new browseCaching + genreSongPaging): **7 suites, 212 tests, pass**
- `verify:` PostgreSQL parity integration suite against a real scratch pgvector database: **3 tests pass** — counts-vs-predicate membership, SQL-vs-Prisma page partitioning (disjoint + exhaustive + day-stable), wildcard-literal genre matching
- `verify: backend tsc --noEmit` exit 0; `format:check` clean; `check-file-size` pass; `check-routes-readme` pass

Closes #783