### PR TITLE
fix(downloads): album-queue soulseek selections dispatch through one source policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Album downloads that select Soulseek, including TIDAL or YouTube Music runtime fallbacks and the default setting, now download through Soulseek instead of silently using Lidarr (#788).
 - Playing music no longer re-renders large parts of the app once per second: pages and controls now subscribe only to the playback details they actually show, and dragging the volume slider updates just the volume controls instead of rippling through every open page (#785).
 - Queued album downloads waiting on the deployment-wide claim now return to Bull with a delay instead of occupying an active worker slot for up to four hours.
 - Pressing get-all-missing-albums now queues the artist's albums immediately even while other downloads are running (#808).

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -185,6 +185,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/rssParser.ts` | Core |
 | `backend/src/services/search.ts` | Core |
 | `backend/src/services/simpleDownloadManager.ts` | Core |
+| `backend/src/services/soulseekLibraryDownload.ts` | Soulseek album track-list resolution, batch download, and download-job persistence |
 | `backend/src/services/socialPresenceEvents.ts` | Core |
 | `backend/src/services/soulseek.ts` | Core |
 | `backend/src/services/spotify.ts` | Core |

--- a/backend/src/services/__tests__/acquisitionService.test.ts
+++ b/backend/src/services/__tests__/acquisitionService.test.ts
@@ -4,6 +4,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -21,6 +27,31 @@ jest.mock("../../utils/db", () => ({
 const getSystemSettings = jest.fn();
 jest.mock("../../utils/systemSettings", () => ({
     getSystemSettings,
+}));
+
+const probeDownloadSourceAvailability = jest.fn();
+jest.mock("../downloadSourcePolicy", () => ({
+    ...jest.requireActual("../downloadSourcePolicy"),
+    probeDownloadSourceAvailability: (...args: unknown[]) =>
+        probeDownloadSourceAvailability(...args),
+}));
+
+jest.mock("../lidarr", () => ({
+    lidarrService: { isEnabled: jest.fn() },
+}));
+
+jest.mock("../tidal", () => ({
+    tidalService: { isAvailable: jest.fn() },
+}));
+
+jest.mock("../youtubeDownload", () => ({
+    youtubeDownloadService: { isAvailable: jest.fn() },
+}));
+
+const processSoulseekDownload = jest.fn();
+jest.mock("../soulseekLibraryDownload", () => ({
+    processSoulseekDownload: (...args: unknown[]) =>
+        processSoulseekDownload(...args),
 }));
 
 const soulseekService = {
@@ -104,6 +135,17 @@ describe("acquisitionService", () => {
             successful: 2,
             errors: [],
         });
+        probeDownloadSourceAvailability.mockResolvedValue({
+            tidal: false,
+            lidarr: false,
+            soulseek: true,
+            youtube: false,
+        });
+        processSoulseekDownload.mockResolvedValue({
+            success: true,
+            source: "soulseek",
+            downloadJobId: 101,
+        });
 
         musicBrainzService.getAlbumTracks.mockResolvedValue([
             { title: "Track A", position: 1 },
@@ -126,81 +168,24 @@ describe("acquisitionService", () => {
         });
     });
 
-    it("computes behavior matrix for no sources, single-source, and dual-source cases", async () => {
-        getSystemSettings.mockResolvedValueOnce({
-            downloadSource: "soulseek",
-            primaryFailureFallback: "none",
-            lidarrEnabled: false,
-            lidarrUrl: null,
-            lidarrApiKey: null,
-        });
-        soulseekService.isAvailable.mockResolvedValueOnce(false);
-        await expect(svc.getDownloadBehavior()).resolves.toEqual({
-            hasPrimarySource: false,
-            primarySource: null,
-            hasFallbackSource: false,
-            fallbackSource: null,
-        });
-
-        getSystemSettings.mockResolvedValueOnce({
+    it("respects the shared policy when an unavailable primary is set to Skip", async () => {
+        getSystemSettings.mockResolvedValue({
             downloadSource: "lidarr",
             primaryFailureFallback: "none",
-            lidarrEnabled: false,
-            lidarrUrl: null,
-            lidarrApiKey: null,
-        });
-        soulseekService.isAvailable.mockResolvedValueOnce(true);
-        await expect(svc.getDownloadBehavior()).resolves.toEqual({
-            hasPrimarySource: true,
-            primarySource: "soulseek",
-            hasFallbackSource: false,
-            fallbackSource: null,
         });
 
-        getSystemSettings.mockResolvedValueOnce({
-            downloadSource: "soulseek",
-            primaryFailureFallback: "none",
-            lidarrEnabled: true,
-            lidarrUrl: "http://lidarr",
-            lidarrApiKey: "key",
-        });
-        soulseekService.isAvailable.mockResolvedValueOnce(false);
-        await expect(svc.getDownloadBehavior()).resolves.toEqual({
-            hasPrimarySource: true,
-            primarySource: "lidarr",
-            hasFallbackSource: false,
-            fallbackSource: null,
+        await expect(
+            svc.acquireAlbum(
+                { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
+                { userId: "user-1" },
+            ),
+        ).resolves.toEqual({
+            success: false,
+            error: "No download sources available (neither Soulseek nor Lidarr configured)",
         });
 
-        getSystemSettings.mockResolvedValueOnce({
-            downloadSource: "lidarr",
-            primaryFailureFallback: undefined,
-            lidarrEnabled: true,
-            lidarrUrl: "http://lidarr",
-            lidarrApiKey: "key",
-        });
-        soulseekService.isAvailable.mockResolvedValueOnce(true);
-        await expect(svc.getDownloadBehavior()).resolves.toEqual({
-            hasPrimarySource: true,
-            primarySource: "lidarr",
-            hasFallbackSource: true,
-            fallbackSource: "soulseek",
-        });
-
-        getSystemSettings.mockResolvedValueOnce({
-            downloadSource: "soulseek",
-            primaryFailureFallback: "none",
-            lidarrEnabled: true,
-            lidarrUrl: "http://lidarr",
-            lidarrApiKey: "key",
-        });
-        soulseekService.isAvailable.mockResolvedValueOnce(true);
-        await expect(svc.getDownloadBehavior()).resolves.toEqual({
-            hasPrimarySource: true,
-            primarySource: "soulseek",
-            hasFallbackSource: false,
-            fallbackSource: null,
-        });
+        expect(processSoulseekDownload).not.toHaveBeenCalled();
+        expect(simpleDownloadManager.startDownload).not.toHaveBeenCalled();
     });
 
     it("updates queue concurrency when settings change", async () => {
@@ -378,50 +363,21 @@ describe("acquisitionService", () => {
         });
     });
 
-    it("routes primary/fallback logic in acquireAlbum", async () => {
-        jest.spyOn(svc, "updateQueueConcurrency").mockResolvedValue(undefined);
-        jest.spyOn(svc, "getDownloadBehavior")
-            .mockResolvedValueOnce({
-                hasPrimarySource: false,
-                primarySource: null,
-                hasFallbackSource: false,
-                fallbackSource: null,
-            })
-            .mockResolvedValueOnce({
-                hasPrimarySource: true,
-                primarySource: "soulseek",
-                hasFallbackSource: false,
-                fallbackSource: null,
-            })
-            .mockResolvedValueOnce({
-                hasPrimarySource: true,
-                primarySource: "soulseek",
-                hasFallbackSource: true,
-                fallbackSource: "lidarr",
-            })
-            .mockResolvedValueOnce({
-                hasPrimarySource: true,
-                primarySource: "lidarr",
-                hasFallbackSource: true,
-                fallbackSource: "soulseek",
-            });
-
-        jest.spyOn(svc, "acquireAlbumViaSoulseek")
-            .mockResolvedValueOnce({ success: true, source: "soulseek" })
-            .mockResolvedValueOnce({ success: false, error: "failed primary" })
-            .mockResolvedValueOnce({ success: true, source: "soulseek" });
-        jest.spyOn(svc, "acquireAlbumViaLidarr")
-            .mockResolvedValueOnce({ success: true, source: "lidarr" })
-            .mockResolvedValueOnce({ success: false, error: "lidarr failed" });
-
-        await expect(
-            svc.acquireAlbum(
-                { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
-                { userId: "user-1" },
-            ),
-        ).resolves.toEqual({
+    it("uses the shared policy for primary and runtime fallback routing", async () => {
+        getSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            downloadSource: "soulseek",
+            primaryFailureFallback: "lidarr",
+        });
+        probeDownloadSourceAvailability.mockResolvedValue({
+            tidal: true,
+            lidarr: true,
+            soulseek: true,
+            youtube: true,
+        });
+        processSoulseekDownload.mockResolvedValueOnce({
             success: false,
-            error: "No download sources available (neither Soulseek nor Lidarr configured)",
+            error: "failed primary",
         });
 
         await expect(
@@ -429,27 +385,70 @@ describe("acquisitionService", () => {
                 { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
                 { userId: "user-1" },
             ),
-        ).resolves.toEqual({ success: true, source: "soulseek" });
+        ).resolves.toEqual({
+            success: true,
+            source: "lidarr",
+            downloadJobId: 101,
+            correlationId: "corr-1",
+        });
 
-        await expect(
-            svc.acquireAlbum(
-                { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
-                { userId: "user-1" },
-            ),
-        ).resolves.toEqual({ success: true, source: "lidarr" });
-
-        await expect(
-            svc.acquireAlbum(
-                { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
-                { userId: "user-1" },
-            ),
-        ).resolves.toEqual({ success: true, source: "soulseek" });
+        expect(processSoulseekDownload).toHaveBeenCalledWith(
+            "101",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(simpleDownloadManager.startDownload).toHaveBeenCalledTimes(1);
     });
 
-    it("acquireAlbumViaSoulseek handles missing settings, missing mbid, and requested-track success", async () => {
-        getSystemSettings.mockResolvedValueOnce({ musicPath: "" });
+    it("routes a failed Lidarr primary to the Soulseek fallback", async () => {
+        getSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            soulseekConcurrentDownloads: 4,
+            downloadSource: "lidarr",
+            primaryFailureFallback: "soulseek",
+        });
+        probeDownloadSourceAvailability.mockResolvedValue({
+            tidal: false,
+            lidarr: true,
+            soulseek: true,
+            youtube: false,
+        });
+        simpleDownloadManager.startDownload.mockResolvedValueOnce({
+            success: false,
+            error: "Lidarr primary failed",
+        });
+
         await expect(
-            svc.acquireAlbumViaSoulseek(
+            svc.acquireAlbum(
+                { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
+                { userId: "user-1" },
+            ),
+        ).resolves.toEqual({
+            success: true,
+            source: "soulseek",
+            downloadJobId: 101,
+        });
+
+        expect(simpleDownloadManager.startDownload).toHaveBeenCalledTimes(1);
+        expect(processSoulseekDownload).toHaveBeenCalledWith(
+            "101",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+    });
+
+    it("does not create a Soulseek job when the music path is missing", async () => {
+        getSystemSettings.mockResolvedValue({
+            musicPath: "",
+            soulseekConcurrentDownloads: 4,
+            downloadSource: "soulseek",
+            primaryFailureFallback: "none",
+        });
+
+        await expect(
+            svc.acquireAlbum(
                 { artistName: "Artist", albumTitle: "Album", mbid: "rg-1" },
                 { userId: "user-1" },
             ),
@@ -458,168 +457,41 @@ describe("acquisitionService", () => {
             error: "Music path not configured",
         });
 
-        getSystemSettings.mockResolvedValueOnce({ musicPath: "/music" });
+        expect(prisma.downloadJob.create).not.toHaveBeenCalled();
+        expect(processSoulseekDownload).not.toHaveBeenCalled();
+    });
+
+    it("delegates requested-track Soulseek albums to the moved processor", async () => {
+        const requestedTracks = [{ title: "Only Track" }, { title: "Two" }];
+
         await expect(
-            svc.acquireAlbumViaSoulseek(
-                { artistName: "Artist", albumTitle: "Album" },
+            svc.acquireAlbum(
+                {
+                    artistName: "Artist",
+                    albumTitle: "Album",
+                    mbid: "rg-3",
+                    requestedTracks,
+                },
                 { userId: "user-1" },
             ),
         ).resolves.toEqual({
-            success: false,
-            error: "Album MBID required for Soulseek download",
-        });
-
-        getSystemSettings.mockResolvedValueOnce({
-            musicPath: "/music",
-            soulseekConcurrentDownloads: 3,
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "303",
-            metadata: { soulseekAttempts: 1 },
-        });
-        soulseekService.searchAndDownloadBatch.mockResolvedValueOnce({
-            successful: 2,
-            errors: [],
-        });
-
-        const result = await svc.acquireAlbumViaSoulseek(
-            {
-                artistName: "Artist",
-                albumTitle: "Album",
-                mbid: "rg-3",
-                requestedTracks: [{ title: "Only Track" }, { title: "Two" }],
-            },
-            { userId: "user-1" },
-        );
-
-        expect(result).toEqual({
             success: true,
             source: "soulseek",
-            downloadJobId: 303,
-            tracksDownloaded: 2,
-            tracksTotal: 2,
-            error: undefined,
+            downloadJobId: 101,
         });
-        expect(soulseekService.searchAndDownloadBatch).toHaveBeenCalledWith(
-            [
-                { artist: "Artist", title: "Only Track", album: "Album" },
-                { artist: "Artist", title: "Two", album: "Album" },
-            ],
-            "/music",
-            3,
+
+        expect(prisma.downloadJob.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                targetMbid: "rg-3",
+                metadata: expect.objectContaining({ requestedTracks }),
+            }),
+        });
+        expect(processSoulseekDownload).toHaveBeenCalledWith(
+            "101",
+            "Artist",
+            "Album",
+            "user-1",
         );
-    });
-
-    it("acquireAlbumViaSoulseek uses MusicBrainz/Last.fm fallback and handles empty or partial failures", async () => {
-        getSystemSettings.mockResolvedValueOnce({
-            musicPath: "/music",
-            soulseekConcurrentDownloads: 4,
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "401",
-            metadata: {},
-        });
-        musicBrainzService.getAlbumTracks.mockResolvedValueOnce([]);
-        lastFmService.getAlbumInfo.mockResolvedValueOnce({
-            tracks: {
-                track: [{ name: "LFM Track", "@attr": { rank: "1" } }],
-            },
-        });
-        soulseekService.searchAndDownloadBatch.mockResolvedValueOnce({
-            successful: 0,
-            errors: ["Artist - LFM Track: missing"],
-        });
-
-        await expect(
-            svc.acquireAlbumViaSoulseek(
-                { artistName: "Artist", albumTitle: "Album", mbid: "rg-4" },
-                { userId: "user-1" },
-            ),
-        ).resolves.toEqual({
-            success: false,
-            tracksTotal: 1,
-            downloadJobId: 401,
-            error: "No tracks found on Soulseek (searched 1 tracks)",
-        });
-
-        getSystemSettings.mockResolvedValueOnce({
-            musicPath: "/music",
-            soulseekConcurrentDownloads: 4,
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "402",
-            metadata: {},
-        });
-        musicBrainzService.getAlbumTracks.mockResolvedValueOnce([
-            { title: "Track 1" },
-            { title: "Track 2" },
-            { title: "Track 3" },
-            { title: "Track 4" },
-        ]);
-        soulseekService.searchAndDownloadBatch.mockResolvedValueOnce({
-            successful: 1,
-            errors: ["x"],
-        });
-
-        const partialResult = await svc.acquireAlbumViaSoulseek(
-            { artistName: "Artist", albumTitle: "Album", mbid: "rg-5" },
-            { userId: "user-1" },
-        );
-        expect(partialResult).toEqual({
-            success: false,
-            source: "soulseek",
-            downloadJobId: 402,
-            tracksDownloaded: 1,
-            tracksTotal: 4,
-            error: "Only 1/4 tracks found",
-        });
-
-        getSystemSettings.mockResolvedValueOnce({
-            musicPath: "/music",
-            soulseekConcurrentDownloads: 4,
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "403",
-            metadata: {},
-        });
-        musicBrainzService.getAlbumTracks.mockResolvedValueOnce([]);
-        lastFmService.getAlbumInfo.mockResolvedValueOnce({
-            tracks: { track: [] },
-        });
-
-        await expect(
-            svc.acquireAlbumViaSoulseek(
-                { artistName: "Artist", albumTitle: "Album", mbid: "rg-6" },
-                { userId: "user-1" },
-            ),
-        ).resolves.toEqual({
-            success: false,
-            error: "Could not get track list from MusicBrainz or Last.fm",
-        });
-    });
-
-    it("acquireAlbumViaSoulseek handles thrown errors and job-status update failures", async () => {
-        getSystemSettings.mockResolvedValueOnce({
-            musicPath: "/music",
-            soulseekConcurrentDownloads: 4,
-        });
-        prisma.downloadJob.create.mockResolvedValueOnce({
-            id: "501",
-            metadata: {},
-        });
-        prisma.downloadJob.update
-            .mockRejectedValueOnce(new Error("status write failed"))
-            .mockResolvedValue({});
-
-        const result = await svc.acquireAlbumViaSoulseek(
-            { artistName: "Artist", albumTitle: "Album", mbid: "rg-7" },
-            { userId: "user-1" },
-        );
-
-        expect(result).toEqual({
-            success: false,
-            error: "status write failed",
-        });
     });
 
     it("acquireAlbumViaLidarr handles missing mbid, success, structured failure, and exception", async () => {

--- a/backend/src/services/__tests__/downloadDispatcher.test.ts
+++ b/backend/src/services/__tests__/downloadDispatcher.test.ts
@@ -67,6 +67,12 @@ jest.mock("../youtubeLibraryDownload", () => ({
         mockProcessYoutubeDownload(...args),
 }));
 
+const mockProcessSoulseekDownload = jest.fn();
+jest.mock("../soulseekLibraryDownload", () => ({
+    processSoulseekDownload: (...args: unknown[]) =>
+        mockProcessSoulseekDownload(...args),
+}));
+
 const mockStartDownload = jest.fn();
 jest.mock("../simpleDownloadManager", () => ({
     simpleDownloadManager: {
@@ -108,6 +114,7 @@ describe("dispatchAlbumDownload", () => {
         mockYoutubeAvailable.mockResolvedValue(false);
         mockProcessTidalDownload.mockResolvedValue(undefined);
         mockProcessYoutubeDownload.mockResolvedValue(undefined);
+        mockProcessSoulseekDownload.mockResolvedValue(undefined);
         mockStartDownload.mockResolvedValue({ success: true });
     });
 
@@ -169,6 +176,31 @@ describe("dispatchAlbumDownload", () => {
         expect(mockProcessTidalDownload).toHaveBeenCalledTimes(1);
     });
 
+    it("passes the resolved Soulseek runtime fallback snapshot to TIDAL", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "soulseek",
+        });
+        mockTidalAvailable.mockResolvedValue(true);
+        const routing = await resolveAlbumDownloadRouting(baseParams);
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "tidal",
+            primaryFailureFallback: "lidarr",
+        });
+
+        await dispatchResolvedAlbumDownload(routing, baseParams);
+
+        expect(mockGetSystemSettings).toHaveBeenCalledTimes(1);
+        expect(mockProcessTidalDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+            { fallbackSource: "soulseek" },
+        );
+        expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+
     it("uses YouTube as an available explicit fallback", async () => {
         mockGetSystemSettings.mockResolvedValue({
             downloadSource: "tidal",
@@ -186,7 +218,7 @@ describe("dispatchAlbumDownload", () => {
         );
     });
 
-    it("falls back from unavailable YouTube to the manager-backed Soulseek path", async () => {
+    it("falls back from unavailable YouTube to Soulseek", async () => {
         mockGetSystemSettings.mockResolvedValue({
             downloadSource: "youtube",
             primaryFailureFallback: "soulseek",
@@ -194,17 +226,17 @@ describe("dispatchAlbumDownload", () => {
 
         await dispatchAlbumDownload(baseParams);
 
-        expect(mockStartDownload).toHaveBeenCalledWith(
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
             "job-1",
             "Artist",
             "Album",
-            "rg-1",
             "user-1",
         );
         expect(mockProcessYoutubeDownload).not.toHaveBeenCalled();
+        expect(mockStartDownload).not.toHaveBeenCalled();
     });
 
-    it("uses the manager for an available configured Soulseek source", async () => {
+    it("dispatches an available configured Soulseek source", async () => {
         await dispatchAlbumDownload({
             ...baseParams,
             artistName: undefined,
@@ -212,16 +244,37 @@ describe("dispatchAlbumDownload", () => {
             subject: "Split Artist - Split - Album",
         });
 
-        expect(mockStartDownload).toHaveBeenCalledWith(
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
             "job-1",
             "Split Artist",
             "Split - Album",
-            "rg-1",
             "user-1",
         );
+        expect(mockStartDownload).not.toHaveBeenCalled();
     });
 
-    it("passes a supplied artist MBID to the manager-backed source", async () => {
+    it("keeps an all-unavailable legacy resolution on Soulseek", async () => {
+        mockGetSystemSettings.mockResolvedValue({ downloadSource: "soulseek" });
+        mockLidarrAvailable.mockResolvedValue(false);
+        mockSoulseekAvailable.mockResolvedValue(false);
+
+        await dispatchAlbumDownload(baseParams);
+
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(mockStartDownload).not.toHaveBeenCalled();
+    });
+
+    it("passes a supplied artist MBID to the Lidarr manager", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "lidarr",
+            primaryFailureFallback: "none",
+        });
+
         await dispatchAlbumDownload({
             ...baseParams,
             artistMbid: "artist-mbid-1",
@@ -239,6 +292,11 @@ describe("dispatchAlbumDownload", () => {
     });
 
     it("uses the subject for both names when no delimiter or metadata exists", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "lidarr",
+            primaryFailureFallback: "none",
+        });
+
         await dispatchAlbumDownload({
             ...baseParams,
             artistName: undefined,
@@ -256,6 +314,11 @@ describe("dispatchAlbumDownload", () => {
     });
 
     it("logs unsuccessful manager starts without throwing", async () => {
+        mockGetSystemSettings.mockResolvedValue({
+            downloadSource: "lidarr",
+            primaryFailureFallback: "none",
+        });
+
         mockStartDownload.mockResolvedValueOnce({
             success: false,
             error: "unavailable indexer",
@@ -346,13 +409,13 @@ describe("dispatchAlbumDownload", () => {
 
         await dispatchAlbumDownload(baseParams);
 
-        expect(mockStartDownload).toHaveBeenCalledWith(
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
             "job-1",
             "Artist",
             "Album",
-            "rg-1",
             "user-1",
         );
+        expect(mockStartDownload).not.toHaveBeenCalled();
         expect(mockUpdate).not.toHaveBeenCalled();
     });
 

--- a/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
+++ b/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
@@ -24,6 +24,12 @@ jest.mock("../simpleDownloadManager", () => ({
     simpleDownloadManager: { startDownload: jest.fn() },
 }));
 
+const processSoulseekDownload = jest.fn();
+jest.mock("../soulseekLibraryDownload", () => ({
+    processSoulseekDownload: (...args: unknown[]) =>
+        processSoulseekDownload(...args),
+}));
+
 jest.mock("../coalescedLibraryScan", () => ({
     requestCoalescedLibraryScan: jest.fn(),
 }));
@@ -73,10 +79,9 @@ const processorConfig: LibraryDownloadProcessorConfig<FakeMatch, FakeResult> = {
         metadata: { fakeResult: { downloaded: result.downloaded } },
     }),
     fallbackPeer: {
-        sourceKey: "peer",
+        sourceKey: "youtube",
         run: fallbackPeer,
     },
-    fallbackOrder: "manager-first",
     logFallbackSelection: false,
     prefixManagerFailureLog: false,
     scanSource: "fake-download",
@@ -102,16 +107,13 @@ describe("libraryDownloadProcessor", () => {
 
     it("hands a search miss to the configured peer", async () => {
         findMatch.mockResolvedValueOnce(null);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "peer",
-        });
-
         await runLibraryAlbumDownload(
             processorConfig,
             "job-1",
             "Artist",
             "Album",
             "user-1",
+            { fallbackSource: "youtube" },
         );
 
         expect(fallbackPeer).toHaveBeenCalledWith(
@@ -128,12 +130,45 @@ describe("libraryDownloadProcessor", () => {
                     albumMbid: "rg-1",
                     queuedVia: "album-download-queue",
                     failedAt: "2026-08-24T10:00:00.000Z",
-                    currentSource: "peer",
-                    statusText: "Fake Music not found → peer",
+                    currentSource: "youtube",
+                    statusText: "Fake Music not found → youtube",
                 },
             },
         });
         expect(download).not.toHaveBeenCalled();
+    });
+
+    it("uses the resolved snapshot to hand a search miss to Soulseek", async () => {
+        findMatch.mockResolvedValueOnce(null);
+        mockSettings.mockResolvedValueOnce({
+            primaryFailureFallback: "lidarr",
+        });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+            { fallbackSource: "soulseek" } as LibraryAlbumDownloadOptions,
+        );
+
+        expect(mockSettings).not.toHaveBeenCalled();
+        expect(processSoulseekDownload).toHaveBeenCalledWith(
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(mockUpdate).toHaveBeenCalledWith({
+            where: { id: "job-1" },
+            data: {
+                metadata: expect.objectContaining({
+                    currentSource: "soulseek",
+                    statusText: "Fake Music not found → soulseek",
+                }),
+            },
+        });
     });
 
     it("marks a forwarded peer attempt as fallback and stops after both providers miss", async () => {
@@ -148,11 +183,11 @@ describe("libraryDownloadProcessor", () => {
             FakeResult
         > = {
             ...processorConfig,
-            sourceKey: "peer",
+            sourceKey: "youtube",
             sourceLabel: "Peer Music",
             findMatch: siblingFindMatch,
             fallbackPeer: {
-                sourceKey: "peer",
+                sourceKey: "youtube",
                 run: recursivePeer,
             },
         };
@@ -171,18 +206,17 @@ describe("libraryDownloadProcessor", () => {
             ...processorConfig,
             findMatch: primaryFindMatch,
             fallbackPeer: {
-                sourceKey: "peer",
+                sourceKey: "youtube",
                 run: (...args) => siblingProcessor(...args),
             },
         };
-        mockSettings.mockResolvedValue({ primaryFailureFallback: "peer" });
-
         await runLibraryAlbumDownload(
             forwardingConfig,
             "job-1",
             "Artist",
             "Album",
             "user-1",
+            { fallbackSource: "youtube" },
         );
 
         expect(siblingProcessor).toHaveBeenCalledWith(
@@ -253,17 +287,13 @@ describe("libraryDownloadProcessor", () => {
 
     it("does not hand a fallback search miss back to the peer", async () => {
         findMatch.mockResolvedValueOnce(null);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "peer",
-        });
-
         await runLibraryAlbumDownload(
             processorConfig,
             "job-1",
             "Artist",
             "Album",
             "user-1",
-            { isFallback: true },
+            { isFallback: true, fallbackSource: "youtube" },
         );
 
         expect(fallbackPeer).not.toHaveBeenCalled();

--- a/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
@@ -1,0 +1,273 @@
+const mockLog = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+
+jest.mock("../../utils/logger", () => ({
+    logger: { child: jest.fn(() => mockLog) },
+}));
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+jest.mock("../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findUnique: (...args: unknown[]) => mockFindUnique(...args),
+            update: (...args: unknown[]) => mockUpdate(...args),
+        },
+    },
+}));
+
+const mockGetSystemSettings = jest.fn();
+jest.mock("../../utils/systemSettings", () => ({
+    getSystemSettings: (...args: unknown[]) => mockGetSystemSettings(...args),
+}));
+
+const mockGetAlbumTracks = jest.fn();
+jest.mock("../musicbrainz", () => ({
+    musicBrainzService: {
+        getAlbumTracks: (...args: unknown[]) => mockGetAlbumTracks(...args),
+    },
+}));
+
+const mockGetAlbumInfo = jest.fn();
+jest.mock("../lastfm", () => ({
+    lastFmService: {
+        getAlbumInfo: (...args: unknown[]) => mockGetAlbumInfo(...args),
+    },
+}));
+
+const mockSearchAndDownloadBatch = jest.fn();
+jest.mock("../soulseek", () => ({
+    soulseekService: {
+        searchAndDownloadBatch: (...args: unknown[]) =>
+            mockSearchAndDownloadBatch(...args),
+    },
+}));
+
+import { processSoulseekDownload } from "../soulseekLibraryDownload";
+
+describe("processSoulseekDownload", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindUnique.mockResolvedValue({
+            targetMbid: "rg-1",
+            metadata: {},
+        });
+        mockUpdate.mockResolvedValue({});
+        mockGetSystemSettings.mockResolvedValue({
+            musicPath: "/music",
+            soulseekConcurrentDownloads: 3,
+        });
+        mockGetAlbumTracks.mockResolvedValue([
+            { title: "Track A", position: 1 },
+            { title: "Track B", position: 2 },
+        ]);
+        mockGetAlbumInfo.mockResolvedValue(null);
+        mockSearchAndDownloadBatch.mockResolvedValue({
+            successful: 2,
+            errors: [],
+        });
+    });
+
+    it("downloads requested tracks through Soulseek and completes the job", async () => {
+        const requestedTracks = [{ title: "Only Track" }, { title: "Two" }];
+        mockFindUnique.mockResolvedValue({
+            targetMbid: "rg-1",
+            metadata: { requestedTracks, soulseekAttempts: 1 },
+        });
+
+        await expect(
+            processSoulseekDownload("303", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: true,
+            source: "soulseek",
+            downloadJobId: 303,
+            tracksDownloaded: 2,
+            tracksTotal: 2,
+            error: undefined,
+        });
+
+        expect(mockGetAlbumTracks).not.toHaveBeenCalled();
+        expect(mockSearchAndDownloadBatch).toHaveBeenCalledWith(
+            [
+                { artist: "Artist", title: "Only Track", album: "Album" },
+                { artist: "Artist", title: "Two", album: "Album" },
+            ],
+            "/music",
+            3,
+        );
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "303" },
+            data: {
+                status: "completed",
+                error: null,
+                completedAt: expect.any(Date),
+                metadata: {
+                    requestedTracks,
+                    soulseekAttempts: 1,
+                    tracksDownloaded: 2,
+                    tracksTotal: 2,
+                },
+            },
+        });
+    });
+
+    it("uses Last.fm when MusicBrainz has no tracks and persists no-match failure", async () => {
+        mockGetAlbumTracks.mockResolvedValueOnce([]);
+        mockGetAlbumInfo.mockResolvedValueOnce({
+            tracks: {
+                track: [{ name: "LFM Track", "@attr": { rank: "1" } }],
+            },
+        });
+        mockSearchAndDownloadBatch.mockResolvedValueOnce({
+            successful: 0,
+            errors: ["Artist - LFM Track: missing"],
+        });
+
+        await expect(
+            processSoulseekDownload("401", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            tracksTotal: 1,
+            downloadJobId: 401,
+            error: "No tracks found on Soulseek (searched 1 tracks)",
+        });
+
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "401" },
+            data: {
+                status: "failed",
+                error: "No tracks found on Soulseek (searched 1 tracks)",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("persists missing-path and missing-MBID failures", async () => {
+        mockGetSystemSettings.mockResolvedValueOnce({ musicPath: "" });
+        await expect(
+            processSoulseekDownload("402", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Music path not configured",
+        });
+
+        mockFindUnique.mockResolvedValueOnce({
+            targetMbid: "",
+            metadata: {},
+        });
+        await expect(
+            processSoulseekDownload("403", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Album MBID required for Soulseek download",
+        });
+
+        expect(mockSearchAndDownloadBatch).not.toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "403" },
+            data: {
+                status: "failed",
+                error: "Album MBID required for Soulseek download",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("persists empty track lists and below-threshold partial downloads", async () => {
+        mockGetAlbumTracks.mockResolvedValueOnce([]);
+        mockGetAlbumInfo.mockResolvedValueOnce({ tracks: { track: [] } });
+        await expect(
+            processSoulseekDownload("404", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Could not get track list from MusicBrainz or Last.fm",
+        });
+
+        mockGetAlbumTracks.mockResolvedValueOnce([
+            { title: "Track 1" },
+            { title: "Track 2" },
+            { title: "Track 3" },
+            { title: "Track 4" },
+        ]);
+        mockSearchAndDownloadBatch.mockResolvedValueOnce({
+            successful: 1,
+            errors: ["three unavailable tracks"],
+        });
+        await expect(
+            processSoulseekDownload("405", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            source: "soulseek",
+            downloadJobId: 405,
+            tracksDownloaded: 1,
+            tracksTotal: 4,
+            error: "Only 1/4 tracks found",
+        });
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "405" },
+            data: {
+                status: "failed",
+                error: "Only 1/4 tracks found",
+                completedAt: expect.any(Date),
+                metadata: {
+                    tracksDownloaded: 1,
+                    tracksTotal: 4,
+                },
+            },
+        });
+    });
+
+    it("persists unexpected Soulseek failures and returns without throwing", async () => {
+        const rawDetail = "Soulseek network failed for user secret-token";
+        const failure = new Error(rawDetail);
+        mockSearchAndDownloadBatch.mockRejectedValueOnce(failure);
+
+        await expect(
+            processSoulseekDownload("501", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Soulseek download failed",
+        });
+
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "501" },
+            data: {
+                status: "failed",
+                error: "Soulseek download failed",
+                completedAt: expect.any(Date),
+            },
+        });
+        expect(JSON.stringify(mockUpdate.mock.calls)).not.toContain(rawDetail);
+        expect(mockLog.error).toHaveBeenCalledWith(
+            "Soulseek album download failed",
+            { jobId: "501", error: failure },
+        );
+        expect(mockSearchAndDownloadBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns a safe failure when the attempt status write is rejected", async () => {
+        const rawDetail = "attempt status write exposed row contents";
+        mockUpdate.mockRejectedValueOnce(new Error(rawDetail));
+
+        await expect(
+            processSoulseekDownload("502", "Artist", "Album", "user-1"),
+        ).resolves.toEqual({
+            success: false,
+            error: "Soulseek download failed",
+        });
+
+        expect(mockUpdate).toHaveBeenLastCalledWith({
+            where: { id: "502" },
+            data: {
+                status: "failed",
+                error: "Soulseek download failed",
+                completedAt: expect.any(Date),
+            },
+        });
+        expect(JSON.stringify(mockUpdate.mock.calls)).not.toContain(rawDetail);
+    });
+});

--- a/backend/src/services/__tests__/tidalLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/tidalLibraryDownload.test.ts
@@ -37,6 +37,10 @@ jest.mock("../youtubeLibraryDownload", () => ({
     processYoutubeDownload: jest.fn(),
 }));
 
+jest.mock("../soulseekLibraryDownload", () => ({
+    processSoulseekDownload: jest.fn(),
+}));
+
 jest.mock("../coalescedLibraryScan", () => ({
     requestCoalescedLibraryScan: jest.fn(),
 }));
@@ -46,6 +50,7 @@ import { getSystemSettings } from "../../utils/systemSettings";
 import { simpleDownloadManager } from "../simpleDownloadManager";
 import { tidalService } from "../tidal";
 import { processYoutubeDownload } from "../youtubeLibraryDownload";
+import { processSoulseekDownload } from "../soulseekLibraryDownload";
 import { processTidalDownload } from "../tidalLibraryDownload";
 import { requestCoalescedLibraryScan } from "../coalescedLibraryScan";
 
@@ -56,6 +61,7 @@ const mockFindAlbum = tidalService.findAlbum as jest.Mock;
 const mockDownloadAlbum = tidalService.downloadAlbum as jest.Mock;
 const mockFallback = simpleDownloadManager.startDownload as jest.Mock;
 const mockProcessYoutubeDownload = processYoutubeDownload as jest.Mock;
+const mockProcessSoulseekDownload = processSoulseekDownload as jest.Mock;
 const mockScan = requestCoalescedLibraryScan as jest.Mock;
 
 describe("tidalLibraryDownload", () => {
@@ -151,11 +157,9 @@ describe("tidalLibraryDownload", () => {
 
     it("hands a search miss to a configured youtube fallback", async () => {
         mockFindAlbum.mockResolvedValueOnce(null);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "youtube",
+        await processTidalDownload("job-1", "Artist", "Album", "user-1", {
+            fallbackSource: "youtube",
         });
-
-        await processTidalDownload("job-1", "Artist", "Album", "user-1");
 
         expect(mockProcessYoutubeDownload).toHaveBeenCalledWith(
             "job-1",
@@ -178,27 +182,24 @@ describe("tidalLibraryDownload", () => {
         expect(mockDownloadAlbum).not.toHaveBeenCalled();
     });
 
-    it("hands a search miss to a manager fallback and records the hand-off", async () => {
+    it("hands a search miss to Soulseek instead of the Lidarr manager", async () => {
         mockFindAlbum.mockResolvedValueOnce(null);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "soulseek",
-        });
-        mockFallback.mockResolvedValueOnce({
-            success: false,
-            error: "fallback failed",
+        mockProcessSoulseekDownload.mockResolvedValueOnce({
+            success: true,
+            source: "soulseek",
         });
 
-        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+        await processTidalDownload("job-1", "Artist", "Album", "user-1", {
+            fallbackSource: "soulseek",
+        });
 
-        expect(mockFallback).toHaveBeenCalledWith(
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
             "job-1",
             "Artist",
             "Album",
-            "rg-1",
             "user-1",
-            false,
-            undefined,
         );
+        expect(mockFallback).not.toHaveBeenCalled();
         expect(mockUpdate).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: { id: "job-1" },
@@ -288,6 +289,7 @@ describe("tidalLibraryDownload", () => {
 
         await processTidalDownload("job-1", "Artist", "Album", "user-1", {
             isFallback: true,
+            fallbackSource: "youtube",
         });
 
         expect(mockProcessYoutubeDownload).not.toHaveBeenCalled();

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -288,11 +288,9 @@ describe("youtubeLibraryDownload", () => {
 
     it("hands a search miss to a configured lidarr fallback", async () => {
         mockSearch.mockResolvedValueOnce([]);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "lidarr",
+        await processYoutubeDownload("job-1", "Artist", "Album", "user-1", {
+            fallbackSource: "lidarr",
         });
-
-        await processYoutubeDownload("job-1", "Artist", "Album", "user-1");
 
         expect(mockFallback).toHaveBeenCalledWith(
             "job-1",
@@ -308,11 +306,9 @@ describe("youtubeLibraryDownload", () => {
 
     it("hands a search miss to a configured tidal fallback", async () => {
         mockSearch.mockResolvedValueOnce([]);
-        mockSettings.mockResolvedValueOnce({
-            primaryFailureFallback: "tidal",
+        await processYoutubeDownload("job-1", "Artist", "Album", "user-1", {
+            fallbackSource: "tidal",
         });
-
-        await processYoutubeDownload("job-1", "Artist", "Album", "user-1");
 
         expect(mockProcessTidalDownload).toHaveBeenCalledWith(
             "job-1",
@@ -342,6 +338,7 @@ describe("youtubeLibraryDownload", () => {
 
         await processYoutubeDownload("job-1", "Artist", "Album", "user-1", {
             isFallback: true,
+            fallbackSource: "tidal",
         });
 
         expect(mockProcessTidalDownload).not.toHaveBeenCalled();

--- a/backend/src/services/acquisitionService.ts
+++ b/backend/src/services/acquisitionService.ts
@@ -14,12 +14,18 @@
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { getSystemSettings } from "../utils/systemSettings";
-import { soulseekService } from "./soulseek";
 import { simpleDownloadManager } from "./simpleDownloadManager";
-import { musicBrainzService } from "./musicbrainz";
+import { soulseekService } from "./soulseek";
 import { lastFmService } from "./lastfm";
-import { AcquisitionError, AcquisitionErrorType } from "./lidarr";
+import type { AcquisitionErrorType } from "./lidarr";
 import PQueue from "p-queue";
+import {
+    type DownloadSource,
+    type DownloadSourceAvailability,
+    probeDownloadSourceAvailability,
+    resolveDownloadSource,
+} from "./downloadSourcePolicy";
+import { processSoulseekDownload } from "./soulseekLibraryDownload";
 import { patchDownloadJobMetadata } from "./downloadJobStatus";
 
 /**
@@ -69,14 +75,6 @@ export interface AcquisitionResult {
 }
 
 /**
- * Service availability check result
- */
-interface ServiceAvailability {
-    lidarrAvailable: boolean;
-    soulseekAvailable: boolean;
-}
-
-/**
  * Download behavior matrix configuration
  */
 interface DownloadBehavior {
@@ -84,6 +82,93 @@ interface DownloadBehavior {
     primarySource: "soulseek" | "lidarr" | null;
     hasFallbackSource: boolean;
     fallbackSource: "soulseek" | "lidarr" | null;
+}
+
+const NO_ACQUISITION_SOURCES: DownloadBehavior = {
+    hasPrimarySource: false,
+    primarySource: null,
+    hasFallbackSource: false,
+    fallbackSource: null,
+};
+
+function acquisitionAvailability(
+    availability: DownloadSourceAvailability,
+): DownloadSourceAvailability {
+    return { ...availability, tidal: false, youtube: false };
+}
+
+function isAcquisitionSource(
+    source: DownloadSource,
+): source is "soulseek" | "lidarr" {
+    return source === "soulseek" || source === "lidarr";
+}
+
+function availableAcquisitionSource(
+    source: DownloadSource,
+    availability: DownloadSourceAvailability,
+): "soulseek" | "lidarr" | null {
+    return isAcquisitionSource(source) && availability[source] ? source : null;
+}
+
+function fallbackAcquisitionSource(
+    configuredSource: DownloadSource,
+    fallback: string | null | undefined,
+    availability: DownloadSourceAvailability,
+    primarySource: "soulseek" | "lidarr",
+): "soulseek" | "lidarr" | null {
+    const resolution = resolveDownloadSource({
+        configuredSource,
+        fallback,
+        availability: { ...availability, [primarySource]: false },
+    });
+    if (resolution.kind === "fail") return null;
+    return availableAcquisitionSource(resolution.source, availability);
+}
+
+function acquisitionBehavior(
+    configuredSource: DownloadSource,
+    fallback: string | null | undefined,
+    availability: DownloadSourceAvailability,
+): DownloadBehavior {
+    const primaryResolution = resolveDownloadSource({
+        configuredSource,
+        fallback,
+        availability,
+    });
+    if (primaryResolution.kind === "fail") return NO_ACQUISITION_SOURCES;
+    const primarySource = availableAcquisitionSource(
+        primaryResolution.source,
+        availability,
+    );
+    if (!primarySource) return NO_ACQUISITION_SOURCES;
+    const fallbackSource = fallbackAcquisitionSource(
+        configuredSource,
+        fallback,
+        availability,
+        primarySource,
+    );
+    const hasFallbackSource =
+        fallbackSource !== null && fallbackSource !== primarySource;
+    return {
+        hasPrimarySource: true,
+        primarySource,
+        hasFallbackSource,
+        fallbackSource: hasFallbackSource ? fallbackSource : null,
+    };
+}
+
+async function resolveAcquisitionBehavior(): Promise<DownloadBehavior> {
+    const settings = await getSystemSettings();
+    const configuredSource = (settings?.downloadSource ||
+        "soulseek") as DownloadSource;
+    const availability = acquisitionAvailability(
+        await probeDownloadSourceAvailability(),
+    );
+    return acquisitionBehavior(
+        configuredSource,
+        settings?.primaryFailureFallback,
+        availability,
+    );
 }
 
 class AcquisitionService {
@@ -113,118 +198,6 @@ class AcquisitionService {
                 `[Acquisition] Updated album queue concurrency to ${concurrency}`,
             );
         }
-    }
-
-    /**
-     * Get download behavior configuration (settings + service availability)
-     * Auto-detects and selects download source based on actual availability
-     */
-    private async getDownloadBehavior(): Promise<DownloadBehavior> {
-        const settings = await getSystemSettings();
-
-        // Get download source settings
-        const downloadSource = settings?.downloadSource || "soulseek";
-        const primaryFailureFallback = settings?.primaryFailureFallback;
-
-        // Determine actual availability
-        const hasSoulseek = await soulseekService.isAvailable();
-        const hasLidarr = !!(
-            settings?.lidarrEnabled &&
-            settings?.lidarrUrl &&
-            settings?.lidarrApiKey
-        );
-
-        // Case 1: No sources available
-        if (!hasSoulseek && !hasLidarr) {
-            logger.debug(
-                "[Acquisition] Available sources: Lidarr=false, Soulseek=false",
-            );
-            logger.error("[Acquisition] No download sources configured");
-            return {
-                hasPrimarySource: false,
-                primarySource: null,
-                hasFallbackSource: false,
-                fallbackSource: null,
-            };
-        }
-
-        // Case 2: Only one source available - use it regardless of preference
-        if (hasSoulseek && !hasLidarr) {
-            logger.debug(
-                "[Acquisition] Available sources: Lidarr=false, Soulseek=true",
-            );
-            logger.debug(
-                "[Acquisition] Using Soulseek as primary source (only source available)",
-            );
-            logger.debug(
-                "[Acquisition] No fallback configured (only one source available)",
-            );
-            return {
-                hasPrimarySource: true,
-                primarySource: "soulseek",
-                hasFallbackSource: false,
-                fallbackSource: null,
-            };
-        }
-
-        if (hasLidarr && !hasSoulseek) {
-            logger.debug(
-                "[Acquisition] Available sources: Lidarr=true, Soulseek=false",
-            );
-            logger.debug(
-                "[Acquisition] Using Lidarr as primary source (only source available)",
-            );
-            logger.debug(
-                "[Acquisition] No fallback configured (only one source available)",
-            );
-            return {
-                hasPrimarySource: true,
-                primarySource: "lidarr",
-                hasFallbackSource: false,
-                fallbackSource: null,
-            };
-        }
-
-        // Case 3: Both available - respect user preference for primary
-        const userPrimary = downloadSource; // "soulseek" or "lidarr"
-        const alternative = userPrimary === "soulseek" ? "lidarr" : "soulseek";
-
-        // Auto-enable fallback if both sources are configured and no explicit setting
-        let useFallback =
-            primaryFailureFallback !== "none" &&
-            primaryFailureFallback === alternative;
-
-        // Only auto-enable fallback if the setting is truly undefined/null (first-time users)
-        // "none" = explicit "Skip Track" choice, respect it (Fixes #68)
-        if (
-            !useFallback &&
-            (primaryFailureFallback === undefined ||
-                primaryFailureFallback === null)
-        ) {
-            useFallback = true;
-            logger.debug(
-                `[Acquisition] Auto-enabled fallback: ${alternative} (both sources configured)`,
-            );
-        }
-
-        logger.debug(
-            "[Acquisition] Available sources: Lidarr=true, Soulseek=true",
-        );
-        logger.debug(
-            `[Acquisition] Using ${userPrimary} as primary source (user preference)`,
-        );
-        logger.debug(
-            `[Acquisition] Fallback configured: ${
-                useFallback ? alternative : "none"
-            }`,
-        );
-
-        return {
-            hasPrimarySource: true,
-            primarySource: userPrimary,
-            hasFallbackSource: useFallback,
-            fallbackSource: useFallback ? alternative : null,
-        };
     }
 
     /**
@@ -307,7 +280,7 @@ class AcquisitionService {
         }
 
         // Get download behavior configuration
-        const behavior = await this.getDownloadBehavior();
+        const behavior = await resolveAcquisitionBehavior();
 
         // Validate at least one source is available
         if (!behavior.hasPrimarySource) {
@@ -322,7 +295,7 @@ class AcquisitionService {
 
         if (behavior.primarySource === "soulseek") {
             logger.debug(`[Acquisition] Trying primary: Soulseek`);
-            result = await this.acquireAlbumViaSoulseek(request, context);
+            result = await this.processSoulseekAcquisition(request, context);
 
             // Fallback to Lidarr if Soulseek fails and fallback is configured
             if (!result.success) {
@@ -365,7 +338,7 @@ class AcquisitionService {
                     logger.debug(
                         `[Acquisition] Attempting Soulseek fallback...`,
                     );
-                    result = await this.acquireAlbumViaSoulseek(
+                    result = await this.processSoulseekAcquisition(
                         request,
                         context,
                     );
@@ -474,193 +447,27 @@ class AcquisitionService {
         }
     }
 
-    /**
-     * Acquire album via Soulseek (track-by-track download)
-     * Gets track list from MusicBrainz or Last.fm, then batch downloads
-     * Marks job as completed immediately (no webhook needed)
-     *
-     * @param request - Album to acquire
-     * @param context - Tracking context
-     * @returns Acquisition result
-     */
-    private async acquireAlbumViaSoulseek(
+    private async processSoulseekAcquisition(
         request: AlbumAcquisitionRequest,
         context: AcquisitionContext,
     ): Promise<AcquisitionResult> {
-        logger.debug(
-            `[Acquisition/Soulseek] Downloading: ${request.artistName} - ${request.albumTitle}`,
-        );
-
-        // Get music path
-        const settings = await getSystemSettings();
-        const musicPath = settings?.musicPath;
-        if (!musicPath) {
-            return { success: false, error: "Music path not configured" };
-        }
-
         if (!request.mbid) {
             return {
                 success: false,
                 error: "Album MBID required for Soulseek download",
             };
         }
-
-        let job: any;
-        try {
-            // Create download job at start for tracking
-            job = await this.createDownloadJob(request, context);
-
-            // Calculate attempt number (existing soulseek attempts + 1)
-            const jobMetadata = (job.metadata as any) || {};
-            const soulseekAttempts = (jobMetadata.soulseekAttempts || 0) + 1;
-            await this.updateJobStatusText(
-                job.id,
-                "soulseek",
-                soulseekAttempts,
-            );
-
-            let tracks: Array<{ title: string; position?: number }>;
-
-            // If specific tracks requested, use those instead of full album
-            if (request.requestedTracks && request.requestedTracks.length > 0) {
-                tracks = request.requestedTracks;
-                logger.debug(
-                    `[Acquisition/Soulseek] Using ${tracks.length} requested tracks (not full album)`,
-                );
-            } else {
-                // Strategy 1: Get track list from MusicBrainz
-                tracks = await musicBrainzService.getAlbumTracks(request.mbid);
-
-                // Strategy 2: Fallback to Last.fm (always try when MusicBrainz fails)
-                if (!tracks || tracks.length === 0) {
-                    logger.debug(
-                        `[Acquisition/Soulseek] MusicBrainz has no tracks, trying Last.fm`,
-                    );
-
-                    try {
-                        const albumInfo = await lastFmService.getAlbumInfo(
-                            request.artistName,
-                            request.albumTitle,
-                        );
-                        const lastFmTracks = albumInfo?.tracks?.track || [];
-
-                        if (
-                            Array.isArray(lastFmTracks) &&
-                            lastFmTracks.length > 0
-                        ) {
-                            tracks = lastFmTracks.map((t: any) => ({
-                                title: t.name || t.title,
-                                position: t["@attr"]?.rank
-                                    ? parseInt(t["@attr"].rank)
-                                    : undefined,
-                            }));
-                            logger.debug(
-                                `[Acquisition/Soulseek] Got ${tracks.length} tracks from Last.fm`,
-                            );
-                        }
-                    } catch (lastfmError: any) {
-                        logger.warn(
-                            `[Acquisition/Soulseek] Last.fm fallback failed: ${lastfmError.message}`,
-                        );
-                    }
-                }
-
-                if (!tracks || tracks.length === 0) {
-                    // Mark job as failed
-                    await this.updateJobStatus(
-                        job.id,
-                        "failed",
-                        "Could not get track list from MusicBrainz or Last.fm",
-                    );
-                    return {
-                        success: false,
-                        error: "Could not get track list from MusicBrainz or Last.fm",
-                    };
-                }
-
-                logger.debug(
-                    `[Acquisition/Soulseek] Found ${tracks.length} tracks for album`,
-                );
-            }
-
-            // Prepare tracks for batch download
-            const tracksToDownload = tracks.map((track) => ({
-                artist: request.artistName,
-                title: track.title,
-                album: request.albumTitle,
-            }));
-
-            // Use Soulseek batch download (parallel with concurrency limit)
-            const batchResult = await soulseekService.searchAndDownloadBatch(
-                tracksToDownload,
-                musicPath,
-                settings?.soulseekConcurrentDownloads || 4, // concurrency
-            );
-
-            if (batchResult.successful === 0) {
-                // Mark job as failed
-                await this.updateJobStatus(
-                    job.id,
-                    "failed",
-                    `No tracks found on Soulseek (searched ${tracks.length} tracks)`,
-                );
-                return {
-                    success: false,
-                    tracksTotal: tracks.length,
-                    downloadJobId: parseInt(job.id),
-                    error: `No tracks found on Soulseek (searched ${tracks.length} tracks)`,
-                };
-            }
-
-            // Success threshold: at least 50% of tracks
-            const successThreshold = Math.ceil(tracks.length * 0.5);
-            const isSuccess = batchResult.successful >= successThreshold;
-
-            logger.debug(
-                `[Acquisition/Soulseek] Downloaded ${batchResult.successful}/${tracks.length} tracks (threshold: ${successThreshold})`,
-            );
-
-            // Mark job as completed immediately (Soulseek doesn't use webhooks)
-            await this.updateJobStatus(
-                job.id,
-                isSuccess ? "completed" : "failed",
-                isSuccess
-                    ? undefined
-                    : `Only ${batchResult.successful}/${tracks.length} tracks found`,
-            );
-
-            // Update job metadata with track counts
-            await patchDownloadJobMetadata(job.id, {
-                tracksDownloaded: batchResult.successful,
-                tracksTotal: tracks.length,
-            });
-
-            return {
-                success: isSuccess,
-                source: "soulseek",
-                downloadJobId: parseInt(job.id),
-                tracksDownloaded: batchResult.successful,
-                tracksTotal: tracks.length,
-                error: isSuccess
-                    ? undefined
-                    : `Only ${batchResult.successful}/${tracks.length} tracks found`,
-            };
-        } catch (error: any) {
-            logger.error(`[Acquisition/Soulseek] Error: ${error.message}`);
-            // Update job status if job was created
-            if (job) {
-                await this.updateJobStatus(
-                    job.id,
-                    "failed",
-                    error.message,
-                ).catch((e) =>
-                    logger.error(
-                        `[Acquisition/Soulseek] Failed to update job status: ${e.message}`,
-                    ),
-                );
-            }
-            return { success: false, error: error.message };
+        const settings = await getSystemSettings();
+        if (!settings?.musicPath) {
+            return { success: false, error: "Music path not configured" };
         }
+        const job = await this.createDownloadJob(request, context);
+        return processSoulseekDownload(
+            job.id,
+            request.artistName,
+            request.albumTitle,
+            context.userId,
+        );
     }
 
     /**
@@ -803,6 +610,9 @@ class AcquisitionService {
                 artistName: request.artistName,
                 albumTitle: request.albumTitle,
                 albumMbid: request.mbid,
+                ...(request.requestedTracks
+                    ? { requestedTracks: request.requestedTracks }
+                    : {}),
             },
         };
 

--- a/backend/src/services/downloadDispatcher.ts
+++ b/backend/src/services/downloadDispatcher.ts
@@ -12,6 +12,7 @@ import {
 import { simpleDownloadManager } from "./simpleDownloadManager";
 import { processTidalDownload } from "./tidalLibraryDownload";
 import { processYoutubeDownload } from "./youtubeLibraryDownload";
+import { processSoulseekDownload } from "./soulseekLibraryDownload";
 import { parseArtistAlbumSubject } from "../utils/downloadSubject";
 import { patchDownloadJobMetadataFrom } from "./downloadJobStatus";
 
@@ -33,6 +34,14 @@ interface AlbumNames {
     album: string;
 }
 
+type ProviderDownloadProcessor = (
+    jobId: string,
+    artistName: string,
+    albumTitle: string,
+    userId: string,
+    options?: { fallbackSource?: DownloadSource },
+) => Promise<void>;
+
 type FailedDownloadSourceResolution = Extract<
     DownloadSourceResolution,
     { kind: "fail" }
@@ -48,6 +57,7 @@ export type AlbumDownloadRouting =
     | {
           kind: "dispatch";
           source: DownloadSource;
+          fallbackSource?: DownloadSource;
           availability: DownloadSourceAvailability;
           job: DownloadJob;
           names: AlbumNames;
@@ -93,24 +103,51 @@ async function failJobWithoutDispatch(
     );
 }
 
-async function dispatchResolvedSource(
-    source: DownloadSource,
-    availability: DownloadSourceAvailability,
+async function dispatchProviderSource(
+    processor: ProviderDownloadProcessor,
+    fallbackSource: DownloadSource | undefined,
     params: AlbumDownloadDispatchParams,
     names: AlbumNames,
     userId: string,
 ): Promise<void> {
-    if (source === "tidal" && availability.tidal) {
-        await processTidalDownload(
-            params.jobId,
-            names.artist,
-            names.album,
+    if (fallbackSource) {
+        await processor(params.jobId, names.artist, names.album, userId, {
+            fallbackSource,
+        });
+        return;
+    }
+    await processor(params.jobId, names.artist, names.album, userId);
+}
+
+async function dispatchResolvedSource(
+    source: DownloadSource,
+    fallbackSource: DownloadSource | undefined,
+    params: AlbumDownloadDispatchParams,
+    names: AlbumNames,
+    userId: string,
+): Promise<void> {
+    if (source === "tidal") {
+        await dispatchProviderSource(
+            processTidalDownload,
+            fallbackSource,
+            params,
+            names,
             userId,
         );
         return;
     }
-    if (source === "youtube" && availability.youtube) {
-        await processYoutubeDownload(
+    if (source === "youtube") {
+        await dispatchProviderSource(
+            processYoutubeDownload,
+            fallbackSource,
+            params,
+            names,
+            userId,
+        );
+        return;
+    }
+    if (source === "soulseek") {
+        await processSoulseekDownload(
             params.jobId,
             names.artist,
             names.album,
@@ -119,10 +156,6 @@ async function dispatchResolvedSource(
         return;
     }
 
-    // Non-TIDAL dispatch goes through simpleDownloadManager, which is
-    // Lidarr-backed — there is no per-source dispatch below this point, so a
-    // "soulseek" selection is executed by the Lidarr manager (pre-existing
-    // pipeline limitation).
     const managerParams = [
         params.jobId,
         names.artist,
@@ -140,6 +173,24 @@ async function dispatchResolvedSource(
     if (!result.success) {
         logger.error(`Failed to start download: ${result.error}`);
     }
+}
+
+function resolveRuntimeFallback(
+    configuredSource: DownloadSource,
+    dispatchedSource: DownloadSource,
+    fallback: string | null | undefined,
+    availability: DownloadSourceAvailability,
+): DownloadSource | undefined {
+    if (configuredSource !== dispatchedSource) return undefined;
+    const resolution = resolveDownloadSource({
+        configuredSource,
+        fallback,
+        availability: { ...availability, [configuredSource]: false },
+    });
+    if (resolution.kind === "fail" || resolution.source === dispatchedSource) {
+        return undefined;
+    }
+    return resolution.source;
 }
 
 /** Resolve one album download against a single settings and availability snapshot. */
@@ -181,6 +232,12 @@ export async function resolveAlbumDownloadRouting(
     return {
         kind: "dispatch",
         source: resolution.source,
+        fallbackSource: resolveRuntimeFallback(
+            configuredSource,
+            resolution.source,
+            settings?.primaryFailureFallback,
+            availability,
+        ),
         availability,
         job,
         names,
@@ -210,7 +267,7 @@ export async function dispatchResolvedAlbumDownload(
 
     await dispatchResolvedSource(
         routing.source,
-        routing.availability,
+        routing.fallbackSource,
         params,
         routing.names,
         routing.userId,

--- a/backend/src/services/libraryDownloadProcessor.ts
+++ b/backend/src/services/libraryDownloadProcessor.ts
@@ -3,13 +3,12 @@
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { asPlainObject } from "../utils/plainObject";
-import { getSystemSettings } from "../utils/systemSettings";
 import { requestCoalescedLibraryScan } from "./coalescedLibraryScan";
+import type { DownloadSource } from "./downloadSourcePolicy";
 import { patchDownloadJobMetadata } from "./downloadJobStatus";
 import { simpleDownloadManager } from "./simpleDownloadManager";
 
 type DownloadMetadata = Record<string, unknown>;
-type ManagerFallback = "lidarr" | "soulseek";
 type PeerFallbackOptions = LibraryAlbumDownloadOptions & {
     isFallback: true;
 };
@@ -24,6 +23,7 @@ interface ProcessorContext extends DownloadContext {
     albumTitle: string;
     userId: string;
     isFallback: boolean;
+    fallbackSource?: DownloadSource;
 }
 
 interface ResultSummary {
@@ -34,6 +34,7 @@ interface ResultSummary {
 /** Controls hand-off behavior when a processor is itself a fallback. */
 export interface LibraryAlbumDownloadOptions {
     isFallback?: boolean;
+    fallbackSource?: DownloadSource;
 }
 
 /** Defines provider-specific steps and text for the shared processor. */
@@ -59,7 +60,6 @@ export interface LibraryDownloadProcessorConfig<TMatch, TResult> {
             options: PeerFallbackOptions,
         ) => Promise<void>;
     };
-    fallbackOrder: "manager-first" | "peer-first";
     logFallbackSelection: boolean;
     prefixManagerFailureLog: boolean;
     scanSource: string;
@@ -69,10 +69,6 @@ export interface LibraryDownloadProcessorConfig<TMatch, TResult> {
 function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
     const { failedAt: _failedAt, ...retainedMetadata } = metadata;
     return retainedMetadata;
-}
-
-function isManagerFallback(value: unknown): value is ManagerFallback {
-    return value === "lidarr" || value === "soulseek";
 }
 
 async function markSearching<TMatch, TResult>(
@@ -105,7 +101,6 @@ async function markSearchMissHandOff<TMatch, TResult>(
 
 async function handOffToManager<TMatch, TResult>(
     config: LibraryDownloadProcessorConfig<TMatch, TResult>,
-    fallback: ManagerFallback,
     context: ProcessorContext,
 ): Promise<void> {
     const result = await simpleDownloadManager.startDownload(
@@ -125,7 +120,7 @@ async function handOffToManager<TMatch, TResult>(
     const prefix = config.prefixManagerFailureLog
         ? `[${config.sourceLabel}] `
         : "";
-    logger.error(`${prefix}Fallback ${fallback} failed: ${result.error}`);
+    logger.error(`${prefix}Fallback lidarr failed: ${result.error}`);
 }
 
 async function handOffToPeer<TMatch, TResult>(
@@ -144,24 +139,26 @@ async function handOffToPeer<TMatch, TResult>(
 
 async function dispatchHandOff<TMatch, TResult>(
     config: LibraryDownloadProcessorConfig<TMatch, TResult>,
-    fallback: string,
+    fallback: DownloadSource,
     context: ProcessorContext,
 ): Promise<void> {
-    const managerFallback = isManagerFallback(fallback);
-    if (config.fallbackOrder === "manager-first") {
-        if (managerFallback) {
-            await handOffToManager(config, fallback, context);
-            return;
-        }
-        await handOffToPeer(config, context);
-        return;
-    }
     if (fallback === config.fallbackPeer.sourceKey) {
         await handOffToPeer(config, context);
         return;
     }
-    if (managerFallback) {
-        await handOffToManager(config, fallback, context);
+    if (fallback === "soulseek") {
+        const { processSoulseekDownload } =
+            await import("./soulseekLibraryDownload");
+        await processSoulseekDownload(
+            context.jobId,
+            context.artistName,
+            context.albumTitle,
+            context.userId,
+        );
+        return;
+    }
+    if (fallback === "lidarr") {
+        await handOffToManager(config, context);
     }
 }
 
@@ -169,18 +166,8 @@ async function handOffSearchMiss<TMatch, TResult>(
     config: LibraryDownloadProcessorConfig<TMatch, TResult>,
     context: ProcessorContext,
 ): Promise<boolean> {
-    const settings = await getSystemSettings();
-    const fallback: unknown = settings?.primaryFailureFallback;
-    const managerFallback = isManagerFallback(fallback);
-    if (
-        !managerFallback &&
-        (fallback !== config.fallbackPeer.sourceKey || context.isFallback)
-    ) {
-        return false;
-    }
-    const selectedFallback = managerFallback
-        ? fallback
-        : config.fallbackPeer.sourceKey;
+    const selectedFallback = context.fallbackSource;
+    if (!selectedFallback || context.isFallback) return false;
     if (config.logFallbackSelection) {
         logger.debug(
             `[${config.sourceLabel}] Album not found, falling back to ${selectedFallback}`,
@@ -296,6 +283,7 @@ export async function runLibraryAlbumDownload<TMatch, TResult>(
             userId,
             metadata,
             isFallback: options.isFallback === true,
+            fallbackSource: options.fallbackSource,
         });
     } catch (error: unknown) {
         logger.error(

--- a/backend/src/services/soulseekLibraryDownload.ts
+++ b/backend/src/services/soulseekLibraryDownload.ts
@@ -1,0 +1,252 @@
+/** Soulseek album track-list resolution, batch download, and job persistence. */
+
+import { prisma } from "../utils/db";
+import { logger as rootLogger } from "../utils/logger";
+import { asPlainObject } from "../utils/plainObject";
+import { getSystemSettings } from "../utils/systemSettings";
+import {
+    failDownloadJob,
+    patchDownloadJobMetadata,
+    patchDownloadJobMetadataFrom,
+} from "./downloadJobStatus";
+import { lastFmService } from "./lastfm";
+import { musicBrainzService } from "./musicbrainz";
+import { soulseekService } from "./soulseek";
+
+const logger = rootLogger.child("SoulseekLibraryDownload");
+const SOULSEEK_DOWNLOAD_FAILED = "Soulseek download failed";
+
+interface AlbumTrack {
+    title: string;
+    position?: number;
+}
+
+/** Result returned to compatibility acquisition callers. */
+export interface SoulseekAlbumDownloadResult {
+    success: boolean;
+    source?: "soulseek";
+    downloadJobId?: number;
+    error?: string;
+    tracksDownloaded?: number;
+    tracksTotal?: number;
+}
+
+function requestedTracksFrom(metadata: unknown): AlbumTrack[] | null {
+    const requestedTracks = asPlainObject(metadata).requestedTracks;
+    if (!Array.isArray(requestedTracks) || requestedTracks.length === 0) {
+        return null;
+    }
+    const tracks = requestedTracks.filter(
+        (track): track is AlbumTrack =>
+            typeof track === "object" &&
+            track !== null &&
+            typeof (track as Record<string, unknown>).title === "string",
+    );
+    return tracks.length === requestedTracks.length ? tracks : null;
+}
+
+async function lastFmTracks(
+    artistName: string,
+    albumTitle: string,
+): Promise<AlbumTrack[]> {
+    const albumInfo = await lastFmService.getAlbumInfo(artistName, albumTitle);
+    const tracks = albumInfo?.tracks?.track;
+    if (!Array.isArray(tracks)) return [];
+    return tracks
+        .map(asLastFmTrack)
+        .filter((track): track is AlbumTrack => track !== null);
+}
+
+function asLastFmTrack(value: unknown): AlbumTrack | null {
+    const track = asPlainObject(value);
+    const title =
+        typeof track.name === "string"
+            ? track.name
+            : typeof track.title === "string"
+              ? track.title
+              : null;
+    if (!title) return null;
+    const rank = asPlainObject(track["@attr"]).rank;
+    return {
+        title,
+        position:
+            typeof rank === "string" ? Number.parseInt(rank, 10) : undefined,
+    };
+}
+
+async function resolveAlbumTracks(
+    albumMbid: string,
+    artistName: string,
+    albumTitle: string,
+    requestedTracks: AlbumTrack[] | null,
+): Promise<AlbumTrack[]> {
+    if (requestedTracks) return requestedTracks;
+    const musicBrainzTracks =
+        await musicBrainzService.getAlbumTracks(albumMbid);
+    if (musicBrainzTracks.length > 0) return musicBrainzTracks;
+    logger.debug("MusicBrainz has no tracks; trying Last.fm", {
+        artistName,
+        albumTitle,
+    });
+    try {
+        return await lastFmTracks(artistName, albumTitle);
+    } catch (error) {
+        logger.warn("Last.fm track-list fallback failed", { error });
+        return [];
+    }
+}
+
+async function markFailed(
+    jobId: string,
+    failureMessage: string,
+    result: SoulseekAlbumDownloadResult = {
+        success: false,
+        error: failureMessage,
+    },
+): Promise<SoulseekAlbumDownloadResult> {
+    await failDownloadJob(jobId, failureMessage);
+    return result;
+}
+
+async function updateAttempt(jobId: string, metadata: unknown): Promise<void> {
+    const current = asPlainObject(metadata);
+    const soulseekAttempts =
+        (typeof current.soulseekAttempts === "number"
+            ? current.soulseekAttempts
+            : 0) + 1;
+    await patchDownloadJobMetadataFrom(current, jobId, {
+        currentSource: "soulseek",
+        lidarrAttempts:
+            typeof current.lidarrAttempts === "number"
+                ? current.lidarrAttempts
+                : 0,
+        soulseekAttempts,
+        statusText: `Soulseek #${soulseekAttempts}`,
+    });
+}
+
+async function persistBatchOutcome(
+    jobId: string,
+    successful: number,
+    total: number,
+): Promise<SoulseekAlbumDownloadResult> {
+    const success = successful >= Math.ceil(total * 0.5);
+    const failureMessage = success
+        ? undefined
+        : `Only ${successful}/${total} tracks found`;
+    await patchDownloadJobMetadata(
+        jobId,
+        { tracksDownloaded: successful, tracksTotal: total },
+        {
+            status: success ? "completed" : "failed",
+            error: failureMessage ?? null,
+            completedAt: new Date(),
+        },
+    );
+    return {
+        success,
+        source: "soulseek",
+        downloadJobId: Number.parseInt(jobId, 10),
+        tracksDownloaded: successful,
+        tracksTotal: total,
+        error: failureMessage,
+    };
+}
+
+async function persistUnexpectedFailure(
+    jobId: string,
+    error: unknown,
+): Promise<SoulseekAlbumDownloadResult> {
+    logger.error("Soulseek album download failed", { jobId, error });
+    await failDownloadJob(jobId, SOULSEEK_DOWNLOAD_FAILED).catch(
+        (persistenceError) => {
+            logger.error("Failed to persist Soulseek download failure", {
+                jobId,
+                error: persistenceError,
+            });
+        },
+    );
+    return { success: false, error: SOULSEEK_DOWNLOAD_FAILED };
+}
+
+async function runSoulseekDownload(
+    jobId: string,
+    artistName: string,
+    albumTitle: string,
+    albumMbid: string,
+    metadata: unknown,
+    musicPath: string,
+    concurrency: number,
+): Promise<SoulseekAlbumDownloadResult> {
+    await updateAttempt(jobId, metadata);
+    const tracks = await resolveAlbumTracks(
+        albumMbid,
+        artistName,
+        albumTitle,
+        requestedTracksFrom(metadata),
+    );
+    if (tracks.length === 0) {
+        return markFailed(
+            jobId,
+            "Could not get track list from MusicBrainz or Last.fm",
+        );
+    }
+    const result = await soulseekService.searchAndDownloadBatch(
+        tracks.map((track) => ({
+            artist: artistName,
+            title: track.title,
+            album: albumTitle,
+        })),
+        musicPath,
+        concurrency,
+    );
+    if (result.successful > 0) {
+        return persistBatchOutcome(jobId, result.successful, tracks.length);
+    }
+    const failureMessage = `No tracks found on Soulseek (searched ${tracks.length} tracks)`;
+    return markFailed(jobId, failureMessage, {
+        success: false,
+        downloadJobId: Number.parseInt(jobId, 10),
+        tracksTotal: tracks.length,
+        error: failureMessage,
+    });
+}
+
+/** Process one existing library album job through Soulseek. */
+export async function processSoulseekDownload(
+    jobId: string,
+    artistName: string,
+    albumTitle: string,
+    userId: string,
+): Promise<SoulseekAlbumDownloadResult> {
+    void userId;
+    const job = await prisma.downloadJob.findUnique({
+        where: { id: jobId },
+        select: { targetMbid: true, metadata: true },
+    });
+    if (!job) return { success: false, error: "Download job not found" };
+
+    try {
+        const settings = await getSystemSettings();
+        if (!settings?.musicPath) {
+            return markFailed(jobId, "Music path not configured");
+        }
+        if (!job.targetMbid) {
+            return markFailed(
+                jobId,
+                "Album MBID required for Soulseek download",
+            );
+        }
+        return await runSoulseekDownload(
+            jobId,
+            artistName,
+            albumTitle,
+            job.targetMbid,
+            job.metadata,
+            settings.musicPath,
+            settings.soulseekConcurrentDownloads || 4,
+        );
+    } catch (error) {
+        return persistUnexpectedFailure(jobId, error);
+    }
+}

