### PR TITLE
fix(scan): flatten download-reconciliation album matching into bounded queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Post-scan download reconciliation no longer risks heavy database load when many downloads are queued.
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.
 - Album genres, label, and release year now populate during normal background enrichment instead of only via the admin per-album tool, and admin re-enrichment now applies the same rules as the background worker.

--- a/backend/src/workers/processors/__tests__/scanProcessorRuntime.test.ts
+++ b/backend/src/workers/processors/__tests__/scanProcessorRuntime.test.ts
@@ -25,12 +25,12 @@ describe("scanProcessor runtime behavior", () => {
             metadata?: Record<string, unknown> | null;
         }>;
         candidateAlbums?: Array<{
+            id?: string;
             title: string;
-            tracks: Array<{ id: string }>;
-            artist: {
-                name: string;
-                enrichmentStatus?: string;
-            };
+            artistName?: string;
+            hasTracks?: boolean;
+            tracks?: Array<{ id: string }>;
+            artist?: { name: string; enrichmentStatus?: string };
         }>;
         fuzzyMatchImpl?: (
             artistName: string,
@@ -87,6 +87,15 @@ describe("scanProcessor runtime behavior", () => {
         };
 
         const prisma = {
+            $queryRaw: jest.fn(async () =>
+                (options.candidateAlbums ?? []).map((album, index) => ({
+                    id: album.id ?? `candidate-${index}`,
+                    title: album.title,
+                    artistName: album.artistName ?? album.artist?.name ?? "",
+                    hasTracks:
+                        album.hasTracks ?? (album.tracks?.length ?? 0) > 0,
+                })),
+            ),
             downloadJob: {
                 findMany: jest.fn(async () => options.activeJobs ?? []),
                 updateMany: jest.fn(async (args: any) => {
@@ -115,7 +124,6 @@ describe("scanProcessor runtime behavior", () => {
                 }),
             },
             album: {
-                findMany: jest.fn(async () => options.candidateAlbums ?? []),
                 findFirst: jest.fn(async () => options.albumByRgMbid ?? null),
             },
             artist: {
@@ -283,7 +291,7 @@ describe("scanProcessor runtime behavior", () => {
         );
 
         expect(prisma.downloadJob.findMany).toHaveBeenCalledTimes(1);
-        expect(prisma.album.findMany).not.toHaveBeenCalled();
+        expect(prisma.$queryRaw).not.toHaveBeenCalled();
         expect(matchAlbum).not.toHaveBeenCalled();
         expect(
             discoverWeeklyService.checkBatchCompletion,
@@ -320,7 +328,7 @@ describe("scanProcessor runtime behavior", () => {
         await module.processScan(createJob());
 
         expect(prisma.downloadJob.findMany).toHaveBeenCalledTimes(1);
-        expect(prisma.album.findMany).not.toHaveBeenCalled();
+        expect(prisma.$queryRaw).not.toHaveBeenCalled();
         expect(matchAlbum).not.toHaveBeenCalled();
         expect(prisma.downloadJob.updateMany).not.toHaveBeenCalledWith(
             expect.objectContaining({
@@ -362,7 +370,7 @@ describe("scanProcessor runtime behavior", () => {
 
         await module.processScan(createJob());
 
-        expect(prisma.album.findMany).toHaveBeenCalledTimes(1);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
         expect(matchAlbum).toHaveBeenCalledWith(
             "Known Artist",
             "Known Album",
@@ -472,6 +480,56 @@ describe("scanProcessor runtime behavior", () => {
             ["batch-1"],
             ["batch-2"],
         ]);
+    });
+
+    it("bounds active jobs and candidate queries for a large queue", async () => {
+        const activeJobs = Array.from({ length: 501 }, (_unused, index) => ({
+            id: `dl-${index.toString().padStart(3, "0")}`,
+            metadata: {
+                artistName: `${index.toString().padStart(5, "0")} Artist`,
+                albumTitle: `Album ${index}`,
+            },
+        }));
+        const { module, prisma, logger } = loadScanProcessor({
+            scanResult: {
+                tracksAdded: 1,
+                tracksUpdated: 0,
+                tracksRemoved: 0,
+                errors: [],
+                duration: 1,
+            },
+            activeJobs,
+        });
+
+        await module.processScan(createJob());
+
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledWith({
+            where: { status: { in: ["pending", "processing"] } },
+            select: { id: true, metadata: true, discoveryBatchId: true },
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            take: 501,
+        });
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(5);
+        const queryRawCalls = prisma.$queryRaw.mock.calls as unknown as Array<
+            [{ text: string; values: unknown[] }]
+        >;
+        const queryPatternCounts = queryRawCalls.map(
+            ([query]: [{ values: unknown[] }]) =>
+                (query.values[0] as string[]).length,
+        );
+        expect(queryPatternCounts).toEqual([100, 100, 100, 100, 100]);
+        for (const [query] of queryRawCalls) {
+            expect(query.text).toContain("ILIKE ANY($1::text[])");
+            expect(query.text).not.toContain(" OR ");
+            expect(query.values[1]).toBe(1001);
+        }
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Scan reconciliation active-job cap truncated work",
+            expect.objectContaining({
+                processedJobs: 500,
+                deferredJobsAtLeast: 1,
+            }),
+        );
     });
 
     it("reports progress callback updates and logs callback progress failures", async () => {

--- a/backend/src/workers/processors/__tests__/scanReconcileQuery.test.ts
+++ b/backend/src/workers/processors/__tests__/scanReconcileQuery.test.ts
@@ -1,0 +1,57 @@
+import {
+    buildScanReconcileCandidateQuery,
+    buildScanReconcilePatterns,
+    chunkScanReconcilePatterns,
+    SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT,
+    SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+} from "../scanReconcileQuery";
+
+describe("scan reconciliation query construction", () => {
+    it("escapes LIKE metacharacters and preserves contains matching", () => {
+        expect(buildScanReconcilePatterns(["100%_\\ Mix", "plain"])).toEqual([
+            "%100\\%\\_\\\\ Mix%",
+            "%plain%",
+        ]);
+    });
+
+    it("chunks patterns at the bounded query size", () => {
+        const patterns = Array.from(
+            { length: SCAN_RECONCILE_PATTERN_CHUNK_SIZE * 2 + 5 },
+            (_unused, index) => `%artist-${index}%`,
+        );
+
+        expect(
+            chunkScanReconcilePatterns(patterns).map((chunk) => chunk.length),
+        ).toEqual([
+            SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+            SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+            5,
+        ]);
+    });
+
+    it("binds one pattern array and the candidate sentinel limit", () => {
+        const patterns = ["%first%", "%second%"];
+        const query = buildScanReconcileCandidateQuery(patterns);
+
+        expect(query.text).toContain("ar.name ILIKE ANY($1::text[])");
+        expect(query.text).toContain('ORDER BY al."updatedAt" DESC, al.id ASC');
+        expect(query.text).toContain("LIMIT $2");
+        expect(query.text).not.toContain(" OR ");
+        expect(query.values).toEqual([
+            patterns,
+            SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT,
+        ]);
+    });
+
+    it("rejects empty and oversized pattern chunks", () => {
+        expect(() => buildScanReconcileCandidateQuery([])).toThrow(RangeError);
+        expect(() =>
+            buildScanReconcileCandidateQuery(
+                Array.from(
+                    { length: SCAN_RECONCILE_PATTERN_CHUNK_SIZE + 1 },
+                    () => "%artist%",
+                ),
+            ),
+        ).toThrow(RangeError);
+    });
+});

--- a/backend/src/workers/processors/scanProcessor.ts
+++ b/backend/src/workers/processors/scanProcessor.ts
@@ -2,148 +2,11 @@ import { Job } from "bull";
 import { logger } from "../../utils/logger";
 import { MusicScannerService } from "../../services/musicScanner";
 import { config } from "../../config";
-import { resolveDownloadJobMetadata } from "../../utils/downloadJobMetadata";
+import { ACTIVE_DOWNLOAD_JOB_STATUSES } from "../../services/downloadJobStatus";
+import { reconcileDownloadJobsWithScan } from "./scanReconcileQuery";
 import * as path from "path";
 
 const log = logger.child("ScanProcessor");
-
-/**
- * Reconcile pending/processing download jobs with newly scanned albums
- * This is called after every scan to catch downloads that completed but webhooks failed
- * Part of Phase 2 & 3 fix for #31
- *
- * Phase 3 enhancement: Uses fuzzy matching to catch more name variations
- * Phase 4 optimization: Batched queries instead of N+1 pattern
- */
-async function reconcileDownloadJobsWithScan(): Promise<number> {
-    const { prisma } = await import("../../utils/db");
-
-    // Get all pending/processing download jobs
-    const activeJobs = await prisma.downloadJob.findMany({
-        where: { status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES } },
-    });
-
-    if (activeJobs.length === 0) {
-        return 0;
-    }
-
-    // Extract job metadata for matching
-    const jobsWithMetadata = activeJobs
-        .map((job) => {
-            const { artistName, albumTitle } = resolveDownloadJobMetadata(
-                job.metadata,
-            );
-            return {
-                job,
-                artistName,
-                albumTitle,
-            };
-        })
-        .filter((j) => j.artistName && j.albumTitle);
-
-    if (jobsWithMetadata.length === 0) {
-        return 0;
-    }
-
-    // Batch fetch: Get all albums that might match any of our jobs
-    // Use OR conditions for all artist name prefixes (for fuzzy matching)
-    const artistPrefixes = [
-        ...new Set(
-            jobsWithMetadata.map((j) =>
-                j.artistName!.substring(0, 5).toLowerCase(),
-            ),
-        ),
-    ];
-
-    const candidateAlbums = await prisma.album.findMany({
-        where: {
-            OR: artistPrefixes.map((prefix) => ({
-                artist: {
-                    name: {
-                        contains: prefix,
-                        mode: "insensitive" as const,
-                    },
-                },
-            })),
-        },
-        include: {
-            tracks: {
-                select: { id: true },
-                take: 1,
-            },
-            artist: {
-                select: { name: true },
-            },
-        },
-    });
-
-    // Import fuzzy matcher once
-    const { matchAlbum } = await import("../../utils/fuzzyMatch");
-
-    // Match jobs to albums
-    const jobsToComplete: string[] = [];
-    const discoveryBatchIds: string[] = [];
-
-    for (const { job, artistName, albumTitle } of jobsWithMetadata) {
-        // Try exact/contains match first
-        let matchedAlbum = candidateAlbums.find(
-            (album) =>
-                album.tracks.length > 0 &&
-                album.artist.name
-                    .toLowerCase()
-                    .includes(artistName!.toLowerCase()) &&
-                album.title.toLowerCase().includes(albumTitle!.toLowerCase()),
-        );
-
-        // Fuzzy match if exact match failed
-        if (!matchedAlbum) {
-            matchedAlbum = candidateAlbums.find(
-                (album) =>
-                    album.tracks.length > 0 &&
-                    matchAlbum(
-                        artistName!,
-                        albumTitle!,
-                        album.artist.name,
-                        album.title,
-                        0.75,
-                    ),
-            );
-        }
-
-        if (matchedAlbum) {
-            jobsToComplete.push(job.id);
-            if (job.discoveryBatchId) {
-                discoveryBatchIds.push(job.discoveryBatchId);
-            }
-        }
-    }
-
-    if (jobsToComplete.length === 0) {
-        return 0;
-    }
-
-    // Batch update: Mark all matched jobs as completed
-    await prisma.downloadJob.updateMany({
-        where: { id: { in: jobsToComplete } },
-        data: {
-            status: "completed",
-            completedAt: new Date(),
-            error: null,
-        },
-    });
-
-    // Check batch completion for discovery jobs (deduplicated)
-    const uniqueBatchIds = [...new Set(discoveryBatchIds)];
-    if (uniqueBatchIds.length > 0) {
-        const { discoverWeeklyService } =
-            await import("../../services/discoverWeekly");
-        for (const batchId of uniqueBatchIds) {
-            await discoverWeeklyService.checkBatchCompletion(batchId);
-        }
-    }
-
-    return jobsToComplete.length;
-}
 
 export interface ScanJobData {
     userId: string | null;
@@ -604,4 +467,3 @@ export async function processScan(
         throw error;
     }
 }
-import { ACTIVE_DOWNLOAD_JOB_STATUSES } from "../../services/downloadJobStatus";

--- a/backend/src/workers/processors/scanReconcileQuery.ts
+++ b/backend/src/workers/processors/scanReconcileQuery.ts
@@ -1,0 +1,218 @@
+import { Prisma } from "@prisma/client";
+import { ACTIVE_DOWNLOAD_JOB_STATUSES } from "../../services/downloadJobStatus";
+import { matchAlbum } from "../../utils/fuzzyMatch";
+import { prisma } from "../../utils/db";
+import { escapeLikePattern } from "../../utils/likePattern";
+import { logger } from "../../utils/logger";
+import { resolveDownloadJobMetadata } from "../../utils/downloadJobMetadata";
+
+const log = logger.child("ScanReconcileQuery");
+const ARTIST_PREFIX_LENGTH = 5;
+
+/** Maximum active download jobs reconciled after one scan. */
+export const SCAN_RECONCILE_ACTIVE_JOB_LIMIT = 500;
+/** Maximum artist patterns bound to one candidate query. */
+export const SCAN_RECONCILE_PATTERN_CHUNK_SIZE = 100;
+/** Maximum candidate albums retained from one pattern chunk. */
+export const SCAN_RECONCILE_CANDIDATE_LIMIT = 1_000;
+/** Query limit including one sentinel row used to detect truncation. */
+export const SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT =
+    SCAN_RECONCILE_CANDIDATE_LIMIT + 1;
+
+/** Flat album row used by post-scan download reconciliation. */
+export interface ScanReconcileCandidate {
+    id: string;
+    title: string;
+    artistName: string;
+    hasTracks: boolean;
+}
+
+interface ReconcileJob {
+    id: string;
+    discoveryBatchId: string | null;
+    artistName: string;
+    albumTitle: string;
+}
+
+/** Convert literal artist prefixes into case-insensitive contains patterns. */
+export function buildScanReconcilePatterns(prefixes: string[]): string[] {
+    return prefixes.map((prefix) => `%${escapeLikePattern(prefix)}%`);
+}
+
+/** Split candidate patterns into bounded query chunks. */
+export function chunkScanReconcilePatterns(patterns: string[]): string[][] {
+    const chunkCount = Math.ceil(
+        patterns.length / SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+    );
+    return Array.from({ length: chunkCount }, (_unused, index) =>
+        patterns.slice(
+            index * SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+            (index + 1) * SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
+        ),
+    );
+}
+
+/** Build one parameter-bound flat candidate query. */
+export function buildScanReconcileCandidateQuery(
+    patterns: string[],
+): Prisma.Sql {
+    if (
+        patterns.length === 0 ||
+        patterns.length > SCAN_RECONCILE_PATTERN_CHUNK_SIZE
+    ) {
+        throw new RangeError("Scan reconcile pattern chunk is out of bounds");
+    }
+
+    // PostgreSQL forbids an ESCAPE clause with operator ANY. Its default LIKE
+    // escape is backslash, which buildScanReconcilePatterns applies literally.
+    return Prisma.sql`
+        SELECT
+            al.id,
+            al.title,
+            ar.name AS "artistName",
+            EXISTS (
+                SELECT 1
+                FROM "Track" AS tr
+                WHERE tr."albumId" = al.id
+            ) AS "hasTracks"
+        FROM "Album" AS al
+        INNER JOIN "Artist" AS ar ON ar.id = al."artistId"
+        WHERE ar.name ILIKE ANY(${patterns}::text[])
+        ORDER BY al."updatedAt" DESC, al.id ASC
+        LIMIT ${SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT}
+    `;
+}
+
+/** Load bounded, deduplicated album candidates for literal artist prefixes. */
+export async function loadScanReconcileCandidates(
+    prefixes: string[],
+): Promise<ScanReconcileCandidate[]> {
+    if (prefixes.length > SCAN_RECONCILE_ACTIVE_JOB_LIMIT) {
+        throw new RangeError("Scan reconcile prefix count is out of bounds");
+    }
+    const chunks = chunkScanReconcilePatterns(
+        buildScanReconcilePatterns(prefixes),
+    );
+    const candidates = new Map<string, ScanReconcileCandidate>();
+
+    for (const [chunkIndex, patterns] of chunks.entries()) {
+        const rows = await prisma.$queryRaw<ScanReconcileCandidate[]>(
+            buildScanReconcileCandidateQuery(patterns),
+        );
+        if (rows.length > SCAN_RECONCILE_CANDIDATE_LIMIT) {
+            log.warn("Scan reconciliation candidate cap truncated work", {
+                chunkIndex,
+                patternCount: patterns.length,
+                retainedCandidates: SCAN_RECONCILE_CANDIDATE_LIMIT,
+            });
+        }
+        for (const candidate of rows.slice(0, SCAN_RECONCILE_CANDIDATE_LIMIT)) {
+            candidates.set(candidate.id, candidate);
+        }
+    }
+
+    return [...candidates.values()];
+}
+
+function resolveReconcileJobs(
+    activeJobs: Array<{
+        id: string;
+        metadata: unknown;
+        discoveryBatchId: string | null;
+    }>,
+): ReconcileJob[] {
+    return activeJobs.flatMap((job) => {
+        const { artistName, albumTitle } = resolveDownloadJobMetadata(
+            job.metadata,
+        );
+        if (!artistName || !albumTitle) return [];
+        return [{ ...job, artistName, albumTitle }];
+    });
+}
+
+function candidateMatchesJob(
+    job: ReconcileJob,
+    candidates: ScanReconcileCandidate[],
+): boolean {
+    const artistName = job.artistName.toLowerCase();
+    const albumTitle = job.albumTitle.toLowerCase();
+    const exactMatch = candidates.some(
+        (candidate) =>
+            candidate.hasTracks &&
+            candidate.artistName.toLowerCase().includes(artistName) &&
+            candidate.title.toLowerCase().includes(albumTitle),
+    );
+    if (exactMatch) return true;
+
+    return candidates.some(
+        (candidate) =>
+            candidate.hasTracks &&
+            matchAlbum(
+                job.artistName,
+                job.albumTitle,
+                candidate.artistName,
+                candidate.title,
+                0.75,
+            ),
+    );
+}
+
+async function checkDiscoveryBatches(jobs: ReconcileJob[]): Promise<void> {
+    const batchIds = [
+        ...new Set(
+            jobs.flatMap((job) =>
+                job.discoveryBatchId ? [job.discoveryBatchId] : [],
+            ),
+        ),
+    ];
+    if (batchIds.length === 0) return;
+
+    const { discoverWeeklyService } =
+        await import("../../services/discoverWeekly");
+    for (const batchId of batchIds) {
+        await discoverWeeklyService.checkBatchCompletion(batchId);
+    }
+}
+
+/** Reconcile the oldest bounded window of active download jobs after a scan. */
+export async function reconcileDownloadJobsWithScan(): Promise<number> {
+    const fetchedJobs = await prisma.downloadJob.findMany({
+        where: { status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES } },
+        select: { id: true, metadata: true, discoveryBatchId: true },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        take: SCAN_RECONCILE_ACTIVE_JOB_LIMIT + 1,
+    });
+    const activeJobs = fetchedJobs.slice(0, SCAN_RECONCILE_ACTIVE_JOB_LIMIT);
+    if (fetchedJobs.length > SCAN_RECONCILE_ACTIVE_JOB_LIMIT) {
+        log.warn("Scan reconciliation active-job cap truncated work", {
+            processedJobs: SCAN_RECONCILE_ACTIVE_JOB_LIMIT,
+            deferredJobsAtLeast: 1,
+        });
+    }
+    const jobs = resolveReconcileJobs(activeJobs);
+    if (jobs.length === 0) return 0;
+
+    const prefixes = [
+        ...new Set(
+            jobs.map((job) =>
+                job.artistName.substring(0, ARTIST_PREFIX_LENGTH).toLowerCase(),
+            ),
+        ),
+    ];
+    const candidates = await loadScanReconcileCandidates(prefixes);
+    const matchedJobs = jobs.filter((job) =>
+        candidateMatchesJob(job, candidates),
+    );
+    if (matchedJobs.length === 0) return 0;
+
+    await prisma.downloadJob.updateMany({
+        where: { id: { in: matchedJobs.map((job) => job.id) } },
+        data: {
+            status: "completed",
+            completedAt: new Date(),
+            error: null,
+        },
+    });
+    await checkDiscoveryBatches(matchedJobs);
+    return matchedJobs.length;
+}

--- a/backend/tests-integration/scanReconcilePostgres.integration.test.ts
+++ b/backend/tests-integration/scanReconcilePostgres.integration.test.ts
@@ -1,0 +1,218 @@
+import type { Client } from "pg";
+import { prisma } from "../src/utils/db";
+import {
+    loadScanReconcileCandidates,
+    reconcileDownloadJobsWithScan,
+    SCAN_RECONCILE_ACTIVE_JOB_LIMIT,
+    SCAN_RECONCILE_CANDIDATE_LIMIT,
+} from "../src/workers/processors/scanReconcileQuery";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+
+const USER_ID = "scan-reconcile-user";
+const FIXED_TIME = new Date("2026-08-25T12:00:00.000Z");
+
+async function seedAlbum(
+    id: string,
+    artistName: string,
+    title: string,
+    hasTracks = true,
+): Promise<void> {
+    const artistId = `${id}-artist`;
+    await prisma.artist.create({
+        data: { id: artistId, mbid: `${artistId}-mbid`, name: artistName },
+    });
+    await prisma.album.create({
+        data: {
+            id,
+            rgMbid: `${id}-mbid`,
+            artistId,
+            title,
+            primaryType: "Album",
+            updatedAt: FIXED_TIME,
+        },
+    });
+    if (hasTracks) {
+        await prisma.track.create({
+            data: {
+                id: `${id}-track`,
+                albumId: id,
+                title: `${title} Track`,
+                trackNo: 1,
+                duration: 180,
+                fileModified: FIXED_TIME,
+                fileSize: 1_000,
+            },
+        });
+    }
+}
+
+async function seedJob(
+    id: string,
+    artistName: string,
+    albumTitle: string,
+    createdAt = FIXED_TIME,
+): Promise<void> {
+    await prisma.downloadJob.create({
+        data: {
+            id,
+            userId: USER_ID,
+            subject: albumTitle,
+            type: "album",
+            targetMbid: `${id}-target`,
+            status: "pending",
+            metadata: { artistName, albumTitle },
+            createdAt,
+        },
+    });
+}
+
+describeWithPostgres("scan reconciliation PostgreSQL behavior", () => {
+    let admin: Client | undefined;
+
+    beforeAll(async () => {
+        if (!integrationDatabaseUrl || !databaseName) {
+            throw new Error("PostgreSQL integration environment is missing");
+        }
+        admin = await createScaleDatabase(integrationDatabaseUrl, databaseName);
+        const runtimeDatabaseUrl = process.env.DATABASE_URL;
+        if (!runtimeDatabaseUrl) {
+            throw new Error("Integration database URL was not initialized");
+        }
+        await applyScaleMigrations(runtimeDatabaseUrl);
+        await prisma.user.create({
+            data: { id: USER_ID, username: "scan-reconcile-user" },
+        });
+    });
+
+    afterEach(async () => {
+        await prisma.downloadJob.deleteMany({ where: { userId: USER_ID } });
+        await prisma.track.deleteMany({});
+        await prisma.album.deleteMany({});
+        await prisma.artist.deleteMany({});
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+        if (admin && databaseName) {
+            await dropScaleDatabase(admin, databaseName);
+        }
+    });
+
+    it("preserves exact, fuzzy, no-track, and unmatched outcomes", async () => {
+        await seedAlbum("exact-album", "The National", "Boxer Deluxe");
+        await seedAlbum(
+            "fuzzy-album",
+            "The Beatles",
+            "Abbey Road (Remastered)",
+        );
+        await seedAlbum(
+            "no-track-album",
+            "Silent Artist",
+            "Silent Album",
+            false,
+        );
+        await seedJob("exact-job", "The National", "Boxer");
+        await seedJob("fuzzy-job", "Beatles", "Abbey Road");
+        await seedJob("no-track-job", "Silent Artist", "Silent Album");
+        await seedJob("unmatched-job", "Missing Artist", "Missing Album");
+
+        await expect(reconcileDownloadJobsWithScan()).resolves.toBe(2);
+
+        const jobs = await prisma.downloadJob.findMany({
+            orderBy: { id: "asc" },
+            select: { id: true, status: true },
+        });
+        expect(jobs).toEqual([
+            { id: "exact-job", status: "completed" },
+            { id: "fuzzy-job", status: "completed" },
+            { id: "no-track-job", status: "pending" },
+            { id: "unmatched-job", status: "pending" },
+        ]);
+    });
+
+    it("treats percent, underscore, and backslash in artist prefixes literally", async () => {
+        await seedAlbum("literal-album", "%_\\ab Artist", "Literal Album");
+        await seedAlbum("wildcard-decoy", "XYzab Artist", "Decoy Album");
+        await seedJob("literal-job", "%_\\ab Artist", "Literal Album");
+
+        const candidates = await loadScanReconcileCandidates(["%_\\ab"]);
+        expect(candidates.map((candidate) => candidate.id)).toEqual([
+            "literal-album",
+        ]);
+
+        await expect(reconcileDownloadJobsWithScan()).resolves.toBe(1);
+        await expect(
+            prisma.downloadJob.findUniqueOrThrow({
+                where: { id: "literal-job" },
+                select: { status: true },
+            }),
+        ).resolves.toEqual({ status: "completed" });
+    });
+
+    it("caps candidates and defers jobs beyond the oldest active-job window", async () => {
+        await prisma.artist.create({
+            data: {
+                id: "common-artist",
+                mbid: "common-artist-mbid",
+                name: "Common Artist",
+            },
+        });
+        const albums = Array.from(
+            { length: SCAN_RECONCILE_CANDIDATE_LIMIT + 1 },
+            (_unused, index) => ({
+                id: `common-album-${index.toString().padStart(4, "0")}`,
+                rgMbid: `common-album-mbid-${index}`,
+                artistId: "common-artist",
+                title: `Common Album ${index}`,
+                primaryType: "Album",
+                updatedAt: FIXED_TIME,
+            }),
+        );
+        await prisma.album.createMany({ data: albums });
+        const candidates = await loadScanReconcileCandidates(["commo"]);
+        expect(candidates).toHaveLength(SCAN_RECONCILE_CANDIDATE_LIMIT);
+        expect(candidates.at(-1)?.id).toBe("common-album-0999");
+
+        await prisma.downloadJob.createMany({
+            data: Array.from(
+                { length: SCAN_RECONCILE_ACTIVE_JOB_LIMIT },
+                (_unused, index) => ({
+                    id: `old-job-${index.toString().padStart(3, "0")}`,
+                    userId: USER_ID,
+                    subject: `Missing Album ${index}`,
+                    type: "album",
+                    targetMbid: `old-target-${index}`,
+                    status: "pending",
+                    metadata: {
+                        artistName: "Missing Artist",
+                        albumTitle: `Missing Album ${index}`,
+                    },
+                    createdAt: new Date("2026-08-24T12:00:00.000Z"),
+                }),
+            ),
+        });
+        await seedJob(
+            "newest-matching-job",
+            "Common Artist",
+            "Common Album 0",
+            new Date("2026-08-26T12:00:00.000Z"),
+        );
+
+        await expect(reconcileDownloadJobsWithScan()).resolves.toBe(0);
+        await expect(
+            prisma.downloadJob.findUniqueOrThrow({
+                where: { id: "newest-matching-job" },
+                select: { status: true },
+            }),
+        ).resolves.toEqual({ status: "pending" });
+    });
+});


### PR DESCRIPTION
## Problem (#778)

`reconcileDownloadJobsWithScan` (after every scan) built its album-candidate query as an N-way `OR` of nested relation filters — one correlated subquery per active download job, unbounded jobs list, no outer `take`, full materialization with includes to feed a JS fuzzy loop. **Same query-generator shape as the federation positional-dedup query that OOM-killed the CNPG primary**; a backed-up queue or Discover Weekly batch arms it.

## Change

- New `scanReconcileQuery.ts`: one parameter-bound `ar.name ILIKE ANY($1::text[])` per 100-prefix chunk (trigram-indexed), selecting exactly `{id, title, artistName, hasTracks}`; `LIMIT 1001` retains 1,000 candidates + truncation sentinel.
- Bounds: 500 oldest active jobs (`createdAt ASC` so old work isn't displaced; job 501 = deferral sentinel, warn-logged), ≤5 candidate queries, per-chunk candidate cap with warn on truncation.
- Wildcards in artist names escaped via the shared `escapeLikePattern` (the same literal-vs-wildcard class just fixed in subsonic genre paging).
- Matching semantics unchanged: 5-char insensitive `%prefix%`, exact-contains → 0.75 fuzzy, has-tracks, completion updates, discovery-batch dedupe.

## Verification

- `verify:` builder + runtime suites: 2 suites, 31 tests, pass
- `verify:` new PostgreSQL integration suite **run against a real scratch pgvector database**: 3/3 — match parity, wildcard-literal artists (`%_\ab Artist`), truncation bounds
- `verify: backend tsc` exit 0; `format:check` clean; `check-file-size` pass

Closes #778