### PR TITLE
fix(downloads): artist expansion no longer waits behind the album-download queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pressing get-all-missing-albums now queues the artist's albums immediately even while other downloads are running (#808).
 - Post-scan download reconciliation no longer risks heavy database load when many downloads are queued.
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.

--- a/backend/src/__tests__/apiEntrypointRuntime.test.ts
+++ b/backend/src/__tests__/apiEntrypointRuntime.test.ts
@@ -267,6 +267,7 @@ describe("api entrypoint runtime behavior", () => {
             genericImportQueue: { name: "generic-import" },
             federationQueue: { name: "federation" },
             albumDownloadQueue: { name: "album-download" },
+            artistExpansionQueue: { name: "worker-artist-expansion" },
         };
         const queueRegistry = Object.values(workersQueues);
         const registerQueueMetrics = jest.fn();
@@ -516,6 +517,9 @@ describe("api entrypoint runtime behavior", () => {
         expect(mocks.queueRegistry).toContainEqual({
             name: "scheduler-maintenance",
         });
+        expect(mocks.queueRegistry).toContainEqual({
+            name: "worker-artist-expansion",
+        });
         expect(mocks.server.listen).toHaveBeenCalledWith(
             3006,
             "0.0.0.0",
@@ -550,7 +554,7 @@ describe("api entrypoint runtime behavior", () => {
         expect(socket.setKeepAlive).toHaveBeenCalledWith(true, 30_000);
         expect(mocks.startPersistLoop).toHaveBeenCalledTimes(1);
         expect(mocks.createBullBoard).toHaveBeenCalledTimes(1);
-        expect(mocks.BullAdapter).toHaveBeenCalledTimes(10);
+        expect(mocks.BullAdapter).toHaveBeenCalledTimes(11);
         expect(mocks.app.get).toHaveBeenCalledWith(
             "/api/docs.json",
             expect.any(Function),

--- a/backend/src/services/__tests__/albumDownloadQueueService.test.ts
+++ b/backend/src/services/__tests__/albumDownloadQueueService.test.ts
@@ -1,4 +1,5 @@
 const mockQueueAdd = jest.fn();
+const mockArtistExpansionQueueAdd = jest.fn();
 const mockQueueGetJob = jest.fn();
 const mockDownloadJobFindMany = jest.fn();
 const mockDownloadJobFindUnique = jest.fn();
@@ -11,6 +12,9 @@ jest.mock("../../workers/queues", () => ({
     albumDownloadQueue: {
         add: (...args: unknown[]) => mockQueueAdd(...args),
         getJob: (...args: unknown[]) => mockQueueGetJob(...args),
+    },
+    artistExpansionQueue: {
+        add: (...args: unknown[]) => mockArtistExpansionQueueAdd(...args),
     },
 }));
 
@@ -62,6 +66,9 @@ describe("album download queue service", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockQueueAdd.mockResolvedValue({ id: "albumdl:download-job-1" });
+        mockArtistExpansionQueueAdd.mockResolvedValue({
+            id: "artistdl:artist-job-1",
+        });
         mockQueueGetJob.mockResolvedValue(null);
         mockDownloadJobFindMany.mockResolvedValue([]);
         mockDownloadJobFindUnique.mockResolvedValue({
@@ -122,16 +129,17 @@ describe("album download queue service", () => {
 
         await enqueueArtistDownloadExpansion(artistPayload);
 
-        expect(mockQueueAdd).toHaveBeenCalledWith(
+        expect(mockArtistExpansionQueueAdd).toHaveBeenCalledWith(
             "artist-download-expand",
             artistPayload,
             { jobId: "artistdl:artist-job-1" },
         );
+        expect(mockQueueAdd).not.toHaveBeenCalled();
     });
 
     it("keeps artist expansion pending when queue admission fails", async () => {
         const enqueueError = new Error("redis unavailable");
-        mockQueueAdd.mockRejectedValueOnce(enqueueError);
+        mockArtistExpansionQueueAdd.mockRejectedValueOnce(enqueueError);
 
         await expect(
             enqueueArtistDownloadExpansion({
@@ -359,7 +367,7 @@ describe("album download queue service", () => {
                 take: 20,
             }),
         );
-        expect(mockQueueAdd).toHaveBeenCalledWith(
+        expect(mockArtistExpansionQueueAdd).toHaveBeenCalledWith(
             "artist-download-expand",
             {
                 jobId: "artist-job-1",
@@ -371,6 +379,7 @@ describe("album download queue service", () => {
             },
             { jobId: "artistdl:artist-job-1" },
         );
+        expect(mockQueueAdd).not.toHaveBeenCalled();
     });
 
     it.each<[string, "skip" | "finalize-and-remove" | "remove-and-re-enqueue"]>(

--- a/backend/src/services/albumDownloadQueueService.ts
+++ b/backend/src/services/albumDownloadQueueService.ts
@@ -1,5 +1,5 @@
 import type { AlbumDownloadDispatchParams } from "./downloadDispatcher";
-import { albumDownloadQueue } from "../workers/queues";
+import { albumDownloadQueue, artistExpansionQueue } from "../workers/queues";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import {
@@ -83,13 +83,13 @@ export async function enqueueAlbumDownload(
     }
 }
 
-/** Add one artist discography expansion to the album-download queue. */
+/** Add one artist discography expansion to its durable worker queue. */
 export async function enqueueArtistDownloadExpansion(
     params: ArtistDownloadExpansionParams,
 ): Promise<void> {
     const queueJobId = artistDownloadQueueJobId(params.jobId);
     try {
-        await albumDownloadQueue.add(
+        await artistExpansionQueue.add(
             ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
             params,
             { jobId: queueJobId },

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -43,6 +43,7 @@ describe("workers runtime behavior", () => {
         const genericImportQueue = createQueueMock();
         const federationQueue = createQueueMock();
         const albumDownloadQueue = createQueueMock();
+        const artistExpansionQueue = createQueueMock();
 
         const logger = {
             debug: jest.fn(),
@@ -210,6 +211,7 @@ describe("workers runtime behavior", () => {
             genericImportQueue,
             federationQueue,
             albumDownloadQueue,
+            artistExpansionQueue,
         }));
         jest.doMock("../federationJobs", () => ({
             registerFederationProcessors,
@@ -369,6 +371,7 @@ describe("workers runtime behavior", () => {
             genericImportQueue,
             federationQueue,
             albumDownloadQueue,
+            artistExpansionQueue,
             logger,
             startUnifiedEnrichmentWorker,
             stopUnifiedEnrichmentWorker,
@@ -485,6 +488,10 @@ describe("workers runtime behavior", () => {
         expect(mocks.albumDownloadQueue.process).toHaveBeenCalledWith(
             "artist-download-expand",
             1,
+            mocks.processArtistDownloadExpansion,
+        );
+        expect(mocks.artistExpansionQueue.process).toHaveBeenCalledWith(
+            "artist-download-expand",
             mocks.processArtistDownloadExpansion,
         );
         expect(mocks.registerRecoveryJobs).toHaveBeenCalledTimes(1);
@@ -1126,6 +1133,7 @@ describe("workers runtime behavior", () => {
         );
         expect(workers.genericImportQueue).toBe(mocks.genericImportQueue);
         expect(workers.albumDownloadQueue).toBe(mocks.albumDownloadQueue);
+        expect(workers.artistExpansionQueue).toBe(mocks.artistExpansionQueue);
     });
 
     it("shuts down workers and queue resources cleanly", async () => {
@@ -1159,10 +1167,14 @@ describe("workers runtime behavior", () => {
         expect(
             mocks.albumDownloadQueue.removeAllListeners,
         ).toHaveBeenCalledTimes(1);
+        expect(
+            mocks.artistExpansionQueue.removeAllListeners,
+        ).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.schedulerMaintenanceQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.genericImportQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.albumDownloadQueue.close).toHaveBeenCalledTimes(1);
+        expect(mocks.artistExpansionQueue.close).toHaveBeenCalledTimes(1);
         expect(mocks.scanQueue.close.mock.invocationCallOrder[0]).toBeLessThan(
             mocks.scanQueue.removeAllListeners.mock.invocationCallOrder[0],
         );

--- a/backend/src/workers/__tests__/queues.test.ts
+++ b/backend/src/workers/__tests__/queues.test.ts
@@ -50,7 +50,7 @@ describe("workers/queues", () => {
             "rediss://user:pass@cache.example:6381/2",
         );
 
-        expect(bullCtor).toHaveBeenCalledTimes(10);
+        expect(bullCtor).toHaveBeenCalledTimes(11);
         const firstCallArgs = bullCtor.mock.calls[0];
         const firstQueueOptions = firstCallArgs[1];
 
@@ -65,7 +65,7 @@ describe("workers/queues", () => {
                 tls: {},
             }),
         );
-        expect(queuesModule.queues).toHaveLength(10);
+        expect(queuesModule.queues).toHaveLength(11);
         expect(bullCtor.mock.calls.map((call) => call[0])).toEqual([
             "library-scan",
             "discover-weekly",
@@ -77,6 +77,7 @@ describe("workers/queues", () => {
             "generic-import",
             "federation-sync",
             "album-download",
+            "worker-artist-expansion",
         ]);
         expect(logger.debug).toHaveBeenCalledWith(
             expect.stringContaining("Redis config resolved"),
@@ -141,8 +142,12 @@ describe("workers/queues", () => {
         const albumDownloadCall = bullCtor.mock.calls.find(
             (call: any[]) => call[0] === "album-download",
         );
+        const artistExpansionCall = bullCtor.mock.calls.find(
+            (call: any[]) => call[0] === "worker-artist-expansion",
+        );
 
         expect(albumDownloadCall).toBeDefined();
+        expect(artistExpansionCall).toBeDefined();
         expect(albumDownloadCall![1].settings).toEqual(
             expect.objectContaining({
                 stalledInterval: 30_000,
@@ -156,6 +161,7 @@ describe("workers/queues", () => {
             removeOnComplete: 100,
             removeOnFail: 200,
         });
+        expect(artistExpansionCall![1]).toEqual(albumDownloadCall![1]);
     });
 
     it("wires queue error and stalled handlers for observability", () => {

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -13,6 +13,7 @@ import {
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,
+    artistExpansionQueue,
 } from "./queues";
 import { processScan } from "./processors/scanProcessor";
 import {
@@ -890,6 +891,11 @@ albumDownloadQueue.process(
     ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
     processAlbumDownload,
 );
+artistExpansionQueue.process(
+    ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
+    processArtistDownloadExpansion,
+);
+// Legacy drain: process expansion jobs admitted to album-download before upgrade.
 albumDownloadQueue.process(
     ARTIST_DOWNLOAD_EXPANSION_JOB_NAME,
     ALBUM_DOWNLOAD_WORKER_CONCURRENCY,
@@ -1250,6 +1256,10 @@ registerQueueProcessorEvents(albumDownloadQueue, "album-download", {
     },
 });
 
+registerQueueProcessorEvents(artistExpansionQueue, "worker-artist-expansion", {
+    record: recordQueueProcessorEvent,
+});
+
 albumDownloadQueue.on("stalled", () => {
     recordAlbumDownloadOutcome("retried");
 });
@@ -1379,6 +1389,9 @@ export async function shutdownWorkers(): Promise<void> {
     // Shutdown download queue manager
     downloadQueueManager.shutdown();
 
+    // Drain expansion first because it can still admit new album jobs.
+    await artistExpansionQueue.close();
+
     // Drain the album processor while its finalizer listener is still active.
     await albumDownloadQueue.close();
 
@@ -1401,6 +1414,7 @@ export async function shutdownWorkers(): Promise<void> {
     genericImportQueue.removeAllListeners();
     federationQueue.removeAllListeners();
     albumDownloadQueue.removeAllListeners();
+    artistExpansionQueue.removeAllListeners();
 
     // Close all queues gracefully
     await Promise.all([
@@ -1454,4 +1468,5 @@ export {
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,
+    artistExpansionQueue,
 };

--- a/backend/src/workers/queues.ts
+++ b/backend/src/workers/queues.ts
@@ -164,6 +164,18 @@ export const albumDownloadQueue = new Bull("album-download", {
     settings: defaultQueueSettings,
 });
 
+/** Durable queue for artist discography expansion ahead of album admission. */
+export const artistExpansionQueue = new Bull("worker-artist-expansion", {
+    redis: redisConfig,
+    defaultJobOptions: {
+        attempts: 2,
+        backoff: { type: "exponential", delay: 60000 },
+        removeOnComplete: 100,
+        removeOnFail: 200,
+    },
+    settings: defaultQueueSettings,
+});
+
 // Export all queues for monitoring
 export const queues = [
     scanQueue,
@@ -176,6 +188,7 @@ export const queues = [
     genericImportQueue,
     federationQueue,
     albumDownloadQueue,
+    artistExpansionQueue,
 ];
 
 // Add error handlers to all queues to prevent unhandled exceptions


### PR DESCRIPTION
## Problem (#808)

"Get all missing albums" enqueued its expansion job — a lightweight MusicBrainz fetch that exists only to enqueue individual album downloads — onto the **same FIFO queue** as the downloads themselves (global one-at-a-time). With N downloads queued, the button silently parked at position N+1 until the queue drained.

## Change

- New `worker-artist-expansion` queue via the shared registry (Bull Board + depth metrics wired like #811's maintenance queue).
- `enqueueArtistDownloadExpansion` + recovery target the new queue; processor registered there; **legacy-drain processor stays on `album-download`** so pre-upgrade jobs still run.
- Shutdown drains expansions before album downloads.
- The locked #734/#735 contract is untouched: job name, payload, deterministic id, `queuedVia` marker, reconciliation exemption, recovery-scan semantics. Album-download concurrency/ordering unchanged.

## Verification

- `verify:` queue service + queues + worker runtime + entrypoint mount-contract + expansion processor suites: 5 suites, 110 tests, pass (post-rebase)
- `verify: tsc` exit 0; `format:check` clean; `check-file-size` pass

Closes #808