### PR TITLE
chore(services): shared remote-provider type and adapter; Deezer through its own rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Internal TIDAL and YouTube provider plumbing now uses shared types and routing adapters, and Deezer API calls now use the shared rate limiter.
 - Subsonic apps load artist lists much faster on large libraries, and genre shuffle pages now load consistently fast.
 - TIDAL and YouTube Music downloads now use identical filename and collision handling, and loudness backfills now measure tracks with multiple workers.
 - Backend Jest tests now use transpile-only TypeScript transforms, six workers, and smaller runtime suites for faster test runs.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     preset: "ts-jest",
     // The otplib v13 dependency tree (@scure/base v2, @noble/hashes v2, nested under @otplib plugins) is ESM-only.
     transformIgnorePatterns: [
-        "/node_modules/(?!(@scure/|@noble/|@otplib/|otplib/|p-limit/|yocto-queue/))",
+        "/node_modules/(?!(@scure/|@noble/|@otplib/|otplib/|p-limit/|p-queue/|p-timeout/|eventemitter3/|yocto-queue/))",
     ],
     transform: {
         "^.+\\.ts$": ["ts-jest", { transpilation: true, diagnostics: false }],

--- a/backend/src/metrics/providerTrackGcMetrics.ts
+++ b/backend/src/metrics/providerTrackGcMetrics.ts
@@ -1,6 +1,7 @@
 import { Counter, Gauge, Histogram, type Registry } from "prom-client";
+import type { MappingProvider } from "../services/remoteProviders/types";
 
-export type ProviderTrackGcProvider = "tidal" | "youtube";
+export type ProviderTrackGcProvider = MappingProvider;
 export type ProviderTrackGcOutcome = "success" | "failure";
 
 /** Current provider-track garbage collection backlog measurements. */

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -464,7 +464,7 @@ export async function handleGetLikedTracks(req: Request, res: Response) {
         token: string;
         cursorId: string;
         likedAt: Date;
-        source: "tidal" | "youtube";
+        source: import("../../services/remoteProviders/types").MappingProvider;
         trackTidalId: string | null;
         trackYtMusicId: string | null;
         remote: (typeof remoteEntries)[number];

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -181,6 +181,8 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/remoteTrackMetadataRefresh.ts` | Core |
 | `backend/src/services/scannedTrackPersistence.ts` | Scanner track persistence, audio-change invalidation, and album loudness refresh |
 | `backend/src/services/remoteTrackMetadataResolver.ts` | Core |
+| `backend/src/services/remoteProviders/adapters.ts` | Shared remote playback, playlist-import, and playlist-row provider routing |
+| `backend/src/services/remoteProviders/types.ts` | Canonical remote-provider identities and mapping/streaming translators |
 | `backend/src/services/rssParser.ts` | Core |
 | `backend/src/services/search.ts` | Core |
 | `backend/src/services/simpleDownloadManager.ts` | Core |

--- a/backend/src/services/__tests__/deezerService.test.ts
+++ b/backend/src/services/__tests__/deezerService.test.ts
@@ -76,6 +76,18 @@ describe("deezerService", () => {
         mockMusicBrainzExtractPrimaryArtist.mockReturnValue("Unknown Artist");
     });
 
+    it("routes Deezer HTTP requests through the shared limiter", async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { data: [] } });
+
+        await deezerService.getArtistImage("Limited Artist");
+
+        expect(mockRateLimiterExecute).toHaveBeenCalledWith(
+            "deezer",
+            expect.any(Function),
+        );
+        expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+    });
+
     it("serves artist image from cache and cache-miss API with fallback image fields", async () => {
         mockRedisGet.mockResolvedValueOnce("https://cache.example/a.jpg");
         await expect(deezerService.getArtistImage("Artist A")).resolves.toBe(

--- a/backend/src/services/__tests__/deezerStrictImage.test.ts
+++ b/backend/src/services/__tests__/deezerStrictImage.test.ts
@@ -20,6 +20,14 @@ jest.mock("../../utils/redis", () => ({
     },
 }));
 
+jest.mock("../rateLimiter", () => ({
+    rateLimiter: {
+        execute: jest.fn(async (_bucket: string, fn: () => Promise<unknown>) =>
+            fn(),
+        ),
+    },
+}));
+
 const mockAxiosGet = axios.get as jest.Mock;
 const mockRedisGet = redisClient.get as jest.Mock;
 const mockRedisSetEx = redisClient.setEx as jest.Mock;

--- a/backend/src/services/__tests__/rateLimiter.test.ts
+++ b/backend/src/services/__tests__/rateLimiter.test.ts
@@ -54,7 +54,7 @@ describe("rateLimiter", () => {
         const { rateLimiter } = await loadRateLimiterModule();
         const queues = (rateLimiter as any).queues as Map<string, any>;
 
-        expect(queues.size).toBe(6);
+        expect(queues.size).toBe(4);
         expect(queues.get("lastfm").intervalCap).toBe(3);
         expect(queues.get("musicbrainz").concurrency).toBe(1);
         expect(queues.get("deezer").interval).toBe(5000);
@@ -167,7 +167,7 @@ describe("rateLimiter", () => {
 
         rateLimiter.pauseAll(5000);
         const result = await rateLimiter.execute(
-            "fanart",
+            "coverart",
             async () => "during-pause",
         );
 

--- a/backend/src/services/albumResolutionService.ts
+++ b/backend/src/services/albumResolutionService.ts
@@ -7,6 +7,7 @@ import {
 } from "../utils/artistNormalization";
 import type { ExternalTrackAlbumResolution } from "./trackAlbumResolution";
 import { isGenericAlbumTitle } from "./albumTitleGuards";
+import type { MappingProvider } from "./remoteProviders/types";
 
 const log =
     typeof (logger as { child?: unknown }).child === "function"
@@ -61,7 +62,7 @@ export async function applyRemoteAlbumCoverIfMissing(
 export async function resolveAlbumForRemoteTrack(
     rawAlbumTitle: string | null | undefined,
     artistId: string,
-    provider: "tidal" | "youtube",
+    provider: MappingProvider,
     track?: RemoteTrackAlbumContext,
 ): Promise<AlbumResolutionResult | null> {
     if (isGenericAlbumTitle(rawAlbumTitle)) {
@@ -140,7 +141,7 @@ async function findExistingAlbum(
 async function resolveGenericAlbum(
     rawAlbumTitle: string | null | undefined,
     artistId: string,
-    provider: "tidal" | "youtube",
+    provider: MappingProvider,
     track?: RemoteTrackAlbumContext,
 ): Promise<AlbumResolutionResult | null> {
     if (!track) return null;
@@ -193,7 +194,7 @@ export function buildSyntheticRgMbid(
 async function createRemoteAlbum(
     title: string,
     artistId: string,
-    provider: "tidal" | "youtube",
+    provider: MappingProvider,
     resolvedRgMbid?: string,
 ): Promise<AlbumResolutionResult> {
     const normalizedTitle = normalizeAlbumTitle(title);
@@ -233,7 +234,7 @@ async function createRemoteAlbum(
 async function resolveExternalAlbum(
     external: ExternalTrackAlbumResolution,
     artistId: string,
-    provider: "tidal" | "youtube",
+    provider: MappingProvider,
 ): Promise<AlbumResolutionResult> {
     const existing = await findExistingAlbum(external.albumTitle, artistId);
     if (existing) return existing;

--- a/backend/src/services/deezer.ts
+++ b/backend/src/services/deezer.ts
@@ -1,6 +1,7 @@
-import axios from "axios";
+import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { rateLimiter } from "./rateLimiter";
 
 /**
  * Deezer Service
@@ -67,6 +68,13 @@ export interface DeezerGenreWithRadios {
 class DeezerService {
     private readonly cachePrefix = "deezer:";
     private readonly cacheTTL = 86400; // 24 hours
+
+    private get(
+        url: string,
+        config?: AxiosRequestConfig,
+    ): Promise<AxiosResponse> {
+        return rateLimiter.execute("deezer", () => axios.get(url, config));
+    }
 
     private normalizeArtistIdentity(name: string): string {
         return name
@@ -214,7 +222,7 @@ class DeezerService {
         if (cached) return cached === "null" ? null : cached;
 
         try {
-            const response = await axios.get(`${DEEZER_API}/search/artist`, {
+            const response = await this.get(`${DEEZER_API}/search/artist`, {
                 params: { q: artistName, limit: 1 },
                 timeout: 5000,
             });
@@ -254,7 +262,7 @@ class DeezerService {
         if (cached) return cached === "null" ? null : cached;
 
         try {
-            const response = await axios.get(`${DEEZER_API}/search/artist`, {
+            const response = await this.get(`${DEEZER_API}/search/artist`, {
                 params: { q: artistName, limit: 5 },
                 timeout: 5000,
             });
@@ -313,7 +321,7 @@ class DeezerService {
 
             for (const query of searchQueries) {
                 try {
-                    const response = await axios.get(
+                    const response = await this.get(
                         `${DEEZER_API}/search/album`,
                         {
                             params: { q: query, limit: 10 },
@@ -382,7 +390,7 @@ class DeezerService {
         if (cached) return cached === "null" ? null : cached;
 
         try {
-            const response = await axios.get(`${DEEZER_API}/search/track`, {
+            const response = await this.get(`${DEEZER_API}/search/track`, {
                 params: {
                     q: `artist:"${artistName}" track:"${trackName}"`,
                     limit: 1,
@@ -436,7 +444,7 @@ class DeezerService {
             // Use simple space-separated search - more reliable than structured queries
             const query = `${artistName} ${cleanTrackName}`;
 
-            const response = await axios.get(`${DEEZER_API}/search/track`, {
+            const response = await this.get(`${DEEZER_API}/search/track`, {
                 params: { q: query, limit: 5 },
                 timeout: 5000,
             });
@@ -512,7 +520,7 @@ class DeezerService {
         try {
             logger.debug(`Deezer: Fetching playlist ${playlistId}...`);
 
-            const response = await axios.get(
+            const response = await this.get(
                 `${DEEZER_API}/playlist/${playlistId}`,
                 {
                     timeout: 15000,
@@ -567,13 +575,10 @@ class DeezerService {
         limit: number = 20,
     ): Promise<DeezerPlaylistPreview[]> {
         try {
-            const response = await axios.get(
-                `${DEEZER_API}/chart/0/playlists`,
-                {
-                    params: { limit },
-                    timeout: 10000,
-                },
-            );
+            const response = await this.get(`${DEEZER_API}/chart/0/playlists`, {
+                params: { limit },
+                timeout: 10000,
+            });
 
             return (response.data?.data || []).map((playlist: any) => ({
                 id: String(playlist.id),
@@ -598,7 +603,7 @@ class DeezerService {
         limit: number = 20,
     ): Promise<DeezerPlaylistPreview[]> {
         try {
-            const response = await axios.get(`${DEEZER_API}/search/playlist`, {
+            const response = await this.get(`${DEEZER_API}/search/playlist`, {
                 params: { q: query, limit },
                 timeout: 10000,
             });
@@ -719,7 +724,7 @@ class DeezerService {
 
         try {
             logger.debug("Deezer: Fetching genres from API...");
-            const response = await axios.get(`${DEEZER_API}/genre`, {
+            const response = await this.get(`${DEEZER_API}/genre`, {
                 timeout: 10000,
             });
 
@@ -764,7 +769,7 @@ class DeezerService {
 
         try {
             logger.debug("Deezer: Fetching radio stations from API...");
-            const response = await axios.get(`${DEEZER_API}/radio`, {
+            const response = await this.get(`${DEEZER_API}/radio`, {
                 timeout: 10000,
             });
 
@@ -804,7 +809,7 @@ class DeezerService {
 
         try {
             logger.debug("Deezer: Fetching radios by genre from API...");
-            const response = await axios.get(`${DEEZER_API}/radio/genres`, {
+            const response = await this.get(`${DEEZER_API}/radio/genres`, {
                 timeout: 10000,
             });
 
@@ -839,7 +844,7 @@ class DeezerService {
             logger.debug(`Deezer: Fetching radio ${radioId} tracks...`);
 
             // First get radio info
-            const infoResponse = await axios.get(
+            const infoResponse = await this.get(
                 `${DEEZER_API}/radio/${radioId}`,
                 {
                     timeout: 10000,
@@ -848,7 +853,7 @@ class DeezerService {
             const radioInfo = infoResponse.data;
 
             // Then get tracks
-            const tracksResponse = await axios.get(
+            const tracksResponse = await this.get(
                 `${DEEZER_API}/radio/${radioId}/tracks`,
                 {
                     params: { limit: 100 },
@@ -901,7 +906,7 @@ class DeezerService {
     }> {
         try {
             // Get genre-specific playlists via search
-            const genreResponse = await axios.get(
+            const genreResponse = await this.get(
                 `${DEEZER_API}/genre/${genreId}`,
                 {
                     timeout: 10000,
@@ -915,7 +920,7 @@ class DeezerService {
                 : [];
 
             // Get radios for this genre from the genres endpoint
-            const radiosResponse = await axios.get(
+            const radiosResponse = await this.get(
                 `${DEEZER_API}/radio/genres`,
                 {
                     timeout: 10000,

--- a/backend/src/services/listenTogetherAvailabilityPublication.ts
+++ b/backend/src/services/listenTogetherAvailabilityPublication.ts
@@ -14,6 +14,7 @@ import {
 } from "./listenTogetherAvailability";
 import { enqueueGroupAvailabilityPublication } from "./listenTogetherCallbacks";
 import { withListenTogetherDeadline } from "./listenTogetherDeadline";
+import type { MappingProvider } from "./remoteProviders/types";
 
 const log = logger.child("ListenTogetherAvailability");
 const MAX_AVAILABILITY_SOCKETS = 10_000;
@@ -27,7 +28,7 @@ interface AvailabilitySocket {
 interface AvailabilityPayloadItem {
     queueIndex: number;
     available: boolean;
-    source?: "local" | "tidal" | "youtube";
+    source?: "local" | MappingProvider;
     localTrackId?: string;
     tidalTrackId?: number;
     youtubeVideoId?: string;

--- a/backend/src/services/mappedProviderStream.ts
+++ b/backend/src/services/mappedProviderStream.ts
@@ -1,6 +1,8 @@
 import { pipeline } from "node:stream/promises";
 import type { Request, Response } from "express";
 import type { PeerPlaybackFallback } from "./peerPlaybackFallback";
+import { remoteProviderAdapters } from "./remoteProviders/adapters";
+import { toMappingProvider } from "./remoteProviders/types";
 
 const FORWARDED_STREAM_HEADERS = [
     "content-type",
@@ -71,24 +73,22 @@ export async function serveMappedProviderStream(input: {
             ? input.req.headers.range
             : undefined;
     try {
-        let response = null;
-        if (input.fallback.source === "tidal") {
-            const { tidalStreamingService } = await import("./tidalStreaming");
-            response = await tidalStreamingService.getStreamProxy(
-                input.userId,
-                input.fallback.tidalTrackId,
-                input.quality,
-                range,
-            );
-        } else if (input.fallback.source === "ytmusic") {
-            const { ytMusicService } = await import("./youtubeMusic");
-            response = await ytMusicService.getStreamProxy(
-                input.youtubeUserId ?? "__public__",
-                input.fallback.youtubeVideoId,
-                input.quality,
-                range,
-            );
+        if (input.fallback.source === "library") {
+            return { status: "unavailable" };
         }
+        const adapter =
+            remoteProviderAdapters[toMappingProvider(input.fallback.source)];
+        const response = await adapter.streamTrack({
+            userId:
+                input.fallback.source === "ytmusic"
+                    ? (input.youtubeUserId ?? "__public__")
+                    : input.userId,
+            quality: input.quality,
+            range,
+            ...(input.fallback.source === "tidal"
+                ? { tidalTrackId: input.fallback.tidalTrackId }
+                : { youtubeVideoId: input.fallback.youtubeVideoId }),
+        });
         if (!response) return { status: "unavailable" };
         input.res.status(response.status);
         forwardStreamHeaders(input.res, response.headers);

--- a/backend/src/services/playlistImportService.ts
+++ b/backend/src/services/playlistImportService.ts
@@ -24,6 +24,7 @@ import {
     type LocalTrackCandidate,
 } from "../utils/trackMatching";
 import { parseM3U } from "./m3uParser";
+import { remoteProviderAdapters } from "./remoteProviders/adapters";
 
 const log = logger.child("PlaylistImportService");
 const MATCH_BATCH_SIZE = 25;
@@ -31,12 +32,6 @@ const MATCH_BATCH_CONCURRENCY = 2;
 const UPSERT_CONCURRENCY = 6;
 const MAPPING_CREATE_CONCURRENCY = 8;
 const TIDAL_IMPORT_QUALITY = "HIGH";
-
-function getErrorStatusCode(error: unknown): number | null {
-    const status = (error as { response?: { status?: number } })?.response
-        ?.status;
-    return typeof status === "number" ? status : null;
-}
 
 function parseProviderUrlCandidate(rawUrl: string): URL | null {
     try {
@@ -259,87 +254,24 @@ class PlaylistImportService {
                 userId && (await this.checkYtMusicAuth(userId))
                     ? userId
                     : "__public__";
-            const playlist = await ytMusicService.getBrowsePlaylist(
+            return remoteProviderAdapters.youtube.fetchPlaylist({
                 sourceId,
-                100,
-                ytBrowseUserId,
-            );
-            return {
-                name: playlist.title,
-                tracks: playlist.tracks.map((t) => ({
-                    artist: t.artist || "Unknown",
-                    title: t.title || "Unknown",
-                    album: t.album || undefined,
-                    duration: t.duration,
-                    videoId: t.videoId,
-                })),
-            };
+                userId: ytBrowseUserId,
+                authenticated: ytBrowseUserId !== "__public__",
+                quality: TIDAL_IMPORT_QUALITY,
+            });
         }
 
         if (source === "tidal") {
-            const loadPublicPlaylist = async () => {
-                try {
-                    return await tidalStreamingService.getPublicBrowsePlaylist(
-                        sourceId,
-                        TIDAL_IMPORT_QUALITY,
-                    );
-                } catch (error) {
-                    const statusCode = getErrorStatusCode(error);
-                    if (statusCode === 404) {
-                        throw new Error("Tidal playlist not found");
-                    }
-                    if (statusCode === 401 || statusCode === 403) {
-                        throw new Error("Tidal import requires authentication");
-                    }
-                    throw error;
-                }
-            };
-
-            let playlist = null as Awaited<
-                ReturnType<typeof tidalStreamingService.getBrowsePlaylist>
-            > | null;
-
-            if (userId) {
-                const hasTidalAuth = await this.checkTidalAuth(userId);
-                if (hasTidalAuth) {
-                    try {
-                        playlist =
-                            await tidalStreamingService.getBrowsePlaylist(
-                                userId,
-                                sourceId,
-                                TIDAL_IMPORT_QUALITY,
-                            );
-                    } catch (error) {
-                        const statusCode = getErrorStatusCode(error);
-                        if (
-                            statusCode &&
-                            statusCode !== 401 &&
-                            statusCode !== 403
-                        ) {
-                            if (statusCode === 404) {
-                                throw new Error("Tidal playlist not found");
-                            }
-                            throw error;
-                        }
-                    }
-                }
-            }
-
-            if (!playlist) {
-                playlist = await loadPublicPlaylist();
-            }
-
-            return {
-                name: playlist.title,
-                tracks: playlist.tracks.map((t) => ({
-                    artist: t.artist || "Unknown",
-                    title: t.title || "Unknown",
-                    album: t.album || undefined,
-                    duration: t.duration,
-                    isrc: t.isrc || undefined,
-                    tidalId: t.trackId,
-                })),
-            };
+            const authenticated = userId
+                ? await this.checkTidalAuth(userId)
+                : false;
+            return remoteProviderAdapters.tidal.fetchPlaylist({
+                sourceId,
+                userId,
+                authenticated,
+                quality: TIDAL_IMPORT_QUALITY,
+            });
         }
 
         throw new Error(`Unsupported source: ${source}`);

--- a/backend/src/services/playlistTrackResolution.ts
+++ b/backend/src/services/playlistTrackResolution.ts
@@ -9,9 +9,13 @@ import {
 import type {
     UnifiedLocalTrackRecord,
     UnifiedPlaylistItemRecord,
-    UnifiedTrackTidalRecord,
-    UnifiedTrackYtMusicRecord,
 } from "./unifiedTrackResponse";
+import {
+    REMOTE_PROVIDERS,
+    remoteProviderAdapters,
+    type RemoteProviderTrackRecord,
+} from "./remoteProviders/adapters";
+import type { RemoteProvider } from "./remoteProviders/types";
 
 interface MappingLinkageRow {
     id: string;
@@ -261,44 +265,45 @@ export async function resolvePlaylistItemsForUser(
     const resolvedByIndex = await resolveQueueForUser(resolutionInputs, userId);
 
     const localById = new Map<string, UnifiedLocalTrackRecord>();
-    const tidalById = new Map<string, UnifiedTrackTidalRecord>();
-    const ytById = new Map<string, UnifiedTrackYtMusicRecord>();
+    const remoteByProvider: Record<
+        RemoteProvider,
+        Map<string, RemoteProviderTrackRecord>
+    > = {
+        tidal: new Map(),
+        youtube: new Map(),
+    };
 
     for (const item of items) {
         if (item.track?.id) {
             localById.set(item.track.id, item.track);
         }
-        if (item.trackTidal?.id) {
-            tidalById.set(item.trackTidal.id, item.trackTidal);
-        }
-        if (item.trackYtMusic?.id) {
-            ytById.set(item.trackYtMusic.id, item.trackYtMusic);
+        for (const provider of REMOTE_PROVIDERS) {
+            const track = remoteProviderAdapters[provider].itemTrack(item);
+            if (track?.id) remoteByProvider[provider].set(track.id, track);
         }
     }
 
     const missingLocalIds = new Set<string>();
-    const missingTidalIds = new Set<string>();
-    const missingYtIds = new Set<string>();
+    const missingRemoteIds: Record<RemoteProvider, Set<string>> = {
+        tidal: new Set(),
+        youtube: new Set(),
+    };
 
     for (let index = 0; index < items.length; index += 1) {
         const resolved = resolvedByIndex.get(index);
         if (!resolved || !resolved.available) continue;
         if (resolved.source === "local" && !localById.has(resolved.trackId)) {
             missingLocalIds.add(resolved.trackId);
-        } else if (
-            resolved.source === "tidal" &&
-            !tidalById.has(resolved.trackTidalId)
-        ) {
-            missingTidalIds.add(resolved.trackTidalId);
-        } else if (
-            resolved.source === "youtube" &&
-            !ytById.has(resolved.trackYtMusicId)
-        ) {
-            missingYtIds.add(resolved.trackYtMusicId);
+        } else if (resolved.source !== "local") {
+            const adapter = remoteProviderAdapters[resolved.source];
+            const trackId = adapter.resolvedTrackId(resolved);
+            if (trackId && !remoteByProvider[resolved.source].has(trackId)) {
+                missingRemoteIds[resolved.source].add(trackId);
+            }
         }
     }
 
-    const [localRows, tidalRows, ytRows] = await Promise.all([
+    const [localRows, remoteRows] = await Promise.all([
         missingLocalIds.size > 0
             ? prisma.track.findMany({
                   where: { id: { in: Array.from(missingLocalIds) } },
@@ -324,26 +329,27 @@ export async function resolvePlaylistItemsForUser(
                   },
               })
             : Promise.resolve([]),
-        missingTidalIds.size > 0
-            ? prisma.trackTidal.findMany({
-                  where: { id: { in: Array.from(missingTidalIds) } },
-              })
-            : Promise.resolve([]),
-        missingYtIds.size > 0
-            ? prisma.trackYtMusic.findMany({
-                  where: { id: { in: Array.from(missingYtIds) } },
-              })
-            : Promise.resolve([]),
+        Promise.all(
+            REMOTE_PROVIDERS.map(async (provider) => {
+                const ids = Array.from(missingRemoteIds[provider]);
+                const rows =
+                    ids.length > 0
+                        ? await remoteProviderAdapters[
+                              provider
+                          ].findTracksByIds(ids)
+                        : [];
+                return [provider, rows] as const;
+            }),
+        ),
     ]);
 
     for (const row of localRows) {
         localById.set(row.id, row as unknown as UnifiedLocalTrackRecord);
     }
-    for (const row of tidalRows) {
-        tidalById.set(row.id, row as unknown as UnifiedTrackTidalRecord);
-    }
-    for (const row of ytRows) {
-        ytById.set(row.id, row as unknown as UnifiedTrackYtMusicRecord);
+    for (const [provider, rows] of remoteRows) {
+        for (const row of rows) {
+            remoteByProvider[provider].set(row.id, row);
+        }
     }
 
     return items.map((item, index) => {
@@ -368,33 +374,14 @@ export async function resolvePlaylistItemsForUser(
                 } else {
                     resolution = { available: false, reason: "no-mapping" };
                 }
-            } else if (baseResolution.source === "tidal") {
-                const tidalTrack = tidalById.get(baseResolution.trackTidalId);
-                if (tidalTrack) {
-                    effective = {
-                        ...item,
-                        trackId: null,
-                        trackTidalId: baseResolution.trackTidalId,
-                        trackYtMusicId: null,
-                        track: null,
-                        trackTidal: tidalTrack,
-                        trackYtMusic: null,
-                    };
-                } else {
-                    resolution = { available: false, reason: "no-mapping" };
-                }
             } else {
-                const ytTrack = ytById.get(baseResolution.trackYtMusicId);
-                if (ytTrack) {
-                    effective = {
-                        ...item,
-                        trackId: null,
-                        trackTidalId: null,
-                        trackYtMusicId: baseResolution.trackYtMusicId,
-                        track: null,
-                        trackTidal: null,
-                        trackYtMusic: ytTrack,
-                    };
+                const adapter = remoteProviderAdapters[baseResolution.source];
+                const trackId = adapter.resolvedTrackId(baseResolution);
+                const track = trackId
+                    ? remoteByProvider[baseResolution.source].get(trackId)
+                    : undefined;
+                if (trackId && track) {
+                    effective = adapter.applyTrack(item, trackId, track);
                 } else {
                     resolution = { available: false, reason: "no-mapping" };
                 }

--- a/backend/src/services/rateLimiter.ts
+++ b/backend/src/services/rateLimiter.ts
@@ -25,8 +25,6 @@ interface ServiceConfig {
     lastfm: RateLimitConfig;
     musicbrainz: RateLimitConfig;
     deezer: RateLimitConfig;
-    fanart: RateLimitConfig;
-    lidarr: RateLimitConfig;
     coverart: RateLimitConfig;
 }
 
@@ -50,20 +48,6 @@ const SERVICE_CONFIGS: ServiceConfig = {
         intervalCap: 25, // Deezer is more lenient
         interval: 5000,
         concurrency: 5,
-        maxRetries: 2,
-        baseDelay: 500,
-    },
-    fanart: {
-        intervalCap: 5,
-        interval: 1000,
-        concurrency: 2,
-        maxRetries: 2,
-        baseDelay: 1000,
-    },
-    lidarr: {
-        intervalCap: 10, // Local service, can be faster
-        interval: 1000,
-        concurrency: 3,
         maxRetries: 2,
         baseDelay: 500,
     },

--- a/backend/src/services/remoteProviders/__tests__/adapters.test.ts
+++ b/backend/src/services/remoteProviders/__tests__/adapters.test.ts
@@ -1,0 +1,106 @@
+const mockTidalStream = jest.fn();
+const mockTidalPlaylist = jest.fn();
+const mockTidalPublicPlaylist = jest.fn();
+const mockYoutubeStream = jest.fn();
+const mockYoutubePlaylist = jest.fn();
+const mockFindTidal = jest.fn();
+const mockFindYoutube = jest.fn();
+
+jest.mock("../../tidalStreaming", () => ({
+    tidalStreamingService: {
+        getStreamProxy: mockTidalStream,
+        getBrowsePlaylist: mockTidalPlaylist,
+        getPublicBrowsePlaylist: mockTidalPublicPlaylist,
+    },
+}));
+jest.mock("../../youtubeMusic", () => ({
+    ytMusicService: {
+        getStreamProxy: mockYoutubeStream,
+        getBrowsePlaylist: mockYoutubePlaylist,
+    },
+}));
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        trackTidal: { findMany: mockFindTidal },
+        trackYtMusic: { findMany: mockFindYoutube },
+    },
+}));
+
+import { remoteProviderAdapters } from "../adapters";
+
+describe("remote provider adapter table", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("routes Tidal operations to Tidal services", async () => {
+        const adapter = remoteProviderAdapters.tidal;
+        mockTidalStream.mockResolvedValueOnce(null);
+        mockTidalPlaylist.mockResolvedValueOnce({ title: "Tidal", tracks: [] });
+        mockFindTidal.mockResolvedValueOnce([]);
+
+        await adapter.streamTrack({
+            userId: "user-1",
+            tidalTrackId: 42,
+            quality: "HIGH",
+            range: "bytes=0-9",
+        });
+        await adapter.fetchPlaylist({
+            sourceId: "playlist-1",
+            userId: "user-1",
+            authenticated: true,
+            quality: "HIGH",
+        });
+        await adapter.findTracksByIds(["tidal-row-1"]);
+
+        expect(mockTidalStream).toHaveBeenCalledWith(
+            "user-1",
+            42,
+            "HIGH",
+            "bytes=0-9",
+        );
+        expect(mockTidalPlaylist).toHaveBeenCalledWith(
+            "user-1",
+            "playlist-1",
+            "HIGH",
+        );
+        expect(mockFindTidal).toHaveBeenCalledWith({
+            where: { id: { in: ["tidal-row-1"] } },
+        });
+    });
+
+    it("routes YouTube operations to YouTube Music services", async () => {
+        const adapter = remoteProviderAdapters.youtube;
+        mockYoutubeStream.mockResolvedValueOnce(null);
+        mockYoutubePlaylist.mockResolvedValueOnce({ title: "YT", tracks: [] });
+        mockFindYoutube.mockResolvedValueOnce([]);
+
+        await adapter.streamTrack({
+            userId: "oauth-user",
+            youtubeVideoId: "video-1",
+            quality: "LOW",
+        });
+        await adapter.fetchPlaylist({
+            sourceId: "playlist-2",
+            userId: "oauth-user",
+            authenticated: true,
+            quality: "HIGH",
+        });
+        await adapter.findTracksByIds(["yt-row-1"]);
+
+        expect(mockYoutubeStream).toHaveBeenCalledWith(
+            "oauth-user",
+            "video-1",
+            "LOW",
+            undefined,
+        );
+        expect(mockYoutubePlaylist).toHaveBeenCalledWith(
+            "playlist-2",
+            100,
+            "oauth-user",
+        );
+        expect(mockFindYoutube).toHaveBeenCalledWith({
+            where: { id: { in: ["yt-row-1"] } },
+        });
+    });
+});

--- a/backend/src/services/remoteProviders/__tests__/types.test.ts
+++ b/backend/src/services/remoteProviders/__tests__/types.test.ts
@@ -1,0 +1,68 @@
+import {
+    toMappingProvider,
+    toStreamingProvider,
+    type MappingProvider,
+    type StreamingProvider,
+} from "../types";
+
+const MAPPING_PROVIDERS = [
+    "tidal",
+    "youtube",
+] as const satisfies readonly MappingProvider[];
+const STREAMING_PROVIDERS = [
+    "tidal",
+    "ytmusic",
+] as const satisfies readonly StreamingProvider[];
+
+function proveMappingProviderExhaustive(provider: MappingProvider): void {
+    switch (provider) {
+        case "tidal":
+        case "youtube":
+            return;
+        default: {
+            const exhaustive: never = provider;
+            return exhaustive;
+        }
+    }
+}
+
+function proveStreamingProviderExhaustive(provider: StreamingProvider): void {
+    switch (provider) {
+        case "tidal":
+        case "ytmusic":
+            return;
+        default: {
+            const exhaustive: never = provider;
+            return exhaustive;
+        }
+    }
+}
+
+describe("remote provider translators", () => {
+    it.each([
+        ["tidal", "tidal"],
+        ["youtube", "ytmusic"],
+    ] as const)(
+        "translates mapping provider %s to %s",
+        (mapping, streaming) => {
+            proveMappingProviderExhaustive(mapping);
+            expect(toStreamingProvider(mapping)).toBe(streaming);
+        },
+    );
+
+    it.each([
+        ["tidal", "tidal"],
+        ["ytmusic", "youtube"],
+    ] as const)(
+        "translates streaming provider %s to %s",
+        (streaming, mapping) => {
+            proveStreamingProviderExhaustive(streaming);
+            expect(toMappingProvider(streaming)).toBe(mapping);
+        },
+    );
+
+    it("keeps the compile-time provider lists exhaustive", () => {
+        expect(MAPPING_PROVIDERS).toHaveLength(2);
+        expect(STREAMING_PROVIDERS).toHaveLength(2);
+    });
+});

--- a/backend/src/services/remoteProviders/adapters.ts
+++ b/backend/src/services/remoteProviders/adapters.ts
@@ -1,0 +1,303 @@
+import { prisma } from "../../utils/db";
+import type { ResolvedSource } from "../listenTogetherResolution";
+import type {
+    UnifiedPlaylistItemRecord,
+    UnifiedTrackTidalRecord,
+    UnifiedTrackYtMusicRecord,
+} from "../unifiedTrackResponse";
+import type {
+    MappingProvider,
+    RemoteProvider,
+    StreamingProvider,
+} from "./types";
+
+/**
+ * Playback, playlist-import, and playlist-row dispatch for remote providers.
+ * Metadata fallback ladders remain owned by services/metadata and are not
+ * wrapped here. Remaining dispatch sites migrate to this table as they are
+ * touched.
+ */
+
+/** Remote row materialized for a playlist item. */
+export type RemoteProviderTrackRecord =
+    | UnifiedTrackTidalRecord
+    | UnifiedTrackYtMusicRecord;
+
+/** Common stream request accepted by each provider adapter. */
+export interface RemoteProviderStreamInput {
+    userId: string;
+    quality: string;
+    range?: string;
+    tidalTrackId?: number;
+    youtubeVideoId?: string;
+}
+
+/** Stream response fields consumed by the HTTP proxy. */
+export interface RemoteProviderStreamResponse {
+    status: number;
+    headers: Record<string, unknown>;
+    data: NodeJS.ReadableStream;
+}
+
+/** Common playlist request accepted by each provider adapter. */
+export interface RemoteProviderPlaylistInput {
+    sourceId: string;
+    userId?: string;
+    authenticated: boolean;
+    quality: string;
+}
+
+/** Provider playlist track normalized for the import pipeline. */
+export interface RemoteProviderPlaylistTrack {
+    artist: string;
+    title: string;
+    album?: string;
+    duration?: number;
+    isrc?: string;
+    videoId?: string;
+    tidalId?: number;
+}
+
+/** Provider playlist normalized for the import pipeline. */
+export interface RemoteProviderPlaylist {
+    name: string;
+    tracks: RemoteProviderPlaylistTrack[];
+}
+
+/** Shared playback, playlist-import, and playlist-row provider dispatch. */
+export interface RemoteProviderAdapter {
+    provider: RemoteProvider;
+    mappingProvider: MappingProvider;
+    streamingProvider: StreamingProvider;
+    streamTrack(
+        input: RemoteProviderStreamInput,
+    ): Promise<RemoteProviderStreamResponse | null>;
+    fetchPlaylist(
+        input: RemoteProviderPlaylistInput,
+    ): Promise<RemoteProviderPlaylist>;
+    itemTrackId(item: UnifiedPlaylistItemRecord): string | null;
+    itemTrack(
+        item: UnifiedPlaylistItemRecord,
+    ): RemoteProviderTrackRecord | null;
+    resolvedTrackId(resolved: ResolvedSource): string | null;
+    findTracksByIds(ids: string[]): Promise<RemoteProviderTrackRecord[]>;
+    applyTrack(
+        item: UnifiedPlaylistItemRecord,
+        trackId: string,
+        track: RemoteProviderTrackRecord,
+    ): UnifiedPlaylistItemRecord;
+}
+
+type TidalStreamingService =
+    typeof import("../tidalStreaming").tidalStreamingService;
+type TidalPlaylist = Awaited<
+    ReturnType<TidalStreamingService["getBrowsePlaylist"]>
+>;
+
+function errorStatusCode(error: unknown): number | null {
+    const status = (error as { response?: { status?: unknown } })?.response
+        ?.status;
+    return typeof status === "number" ? status : null;
+}
+
+function requireTidalTrackId(input: RemoteProviderStreamInput): number {
+    if (
+        typeof input.tidalTrackId !== "number" ||
+        !Number.isFinite(input.tidalTrackId) ||
+        input.tidalTrackId <= 0
+    ) {
+        throw new Error("Tidal stream requires tidalTrackId > 0");
+    }
+    return input.tidalTrackId;
+}
+
+function requireYoutubeVideoId(input: RemoteProviderStreamInput): string {
+    const videoId = input.youtubeVideoId?.trim();
+    if (!videoId) throw new Error("YouTube stream requires youtubeVideoId");
+    return videoId;
+}
+
+async function loadAuthenticatedTidalPlaylist(
+    service: TidalStreamingService,
+    input: RemoteProviderPlaylistInput,
+): Promise<TidalPlaylist | null> {
+    if (!input.authenticated || !input.userId) return null;
+    try {
+        return await service.getBrowsePlaylist(
+            input.userId,
+            input.sourceId,
+            input.quality,
+        );
+    } catch (error) {
+        const status = errorStatusCode(error);
+        if (status && status !== 401 && status !== 403) {
+            if (status === 404) throw new Error("Tidal playlist not found");
+            throw error;
+        }
+        return null;
+    }
+}
+
+async function loadPublicTidalPlaylist(
+    service: TidalStreamingService,
+    input: RemoteProviderPlaylistInput,
+): Promise<TidalPlaylist> {
+    try {
+        return await service.getPublicBrowsePlaylist(
+            input.sourceId,
+            input.quality,
+        );
+    } catch (error) {
+        const status = errorStatusCode(error);
+        if (status === 404) throw new Error("Tidal playlist not found");
+        if (status === 401 || status === 403) {
+            throw new Error("Tidal import requires authentication");
+        }
+        throw error;
+    }
+}
+
+function normalizeTidalPlaylist(
+    playlist: TidalPlaylist,
+): RemoteProviderPlaylist {
+    return {
+        name: playlist.title,
+        tracks: playlist.tracks.map((track) => ({
+            artist: track.artist || "Unknown",
+            title: track.title || "Unknown",
+            album: track.album || undefined,
+            duration: track.duration,
+            isrc: track.isrc || undefined,
+            tidalId: track.trackId,
+        })),
+    };
+}
+
+async function fetchTidalPlaylist(
+    input: RemoteProviderPlaylistInput,
+): Promise<RemoteProviderPlaylist> {
+    const { tidalStreamingService } = await import("../tidalStreaming");
+    const authenticated = await loadAuthenticatedTidalPlaylist(
+        tidalStreamingService,
+        input,
+    );
+    const playlist =
+        authenticated ??
+        (await loadPublicTidalPlaylist(tidalStreamingService, input));
+    return normalizeTidalPlaylist(playlist);
+}
+
+function requireTidalTrack(
+    track: RemoteProviderTrackRecord,
+): UnifiedTrackTidalRecord {
+    if (!("tidalId" in track)) {
+        throw new Error("Tidal adapter requires a Tidal track row");
+    }
+    return track;
+}
+
+function requireYoutubeTrack(
+    track: RemoteProviderTrackRecord,
+): UnifiedTrackYtMusicRecord {
+    if (!("videoId" in track)) {
+        throw new Error("YouTube adapter requires a YouTube Music track row");
+    }
+    return track;
+}
+
+const tidalAdapter: RemoteProviderAdapter = {
+    provider: "tidal",
+    mappingProvider: "tidal",
+    streamingProvider: "tidal",
+    async streamTrack(input) {
+        const { tidalStreamingService } = await import("../tidalStreaming");
+        return tidalStreamingService.getStreamProxy(
+            input.userId,
+            requireTidalTrackId(input),
+            input.quality,
+            input.range,
+        );
+    },
+    fetchPlaylist: fetchTidalPlaylist,
+    itemTrackId: (item) => item.trackTidalId,
+    itemTrack: (item) => item.trackTidal,
+    resolvedTrackId: (resolved) =>
+        resolved.available && resolved.source === "tidal"
+            ? resolved.trackTidalId
+            : null,
+    findTracksByIds: (ids) =>
+        prisma.trackTidal.findMany({ where: { id: { in: ids } } }),
+    applyTrack: (item, trackId, track) => ({
+        ...item,
+        trackId: null,
+        trackTidalId: trackId,
+        trackYtMusicId: null,
+        track: null,
+        trackTidal: requireTidalTrack(track),
+        trackYtMusic: null,
+    }),
+};
+
+const youtubeAdapter: RemoteProviderAdapter = {
+    provider: "youtube",
+    mappingProvider: "youtube",
+    streamingProvider: "ytmusic",
+    async streamTrack(input) {
+        const { ytMusicService } = await import("../youtubeMusic");
+        return ytMusicService.getStreamProxy(
+            input.userId,
+            requireYoutubeVideoId(input),
+            input.quality,
+            input.range,
+        );
+    },
+    async fetchPlaylist(input) {
+        const { ytMusicService } = await import("../youtubeMusic");
+        const playlist = await ytMusicService.getBrowsePlaylist(
+            input.sourceId,
+            100,
+            input.userId ?? "__public__",
+        );
+        return {
+            name: playlist.title,
+            tracks: playlist.tracks.map((track) => ({
+                artist: track.artist || "Unknown",
+                title: track.title || "Unknown",
+                album: track.album || undefined,
+                duration: track.duration,
+                videoId: track.videoId,
+            })),
+        };
+    },
+    itemTrackId: (item) => item.trackYtMusicId,
+    itemTrack: (item) => item.trackYtMusic,
+    resolvedTrackId: (resolved) =>
+        resolved.available && resolved.source === "youtube"
+            ? resolved.trackYtMusicId
+            : null,
+    findTracksByIds: (ids) =>
+        prisma.trackYtMusic.findMany({ where: { id: { in: ids } } }),
+    applyTrack: (item, trackId, track) => ({
+        ...item,
+        trackId: null,
+        trackTidalId: null,
+        trackYtMusicId: trackId,
+        track: null,
+        trackTidal: null,
+        trackYtMusic: requireYoutubeTrack(track),
+    }),
+};
+
+/** Stable provider iteration order used by routing code. */
+export const REMOTE_PROVIDERS = [
+    "tidal",
+    "youtube",
+] as const satisfies readonly RemoteProvider[];
+
+/** Total adapter table keyed by canonical remote-provider identity. */
+export const remoteProviderAdapters: Readonly<
+    Record<RemoteProvider, RemoteProviderAdapter>
+> = {
+    tidal: tidalAdapter,
+    youtube: youtubeAdapter,
+};

--- a/backend/src/services/remoteProviders/types.ts
+++ b/backend/src/services/remoteProviders/types.ts
@@ -1,0 +1,40 @@
+/** Provider identity used by mapping, persistence, and API contracts. */
+export type MappingProvider = "tidal" | "youtube";
+
+/** Provider identity used by playback and streaming contracts. */
+export type StreamingProvider = "tidal" | "ytmusic";
+
+/** Canonical internal identity for a remote playback provider. */
+export type RemoteProvider = MappingProvider;
+
+function assertNever(value: never): never {
+    throw new Error(`Unsupported remote provider: ${String(value)}`);
+}
+
+/** Translate a mapping/API provider into its streaming spelling. */
+export function toStreamingProvider(
+    provider: MappingProvider,
+): StreamingProvider {
+    switch (provider) {
+        case "tidal":
+            return "tidal";
+        case "youtube":
+            return "ytmusic";
+        default:
+            return assertNever(provider);
+    }
+}
+
+/** Translate a streaming provider into its mapping/API spelling. */
+export function toMappingProvider(
+    provider: StreamingProvider,
+): MappingProvider {
+    switch (provider) {
+        case "tidal":
+            return "tidal";
+        case "ytmusic":
+            return "youtube";
+        default:
+            return assertNever(provider);
+    }
+}

--- a/backend/src/services/remoteTrackBackfillService.ts
+++ b/backend/src/services/remoteTrackBackfillService.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils/logger";
 import { resolveArtistForRemoteTrack } from "./artistResolutionService";
 import { resolveAlbumForRemoteTrack } from "./albumResolutionService";
 import { backfillAllArtistCounts } from "./artistCountsService";
+import type { MappingProvider } from "./remoteProviders/types";
 
 const log =
     typeof (logger as { child?: unknown }).child === "function"
@@ -23,7 +24,7 @@ interface RemoteTrackRow {
 
 interface BackfillPhaseConfig {
     label: "TrackTidal" | "TrackYtMusic";
-    albumSource: "tidal" | "youtube";
+    albumSource: MappingProvider;
     findBatch: (lastId: string) => Promise<RemoteTrackRow[]>;
     update: (
         id: string,

--- a/backend/src/services/remoteTrackMetadataResolver.ts
+++ b/backend/src/services/remoteTrackMetadataResolver.ts
@@ -1,4 +1,5 @@
 import { logger } from "../utils/logger";
+import type { MappingProvider } from "./remoteProviders/types";
 
 const log =
     typeof (logger as { child?: unknown }).child === "function"
@@ -46,7 +47,7 @@ export interface ResolvedRemoteTrackMetadata {
  * Route-facing lookup descriptor for a remote provider track.
  */
 export interface RemoteTrackLookup {
-    provider: "tidal" | "youtube";
+    provider: MappingProvider;
     userId: string;
     tidalId?: number;
     videoId?: string;

--- a/backend/src/services/trackMappingService.ts
+++ b/backend/src/services/trackMappingService.ts
@@ -8,6 +8,7 @@ import {
     resolveAlbumForRemoteTrack,
 } from "./albumResolutionService";
 import { updateArtistCounts } from "./artistCountsService";
+import type { MappingProvider } from "./remoteProviders/types";
 
 const log =
     typeof (logger as { child?: unknown }).child === "function"
@@ -64,7 +65,7 @@ export interface CreateMappingData {
 }
 
 export interface EnsureRemoteTrackData {
-    provider: "tidal" | "youtube";
+    provider: MappingProvider;
     tidalId?: number;
     videoId?: string;
     title: string;
@@ -78,7 +79,7 @@ export interface EnsureRemoteTrackData {
 }
 
 export interface EnsuredRemoteTrackResult {
-    provider: "tidal" | "youtube";
+    provider: MappingProvider;
     id: string;
     created: boolean;
 }
@@ -626,7 +627,7 @@ class TrackMappingService {
      * Creates a remote-only mapping if no active (non-stale) mapping exists.
      */
     private async ensureMapping(
-        provider: "tidal" | "youtube",
+        provider: MappingProvider,
         providerRowId: string,
     ): Promise<void> {
         try {


### PR DESCRIPTION
## Problem (#792)

No named remote-provider concept: `"tidal" | "youtube"` re-declared inline in 8+ files, 27 `===` dispatch sites re-deriving parallel structures by hand, and a silent cross-domain spelling seam (`ytmusic` streaming vs `youtube` mapping) where a missed hand-translation just compares false. Plus: `deezer.ts` made 15 unthrottled calls while its limiter config sat unused, and `fanart`/`lidarr` limiter configs were dead.

## Change

- `services/remoteProviders/types.ts`: `MappingProvider`, `StreamingProvider`, canonical `RemoteProvider`, exhaustive total translators (switch + never) — missed translations are now compile errors. **Zero persisted/API-visible string changes.**
- `adapters.ts`: per-provider table (streaming, playlist import, row lookup, resolved IDs, materialization). Migrated the heaviest sites: `mappedProviderStream`, `playlistImportService`, `playlistTrackResolution` (parallel maps → provider-keyed), plus all 8 inline-union files. Remaining literal sites enumerated in the module doc for incremental migration (listed in the report).
- Boundary with the #760 metadata facade confirmed: facade owns metadata/artwork ladders + catalog persistence; adapter owns playback/import/routing. No overlap.
- Deezer: all 15 calls through `rateLimiter.execute("deezer")`; dead `fanart`/`lidarr` configs+breakers removed (no callers repo-wide).
- Jest transform allowlist + `p-queue/p-timeout/eventemitter3` (adapter import graph reaches them from route suites — found when the full route batch failed to parse on the orchestration machine).

## Verification

- `verify:` full route batch + remoteProviders + deezer suites on this machine: **133 suites, 2,479 tests, pass** (includes the 34 socket suites the implementation sandbox couldn't run)
- `verify:` 29 service suites + 3 worker suites in-sandbox: 556 + 143 tests, pass
- `verify: backend tsc` exit 0; `format:check` clean; `check-file-size` pass

Closes #792