--- a/backend/src/services/tidalLibraryDownload.ts
+++ b/backend/src/services/tidalLibraryDownload.ts
@@ -2,6 +2,7 @@
 
 import { logger } from "../utils/logger";
 import {
+    type LibraryAlbumDownloadOptions,
     type LibraryDownloadProcessorConfig,
     runLibraryAlbumDownload,
 } from "./libraryDownloadProcessor";
@@ -13,9 +14,7 @@ type TidalAlbumMatch = NonNullable<
 >;
 
 /** Controls hand-off behavior when this processor is itself a fallback. */
-export interface TidalLibraryDownloadOptions {
-    isFallback?: boolean;
-}
+export type TidalLibraryDownloadOptions = LibraryAlbumDownloadOptions;
 
 function completedStatusText(result: TidalAlbumDownloadResult): string {
     return result.failed > 0
@@ -76,7 +75,6 @@ const tidalLibraryDownloadConfig = {
             );
         },
     },
-    fallbackOrder: "manager-first",
     logFallbackSelection: true,
     prefixManagerFailureLog: false,
     scanSource: "tidal-download",

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -1,6 +1,7 @@
 /** YouTube Music album search, sidecar job orchestration, and library scanning. */
 
 import {
+    type LibraryAlbumDownloadOptions,
     type LibraryDownloadProcessorConfig,
     runLibraryAlbumDownload,
 } from "./libraryDownloadProcessor";
