### PR TITLE
chore(sidecars): one download-identity implementation; parallel loudness backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Subsonic apps load artist lists much faster on large libraries, and genre shuffle pages now load consistently fast.
+- TIDAL and YouTube Music downloads now use identical filename and collision handling, and loudness backfills now measure tracks with multiple workers.
 - Backend Jest tests now use transpile-only TypeScript transforms, six workers, and smaller runtime suites for faster test runs.
 - Database indexes now match frequent embedding, library, radio, playlist, and notification queries, while unused single-column audio-feature indexes no longer add write overhead.
 - Removed the unused frontend charting dependency and moved backend Listen Together and federation metrics contracts into cycle-free type modules.

--- a/services/audio-analyzer/loudness_backfill.py
+++ b/services/audio-analyzer/loudness_backfill.py
@@ -1,12 +1,13 @@
-"""Sequential persistence flow for loudness-only analyzer queue jobs."""
+"""Concurrent measurement and ordered persistence for loudness-only queue jobs."""
 
 from __future__ import annotations
 
 import os
 import re
 from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from hashlib import sha256
-from typing import Any, Literal, Protocol, TypedDict
+from typing import Any, Literal, NamedTuple, Protocol, TypedDict
 
 from loudness import (
     ALBUM_LOUDNESS_LOCK_SQL,
@@ -181,6 +182,15 @@ PathExists = Callable[[str], bool]
 PathSize = Callable[[str], int]
 
 
+class _ScheduledJob(NamedTuple):
+    """Keep one input-ordered job beside its immediate or future result."""
+
+    job: AnalysisQueueJob
+    track: tuple[str, str]
+    immediate_result: JobResult | None
+    measurement_future: Future[LoudnessMeasurementResult] | None
+
+
 def partition_analysis_jobs(
     jobs: Sequence[AnalysisQueueJob],
 ) -> tuple[list[tuple[str, str]], list[AnalysisQueueJob]]:
@@ -256,32 +266,12 @@ def _persist_measurement(
         cursor.close()
 
 
-def _process_job(
-    job: AnalysisQueueJob,
+def _complete_measurement(
+    measurement_result: LoudnessMeasurementResult,
     database: Database,
-    resolve_path: ResolvePath,
-    max_file_size_mb: int,
-    timeout_seconds: int,
-    measure: MeasureLoudness,
-    path_exists: PathExists,
-    path_size: PathSize,
+    track_id: str,
 ) -> JobResult:
-    """Measure and persist one eligible loudness-only queue job."""
-    track_id = job["trackId"]
-    file_path = job.get("filePath", "")
-    if _already_measured(database, track_id):
-        return "already_measured"
-    resolved_path, path_failure = _resolve_eligible_path(
-        file_path,
-        resolve_path,
-        max_file_size_mb,
-        path_exists,
-        path_size,
-    )
-    if resolved_path is None:
-        logger.warning("Skipping ineligible loudness backfill file for track %s", track_id)
-        return path_failure or "transient_failure"
-    measurement_result = measure(resolved_path, timeout_seconds)
+    """Convert one completed measurement into a coordinator-owned database result."""
     measurement = measurement_result["measurement"]
     if measurement is None:
         logger.warning("Loudness backfill measurement failed for track %s", track_id)
@@ -289,6 +279,40 @@ def _process_job(
         return "permanent_failure" if failure == "permanent" else "transient_failure"
     persisted = _persist_measurement(database, track_id, measurement)
     return "measured" if persisted else "already_measured"
+
+
+def _schedule_job(
+    job: AnalysisQueueJob,
+    *,
+    database: Database,
+    resolve_path: ResolvePath,
+    max_file_size_mb: int,
+    timeout_seconds: int,
+    measure: MeasureLoudness,
+    path_exists: PathExists,
+    path_size: PathSize,
+    executor: ThreadPoolExecutor,
+) -> _ScheduledJob:
+    """Validate one job on the coordinator and schedule only its measurement."""
+    track = (job["trackId"], job.get("filePath", ""))
+    try:
+        if _already_measured(database, track[0]):
+            return _ScheduledJob(job, track, "already_measured", None)
+        resolved_path, path_failure = _resolve_eligible_path(
+            track[1], resolve_path, max_file_size_mb, path_exists, path_size
+        )
+        if resolved_path is None:
+            logger.warning("Skipping ineligible loudness backfill file for track %s", track[0])
+            return _ScheduledJob(job, track, path_failure or "transient_failure", None)
+        future = executor.submit(measure, resolved_path, timeout_seconds)
+        return _ScheduledJob(job, track, None, future)
+    except Exception as error:
+        logger.warning(
+            "Loudness backfill failed for track %s: %s",
+            track[0],
+            type(error).__name__,
+        )
+        return _ScheduledJob(job, track, "transient_failure", None)
 
 
 def _legacy_attempt_key(track_id: str) -> str:
@@ -345,6 +369,39 @@ def _record_job_result(
     bookkeeping.increment_outcome("transient_failure")
 
 
+def _settle_scheduled_job(
+    scheduled: _ScheduledJob,
+    database: Database,
+    bookkeeping: LoudnessBackfillBookkeeping,
+    release_reservations: ReleaseReservations,
+) -> None:
+    """Settle one scheduled job on the coordinator and release its reservation."""
+    result = scheduled.immediate_result
+    try:
+        if scheduled.measurement_future is not None:
+            measurement_result = scheduled.measurement_future.result()
+            result = _complete_measurement(measurement_result, database, scheduled.track[0])
+        if result is None:
+            raise RuntimeError("Loudness job completed without a result")
+    except Exception as error:
+        logger.warning(
+            "Loudness backfill failed for track %s: %s",
+            scheduled.track[0],
+            type(error).__name__,
+        )
+        result = "transient_failure"
+    try:
+        _record_job_result(scheduled.job, result, bookkeeping)
+    except Exception as error:
+        logger.warning(
+            "Failed to persist loudness backfill bookkeeping for track %s: %s",
+            scheduled.track[0],
+            type(error).__name__,
+        )
+    finally:
+        release_reservations([scheduled.track])
+
+
 def process_loudness_backfill_jobs(
     jobs: Sequence[AnalysisQueueJob],
     *,
@@ -358,41 +415,31 @@ def process_loudness_backfill_jobs(
     path_exists: PathExists = os.path.exists,
     path_size: PathSize = os.path.getsize,
 ) -> None:
-    """Process loudness-only jobs sequentially and always release reservations."""
-    legacy_fallback_jobs = 0
-    for job in jobs:
-        if "loudnessAttemptKey" not in job:
-            legacy_fallback_jobs += 1
-        track = (job["trackId"], job.get("filePath", ""))
-        result: JobResult
-        try:
-            result = _process_job(
+    """Measure jobs in a bounded pool and coordinate persistence in input order."""
+    legacy_fallback_jobs = sum("loudnessAttemptKey" not in job for job in jobs)
+    if not jobs:
+        return
+    worker_count = min(4, len(jobs))
+    with ThreadPoolExecutor(
+        max_workers=worker_count,
+        thread_name_prefix="loudness-backfill",
+    ) as executor:
+        scheduled_jobs = [
+            _schedule_job(
                 job,
-                database,
-                resolve_path,
-                max_file_size_mb,
-                timeout_seconds,
-                measure,
-                path_exists,
-                path_size,
+                database=database,
+                resolve_path=resolve_path,
+                max_file_size_mb=max_file_size_mb,
+                timeout_seconds=timeout_seconds,
+                measure=measure,
+                path_exists=path_exists,
+                path_size=path_size,
+                executor=executor,
             )
-        except Exception as error:
-            logger.warning(
-                "Loudness backfill failed for track %s: %s",
-                track[0],
-                type(error).__name__,
-            )
-            result = "transient_failure"
-        try:
-            _record_job_result(job, result, bookkeeping)
-        except Exception as error:
-            logger.warning(
-                "Failed to persist loudness backfill bookkeeping for track %s: %s",
-                track[0],
-                type(error).__name__,
-            )
-        finally:
-            release_reservations([track])
+            for job in jobs
+        ]
+        for scheduled in scheduled_jobs:
+            _settle_scheduled_job(scheduled, database, bookkeeping, release_reservations)
     if legacy_fallback_jobs > 0:
         logger.info(
             "Using legacy fallback attempt keys for %d loudness jobs without a producer key",

--- a/services/audio-analyzer/tests/test_loudness_backfill.py
+++ b/services/audio-analyzer/tests/test_loudness_backfill.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from collections.abc import Callable
 from hashlib import sha256
 from types import ModuleType
@@ -247,6 +248,61 @@ def test_loudness_job_orchestrates_save_lock_and_rollup() -> None:
     assert database.rollback_calls == 0
     assert bookkeeping.outcomes == ["measured_success"]
     assert releases == [[("track-1", "Artist/track-1.flac")]]
+
+
+def test_loudness_measurements_run_concurrently_and_settle_in_input_order() -> None:
+    """Run blocking measurement calls together but coordinate state in batch order."""
+    database = FakeDatabaseConnection(
+        [
+            [{"loudnessLufs": None}],
+            [{"loudnessLufs": None}],
+            [{"id": "track-1"}],
+            [{"id": "track-2"}],
+        ]
+    )
+    bookkeeping = _Bookkeeping()
+    releases, release = _release_recorder()
+    lock = threading.Lock()
+    both_started = threading.Event()
+    active = 0
+    maximum_active = 0
+
+    def measure(path: str, _timeout: int) -> dict[str, Any]:
+        nonlocal active, maximum_active
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if active == 2:
+                both_started.set()
+        try:
+            assert both_started.wait(timeout=1)
+            return {
+                "measurement": {"loudnessLufs": -18.0, "truePeakDb": -1.0},
+                "failure": None,
+            }
+        finally:
+            with lock:
+                active -= 1
+
+    loudness_backfill.process_loudness_backfill_jobs(
+        [_job("track-1"), _job("track-2")],
+        database=database,
+        release_reservations=release,
+        resolve_path=lambda path: f"/music/{path}",
+        max_file_size_mb=500,
+        timeout_seconds=120,
+        bookkeeping=bookkeeping,
+        measure=measure,
+        path_exists=lambda _path: True,
+        path_size=lambda _path: 1024,
+    )
+
+    assert maximum_active == 2
+    assert bookkeeping.outcomes == ["measured_success", "measured_success"]
+    assert releases == [
+        [("track-1", "Artist/track-1.flac")],
+        [("track-2", "Artist/track-2.flac")],
+    ]
 
 
 def test_loudness_job_releases_reservation_after_measurement_failure() -> None:

--- a/services/common/download_identity.py
+++ b/services/common/download_identity.py
@@ -1,0 +1,73 @@
+"""Shared bounded filename and embedded-identity collision handling."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from .download_paths import require_contained_download_path
+
+MAX_FILENAME_BYTES = 255
+MAX_COLLISION_COUNTER = 5
+
+Identity = TypeVar("Identity", str, int)
+
+
+def build_bounded_filename(stem: str, suffix: str, extension: str) -> str:
+    """Build one UTF-8 filename component within the common byte limit."""
+    reserved_bytes = len(f"{suffix}{extension}".encode())
+    stem_budget = MAX_FILENAME_BYTES - reserved_bytes
+    if stem_budget < 1:
+        raise ValueError("Download filename suffix exceeds the 255-byte component limit")
+    bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
+    if not bounded_stem:
+        raise ValueError("Download filename has no stem within the 255-byte component limit")
+    return f"{bounded_stem}{suffix}{extension}"
+
+
+def build_identity_candidates(planned_path: Path, identity_token: str) -> tuple[Path, ...]:
+    """Build the planned path and five byte-bounded identity alternatives."""
+    candidates = [planned_path]
+    for counter in range(1, MAX_COLLISION_COUNTER + 1):
+        identity_suffix = (
+            f" [{identity_token}]" if counter == 1 else f" [{identity_token}-{counter}]"
+        )
+        candidate_name = build_bounded_filename(
+            planned_path.stem,
+            identity_suffix,
+            planned_path.suffix,
+        )
+        candidates.append(planned_path.with_name(candidate_name))
+    return tuple(candidates)
+
+
+def resolve_identity_path(
+    planned_path: Path,
+    destination_root: Path,
+    identity_token: str,
+    expected_identity: Identity,
+    read_embedded_id: Callable[[Path], Identity | None],
+) -> Path:
+    """Reuse an identity match or return the first safe free candidate."""
+    candidates = build_identity_candidates(planned_path, identity_token)
+    first_free: Path | None = None
+    for index, candidate in enumerate(candidates):
+        contained = require_contained_download_path(candidate, destination_root)
+        if not contained.exists():
+            if first_free is None:
+                first_free = contained
+            continue
+        if not contained.is_file():
+            continue
+        embedded_id = read_embedded_id(contained)
+        if embedded_id == expected_identity:
+            return contained
+        if embedded_id is None and index == 0:
+            return contained
+    if first_free is not None:
+        return first_free
+    raise RuntimeError(
+        f"No safe download path for identity {expected_identity}; all {len(candidates)} "
+        "candidates are occupied by other or unidentified files"
+    )

--- a/services/common/job_registry.py
+++ b/services/common/job_registry.py
@@ -1,0 +1,69 @@
+"""Shared bounded in-memory registry for ephemeral sidecar jobs."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Collection, Mapping, Sequence
+from typing import Any
+from uuid import uuid4
+
+Job = dict[str, Any]
+
+
+class JobRegistry:
+    """Own one TTL-bounded dictionary of sidecar job records."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float,
+        terminal_statuses: Collection[str],
+        clock: Callable[[], float] = time.time,
+        id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("Job registry TTL must be positive")
+        if not terminal_statuses:
+            raise ValueError("Job registry terminal statuses must not be empty")
+        self.ttl_seconds = ttl_seconds
+        self.terminal_statuses = frozenset(terminal_statuses)
+        self.clock = clock
+        self.id_factory = id_factory or (lambda: uuid4().hex)
+        self.jobs: dict[str, Job] = {}
+
+    def prune(self) -> int:
+        """Remove expired terminal jobs and return the removal count."""
+        cutoff = self.clock() - self.ttl_seconds
+        stale_ids = [
+            job_id
+            for job_id, job in self.jobs.items()
+            if job.get("status") in self.terminal_statuses and _created_at(job) <= cutoff
+        ]
+        for job_id in stale_ids:
+            del self.jobs[job_id]
+        return len(stale_ids)
+
+    def create(self, fields: Mapping[str, Any]) -> Job:
+        """Prune the registry, add one timestamped job, and return it."""
+        self.prune()
+        if "job_id" in fields or "created_at" in fields:
+            raise ValueError("Job fields cannot replace registry-owned values")
+        job_id = self.id_factory()
+        if not job_id or job_id in self.jobs:
+            raise RuntimeError("Job registry generated an invalid or duplicate id")
+        job: Job = {"job_id": job_id, **fields, "created_at": self.clock()}
+        self.jobs[job_id] = job
+        return job
+
+    @staticmethod
+    def payload(job: Mapping[str, Any], fields: Sequence[str]) -> Job:
+        """Project one job into its caller-owned public payload shape."""
+        return {field: job.get(field) for field in fields}
+
+
+def _created_at(job: Mapping[str, Any]) -> float:
+    """Return a safe comparable creation time for pruning."""
+    created_at = job.get("created_at", 0)
+    if isinstance(created_at, bool) or not isinstance(created_at, (int, float)):
+        return 0.0
+    return float(created_at)

--- a/services/common/tests/conftest.py
+++ b/services/common/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Expose the shared service package under its runtime import name."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SERVICES_ROOT = Path(__file__).resolve().parents[2]
+
+if str(SERVICES_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICES_ROOT))

--- a/services/common/tests/test_download_identity.py
+++ b/services/common/tests/test_download_identity.py
@@ -1,0 +1,128 @@
+"""Behavioral coverage for shared sidecar download identity allocation."""
+
+from pathlib import Path
+
+import pytest
+from common.download_identity import (
+    MAX_COLLISION_COUNTER,
+    MAX_FILENAME_BYTES,
+    build_bounded_filename,
+    build_identity_candidates,
+    resolve_identity_path,
+)
+
+
+def test_bounded_filename_preserves_suffix_and_valid_utf8() -> None:
+    """Truncate a multibyte stem without splitting its final code point."""
+    filename = build_bounded_filename("é" * 130, " [identity-5]", ".flac")
+
+    assert len(filename.encode()) <= MAX_FILENAME_BYTES
+    assert filename.endswith(" [identity-5].flac")
+    assert filename.encode().decode() == filename
+
+
+@pytest.mark.parametrize(
+    ("stem", "suffix", "extension", "message"),
+    [
+        ("track", "x" * 255, ".flac", "suffix exceeds"),
+        ("é", "x" * 250, ".m4a", "no stem"),
+    ],
+)
+def test_bounded_filename_rejects_names_without_a_stem_budget(
+    stem: str,
+    suffix: str,
+    extension: str,
+    message: str,
+) -> None:
+    """Reject reserved components that leave no complete stem character."""
+    with pytest.raises(ValueError, match=message):
+        build_bounded_filename(stem, suffix, extension)
+
+
+def test_identity_candidates_use_one_bounded_sequence(tmp_path: Path) -> None:
+    """Build the planned path followed by the five numbered alternatives."""
+    planned = tmp_path / "Track.flac"
+
+    candidates = build_identity_candidates(planned, "tidal-8")
+
+    assert candidates == (
+        planned,
+        tmp_path / "Track [tidal-8].flac",
+        tmp_path / "Track [tidal-8-2].flac",
+        tmp_path / "Track [tidal-8-3].flac",
+        tmp_path / "Track [tidal-8-4].flac",
+        tmp_path / "Track [tidal-8-5].flac",
+    )
+    assert len(candidates) == MAX_COLLISION_COUNTER + 1
+
+
+def test_resolver_prefers_matching_identity_after_an_earlier_free_path(
+    tmp_path: Path,
+) -> None:
+    """Scan beyond the first gap so a prior identity-owned file is reused."""
+    planned = tmp_path / "Track.flac"
+    matching = tmp_path / "Track [video-2].flac"
+    matching.write_bytes(b"existing")
+
+    resolved = resolve_identity_path(
+        planned,
+        tmp_path,
+        "video-2",
+        "video-2",
+        lambda path: "video-2" if path == matching else None,
+    )
+
+    assert resolved == matching
+
+
+def test_resolver_ignores_directories_and_returns_first_free_file_path(
+    tmp_path: Path,
+) -> None:
+    """Never treat an occupied directory as a reusable legacy audio file."""
+    planned = tmp_path / "Track.flac"
+    planned.mkdir()
+    reader_calls: list[Path] = []
+
+    resolved = resolve_identity_path(
+        planned,
+        tmp_path,
+        "tidal-8",
+        8,
+        lambda path: reader_calls.append(path),
+    )
+
+    assert resolved == tmp_path / "Track [tidal-8].flac"
+    assert reader_calls == []
+
+
+def test_resolver_returns_planned_unidentified_legacy_file(tmp_path: Path) -> None:
+    """Preserve the established planned-path compatibility rule."""
+    planned = tmp_path / "Track.flac"
+    planned.write_bytes(b"legacy")
+
+    resolved = resolve_identity_path(
+        planned,
+        tmp_path,
+        "tidal-8",
+        8,
+        lambda _path: None,
+    )
+
+    assert resolved == planned
+
+
+def test_resolver_raises_when_every_candidate_is_taken(tmp_path: Path) -> None:
+    """Fail closed after the complete bounded candidate sequence is occupied."""
+    planned = tmp_path / "Track.flac"
+    candidates = build_identity_candidates(planned, "tidal-8")
+    for candidate in candidates:
+        candidate.write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError, match=r"identity 8.*6 candidates"):
+        resolve_identity_path(
+            planned,
+            tmp_path,
+            "tidal-8",
+            8,
+            lambda _path: 999,
+        )

--- a/services/common/tests/test_job_registry.py
+++ b/services/common/tests/test_job_registry.py
@@ -1,0 +1,42 @@
+"""Behavioral coverage for the shared in-memory TTL job registry."""
+
+from common.job_registry import JobRegistry
+
+
+def test_registry_prunes_only_expired_terminal_jobs() -> None:
+    """Retain active and recent jobs while dropping expired terminal records."""
+    now = [100.0]
+    ids = iter(("active", "expired", "recent"))
+    registry = JobRegistry(
+        ttl_seconds=10,
+        terminal_statuses=("completed", "failed", "cancelled"),
+        clock=lambda: now[0],
+        id_factory=lambda: next(ids),
+    )
+    active = registry.create({"status": "queued"})
+    expired = registry.create({"status": "completed"})
+    now[0] = 105.0
+    recent = registry.create({"status": "failed"})
+    now[0] = 111.0
+
+    assert registry.prune() == 1
+    assert registry.jobs == {"active": active, "recent": recent}
+    assert expired["job_id"] == "expired"
+
+
+def test_registry_projects_payload_fields_without_changing_shape() -> None:
+    """Return exactly the caller-owned public fields in caller order."""
+    registry = JobRegistry(
+        ttl_seconds=10,
+        terminal_statuses=("completed",),
+        clock=lambda: 123.0,
+        id_factory=lambda: "job-id",
+    )
+    job = registry.create({"status": "queued", "title": "Track"})
+
+    assert registry.payload(job, ("job_id", "status", "missing", "created_at")) == {
+        "job_id": "job-id",
+        "status": "queued",
+        "missing": None,
+        "created_at": 123.0,
+    }

--- a/services/tidal-streamer/tests/test_download_collisions.py
+++ b/services/tidal-streamer/tests/test_download_collisions.py
@@ -170,6 +170,47 @@ def test_allocator_skips_planned_and_suffixed_paths_owned_by_other_tracks(
     assert suffixed.read_bytes() == b"track-two"
 
 
+def test_allocator_reuses_matching_identity_after_an_earlier_free_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Match YouTube Music by scanning past a free candidate before allocation."""
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    matching = tmp_path / "Track [tidal-8].m4a"
+    matching.write_bytes(b"current-track")
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: 8 if path == matching else None,
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved == matching
+
+
+def test_allocator_skips_directory_at_planned_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Match YouTube Music by never treating a directory as legacy audio."""
+    import tidal_downloads
+
+    planned = tmp_path / "Track.m4a"
+    planned.mkdir()
+    reader_calls: list[Path] = []
+    monkeypatch.setattr(
+        tidal_downloads,
+        "_read_embedded_tidal_id",
+        lambda path: reader_calls.append(path),
+    )
+
+    resolved = tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
+
+    assert resolved == tmp_path / "Track [tidal-8].m4a"
+    assert reader_calls == []
+
+
 def test_allocator_raises_when_every_bounded_candidate_is_occupied(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -190,7 +231,7 @@ def test_allocator_raises_when_every_bounded_candidate_is_occupied(
         lambda path: embedded_ids.get(path),
     )
 
-    with pytest.raises(RuntimeError, match=r"track 8.*6 candidates"):
+    with pytest.raises(RuntimeError, match=r"identity 8.*6 candidates"):
         tidal_downloads._resolve_final_download_path(planned, tmp_path.resolve(), 8)
 
 
@@ -209,7 +250,7 @@ def test_download_allocator_exhaustion_removes_uuid_temp(
     _configure_download(monkeypatch, tidal_downloads, lambda _track_id: b"new-audio")
     monkeypatch.setattr(tidal_downloads, "_read_embedded_tidal_id", lambda _path: 999)
 
-    with pytest.raises(RuntimeError, match=r"track 8.*6 candidates"):
+    with pytest.raises(RuntimeError, match=r"identity 8.*6 candidates"):
         tidal_downloads._download_track_sync(
             _FakeDownloadApi({8: "Track"}), 8, "HIGH", "ignored", destination
         )

--- a/services/tidal-streamer/tidal_downloads.py
+++ b/services/tidal-streamer/tidal_downloads.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import fromstring as xml_fromstring
 
+from common.download_identity import build_bounded_filename as _build_bounded_filename
+from common.download_identity import build_identity_candidates, resolve_identity_path
 from common.download_paths import (
     require_contained_download_path as _require_contained_download_path,
 )
@@ -45,8 +47,6 @@ __all__ = (
 JsonObject = dict[str, Any]
 log = logging.getLogger("tidal-streamer")
 
-_MAX_FILENAME_BYTES = 255
-_MAX_COLLISION_COUNTER = 5
 # Backend queue claims serialize downloads across replicas; this lock closes in-process races.
 _DOWNLOAD_INSTALL_LOCK = threading.Lock()
 
@@ -116,18 +116,6 @@ def _build_download_file_path(
     return relative_file, file_path, tmp_path
 
 
-def _build_bounded_filename(stem: str, suffix: str, extension: str) -> str:
-    """Build one UTF-8 filename component within the common 255-byte limit."""
-    reserved_bytes = len(f"{suffix}{extension}".encode())
-    stem_budget = _MAX_FILENAME_BYTES - reserved_bytes
-    if stem_budget < 1:
-        raise ValueError("Download filename suffix exceeds the 255-byte component limit")
-    bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
-    if not bounded_stem:
-        raise ValueError("Download filename has no stem within the 255-byte component limit")
-    return f"{bounded_stem}{suffix}{extension}"
-
-
 def _parse_tidal_comment(tag_values: object) -> int | None:
     """Parse the single identity value written by tiddl's comment metadata."""
     if not isinstance(tag_values, list) or not tag_values:
@@ -159,56 +147,32 @@ def _resolve_final_download_path(
     track_id: int,
 ) -> Path:
     """Reuse planned legacy files but require identity for occupied suffixes."""
-    candidates = _build_download_candidates(planned_path, track_id)
-    for candidate_index, candidate in enumerate(candidates):
-        contained_candidate = _require_contained_download_path(candidate, destination_root)
-        if not contained_candidate.exists():
-            if contained_candidate != planned_path:
-                log.info(
-                    "Download path collision at %s; saving track %s to %s",
-                    planned_path,
-                    track_id,
-                    contained_candidate,
-                )
-            return contained_candidate
-        embedded_id = _read_embedded_tidal_id(contained_candidate)
-        if embedded_id == track_id:
-            if contained_candidate != planned_path:
-                log.info(
-                    "Download path collision at %s; saving track %s to %s",
-                    planned_path,
-                    track_id,
-                    contained_candidate,
-                )
-            return contained_candidate
-        if candidate_index == 0 and embedded_id is None:
-            log.debug(
-                "Refreshing unidentified legacy file at planned path %s for track %s",
-                contained_candidate,
-                track_id,
-            )
-            return contained_candidate
-
-    raise RuntimeError(
-        f"No safe download path for TIDAL track {track_id}; all {len(candidates)} candidates "
-        "are occupied by other or unidentified files"
+    resolved = resolve_identity_path(
+        planned_path,
+        destination_root,
+        f"tidal-{track_id}",
+        track_id,
+        _read_embedded_tidal_id,
     )
+    if resolved != planned_path:
+        log.info(
+            "Download path collision at %s; saving track %s to %s",
+            planned_path,
+            track_id,
+            resolved,
+        )
+    elif resolved.is_file() and _read_embedded_tidal_id(resolved) is None:
+        log.debug(
+            "Refreshing unidentified legacy file at planned path %s for track %s",
+            resolved,
+            track_id,
+        )
+    return resolved
 
 
 def _build_download_candidates(planned_path: Path, track_id: int) -> tuple[Path, ...]:
     """Build the planned path and five byte-bounded identity alternatives."""
-    candidates = [planned_path]
-    for counter in range(1, _MAX_COLLISION_COUNTER + 1):
-        identity_suffix = (
-            f" [tidal-{track_id}]" if counter == 1 else f" [tidal-{track_id}-{counter}]"
-        )
-        candidate_name = _build_bounded_filename(
-            planned_path.stem,
-            identity_suffix,
-            planned_path.suffix,
-        )
-        candidates.append(planned_path.with_name(candidate_name))
-    return tuple(candidates)
+    return build_identity_candidates(planned_path, f"tidal-{track_id}")
 
 
 def _finalize_flac_download(

--- a/services/ytmusic-streamer/yt_download.py
+++ b/services/ytmusic-streamer/yt_download.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 from uuid import uuid4
 
+from common.download_identity import build_bounded_filename as _build_bounded_filename
+from common.download_identity import build_identity_candidates
 from common.download_paths import (
     require_contained_download_path as _require_contained_download_path,
 )
@@ -35,9 +37,6 @@ AUDIO_EXTENSIONS = {".mp3", ".opus", ".flac", ".m4a", ".ogg", ".webm"}
 
 # Download-job states that mean a download is still in flight.
 ACTIVE_DOWNLOAD_STATUSES = {"queued", "downloading", "processing"}
-
-_MAX_FILENAME_BYTES = 255
-_MAX_COLLISION_COUNTER = 5
 
 
 def find_active_download_job(
@@ -117,30 +116,9 @@ class _Mp4Reader(Protocol):
     tags: _TagReader | None
 
 
-def _build_bounded_filename(stem: str, suffix: str, extension: str) -> str:
-    """Build one UTF-8 filename component within the common 255-byte limit."""
-    reserved_bytes = len(f"{suffix}{extension}".encode())
-    stem_budget = _MAX_FILENAME_BYTES - reserved_bytes
-    if stem_budget < 1:
-        raise ValueError("Download filename suffix exceeds the 255-byte component limit")
-    bounded_stem = stem.encode()[:stem_budget].decode(errors="ignore")
-    if not bounded_stem:
-        raise ValueError("Download filename has no stem within the 255-byte component limit")
-    return f"{bounded_stem}{suffix}{extension}"
-
-
 def _build_album_track_candidates(planned_path: Path, video_id: str) -> tuple[Path, ...]:
     """Build the planned album path and five byte-bounded identity alternatives."""
-    candidates = [planned_path]
-    for counter in range(1, _MAX_COLLISION_COUNTER + 1):
-        identity_suffix = f" [{video_id}]" if counter == 1 else f" [{video_id}-{counter}]"
-        candidate_name = _build_bounded_filename(
-            planned_path.stem,
-            identity_suffix,
-            planned_path.suffix,
-        )
-        candidates.append(planned_path.with_name(candidate_name))
-    return tuple(candidates)
+    return build_identity_candidates(planned_path, video_id)
 
 
 def _build_album_track_tmp_path(final_path: Path, destination_root: Path) -> Path:

--- a/services/ytmusic-streamer/ytmusic_album_downloads.py
+++ b/services/ytmusic-streamer/ytmusic_album_downloads.py
@@ -4,21 +4,17 @@ import asyncio
 import glob
 import os
 import threading
-import time
-import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from itertools import islice
 from pathlib import Path
 from typing import Any
 
-from common.download_paths import (
-    require_contained_download_path as _require_contained_download_path,
-)
+from common.download_identity import resolve_identity_path
+from common.job_registry import JobRegistry
 from common.sidecar_runtime_utils import env_int
 from fastapi import HTTPException, Query
 from yt_download import (
-    _build_album_track_candidates,
     _build_album_track_tmp_path,
     _read_embedded_video_id,
     _stamp_audio_tags,
@@ -39,7 +35,11 @@ _yt_album_download_executor = ThreadPoolExecutor(
     max_workers=YT_ALBUM_DOWNLOAD_CONCURRENCY,
     thread_name_prefix="yt-album-download",
 )
-_yt_album_download_jobs: dict[str, JsonObject] = {}
+_yt_album_download_registry = JobRegistry(
+    ttl_seconds=YT_ALBUM_DOWNLOAD_JOB_TTL,
+    terminal_statuses=TERMINAL_DOWNLOAD_STATUSES,
+)
+_yt_album_download_jobs = _yt_album_download_registry.jobs
 _yt_album_download_tasks: set[asyncio.Task[None]] = set()
 _album_track_install_lock = threading.Lock()
 _MAX_OWNED_TEMP_ARTIFACTS = 64
@@ -100,36 +100,26 @@ async def yt_album_search(
 
 def _prune_yt_album_download_jobs() -> None:
     """Drop terminal album jobs older than the bounded retention period."""
-    cutoff = time.time() - YT_ALBUM_DOWNLOAD_JOB_TTL
-    stale = [
-        job_id
-        for job_id, job in _yt_album_download_jobs.items()
-        if job.get("status") in TERMINAL_DOWNLOAD_STATUSES and job.get("created_at", 0) <= cutoff
-    ]
-    for job_id in stale:
-        del _yt_album_download_jobs[job_id]
+    _yt_album_download_registry.prune()
 
 
 def _new_yt_album_download_job(browse_id: str) -> JsonObject:
     """Create and register an isolated album download job."""
-    _prune_yt_album_download_jobs()
-    job: JsonObject = {
-        "job_id": uuid.uuid4().hex,
-        "browse_id": browse_id,
-        "status": "queued",
-        "progress_pct": 0.0,
-        "album_title": "",
-        "album_artist": "",
-        "total_tracks": 0,
-        "downloaded": 0,
-        "failed": 0,
-        "errors": [],
-        "error": None,
-        "cancel_requested": False,
-        "created_at": time.time(),
-    }
-    _yt_album_download_jobs[str(job["job_id"])] = job
-    return job
+    return _yt_album_download_registry.create(
+        {
+            "browse_id": browse_id,
+            "status": "queued",
+            "progress_pct": 0.0,
+            "album_title": "",
+            "album_artist": "",
+            "total_tracks": 0,
+            "downloaded": 0,
+            "failed": 0,
+            "errors": [],
+            "error": None,
+            "cancel_requested": False,
+        }
+    )
 
 
 def _yt_album_download_job_payload(job: JsonObject) -> JsonObject:
@@ -148,7 +138,7 @@ def _yt_album_download_job_payload(job: JsonObject) -> JsonObject:
         "error",
         "created_at",
     )
-    return {key: job.get(key) for key in keys}
+    return _yt_album_download_registry.payload(job, keys)
 
 
 def _track_details(track: JsonObject, index: int) -> tuple[str, str, int, list[str]]:
@@ -192,31 +182,23 @@ def _resolve_album_track_path(
     video_id: str,
 ) -> Path:
     """Resolve one bounded identity-checked album path without overwriting files."""
-    candidates = _build_album_track_candidates(planned_path, video_id)
-    first_free: Path | None = None
-    for index, candidate in enumerate(candidates):
-        contained = _require_contained_download_path(candidate, destination_root)
-        if not contained.exists():
-            if first_free is None:
-                first_free = contained
-            continue
-        if not contained.is_file():
-            continue
-        embedded_id = _read_embedded_video_id(contained)
-        if embedded_id == video_id:
-            return contained
-        if embedded_id is None and index == 0:
-            log.debug(
-                "Keeping legacy YouTube Music album track without embedded identity at %s",
-                contained,
-            )
-            return contained
-    if first_free is not None:
-        return first_free
-    raise RuntimeError(
-        f"No safe download path for YouTube Music video {video_id}; all {len(candidates)} "
-        "candidates are occupied by other or unidentified files"
+    resolved = resolve_identity_path(
+        planned_path,
+        destination_root,
+        video_id,
+        video_id,
+        _read_embedded_video_id,
     )
+    if (
+        resolved == planned_path
+        and resolved.is_file()
+        and _read_embedded_video_id(resolved) is None
+    ):
+        log.debug(
+            "Keeping legacy YouTube Music album track without embedded identity at %s",
+            resolved,
+        )
+    return resolved
 
 
 def _install_album_track(

--- a/services/ytmusic-streamer/ytmusic_downloads.py
+++ b/services/ytmusic-streamer/ytmusic_downloads.py
@@ -2,11 +2,9 @@
 
 import asyncio
 import os
-import time
-import uuid
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
 
+from common.job_registry import JobRegistry
 from common.sidecar_runtime_utils import env_int
 from fastapi import HTTPException
 from yt_download import (
@@ -25,7 +23,6 @@ from ytmusic_stream import YTDLP_SOCKET_TIMEOUT, _extract_pacer
 YT_DOWNLOAD_DIR = os.getenv("YT_DOWNLOAD_DIR", "/music/YouTube Downloads")
 
 # Download job store (in-memory). Jobs are lost on restart.
-_yt_download_jobs: dict[str, JsonObject] = {}
 _yt_download_tasks: set[asyncio.Task[None]] = set()
 YT_DOWNLOAD_JOB_TTL = 6 * 60 * 60
 YT_DOWNLOAD_CONCURRENCY = max(1, env_int("YT_DOWNLOAD_CONCURRENCY", "2"))
@@ -34,20 +31,18 @@ _yt_download_executor = ThreadPoolExecutor(
     thread_name_prefix="yt-download",
 )
 TERMINAL_DOWNLOAD_STATUSES = ("completed", "failed", "cancelled")
+_yt_download_registry = JobRegistry(
+    ttl_seconds=YT_DOWNLOAD_JOB_TTL,
+    terminal_statuses=TERMINAL_DOWNLOAD_STATUSES,
+)
+_yt_download_jobs = _yt_download_registry.jobs
 
 
 def _prune_yt_download_jobs() -> None:
     """Drop terminal jobs older than the TTL to bound memory."""
-    cutoff = time.time() - YT_DOWNLOAD_JOB_TTL
-    stale = [
-        job_id
-        for job_id, job in _yt_download_jobs.items()
-        if job.get("status") in TERMINAL_DOWNLOAD_STATUSES and job.get("created_at", 0) <= cutoff
-    ]
-    for job_id in stale:
-        del _yt_download_jobs[job_id]
-    if stale:
-        log.debug(f"Pruned {len(stale)} stale YT download job(s)")
+    pruned = _yt_download_registry.prune()
+    if pruned:
+        log.debug(f"Pruned {pruned} stale YT download job(s)")
 
 
 def _new_yt_download_job(
@@ -57,39 +52,37 @@ def _new_yt_download_job(
     source_kind: str | None = None,
 ) -> JsonObject:
     """Create and register a download job record."""
-    _prune_yt_download_jobs()
-    job: dict[str, Any] = {
-        "job_id": uuid.uuid4().hex,
-        "video_id": video_id,
-        "status": status,
-        "progress_pct": 0.0,
-        "file_path": None,
-        "title": "",
-        "error": None,
-        "already_existed": False,
-        "source": source,
-        "source_kind": source_kind,
-        "cancel_requested": False,
-        "created_at": time.time(),
-    }
-    _yt_download_jobs[job["job_id"]] = job
-    return job
+    return _yt_download_registry.create(
+        {
+            "video_id": video_id,
+            "status": status,
+            "progress_pct": 0.0,
+            "file_path": None,
+            "title": "",
+            "error": None,
+            "already_existed": False,
+            "source": source,
+            "source_kind": source_kind,
+            "cancel_requested": False,
+        }
+    )
 
 
 def _yt_download_job_payload(job: JsonObject) -> JsonObject:
     """Public job-status shape returned to the backend."""
-    return {
-        "job_id": job["job_id"],
-        "video_id": job["video_id"],
-        "status": job["status"],
-        "progress_pct": job["progress_pct"],
-        "file_path": job["file_path"],
-        "title": job["title"],
-        "error": job["error"],
-        "already_existed": job["already_existed"],
-        "source": job.get("source"),
-        "created_at": job.get("created_at"),
-    }
+    keys = (
+        "job_id",
+        "video_id",
+        "status",
+        "progress_pct",
+        "file_path",
+        "title",
+        "error",
+        "already_existed",
+        "source",
+        "created_at",
+    )
+    return _yt_download_registry.payload(job, keys)
 
 
 def _update_yt_download_progress(


### PR DESCRIPTION
## Problem (#799)

The streamer download identity/collision layer was copy-pasted and had diverged: `_build_bounded_filename` byte-identical in both streamers, candidate builders differing only in the suffix literal, and **two resolvers with different semantics for the same rule** (TIDAL: first-free-wins, no dir guard; ytmusic: `first_free` tracking + `is_file()` guard + identity-match preference). Collision handling is data-destructive when wrong. Separately, loudness backfill ran up to 10 serial blocking ffmpeg runs on the analyzer coordinator thread, starving the BRPOP loop and control channel.

## Change

- `services/common/download_identity.py`: bounded filenames (multibyte-safe truncation), the six-candidate sequence, and `resolve_identity_path` with per-candidate containment via the existing `require_contained_download_path`. **Reconciled on the ytmusic semantics** per the issue: TIDAL now prefers an existing identity match over an earlier free slot and ignores directories. Streamers keep only their token/tag formats.
- `services/common/job_registry.py`: the ytmusic TTL job-dict triplication collapses to one registry; payload fields unchanged.
- Loudness backfill: measurements on a per-batch `ThreadPoolExecutor` (≤4 threads); DB writes/bookkeeping stay on the coordinator; input-order settling; concurrency proven by a scheduling test. `analyzer.py` untouched (ratchet-pinned).

## Verification

- `verify:` shared + streamer suites on this machine (full async included): tidal+common **189 passed**, ytmusic **309 passed**; clean-main baseline for tidal was 177 passed (the implementation sandbox's one "failure" was its own Python env's `pathlib._local` repr, not reproducible here)
- `verify:` audio-analyzer suite: 111 passed, 2 skipped (includes the new concurrency test)
- `verify:` ruff lint + format clean; mypy clean across common/tidal/ytmusic/analyzer; `check-file-size` pass; `git diff --check` clean

Closes #799