### PR TITLE
chore(subsonic): share the library read model for search3 and getArtist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Subsonic search and artist views now share the main library's data layer.
 - App screens now share one catalog of data-cache keys, so library, playlist, download, and notification views refresh reliably after changes instead of occasionally showing stale lists.
 - `DISCOVERY_MODE=legacy` remains accepted but now serves the modern discovery implementation and logs one deprecation warning at process startup (#795).
 - The TIDAL streamer now uses focused internal modules, and all Python sidecars use one shared-package import prefix without changing their HTTP APIs.

--- a/backend/src/routes/__tests__/libraryArtistReadDivergenceGuard.test.ts
+++ b/backend/src/routes/__tests__/libraryArtistReadDivergenceGuard.test.ts
@@ -1,0 +1,114 @@
+import type { Request, Response } from "express";
+
+const mockReadLibraryArtist = jest.fn();
+
+jest.mock("../../middleware/auth", () => ({
+    requireAdmin: jest.fn(),
+    requireAuth: jest.fn(),
+    requireAuthOrToken: jest.fn(),
+}));
+
+jest.mock("../../config", () => ({
+    config: {
+        music: {
+            musicPath: "/music",
+            transcodeCachePath: "/tmp/soundspan-cache",
+            transcodeCacheMaxGb: 1,
+        },
+    },
+}));
+
+jest.mock("../../utils/db", () => ({
+    prisma: {},
+    Prisma: jest.requireActual("@prisma/client").Prisma,
+}));
+
+jest.mock("../../utils/redis", () => ({ redisClient: {} }));
+jest.mock("../../services/lastfm", () => ({ lastFmService: {} }));
+jest.mock("../../services/musicbrainz", () => ({ musicBrainzService: {} }));
+jest.mock("../../services/dataCache", () => ({ dataCacheService: {} }));
+jest.mock("../../services/metadata/albumCoverResolver", () => ({
+    resolveAlbumCover: jest.fn(),
+}));
+jest.mock("../../services/metadata/artistImageResolver", () => ({
+    resolveArtistImage: jest.fn(),
+}));
+jest.mock("../../services/metadata/catalogPersistence", () => ({
+    logCatalogPersistenceError: jest.fn(),
+    persistCatalogReleaseGroups: jest.fn(),
+    readFreshCatalogReleaseGroups: jest.fn(),
+}));
+
+jest.mock("../../services/libraryArtistReads", () => ({
+    readLibraryArtist: mockReadLibraryArtist,
+}));
+
+jest.mock("../../utils/logger", () => {
+    const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    return { logger };
+});
+
+jest.mock("../../utils/subsonicResponse", () => ({
+    getResponseFormat: jest.fn(() => "json"),
+    sendSubsonicError: jest.fn(),
+    sendSubsonicSuccess: jest.fn(),
+    SubsonicErrorCode: { GENERIC: 0, NOT_FOUND: 70 },
+}));
+
+import { handleGetArtist as handleLibraryGetArtist } from "../library/artists";
+import { handleGetArtist as handleSubsonicGetArtist } from "../subsonic/browsing";
+
+describe("shared library artist read divergence guard", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockReadLibraryArtist.mockResolvedValue(null);
+    });
+
+    it("links both artist handlers to the same visibility-aware service", async () => {
+        const libraryResponse = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis(),
+        } as unknown as Response;
+        await handleLibraryGetArtist(
+            {
+                params: { id: "artist-1" },
+                query: {
+                    includeDiscography: "false",
+                    includeTopTracks: "false",
+                    includeSimilarArtists: "false",
+                },
+                user: { id: "user-1" },
+            } as unknown as Request<{ id: string }>,
+            libraryResponse,
+        );
+        await handleSubsonicGetArtist(
+            {
+                query: { id: "ar-artist-1" },
+                user: { id: "user-1" },
+            } as unknown as Request,
+            {} as Response,
+        );
+
+        expect(mockReadLibraryArtist).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                albumLocations: ["LIBRARY", "DISCOVER", "REMOTE", "FEDERATED"],
+                requireVisibleAlbum: false,
+            }),
+        );
+        expect(mockReadLibraryArtist).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                albumLocations: ["LIBRARY", "FEDERATED"],
+                requireVisibleAlbum: true,
+            }),
+        );
+    });
+});

