### PR TITLE
fix(workers): bounded reconciliation with cancellation; scheduler lanes, batched dataIntegrity, observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.
+- Download reconciliation, album recovery, and Lidarr cleanup now use a dedicated fast Bull queue, while long-running maintenance jobs use a separate monitored queue. Reconciliation breaker state is shared through TTL-managed Redis with a process-local outage fallback, so worker replicas coordinate open and half-open states without leaving probes stuck forever (#780).
+- Slow or unresponsive Lidarr album-catalog requests now abort within a bounded reconciliation tick instead of piling up overlapping requests and memory use (#779).
 - Album genres, label, and release year now populate during normal background enrichment instead of only via the admin per-album tool, and admin re-enrichment now applies the same rules as the background worker.
 - Search results now reflect library changes immediately after a scan or deletion; artist-page popular tracks and discography now recognize remasters and editions you own (#758).
 - Artist-page popular tracks now show artist identity and use correct Last.fm durations for unowned tracks (#757).

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -260,6 +260,13 @@ describe("api entrypoint runtime behavior", () => {
             scanQueue: { name: "scan" },
             discoverQueue: { name: "discover" },
             imageQueue: { name: "image" },
+            validationQueue: { name: "validation" },
+            analysisQueue: { name: "analysis" },
+            schedulerQueue: { name: "scheduler" },
+            schedulerMaintenanceQueue: { name: "scheduler-maintenance" },
+            genericImportQueue: { name: "generic-import" },
+            federationQueue: { name: "federation" },
+            albumDownloadQueue: { name: "album-download" },
         };
         const queueRegistry = Object.values(workersQueues);
         const registerQueueMetrics = jest.fn();
@@ -398,6 +405,7 @@ describe("api entrypoint runtime behavior", () => {
             compressionFilter,
             createMetricsRouter,
             registerQueueMetrics,
+            queueRegistry,
             metricsRegistry,
             metricsRouter,
             httpMetricsMiddleware,
@@ -501,7 +509,13 @@ describe("api entrypoint runtime behavior", () => {
             token: "metrics-token",
             publicAccess: false,
         });
-        expect(mocks.registerQueueMetrics).toHaveBeenCalled();
+        expect(mocks.registerQueueMetrics).toHaveBeenCalledWith(
+            mocks.metricsRegistry,
+            mocks.queueRegistry,
+        );
+        expect(mocks.queueRegistry).toContainEqual({
+            name: "scheduler-maintenance",
+        });
         expect(mocks.server.listen).toHaveBeenCalledWith(
             3006,
             "0.0.0.0",
@@ -536,6 +550,7 @@ describe("api entrypoint runtime behavior", () => {
         expect(socket.setKeepAlive).toHaveBeenCalledWith(true, 30_000);
         expect(mocks.startPersistLoop).toHaveBeenCalledTimes(1);
         expect(mocks.createBullBoard).toHaveBeenCalledTimes(1);
+        expect(mocks.BullAdapter).toHaveBeenCalledTimes(10);
         expect(mocks.app.get).toHaveBeenCalledWith(
             "/api/docs.json",
             expect.any(Function),

--- a/backend/src/__tests__/workerSchedulerClaimContract.test.ts
+++ b/backend/src/__tests__/workerSchedulerClaimContract.test.ts
@@ -1,30 +1,56 @@
-import fs from "fs";
-import path from "path";
+jest.mock("../workers/loudnessBackfillSchedule", () => ({
+    loudnessBackfillRepeatSchedule: {
+        type: "track-loudness-backfill",
+        data: { mode: "repeat" },
+        opts: {
+            jobId: "scheduler:loudness-backfill:repeat",
+            repeat: { every: 6 * 60 * 60 * 1_000 },
+        },
+    },
+}));
 
-describe("worker scheduler claim contract", () => {
-    it("registers queue-backed repeatable scheduler jobs", () => {
-        const workersPath = path.resolve(__dirname, "../workers/index.ts");
-        const workersSource = fs.readFileSync(workersPath, "utf8");
-        const registryPath = path.resolve(
-            __dirname,
-            "../workers/schedulerJobRegistry.ts",
-        );
-        const registrySource = fs.readFileSync(registryPath, "utf8");
+import {
+    buildSchedulerJobs,
+    ONE_HOUR_MS,
+    ONE_MINUTE_MS,
+    SCHEDULER_JOB_IDS,
+    SCHEDULER_JOB_TYPES,
+} from "../workers/schedulerJobRegistry";
 
-        expect(workersSource).toContain("schedulerQueue.add(");
-        expect(workersSource).toContain("buildSchedulerJobs()");
-        expect(registrySource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
-        expect(registrySource).toContain(
-            "repeat: { every: 2 * ONE_MINUTE_MS }",
+describe("worker scheduler registration contract", () => {
+    it("returns stable queue-backed repeat schedules", () => {
+        const repeatJobs = buildSchedulerJobs().filter(
+            (job) => job.data.mode === "repeat",
         );
-        expect(registrySource).toContain(
-            "repeat: { every: 5 * ONE_MINUTE_MS }",
+        const repeatById = new Map(
+            repeatJobs.map((job) => [job.opts.jobId, job]),
         );
-        expect(workersSource).toContain(
-            'schedulerQueue.process("*", async (job: Bull.Job<any>) =>',
+
+        expect(repeatById.get(SCHEDULER_JOB_IDS.dataIntegrityRepeat)).toEqual(
+            expect.objectContaining({
+                type: SCHEDULER_JOB_TYPES.dataIntegrity,
+                opts: expect.objectContaining({
+                    repeat: { every: 24 * ONE_HOUR_MS },
+                }),
+            }),
         );
-        expect(workersSource).toContain("await processSchedulerJob(job);");
-        expect(workersSource).not.toContain("runReconciliationCycle");
-        expect(workersSource).not.toContain("runLidarrCleanupCycle");
+        expect(repeatById.get(SCHEDULER_JOB_IDS.reconciliationRepeat)).toEqual(
+            expect.objectContaining({
+                type: SCHEDULER_JOB_TYPES.reconciliation,
+                opts: expect.objectContaining({
+                    repeat: { every: 2 * ONE_MINUTE_MS },
+                }),
+            }),
+        );
+        expect(
+            repeatById.get(SCHEDULER_JOB_IDS.albumDownloadRecoveryRepeat),
+        ).toEqual(
+            expect.objectContaining({
+                type: SCHEDULER_JOB_TYPES.albumDownloadRecovery,
+                opts: expect.objectContaining({
+                    repeat: { every: 5 * ONE_MINUTE_MS },
+                }),
+            }),
+        );
     });
 });

--- a/backend/src/__tests__/workerStartupMaintenanceQueueContract.test.ts
+++ b/backend/src/__tests__/workerStartupMaintenanceQueueContract.test.ts
@@ -1,48 +1,73 @@
-import fs from "fs";
-import path from "path";
+jest.mock("../workers/loudnessBackfillSchedule", () => ({
+    loudnessBackfillRepeatSchedule: {
+        type: "track-loudness-backfill",
+        data: { mode: "repeat" },
+        opts: {
+            jobId: "scheduler:loudness-backfill:repeat",
+            repeat: { every: 6 * 60 * 60 * 1_000 },
+        },
+    },
+}));
+
+import {
+    buildSchedulerJobs,
+    SCHEDULER_JOB_IDS,
+    SCHEDULER_JOB_TYPES,
+} from "../workers/schedulerJobRegistry";
+import { schedulerLaneForJob } from "../workers/schedulerPolicy";
 
 describe("worker startup maintenance queue contract", () => {
-    const workersPath = path.resolve(__dirname, "../workers/index.ts");
-    const registryPath = path.resolve(
-        __dirname,
-        "../workers/schedulerJobRegistry.ts",
-    );
-    const indexPath = path.resolve(__dirname, "../index.ts");
-    const workerPath = path.resolve(__dirname, "../worker.ts");
+    it("returns startup maintenance registrations with stable names and IDs", () => {
+        const jobs = buildSchedulerJobs();
+        const registrations = jobs.map(({ type, data, opts }) => ({
+            type,
+            mode: data.mode,
+            jobId: opts.jobId,
+            queue:
+                schedulerLaneForJob(type) === "fast"
+                    ? "worker-scheduler"
+                    : "worker-scheduler-maintenance",
+        }));
 
-    const workersSource = fs.readFileSync(workersPath, "utf8");
-    const registrySource = fs.readFileSync(registryPath, "utf8");
-    const indexSource = fs.readFileSync(indexPath, "utf8");
-    const workerSource = fs.readFileSync(workerPath, "utf8");
-
-    it("registers startup maintenance via scheduler queue jobs", () => {
-        expect(workersSource).toContain("cacheWarmup");
-        expect(workersSource).toContain("podcastCleanup");
-        expect(workersSource).toContain("audiobookAutoSync");
-        expect(workersSource).toContain("downloadQueueReconcile");
-        expect(workersSource).toContain("artistCountsBackfill");
-        expect(workersSource).toContain("imageBackfill");
-        expect(workersSource).toContain("buildSchedulerJobs()");
-        expect(registrySource).toContain("repeat: { every: 24 * ONE_HOUR_MS }");
-    });
-
-    it("removes direct startup side-effects from api and worker entrypoints", () => {
-        expect(indexSource).not.toContain("dataCacheService.warmupCache()");
-        expect(indexSource).not.toContain("cleanupExpiredCache()");
-        expect(indexSource).not.toContain("audiobookCacheService.syncAll()");
-        expect(indexSource).not.toContain(
-            "downloadQueueManager.reconcileOnStartup()",
+        expect(registrations).toEqual(
+            expect.arrayContaining([
+                {
+                    type: SCHEDULER_JOB_TYPES.cacheWarmup,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.cacheWarmupStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+                {
+                    type: SCHEDULER_JOB_TYPES.podcastCleanup,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.podcastCleanupStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+                {
+                    type: SCHEDULER_JOB_TYPES.audiobookAutoSync,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.audiobookAutoSyncStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+                {
+                    type: SCHEDULER_JOB_TYPES.downloadQueueReconcile,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.downloadQueueReconcileStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+                {
+                    type: SCHEDULER_JOB_TYPES.artistCountsBackfill,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.artistCountsBackfillStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+                {
+                    type: SCHEDULER_JOB_TYPES.imageBackfill,
+                    mode: "startup",
+                    jobId: SCHEDULER_JOB_IDS.imageBackfillStartup,
+                    queue: "worker-scheduler-maintenance",
+                },
+            ]),
         );
-        expect(indexSource).not.toContain("backfillAllArtistCounts()");
-        expect(indexSource).not.toContain("backfillAllImages()");
-
-        expect(workerSource).not.toContain("dataCacheService.warmupCache()");
-        expect(workerSource).not.toContain("cleanupExpiredCache()");
-        expect(workerSource).not.toContain("audiobookCacheService.syncAll()");
-        expect(workerSource).not.toContain(
-            "downloadQueueManager.reconcileOnStartup()",
-        );
-        expect(workerSource).not.toContain("backfillAllArtistCounts()");
-        expect(workerSource).not.toContain("backfillAllImages()");
     });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -641,8 +641,7 @@ httpServer.listen(config.port, "0.0.0.0", async () => {
         const { createBullBoard } = await import("@bull-board/api");
         const { BullAdapter } = await import("@bull-board/api/bullAdapter");
         const { ExpressAdapter } = await import("@bull-board/express");
-        const { scanQueue, discoverQueue, imageQueue, queues } =
-            await import("./workers/queues");
+        const { queues } = await import("./workers/queues");
 
         registerQueueMetrics(metricsRegistry, queues);
 
@@ -650,11 +649,7 @@ httpServer.listen(config.port, "0.0.0.0", async () => {
         serverAdapter.setBasePath("/api/admin/queues");
 
         createBullBoard({
-            queues: [
-                new BullAdapter(scanQueue),
-                new BullAdapter(discoverQueue),
-                new BullAdapter(imageQueue),
-            ],
+            queues: queues.map((queue) => new BullAdapter(queue)),
             serverAdapter,
         });
 

--- a/backend/src/metrics/__tests__/schedulerMetrics.test.ts
+++ b/backend/src/metrics/__tests__/schedulerMetrics.test.ts
@@ -1,0 +1,46 @@
+jest.mock("../../config", () => ({
+    config: {
+        workers: { loudnessBackfillBatchSize: 100 },
+    },
+}));
+
+import { Registry } from "prom-client";
+import { createSchedulerMetrics } from "../schedulerMetrics";
+import { SCHEDULER_JOB_TYPES } from "../../workers/schedulerJobTypes";
+
+describe("scheduler metrics", () => {
+    it("records bounded timeout, duration, and last-success labels", async () => {
+        const registry = new Registry();
+        const metrics = createSchedulerMetrics(registry);
+
+        metrics.timeouts.inc({ operation: "getReconciliationSnapshot" });
+        metrics.jobDuration.observe(
+            { job: SCHEDULER_JOB_TYPES.reconciliation },
+            6 * 60 * 60,
+        );
+        metrics.lastSuccess.set(
+            { job: SCHEDULER_JOB_TYPES.reconciliation },
+            1_700_000_000,
+        );
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            'soundspan_scheduler_timeouts_total{operation="getReconciliationSnapshot"} 1',
+        );
+        expect(exposition).toContain(
+            'soundspan_scheduler_job_duration_seconds_bucket{le="7200",job="download-reconciliation-cycle"} 0',
+        );
+        expect(exposition).toContain(
+            'soundspan_scheduler_job_duration_seconds_bucket{le="14400",job="download-reconciliation-cycle"} 0',
+        );
+        expect(exposition).toContain(
+            'soundspan_scheduler_job_duration_seconds_bucket{le="21600",job="download-reconciliation-cycle"} 1',
+        );
+        expect(exposition).toContain(
+            'soundspan_scheduler_job_duration_seconds_sum{job="download-reconciliation-cycle"} 21600',
+        );
+        expect(exposition).toContain(
+            'soundspan_scheduler_job_last_success_timestamp_seconds{job="download-reconciliation-cycle"} 1700000000',
+        );
+    });
+});

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -63,6 +63,11 @@ import {
     type AlbumDownloadOutcome,
 } from "./albumDownloadMetrics";
 import { createCatalogMetrics, type CatalogWriteKind } from "./catalogMetrics";
+import {
+    createSchedulerMetrics,
+    type SchedulerMetricJob,
+    type SchedulerTimeoutOperation,
+} from "./schedulerMetrics";
 
 export type {
     FederationAuthFailureReason,
@@ -92,6 +97,7 @@ const providerTrackGcMetrics = createProviderTrackGcMetrics(metricsRegistry);
 const requestMetrics = createRequestMetrics(metricsRegistry);
 const albumDownloadMetrics = createAlbumDownloadMetrics(metricsRegistry);
 const catalogMetrics = createCatalogMetrics(metricsRegistry);
+const schedulerMetrics = createSchedulerMetrics(metricsRegistry);
 createLoudnessMetrics(metricsRegistry, prisma, {
     getBackfillOutcomes: async () => {
         const { redisClient } = await import("../utils/redis");
@@ -154,6 +160,29 @@ export function recordAlbumDownloadOutcome(
     outcome: AlbumDownloadOutcome,
 ): void {
     albumDownloadMetrics.downloads.inc({ outcome });
+}
+
+/** Records one scheduler-owned operation timeout. */
+export function recordSchedulerTimeout(
+    operation: SchedulerTimeoutOperation,
+): void {
+    schedulerMetrics.timeouts.inc({ operation });
+}
+
+/** Records one completed scheduler job duration. */
+export function recordSchedulerJobDuration(
+    job: SchedulerMetricJob,
+    durationSeconds: number,
+): void {
+    schedulerMetrics.jobDuration.observe({ job }, durationSeconds);
+}
+
+/** Replaces the last-success timestamp for one scheduler job. */
+export function recordSchedulerJobSuccess(
+    job: SchedulerMetricJob,
+    timestampSeconds: number,
+): void {
+    schedulerMetrics.lastSuccess.set({ job }, timestampSeconds);
 }
 
 /** Records one successful metadata catalog write-through operation. */

--- a/backend/src/metrics/schedulerMetrics.ts
+++ b/backend/src/metrics/schedulerMetrics.ts
@@ -1,0 +1,56 @@
+import { Counter, Gauge, Histogram, type Registry } from "prom-client";
+import { REQUEST_FULFILLMENT_JOB_NAME } from "../workers/requestFulfillmentSchedule";
+import { SCHEDULER_JOB_TYPES } from "../workers/schedulerJobTypes";
+
+/** Closed scheduler job label vocabulary accepted by metrics. */
+export const SCHEDULER_METRIC_JOBS = [
+    ...Object.values(SCHEDULER_JOB_TYPES),
+    REQUEST_FULFILLMENT_JOB_NAME,
+] as const;
+export type SchedulerMetricJob = (typeof SCHEDULER_METRIC_JOBS)[number];
+
+/** Closed operation vocabulary for scheduler-owned timeout events. */
+export const SCHEDULER_TIMEOUT_OPERATIONS = [
+    "getReconciliationSnapshot",
+    "markStaleJobsAsFailed",
+    "reconcileWithLidarr",
+    "reconcileWithLocalLibrary",
+    "syncWithLidarrQueue",
+    "clearLidarrQueue",
+    "warmupCache",
+    "cleanupExpiredCache",
+    "audiobookCacheService.syncMissing",
+    "downloadQueueManager.reconcileOnStartup",
+    "backfillAllArtistCounts",
+    "backfillAllImages",
+] as const;
+export type SchedulerTimeoutOperation =
+    (typeof SCHEDULER_TIMEOUT_OPERATIONS)[number];
+
+/** Registers bounded scheduler reliability and duration instruments. */
+export function createSchedulerMetrics(registry: Registry) {
+    return {
+        timeouts: new Counter({
+            name: "soundspan_scheduler_timeouts_total",
+            help: "Scheduler-owned operation timeouts by bounded operation name.",
+            labelNames: ["operation"] as const,
+            registers: [registry],
+        }),
+        jobDuration: new Histogram({
+            name: "soundspan_scheduler_job_duration_seconds",
+            help: "Scheduler job execution duration by bounded persisted job name.",
+            labelNames: ["job"] as const,
+            buckets: [
+                0.1, 0.5, 1, 5, 15, 30, 60, 120, 300, 900, 3_600, 7_200, 14_400,
+                21_600,
+            ],
+            registers: [registry],
+        }),
+        lastSuccess: new Gauge({
+            name: "soundspan_scheduler_job_last_success_timestamp_seconds",
+            help: "Unix timestamp of the last successful scheduler job execution.",
+            labelNames: ["job"] as const,
+            registers: [registry],
+        }),
+    };
+}

--- a/backend/src/routes/__tests__/admin.test.ts
+++ b/backend/src/routes/__tests__/admin.test.ts
@@ -68,6 +68,7 @@ jest.mock("../../utils/logger", () => ({
 
 jest.mock("../../workers/queues", () => ({
     schedulerQueue: mockSchedulerQueue,
+    schedulerMaintenanceQueue: mockSchedulerQueue,
 }));
 
 jest.mock("../../config", () => ({

--- a/backend/src/routes/__tests__/adminRuntime.test.ts
+++ b/backend/src/routes/__tests__/adminRuntime.test.ts
@@ -37,13 +37,14 @@ jest.mock("../../utils/redis", () => ({
     redisClient: { eval: mockRedisEval },
 }));
 
+const mockSchedulerMaintenanceQueue = {
+    add: jest.fn(),
+    getJob: jest.fn(),
+    getJobs: jest.fn(),
+    getFailed: jest.fn(),
+};
 jest.mock("../../workers/queues", () => ({
-    schedulerQueue: {
-        add: jest.fn(),
-        getJob: jest.fn(),
-        getJobs: jest.fn(),
-        getFailed: jest.fn(),
-    },
+    schedulerMaintenanceQueue: mockSchedulerMaintenanceQueue,
 }));
 
 jest.mock("../../config", () => ({
@@ -52,7 +53,7 @@ jest.mock("../../config", () => ({
 
 import router from "../admin";
 import { prisma } from "../../utils/db";
-import { schedulerQueue } from "../../workers/queues";
+import { schedulerMaintenanceQueue as schedulerQueue } from "../../workers/queues";
 
 const mockFindMany = prisma.libraryHealthRecord.findMany as jest.Mock;
 const mockCount = prisma.libraryHealthRecord.count as jest.Mock;

--- a/backend/src/routes/adminLibraryHealthPurge.ts
+++ b/backend/src/routes/adminLibraryHealthPurge.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
-import { schedulerQueue } from "../workers/queues";
+import { schedulerMaintenanceQueue } from "../workers/queues";
 import { TRACK_REMOVAL_PURGE_JOB_NAME } from "../workers/processors/trackRemovalPurgeProcessor";
 import { readLibraryHealthPurgeMarker } from "../services/libraryHealthDashboard/purgeMarker";
 import { sendInternalRouteError } from "../utils/routeErrorResponse";
@@ -27,7 +27,7 @@ async function countRemovedLocalTracks(): Promise<number> {
 }
 
 async function addPurgeAt(cutoff: Date): Promise<void> {
-    await schedulerQueue.add(
+    await schedulerMaintenanceQueue.add(
         TRACK_REMOVAL_PURGE_JOB_NAME,
         { cutoffAt: cutoff.toISOString() },
         PURGE_NOW_JOB_OPTIONS,
@@ -35,7 +35,8 @@ async function addPurgeAt(cutoff: Date): Promise<void> {
 }
 
 async function enqueuePurgeAt(cutoff: Date): Promise<void> {
-    const existingJob = await schedulerQueue.getJob(PURGE_NOW_JOB_ID);
+    const existingJob =
+        await schedulerMaintenanceQueue.getJob(PURGE_NOW_JOB_ID);
     if (!existingJob) {
         await addPurgeAt(cutoff);
         return;
@@ -98,7 +99,10 @@ function boundedFailureReason(reason: string | undefined): string {
 const FAILURE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 
 async function findLatestPurgeFailure(): Promise<string | null> {
-    const failed = await schedulerQueue.getFailed(0, FAILED_SCAN_LIMIT);
+    const failed = await schedulerMaintenanceQueue.getFailed(
+        0,
+        FAILED_SCAN_LIMIT,
+    );
     const cutoff = Date.now() - FAILURE_MAX_AGE_MS;
     for (const job of failed) {
         if (job?.name !== TRACK_REMOVAL_PURGE_JOB_NAME) continue;
@@ -124,7 +128,8 @@ function isPurgeContinuation(job: {
 }
 
 async function isPurgeInFlight(): Promise<boolean> {
-    const purgeNowJob = await schedulerQueue.getJob(PURGE_NOW_JOB_ID);
+    const purgeNowJob =
+        await schedulerMaintenanceQueue.getJob(PURGE_NOW_JOB_ID);
     if (purgeNowJob) {
         const state = await purgeNowJob.getState();
         if (PURGE_STATES_IN_FLIGHT.has(state)) return true;
@@ -132,8 +137,12 @@ async function isPurgeInFlight(): Promise<boolean> {
     // The marker is the primary signal. This bounded queue fallback covers
     // marker loss during Redis flaps, with residual risk beyond 500 jobs.
     const [active, waitingOrDelayed] = await Promise.all([
-        schedulerQueue.getJobs(["active"], 0, IN_FLIGHT_SCAN_LIMIT),
-        schedulerQueue.getJobs(["waiting", "delayed"], 0, IN_FLIGHT_SCAN_LIMIT),
+        schedulerMaintenanceQueue.getJobs(["active"], 0, IN_FLIGHT_SCAN_LIMIT),
+        schedulerMaintenanceQueue.getJobs(
+            ["waiting", "delayed"],
+            0,
+            IN_FLIGHT_SCAN_LIMIT,
+        ),
     ]);
     return (
         active.some((job) => job?.name === TRACK_REMOVAL_PURGE_JOB_NAME) ||

--- a/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
+++ b/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
@@ -198,7 +198,7 @@ describe("lidarr service behavior", () => {
         ).toEqual({ active: false, progress: 30 });
     });
 
-    it("keeps queue state when album indexing fails during snapshot creation", async () => {
+    it("fails closed when album indexing fails during snapshot creation", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
 
@@ -219,9 +219,9 @@ describe("lidarr service behavior", () => {
             })
             .mockRejectedValueOnce(new Error("album index down"));
 
-        const snapshot = await lidarrService.getReconciliationSnapshot();
-        expect(snapshot.queue.size).toBe(1);
-        expect(snapshot.albumsByMbid.size).toBe(0);
+        await expect(lidarrService.getReconciliationSnapshot()).rejects.toThrow(
+            "album index down",
+        );
     });
 
     it("deletes artists/albums and checks availability helpers", async () => {
@@ -886,7 +886,7 @@ describe("lidarr service behavior", () => {
         });
     });
 
-    it("getReconciliationSnapshot tolerates queue failures and uses album fallback", async () => {
+    it("getReconciliationSnapshot fails closed on queue failures", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
 
@@ -904,9 +904,9 @@ describe("lidarr service behavior", () => {
                 ],
             });
 
-        const snapshot = await lidarrService.getReconciliationSnapshot();
-        expect(snapshot.queue.size).toBe(0);
-        expect(snapshot.albumsByMbid.has("album-fallback")).toBe(true);
+        await expect(lidarrService.getReconciliationSnapshot()).rejects.toThrow(
+            "queue fail",
+        );
     });
 
     it("searchArtist returns direct results when Lidarr lookup is populated", async () => {
@@ -1806,7 +1806,7 @@ describe("lidarr service behavior", () => {
         );
     });
 
-    it("returns empty snapshot when reconciliation snapshot enrichment fails", async () => {
+    it("rejects when reconciliation snapshot enrichment is malformed", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
 
@@ -1822,11 +1822,9 @@ describe("lidarr service behavior", () => {
                 },
             });
 
-        const snapshot = await lidarrService.getReconciliationSnapshot();
-
-        expect(snapshot.queue.size).toBe(0);
-        expect(snapshot.albumsByMbid.size).toBe(0);
-        expect(snapshot.albumsByTitle.size).toBe(0);
+        await expect(lidarrService.getReconciliationSnapshot()).rejects.toThrow(
+            "not readable",
+        );
         expect(logger.error).toHaveBeenCalledWith(
             "[LIDARR] Failed to create reconciliation snapshot:",
             expect.any(String),

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -5,6 +5,7 @@ import { BRAND_SLUG } from "../config/brand";
 import { getSystemSettings } from "../utils/systemSettings";
 import { stripAlbumEdition } from "../utils/artistNormalization";
 import { stripDelimitedSegments } from "../utils/stripDelimitedSegments";
+import { fetchReconciliationAlbumMaps } from "./lidarr/reconciliationAlbumStream";
 
 /**
  * Error types for music acquisition failures
@@ -2430,7 +2431,9 @@ class LidarrService {
      *
      * This replaces multiple per-job API calls with a single snapshot fetch.
      */
-    async getReconciliationSnapshot(): Promise<ReconciliationSnapshot> {
+    async getReconciliationSnapshot(
+        signal?: AbortSignal,
+    ): Promise<ReconciliationSnapshot> {
         await this.ensureInitialized();
 
         const snapshot: ReconciliationSnapshot = {
@@ -2444,31 +2447,25 @@ class LidarrService {
             return snapshot;
         }
 
+        const ownedController = new AbortController();
+        const requestSignal = signal
+            ? AbortSignal.any([signal, ownedController.signal])
+            : ownedController.signal;
         try {
-            // Fetch queue and albums in parallel
-            const [queueResponse, albumsResponse] = await Promise.all([
-                this.client
-                    .get("/api/v1/queue", {
-                        params: {
-                            page: 1,
-                            pageSize: 1000,
-                            includeUnknownArtistItems: true,
-                        },
-                    })
-                    .catch((err) => {
-                        logger.error(
-                            "[LIDARR] Failed to fetch queue for snapshot:",
-                            err.message,
-                        );
-                        return { data: { records: [] } };
-                    }),
-                this.client.get("/api/v1/album").catch((err) => {
-                    logger.error(
-                        "[LIDARR] Failed to fetch albums for snapshot:",
-                        err.message,
-                    );
-                    return { data: [] };
+            const [queueResponse] = await Promise.all([
+                this.client.get("/api/v1/queue", {
+                    params: {
+                        page: 1,
+                        pageSize: 1000,
+                        includeUnknownArtistItems: true,
+                    },
+                    signal: requestSignal,
                 }),
+                fetchReconciliationAlbumMaps(
+                    this.client,
+                    snapshot,
+                    requestSignal,
+                ),
             ]);
 
             // Index queue items by downloadId
@@ -2492,43 +2489,18 @@ class LidarrService {
                 }
             }
 
-            // Index albums by MBID and normalized title
-            const albums = albumsResponse.data || [];
-            for (const album of albums) {
-                const hasFiles = album.statistics?.percentOfTracks > 0;
-                if (!hasFiles) continue; // Only index albums with files
-
-                const albumInfo: AlbumSnapshotInfo = {
-                    id: album.id,
-                    title: album.title,
-                    foreignAlbumId: album.foreignAlbumId,
-                    artistName: album.artist?.artistName || "",
-                    hasFiles: true,
-                };
-
-                // Index by MBID
-                if (album.foreignAlbumId) {
-                    snapshot.albumsByMbid.set(album.foreignAlbumId, albumInfo);
-                }
-
-                // Index by normalized "artist|title" for title-based lookups
-                if (albumInfo.artistName && album.title) {
-                    const key = `${albumInfo.artistName.toLowerCase().trim()}|${album.title.toLowerCase().trim()}`;
-                    snapshot.albumsByTitle.set(key, albumInfo);
-                }
-            }
-
             logger.debug(
                 `[LIDARR] Snapshot fetched: ${snapshot.queue.size} queue items, ${snapshot.albumsByMbid.size} albums with files`,
             );
 
             return snapshot;
         } catch (error: any) {
+            ownedController.abort(error);
             logger.error(
                 "[LIDARR] Failed to create reconciliation snapshot:",
                 error.message,
             );
-            return snapshot;
+            throw error;
         }
     }
 

--- a/backend/src/services/lidarr/__tests__/lidarrHttpClient.test.ts
+++ b/backend/src/services/lidarr/__tests__/lidarrHttpClient.test.ts
@@ -97,9 +97,23 @@ describe("LidarrHttpClient", () => {
             url: "/api/v1/queue",
             params: undefined,
             data: undefined,
+            signal: undefined,
         });
         expect(allLogOutput()).not.toContain(API_KEY);
         expect(allLogOutput()).not.toContain("lidarr.internal.example");
+    });
+
+    it("threads caller cancellation through Axios without retrying aborts", async () => {
+        const controller = new AbortController();
+        mockRequest.mockRejectedValueOnce({ code: "ERR_CANCELED" });
+
+        await expect(
+            createClient().get("/api/v1/album", undefined, controller.signal),
+        ).rejects.toMatchObject({ attempts: 1, isTransient: false });
+        expect(mockRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ signal: controller.signal }),
+        );
+        expect(mockSleep).not.toHaveBeenCalled();
     });
 
     it("retries a transient GET failure and returns the second result", async () => {

--- a/backend/src/services/lidarr/__tests__/reconciliationAlbumStream.test.ts
+++ b/backend/src/services/lidarr/__tests__/reconciliationAlbumStream.test.ts
@@ -1,0 +1,90 @@
+import { Readable } from "node:stream";
+import type { AxiosInstance } from "axios";
+import {
+    LIDARR_ALBUM_RESPONSE_MAX_BYTES,
+    fetchReconciliationAlbumMaps,
+} from "../reconciliationAlbumStream";
+
+describe("Lidarr reconciliation album stream", () => {
+    it("indexes streamed array entries without retaining the raw catalog", async () => {
+        const get = jest.fn(async () => ({
+            data: Readable.from([
+                '[{"id":1,"title":"Album ',
+                'One","foreignAlbumId":"rg-1","artist":{"artistName":"Artist"},',
+                '"statistics":{"percentOfTracks":100}},',
+                '{"id":2,"title":"Empty","foreignAlbumId":"rg-2",',
+                '"artist":{"artistName":"Artist"},"statistics":{"percentOfTracks":0}}]',
+            ]),
+        }));
+        const albumsByMbid = new Map();
+        const albumsByTitle = new Map();
+        const signal = new AbortController().signal;
+
+        await fetchReconciliationAlbumMaps(
+            { get } as unknown as AxiosInstance,
+            { albumsByMbid, albumsByTitle },
+            signal,
+        );
+
+        expect(get).toHaveBeenCalledWith("/api/v1/album", {
+            signal,
+            responseType: "stream",
+            maxContentLength: LIDARR_ALBUM_RESPONSE_MAX_BYTES,
+            maxBodyLength: LIDARR_ALBUM_RESPONSE_MAX_BYTES,
+        });
+        expect(albumsByMbid).toEqual(
+            new Map([
+                [
+                    "rg-1",
+                    {
+                        id: 1,
+                        title: "Album One",
+                        foreignAlbumId: "rg-1",
+                        artistName: "Artist",
+                        hasFiles: true,
+                    },
+                ],
+            ]),
+        );
+        expect(albumsByTitle.has("artist|album one")).toBe(true);
+    });
+
+    it("supports buffered arrays returned by existing Axios test doubles", async () => {
+        const get = jest.fn(async () => ({
+            data: [
+                {
+                    id: 3,
+                    title: "Buffered",
+                    foreignAlbumId: "rg-3",
+                    artist: { artistName: "Artist" },
+                    statistics: { percentOfTracks: 50 },
+                },
+            ],
+        }));
+        const albumsByMbid = new Map();
+        const albumsByTitle = new Map();
+
+        await fetchReconciliationAlbumMaps(
+            { get } as unknown as AxiosInstance,
+            { albumsByMbid, albumsByTitle },
+            new AbortController().signal,
+        );
+
+        expect(albumsByMbid.has("rg-3")).toBe(true);
+    });
+
+    it("rejects an aborted response before indexing entries", async () => {
+        const controller = new AbortController();
+        controller.abort(new Error("stop"));
+        const get = jest.fn();
+
+        await expect(
+            fetchReconciliationAlbumMaps(
+                { get } as unknown as AxiosInstance,
+                { albumsByMbid: new Map(), albumsByTitle: new Map() },
+                controller.signal,
+            ),
+        ).rejects.toThrow("stop");
+        expect(get).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/services/lidarr/lidarrHttpClient.ts
+++ b/backend/src/services/lidarr/lidarrHttpClient.ts
@@ -69,6 +69,7 @@ export interface LidarrRequestConfig {
     params?: Record<string, unknown>;
     data?: unknown;
     retryable?: boolean;
+    signal?: AbortSignal;
 }
 
 interface ResolvedOptions {
@@ -100,10 +101,16 @@ function getStatus(error: unknown): number | undefined {
 }
 
 function isTransient(error: unknown): boolean {
+    if (isAbortError(error)) return false;
     const response = getErrorResponse(error);
     if (!response) return true;
     const status = getStatus(error);
     return status !== undefined && TRANSIENT_STATUSES.has(status);
+}
+
+function isAbortError(error: unknown): boolean {
+    if (!isRecord(error)) return false;
+    return error.code === "ERR_CANCELED" || error.name === "CanceledError";
 }
 
 function classifyRetry(config: LidarrRequestConfig, error: unknown): boolean {
@@ -222,6 +229,7 @@ async function executeAttempt<T>(
         url: config.path,
         params: config.params,
         data: config.data,
+        signal: config.signal,
     });
 }
 
@@ -250,9 +258,11 @@ export class LidarrHttpClient {
     async request<T>(requestConfig: LidarrRequestConfig): Promise<T> {
         assertRelativePath(requestConfig.path);
         return this.limit(async () => {
+            requestConfig.signal?.throwIfAborted();
             const maxAttempts = this.options.maxRetries + 1;
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
                 try {
+                    requestConfig.signal?.throwIfAborted();
                     const response = await executeAttempt<T>(
                         this.instance,
                         requestConfig,
@@ -293,6 +303,7 @@ export class LidarrHttpClient {
                         delayMs: delay,
                     });
                     await this.options.sleep(delay);
+                    requestConfig.signal?.throwIfAborted();
                 }
             }
             throw new Error("Lidarr request attempt bound was violated");
@@ -300,23 +311,31 @@ export class LidarrHttpClient {
     }
 
     /** Sends a typed GET request. */
-    get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
-        return this.request<T>({ method: "GET", path, params });
+    get<T>(
+        path: string,
+        params?: Record<string, unknown>,
+        signal?: AbortSignal,
+    ): Promise<T> {
+        return this.request<T>({ method: "GET", path, params, signal });
     }
 
     /** Sends a typed POST request. */
-    post<T>(path: string, data?: unknown): Promise<T> {
-        return this.request<T>({ method: "POST", path, data });
+    post<T>(path: string, data?: unknown, signal?: AbortSignal): Promise<T> {
+        return this.request<T>({ method: "POST", path, data, signal });
     }
 
     /** Sends a typed PUT request. */
-    put<T>(path: string, data?: unknown): Promise<T> {
-        return this.request<T>({ method: "PUT", path, data });
+    put<T>(path: string, data?: unknown, signal?: AbortSignal): Promise<T> {
+        return this.request<T>({ method: "PUT", path, data, signal });
     }
 
     /** Sends a typed DELETE request. */
-    delete<T>(path: string, params?: Record<string, unknown>): Promise<T> {
-        return this.request<T>({ method: "DELETE", path, params });
+    delete<T>(
+        path: string,
+        params?: Record<string, unknown>,
+        signal?: AbortSignal,
+    ): Promise<T> {
+        return this.request<T>({ method: "DELETE", path, params, signal });
     }
 }
 

--- a/backend/src/services/lidarr/reconciliationAlbumStream.ts
+++ b/backend/src/services/lidarr/reconciliationAlbumStream.ts
@@ -1,0 +1,231 @@
+import { StringDecoder } from "node:string_decoder";
+import type { Readable } from "node:stream";
+import type { AxiosInstance } from "axios";
+
+export const LIDARR_ALBUM_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
+const LIDARR_ALBUM_MAX_ITEMS = 250_000;
+const LIDARR_ALBUM_MAX_ITEM_BYTES = 1024 * 1024;
+const LIDARR_ALBUM_MAX_STREAM_CHUNKS = 1_000_000;
+
+interface AlbumSnapshotInfo {
+    id: number;
+    title: string;
+    foreignAlbumId: string;
+    artistName: string;
+    hasFiles: boolean;
+}
+
+interface ReconciliationAlbumMaps {
+    albumsByMbid: Map<string, AlbumSnapshotInfo>;
+    albumsByTitle: Map<string, AlbumSnapshotInfo>;
+}
+
+interface JsonArrayParserState {
+    started: boolean;
+    ended: boolean;
+    depth: number;
+    inString: boolean;
+    escaped: boolean;
+    current: string;
+    currentBytes: number;
+    items: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function snapshotAlbum(value: unknown): AlbumSnapshotInfo | null {
+    if (!isRecord(value) || !isRecord(value.statistics)) return null;
+    if (!(Number(value.statistics.percentOfTracks) > 0)) return null;
+    if (
+        typeof value.id !== "number" ||
+        typeof value.title !== "string" ||
+        typeof value.foreignAlbumId !== "string"
+    ) {
+        return null;
+    }
+    const artistName =
+        isRecord(value.artist) && typeof value.artist.artistName === "string"
+            ? value.artist.artistName
+            : "";
+    return {
+        id: value.id,
+        title: value.title,
+        foreignAlbumId: value.foreignAlbumId,
+        artistName,
+        hasFiles: true,
+    };
+}
+
+function indexAlbum(target: ReconciliationAlbumMaps, value: unknown): void {
+    const album = snapshotAlbum(value);
+    if (!album) return;
+    if (album.foreignAlbumId) {
+        target.albumsByMbid.set(album.foreignAlbumId, album);
+    }
+    if (!album.artistName || !album.title) return;
+    const key = `${album.artistName.toLowerCase().trim()}|${album.title.toLowerCase().trim()}`;
+    target.albumsByTitle.set(key, album);
+}
+
+function completeItem(
+    state: JsonArrayParserState,
+    target: ReconciliationAlbumMaps,
+): void {
+    state.items += 1;
+    if (state.items > LIDARR_ALBUM_MAX_ITEMS) {
+        throw new Error("Lidarr album response exceeded the item bound");
+    }
+    indexAlbum(target, JSON.parse(state.current) as unknown);
+    state.current = "";
+    state.currentBytes = 0;
+}
+
+function consumeOutsideItem(state: JsonArrayParserState, char: string): void {
+    if (/\s/.test(char) || char === ",") return;
+    if (!state.started && char === "[") {
+        state.started = true;
+        return;
+    }
+    if (state.started && char === "]") {
+        state.ended = true;
+        return;
+    }
+    if (state.started && !state.ended && char === "{") {
+        state.depth = 1;
+        state.current = char;
+        state.currentBytes = 1;
+        return;
+    }
+    throw new Error("Lidarr album response was not a JSON object array");
+}
+
+function consumeInsideItem(
+    state: JsonArrayParserState,
+    char: string,
+    target: ReconciliationAlbumMaps,
+): void {
+    state.current += char;
+    state.currentBytes += Buffer.byteLength(char);
+    if (state.currentBytes > LIDARR_ALBUM_MAX_ITEM_BYTES) {
+        throw new Error("Lidarr album item exceeded the byte bound");
+    }
+    if (state.escaped) {
+        state.escaped = false;
+        return;
+    }
+    if (state.inString && char === "\\") {
+        state.escaped = true;
+        return;
+    }
+    if (char === '"') {
+        state.inString = !state.inString;
+        return;
+    }
+    if (state.inString) return;
+    if (char === "{" || char === "[") state.depth += 1;
+    if (char === "}" || char === "]") state.depth -= 1;
+    if (state.depth === 0) completeItem(state, target);
+}
+
+function consumeText(
+    state: JsonArrayParserState,
+    text: string,
+    target: ReconciliationAlbumMaps,
+): void {
+    for (let index = 0; index < text.length; index += 1) {
+        const char = text[index];
+        if (state.depth === 0) consumeOutsideItem(state, char);
+        else consumeInsideItem(state, char, target);
+    }
+}
+
+function assertComplete(state: JsonArrayParserState): void {
+    if (!state.started || !state.ended || state.depth !== 0) {
+        throw new Error("Lidarr album response ended before the JSON array");
+    }
+}
+
+async function indexStream(
+    stream: Readable,
+    target: ReconciliationAlbumMaps,
+    signal: AbortSignal,
+): Promise<void> {
+    const decoder = new StringDecoder("utf8");
+    const state: JsonArrayParserState = {
+        started: false,
+        ended: false,
+        depth: 0,
+        inString: false,
+        escaped: false,
+        current: "",
+        currentBytes: 0,
+        items: 0,
+    };
+    const iterator = stream[Symbol.asyncIterator]();
+    let totalBytes = 0;
+    try {
+        for (
+            let chunkIndex = 0;
+            chunkIndex < LIDARR_ALBUM_MAX_STREAM_CHUNKS;
+            chunkIndex += 1
+        ) {
+            signal.throwIfAborted();
+            const next = await iterator.next();
+            if (next.done) {
+                consumeText(state, decoder.end(), target);
+                assertComplete(state);
+                return;
+            }
+            const chunk = Buffer.isBuffer(next.value)
+                ? next.value
+                : Buffer.from(next.value);
+            totalBytes += chunk.byteLength;
+            if (totalBytes > LIDARR_ALBUM_RESPONSE_MAX_BYTES) {
+                throw new Error(
+                    "Lidarr album response exceeded the byte bound",
+                );
+            }
+            consumeText(state, decoder.write(chunk), target);
+        }
+        throw new Error("Lidarr album response exceeded the chunk bound");
+    } finally {
+        await iterator.return?.();
+        stream.destroy();
+    }
+}
+
+function isReadable(value: unknown): value is Readable {
+    return (
+        isRecord(value) &&
+        typeof value.destroy === "function" &&
+        Symbol.asyncIterator in value
+    );
+}
+
+/** Streams the unpaged Lidarr album array into the two derived snapshot maps. */
+export async function fetchReconciliationAlbumMaps(
+    client: AxiosInstance,
+    target: ReconciliationAlbumMaps,
+    signal: AbortSignal,
+): Promise<void> {
+    signal.throwIfAborted();
+    const response = await client.get("/api/v1/album", {
+        signal,
+        responseType: "stream",
+        maxContentLength: LIDARR_ALBUM_RESPONSE_MAX_BYTES,
+        maxBodyLength: LIDARR_ALBUM_RESPONSE_MAX_BYTES,
+    });
+    if (Array.isArray(response.data)) {
+        if (response.data.length > LIDARR_ALBUM_MAX_ITEMS) {
+            throw new Error("Lidarr album response exceeded the item bound");
+        }
+        for (const album of response.data) indexAlbum(target, album);
+        return;
+    }
+    if (!isReadable(response.data)) {
+        throw new Error("Lidarr album response was not readable");
+    }
+    await indexStream(response.data, target, signal);
+}

--- a/backend/src/utils/__tests__/circuitBreaker.test.ts
+++ b/backend/src/utils/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,186 @@
+import {
+    ConsecutiveFailureCircuitBreaker,
+    RedisCircuitBreakerStore,
+} from "../circuitBreaker";
+
+describe("ConsecutiveFailureCircuitBreaker", () => {
+    it("opens after the failure threshold and permits one cooldown probe", async () => {
+        let now = 1_000;
+        const breaker = new ConsecutiveFailureCircuitBreaker({
+            failureThreshold: 3,
+            cooldownMs: 5_000,
+            now: () => now,
+        });
+
+        await expect(breaker.tryAcquire()).resolves.toBe(true);
+        await breaker.recordFailure();
+        await breaker.recordFailure();
+        await expect(breaker.tryAcquire()).resolves.toBe(true);
+        await breaker.recordFailure();
+        await expect(breaker.snapshot()).resolves.toEqual({
+            state: "open",
+            consecutiveFailures: 3,
+        });
+        await expect(breaker.tryAcquire()).resolves.toBe(false);
+
+        now += 5_000;
+        await expect(breaker.tryAcquire()).resolves.toBe(true);
+        await expect(breaker.tryAcquire()).resolves.toBe(false);
+        await breaker.recordSuccess();
+        await expect(breaker.snapshot()).resolves.toEqual({
+            state: "closed",
+            consecutiveFailures: 0,
+        });
+    });
+
+    it("reopens when the half-open probe fails", async () => {
+        let now = 0;
+        const breaker = new ConsecutiveFailureCircuitBreaker({
+            failureThreshold: 1,
+            cooldownMs: 100,
+            now: () => now,
+        });
+
+        await breaker.recordFailure();
+        now = 100;
+        await expect(breaker.tryAcquire()).resolves.toBe(true);
+        await breaker.recordFailure();
+        await expect(breaker.tryAcquire()).resolves.toBe(false);
+    });
+
+    function createRedisMock() {
+        let state = "closed";
+        let failures = 0;
+        let openedAt = 0;
+        let probeToken: string | null = null;
+        const evalMock = jest.fn(
+            async (
+                script: string,
+                _keys: number,
+                _key: string,
+                ...args: string[]
+            ) => {
+                if (script.includes("circuit-breaker:acquire")) {
+                    const [nowRaw, cooldownRaw, token] = args;
+                    const now = Number(nowRaw);
+                    const cooldown = Number(cooldownRaw);
+                    if (state === "closed") return [1, state, failures];
+                    if (state === "half-open") return [0, state, failures];
+                    if (now - openedAt < cooldown) return [0, state, failures];
+                    state = "half-open";
+                    probeToken = token;
+                    return [1, state, failures];
+                }
+                if (script.includes("circuit-breaker:success")) {
+                    const [token] = args;
+                    if (state !== "half-open" || probeToken === token) {
+                        state = "closed";
+                        failures = 0;
+                        probeToken = null;
+                    }
+                    return [state, failures];
+                }
+                if (script.includes("circuit-breaker:failure")) {
+                    const [nowRaw, thresholdRaw, token] = args;
+                    if (state === "half-open" && probeToken !== token) {
+                        return [state, failures];
+                    }
+                    failures += 1;
+                    if (
+                        state === "half-open" ||
+                        failures >= Number(thresholdRaw)
+                    ) {
+                        state = "open";
+                        openedAt = Number(nowRaw);
+                        probeToken = null;
+                    }
+                    return [state, failures];
+                }
+                return [state, failures];
+            },
+        );
+        return { eval: evalMock };
+    }
+
+    it("shares open state across breaker instances through Redis", async () => {
+        const redis = createRedisMock();
+        const options = {
+            failureThreshold: 1,
+            cooldownMs: 5_000,
+            now: () => 1_000,
+        };
+        const first = new ConsecutiveFailureCircuitBreaker({
+            ...options,
+            store: new RedisCircuitBreakerStore(redis, "breaker:test", 30_000),
+        });
+        const second = new ConsecutiveFailureCircuitBreaker({
+            ...options,
+            store: new RedisCircuitBreakerStore(redis, "breaker:test", 30_000),
+        });
+
+        await first.recordFailure();
+
+        await expect(second.tryAcquire()).resolves.toBe(false);
+        await expect(second.snapshot()).resolves.toEqual({
+            state: "open",
+            consecutiveFailures: 1,
+        });
+        expect(redis.eval).toHaveBeenCalled();
+    });
+
+    it("grants one atomic half-open probe token across instances", async () => {
+        let now = 0;
+        const redis = createRedisMock();
+        const createBreaker = () =>
+            new ConsecutiveFailureCircuitBreaker({
+                failureThreshold: 1,
+                cooldownMs: 100,
+                now: () => now,
+                store: new RedisCircuitBreakerStore(
+                    redis,
+                    "breaker:probe",
+                    30_000,
+                ),
+            });
+        const first = createBreaker();
+        const second = createBreaker();
+        await first.recordFailure();
+        now = 100;
+
+        const permits = await Promise.all([
+            first.tryAcquire(),
+            second.tryAcquire(),
+        ]);
+
+        expect(permits.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("fails toward the closed local fallback when Redis is unavailable", async () => {
+        const redis = {
+            eval: jest.fn(async () => {
+                throw new Error("redis unavailable");
+            }),
+        };
+        const timeoutLogger = { warn: jest.fn() };
+        const breaker = new ConsecutiveFailureCircuitBreaker({
+            failureThreshold: 3,
+            cooldownMs: 1_000,
+            store: new RedisCircuitBreakerStore(
+                redis,
+                "breaker:outage",
+                30_000,
+            ),
+            logger: timeoutLogger,
+        });
+
+        await expect(breaker.tryAcquire()).resolves.toBe(true);
+        await expect(breaker.snapshot()).resolves.toEqual({
+            state: "closed",
+            consecutiveFailures: 0,
+        });
+        expect(timeoutLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("using process-local fallback"),
+            { error: expect.any(Error) },
+        );
+    });
+});

--- a/backend/src/utils/__tests__/withTimeout.test.ts
+++ b/backend/src/utils/__tests__/withTimeout.test.ts
@@ -1,0 +1,92 @@
+import { withTimeout } from "../withTimeout";
+
+describe("withTimeout", () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("aborts timed-out work, awaits settlement, and returns a timeout result", async () => {
+        jest.useFakeTimers();
+        const events: string[] = [];
+        const operation = jest.fn(
+            (signal: AbortSignal) =>
+                new Promise<string>((_resolve, reject) => {
+                    signal.addEventListener("abort", () => {
+                        events.push("aborted");
+                        queueMicrotask(() => {
+                            events.push("settled");
+                            reject(signal.reason);
+                        });
+                    });
+                }),
+        );
+
+        const pending = withTimeout(operation, 100, "bounded-operation", {
+            result: true,
+            logger: { warn: jest.fn() },
+        });
+        await jest.advanceTimersByTimeAsync(100);
+
+        await expect(pending).resolves.toEqual({ ok: false, timedOut: true });
+        expect(operation).toHaveBeenCalledTimes(1);
+        expect(operation.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
+        expect(events).toEqual(["aborted", "settled"]);
+    });
+
+    it("returns a successful discriminated result before the deadline", async () => {
+        await expect(
+            withTimeout(
+                async (signal) => {
+                    expect(signal.aborted).toBe(false);
+                    return 42;
+                },
+                1_000,
+                "quick-operation",
+                {
+                    result: true,
+                    logger: { warn: jest.fn() },
+                },
+            ),
+        ).resolves.toEqual({ ok: true, value: 42 });
+    });
+
+    it("stops waiting when aborted work never settles", async () => {
+        jest.useFakeTimers();
+        const timeoutLogger = { warn: jest.fn() };
+        const pending = withTimeout(
+            () => new Promise<string>(() => undefined),
+            100,
+            "never-settling-operation",
+            { result: true, logger: timeoutLogger },
+        );
+
+        await jest.advanceTimersByTimeAsync(100);
+        let completed = false;
+        void pending.then(() => {
+            completed = true;
+        });
+        await jest.advanceTimersByTimeAsync(29_999);
+        expect(completed).toBe(false);
+
+        await jest.advanceTimersByTimeAsync(1);
+        await expect(pending).resolves.toEqual({ ok: false, timedOut: true });
+        expect(timeoutLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Aborted operation did not settle within 30000ms",
+            ),
+        );
+    });
+
+    it("keeps the legacy undefined-on-timeout contract", async () => {
+        jest.useFakeTimers();
+        const pending = withTimeout(
+            () => new Promise<string>(() => undefined),
+            50,
+            "legacy-operation",
+            { warn: jest.fn() },
+        );
+
+        await jest.advanceTimersByTimeAsync(50);
+        await expect(pending).resolves.toBeUndefined();
+    });
+});

--- a/backend/src/utils/circuitBreaker.ts
+++ b/backend/src/utils/circuitBreaker.ts
@@ -1,0 +1,346 @@
+import { randomUUID } from "crypto";
+import { logger } from "./logger";
+
+type CircuitState = "closed" | "open" | "half-open";
+type CircuitBreakerLogger = Pick<typeof logger, "warn">;
+
+interface CircuitBreakerOptions {
+    failureThreshold: number;
+    cooldownMs: number;
+    now?: () => number;
+    store?: CircuitBreakerStateStore;
+    logger?: CircuitBreakerLogger;
+    tokenFactory?: () => string;
+}
+
+/** Snapshot safe for logs and deterministic state-machine tests. */
+export interface CircuitBreakerSnapshot {
+    state: CircuitState;
+    consecutiveFailures: number;
+}
+
+interface CircuitBreakerPermit {
+    acquired: boolean;
+    snapshot: CircuitBreakerSnapshot;
+}
+
+interface CircuitBreakerStateStore {
+    tryAcquire(
+        now: number,
+        cooldownMs: number,
+        probeToken: string,
+    ): Promise<CircuitBreakerPermit>;
+    recordSuccess(probeToken: string): Promise<CircuitBreakerSnapshot>;
+    recordFailure(
+        now: number,
+        failureThreshold: number,
+        probeToken: string,
+    ): Promise<CircuitBreakerSnapshot>;
+    snapshot(): Promise<CircuitBreakerSnapshot>;
+}
+
+/** Minimal atomic Redis command surface used by the breaker state store. */
+export interface CircuitBreakerRedisClient {
+    eval(
+        script: string,
+        numberOfKeys: number,
+        key: string,
+        ...args: string[]
+    ): Promise<unknown>;
+}
+
+const ACQUIRE_SCRIPT = `
+-- circuit-breaker:acquire
+local state = redis.call("HGET", KEYS[1], "state") or "closed"
+local failures = tonumber(redis.call("HGET", KEYS[1], "failures") or "0")
+if state == "closed" then
+    redis.call("PEXPIRE", KEYS[1], ARGV[4])
+    return {1, state, failures}
+end
+if state == "half-open" then
+    return {0, state, failures}
+end
+local openedAt = tonumber(redis.call("HGET", KEYS[1], "openedAt") or "0")
+if tonumber(ARGV[1]) - openedAt < tonumber(ARGV[2]) then
+    return {0, state, failures}
+end
+redis.call("HSET", KEYS[1], "state", "half-open", "probeToken", ARGV[3])
+redis.call("PEXPIRE", KEYS[1], ARGV[4])
+return {1, "half-open", failures}
+`;
+
+const SUCCESS_SCRIPT = `
+-- circuit-breaker:success
+local state = redis.call("HGET", KEYS[1], "state") or "closed"
+local failures = tonumber(redis.call("HGET", KEYS[1], "failures") or "0")
+local owner = redis.call("HGET", KEYS[1], "probeToken")
+if state == "half-open" and owner ~= ARGV[1] then
+    return {state, failures}
+end
+redis.call("HSET", KEYS[1], "state", "closed", "failures", 0)
+redis.call("HDEL", KEYS[1], "openedAt", "probeToken")
+redis.call("PEXPIRE", KEYS[1], ARGV[2])
+return {"closed", 0}
+`;
+
+const FAILURE_SCRIPT = `
+-- circuit-breaker:failure
+local state = redis.call("HGET", KEYS[1], "state") or "closed"
+local failures = tonumber(redis.call("HGET", KEYS[1], "failures") or "0")
+local owner = redis.call("HGET", KEYS[1], "probeToken")
+if state == "half-open" and owner ~= ARGV[3] then
+    return {state, failures}
+end
+failures = failures + 1
+if state == "half-open" or failures >= tonumber(ARGV[2]) then
+    state = "open"
+    redis.call("HSET", KEYS[1], "openedAt", ARGV[1])
+    redis.call("HDEL", KEYS[1], "probeToken")
+end
+redis.call("HSET", KEYS[1], "state", state, "failures", failures)
+redis.call("PEXPIRE", KEYS[1], ARGV[4])
+return {state, failures}
+`;
+
+const SNAPSHOT_SCRIPT = `
+-- circuit-breaker:snapshot
+local state = redis.call("HGET", KEYS[1], "state") or "closed"
+local failures = tonumber(redis.call("HGET", KEYS[1], "failures") or "0")
+return {state, failures}
+`;
+
+function parseState(value: unknown): CircuitState {
+    if (value === "closed" || value === "open" || value === "half-open") {
+        return value;
+    }
+    throw new Error("Redis circuit breaker returned an invalid state");
+}
+
+function parseFailures(value: unknown): number {
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+        throw new Error(
+            "Redis circuit breaker returned an invalid failure count",
+        );
+    }
+    return parsed;
+}
+
+function parseSnapshot(value: unknown): CircuitBreakerSnapshot {
+    if (!Array.isArray(value) || value.length < 2) {
+        throw new Error("Redis circuit breaker returned an invalid snapshot");
+    }
+    return {
+        state: parseState(value[0]),
+        consecutiveFailures: parseFailures(value[1]),
+    };
+}
+
+/** TTL-managed Redis state with atomic open and half-open transitions. */
+export class RedisCircuitBreakerStore implements CircuitBreakerStateStore {
+    constructor(
+        private readonly redis: CircuitBreakerRedisClient,
+        private readonly key: string,
+        private readonly ttlMs: number,
+    ) {
+        if (!key || !Number.isSafeInteger(ttlMs) || ttlMs < 1) {
+            throw new Error("Redis circuit breaker key and TTL are required");
+        }
+    }
+
+    async tryAcquire(
+        now: number,
+        cooldownMs: number,
+        probeToken: string,
+    ): Promise<CircuitBreakerPermit> {
+        const result = await this.redis.eval(
+            ACQUIRE_SCRIPT,
+            1,
+            this.key,
+            String(now),
+            String(cooldownMs),
+            probeToken,
+            String(this.ttlMs),
+        );
+        if (!Array.isArray(result) || result.length < 3) {
+            throw new Error("Redis circuit breaker returned an invalid permit");
+        }
+        return {
+            acquired: result[0] === 1 || result[0] === "1",
+            snapshot: parseSnapshot(result.slice(1)),
+        };
+    }
+
+    async recordSuccess(probeToken: string): Promise<CircuitBreakerSnapshot> {
+        const result = await this.redis.eval(
+            SUCCESS_SCRIPT,
+            1,
+            this.key,
+            probeToken,
+            String(this.ttlMs),
+        );
+        return parseSnapshot(result);
+    }
+
+    async recordFailure(
+        now: number,
+        failureThreshold: number,
+        probeToken: string,
+    ): Promise<CircuitBreakerSnapshot> {
+        const result = await this.redis.eval(
+            FAILURE_SCRIPT,
+            1,
+            this.key,
+            String(now),
+            String(failureThreshold),
+            probeToken,
+            String(this.ttlMs),
+        );
+        return parseSnapshot(result);
+    }
+
+    async snapshot(): Promise<CircuitBreakerSnapshot> {
+        const result = await this.redis.eval(SNAPSHOT_SCRIPT, 1, this.key);
+        return parseSnapshot(result);
+    }
+}
+
+class InMemoryCircuitBreaker {
+    private state: CircuitState = "closed";
+    private consecutiveFailures = 0;
+    private openedAt = 0;
+
+    tryAcquire(now: number, cooldownMs: number): boolean {
+        if (this.state === "closed") return true;
+        if (this.state === "half-open") return false;
+        if (now - this.openedAt < cooldownMs) return false;
+        this.state = "half-open";
+        return true;
+    }
+
+    recordSuccess(): void {
+        this.state = "closed";
+        this.consecutiveFailures = 0;
+    }
+
+    recordFailure(now: number, failureThreshold: number): void {
+        this.consecutiveFailures += 1;
+        if (
+            this.state === "half-open" ||
+            this.consecutiveFailures >= failureThreshold
+        ) {
+            this.state = "open";
+            this.openedAt = now;
+        }
+    }
+
+    snapshot(): CircuitBreakerSnapshot {
+        return {
+            state: this.state,
+            consecutiveFailures: this.consecutiveFailures,
+        };
+    }
+}
+
+/** Consecutive-failure breaker backed by Redis with local outage fallback. */
+export class ConsecutiveFailureCircuitBreaker {
+    private readonly fallback = new InMemoryCircuitBreaker();
+    private readonly now: () => number;
+    private readonly tokenFactory: () => string;
+    private readonly log: CircuitBreakerLogger;
+    private probeToken = "";
+
+    constructor(private readonly options: CircuitBreakerOptions) {
+        if (!Number.isSafeInteger(options.failureThreshold)) {
+            throw new Error("failureThreshold must be an integer");
+        }
+        if (options.failureThreshold < 1 || options.cooldownMs < 1) {
+            throw new Error("circuit breaker bounds must be positive");
+        }
+        this.now = options.now ?? Date.now;
+        this.tokenFactory = options.tokenFactory ?? randomUUID;
+        this.log = options.logger ?? logger;
+    }
+
+    /** Acquires permission for ordinary work or the single recovery probe. */
+    async tryAcquire(): Promise<boolean> {
+        const token = this.tokenFactory();
+        if (!this.options.store) {
+            this.probeToken = token;
+            return this.fallback.tryAcquire(
+                this.now(),
+                this.options.cooldownMs,
+            );
+        }
+        try {
+            const permit = await this.options.store.tryAcquire(
+                this.now(),
+                this.options.cooldownMs,
+                token,
+            );
+            if (permit.acquired) this.probeToken = token;
+            return permit.acquired;
+        } catch (error) {
+            this.warnFallback("acquire", error);
+            this.probeToken = token;
+            return this.fallback.tryAcquire(
+                this.now(),
+                this.options.cooldownMs,
+            );
+        }
+    }
+
+    /** Closes the breaker after any successful permitted execution. */
+    async recordSuccess(): Promise<void> {
+        if (this.options.store) {
+            try {
+                await this.options.store.recordSuccess(this.probeToken);
+                this.fallback.recordSuccess();
+                return;
+            } catch (error) {
+                this.warnFallback("success", error);
+            }
+        }
+        this.fallback.recordSuccess();
+    }
+
+    /** Counts one failure and opens or reopens at the configured threshold. */
+    async recordFailure(): Promise<void> {
+        if (this.options.store) {
+            try {
+                await this.options.store.recordFailure(
+                    this.now(),
+                    this.options.failureThreshold,
+                    this.probeToken,
+                );
+                this.fallback.recordFailure(
+                    this.now(),
+                    this.options.failureThreshold,
+                );
+                return;
+            } catch (error) {
+                this.warnFallback("failure", error);
+            }
+        }
+        this.fallback.recordFailure(this.now(), this.options.failureThreshold);
+    }
+
+    /** Returns the current bounded state for diagnostics. */
+    async snapshot(): Promise<CircuitBreakerSnapshot> {
+        if (this.options.store) {
+            try {
+                return await this.options.store.snapshot();
+            } catch (error) {
+                this.warnFallback("snapshot", error);
+            }
+        }
+        return this.fallback.snapshot();
+    }
+
+    private warnFallback(operation: string, error: unknown): void {
+        this.log.warn(
+            `Redis circuit breaker ${operation} failed; using process-local fallback`,
+            { error },
+        );
+    }
+}

--- a/backend/src/utils/withTimeout.ts
+++ b/backend/src/utils/withTimeout.ts
@@ -1,26 +1,105 @@
 import { logger } from "./logger";
 
 type TimeoutLogger = Pick<typeof logger, "warn">;
+const MIN_POST_ABORT_SETTLE_MS = 30_000;
 
-/** Runs an operation until its deadline and returns undefined on timeout. */
-export async function withTimeout<T>(
+/** Explicit outcome returned by cancellation-aware timeout callers. */
+export type TimeoutResult<T> =
+    | { ok: true; value: T }
+    | { ok: false; timedOut: true };
+
+/** Options selecting the cancellation-aware discriminated timeout contract. */
+export interface TimeoutResultOptions {
+    result: true;
+    logger?: TimeoutLogger;
+}
+
+async function waitForAbortedSettlement<T>(
+    operationPromise: Promise<T>,
+    settleTimeoutMs: number,
+    operationName: string,
+    timeoutLogger: TimeoutLogger,
+): Promise<void> {
+    const settled = Symbol("settled");
+    const settleTimedOut = Symbol("settle-timed-out");
+    let settleTimeoutId: NodeJS.Timeout | undefined;
+    const observedOperation = operationPromise.then(
+        () => settled,
+        () => settled,
+    );
+    const settleTimeout = new Promise<typeof settleTimedOut>((resolve) => {
+        settleTimeoutId = setTimeout(
+            () => resolve(settleTimedOut),
+            settleTimeoutMs,
+        );
+    });
+    try {
+        const outcome = await Promise.race([observedOperation, settleTimeout]);
+        if (outcome === settleTimedOut) {
+            timeoutLogger.warn(
+                `Aborted operation did not settle within ${settleTimeoutMs}ms: ${operationName}`,
+            );
+        }
+    } finally {
+        if (settleTimeoutId) clearTimeout(settleTimeoutId);
+    }
+}
+
+export function withTimeout<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
+    timeoutMs: number,
+    operationName: string,
+    options: TimeoutResultOptions,
+): Promise<TimeoutResult<T>>;
+
+export function withTimeout<T>(
     operation: () => Promise<T>,
     timeoutMs: number,
     operationName: string,
-    timeoutLogger: TimeoutLogger = logger,
-): Promise<T | undefined> {
+    timeoutLogger?: TimeoutLogger,
+): Promise<T | undefined>;
+
+/** Runs an operation until its deadline and aborts timed-out owned work. */
+export async function withTimeout<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
+    timeoutMs: number,
+    operationName: string,
+    loggerOrOptions: TimeoutLogger | TimeoutResultOptions = logger,
+): Promise<T | undefined | TimeoutResult<T>> {
+    const options = "result" in loggerOrOptions ? loggerOrOptions : undefined;
+    const timeoutLogger: TimeoutLogger =
+        options?.logger ??
+        ("warn" in loggerOrOptions ? loggerOrOptions : logger);
+    const controller = new AbortController();
     let timeoutId: NodeJS.Timeout | undefined;
-    const timeoutPromise = new Promise<undefined>((resolve) => {
+    const timedOut = Symbol("timed-out");
+    const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
         timeoutId = setTimeout(() => {
             timeoutLogger.warn(
                 `Operation timed out after ${timeoutMs}ms: ${operationName}`,
             );
-            resolve(undefined);
+            controller.abort(new Error(`${operationName} timed out`));
+            resolve(timedOut);
         }, timeoutMs);
     });
 
     try {
-        return await Promise.race([operation(), timeoutPromise]);
+        const operationPromise = Promise.resolve().then(() =>
+            operation(controller.signal),
+        );
+        const outcome = await Promise.race([operationPromise, timeoutPromise]);
+        if (outcome !== timedOut) {
+            return options ? { ok: true, value: outcome as T } : (outcome as T);
+        }
+        if (options) {
+            await waitForAbortedSettlement(
+                operationPromise,
+                Math.max(timeoutMs, MIN_POST_ABORT_SETTLE_MS),
+                operationName,
+                timeoutLogger,
+            );
+        }
+        return options ? { ok: false, timedOut: true } : undefined;
     } finally {
         if (timeoutId) clearTimeout(timeoutId);
     }

--- a/backend/src/workers/__tests__/dataIntegrity.test.ts
+++ b/backend/src/workers/__tests__/dataIntegrity.test.ts
@@ -22,7 +22,9 @@ describe("dataIntegrity worker", () => {
             debug: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
+            child: jest.fn(),
         };
+        logger.child.mockReturnValue(logger);
         const cleanupOrphanedLibraryEntities = jest.fn(async () => ({
             albumsDeleted: 0,
             artistsDeleted: 0,
@@ -63,6 +65,7 @@ describe("dataIntegrity worker", () => {
             },
             ownedAlbum: {
                 findFirst: jest.fn(async () => null),
+                findMany: jest.fn(async () => []),
                 deleteMany: jest.fn(async () => ({ count: 0 })),
             },
             discoveryAlbum: {
@@ -225,6 +228,9 @@ describe("dataIntegrity worker", () => {
             .mockResolvedValueOnce([]); // empty albums
         (prisma.ownedAlbum.findFirst as jest.Mock).mockResolvedValue(null);
         (prisma.discoveryAlbum.findFirst as jest.Mock).mockResolvedValue(null);
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
+        });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
             expect.objectContaining({
@@ -232,13 +238,13 @@ describe("dataIntegrity worker", () => {
             }),
         );
 
-        expect(prisma.album.update).toHaveBeenCalledWith({
-            where: { id: "album-1" },
+        expect(prisma.album.updateMany).toHaveBeenCalledWith({
+            where: { id: { in: ["album-1"] }, location: "LIBRARY" },
             data: { location: "DISCOVER" },
         });
         expect(prisma.ownedAlbum.deleteMany).toHaveBeenCalledWith({
             where: {
-                rgMbid: "rg-1",
+                rgMbid: { in: ["rg-1"] },
                 source: { not: "native_scan" },
             },
         });
@@ -271,9 +277,11 @@ describe("dataIntegrity worker", () => {
                 },
             ]) // library albums
             .mockResolvedValueOnce([]); // empty albums
-        (prisma.ownedAlbum.findFirst as jest.Mock).mockResolvedValueOnce({
-            id: "owned-1",
-            source: "native_scan",
+        (prisma.ownedAlbum.findMany as jest.Mock).mockResolvedValueOnce([
+            { artistId: "artist-1" },
+        ]);
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
         });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
@@ -282,11 +290,7 @@ describe("dataIntegrity worker", () => {
             }),
         );
 
-        expect(prisma.album.update).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: { location: "DISCOVER" },
-            }),
-        );
+        expect(prisma.album.updateMany).not.toHaveBeenCalled();
     });
 
     it("delegates orphaned parent deletion to shared tombstone-aware cleanup", async () => {
@@ -329,11 +333,19 @@ describe("dataIntegrity worker", () => {
                 tracksTidal: { none: { NOT: expect.any(Object) } },
                 tracksYtMusic: { none: { NOT: expect.any(Object) } },
             },
-            include: { artist: true },
+            orderBy: { id: "asc" },
+            take: 250,
+            select: {
+                id: true,
+                rgMbid: true,
+                title: true,
+                artistId: true,
+                artist: { select: { name: true, mbid: true } },
+            },
         });
         expect(prisma.track.deleteMany).toHaveBeenCalledWith({
             where: {
-                albumId: "discover-album-1",
+                albumId: { in: ["discover-album-1"] },
                 album: expect.objectContaining({
                     NOT: expect.any(Object),
                     discoveryRecords: {
@@ -363,10 +375,12 @@ describe("dataIntegrity worker", () => {
                     normalizedName: "artist name",
                 },
             ]); // temp artists
-        (prisma.artist.findFirst as jest.Mock).mockResolvedValueOnce({
-            id: "real-artist-1",
-            mbid: "real-mbid",
-        });
+        (prisma.artist.findMany as jest.Mock).mockResolvedValueOnce([
+            {
+                id: "real-artist-1",
+                normalizedName: "artist name",
+            },
+        ]);
         cleanupOrphanedLibraryEntities.mockResolvedValueOnce({
             albumsDeleted: 0,
             artistsDeleted: 1,
@@ -501,6 +515,9 @@ describe("dataIntegrity worker", () => {
             .mockResolvedValueOnce([]); // empty albums
         (prisma.ownedAlbum.findFirst as jest.Mock).mockResolvedValue(null);
         (prisma.discoveryAlbum.findFirst as jest.Mock).mockResolvedValue(null);
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
+        });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
             expect.objectContaining({
@@ -528,6 +545,13 @@ describe("dataIntegrity worker", () => {
             id: "active-record-1",
             status: "ACTIVE",
         });
+        (prisma.discoveryAlbum.findMany as jest.Mock).mockResolvedValueOnce([
+            {
+                rgMbid: "rg-active-1",
+                albumTitle: "Still Active",
+                artistName: "Artist Active",
+            },
+        ]);
         (prisma.ownedAlbum.findFirst as jest.Mock).mockResolvedValueOnce(null);
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
@@ -610,6 +634,9 @@ describe("dataIntegrity worker", () => {
         (prisma.discoveryAlbum.findFirst as jest.Mock).mockResolvedValueOnce(
             null,
         );
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
+        });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
             expect.objectContaining({
@@ -650,14 +677,20 @@ describe("dataIntegrity worker", () => {
         (prisma.discoveryAlbum.findFirst as jest.Mock).mockResolvedValueOnce(
             null,
         );
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
+        });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
             expect.objectContaining({
                 mislocatedAlbums: 1,
             }),
         );
-        expect(prisma.album.update).toHaveBeenCalledWith({
-            where: { id: "album-discovery-table-1" },
+        expect(prisma.album.updateMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["album-discovery-table-1"] },
+                location: "LIBRARY",
+            },
             data: { location: "DISCOVER" },
         });
     });
@@ -694,9 +727,11 @@ describe("dataIntegrity worker", () => {
             ])
             .mockResolvedValueOnce([]);
         (prisma.ownedAlbum.findFirst as jest.Mock).mockResolvedValueOnce(null);
-        (prisma.discoveryAlbum.findFirst as jest.Mock).mockResolvedValueOnce({
-            id: "liked-1",
-            status: "LIKED",
+        (prisma.discoveryAlbum.findMany as jest.Mock)
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{ artistMbid: "artist-mbid-liked" }]);
+        (prisma.album.updateMany as jest.Mock).mockResolvedValueOnce({
+            count: 1,
         });
 
         await expect(module.runDataIntegrityCheck()).resolves.toEqual(
@@ -704,11 +739,7 @@ describe("dataIntegrity worker", () => {
                 mislocatedAlbums: 0,
             }),
         );
-        expect(prisma.album.update).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "album-liked-1" },
-            }),
-        );
+        expect(prisma.album.updateMany).not.toHaveBeenCalled();
     });
 
     it("does not consolidate temp artists when no real artist match exists", async () => {
@@ -734,6 +765,49 @@ describe("dataIntegrity worker", () => {
             expect.objectContaining({
                 where: { artistId: "temp-artist-no-real" },
             }),
+        );
+    });
+
+    it("completes when a bounded scan contains exactly the maximum rows", async () => {
+        const { module, prisma, logger } = loadDataIntegrity();
+        const fullPage = Array.from({ length: 250 }, (_, index) => ({
+            id: `download-${index.toString().padStart(3, "0")}`,
+            metadata: {},
+        }));
+        (prisma.downloadJob.findMany as jest.Mock).mockImplementation(
+            async () =>
+                prisma.downloadJob.findMany.mock.calls.length <= 1_000
+                    ? fullPage
+                    : [],
+        );
+
+        await expect(module.runDataIntegrityCheck()).resolves.toEqual(
+            expect.objectContaining({ oldDownloadJobs: 3 }),
+        );
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledTimes(1_001);
+        expect(logger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining("truncated at 250000 rows"),
+        );
+    });
+
+    it("truncates and warns only when rows exist beyond the scan bound", async () => {
+        const { module, prisma, logger } = loadDataIntegrity();
+        const fullPage = Array.from({ length: 250 }, (_, index) => ({
+            id: `download-${index.toString().padStart(3, "0")}`,
+            metadata: {},
+        }));
+        (prisma.downloadJob.findMany as jest.Mock).mockImplementation(
+            async () =>
+                prisma.downloadJob.findMany.mock.calls.length <= 1_000
+                    ? fullPage
+                    : [{ id: "download-over-bound", metadata: {} }],
+        );
+
+        await expect(module.runDataIntegrityCheck()).resolves.toEqual(
+            expect.objectContaining({ oldDownloadJobs: 3 }),
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+            "runDataIntegrityCheck.downloadJob.findMany.discoveryBatch truncated at 250000 rows",
         );
     });
 });

--- a/backend/src/workers/__tests__/dataIntegrityBatches.test.ts
+++ b/backend/src/workers/__tests__/dataIntegrityBatches.test.ts
@@ -1,0 +1,135 @@
+import {
+    addDiscoveryAlbumMarkers,
+    addDownloadJobMarkers,
+    createDiscoveryMarkers,
+    findMislocatedAlbums,
+    findUnprotectedDiscoverAlbumIds,
+} from "../dataIntegrityBatches";
+
+describe("data-integrity batch decisions", () => {
+    it("builds normalized bounded discovery markers from selected fields", () => {
+        const markers = createDiscoveryMarkers(10);
+        addDownloadJobMarkers(markers, [
+            {
+                metadata: {
+                    albumTitle: "  Album One ",
+                    artistName: "Artist One",
+                    artistMbid: "artist-mbid-1",
+                },
+            },
+        ]);
+        addDiscoveryAlbumMarkers(markers, [
+            {
+                albumTitle: "Album Two",
+                artistName: "ARTIST TWO",
+                artistMbid: null,
+            },
+        ]);
+
+        expect(markers.albumTitles).toEqual(
+            new Set(["album one", "album two"]),
+        );
+        expect(markers.artistNames).toEqual(
+            new Set(["artist one", "artist two"]),
+        );
+        expect(markers.artistMbids).toEqual(new Set(["artist-mbid-1"]));
+    });
+
+    it("selects only matching albums without protected artist state", () => {
+        const markers = createDiscoveryMarkers(10);
+        addDiscoveryAlbumMarkers(markers, [
+            {
+                albumTitle: "Discovery Album",
+                artistName: "Discovery Artist",
+                artistMbid: "artist-match",
+            },
+        ]);
+        const albums = [
+            {
+                id: "move",
+                rgMbid: "rg-move",
+                title: "Discovery Album",
+                artistId: "artist-move",
+                artist: { name: "Other", mbid: null },
+            },
+            {
+                id: "owned",
+                rgMbid: "rg-owned",
+                title: "Other",
+                artistId: "artist-owned",
+                artist: { name: "Discovery Artist", mbid: null },
+            },
+            {
+                id: "liked",
+                rgMbid: "rg-liked",
+                title: "Other",
+                artistId: "artist-liked",
+                artist: { name: "Other", mbid: "artist-match" },
+            },
+        ];
+
+        expect(
+            findMislocatedAlbums(
+                albums,
+                markers,
+                new Set(["artist-owned"]),
+                new Set(["artist-match"]),
+            ).map((album) => album.id),
+        ).toEqual(["move"]);
+    });
+
+    it("matches active and owned discovery references by exact keys", () => {
+        const albums = [
+            {
+                id: "by-mbid",
+                rgMbid: "rg-1",
+                title: "One",
+                artistId: "artist-1",
+                artist: { name: "A", mbid: null },
+            },
+            {
+                id: "by-title",
+                rgMbid: "rg-2",
+                title: "Two",
+                artistId: "artist-2",
+                artist: { name: "B", mbid: null },
+            },
+            {
+                id: "orphan",
+                rgMbid: "rg-3",
+                title: "Three",
+                artistId: "artist-3",
+                artist: { name: "C", mbid: null },
+            },
+        ];
+
+        expect(
+            findUnprotectedDiscoverAlbumIds(
+                albums,
+                [
+                    {
+                        rgMbid: "rg-1",
+                        albumTitle: "ignored",
+                        artistName: "ignored",
+                    },
+                    {
+                        rgMbid: "different",
+                        albumTitle: " TWO ",
+                        artistName: " b ",
+                    },
+                ],
+                [{ artistId: "different", rgMbid: "rg-3" }],
+            ),
+        ).toEqual(["orphan"]);
+    });
+
+    it("rejects marker growth beyond the configured bound", () => {
+        const markers = createDiscoveryMarkers(2);
+        expect(() =>
+            addDiscoveryAlbumMarkers(markers, [
+                { albumTitle: "one", artistName: "a", artistMbid: null },
+                { albumTitle: "two", artistName: "b", artistMbid: null },
+            ]),
+        ).toThrow("discovery marker bound");
+    });
+});

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -39,6 +39,7 @@ describe("workers runtime behavior", () => {
         const imageQueue = createQueueMock();
         const validationQueue = createQueueMock();
         const schedulerQueue = createQueueMock();
+        const schedulerMaintenanceQueue = createQueueMock();
         const genericImportQueue = createQueueMock();
         const federationQueue = createQueueMock();
         const albumDownloadQueue = createQueueMock();
@@ -99,6 +100,9 @@ describe("workers runtime behavior", () => {
         const recoverUnqueuedAlbumDownloads = jest.fn(async () => 0);
         const recoverUnqueuedArtistDownloadExpansions = jest.fn(async () => 0);
         const recordAlbumDownloadOutcome = jest.fn();
+        const recordSchedulerJobDuration = jest.fn();
+        const recordSchedulerJobSuccess = jest.fn();
+        const recordSchedulerTimeout = jest.fn();
         const registerRecoveryJobs = jest.fn(async () => undefined);
         const registerFederationProcessors = jest.fn();
         const registerFederationSchedules = jest.fn(async () => undefined);
@@ -202,6 +206,7 @@ describe("workers runtime behavior", () => {
             imageQueue,
             validationQueue,
             schedulerQueue,
+            schedulerMaintenanceQueue,
             genericImportQueue,
             federationQueue,
             albumDownloadQueue,
@@ -255,6 +260,9 @@ describe("workers runtime behavior", () => {
         }));
         jest.doMock("../../metrics", () => ({
             recordAlbumDownloadOutcome,
+            recordSchedulerJobDuration,
+            recordSchedulerJobSuccess,
+            recordSchedulerTimeout,
         }));
         jest.doMock("../processors/trackRemovalPurgeProcessor", () => ({
             TRACK_REMOVAL_PURGE_JOB_NAME: "track-removal-purge",
@@ -357,6 +365,7 @@ describe("workers runtime behavior", () => {
             imageQueue,
             validationQueue,
             schedulerQueue,
+            schedulerMaintenanceQueue,
             genericImportQueue,
             federationQueue,
             albumDownloadQueue,
@@ -381,6 +390,9 @@ describe("workers runtime behavior", () => {
             recoverUnqueuedAlbumDownloads,
             recoverUnqueuedArtistDownloadExpansions,
             recordAlbumDownloadOutcome,
+            recordSchedulerJobDuration,
+            recordSchedulerJobSuccess,
+            recordSchedulerTimeout,
             registerRecoveryJobs,
             registerFederationProcessors,
             registerFederationSchedules,
@@ -438,6 +450,28 @@ describe("workers runtime behavior", () => {
             "*",
             expect.any(Function),
         );
+        expect(mocks.schedulerQueue.process).toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            1,
+            expect.any(Function),
+        );
+        expect(mocks.schedulerMaintenanceQueue.process).toHaveBeenCalledWith(
+            "data-integrity-check",
+            1,
+            expect.any(Function),
+        );
+        expect(mocks.schedulerQueue.process).not.toHaveBeenCalledWith(
+            "data-integrity-check",
+            1,
+            expect.any(Function),
+        );
+        expect(
+            mocks.schedulerMaintenanceQueue.process,
+        ).not.toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            1,
+            expect.any(Function),
+        );
         expect(mocks.genericImportQueue.process).toHaveBeenCalledWith(
             "*",
             2,
@@ -462,6 +496,20 @@ describe("workers runtime behavior", () => {
         expect(mocks.startDiscoverWeeklyCron).toHaveBeenCalledTimes(1);
         expect(mocks.stopDiscoverWeeklyCron).not.toHaveBeenCalled();
         expect(mocks.schedulerQueue.isReady).toHaveBeenCalledTimes(1);
+        expect(mocks.schedulerMaintenanceQueue.isReady).toHaveBeenCalledTimes(
+            1,
+        );
+        const namedSchedulerRegistrationIndex =
+            mocks.schedulerQueue.process.mock.calls.findIndex(
+                (call) => call[0] === "download-reconciliation-cycle",
+            );
+        expect(
+            mocks.schedulerQueue.isReady.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            mocks.schedulerQueue.process.mock.invocationCallOrder[
+                namedSchedulerRegistrationIndex
+            ],
+        );
         expect(mocks.schedulerQueue.add).toHaveBeenCalled();
         expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
             "album-download-recovery-cycle",
@@ -473,7 +521,7 @@ describe("workers runtime behavior", () => {
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "catalog-retention-sweep",
             { mode: "startup" },
             {
@@ -483,7 +531,7 @@ describe("workers runtime behavior", () => {
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "catalog-retention-sweep",
             { mode: "repeat" },
             {
@@ -498,22 +546,22 @@ describe("workers runtime behavior", () => {
             { mode: "repeat" },
             {
                 jobId: "scheduler:album-download-recovery:repeat",
-                repeat: { every: 5 * 60_000 },
+                repeat: { cron: "30 */5 * * * *" },
                 removeOnComplete: true,
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "audiobook-auto-sync-startup",
             { mode: "repeat" },
             {
                 jobId: "scheduler:audiobook-auto-sync:repeat",
-                repeat: { every: 5 * 60 * 1000 },
+                repeat: { cron: "9 */5 * * * *" },
                 removeOnComplete: true,
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "track-audio-hash-backfill",
             {
                 mode: "startup",
@@ -523,7 +571,7 @@ describe("workers runtime behavior", () => {
                 jobId: "scheduler:audio-hash-backfill:startup",
             }),
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "track-loudness-backfill",
             {
                 mode: "startup",
@@ -534,7 +582,7 @@ describe("workers runtime behavior", () => {
                 delay: 55_000,
             }),
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "track-loudness-backfill",
             { mode: "repeat" },
             {
@@ -546,7 +594,7 @@ describe("workers runtime behavior", () => {
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "track-removal-purge",
             { mode: "startup" },
             {
@@ -558,7 +606,7 @@ describe("workers runtime behavior", () => {
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "track-removal-purge",
             { mode: "repeat" },
             {
@@ -570,16 +618,178 @@ describe("workers runtime behavior", () => {
                 removeOnFail: 10,
             },
         );
-        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
             "request-fulfillment-reconcile",
             { mode: "repeat" },
             {
                 jobId: "scheduler:request-fulfillment:repeat",
-                repeat: { every: 5 * 60 * 1000 },
+                repeat: { cron: "33 */5 * * * *" },
                 removeOnComplete: true,
                 removeOnFail: 10,
             },
         );
+        expect(mocks.schedulerQueue.removeRepeatable).toHaveBeenCalledWith(
+            "album-download-recovery-cycle",
+            {
+                every: 5 * 60_000,
+                jobId: "scheduler:album-download-recovery:repeat",
+            },
+        );
+        expect(mocks.schedulerQueue.removeRepeatable).toHaveBeenCalledWith(
+            "catalog-retention-sweep",
+            {
+                every: 60 * 60_000,
+                jobId: "scheduler:catalog-retention:repeat",
+            },
+        );
+    });
+
+    it("registers slow and fast jobs on structurally isolated queues", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        const fastNames = mocks.schedulerQueue.process.mock.calls.map(
+            (call) => call[0],
+        );
+        const slowNames =
+            mocks.schedulerMaintenanceQueue.process.mock.calls.map(
+                (call) => call[0],
+            );
+        expect(fastNames).toEqual(
+            expect.arrayContaining([
+                "download-reconciliation-cycle",
+                "album-download-recovery-cycle",
+                "lidarr-cleanup-cycle",
+                "*",
+            ]),
+        );
+        expect(fastNames).not.toContain("data-integrity-check");
+        expect(slowNames).toContain("data-integrity-check");
+        expect(slowNames).not.toContain("download-reconciliation-cycle");
+        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            expect.anything(),
+            expect.anything(),
+        );
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
+            "data-integrity-check",
+            expect.anything(),
+            expect.anything(),
+        );
+    });
+
+    it("continues scheduler registration after one legacy removal fails", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        mocks.schedulerQueue.removeRepeatable.mockRejectedValueOnce(
+            new Error("transient repeat removal failure"),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+
+        expect(mocks.schedulerMaintenanceQueue.add).toHaveBeenCalledWith(
+            "data-integrity-check",
+            { mode: "repeat" },
+            expect.objectContaining({
+                jobId: "scheduler:data-integrity:repeat",
+            }),
+        );
+        expect(mocks.schedulerQueue.add).toHaveBeenCalledWith(
+            "download-reconciliation-cycle",
+            expect.anything(),
+            expect.anything(),
+        );
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("Failed scheduler registration step"),
+            expect.objectContaining({ error: expect.any(Error) }),
+        );
+    });
+
+    it("opens the reconciliation circuit after three failures and skips the next tick", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        mocks.lidarrService.getReconciliationSnapshot.mockRejectedValue(
+            new Error("lidarr unavailable"),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+        const job = {
+            id: "reconciliation-failure",
+            name: "download-reconciliation-cycle",
+            data: { mode: "repeat" },
+        };
+
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            await expect(schedulerHandler(job)).rejects.toThrow(
+                "lidarr unavailable",
+            );
+        }
+        await expect(schedulerHandler(job)).resolves.toBeUndefined();
+
+        expect(
+            mocks.lidarrService.getReconciliationSnapshot,
+        ).toHaveBeenCalledTimes(3);
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            "Skipping reconciliation while circuit breaker is open",
+            expect.objectContaining({
+                circuit: { state: "open", consecutiveFailures: 3 },
+            }),
+        );
+    });
+
+    it("finishes never-settling reconciliation timeouts and records breaker failures", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        mocks.lidarrService.getReconciliationSnapshot.mockImplementation(
+            () => new Promise(() => undefined),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../index");
+        await flushPromises();
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+        const job = {
+            id: "never-settling-reconciliation",
+            name: "download-reconciliation-cycle",
+            data: { mode: "repeat" },
+        };
+        jest.useFakeTimers();
+
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            const tick = schedulerHandler(job);
+            const rejected = expect(tick).rejects.toThrow(
+                "Scheduler operation timed out: getReconciliationSnapshot",
+            );
+            await jest.advanceTimersByTimeAsync(30_000);
+            await jest.advanceTimersByTimeAsync(30_000);
+            await rejected;
+        }
+        await expect(schedulerHandler(job)).resolves.toBeUndefined();
+
+        expect(mocks.recordSchedulerTimeout).toHaveBeenCalledTimes(3);
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+            "Reconciliation failure recorded by circuit breaker",
+            expect.objectContaining({
+                circuit: { state: "open", consecutiveFailures: 3 },
+                error: expect.any(Error),
+            }),
+        );
+        expect(
+            mocks.lidarrService.getReconciliationSnapshot,
+        ).toHaveBeenCalledTimes(3);
     });
 
     it("removes the persisted request schedule when the feature is disabled", async () => {
@@ -911,6 +1121,9 @@ describe("workers runtime behavior", () => {
         expect(workers.imageQueue).toBe(mocks.imageQueue);
         expect(workers.validationQueue).toBe(mocks.validationQueue);
         expect(workers.schedulerQueue).toBe(mocks.schedulerQueue);
+        expect(workers.schedulerMaintenanceQueue).toBe(
+            mocks.schedulerMaintenanceQueue,
+        );
         expect(workers.genericImportQueue).toBe(mocks.genericImportQueue);
         expect(workers.albumDownloadQueue).toBe(mocks.albumDownloadQueue);
     });
@@ -947,6 +1160,7 @@ describe("workers runtime behavior", () => {
             mocks.albumDownloadQueue.removeAllListeners,
         ).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.close).toHaveBeenCalledTimes(1);
+        expect(mocks.schedulerMaintenanceQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.genericImportQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.albumDownloadQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.scanQueue.close.mock.invocationCallOrder[0]).toBeLessThan(
@@ -1060,6 +1274,10 @@ describe("workers runtime behavior", () => {
         });
 
         expect(mocks.runDataIntegrityCheck).toHaveBeenCalledTimes(1);
+        expect(mocks.recordSchedulerJobSuccess).toHaveBeenCalledWith(
+            "data-integrity-check",
+            expect.any(Number),
+        );
         expect(mocks.schedulerLockRedis.set).toHaveBeenCalled();
         expect(mocks.schedulerLockRedis.eval).toHaveBeenCalled();
     });
@@ -1088,6 +1306,7 @@ describe("workers runtime behavior", () => {
         });
 
         expect(mocks.runDataIntegrityCheck).not.toHaveBeenCalled();
+        expect(mocks.recordSchedulerJobSuccess).not.toHaveBeenCalled();
         expect(mocks.schedulerLockRedis.eval).not.toHaveBeenCalled();
     });
 
@@ -2226,23 +2445,41 @@ describe("workers runtime behavior", () => {
     it("times out startup maintenance tasks and skips completion logs when timed out", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
-        const neverSyncMissing = () =>
+        const settleAfterTimeoutSyncMissing = () =>
             new Promise<{
                 synced: number;
                 failed: number;
                 skipped: number;
                 errors: string[];
-            }>(() => undefined);
-        const neverReconcileOnStartup = () =>
-            new Promise<{ loaded: number; failed: number }>(() => undefined);
-        const neverBackfillArtistCounts = () =>
-            new Promise<{ processed: number; errors: number }>(() => undefined);
-        const neverBackfillImages = () =>
-            new Promise<undefined>(() => undefined);
+            }>((_resolve, reject) =>
+                queueMicrotask(() =>
+                    reject(new Error("settled after timeout")),
+                ),
+            );
+        const settleAfterTimeoutReconcile = () =>
+            new Promise<{ loaded: number; failed: number }>(
+                (_resolve, reject) =>
+                    queueMicrotask(() =>
+                        reject(new Error("settled after timeout")),
+                    ),
+            );
+        const settleAfterTimeoutArtistCounts = () =>
+            new Promise<{ processed: number; errors: number }>(
+                (_resolve, reject) =>
+                    queueMicrotask(() =>
+                        reject(new Error("settled after timeout")),
+                    ),
+            );
+        const settleAfterTimeoutImages = () =>
+            new Promise<undefined>((_resolve, reject) =>
+                queueMicrotask(() =>
+                    reject(new Error("settled after timeout")),
+                ),
+            );
         const setTimeoutSpy = jest
             .spyOn(global, "setTimeout")
             .mockImplementation(((cb: (...args: any[]) => void) => {
-                cb();
+                queueMicrotask(cb);
                 return 0 as unknown as NodeJS.Timeout;
             }) as any);
 
@@ -2251,21 +2488,23 @@ describe("workers runtime behavior", () => {
             audiobookshelfUrl: "http://audiobookshelf",
         });
         mocks.audiobookCacheService.syncMissing.mockImplementationOnce(
-            neverSyncMissing,
+            settleAfterTimeoutSyncMissing,
         );
         mocks.downloadQueueManager.reconcileOnStartup.mockImplementationOnce(
-            neverReconcileOnStartup,
+            settleAfterTimeoutReconcile,
         );
         mocks.isBackfillNeeded.mockResolvedValueOnce(true);
         mocks.backfillAllArtistCounts.mockImplementationOnce(
-            neverBackfillArtistCounts,
+            settleAfterTimeoutArtistCounts,
         );
         mocks.isImageBackfillNeeded.mockResolvedValueOnce({
             needed: true,
             artistsWithExternalUrls: 1,
             albumsWithExternalUrls: 1,
         });
-        mocks.backfillAllImages.mockImplementationOnce(neverBackfillImages);
+        mocks.backfillAllImages.mockImplementationOnce(
+            settleAfterTimeoutImages,
+        );
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         require("../index");
@@ -2377,13 +2616,18 @@ describe("workers runtime behavior", () => {
     it("handles scheduler timeout paths when lidarr cleanup exceeds timeout", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
+        let rejectWork!: (error: Error) => void;
         mocks.simpleDownloadManager.clearLidarrQueue.mockImplementation(
-            () => new Promise(() => undefined),
+            () =>
+                new Promise((_resolve, reject) => {
+                    rejectWork = reject;
+                }),
         );
+        let timeoutCallback!: () => void;
         const setTimeoutSpy = jest
             .spyOn(global, "setTimeout")
             .mockImplementation(((cb: (...args: any[]) => void) => {
-                cb();
+                timeoutCallback = cb;
                 return 0 as unknown as NodeJS.Timeout;
             }) as any);
 
@@ -2395,16 +2639,24 @@ describe("workers runtime behavior", () => {
             (call) => call[0] === "*",
         )?.[1];
 
-        await schedulerHandler({
+        const handled = schedulerHandler({
             id: "cleanup-timeout",
             name: "lidarr-cleanup-cycle",
             data: { mode: "startup" },
         });
+        await flushPromises();
+        timeoutCallback();
+        rejectWork(new Error("cancelled work settled"));
+        await handled;
         setTimeoutSpy.mockRestore();
 
         expect(mocks.logger.warn).toHaveBeenCalledWith(
             expect.stringContaining("Operation timed out after 180000ms"),
         );
+        expect(mocks.recordSchedulerTimeout).toHaveBeenCalledWith(
+            "clearLidarrQueue",
+        );
+        expect(mocks.recordSchedulerJobSuccess).not.toHaveBeenCalled();
     });
 
     it("surfaces scheduler processor errors when a job handler throws", async () => {

--- a/backend/src/workers/__tests__/queues.test.ts
+++ b/backend/src/workers/__tests__/queues.test.ts
@@ -50,7 +50,7 @@ describe("workers/queues", () => {
             "rediss://user:pass@cache.example:6381/2",
         );
 
-        expect(bullCtor).toHaveBeenCalledTimes(9);
+        expect(bullCtor).toHaveBeenCalledTimes(10);
         const firstCallArgs = bullCtor.mock.calls[0];
         const firstQueueOptions = firstCallArgs[1];
 
@@ -65,7 +65,7 @@ describe("workers/queues", () => {
                 tls: {},
             }),
         );
-        expect(queuesModule.queues).toHaveLength(9);
+        expect(queuesModule.queues).toHaveLength(10);
         expect(bullCtor.mock.calls.map((call) => call[0])).toEqual([
             "library-scan",
             "discover-weekly",
@@ -73,6 +73,7 @@ describe("workers/queues", () => {
             "file-validation",
             "audio-analysis",
             "worker-scheduler",
+            "worker-scheduler-maintenance",
             "generic-import",
             "federation-sync",
             "album-download",

--- a/backend/src/workers/__tests__/schedulerPolicy.test.ts
+++ b/backend/src/workers/__tests__/schedulerPolicy.test.ts
@@ -1,0 +1,52 @@
+jest.mock("../../config", () => ({
+    config: {
+        workers: { loudnessBackfillBatchSize: 100 },
+    },
+}));
+
+import {
+    FIVE_MINUTE_JITTER_MAX_SECONDS,
+    jitterFiveMinuteRepeat,
+    schedulerLaneForJob,
+} from "../schedulerPolicy";
+import { SCHEDULER_JOB_TYPES } from "../schedulerJobTypes";
+
+describe("scheduler policy", () => {
+    it("routes reconciliation, recovery, and Lidarr cleanup to the fast lane", () => {
+        expect(schedulerLaneForJob(SCHEDULER_JOB_TYPES.reconciliation)).toBe(
+            "fast",
+        );
+        expect(
+            schedulerLaneForJob(SCHEDULER_JOB_TYPES.albumDownloadRecovery),
+        ).toBe("fast");
+        expect(schedulerLaneForJob(SCHEDULER_JOB_TYPES.lidarrCleanup)).toBe(
+            "fast",
+        );
+        expect(schedulerLaneForJob(SCHEDULER_JOB_TYPES.dataIntegrity)).toBe(
+            "slow",
+        );
+        expect(schedulerLaneForJob("unknown-job")).toBe("unknown");
+    });
+
+    it("converts five-minute repeats to stable bounded cron offsets", () => {
+        const first = jitterFiveMinuteRepeat("scheduler:job-a", {
+            every: 5 * 60_000,
+        });
+        const repeated = jitterFiveMinuteRepeat("scheduler:job-a", {
+            every: 5 * 60_000,
+        });
+        if (!("cron" in first)) throw new Error("expected cron jitter");
+        const seconds = Number(first.cron.split(" ")[0]);
+
+        expect(first).toEqual(repeated);
+        expect(seconds).toBeGreaterThanOrEqual(1);
+        expect(seconds).toBeLessThanOrEqual(FIVE_MINUTE_JITTER_MAX_SECONDS);
+        expect(first).toEqual({ cron: `${seconds} */5 * * * *` });
+    });
+
+    it("leaves other cadences unchanged", () => {
+        expect(
+            jitterFiveMinuteRepeat("scheduler:hourly", { every: 60 * 60_000 }),
+        ).toEqual({ every: 60 * 60_000 });
+    });
+});

--- a/backend/src/workers/dataIntegrity.ts
+++ b/backend/src/workers/dataIntegrity.ts
@@ -13,18 +13,30 @@
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { Prisma } from "@prisma/client";
-import { resolveDownloadJobMetadata } from "../utils/downloadJobMetadata";
 import { config } from "../config";
 import { cleanupOrphanedLibraryEntities } from "../services/libraryOrphanCleanup";
 import { DISCOVERY_LIKED_OWNERSHIP_SOURCE } from "../services/albumOwnershipPromotion";
 import {
     albumOrphanRetentionGuardWhere,
     artistOrphanRetentionGuardWhere,
-    discoveryAlbumTracksOrphanRetentionGuardWhere,
+    discoveryAlbumOrphanRetentionGuardWhere,
     providerTrackRetentionCutoff,
 } from "../services/providerTrackRetention";
+import {
+    addDiscoveryAlbumMarkers,
+    addDownloadJobMarkers,
+    createDiscoveryMarkers,
+    findMislocatedAlbums,
+    findUnprotectedDiscoverAlbumIds,
+    type AlbumCandidate,
+    type DiscoveryMarkers,
+} from "./dataIntegrityBatches";
 
 const DATA_INTEGRITY_PRISMA_RETRY_ATTEMPTS = 3;
+const DATA_INTEGRITY_BATCH_SIZE = 250;
+const DATA_INTEGRITY_MAX_PAGES = 1_000;
+const DATA_INTEGRITY_MAX_MARKERS = 250_000;
+const log = logger.child("DataIntegrity");
 
 function isRetryableDataIntegrityPrismaError(error: unknown): boolean {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -77,8 +89,8 @@ export async function withDataIntegrityPrismaRetry<T>(
                 throw error;
             }
 
-            logger.warn(
-                `[DataIntegrity/Prisma] ${operationName} failed (attempt ${attempt}/${DATA_INTEGRITY_PRISMA_RETRY_ATTEMPTS}), retrying`,
+            log.warn(
+                `${operationName} failed (attempt ${attempt}/${DATA_INTEGRITY_PRISMA_RETRY_ATTEMPTS}), retrying`,
                 error,
             );
             await prisma.$connect().catch(() => {});
@@ -98,11 +110,372 @@ interface IntegrityReport {
     oldDownloadJobs: number;
 }
 
-/**
- * Executes runDataIntegrityCheck.
- */
+type CursorRow = { id: string };
+type BatchLoader<T extends CursorRow> = (cursor?: string) => Promise<T[]>;
+
+async function scanBatches<T extends CursorRow>(
+    operationName: string,
+    load: BatchLoader<T>,
+    consume: (rows: T[]) => Promise<void> | void,
+): Promise<void> {
+    let cursor: string | undefined;
+    for (let page = 0; page < DATA_INTEGRITY_MAX_PAGES; page += 1) {
+        const rows = await withDataIntegrityPrismaRetry(operationName, () =>
+            load(cursor),
+        );
+        if (rows.length === 0) return;
+        await consume(rows);
+        if (rows.length < DATA_INTEGRITY_BATCH_SIZE) return;
+        cursor = rows[rows.length - 1].id;
+    }
+    const overflow = await withDataIntegrityPrismaRetry(operationName, () =>
+        load(cursor),
+    );
+    if (overflow.length > 0) {
+        log.warn(
+            `${operationName} truncated at ${DATA_INTEGRITY_MAX_PAGES * DATA_INTEGRITY_BATCH_SIZE} rows`,
+        );
+    }
+}
+
+async function removeExpiredRows(
+    report: IntegrityReport,
+    now: Date,
+): Promise<void> {
+    const exclusions = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.discoverExclusion.deleteMany",
+        () =>
+            prisma.discoverExclusion.deleteMany({
+                where: { expiresAt: { lt: now } },
+            }),
+    );
+    report.expiredExclusions = exclusions.count;
+    const tracks = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.discoveryTrack.deleteMany",
+        () => prisma.discoveryTrack.deleteMany({ where: { trackId: null } }),
+    );
+    report.orphanedDiscoveryTracks = tracks.count;
+}
+
+async function findDiscoveryReferences(albums: AlbumCandidate[]) {
+    return withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.discoveryAlbum.findMany.activeBatch",
+        () =>
+            prisma.discoveryAlbum.findMany({
+                where: {
+                    status: { in: ["ACTIVE", "LIKED", "MOVED"] },
+                    OR: [
+                        { rgMbid: { in: albums.map((album) => album.rgMbid) } },
+                        ...albums.map((album) => ({
+                            albumTitle: {
+                                equals: album.title,
+                                mode: "insensitive" as const,
+                            },
+                            artistName: {
+                                equals: album.artist.name,
+                                mode: "insensitive" as const,
+                            },
+                        })),
+                    ],
+                },
+                select: { rgMbid: true, albumTitle: true, artistName: true },
+            }),
+    );
+}
+
+async function findOwnedReferences(albums: AlbumCandidate[]) {
+    return withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.ownedAlbum.findMany.batch",
+        () =>
+            prisma.ownedAlbum.findMany({
+                where: {
+                    OR: albums.map((album) => ({
+                        artistId: album.artistId,
+                        rgMbid: album.rgMbid,
+                    })),
+                },
+                select: { artistId: true, rgMbid: true },
+            }),
+    );
+}
+
+async function removeOrphanedDiscoverTracks(
+    albumRetentionWhere: Prisma.AlbumWhereInput,
+    cutoff: Date,
+): Promise<void> {
+    await scanBatches(
+        "runDataIntegrityCheck.album.findMany.discoverBatch",
+        (cursor) =>
+            prisma.album.findMany({
+                where: {
+                    location: "DISCOVER",
+                    ...albumRetentionWhere,
+                    ...(cursor ? { id: { gt: cursor } } : {}),
+                },
+                orderBy: { id: "asc" },
+                take: DATA_INTEGRITY_BATCH_SIZE,
+                select: {
+                    id: true,
+                    rgMbid: true,
+                    title: true,
+                    artistId: true,
+                    artist: { select: { name: true, mbid: true } },
+                },
+            }),
+        async (albums) => {
+            const [discovery, owned] = await Promise.all([
+                findDiscoveryReferences(albums),
+                findOwnedReferences(albums),
+            ]);
+            const orphanIds = findUnprotectedDiscoverAlbumIds(
+                albums,
+                discovery,
+                owned,
+            );
+            if (orphanIds.length === 0) return;
+            await withDataIntegrityPrismaRetry(
+                "runDataIntegrityCheck.track.deleteMany.orphanedAlbumBatch",
+                () =>
+                    prisma.track.deleteMany({
+                        where: {
+                            albumId: { in: orphanIds },
+                            album: discoveryAlbumOrphanRetentionGuardWhere(
+                                cutoff,
+                            ),
+                        },
+                    }),
+            );
+        },
+    );
+}
+
+async function collectDiscoveryMarkers(): Promise<DiscoveryMarkers> {
+    const markers = createDiscoveryMarkers(DATA_INTEGRITY_MAX_MARKERS);
+    await scanBatches(
+        "runDataIntegrityCheck.downloadJob.findMany.discoveryBatch",
+        (cursor) =>
+            prisma.downloadJob.findMany({
+                where: {
+                    discoveryBatchId: { not: null },
+                    status: { in: ["pending", "processing", "completed"] },
+                    ...(cursor ? { id: { gt: cursor } } : {}),
+                },
+                orderBy: { id: "asc" },
+                take: DATA_INTEGRITY_BATCH_SIZE,
+                select: { id: true, metadata: true },
+            }),
+        (jobs) => addDownloadJobMarkers(markers, jobs),
+    );
+    await scanBatches(
+        "runDataIntegrityCheck.discoveryAlbum.findMany.markerBatch",
+        (cursor) =>
+            prisma.discoveryAlbum.findMany({
+                where: cursor ? { id: { gt: cursor } } : undefined,
+                orderBy: { id: "asc" },
+                take: DATA_INTEGRITY_BATCH_SIZE,
+                select: {
+                    id: true,
+                    albumTitle: true,
+                    artistName: true,
+                    artistMbid: true,
+                },
+            }),
+        (albums) => addDiscoveryAlbumMarkers(markers, albums),
+    );
+    return markers;
+}
+
+async function findProtectedArtistIds(albums: AlbumCandidate[]) {
+    const rows = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.ownedAlbum.findMany.protectedBatch",
+        () =>
+            prisma.ownedAlbum.findMany({
+                where: {
+                    artistId: { in: albums.map((album) => album.artistId) },
+                    source: {
+                        in: ["native_scan", DISCOVERY_LIKED_OWNERSHIP_SOURCE],
+                    },
+                },
+                select: { artistId: true },
+                distinct: ["artistId"],
+            }),
+    );
+    return new Set(rows.map((row) => row.artistId));
+}
+
+async function findLikedArtistMbids(albums: AlbumCandidate[]) {
+    const mbids = albums.flatMap((album) =>
+        album.artist.mbid ? [album.artist.mbid] : [],
+    );
+    if (mbids.length === 0) return new Set<string>();
+    const rows = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.discoveryAlbum.findMany.likedBatch",
+        () =>
+            prisma.discoveryAlbum.findMany({
+                where: {
+                    artistMbid: { in: mbids },
+                    status: { in: ["LIKED", "MOVED"] },
+                },
+                select: { artistMbid: true },
+                distinct: ["artistMbid"],
+            }),
+    );
+    return new Set(
+        rows.flatMap((row) => (row.artistMbid ? [row.artistMbid] : [])),
+    );
+}
+
+async function relocateLibraryBatch(
+    albums: AlbumCandidate[],
+    markers: DiscoveryMarkers,
+): Promise<number> {
+    const [protectedArtists, likedMbids] = await Promise.all([
+        findProtectedArtistIds(albums),
+        findLikedArtistMbids(albums),
+    ]);
+    const mislocated = findMislocatedAlbums(
+        albums,
+        markers,
+        protectedArtists,
+        likedMbids,
+    );
+    if (mislocated.length === 0) return 0;
+    const ids = mislocated.map((album) => album.id);
+    const rgMbids = mislocated.map((album) => album.rgMbid);
+    const updated = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.album.updateMany.mislocatedBatch",
+        () =>
+            prisma.album.updateMany({
+                where: { id: { in: ids }, location: "LIBRARY" },
+                data: { location: "DISCOVER" },
+            }),
+    );
+    await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.ownedAlbum.deleteMany.mislocatedBatch",
+        () =>
+            prisma.ownedAlbum.deleteMany({
+                where: {
+                    rgMbid: { in: rgMbids },
+                    source: { not: "native_scan" },
+                },
+            }),
+    );
+    return updated.count;
+}
+
+async function fixMislocatedAlbums(markers: DiscoveryMarkers): Promise<number> {
+    let fixed = 0;
+    await scanBatches(
+        "runDataIntegrityCheck.album.findMany.libraryBatch",
+        (cursor) =>
+            prisma.album.findMany({
+                where: {
+                    location: "LIBRARY",
+                    ...(cursor ? { id: { gt: cursor } } : {}),
+                },
+                orderBy: { id: "asc" },
+                take: DATA_INTEGRITY_BATCH_SIZE,
+                select: {
+                    id: true,
+                    rgMbid: true,
+                    title: true,
+                    artistId: true,
+                    artist: { select: { name: true, mbid: true } },
+                },
+            }),
+        async (albums) => {
+            fixed += await relocateLibraryBatch(albums, markers);
+        },
+    );
+    return fixed;
+}
+
+async function consolidateArtistBatch(
+    artists: Array<{ id: string; normalizedName: string }>,
+): Promise<number> {
+    const realArtists = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.artist.findMany.realBatch",
+        () =>
+            prisma.artist.findMany({
+                where: {
+                    normalizedName: {
+                        in: artists.map((row) => row.normalizedName),
+                    },
+                    mbid: { not: { startsWith: "temp-" } },
+                },
+                orderBy: { id: "asc" },
+                select: { id: true, normalizedName: true },
+            }),
+    );
+    const realByName = new Map<string, string>();
+    for (const artist of realArtists) {
+        if (!realByName.has(artist.normalizedName)) {
+            realByName.set(artist.normalizedName, artist.id);
+        }
+    }
+    let consolidated = 0;
+    for (const artist of artists) {
+        const realId = realByName.get(artist.normalizedName);
+        if (!realId) continue;
+        await withDataIntegrityPrismaRetry(
+            "runDataIntegrityCheck.album.updateMany.consolidateArtist",
+            () =>
+                prisma.album.updateMany({
+                    where: { artistId: artist.id },
+                    data: { artistId: realId },
+                }),
+        );
+        consolidated += 1;
+    }
+    return consolidated;
+}
+
+async function consolidateTempArtists(
+    artistRetentionWhere: Prisma.ArtistWhereInput,
+): Promise<number> {
+    let consolidated = 0;
+    await scanBatches(
+        "runDataIntegrityCheck.artist.findMany.tempBatch",
+        (cursor) =>
+            prisma.artist.findMany({
+                where: {
+                    mbid: { startsWith: "temp-" },
+                    ...artistRetentionWhere,
+                    ...(cursor ? { id: { gt: cursor } } : {}),
+                },
+                orderBy: { id: "asc" },
+                take: DATA_INTEGRITY_BATCH_SIZE,
+                select: { id: true, normalizedName: true },
+            }),
+        async (artists) => {
+            consolidated += await consolidateArtistBatch(artists);
+        },
+    );
+    return consolidated;
+}
+
+async function removeOldDownloadJobs(now: Date): Promise<number> {
+    const cutoff = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1_000);
+    const result = await withDataIntegrityPrismaRetry(
+        "runDataIntegrityCheck.downloadJob.deleteMany.oldJobs",
+        () =>
+            prisma.downloadJob.deleteMany({
+                where: {
+                    status: { in: ["completed", "failed"] },
+                    completedAt: { lt: cutoff },
+                },
+            }),
+    );
+    return result.count;
+}
+
+function logReport(report: IntegrityReport): void {
+    log.debug("Data integrity check complete", report);
+}
+
+/** Runs bounded, cursor-paginated database integrity maintenance. */
 export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
-    logger.debug("\nRunning data integrity check...");
+    log.debug("Running data integrity check");
     const now = new Date();
     const cutoff = providerTrackRetentionCutoff(
         now,
@@ -121,343 +494,16 @@ export async function runDataIntegrityCheck(): Promise<IntegrityReport> {
         oldDownloadJobs: 0,
     };
 
-    // 1. Remove expired DiscoverExclusion records
-    const expiredExclusions = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.discoverExclusion.deleteMany",
-        () =>
-            prisma.discoverExclusion.deleteMany({
-                where: {
-                    expiresAt: { lt: new Date() },
-                },
-            }),
-    );
-    report.expiredExclusions = expiredExclusions.count;
-    if (expiredExclusions.count > 0) {
-        logger.debug(
-            `     Removed ${expiredExclusions.count} expired exclusions`,
-        );
-    }
-
-    // 2. Clean up orphaned DiscoveryTrack records (tracks whose Track record was deleted)
-    const orphanedDiscoveryTracks = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.discoveryTrack.deleteMany",
-        () =>
-            prisma.discoveryTrack.deleteMany({
-                where: {
-                    trackId: null,
-                },
-            }),
-    );
-    report.orphanedDiscoveryTracks = orphanedDiscoveryTracks.count;
-    if (orphanedDiscoveryTracks.count > 0) {
-        logger.debug(
-            `     Removed ${orphanedDiscoveryTracks.count} orphaned discovery track records`,
-        );
-    }
-
-    // 3. Clean up orphaned DISCOVER albums (no active DiscoveryAlbum record AND no OwnedAlbum)
-    const discoverAlbums = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.album.findMany.discover",
-        () =>
-            prisma.album.findMany({
-                where: {
-                    location: "DISCOVER",
-                    ...albumRetentionWhere,
-                },
-                include: { artist: true },
-            }),
-    );
-
-    for (const album of discoverAlbums) {
-        // Check if there's an ACTIVE, LIKED, or MOVED DiscoveryAlbum record
-        const hasActiveRecord = await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.discoveryAlbum.findFirst.activeRecord",
-            () =>
-                prisma.discoveryAlbum.findFirst({
-                    where: {
-                        OR: [
-                            { rgMbid: album.rgMbid },
-                            {
-                                albumTitle: {
-                                    equals: album.title,
-                                    mode: "insensitive",
-                                },
-                                artistName: {
-                                    equals: album.artist.name,
-                                    mode: "insensitive",
-                                },
-                            },
-                        ],
-                        status: { in: ["ACTIVE", "LIKED", "MOVED"] },
-                    },
-                }),
-        );
-
-        // Also check if there's an OwnedAlbum record (user liked it)
-        const hasOwnedRecord = await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.ownedAlbum.findFirst.ownedRecord",
-            () =>
-                prisma.ownedAlbum.findFirst({
-                    where: {
-                        artistId: album.artistId,
-                        rgMbid: album.rgMbid,
-                    },
-                }),
-        );
-
-        if (!hasActiveRecord && !hasOwnedRecord) {
-            // Delete tracks first
-            await withDataIntegrityPrismaRetry(
-                "runDataIntegrityCheck.track.deleteMany.orphanedAlbumTracks",
-                () =>
-                    prisma.track.deleteMany({
-                        where: discoveryAlbumTracksOrphanRetentionGuardWhere(
-                            album.id,
-                            cutoff,
-                        ),
-                    }),
-            );
-            logger.debug(
-                `     Removed tracks from orphaned album: ${album.artist.name} - ${album.title}`,
-            );
-        }
-    }
-
-    // 4. Fix mislocated LIBRARY albums that should be DISCOVER
-    // This happens when:
-    // - Discovery tracks have featured artists that don't match the download job
-    // - Lidarr downloads a different album than requested (e.g., "Broods" album vs "Evergreen" album)
-    // - Album title metadata differs from the requested album
-    // - Scanner ran before DiscoveryAlbum records were created
-
-    const discoveryJobs = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.downloadJob.findMany.discoveryJobs",
-        () =>
-            prisma.downloadJob.findMany({
-                where: {
-                    discoveryBatchId: { not: null },
-                    status: { in: ["pending", "processing", "completed"] },
-                },
-            }),
-    );
-
-    // Build sets of discovery album titles AND artist names (normalized)
-    const discoveryAlbumTitles = new Set<string>();
-    const discoveryArtistNames = new Set<string>();
-    const discoveryArtistMbids = new Set<string>();
-
-    for (const job of discoveryJobs) {
-        const {
-            normalizedAlbumTitle: albumTitle,
-            normalizedArtistName: artistName,
-            artistMbid,
-        } = resolveDownloadJobMetadata(job.metadata);
-        if (albumTitle) discoveryAlbumTitles.add(albumTitle);
-        if (artistName) discoveryArtistNames.add(artistName);
-        if (artistMbid) discoveryArtistMbids.add(artistMbid);
-    }
-
-    // Also check DiscoveryAlbum table for ALL discoveries (not just active)
-    // This catches albums where Lidarr downloaded a different album than requested
-    const allDiscoveryAlbums = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.discoveryAlbum.findMany.all",
-        () => prisma.discoveryAlbum.findMany(),
-    );
-    for (const da of allDiscoveryAlbums) {
-        discoveryAlbumTitles.add(da.albumTitle.toLowerCase().trim());
-        discoveryArtistNames.add(da.artistName.toLowerCase().trim());
-        if (da.artistMbid) discoveryArtistMbids.add(da.artistMbid);
-    }
-
-    // Find LIBRARY albums that might be discovery
-    const libraryAlbums = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.album.findMany.library",
-        () =>
-            prisma.album.findMany({
-                where: { location: "LIBRARY" },
-                include: { artist: true },
-            }),
-    );
-
-    let mislocatedAlbumsFixed = 0;
-    for (const album of libraryAlbums) {
-        const normalizedTitle = album.title.toLowerCase().trim();
-        const normalizedArtist = album.artist.name.toLowerCase().trim();
-
-        // Match criteria:
-        // 1. Album title matches a discovery download, OR
-        // 2. Artist name matches a discovery download (catches Lidarr downloading wrong album), OR
-        // 3. Artist MBID matches a discovery download
-        const albumMatches = discoveryAlbumTitles.has(normalizedTitle);
-        const artistNameMatches = discoveryArtistNames.has(normalizedArtist);
-        const artistMbidMatches = album.artist.mbid
-            ? discoveryArtistMbids.has(album.artist.mbid)
-            : false;
-
-        if (!albumMatches && !artistNameMatches && !artistMbidMatches) continue;
-
-        // KEY FIX: Check if artist has ANY protected OwnedAlbum records:
-        // - native_scan = real user library from before discovery
-        // - discovery_liked = user liked a discovery album (should be kept!)
-        const hasProtectedOwnedAlbum = await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.ownedAlbum.findFirst.protected",
-            () =>
-                prisma.ownedAlbum.findFirst({
-                    where: {
-                        artistId: album.artistId,
-                        source: {
-                            in: [
-                                "native_scan",
-                                DISCOVERY_LIKED_OWNERSHIP_SOURCE,
-                            ],
-                        },
-                    },
-                }),
-        );
-
-        if (hasProtectedOwnedAlbum) {
-            // Artist has protected content - this album should stay as LIBRARY
-            continue;
-        }
-
-        // Also check if artist has any LIKED discovery albums (double-check)
-        const hasLikedDiscovery = await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.discoveryAlbum.findFirst.liked",
-            () =>
-                prisma.discoveryAlbum.findFirst({
-                    where: {
-                        artistMbid: album.artist.mbid || undefined,
-                        status: { in: ["LIKED", "MOVED"] },
-                    },
-                }),
-        );
-
-        if (hasLikedDiscovery) {
-            // User liked albums from this artist - don't touch
-            continue;
-        }
-
-        const reason = albumMatches
-            ? `album title "${album.title}" matches discovery`
-            : artistNameMatches
-              ? `artist "${album.artist.name}" matches discovery`
-              : `artist MBID matches discovery`;
-        logger.debug(
-            `     Fixing mislocated album: ${album.artist.name} - ${album.title} (LIBRARY -> DISCOVER, ${reason})`,
-        );
-
-        // Update album location
-        await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.album.update.mislocated",
-            () =>
-                prisma.album.update({
-                    where: { id: album.id },
-                    data: { location: "DISCOVER" },
-                }),
-        );
-
-        // Remove OwnedAlbum record (but only non-native ones)
-        await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.ownedAlbum.deleteMany.mislocated",
-            () =>
-                prisma.ownedAlbum.deleteMany({
-                    where: {
-                        rgMbid: album.rgMbid,
-                        source: { not: "native_scan" },
-                    },
-                }),
-        );
-
-        mislocatedAlbumsFixed++;
-    }
-
-    report.mislocatedAlbums = mislocatedAlbumsFixed;
-    if (mislocatedAlbumsFixed > 0) {
-        logger.debug(`     Fixed ${mislocatedAlbumsFixed} mislocated albums`);
-    }
-
-    // 5. Consolidate duplicate artists (same name, one with temp MBID, one with real)
-    const tempArtists = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.artist.findMany.temp",
-        () =>
-            prisma.artist.findMany({
-                where: {
-                    mbid: { startsWith: "temp-" },
-                    ...artistRetentionWhere,
-                },
-                include: { albums: true },
-            }),
-    );
-
-    for (const tempArtist of tempArtists) {
-        // Find a real artist with the same normalized name
-        const realArtist = await withDataIntegrityPrismaRetry(
-            "runDataIntegrityCheck.artist.findFirst.realMatch",
-            () =>
-                prisma.artist.findFirst({
-                    where: {
-                        normalizedName: tempArtist.normalizedName,
-                        mbid: { not: { startsWith: "temp-" } },
-                    },
-                }),
-        );
-
-        if (realArtist) {
-            // Move all albums from temp artist to real artist
-            await withDataIntegrityPrismaRetry(
-                "runDataIntegrityCheck.album.updateMany.consolidateArtist",
-                () =>
-                    prisma.album.updateMany({
-                        where: { artistId: tempArtist.id },
-                        data: { artistId: realArtist.id },
-                    }),
-            );
-
-            report.consolidatedArtists++;
-            logger.debug(
-                `     Consolidated "${tempArtist.name}" (temp) into real artist`,
-            );
-        }
-    }
-
-    // 6. Delete catalog parents through the tombstone-aware shared transaction.
+    await removeExpiredRows(report, now);
+    await removeOrphanedDiscoverTracks(albumRetentionWhere, cutoff);
+    const markers = await collectDiscoveryMarkers();
+    report.mislocatedAlbums = await fixMislocatedAlbums(markers);
+    report.consolidatedArtists =
+        await consolidateTempArtists(artistRetentionWhere);
     const orphanedParents = await cleanupOrphanedLibraryEntities(now);
     report.orphanedAlbums = orphanedParents.albumsDeleted;
     report.orphanedArtists = orphanedParents.artistsDeleted;
-
-    // 7. Clean up old DownloadJob records (older than 30 days, completed/failed)
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-    const oldJobs = await withDataIntegrityPrismaRetry(
-        "runDataIntegrityCheck.downloadJob.deleteMany.oldJobs",
-        () =>
-            prisma.downloadJob.deleteMany({
-                where: {
-                    // Exhausted jobs are deliberately retained by this cleanup.
-                    status: { in: ["completed", "failed"] },
-                    completedAt: { lt: thirtyDaysAgo },
-                },
-            }),
-    );
-    report.oldDownloadJobs = oldJobs.count;
-    if (oldJobs.count > 0) {
-        logger.debug(`     Removed ${oldJobs.count} old download jobs`);
-    }
-
-    // Summary
-    logger.debug("\nData integrity check complete:");
-    logger.debug(`   - Expired exclusions: ${report.expiredExclusions}`);
-    logger.debug(
-        `   - Orphaned discovery tracks: ${report.orphanedDiscoveryTracks}`,
-    );
-    logger.debug(
-        `   - Mislocated albums (LIBRARY->DISCOVER): ${report.mislocatedAlbums}`,
-    );
-    logger.debug(`   - Orphaned albums: ${report.orphanedAlbums}`);
-    logger.debug(`   - Consolidated artists: ${report.consolidatedArtists}`);
-    logger.debug(`   - Orphaned artists: ${report.orphanedArtists}`);
-    logger.debug(`   - Old download jobs: ${report.oldDownloadJobs}`);
-
+    report.oldDownloadJobs = await removeOldDownloadJobs(now);
+    logReport(report);
     return report;
 }

--- a/backend/src/workers/dataIntegrityBatches.ts
+++ b/backend/src/workers/dataIntegrityBatches.ts
@@ -1,0 +1,164 @@
+import { resolveDownloadJobMetadata } from "../utils/downloadJobMetadata";
+
+export interface DiscoveryMarkers {
+    albumTitles: Set<string>;
+    artistNames: Set<string>;
+    artistMbids: Set<string>;
+    maxEntries: number;
+}
+
+export interface AlbumCandidate {
+    id: string;
+    rgMbid: string;
+    title: string;
+    artistId: string;
+    artist: { name: string; mbid: string | null };
+}
+
+interface DiscoveryReference {
+    rgMbid: string;
+    albumTitle: string;
+    artistName: string;
+}
+
+interface OwnedReference {
+    artistId: string;
+    rgMbid: string;
+}
+
+function normalize(value: string): string {
+    return value.toLowerCase().trim();
+}
+
+function totalMarkerEntries(markers: DiscoveryMarkers): number {
+    return (
+        markers.albumTitles.size +
+        markers.artistNames.size +
+        markers.artistMbids.size
+    );
+}
+
+function assertMarkerBound(markers: DiscoveryMarkers): void {
+    if (totalMarkerEntries(markers) > markers.maxEntries) {
+        throw new Error("Data integrity discovery marker bound exceeded");
+    }
+}
+
+/** Creates bounded marker sets used across cursor-paginated scans. */
+export function createDiscoveryMarkers(maxEntries: number): DiscoveryMarkers {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+        throw new Error("maxEntries must be a positive integer");
+    }
+    return {
+        albumTitles: new Set(),
+        artistNames: new Set(),
+        artistMbids: new Set(),
+        maxEntries,
+    };
+}
+
+function addMarkerValues(
+    markers: DiscoveryMarkers,
+    albumTitle?: string,
+    artistName?: string,
+    artistMbid?: string | null,
+): void {
+    if (albumTitle) markers.albumTitles.add(normalize(albumTitle));
+    if (artistName) markers.artistNames.add(normalize(artistName));
+    if (artistMbid) markers.artistMbids.add(artistMbid);
+    assertMarkerBound(markers);
+}
+
+/** Adds selected discovery-download metadata to the bounded marker sets. */
+export function addDownloadJobMarkers(
+    markers: DiscoveryMarkers,
+    jobs: ReadonlyArray<{ metadata: unknown }>,
+): void {
+    for (const job of jobs) {
+        const metadata = resolveDownloadJobMetadata(job.metadata);
+        addMarkerValues(
+            markers,
+            metadata.normalizedAlbumTitle,
+            metadata.normalizedArtistName,
+            metadata.artistMbid,
+        );
+    }
+}
+
+/** Adds selected DiscoveryAlbum fields to the bounded marker sets. */
+export function addDiscoveryAlbumMarkers(
+    markers: DiscoveryMarkers,
+    albums: ReadonlyArray<{
+        albumTitle: string;
+        artistName: string;
+        artistMbid: string | null;
+    }>,
+): void {
+    for (const album of albums) {
+        addMarkerValues(
+            markers,
+            album.albumTitle,
+            album.artistName,
+            album.artistMbid,
+        );
+    }
+}
+
+function matchesDiscovery(
+    album: AlbumCandidate,
+    markers: DiscoveryMarkers,
+): boolean {
+    return (
+        markers.albumTitles.has(normalize(album.title)) ||
+        markers.artistNames.has(normalize(album.artist.name)) ||
+        (album.artist.mbid !== null &&
+            markers.artistMbids.has(album.artist.mbid))
+    );
+}
+
+/** Selects discovery matches that have no protected ownership or liked state. */
+export function findMislocatedAlbums(
+    albums: ReadonlyArray<AlbumCandidate>,
+    markers: DiscoveryMarkers,
+    protectedArtistIds: ReadonlySet<string>,
+    likedArtistMbids: ReadonlySet<string>,
+): AlbumCandidate[] {
+    return albums.filter(
+        (album) =>
+            matchesDiscovery(album, markers) &&
+            !protectedArtistIds.has(album.artistId) &&
+            (album.artist.mbid === null ||
+                !likedArtistMbids.has(album.artist.mbid)),
+    );
+}
+
+function titleArtistKey(title: string, artist: string): string {
+    return `${normalize(artist)}|${normalize(title)}`;
+}
+
+/** Selects DISCOVER album IDs lacking an exact active or owned reference. */
+export function findUnprotectedDiscoverAlbumIds(
+    albums: ReadonlyArray<AlbumCandidate>,
+    discoveryReferences: ReadonlyArray<DiscoveryReference>,
+    ownedReferences: ReadonlyArray<OwnedReference>,
+): string[] {
+    const activeMbids = new Set(discoveryReferences.map((row) => row.rgMbid));
+    const activeTitles = new Set(
+        discoveryReferences.map((row) =>
+            titleArtistKey(row.albumTitle, row.artistName),
+        ),
+    );
+    const ownedKeys = new Set(
+        ownedReferences.map((row) => `${row.artistId}|${row.rgMbid}`),
+    );
+    return albums
+        .filter(
+            (album) =>
+                !activeMbids.has(album.rgMbid) &&
+                !activeTitles.has(
+                    titleArtistKey(album.title, album.artist.name),
+                ) &&
+                !ownedKeys.has(`${album.artistId}|${album.rgMbid}`),
+        )
+        .map((album) => album.id);
+}

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -1,5 +1,6 @@
 import { logger } from "../utils/logger";
 import { randomUUID } from "crypto";
+import pLimit from "p-limit";
 import { trackJobStart, trackJobEnd } from "../services/workerEventLoopMonitor";
 import type Bull from "bull";
 import {
@@ -8,6 +9,7 @@ import {
     imageQueue,
     validationQueue,
     schedulerQueue,
+    schedulerMaintenanceQueue,
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,
@@ -31,7 +33,12 @@ import {
     processAlbumDownload,
 } from "./processors/albumDownloadProcessor";
 import { processArtistDownloadExpansion } from "./processors/artistDownloadExpansionProcessor";
-import { recordAlbumDownloadOutcome } from "../metrics";
+import {
+    recordAlbumDownloadOutcome,
+    recordSchedulerJobDuration,
+    recordSchedulerJobSuccess,
+    recordSchedulerTimeout,
+} from "../metrics";
 import {
     ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
     recoverUnqueuedAlbumDownloads,
@@ -100,6 +107,16 @@ import {
     consumeCoalescedScanFollowUp,
 } from "../services/coalescedLibraryScan";
 import { registerQueueProcessorEvents } from "./queueEvents";
+import {
+    ConsecutiveFailureCircuitBreaker,
+    RedisCircuitBreakerStore,
+} from "../utils/circuitBreaker";
+import { jitterFiveMinuteRepeat, schedulerLaneForJob } from "./schedulerPolicy";
+import {
+    SCHEDULER_METRIC_JOBS,
+    type SchedulerMetricJob,
+    type SchedulerTimeoutOperation,
+} from "../metrics/schedulerMetrics";
 
 const log = logger.child("WorkerScheduler");
 const queueProcessorLog = log.child("QueueProcessor");
@@ -116,6 +133,58 @@ const queueProcessorCounters = {
     failed: 0,
 };
 const coalescedFollowUpConsumptions = new Set<Promise<void>>();
+const fastSchedulerLane = pLimit(1);
+const slowSchedulerLane = pLimit(1);
+const reconciliationCircuitBreakerStore = new RedisCircuitBreakerStore(
+    {
+        eval: (script, numberOfKeys, key, ...args) =>
+            withSchedulerClaimRedisRetry(
+                "reconciliation circuit breaker transition",
+                (client) => client.eval(script, numberOfKeys, key, ...args),
+            ),
+    },
+    "scheduler:circuit-breaker:reconciliation:v1",
+    30 * ONE_MINUTE_MS,
+);
+const reconciliationCircuitBreaker = new ConsecutiveFailureCircuitBreaker({
+    failureThreshold: 3,
+    cooldownMs: 5 * ONE_MINUTE_MS,
+    store: reconciliationCircuitBreakerStore,
+    logger: log,
+});
+
+class SchedulerOperationTimeoutError extends Error {
+    constructor(readonly operation: SchedulerTimeoutOperation) {
+        super(`Scheduler operation timed out: ${operation}`);
+        this.name = "SchedulerOperationTimeoutError";
+    }
+}
+
+async function runSchedulerTimedOperation<T>(
+    operation: SchedulerTimeoutOperation,
+    timeoutMs: number,
+    work: (signal: AbortSignal) => Promise<T>,
+    timeoutLogger = log,
+): Promise<T | undefined> {
+    const result = await withTimeout(work, timeoutMs, operation, {
+        result: true,
+        logger: timeoutLogger,
+    });
+    if (result.ok) return result.value;
+    recordSchedulerTimeout(operation);
+    return undefined;
+}
+
+async function requireSchedulerTimedOperation<T>(
+    operation: SchedulerTimeoutOperation,
+    timeoutMs: number,
+    work: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+    const value = await runSchedulerTimedOperation(operation, timeoutMs, work);
+    if (value === undefined)
+        throw new SchedulerOperationTimeoutError(operation);
+    return value;
+}
 
 function consumeCoalescedFollowUpAfterSettlement(job: Bull.Job<any>): void {
     if (String(job.id) !== COALESCED_SCAN_JOB_ID) return;
@@ -151,6 +220,7 @@ function recordQueueProcessorEvent(
         // long-running album downloads need this; other queues stay sampled.
         if (
             queueName === "worker-scheduler" ||
+            queueName === "worker-scheduler-maintenance" ||
             queueName === "library-scan" ||
             queueName === "album-download"
         ) {
@@ -239,8 +309,8 @@ async function saveReconciliationCursor(
     );
 }
 
-async function processDataIntegrityJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processDataIntegrityJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:data-integrity",
         30 * ONE_MINUTE_MS,
         "data integrity check",
@@ -248,70 +318,96 @@ async function processDataIntegrityJob(): Promise<void> {
             await runDataIntegrityCheck();
         },
     );
+    return claim.acquired;
 }
 
-async function processReconciliationJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processReconciliationJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:reconciliation-cycle",
         10 * ONE_MINUTE_MS,
         "download reconciliation cycle",
         async () => {
-            const { lidarrService } = await import("../services/lidarr");
-            const snapshot = await withTimeout(
-                () => lidarrService.getReconciliationSnapshot(),
-                30_000,
-                "getReconciliationSnapshot",
-            );
-
-            const staleCount = await withTimeout(
-                () => simpleDownloadManager.markStaleJobsAsFailed(snapshot),
-                120_000,
-                "markStaleJobsAsFailed",
-            );
-            if (staleCount && staleCount > 0) {
-                log.debug(
-                    `Periodic cleanup: marked ${staleCount} stale download(s) as failed`,
+            if (!(await reconciliationCircuitBreaker.tryAcquire())) {
+                log.warn(
+                    "Skipping reconciliation while circuit breaker is open",
+                    {
+                        circuit: await reconciliationCircuitBreaker.snapshot(),
+                    },
                 );
+                return false;
             }
-
-            const lidarrResult = await withTimeout(
-                () => simpleDownloadManager.reconcileWithLidarr(snapshot),
-                120_000,
-                "reconcileWithLidarr",
-            );
-            if (lidarrResult && lidarrResult.reconciled > 0) {
-                log.debug(
-                    `Periodic reconcile: ${lidarrResult.reconciled} job(s) matched in Lidarr`,
-                );
-            }
-
-            const localResult = await withTimeout(
-                () => queueCleaner.reconcileWithLocalLibrary(),
-                120_000,
-                "reconcileWithLocalLibrary",
-            );
-            if (localResult && localResult.reconciled > 0) {
-                log.debug(
-                    `Periodic reconcile: ${localResult.reconciled} job(s) matched in local library`,
-                );
-            }
-
-            const syncResult = await withTimeout(
-                () => simpleDownloadManager.syncWithLidarrQueue(snapshot),
-                120_000,
-                "syncWithLidarrQueue",
-            );
-            if (syncResult && syncResult.cancelled > 0) {
-                log.debug(
-                    `Periodic sync: ${syncResult.cancelled} job(s) synced with Lidarr queue`,
-                );
+            try {
+                await runReconciliationCycle();
+                await reconciliationCircuitBreaker.recordSuccess();
+                return true;
+            } catch (error) {
+                await reconciliationCircuitBreaker.recordFailure();
+                log.warn("Reconciliation failure recorded by circuit breaker", {
+                    circuit: await reconciliationCircuitBreaker.snapshot(),
+                    error,
+                });
+                throw error;
             }
         },
     );
+    return claim.acquired && claim.value;
 }
 
-async function processAlbumDownloadRecoveryJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function runReconciliationCycle(): Promise<void> {
+    const { lidarrService } = await import("../services/lidarr");
+    const snapshot = await requireSchedulerTimedOperation(
+        "getReconciliationSnapshot",
+        30_000,
+        (signal) => lidarrService.getReconciliationSnapshot(signal),
+    );
+
+    const staleCount = await requireSchedulerTimedOperation(
+        "markStaleJobsAsFailed",
+        120_000,
+        () => simpleDownloadManager.markStaleJobsAsFailed(snapshot),
+    );
+    if (staleCount > 0) {
+        log.debug(
+            `Periodic cleanup: marked ${staleCount} stale download(s) as failed`,
+        );
+    }
+
+    const lidarrResult = await requireSchedulerTimedOperation(
+        "reconcileWithLidarr",
+        120_000,
+        () => simpleDownloadManager.reconcileWithLidarr(snapshot),
+    );
+    if (lidarrResult.reconciled > 0) {
+        log.debug(
+            `Periodic reconcile: ${lidarrResult.reconciled} job(s) matched in Lidarr`,
+        );
+    }
+
+    const localResult = await requireSchedulerTimedOperation(
+        "reconcileWithLocalLibrary",
+        120_000,
+        () => queueCleaner.reconcileWithLocalLibrary(),
+    );
+    if (localResult.reconciled > 0) {
+        log.debug(
+            `Periodic reconcile: ${localResult.reconciled} job(s) matched in local library`,
+        );
+    }
+
+    const syncResult = await requireSchedulerTimedOperation(
+        "syncWithLidarrQueue",
+        120_000,
+        () => simpleDownloadManager.syncWithLidarrQueue(snapshot),
+    );
+    if (syncResult.cancelled > 0) {
+        log.debug(
+            `Periodic sync: ${syncResult.cancelled} job(s) synced with Lidarr queue`,
+        );
+    }
+}
+
+async function processAlbumDownloadRecoveryJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:album-download-recovery",
         5 * ONE_MINUTE_MS,
         "album download recovery",
@@ -329,21 +425,23 @@ async function processAlbumDownloadRecoveryJob(): Promise<void> {
             }
         },
     );
+    return claim.acquired;
 }
 
-async function processCatalogRetentionJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processCatalogRetentionJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:catalog-retention",
         30 * ONE_MINUTE_MS,
         "catalog retention sweep",
         processCatalogRetention,
     );
+    return claim.acquired;
 }
 
 async function processLidarrCleanupJob(
     mode: "startup" | "repeat",
-): Promise<void> {
-    await runWithSchedulerClaim(
+): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:lidarr-cleanup-cycle",
         5 * ONE_MINUTE_MS,
         mode === "startup"
@@ -354,14 +452,14 @@ async function processLidarrCleanupJob(
                 log.debug("Running initial Lidarr queue cleanup...");
             }
 
-            const result = await withTimeout(
-                () => simpleDownloadManager.clearLidarrQueue(),
-                180_000,
+            const result = await runSchedulerTimedOperation(
                 "clearLidarrQueue",
+                180_000,
+                () => simpleDownloadManager.clearLidarrQueue(),
             );
 
             if (!result) {
-                return;
+                return false;
             }
 
             if (result.removed > 0) {
@@ -375,29 +473,36 @@ async function processLidarrCleanupJob(
             } else if (mode === "startup") {
                 log.debug("Initial cleanup: queue is clean");
             }
+            return true;
         },
     );
+    return claim.acquired && claim.value;
 }
 
-async function processCacheWarmupJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processCacheWarmupJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:cache-warmup-startup",
         30 * ONE_MINUTE_MS,
         "startup cache warmup",
         async () => {
-            await withTimeout(
-                () => dataCacheService.warmupCache(),
-                15 * ONE_MINUTE_MS,
+            const result = await runSchedulerTimedOperation(
                 "warmupCache",
+                15 * ONE_MINUTE_MS,
+                async () => {
+                    await dataCacheService.warmupCache();
+                    return true;
+                },
             );
+            return result === true;
         },
     );
+    return claim.acquired && claim.value;
 }
 
 async function processPodcastCleanupJob(
     mode: "startup" | "repeat",
-): Promise<void> {
-    await runWithSchedulerClaim(
+): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:podcast-cleanup",
         30 * ONE_MINUTE_MS,
         mode === "startup"
@@ -406,13 +511,18 @@ async function processPodcastCleanupJob(
         async () => {
             const { cleanupExpiredCache } =
                 await import("../services/podcastDownload");
-            await withTimeout(
-                () => cleanupExpiredCache(),
-                10 * ONE_MINUTE_MS,
+            const result = await runSchedulerTimedOperation(
                 "cleanupExpiredCache",
+                10 * ONE_MINUTE_MS,
+                async () => {
+                    await cleanupExpiredCache();
+                    return true;
+                },
             );
+            return result === true;
         },
     );
+    return claim.acquired && claim.value;
 }
 
 const REPEAT_SYNC_FAILURE_WARN_INTERVAL_MS = ONE_HOUR_MS;
@@ -420,7 +530,7 @@ let lastAudiobookRepeatFailureWarnAt = 0;
 
 async function processAudiobookAutoSyncJob(
     mode: "startup" | "repeat",
-): Promise<void> {
+): Promise<boolean> {
     const { getSystemSettings } = await import("../utils/systemSettings");
     const settings = await getSystemSettings();
     if (!settings?.audiobookshelfEnabled || !settings?.audiobookshelfUrl) {
@@ -429,16 +539,16 @@ async function processAudiobookAutoSyncJob(
                 "Audiobookshelf is disabled or unconfigured - skipping auto-sync",
             );
         }
-        return;
+        return false;
     }
     const { audiobookCacheService } =
         await import("../services/audiobookCache");
     let result;
     try {
-        result = await withTimeout(
-            () => audiobookCacheService.syncMissing(),
-            AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+        result = await runSchedulerTimedOperation(
             "audiobookCacheService.syncMissing",
+            AUDIOBOOK_SYNC_WORK_TIMEOUT_MS,
+            () => audiobookCacheService.syncMissing(),
             log,
         );
     } catch (error) {
@@ -455,25 +565,26 @@ async function processAudiobookAutoSyncJob(
         } else {
             startupLog.debug(message, error);
         }
-        return;
+        return false;
     }
     if (result && (mode === "startup" || result.synced || result.failed)) {
         startupLog.debug(
             `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
         );
     }
+    return result !== undefined;
 }
 
-async function processDownloadQueueReconcileJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processDownloadQueueReconcileJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:download-queue-reconcile-startup",
         30 * ONE_MINUTE_MS,
         "startup download queue reconciliation",
         async () => {
-            const result = await withTimeout(
-                () => downloadQueueManager.reconcileOnStartup(),
-                20 * ONE_MINUTE_MS,
+            const result = await runSchedulerTimedOperation(
                 "downloadQueueManager.reconcileOnStartup",
+                20 * ONE_MINUTE_MS,
+                () => downloadQueueManager.reconcileOnStartup(),
             );
 
             if (result) {
@@ -481,12 +592,14 @@ async function processDownloadQueueReconcileJob(): Promise<void> {
                     `Download queue reconciled: ${result.loaded} active, ${result.failed} marked failed`,
                 );
             }
+            return result !== undefined;
         },
     );
+    return claim.acquired && claim.value;
 }
 
-async function processArtistCountsBackfillJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processArtistCountsBackfillJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:artist-counts-backfill-startup",
         3 * ONE_HOUR_MS,
         "startup artist-counts backfill",
@@ -496,17 +609,17 @@ async function processArtistCountsBackfillJob(): Promise<void> {
             const needsBackfill = await isBackfillNeeded();
             if (!needsBackfill) {
                 startupLog.debug("Artist counts already populated");
-                return;
+                return true;
             }
 
             startupLog.info(
                 "Artist counts need backfilling, starting in background...",
             );
 
-            const result = await withTimeout(
-                () => backfillAllArtistCounts(),
-                3 * ONE_HOUR_MS,
+            const result = await runSchedulerTimedOperation(
                 "backfillAllArtistCounts",
+                3 * ONE_HOUR_MS,
+                () => backfillAllArtistCounts(),
             );
 
             if (result) {
@@ -514,12 +627,14 @@ async function processArtistCountsBackfillJob(): Promise<void> {
                     `Artist counts backfill complete: ${result.processed} processed, ${result.errors} errors`,
                 );
             }
+            return result !== undefined;
         },
     );
+    return claim.acquired && claim.value;
 }
 
-async function processImageBackfillJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processImageBackfillJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:image-backfill-startup",
         6 * ONE_HOUR_MS,
         "startup image backfill",
@@ -529,31 +644,33 @@ async function processImageBackfillJob(): Promise<void> {
             const status = await isImageBackfillNeeded();
             if (!status.needed) {
                 startupLog.debug("All images already stored locally");
-                return;
+                return true;
             }
 
             startupLog.info(
                 `Image backfill needed: ${status.artistsWithExternalUrls} artists, ${status.albumsWithExternalUrls} albums with external URLs`,
             );
 
-            const completed = await withTimeout(
+            const completed = await runSchedulerTimedOperation(
+                "backfillAllImages",
+                6 * ONE_HOUR_MS,
                 async () => {
                     await backfillAllImages();
                     return true;
                 },
-                6 * ONE_HOUR_MS,
-                "backfillAllImages",
             );
 
             if (completed) {
                 startupLog.info("Image backfill complete");
             }
+            return completed === true;
         },
     );
+    return claim.acquired && claim.value;
 }
 
-async function processTrackMappingReconcileJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processTrackMappingReconcileJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:track-mapping-reconcile",
         ONE_HOUR_MS,
         "track mapping reconciliation",
@@ -595,10 +712,11 @@ async function processTrackMappingReconcileJob(): Promise<void> {
             }
         },
     );
+    return claim.acquired;
 }
 
-async function processRemoteTrackMetadataRefreshJob(): Promise<void> {
-    await runWithSchedulerClaim(
+async function processRemoteTrackMetadataRefreshJob(): Promise<boolean> {
+    const claim = await runWithSchedulerClaim(
         "scheduler-claim:remote-track-metadata-refresh",
         ONE_HOUR_MS,
         "remote track metadata refresh",
@@ -614,27 +732,135 @@ async function processRemoteTrackMetadataRefreshJob(): Promise<void> {
             }
         },
     );
+    return claim.acquired;
 }
 
 async function registerSchedulerJobs(): Promise<void> {
     await schedulerQueue.isReady();
+    await schedulerMaintenanceQueue.isReady();
+    registerSchedulerProcessors();
 
     const schedulerJobs = buildSchedulerJobs();
     for (const job of schedulerJobs) {
-        await schedulerQueue.add(job.type, job.data, job.opts);
+        await registerSchedulerJob(job);
     }
     if (config.features.requests) {
-        const job = requestFulfillmentRepeatSchedule;
-        await schedulerQueue.add(job.type, job.data, job.opts);
+        await registerSchedulerJob(requestFulfillmentRepeatSchedule);
         return;
     }
-    await schedulerQueue.removeRepeatable(REQUEST_FULFILLMENT_JOB_NAME, {
-        every: REQUEST_FULFILLMENT_INTERVAL_MS,
-        jobId: REQUEST_FULFILLMENT_JOB_ID,
-    });
+    await removeRequestFulfillmentSchedules();
     log.info(
         "Music requests disabled (FEATURE_REQUESTS=false); fulfillment scheduler not registered",
     );
+}
+
+type SchedulerRegistrationInput = {
+    type: string;
+    data: Record<string, unknown>;
+    opts: Bull.JobOptions;
+};
+
+type SchedulerBullQueue = typeof schedulerQueue;
+
+function isFiveMinuteRepeat(opts: Bull.JobOptions): boolean {
+    return Boolean(
+        opts.repeat &&
+        "every" in opts.repeat &&
+        opts.repeat.every === REQUEST_FULFILLMENT_INTERVAL_MS,
+    );
+}
+
+function prepareSchedulerRegistration<T extends SchedulerRegistrationInput>(
+    job: T,
+): T {
+    if (!isFiveMinuteRepeat(job.opts)) return job;
+    const jobId = String(job.opts.jobId);
+    return {
+        ...job,
+        opts: {
+            ...job.opts,
+            repeat: jitterFiveMinuteRepeat(jobId, job.opts.repeat!),
+        },
+    };
+}
+
+async function removeLegacyFiveMinuteRepeat(
+    job: SchedulerRegistrationInput,
+): Promise<void> {
+    if (!isFiveMinuteRepeat(job.opts)) return;
+    await schedulerQueue.removeRepeatable(job.type, {
+        every: REQUEST_FULFILLMENT_INTERVAL_MS,
+        jobId: job.opts.jobId,
+    });
+}
+
+function schedulerQueueForJob(jobName: string): SchedulerBullQueue {
+    return schedulerLaneForJob(jobName) === "fast"
+        ? schedulerQueue
+        : schedulerMaintenanceQueue;
+}
+
+async function runSchedulerRegistrationStep(
+    step: string,
+    operation: () => Promise<unknown>,
+): Promise<void> {
+    try {
+        await operation();
+    } catch (error) {
+        log.warn(`Failed scheduler registration step: ${step}`, { error });
+    }
+}
+
+async function removeSlowRepeatFromFastQueue(
+    job: SchedulerRegistrationInput,
+): Promise<void> {
+    if (schedulerLaneForJob(job.type) !== "slow" || !job.opts.repeat) return;
+    await schedulerQueue.removeRepeatable(job.type, {
+        ...job.opts.repeat,
+        jobId: job.opts.jobId,
+    });
+}
+
+async function registerSchedulerJob(
+    job: SchedulerRegistrationInput,
+): Promise<void> {
+    const prepared = prepareSchedulerRegistration(job);
+    const targetQueue = schedulerQueueForJob(prepared.type);
+    await runSchedulerRegistrationStep(
+        `remove legacy repeat for ${job.type}`,
+        () => removeLegacyFiveMinuteRepeat(job),
+    );
+    await runSchedulerRegistrationStep(
+        `remove old fast-queue repeat for ${prepared.type}`,
+        () => removeSlowRepeatFromFastQueue(prepared),
+    );
+    await runSchedulerRegistrationStep(`register ${prepared.type}`, () =>
+        targetQueue.add(prepared.type, prepared.data, prepared.opts),
+    );
+}
+
+async function removeRequestFulfillmentSchedules(): Promise<void> {
+    const jittered = jitterFiveMinuteRepeat(REQUEST_FULFILLMENT_JOB_ID, {
+        every: REQUEST_FULFILLMENT_INTERVAL_MS,
+    });
+    for (const queue of [schedulerQueue, schedulerMaintenanceQueue]) {
+        await runSchedulerRegistrationStep(
+            `remove disabled request interval from ${queue.name}`,
+            () =>
+                queue.removeRepeatable(REQUEST_FULFILLMENT_JOB_NAME, {
+                    every: REQUEST_FULFILLMENT_INTERVAL_MS,
+                    jobId: REQUEST_FULFILLMENT_JOB_ID,
+                }),
+        );
+        await runSchedulerRegistrationStep(
+            `remove disabled request cron from ${queue.name}`,
+            () =>
+                queue.removeRepeatable(REQUEST_FULFILLMENT_JOB_NAME, {
+                    ...jittered,
+                    jobId: REQUEST_FULFILLMENT_JOB_ID,
+                }),
+        );
+    }
 }
 
 // Register processors with named job types
@@ -676,92 +902,148 @@ if (config.features.federation) {
         "Federation disabled (FEDERATION_ENABLED=false); federation processors and schedules not registered",
     );
 }
-async function processSchedulerJob(job: Bull.Job<any>): Promise<void> {
-    const mode = job?.data?.mode === "startup" ? "startup" : "repeat";
-
+async function processPrimarySchedulerJob(
+    job: Bull.Job<any>,
+    mode: "startup" | "repeat",
+): Promise<boolean | null> {
     switch (job?.name) {
         case SCHEDULER_JOB_TYPES.dataIntegrity:
-            await processDataIntegrityJob();
-            break;
+            return processDataIntegrityJob();
         case SCHEDULER_JOB_TYPES.reconciliation:
-            await processReconciliationJob();
-            break;
+            return processReconciliationJob();
         case SCHEDULER_JOB_TYPES.albumDownloadRecovery:
-            await processAlbumDownloadRecoveryJob();
-            break;
+            return processAlbumDownloadRecoveryJob();
         case SCHEDULER_JOB_TYPES.catalogRetention:
-            await processCatalogRetentionJob();
-            break;
+            return processCatalogRetentionJob();
         case SCHEDULER_JOB_TYPES.lidarrCleanup:
-            await processLidarrCleanupJob(mode);
-            break;
+            return processLidarrCleanupJob(mode);
         case SCHEDULER_JOB_TYPES.cacheWarmup:
-            await processCacheWarmupJob();
-            break;
+            return processCacheWarmupJob();
         case SCHEDULER_JOB_TYPES.podcastCleanup:
         case "podcast-cleanup":
-            await processPodcastCleanupJob(mode);
-            break;
+            return processPodcastCleanupJob(mode);
         case SCHEDULER_JOB_TYPES.audiobookAutoSync:
         case "audiobook-auto-sync":
-            await processAudiobookAutoSyncJob(mode);
-            break;
-        case SCHEDULER_JOB_TYPES.downloadQueueReconcile:
-        case "download-queue-reconcile":
-            await processDownloadQueueReconcileJob();
-            break;
-        case SCHEDULER_JOB_TYPES.artistCountsBackfill:
-        case "artist-counts-backfill":
-            await processArtistCountsBackfillJob();
-            break;
-        case SCHEDULER_JOB_TYPES.imageBackfill:
-        case "image-backfill":
-            await processImageBackfillJob();
-            break;
-        case SCHEDULER_JOB_TYPES.audioHashBackfill:
-            await processAudioHashBackfill(job);
-            break;
-        case SCHEDULER_JOB_TYPES.loudnessBackfill:
-            await processLoudnessBackfill(job);
-            break;
-        case SCHEDULER_JOB_TYPES.trackRemovalPurge:
-            await processTrackRemovalPurge(job);
-            break;
-        case SCHEDULER_JOB_TYPES.trackMappingReconcile:
-        case "track-mapping-reconcile":
-            await processTrackMappingReconcileJob();
-            break;
-        case SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh:
-        case "remote-track-metadata-refresh":
-            await processRemoteTrackMetadataRefreshJob();
-            break;
-        case REQUEST_FULFILLMENT_JOB_NAME:
-            if (config.features.requests) {
-                await processRequestFulfillmentBatch();
-            }
-            break;
+            return processAudiobookAutoSyncJob(mode);
         default:
-            log.warn(
-                `Scheduler wildcard received unknown job type "${job?.name ?? "unknown"}" (jobId=${job?.id ?? "unknown"}); skipping`,
-            );
-            break;
+            return null;
     }
 }
 
-// Safety net + primary scheduler processor:
-// Use a single wildcard processor so startup does not attach many pre-ready listeners
-// on the same queue client (which can trip Node's max-listener warning threshold).
-schedulerQueue.process("*", async (job: Bull.Job<any>) => {
+async function processMaintenanceSchedulerJob(
+    job: Bull.Job<any>,
+): Promise<boolean | null> {
+    switch (job?.name) {
+        case SCHEDULER_JOB_TYPES.downloadQueueReconcile:
+        case "download-queue-reconcile":
+            return processDownloadQueueReconcileJob();
+        case SCHEDULER_JOB_TYPES.artistCountsBackfill:
+        case "artist-counts-backfill":
+            return processArtistCountsBackfillJob();
+        case SCHEDULER_JOB_TYPES.imageBackfill:
+        case "image-backfill":
+            return processImageBackfillJob();
+        case SCHEDULER_JOB_TYPES.audioHashBackfill:
+            await processAudioHashBackfill(job);
+            return true;
+        case SCHEDULER_JOB_TYPES.loudnessBackfill:
+            await processLoudnessBackfill(job);
+            return true;
+        case SCHEDULER_JOB_TYPES.trackRemovalPurge:
+            await processTrackRemovalPurge(job);
+            return true;
+        case SCHEDULER_JOB_TYPES.trackMappingReconcile:
+        case "track-mapping-reconcile":
+            return processTrackMappingReconcileJob();
+        case SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh:
+        case "remote-track-metadata-refresh":
+            return processRemoteTrackMetadataRefreshJob();
+        case REQUEST_FULFILLMENT_JOB_NAME:
+            if (config.features.requests) {
+                await processRequestFulfillmentBatch();
+                return true;
+            }
+            return false;
+        default:
+            return null;
+    }
+}
+
+async function processSchedulerJob(job: Bull.Job<any>): Promise<boolean> {
+    const mode = job?.data?.mode === "startup" ? "startup" : "repeat";
+    const primary = await processPrimarySchedulerJob(job, mode);
+    if (primary !== null) return primary;
+    const maintenance = await processMaintenanceSchedulerJob(job);
+    if (maintenance !== null) return maintenance;
+    log.warn(
+        `Scheduler wildcard received unknown job type "${job?.name ?? "unknown"}" (jobId=${job?.id ?? "unknown"}); skipping`,
+    );
+    return false;
+}
+
+function canonicalSchedulerMetricJob(
+    jobName: string,
+): SchedulerMetricJob | null {
+    const aliases: Record<string, SchedulerMetricJob> = {
+        "podcast-cleanup": SCHEDULER_JOB_TYPES.podcastCleanup,
+        "audiobook-auto-sync": SCHEDULER_JOB_TYPES.audiobookAutoSync,
+        "download-queue-reconcile": SCHEDULER_JOB_TYPES.downloadQueueReconcile,
+        "artist-counts-backfill": SCHEDULER_JOB_TYPES.artistCountsBackfill,
+        "image-backfill": SCHEDULER_JOB_TYPES.imageBackfill,
+        "track-mapping-reconcile": SCHEDULER_JOB_TYPES.trackMappingReconcile,
+        "remote-track-metadata-refresh":
+            SCHEDULER_JOB_TYPES.remoteTrackMetadataRefresh,
+    };
+    if (aliases[jobName]) return aliases[jobName];
+    return SCHEDULER_METRIC_JOBS.includes(jobName as SchedulerMetricJob)
+        ? (jobName as SchedulerMetricJob)
+        : null;
+}
+
+async function processSchedulerJobWithMetrics(
+    job: Bull.Job<any>,
+): Promise<void> {
+    const metricJob = canonicalSchedulerMetricJob(String(job?.name ?? ""));
+    const startedAt = process.hrtime.bigint();
     try {
-        await processSchedulerJob(job);
+        const executed = await processSchedulerJob(job);
+        if (metricJob && executed) {
+            recordSchedulerJobSuccess(metricJob, Date.now() / 1_000);
+        }
     } catch (err) {
         log.error(
             `Scheduler processor failed (${job?.name ?? "unknown"}):`,
             err,
         );
         throw err;
+    } finally {
+        if (metricJob) {
+            const durationSeconds =
+                Number(process.hrtime.bigint() - startedAt) / 1_000_000_000;
+            recordSchedulerJobDuration(metricJob, durationSeconds);
+        }
     }
-});
+}
+
+function processSchedulerLaneJob(job: Bull.Job<any>): Promise<void> {
+    const lane = schedulerLaneForJob(String(job?.name ?? ""));
+    if (lane === "fast") {
+        return fastSchedulerLane(() => processSchedulerJobWithMetrics(job));
+    }
+    return slowSchedulerLane(() => processSchedulerJobWithMetrics(job));
+}
+
+function registerSchedulerProcessors(): void {
+    for (const jobName of SCHEDULER_METRIC_JOBS) {
+        schedulerQueueForJob(jobName).process(
+            jobName,
+            1,
+            processSchedulerLaneJob,
+        );
+    }
+    // Retain the wildcard as a compatibility fallback for legacy persisted names.
+    schedulerQueue.process("*", processSchedulerLaneJob);
+}
 
 // Register download queue callback for unavailable albums
 downloadQueueManager.onUnavailableAlbum(async (info) => {
@@ -1003,6 +1285,25 @@ registerQueueProcessorEvents(schedulerQueue, "worker-scheduler", {
     },
 });
 
+registerQueueProcessorEvents(
+    schedulerMaintenanceQueue,
+    "worker-scheduler-maintenance",
+    {
+        record: recordQueueProcessorEvent,
+        completed: (job) => {
+            log.debug(
+                `Scheduler maintenance job ${job.id} completed (${job.name}) (workerId=${WORKER_PROCESSOR_ID})`,
+            );
+        },
+        failed: (job, error) => {
+            log.error(
+                `Scheduler maintenance job ${job?.id ?? "unknown"} failed (${job?.name ?? "unknown"}) (workerId=${WORKER_PROCESSOR_ID}):`,
+                error.message,
+            );
+        },
+    },
+);
+
 // analysisQueue has no processor in this module, so processor-event wiring remains owner-local.
 // federationQueue processing is owned by federationJobs; no generic wiring is added here.
 
@@ -1096,6 +1397,7 @@ export async function shutdownWorkers(): Promise<void> {
     imageQueue.removeAllListeners();
     validationQueue.removeAllListeners();
     schedulerQueue.removeAllListeners();
+    schedulerMaintenanceQueue.removeAllListeners();
     genericImportQueue.removeAllListeners();
     federationQueue.removeAllListeners();
     albumDownloadQueue.removeAllListeners();
@@ -1106,6 +1408,7 @@ export async function shutdownWorkers(): Promise<void> {
         imageQueue.close(),
         validationQueue.close(),
         schedulerQueue.close(),
+        schedulerMaintenanceQueue.close(),
         genericImportQueue.close(),
         federationQueue.close(),
     ]);
@@ -1147,6 +1450,7 @@ export {
     imageQueue,
     validationQueue,
     schedulerQueue,
+    schedulerMaintenanceQueue,
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,

--- a/backend/src/workers/processors/__tests__/audioHashBackfillProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/audioHashBackfillProcessor.test.ts
@@ -82,7 +82,9 @@ describe("audioHashBackfillProcessor", () => {
         jest.doMock("music-metadata", () => ({ parseFile }), {
             virtual: true,
         });
-        jest.doMock("../../queues", () => ({ schedulerQueue }));
+        jest.doMock("../../queues", () => ({
+            schedulerMaintenanceQueue: schedulerQueue,
+        }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const module = require("../audioHashBackfillProcessor");

--- a/backend/src/workers/processors/__tests__/loudnessBackfillProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/loudnessBackfillProcessor.test.ts
@@ -64,7 +64,9 @@ describe("loudnessBackfillProcessor", () => {
         jest.doMock("../../enrichmentQueue", () => ({
             enqueueReservedWork,
         }));
-        jest.doMock("../../queues", () => ({ schedulerQueue }));
+        jest.doMock("../../queues", () => ({
+            schedulerMaintenanceQueue: schedulerQueue,
+        }));
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const module = require("../loudnessBackfillProcessor");

--- a/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/trackRemovalPurgeProcessor.test.ts
@@ -108,7 +108,9 @@ describe("trackRemovalPurgeProcessor", () => {
                 },
             },
         }));
-        jest.doMock("../../queues", () => ({ schedulerQueue }));
+        jest.doMock("../../queues", () => ({
+            schedulerMaintenanceQueue: schedulerQueue,
+        }));
         jest.doMock("../../../utils/redis", () => ({ redisClient }));
         jest.doMock("../../../services/libraryOrphanCleanup", () => ({
             cleanupOrphanedLibraryEntities,

--- a/backend/src/workers/processors/audioHashBackfillProcessor.ts
+++ b/backend/src/workers/processors/audioHashBackfillProcessor.ts
@@ -8,7 +8,7 @@ import { computeAudioStreamHash } from "../../services/audioHash";
 import { extractTrackIdentityTags } from "../../services/trackIdentityTags";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
-import { schedulerQueue } from "../queues";
+import { schedulerMaintenanceQueue } from "../queues";
 
 const log = logger.child("AudioHashBackfillProcessor");
 const BATCH_SIZE = 50;
@@ -126,7 +126,7 @@ async function enqueueContinuation(
     startAfterId: string,
     sweepStartedAt: string,
 ): Promise<void> {
-    await schedulerQueue.add(
+    await schedulerMaintenanceQueue.add(
         AUDIO_HASH_BACKFILL_JOB_NAME,
         { startAfterId, sweepStartedAt },
         {

--- a/backend/src/workers/processors/loudnessBackfillProcessor.ts
+++ b/backend/src/workers/processors/loudnessBackfillProcessor.ts
@@ -5,7 +5,7 @@ import { config } from "../../config";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
 import { enqueueReservedWork } from "../enrichmentQueue";
-import { schedulerQueue } from "../queues";
+import { schedulerMaintenanceQueue } from "../queues";
 
 const log = logger.child("LoudnessBackfillProcessor");
 const AUDIO_ANALYSIS_QUEUE = "audio:analysis:queue";
@@ -131,7 +131,7 @@ async function loadBackfillPage(
 
 async function enqueueTrack(track: BackfillTrack, attemptKey: string) {
     if (track.filePath === null) return "skipped" as const;
-    return enqueueReservedWork(schedulerQueue.client, {
+    return enqueueReservedWork(schedulerMaintenanceQueue.client, {
         queueKey: AUDIO_ANALYSIS_QUEUE,
         trackId: track.id,
         payload: JSON.stringify({
@@ -150,7 +150,9 @@ async function loadFailureCounts(
     tracks: readonly BackfillTrack[],
 ): Promise<Array<string | null>> {
     if (tracks.length === 0) return [];
-    return schedulerQueue.client.mget(...tracks.map(buildAttemptKey));
+    return schedulerMaintenanceQueue.client.mget(
+        ...tracks.map(buildAttemptKey),
+    );
 }
 
 type FailureState = number | typeof PERMANENT_FAILURE_MARKER;
@@ -169,7 +171,7 @@ function parseFailureState(value: string | null | undefined): FailureState {
 }
 
 async function claimSweep(sweepStartedAt: string): Promise<boolean> {
-    const result = await schedulerQueue.client.eval(
+    const result = await schedulerMaintenanceQueue.client.eval(
         CLAIM_SWEEP_SCRIPT,
         1,
         LOUDNESS_SWEEP_LOCK_KEY,
@@ -180,7 +182,7 @@ async function claimSweep(sweepStartedAt: string): Promise<boolean> {
 }
 
 async function releaseSweep(sweepStartedAt: string): Promise<void> {
-    await schedulerQueue.client.eval(
+    await schedulerMaintenanceQueue.client.eval(
         RELEASE_SWEEP_SCRIPT,
         1,
         LOUDNESS_SWEEP_LOCK_KEY,
@@ -193,7 +195,7 @@ async function deferPeriodicSweep(
 ): Promise<void> {
     const sweepStartedAt = new Date().toISOString();
     const delay = Math.floor(Math.random() * LOUDNESS_SWEEP_JITTER_MS);
-    await schedulerQueue.add(
+    await schedulerMaintenanceQueue.add(
         LOUDNESS_BACKFILL_JOB_NAME,
         { mode: "periodic", sweepStartedAt },
         {
@@ -222,7 +224,11 @@ async function enqueueContinuation(
                   jobId: `scheduler:loudness-backfill:${sweepStartedAt}:${startAfterId}`,
               }),
     };
-    await schedulerQueue.add(LOUDNESS_BACKFILL_JOB_NAME, data, options);
+    await schedulerMaintenanceQueue.add(
+        LOUDNESS_BACKFILL_JOB_NAME,
+        data,
+        options,
+    );
 }
 
 async function processBackfillBatch(
@@ -241,7 +247,7 @@ async function processBackfillBatch(
             result.processed += 1;
             result.skipped += 1;
             nextCursor = track.id;
-            await schedulerQueue.client.expire(
+            await schedulerMaintenanceQueue.client.expire(
                 attemptKey,
                 LOUDNESS_ATTEMPT_TTL_SECONDS,
             );

--- a/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
+++ b/backend/src/workers/processors/trackRemovalPurgeProcessor.ts
@@ -13,7 +13,7 @@ import {
 } from "../../services/libraryHealthDashboard/purgeMarker";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
-import { schedulerQueue } from "../queues";
+import { schedulerMaintenanceQueue } from "../queues";
 
 const log = logger.child("TrackRemovalPurgeProcessor");
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -238,7 +238,7 @@ async function enqueueContinuation(
     progress: SweepProgress,
 ): Promise<void> {
     const cursorKey = startAfterId ?? `restart-${progress.pageNumber}`;
-    await schedulerQueue.add(
+    await schedulerMaintenanceQueue.add(
         TRACK_REMOVAL_PURGE_JOB_NAME,
         {
             ...(startAfterId ? { startAfterId } : {}),

--- a/backend/src/workers/queues.ts
+++ b/backend/src/workers/queues.ts
@@ -121,6 +121,15 @@ export const schedulerQueue = new Bull("worker-scheduler", {
     settings: defaultQueueSettings,
 });
 
+/** Durable slow lane for scheduler maintenance and backfill jobs. */
+export const schedulerMaintenanceQueue = new Bull(
+    "worker-scheduler-maintenance",
+    {
+        redis: redisConfig,
+        settings: defaultQueueSettings,
+    },
+);
+
 /** Durable Redis queue for persisted generic playlist-import jobs. */
 export const genericImportQueue = new Bull("generic-import", {
     redis: redisConfig,
@@ -163,6 +172,7 @@ export const queues = [
     validationQueue,
     analysisQueue,
     schedulerQueue,
+    schedulerMaintenanceQueue,
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,

--- a/backend/src/workers/schedulerJobRegistry.ts
+++ b/backend/src/workers/schedulerJobRegistry.ts
@@ -1,34 +1,14 @@
 import type Bull from "bull";
 import { loudnessBackfillRepeatSchedule } from "./loudnessBackfillSchedule";
-import { AUDIO_HASH_BACKFILL_JOB_NAME } from "./processors/audioHashBackfillProcessor";
-import { LOUDNESS_BACKFILL_JOB_NAME } from "./processors/loudnessBackfillProcessor";
-import { TRACK_REMOVAL_PURGE_JOB_NAME } from "./processors/trackRemovalPurgeProcessor";
+import { SCHEDULER_JOB_TYPES } from "./schedulerJobTypes";
+
+export { SCHEDULER_JOB_TYPES } from "./schedulerJobTypes";
 
 /** Milliseconds in one minute for scheduler intervals and timeouts. */
 export const ONE_MINUTE_MS = 60_000;
 
 /** Milliseconds in one hour for scheduler intervals and timeouts. */
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-
-/** Bull job names handled by the worker scheduler. */
-export const SCHEDULER_JOB_TYPES = {
-    dataIntegrity: "data-integrity-check",
-    reconciliation: "download-reconciliation-cycle",
-    albumDownloadRecovery: "album-download-recovery-cycle",
-    catalogRetention: "catalog-retention-sweep",
-    lidarrCleanup: "lidarr-cleanup-cycle",
-    cacheWarmup: "cache-warmup-startup",
-    podcastCleanup: "podcast-cache-cleanup",
-    audiobookAutoSync: "audiobook-auto-sync-startup",
-    downloadQueueReconcile: "download-queue-reconcile-startup",
-    artistCountsBackfill: "artist-counts-backfill-startup",
-    imageBackfill: "image-backfill-startup",
-    audioHashBackfill: AUDIO_HASH_BACKFILL_JOB_NAME,
-    loudnessBackfill: LOUDNESS_BACKFILL_JOB_NAME,
-    trackRemovalPurge: TRACK_REMOVAL_PURGE_JOB_NAME,
-    trackMappingReconcile: "track-mapping-reconcile",
-    remoteTrackMetadataRefresh: "remote-track-metadata-refresh",
-} as const;
 
 /** Stable Bull job IDs used to deduplicate scheduler registrations. */
 export const SCHEDULER_JOB_IDS = {

--- a/backend/src/workers/schedulerJobTypes.ts
+++ b/backend/src/workers/schedulerJobTypes.ts
@@ -1,0 +1,23 @@
+/** Bull job names handled by the worker scheduler. */
+export const SCHEDULER_JOB_TYPES = {
+    dataIntegrity: "data-integrity-check",
+    reconciliation: "download-reconciliation-cycle",
+    albumDownloadRecovery: "album-download-recovery-cycle",
+    catalogRetention: "catalog-retention-sweep",
+    lidarrCleanup: "lidarr-cleanup-cycle",
+    cacheWarmup: "cache-warmup-startup",
+    podcastCleanup: "podcast-cache-cleanup",
+    audiobookAutoSync: "audiobook-auto-sync-startup",
+    downloadQueueReconcile: "download-queue-reconcile-startup",
+    artistCountsBackfill: "artist-counts-backfill-startup",
+    imageBackfill: "image-backfill-startup",
+    audioHashBackfill: "track-audio-hash-backfill",
+    loudnessBackfill: "track-loudness-backfill",
+    trackRemovalPurge: "track-removal-purge",
+    trackMappingReconcile: "track-mapping-reconcile",
+    remoteTrackMetadataRefresh: "remote-track-metadata-refresh",
+} as const;
+
+/** Persisted scheduler job name accepted by the canonical dispatcher. */
+export type SchedulerJobType =
+    (typeof SCHEDULER_JOB_TYPES)[keyof typeof SCHEDULER_JOB_TYPES];

--- a/backend/src/workers/schedulerPolicy.ts
+++ b/backend/src/workers/schedulerPolicy.ts
@@ -1,0 +1,48 @@
+import type Bull from "bull";
+import { createHash } from "node:crypto";
+import { REQUEST_FULFILLMENT_JOB_NAME } from "./requestFulfillmentSchedule";
+import { SCHEDULER_JOB_TYPES } from "./schedulerJobTypes";
+
+export type SchedulerLane = "fast" | "slow" | "unknown";
+type BullRepeatOptions = NonNullable<Bull.JobOptions["repeat"]>;
+export const FIVE_MINUTE_JITTER_MAX_SECONDS = 45;
+const FIVE_MINUTE_MS = 5 * 60_000;
+
+const FAST_JOB_NAMES = new Set<string>([
+    SCHEDULER_JOB_TYPES.reconciliation,
+    SCHEDULER_JOB_TYPES.albumDownloadRecovery,
+    SCHEDULER_JOB_TYPES.lidarrCleanup,
+]);
+const SLOW_JOB_NAMES = new Set<string>([
+    ...Object.values(SCHEDULER_JOB_TYPES),
+    REQUEST_FULFILLMENT_JOB_NAME,
+    "podcast-cleanup",
+    "audiobook-auto-sync",
+    "download-queue-reconcile",
+    "artist-counts-backfill",
+    "image-backfill",
+    "track-mapping-reconcile",
+    "remote-track-metadata-refresh",
+]);
+
+/** Selects the isolated scheduler capacity lane for one persisted job name. */
+export function schedulerLaneForJob(jobName: string): SchedulerLane {
+    if (FAST_JOB_NAMES.has(jobName)) return "fast";
+    if (SLOW_JOB_NAMES.has(jobName)) return "slow";
+    return "unknown";
+}
+
+function stableJitterSeconds(jobId: string): number {
+    const digest = createHash("sha256").update(jobId).digest();
+    return (digest.readUInt32BE(0) % FIVE_MINUTE_JITTER_MAX_SECONDS) + 1;
+}
+
+/** Converts five-minute Bull intervals to stable second-offset cron schedules. */
+export function jitterFiveMinuteRepeat(
+    jobId: string,
+    repeat: BullRepeatOptions,
+): BullRepeatOptions {
+    if (!("every" in repeat) || repeat.every !== FIVE_MINUTE_MS) return repeat;
+    const seconds = stableJitterSeconds(jobId);
+    return { cron: `${seconds} */5 * * * *` };
+}

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -62,7 +62,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/podcasts.ts": 2541,
     "backend/src/routes/systemSettings.ts": 1506,
     "backend/src/routes/youtubeMusic.ts": 1612,
-    "backend/src/services/lidarr.ts": 2990,
+    "backend/src/services/lidarr.ts": 2962,
     "backend/src/services/simpleDownloadManager.ts": 2306,
     "backend/src/services/spotify.ts": 1624,
     "backend/src/workers/unifiedEnrichment.ts": 1904,


### PR DESCRIPTION
One PR for #779 + #780 — they share `workers/index.ts`.

## #779 — the reconciliation tick could stack abandoned full-catalog fetches

- `withTimeout` resolved `undefined` on timeout with **no AbortController**: the axios request kept buffering, the scheduler claim released, and the next 2-minute tick started another fetch — the most direct OOM path in the worker tree. It now creates an AbortSignal, aborts on timeout, and offers a discriminated result mode (legacy shape preserved for non-scheduler call sites); scheduler call sites hold the claim until aborted work settles.
- Lidarr's `/api/v1/album` has **no paging parameters** (verified against the upstream `AlbumController`) — the proposal's "paginate like the queue call" is impossible, so the snapshot streams the array into its two lookup maps under 64MiB/item/count/chunk bounds (`reconciliationAlbumStream.ts`).
- New shared circuit breaker (3 consecutive failures → 5-min open → half-open probe) skips the tick while Lidarr is down; `soundspan_scheduler_timeouts_total{operation}` counts abandonments.
- **Behavior fix:** snapshot creation fails closed instead of returning partial data (empty queue map / album fallback) — partial snapshots fed wrong reconciliation decisions. Tests updated accordingly.

## #780 — scheduler lanes, bounded dataIntegrity, observability

- Fast lane (reconciliation, album-download-recovery, lidarrCleanup) / slow maintenance lane; named processors registered after `isReady()`; persisted job names unchanged.
- `dataIntegrity`: 250-row keyset pages (1,000-page bound), selected columns only, two batched prefetches per page replacing 1–2 `findFirst` per row.
- Bull Board now shows all nine queues. `soundspan_scheduler_job_duration_seconds{job}` + last-success gauge, closed 17-name vocabulary.
- 5-minute cohort jittered via stable SHA-256 second-offset cron; stale `every:300000` repeatables removed at startup (no duplicate repeatables).

## Verification

- `verify:` (post-rebase onto current main, including transplanting the fail-closed test edits into the #797 split files) `workers` + lidarr + utils + metrics + entrypoint suites: **43 suites, 659 tests, pass**
- `verify: backend tsc --noEmit` exit 0; `format:check` clean; `check-file-size` pass (lidarr.ts baseline tightened to 2,962)

Closes #779
Closes #780