### PR TITLE
chore(enrichment): idle ticks stop paying the full working cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Internal TIDAL and YouTube provider plumbing now uses shared types and routing adapters, and Deezer API calls now use the shared rate limiter.
+- The enrichment worker now idles cheaply when the library is fully enriched.
 - Subsonic apps load artist lists much faster on large libraries, and genre shuffle pages now load consistently fast.
 - TIDAL and YouTube Music downloads now use identical filename and collision handling, and loudness backfills now measure tracks with multiple workers.
 - Backend Jest tests now use transpile-only TypeScript transforms, six workers, and smaller runtime suites for faster test runs.

--- a/backend/src/__tests__/prismaConnectionResilienceContract.test.ts
+++ b/backend/src/__tests__/prismaConnectionResilienceContract.test.ts
@@ -6,6 +6,10 @@ describe("prisma connection resilience contract", () => {
         path.resolve(__dirname, "../workers/unifiedEnrichment.ts"),
         "utf8",
     );
+    const enrichmentRetrySource = fs.readFileSync(
+        path.resolve(__dirname, "../workers/enrichmentPrismaRetry.ts"),
+        "utf8",
+    );
     const moodBucketSource = fs.readFileSync(
         path.resolve(__dirname, "../services/moodBucketService.ts"),
         "utf8",
@@ -24,7 +28,7 @@ describe("prisma connection resilience contract", () => {
     );
 
     it("treats Prisma P2037 too-many-connections errors as transient in high-volume enrichment paths", () => {
-        expect(unifiedEnrichmentSource).toContain("P2037");
+        expect(enrichmentRetrySource).toContain("P2037");
         expect(moodBucketSource).toContain("P2037");
     });
 

--- a/backend/src/workers/__tests__/enrichmentIdlePolicy.test.ts
+++ b/backend/src/workers/__tests__/enrichmentIdlePolicy.test.ts
@@ -1,0 +1,98 @@
+import {
+    EnrichmentIdleBackoff,
+    ExpiringMemo,
+    shouldSkipEnrichmentSnapshot,
+} from "../enrichmentIdlePolicy";
+
+describe("enrichment idle policy", () => {
+    it("backs off exponentially after idle cycles and caps at five minutes", () => {
+        const policy = new EnrichmentIdleBackoff(5_000, 300_000);
+        let now = 1_000;
+
+        expect(policy.getDelayMs()).toBe(5_000);
+        for (const expectedDelay of [10_000, 20_000, 40_000, 80_000]) {
+            policy.recordIdle(now);
+            expect(policy.getDelayMs()).toBe(expectedDelay);
+            expect(policy.isDue(now + expectedDelay - 1)).toBe(false);
+            now += expectedDelay;
+            expect(policy.isDue(now)).toBe(true);
+        }
+
+        for (let cycle = 0; cycle < 10; cycle += 1) {
+            policy.recordIdle(now);
+        }
+        expect(policy.getDelayMs()).toBe(300_000);
+    });
+
+    it("resets to the base delay when work or a library-change signal arrives", () => {
+        const policy = new EnrichmentIdleBackoff(5_000, 300_000);
+
+        policy.recordIdle(1_000);
+        policy.recordIdle(11_000);
+        policy.recordWork(31_000);
+
+        expect(policy.getDelayMs()).toBe(5_000);
+        expect(policy.isDue(35_999)).toBe(false);
+        expect(policy.isDue(36_000)).toBe(true);
+
+        policy.recordIdle(36_000);
+        policy.reset();
+        expect(policy.getDelayMs()).toBe(5_000);
+        expect(policy.isDue(36_000)).toBe(true);
+    });
+
+    it("skips snapshots only for authoritative, follow-up-free idle state", () => {
+        const completeIdleState = {
+            status: "idle",
+            completionNotificationSent: true,
+            coreCacheCleared: true,
+            fullCacheCleared: true,
+            pendingMoodBucketBackfill: false,
+            moodBucketBackfillInProgress: false,
+        } as const;
+
+        expect(shouldSkipEnrichmentSnapshot(completeIdleState, false)).toBe(
+            true,
+        );
+        expect(shouldSkipEnrichmentSnapshot(completeIdleState, true)).toBe(
+            false,
+        );
+        expect(
+            shouldSkipEnrichmentSnapshot({
+                ...completeIdleState,
+                status: "running",
+            }),
+        ).toBe(false);
+        expect(
+            shouldSkipEnrichmentSnapshot({
+                ...completeIdleState,
+                pendingMoodBucketBackfill: true,
+            }),
+        ).toBe(false);
+        expect(
+            shouldSkipEnrichmentSnapshot({
+                ...completeIdleState,
+                completionNotificationSent: false,
+            }),
+        ).toBe(false);
+    });
+
+    it("memoizes within the TTL and reloads after expiry or invalidation", async () => {
+        let now = 10_000;
+        const memo = new ExpiringMemo<string>(3_000, () => now);
+        const load = jest
+            .fn<Promise<string>, []>()
+            .mockResolvedValueOnce("first")
+            .mockResolvedValueOnce("second")
+            .mockResolvedValueOnce("third");
+
+        await expect(memo.get(load)).resolves.toBe("first");
+        now = 12_999;
+        await expect(memo.get(load)).resolves.toBe("first");
+        now = 13_000;
+        await expect(memo.get(load)).resolves.toBe("second");
+        memo.invalidate();
+        await expect(memo.get(load)).resolves.toBe("third");
+        expect(load).toHaveBeenCalledTimes(3);
+    });
+});

--- a/backend/src/workers/__tests__/enrichmentMixCache.test.ts
+++ b/backend/src/workers/__tests__/enrichmentMixCache.test.ts
@@ -1,0 +1,44 @@
+import { scanRedisKeys } from "../enrichmentMixCache";
+
+describe("enrichment mix-cache scanning", () => {
+    it("returns the same matching key set across bounded SCAN pages", async () => {
+        const scan = jest
+            .fn()
+            .mockResolvedValueOnce(["7", ["mixes:first", "mixes:second"]])
+            .mockResolvedValueOnce(["0", ["mixes:second", "mixes:third"]]);
+
+        const keys = await scanRedisKeys({ scan }, "mixes:*", 250, 10);
+
+        expect(new Set(keys)).toEqual(
+            new Set(["mixes:first", "mixes:second", "mixes:third"]),
+        );
+        expect(scan).toHaveBeenNthCalledWith(
+            1,
+            "0",
+            "MATCH",
+            "mixes:*",
+            "COUNT",
+            250,
+        );
+        expect(scan).toHaveBeenNthCalledWith(
+            2,
+            "7",
+            "MATCH",
+            "mixes:*",
+            "COUNT",
+            250,
+        );
+    });
+
+    it("fails closed when the scan iteration bound is exhausted", async () => {
+        const scan = jest.fn<
+            Promise<[string, string[]]>,
+            [string, "MATCH", string, "COUNT", number]
+        >(async () => ["1", ["mixes:first"]]);
+
+        await expect(
+            scanRedisKeys({ scan }, "mixes:*", 250, 2),
+        ).rejects.toThrow("iteration limit");
+        expect(scan).toHaveBeenCalledTimes(2);
+    });
+});

--- a/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
+++ b/backend/src/workers/__tests__/unifiedEnrichmentRuntime.test.ts
@@ -72,6 +72,7 @@ describe("unified enrichment runtime behavior", () => {
             mget: jest.fn(async (...keys: string[]) => keys.map(() => null)),
             rpush: jest.fn(async (_queue?: string, _payload?: string) => 1),
             eval: jest.fn(async () => 1),
+            scan: jest.fn(async () => ["0", []]),
             keys: jest.fn(async () => []),
             del: jest.fn(async () => 0),
             disconnect: jest.fn(),
@@ -81,6 +82,7 @@ describe("unified enrichment runtime behavior", () => {
             mget: jest.fn(async (...keys: string[]) => keys.map(() => null)),
             rpush: jest.fn(async (_queue?: string, _payload?: string) => 1),
             eval: jest.fn(async () => 1),
+            scan: jest.fn(async () => ["0", []]),
             keys: jest.fn(async () => []),
             del: jest.fn(async () => 0),
             disconnect: jest.fn(),
@@ -543,6 +545,85 @@ describe("unified enrichment runtime behavior", () => {
         await enrichment.stopUnifiedEnrichmentWorker();
     });
 
+    it("skips the progress snapshot transaction on authoritative idle ticks", async () => {
+        const { prisma, enrichmentStateService } =
+            setupUnifiedEnrichmentMocks();
+        (enrichmentStateService.getState as jest.Mock).mockResolvedValue({
+            status: "idle",
+            completionNotificationSent: true,
+            coreCacheCleared: true,
+            fullCacheCleared: true,
+            pendingMoodBucketBackfill: false,
+            moodBucketBackfillInProgress: false,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const enrichment = require("../unifiedEnrichment");
+        enrichment.__unifiedEnrichmentTestables.__setRuntimeStateForTests({
+            lastRunTime: 0,
+        });
+
+        await expect(
+            enrichment.__unifiedEnrichmentTestables.runEnrichmentCycle(false),
+        ).resolves.toEqual({ artists: 0, tracks: 0, audioQueued: 0 });
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(prisma.artist.findMany).not.toHaveBeenCalled();
+        expect(prisma.track.findMany).not.toHaveBeenCalled();
+    });
+
+    it("runs working-state ticks through the existing ordered phases", async () => {
+        const {
+            prisma,
+            enrichmentStateService,
+            audioAnalysisCleanupService,
+            vibeAnalysisCleanupService,
+        } = setupUnifiedEnrichmentMocks();
+        (enrichmentStateService.getState as jest.Mock).mockResolvedValue({
+            status: "running",
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const enrichment = require("../unifiedEnrichment");
+        enrichment.__unifiedEnrichmentTestables.__setRuntimeStateForTests({
+            lastRunTime: 0,
+        });
+
+        await enrichment.__unifiedEnrichmentTestables.runEnrichmentCycle(false);
+
+        expect(prisma.$transaction).toHaveBeenCalled();
+        expect(prisma.artist.findMany).toHaveBeenCalled();
+        expect(prisma.track.findMany).toHaveBeenCalled();
+        expect(
+            audioAnalysisCleanupService.cleanupStaleProcessing,
+        ).toHaveBeenCalled();
+        expect(
+            vibeAnalysisCleanupService.cleanupStaleProcessing,
+        ).toHaveBeenCalled();
+        const phases = (
+            enrichmentStateService.updateState as jest.Mock
+        ).mock.calls
+            .map(([update]) => update.currentPhase)
+            .filter(Boolean);
+        expect(phases.slice(0, 5)).toEqual([
+            "artists",
+            "tracks",
+            "audio",
+            "vibe",
+            "podcasts",
+        ]);
+    });
+
+    it("memoizes repeated progress reads inside the three-second TTL", async () => {
+        const { prisma } = setupUnifiedEnrichmentMocks();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const enrichment = require("../unifiedEnrichment");
+        await enrichment.getEnrichmentProgress();
+        await enrichment.getEnrichmentProgress();
+
+        expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    });
+
     it("handles state update failures during stop without crashing teardown", async () => {
         const { enrichmentStateService } = setupUnifiedEnrichmentMocks();
         (enrichmentStateService.updateState as jest.Mock).mockRejectedValueOnce(
@@ -864,9 +945,9 @@ describe("unified enrichment runtime behavior", () => {
             0,
             0,
         ]);
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce(["mixes:core"])
-            .mockResolvedValueOnce(["mixes:full"]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", ["mixes:core"]])
+            .mockResolvedValueOnce(["0", ["mixes:full"]]);
         (queueRedisPrimary.del as jest.Mock).mockResolvedValue(1);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
@@ -883,7 +964,8 @@ describe("unified enrichment runtime behavior", () => {
         const result = await enrichment.runFullEnrichment();
 
         expect(result).toEqual({ artists: 0, tracks: 0, audioQueued: 0 });
-        expect(queueRedisPrimary.keys).toHaveBeenCalledTimes(2);
+        expect(queueRedisPrimary.scan).toHaveBeenCalledTimes(2);
+        expect(queueRedisPrimary.keys).not.toHaveBeenCalled();
         expect(queueRedisPrimary.del).toHaveBeenCalledTimes(2);
         expect(enrichmentStateService.updateState).toHaveBeenCalledWith(
             expect.objectContaining({ completionNotificationSent: true }),
@@ -933,9 +1015,9 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce(["mixes:core"])
-            .mockResolvedValueOnce(["mixes:full"]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", ["mixes:core"]])
+            .mockResolvedValueOnce(["0", ["mixes:full"]]);
         (queueRedisPrimary.del as jest.Mock).mockResolvedValue(1);
         (moodBucketService.backfillAllTracks as jest.Mock).mockResolvedValue({
             processed: 3,
@@ -1368,9 +1450,9 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", []])
+            .mockResolvedValueOnce(["0", []]);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
             .mockResolvedValueOnce({ coreCacheCleared: true })
@@ -1455,9 +1537,9 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", []])
+            .mockResolvedValueOnce(["0", []]);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
             .mockResolvedValueOnce({ coreCacheCleared: true })
@@ -1549,9 +1631,9 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", []])
+            .mockResolvedValueOnce(["0", []]);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
             .mockResolvedValueOnce({ coreCacheCleared: true })
@@ -1625,6 +1707,7 @@ describe("unified enrichment runtime behavior", () => {
 
     it("executes the interval callback cycle after startup", async () => {
         jest.useFakeTimers();
+        const setIntervalSpy = jest.spyOn(global, "setInterval");
         const { claimRedisPrimary } = setupUnifiedEnrichmentMocks();
         (claimRedisPrimary.set as jest.Mock).mockResolvedValue(null);
 
@@ -1632,12 +1715,16 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         await enrichment.startUnifiedEnrichmentWorker();
 
-        await jest.advanceTimersByTimeAsync(5_000);
+        const interval = setIntervalSpy.mock.results.at(-1)?.value;
+        expect(interval.hasRef()).toBe(false);
+
+        await jest.advanceTimersByTimeAsync(10_000);
         expect(
             (claimRedisPrimary.set as jest.Mock).mock.calls.length,
         ).toBeGreaterThan(1);
 
         await enrichment.stopUnifiedEnrichmentWorker();
+        setIntervalSpy.mockRestore();
     });
 
     it("warns when post-batch progress read/update fails after work was processed", async () => {
@@ -1730,8 +1817,8 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock).mockRejectedValueOnce(
-            new Error("keys failed"),
+        (queueRedisPrimary.scan as jest.Mock).mockRejectedValueOnce(
+            new Error("scan failed"),
         );
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
@@ -1930,9 +2017,9 @@ describe("unified enrichment runtime behavior", () => {
         (
             moodBucketService.backfillAllTracks as jest.Mock
         ).mockRejectedValueOnce(new Error("backfill failed"));
-        (queueRedisPrimary.keys as jest.Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([]);
+        (queueRedisPrimary.scan as jest.Mock)
+            .mockResolvedValueOnce(["0", []])
+            .mockResolvedValueOnce(["0", []]);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
             .mockResolvedValueOnce({ coreCacheCleared: true })
@@ -1994,7 +2081,7 @@ describe("unified enrichment runtime behavior", () => {
                 0,
                 0,
             ]);
-        (queueRedisPrimary.keys as jest.Mock).mockRejectedValueOnce(
+        (queueRedisPrimary.scan as jest.Mock).mockRejectedValueOnce(
             new Error("mix key lookup failed"),
         );
         (enrichmentStateService.getState as jest.Mock)
@@ -2011,7 +2098,14 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         await enrichment.runFullEnrichment();
 
-        expect(queueRedisPrimary.keys).toHaveBeenCalledWith("mixes:*");
+        expect(queueRedisPrimary.scan).toHaveBeenCalledWith(
+            "0",
+            "MATCH",
+            "mixes:*",
+            "COUNT",
+            250,
+        );
+        expect(queueRedisPrimary.keys).not.toHaveBeenCalled();
         expect(logger.error).toHaveBeenCalledWith(
             "Failed to clear mix cache on full complete:",
             expect.any(Error),
@@ -3235,7 +3329,7 @@ describe("unified enrichment runtime behavior", () => {
             0,
             0,
         ]);
-        (queueRedisPrimary.keys as jest.Mock).mockResolvedValue([]);
+        (queueRedisPrimary.scan as jest.Mock).mockResolvedValue(["0", []]);
         (enrichmentStateService.getState as jest.Mock)
             .mockResolvedValueOnce({ status: "idle" })
             .mockResolvedValueOnce({ coreCacheCleared: false })
@@ -3250,7 +3344,14 @@ describe("unified enrichment runtime behavior", () => {
         const enrichment = require("../unifiedEnrichment");
         await enrichment.runFullEnrichment();
 
-        expect(queueRedisPrimary.keys).toHaveBeenCalledWith("mixes:*");
+        expect(queueRedisPrimary.scan).toHaveBeenCalledWith(
+            "0",
+            "MATCH",
+            "mixes:*",
+            "COUNT",
+            250,
+        );
+        expect(queueRedisPrimary.keys).not.toHaveBeenCalled();
         expect(queueRedisPrimary.del).not.toHaveBeenCalled();
     });
 

--- a/backend/src/workers/enrichmentIdlePolicy.ts
+++ b/backend/src/workers/enrichmentIdlePolicy.ts
@@ -1,0 +1,115 @@
+import type { EnrichmentState } from "../services/enrichmentState";
+
+type EnrichmentCompletionState = Pick<
+    EnrichmentState,
+    | "status"
+    | "completionNotificationSent"
+    | "coreCacheCleared"
+    | "fullCacheCleared"
+    | "pendingMoodBucketBackfill"
+    | "moodBucketBackfillInProgress"
+>;
+
+/** Return true when persisted completion markers make a progress snapshot redundant. */
+export function shouldSkipEnrichmentSnapshot(
+    state: Partial<EnrichmentCompletionState> | null,
+    bypassIdle = false,
+): boolean {
+    return (
+        !bypassIdle &&
+        state?.status === "idle" &&
+        state.completionNotificationSent === true &&
+        state.coreCacheCleared === true &&
+        state.fullCacheCleared === true &&
+        state.pendingMoodBucketBackfill !== true &&
+        state.moodBucketBackfillInProgress !== true
+    );
+}
+
+/** Track bounded exponential delay between enrichment cycles that find no work. */
+export class EnrichmentIdleBackoff {
+    private idleCycles = 0;
+    private nextCycleAtMs = 0;
+
+    constructor(
+        private readonly baseDelayMs: number,
+        private readonly maximumDelayMs: number,
+    ) {
+        if (baseDelayMs <= 0 || maximumDelayMs < baseDelayMs) {
+            throw new RangeError("Invalid enrichment idle backoff bounds");
+        }
+    }
+
+    /** Return the current delay after applying the configured cap. */
+    getDelayMs(): number {
+        return Math.min(
+            this.maximumDelayMs,
+            this.baseDelayMs * 2 ** this.idleCycles,
+        );
+    }
+
+    /** Return whether the next scheduled cycle may run. */
+    isDue(nowMs: number): boolean {
+        return nowMs >= this.nextCycleAtMs;
+    }
+
+    /** Extend the next-cycle delay after a cycle found no work. */
+    recordIdle(nowMs: number): void {
+        this.idleCycles = Math.min(this.idleCycles + 1, 31);
+        this.nextCycleAtMs = nowMs + this.getDelayMs();
+    }
+
+    /** Restore the base delay after a cycle found work. */
+    recordWork(nowMs: number): void {
+        this.idleCycles = 0;
+        this.nextCycleAtMs = nowMs + this.baseDelayMs;
+    }
+
+    /** Record whether a completed scheduled cycle found work. */
+    recordCycle(processedWork: boolean, nowMs: number): void {
+        if (processedWork) this.recordWork(nowMs);
+        else this.recordIdle(nowMs);
+    }
+
+    /** Make the next cycle immediately eligible after an external work signal. */
+    reset(): void {
+        this.idleCycles = 0;
+        this.nextCycleAtMs = 0;
+    }
+}
+
+/** Memoize an asynchronous value for a fixed TTL using an injectable clock. */
+export class ExpiringMemo<T> {
+    private cached: { value: Promise<T>; expiresAtMs: number } | null = null;
+
+    constructor(
+        private readonly ttlMs: number,
+        private readonly now: () => number = Date.now,
+    ) {
+        if (ttlMs <= 0) {
+            throw new RangeError("Memo TTL must be positive");
+        }
+    }
+
+    /** Return a fresh or unexpired value and coalesce concurrent loads. */
+    async get(load: () => Promise<T>): Promise<T> {
+        const nowMs = this.now();
+        if (this.cached && nowMs < this.cached.expiresAtMs) {
+            return this.cached.value;
+        }
+
+        const value = load();
+        this.cached = { value, expiresAtMs: nowMs + this.ttlMs };
+        try {
+            return await value;
+        } catch (error) {
+            if (this.cached?.value === value) this.cached = null;
+            throw error;
+        }
+    }
+
+    /** Remove any memoized progress value. */
+    invalidate(): void {
+        this.cached = null;
+    }
+}

--- a/backend/src/workers/enrichmentMixCache.ts
+++ b/backend/src/workers/enrichmentMixCache.ts
@@ -1,0 +1,44 @@
+const DEFAULT_SCAN_BATCH_SIZE = 250;
+const DEFAULT_SCAN_ITERATION_LIMIT = 10_000;
+
+interface RedisScanClient {
+    scan(
+        cursor: string,
+        matchKeyword: "MATCH",
+        pattern: string,
+        countKeyword: "COUNT",
+        count: number,
+    ): Promise<[string, string[]]>;
+}
+
+/** Collect matching Redis keys with bounded, incremental SCAN calls. */
+export async function scanRedisKeys(
+    redis: RedisScanClient,
+    pattern: string,
+    batchSize = DEFAULT_SCAN_BATCH_SIZE,
+    iterationLimit = DEFAULT_SCAN_ITERATION_LIMIT,
+): Promise<string[]> {
+    if (batchSize <= 0 || iterationLimit <= 0) {
+        throw new RangeError("Redis scan bounds must be positive");
+    }
+
+    const keys = new Set<string>();
+    let cursor = "0";
+    for (let iteration = 0; iteration < iterationLimit; iteration += 1) {
+        const [nextCursor, page] = await redis.scan(
+            cursor,
+            "MATCH",
+            pattern,
+            "COUNT",
+            batchSize,
+        );
+        page.forEach((key) => keys.add(key));
+        cursor = nextCursor;
+        if (cursor === "0") return [...keys];
+    }
+
+    throw new Error(`Redis SCAN iteration limit reached for ${pattern}`);
+}
+
+/** Redis COUNT hint used for enrichment mix-cache scans. */
+export const ENRICHMENT_MIX_SCAN_BATCH_SIZE = DEFAULT_SCAN_BATCH_SIZE;

--- a/backend/src/workers/enrichmentPrismaRetry.ts
+++ b/backend/src/workers/enrichmentPrismaRetry.ts
@@ -1,0 +1,66 @@
+import { Prisma, prisma } from "../utils/db";
+import { toErrorMessage } from "../utils/errors";
+import { logger } from "../utils/logger";
+
+const log = logger.child("Enrichment");
+const ENRICHMENT_PRISMA_RETRY_ATTEMPTS = 3;
+
+function isRetryableEnrichmentPrismaError(error: unknown): boolean {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return ["P1001", "P1002", "P1017", "P2024", "P2037"].includes(
+            error.code,
+        );
+    }
+    if (error instanceof Prisma.PrismaClientRustPanicError) return true;
+    if (error instanceof Prisma.PrismaClientUnknownRequestError) {
+        return (
+            error.message.includes("Response from the Engine was empty") ||
+            error.message.includes("Engine has already exited")
+        );
+    }
+
+    const message = toErrorMessage(error);
+    return (
+        message.includes("Response from the Engine was empty") ||
+        message.includes("Engine has already exited") ||
+        message.includes("Can't reach database server") ||
+        message.includes("Connection reset")
+    );
+}
+
+function isTooManyConnectionsPrismaError(error: unknown): boolean {
+    return (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2037"
+    );
+}
+
+/** Retry bounded enrichment database reads after transient Prisma failures. */
+export async function withEnrichmentPrismaRetry<T>(
+    operationName: string,
+    operation: () => Promise<T>,
+): Promise<T> {
+    for (let attempt = 1; ; attempt += 1) {
+        try {
+            return await operation();
+        } catch (error) {
+            if (
+                !isRetryableEnrichmentPrismaError(error) ||
+                attempt === ENRICHMENT_PRISMA_RETRY_ATTEMPTS
+            ) {
+                throw error;
+            }
+            log.warn(
+                `${operationName} failed (attempt ${attempt}/${ENRICHMENT_PRISMA_RETRY_ATTEMPTS}), retrying`,
+                error,
+            );
+            const tooManyConnections = isTooManyConnectionsPrismaError(error);
+            const delayMs = tooManyConnections ? 1000 * attempt : 250 * attempt;
+            if (tooManyConnections) {
+                await prisma.$disconnect().catch(() => {});
+            }
+            await prisma.$connect().catch(() => {});
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+    }
+}

--- a/backend/src/workers/unifiedEnrichment.ts
+++ b/backend/src/workers/unifiedEnrichment.ts
@@ -12,7 +12,7 @@
  */
 
 import { logger } from "../utils/logger";
-import { prisma, Prisma } from "../utils/db";
+import { prisma } from "../utils/db";
 import { enrichSimilarArtist } from "./artistEnrichment";
 import { lastFmService } from "../services/lastfm";
 import { randomUUID } from "crypto";
@@ -40,6 +40,13 @@ import {
 import { getActiveSpace } from "../services/embeddingSpaces";
 import { findLocalTracksNeedingActiveEmbedding } from "../services/trackEmbeddings";
 import { filterVibeRetryEligibleCandidates } from "../services/vibeEmbedJobs";
+import {
+    EnrichmentIdleBackoff,
+    ExpiringMemo,
+    shouldSkipEnrichmentSnapshot,
+} from "./enrichmentIdlePolicy";
+import { scanRedisKeys } from "./enrichmentMixCache";
+import { withEnrichmentPrismaRetry } from "./enrichmentPrismaRetry";
 
 const log = logger.child("Enrichment");
 
@@ -47,10 +54,11 @@ const log = logger.child("Enrichment");
 const ARTIST_BATCH_SIZE = 10;
 const TRACK_BATCH_SIZE = 20;
 const ENRICHMENT_INTERVAL_MS = 5 * 1000; // 5 seconds - rate limiter handles API limits
+const ENRICHMENT_IDLE_MAX_INTERVAL_MS = 5 * 60 * 1000;
+const ENRICHMENT_PROGRESS_MEMO_TTL_MS = 3 * 1000;
 const MAX_CONSECUTIVE_SYSTEM_FAILURES = 5; // Circuit breaker threshold
 const ENRICHMENT_STOP_WAIT_INTERVAL_MS = 100;
 const ENRICHMENT_STOP_MAX_WAIT_MS = 30_000;
-const ENRICHMENT_PRISMA_RETRY_ATTEMPTS = 3;
 const AUDIO_QUEUE_VIBE_HIGH_WATER_MARK = 500;
 
 let isRunning = false;
@@ -63,10 +71,18 @@ let isStopping = false;
 let immediateEnrichmentRequested = false;
 let consecutiveSystemFailures = 0; // Track consecutive system-level failures
 let lastRunTime = 0;
+let lastCycleProcessedWork = false;
 const MIN_INTERVAL_MS = 10000; // Minimum 10s between cycles
 const ENRICHMENT_CLAIM_KEY = "enrichment:cycle:claim";
 const ENRICHMENT_CLAIM_OWNER_ID = randomUUID();
 const ENRICHMENT_CLAIM_TTL_MS = config.workers.enrichmentClaimTtlMs;
+const enrichmentIdleBackoff = new EnrichmentIdleBackoff(
+    ENRICHMENT_INTERVAL_MS,
+    ENRICHMENT_IDLE_MAX_INTERVAL_MS,
+);
+const enrichmentProgressMemo = new ExpiringMemo<
+    Awaited<ReturnType<typeof loadEnrichmentProgress>>
+>(ENRICHMENT_PROGRESS_MEMO_TTL_MS);
 
 // Batch failure tracking
 interface BatchFailures {
@@ -170,74 +186,6 @@ async function withEnrichmentClaimRedisRetry<T>(
     }
 }
 
-function isRetryableEnrichmentPrismaError(error: unknown): boolean {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        return ["P1001", "P1002", "P1017", "P2024", "P2037"].includes(
-            error.code,
-        );
-    }
-
-    if (error instanceof Prisma.PrismaClientRustPanicError) {
-        return true;
-    }
-
-    if (error instanceof Prisma.PrismaClientUnknownRequestError) {
-        const message = error.message || "";
-        return (
-            message.includes("Response from the Engine was empty") ||
-            message.includes("Engine has already exited")
-        );
-    }
-
-    const message =
-        error instanceof Error ? error.message : String(error ?? "");
-    return (
-        message.includes("Response from the Engine was empty") ||
-        message.includes("Engine has already exited") ||
-        message.includes("Can't reach database server") ||
-        message.includes("Connection reset")
-    );
-}
-
-function isTooManyConnectionsPrismaError(error: unknown): boolean {
-    return (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === "P2037"
-    );
-}
-
-async function withEnrichmentPrismaRetry<T>(
-    operationName: string,
-    operation: () => Promise<T>,
-): Promise<T> {
-    for (let attempt = 1; ; attempt += 1) {
-        try {
-            return await operation();
-        } catch (error) {
-            if (
-                !isRetryableEnrichmentPrismaError(error) ||
-                attempt === ENRICHMENT_PRISMA_RETRY_ATTEMPTS
-            ) {
-                throw error;
-            }
-
-            log.warn(
-                `${operationName} failed (attempt ${attempt}/${ENRICHMENT_PRISMA_RETRY_ATTEMPTS}), retrying`,
-                error,
-            );
-
-            const delayMs = isTooManyConnectionsPrismaError(error)
-                ? 1000 * attempt
-                : 250 * attempt;
-            if (isTooManyConnectionsPrismaError(error)) {
-                await prisma.$disconnect().catch(() => {});
-            }
-            await prisma.$connect().catch(() => {});
-            await new Promise((resolve) => setTimeout(resolve, delayMs));
-        }
-    }
-}
-
 async function runEnrichmentCycleClaimed(
     fullMode: boolean,
     operationName: string,
@@ -246,6 +194,7 @@ async function runEnrichmentCycleClaimed(
     tracks: number;
     audioQueued: number;
 }> {
+    lastCycleProcessedWork = false;
     const emptyResult = { artists: 0, tracks: 0, audioQueued: 0 };
     const claimToken = `${ENRICHMENT_CLAIM_OWNER_ID}:${Date.now()}:${Math.random()}`;
     const ttlSeconds = Math.max(1, Math.ceil(ENRICHMENT_CLAIM_TTL_MS / 1000));
@@ -367,11 +316,14 @@ export async function startUnifiedEnrichmentWorker() {
 
     // Run immediately
     await runEnrichmentCycleClaimed(false, "startup enrichment cycle");
+    enrichmentIdleBackoff.recordCycle(lastCycleProcessedWork, Date.now());
 
-    // Then run at interval
     enrichmentInterval = setInterval(async () => {
+        if (!enrichmentIdleBackoff.isDue(Date.now())) return;
         await runEnrichmentCycleClaimed(false, "interval enrichment cycle");
+        enrichmentIdleBackoff.recordCycle(lastCycleProcessedWork, Date.now());
     }, ENRICHMENT_INTERVAL_MS);
+    enrichmentInterval.unref();
 }
 
 /**
@@ -448,6 +400,8 @@ export async function runFullEnrichment(options?: {
     audioQueued: number;
 }> {
     log.debug("\n=== FULL ENRICHMENT: Re-enriching everything ===\n");
+    enrichmentIdleBackoff.reset();
+    enrichmentProgressMemo.invalidate();
 
     try {
         const reconciliation =
@@ -572,10 +526,17 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
 }> {
     const emptyResult = { artists: 0, tracks: 0, audioQueued: 0 };
 
+    let currentState: Awaited<
+        ReturnType<typeof enrichmentStateService.getState>
+    > = null;
+
     // Sync local pause flag with state service
     if (!isPaused) {
-        const state = await enrichmentStateService.getState();
-        if (state?.status === "paused" || state?.status === "stopping") {
+        currentState = await enrichmentStateService.getState();
+        if (
+            currentState?.status === "paused" ||
+            currentState?.status === "stopping"
+        ) {
             isPaused = true;
         }
     }
@@ -593,6 +554,11 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
     // Enforce minimum interval (unless full mode or immediate request)
     const now = Date.now();
     if (!bypassRunningCheck && now - lastRunTime < MIN_INTERVAL_MS) {
+        return emptyResult;
+    }
+
+    if (shouldSkipEnrichmentSnapshot(currentState, bypassRunningCheck)) {
+        consecutiveSystemFailures = 0;
         return emptyResult;
     }
 
@@ -651,6 +617,7 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
             return { artists: 0, tracks: 0, audioQueued: 0 };
         }
         artistsProcessed = artistResult;
+        lastCycleProcessedWork ||= artistsProcessed > 0;
 
         const trackResult = await runPhase("tracks", executeMoodTagsPhase);
         if (trackResult === null) {
@@ -658,6 +625,7 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
             return { artists: artistsProcessed, tracks: 0, audioQueued: 0 };
         }
         tracksProcessed = trackResult;
+        lastCycleProcessedWork ||= tracksProcessed > 0;
 
         // Steps 3-4 (audio analysis + vibe embeddings queueing) are gated by
         // the coarse AUDIO_ANALYSIS_ENABLED feature flag.
@@ -673,6 +641,7 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
                 };
             }
             audioQueued = audioResult;
+            lastCycleProcessedWork ||= audioQueued > 0;
 
             const vibeResult = await runPhase("vibe", executeVibePhase);
             if (vibeResult === null) {
@@ -684,20 +653,26 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
                 };
             }
             vibeQueued = vibeResult;
+            lastCycleProcessedWork ||= vibeQueued > 0;
         }
 
         // Podcast refresh phase -- only runs if subscriptions exist
-        await runPhase("podcasts", executePodcastRefreshPhase);
+        const podcastsProcessed =
+            (await runPhase("podcasts", executePodcastRefreshPhase)) ?? 0;
+        lastCycleProcessedWork ||= podcastsProcessed > 0;
 
         const features = await featureDetection.getFeatures();
 
         // Log progress (only if work was done)
-        if (
+        const processedWorkThisCycle =
             artistsProcessed > 0 ||
             tracksProcessed > 0 ||
             audioQueued > 0 ||
-            vibeQueued > 0
-        ) {
+            vibeQueued > 0 ||
+            podcastsProcessed > 0;
+        lastCycleProcessedWork = processedWorkThisCycle;
+        if (processedWorkThisCycle) {
+            enrichmentProgressMemo.invalidate();
             try {
                 const progress = await getEnrichmentProgress();
                 log.debug(`\nEnrichment Progress`);
@@ -758,6 +733,13 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
 
         // If everything is complete, mark as idle and send notification (only once)
         let progress: Awaited<ReturnType<typeof getEnrichmentProgress>>;
+        if (
+            !processedWorkThisCycle &&
+            startingProgress &&
+            !startingProgress.isFullyComplete
+        ) {
+            enrichmentProgressMemo.invalidate();
+        }
         try {
             progress = await getEnrichmentProgress();
         } catch (error) {
@@ -778,7 +760,10 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
             if (!state?.coreCacheCleared) {
                 try {
                     const redisInstance = getRedis();
-                    const mixKeys = await redisInstance.keys("mixes:*");
+                    const mixKeys = await scanRedisKeys(
+                        redisInstance,
+                        "mixes:*",
+                    );
                     if (mixKeys.length > 0) {
                         await redisInstance.del(...mixKeys);
                         log.info(
@@ -847,7 +832,10 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
             if (!stateBeforeNotify?.fullCacheCleared) {
                 try {
                     const redisInstance = getRedis();
-                    const mixKeys = await redisInstance.keys("mixes:*");
+                    const mixKeys = await scanRedisKeys(
+                        redisInstance,
+                        "mixes:*",
+                    );
                     if (mixKeys.length > 0) {
                         await redisInstance.del(...mixKeys);
                         log.info(
@@ -867,11 +855,6 @@ async function runEnrichmentCycle(fullMode: boolean): Promise<{
 
             // Send completion notification only if not already sent
             const state = await enrichmentStateService.getState();
-            const processedWorkThisCycle =
-                artistsProcessed > 0 ||
-                tracksProcessed > 0 ||
-                audioQueued > 0 ||
-                vibeQueued > 0;
             const totalSessionFailures =
                 sessionFailureCount.artists +
                 sessionFailureCount.tracks +
@@ -1535,6 +1518,10 @@ async function executeVibePhase(): Promise<number> {
  * - Audio Analysis: "Background" enrichment (runs in separate container, non-blocking)
  */
 export async function getEnrichmentProgress() {
+    return enrichmentProgressMemo.get(loadEnrichmentProgress);
+}
+
+async function loadEnrichmentProgress() {
     const [
         artistCounts,
         trackTotal,
@@ -1744,6 +1731,8 @@ export async function triggerEnrichmentNow(): Promise<{
     audioQueued: number;
 }> {
     log.debug("Triggering immediate enrichment cycle...");
+    enrichmentIdleBackoff.reset();
+    enrichmentProgressMemo.invalidate();
 
     // Reset pause state when triggering enrichment
     isPaused = false;
@@ -1760,6 +1749,7 @@ export async function triggerEnrichmentNow(): Promise<{
  */
 export async function reRunArtistsOnly(): Promise<{ count: number }> {
     log.debug("Re-running artist enrichment only...");
+    enrichmentProgressMemo.invalidate();
 
     const result = await resetArtistsOnly();
 
@@ -1782,6 +1772,7 @@ export async function reRunArtistsOnly(): Promise<{ count: number }> {
  */
 export async function reRunMoodTagsOnly(): Promise<{ count: number }> {
     log.debug("Re-running mood tags only...");
+    enrichmentProgressMemo.invalidate();
 
     const result = await resetMoodTagsOnly();
 
@@ -1803,6 +1794,7 @@ export async function reRunMoodTagsOnly(): Promise<{ count: number }> {
  */
 export async function reRunAudioAnalysisOnly(): Promise<number> {
     log.debug("Re-running audio analysis only...");
+    enrichmentProgressMemo.invalidate();
 
     await audioAnalysisCleanupService.cleanupStaleProcessing();
 
@@ -1826,6 +1818,7 @@ export async function reRunAudioAnalysisOnly(): Promise<number> {
  */
 export async function reRunVibeEmbeddingsOnly(): Promise<number> {
     log.debug("Re-running vibe embeddings only...");
+    enrichmentProgressMemo.invalidate();
 
     const features = await featureDetection.getFeatures();
     if (!features.vibeEmbeddings) {

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -65,7 +65,7 @@ const BASELINE = Object.freeze({
     "backend/src/services/lidarr.ts": 2962,
     "backend/src/services/simpleDownloadManager.ts": 2306,
     "backend/src/services/spotify.ts": 1624,
-    "backend/src/workers/unifiedEnrichment.ts": 1904,
+    "backend/src/workers/unifiedEnrichment.ts": 1897,
     "frontend/app/playlist/[id]/page.tsx": 1505,
     "frontend/app/vibe/page.tsx": 1524,
     "frontend/components/player/AudioPlaybackOrchestrator.tsx": 1595,

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -160,7 +160,7 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/workers/processors/imageProcessor.ts": 1,
     "backend/src/workers/umapWorker.ts": 0,
     // unifiedEnrichment.ts remaining 7: retry classifiers, scoped worker diagnostics, and internal failure/batch-state records.
-    "backend/src/workers/unifiedEnrichment.ts": 7,
+    "backend/src/workers/unifiedEnrichment.ts": 5,
 });
 
 export function countPattern(source) {


### PR DESCRIPTION
## Problem (#781)

The enrichment worker's idle fast-path sat **downstream** of `getEnrichmentProgress()` — an 11-aggregate `$transaction` (Artist groupBy, 7 Track counts, 2 raw COUNT(*)) running up to 3× per cycle on a 5s interval. Fully-enriched steady state: ~2,900 Track count-scans/hour, forever, plus blocking `KEYS mixes:*` scans and an un-unref'd interval.

## Change

- **Sentinel before snapshot:** persisted worker completion state (idle + cache clears complete + completion notified + no mood-backfill follow-up) gates the tick; idle ticks issue zero snapshot queries.
- **3s memo** on the snapshot collapses in-cycle repeats; invalidated when work is found or enrichment is triggered.
- **Exponential idle backoff** 5s → 300s cap, reset by the scan-completion `triggerEnrichmentNow()` signal and any phase finding work. Policy math in a pure module (`enrichmentIdlePolicy.ts`) with unit tests.
- `KEYS mixes:*` → bounded `SCAN` (batch 250, 10k-iteration cap); interval `unref()`d per the vibe-worker precedent.
- Working-path behavior and progress payload unchanged; `unifiedEnrichment.ts` shrank (baseline tightened 1904 → 1897).

## Verification (post-rebase onto main including #778's scanProcessor changes)

- `verify:` enrichment + policy + scanProcessor runtime suites: 3 suites, 119 tests, pass
- `verify: backend tsc` exit 0; `format:check` clean; `check-file-size` pass

Closes #781