--- a/backend/src/routes/library/artists.ts
+++ b/backend/src/routes/library/artists.ts
@@ -36,6 +36,7 @@ import {
 import {
     ALBUM_SORT_MAP,
     ARTIST_SORT_MAP,
+    LIBRARY_SURFACE_ALBUM_LOCATIONS,
     TRACK_SORT_MAP,
     TRACK_VISIBLE_WHERE,
     isLibrarySurfaceAlbumLocation,
@@ -52,6 +53,7 @@ import { findRouteNameMatch } from "../artistRouteName";
 import { deleteArtistCatalogEntry } from "../../services/artistCatalogDeletion";
 import { withFederatedTrackPlayback } from "../../services/federatedTrackPayload";
 import { bumpSearchCacheVersion } from "../../services/searchCacheVersion";
+import { readLibraryArtist } from "../../services/libraryArtistReads";
 import {
     buildArtistTrackTitleIndex,
     filterDistinctDiscographyAlbums,
@@ -462,71 +464,13 @@ export async function handleGetArtist(
     );
     const shouldResolveMbid =
         includeDiscography || includeTopTracks || includeSimilarArtists;
-    const browseTrackWhere = {
-        ...TRACK_VISIBLE_WHERE,
-        ...trackBrowseWhere("all"),
-    };
-
-    const artistInclude = {
-        albums: {
-            where: { tracks: { some: browseTrackWhere } },
-            orderBy: { year: Prisma.SortOrder.desc },
-            include: {
-                federationPeer: {
-                    select: { id: true, name: true, outboundStatus: true },
-                },
-                tracks: {
-                    where: browseTrackWhere,
-                    orderBy: [
-                        { discNo: Prisma.SortOrder.asc },
-                        { trackNo: Prisma.SortOrder.asc },
-                    ],
-                    take: 10, // Top tracks
-                    include: {
-                        federationPeer: {
-                            select: {
-                                id: true,
-                                name: true,
-                                outboundStatus: true,
-                            },
-                        },
-                        album: {
-                            select: {
-                                id: true,
-                                title: true,
-                                coverUrl: true,
-                                albumLoudnessLufs: true,
-                                albumTruePeakDb: true,
-                                artist: {
-                                    select: {
-                                        id: true,
-                                        name: true,
-                                        mbid: true,
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        ownedAlbums: true,
-        federationPeer: {
-            select: { id: true, name: true, outboundStatus: true },
-        },
-        // similarFrom is retired; similarArtistsJson is fetched by default.
-    };
-
     const artist = await findRouteNameMatch(idParam, (name) =>
-        prisma.artist.findFirst({
-            where: {
-                OR: [
-                    { id: idParam },
-                    { name: { equals: name, mode: "insensitive" } },
-                    { mbid: idParam },
-                ],
-            },
-            include: artistInclude,
+        readLibraryArtist({
+            lookup: { id: idParam, name, mbid: idParam },
+            albumLocations: LIBRARY_SURFACE_ALBUM_LOCATIONS,
+            requireVisibleAlbum: false,
+            albumOrder: "year",
+            maxTracksPerAlbum: 10,
         }),
     );
 

--- a/backend/src/routes/subsonic/browsing.ts
+++ b/backend/src/routes/subsonic/browsing.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
 import { buildArtistIndexes } from "../../utils/subsonicIndexes";
 import { loadSubsonicArtistIndexSnapshot } from "../../services/subsonicArtistIndexCache";
+import { readLibraryArtist } from "../../services/libraryArtistReads";
 import {
     parseSubsonicId,
     toSubsonicId,
@@ -210,46 +211,11 @@ export async function handleGetArtist(
     }
 
     try {
-        const artist = await prisma.artist.findFirst({
-            where: {
-                id: artistId,
-                albums: {
-                    some: LIBRARY_ALBUM_WHERE,
-                },
-            },
-            select: {
-                id: true,
-                name: true,
-                heroUrl: true,
-                albums: {
-                    where: LIBRARY_ALBUM_WHERE,
-                    select: {
-                        id: true,
-                        title: true,
-                        year: true,
-                        lastSynced: true,
-                        coverUrl: true,
-                        location: true,
-                        genres: true,
-                        userGenres: true,
-                        tracks: {
-                            where: LIBRARY_TRACK_WHERE,
-                            select: {
-                                id: true,
-                                duration: true,
-                            },
-                        },
-                        _count: {
-                            select: {
-                                tracks: {
-                                    where: LIBRARY_TRACK_WHERE,
-                                },
-                            },
-                        },
-                    },
-                    orderBy: [{ year: "desc" }, { title: "asc" }],
-                },
-            },
+        const artist = await readLibraryArtist({
+            lookup: { id: artistId },
+            albumLocations: ["LIBRARY", "FEDERATED"],
+            requireVisibleAlbum: true,
+            albumOrder: "year-title",
         });
 
         if (!artist) {
@@ -284,7 +250,7 @@ export async function handleGetArtist(
                         id: artist.id,
                         name: artist.name,
                     },
-                    songCount: album._count.tracks,
+                    songCount: album.tracks.length,
                     duration: album.tracks.reduce(
                         (sum, track) => sum + (track.duration ?? 0),
                         0,

--- a/backend/src/routes/subsonic/searching.ts
+++ b/backend/src/routes/subsonic/searching.ts
@@ -1,5 +1,6 @@
 import { type Request, type Response } from "express";
 import { prisma } from "../../utils/db";
+import { searchLibraryMusic } from "../../services/librarySearchReads";
 import {
     sendSubsonicError,
     sendSubsonicSuccess,
@@ -79,175 +80,18 @@ export async function handleSearch3(
     const songOffset = parseOffsetParam(req.query.songOffset);
 
     try {
-        const [artists, albums, tracks] = await Promise.all([
-            prisma.artist.findMany({
-                where: {
-                    albums: {
-                        some: LIBRARY_ALBUM_WHERE,
-                    },
-                    ...(query
-                        ? {
-                              name: {
-                                  contains: query,
-                                  mode: "insensitive" as const,
-                              },
-                          }
-                        : {}),
-                },
-                select: {
-                    id: true,
-                    name: true,
-                    heroUrl: true,
-                    _count: {
-                        select: {
-                            albums: { where: LIBRARY_ALBUM_WHERE },
-                        },
-                    },
-                },
-                orderBy: {
-                    name: "asc",
-                },
-                take: artistCount,
-                skip: artistOffset,
-            }),
-            prisma.album.findMany({
-                where: {
-                    ...LIBRARY_ALBUM_WHERE,
-                    ...(query
-                        ? {
-                              OR: [
-                                  {
-                                      title: {
-                                          contains: query,
-                                          mode: "insensitive" as const,
-                                      },
-                                  },
-                                  {
-                                      artist: {
-                                          name: {
-                                              contains: query,
-                                              mode: "insensitive" as const,
-                                          },
-                                      },
-                                  },
-                              ],
-                          }
-                        : {}),
-                },
-                select: {
-                    id: true,
-                    title: true,
-                    year: true,
-                    lastSynced: true,
-                    coverUrl: true,
-                    location: true,
-                    genres: true,
-                    userGenres: true,
-                    artist: {
-                        select: {
-                            id: true,
-                            name: true,
-                        },
-                    },
-                    tracks: {
-                        where: LIBRARY_TRACK_WHERE,
-                        select: {
-                            id: true,
-                            duration: true,
-                        },
-                    },
-                    _count: {
-                        select: {
-                            tracks: {
-                                where: LIBRARY_TRACK_WHERE,
-                            },
-                        },
-                    },
-                },
-                orderBy: {
-                    title: "asc",
-                },
-                take: albumCount,
-                skip: albumOffset,
-            }),
-            prisma.track.findMany({
-                where: {
-                    ...LIBRARY_TRACK_WHERE,
-                    album: {
-                        location: SUBSONIC_ALBUM_LOCATION_WHERE,
-                    },
-                    ...(query
-                        ? {
-                              OR: [
-                                  {
-                                      title: {
-                                          contains: query,
-                                          mode: "insensitive" as const,
-                                      },
-                                  },
-                                  {
-                                      album: {
-                                          title: {
-                                              contains: query,
-                                              mode: "insensitive" as const,
-                                          },
-                                      },
-                                  },
-                                  {
-                                      album: {
-                                          artist: {
-                                              name: {
-                                                  contains: query,
-                                                  mode: "insensitive" as const,
-                                              },
-                                          },
-                                      },
-                                  },
-                              ],
-                          }
-                        : {}),
-                },
-                select: {
-                    id: true,
-                    title: true,
-                    trackNo: true,
-                    discNo: true,
-                    duration: true,
-                    fileSize: true,
-                    mime: true,
-                    filePath: true,
-                    ...SONG_LOUDNESS_TRACK_SELECT,
-                    album: {
-                        select: {
-                            id: true,
-                            title: true,
-                            year: true,
-                            coverUrl: true,
-                            location: true,
-                            genres: true,
-                            userGenres: true,
-                            ...SONG_LOUDNESS_ALBUM_SELECT,
-                            artist: {
-                                select: {
-                                    id: true,
-                                    name: true,
-                                },
-                            },
-                        },
-                    },
-                },
-                orderBy: [{ title: "asc" }, { id: "asc" }],
-                take: songCount,
-                skip: songOffset,
-            }),
-        ]);
+        const { artists, albums, tracks } = await searchLibraryMusic({
+            query,
+            albumLocations: ["LIBRARY", "FEDERATED"],
+            artists: { limit: artistCount, offset: artistOffset },
+            albums: { limit: albumCount, offset: albumOffset },
+            tracks: { limit: songCount, offset: songOffset },
+        });
         const playedAtByTrackId = await loadSongEnrichmentByTrackId(
             req.user!.id,
             [
                 ...tracks.map((track) => track.id),
-                ...albums.flatMap((album) =>
-                    album.tracks.map((track) => track.id),
-                ),
+                ...albums.flatMap((album) => album.trackIds),
             ],
         );
 
@@ -259,7 +103,7 @@ export async function handleSearch3(
                         formatArtistForSubsonic({
                             id: artist.id,
                             name: artist.name,
-                            albumCount: artist._count.albums,
+                            albumCount: artist.albumCount,
                             heroUrl: artist.heroUrl,
                         }),
                     ),
@@ -275,14 +119,11 @@ export async function handleSearch3(
                                 genres: album.genres,
                                 userGenres: album.userGenres,
                                 artist: album.artist,
-                                songCount: album._count.tracks,
-                                duration: album.tracks.reduce(
-                                    (sum, track) => sum + (track.duration ?? 0),
-                                    0,
-                                ),
+                                songCount: album.songCount,
+                                duration: album.duration,
                             },
                             combineSongEnrichmentForAlbum(
-                                album.tracks.map((track) => track.id),
+                                album.trackIds,
                                 playedAtByTrackId,
                             ),
                         ),

--- a/backend/src/services/__tests__/libraryArtistReads.test.ts
+++ b/backend/src/services/__tests__/libraryArtistReads.test.ts
@@ -1,0 +1,74 @@
+const prisma = {
+    artist: { findFirst: jest.fn() },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+import { readLibraryArtist } from "../libraryArtistReads";
+
+describe("library artist reads", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        prisma.artist.findFirst.mockResolvedValue(null);
+    });
+
+    it("builds a strict visible artist slice with complete album tracks", async () => {
+        await readLibraryArtist({
+            lookup: { id: "artist-1" },
+            albumLocations: ["LIBRARY", "FEDERATED"],
+            requireVisibleAlbum: true,
+            albumOrder: "year-title",
+        });
+
+        expect(prisma.artist.findFirst).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    id: "artist-1",
+                    albums: {
+                        some: expect.objectContaining({
+                            location: { in: ["LIBRARY", "FEDERATED"] },
+                        }),
+                    },
+                },
+                include: expect.objectContaining({
+                    albums: expect.objectContaining({
+                        where: expect.objectContaining({
+                            location: { in: ["LIBRARY", "FEDERATED"] },
+                        }),
+                        orderBy: [{ year: "desc" }, { title: "asc" }],
+                        include: expect.objectContaining({
+                            tracks: expect.not.objectContaining({
+                                take: expect.anything(),
+                            }),
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it("preserves flexible library lookup and the per-album track cap", async () => {
+        await readLibraryArtist({
+            lookup: {
+                id: "route-value",
+                name: "decoded name",
+                mbid: "route-value",
+            },
+            albumLocations: ["LIBRARY", "DISCOVER", "REMOTE", "FEDERATED"],
+            requireVisibleAlbum: false,
+            albumOrder: "year",
+            maxTracksPerAlbum: 10,
+        });
+
+        const args = prisma.artist.findFirst.mock.calls[0][0];
+        expect(args.where).toEqual({
+            OR: [
+                { id: "route-value" },
+                { name: { equals: "decoded name", mode: "insensitive" } },
+                { mbid: "route-value" },
+            ],
+        });
+        expect(args.include.albums.include.tracks.take).toBe(10);
+        expect(args.include.albums.orderBy).toEqual([{ year: "desc" }]);
+    });
+});

--- a/backend/src/services/__tests__/librarySearchReads.test.ts
+++ b/backend/src/services/__tests__/librarySearchReads.test.ts
@@ -1,0 +1,122 @@
+const prisma = {
+    artist: { findMany: jest.fn() },
+    album: { findMany: jest.fn() },
+    track: { findMany: jest.fn() },
+};
+
+jest.mock("../../utils/db", () => ({ prisma }));
+
+import { searchLibraryMusic } from "../librarySearchReads";
+
+describe("library search reads", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        prisma.artist.findMany.mockResolvedValue([]);
+        prisma.album.findMany.mockResolvedValue([]);
+        prisma.track.findMany.mockResolvedValue([]);
+    });
+
+    it("applies independent paging and owned/federated visibility", async () => {
+        await searchLibraryMusic({
+            query: "Needle",
+            albumLocations: ["LIBRARY", "FEDERATED"],
+            artists: { limit: 3, offset: 11 },
+            albums: { limit: 4, offset: 12 },
+            tracks: { limit: 5, offset: 13 },
+        });
+
+        expect(prisma.artist.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                take: 3,
+                skip: 11,
+                where: expect.objectContaining({
+                    name: { contains: "Needle", mode: "insensitive" },
+                    albums: {
+                        some: expect.objectContaining({
+                            location: { in: ["LIBRARY", "FEDERATED"] },
+                        }),
+                    },
+                }),
+            }),
+        );
+        expect(prisma.album.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                take: 4,
+                skip: 12,
+                where: expect.objectContaining({
+                    location: { in: ["LIBRARY", "FEDERATED"] },
+                    tracks: { some: expect.any(Object) },
+                }),
+            }),
+        );
+        expect(prisma.track.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                take: 5,
+                skip: 13,
+                where: expect.objectContaining({
+                    removedAt: null,
+                    album: {
+                        location: { in: ["LIBRARY", "FEDERATED"] },
+                    },
+                }),
+            }),
+        );
+    });
+
+    it("returns neutral counts and duration from visible selected tracks", async () => {
+        prisma.artist.findMany.mockResolvedValueOnce([
+            {
+                id: "artist-1",
+                name: "Artist One",
+                heroUrl: "artist.jpg",
+                _count: { albums: 2 },
+            },
+        ]);
+        prisma.album.findMany.mockResolvedValueOnce([
+            {
+                id: "album-1",
+                title: "Album One",
+                year: 2024,
+                lastSynced: new Date("2026-01-01T00:00:00.000Z"),
+                coverUrl: "cover.jpg",
+                location: "LIBRARY",
+                genres: ["rock"],
+                userGenres: null,
+                artist: { id: "artist-1", name: "Artist One" },
+                tracks: [
+                    { id: "track-1", duration: 120 },
+                    { id: "track-2", duration: null },
+                ],
+                _count: { tracks: 2 },
+            },
+        ]);
+
+        const result = await searchLibraryMusic({
+            query: "",
+            albumLocations: ["LIBRARY", "FEDERATED"],
+            artists: { limit: 20, offset: 0 },
+            albums: { limit: 20, offset: 0 },
+            tracks: { limit: 20, offset: 0 },
+        });
+
+        expect(result.artists).toEqual([
+            {
+                id: "artist-1",
+                name: "Artist One",
+                heroUrl: "artist.jpg",
+                albumCount: 2,
+            },
+        ]);
+        expect(result.albums).toEqual([
+            expect.objectContaining({
+                id: "album-1",
+                songCount: 2,
+                duration: 120,
+                trackIds: ["track-1", "track-2"],
+            }),
+        ]);
+        expect(
+            prisma.artist.findMany.mock.calls[0][0].where,
+        ).not.toHaveProperty("name");
+    });
+});

--- a/backend/src/services/libraryArtistReads.ts
+++ b/backend/src/services/libraryArtistReads.ts
@@ -1,0 +1,143 @@
+import { Prisma, type AlbumLocation } from "@prisma/client";
+import { prisma } from "../utils/db";
+import {
+    TRACK_BROWSE_WHERE,
+    TRACK_VISIBLE_WHERE,
+} from "../utils/librarySorting";
+
+/** Identity fields accepted by the shared artist read. */
+export interface LibraryArtistLookup {
+    id: string;
+    name?: string;
+    mbid?: string;
+}
+
+/** Visibility, ordering, and paging controls for a shared artist read. */
+export interface LibraryArtistReadOptions {
+    lookup: LibraryArtistLookup;
+    albumLocations: readonly AlbumLocation[];
+    requireVisibleAlbum: boolean;
+    albumOrder: "year" | "year-title";
+    maxTracksPerAlbum?: number;
+}
+
+/** Builds the visible track predicate shared by library artist consumers. */
+export function buildLibraryTrackWhere(
+    albumLocations: readonly AlbumLocation[],
+): Prisma.TrackWhereInput {
+    return {
+        ...TRACK_VISIBLE_WHERE,
+        ...TRACK_BROWSE_WHERE,
+        album: { location: { in: [...albumLocations] } },
+    };
+}
+
+/** Builds the visible album predicate shared by library artist consumers. */
+export function buildLibraryAlbumWhere(
+    albumLocations: readonly AlbumLocation[],
+): Prisma.AlbumWhereInput {
+    const trackWhere = buildLibraryTrackWhere(albumLocations);
+    return {
+        location: { in: [...albumLocations] },
+        tracks: { some: trackWhere },
+    };
+}
+
+function buildArtistWhere(
+    options: LibraryArtistReadOptions,
+    albumWhere: Prisma.AlbumWhereInput,
+): Prisma.ArtistWhereInput {
+    const { lookup } = options;
+    const identityWhere =
+        lookup.name === undefined && lookup.mbid === undefined
+            ? { id: lookup.id }
+            : {
+                  OR: [
+                      { id: lookup.id },
+                      ...(lookup.name === undefined
+                          ? []
+                          : [
+                                {
+                                    name: {
+                                        equals: lookup.name,
+                                        mode: Prisma.QueryMode.insensitive,
+                                    },
+                                },
+                            ]),
+                      ...(lookup.mbid === undefined
+                          ? []
+                          : [{ mbid: lookup.mbid }]),
+                  ],
+              };
+    return options.requireVisibleAlbum
+        ? { ...identityWhere, albums: { some: albumWhere } }
+        : identityWhere;
+}
+
+const federationPeerSelect = {
+    id: true,
+    name: true,
+    outboundStatus: true,
+} as const;
+
+function buildAlbumRead(
+    options: LibraryArtistReadOptions,
+    albumWhere: Prisma.AlbumWhereInput,
+    trackWhere: Prisma.TrackWhereInput,
+) {
+    const trackTake =
+        options.maxTracksPerAlbum === undefined
+            ? {}
+            : { take: options.maxTracksPerAlbum };
+    const orderBy =
+        options.albumOrder === "year-title"
+            ? [{ year: Prisma.SortOrder.desc }, { title: Prisma.SortOrder.asc }]
+            : [{ year: Prisma.SortOrder.desc }];
+    return {
+        where: albumWhere,
+        orderBy,
+        include: {
+            federationPeer: { select: federationPeerSelect },
+            tracks: {
+                where: trackWhere,
+                orderBy: [
+                    { discNo: Prisma.SortOrder.asc },
+                    { trackNo: Prisma.SortOrder.asc },
+                ],
+                ...trackTake,
+                include: {
+                    federationPeer: { select: federationPeerSelect },
+                    album: {
+                        select: {
+                            id: true,
+                            title: true,
+                            coverUrl: true,
+                            albumLoudnessLufs: true,
+                            albumTruePeakDb: true,
+                            artist: {
+                                select: { id: true, name: true, mbid: true },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+/**
+ * Reads an artist and its visible albums for library-facing serializers.
+ * Callers own transport parsing and response mapping.
+ */
+export async function readLibraryArtist(options: LibraryArtistReadOptions) {
+    const trackWhere = buildLibraryTrackWhere(options.albumLocations);
+    const albumWhere = buildLibraryAlbumWhere(options.albumLocations);
+    return prisma.artist.findFirst({
+        where: buildArtistWhere(options, albumWhere),
+        include: {
+            albums: buildAlbumRead(options, albumWhere, trackWhere),
+            ownedAlbums: true,
+            federationPeer: { select: federationPeerSelect },
+        },
+    });
+}

--- a/backend/src/services/librarySearchReads.ts
+++ b/backend/src/services/librarySearchReads.ts
@@ -1,0 +1,223 @@
+import { type AlbumLocation, Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import {
+    buildLibraryAlbumWhere,
+    buildLibraryTrackWhere,
+} from "./libraryArtistReads";
+
+interface PageSlice {
+    limit: number;
+    offset: number;
+}
+
+/** Independent entity slices and visibility scope for a library music search. */
+export interface LibraryMusicSearchOptions {
+    query: string;
+    albumLocations: readonly AlbumLocation[];
+    artists: PageSlice;
+    albums: PageSlice;
+    tracks: PageSlice;
+}
+
+const trackSelect = Prisma.validator<Prisma.TrackSelect>()({
+    id: true,
+    title: true,
+    trackNo: true,
+    discNo: true,
+    duration: true,
+    fileSize: true,
+    mime: true,
+    filePath: true,
+    loudnessLufs: true,
+    truePeakDb: true,
+    album: {
+        select: {
+            id: true,
+            title: true,
+            year: true,
+            coverUrl: true,
+            location: true,
+            genres: true,
+            userGenres: true,
+            albumLoudnessLufs: true,
+            albumTruePeakDb: true,
+            artist: { select: { id: true, name: true } },
+        },
+    },
+});
+
+/** Track fields required by transport-specific library serializers. */
+export type LibrarySearchTrack = Prisma.TrackGetPayload<{
+    select: typeof trackSelect;
+}>;
+
+/** Neutral artist search projection. */
+export interface LibrarySearchArtist {
+    id: string;
+    name: string;
+    heroUrl: string | null;
+    albumCount: number;
+}
+
+/** Neutral album search projection with visible-track aggregates. */
+export interface LibrarySearchAlbum {
+    id: string;
+    title: string;
+    year: number | null;
+    lastSynced: Date;
+    coverUrl: string | null;
+    location: AlbumLocation;
+    genres: Prisma.JsonValue;
+    userGenres: Prisma.JsonValue;
+    artist: { id: string; name: string };
+    songCount: number;
+    duration: number;
+    trackIds: string[];
+}
+
+/** Neutral artist, album, and track search result. */
+export interface LibraryMusicSearchResult {
+    artists: LibrarySearchArtist[];
+    albums: LibrarySearchAlbum[];
+    tracks: LibrarySearchTrack[];
+}
+
+function contains(value: string) {
+    return { contains: value, mode: Prisma.QueryMode.insensitive };
+}
+
+function searchArtists(
+    options: LibraryMusicSearchOptions,
+    albumWhere: Prisma.AlbumWhereInput,
+) {
+    return prisma.artist.findMany({
+        where: {
+            albums: { some: albumWhere },
+            ...(options.query ? { name: contains(options.query) } : {}),
+        },
+        select: {
+            id: true,
+            name: true,
+            heroUrl: true,
+            _count: { select: { albums: { where: albumWhere } } },
+        },
+        orderBy: { name: Prisma.SortOrder.asc },
+        take: options.artists.limit,
+        skip: options.artists.offset,
+    });
+}
+
+function searchAlbums(
+    options: LibraryMusicSearchOptions,
+    albumWhere: Prisma.AlbumWhereInput,
+    trackWhere: Prisma.TrackWhereInput,
+) {
+    const queryWhere = options.query
+        ? {
+              OR: [
+                  { title: contains(options.query) },
+                  { artist: { name: contains(options.query) } },
+              ],
+          }
+        : {};
+    return prisma.album.findMany({
+        where: { ...albumWhere, ...queryWhere },
+        select: {
+            id: true,
+            title: true,
+            year: true,
+            lastSynced: true,
+            coverUrl: true,
+            location: true,
+            genres: true,
+            userGenres: true,
+            artist: { select: { id: true, name: true } },
+            tracks: {
+                where: trackWhere,
+                select: { id: true, duration: true },
+            },
+            _count: { select: { tracks: { where: trackWhere } } },
+        },
+        orderBy: { title: Prisma.SortOrder.asc },
+        take: options.albums.limit,
+        skip: options.albums.offset,
+    });
+}
+
+function searchTracks(
+    options: LibraryMusicSearchOptions,
+    trackWhere: Prisma.TrackWhereInput,
+) {
+    const queryWhere = options.query
+        ? {
+              OR: [
+                  { title: contains(options.query) },
+                  { album: { title: contains(options.query) } },
+                  {
+                      album: {
+                          artist: { name: contains(options.query) },
+                      },
+                  },
+              ],
+          }
+        : {};
+    return prisma.track.findMany({
+        where: { ...trackWhere, ...queryWhere },
+        select: trackSelect,
+        orderBy: [
+            { title: Prisma.SortOrder.asc },
+            { id: Prisma.SortOrder.asc },
+        ],
+        take: options.tracks.limit,
+        skip: options.tracks.offset,
+    });
+}
+
+type AlbumRow = Awaited<ReturnType<typeof searchAlbums>>[number];
+
+function mapAlbum(album: AlbumRow): LibrarySearchAlbum {
+    return {
+        id: album.id,
+        title: album.title,
+        year: album.year,
+        lastSynced: album.lastSynced,
+        coverUrl: album.coverUrl,
+        location: album.location,
+        genres: album.genres,
+        userGenres: album.userGenres,
+        artist: album.artist,
+        songCount: album._count.tracks,
+        duration: album.tracks.reduce(
+            (sum, track) => sum + (track.duration ?? 0),
+            0,
+        ),
+        trackIds: album.tracks.map((track) => track.id),
+    };
+}
+
+/**
+ * Searches the local library read model with independent entity paging.
+ * Empty queries intentionally list the selected library scope.
+ */
+export async function searchLibraryMusic(
+    options: LibraryMusicSearchOptions,
+): Promise<LibraryMusicSearchResult> {
+    const albumWhere = buildLibraryAlbumWhere(options.albumLocations);
+    const trackWhere = buildLibraryTrackWhere(options.albumLocations);
+    const [artists, albums, tracks] = await Promise.all([
+        searchArtists(options, albumWhere),
+        searchAlbums(options, albumWhere, trackWhere),
+        searchTracks(options, trackWhere),
+    ]);
+
+    return {
+        artists: artists.map((artist) => ({
+            id: artist.id,
+            name: artist.name,
+            heroUrl: artist.heroUrl,
+            albumCount: artist._count.albums,
+        })),
+        albums: albums.map(mapAlbum),
+        tracks,
+    };
+}

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -55,7 +55,6 @@ const FIXED_SCAN_ROOTS = Object.freeze([
 const BASELINE = Object.freeze({
     "backend/src/routes/browse.ts": 1540,
     "backend/src/routes/enrichment.ts": 2261,
-    "backend/src/routes/library/artists.ts": 1525,
     "backend/src/routes/library/radio.ts": 1563,
     "backend/src/routes/library/tracks.ts": 1655,
     "backend/src/routes/playlists.ts": 2262,


### PR DESCRIPTION
## Problem (#796)

`routes/subsonic/` re-implemented the library read model (8,726 LOC, ~78 inline prisma sites, zero imports from library routes): `handleSearch3` (278 lines) never imported `services/search`; both surfaces maintained parallel `getArtist` query shapes. Library-semantics changes had to land twice.

## Change (the two slices the issue names — rest follows incrementally)

- **search3** → neutral `librarySearchReads` service (net **−159** route lines). Subsonic's real semantic differences are preserved as documented parameters, not forked queries: alphabetical substring matching, independent per-entity counts/offsets, unbounded offsets, blank-query scope listing, LIBRARY/FEDERATED only.
- **getArtist** → shared `libraryArtistReads` consumed by BOTH the library route and subsonic (net **−90**), parameterized per surface (lookup keys, ordering, album-required, track limits).
- **Divergence guard:** a test pins both handlers to the shared services — a future visibility change compiles/tests through one seam.
- `artists.ts` 1,525 → 1,469: dropped from the size baseline entirely.

## Verification

- `verify:` compat suites **byte-identical**: 11 suites / 293 tests pass before AND after, zero fixture or docs changes
- `verify:` **full backend suite post-rebase: 501/501 suites, 7,567 tests pass**
- `verify:` artist runtime 4/87; search 6/76; new service + guard 2/3; `tsc` exit 0; format/file-size/routes-readme clean

Closes #796