### PR TITLE
chore(services): one canonical match-normalization module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pressing get-all-missing-albums now queues the artist's albums immediately even while other downloads are running (#808).
 - Radio stations now start quickly on large libraries, and genre and decade stations load instantly without recounting the full library on every request (#776). Preferences now reorder the selected station without promoting liked tracks into it or displacing disliked tracks near the cutoff.
+- Provider matching now treats accents, punctuation, conjunctions, and album edition suffixes consistently, reducing wrong or missed album and track matches (#791).
 - Post-scan download reconciliation no longer risks heavy database load when many downloads are queued.
 - Long track lists (Liked Songs, queue, large playlists) now render only the rows on screen instead of every row at once, so pages with thousands of tracks scroll smoothly and no longer stutter once per second during playback (#784).
 - The metrics endpoint now rate-limits failed access attempts, and internal Subsonic auth-type reporting no longer re-reads credential query parameters.

--- a/backend/src/services/__tests__/deezerService.test.ts
+++ b/backend/src/services/__tests__/deezerService.test.ts
@@ -171,6 +171,23 @@ describe("deezerService", () => {
         );
     });
 
+    it("strictly matches canonical accent, punctuation, and conjunction variants", async () => {
+        mockAxiosGet.mockResolvedValueOnce({
+            data: {
+                data: [
+                    {
+                        name: "Beyonce and Jay-Z",
+                        picture_xl: "https://img/canonical.jpg",
+                    },
+                ],
+            },
+        });
+
+        await expect(
+            deezerService.getArtistImageStrict("Beyoncé & Jay Z"),
+        ).resolves.toBe("https://img/canonical.jpg");
+    });
+
     it("returns album cover and preview URL with best match logic and error fallback", async () => {
         mockAxiosGet.mockResolvedValueOnce({
             data: {

--- a/backend/src/services/__tests__/lidarrService.acquisition.test.ts
+++ b/backend/src/services/__tests__/lidarrService.acquisition.test.ts
@@ -1593,6 +1593,68 @@ describe("lidarr service behavior", () => {
         ).resolves.toBeNull();
     });
 
+    it("addAlbum matches accent, punctuation, and edition variants", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        mockStripAlbumEdition.mockImplementation((title: string) =>
+            title.replace(/\s*\(Deluxe Edition\)\s*$/i, ""),
+        );
+        const album = {
+            id: 903,
+            title: "Beyonce - Renaissance",
+            foreignAlbumId: "catalog-mbid",
+            artistId: 57,
+        };
+        client.get
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 57,
+                        artistName: "Beyoncé",
+                        foreignArtistId: "artist-mbid",
+                        monitored: true,
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({ data: [album] })
+            .mockResolvedValueOnce({
+                data: {
+                    ...album,
+                    monitored: false,
+                    anyReleaseOk: false,
+                    releases: [{ id: 1 }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    ...album,
+                    monitored: true,
+                    anyReleaseOk: false,
+                    releases: [{ id: 1 }],
+                },
+            });
+        client.put.mockResolvedValue({ data: { ...album, monitored: true } });
+        client.post.mockResolvedValue({ data: { id: 9102 } });
+        const waitSpy = jest
+            .spyOn(lidarrService as any, "waitForCommand")
+            .mockResolvedValue({
+                status: "completed",
+                message: "Search completed with 1 report",
+            });
+
+        await expect(
+            lidarrService.addAlbum(
+                "requested-mbid",
+                "Beyoncé",
+                "Beyoncé – Renaissance (Deluxe Edition)",
+                "/music",
+                "artist-mbid",
+            ),
+        ).resolves.toEqual(expect.objectContaining({ id: 903 }));
+
+        waitSpy.mockRestore();
+    });
+
     it("adds existing unmonitored artist and enables monitoring before album search", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);

--- a/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
+++ b/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
@@ -641,6 +641,65 @@ describe("lidarr service behavior", () => {
         ).resolves.toBe(true);
     });
 
+    it("matches available albums across accents, punctuation, and conjunctions", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        client.get
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 55,
+                        artistName: "Beyonce and Jay-Z",
+                        sortName: "Beyonce and Jay-Z",
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        title: "Renaissance – Deluxe",
+                        statistics: { percentOfTracks: 100 },
+                    },
+                ],
+            });
+
+        await expect(
+            lidarrService.isAlbumAvailableByTitle(
+                "Beyoncé & Jay Z",
+                "Renaissance - Deluxe",
+            ),
+        ).resolves.toBe(true);
+    });
+
+    it("matches reconciliation snapshot keys across canonical variants", () => {
+        const snapshot = {
+            queue: new Map(),
+            albumsByMbid: new Map(),
+            albumsByTitle: new Map([
+                [
+                    "beyonceandjayz|renaissancedeluxe",
+                    {
+                        id: 1,
+                        title: "Renaissance – Deluxe",
+                        foreignAlbumId: "album-mbid",
+                        artistName: "Beyonce and Jay-Z",
+                        hasFiles: true,
+                    },
+                ],
+            ]),
+            fetchedAt: new Date(),
+        } as any;
+
+        expect(
+            (lidarrService as any).isAlbumAvailableInSnapshot(
+                snapshot,
+                undefined,
+                "Beyoncé & Jay Z",
+                "Renaissance - Deluxe",
+            ),
+        ).toBe(true);
+    });
+
     it("returns false on Lidarr availability lookup failures and checks snapshot helpers", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -686,7 +745,7 @@ describe("lidarr service behavior", () => {
             ]),
             albumsByTitle: new Map([
                 [
-                    "artist|album deluxe",
+                    "artist|albumdeluxe",
                     {
                         id: 1,
                         title: "Album Deluxe",
@@ -1424,6 +1483,9 @@ describe("lidarr service behavior", () => {
     });
 
     it("addAlbum matches album title using exact normalized comparison", async () => {
+        mockStripAlbumEdition.mockImplementation((title: string) =>
+            title.replace("((Deluxe Edition) ", "").replace(/\)$/, ""),
+        );
         const client = createClientMock();
         primeServiceWithClient(client);
 

--- a/backend/src/services/__tests__/lidarrService.helpers.ts
+++ b/backend/src/services/__tests__/lidarrService.helpers.ts
@@ -31,6 +31,7 @@ jest.mock("../../utils/systemSettings", () => ({
 }));
 
 jest.mock("../../utils/artistNormalization", () => ({
+    ...jest.requireActual("../../utils/artistNormalization"),
     stripAlbumEdition: jest.fn((title: string) => title),
 }));
 

--- a/backend/src/services/__tests__/lyricsService.test.ts
+++ b/backend/src/services/__tests__/lyricsService.test.ts
@@ -481,6 +481,42 @@ describe("lyrics service", () => {
         expect(searchCalls).toHaveLength(1);
     });
 
+    it("ranks accent and punctuation variants as the same LRCLIB identity", async () => {
+        mockPrisma.track.findUnique.mockResolvedValue({
+            id: "track-canonical-match",
+            filePath: null,
+            displayTitle: "R.E.M.",
+            title: "R.E.M.",
+            duration: null,
+            album: {
+                title: "Renaissance",
+                artist: { name: "Beyoncé" },
+            },
+        });
+        mockAxiosGet.mockResolvedValueOnce({
+            data: [
+                {
+                    trackName: "Wrong Song",
+                    artistName: "Beyoncé",
+                    albumName: "Renaissance",
+                    plainLyrics: "wrong",
+                    syncedLyrics: null,
+                },
+                {
+                    trackName: "REM",
+                    artistName: "Beyonce",
+                    albumName: "Renaissance",
+                    plainLyrics: "canonical",
+                    syncedLyrics: null,
+                },
+            ],
+        } as any);
+
+        await expect(getLyrics("track-canonical-match")).resolves.toEqual(
+            expect.objectContaining({ plainLyrics: "canonical" }),
+        );
+    });
+
     it("sets LRCLIB backoff on 429 and skips further LRCLIB requests", async () => {
         mockPrisma.track.findUnique.mockResolvedValue({
             id: "track-backoff-429",

--- a/backend/src/services/__tests__/musicScannerService.helpers.ts
+++ b/backend/src/services/__tests__/musicScannerService.helpers.ts
@@ -220,6 +220,7 @@ jest.mock("../metadata/albumCoverResolver", () => ({
 }));
 
 jest.mock("../../utils/artistNormalization", () => ({
+    ...jest.requireActual("../../utils/artistNormalization"),
     normalizeArtistName: mockNormalizeArtistName,
     areArtistNamesSimilar: mockAreArtistNamesSimilar,
     canonicalizeVariousArtists: mockCanonicalizeVariousArtists,

--- a/backend/src/services/__tests__/trackIdentityMatcher.test.ts
+++ b/backend/src/services/__tests__/trackIdentityMatcher.test.ts
@@ -116,6 +116,23 @@ describe("matchTrackIdentities", () => {
         expect(matches).toHaveLength(4);
     });
 
+    it("matches title identity across accents and punctuation", () => {
+        const missing = track("missing-canonical", {
+            fileSize: 4_200,
+            title: "Beyoncé – R.E.M.",
+            duration: 200,
+        });
+        const candidate = track("candidate-canonical", {
+            fileSize: 4_200,
+            title: "Beyonce REM",
+            duration: 201,
+        });
+
+        expect(matchTrackIdentities([missing], [candidate])).toEqual([
+            { missing, candidate, tier: "fileSizeTitleDuration" },
+        ]);
+    });
+
     it("lets a lower tier disambiguate identical audio hashes", () => {
         const missingOne = track("missing-1", {
             audioHash: "sha256:duplicate",

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -125,6 +125,28 @@ describe("youtubeLibraryDownload", () => {
         expect(mockSearch).toHaveBeenCalledWith("Artist Album");
     });
 
+    it("matches accent, punctuation, conjunction, and edition variants", async () => {
+        mockSearch.mockResolvedValueOnce([
+            {
+                browseId: "WRONG-ARTIST",
+                title: "Renaissance (Deluxe Edition)",
+                artists: ["Different Artist"],
+            },
+            {
+                browseId: "CANONICAL",
+                title: "Renaissance (Deluxe Edition)",
+                artists: ["Beyonce and Jay-Z"],
+            },
+        ]);
+
+        await expect(
+            findAlbumBrowseId(
+                "Beyoncé & Jay Z",
+                "Renaissance (Deluxe Edition)",
+            ),
+        ).resolves.toBe("CANONICAL");
+    });
+
     it("falls back to an exact normalized title match", async () => {
         mockSearch.mockResolvedValueOnce([
             {

--- a/backend/src/services/deezer.ts
+++ b/backend/src/services/deezer.ts
@@ -1,6 +1,10 @@
 import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import {
+    normalizeForExactKey,
+    normalizeForFuzzyMatch,
+} from "../utils/artistNormalization";
 import { rateLimiter } from "./rateLimiter";
 
 /**
@@ -76,24 +80,6 @@ class DeezerService {
         return rateLimiter.execute("deezer", () => axios.get(url, config));
     }
 
-    private normalizeArtistIdentity(name: string): string {
-        return name
-            .toLowerCase()
-            .normalize("NFD")
-            .replace(/[\u0300-\u036f]/g, "")
-            .replace(/[^a-z0-9]/g, "");
-    }
-
-    private normalizeAlbumIdentity(name: string): string {
-        return name
-            .toLowerCase()
-            .normalize("NFD")
-            .replace(/[\u0300-\u036f]/g, "")
-            .replace(/['’`]/g, "")
-            .replace(/[^a-z0-9]+/g, " ")
-            .trim();
-    }
-
     private buildAlbumTitleVariants(albumName: string): string[] {
         const variants = new Set<string>();
         const addVariant = (value: string) => {
@@ -147,10 +133,10 @@ class DeezerService {
         normalizedArtistName: string,
         normalizedAlbumVariants: Set<string>,
     ): number {
-        const normalizedCandidateArtist = this.normalizeArtistIdentity(
+        const normalizedCandidateArtist = normalizeForExactKey(
             String(album?.artist?.name || ""),
         );
-        const normalizedCandidateTitle = this.normalizeAlbumIdentity(
+        const normalizedCandidateTitle = normalizeForFuzzyMatch(
             String(album?.title || ""),
         );
 
@@ -250,9 +236,7 @@ class DeezerService {
      * Prevents cross-matching similarly named artists.
      */
     async getArtistImageStrict(artistName: string): Promise<string | null> {
-        const normalizedTarget = this.normalizeArtistIdentity(
-            artistName.trim(),
-        );
+        const normalizedTarget = normalizeForExactKey(artistName);
         if (!normalizedTarget) {
             return null;
         }
@@ -270,7 +254,7 @@ class DeezerService {
             const artists = response.data?.data || [];
             const exactMatch = artists.find(
                 (artist: any) =>
-                    this.normalizeArtistIdentity(artist?.name || "") ===
+                    normalizeForExactKey(artist?.name || "") ===
                     normalizedTarget,
             );
 
@@ -303,11 +287,10 @@ class DeezerService {
         if (cached) return cached === "null" ? null : cached;
 
         try {
-            const normalizedArtistName =
-                this.normalizeArtistIdentity(artistName);
+            const normalizedArtistName = normalizeForExactKey(artistName);
             const normalizedAlbumVariants = new Set(
                 this.buildAlbumTitleVariants(albumName)
-                    .map((variant) => this.normalizeAlbumIdentity(variant))
+                    .map(normalizeForFuzzyMatch)
                     .filter((variant) => variant.length > 0),
             );
 

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -3,8 +3,11 @@ import { logger } from "../utils/logger";
 import { config } from "../config";
 import { BRAND_SLUG } from "../config/brand";
 import { getSystemSettings } from "../utils/systemSettings";
-import { stripAlbumEdition } from "../utils/artistNormalization";
-import { stripDelimitedSegments } from "../utils/stripDelimitedSegments";
+import {
+    normalizeForExactKey,
+    normalizeForFuzzyMatch,
+    stripAlbumEdition,
+} from "../utils/artistNormalization";
 import { fetchReconciliationAlbumMaps } from "./lidarr/reconciliationAlbumStream";
 
 /**
@@ -93,6 +96,10 @@ interface LidarrAlbum {
         foreignArtistId: string; // MusicBrainz artist ID
         artistName: string;
     };
+}
+
+function normalizeAlbumTitleForMatch(title: string): string {
+    return normalizeForFuzzyMatch(stripAlbumEdition(title));
 }
 
 class LidarrService {
@@ -1030,27 +1037,13 @@ class LidarrService {
                     `   Album MBID not found, trying STRICT name match for: ${albumTitle}`,
                 );
 
-                // Normalize title for matching - remove parenthetical suffixes, edition markers, etc.
-                const normalizeTitle = (title: string) =>
-                    stripDelimitedSegments(
-                        stripDelimitedSegments(title.toLowerCase(), "(", ")"),
-                        "[",
-                        "]",
-                    )
-                        .replace(
-                            /[-–—]\s*(deluxe|remaster|bonus|special|anniversary|expanded|limited|collector).*$/i,
-                            "",
-                        ) // Remove edition suffixes
-                        .replace(/[^\w\s]/g, "") // Remove remaining punctuation
-                        .replace(/\s+/g, " ") // Normalize whitespace
-                        .trim();
-
-                const targetTitle = normalizeTitle(albumTitle);
+                const targetTitle = normalizeAlbumTitleForMatch(albumTitle);
                 logger.debug(`   Normalized target: "${targetTitle}"`);
 
                 // Try exact normalized match first
                 albumData = artistAlbums.find(
-                    (a: LidarrAlbum) => normalizeTitle(a.title) === targetTitle,
+                    (a: LidarrAlbum) =>
+                        normalizeAlbumTitleForMatch(a.title) === targetTitle,
                 );
                 if (albumData) {
                     logger.debug(
@@ -1062,7 +1055,7 @@ class LidarrService {
                 // This handles "Album Name" matching "Album Name (Deluxe Edition)"
                 if (!albumData) {
                     albumData = artistAlbums.find((a: LidarrAlbum) => {
-                        const normalized = normalizeTitle(a.title);
+                        const normalized = normalizeAlbumTitleForMatch(a.title);
                         // Only match if one is a substring of the other AND they share significant content
                         // The shorter one must be at least 60% of the longer one's length
                         const shorter =
@@ -1405,18 +1398,13 @@ class LidarrService {
                                     `   Trying base album title fallback: "${albumTitle}" → "${baseAlbumTitle}"`,
                                 );
 
-                                const normalizeForMatch = (s: string) =>
-                                    s
-                                        .toLowerCase()
-                                        .replace(/[^\w\s]/g, "")
-                                        .trim();
                                 const normalizedBase =
-                                    normalizeForMatch(baseAlbumTitle);
+                                    normalizeForFuzzyMatch(baseAlbumTitle);
 
                                 const baseMatch = artistAlbums.find(
                                     (a: LidarrAlbum) => {
                                         const normalizedAlbumTitle =
-                                            normalizeForMatch(a.title);
+                                            normalizeForFuzzyMatch(a.title);
 
                                         if (
                                             normalizedAlbumTitle ===
@@ -1816,8 +1804,8 @@ class LidarrService {
             return false;
         }
 
-        const normalizedArtist = artistName.toLowerCase().trim();
-        const normalizedAlbum = albumTitle.toLowerCase().trim();
+        const normalizedArtist = normalizeForExactKey(artistName);
+        const normalizedAlbum = normalizeForExactKey(albumTitle);
 
         try {
             // Get all artists from Lidarr
@@ -1827,8 +1815,9 @@ class LidarrService {
             // Find matching artist by name
             const matchingArtist = artists.find(
                 (a: any) =>
-                    a.artistName?.toLowerCase().trim() === normalizedArtist ||
-                    a.sortName?.toLowerCase().trim() === normalizedArtist,
+                    normalizeForExactKey(a.artistName || "") ===
+                        normalizedArtist ||
+                    normalizeForExactKey(a.sortName || "") === normalizedArtist,
             );
 
             if (!matchingArtist) {
@@ -1843,7 +1832,7 @@ class LidarrService {
 
             // Check if any album matches the title and has files
             for (const album of albums) {
-                const albumTitleNorm = album.title?.toLowerCase().trim() || "";
+                const albumTitleNorm = normalizeForExactKey(album.title || "");
                 if (
                     albumTitleNorm === normalizedAlbum ||
                     albumTitleNorm.includes(normalizedAlbum)
@@ -2521,15 +2510,15 @@ class LidarrService {
 
         // Strategy 2: Check by normalized artist|title
         if (artistName && albumTitle) {
-            const key = `${artistName.toLowerCase().trim()}|${albumTitle.toLowerCase().trim()}`;
+            const normalizedArtist = normalizeForExactKey(artistName);
+            const normalizedAlbum = normalizeForExactKey(albumTitle);
+            const key = `${normalizedArtist}|${normalizedAlbum}`;
             if (snapshot.albumsByTitle.has(key)) {
                 return true;
             }
 
             // Strategy 3: Partial title match (handles edition differences)
-            const normalizedArtist = artistName.toLowerCase().trim();
-            const normalizedAlbum = albumTitle.toLowerCase().trim();
-            for (const [titleKey, info] of snapshot.albumsByTitle) {
+            for (const titleKey of snapshot.albumsByTitle.keys()) {
                 const [keyArtist, keyAlbum] = titleKey.split("|");
                 if (
                     keyArtist === normalizedArtist &&

--- a/backend/src/services/lidarr/__tests__/reconciliationAlbumStream.test.ts
+++ b/backend/src/services/lidarr/__tests__/reconciliationAlbumStream.test.ts
@@ -46,7 +46,32 @@ describe("Lidarr reconciliation album stream", () => {
                 ],
             ]),
         );
-        expect(albumsByTitle.has("artist|album one")).toBe(true);
+        expect(albumsByTitle.has("artist|albumone")).toBe(true);
+    });
+
+    it("indexes accent, punctuation, and conjunction variants by canonical key", async () => {
+        const get = jest.fn(async () => ({
+            data: [
+                {
+                    id: 4,
+                    title: "Renaissance – Deluxe",
+                    foreignAlbumId: "rg-4",
+                    artist: { artistName: "Beyoncé & Jay Z" },
+                    statistics: { percentOfTracks: 100 },
+                },
+            ],
+        }));
+        const albumsByTitle = new Map();
+
+        await fetchReconciliationAlbumMaps(
+            { get } as unknown as AxiosInstance,
+            { albumsByMbid: new Map(), albumsByTitle },
+            new AbortController().signal,
+        );
+
+        expect(albumsByTitle.has("beyonceandjayz|renaissancedeluxe")).toBe(
+            true,
+        );
     });
 
     it("supports buffered arrays returned by existing Axios test doubles", async () => {

--- a/backend/src/services/lidarr/reconciliationAlbumStream.ts
+++ b/backend/src/services/lidarr/reconciliationAlbumStream.ts
@@ -1,6 +1,7 @@
 import { StringDecoder } from "node:string_decoder";
 import type { Readable } from "node:stream";
 import type { AxiosInstance } from "axios";
+import { normalizeForExactKey } from "../../utils/artistNormalization";
 
 export const LIDARR_ALBUM_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
 const LIDARR_ALBUM_MAX_ITEMS = 250_000;
@@ -65,7 +66,7 @@ function indexAlbum(target: ReconciliationAlbumMaps, value: unknown): void {
         target.albumsByMbid.set(album.foreignAlbumId, album);
     }
     if (!album.artistName || !album.title) return;
-    const key = `${album.artistName.toLowerCase().trim()}|${album.title.toLowerCase().trim()}`;
+    const key = `${normalizeForExactKey(album.artistName)}|${normalizeForExactKey(album.title)}`;
     target.albumsByTitle.set(key, album);
 }
 

--- a/backend/src/services/lyrics.ts
+++ b/backend/src/services/lyrics.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/librarySorting";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { normalizeForFuzzyMatch } from "../utils/artistNormalization";
 import { BRAND_USER_AGENT } from "../config/brand";
 
 const LRCLIB_BASE_URL = "https://lrclib.net/api";
@@ -151,28 +152,18 @@ function buildLrclibDurationCandidates(duration?: number): number[] {
     );
 }
 
-function normalizeLrclibMatchValue(value: string): string {
-    return value
-        .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-}
-
 function scoreLrclibCandidate(
     candidate: LrclibResponse,
     artistName: string,
     trackName: string,
     albumName?: string,
 ): number {
-    const candidateArtist = normalizeLrclibMatchValue(
-        candidate.artistName || "",
-    );
-    const candidateTrack = normalizeLrclibMatchValue(candidate.trackName || "");
-    const candidateAlbum = normalizeLrclibMatchValue(candidate.albumName || "");
-    const targetArtist = normalizeLrclibMatchValue(artistName);
-    const targetTrack = normalizeLrclibMatchValue(trackName);
-    const targetAlbum = normalizeLrclibMatchValue(albumName || "");
+    const candidateArtist = normalizeForFuzzyMatch(candidate.artistName || "");
+    const candidateTrack = normalizeForFuzzyMatch(candidate.trackName || "");
+    const candidateAlbum = normalizeForFuzzyMatch(candidate.albumName || "");
+    const targetArtist = normalizeForFuzzyMatch(artistName);
+    const targetTrack = normalizeForFuzzyMatch(trackName);
+    const targetAlbum = normalizeForFuzzyMatch(albumName || "");
 
     let score = 0;
 

--- a/backend/src/services/metadata/__tests__/albumEnrichmentFields.test.ts
+++ b/backend/src/services/metadata/__tests__/albumEnrichmentFields.test.ts
@@ -119,6 +119,25 @@ describe("album enrichment fields", () => {
         });
     });
 
+    it("matches release-group titles across accents and conjunction punctuation", async () => {
+        musicBrainzService.getReleaseGroups.mockResolvedValueOnce([
+            {
+                id: RELEASE_GROUP_MBID,
+                title: "Beyonce and Jay-Z",
+                "primary-type": "Album",
+            },
+        ]);
+
+        const result = await resolveAlbumEnrichmentFields({
+            id: "album-canonical",
+            title: "Beyoncé & Jay Z",
+            rgMbid: null,
+            artist: { name: "Artist", mbid: ARTIST_MBID },
+        });
+
+        expect(result.rgMbid).toBe(RELEASE_GROUP_MBID);
+    });
+
     it("extracts the first release date and label for an existing MusicBrainz release group", async () => {
         musicBrainzService.getReleaseGroup.mockResolvedValueOnce({
             "first-release-date": "1994-09-19",

--- a/backend/src/services/metadata/albumEnrichmentFields.ts
+++ b/backend/src/services/metadata/albumEnrichmentFields.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
+import { normalizeForExactKey } from "../../utils/artistNormalization";
 import { isRealArtistMbid, rgMbidKind } from "../../utils/musicIds";
 import { downloadAndStoreImage, isNativePath } from "../imageStorage";
 import { lastFmService } from "../lastfm";
@@ -70,17 +71,13 @@ function nonEmptyString(value: unknown): string | undefined {
     return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function normalizedTitle(value: string): string {
-    return value.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
 function matchingReleaseGroup(results: unknown, title: string): unknown {
     if (!Array.isArray(results)) return undefined;
-    const target = normalizedTitle(title);
+    const target = normalizeForExactKey(title);
     return results.slice(0, MAX_RELEASE_GROUPS).find((candidate) => {
         const candidateTitle = nonEmptyString(asRecord(candidate)?.title);
         return candidateTitle
-            ? normalizedTitle(candidateTitle) === target
+            ? normalizeForExactKey(candidateTitle) === target
             : false;
     });
 }

--- a/backend/src/services/trackIdentityMatcher.ts
+++ b/backend/src/services/trackIdentityMatcher.ts
@@ -1,3 +1,5 @@
+import { normalizeForExactKey } from "../utils/artistNormalization";
+
 /** Identity fields used to match a disappeared track to a newly scanned row. */
 export interface TrackIdentity {
     id: string;
@@ -52,15 +54,6 @@ interface TierDefinition {
 const ALBUM_DURATION_TOLERANCE_SECONDS = 10;
 const FILE_DURATION_TOLERANCE_SECONDS = 2;
 
-function normalizeTitle(title: string): string {
-    return title
-        .trim()
-        .toLowerCase()
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .replace(/\s+/g, " ");
-}
-
 function nonEmptyKey(value: string | null): string | null {
     return value !== null && value.length > 0 ? value : null;
 }
@@ -108,16 +101,23 @@ function validInteger(value: number): boolean {
     return Number.isSafeInteger(value) && value >= 0;
 }
 
+/** Rows can surface null/empty titles at runtime; those never form a key. */
+function normalizedTitleKey(title: string | null | undefined): string | null {
+    if (typeof title !== "string" || title.length === 0) return null;
+    const normalized = normalizeForExactKey(title);
+    return normalized.length > 0 ? normalized : null;
+}
+
 function albumPositionTitleKey(track: TrackIdentity): string | null {
     const rgMbid = nonEmptyKey(track.album.rgMbid);
-    const title = normalizeTitle(track.title);
+    const title = normalizedTitleKey(track.title);
     if (!rgMbid || !title || !validInteger(track.discNo)) return null;
     if (!validInteger(track.trackNo)) return null;
     return JSON.stringify([rgMbid, track.discNo, track.trackNo, title]);
 }
 
 function fileSizeTitleKey(track: TrackIdentity): string | null {
-    const title = normalizeTitle(track.title);
+    const title = normalizedTitleKey(track.title);
     if (!title || !validInteger(track.fileSize)) return null;
     return JSON.stringify([track.fileSize, title]);
 }

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -5,6 +5,7 @@ import {
     runLibraryAlbumDownload,
 } from "./libraryDownloadProcessor";
 import { patchDownloadJobMetadata } from "./downloadJobStatus";
+import { normalizeForExactKey } from "../utils/artistNormalization";
 import {
     type YtAlbumDownloadJobStatus,
     watchYouTubeDownloadJobUntilTerminal,
@@ -39,26 +40,23 @@ function asAlbumSearchCandidate(value: unknown): AlbumSearchCandidate | null {
     };
 }
 
-function normalizeMatchText(value: string): string {
-    return value.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
 function selectAlbumBrowseId(
     candidates: AlbumSearchCandidate[],
     artistName: string,
     albumTitle: string,
 ): string | null {
-    const normalizedTitle = normalizeMatchText(albumTitle);
-    const normalizedArtist = normalizeMatchText(artistName);
+    const normalizedTitle = normalizeForExactKey(albumTitle);
+    const normalizedArtist = normalizeForExactKey(artistName);
     const exactMatch = candidates.find(
         (candidate) =>
-            normalizeMatchText(candidate.title) === normalizedTitle &&
+            normalizeForExactKey(candidate.title) === normalizedTitle &&
             candidate.artists.some(
-                (artist) => normalizeMatchText(artist) === normalizedArtist,
+                (artist) => normalizeForExactKey(artist) === normalizedArtist,
             ),
     );
     const titleMatch = candidates.find(
-        (candidate) => normalizeMatchText(candidate.title) === normalizedTitle,
+        (candidate) =>
+            normalizeForExactKey(candidate.title) === normalizedTitle,
     );
     return (
         exactMatch?.browseId ??

--- a/backend/src/utils/__tests__/artistNormalization.test.ts
+++ b/backend/src/utils/__tests__/artistNormalization.test.ts
@@ -7,6 +7,8 @@ import {
     getPreferredArtistName,
     normalizeArtistName,
     normalizeAlbumTitle,
+    normalizeForExactKey,
+    normalizeForFuzzyMatch,
     stripAlbumEdition,
     areArtistNamesSimilar,
     findBestArtistMatch,
@@ -55,6 +57,55 @@ describe("artistNormalization utilities", () => {
             "a love supreme",
         );
         expect(normalizeAlbumTitle(null as any)).toBe("");
+    });
+
+    describe("canonical match normalization", () => {
+        it.each([
+            ["Beyoncé", "beyonce"],
+            ["Motörhead", "motorhead"],
+            ["Sigur Rós", "sigur ros"],
+            ["AC/DC", "acdc"],
+            ["Panic! at the Disco", "panic at the disco"],
+            ["R.E.M.", "rem"],
+            ["Of Mice & Men", "of mice and men"],
+            ["Of Mice and Men", "of mice and men"],
+            ["Beyoncé – Renaissance", "beyonce renaissance"],
+            ["Beyoncé — Renaissance", "beyonce renaissance"],
+            ["Beyoncé - Renaissance", "beyonce renaissance"],
+            ["\u2002Sigur\u00a0\u2009Rós\n", "sigur ros"],
+            ["", ""],
+            ["  — !?  ", ""],
+        ])("normalizes %p for fuzzy matching", (input, expected) => {
+            expect(normalizeForFuzzyMatch(input)).toBe(expected);
+        });
+
+        it.each([
+            ["Beyoncé", "beyonce"],
+            ["Motörhead", "motorhead"],
+            ["Sigur Rós", "sigurros"],
+            ["AC/DC", "acdc"],
+            ["Panic! at the Disco", "panicatthedisco"],
+            ["R.E.M.", "rem"],
+            ["Of Mice & Men", "ofmiceandmen"],
+            ["Of Mice and Men", "ofmiceandmen"],
+            ["Beyoncé – Renaissance", "beyoncerenaissance"],
+            ["Beyoncé-Renaissance", "beyoncerenaissance"],
+            ["\u2002Sigur\u00a0\u2009Rós\n", "sigurros"],
+            ["", ""],
+            ["  — !?  ", ""],
+        ])("normalizes %p as an exact key", (input, expected) => {
+            expect(normalizeForExactKey(input)).toBe(expected);
+        });
+
+        it("composes edition stripping with either match normalizer", () => {
+            const title = "Beyoncé – Renaissance (Deluxe Edition)";
+            const baseTitle = stripAlbumEdition(title);
+
+            expect(normalizeForFuzzyMatch(baseTitle)).toBe(
+                "beyonce renaissance",
+            );
+            expect(normalizeForExactKey(baseTitle)).toBe("beyoncerenaissance");
+        });
     });
 
     it("strips album edition markers and guards oversized input", () => {

--- a/backend/src/utils/artistNormalization.ts
+++ b/backend/src/utils/artistNormalization.ts
@@ -57,6 +57,10 @@ function stripDiacritics(str: string): string {
     return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
 
+function removePunctuation(str: string): string {
+    return str.replace(/\p{P}+/gu, "");
+}
+
 /**
  * Check if a string contains any diacritics/accents
  * Used to prefer the accented version when merging duplicates
@@ -113,6 +117,29 @@ export function normalizeArtistName(name: string): string {
 export function normalizeAlbumTitle(title: string): string {
     if (title == null) return "";
     return title.trim().toLowerCase();
+}
+
+/**
+ * Normalize text for fuzzy match comparisons.
+ * Lowercases, strips diacritics and punctuation, expands ampersands to "and",
+ * and collapses Unicode whitespace while preserving word boundaries.
+ */
+export function normalizeForFuzzyMatch(value: string): string {
+    const withCanonicalConjunctions = stripDiacritics(
+        value.toLowerCase(),
+    ).replace(/\s*&\s*/g, " and ");
+    return removePunctuation(withCanonicalConjunctions)
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+/**
+ * Normalize text as an exact comparison key.
+ * Applies fuzzy-match normalization, then deletes every remaining whitespace
+ * separator so differences in spacing and punctuation cannot split the key.
+ */
+export function normalizeForExactKey(value: string): string {
+    return normalizeForFuzzyMatch(value).replace(/\s+/g, "");
 }
 
 /**

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -62,7 +62,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/podcasts.ts": 2541,
     "backend/src/routes/systemSettings.ts": 1506,
     "backend/src/routes/youtubeMusic.ts": 1612,
-    "backend/src/services/lidarr.ts": 2962,
+    "backend/src/services/lidarr.ts": 2951,
     "backend/src/services/simpleDownloadManager.ts": 2306,
     "backend/src/services/spotify.ts": 1624,
     "backend/src/workers/unifiedEnrichment.ts": 1897,


### PR DESCRIPTION
## Problem (#791)

Match normalization was forked **seven** ways (the issue counted six; the sweep found another in the metadata facade's release-group matching) with incompatible diacritics/whitespace/punctuation/edition semantics. Every provider match, album resolution, and download title check ran through one of them — mismatches surfaced as wrong-album-downloaded reports.

## Change

- `utils/artistNormalization` gains `normalizeForFuzzyMatch` and `normalizeForExactKey` (documented recipes, pure, table-driven tests: Beyoncé/Motörhead/Sigur Rós, AC/DC/Panic!/R.E.M., &↔and, dash variants, unicode whitespace, `stripAlbumEdition` composition).
- All seven local variants migrated (choice per site documented in the table below) and **deleted**; the two untestable `lidarr.addAlbum` closures hoisted; the four bare `toLowerCase().trim()` comparison sites replaced; lidarr snapshot producer/consumer now build identical keys; the metadata facade consumes the canonical functions.
- Orchestration fixes on top of the implementation: null-title guard in `trackIdentityMatcher` (DB rows surface null titles; the old local variant tolerated them) and the scanner suite's module mock updated via `requireActual` spread.
- Per-site behavior deltas are pinned by new divergent-input tests in each consuming suite (deezer, youtubeLibraryDownload, lyrics, trackIdentityMatcher, lidarr acquisition + clientHelpers + reconciliationAlbumStream, albumEnrichmentFields).

## Verification

- `verify:` **full backend suite in this worktree: 496/496 suites, 7,574 tests pass**
- `verify: tsc` exit 0; `format:check` clean; `check-file-size` pass (lidarr.ts tightened 2,962 → 2,951)
- `verify:` residual grep: zero occurrences of the old variant names; remaining "normalize" hits are unrelated domains (URLs, DTOs, pagination) — enumerated in the work log

Closes #791