### PR TITLE
chore(routes): shared validate/pagination/ownership middlewares; enrichment and youtubeMusic converted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Subsonic search and artist views now share the main library's data layer.
+- Internal route handling now shares validation, pagination, and ownership middleware, and enrichment and YouTube Music administrator errors use the documented response format.
 - App screens now share one catalog of data-cache keys, so library, playlist, download, and notification views refresh reliably after changes instead of occasionally showing stale lists.
 - `DISCOVERY_MODE=legacy` remains accepted but now serves the modern discovery implementation and logs one deprecation warning at process startup (#795).
 - The TIDAL streamer now uses focused internal modules, and all Python sidecars use one shared-package import prefix without changing their HTTP APIs.

--- a/backend/src/__tests__/enrichmentRouteAuthz.test.ts
+++ b/backend/src/__tests__/enrichmentRouteAuthz.test.ts
@@ -152,6 +152,12 @@ jest.mock("../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/middleware/__tests__/loadOwned.test.ts
+++ b/backend/src/middleware/__tests__/loadOwned.test.ts
@@ -1,0 +1,80 @@
+jest.mock("../../utils/db", () => ({
+    prisma: { playlist: { findUnique: jest.fn() } },
+}));
+
+import type { NextFunction, Request, Response } from "express";
+import { prisma } from "../../utils/db";
+import { loadOwned } from "../loadOwned";
+
+const findUnique = prisma.playlist.findUnique as jest.Mock;
+
+function createResponse() {
+    const response = { status: jest.fn(), json: jest.fn() };
+    response.status.mockReturnValue(response);
+    response.json.mockReturnValue(response);
+    return response;
+}
+
+async function run(resource: unknown) {
+    findUnique.mockResolvedValue(resource);
+    const req = {
+        params: { id: "playlist-1" },
+        user: { id: "user-1", username: "alice", role: "user" },
+    } as unknown as Request;
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+    await loadOwned("playlist")(req, res as unknown as Response, next);
+    return { req, res, next };
+}
+
+describe("loadOwned middleware", () => {
+    beforeEach(() => findUnique.mockReset());
+
+    it("loads an owned resource onto req.owned", async () => {
+        const resource = { id: "playlist-1", userId: "user-1" };
+        const { req, next } = await run(resource);
+
+        expect(req.owned).toEqual(resource);
+        expect(findUnique).toHaveBeenCalledWith({
+            where: { id: "playlist-1" },
+        });
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it("uses a custom route parameter as the model id", async () => {
+        findUnique.mockResolvedValue({ id: "playlist-2", userId: "user-1" });
+        const req = {
+            params: { playlistId: "playlist-2" },
+            user: { id: "user-1", username: "alice", role: "user" },
+        } as unknown as Request;
+
+        await loadOwned("playlist", "playlistId")(
+            req,
+            createResponse() as unknown as Response,
+            jest.fn(),
+        );
+
+        expect(findUnique).toHaveBeenCalledWith({
+            where: { id: "playlist-2" },
+        });
+    });
+
+    it("returns 404 when the resource is missing", async () => {
+        const { res, next } = await run(null);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: "Playlist not found" });
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the resource belongs to another user", async () => {
+        const { res, next } = await run({
+            id: "playlist-1",
+            userId: "user-2",
+        });
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({ error: "Access denied" });
+        expect(next).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/middleware/__tests__/parsePagination.test.ts
+++ b/backend/src/middleware/__tests__/parsePagination.test.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from "express";
+import { parsePagination } from "../parsePagination";
+
+function run(query: Record<string, unknown>, options = {}) {
+    const req = { query } as unknown as Request;
+    const next = jest.fn();
+    parsePagination(options)(req, {} as Response, next);
+    return { req, next };
+}
+
+describe("parsePagination middleware", () => {
+    it("uses bounded defaults", () => {
+        const { req, next } = run({});
+
+        expect(req.pagination).toEqual({ limit: 100, offset: 0 });
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it("clamps an over-limit value and a negative offset", () => {
+        const { req } = run(
+            { limit: "999", offset: "-8" },
+            { defaultLimit: 25, maxLimit: 50 },
+        );
+
+        expect(req.pagination).toEqual({ limit: 50, offset: 0 });
+    });
+
+    it("pins normalized values on req.query", () => {
+        const { req } = run({ limit: "nope", offset: "4" });
+
+        expect(req.query).toEqual({ limit: "100", offset: "4" });
+    });
+});

--- a/backend/src/middleware/__tests__/validate.test.ts
+++ b/backend/src/middleware/__tests__/validate.test.ts
@@ -1,0 +1,56 @@
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import { validate } from "../validate";
+
+function createResponse() {
+    const response = {
+        status: jest.fn(),
+        json: jest.fn(),
+    };
+    response.status.mockReturnValue(response);
+    response.json.mockReturnValue(response);
+    return response;
+}
+
+describe("validate middleware", () => {
+    const schema = {
+        body: z.object({ name: z.string().trim().min(1) }),
+        query: z.object({ limit: z.coerce.number().int().positive() }),
+        params: z.object({ id: z.string().min(1) }),
+    };
+
+    it("parses all request boundaries and pins the Express 5 query", () => {
+        const req = {
+            body: { name: "  Alice  " },
+            query: { limit: "7" },
+            params: { id: "artist-1" },
+        } as unknown as Request;
+        const next = jest.fn();
+
+        validate(schema)(req, createResponse() as unknown as Response, next);
+
+        expect(req.valid).toEqual({
+            body: { name: "Alice" },
+            query: { limit: 7 },
+            params: { id: "artist-1" },
+        });
+        expect(req.query).toEqual({ limit: 7 });
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it("returns the canonical 400 response for an invalid body", () => {
+        const req = {
+            body: { name: "" },
+            query: { limit: "7" },
+            params: { id: "artist-1" },
+        } as unknown as Request;
+        const res = createResponse();
+        const next = jest.fn() as NextFunction;
+
+        validate(schema)(req, res as unknown as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "Invalid request" });
+        expect(next).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/middleware/loadOwned.ts
+++ b/backend/src/middleware/loadOwned.ts
@@ -1,0 +1,63 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { prisma } from "../utils/db";
+import { sendRouteError } from "../utils/routeErrorResponse";
+
+const OWNED_MODEL_LABELS = {
+    downloadJob: "Download job",
+    importJob: "Import job",
+    musicRequest: "Music request",
+    playlist: "Playlist",
+    shareLink: "Share link",
+    spotifyImportJob: "Import job",
+} as const;
+
+export type OwnedModel = keyof typeof OWNED_MODEL_LABELS;
+
+export interface OwnedResource {
+    id: string;
+    userId: string;
+    [key: string]: unknown;
+}
+
+interface OwnedDelegate {
+    findUnique(args: {
+        where: Record<string, string>;
+    }): Promise<OwnedResource | null>;
+}
+
+function ownedDelegate(model: OwnedModel): OwnedDelegate {
+    const delegates = prisma as unknown as Record<OwnedModel, OwnedDelegate>;
+    return delegates[model];
+}
+
+/** Loads a user-owned Prisma model by route parameter and enforces 404/403 semantics. */
+export function loadOwned(model: OwnedModel, param = "id"): RequestHandler {
+    return async (
+        req: Request,
+        res: Response,
+        next: NextFunction,
+    ): Promise<void> => {
+        if (!req.user) {
+            sendRouteError(res, 401, "Not authenticated");
+            return;
+        }
+        const resourceId = req.params[param];
+        if (typeof resourceId !== "string" || resourceId.length === 0) {
+            sendRouteError(res, 400, "Invalid request");
+            return;
+        }
+        const resource = await ownedDelegate(model).findUnique({
+            where: { id: resourceId },
+        });
+        if (!resource) {
+            sendRouteError(res, 404, `${OWNED_MODEL_LABELS[model]} not found`);
+            return;
+        }
+        if (resource.userId !== req.user.id) {
+            sendRouteError(res, 403, "Access denied");
+            return;
+        }
+        req.owned = resource;
+        next();
+    };
+}

--- a/backend/src/middleware/parsePagination.ts
+++ b/backend/src/middleware/parsePagination.ts
@@ -1,0 +1,58 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+export interface Pagination {
+    limit: number;
+    offset: number;
+}
+
+export interface PaginationOptions {
+    defaultLimit?: number;
+    maxLimit?: number;
+}
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 100;
+
+function positiveInteger(value: unknown, fallback: number): number {
+    if (typeof value !== "string" || !/^\d+$/.test(value)) return fallback;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nonNegativeInteger(value: unknown): number {
+    if (typeof value !== "string" || !/^\d+$/.test(value)) return 0;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isSafeInteger(parsed) ? parsed : 0;
+}
+
+/** Parses and clamps `limit`/`offset`, then pins normalized Express 5 query values. */
+export function parsePagination(
+    options: PaginationOptions = {},
+): RequestHandler {
+    const maxLimit = Math.max(1, Math.floor(options.maxLimit ?? MAX_LIMIT));
+    const defaultLimit = Math.min(
+        maxLimit,
+        Math.max(1, Math.floor(options.defaultLimit ?? DEFAULT_LIMIT)),
+    );
+
+    return (req: Request, _res: Response, next: NextFunction): void => {
+        const pagination = {
+            limit: Math.min(
+                positiveInteger(req.query.limit, defaultLimit),
+                maxLimit,
+            ),
+            offset: nonNegativeInteger(req.query.offset),
+        };
+        const query = {
+            ...req.query,
+            limit: String(pagination.limit),
+            offset: String(pagination.offset),
+        };
+        req.pagination = pagination;
+        Object.defineProperty(req, "query", {
+            configurable: true,
+            value: query,
+        });
+        next();
+    };
+}

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,59 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { z } from "zod";
+import { sendRouteError } from "../utils/routeErrorResponse";
+
+export interface ValidationSchemas {
+    body?: z.ZodType;
+    query?: z.ZodType;
+    params?: z.ZodType;
+}
+
+type ParsedSchemas<S extends ValidationSchemas> = {
+    [K in keyof S]: S[K] extends z.ZodType ? z.output<S[K]> : never;
+};
+
+export type ValidatedRequest<S extends ValidationSchemas> = Request & {
+    valid: ParsedSchemas<S>;
+};
+
+function parseRequestPart(
+    schema: z.ZodType | undefined,
+    value: unknown,
+): unknown {
+    return schema ? schema.parse(value) : undefined;
+}
+
+/** Parses selected request boundaries and exposes their typed values on `req.valid`. */
+export function validate<S extends ValidationSchemas>(
+    schemas: S,
+): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        try {
+            const valid = {
+                ...(schemas.body
+                    ? { body: parseRequestPart(schemas.body, req.body) }
+                    : {}),
+                ...(schemas.query
+                    ? { query: parseRequestPart(schemas.query, req.query) }
+                    : {}),
+                ...(schemas.params
+                    ? { params: parseRequestPart(schemas.params, req.params) }
+                    : {}),
+            };
+            req.valid = valid;
+            if (valid.query !== undefined) {
+                Object.defineProperty(req, "query", {
+                    configurable: true,
+                    value: valid.query,
+                });
+            }
+            next();
+        } catch (error) {
+            if (error instanceof z.ZodError) {
+                sendRouteError(res, 400, "Invalid request");
+                return;
+            }
+            next(error);
+        }
+    };
+}

--- a/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMetadataCompat.test.ts
@@ -150,7 +150,7 @@ const mockRedisDel = redisClient.del as jest.Mock;
 function getHandler(
     path: string,
     method: "get" | "put" | "post",
-    stackIndex = 0,
+    stackIndex = -1,
 ) {
     const layer = (router as any).stack.find(
         (entry: any) =>
@@ -161,7 +161,9 @@ function getHandler(
         throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
     }
 
-    return layer.route.stack[stackIndex].handle;
+    const resolvedIndex =
+        stackIndex < 0 ? layer.route.stack.length - 1 : stackIndex;
+    return layer.route.stack[resolvedIndex].handle;
 }
 
 function createRes() {

--- a/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
+++ b/backend/src/routes/__tests__/enrichmentMusicBrainzLookupCompat.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/enrichmentRepairCovers.test.ts
+++ b/backend/src/routes/__tests__/enrichmentRepairCovers.test.ts
@@ -11,6 +11,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 

--- a/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
+++ b/backend/src/routes/__tests__/youtubeMusicRuntime.test.ts
@@ -501,7 +501,7 @@ describe("youtube music route runtime behavior", () => {
         const errorRes = createRes();
         await deviceCodeHandler(req, errorRes);
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "init failed" });
+        expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("polls device auth with validation, pending, success, and error branches", async () => {
@@ -569,7 +569,7 @@ describe("youtube music route runtime behavior", () => {
             errorRes,
         );
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "poll failed" });
+        expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("validates save-token payload and persists encrypted oauth", async () => {
@@ -625,7 +625,7 @@ describe("youtube music route runtime behavior", () => {
             errorRes,
         );
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "restore failed" });
+        expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("clears auth for sidecar and db and maps failures", async () => {
@@ -648,7 +648,7 @@ describe("youtube music route runtime behavior", () => {
         const errorRes = createRes();
         await clearAuthHandler(req, errorRes);
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "clear failed" });
+        expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("handles search validation, success, auth failures, and generic errors", async () => {
@@ -700,7 +700,7 @@ describe("youtube music route runtime behavior", () => {
             errorRes,
         );
         expect(errorRes.statusCode).toBe(500);
-        expect(errorRes.body).toEqual({ error: "search crashed" });
+        expect(errorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("covers album/artist/song auth and detail fallback branches", async () => {
@@ -747,7 +747,7 @@ describe("youtube music route runtime behavior", () => {
             albumDetailRes,
         );
         expect(albumDetailRes.statusCode).toBe(500);
-        expect(albumDetailRes.body).toEqual({ error: "album failed to load" });
+        expect(albumDetailRes.body).toEqual({ error: "Internal server error" });
 
         ytMusicService.getArtist.mockRejectedValueOnce({
             response: { status: 401 },
@@ -771,7 +771,9 @@ describe("youtube music route runtime behavior", () => {
             artistDetailRes,
         );
         expect(artistDetailRes.statusCode).toBe(500);
-        expect(artistDetailRes.body).toEqual({ error: "artist lookup failed" });
+        expect(artistDetailRes.body).toEqual({
+            error: "Internal server error",
+        });
 
         ytMusicService.getSong.mockRejectedValueOnce({
             response: { status: 401 },
@@ -795,7 +797,7 @@ describe("youtube music route runtime behavior", () => {
             songDetailRes,
         );
         expect(songDetailRes.statusCode).toBe(500);
-        expect(songDetailRes.body).toEqual({ error: "song failed to load" });
+        expect(songDetailRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("covers library albums auth and detail fallback branches", async () => {
@@ -829,7 +831,7 @@ describe("youtube music route runtime behavior", () => {
         );
         expect(albumsDetailRes.statusCode).toBe(500);
         expect(albumsDetailRes.body).toEqual({
-            error: "library albums failed",
+            error: "Internal server error",
         });
     });
 
@@ -1207,7 +1209,7 @@ describe("youtube music route runtime behavior", () => {
             songsErrorRes,
         );
         expect(songsErrorRes.statusCode).toBe(500);
-        expect(songsErrorRes.body).toEqual({ error: "library songs failed" });
+        expect(songsErrorRes.body).toEqual({ error: "Internal server error" });
     });
 
     it("covers match and match-batch validation, success, and failure paths", async () => {

--- a/backend/src/routes/enrichment.ts
+++ b/backend/src/routes/enrichment.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { logger } from "../utils/logger";
 import { requireAuth, requireAdmin } from "../middleware/auth";
+import { asyncHandler } from "../middleware/asyncHandler";
+import { validate } from "../middleware/validate";
 import { enrichmentService } from "../services/enrichment";
 import {
     getEnrichmentProgress,
@@ -20,16 +22,18 @@ import {
     type EnrichmentFailure,
 } from "../services/enrichmentFailureService";
 import { sanitizeEnrichmentErrorSummary } from "../utils/enrichmentErrorSummary";
-import { musicBrainzService } from "../services/musicbrainz";
+import {
+    musicBrainzService,
+    type MusicBrainzArtistSearchResult,
+    type MusicBrainzReleaseGroupSearchResult,
+} from "../services/musicbrainz";
 import { coverArtService } from "../services/coverArt";
 import {
     getSystemSettings,
     invalidateSystemSettingsCache,
 } from "../utils/systemSettings";
 import { rateLimiter } from "../services/rateLimiter";
-import { redisClient } from "../utils/redis";
 import { prisma } from "../utils/db";
-import { TRACK_VISIBLE_WHERE } from "../utils/librarySorting";
 import { config } from "../config";
 import { sendFeatureDisabled } from "../utils/featureGate";
 import { parseBoundedInt } from "../utils/queryParams";
@@ -38,7 +42,15 @@ import {
     sendRouteError,
 } from "../utils/routeErrorResponse";
 import { invalidateVibeAnalysis } from "../services/vibeInvalidation";
-import { updateAlbumMetadataWithOwnership } from "../services/albumMetadataPersistence";
+import {
+    applyMetadataOverrides,
+    albumMetadataSchema,
+    artistMetadataSchema,
+    MetadataEntityNotFoundError,
+    resetMetadataOverrides,
+    trackMetadataSchema,
+    type MetadataFieldMap,
+} from "../services/metadataOverrideActions";
 import {
     applyArtistEnrichmentFields,
     enrichArtistFields,
@@ -52,15 +64,57 @@ router.use(requireAuth);
 const MBID_FORMAT_EXAMPLE = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 const MBID_UUID_REGEX =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ARTIST_METADATA_FIELDS: MetadataFieldMap = {
+    name: { target: "displayName" },
+    bio: { target: "userSummary" },
+    genres: { target: "userGenres" },
+    heroUrl: { target: "userHeroUrl" },
+    mbid: { target: "mbid", marksOverride: false },
+};
+const ALBUM_METADATA_FIELDS: MetadataFieldMap = {
+    title: { target: "displayTitle" },
+    year: {
+        target: "displayYear",
+        transform: (value) => parseInt(String(value)),
+    },
+    genres: { target: "userGenres" },
+    coverUrl: { target: "userCoverUrl" },
+    rgMbid: { target: "rgMbid", marksOverride: false },
+};
+const TRACK_METADATA_FIELDS: MetadataFieldMap = {
+    title: { target: "displayTitle" },
+    trackNo: {
+        target: "displayTrackNo",
+        transform: (value) => parseInt(String(value)),
+    },
+};
 
 function isValidMusicBrainzId(value: string): boolean {
     return MBID_UUID_REGEX.test(value);
+}
+
+function getErrorCode(error: unknown): string | undefined {
+    if (typeof error !== "object" || error === null || !("code" in error)) {
+        return undefined;
+    }
+    return typeof error.code === "string" ? error.code : undefined;
 }
 
 type ClientSafeEnrichmentFailure = Omit<
     EnrichmentFailure,
     "errorMessage" | "metadata"
 > & { errorSummary: string | null };
+
+function isFailureEntityType(
+    value: unknown,
+): value is EnrichmentFailure["entityType"] {
+    return (
+        value === "artist" ||
+        value === "track" ||
+        value === "audio" ||
+        value === "vibe"
+    );
+}
 
 function toClientSafeEnrichmentFailure(
     failure: EnrichmentFailure,
@@ -101,15 +155,18 @@ function toClientSafeEnrichmentFailure(
  * GET /enrichment/progress
  * Get comprehensive enrichment progress (artists, track tags, audio analysis)
  */
-router.get("/progress", async (req, res) => {
-    try {
-        const progress = await getEnrichmentProgress();
-        res.json(progress);
-    } catch (error) {
-        logger.error("Get enrichment progress error:", error);
-        res.status(500).json({ error: "Failed to get progress" });
-    }
-});
+router.get(
+    "/progress",
+    asyncHandler(async (req, res) => {
+        try {
+            const progress = await getEnrichmentProgress();
+            res.json(progress);
+        } catch (error) {
+            logger.error("Get enrichment progress error:", error);
+            sendInternalRouteError(res, "Failed to get progress");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -129,23 +186,26 @@ router.get("/progress", async (req, res) => {
  * GET /enrichment/status
  * Get detailed enrichment state (running, paused, etc.)
  */
-router.get("/status", async (req, res) => {
-    try {
-        const state = await enrichmentStateService.getState();
-        const idleState: EnrichmentState = {
-            status: "idle",
-            currentPhase: null,
-            lastActivity: new Date().toISOString(),
-            artists: { total: 0, completed: 0, failed: 0 },
-            tracks: { total: 0, completed: 0, failed: 0 },
-            audio: { total: 0, completed: 0, failed: 0, processing: 0 },
-        };
-        res.json(state || idleState);
-    } catch (error) {
-        logger.error("Get enrichment status error:", error);
-        res.status(500).json({ error: "Failed to get status" });
-    }
-});
+router.get(
+    "/status",
+    asyncHandler(async (req, res) => {
+        try {
+            const state = await enrichmentStateService.getState();
+            const idleState: EnrichmentState = {
+                status: "idle",
+                currentPhase: null,
+                lastActivity: new Date().toISOString(),
+                artists: { total: 0, completed: 0, failed: 0 },
+                tracks: { total: 0, completed: 0, failed: 0 },
+                audio: { total: 0, completed: 0, failed: 0, processing: 0 },
+            };
+            res.json(state || idleState);
+        } catch (error) {
+            logger.error("Get enrichment status error:", error);
+            sendInternalRouteError(res, "Failed to get status");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -169,20 +229,24 @@ router.get("/status", async (req, res) => {
  * POST /enrichment/pause
  * Pause the enrichment process
  */
-router.post("/pause", requireAdmin, async (req, res) => {
-    try {
-        const state = await enrichmentStateService.pause();
-        res.json({
-            message: "Enrichment paused",
-            state,
-        });
-    } catch (error: any) {
-        logger.error("Pause enrichment error:", error);
-        res.status(400).json({
-            error: "Failed to pause enrichment",
-        });
-    }
-});
+router.post(
+    "/pause",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const state = await enrichmentStateService.pause();
+            res.json({
+                message: "Enrichment paused",
+                state,
+            });
+        } catch (error: unknown) {
+            logger.error("Pause enrichment error:", error);
+            res.status(400).json({
+                error: "Failed to pause enrichment",
+            });
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -206,20 +270,24 @@ router.post("/pause", requireAdmin, async (req, res) => {
  * POST /enrichment/resume
  * Resume a paused enrichment process
  */
-router.post("/resume", requireAdmin, async (req, res) => {
-    try {
-        const state = await enrichmentStateService.resume();
-        res.json({
-            message: "Enrichment resumed",
-            state,
-        });
-    } catch (error: any) {
-        logger.error("Resume enrichment error:", error);
-        res.status(400).json({
-            error: "Failed to resume enrichment",
-        });
-    }
-});
+router.post(
+    "/resume",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const state = await enrichmentStateService.resume();
+            res.json({
+                message: "Enrichment resumed",
+                state,
+            });
+        } catch (error: unknown) {
+            logger.error("Resume enrichment error:", error);
+            res.status(400).json({
+                error: "Failed to resume enrichment",
+            });
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -243,20 +311,24 @@ router.post("/resume", requireAdmin, async (req, res) => {
  * POST /enrichment/stop
  * Stop the enrichment process
  */
-router.post("/stop", requireAdmin, async (req, res) => {
-    try {
-        const state = await enrichmentStateService.stop();
-        res.json({
-            message: "Enrichment stopping...",
-            state,
-        });
-    } catch (error: any) {
-        logger.error("Stop enrichment error:", error);
-        res.status(400).json({
-            error: "Failed to stop enrichment",
-        });
-    }
-});
+router.post(
+    "/stop",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const state = await enrichmentStateService.stop();
+            res.json({
+                message: "Enrichment stopping...",
+                state,
+            });
+        } catch (error: unknown) {
+            logger.error("Stop enrichment error:", error);
+            res.status(400).json({
+                error: "Failed to stop enrichment",
+            });
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -291,33 +363,37 @@ router.post("/stop", requireAdmin, async (req, res) => {
  * Trigger full enrichment (re-enriches everything regardless of status)
  * Admin only
  */
-router.post("/full", requireAdmin, async (req, res) => {
-    try {
-        const forceVibeRebuild = req.body?.forceVibeRebuild === true;
-        const forceMoodBucketBackfill =
-            req.body?.forceMoodBucketBackfill === true;
+router.post(
+    "/full",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const forceVibeRebuild = req.body?.forceVibeRebuild === true;
+            const forceMoodBucketBackfill =
+                req.body?.forceMoodBucketBackfill === true;
 
-        // This runs in the background
-        runFullEnrichment({
-            forceVibeRebuild,
-            forceMoodBucketBackfill,
-        }).catch((err) => {
-            logger.error("Full enrichment error:", err);
-        });
+            // This runs in the background
+            runFullEnrichment({
+                forceVibeRebuild,
+                forceMoodBucketBackfill,
+            }).catch((err) => {
+                logger.error("Full enrichment error:", err);
+            });
 
-        res.json({
-            message: "Full enrichment started",
-            description: forceVibeRebuild
-                ? "All artists, track tags, audio analysis, and CLAP embeddings will be re-processed"
-                : "All artists, track tags, and audio analysis will be re-processed",
-            forceVibeRebuild,
-            forceMoodBucketBackfill,
-        });
-    } catch (error) {
-        logger.error("Trigger full enrichment error:", error);
-        res.status(500).json({ error: "Failed to start full enrichment" });
-    }
-});
+            res.json({
+                message: "Full enrichment started",
+                description: forceVibeRebuild
+                    ? "All artists, track tags, audio analysis, and CLAP embeddings will be re-processed"
+                    : "All artists, track tags, and audio analysis will be re-processed",
+                forceVibeRebuild,
+                forceMoodBucketBackfill,
+            });
+        } catch (error) {
+            logger.error("Trigger full enrichment error:", error);
+            sendInternalRouteError(res, "Failed to start full enrichment");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -340,20 +416,24 @@ router.post("/full", requireAdmin, async (req, res) => {
  * Reset only artist enrichment (keeps mood tags and audio analysis intact)
  * Admin only - selective re-enrichment for large libraries
  */
-router.post("/reset-artists", requireAdmin, async (req, res) => {
-    try {
-        const result = await reRunArtistsOnly();
+router.post(
+    "/reset-artists",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const result = await reRunArtistsOnly();
 
-        res.json({
-            message: "Artist enrichment reset",
-            description: `${result.count} artists queued for re-enrichment`,
-            count: result.count,
-        });
-    } catch (error) {
-        logger.error("Reset artists error:", error);
-        res.status(500).json({ error: "Failed to reset artist enrichment" });
-    }
-});
+            res.json({
+                message: "Artist enrichment reset",
+                description: `${result.count} artists queued for re-enrichment`,
+                count: result.count,
+            });
+        } catch (error) {
+            logger.error("Reset artists error:", error);
+            sendInternalRouteError(res, "Failed to reset artist enrichment");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -376,20 +456,24 @@ router.post("/reset-artists", requireAdmin, async (req, res) => {
  * Reset only mood tags (keeps artist metadata and audio analysis intact)
  * Admin only - selective re-enrichment for large libraries
  */
-router.post("/reset-mood-tags", requireAdmin, async (req, res) => {
-    try {
-        const result = await reRunMoodTagsOnly();
+router.post(
+    "/reset-mood-tags",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const result = await reRunMoodTagsOnly();
 
-        res.json({
-            message: "Mood tags reset",
-            description: `${result.count} tracks queued for mood tag re-enrichment`,
-            count: result.count,
-        });
-    } catch (error) {
-        logger.error("Reset mood tags error:", error);
-        res.status(500).json({ error: "Failed to reset mood tags" });
-    }
-});
+            res.json({
+                message: "Mood tags reset",
+                description: `${result.count} tracks queued for mood tag re-enrichment`,
+                count: result.count,
+            });
+        } catch (error) {
+            logger.error("Reset mood tags error:", error);
+            sendInternalRouteError(res, "Failed to reset mood tags");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -416,24 +500,28 @@ router.post("/reset-mood-tags", requireAdmin, async (req, res) => {
  * Gated on config.features.audioAnalysis so disabled deployments never queue
  * analysis work that no consumer will drain.
  */
-router.post("/reset-audio-analysis", requireAdmin, async (req, res) => {
-    if (!config.features.audioAnalysis) {
-        sendFeatureDisabled(res);
-        return;
-    }
-    try {
-        const queued = await reRunAudioAnalysisOnly();
+router.post(
+    "/reset-audio-analysis",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        if (!config.features.audioAnalysis) {
+            sendFeatureDisabled(res);
+            return;
+        }
+        try {
+            const queued = await reRunAudioAnalysisOnly();
 
-        res.json({
-            message: "Audio analysis reset",
-            description: `${queued} tracks queued for audio re-analysis`,
-            count: queued,
-        });
-    } catch (error) {
-        logger.error("Reset audio analysis error:", error);
-        res.status(500).json({ error: "Failed to reset audio analysis" });
-    }
-});
+            res.json({
+                message: "Audio analysis reset",
+                description: `${queued} tracks queued for audio re-analysis`,
+                count: queued,
+            });
+        } catch (error) {
+            logger.error("Reset audio analysis error:", error);
+            sendInternalRouteError(res, "Failed to reset audio analysis");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -460,24 +548,28 @@ router.post("/reset-audio-analysis", requireAdmin, async (req, res) => {
  * Gated on config.features.audioAnalysis (vibe/CLAP is part of the audio
  * analysis subsystem) so disabled deployments never queue undrained work.
  */
-router.post("/reset-vibe-embeddings", requireAdmin, async (req, res) => {
-    if (!config.features.audioAnalysis) {
-        sendFeatureDisabled(res);
-        return;
-    }
-    try {
-        const queued = await reRunVibeEmbeddingsOnly();
+router.post(
+    "/reset-vibe-embeddings",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        if (!config.features.audioAnalysis) {
+            sendFeatureDisabled(res);
+            return;
+        }
+        try {
+            const queued = await reRunVibeEmbeddingsOnly();
 
-        res.json({
-            message: "Vibe embeddings reset",
-            description: `${queued} tracks queued for vibe embedding re-analysis`,
-            count: queued,
-        });
-    } catch (error) {
-        logger.error("Reset vibe embeddings error:", error);
-        res.status(500).json({ error: "Failed to reset vibe embeddings" });
-    }
-});
+            res.json({
+                message: "Vibe embeddings reset",
+                description: `${queued} tracks queued for vibe embedding re-analysis`,
+                count: queued,
+            });
+        } catch (error) {
+            logger.error("Reset vibe embeddings error:", error);
+            sendInternalRouteError(res, "Failed to reset vibe embeddings");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -495,34 +587,38 @@ router.post("/reset-vibe-embeddings", requireAdmin, async (req, res) => {
  *       403:
  *         description: Admin access required
  */
-router.post("/repair-covers", requireAdmin, async (req, res) => {
-    try {
-        const albumsMissingCovers = await prisma.album.findMany({
-            where: {
-                OR: [{ coverUrl: null }, { coverUrl: "" }],
-            },
-            select: { id: true, rgMbid: true },
-        });
+router.post(
+    "/repair-covers",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const albumsMissingCovers = await prisma.album.findMany({
+                where: {
+                    OR: [{ coverUrl: null }, { coverUrl: "" }],
+                },
+                select: { id: true, rgMbid: true },
+            });
 
-        let cacheCleared = 0;
-        for (const album of albumsMissingCovers) {
-            if (album.rgMbid) {
-                await coverArtService.clearNotFoundCache(album.rgMbid);
-                cacheCleared++;
+            let cacheCleared = 0;
+            for (const album of albumsMissingCovers) {
+                if (album.rgMbid) {
+                    await coverArtService.clearNotFoundCache(album.rgMbid);
+                    cacheCleared++;
+                }
             }
-        }
 
-        res.json({
-            message: "Cover repair initiated",
-            description: `Found ${albumsMissingCovers.length} albums missing covers, cleared ${cacheCleared} stale cache entries. Covers will be re-fetched on next access.`,
-            albumsMissingCovers: albumsMissingCovers.length,
-            cacheEntriesCleared: cacheCleared,
-        });
-    } catch (error) {
-        logger.error("Cover repair error:", error);
-        res.status(500).json({ error: "Failed to repair covers" });
-    }
-});
+            res.json({
+                message: "Cover repair initiated",
+                description: `Found ${albumsMissingCovers.length} albums missing covers, cleared ${cacheCleared} stale cache entries. Covers will be re-fetched on next access.`,
+                albumsMissingCovers: albumsMissingCovers.length,
+                cacheEntriesCleared: cacheCleared,
+            });
+        } catch (error) {
+            logger.error("Cover repair error:", error);
+            sendInternalRouteError(res, "Failed to repair covers");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -545,22 +641,24 @@ router.post("/repair-covers", requireAdmin, async (req, res) => {
  * Trigger incremental enrichment (only processes pending items)
  * Fast sync that picks up new content without re-processing everything
  */
-router.post("/sync", requireAdmin, async (req, res) => {
-    try {
-        const result = await triggerEnrichmentNow();
+router.post(
+    "/sync",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const result = await triggerEnrichmentNow();
 
-        res.json({
-            message: "Incremental sync started",
-            description: "Processing new and pending items only",
-            result,
-        });
-    } catch (error: any) {
-        logger.error("Trigger sync error:", error);
-        res.status(500).json({
-            error: "Failed to start sync",
-        });
-    }
-});
+            res.json({
+                message: "Incremental sync started",
+                description: "Processing new and pending items only",
+                result,
+            });
+        } catch (error: unknown) {
+            logger.error("Trigger sync error:", error);
+            sendInternalRouteError(res, "Failed to start sync");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -580,16 +678,19 @@ router.post("/sync", requireAdmin, async (req, res) => {
  * GET /enrichment/settings
  * Get enrichment settings for current user
  */
-router.get("/settings", async (req, res) => {
-    try {
-        const userId = req.user!.id;
-        const settings = await enrichmentService.getSettings(userId);
-        res.json(settings);
-    } catch (error) {
-        logger.error("Get enrichment settings error:", error);
-        res.status(500).json({ error: "Failed to get settings" });
-    }
-});
+router.get(
+    "/settings",
+    asyncHandler(async (req, res) => {
+        try {
+            const userId = req.user!.id;
+            const settings = await enrichmentService.getSettings(userId);
+            res.json(settings);
+        } catch (error) {
+            logger.error("Get enrichment settings error:", error);
+            sendInternalRouteError(res, "Failed to get settings");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -616,19 +717,22 @@ router.get("/settings", async (req, res) => {
  * PUT /enrichment/settings
  * Update enrichment settings for current user
  */
-router.put("/settings", async (req, res) => {
-    try {
-        const userId = req.user!.id;
-        const settings = await enrichmentService.updateSettings(
-            userId,
-            req.body,
-        );
-        res.json(settings);
-    } catch (error) {
-        logger.error("Update enrichment settings error:", error);
-        res.status(500).json({ error: "Failed to update settings" });
-    }
-});
+router.put<{ id: string }>(
+    "/settings",
+    asyncHandler(async (req, res) => {
+        try {
+            const userId = req.user!.id;
+            const settings = await enrichmentService.updateSettings(
+                userId,
+                req.body,
+            );
+            res.json(settings);
+        } catch (error) {
+            logger.error("Update enrichment settings error:", error);
+            sendInternalRouteError(res, "Failed to update settings");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -662,35 +766,41 @@ router.put("/settings", async (req, res) => {
  * Enrich a single artist
  * Admin only - applies results library-wide and makes outbound metadata API calls
  */
-router.post<{ id: string }>("/artist/:id", requireAdmin, async (req, res) => {
-    try {
-        const userId = req.user!.id;
-        const settings = await enrichmentService.getSettings(userId);
+router.post<{ id: string }>(
+    "/artist/:id",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const userId = req.user!.id;
+            const settings = await enrichmentService.getSettings(userId);
 
-        if (!settings.enabled) {
-            return res.status(400).json({ error: "Enrichment is not enabled" });
+            if (!settings.enabled) {
+                return res
+                    .status(400)
+                    .json({ error: "Enrichment is not enabled" });
+            }
+
+            const enrichmentData = await enrichArtistFields(req.params.id);
+
+            if (!enrichmentData) {
+                return res
+                    .status(404)
+                    .json({ error: "No enrichment data found" });
+            }
+
+            await applyArtistEnrichmentFields(req.params.id, enrichmentData);
+
+            res.json({
+                success: true,
+                confidence: enrichmentData.confidence,
+                data: enrichmentData,
+            });
+        } catch (error: unknown) {
+            logger.error("Enrich artist error:", error);
+            sendInternalRouteError(res, "Failed to enrich artist");
         }
-
-        const enrichmentData = await enrichArtistFields(req.params.id);
-
-        if (!enrichmentData) {
-            return res.status(404).json({ error: "No enrichment data found" });
-        }
-
-        await applyArtistEnrichmentFields(req.params.id, enrichmentData);
-
-        res.json({
-            success: true,
-            confidence: enrichmentData.confidence,
-            data: enrichmentData,
-        });
-    } catch (error: any) {
-        logger.error("Enrich artist error:", error);
-        res.status(500).json({
-            error: "Failed to enrich artist",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -724,35 +834,41 @@ router.post<{ id: string }>("/artist/:id", requireAdmin, async (req, res) => {
  * Enrich a single album
  * Admin only - applies results library-wide and makes outbound metadata API calls
  */
-router.post<{ id: string }>("/album/:id", requireAdmin, async (req, res) => {
-    try {
-        const userId = req.user!.id;
-        const settings = await enrichmentService.getSettings(userId);
+router.post<{ id: string }>(
+    "/album/:id",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const userId = req.user!.id;
+            const settings = await enrichmentService.getSettings(userId);
 
-        if (!settings.enabled) {
-            return res.status(400).json({ error: "Enrichment is not enabled" });
+            if (!settings.enabled) {
+                return res
+                    .status(400)
+                    .json({ error: "Enrichment is not enabled" });
+            }
+
+            const enrichmentData = await enrichAlbumFields(req.params.id);
+
+            if (!enrichmentData) {
+                return res
+                    .status(404)
+                    .json({ error: "No enrichment data found" });
+            }
+
+            await applyAlbumEnrichmentFields(req.params.id, enrichmentData);
+
+            res.json({
+                success: true,
+                confidence: enrichmentData.confidence,
+                data: enrichmentData,
+            });
+        } catch (error: unknown) {
+            logger.error("Enrich album error:", error);
+            sendInternalRouteError(res, "Failed to enrich album");
         }
-
-        const enrichmentData = await enrichAlbumFields(req.params.id);
-
-        if (!enrichmentData) {
-            return res.status(404).json({ error: "No enrichment data found" });
-        }
-
-        await applyAlbumEnrichmentFields(req.params.id, enrichmentData);
-
-        res.json({
-            success: true,
-            confidence: enrichmentData.confidence,
-            data: enrichmentData,
-        });
-    } catch (error: any) {
-        logger.error("Enrich album error:", error);
-        res.status(500).json({
-            error: "Failed to enrich album",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -778,36 +894,37 @@ router.post<{ id: string }>("/album/:id", requireAdmin, async (req, res) => {
  * Delegates to the unified enrichment worker for consistent state tracking,
  * failure recording, and pause/stop support.
  */
-router.post("/start", requireAdmin, async (req, res) => {
-    try {
-        const { prisma } = await import("../utils/db");
-        const systemSettings = await prisma.systemSettings.findUnique({
-            where: { id: "default" },
-            select: { autoEnrichMetadata: true },
-        });
-
-        if (!systemSettings?.autoEnrichMetadata) {
-            return res.status(400).json({
-                error: "Enrichment is not enabled. Enable it in settings first.",
+router.post(
+    "/start",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const systemSettings = await prisma.systemSettings.findUnique({
+                where: { id: "default" },
+                select: { autoEnrichMetadata: true },
             });
+
+            if (!systemSettings?.autoEnrichMetadata) {
+                return res.status(400).json({
+                    error: "Enrichment is not enabled. Enable it in settings first.",
+                });
+            }
+
+            // Run via unified worker (handles state, failures, notifications)
+            runFullEnrichment().catch((err) => {
+                logger.error("Background enrichment failed:", err);
+            });
+
+            res.json({
+                success: true,
+                message: "Library enrichment started in background",
+            });
+        } catch (error: unknown) {
+            logger.error("Start enrichment error:", error);
+            sendInternalRouteError(res, "Failed to start enrichment");
         }
-
-        // Run via unified worker (handles state, failures, notifications)
-        runFullEnrichment().catch((err) => {
-            logger.error("Background enrichment failed:", err);
-        });
-
-        res.json({
-            success: true,
-            message: "Library enrichment started in background",
-        });
-    } catch (error: any) {
-        logger.error("Start enrichment error:", error);
-        res.status(500).json({
-            error: "Failed to start enrichment",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -838,36 +955,39 @@ router.post("/start", requireAdmin, async (req, res) => {
  * Search MusicBrainz for artists by name.
  * Used by metadata editing workflows to assist MBID correction.
  */
-router.get("/search/musicbrainz/artists", async (req, res) => {
-    try {
-        const query = String(req.query.q || "").trim();
-        if (query.length < 2) {
-            return res
-                .status(400)
-                .json({ error: "Query must be at least 2 characters" });
+router.get(
+    "/search/musicbrainz/artists",
+    asyncHandler(async (req, res) => {
+        try {
+            const query = String(req.query.q || "").trim();
+            if (query.length < 2) {
+                return res
+                    .status(400)
+                    .json({ error: "Query must be at least 2 characters" });
+            }
+
+            const results = await musicBrainzService.searchArtist(query, 10);
+            const artists = results.map(
+                (artist: MusicBrainzArtistSearchResult) => ({
+                    mbid: artist.id,
+                    name: artist.name,
+                    disambiguation: artist.disambiguation || null,
+                    country: artist.country || null,
+                    type: artist.type || null,
+                    score:
+                        typeof artist.score === "number"
+                            ? artist.score
+                            : Number.parseInt(artist.score || "0", 10),
+                }),
+            );
+
+            res.json({ artists });
+        } catch (error: unknown) {
+            logger.error("MusicBrainz artist search error:", error);
+            sendInternalRouteError(res, "Search failed");
         }
-
-        const results = await musicBrainzService.searchArtist(query, 10);
-        const artists = results.map((artist: any) => ({
-            mbid: artist.id,
-            name: artist.name,
-            disambiguation: artist.disambiguation || null,
-            country: artist.country || null,
-            type: artist.type || null,
-            score:
-                typeof artist.score === "number"
-                    ? artist.score
-                    : Number.parseInt(artist.score || "0", 10),
-        }));
-
-        res.json({ artists });
-    } catch (error: any) {
-        logger.error("MusicBrainz artist search error:", error);
-        res.status(500).json({
-            error: "Search failed",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -903,48 +1023,53 @@ router.get("/search/musicbrainz/artists", async (req, res) => {
  * Search MusicBrainz for release groups by title (optionally constrained by artist).
  * Used by metadata editing workflows to assist release-group MBID correction.
  */
-router.get("/search/musicbrainz/release-groups", async (req, res) => {
-    try {
-        const query = String(req.query.q || "").trim();
-        const artistName = String(req.query.artist || "").trim();
+router.get(
+    "/search/musicbrainz/release-groups",
+    asyncHandler(async (req, res) => {
+        try {
+            const query = String(req.query.q || "").trim();
+            const artistName = String(req.query.artist || "").trim();
 
-        if (query.length < 2) {
-            return res
-                .status(400)
-                .json({ error: "Query must be at least 2 characters" });
+            if (query.length < 2) {
+                return res
+                    .status(400)
+                    .json({ error: "Query must be at least 2 characters" });
+            }
+
+            const releaseGroups = await musicBrainzService.searchReleaseGroups(
+                query,
+                artistName || undefined,
+                10,
+            );
+
+            const albums = releaseGroups.map(
+                (rg: MusicBrainzReleaseGroupSearchResult) => ({
+                    rgMbid: rg.id,
+                    title: rg.title,
+                    primaryType: rg["primary-type"] || "Album",
+                    secondaryTypes: rg["secondary-types"] || [],
+                    firstReleaseDate: rg["first-release-date"] || null,
+                    artistCredit:
+                        rg["artist-credit"]
+                            ?.map(
+                                (credit) => credit.name || credit.artist?.name,
+                            )
+                            .filter(Boolean)
+                            .join(", ") || "Unknown Artist",
+                    score:
+                        typeof rg.score === "number"
+                            ? rg.score
+                            : Number.parseInt(rg.score || "0", 10),
+                }),
+            );
+
+            res.json({ albums });
+        } catch (error: unknown) {
+            logger.error("MusicBrainz release-group search error:", error);
+            sendInternalRouteError(res, "Search failed");
         }
-
-        const releaseGroups = await musicBrainzService.searchReleaseGroups(
-            query,
-            artistName || undefined,
-            10,
-        );
-
-        const albums = releaseGroups.map((rg: any) => ({
-            rgMbid: rg.id,
-            title: rg.title,
-            primaryType: rg["primary-type"] || "Album",
-            secondaryTypes: rg["secondary-types"] || [],
-            firstReleaseDate: rg["first-release-date"] || null,
-            artistCredit:
-                rg["artist-credit"]
-                    ?.map((credit: any) => credit.name || credit.artist?.name)
-                    .filter(Boolean)
-                    .join(", ") || "Unknown Artist",
-            score:
-                typeof rg.score === "number"
-                    ? rg.score
-                    : Number.parseInt(rg.score || "0", 10),
-        }));
-
-        res.json({ albums });
-    } catch (error: any) {
-        logger.error("MusicBrainz release-group search error:", error);
-        res.status(500).json({
-            error: "Search failed",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -999,28 +1124,41 @@ router.get("/search/musicbrainz/release-groups", async (req, res) => {
  * GET /enrichment/failures
  * Get all enrichment failures with filtering (admin only)
  */
-router.get("/failures", requireAdmin, async (req, res) => {
-    try {
-        const { entityType, includeSkipped, includeResolved, limit, offset } =
-            req.query;
+router.get(
+    "/failures",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const {
+                entityType,
+                includeSkipped,
+                includeResolved,
+                limit,
+                offset,
+            } = req.query;
 
-        const options: any = {};
-        if (entityType) options.entityType = entityType as string;
-        if (includeSkipped === "true") options.includeSkipped = true;
-        if (includeResolved === "true") options.includeResolved = true;
-        options.limit = parseBoundedInt(req.query.limit, 100, 1, 100);
-        options.offset = parseBoundedInt(req.query.offset, 0, 0, 1_000_000);
+            const options: Parameters<
+                typeof enrichmentFailureService.getFailures
+            >[0] = {};
+            if (isFailureEntityType(entityType)) {
+                options.entityType = entityType;
+            }
+            if (includeSkipped === "true") options.includeSkipped = true;
+            if (includeResolved === "true") options.includeResolved = true;
+            options.limit = parseBoundedInt(req.query.limit, 100, 1, 100);
+            options.offset = parseBoundedInt(req.query.offset, 0, 0, 1_000_000);
 
-        const result = await enrichmentFailureService.getFailures(options);
-        res.json({
-            failures: result.failures.map(toClientSafeEnrichmentFailure),
-            total: result.total,
-        });
-    } catch (error) {
-        logger.error("Get failures error:", error);
-        res.status(500).json({ error: "Failed to get failures" });
-    }
-});
+            const result = await enrichmentFailureService.getFailures(options);
+            res.json({
+                failures: result.failures.map(toClientSafeEnrichmentFailure),
+                total: result.total,
+            });
+        } catch (error) {
+            logger.error("Get failures error:", error);
+            sendInternalRouteError(res, "Failed to get failures");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -1042,15 +1180,19 @@ router.get("/failures", requireAdmin, async (req, res) => {
  * GET /enrichment/failures/counts
  * Get failure counts by type (admin only)
  */
-router.get("/failures/counts", requireAdmin, async (req, res) => {
-    try {
-        const counts = await enrichmentFailureService.getFailureCounts();
-        res.json(counts);
-    } catch (error) {
-        logger.error("Get failure counts error:", error);
-        res.status(500).json({ error: "Failed to get failure counts" });
-    }
-});
+router.get(
+    "/failures/counts",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const counts = await enrichmentFailureService.getFailureCounts();
+            res.json(counts);
+        } catch (error) {
+            logger.error("Get failure counts error:", error);
+            sendInternalRouteError(res, "Failed to get failure counts");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -1072,15 +1214,20 @@ router.get("/failures/counts", requireAdmin, async (req, res) => {
  * POST /enrichment/failures/reconcile
  * Reconcile stale failure records with authoritative live state (admin only)
  */
-router.post("/failures/reconcile", requireAdmin, async (_req, res) => {
-    try {
-        const result = await enrichmentFailureService.reconcileWithLiveState();
-        res.json(result);
-    } catch (error) {
-        logger.error("Reconcile enrichment failures error:", error);
-        sendInternalRouteError(res, "Failed to reconcile failures");
-    }
-});
+router.post(
+    "/failures/reconcile",
+    requireAdmin,
+    asyncHandler(async (_req, res) => {
+        try {
+            const result =
+                await enrichmentFailureService.reconcileWithLiveState();
+            res.json(result);
+        } catch (error) {
+            logger.error("Reconcile enrichment failures error:", error);
+            sendInternalRouteError(res, "Failed to reconcile failures");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -1117,147 +1264,148 @@ router.post("/failures/reconcile", requireAdmin, async (_req, res) => {
  * POST /enrichment/retry
  * Retry specific failed items
  */
-router.post("/retry", requireAdmin, async (req, res) => {
-    try {
-        const { ids } = req.body;
+router.post(
+    "/retry",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const { ids } = req.body;
 
-        if (!ids || !Array.isArray(ids) || ids.length === 0) {
-            return res
-                .status(400)
-                .json({ error: "Must provide array of failure IDs" });
-        }
-
-        // Reset retry count for these failures
-        await enrichmentFailureService.resetRetryCount(ids);
-
-        // Get the failures to determine what to retry
-        const failures = await Promise.all(
-            ids.map((id) => enrichmentFailureService.getFailure(id)),
-        );
-
-        // Group by type and trigger appropriate re-enrichment
-        const { prisma } = await import("../utils/db");
-        let queued = 0;
-        let skipped = 0;
-
-        for (const failure of failures) {
-            if (!failure) continue;
-
-            try {
-                if (failure.entityType === "artist") {
-                    // Check if artist still exists
-                    const artist = await prisma.artist.findUnique({
-                        where: { id: failure.entityId },
-                        select: { id: true },
-                    });
-
-                    if (!artist) {
-                        // Entity was deleted - mark failure as resolved
-                        await enrichmentFailureService.resolveFailures([
-                            failure.id,
-                        ]);
-                        skipped++;
-                        continue;
-                    }
-
-                    // Reset artist enrichment status
-                    await prisma.artist.update({
-                        where: { id: failure.entityId },
-                        data: { enrichmentStatus: "pending" },
-                    });
-                    queued++;
-                } else if (failure.entityType === "track") {
-                    // Check if track still exists
-                    const track = await prisma.track.findUnique({
-                        where: { id: failure.entityId },
-                        select: { id: true },
-                    });
-
-                    if (!track) {
-                        // Entity was deleted - mark failure as resolved
-                        await enrichmentFailureService.resolveFailures([
-                            failure.id,
-                        ]);
-                        skipped++;
-                        continue;
-                    }
-
-                    // Reset track tag status
-                    await prisma.track.update({
-                        where: { id: failure.entityId },
-                        data: { lastfmTags: [] },
-                    });
-                    queued++;
-                } else if (failure.entityType === "audio") {
-                    // Check if track still exists
-                    const track = await prisma.track.findUnique({
-                        where: { id: failure.entityId },
-                        select: { id: true },
-                    });
-
-                    if (!track) {
-                        // Entity was deleted - mark failure as resolved
-                        await enrichmentFailureService.resolveFailures([
-                            failure.id,
-                        ]);
-                        skipped++;
-                        continue;
-                    }
-
-                    // Reset audio analysis status
-                    await prisma.track.update({
-                        where: { id: failure.entityId },
-                        data: {
-                            analysisStatus: "pending",
-                            analysisError: null,
-                            analysisRetryCount: 0,
-                            analysisStartedAt: null,
-                        },
-                    });
-                    queued++;
-                } else if (failure.entityType === "vibe") {
-                    const track = await prisma.track.findUnique({
-                        where: { id: failure.entityId },
-                        select: { id: true },
-                    });
-
-                    if (!track) {
-                        await enrichmentFailureService.resolveFailures([
-                            failure.id,
-                        ]);
-                        skipped++;
-                        continue;
-                    }
-
-                    const reset = await invalidateVibeAnalysis(
-                        prisma,
-                        { id: failure.entityId },
-                        new Date(),
-                    );
-                    if (reset === 1) queued++;
-                    else skipped++;
-                }
-            } catch (error) {
-                logger.error(
-                    `Failed to reset ${failure.entityType} ${failure.entityId}:`,
-                    error,
-                );
-                // Don't re-throw - continue processing other failures
+            if (!ids || !Array.isArray(ids) || ids.length === 0) {
+                return res
+                    .status(400)
+                    .json({ error: "Must provide array of failure IDs" });
             }
-        }
 
-        res.json({
-            message: `Queued ${queued} items for retry, ${skipped} skipped (entities no longer exist)`,
-            queued,
-            skipped,
-        });
-    } catch (error: any) {
-        logger.error("Retry failures error:", error);
-        res.status(500).json({
-            error: "Failed to retry failures",
-        });
-    }
-});
+            // Reset retry count for these failures
+            await enrichmentFailureService.resetRetryCount(ids);
+
+            // Get the failures to determine what to retry
+            const failures = await Promise.all(
+                ids.map((id) => enrichmentFailureService.getFailure(id)),
+            );
+
+            // Group by type and trigger appropriate re-enrichment
+            let queued = 0;
+            let skipped = 0;
+
+            for (const failure of failures) {
+                if (!failure) continue;
+
+                try {
+                    if (failure.entityType === "artist") {
+                        // Check if artist still exists
+                        const artist = await prisma.artist.findUnique({
+                            where: { id: failure.entityId },
+                            select: { id: true },
+                        });
+
+                        if (!artist) {
+                            // Entity was deleted - mark failure as resolved
+                            await enrichmentFailureService.resolveFailures([
+                                failure.id,
+                            ]);
+                            skipped++;
+                            continue;
+                        }
+
+                        // Reset artist enrichment status
+                        await prisma.artist.update({
+                            where: { id: failure.entityId },
+                            data: { enrichmentStatus: "pending" },
+                        });
+                        queued++;
+                    } else if (failure.entityType === "track") {
+                        // Check if track still exists
+                        const track = await prisma.track.findUnique({
+                            where: { id: failure.entityId },
+                            select: { id: true },
+                        });
+
+                        if (!track) {
+                            // Entity was deleted - mark failure as resolved
+                            await enrichmentFailureService.resolveFailures([
+                                failure.id,
+                            ]);
+                            skipped++;
+                            continue;
+                        }
+
+                        // Reset track tag status
+                        await prisma.track.update({
+                            where: { id: failure.entityId },
+                            data: { lastfmTags: [] },
+                        });
+                        queued++;
+                    } else if (failure.entityType === "audio") {
+                        // Check if track still exists
+                        const track = await prisma.track.findUnique({
+                            where: { id: failure.entityId },
+                            select: { id: true },
+                        });
+
+                        if (!track) {
+                            // Entity was deleted - mark failure as resolved
+                            await enrichmentFailureService.resolveFailures([
+                                failure.id,
+                            ]);
+                            skipped++;
+                            continue;
+                        }
+
+                        // Reset audio analysis status
+                        await prisma.track.update({
+                            where: { id: failure.entityId },
+                            data: {
+                                analysisStatus: "pending",
+                                analysisError: null,
+                                analysisRetryCount: 0,
+                                analysisStartedAt: null,
+                            },
+                        });
+                        queued++;
+                    } else if (failure.entityType === "vibe") {
+                        const track = await prisma.track.findUnique({
+                            where: { id: failure.entityId },
+                            select: { id: true },
+                        });
+
+                        if (!track) {
+                            await enrichmentFailureService.resolveFailures([
+                                failure.id,
+                            ]);
+                            skipped++;
+                            continue;
+                        }
+
+                        const reset = await invalidateVibeAnalysis(
+                            prisma,
+                            { id: failure.entityId },
+                            new Date(),
+                        );
+                        if (reset === 1) queued++;
+                        else skipped++;
+                    }
+                } catch (error) {
+                    logger.error(
+                        `Failed to reset ${failure.entityType} ${failure.entityId}:`,
+                        error,
+                    );
+                    // Don't re-throw - continue processing other failures
+                }
+            }
+
+            res.json({
+                message: `Queued ${queued} items for retry, ${skipped} skipped (entities no longer exist)`,
+                queued,
+                skipped,
+            });
+        } catch (error: unknown) {
+            logger.error("Retry failures error:", error);
+            sendInternalRouteError(res, "Failed to retry failures");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -1294,28 +1442,30 @@ router.post("/retry", requireAdmin, async (req, res) => {
  * POST /enrichment/skip
  * Skip specific failures (won't retry automatically)
  */
-router.post("/skip", requireAdmin, async (req, res) => {
-    try {
-        const { ids } = req.body;
+router.post(
+    "/skip",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const { ids } = req.body;
 
-        if (!ids || !Array.isArray(ids) || ids.length === 0) {
-            return res
-                .status(400)
-                .json({ error: "Must provide array of failure IDs" });
+            if (!ids || !Array.isArray(ids) || ids.length === 0) {
+                return res
+                    .status(400)
+                    .json({ error: "Must provide array of failure IDs" });
+            }
+
+            const count = await enrichmentFailureService.skipFailures(ids);
+            res.json({
+                message: `Skipped ${count} failures`,
+                count,
+            });
+        } catch (error: unknown) {
+            logger.error("Skip failures error:", error);
+            sendInternalRouteError(res, "Failed to skip failures");
         }
-
-        const count = await enrichmentFailureService.skipFailures(ids);
-        res.json({
-            message: `Skipped ${count} failures`,
-            count,
-        });
-    } catch (error: any) {
-        logger.error("Skip failures error:", error);
-        res.status(500).json({
-            error: "Failed to skip failures",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1346,32 +1496,37 @@ router.post("/skip", requireAdmin, async (req, res) => {
  * DELETE /enrichment/failures
  * Clear all unresolved failures (optionally filtered by type)
  */
-router.delete("/failures", requireAdmin, async (req, res) => {
-    try {
-        const entityType = req.query.entityType as
-            | "artist"
-            | "track"
-            | "audio"
-            | undefined;
+router.delete(
+    "/failures",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const entityType = req.query.entityType as
+                | "artist"
+                | "track"
+                | "audio"
+                | undefined;
 
-        if (entityType && !["artist", "track", "audio"].includes(entityType)) {
-            return res.status(400).json({ error: "Invalid entityType" });
+            if (
+                entityType &&
+                !["artist", "track", "audio"].includes(entityType)
+            ) {
+                return res.status(400).json({ error: "Invalid entityType" });
+            }
+
+            const count =
+                await enrichmentFailureService.clearAllFailures(entityType);
+
+            res.json({
+                message: `Cleared ${count} failure${count !== 1 ? "s" : ""}`,
+                count,
+            });
+        } catch (error: unknown) {
+            logger.error("Clear all failures error:", error);
+            sendInternalRouteError(res, "Failed to clear failures");
         }
-
-        const count =
-            await enrichmentFailureService.clearAllFailures(entityType);
-
-        res.json({
-            message: `Cleared ${count} failure${count !== 1 ? "s" : ""}`,
-            count,
-        });
-    } catch (error: any) {
-        logger.error("Clear all failures error:", error);
-        res.status(500).json({
-            error: "Failed to clear failures",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1403,7 +1558,7 @@ router.delete("/failures", requireAdmin, async (req, res) => {
 router.delete<{ id: string }>(
     "/failures/:id",
     requireAdmin,
-    async (req, res) => {
+    asyncHandler(async (req, res) => {
         try {
             const count = await enrichmentFailureService.deleteFailures([
                 req.params.id,
@@ -1412,13 +1567,11 @@ router.delete<{ id: string }>(
                 message: "Failure deleted",
                 count,
             });
-        } catch (error: any) {
+        } catch (error: unknown) {
             logger.error("Delete failure error:", error);
-            res.status(500).json({
-                error: "Failed to delete failure",
-            });
+            sendInternalRouteError(res, "Failed to delete failure");
         }
-    },
+    }),
 );
 
 /**
@@ -1473,64 +1626,21 @@ router.delete<{ id: string }>(
  * Update artist metadata manually (non-destructive overrides)
  * User edits are stored as overrides; canonical data preserved for API lookups
  */
-router.put("/artists/:id/metadata", async (req, res) => {
-    try {
-        const { name, bio, genres, heroUrl, mbid } = req.body;
+router.put<{ id: string }>(
+    "/artists/:id/metadata",
+    validate({ body: artistMetadataSchema }),
+    asyncHandler(async (req, res) => {
+        try {
+            const body = (req.valid?.body ?? req.body) as Record<
+                string,
+                unknown
+            >;
+            const overrideBody = { ...body };
+            const { mbid } = body;
 
-        const updateData: any = {};
-        let hasOverrides = false;
-
-        // Map user edits to override fields (non-destructive)
-        if (name !== undefined) {
-            updateData.displayName = name;
-            hasOverrides = true;
-        }
-        if (bio !== undefined) {
-            updateData.userSummary = bio;
-            hasOverrides = true;
-        }
-        if (heroUrl !== undefined) {
-            updateData.userHeroUrl = heroUrl;
-            hasOverrides = true;
-        }
-        if (genres !== undefined) {
-            updateData.userGenres = genres;
-            hasOverrides = true;
-        }
-        const { prisma } = await import("../utils/db");
-
-        // MBID changes are canonical-link corrections (not override fields).
-        if (mbid !== undefined) {
-            if (typeof mbid !== "string") {
-                return res.status(400).json({
-                    error: "Invalid MusicBrainz ID format",
-                    code: "INVALID_MBID_FORMAT",
-                    field: "mbid",
-                    expectedFormat: MBID_FORMAT_EXAMPLE,
-                });
-            }
-
-            const normalizedMbid = mbid.trim();
-            if (normalizedMbid) {
-                // Only validate strict UUID format when the value is actually being changed.
-                // Existing temporary MBIDs should not block unrelated override edits.
-                const existingArtist = await prisma.artist.findUnique({
-                    where: { id: req.params.id },
-                    select: { mbid: true },
-                });
-
-                if (!existingArtist) {
-                    return sendRouteError(
-                        res,
-                        404,
-                        "Artist not found (the artist may have been deleted)",
-                    );
-                }
-
-                if (
-                    existingArtist.mbid !== normalizedMbid &&
-                    !isValidMusicBrainzId(normalizedMbid)
-                ) {
+            // MBID changes are canonical-link corrections (not override fields).
+            if (mbid !== undefined) {
+                if (typeof mbid !== "string") {
                     return res.status(400).json({
                         error: "Invalid MusicBrainz ID format",
                         code: "INVALID_MBID_FORMAT",
@@ -1539,72 +1649,85 @@ router.put("/artists/:id/metadata", async (req, res) => {
                     });
                 }
 
-                if (existingArtist.mbid !== normalizedMbid) {
-                    const conflictingArtist = await prisma.artist.findFirst({
-                        where: {
-                            mbid: normalizedMbid,
-                            id: { not: req.params.id },
-                        },
-                        select: { id: true },
+                const normalizedMbid = mbid.trim();
+                if (normalizedMbid) {
+                    // Only validate strict UUID format when the value is actually being changed.
+                    // Existing temporary MBIDs should not block unrelated override edits.
+                    const existingArtist = await prisma.artist.findUnique({
+                        where: { id: req.params.id },
+                        select: { mbid: true },
                     });
 
-                    if (conflictingArtist) {
-                        return res.status(409).json({
-                            error: "MusicBrainz ID is already used by another artist",
-                            code: "MBID_CONFLICT",
+                    if (!existingArtist) {
+                        return sendRouteError(
+                            res,
+                            404,
+                            "Artist not found (the artist may have been deleted)",
+                        );
+                    }
+
+                    if (
+                        existingArtist.mbid !== normalizedMbid &&
+                        !isValidMusicBrainzId(normalizedMbid)
+                    ) {
+                        return res.status(400).json({
+                            error: "Invalid MusicBrainz ID format",
+                            code: "INVALID_MBID_FORMAT",
                             field: "mbid",
-                            hint: "Use MusicBrainz lookup to pick the correct artist MBID",
+                            expectedFormat: MBID_FORMAT_EXAMPLE,
                         });
                     }
 
-                    updateData.mbid = normalizedMbid;
+                    if (existingArtist.mbid !== normalizedMbid) {
+                        const conflictingArtist = await prisma.artist.findFirst(
+                            {
+                                where: {
+                                    mbid: normalizedMbid,
+                                    id: { not: req.params.id },
+                                },
+                                select: { id: true },
+                            },
+                        );
+
+                        if (conflictingArtist) {
+                            return res.status(409).json({
+                                error: "MusicBrainz ID is already used by another artist",
+                                code: "MBID_CONFLICT",
+                                field: "mbid",
+                                hint: "Use MusicBrainz lookup to pick the correct artist MBID",
+                            });
+                        }
+
+                        overrideBody.mbid = normalizedMbid;
+                    } else {
+                        delete overrideBody.mbid;
+                    }
+                } else {
+                    delete overrideBody.mbid;
                 }
             }
-        }
 
-        // Set override flag
-        if (hasOverrides) {
-            updateData.hasUserOverrides = true;
-        }
+            const artist = await applyMetadataOverrides(
+                { type: "artist", id: req.params.id },
+                overrideBody,
+                ARTIST_METADATA_FIELDS,
+            );
 
-        const artist = await prisma.artist.update({
-            where: { id: req.params.id },
-            data: updateData,
-            include: {
-                albums: {
-                    select: {
-                        id: true,
-                        title: true,
-                        year: true,
-                        coverUrl: true,
-                    },
-                },
-            },
-        });
-
-        // Invalidate Redis cache for artist hero image
-        try {
-            await redisClient.del(`hero:${req.params.id}`);
-        } catch (err) {
-            logger.warn("Failed to invalidate Redis cache:", err);
+            res.json(artist);
+        } catch (error: unknown) {
+            if (getErrorCode(error) === "P2002") {
+                return res.status(409).json({
+                    error: "MusicBrainz ID is already used by another artist",
+                    code: "MBID_CONFLICT",
+                    field: "mbid",
+                    hint: "Use MusicBrainz lookup to pick the correct artist MBID",
+                });
+            }
+            logger.error("Update artist metadata error:", error);
+            sendInternalRouteError(res, "Failed to update artist");
         }
-
-        res.json(artist);
-    } catch (error: any) {
-        if (error?.code === "P2002") {
-            return res.status(409).json({
-                error: "MusicBrainz ID is already used by another artist",
-                code: "MBID_CONFLICT",
-                field: "mbid",
-                hint: "Use MusicBrainz lookup to pick the correct artist MBID",
-            });
-        }
-        logger.error("Update artist metadata error:", error);
-        res.status(500).json({
-            error: "Failed to update artist",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1658,108 +1781,92 @@ router.put("/artists/:id/metadata", async (req, res) => {
  * Update album metadata manually (non-destructive overrides)
  * User edits are stored as overrides; canonical data preserved for API lookups
  */
-router.put("/albums/:id/metadata", async (req, res) => {
-    try {
-        const { title, year, genres, coverUrl, rgMbid } = req.body;
-
-        const updateData: any = {};
-        let hasOverrides = false;
-
-        // Map user edits to override fields (non-destructive)
-        if (title !== undefined) {
-            updateData.displayTitle = title;
-            hasOverrides = true;
-        }
-        if (year !== undefined) {
-            updateData.displayYear = parseInt(year);
-            hasOverrides = true;
-        }
-        if (coverUrl !== undefined) {
-            updateData.userCoverUrl = coverUrl;
-            hasOverrides = true;
-        }
-        if (genres !== undefined) {
-            updateData.userGenres = genres;
-            hasOverrides = true;
-        }
-        const normalizedRgMbid =
-            typeof rgMbid === "string" && rgMbid.trim() ? rgMbid.trim() : null;
-        if (normalizedRgMbid) {
-            updateData.rgMbid = normalizedRgMbid;
-        }
-
-        // Set override flag
-        if (hasOverrides) {
-            updateData.hasUserOverrides = true;
-        }
-
-        const { prisma } = await import("../utils/db");
-        let existingAlbum: { rgMbid: string } | null = null;
-
-        if (normalizedRgMbid) {
-            existingAlbum = await prisma.album.findUnique({
-                where: { id: req.params.id },
-                select: { rgMbid: true },
-            });
-
-            if (!existingAlbum) {
-                return sendRouteError(
-                    res,
-                    404,
-                    "Album not found (the album may have been deleted)",
-                );
+router.put<{ id: string }>(
+    "/albums/:id/metadata",
+    validate({ body: albumMetadataSchema }),
+    asyncHandler(async (req, res) => {
+        try {
+            const body = (req.valid?.body ?? req.body) as Record<
+                string,
+                unknown
+            >;
+            const overrideBody = { ...body };
+            const { rgMbid } = body;
+            const normalizedRgMbid =
+                typeof rgMbid === "string" && rgMbid.trim()
+                    ? rgMbid.trim()
+                    : null;
+            if (normalizedRgMbid) {
+                overrideBody.rgMbid = normalizedRgMbid;
+            } else {
+                delete overrideBody.rgMbid;
             }
+            let existingAlbum: { rgMbid: string } | null = null;
 
-            if (existingAlbum.rgMbid !== normalizedRgMbid) {
-                if (!isValidMusicBrainzId(normalizedRgMbid)) {
-                    return res.status(400).json({
-                        error: "Invalid release-group MBID format",
-                        code: "INVALID_RG_MBID_FORMAT",
-                        field: "rgMbid",
-                        expectedFormat: MBID_FORMAT_EXAMPLE,
-                    });
-                }
-
-                const conflictingAlbum = await prisma.album.findFirst({
-                    where: {
-                        rgMbid: normalizedRgMbid,
-                        id: { not: req.params.id },
-                    },
-                    select: { id: true },
+            if (normalizedRgMbid) {
+                existingAlbum = await prisma.album.findUnique({
+                    where: { id: req.params.id },
+                    select: { rgMbid: true },
                 });
 
-                if (conflictingAlbum) {
-                    return res.status(409).json({
-                        error: "Release-group MBID is already used by another album",
-                        code: "RG_MBID_CONFLICT",
-                        field: "rgMbid",
-                        hint: "Use MusicBrainz lookup to pick the correct release-group MBID",
+                if (!existingAlbum) {
+                    return sendRouteError(
+                        res,
+                        404,
+                        "Album not found (the album may have been deleted)",
+                    );
+                }
+
+                if (existingAlbum.rgMbid !== normalizedRgMbid) {
+                    if (!isValidMusicBrainzId(normalizedRgMbid)) {
+                        return res.status(400).json({
+                            error: "Invalid release-group MBID format",
+                            code: "INVALID_RG_MBID_FORMAT",
+                            field: "rgMbid",
+                            expectedFormat: MBID_FORMAT_EXAMPLE,
+                        });
+                    }
+
+                    const conflictingAlbum = await prisma.album.findFirst({
+                        where: {
+                            rgMbid: normalizedRgMbid,
+                            id: { not: req.params.id },
+                        },
+                        select: { id: true },
                     });
+
+                    if (conflictingAlbum) {
+                        return res.status(409).json({
+                            error: "Release-group MBID is already used by another album",
+                            code: "RG_MBID_CONFLICT",
+                            field: "rgMbid",
+                            hint: "Use MusicBrainz lookup to pick the correct release-group MBID",
+                        });
+                    }
                 }
             }
-        }
 
-        const album = await updateAlbumMetadataWithOwnership(
-            req.params.id,
-            updateData,
-        );
+            const album = await applyMetadataOverrides(
+                { type: "album", id: req.params.id },
+                overrideBody,
+                ALBUM_METADATA_FIELDS,
+            );
 
-        res.json(album);
-    } catch (error: any) {
-        if (error?.code === "P2002") {
-            return res.status(409).json({
-                error: "Release-group MBID is already used by another album",
-                code: "RG_MBID_CONFLICT",
-                field: "rgMbid",
-                hint: "Use MusicBrainz lookup to pick the correct release-group MBID",
-            });
+            res.json(album);
+        } catch (error: unknown) {
+            if (getErrorCode(error) === "P2002") {
+                return res.status(409).json({
+                    error: "Release-group MBID is already used by another album",
+                    code: "RG_MBID_CONFLICT",
+                    field: "rgMbid",
+                    hint: "Use MusicBrainz lookup to pick the correct release-group MBID",
+                });
+            }
+            logger.error("Update album metadata error:", error);
+            sendInternalRouteError(res, "Failed to update album");
         }
-        logger.error("Update album metadata error:", error);
-        res.status(500).json({
-            error: "Failed to update album",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1798,56 +1905,24 @@ router.put("/albums/:id/metadata", async (req, res) => {
  * Update track metadata manually (non-destructive overrides)
  * User edits are stored as overrides; canonical data preserved
  */
-router.put("/tracks/:id/metadata", async (req, res) => {
-    try {
-        const { title, trackNo } = req.body;
+router.put<{ id: string }>(
+    "/tracks/:id/metadata",
+    validate({ body: trackMetadataSchema }),
+    asyncHandler(async (req, res) => {
+        try {
+            const track = await applyMetadataOverrides(
+                { type: "track", id: req.params.id },
+                (req.valid?.body ?? req.body) as Record<string, unknown>,
+                TRACK_METADATA_FIELDS,
+            );
 
-        const updateData: any = {};
-        let hasOverrides = false;
-
-        // Map user edits to override fields (non-destructive)
-        if (title !== undefined) {
-            updateData.displayTitle = title;
-            hasOverrides = true;
+            res.json(track);
+        } catch (error: unknown) {
+            logger.error("Update track metadata error:", error);
+            sendInternalRouteError(res, "Failed to update track");
         }
-        if (trackNo !== undefined) {
-            updateData.displayTrackNo = parseInt(trackNo);
-            hasOverrides = true;
-        }
-
-        // Set override flag
-        if (hasOverrides) {
-            updateData.hasUserOverrides = true;
-        }
-
-        const { prisma } = await import("../utils/db");
-        const track = await prisma.track.update({
-            where: { id: req.params.id },
-            data: updateData,
-            include: {
-                album: {
-                    select: {
-                        id: true,
-                        title: true,
-                        artist: {
-                            select: {
-                                id: true,
-                                name: true,
-                            },
-                        },
-                    },
-                },
-            },
-        });
-
-        res.json(track);
-    } catch (error: any) {
-        logger.error("Update track metadata error:", error);
-        res.status(500).json({
-            error: "Failed to update track",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1876,71 +1951,38 @@ router.put("/tracks/:id/metadata", async (req, res) => {
  * POST /enrichment/artists/:id/reset
  * Reset artist metadata to canonical values (clear all user overrides)
  */
-router.post("/artists/:id/reset", async (req, res) => {
-    try {
-        const { prisma } = await import("../utils/db");
-
-        // Check if artist exists first
-        const existingArtist = await prisma.artist.findUnique({
-            where: { id: req.params.id },
-            select: { id: true },
-        });
-
-        if (!existingArtist) {
-            return sendRouteError(
-                res,
-                404,
-                "Artist not found (the artist may have been deleted)",
-            );
-        }
-
-        const artist = await prisma.artist.update({
-            where: { id: req.params.id },
-            data: {
-                displayName: null,
-                userSummary: null,
-                userHeroUrl: null,
-                userGenres: [],
-                hasUserOverrides: false,
-            },
-            include: {
-                albums: {
-                    select: {
-                        id: true,
-                        title: true,
-                        year: true,
-                        coverUrl: true,
-                    },
-                },
-            },
-        });
-
-        // Invalidate Redis cache for artist hero image
+router.post(
+    "/artists/:id/reset",
+    asyncHandler(async (req, res) => {
         try {
-            await redisClient.del(`hero:${req.params.id}`);
-        } catch (err) {
-            logger.warn("Failed to invalidate Redis cache:", err);
-        }
+            const artist = await resetMetadataOverrides({
+                type: "artist",
+                id: req.params.id,
+            });
 
-        res.json({
-            message: "Artist metadata reset to original values",
-            artist,
-        });
-    } catch (error: any) {
-        // Handle P2025 specifically in case of race condition
-        if (error.code === "P2025") {
-            return sendRouteError(
-                res,
-                404,
-                "Artist not found (the artist may have been deleted)",
-            );
+            res.json({
+                message: "Artist metadata reset to original values",
+                artist,
+            });
+        } catch (error: unknown) {
+            if (
+                error instanceof MetadataEntityNotFoundError ||
+                (typeof error === "object" &&
+                    error !== null &&
+                    "code" in error &&
+                    error.code === "P2025")
+            ) {
+                return sendRouteError(
+                    res,
+                    404,
+                    "Artist not found (the artist may have been deleted)",
+                );
+            }
+            logger.error("Reset artist metadata error:", error);
+            sendInternalRouteError(res, "Failed to reset artist metadata");
         }
-        logger.error("Reset artist metadata error:", error);
-        res.status(500).json({
-            error: "Failed to reset artist metadata",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -1969,70 +2011,38 @@ router.post("/artists/:id/reset", async (req, res) => {
  * POST /enrichment/albums/:id/reset
  * Reset album metadata to canonical values (clear all user overrides)
  */
-router.post("/albums/:id/reset", async (req, res) => {
-    try {
-        const { prisma } = await import("../utils/db");
+router.post(
+    "/albums/:id/reset",
+    asyncHandler(async (req, res) => {
+        try {
+            const album = await resetMetadataOverrides({
+                type: "album",
+                id: req.params.id,
+            });
 
-        // Check if album exists first
-        const existingAlbum = await prisma.album.findUnique({
-            where: { id: req.params.id },
-            select: { id: true },
-        });
-
-        if (!existingAlbum) {
-            return sendRouteError(
-                res,
-                404,
-                "Album not found (the album may have been deleted)",
-            );
+            res.json({
+                message: "Album metadata reset to original values",
+                album,
+            });
+        } catch (error: unknown) {
+            if (
+                error instanceof MetadataEntityNotFoundError ||
+                (typeof error === "object" &&
+                    error !== null &&
+                    "code" in error &&
+                    error.code === "P2025")
+            ) {
+                return sendRouteError(
+                    res,
+                    404,
+                    "Album not found (the album may have been deleted)",
+                );
+            }
+            logger.error("Reset album metadata error:", error);
+            sendInternalRouteError(res, "Failed to reset album metadata");
         }
-
-        const album = await prisma.album.update({
-            where: { id: req.params.id },
-            data: {
-                displayTitle: null,
-                displayYear: null,
-                userCoverUrl: null,
-                userGenres: [],
-                hasUserOverrides: false,
-            },
-            include: {
-                artist: {
-                    select: {
-                        id: true,
-                        name: true,
-                    },
-                },
-                tracks: {
-                    select: {
-                        id: true,
-                        title: true,
-                        trackNo: true,
-                        duration: true,
-                    },
-                },
-            },
-        });
-
-        res.json({
-            message: "Album metadata reset to original values",
-            album,
-        });
-    } catch (error: any) {
-        // Handle P2025 specifically in case of race condition
-        if (error.code === "P2025") {
-            return sendRouteError(
-                res,
-                404,
-                "Album not found (the album may have been deleted)",
-            );
-        }
-        logger.error("Reset album metadata error:", error);
-        res.status(500).json({
-            error: "Failed to reset album metadata",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -2069,66 +2079,38 @@ router.post("/albums/:id/reset", async (req, res) => {
  * POST /enrichment/tracks/:id/reset
  * Reset track metadata to canonical values (clear all user overrides)
  */
-router.post("/tracks/:id/reset", async (req, res) => {
-    try {
-        const { prisma } = await import("../utils/db");
+router.post(
+    "/tracks/:id/reset",
+    asyncHandler(async (req, res) => {
+        try {
+            const track = await resetMetadataOverrides({
+                type: "track",
+                id: req.params.id,
+            });
 
-        // Check if track exists first
-        const existingTrack = await prisma.track.findFirst({
-            where: { id: req.params.id, ...TRACK_VISIBLE_WHERE },
-            select: { id: true },
-        });
-
-        if (!existingTrack) {
-            return sendRouteError(
-                res,
-                404,
-                "Track not found (the track may have been deleted)",
-            );
+            res.json({
+                message: "Track metadata reset to original values",
+                track,
+            });
+        } catch (error: unknown) {
+            if (
+                error instanceof MetadataEntityNotFoundError ||
+                (typeof error === "object" &&
+                    error !== null &&
+                    "code" in error &&
+                    error.code === "P2025")
+            ) {
+                return sendRouteError(
+                    res,
+                    404,
+                    "Track not found (the track may have been deleted)",
+                );
+            }
+            logger.error("Reset track metadata error:", error);
+            sendInternalRouteError(res, "Failed to reset track metadata");
         }
-
-        const track = await prisma.track.update({
-            where: { id: req.params.id },
-            data: {
-                displayTitle: null,
-                displayTrackNo: null,
-                hasUserOverrides: false,
-            },
-            include: {
-                album: {
-                    select: {
-                        id: true,
-                        title: true,
-                        artist: {
-                            select: {
-                                id: true,
-                                name: true,
-                            },
-                        },
-                    },
-                },
-            },
-        });
-
-        res.json({
-            message: "Track metadata reset to original values",
-            track,
-        });
-    } catch (error: any) {
-        // Handle P2025 specifically in case of race condition
-        if (error.code === "P2025") {
-            return sendRouteError(
-                res,
-                404,
-                "Track not found (the track may have been deleted)",
-            );
-        }
-        logger.error("Reset track metadata error:", error);
-        res.status(500).json({
-            error: "Failed to reset track metadata",
-        });
-    }
-});
+    }),
+);
 
 /**
  * @openapi
@@ -2148,26 +2130,29 @@ router.post("/tracks/:id/reset", async (req, res) => {
  * GET /enrichment/concurrency
  * Get current enrichment concurrency configuration
  */
-router.get("/concurrency", async (req, res) => {
-    try {
-        const settings = await getSystemSettings();
-        const concurrency = settings?.enrichmentConcurrency || 1;
+router.get(
+    "/concurrency",
+    asyncHandler(async (req, res) => {
+        try {
+            const settings = await getSystemSettings();
+            const concurrency = settings?.enrichmentConcurrency || 1;
 
-        // Calculate estimated speeds based on concurrency
-        const artistsPerMin = Math.round(10 * concurrency);
-        const tracksPerMin = Math.round(60 * concurrency);
+            // Calculate estimated speeds based on concurrency
+            const artistsPerMin = Math.round(10 * concurrency);
+            const tracksPerMin = Math.round(60 * concurrency);
 
-        res.json({
-            concurrency,
-            estimatedSpeed: `~${artistsPerMin} artists/min, ~${tracksPerMin} tracks/min`,
-            artistsPerMin,
-            tracksPerMin,
-        });
-    } catch (error) {
-        logger.error("Failed to get enrichment settings:", error);
-        res.status(500).json({ error: "Failed to get enrichment settings" });
-    }
-});
+            res.json({
+                concurrency,
+                estimatedSpeed: `~${artistsPerMin} artists/min, ~${tracksPerMin} tracks/min`,
+                artistsPerMin,
+                tracksPerMin,
+            });
+        } catch (error) {
+            logger.error("Failed to get enrichment settings:", error);
+            sendInternalRouteError(res, "Failed to get enrichment settings");
+        }
+    }),
+);
 
 /**
  * @openapi
@@ -2203,59 +2188,62 @@ router.get("/concurrency", async (req, res) => {
  * PUT /enrichment/concurrency
  * Update enrichment concurrency configuration
  */
-router.put("/concurrency", requireAdmin, async (req, res) => {
-    try {
-        const { concurrency } = req.body;
+router.put(
+    "/concurrency",
+    requireAdmin,
+    asyncHandler(async (req, res) => {
+        try {
+            const { concurrency } = req.body;
 
-        if (!concurrency || typeof concurrency !== "number") {
-            return res
-                .status(400)
-                .json({ error: "Missing or invalid 'concurrency' parameter" });
+            if (!concurrency || typeof concurrency !== "number") {
+                return res.status(400).json({
+                    error: "Missing or invalid 'concurrency' parameter",
+                });
+            }
+
+            // Clamp concurrency to 1-5
+            const clampedConcurrency = Math.max(
+                1,
+                Math.min(5, Math.floor(concurrency)),
+            );
+
+            // Update system settings in database
+            await prisma.systemSettings.upsert({
+                where: { id: "default" },
+                create: {
+                    id: "default",
+                    enrichmentConcurrency: clampedConcurrency,
+                },
+                update: {
+                    enrichmentConcurrency: clampedConcurrency,
+                },
+            });
+
+            // Invalidate cache so next read gets fresh value
+            invalidateSystemSettingsCache();
+
+            // Update rate limiter concurrency multiplier
+            rateLimiter.updateConcurrencyMultiplier(clampedConcurrency);
+
+            // Calculate estimated speeds
+            const artistsPerMin = Math.round(10 * clampedConcurrency);
+            const tracksPerMin = Math.round(60 * clampedConcurrency);
+
+            logger.debug(
+                `[Enrichment Settings] Updated concurrency to ${clampedConcurrency}`,
+            );
+
+            res.json({
+                concurrency: clampedConcurrency,
+                estimatedSpeed: `~${artistsPerMin} artists/min, ~${tracksPerMin} tracks/min`,
+                artistsPerMin,
+                tracksPerMin,
+            });
+        } catch (error) {
+            logger.error("Failed to update enrichment settings:", error);
+            sendInternalRouteError(res, "Failed to update enrichment settings");
         }
-
-        // Clamp concurrency to 1-5
-        const clampedConcurrency = Math.max(
-            1,
-            Math.min(5, Math.floor(concurrency)),
-        );
-
-        // Update system settings in database
-        const { prisma } = await import("../utils/db");
-        await prisma.systemSettings.upsert({
-            where: { id: "default" },
-            create: {
-                id: "default",
-                enrichmentConcurrency: clampedConcurrency,
-            },
-            update: {
-                enrichmentConcurrency: clampedConcurrency,
-            },
-        });
-
-        // Invalidate cache so next read gets fresh value
-        invalidateSystemSettingsCache();
-
-        // Update rate limiter concurrency multiplier
-        rateLimiter.updateConcurrencyMultiplier(clampedConcurrency);
-
-        // Calculate estimated speeds
-        const artistsPerMin = Math.round(10 * clampedConcurrency);
-        const tracksPerMin = Math.round(60 * clampedConcurrency);
-
-        logger.debug(
-            `[Enrichment Settings] Updated concurrency to ${clampedConcurrency}`,
-        );
-
-        res.json({
-            concurrency: clampedConcurrency,
-            estimatedSpeed: `~${artistsPerMin} artists/min, ~${tracksPerMin} tracks/min`,
-            artistsPerMin,
-            tracksPerMin,
-        });
-    } catch (error) {
-        logger.error("Failed to update enrichment settings:", error);
-        res.status(500).json({ error: "Failed to update enrichment settings" });
-    }
-});
+    }),
+);
 
 export default router;

--- a/backend/src/routes/youtubeMusic.ts
+++ b/backend/src/routes/youtubeMusic.ts
@@ -29,11 +29,40 @@ import {
 } from "../middleware/rateLimiter";
 import { coalesceInFlightByKey } from "../utils/singleflight";
 import { config } from "../config";
+import { sendInternalRouteError } from "../utils/routeErrorResponse";
+import { asyncHandler } from "../middleware/asyncHandler";
+import { parsePagination } from "../middleware/parsePagination";
+import { validate } from "../middleware/validate";
 
 const router = Router();
 const OAUTH_CACHE_TTL_MS = config.nodeEnv === "test" ? 0 : 60_000;
 const OAUTH_NEGATIVE_CACHE_TTL_MS = config.nodeEnv === "test" ? 0 : 15_000;
 const DEFAULT_YTMUSIC_STREAM_QUALITY = "high";
+const MATCH_SCHEMA = z.object({
+    artist: z.string().min(1),
+    title: z.string().min(1),
+    albumTitle: z.string().optional(),
+    duration: z.number().positive().optional(),
+    isrc: z.string().trim().min(6).max(20).optional(),
+});
+const MATCH_BATCH_SCHEMA = z.object({
+    tracks: z.array(MATCH_SCHEMA).min(1).max(50),
+});
+
+function getHttpErrorStatus(error: unknown): number | undefined {
+    if (typeof error !== "object" || error === null || !("response" in error)) {
+        return undefined;
+    }
+    const response = error.response;
+    if (
+        typeof response !== "object" ||
+        response === null ||
+        !("status" in response)
+    ) {
+        return undefined;
+    }
+    return typeof response.status === "number" ? response.status : undefined;
+}
 const ytOauthSessionCache = new Map<
     string,
     { authenticated: boolean; expiresAt: number }
@@ -144,7 +173,7 @@ async function requireYtMusicEnabled(
         next();
     } catch (err) {
         logger.error("[YTMusic Route] Failed to check settings:", err);
-        res.status(500).json({ error: "Internal server error" });
+        sendInternalRouteError(res, "Internal server error");
     }
 }
 
@@ -345,6 +374,14 @@ type YtOAuthPollOperationResult =
           response: YtMusicDeviceCodePollResult;
       };
 
+function sanitizeDevicePollError(
+    result: YtMusicDeviceCodePollResult,
+): string | null | undefined {
+    if (result.status === "error") return "Device authorization failed";
+    const rawError = (result as unknown as Record<string, unknown>)["error"];
+    return rawError === null ? null : undefined;
+}
+
 async function pollYtOAuthCredential(
     userId: string,
     generation: number,
@@ -386,7 +423,10 @@ async function pollYtOAuthCredential(
 
     return {
         credentialsConfigured: true,
-        response: { status: result.status, error: result.error },
+        response: {
+            status: result.status,
+            error: sanitizeDevicePollError(result),
+        },
     };
 }
 
@@ -418,10 +458,10 @@ export async function getUserIdOrPublic(userId: string): Promise<string> {
 
 function handleYtMusicAuthError(
     res: Response,
-    err: any,
+    err: unknown,
     userId?: string,
 ): boolean {
-    if (err?.response?.status !== 401) return false;
+    if (getHttpErrorStatus(err) !== 401) return false;
     if (userId) {
         setYtOAuthCache(userId, false);
     } else {
@@ -445,8 +485,8 @@ const YT_MUSIC_STREAM_PROXY_ERRORS: Record<number, StreamProxyErrorBody> = {
     503: { error: "YouTube Music streaming is busy" },
     504: { error: "YouTube Music stream timed out" },
 };
-function handleYtMusicStreamProxyError(res: Response, err: any): boolean {
-    const status = err?.response?.status;
+function handleYtMusicStreamProxyError(res: Response, err: unknown): boolean {
+    const status = getHttpErrorStatus(err);
     if (typeof status !== "number" || !YT_MUSIC_STREAM_PROXY_ERRORS[status])
         return false;
     res.status(status).json(YT_MUSIC_STREAM_PROXY_ERRORS[status]);
@@ -511,42 +551,46 @@ async function resolveYtMusicStreamQuality(
  *       401:
  *         description: Not authenticated
  */
-router.get("/status", requireAuth, async (req: Request, res: Response) => {
-    try {
-        const userId = req.user!.id;
-        const settings = await getSystemSettings();
-        const available = await ytMusicService.isAvailable();
+router.get(
+    "/status",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+        try {
+            const userId = req.user!.id;
+            const settings = await getSystemSettings();
+            const available = await ytMusicService.isAvailable();
 
-        const oauthConfigured = !!(
-            settings?.ytMusicClientId && settings?.ytMusicClientSecret
-        );
+            const oauthConfigured = !!(
+                settings?.ytMusicClientId && settings?.ytMusicClientSecret
+            );
 
-        if (!available) {
+            if (!available) {
+                return res.json({
+                    enabled: settings.ytMusicEnabled,
+                    available: false,
+                    authenticated: false,
+                    credentialsConfigured: oauthConfigured,
+                    oauthConfigured,
+                });
+            }
+
+            // Try to restore OAuth if needed, then check status
+            await ensureUserOAuth(userId);
+            const authStatus = await ytMusicService.getAuthStatus(userId);
+
             return res.json({
                 enabled: settings.ytMusicEnabled,
-                available: false,
-                authenticated: false,
+                available: true,
                 credentialsConfigured: oauthConfigured,
                 oauthConfigured,
+                ...authStatus,
             });
+        } catch (err) {
+            logger.error("[YTMusic Route] Status check failed:", err);
+            sendInternalRouteError(res, "Failed to check YouTube Music status");
         }
-
-        // Try to restore OAuth if needed, then check status
-        await ensureUserOAuth(userId);
-        const authStatus = await ytMusicService.getAuthStatus(userId);
-
-        return res.json({
-            enabled: settings.ytMusicEnabled,
-            available: true,
-            credentialsConfigured: oauthConfigured,
-            oauthConfigured,
-            ...authStatus,
-        });
-    } catch (err) {
-        logger.error("[YTMusic Route] Status check failed:", err);
-        res.status(500).json({ error: "Failed to check YouTube Music status" });
-    }
-});
+    }),
+);
 
 // ── OAuth Device Code Flow (per-user) ──────────────────────────────
 
@@ -570,7 +614,7 @@ router.post(
     "/auth/device-code",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const settings = await getSystemSettings();
             if (!settings?.ytMusicClientId || !settings?.ytMusicClientSecret) {
@@ -585,15 +629,11 @@ router.post(
             );
 
             res.json(result);
-        } catch (err: any) {
+        } catch (err: unknown) {
             logger.error("[YTMusic Route] Device code initiation failed:", err);
-            res.status(500).json({
-                error:
-                    err.response?.data?.detail ||
-                    "Failed to initiate device code flow",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -626,7 +666,7 @@ router.post(
     "/auth/device-code/poll",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
             const { deviceCode } = req.body;
@@ -648,14 +688,11 @@ router.post(
                 });
             }
             res.json(result.response);
-        } catch (err: any) {
+        } catch (err: unknown) {
             logger.error("[YTMusic Route] Device code poll failed:", err);
-            res.status(500).json({
-                error:
-                    err.response?.data?.detail || "Failed to poll device code",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -689,7 +726,7 @@ router.post(
     "/auth/save-token",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
             const { oauthJson } = req.body;
@@ -722,14 +759,11 @@ router.post(
                 );
             }
             res.json({ success });
-        } catch (err: any) {
+        } catch (err: unknown) {
             logger.error("[YTMusic Route] Save OAuth token failed:", err);
-            res.status(500).json({
-                error:
-                    err.response?.data?.detail || "Failed to save OAuth token",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -750,7 +784,7 @@ router.post(
     "/auth/clear",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
 
@@ -760,13 +794,11 @@ router.post(
                 `[YTMusic] OAuth credentials cleared for user ${userId}`,
             );
             res.json({ success: true });
-        } catch (err: any) {
+        } catch (err: unknown) {
             logger.error("[YTMusic Route] Clear auth failed:", err);
-            res.status(500).json({
-                error: err.response?.data?.detail || "Failed to clear auth",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 // ── Search ─────────────────────────────────────────────────────────
@@ -807,7 +839,7 @@ router.post(
     requireAuth,
     requireYtMusicEnabled,
     ytMusicSearchLimiter,
-    async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
 
@@ -821,14 +853,12 @@ router.post(
                 filter,
             );
             res.json(result);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Search failed:", err);
-            res.status(500).json({
-                error: err.response?.data?.detail || "Search failed",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 // ── Browse ─────────────────────────────────────────────────────────
@@ -857,7 +887,7 @@ router.get(
     "/album/:browseId",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request<{ browseId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ browseId: string }>, res: Response) => {
         try {
             const effectiveUserId = await getUserIdOrPublic(req.user!.id);
             const album = await ytMusicService.getAlbum(
@@ -865,14 +895,12 @@ router.get(
                 req.params.browseId,
             );
             res.json(album);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Get album failed:", err);
-            res.status(500).json({
-                error: err.response?.data?.detail || "Failed to get album",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -899,7 +927,7 @@ router.get(
     "/artist/:channelId",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request<{ channelId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ channelId: string }>, res: Response) => {
         try {
             const effectiveUserId = await getUserIdOrPublic(req.user!.id);
             const artist = await ytMusicService.getArtist(
@@ -907,14 +935,12 @@ router.get(
                 req.params.channelId,
             );
             res.json(artist);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Get artist failed:", err);
-            res.status(500).json({
-                error: err.response?.data?.detail || "Failed to get artist",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -941,7 +967,7 @@ router.get(
     "/song/:videoId",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request<{ videoId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ videoId: string }>, res: Response) => {
         try {
             const effectiveUserId = await getUserIdOrPublic(req.user!.id);
             const song = await ytMusicService.getSong(
@@ -949,14 +975,12 @@ router.get(
                 req.params.videoId,
             );
             res.json(song);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Get song failed:", err);
-            res.status(500).json({
-                error: err.response?.data?.detail || "Failed to get song",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 // ── Stream Info ────────────────────────────────────────────────────
@@ -1000,7 +1024,7 @@ router.get(
     requireAuthOrToken,
     requireYtMusicEnabled,
     ytMusicStreamLimiter,
-    async (req: Request<{ videoId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ videoId: string }>, res: Response) => {
         try {
             const userId = req.user!.id;
             const effectiveUserId = await getUserIdOrPublic(userId);
@@ -1024,11 +1048,11 @@ router.get(
                 duration: info.duration,
                 content_type: info.content_type,
             });
-        } catch (err: any) {
-            if (err.response?.status === 404) {
+        } catch (err: unknown) {
+            if (getHttpErrorStatus(err) === 404) {
                 return res.status(404).json({ error: "Stream not found" });
             }
-            if (err.response?.status === 451) {
+            if (getHttpErrorStatus(err) === 451) {
                 return res.status(451).json({
                     error: "age_restricted",
                     message:
@@ -1037,11 +1061,9 @@ router.get(
             }
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Stream info failed:", err);
-            res.status(500).json({
-                error: "Failed to get stream info",
-            });
+            sendInternalRouteError(res, "Failed to get stream info");
         }
-    },
+    }),
 );
 
 // ── Stream Proxy ───────────────────────────────────────────────────
@@ -1092,7 +1114,7 @@ router.get(
     requireAuthOrToken,
     requireYtMusicEnabled,
     ytMusicStreamLimiter,
-    async (req: Request<{ videoId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ videoId: string }>, res: Response) => {
         try {
             const userId = req.user!.id;
             const effectiveUserId = await getUserIdOrPublic(userId);
@@ -1149,15 +1171,13 @@ router.get(
                 }
             });
             proxyRes.data.pipe(res);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicStreamProxyError(res, err)) return;
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Stream proxy failed:", err);
-            res.status(500).json({
-                error: "Failed to stream audio",
-            });
+            sendInternalRouteError(res, "Failed to stream audio");
         }
-    },
+    }),
 );
 
 // ── Library ────────────────────────────────────────────────────────
@@ -1189,22 +1209,21 @@ router.get(
     "/library/songs",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    parsePagination(),
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
             if (!(await requireUserOAuth(userId, res))) return;
-            const limit = parseBoundedLimit(req.query.limit);
+            const limit =
+                req.pagination?.limit ?? parseBoundedLimit(req.query.limit);
             const songs = await ytMusicService.getLibrarySongs(userId, limit);
             res.json({ songs });
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Library songs failed:", err);
-            res.status(500).json({
-                error:
-                    err.response?.data?.detail || "Failed to get library songs",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 /**
@@ -1234,23 +1253,21 @@ router.get(
     "/library/albums",
     requireAuth,
     requireYtMusicEnabled,
-    async (req: Request, res: Response) => {
+    parsePagination(),
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
             if (!(await requireUserOAuth(userId, res))) return;
-            const limit = parseBoundedLimit(req.query.limit);
+            const limit =
+                req.pagination?.limit ?? parseBoundedLimit(req.query.limit);
             const albums = await ytMusicService.getLibraryAlbums(userId, limit);
             res.json({ albums });
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Library albums failed:", err);
-            res.status(500).json({
-                error:
-                    err.response?.data?.detail ||
-                    "Failed to get library albums",
-            });
+            sendInternalRouteError(res, "Internal server error");
         }
-    },
+    }),
 );
 
 // ── Gap-Fill Match ─────────────────────────────────────────────────
@@ -1294,18 +1311,12 @@ router.post(
     requireAuth,
     requireYtMusicEnabled,
     ytMusicSearchLimiter,
-    async (req: Request, res: Response) => {
+    validate({ body: MATCH_SCHEMA }),
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
 
-            const schema = z.object({
-                artist: z.string().min(1),
-                title: z.string().min(1),
-                albumTitle: z.string().optional(),
-                duration: z.number().positive().optional(),
-                isrc: z.string().trim().min(6).max(20).optional(),
-            });
-            const parsed = schema.safeParse(req.body);
+            const parsed = MATCH_SCHEMA.safeParse(req.valid?.body ?? req.body);
             if (!parsed.success) {
                 return res
                     .status(400)
@@ -1320,14 +1331,12 @@ router.post(
                 parsed.data.isrc,
             );
             res.json({ match });
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Match failed:", err);
-            res.status(500).json({
-                error: "Failed to find matching track",
-            });
+            sendInternalRouteError(res, "Failed to find matching track");
         }
-    },
+    }),
 );
 
 // ── Batch Gap-Fill Match ───────────────────────────────────────────
@@ -1378,25 +1387,14 @@ router.post(
     requireAuth,
     requireYtMusicEnabled,
     ytMusicSearchLimiter,
-    async (req: Request, res: Response) => {
+    validate({ body: MATCH_BATCH_SCHEMA }),
+    asyncHandler(async (req: Request, res: Response) => {
         try {
             const userId = req.user!.id;
 
-            const schema = z.object({
-                tracks: z
-                    .array(
-                        z.object({
-                            artist: z.string(),
-                            title: z.string(),
-                            albumTitle: z.string().optional(),
-                            duration: z.number().positive().optional(),
-                            isrc: z.string().trim().min(6).max(20).optional(),
-                        }),
-                    )
-                    .min(1)
-                    .max(50),
-            });
-            const parsed = schema.safeParse(req.body);
+            const parsed = MATCH_BATCH_SCHEMA.safeParse(
+                req.valid?.body ?? req.body,
+            );
             if (!parsed.success) {
                 return res
                     .status(400)
@@ -1435,14 +1433,12 @@ router.post(
 
             // Return matches keyed by index for easy lookup
             res.json({ matches });
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicAuthError(res, err)) return;
             logger.error("[YTMusic Route] Batch match failed:", err);
-            res.status(500).json({
-                error: "Failed to batch-match tracks",
-            });
+            sendInternalRouteError(res, "Failed to batch-match tracks");
         }
-    },
+    }),
 );
 
 // ── Public Stream Routes (no user OAuth required) ─────────────────
@@ -1478,7 +1474,7 @@ router.get(
     requireAuthOrToken,
     requireYtMusicEnabled,
     ytMusicStreamLimiter,
-    async (req: Request<{ videoId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ videoId: string }>, res: Response) => {
         try {
             const { videoId } = req.params;
             const quality = normalizeYtMusicStreamQuality(
@@ -1498,11 +1494,11 @@ router.get(
                 duration: info.duration,
                 content_type: info.content_type,
             });
-        } catch (err: any) {
-            if (err.response?.status === 404) {
+        } catch (err: unknown) {
+            if (getHttpErrorStatus(err) === 404) {
                 return res.status(404).json({ error: "Stream not found" });
             }
-            if (err.response?.status === 451) {
+            if (getHttpErrorStatus(err) === 451) {
                 return res.status(451).json({
                     error: "age_restricted",
                     message:
@@ -1510,11 +1506,9 @@ router.get(
                 });
             }
             logger.error("[YTMusic Route] Public stream info failed:", err);
-            res.status(500).json({
-                error: "Failed to get stream info",
-            });
+            sendInternalRouteError(res, "Failed to get stream info");
         }
-    },
+    }),
 );
 
 /**
@@ -1550,7 +1544,7 @@ router.get(
     requireAuthOrToken,
     requireYtMusicEnabled,
     ytMusicStreamLimiter,
-    async (req: Request<{ videoId: string }>, res: Response) => {
+    asyncHandler(async (req: Request<{ videoId: string }>, res: Response) => {
         try {
             const { videoId } = req.params;
             const quality = normalizeYtMusicStreamQuality(
@@ -1599,14 +1593,12 @@ router.get(
                 }
             });
             proxyRes.data.pipe(res);
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (handleYtMusicStreamProxyError(res, err)) return;
             logger.error("[YTMusic Route] Public stream proxy failed:", err);
-            res.status(500).json({
-                error: "Failed to stream audio",
-            });
+            sendInternalRouteError(res, "Failed to stream audio");
         }
-    },
+    }),
 );
 
 export default router;

--- a/backend/src/services/__tests__/metadataOverrideActions.test.ts
+++ b/backend/src/services/__tests__/metadataOverrideActions.test.ts
@@ -1,0 +1,80 @@
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        artist: { findUnique: jest.fn(), update: jest.fn() },
+        album: { findUnique: jest.fn() },
+        track: { findFirst: jest.fn(), update: jest.fn() },
+    },
+}));
+jest.mock("../../utils/redis", () => ({ redisClient: { del: jest.fn() } }));
+jest.mock("../albumMetadataPersistence", () => ({
+    updateAlbumMetadataWithOwnership: jest.fn(),
+}));
+jest.mock("../../utils/logger", () => ({
+    logger: { child: () => ({ warn: jest.fn() }) },
+}));
+
+import { prisma } from "../../utils/db";
+import {
+    applyMetadataOverrides,
+    resetMetadataOverrides,
+    MetadataEntityNotFoundError,
+    type MetadataFieldMap,
+} from "../metadataOverrideActions";
+
+const artistUpdate = prisma.artist.update as jest.Mock;
+const artistFindUnique = prisma.artist.findUnique as jest.Mock;
+
+describe("metadata override service", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("maps defined fields and marks user overrides", async () => {
+        artistUpdate.mockResolvedValue({ id: "artist-1" });
+        const fieldMap: MetadataFieldMap = {
+            name: { target: "displayName" },
+            genres: { target: "userGenres" },
+            mbid: { target: "mbid", marksOverride: false },
+        };
+
+        await applyMetadataOverrides(
+            { type: "artist", id: "artist-1" },
+            { name: "New name", genres: ["rock"], ignored: true },
+            fieldMap,
+        );
+
+        expect(artistUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "artist-1" },
+                data: {
+                    displayName: "New name",
+                    userGenres: ["rock"],
+                    hasUserOverrides: true,
+                },
+            }),
+        );
+    });
+
+    it("resets an existing artist with the canonical reset fields", async () => {
+        artistFindUnique.mockResolvedValue({ id: "artist-1" });
+        artistUpdate.mockResolvedValue({ id: "artist-1", displayName: null });
+
+        const result = await resetMetadataOverrides({
+            type: "artist",
+            id: "artist-1",
+        });
+
+        expect(result).toEqual({ id: "artist-1", displayName: null });
+        expect(artistUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ hasUserOverrides: false }),
+            }),
+        );
+    });
+
+    it("rejects a reset for a missing entity", async () => {
+        artistFindUnique.mockResolvedValue(null);
+
+        await expect(
+            resetMetadataOverrides({ type: "artist", id: "missing" }),
+        ).rejects.toBeInstanceOf(MetadataEntityNotFoundError);
+    });
+});

--- a/backend/src/services/metadataOverrideActions.ts
+++ b/backend/src/services/metadataOverrideActions.ts
@@ -1,0 +1,181 @@
+import type { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "../utils/db";
+import { redisClient } from "../utils/redis";
+import { logger } from "../utils/logger";
+import { TRACK_VISIBLE_WHERE } from "../utils/librarySorting";
+import { updateAlbumMetadataWithOwnership } from "./albumMetadataPersistence";
+
+const log = logger.child("MetadataOverrides");
+
+export const artistMetadataSchema = z
+    .object({
+        name: z.string().nullable().optional(),
+        bio: z.string().nullable().optional(),
+        genres: z.array(z.string()).optional(),
+        heroUrl: z.string().nullable().optional(),
+        mbid: z.unknown().optional(),
+    })
+    .passthrough();
+export const albumMetadataSchema = z
+    .object({
+        title: z.string().nullable().optional(),
+        year: z.union([z.number(), z.string()]).optional(),
+        genres: z.array(z.string()).optional(),
+        coverUrl: z.string().nullable().optional(),
+        rgMbid: z.unknown().optional(),
+    })
+    .passthrough();
+export const trackMetadataSchema = z
+    .object({
+        title: z.string().nullable().optional(),
+        trackNo: z.union([z.number(), z.string()]).optional(),
+    })
+    .passthrough();
+
+export type MetadataEntity = {
+    type: "artist" | "album" | "track";
+    id: string;
+};
+
+export interface MetadataField {
+    target: string;
+    marksOverride?: boolean;
+    transform?: (value: unknown) => unknown;
+}
+
+export type MetadataFieldMap = Readonly<Record<string, MetadataField>>;
+
+export class MetadataEntityNotFoundError extends Error {
+    constructor(readonly entityType: MetadataEntity["type"]) {
+        super(`${entityType} not found`);
+        this.name = "MetadataEntityNotFoundError";
+    }
+}
+
+function buildUpdateData(
+    body: Readonly<Record<string, unknown>>,
+    fieldMap: MetadataFieldMap,
+): Record<string, unknown> {
+    const updateData: Record<string, unknown> = {};
+    let hasOverrides = false;
+    for (const [source, field] of Object.entries(fieldMap)) {
+        const value = body[source];
+        if (value === undefined) continue;
+        updateData[field.target] = field.transform
+            ? field.transform(value)
+            : value;
+        hasOverrides ||= field.marksOverride !== false;
+    }
+    if (hasOverrides) updateData.hasUserOverrides = true;
+    return updateData;
+}
+
+async function updateArtist(id: string, data: Record<string, unknown>) {
+    const artist = await prisma.artist.update({
+        where: { id },
+        data: data as Prisma.ArtistUpdateInput,
+        include: {
+            albums: {
+                select: { id: true, title: true, year: true, coverUrl: true },
+            },
+        },
+    });
+    try {
+        await redisClient.del(`hero:${id}`);
+    } catch (error) {
+        log.warn("Failed to invalidate artist hero cache", { error, id });
+    }
+    return artist;
+}
+
+async function updateTrack(id: string, data: Record<string, unknown>) {
+    return prisma.track.update({
+        where: { id },
+        data: data as Prisma.TrackUpdateInput,
+        include: {
+            album: {
+                select: {
+                    id: true,
+                    title: true,
+                    artist: { select: { id: true, name: true } },
+                },
+            },
+        },
+    });
+}
+
+/** Maps defined input fields to non-destructive metadata updates and persists them. */
+export async function applyMetadataOverrides(
+    entity: MetadataEntity,
+    body: Readonly<Record<string, unknown>>,
+    fieldMap: MetadataFieldMap,
+) {
+    const data = buildUpdateData(body, fieldMap);
+    switch (entity.type) {
+        case "artist":
+            return updateArtist(entity.id, data);
+        case "album":
+            return updateAlbumMetadataWithOwnership(
+                entity.id,
+                data as Prisma.AlbumUpdateInput,
+            );
+        case "track":
+            return updateTrack(entity.id, data);
+    }
+}
+
+async function resetArtist(id: string) {
+    const existing = await prisma.artist.findUnique({
+        where: { id },
+        select: { id: true },
+    });
+    if (!existing) throw new MetadataEntityNotFoundError("artist");
+    return updateArtist(id, {
+        displayName: null,
+        userSummary: null,
+        userHeroUrl: null,
+        userGenres: [],
+        hasUserOverrides: false,
+    });
+}
+
+async function resetAlbum(id: string) {
+    const existing = await prisma.album.findUnique({
+        where: { id },
+        select: { id: true },
+    });
+    if (!existing) throw new MetadataEntityNotFoundError("album");
+    return updateAlbumMetadataWithOwnership(id, {
+        displayTitle: null,
+        displayYear: null,
+        userCoverUrl: null,
+        userGenres: [],
+        hasUserOverrides: false,
+    });
+}
+
+async function resetTrack(id: string) {
+    const existing = await prisma.track.findFirst({
+        where: { id, ...TRACK_VISIBLE_WHERE },
+        select: { id: true },
+    });
+    if (!existing) throw new MetadataEntityNotFoundError("track");
+    return updateTrack(id, {
+        displayTitle: null,
+        displayTrackNo: null,
+        hasUserOverrides: false,
+    });
+}
+
+/** Clears display overrides while preserving each entity's canonical metadata. */
+export async function resetMetadataOverrides(entity: MetadataEntity) {
+    switch (entity.type) {
+        case "artist":
+            return resetArtist(entity.id);
+        case "album":
+            return resetAlbum(entity.id);
+        case "track":
+            return resetTrack(entity.id);
+    }
+}

--- a/backend/src/services/musicbrainz.ts
+++ b/backend/src/services/musicbrainz.ts
@@ -13,6 +13,33 @@ export { isValidMbid } from "../utils/musicIds";
 
 type MbidEntity = "artist" | "release group" | "release";
 
+/** Artist fields returned by MusicBrainz search. */
+export interface MusicBrainzArtistSearchResult {
+    id: string;
+    name: string;
+    disambiguation?: string;
+    country?: string;
+    type?: string;
+    score?: number | string;
+}
+
+/** Artist-credit fields returned with a MusicBrainz release group. */
+export interface MusicBrainzArtistCredit {
+    name?: string;
+    artist?: { name?: string };
+}
+
+/** Release-group fields returned by MusicBrainz search. */
+export interface MusicBrainzReleaseGroupSearchResult {
+    id: string;
+    title: string;
+    "primary-type"?: string;
+    "secondary-types"?: string[];
+    "first-release-date"?: string;
+    "artist-credit"?: MusicBrainzArtistCredit[];
+    score?: number | string;
+}
+
 function validateMbid(value: unknown, entity: MbidEntity): string {
     if (!isValidMbid(value)) {
         throw new TypeError(`Invalid ${entity} MBID`);

--- a/backend/src/services/youtubeMusic.ts
+++ b/backend/src/services/youtubeMusic.ts
@@ -49,7 +49,7 @@ export interface YtMusicDeviceCode {
 
 export interface YtMusicDeviceCodePollResult {
     status: "pending" | "success" | "error";
-    error?: string;
+    error?: string | null;
     oauth_json?: string;
 }
 

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,18 @@
+import type { Pagination } from "../middleware/parsePagination";
+import type { OwnedResource } from "../middleware/loadOwned";
+
+declare global {
+    namespace Express {
+        interface Request {
+            valid?: {
+                body?: unknown;
+                query?: unknown;
+                params?: unknown;
+            };
+            pagination?: Pagination;
+            owned?: OwnedResource;
+        }
+    }
+}
+
+export {};

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -54,13 +54,13 @@ const FIXED_SCAN_ROOTS = Object.freeze([
 
 const BASELINE = Object.freeze({
     "backend/src/routes/browse.ts": 1540,
-    "backend/src/routes/enrichment.ts": 2261,
+    "backend/src/routes/enrichment.ts": 2249,
     "backend/src/routes/library/radio.ts": 1563,
     "backend/src/routes/library/tracks.ts": 1655,
     "backend/src/routes/playlists.ts": 2262,
     "backend/src/routes/podcasts.ts": 2541,
     "backend/src/routes/systemSettings.ts": 1506,
-    "backend/src/routes/youtubeMusic.ts": 1612,
+    "backend/src/routes/youtubeMusic.ts": 1604,
     "backend/src/services/lidarr.ts": 2951,
     "backend/src/services/simpleDownloadManager.ts": 2306,
     "backend/src/services/spotify.ts": 1624,

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -24,7 +24,6 @@ const BASELINE = Object.freeze({
     "backend/src/routes/discover/exclusions.ts": 1,
     "backend/src/routes/discover/shared.ts": 4,
     "backend/src/routes/downloads.ts": 1,
-    "backend/src/routes/enrichment.ts": 30,
     "backend/src/routes/homepage.ts": 2,
     "backend/src/routes/library/albums.ts": 1,
     "backend/src/routes/library/artists.ts": 2,
@@ -54,7 +53,6 @@ const BASELINE = Object.freeze({
     "backend/src/routes/trackMappings.ts": 2,
     "backend/src/routes/webhooks.ts": 0,
     "backend/src/routes/youtube.ts": 1,
-    "backend/src/routes/youtubeMusic.ts": 18,
 });
 
 // Raw error details can disclose internal implementation data to clients (OWASP).
@@ -85,8 +83,6 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/routes/subsonic/mediaRetrieval.ts": 1,
     // youtube.ts remaining 4: yt-dlp sidecar err.response?.data?.detail echoed in error responses (L68, L126, L335, L341); known backlog item, frozen under the slice-J scope guard.
     "backend/src/routes/youtube.ts": 4,
-    // youtubeMusic.ts remaining 11: ytmusic sidecar err.response?.data?.detail echoes (10x) plus one result.error response (~L434); same sidecar-detail class as youtube.ts, frozen under the slice-J scope guard, flagged for follow-up.
-    "backend/src/routes/youtubeMusic.ts": 11,
     // acquisitionService.ts remaining 4: { success:false, error } acquisition result objects (~L482, ~L678, ~L767) consumed by the download orchestration/admin surface, not raw route 500 bodies; frozen under the slice-E scope guard; plus a result.error passthrough in a { success:false, error } result object (~L748); frozen under the slice-J scope guard.
     "backend/src/services/acquisitionService.ts": 4,
     // artistCountsService.ts +2: numeric backfill error counters returned in result/progress objects (~L237 and ~L277); no error text; frozen under the ratchet-widening (slice-B2) scope guard.


### PR DESCRIPTION
## Problem (#794, slice 1 of the incremental plan)

Routes hand-roll auth/ownership/pagination/validation ~500×; 268 ad-hoc-500 sites frozen in the error-canon ratchet with no repayment path; `enrichment.ts` repeated its override skeleton 3× with `any` and lazy `await import("../utils/db")` inside handlers.

## Change

- **Three middlewares** (`validate`, `parsePagination`, `loadOwned`) with typed `req.valid`/`req.owned`, one Request augmentation, Express-5 query pinning, uniform 404/403, focused negative-path tests. Clamp-policy deltas for future conversions documented (playlists 500-default, audiobooks unbounded → both noted, neither converted here).
- **`enrichment.ts` converted:** canon baseline **30 → 0**; override/reset triplets → typed `metadataOverrideActions` service (renamed from the initial `metadataOverrides` to avoid twinning the existing `utils/metadataOverrides` — orchestration review); six lazy db imports hoisted (cycle detector clean).
- **`youtubeMusic.ts` converted:** canon **18 → 0**, raw-error-leak **11 → 0** (sidecar error detail no longer flows to clients — canonical messages).
- All 51 handlers on `asyncHandler`; zero dynamic imports/`any` in both files. **The ratchet is now the repayment tracker** — baselines shrink monotonically with each future conversion.

## Verification

- `verify:` **full backend suite post-rebase: 505/505 suites, 7,542 tests pass**
- `verify:` targeted enrichment/youtubeMusic/middleware/service suites: 45 suites, 551 tests pass (3 pre-existing logger mocks extended to the standard `.child` shape)
- `verify:` route-error canon **both ratchets pass with shrunken baselines**; tsc exit 0; format/file-size/routes-readme clean

Closes #794