### PR TITLE
chore(player): extract overlay gestures into a tested hook and pure policy module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The full-screen player's swipe gestures (track skip, swipe-down to close, drawer handle) now run through one tested gesture module, in preparation for further player decomposition.
 - Subsonic search and artist views now share the main library's data layer.
 - Internal route handling now shares validation, pagination, and ownership middleware, and enrichment and YouTube Music administrator errors use the documented response format.
 - App screens now share one catalog of data-cache keys, so library, playlist, download, and notification views refresh reliably after changes instead of occasionally showing stale lists.

--- a/frontend/components/player/OverlayPlayer.tsx
+++ b/frontend/components/player/OverlayPlayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useOverlayGestures } from "./hooks/useOverlayGestures";
 import { useOverlayPlayerAudio } from "./hooks/useOverlayPlayerAudio";
 import { useMediaInfo } from "@/hooks/useMediaInfo";
 import { useLyrics } from "@/hooks/useLyrics";
@@ -172,21 +173,9 @@ export function OverlayPlayer() {
 
     // Swipe state for track skipping
     const overlayRef = useRef<HTMLDivElement | null>(null);
-    const touchStartX = useRef<number | null>(null);
-    const overlayCloseTouchStartY = useRef<number | null>(null);
-    const overlayCloseTouchStartX = useRef<number | null>(null);
-    const overlayCloseTouchStartTime = useRef<number | null>(null);
-    const drawerTouchStartY = useRef<number | null>(null);
-    const drawerTouchStartX = useRef<number | null>(null);
-    const drawerTouchStartTime = useRef<number | null>(null);
     const queueListRef = useRef<HTMLDivElement | null>(null);
     const wasQueueTabVisibleRef = useRef(false);
     const previousQueueIndexRef = useRef<number | null>(null);
-    const [swipeOffset, setSwipeOffset] = useState(0);
-    const [overlayDragOffset, setOverlayDragOffset] = useState(0);
-    const [isOverlayDragActive, setIsOverlayDragActive] = useState(false);
-    const [drawerDragOffset, setDrawerDragOffset] = useState(0);
-    const [isDrawerDragActive, setIsDrawerDragActive] = useState(false);
     const [isVibeLoading, setIsVibeLoading] = useState(false);
     const [isRadioLoading, setIsRadioLoading] = useState(false);
     const [isPlaylistSelectorOpen, setIsPlaylistSelectorOpen] = useState(false);
@@ -212,6 +201,23 @@ export function OverlayPlayer() {
     );
     // Skip is queue-based: the unified queue can mix tracks and episodes.
     const canSkip = queue.length > 0;
+    const {
+        swipeOffset,
+        overlayDragOffset,
+        isOverlayDragActive,
+        overlayHeaderHandlers,
+        drawerDragOffset,
+        isDrawerDragActive,
+        drawerHandleHandlers,
+        resetDrawerDrag,
+        trackSwipeHandlers,
+    } = useOverlayGestures({
+        canSkip,
+        onPrevious: previous,
+        onNext: next,
+        onCloseOverlay: returnToPreviousMode,
+        onCloseDrawer: () => setIsDrawerOpen(false),
+    });
     const isTrackMode = playbackType === "track";
     const preferenceTrackId = isTrackMode ? currentTrack?.id : undefined;
     const isDesktopOverlayLayout = canSkip && !isMobileOrTablet;
@@ -617,12 +623,8 @@ export function OverlayPlayer() {
 
     useEffect(() => {
         if (isDrawerOpen) return;
-        setDrawerDragOffset(0);
-        setIsDrawerDragActive(false);
-        drawerTouchStartY.current = null;
-        drawerTouchStartX.current = null;
-        drawerTouchStartTime.current = null;
-    }, [isDrawerOpen]);
+        resetDrawerDrag();
+    }, [isDrawerOpen, resetDrawerDrag]);
 
     useEffect(() => {
         const wasQueueVisible = wasQueueTabVisibleRef.current;
@@ -919,166 +921,6 @@ export function OverlayPlayer() {
         [getRelatedTrackKey, playTrack, relatedStreamMatches],
     );
 
-    // Swipe handlers for track skipping
-    const handleTouchStart = (e: React.TouchEvent) => {
-        touchStartX.current = e.touches[0].clientX;
-    };
-
-    const handleTouchMove = (e: React.TouchEvent) => {
-        if (touchStartX.current === null) return;
-        const deltaX = e.touches[0].clientX - touchStartX.current;
-        setSwipeOffset(Math.max(-100, Math.min(100, deltaX)));
-    };
-
-    const handleTouchEnd = () => {
-        if (touchStartX.current === null) return;
-
-        if (canSkip) {
-            if (swipeOffset > 60) {
-                previous();
-            } else if (swipeOffset < -60) {
-                next();
-            }
-        }
-
-        setSwipeOffset(0);
-        touchStartX.current = null;
-    };
-
-    const handleDrawerHandleTouchStart = (e: React.TouchEvent) => {
-        drawerTouchStartY.current = e.touches[0].clientY;
-        drawerTouchStartX.current = e.touches[0].clientX;
-        drawerTouchStartTime.current = Date.now();
-        setDrawerDragOffset(0);
-        setIsDrawerDragActive(true);
-        e.stopPropagation();
-    };
-
-    const handleDrawerHandleTouchMove = (e: React.TouchEvent) => {
-        if (
-            drawerTouchStartY.current === null ||
-            drawerTouchStartX.current === null
-        )
-            return;
-
-        const deltaY = e.touches[0].clientY - drawerTouchStartY.current;
-        const deltaX = Math.abs(
-            e.touches[0].clientX - drawerTouchStartX.current,
-        );
-
-        if (deltaY > 0 && deltaY > deltaX * 0.9) {
-            setDrawerDragOffset(Math.min(240, deltaY));
-            e.preventDefault();
-        } else if (deltaY <= 0) {
-            setDrawerDragOffset(0);
-        }
-        e.stopPropagation();
-    };
-
-    const handleDrawerHandleTouchEnd = (e: React.TouchEvent) => {
-        if (
-            drawerTouchStartY.current === null ||
-            drawerTouchStartX.current === null
-        ) {
-            setDrawerDragOffset(0);
-            setIsDrawerDragActive(false);
-            return;
-        }
-
-        const endY = e.changedTouches[0].clientY;
-        const endX = e.changedTouches[0].clientX;
-        const deltaY = endY - drawerTouchStartY.current;
-        const deltaX = Math.abs(endX - drawerTouchStartX.current);
-        const elapsedMs = Math.max(
-            1,
-            Date.now() - (drawerTouchStartTime.current ?? Date.now()),
-        );
-        const velocityY = deltaY / elapsedMs;
-        const isVerticalSwipe = deltaY > 0 && deltaY > deltaX * 1.2;
-        const isDistanceClose = deltaY > 44;
-        const isVelocityClose = deltaY > 20 && velocityY > 0.25;
-
-        if (isVerticalSwipe && (isDistanceClose || isVelocityClose)) {
-            setDrawerDragOffset((prev) => Math.max(prev, 140));
-            setIsDrawerDragActive(false);
-            setIsDrawerOpen(false);
-        } else {
-            setDrawerDragOffset(0);
-            setIsDrawerDragActive(false);
-        }
-        drawerTouchStartY.current = null;
-        drawerTouchStartX.current = null;
-        drawerTouchStartTime.current = null;
-        e.stopPropagation();
-    };
-
-    const handleOverlayHeaderTouchStart = (e: React.TouchEvent) => {
-        overlayCloseTouchStartY.current = e.touches[0].clientY;
-        overlayCloseTouchStartX.current = e.touches[0].clientX;
-        overlayCloseTouchStartTime.current = Date.now();
-        setOverlayDragOffset(0);
-        setIsOverlayDragActive(true);
-        e.stopPropagation();
-    };
-
-    const handleOverlayHeaderTouchMove = (e: React.TouchEvent) => {
-        if (
-            overlayCloseTouchStartY.current === null ||
-            overlayCloseTouchStartX.current === null
-        )
-            return;
-        const deltaY = e.touches[0].clientY - overlayCloseTouchStartY.current;
-        const deltaX = Math.abs(
-            e.touches[0].clientX - overlayCloseTouchStartX.current,
-        );
-
-        if (deltaY > 0 && deltaY > deltaX * 0.9) {
-            setOverlayDragOffset(Math.min(220, deltaY));
-            e.preventDefault();
-        } else if (deltaY <= 0) {
-            setOverlayDragOffset(0);
-        }
-        e.stopPropagation();
-    };
-
-    const handleOverlayHeaderTouchEnd = (e: React.TouchEvent) => {
-        if (
-            overlayCloseTouchStartY.current === null ||
-            overlayCloseTouchStartX.current === null
-        ) {
-            setOverlayDragOffset(0);
-            setIsOverlayDragActive(false);
-            return;
-        }
-
-        const endY = e.changedTouches[0].clientY;
-        const endX = e.changedTouches[0].clientX;
-        const deltaY = endY - overlayCloseTouchStartY.current;
-        const deltaX = Math.abs(endX - overlayCloseTouchStartX.current);
-        const elapsedMs = Math.max(
-            1,
-            Date.now() - (overlayCloseTouchStartTime.current ?? Date.now()),
-        );
-        const velocityY = deltaY / elapsedMs;
-        const isVerticalSwipe = deltaY > 0 && deltaY > deltaX * 1.2;
-        const isDistanceClose = deltaY > 44;
-        const isVelocityClose = deltaY > 20 && velocityY > 0.25;
-
-        if (isVerticalSwipe && (isDistanceClose || isVelocityClose)) {
-            setOverlayDragOffset((prev) => Math.max(prev, 140));
-            setIsOverlayDragActive(false);
-            e.preventDefault();
-            returnToPreviousMode();
-        } else {
-            setOverlayDragOffset(0);
-            setIsOverlayDragActive(false);
-        }
-        overlayCloseTouchStartY.current = null;
-        overlayCloseTouchStartX.current = null;
-        overlayCloseTouchStartTime.current = null;
-        e.stopPropagation();
-    };
-
     // Handle Vibe toggle
     const handleVibeToggle = async () => {
         if (!currentTrack?.id) return;
@@ -1209,22 +1051,34 @@ export function OverlayPlayer() {
                 "fixed inset-0 bg-gradient-to-b from-[#1a1a2e] via-[#121218] to-[#000000] z-[9999] flex flex-col overflow-hidden",
                 !isMobileOrTablet && "bottom-24",
             )}
-            onTouchStart={isMobileOrTablet ? handleTouchStart : undefined}
-            onTouchMove={isMobileOrTablet ? handleTouchMove : undefined}
-            onTouchEnd={isMobileOrTablet ? handleTouchEnd : undefined}
+            onTouchStart={
+                isMobileOrTablet ? trackSwipeHandlers.onTouchStart : undefined
+            }
+            onTouchMove={
+                isMobileOrTablet ? trackSwipeHandlers.onTouchMove : undefined
+            }
+            onTouchEnd={
+                isMobileOrTablet ? trackSwipeHandlers.onTouchEnd : undefined
+            }
         >
             {/* Header */}
             <div
                 className="flex-shrink-0 px-4 pt-3 pb-2"
                 style={{ paddingTop: "calc(12px + env(safe-area-inset-top))" }}
                 onTouchStart={
-                    isMobileOrTablet ? handleOverlayHeaderTouchStart : undefined
+                    isMobileOrTablet
+                        ? overlayHeaderHandlers.onTouchStart
+                        : undefined
                 }
                 onTouchMove={
-                    isMobileOrTablet ? handleOverlayHeaderTouchMove : undefined
+                    isMobileOrTablet
+                        ? overlayHeaderHandlers.onTouchMove
+                        : undefined
                 }
                 onTouchEnd={
-                    isMobileOrTablet ? handleOverlayHeaderTouchEnd : undefined
+                    isMobileOrTablet
+                        ? overlayHeaderHandlers.onTouchEnd
+                        : undefined
                 }
             >
                 <div className="flex items-center justify-between">
@@ -1890,13 +1744,13 @@ export function OverlayPlayer() {
                                         <div
                                             className="mb-2 flex h-12 w-full items-center justify-center"
                                             onTouchStart={
-                                                handleDrawerHandleTouchStart
+                                                drawerHandleHandlers.onTouchStart
                                             }
                                             onTouchMove={
-                                                handleDrawerHandleTouchMove
+                                                drawerHandleHandlers.onTouchMove
                                             }
                                             onTouchEnd={
-                                                handleDrawerHandleTouchEnd
+                                                drawerHandleHandlers.onTouchEnd
                                             }
                                             style={{ touchAction: "none" }}
                                             aria-label="Swipe down to close panel"

--- a/frontend/components/player/hooks/useOverlayGestures.ts
+++ b/frontend/components/player/hooks/useOverlayGestures.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+    clampTrackSwipeOffset,
+    resolveTrackSwipeAction,
+    resolveVerticalDragOffset,
+    shouldCloseFromVerticalSwipe,
+} from "@/lib/overlay-gesture-policy";
+
+interface OverlayGestureOptions {
+    canSkip: boolean;
+    onPrevious: () => void;
+    onNext: () => void;
+    /** Close the whole overlay (header swipe-down). */
+    onCloseOverlay: () => void;
+    /** Close the bottom drawer (drawer-handle swipe-down). */
+    onCloseDrawer: () => void;
+}
+
+export interface TouchHandlerSet {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchMove: (e: React.TouchEvent) => void;
+    onTouchEnd: (e: React.TouchEvent) => void;
+}
+
+interface VerticalDragMachine {
+    dragOffset: number;
+    isDragActive: boolean;
+    handlers: TouchHandlerSet;
+    /** Clears drag state when the surface is closed externally. */
+    resetDrag: () => void;
+}
+
+/**
+ * One vertical swipe-to-close state machine (shared by the overlay header
+ * and the drawer handle — identical thresholds, different close targets).
+ */
+function useVerticalCloseGesture(
+    maxOffset: number,
+    onClose: () => void,
+    preventDefaultOnClose: boolean,
+): VerticalDragMachine {
+    const startY = useRef<number | null>(null);
+    const startX = useRef<number | null>(null);
+    const startTime = useRef<number | null>(null);
+    const [dragOffset, setDragOffset] = useState(0);
+    const [isDragActive, setIsDragActive] = useState(false);
+
+    const reset = () => {
+        startY.current = null;
+        startX.current = null;
+        startTime.current = null;
+    };
+
+    return {
+        dragOffset,
+        isDragActive,
+        resetDrag: () => {
+            setDragOffset(0);
+            setIsDragActive(false);
+            reset();
+        },
+        handlers: {
+            onTouchStart: (e) => {
+                startY.current = e.touches[0].clientY;
+                startX.current = e.touches[0].clientX;
+                startTime.current = Date.now();
+                setDragOffset(0);
+                setIsDragActive(true);
+                e.stopPropagation();
+            },
+            onTouchMove: (e) => {
+                if (startY.current === null || startX.current === null) return;
+                const offset = resolveVerticalDragOffset(
+                    e.touches[0].clientY - startY.current,
+                    e.touches[0].clientX - startX.current,
+                    maxOffset,
+                );
+                if (offset !== null) {
+                    setDragOffset(offset);
+                    if (offset > 0) e.preventDefault();
+                }
+                e.stopPropagation();
+            },
+            onTouchEnd: (e) => {
+                if (startY.current === null || startX.current === null) {
+                    setDragOffset(0);
+                    setIsDragActive(false);
+                    return;
+                }
+                const closes = shouldCloseFromVerticalSwipe({
+                    deltaY: e.changedTouches[0].clientY - startY.current,
+                    deltaX: e.changedTouches[0].clientX - startX.current,
+                    elapsedMs: Math.max(
+                        1,
+                        Date.now() - (startTime.current ?? Date.now()),
+                    ),
+                });
+                if (closes) {
+                    setDragOffset((prev) => Math.max(prev, 140));
+                    setIsDragActive(false);
+                    if (preventDefaultOnClose) e.preventDefault();
+                    onClose();
+                } else {
+                    setDragOffset(0);
+                    setIsDragActive(false);
+                }
+                reset();
+                e.stopPropagation();
+            },
+        },
+    };
+}
+
+/**
+ * The overlay player's three touch gestures (GH #787): horizontal track
+ * swipe, header swipe-down to close the overlay, and drawer-handle
+ * swipe-down to close the drawer. Threshold math lives in
+ * lib/overlay-gesture-policy.
+ */
+export function useOverlayGestures({
+    canSkip,
+    onPrevious,
+    onNext,
+    onCloseOverlay,
+    onCloseDrawer,
+}: OverlayGestureOptions) {
+    const touchStartX = useRef<number | null>(null);
+    const [swipeOffset, setSwipeOffset] = useState(0);
+
+    const trackSwipeHandlers: TouchHandlerSet = {
+        onTouchStart: (e) => {
+            touchStartX.current = e.touches[0].clientX;
+        },
+        onTouchMove: (e) => {
+            if (touchStartX.current === null) return;
+            setSwipeOffset(
+                clampTrackSwipeOffset(
+                    e.touches[0].clientX - touchStartX.current,
+                ),
+            );
+        },
+        onTouchEnd: () => {
+            if (touchStartX.current === null) return;
+            const action = resolveTrackSwipeAction(swipeOffset, canSkip);
+            if (action === "previous") onPrevious();
+            if (action === "next") onNext();
+            setSwipeOffset(0);
+            touchStartX.current = null;
+        },
+    };
+
+    const overlayClose = useVerticalCloseGesture(220, onCloseOverlay, true);
+    const drawerClose = useVerticalCloseGesture(240, onCloseDrawer, false);
+
+    return {
+        swipeOffset,
+        overlayDragOffset: overlayClose.dragOffset,
+        isOverlayDragActive: overlayClose.isDragActive,
+        overlayHeaderHandlers: overlayClose.handlers,
+        drawerDragOffset: drawerClose.dragOffset,
+        isDrawerDragActive: drawerClose.isDragActive,
+        drawerHandleHandlers: drawerClose.handlers,
+        resetDrawerDrag: drawerClose.resetDrag,
+        trackSwipeHandlers,
+    };
+}

--- a/frontend/lib/overlay-gesture-policy.ts
+++ b/frontend/lib/overlay-gesture-policy.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure decision math for the overlay player's touch gestures (GH #787).
+ * Kept free of React so the swipe/close thresholds are unit-testable.
+ */
+
+/** Horizontal track-swipe offset, clamped to the visual travel range. */
+export function clampTrackSwipeOffset(deltaX: number): number {
+    return Math.max(-100, Math.min(100, deltaX));
+}
+
+/** Which skip a completed horizontal swipe requests, if any. */
+export function resolveTrackSwipeAction(
+    swipeOffset: number,
+    canSkip: boolean,
+): "previous" | "next" | null {
+    if (!canSkip) return null;
+    if (swipeOffset > 60) return "previous";
+    if (swipeOffset < -60) return "next";
+    return null;
+}
+
+/**
+ * Live drag offset for a downward close gesture. Returns null when the
+ * movement is not a predominantly-vertical downward drag.
+ */
+export function resolveVerticalDragOffset(
+    deltaY: number,
+    deltaX: number,
+    maxOffset: number,
+): number | null {
+    if (deltaY > 0 && deltaY > Math.abs(deltaX) * 0.9) {
+        return Math.min(maxOffset, deltaY);
+    }
+    if (deltaY <= 0) return 0;
+    return null;
+}
+
+export interface VerticalSwipeInput {
+    deltaY: number;
+    deltaX: number;
+    elapsedMs: number;
+}
+
+/** Whether a finished downward swipe closes the surface (distance or flick). */
+export function shouldCloseFromVerticalSwipe({
+    deltaY,
+    deltaX,
+    elapsedMs,
+}: VerticalSwipeInput): boolean {
+    const velocityY = deltaY / Math.max(1, elapsedMs);
+    const isVerticalSwipe = deltaY > 0 && deltaY > Math.abs(deltaX) * 1.2;
+    const isDistanceClose = deltaY > 44;
+    const isVelocityClose = deltaY > 20 && velocityY > 0.25;
+    return isVerticalSwipe && (isDistanceClose || isVelocityClose);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
         "format:check": "prettier --check .",
         "start": "node server.js",
         "prelint": "tsc -p ../packages/media-metadata-contract/tsconfig.json",
-        "lint": "eslint --max-warnings=183",
+        "lint": "eslint --max-warnings=182",
         "lint:hex": "node scripts/check-hardcoded-hex.mjs",
         "typecheck": "tsc --noEmit --incremental false",
         "pretest:unit": "tsc -p ../packages/media-metadata-contract/tsconfig.json",

--- a/frontend/tests/unit/overlayGesturePolicy.test.ts
+++ b/frontend/tests/unit/overlayGesturePolicy.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    clampTrackSwipeOffset,
+    resolveTrackSwipeAction,
+    resolveVerticalDragOffset,
+    shouldCloseFromVerticalSwipe,
+} from "../../lib/overlay-gesture-policy";
+
+test("track swipe offset clamps to the visual travel range", () => {
+    assert.equal(clampTrackSwipeOffset(250), 100);
+    assert.equal(clampTrackSwipeOffset(-250), -100);
+    assert.equal(clampTrackSwipeOffset(42), 42);
+});
+
+test("track swipe action requires the threshold and skip permission", () => {
+    assert.equal(resolveTrackSwipeAction(61, true), "previous");
+    assert.equal(resolveTrackSwipeAction(-61, true), "next");
+    assert.equal(resolveTrackSwipeAction(60, true), null);
+    assert.equal(resolveTrackSwipeAction(-60, true), null);
+    assert.equal(resolveTrackSwipeAction(100, false), null);
+});
+
+test("vertical drag offset tracks downward-dominant movement only", () => {
+    assert.equal(resolveVerticalDragOffset(100, 10, 240), 100);
+    assert.equal(resolveVerticalDragOffset(400, 10, 240), 240);
+    assert.equal(resolveVerticalDragOffset(-5, 0, 240), 0);
+    // Horizontal-dominant drags leave the offset untouched.
+    assert.equal(resolveVerticalDragOffset(50, 100, 240), null);
+});
+
+test("swipe close fires on distance or flick velocity, downward only", () => {
+    const base = { deltaX: 0 };
+    assert.equal(
+        shouldCloseFromVerticalSwipe({ ...base, deltaY: 45, elapsedMs: 1000 }),
+        true,
+        "distance close",
+    );
+    assert.equal(
+        shouldCloseFromVerticalSwipe({ ...base, deltaY: 30, elapsedMs: 50 }),
+        true,
+        "velocity close",
+    );
+    assert.equal(
+        shouldCloseFromVerticalSwipe({ ...base, deltaY: 30, elapsedMs: 1000 }),
+        false,
+        "slow short drag stays open",
+    );
+    assert.equal(
+        shouldCloseFromVerticalSwipe({
+            deltaY: 45,
+            deltaX: 60,
+            elapsedMs: 100,
+        }),
+        false,
+        "diagonal swipe stays open",
+    );
+    assert.equal(
+        shouldCloseFromVerticalSwipe({ ...base, deltaY: -45, elapsedMs: 10 }),
+        false,
+        "upward swipe stays open",
+    );
+});

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -68,7 +68,7 @@ const BASELINE = Object.freeze({
     "frontend/app/playlist/[id]/page.tsx": 1506,
     "frontend/app/vibe/page.tsx": 1524,
     "frontend/components/player/AudioPlaybackOrchestrator.tsx": 1595,
-    "frontend/components/player/OverlayPlayer.tsx": 2865,
+    "frontend/components/player/OverlayPlayer.tsx": 2719,
     "frontend/hooks/useQueries.ts": 1453,
     "frontend/lib/audio-controls-context.tsx": 2305,
     "frontend/lib/listen-together-context.tsx": 2063,


### PR DESCRIPTION
## #787, slice A (the issue is explicitly sliceable — remaining slices follow)

OverlayPlayer carried 7 touch refs + 5 drag states + 9 inline handlers for its three gestures, with the header and drawer swipe-down closers duplicating identical threshold math inline.

## Change

- `useOverlayGestures` hook: one shared vertical swipe-to-close state machine (instantiated for header and drawer with their own max offsets/close targets) + the horizontal track swipe; external drawer-close resets flow through an exposed `resetDrawerDrag`.
- `lib/overlay-gesture-policy`: the pure decision math (clamping, skip thresholds, downward-dominance, distance-or-flick close) with table-driven unit tests — the repo's pure-policy pattern.
- OverlayPlayer **2,865 → 2,719** (baseline tightened); frontend lint cap ratchets **183 → 182** (the extraction removed a warning).

## Verification

- `verify:` component suite **730/730**; unit suite **1042/1042** (4 new policy tests); `tsc` exit 0; lint 0 errors/182 warnings at the new cap; format + file-size clean

Remaining slices (tab extraction onto memoized children owning their queries; listen-together provider decomposition) land as follow-up PRs on this issue.

Part of #787