@@ -19,9 +20,7 @@ interface AlbumSearchCandidate {
 }
 
 /** Controls hand-off behavior when this processor is itself a fallback. */
-export interface YoutubeLibraryDownloadOptions {
-    isFallback?: boolean;
-}
+export type YoutubeLibraryDownloadOptions = LibraryAlbumDownloadOptions;
 
 function asAlbumSearchCandidate(value: unknown): AlbumSearchCandidate | null {
     if (!value || typeof value !== "object") return null;
@@ -165,7 +164,6 @@ const youtubeLibraryDownloadConfig = {
             );
         },
     },
-    fallbackOrder: "peer-first",
     logFallbackSelection: false,
     prefixManagerFailureLog: true,
     scanSource: "youtube-download",

--- a/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/albumDownloadProcessor.test.ts
@@ -10,6 +10,7 @@ const mockLoggerWarn = jest.fn();
 const mockLoggerError = jest.fn();
 const mockProcessTidalDownload = jest.fn();
 const mockProcessYoutubeDownload = jest.fn();
+const mockProcessSoulseekDownload = jest.fn();
 const mockStartDownload = jest.fn();
 
 jest.mock("../../../services/downloadDispatcher", () => ({
@@ -67,6 +68,11 @@ jest.mock("../../../services/youtubeLibraryDownload", () => ({
         mockProcessYoutubeDownload(...args),
 }));
 
+jest.mock("../../../services/soulseekLibraryDownload", () => ({
+    processSoulseekDownload: (...args: unknown[]) =>
+        mockProcessSoulseekDownload(...args),
+}));
+
 jest.mock("../../../services/simpleDownloadManager", () => ({
     simpleDownloadManager: {
         startDownload: (...args: unknown[]) => mockStartDownload(...args),
@@ -102,7 +108,7 @@ const routingJob = {
     metadata: { preserved: true },
 };
 
-function dispatchRouting(source: "tidal" | "youtube" | "lidarr") {
+function dispatchRouting(source: "tidal" | "youtube" | "lidarr" | "soulseek") {
     return {
         kind: "dispatch" as const,
         source,
@@ -126,6 +132,7 @@ describe("album download queue processor", () => {
         mockExtendSchedulerClaim.mockResolvedValue(true);
         mockProcessTidalDownload.mockResolvedValue(undefined);
         mockProcessYoutubeDownload.mockResolvedValue(undefined);
+        mockProcessSoulseekDownload.mockResolvedValue(undefined);
         mockStartDownload.mockResolvedValue({ success: true });
         mockRunWithSchedulerClaim.mockImplementation(
             async (
@@ -246,6 +253,73 @@ describe("album download queue processor", () => {
             false,
             payload.artistMbid,
         );
+    });
+
+    it("acquires the renewable claim before dispatching a Soulseek-routed album", async () => {
+        const ordering: string[] = [];
+        mockResolveAlbumDownloadRouting.mockResolvedValueOnce(
+            dispatchRouting("soulseek"),
+        );
+        mockProcessSoulseekDownload.mockImplementationOnce(async () => {
+            ordering.push("dispatch");
+        });
+        mockRunWithSchedulerClaim.mockImplementationOnce(
+            async (
+                _claimKey: string,
+                _ttlMs: number,
+                _operationName: string,
+                operation: (claimToken: string) => Promise<void>,
+            ) => {
+                ordering.push("acquired");
+                return {
+                    acquired: true,
+                    value: await operation("claim-token"),
+                };
+            },
+        );
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await processAlbumDownload(job);
+
+        expect(mockRunWithSchedulerClaim).toHaveBeenCalledWith(
+            "scheduler-claim:album-download",
+            15 * 60_000,
+            "album download",
+            expect.any(Function),
+        );
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledWith(
+            payload.jobId,
+            "Artist",
+            "Album",
+            "user-1",
+        );
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(ordering).toEqual(["acquired", "dispatch"]);
+    });
+
+    it("surfaces a persisted Soulseek failure without redispatching", async () => {
+        mockResolveAlbumDownloadRouting.mockResolvedValueOnce(
+            dispatchRouting("soulseek"),
+        );
+        mockDownloadJobFindUnique
+            .mockResolvedValueOnce({ status: "pending" })
+            .mockResolvedValueOnce({ status: "processing" })
+            .mockResolvedValueOnce({ status: "failed" });
+        const job = {
+            data: payload,
+            progress: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await expect(processAlbumDownload(job)).rejects.toBeInstanceOf(
+            AlbumDownloadFailedError,
+        );
+
+        expect(mockProcessSoulseekDownload).toHaveBeenCalledTimes(1);
+        expect(mockStartDownload).not.toHaveBeenCalled();
+        expect(job.progress).toHaveBeenCalledTimes(1);
     });
 
     it("persists a failed resolution without a claim", async () => {

--- a/backend/src/workers/processors/albumDownloadProcessor.ts
+++ b/backend/src/workers/processors/albumDownloadProcessor.ts
@@ -210,7 +210,9 @@ function requiresAlbumDownloadClaim(
 ): routing is Extract<AlbumDownloadRouting, { kind: "dispatch" }> {
     return (
         routing?.kind === "dispatch" &&
-        (routing.source === "tidal" || routing.source === "youtube")
+        (routing.source === "tidal" ||
+            routing.source === "youtube" ||
+            routing.source === "soulseek")
     );
 }
 

--- a/scripts/ci/check-route-error-canon.mjs
+++ b/scripts/ci/check-route-error-canon.mjs
@@ -83,8 +83,8 @@ const LEAK_BASELINE = Object.freeze({
     "backend/src/routes/subsonic/mediaRetrieval.ts": 1,
     // youtube.ts remaining 4: yt-dlp sidecar err.response?.data?.detail echoed in error responses (L68, L126, L335, L341); known backlog item, frozen under the slice-J scope guard.
     "backend/src/routes/youtube.ts": 4,
-    // acquisitionService.ts remaining 4: { success:false, error } acquisition result objects (~L482, ~L678, ~L767) consumed by the download orchestration/admin surface, not raw route 500 bodies; frozen under the slice-E scope guard; plus a result.error passthrough in a { success:false, error } result object (~L748); frozen under the slice-J scope guard.
-    "backend/src/services/acquisitionService.ts": 4,
+    // acquisitionService.ts remaining 3: { success:false, error } acquisition result objects consumed by the download orchestration/admin surface, not raw route 500 bodies; frozen under the slice-E/slice-J scope guards. The Soulseek album processor moved to soulseekLibraryDownload.ts and no longer contributes raw-detail matches here.
+    "backend/src/services/acquisitionService.ts": 3,
     // artistCountsService.ts +2: numeric backfill error counters returned in result/progress objects (~L237 and ~L277); no error text; frozen under the ratchet-widening (slice-B2) scope guard.
     "backend/src/services/artistCountsService.ts": 2,
     // audioStreaming.ts remaining 3: internal ffmpeg-error classification (~L285) plus transcode-failure AppError messages (~L303, ~L347); frozen under the slice-E scope guard — AppError messages are echoed by errorHandler, flagged for follow-up sanitization.


### PR DESCRIPTION
Closes #788.

## Problem

Album-queue downloads ignored the user's Soulseek source selection. `acquisitionService` carried its own copy of the source-dispatch decision, separate from `downloadDispatcher`, and the two had drifted: a queue item explicitly marked for Soulseek could still be routed to Lidarr, and the Soulseek album path lived inline in `acquisitionService` as a ~200-line block that nothing else could reuse or test in isolation.

## Fix

- New `backend/src/services/soulseekLibraryDownload.ts` owns the Soulseek album download path (`processSoulseekDownload()`), extracted from `acquisitionService` (866 → 672 lines).
- `acquisitionService` now consumes the shared `downloadSourcePolicy` from `downloadDispatcher` instead of re-deriving source selection — one dispatch decision, used by both entry points.
- Resolver reconciliation deltas: source selection is resolved once up front and threaded through, so a mid-download settings change no longer flips the source of an in-flight album.

## Decision: no legacy escape hatch

I considered an env knob to restore the old dispatch behavior and decided against it. The old behavior was a defect (selections silently ignored), not a mode anyone depends on; keeping it reachable would preserve the bug behind a flag and double the test matrix. If a regression surfaces, revert is cheap because the change is isolated to the dispatch seam.

## Verification

- `npx tsc --noEmit` — 0 errors
- Full backend jest suite at 6 workers — see checks
- New `soulseekLibraryDownload.test.ts` (dispatch, error persistence, terminal outcomes); `acquisitionService.test.ts` rewritten against the policy seam; `downloadDispatcher.test.ts` + `albumDownloadProcessor.test.ts` extended
- `check-route-error-canon.mjs` baseline: acquisitionService 4 → 3 (moved processor no longer contributes raw-detail matches)
- `check-file-size.mjs`, `format:check` — clean
