### PR TITLE
fix(radio): bounded candidate pools, SQL aggregates, and caching for radio, genres, and decades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pressing get-all-missing-albums now queues the artist's albums immediately even while other downloads are running (#808).
+- Radio stations now start quickly on large libraries, and genre and decade stations load instantly without recounting the full library on every request (#776). Preferences now reorder the selected station without promoting liked tracks into it or displacing disliked tracks near the cutoff.
 - Post-scan download reconciliation no longer risks heavy database load when many downloads are queued.
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.

--- a/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryCoverArtCompat.test.ts
@@ -107,6 +107,12 @@ jest.mock("../../services/deezer", () => ({
     },
 }));
 
+jest.mock("../../services/libraryRadioCache", () => ({
+    ...jest.requireActual("../../services/libraryRadioCache"),
+    loadGenreRadioAggregates: jest.fn(),
+    loadDecadeRadioAggregates: jest.fn(),
+}));
+
 jest.mock("../../services/imageProvider", () => ({
     imageProviderService: {
         getAlbumCover: jest.fn(),
@@ -264,6 +270,13 @@ const mockAlbumFindUnique = prisma.album.findUnique as jest.Mock;
 const mockAlbumUpdate = prisma.album.update as jest.Mock;
 const mockAlbumFindMany = prisma.album.findMany as jest.Mock;
 const mockArtistFindMany = prisma.artist.findMany as jest.Mock;
+const {
+    loadGenreRadioAggregates: mockLoadGenreRadioAggregates,
+    loadDecadeRadioAggregates: mockLoadDecadeRadioAggregates,
+} = jest.requireMock("../../services/libraryRadioCache") as {
+    loadGenreRadioAggregates: jest.Mock;
+    loadDecadeRadioAggregates: jest.Mock;
+};
 const mockArtistUpdateMany = prisma.artist.updateMany as jest.Mock;
 const mockQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockResolveAlbumCover = resolveAlbumCover as jest.Mock;
@@ -2358,13 +2371,9 @@ describe("library discovery metadata compatibility", () => {
         );
     });
 
-    it("returns genres while filtering out genres that match artist names", async () => {
-        mockArtistFindMany.mockResolvedValueOnce([
-            { name: "Radiohead", normalizedName: "radiohead" },
-        ]);
-        mockQueryRaw.mockResolvedValueOnce([
-            { genre: "radiohead", track_count: 42n },
-            { genre: "ambient", track_count: 19n },
+    it("returns genres from the cached SQL aggregate (artist-name filtering lives in SQL, pinned by the PostgreSQL fixture)", async () => {
+        mockLoadGenreRadioAggregates.mockResolvedValueOnce([
+            { genre: "ambient", count: 19 },
         ]);
 
         const req = {} as any;
@@ -2378,7 +2387,9 @@ describe("library discovery metadata compatibility", () => {
     });
 
     it("returns 500 when genre aggregation fails", async () => {
-        mockArtistFindMany.mockRejectedValueOnce(new Error("db-unavailable"));
+        mockLoadGenreRadioAggregates.mockRejectedValueOnce(
+            new Error("db-unavailable"),
+        );
 
         const req = {} as any;
         const res = createRes();
@@ -2387,32 +2398,10 @@ describe("library discovery metadata compatibility", () => {
         expect(res.statusCode).toBe(500);
     });
 
-    it("returns sorted decades with minimum-track filtering", async () => {
-        mockAlbumFindMany.mockResolvedValueOnce([
-            {
-                year: 1994,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 9 },
-            },
-            {
-                year: 1996,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 7 },
-            },
-            {
-                year: 2012,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 20 },
-            },
-            {
-                year: 1981,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 4 },
-            },
+    it("returns decades from the cached SQL aggregate (sorting and minimum-track filtering live in SQL, pinned by the PostgreSQL fixture)", async () => {
+        mockLoadDecadeRadioAggregates.mockResolvedValueOnce([
+            { decade: 2010, count: 20 },
+            { decade: 1990, count: 16 },
         ]);
 
         const req = {} as any;

--- a/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
+++ b/backend/src/routes/__tests__/libraryRadioVibeReliabilityCompat.test.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 
+const mockLoadVibeRadioCandidateIds = jest.fn();
+
 jest.mock("../../middleware/auth", () => ({
     requireAuth: (_req: Request, _res: Response, next: () => void) => next(),
     requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
@@ -198,6 +200,16 @@ jest.mock("../../services/metadata/catalogPersistence", () => ({
     readFreshCatalogReleaseGroups: jest.fn(() => null),
 }));
 
+jest.mock("../../services/libraryRadioCache", () => ({
+    loadGenreRadioAggregates: jest.fn(),
+    loadDecadeRadioAggregates: jest.fn(),
+    loadVibeRadioCandidateIds: mockLoadVibeRadioCandidateIds,
+    loadRadioIdCandidatePool: (
+        _discriminator: string,
+        loader: () => Promise<string[]>,
+    ) => loader(),
+}));
+
 import router from "../library";
 import { flattenLibraryRouteLayers } from "./libraryRouteTestUtils";
 import { errorHandler } from "../../middleware/errorHandler";
@@ -261,6 +273,7 @@ describe("library vibe radio reliability compatibility", () => {
         jest.clearAllMocks();
         mockLikedTrackFindMany.mockResolvedValue([]);
         mockDislikedEntityFindMany.mockResolvedValue([]);
+        mockLoadVibeRadioCandidateIds.mockResolvedValue(["candidate-track"]);
     });
 
     it("treats legacy enhanced analysis as standard and requests analysisVersion", async () => {
@@ -385,6 +398,9 @@ describe("library vibe radio reliability compatibility", () => {
             }),
         );
         expect(mockTrackFindMany).toHaveBeenCalled();
+        expect(mockLoadVibeRadioCandidateIds).toHaveBeenCalledWith(
+            "source-track",
+        );
         expect(mockTrackFindMany.mock.calls[0][0]).toEqual(
             expect.objectContaining({
                 select: expect.objectContaining({
@@ -532,6 +548,7 @@ describe("library vibe radio reliability compatibility", () => {
     });
 
     it("falls back to same-artist tracks when source has no audio analysis data", async () => {
+        mockLoadVibeRadioCandidateIds.mockResolvedValueOnce([]);
         const sourceTrack = {
             id: "source-track-noaudio",
             title: "Source Track Without Analysis",

--- a/backend/src/routes/__tests__/libraryRuntime.helpers.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.helpers.ts
@@ -14,6 +14,12 @@ const mockServeMappedProviderStream = jest.fn();
 const mockTerminateCommittedStream = jest.fn((res: Response) => res.end());
 const mockGetYtMusicUserIdOrPublic = jest.fn();
 const mockBumpSearchCacheVersion = jest.fn().mockResolvedValue(undefined);
+const mockLoadGenreRadioAggregates = jest.fn();
+const mockLoadDecadeRadioAggregates = jest.fn();
+const mockLoadVibeRadioCandidateIds = jest.fn();
+const mockLoadRadioIdCandidatePool = jest.fn(
+    (_discriminator: string, loader: () => Promise<string[]>) => loader(),
+);
 
 jest.mock("dns/promises", () => ({
     lookup: (...args: unknown[]) => mockLookup(...args),
@@ -375,6 +381,13 @@ jest.mock("../../services/imageStorage", () => ({
 
 jest.mock("../../services/searchCacheVersion", () => ({
     bumpSearchCacheVersion: mockBumpSearchCacheVersion,
+}));
+
+jest.mock("../../services/libraryRadioCache", () => ({
+    loadGenreRadioAggregates: mockLoadGenreRadioAggregates,
+    loadDecadeRadioAggregates: mockLoadDecadeRadioAggregates,
+    loadVibeRadioCandidateIds: mockLoadVibeRadioCandidateIds,
+    loadRadioIdCandidatePool: mockLoadRadioIdCandidatePool,
 }));
 
 const mockPersistCatalogReleaseGroups = jest.fn();
@@ -754,6 +767,10 @@ export {
     mockTerminateCommittedStream,
     mockGetYtMusicUserIdOrPublic,
     mockBumpSearchCacheVersion,
+    mockLoadGenreRadioAggregates,
+    mockLoadDecadeRadioAggregates,
+    mockLoadVibeRadioCandidateIds,
+    mockLoadRadioIdCandidatePool,
     mockResolveArtistImage,
     mockPersistCatalogReleaseGroups,
     mockLidarrDeleteArtist,

--- a/backend/src/routes/__tests__/libraryRuntime.radioErrors.test.ts
+++ b/backend/src/routes/__tests__/libraryRuntime.radioErrors.test.ts
@@ -15,6 +15,9 @@ import {
     mockTerminateCommittedStream,
     mockGetYtMusicUserIdOrPublic,
     mockBumpSearchCacheVersion,
+    mockLoadGenreRadioAggregates,
+    mockLoadDecadeRadioAggregates,
+    mockLoadVibeRadioCandidateIds,
     mockResolveArtistImage,
     mockPersistCatalogReleaseGroups,
     mockLidarrDeleteArtist,
@@ -241,6 +244,9 @@ describe("library catalog list runtime coverage", () => {
         mockSimilarArtistDeleteMany.mockReset();
         mockPrismaTransaction.mockReset();
         mockPrismaQueryRaw.mockReset();
+        mockLoadGenreRadioAggregates.mockReset();
+        mockLoadDecadeRadioAggregates.mockReset();
+        mockLoadVibeRadioCandidateIds.mockReset();
         mockUserSettingsFindUnique.mockReset();
         mockStreamGetStreamFilePath.mockReset();
         mockStreamWithRangeSupport.mockReset();
@@ -301,6 +307,9 @@ describe("library catalog list runtime coverage", () => {
         mockRedisGet.mockResolvedValue(null);
         mockRedisSetEx.mockResolvedValue("OK");
         mockPrismaQueryRaw.mockResolvedValue([]);
+        mockLoadGenreRadioAggregates.mockResolvedValue([]);
+        mockLoadDecadeRadioAggregates.mockResolvedValue([]);
+        mockLoadVibeRadioCandidateIds.mockResolvedValue([]);
         mockPrismaExecuteRaw.mockResolvedValue(0);
         // The transactional client mirrors the full prisma mock so services
         // that run model operations inside $transaction (track deletion with
@@ -570,13 +579,8 @@ describe("library catalog list runtime coverage", () => {
     });
 
     it("filters artist-name genres and converts bigint counts", async () => {
-        mockArtistFindMany.mockResolvedValueOnce([
-            { name: "Radiohead", normalizedName: "radiohead" },
-            { name: "Aphex Twin", normalizedName: "aphextwin" },
-        ]);
-        mockPrismaQueryRaw.mockResolvedValueOnce([
-            { genre: "electronic", track_count: 24n },
-            { genre: "radiohead", track_count: 30n },
+        mockLoadGenreRadioAggregates.mockResolvedValueOnce([
+            { genre: "electronic", count: 24 },
         ]);
 
         const req = {} as any;
@@ -588,7 +592,7 @@ describe("library catalog list runtime coverage", () => {
             genres: [{ genre: "electronic", count: 24 }],
         });
 
-        mockPrismaQueryRaw.mockRejectedValueOnce(
+        mockLoadGenreRadioAggregates.mockRejectedValueOnce(
             new Error("genre query failed"),
         );
         const errRes = createRes();
@@ -597,25 +601,8 @@ describe("library catalog list runtime coverage", () => {
     });
 
     it("returns decades based on effective year and minimum track threshold", async () => {
-        mockAlbumFindMany.mockResolvedValueOnce([
-            {
-                year: 1992,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 8 },
-            },
-            {
-                year: 1998,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 9 },
-            },
-            {
-                year: 2005,
-                originalYear: null,
-                displayYear: null,
-                _count: { tracks: 6 },
-            },
+        mockLoadDecadeRadioAggregates.mockResolvedValueOnce([
+            { decade: 1990, count: 17 },
         ]);
 
         const req = {} as any;
@@ -627,7 +614,7 @@ describe("library catalog list runtime coverage", () => {
             decades: [{ decade: 1990, count: 17 }],
         });
 
-        mockAlbumFindMany.mockRejectedValueOnce(
+        mockLoadDecadeRadioAggregates.mockRejectedValueOnce(
             new Error("decade query failed"),
         );
         const errRes = createRes();
@@ -1117,7 +1104,7 @@ describe("library catalog list runtime coverage", () => {
         mockTrackFindMany.mockImplementation(async (args: any) => {
             if (
                 args.where?.analysisStatus === "completed" &&
-                args.where?.id?.not === "source-track"
+                Array.isArray(args.where?.id?.in)
             ) {
                 return [
                     {
@@ -1197,6 +1184,7 @@ describe("library catalog list runtime coverage", () => {
         mockSimilarArtistFindMany.mockResolvedValueOnce([
             { toArtistId: "artist-sim-1", weight: 0.9 },
         ]);
+        mockLoadVibeRadioCandidateIds.mockResolvedValueOnce(["an-1", "an-2"]);
         mockPrismaQueryRaw
             .mockResolvedValueOnce([{ id: "genre-c1" }])
             .mockResolvedValueOnce(
@@ -1238,6 +1226,39 @@ describe("library catalog list runtime coverage", () => {
                 audioFeatures: expect.objectContaining({
                     bpm: expect.any(Number),
                 }),
+            }),
+        );
+        const sameArtistQuery = mockTrackFindMany.mock.calls.find(
+            ([args]) => args.where?.album?.artistId === "artist-source",
+        )?.[0];
+        const similarArtistTracksQuery = mockTrackFindMany.mock.calls.find(
+            ([args]) => Array.isArray(args.where?.album?.artistId?.in),
+        )?.[0];
+        expect(sameArtistQuery).toEqual(
+            expect.objectContaining({
+                select: { id: true },
+                orderBy: { id: "asc" },
+                take: 400,
+            }),
+        );
+        expect(mockOwnedAlbumFindMany).toHaveBeenCalledWith({
+            select: { artistId: true },
+            distinct: ["artistId"],
+            orderBy: { artistId: "asc" },
+            take: 400,
+        });
+        expect(mockSimilarArtistFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                select: { toArtistId: true },
+                orderBy: [{ weight: "desc" }, { toArtistId: "asc" }],
+                take: 10,
+            }),
+        );
+        expect(similarArtistTracksQuery).toEqual(
+            expect.objectContaining({
+                select: { id: true },
+                orderBy: { id: "asc" },
+                take: 400,
             }),
         );
         expectBoundedRandomQuery(mockPrismaQueryRaw.mock.calls[0], 55);

--- a/backend/src/routes/library/radio.ts
+++ b/backend/src/routes/library/radio.ts
@@ -9,7 +9,6 @@ import {
     getMergedGenres,
     getArtistDisplaySummary,
 } from "../../utils/metadataOverrides";
-import { getEffectiveYear, getDecadeFromYear } from "../../utils/dateFilters";
 import { shuffleArray } from "../../utils/shuffle";
 import { separateArtists } from "../../utils/separateArtists";
 import {
@@ -43,6 +42,12 @@ import {
     selectLibraryRadioStationTracks,
 } from "../../services/libraryRadioStationSelection";
 import {
+    loadDecadeRadioAggregates,
+    loadGenreRadioAggregates,
+    loadRadioIdCandidatePool,
+    loadVibeRadioCandidateIds,
+} from "../../services/libraryRadioCache";
+import {
     hasReliableEnhancedAnalysis,
     TRACK_BROWSE_SQL,
     moodPoolCondition,
@@ -62,6 +67,7 @@ import {
  * Router segment for radio routes registered at this position.
  */
 export const radioRouter = Router();
+const VIBE_FALLBACK_QUERY_LIMIT = 400;
 /**
  * @openapi
  * /api/library/genres:
@@ -94,48 +100,7 @@ export const radioRouter = Router();
  * Handles GET /api/library/genres.
  */
 export async function handleGetGenres(req: Request, res: Response) {
-    // Get artist names to filter them out of genres (they sometimes get incorrectly tagged)
-    const artists = await prisma.artist.findMany({
-        select: { name: true, normalizedName: true },
-    });
-    const artistNames = new Set(
-        artists.flatMap((a) =>
-            [a.name.toLowerCase(), a.normalizedName?.toLowerCase()].filter(
-                Boolean,
-            ),
-        ),
-    );
-
-    // Query Artist.genres field (populated by enrichment from Last.fm tags)
-    // Use raw SQL to expand JSONB array and count tracks per genre
-    const minTracks = 15; // Minimum tracks for a genre to show up
-    const genreResults = await prisma.$queryRaw<
-        { genre: string; track_count: bigint }[]
-    >`
-            SELECT LOWER(g.genre) as genre, COUNT(DISTINCT t.id) as track_count
-            FROM "Artist" ar
-            CROSS JOIN LATERAL jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
-            JOIN "Album" a ON a."artistId" = ar.id
-            JOIN "Track" t ON t."albumId" = a.id
-            WHERE ${VISIBLE_TRACK_SQL} AND ${TRACK_BROWSE_SQL} AND ar.genres IS NOT NULL
-            GROUP BY LOWER(g.genre)
-            HAVING COUNT(DISTINCT t.id) >= ${minTracks}
-            ORDER BY track_count DESC
-            LIMIT 20
-        `;
-
-    // Filter out artist names and convert bigint to number
-    const genres = genreResults
-        .map((row) => ({
-            genre: row.genre,
-            count: Number(row.track_count),
-        }))
-        .filter((g) => !artistNames.has(g.genre.toLowerCase()));
-
-    logger.debug(
-        `[Genres] Found ${genres.length} genres from Artist.genres (min ${minTracks} tracks)`,
-    );
-
+    const genres = await loadGenreRadioAggregates();
     res.json({ genres });
 }
 
@@ -174,45 +139,7 @@ radioRouter.get("/genres", asyncHandler(handleGetGenres));
  * Handles GET /api/library/decades.
  */
 export async function handleGetDecades(req: Request, res: Response) {
-    // Get all albums with year fields and track count
-    const albums = await prisma.album.findMany({
-        select: {
-            year: true,
-            originalYear: true,
-            displayYear: true,
-            _count: {
-                select: {
-                    tracks: {
-                        where: {
-                            ...TRACK_VISIBLE_WHERE,
-                            ...TRACK_BROWSE_WHERE,
-                        },
-                    },
-                },
-            },
-        },
-    });
-
-    // Group by decade using effective year (displayYear > originalYear > year)
-    const decadeMap = new Map<number, number>();
-
-    for (const album of albums) {
-        const effectiveYear = getEffectiveYear(album);
-        if (effectiveYear) {
-            const decadeStart = getDecadeFromYear(effectiveYear);
-            decadeMap.set(
-                decadeStart,
-                (decadeMap.get(decadeStart) || 0) + album._count.tracks,
-            );
-        }
-    }
-
-    // Convert to array, filter by minimum tracks, and sort by decade
-    const decades = Array.from(decadeMap.entries())
-        .map(([decade, count]) => ({ decade, count }))
-        .filter((d) => d.count >= 15) // Minimum 15 tracks for a radio station
-        .sort((a, b) => b.decade - a.decade); // Newest first
-
+    const decades = await loadDecadeRadioAggregates();
     res.json({ decades });
 }
 
@@ -351,13 +278,18 @@ export async function handleGetRadio(req: Request, res: Response) {
             // Mood-based filtering using audio analysis features
             const moodValue = (radioValue || "").toLowerCase();
             const moodCondition = moodPoolCondition(moodValue);
-            const moodTracks = await prisma.$queryRaw<{ id: string }[]>`
+            trackIds = await loadRadioIdCandidatePool(
+                `mood:${moodValue}:${limitNum}`,
+                async () => {
+                    const moodTracks = await prisma.$queryRaw<{ id: string }[]>`
                     SELECT t.id FROM "Track" t
                     WHERE ${VISIBLE_TRACK_SQL} AND ${TRACK_BROWSE_SQL} AND ${moodCondition}
                     ORDER BY random()
                     LIMIT ${limitNum * 4}
                 `;
-            trackIds = moodTracks.map((t) => t.id);
+                    return moodTracks.map((track) => track.id);
+                },
+            );
             break;
         }
 
@@ -605,33 +537,6 @@ export async function handleGetRadio(req: Request, res: Response) {
                 );
             }
 
-            const similarTrackPreferenceScores =
-                await buildTrackPreferenceScoreMapForUser(
-                    userId,
-                    similarTracks.map((track) => track.id),
-                );
-            if (similarTrackPreferenceScores.size > 0) {
-                similarTracks = similarTracks
-                    .map((track) => {
-                        const adjustedScore =
-                            applyTrackPreferenceSimilarityBias(
-                                track.vibeScore ?? 0.5,
-                                similarTrackPreferenceScores.get(track.id) ?? 0,
-                            );
-                        return {
-                            ...track,
-                            vibeScore: adjustedScore,
-                        };
-                    })
-                    .sort(
-                        (left, right) =>
-                            (right.vibeScore ?? 0) - (left.vibeScore ?? 0),
-                    );
-                logger.debug(
-                    `[Radio:artist] Applied light preference weighting across ${similarTrackPreferenceScores.size} similar-track preferences`,
-                );
-            }
-
             // 7. Mix: ~40% original artist, ~60% similar (vibe-boosted)
             const originalCount = Math.min(
                 Math.ceil(limitNum * 0.4),
@@ -764,17 +669,17 @@ export async function handleGetRadio(req: Request, res: Response) {
             let vibeMatchedIds: string[] = [];
             const sourceArtistId = sourceTrack.album.artistId;
 
-            // 2. Try audio feature matching first (if track is analyzed)
-            const hasAudioData =
-                sourceTrack.bpm || sourceTrack.energy || sourceTrack.valence;
-
-            if (hasAudioData) {
-                // Get all analyzed tracks (excluding source) - include Enhanced mode fields
+            // 2. Use embedding similarity to bound the feature re-ranking pool.
+            const annCandidateIds =
+                await loadVibeRadioCandidateIds(sourceTrackId);
+            if (annCandidateIds.length > 0) {
+                // Hydrate only the bounded embedding-ranked pool for the existing
+                // feature and tag re-ranking step.
                 const analyzedTracks = await prisma.track.findMany({
                     where: {
                         ...TRACK_VISIBLE_WHERE,
                         ...TRACK_BROWSE_WHERE,
-                        id: { not: sourceTrackId },
+                        id: { in: annCandidateIds },
                         analysisStatus: "completed",
                     },
                     select: {
@@ -1045,11 +950,7 @@ export async function handleGetRadio(req: Request, res: Response) {
 
                     // Build source feature vector once
                     const sourceVector = buildFeatureVector(sourceTrack);
-                    const vibePreferenceScores =
-                        await buildTrackPreferenceScoreMapForUser(
-                            userId,
-                            analyzedTracks.map((track) => track.id),
-                        );
+                    const vibePreferenceScores = new Map<string, number>();
 
                     // Check if source track has Enhanced mode data
                     const sourceUsesEnhancedFeatures =
@@ -1145,7 +1046,6 @@ export async function handleGetRadio(req: Request, res: Response) {
                 }
             }
 
-            // 3. Fallback A: Same artist's other tracks
             if (vibeMatchedIds.length < limitNum) {
                 const artistTracks = await prisma.track.findMany({
                     where: {
@@ -1155,6 +1055,8 @@ export async function handleGetRadio(req: Request, res: Response) {
                         id: { notIn: [sourceTrackId, ...vibeMatchedIds] },
                     },
                     select: { id: true },
+                    orderBy: { id: "asc" },
+                    take: VIBE_FALLBACK_QUERY_LIMIT,
                 });
                 const newIds = artistTracks.map((t) => t.id);
                 vibeMatchedIds = [...vibeMatchedIds, ...newIds];
@@ -1162,27 +1064,26 @@ export async function handleGetRadio(req: Request, res: Response) {
                     `[Radio:vibe] Fallback A (same artist): added ${newIds.length} tracks, total: ${vibeMatchedIds.length}`,
                 );
             }
-
-            // 4. Fallback B: Similar artists from Last.fm (filtered to library)
             if (vibeMatchedIds.length < limitNum) {
                 const ownedArtistIds = await prisma.ownedAlbum.findMany({
                     select: { artistId: true },
                     distinct: ["artistId"],
+                    orderBy: { artistId: "asc" },
+                    take: VIBE_FALLBACK_QUERY_LIMIT,
                 });
                 const libraryArtistSet = new Set(
                     ownedArtistIds.map((o) => o.artistId),
                 );
                 libraryArtistSet.delete(sourceArtistId);
-
                 const similarArtists = await prisma.similarArtist.findMany({
                     where: {
                         fromArtistId: sourceArtistId,
                         toArtistId: { in: Array.from(libraryArtistSet) },
                     },
-                    orderBy: { weight: "desc" },
+                    select: { toArtistId: true },
+                    orderBy: [{ weight: "desc" }, { toArtistId: "asc" }],
                     take: 10,
                 });
-
                 if (similarArtists.length > 0) {
                     const similarArtistTracks = await prisma.track.findMany({
                         where: {
@@ -1198,6 +1099,8 @@ export async function handleGetRadio(req: Request, res: Response) {
                             },
                         },
                         select: { id: true },
+                        orderBy: { id: "asc" },
+                        take: VIBE_FALLBACK_QUERY_LIMIT,
                     });
                     const newIds = similarArtistTracks.map((t) => t.id);
                     vibeMatchedIds = [...vibeMatchedIds, ...newIds];
@@ -1206,8 +1109,6 @@ export async function handleGetRadio(req: Request, res: Response) {
                     );
                 }
             }
-
-            // 5. Fallback C: Same genre (using TrackGenre relation)
             const sourceGenres = (sourceTrack.album.genres as string[]) || [];
             if (vibeMatchedIds.length < limitNum && sourceGenres.length > 0) {
                 // Search using the TrackGenre relation for better accuracy.
@@ -1237,7 +1138,6 @@ export async function handleGetRadio(req: Request, res: Response) {
                 );
             }
 
-            // 6. Fallback D: Random from library
             if (vibeMatchedIds.length < limitNum) {
                 const remainingLimit = limitNum - vibeMatchedIds.length;
                 const randomTracks = await prisma.$queryRaw<{ id: string }[]>`
@@ -1385,13 +1285,18 @@ export async function handleGetRadio(req: Request, res: Response) {
         case "all":
         default:
             // Random selection from all tracks in library
-            const allTracks = await prisma.$queryRaw<{ id: string }[]>`
+            trackIds = await loadRadioIdCandidatePool(
+                `all:${limitNum}`,
+                async () => {
+                    const allTracks = await prisma.$queryRaw<{ id: string }[]>`
                     SELECT t.id FROM "Track" t
                     WHERE ${VISIBLE_TRACK_SQL} AND ${TRACK_BROWSE_SQL}
                     ORDER BY random()
                     LIMIT ${limitNum * 4}
                 `;
-            trackIds = allTracks.map((t) => t.id);
+                    return allTracks.map((track) => track.id);
+                },
+            );
     }
 
     // Keep deterministic ordering for vibe (similarity-ranked) and liked (likedAt-ranked) queues.
@@ -1435,21 +1340,18 @@ export async function handleGetRadio(req: Request, res: Response) {
             `[Radio:${radioType}] Artist-weighted selection: ${diversifiedPoolIds.length}/${basePoolIds.length} tracks (alpha=${config.generationDiversity.weightAlpha}, ceiling=${config.generationDiversity.shareCeiling})`,
         );
     }
+    const selectedPoolIds = diversifiedPoolIds.slice(0, limitNum);
     const preferenceScoreMap =
         radioType === "liked"
             ? new Map<string, number>()
             : await buildTrackPreferenceScoreMapForUser(
                   userId,
-                  diversifiedPoolIds,
+                  selectedPoolIds,
               );
-    const preferenceWeightedPoolIds =
+    const finalIds =
         preferenceScoreMap.size > 0
-            ? applyTrackPreferenceOrderBias(
-                  diversifiedPoolIds,
-                  preferenceScoreMap,
-              )
-            : diversifiedPoolIds;
-    const finalIds = preferenceWeightedPoolIds.slice(0, limitNum);
+            ? applyTrackPreferenceOrderBias(selectedPoolIds, preferenceScoreMap)
+            : selectedPoolIds;
 
     if (preferenceScoreMap.size > 0) {
         logger.debug(

--- a/backend/src/services/__tests__/libraryRadioBuilder.test.ts
+++ b/backend/src/services/__tests__/libraryRadioBuilder.test.ts
@@ -3,6 +3,7 @@ const mockPrismaQueryRaw = jest.fn();
 const mockComputeAggregateFeatureVector = jest.fn();
 const mockScoreTracksAgainstSeed = jest.fn();
 const mockBuildTrackPreferenceScoreMapForUser = jest.fn();
+const mockLoadScalarRadioCandidatePool = jest.fn();
 const MAX_SQL_FRAGMENT_VALUES = 64;
 
 interface SqlFragment {
@@ -85,6 +86,10 @@ jest.mock("../libraryTrackPreferences", () => ({
         mockBuildTrackPreferenceScoreMapForUser,
 }));
 
+jest.mock("../libraryRadioCache", () => ({
+    loadScalarRadioCandidatePool: mockLoadScalarRadioCandidatePool,
+}));
+
 jest.mock("../../utils/shuffle", () => ({
     shuffleArray: (values: unknown[]) => values,
 }));
@@ -151,6 +156,7 @@ describe("buildMultiTrackRadio genre fallback", () => {
         mockComputeAggregateFeatureVector.mockReturnValue({ energy: 0.5 });
         mockScoreTracksAgainstSeed.mockReturnValue([]);
         mockBuildTrackPreferenceScoreMapForUser.mockResolvedValue(new Map());
+        mockLoadScalarRadioCandidatePool.mockResolvedValue([]);
         mockPrismaQueryRaw.mockResolvedValue([]);
     });
 
@@ -161,7 +167,6 @@ describe("buildMultiTrackRadio genre fallback", () => {
         mockTrackFindMany
             .mockResolvedValueOnce([createSeedTrack(genre)])
             .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([])
             .mockResolvedValueOnce([]);
 
         await buildMultiTrackRadio(["seed-1"], ["seed-1"], 10, "user-1");
@@ -171,5 +176,26 @@ describe("buildMultiTrackRadio genre fallback", () => {
         const query = collectSql({ strings: [...strings], values });
         expect(query.values).toContain(pattern);
         expect(query.text).toContain("ESCAPE '\\'");
+    });
+
+    it("loads preferences only for the final scalar selection", async () => {
+        const candidates = [
+            { id: "candidate-1", album: { artistId: "artist-2" } },
+            { id: "candidate-2", album: { artistId: "artist-3" } },
+        ];
+        mockTrackFindMany.mockResolvedValueOnce([createSeedTrack("rock")]);
+        mockLoadScalarRadioCandidatePool.mockResolvedValue(candidates);
+        mockScoreTracksAgainstSeed.mockReturnValue([
+            { id: "candidate-1", score: 0.9 },
+            { id: "candidate-2", score: 0.8 },
+        ]);
+
+        await buildMultiTrackRadio(["seed-1"], ["seed-1"], 1, "user-1");
+
+        expect(mockLoadScalarRadioCandidatePool).toHaveBeenCalledTimes(1);
+        expect(mockBuildTrackPreferenceScoreMapForUser).toHaveBeenCalledWith(
+            "user-1",
+            ["candidate-1"],
+        );
     });
 });

--- a/backend/src/services/__tests__/libraryRadioCache.test.ts
+++ b/backend/src/services/__tests__/libraryRadioCache.test.ts
@@ -1,0 +1,257 @@
+const redisClient = {
+    get: jest.fn(),
+    setEx: jest.fn(),
+};
+const getSearchCacheVersion = jest.fn();
+const trackFindMany = jest.fn();
+const queryRaw = jest.fn();
+const findSimilarTracks = jest.fn();
+
+jest.mock("../../utils/redis", () => ({ redisClient }));
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        track: { findMany: trackFindMany },
+        $queryRaw: queryRaw,
+    },
+}));
+jest.mock("../searchCacheVersion", () => ({ getSearchCacheVersion }));
+jest.mock("../hybridSimilarity", () => ({ findSimilarTracks }));
+jest.mock("../../utils/logger", () => ({
+    logger: { child: () => ({ warn: jest.fn() }) },
+}));
+
+import {
+    RADIO_ANN_CANDIDATE_LIMIT,
+    RADIO_SCALAR_CANDIDATE_LIMIT,
+    buildDecadeAggregateQuery,
+    buildGenreAggregateQuery,
+    loadDecadeRadioAggregates,
+    loadGenreRadioAggregates,
+    loadRadioIdCandidatePool,
+    loadScalarRadioCandidatePool,
+    loadVibeRadioCandidateIds,
+} from "../libraryRadioCache";
+
+interface SqlFragment {
+    strings: readonly string[];
+    values: readonly unknown[];
+}
+
+function inspectSql(fragment: SqlFragment): {
+    text: string;
+    values: readonly unknown[];
+} {
+    return { text: fragment.strings.join("?"), values: fragment.values };
+}
+
+const scalarCandidate = {
+    id: "candidate-1",
+    bpm: 120,
+    energy: 0.7,
+    valence: 0.6,
+    arousal: 0.65,
+    danceability: 0.55,
+    keyScale: "major",
+    moodTags: ["upbeat"],
+    lastfmTags: ["rock"],
+    essentiaGenres: ["rock"],
+    instrumentalness: 0.1,
+    moodHappy: 0.8,
+    moodSad: 0.1,
+    moodRelaxed: 0.2,
+    moodAggressive: 0.4,
+    moodParty: 0.7,
+    moodAcoustic: 0.2,
+    moodElectronic: 0.4,
+    danceabilityMl: 0.58,
+    analysisMode: "enhanced",
+    analysisVersion: "2.1b6-enhanced-v3-test",
+    origin: "LOCAL",
+    dedupOfTrackId: null,
+    federationPeer: null,
+    dedupOfTrack: null,
+    album: { artistId: "artist-1", location: "LIBRARY" },
+};
+
+describe("library radio aggregate SQL", () => {
+    it("folds artist-name blocking into the genre aggregate query", () => {
+        const query = inspectSql(buildGenreAggregateQuery());
+
+        expect(query.text).toContain("NOT EXISTS");
+        expect(query.text).toContain(
+            "LOWER(blocked_artist.name) = LOWER(g.genre)",
+        );
+        expect(query.text).toContain(
+            'LOWER(blocked_artist."normalizedName") = LOWER(g.genre)',
+        );
+        expect(query.values).toEqual(expect.arrayContaining([15, 20]));
+    });
+
+    it("groups decades by the effective-year expression in PostgreSQL", () => {
+        const query = inspectSql(buildDecadeAggregateQuery());
+
+        expect(query.text).toContain(
+            'COALESCE(a."displayYear", a."originalYear", a.year)',
+        );
+        expect(query.text).toContain("GROUP BY decade");
+        expect(query.text).toContain("HAVING COUNT(t.id) >=");
+        expect(query.values).toContain(15);
+    });
+});
+
+describe("library radio cache", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getSearchCacheVersion.mockResolvedValue(7);
+        redisClient.get.mockResolvedValue(null);
+        redisClient.setEx.mockResolvedValue("OK");
+        queryRaw.mockResolvedValue([]);
+        trackFindMany.mockResolvedValue([]);
+        findSimilarTracks.mockResolvedValue([]);
+    });
+
+    it("caches validated genre aggregates on a miss", async () => {
+        queryRaw.mockResolvedValue([{ genre: "rock", track_count: 27n }]);
+
+        await expect(loadGenreRadioAggregates()).resolves.toEqual([
+            { genre: "rock", count: 27 },
+        ]);
+
+        expect(redisClient.get).toHaveBeenCalledWith("library:genres:v7");
+        expect(queryRaw).toHaveBeenCalledTimes(1);
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+            "library:genres:v7",
+            300,
+            JSON.stringify([{ genre: "rock", count: 27 }]),
+        );
+    });
+
+    it("returns a valid cached decade aggregate without querying PostgreSQL", async () => {
+        const cached = [{ decade: 1990, count: 42 }];
+        redisClient.get.mockResolvedValue(JSON.stringify(cached));
+
+        await expect(loadDecadeRadioAggregates()).resolves.toEqual(cached);
+
+        expect(queryRaw).not.toHaveBeenCalled();
+        expect(redisClient.setEx).not.toHaveBeenCalled();
+    });
+
+    it("uses a fresh aggregate namespace after invalidation", async () => {
+        getSearchCacheVersion.mockResolvedValueOnce(7).mockResolvedValueOnce(8);
+        redisClient.get.mockResolvedValue(null);
+
+        await loadGenreRadioAggregates();
+        await loadGenreRadioAggregates();
+
+        expect(redisClient.get).toHaveBeenNthCalledWith(1, "library:genres:v7");
+        expect(redisClient.get).toHaveBeenNthCalledWith(2, "library:genres:v8");
+        expect(queryRaw).toHaveBeenCalledTimes(2);
+    });
+
+    it("bounds a deterministically ordered pool of visible scalar candidates", async () => {
+        trackFindMany.mockResolvedValue([scalarCandidate]);
+
+        await expect(loadScalarRadioCandidatePool()).resolves.toEqual([
+            expect.objectContaining({
+                id: "candidate-1",
+                album: { artistId: "artist-1" },
+            }),
+        ]);
+
+        expect(trackFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    analysisStatus: "completed",
+                    removedAt: null,
+                    album: {
+                        location: {
+                            in: ["LIBRARY", "DISCOVER", "REMOTE", "FEDERATED"],
+                        },
+                    },
+                    OR: [
+                        { origin: "LOCAL" },
+                        {
+                            origin: "FEDERATED",
+                            OR: [
+                                { dedupOfTrackId: null },
+                                {
+                                    federationPeer: {
+                                        showDedupedCopies: true,
+                                    },
+                                },
+                                {
+                                    dedupOfTrack: {
+                                        removedAt: { not: null },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                orderBy: { id: "asc" },
+                take: RADIO_SCALAR_CANDIDATE_LIMIT,
+            }),
+        );
+    });
+
+    it("coalesces concurrent misses for the same cache key", async () => {
+        let releaseQuery:
+            | ((rows: { genre: string; track_count: bigint }[]) => void)
+            | undefined;
+        let markQueryStarted: (() => void) | undefined;
+        const queryStarted = new Promise<void>((resolve) => {
+            markQueryStarted = resolve;
+        });
+        queryRaw.mockImplementationOnce(() => {
+            markQueryStarted?.();
+            return new Promise((resolve) => {
+                releaseQuery = resolve;
+            });
+        });
+
+        const first = loadGenreRadioAggregates();
+        const second = loadGenreRadioAggregates();
+        await queryStarted;
+
+        expect(queryRaw).toHaveBeenCalledTimes(1);
+        releaseQuery?.([{ genre: "rock", track_count: 27n }]);
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            [{ genre: "rock", count: 27 }],
+            [{ genre: "rock", count: 27 }],
+        ]);
+        expect(redisClient.setEx).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches a bounded ANN id pool under an escaped source key", async () => {
+        findSimilarTracks.mockResolvedValue([
+            { id: "similar-1" },
+            { id: "similar-2" },
+        ]);
+
+        await expect(loadVibeRadioCandidateIds("source:/?%")).resolves.toEqual([
+            "similar-1",
+            "similar-2",
+        ]);
+
+        expect(redisClient.get).toHaveBeenCalledWith(
+            "library:radio:vibe:v7:source%3A%2F%3F%25",
+        );
+        expect(findSimilarTracks).toHaveBeenCalledWith(
+            "source:/?%",
+            RADIO_ANN_CANDIDATE_LIMIT,
+        );
+    });
+
+    it("caches a reusable radio id pool without caching final shuffle order", async () => {
+        const loader = jest.fn().mockResolvedValue(["pool-1", "pool-2"]);
+
+        await expect(
+            loadRadioIdCandidatePool("genre:drum/bass:50", loader),
+        ).resolves.toEqual(["pool-1", "pool-2"]);
+
+        expect(redisClient.get).toHaveBeenCalledWith(
+            "library:radio:ids:v7:genre%3Adrum%2Fbass%3A50",
+        );
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/services/libraryRadioBuilder.ts
+++ b/backend/src/services/libraryRadioBuilder.ts
@@ -4,8 +4,12 @@ import {
     computeAggregateFeatureVector,
     scoreTracksAgainstSeed,
 } from "./radioVibeEngine";
-import { applyTrackPreferenceSimilarityBias } from "./trackPreference";
+import {
+    applyTrackPreferenceOrderBias,
+    applyTrackPreferenceSimilarityBias,
+} from "./trackPreference";
 import { buildTrackPreferenceScoreMapForUser } from "./libraryTrackPreferences";
+import { loadScalarRadioCandidatePool } from "./libraryRadioCache";
 import { getMergedGenres } from "../utils/metadataOverrides";
 import { shuffleArray } from "../utils/shuffle";
 import { escapeLikePattern } from "../utils/likePattern";
@@ -143,45 +147,12 @@ export const buildMultiTrackRadio = async (
 
     // 4. Score candidates via vibe matching (if we have a valid centroid)
     if (seedVector) {
-        const candidates = await prisma.track.findMany({
-            where: {
-                ...TRACK_VISIBLE_WHERE,
-                id: { notIn: [...excludeSet] },
-                analysisStatus: "completed",
-            },
-            select: {
-                id: true,
-                bpm: true,
-                energy: true,
-                valence: true,
-                arousal: true,
-                danceability: true,
-                keyScale: true,
-                moodTags: true,
-                lastfmTags: true,
-                essentiaGenres: true,
-                instrumentalness: true,
-                moodHappy: true,
-                moodSad: true,
-                moodRelaxed: true,
-                moodAggressive: true,
-                moodParty: true,
-                moodAcoustic: true,
-                moodElectronic: true,
-                danceabilityMl: true,
-                analysisMode: true,
-                analysisVersion: true,
-                album: { select: { artistId: true } },
-            },
-        });
+        const candidates = (await loadScalarRadioCandidatePool()).filter(
+            (candidate) => !excludeSet.has(candidate.id),
+        );
 
         logger.debug(
             `[Radio:multi-seed] Found ${candidates.length} analyzed candidates to score against ${seedTracks.length} seed tracks`,
-        );
-
-        const preferenceScores = await buildTrackPreferenceScoreMapForUser(
-            userId,
-            candidates.map((c) => c.id),
         );
 
         const scored = scoreTracksAgainstSeed(
@@ -189,7 +160,7 @@ export const buildMultiTrackRadio = async (
             [...allTags],
             [...allGenres],
             candidates,
-            preferenceScores,
+            new Map(),
             applyTrackPreferenceSimilarityBias,
         );
 
@@ -301,6 +272,17 @@ export const buildMultiTrackRadio = async (
                 `[Radio:multi-seed] Fallback C: added ${newRandomIds.length} random library tracks`,
             );
         }
+    }
+
+    const finalPreferenceScores = await buildTrackPreferenceScoreMapForUser(
+        userId,
+        resultIds,
+    );
+    if (finalPreferenceScores.size > 0) {
+        resultIds = applyTrackPreferenceOrderBias(
+            resultIds,
+            finalPreferenceScores,
+        );
     }
 
     logger.debug(`[Radio:multi-seed] Final queue: ${resultIds.length} tracks`);

--- a/backend/src/services/libraryRadioCache.ts
+++ b/backend/src/services/libraryRadioCache.ts
@@ -1,0 +1,442 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import { LIBRARY_SURFACE_ALBUM_LOCATIONS } from "../utils/librarySorting";
+import {
+    TRACK_BROWSE_SQL,
+    VISIBLE_TRACK_SQL,
+} from "../utils/libraryRadioPredicates";
+import { logger } from "../utils/logger";
+import { redisClient } from "../utils/redis";
+import { findSimilarTracks } from "./hybridSimilarity";
+import { getSearchCacheVersion } from "./searchCacheVersion";
+
+const CACHE_TTL_SECONDS = 300;
+const MIN_AGGREGATE_TRACKS = 15;
+const MAX_GENRE_AGGREGATES = 20;
+const cacheLogger = logger.child("LibraryRadioCache");
+// This map coalesces fills only within one process. Multi-replica protection is out of scope.
+const inFlightLoads = new Map<string, Promise<unknown>>();
+
+/** Maximum analyzed scalar candidates scored for one multi-seed radio build. */
+export const RADIO_SCALAR_CANDIDATE_LIMIT = 4_000;
+
+/** Maximum embedding-ranked candidates retained for one source-track station. */
+export const RADIO_ANN_CANDIDATE_LIMIT = 500;
+
+export interface GenreRadioAggregate {
+    genre: string;
+    count: number;
+}
+
+export interface DecadeRadioAggregate {
+    decade: number;
+    count: number;
+}
+
+/** Analysis fields required by the multi-seed scalar scoring engine. */
+export interface RadioScalarCandidate {
+    id: string;
+    bpm: number | null;
+    energy: number | null;
+    valence: number | null;
+    arousal: number | null;
+    danceability: number | null;
+    keyScale: string | null;
+    moodTags: string[];
+    lastfmTags: string[];
+    essentiaGenres: string[];
+    instrumentalness: number | null;
+    moodHappy: number | null;
+    moodSad: number | null;
+    moodRelaxed: number | null;
+    moodAggressive: number | null;
+    moodParty: number | null;
+    moodAcoustic: number | null;
+    moodElectronic: number | null;
+    danceabilityMl: number | null;
+    analysisMode: string | null;
+    analysisVersion: string | null;
+    album: { artistId: string };
+}
+
+interface GenreAggregateRow {
+    genre: string;
+    track_count: bigint;
+}
+
+interface DecadeAggregateRow {
+    decade: number;
+    track_count: bigint;
+}
+
+/** Builds the bounded, parameterized genre aggregate query. */
+export function buildGenreAggregateQuery(): Prisma.Sql {
+    return Prisma.sql`
+        SELECT LOWER(g.genre) AS genre, COUNT(DISTINCT t.id) AS track_count
+        FROM "Artist" ar
+        CROSS JOIN LATERAL jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
+        JOIN "Album" a ON a."artistId" = ar.id
+        JOIN "Track" t ON t."albumId" = a.id
+        WHERE ${VISIBLE_TRACK_SQL}
+          AND ${TRACK_BROWSE_SQL}
+          AND a.location IN (${Prisma.join([...LIBRARY_SURFACE_ALBUM_LOCATIONS])})
+          AND ar.genres IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM "Artist" blocked_artist
+              WHERE LOWER(blocked_artist.name) = LOWER(g.genre)
+                 OR LOWER(blocked_artist."normalizedName") = LOWER(g.genre)
+          )
+        GROUP BY LOWER(g.genre)
+        HAVING COUNT(DISTINCT t.id) >= ${MIN_AGGREGATE_TRACKS}
+        ORDER BY track_count DESC
+        LIMIT ${MAX_GENRE_AGGREGATES}
+    `;
+}
+
+/** Builds the parameterized effective-year decade aggregate query. */
+export function buildDecadeAggregateQuery(): Prisma.Sql {
+    return Prisma.sql`
+        SELECT
+            FLOOR(COALESCE(a."displayYear", a."originalYear", a.year) / 10.0)::int * 10 AS decade,
+            COUNT(t.id) AS track_count
+        FROM "Album" a
+        JOIN "Track" t ON t."albumId" = a.id
+        WHERE ${VISIBLE_TRACK_SQL}
+          AND ${TRACK_BROWSE_SQL}
+          AND a.location IN (${Prisma.join([...LIBRARY_SURFACE_ALBUM_LOCATIONS])})
+          AND COALESCE(a."displayYear", a."originalYear", a.year) IS NOT NULL
+        GROUP BY decade
+        HAVING COUNT(t.id) >= ${MIN_AGGREGATE_TRACKS}
+        ORDER BY decade DESC
+    `;
+}
+
+function isSafePositiveInteger(value: unknown): value is number {
+    return Number.isSafeInteger(value) && Number(value) > 0;
+}
+
+function isGenreAggregate(value: unknown): value is GenreRadioAggregate {
+    if (typeof value !== "object" || value === null) return false;
+    const row = value as Record<string, unknown>;
+    return typeof row.genre === "string" && isSafePositiveInteger(row.count);
+}
+
+function isDecadeAggregate(value: unknown): value is DecadeRadioAggregate {
+    if (typeof value !== "object" || value === null) return false;
+    const row = value as Record<string, unknown>;
+    return Number.isSafeInteger(row.decade) && isSafePositiveInteger(row.count);
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+    return (
+        value === null || (typeof value === "number" && Number.isFinite(value))
+    );
+}
+
+function isNullableString(value: unknown): value is string | null {
+    return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+    return (
+        Array.isArray(value) && value.every((item) => typeof item === "string")
+    );
+}
+
+function isScalarCandidate(value: unknown): value is RadioScalarCandidate {
+    if (typeof value !== "object" || value === null) return false;
+    const row = value as Record<string, unknown>;
+    const album = row.album as Record<string, unknown> | undefined;
+    const numericFields = [
+        "bpm",
+        "energy",
+        "valence",
+        "arousal",
+        "danceability",
+        "instrumentalness",
+        "moodHappy",
+        "moodSad",
+        "moodRelaxed",
+        "moodAggressive",
+        "moodParty",
+        "moodAcoustic",
+        "moodElectronic",
+        "danceabilityMl",
+    ];
+    return (
+        typeof row.id === "string" &&
+        numericFields.every((field) => isNullableNumber(row[field])) &&
+        isNullableString(row.keyScale) &&
+        isNullableString(row.analysisMode) &&
+        isNullableString(row.analysisVersion) &&
+        isStringArray(row.moodTags) &&
+        isStringArray(row.lastfmTags) &&
+        isStringArray(row.essentiaGenres) &&
+        typeof album?.artistId === "string"
+    );
+}
+
+async function readCache<T>(
+    cacheKey: string,
+    validate: (value: unknown) => value is T,
+): Promise<T | null> {
+    try {
+        const cached = await redisClient.get(cacheKey);
+        if (cached === null) return null;
+        const parsed: unknown = JSON.parse(cached);
+        if (validate(parsed)) return parsed;
+        cacheLogger.warn("Invalid library radio cache payload", { cacheKey });
+    } catch (error) {
+        cacheLogger.warn("Library radio cache read failed", { error });
+    }
+    return null;
+}
+
+async function writeCache(cacheKey: string, value: unknown): Promise<void> {
+    try {
+        await redisClient.setEx(
+            cacheKey,
+            CACHE_TTL_SECONDS,
+            JSON.stringify(value),
+        );
+    } catch (error) {
+        cacheLogger.warn("Library radio cache write failed", { error });
+    }
+}
+
+async function cacheKey(name: string): Promise<string> {
+    const version = await getSearchCacheVersion();
+    return `${name}:v${version}`;
+}
+
+async function coalesceCacheLoad<T>(
+    key: string,
+    validate: (value: unknown) => value is T,
+    load: () => Promise<T>,
+): Promise<T> {
+    const existing = inFlightLoads.get(key);
+    if (existing) {
+        const value = await existing;
+        if (!validate(value)) {
+            throw new TypeError("In-flight library radio cache type mismatch");
+        }
+        return value;
+    }
+    const pending = (async () => {
+        try {
+            return await load();
+        } finally {
+            inFlightLoads.delete(key);
+        }
+    })();
+    inFlightLoads.set(key, pending);
+    return pending;
+}
+
+function loadCachedValue<T>(
+    key: string,
+    validate: (value: unknown) => value is T,
+    fill: () => Promise<T>,
+): Promise<T> {
+    return coalesceCacheLoad(key, validate, async () => {
+        const cached = await readCache(key, validate);
+        if (cached) return cached;
+        const value = await fill();
+        await writeCache(key, value);
+        return value;
+    });
+}
+
+function normalizeCount(value: bigint): number {
+    const count = Number(value);
+    if (!isSafePositiveInteger(count)) {
+        throw new RangeError(
+            "Radio aggregate count is outside the safe integer range",
+        );
+    }
+    return count;
+}
+
+/** Loads the versioned genre aggregate snapshot. */
+export async function loadGenreRadioAggregates(): Promise<
+    GenreRadioAggregate[]
+> {
+    const key = await cacheKey("library:genres");
+    return loadCachedValue(
+        key,
+        (value): value is GenreRadioAggregate[] =>
+            Array.isArray(value) && value.every(isGenreAggregate),
+        async () => {
+            const rows = await prisma.$queryRaw<GenreAggregateRow[]>(
+                buildGenreAggregateQuery(),
+            );
+            return rows.map((row) => ({
+                genre: row.genre,
+                count: normalizeCount(row.track_count),
+            }));
+        },
+    );
+}
+
+/** Loads the versioned effective-year decade aggregate snapshot. */
+export async function loadDecadeRadioAggregates(): Promise<
+    DecadeRadioAggregate[]
+> {
+    const key = await cacheKey("library:decades");
+    return loadCachedValue(
+        key,
+        (value): value is DecadeRadioAggregate[] =>
+            Array.isArray(value) && value.every(isDecadeAggregate),
+        async () => {
+            const rows = await prisma.$queryRaw<DecadeAggregateRow[]>(
+                buildDecadeAggregateQuery(),
+            );
+            return rows.map((row) => ({
+                decade: Number(row.decade),
+                count: normalizeCount(row.track_count),
+            }));
+        },
+    );
+}
+
+const scalarCandidateSelect = {
+    id: true,
+    bpm: true,
+    energy: true,
+    valence: true,
+    arousal: true,
+    danceability: true,
+    keyScale: true,
+    moodTags: true,
+    lastfmTags: true,
+    essentiaGenres: true,
+    instrumentalness: true,
+    moodHappy: true,
+    moodSad: true,
+    moodRelaxed: true,
+    moodAggressive: true,
+    moodParty: true,
+    moodAcoustic: true,
+    moodElectronic: true,
+    danceabilityMl: true,
+    analysisMode: true,
+    analysisVersion: true,
+    album: { select: { artistId: true } },
+} as const;
+
+function toScalarCandidate(row: RadioScalarCandidate): RadioScalarCandidate {
+    return {
+        id: row.id,
+        bpm: row.bpm,
+        energy: row.energy,
+        valence: row.valence,
+        arousal: row.arousal,
+        danceability: row.danceability,
+        keyScale: row.keyScale,
+        moodTags: row.moodTags,
+        lastfmTags: row.lastfmTags,
+        essentiaGenres: row.essentiaGenres,
+        instrumentalness: row.instrumentalness,
+        moodHappy: row.moodHappy,
+        moodSad: row.moodSad,
+        moodRelaxed: row.moodRelaxed,
+        moodAggressive: row.moodAggressive,
+        moodParty: row.moodParty,
+        moodAcoustic: row.moodAcoustic,
+        moodElectronic: row.moodElectronic,
+        danceabilityMl: row.danceabilityMl,
+        analysisMode: row.analysisMode,
+        analysisVersion: row.analysisVersion,
+        album: { artistId: row.album.artistId },
+    };
+}
+
+async function loadScalarCandidatesFromDatabase(): Promise<
+    RadioScalarCandidate[]
+> {
+    const rows = await prisma.track.findMany({
+        where: {
+            analysisStatus: "completed",
+            removedAt: null,
+            album: {
+                location: { in: [...LIBRARY_SURFACE_ALBUM_LOCATIONS] },
+            },
+            OR: [
+                { origin: "LOCAL" },
+                {
+                    origin: "FEDERATED",
+                    OR: [
+                        { dedupOfTrackId: null },
+                        { federationPeer: { showDedupedCopies: true } },
+                        { dedupOfTrack: { removedAt: { not: null } } },
+                    ],
+                },
+            ],
+        },
+        select: scalarCandidateSelect,
+        orderBy: { id: "asc" },
+        take: RADIO_SCALAR_CANDIDATE_LIMIT,
+    });
+    return rows.map(toScalarCandidate);
+}
+
+/** Loads the cached, composite-index-filtered scalar candidate pool. */
+export async function loadScalarRadioCandidatePool(): Promise<
+    RadioScalarCandidate[]
+> {
+    const key = await cacheKey("library:radio:scalar");
+    return loadCachedValue(
+        key,
+        (value): value is RadioScalarCandidate[] =>
+            Array.isArray(value) &&
+            value.length <= RADIO_SCALAR_CANDIDATE_LIMIT &&
+            value.every(isScalarCandidate),
+        loadScalarCandidatesFromDatabase,
+    );
+}
+
+function isVibeIdPool(value: unknown): value is string[] {
+    return (
+        Array.isArray(value) &&
+        value.length <= RADIO_ANN_CANDIDATE_LIMIT &&
+        value.every((id) => typeof id === "string" && id.length > 0)
+    );
+}
+
+function isRadioIdPool(value: unknown): value is string[] {
+    return (
+        Array.isArray(value) &&
+        value.length <= RADIO_SCALAR_CANDIDATE_LIMIT &&
+        value.every((id) => typeof id === "string" && id.length > 0)
+    );
+}
+
+/** Loads a versioned candidate ID pool while leaving final shuffling to callers. */
+export async function loadRadioIdCandidatePool(
+    discriminator: string,
+    loader: () => Promise<string[]>,
+): Promise<string[]> {
+    const version = await getSearchCacheVersion();
+    const escapedDiscriminator = encodeURIComponent(discriminator);
+    const key = `library:radio:ids:v${version}:${escapedDiscriminator}`;
+    return loadCachedValue(key, isRadioIdPool, async () =>
+        (await loader()).slice(0, RADIO_SCALAR_CANDIDATE_LIMIT),
+    );
+}
+
+/** Loads an embedding-ranked candidate ID pool for one source track. */
+export async function loadVibeRadioCandidateIds(
+    sourceTrackId: string,
+): Promise<string[]> {
+    const version = await getSearchCacheVersion();
+    const escapedId = encodeURIComponent(sourceTrackId);
+    const key = `library:radio:vibe:v${version}:${escapedId}`;
+    return loadCachedValue(key, isVibeIdPool, async () => {
+        const similar = await findSimilarTracks(
+            sourceTrackId,
+            RADIO_ANN_CANDIDATE_LIMIT,
+        );
+        return similar.map((track) => track.id);
+    });
+}

--- a/backend/src/services/libraryRadioStationSelection.ts
+++ b/backend/src/services/libraryRadioStationSelection.ts
@@ -17,6 +17,7 @@ import {
     VISIBLE_TRACK_SQL,
 } from "../utils/libraryRadioPredicates";
 import { transformRadioTrack } from "./libraryRadioTrackResponse";
+import { loadRadioIdCandidatePool } from "./libraryRadioCache";
 
 const selectionLogger = logger.child("LibraryRadioStationSelection");
 type RadioSelectionClient = Prisma.TransactionClient | typeof prisma;
@@ -378,7 +379,13 @@ export async function selectLibraryRadioStationTracks(
     input: LibraryRadioStationSelectionInput,
     client: RadioSelectionClient = prisma,
 ): Promise<LibraryRadioStationSelection> {
-    const candidateIds = await selectCandidateIds(input, client);
+    const candidateIds =
+        client === prisma
+            ? await loadRadioIdCandidatePool(
+                  `${input.type}:${input.value ?? ""}:${input.limit}`,
+                  () => selectCandidateIds(input, client),
+              )
+            : await selectCandidateIds(input, client);
     const diversifiedIds = await diversifyIds(
         candidateIds,
         input.limit,

--- a/backend/tests-integration/libraryRadioAggregatesPostgres.integration.test.ts
+++ b/backend/tests-integration/libraryRadioAggregatesPostgres.integration.test.ts
@@ -1,0 +1,170 @@
+import type { Client } from "pg";
+import {
+    buildDecadeAggregateQuery,
+    buildGenreAggregateQuery,
+} from "../src/services/libraryRadioCache";
+import { getDecadeFromYear, getEffectiveYear } from "../src/utils/dateFilters";
+import { prisma } from "../src/utils/db";
+import {
+    TRACK_BROWSE_WHERE,
+    TRACK_VISIBLE_WHERE,
+} from "../src/utils/librarySorting";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+const TRACK_COUNTS = [16, 15, 14] as const;
+
+async function seedTracks(albumId: string, count: number): Promise<void> {
+    await prisma.track.createMany({
+        data: Array.from({ length: count }, (_, index) => ({
+            id: `${albumId}-track-${index + 1}`,
+            albumId,
+            title: `${albumId} track ${index + 1}`,
+            trackNo: index + 1,
+            duration: 180,
+            fileModified: new Date("2026-08-25T00:00:00.000Z"),
+            fileSize: 1_000,
+        })),
+    });
+}
+
+async function seedFixture(): Promise<void> {
+    await prisma.artist.createMany({
+        data: [
+            {
+                id: "aggregate-source",
+                mbid: "aggregate-source-mbid",
+                name: "Aggregate Source",
+                genres: ["Rock", "Radiohead"],
+            },
+            {
+                id: "aggregate-blocker",
+                mbid: "aggregate-blocker-mbid",
+                name: "Different Display Name",
+                normalizedName: "radiohead",
+            },
+        ],
+    });
+    await prisma.album.createMany({
+        data: [
+            {
+                id: "aggregate-nineties",
+                rgMbid: "aggregate-nineties-mbid",
+                artistId: "aggregate-source",
+                title: "Nineties",
+                primaryType: "Album",
+                year: 2022,
+                originalYear: 1995,
+            },
+            {
+                id: "aggregate-override",
+                rgMbid: "aggregate-override-mbid",
+                artistId: "aggregate-source",
+                title: "Override",
+                primaryType: "Album",
+                year: 2011,
+                originalYear: 1988,
+                displayYear: 2004,
+            },
+            {
+                id: "aggregate-under-minimum",
+                rgMbid: "aggregate-under-minimum-mbid",
+                artistId: "aggregate-source",
+                title: "Under Minimum",
+                primaryType: "Album",
+                year: 1977,
+            },
+        ],
+    });
+    await seedTracks("aggregate-nineties", TRACK_COUNTS[0]);
+    await seedTracks("aggregate-override", TRACK_COUNTS[1]);
+    await seedTracks("aggregate-under-minimum", TRACK_COUNTS[2]);
+}
+
+async function computeLegacyDecades(): Promise<
+    { decade: number; count: number }[]
+> {
+    const albums = await prisma.album.findMany({
+        select: {
+            year: true,
+            originalYear: true,
+            displayYear: true,
+            _count: {
+                select: {
+                    tracks: {
+                        where: {
+                            ...TRACK_VISIBLE_WHERE,
+                            ...TRACK_BROWSE_WHERE,
+                        },
+                    },
+                },
+            },
+        },
+    });
+    const counts = new Map<number, number>();
+    for (const album of albums) {
+        const year = getEffectiveYear(album);
+        if (year === null) continue;
+        const decade = getDecadeFromYear(year);
+        counts.set(decade, (counts.get(decade) ?? 0) + album._count.tracks);
+    }
+    return [...counts.entries()]
+        .map(([decade, count]) => ({ decade, count }))
+        .filter(({ count }) => count >= 15)
+        .sort((left, right) => right.decade - left.decade);
+}
+
+describeWithPostgres("library radio aggregate PostgreSQL behavior", () => {
+    let admin: Client | undefined;
+
+    beforeAll(async () => {
+        if (!integrationDatabaseUrl || !databaseName) {
+            throw new Error("PostgreSQL integration environment is missing");
+        }
+        admin = await createScaleDatabase(integrationDatabaseUrl, databaseName);
+        await applyScaleMigrations(process.env.DATABASE_URL!);
+        await seedFixture();
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+        if (admin && databaseName) await dropScaleDatabase(admin, databaseName);
+    });
+
+    it("matches the previous effective-year JavaScript aggregation", async () => {
+        const rows = await prisma.$queryRaw<
+            { decade: number; track_count: bigint }[]
+        >(buildDecadeAggregateQuery());
+        const sqlDecades = rows.map((row) => ({
+            decade: row.decade,
+            count: Number(row.track_count),
+        }));
+
+        await expect(computeLegacyDecades()).resolves.toEqual(sqlDecades);
+        expect(sqlDecades).toEqual([
+            { decade: 2000, count: 15 },
+            { decade: 1990, count: 16 },
+        ]);
+        expect(sqlDecades).not.toContainEqual({ decade: 1970, count: 14 });
+    });
+
+    it("counts genres while blocking artist-name tags inside SQL", async () => {
+        const rows = await prisma.$queryRaw<
+            { genre: string; track_count: bigint }[]
+        >(buildGenreAggregateQuery());
+
+        expect(
+            rows.map((row) => ({
+                genre: row.genre,
+                count: Number(row.track_count),
+            })),
+        ).toEqual([{ genre: "rock", count: 45 }]);
+    });
+});

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -56,7 +56,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/browse.ts": 1540,
     "backend/src/routes/enrichment.ts": 2261,
     "backend/src/routes/library/artists.ts": 1525,
-    "backend/src/routes/library/radio.ts": 1661,
+    "backend/src/routes/library/radio.ts": 1563,
     "backend/src/routes/library/tracks.ts": 1655,
     "backend/src/routes/playlists.ts": 2262,
     "backend/src/routes/podcasts.ts": 2541,


### PR DESCRIPTION
## Problem (#776)

- `GET /library/radio` loaded the entire analyzed Track table (~21 columns × N rows incl. three `String[]` columns) into Node per request, JS-cosine-scored it, then shipped the full id list back as bind params for preference scoring.
- `/library/genres` loaded every artist row for a name blocklist; `/library/decades` loaded every album + per-album filtered `_count` with the full `TRACK_BROWSE_WHERE` OR-expansion.
- No caching anywhere.

## Change

- **Vibe radio → existing pgvector ANN path** (`hybridSimilarity`/`annQuery` consumed as-is; `radioVibeEngine` gating untouched): 500-track retained pool, 5× ANN expansion before the diversity cap.
- **Multi-seed (playlist/tracks) radio** keeps scalar centroid scoring (no embedding-centroid contract exists) but prefilters in SQL on the #782 `(analysisStatus, origin, removedAt)` composite with a named 4,000-track bound. **No scalar indexes re-added.**
- **Preferences** load only for final selected ids — reorder, never promote membership.
- **/genres**: one SQL aggregate, artist blocklist as `NOT EXISTS` (genre filtering now happens before `LIMIT`, so artist-name tags no longer consume result slots). **/decades**: one `GROUP BY` on `COALESCE(displayYear, originalYear, year)`.
- **Caching** via the search-cache version pattern (300s TTL, validated reads, Prisma fallback): genre/decade aggregates, scalar pools, ANN-ranked id lists, and station id pools. Final shuffle/hydration stays per-request.
- Compat suite updated to mock the new aggregate loaders (response shapes unchanged); SQL truth pinned by the new PostgreSQL fixture.

## Verification

- `verify:` full backend suite in this worktree: **495/495 suites, 7,539 tests pass**
- `verify:` PostgreSQL aggregate parity fixture on a real scratch pgvector DB: 2/2 pass
- `verify: tsc` exit 0; `format:check` clean; `check-file-size` pass (radio.ts baseline tightened 1,661 → 1,563); route-error canon pass

Closes #776