### PR TITLE
chore(player): overlay drawer tabs become query-owning children with a windowed queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The full-screen player's swipe gestures (track skip, swipe-down to close, drawer handle) now run through one tested gesture module, in preparation for further player decomposition.
+- The full-screen player's Up Next list now renders only the rows in view, so very large queues open and scroll smoothly, and the Queue, Lyrics, and Related panels fetch their data independently so an open player does less background work.
 - Subsonic search and artist views now share the main library's data layer.
 - Internal route handling now shares validation, pagination, and ownership middleware, and enrichment and YouTube Music administrator errors use the documented response format.
 - App screens now share one catalog of data-cache keys, so library, playlist, download, and notification views refresh reliably after changes instead of occasionally showing stale lists.

--- a/frontend/components/player/OverlayPlayer.tsx
+++ b/frontend/components/player/OverlayPlayer.tsx
@@ -3,9 +3,7 @@
 import { useOverlayGestures } from "./hooks/useOverlayGestures";
 import { useOverlayPlayerAudio } from "./hooks/useOverlayPlayerAudio";
 import { useMediaInfo } from "@/hooks/useMediaInfo";
-import { useLyrics } from "@/hooks/useLyrics";
 import { resolvePlaybackQualityBadgeFromStreamSource } from "@/hooks/useStreamBitrate";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
@@ -19,7 +17,6 @@ import {
     RotateCw,
     ChevronDown,
     Music as MusicIcon,
-    ListMusic,
     Shuffle,
     Repeat,
     Repeat1,
@@ -27,8 +24,6 @@ import {
     Radio,
     Loader2,
     RefreshCw,
-    Trash2,
-    X,
     Plus,
 } from "lucide-react";
 import { formatTime, clampTime, formatTimeRemaining } from "@/utils/formatTime";
@@ -37,13 +32,11 @@ import { useIsMobile, useIsTablet } from "@/hooks/useMediaQuery";
 import { toast } from "sonner";
 import { SeekSlider } from "./SeekSlider";
 import { useFeatures } from "@/lib/features-context";
-import { SyncedLyrics } from "./SyncedLyrics";
 import { api } from "@/lib/api";
 import { TidalBadge } from "@/components/ui/TidalBadge";
 import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
 import { SyncBadge } from "@/components/player/SyncBadge";
 import { useListenTogether } from "@/lib/listen-together-context";
-import { getArtistHref } from "@/utils/artistRoute";
 import {
     OVERLAY_ACTIVE_TAB_STORAGE_KEY,
     readMigratingStorageItem,
@@ -51,61 +44,15 @@ import {
 } from "@/lib/storage-migration";
 import { TrackPreferenceButtons } from "./TrackPreferenceButtons";
 import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
-import {
-    TrackOverflowMenu,
-    TrackMenuButton,
-} from "@/components/ui/TrackOverflowMenu";
 import { PlaylistSelector } from "@/components/ui/PlaylistSelector";
+import { OverlayQueueTab } from "./overlay-tabs/OverlayQueueTab";
+import { OverlayLyricsTab } from "./overlay-tabs/OverlayLyricsTab";
+import { OverlayRelatedTab } from "./overlay-tabs/OverlayRelatedTab";
 import { frontendLogger as sharedFrontendLogger } from "@/lib/logger";
 import { toAddToPlaylistRef } from "@/lib/trackRef";
 import type { Track } from "@/lib/audio-state-context";
-import { queryKeys } from "@/lib/queryKeys";
 
 const OVERLAY_ACTIVE_TAB_KEY = OVERLAY_ACTIVE_TAB_STORAGE_KEY;
-
-interface RelatedTrack {
-    id?: string;
-    title: string;
-    artist?: string;
-    similarity?: number;
-    inLibrary?: boolean;
-    matchConfidence?: number;
-    duration?: number;
-    filePath?: string;
-    streamSource?: "tidal" | "youtube";
-    tidalTrackId?: number;
-    youtubeVideoId?: string;
-    lastFmUrl?: string;
-    album?: {
-        id?: string;
-        title?: string;
-        coverArt?: string;
-        coverUrl?: string;
-        artist?: { id?: string; name?: string; mbid?: string };
-    };
-}
-
-interface RelatedArtist {
-    name: string;
-    mbid?: string;
-    image?: string;
-}
-
-interface RelatedAlbum {
-    id: string;
-    title: string;
-    year?: number;
-    coverArt?: string | null;
-}
-
-interface RelatedStreamMatch {
-    streamSource: "tidal" | "youtube";
-    tidalTrackId?: number;
-    youtubeVideoId?: string;
-    title?: string;
-    artist?: string;
-    duration?: number;
-}
 
 function isPlayableTrack(value: unknown): value is Track {
     if (!value || typeof value !== "object") return false;
@@ -173,9 +120,6 @@ export function OverlayPlayer() {
 
     // Swipe state for track skipping
     const overlayRef = useRef<HTMLDivElement | null>(null);
-    const queueListRef = useRef<HTMLDivElement | null>(null);
-    const wasQueueTabVisibleRef = useRef(false);
-    const previousQueueIndexRef = useRef<number | null>(null);
     const [isVibeLoading, setIsVibeLoading] = useState(false);
     const [isRadioLoading, setIsRadioLoading] = useState(false);
     const [isPlaylistSelectorOpen, setIsPlaylistSelectorOpen] = useState(false);
@@ -183,12 +127,6 @@ export function OverlayPlayer() {
     const [activeTab, setActiveTab] = useState<"queue" | "lyrics" | "related">(
         "queue",
     );
-    const [relatedStreamMatches, setRelatedStreamMatches] = useState<
-        Record<string, RelatedStreamMatch>
-    >({});
-    const [matchingRelatedTrackKey, setMatchingRelatedTrackKey] = useState<
-        string | null
-    >(null);
     const { vibeEmbeddings, loading: featuresLoading } = useFeatures();
     const { title, subtitle, coverUrl, artistLink, mediaLink } =
         useMediaInfo(768);
@@ -221,28 +159,20 @@ export function OverlayPlayer() {
     const isTrackMode = playbackType === "track";
     const preferenceTrackId = isTrackMode ? currentTrack?.id : undefined;
     const isDesktopOverlayLayout = canSkip && !isMobileOrTablet;
-    const isTabPanelVisible =
-        canSkip && (isDesktopOverlayLayout || isDrawerOpen);
-    const lyricsTrackId =
-        isTabPanelVisible && activeTab === "lyrics" && playbackType === "track"
-            ? currentTrack?.id
-            : undefined;
-    const lyricsLookupMetadata =
-        lyricsTrackId && currentTrack
-            ? {
-                  artist: currentTrack.artist?.name,
-                  title: currentTrack.displayTitle || currentTrack.title,
-                  album: currentTrack.album?.title,
-                  duration: currentTrack.duration,
-              }
-            : undefined;
-
-    // Lyrics query — only fetch when the lyrics panel is shown
-    const {
-        data: lyricsData,
-        isLoading: isLyricsLoading,
-        isError: isLyricsError,
-    } = useLyrics(lyricsTrackId, lyricsLookupMetadata);
+    // The lyrics tab mounts only while shown, so it owns its own fetch.
+    const lyricsLookupTrack = useMemo(
+        () =>
+            playbackType === "track" && currentTrack?.id
+                ? {
+                      id: currentTrack.id,
+                      artist: currentTrack.artist?.name,
+                      title: currentTrack.displayTitle || currentTrack.title,
+                      album: currentTrack.album?.title,
+                      duration: currentTrack.duration,
+                  }
+                : null,
+        [currentTrack, playbackType],
+    );
 
     const duration = (() => {
         if (playbackType === "podcast" && currentPodcast?.duration) {
@@ -293,164 +223,8 @@ export function OverlayPlayer() {
         "default";
     const artworkLayoutId = `mobile-player-artwork-${currentMediaId}`;
     const queueTracks = queue;
-    const isQueueTabVisible = isTabPanelVisible && activeTab === "queue";
 
-    const queryClient = useQueryClient();
-
-    const {
-        data: relatedTrackData,
-        isLoading: isRelatedTracksLoading,
-        isError: isRelatedTracksError,
-    } = useQuery({
-        queryKey: queryKeys.playerRelatedTracks(currentTrack?.id),
-        queryFn: async () => {
-            if (!currentTrack?.id) return [];
-            const response = await api.getSimilarTracks(
-                currentTrack.id,
-                12,
-                currentTrack.artist?.name,
-                currentTrack.displayTitle || currentTrack.title,
-            );
-            return response.recommendations || [];
-        },
-        enabled:
-            isTabPanelVisible &&
-            activeTab === "related" &&
-            playbackType === "track" &&
-            !!currentTrack?.id,
-        staleTime: 5 * 60 * 1000,
-        retry: 1,
-    });
-
-    const {
-        data: relatedArtistsData,
-        isLoading: isRelatedArtistsLoading,
-        isError: isRelatedArtistsError,
-    } = useQuery({
-        queryKey: queryKeys.playerRelatedArtists(
-            currentTrack?.artist?.name,
-            currentTrack?.artist?.mbid,
-        ),
-        queryFn: async () => {
-            if (!currentTrack?.artist?.name) return [];
-            const response = await api.discoverSimilarArtists(
-                currentTrack.artist.name,
-                currentTrack.artist.mbid || "",
-                8,
-            );
-            return response.similarArtists || [];
-        },
-        enabled:
-            isTabPanelVisible &&
-            activeTab === "related" &&
-            playbackType === "track" &&
-            !!currentTrack?.artist?.name,
-        staleTime: 30 * 60 * 1000,
-        retry: 1,
-    });
-
-    const {
-        data: moreFromArtistData,
-        isLoading: isMoreFromArtistLoading,
-        isError: isMoreFromArtistError,
-    } = useQuery({
-        queryKey: queryKeys.playerRelatedAlbums(currentTrack?.artist?.id),
-        queryFn: async () => {
-            if (!currentTrack?.artist?.id) return [];
-            const response = await api.getAlbums({
-                artistId: currentTrack.artist.id,
-                limit: 8,
-                sortBy: "recent",
-            });
-            return response.albums || [];
-        },
-        enabled:
-            isTabPanelVisible &&
-            activeTab === "related" &&
-            playbackType === "track" &&
-            !!currentTrack?.artist?.id,
-        staleTime: 10 * 60 * 1000,
-        retry: 1,
-    });
-    const relatedTracks = useMemo<RelatedTrack[]>(
-        () =>
-            Array.isArray(relatedTrackData)
-                ? (relatedTrackData as RelatedTrack[])
-                : [],
-        [relatedTrackData],
-    );
-    const relatedArtists = useMemo<RelatedArtist[]>(
-        () =>
-            Array.isArray(relatedArtistsData)
-                ? (relatedArtistsData as RelatedArtist[])
-                : [],
-        [relatedArtistsData],
-    );
-    const moreFromArtist = useMemo<RelatedAlbum[]>(
-        () =>
-            Array.isArray(moreFromArtistData)
-                ? (moreFromArtistData as RelatedAlbum[])
-                : [],
-        [moreFromArtistData],
-    );
     const tabPanelHeightClass = "min-h-0 flex-1";
-    const sortedRelatedTracks = useMemo(() => {
-        if (!relatedTracks.length) return [];
-        return [...relatedTracks].sort((a, b) => {
-            const scoreA =
-                (a.inLibrary ? 1000 : 0) +
-                (typeof a.matchConfidence === "number" &&
-                Number.isFinite(a.matchConfidence)
-                    ? a.matchConfidence
-                    : 0) *
-                    2 +
-                (typeof a.similarity === "number" &&
-                Number.isFinite(a.similarity)
-                    ? a.similarity * 100
-                    : 0);
-            const scoreB =
-                (b.inLibrary ? 1000 : 0) +
-                (typeof b.matchConfidence === "number" &&
-                Number.isFinite(b.matchConfidence)
-                    ? b.matchConfidence
-                    : 0) *
-                    2 +
-                (typeof b.similarity === "number" &&
-                Number.isFinite(b.similarity)
-                    ? b.similarity * 100
-                    : 0);
-            return scoreB - scoreA;
-        });
-    }, [relatedTracks]);
-    const visibleRelatedTracks = useMemo(
-        () => sortedRelatedTracks.slice(0, 8),
-        [sortedRelatedTracks],
-    );
-    const tabTransitionProps = shouldReduceMotion
-        ? {
-              initial: { opacity: 1, y: 0 },
-              animate: { opacity: 1, y: 0 },
-              exit: { opacity: 1, y: 0 },
-              transition: { duration: 0 },
-          }
-        : {
-              initial: { opacity: 0, y: 8 },
-              animate: { opacity: 1, y: 0 },
-              exit: { opacity: 0, y: -8 },
-              transition: { duration: 0.18 },
-          };
-    const getRelatedTrackKey = useCallback((track: RelatedTrack) => {
-        if (track.id) return `lib:${track.id}`;
-        const normalizedArtist = (
-            track.artist ||
-            track.album?.artist?.name ||
-            "unknown"
-        )
-            .trim()
-            .toLowerCase();
-        const normalizedTitle = (track.title || "unknown").trim().toLowerCase();
-        return `ext:${normalizedArtist}::${normalizedTitle}`;
-    }, []);
 
     const handlePlayPause = useCallback(() => {
         if (audioError) {
@@ -465,75 +239,6 @@ export function OverlayPlayer() {
             resume();
         }
     }, [audioError, clearAudioError, isBuffering, isPlaying, pause, resume]);
-
-    const scrollQueueToCurrentTrack = useCallback(
-        (behavior: ScrollBehavior) => {
-            const listElement = queueListRef.current;
-            if (!listElement || queueTracks.length === 0) return false;
-
-            const targetIndex =
-                currentIndex >= 0 && currentIndex < queueTracks.length
-                    ? currentIndex
-                    : 0;
-            const target = listElement.querySelector<HTMLElement>(
-                `[data-queue-index="${targetIndex}"]`,
-            );
-            if (!target) return false;
-
-            const targetTop =
-                target.offsetTop -
-                listElement.clientHeight / 2 +
-                target.clientHeight / 2;
-
-            listElement.scrollTo({
-                top: Math.max(0, targetTop),
-                behavior,
-            });
-
-            return true;
-        },
-        [currentIndex, queueTracks.length],
-    );
-
-    const scheduleQueueCentering = useCallback(
-        (
-            behavior: ScrollBehavior,
-            options?: { waitForQueueLayout?: boolean },
-        ) => {
-            const maxAttempts = 8;
-            let attempts = 0;
-            let frameA = 0;
-            let frameB = 0;
-            let settleTimeout: number | null = null;
-
-            const runCenterAttempt = () => {
-                attempts += 1;
-                const centered = scrollQueueToCurrentTrack(behavior);
-                if (!centered && attempts < maxAttempts) {
-                    frameA = window.requestAnimationFrame(() => {
-                        frameB = window.requestAnimationFrame(runCenterAttempt);
-                    });
-                }
-            };
-
-            frameA = window.requestAnimationFrame(() => {
-                frameB = window.requestAnimationFrame(runCenterAttempt);
-            });
-
-            if (options?.waitForQueueLayout) {
-                settleTimeout = window.setTimeout(() => {
-                    scrollQueueToCurrentTrack("auto");
-                }, 240);
-            }
-
-            return () => {
-                if (frameA) window.cancelAnimationFrame(frameA);
-                if (frameB) window.cancelAnimationFrame(frameB);
-                if (settleTimeout !== null) window.clearTimeout(settleTimeout);
-            };
-        },
-        [scrollQueueToCurrentTrack],
-    );
 
     useEffect(() => {
         const savedTab = readMigratingStorageItem(OVERLAY_ACTIVE_TAB_KEY);
@@ -626,300 +331,39 @@ export function OverlayPlayer() {
         resetDrawerDrag();
     }, [isDrawerOpen, resetDrawerDrag]);
 
-    useEffect(() => {
-        const wasQueueVisible = wasQueueTabVisibleRef.current;
-        const previousIndex = previousQueueIndexRef.current;
-        const becameVisible = isQueueTabVisible && !wasQueueVisible;
-        const trackChangedWhileVisible =
-            isQueueTabVisible &&
-            wasQueueVisible &&
-            previousIndex !== null &&
-            currentIndex !== previousIndex;
+    const handleSeek = useCallback(
+        (time: number) => {
+            seek(time);
+        },
+        [seek],
+    );
 
-        wasQueueTabVisibleRef.current = isQueueTabVisible;
-        previousQueueIndexRef.current = currentIndex;
-
-        if (!isQueueTabVisible || queueTracks.length === 0) return;
-        if (!becameVisible && !trackChangedWhileVisible) return;
-
-        const behavior: ScrollBehavior =
-            becameVisible || shouldReduceMotion ? "auto" : "smooth";
-
-        return scheduleQueueCentering(behavior, {
-            waitForQueueLayout: becameVisible,
-        });
-    }, [
-        isQueueTabVisible,
-        queueTracks.length,
-        currentIndex,
-        scheduleQueueCentering,
-        shouldReduceMotion,
-    ]);
-
-    useEffect(() => {
-        if (
-            !isTabPanelVisible ||
-            activeTab !== "related" ||
-            playbackType !== "track"
-        )
-            return;
-
-        const missingTracks = visibleRelatedTracks.filter((track) => {
-            if (track.inLibrary) return false;
-            const hasArtist = !!(track.artist || track.album?.artist?.name);
-            if (!track.title || !hasArtist) return false;
-            return !relatedStreamMatches[getRelatedTrackKey(track)];
-        });
-        if (missingTracks.length === 0) return;
-
-        let cancelled = false;
-
-        const hydrateMissingRelatedStreams = async () => {
-            const payload = missingTracks.map((track) => ({
-                artist: track.artist || track.album?.artist?.name || "",
-                title: track.title,
-                albumTitle: track.album?.title,
-                duration: track.duration,
-            }));
-            const foundMatches: Record<string, RelatedStreamMatch> = {};
-
-            let tidalMatches: Array<{
-                id: number;
-                title: string;
-                artist: string;
-                duration: number;
-                isrc?: string;
-            } | null> = [];
-            try {
-                const tidalResponse = await api.matchTidalBatch(payload);
-                tidalMatches = Array.isArray(tidalResponse.matches)
-                    ? tidalResponse.matches
-                    : [];
-            } catch {
-                tidalMatches = [];
-            }
-
-            const ytPayload: Array<{
-                artist: string;
-                title: string;
-                albumTitle?: string;
-                duration?: number;
-            }> = [];
-            const ytTrackKeys: string[] = [];
-
-            missingTracks.forEach((track, index) => {
-                const trackKey = getRelatedTrackKey(track);
-                const tidalMatch = tidalMatches[index];
-                if (tidalMatch?.id) {
-                    foundMatches[trackKey] = {
-                        streamSource: "tidal",
-                        tidalTrackId: tidalMatch.id,
-                        title: tidalMatch.title,
-                        artist: tidalMatch.artist,
-                        duration: tidalMatch.duration,
-                    };
+    const handlePlayFromQueue = useCallback(
+        (index: number) => {
+            if (isInGroup) {
+                if (!isHost) {
+                    toast.info("Only the host can change the current track");
                     return;
                 }
-                ytPayload.push(payload[index]);
-                ytTrackKeys.push(trackKey);
-            });
-
-            if (ytPayload.length > 0) {
-                try {
-                    const ytResponse = await api.matchYtMusicBatch(ytPayload);
-                    const ytMatches = Array.isArray(ytResponse.matches)
-                        ? ytResponse.matches
-                        : [];
-                    ytTrackKeys.forEach((trackKey, index) => {
-                        const ytMatch = ytMatches[index];
-                        if (!ytMatch?.videoId) return;
-                        foundMatches[trackKey] = {
-                            streamSource: "youtube",
-                            youtubeVideoId: ytMatch.videoId,
-                            title: ytMatch.title,
-                            duration: ytMatch.duration,
-                        };
-                    });
-                } catch {
-                    // Ignore YT matching failures; rows still fall back to info links.
-                }
-            }
-
-            if (cancelled || Object.keys(foundMatches).length === 0) return;
-            setRelatedStreamMatches((prev) => ({ ...prev, ...foundMatches }));
-        };
-
-        hydrateMissingRelatedStreams();
-
-        return () => {
-            cancelled = true;
-        };
-    }, [
-        activeTab,
-        getRelatedTrackKey,
-        isTabPanelVisible,
-        playbackType,
-        relatedStreamMatches,
-        visibleRelatedTracks,
-    ]);
-
-    const handleSeek = (time: number) => {
-        seek(time);
-    };
-
-    const handlePlayFromQueue = (index: number) => {
-        if (isInGroup) {
-            if (!isHost) {
-                toast.info("Only the host can change the current track");
+                syncSetTrack(index);
                 return;
             }
-            syncSetTrack(index);
-            return;
-        }
-        playQueueIndex(index);
-    };
+            playQueueIndex(index);
+        },
+        [isInGroup, isHost, syncSetTrack, playQueueIndex],
+    );
 
-    const handleRemoveFromQueue = (index: number) => {
-        removeFromQueue(index);
-    };
+    const handleRemoveFromQueue = useCallback(
+        (index: number) => {
+            removeFromQueue(index);
+        },
+        [removeFromQueue],
+    );
 
-    const handleClearQueue = () => {
+    const handleClearQueue = useCallback(() => {
         clearQueue();
         toast.success("Queue cleared");
-    };
-
-    const playRelatedTrack = useCallback(
-        async (track: RelatedTrack) => {
-            const artistName =
-                track.album?.artist?.name || track.artist || "Unknown artist";
-
-            if (track.inLibrary && track.id) {
-                playTrack({
-                    id: track.id,
-                    title: track.title,
-                    artist: {
-                        id: track.album?.artist?.id,
-                        mbid: track.album?.artist?.mbid,
-                        name: artistName,
-                    },
-                    album: {
-                        id: track.album?.id,
-                        title: track.album?.title || "Unknown album",
-                        coverArt:
-                            track.album?.coverArt || track.album?.coverUrl,
-                    },
-                    duration: track.duration || 0,
-                    filePath: track.filePath,
-                    streamSource: track.streamSource,
-                    tidalTrackId: track.tidalTrackId,
-                    youtubeVideoId: track.youtubeVideoId,
-                });
-                return;
-            }
-
-            const trackKey = getRelatedTrackKey(track);
-            setMatchingRelatedTrackKey(trackKey);
-
-            try {
-                const existingMatch = relatedStreamMatches[trackKey];
-                let resolvedMatch = existingMatch;
-
-                if (!resolvedMatch) {
-                    const searchableArtist = (
-                        track.artist ||
-                        track.album?.artist?.name ||
-                        ""
-                    ).trim();
-                    const searchableTitle = (track.title || "").trim();
-
-                    if (searchableArtist && searchableTitle) {
-                        try {
-                            const tidalResponse = await api.matchTidalTrack(
-                                searchableArtist,
-                                searchableTitle,
-                                track.album?.title,
-                                track.duration,
-                            );
-                            if (tidalResponse.match?.id) {
-                                resolvedMatch = {
-                                    streamSource: "tidal",
-                                    tidalTrackId: tidalResponse.match.id,
-                                    title: tidalResponse.match.title,
-                                    artist: tidalResponse.match.artist,
-                                    duration: tidalResponse.match.duration,
-                                };
-                            }
-                        } catch {
-                            // Ignore TIDAL single-match failures and try YT.
-                        }
-
-                        if (!resolvedMatch) {
-                            try {
-                                const ytResponse = await api.matchYtMusicTrack(
-                                    searchableArtist,
-                                    searchableTitle,
-                                    track.album?.title,
-                                    track.duration,
-                                );
-                                if (ytResponse.match?.videoId) {
-                                    resolvedMatch = {
-                                        streamSource: "youtube",
-                                        youtubeVideoId:
-                                            ytResponse.match.videoId,
-                                        title: ytResponse.match.title,
-                                        duration: ytResponse.match.duration,
-                                    };
-                                }
-                            } catch {
-                                // Ignore YT single-match failures and fall through to info.
-                            }
-                        }
-                    }
-                }
-
-                if (resolvedMatch) {
-                    setRelatedStreamMatches((prev) => ({
-                        ...prev,
-                        [trackKey]: resolvedMatch,
-                    }));
-                    playTrack({
-                        id:
-                            resolvedMatch.streamSource === "tidal"
-                                ? `related-tidal-${resolvedMatch.tidalTrackId}`
-                                : `related-yt-${resolvedMatch.youtubeVideoId}`,
-                        title: track.title,
-                        artist: { name: artistName },
-                        album: {
-                            title: track.album?.title || "Related Tracks",
-                            coverArt:
-                                track.album?.coverArt || track.album?.coverUrl,
-                        },
-                        duration: resolvedMatch.duration || track.duration || 0,
-                        streamSource: resolvedMatch.streamSource,
-                        tidalTrackId: resolvedMatch.tidalTrackId,
-                        youtubeVideoId: resolvedMatch.youtubeVideoId,
-                    });
-                    return;
-                }
-
-                if (track.lastFmUrl) {
-                    window.open(
-                        track.lastFmUrl,
-                        "_blank",
-                        "noopener,noreferrer",
-                    );
-                    return;
-                }
-
-                toast.error(
-                    "No playable stream found for this related track yet",
-                );
-            } finally {
-                setMatchingRelatedTrackKey(null);
-            }
-        },
-        [getRelatedTrackKey, playTrack, relatedStreamMatches],
-    );
+    }, [clearQueue]);
 
     // Handle Vibe toggle
     const handleVibeToggle = async () => {
@@ -1854,849 +1298,42 @@ export function OverlayPlayer() {
                                         mode="wait"
                                     >
                                         {activeTab === "queue" && (
-                                            <motion.section
+                                            <OverlayQueueTab
                                                 key="queue"
-                                                {...tabTransitionProps}
-                                                className="h-full overflow-hidden flex flex-col"
-                                            >
-                                                <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-2">
-                                                    <div className="flex items-center gap-2">
-                                                        <ListMusic className="h-4 w-4 text-brand-hover" />
-                                                        <h2 className="text-sm font-semibold text-white">
-                                                            Up Next
-                                                        </h2>
-                                                    </div>
-                                                    <div className="flex items-center gap-3">
-                                                        {queueTracks.length >
-                                                            0 && (
-                                                            <button
-                                                                type="button"
-                                                                onClick={
-                                                                    handleClearQueue
-                                                                }
-                                                                className="inline-flex items-center gap-1 text-xs text-gray-400 transition-colors hover:text-white"
-                                                                title="Clear queue"
-                                                                aria-label="Clear queue"
-                                                            >
-                                                                <Trash2 className="h-3 w-3" />
-                                                                Clear Queue
-                                                            </button>
-                                                        )}
-                                                        <span className="text-xs text-gray-400">
-                                                            {queueTracks.length}{" "}
-                                                            items
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                {queueTracks.length === 0 ? (
-                                                    <div className="flex min-h-0 flex-1 items-center justify-center px-4">
-                                                        <p className="text-sm text-gray-400">
-                                                            No tracks in queue.
-                                                        </p>
-                                                    </div>
-                                                ) : (
-                                                    <div
-                                                        ref={queueListRef}
-                                                        className="min-h-0 flex-1 overflow-y-auto px-2 py-2"
-                                                    >
-                                                        {queueTracks.map(
-                                                            (
-                                                                item,
-                                                                queueIndex,
-                                                            ) => {
-                                                                const isCurrentTrack =
-                                                                    queueIndex ===
-                                                                    currentIndex;
-                                                                const isPlayedTrack =
-                                                                    queueIndex <
-                                                                    currentIndex;
-                                                                if (
-                                                                    item.itemType ===
-                                                                    "episode"
-                                                                ) {
-                                                                    return (
-                                                                        <div
-                                                                            key={`${item.id}-${queueIndex}`}
-                                                                            data-queue-index={
-                                                                                queueIndex
-                                                                            }
-                                                                            className={cn(
-                                                                                "mb-1.5 flex items-center gap-2 px-2 py-2 transition-colors",
-                                                                                isCurrentTrack
-                                                                                    ? "rounded-md border border-brand-hover/35 bg-brand-hover/10"
-                                                                                    : isPlayedTrack
-                                                                                      ? "rounded-md bg-white/[0.03] hover:bg-white/[0.06]"
-                                                                                      : "hover:bg-white/[0.06]",
-                                                                            )}
-                                                                        >
-                                                                            <span
-                                                                                className={cn(
-                                                                                    "w-5 flex-shrink-0 text-center text-[11px] tabular-nums",
-                                                                                    isCurrentTrack
-                                                                                        ? "text-brand-hover"
-                                                                                        : "text-gray-400",
-                                                                                )}
-                                                                            >
-                                                                                {queueIndex +
-                                                                                    1}
-                                                                            </span>
-                                                                            <button
-                                                                                onClick={() => {
-                                                                                    if (
-                                                                                        !isCurrentTrack
-                                                                                    ) {
-                                                                                        handlePlayFromQueue(
-                                                                                            queueIndex,
-                                                                                        );
-                                                                                    }
-                                                                                }}
-                                                                                className={cn(
-                                                                                    "flex min-w-0 flex-1 items-center gap-3 text-left",
-                                                                                    isCurrentTrack &&
-                                                                                        "cursor-default",
-                                                                                )}
-                                                                                title={
-                                                                                    isCurrentTrack
-                                                                                        ? "Now playing"
-                                                                                        : "Play this episode now"
-                                                                                }
-                                                                            >
-                                                                                <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
-                                                                                    {item.coverUrl ? (
-                                                                                        <Image
-                                                                                            src={
-                                                                                                item.coverUrl
-                                                                                            }
-                                                                                            alt={
-                                                                                                item.podcastTitle
-                                                                                            }
-                                                                                            fill
-                                                                                            sizes="44px"
-                                                                                            className="object-cover"
-                                                                                            unoptimized
-                                                                                        />
-                                                                                    ) : (
-                                                                                        <div className="flex h-full w-full items-center justify-center">
-                                                                                            <MusicIcon className="h-4 w-4 text-gray-400" />
-                                                                                        </div>
-                                                                                    )}
-                                                                                </div>
-                                                                                <div className="min-w-0">
-                                                                                    <p
-                                                                                        className={cn(
-                                                                                            "min-w-0 truncate text-sm",
-                                                                                            isCurrentTrack
-                                                                                                ? "text-brand-hover"
-                                                                                                : "text-white",
-                                                                                        )}
-                                                                                    >
-                                                                                        {
-                                                                                            item.title
-                                                                                        }
-                                                                                    </p>
-                                                                                    <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
-                                                                                        <p className="min-w-0 truncate text-xs text-gray-400">
-                                                                                            {item.podcastTitle ||
-                                                                                                "Podcast"}
-                                                                                        </p>
-                                                                                        {isCurrentTrack && (
-                                                                                            <span className="inline-flex shrink-0 items-center rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
-                                                                                                Playing
-                                                                                            </span>
-                                                                                        )}
-                                                                                        {isPlayedTrack &&
-                                                                                            !isCurrentTrack && (
-                                                                                                <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-gray-400">
-                                                                                                    Played
-                                                                                                </span>
-                                                                                            )}
-                                                                                    </div>
-                                                                                </div>
-                                                                            </button>
-                                                                            <span
-                                                                                className={cn(
-                                                                                    "text-[11px] tabular-nums",
-                                                                                    isCurrentTrack
-                                                                                        ? "text-brand-hover"
-                                                                                        : "text-gray-400",
-                                                                                )}
-                                                                            >
-                                                                                {formatTime(
-                                                                                    item.duration ||
-                                                                                        0,
-                                                                                )}
-                                                                            </span>
-                                                                            {!isCurrentTrack && (
-                                                                                <button
-                                                                                    onClick={(
-                                                                                        e,
-                                                                                    ) => {
-                                                                                        e.stopPropagation();
-                                                                                        handleRemoveFromQueue(
-                                                                                            queueIndex,
-                                                                                        );
-                                                                                    }}
-                                                                                    className="ml-1 h-7 w-7 flex items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
-                                                                                    title="Remove from queue"
-                                                                                    aria-label="Remove from queue"
-                                                                                >
-                                                                                    <X className="h-3.5 w-3.5" />
-                                                                                </button>
-                                                                            )}
-                                                                        </div>
-                                                                    );
-                                                                }
-                                                                const track =
-                                                                    item;
-                                                                const queueTrackQualityBadge =
-                                                                    resolvePlaybackQualityBadgeFromStreamSource(
-                                                                        track.streamSource,
-                                                                    );
-                                                                return (
-                                                                    <div
-                                                                        key={`${track.id}-${queueIndex}`}
-                                                                        data-queue-index={
-                                                                            queueIndex
-                                                                        }
-                                                                        className={cn(
-                                                                            "mb-1.5 flex items-center gap-2 px-2 py-2 transition-colors",
-                                                                            isCurrentTrack
-                                                                                ? "rounded-md border border-brand-hover/35 bg-brand-hover/10"
-                                                                                : isPlayedTrack
-                                                                                  ? "rounded-md bg-white/[0.03] hover:bg-white/[0.06]"
-                                                                                  : "hover:bg-white/[0.06]",
-                                                                        )}
-                                                                    >
-                                                                        <span
-                                                                            className={cn(
-                                                                                "w-5 flex-shrink-0 text-center text-[11px] tabular-nums",
-                                                                                isCurrentTrack
-                                                                                    ? "text-brand-hover"
-                                                                                    : "text-gray-400",
-                                                                            )}
-                                                                        >
-                                                                            {queueIndex +
-                                                                                1}
-                                                                        </span>
-                                                                        <button
-                                                                            onClick={() => {
-                                                                                if (
-                                                                                    !isCurrentTrack
-                                                                                ) {
-                                                                                    handlePlayFromQueue(
-                                                                                        queueIndex,
-                                                                                    );
-                                                                                }
-                                                                            }}
-                                                                            className={cn(
-                                                                                "flex min-w-0 flex-1 items-center gap-3 text-left",
-                                                                                isCurrentTrack &&
-                                                                                    "cursor-default",
-                                                                            )}
-                                                                            title={
-                                                                                isCurrentTrack
-                                                                                    ? "Now playing"
-                                                                                    : "Play this track now"
-                                                                            }
-                                                                        >
-                                                                            <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
-                                                                                {track
-                                                                                    .album
-                                                                                    ?.coverArt ? (
-                                                                                    <Image
-                                                                                        src={api.getCoverArtUrl(
-                                                                                            track
-                                                                                                .album
-                                                                                                .coverArt,
-                                                                                            100,
-                                                                                        )}
-                                                                                        alt={
-                                                                                            track
-                                                                                                .album
-                                                                                                .title
-                                                                                        }
-                                                                                        fill
-                                                                                        sizes="44px"
-                                                                                        className="object-cover"
-                                                                                        unoptimized
-                                                                                    />
-                                                                                ) : (
-                                                                                    <div className="flex h-full w-full items-center justify-center">
-                                                                                        <MusicIcon className="h-4 w-4 text-gray-400" />
-                                                                                    </div>
-                                                                                )}
-                                                                            </div>
-                                                                            <div className="min-w-0">
-                                                                                <div className="flex min-w-0 items-center gap-1.5">
-                                                                                    <p
-                                                                                        className={cn(
-                                                                                            "min-w-0 truncate text-sm",
-                                                                                            isCurrentTrack
-                                                                                                ? "text-brand-hover"
-                                                                                                : "text-white",
-                                                                                        )}
-                                                                                    >
-                                                                                        {track.displayTitle ??
-                                                                                            track.title}
-                                                                                    </p>
-                                                                                    {queueTrackQualityBadge?.variant ===
-                                                                                        "tidal" && (
-                                                                                        <TidalBadge />
-                                                                                    )}
-                                                                                    {queueTrackQualityBadge?.variant ===
-                                                                                        "youtube" && (
-                                                                                        <YouTubeBadge />
-                                                                                    )}
-                                                                                </div>
-                                                                                <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
-                                                                                    <p className="min-w-0 truncate text-xs text-gray-400">
-                                                                                        {track
-                                                                                            .artist
-                                                                                            ?.name ||
-                                                                                            "Unknown artist"}
-                                                                                    </p>
-                                                                                    {isCurrentTrack && (
-                                                                                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
-                                                                                            <span className="inline-flex items-end gap-0.5">
-                                                                                                <span className="h-2 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.2s]" />
-                                                                                                <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-brand-hover" />
-                                                                                                <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.35s]" />
-                                                                                            </span>
-                                                                                            Playing
-                                                                                        </span>
-                                                                                    )}
-                                                                                    {isPlayedTrack &&
-                                                                                        !isCurrentTrack && (
-                                                                                            <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-gray-400">
-                                                                                                Played
-                                                                                            </span>
-                                                                                        )}
-                                                                                </div>
-                                                                            </div>
-                                                                        </button>
-
-                                                                        <span
-                                                                            className={cn(
-                                                                                "text-[11px] tabular-nums",
-                                                                                isCurrentTrack
-                                                                                    ? "text-brand-hover"
-                                                                                    : "text-gray-400",
-                                                                            )}
-                                                                        >
-                                                                            {formatTime(
-                                                                                track.duration ||
-                                                                                    0,
-                                                                            )}
-                                                                        </span>
-                                                                        <div className="ml-1 flex items-center gap-1">
-                                                                            <TrackPreferenceButtons
-                                                                                trackId={
-                                                                                    track.id
-                                                                                }
-                                                                                mode="up-only"
-                                                                                buttonSizeClassName="h-10 w-10"
-                                                                                iconSizeClassName="h-5 w-5"
-                                                                                metadata={buildPreferenceMetadata(
-                                                                                    track,
-                                                                                )}
-                                                                            />
-                                                                            <TrackOverflowMenu
-                                                                                track={
-                                                                                    track
-                                                                                }
-                                                                                showPlayNext={
-                                                                                    false
-                                                                                }
-                                                                                showAddToQueue={
-                                                                                    false
-                                                                                }
-                                                                                triggerClassName="!opacity-100"
-                                                                                extraItemsAfter={
-                                                                                    !isCurrentTrack ? (
-                                                                                        <TrackMenuButton
-                                                                                            onClick={(
-                                                                                                e,
-                                                                                            ) => {
-                                                                                                e.stopPropagation();
-                                                                                                handleRemoveFromQueue(
-                                                                                                    queueIndex,
-                                                                                                );
-                                                                                            }}
-                                                                                            icon={
-                                                                                                <X className="h-4 w-4" />
-                                                                                            }
-                                                                                            label="Remove from queue"
-                                                                                            className="text-red-400 hover:text-red-300"
-                                                                                        />
-                                                                                    ) : undefined
-                                                                                }
-                                                                            />
-                                                                            {!isCurrentTrack && (
-                                                                                <button
-                                                                                    onClick={(
-                                                                                        e,
-                                                                                    ) => {
-                                                                                        e.stopPropagation();
-                                                                                        handleRemoveFromQueue(
-                                                                                            queueIndex,
-                                                                                        );
-                                                                                    }}
-                                                                                    className="h-7 w-7 flex items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
-                                                                                    title="Remove from queue"
-                                                                                    aria-label="Remove from queue"
-                                                                                >
-                                                                                    <X className="h-3.5 w-3.5" />
-                                                                                </button>
-                                                                            )}
-                                                                        </div>
-                                                                    </div>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </div>
-                                                )}
-                                            </motion.section>
+                                                queueTracks={queueTracks}
+                                                currentIndex={currentIndex}
+                                                onPlayFromQueue={
+                                                    handlePlayFromQueue
+                                                }
+                                                onRemoveFromQueue={
+                                                    handleRemoveFromQueue
+                                                }
+                                                onClearQueue={handleClearQueue}
+                                            />
                                         )}
 
                                         {activeTab === "lyrics" && (
-                                            <motion.section
+                                            <OverlayLyricsTab
                                                 key="lyrics"
-                                                {...tabTransitionProps}
-                                                className="h-full overflow-hidden"
-                                            >
-                                                {isLyricsLoading ? (
-                                                    <div className="flex h-full items-center justify-center gap-2 text-gray-400">
-                                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                                        <span className="text-sm">
-                                                            Loading lyrics...
-                                                        </span>
-                                                    </div>
-                                                ) : isLyricsError ? (
-                                                    <div className="flex h-full items-center justify-center px-4">
-                                                        <p className="text-center text-sm text-gray-400">
-                                                            Failed to load
-                                                            lyrics
-                                                        </p>
-                                                    </div>
-                                                ) : (
-                                                    <SyncedLyrics
-                                                        syncedLyrics={
-                                                            lyricsData?.syncedLyrics ??
-                                                            null
-                                                        }
-                                                        plainLyrics={
-                                                            lyricsData?.plainLyrics ??
-                                                            null
-                                                        }
-                                                        currentTime={
-                                                            displayTime
-                                                        }
-                                                        isPlaying={isPlaying}
-                                                        onSeek={handleSeek}
-                                                        className="h-full"
-                                                    />
-                                                )}
-                                            </motion.section>
+                                                lookupTrack={lyricsLookupTrack}
+                                                currentTime={displayTime}
+                                                isPlaying={isPlaying}
+                                                onSeek={handleSeek}
+                                            />
                                         )}
 
                                         {activeTab === "related" && (
-                                            <motion.section
+                                            <OverlayRelatedTab
                                                 key="related"
-                                                {...tabTransitionProps}
-                                                className="h-full space-y-5 overflow-y-auto px-4 py-3"
-                                            >
-                                                <section>
-                                                    <h3 className="mb-2 text-xs uppercase tracking-wide text-gray-400">
-                                                        Similar Songs
-                                                    </h3>
-                                                    {isRelatedTracksLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-400">
-                                                            <Loader2 className="h-4 w-4 animate-spin" />
-                                                            <span className="text-sm">
-                                                                Loading...
-                                                            </span>
-                                                        </div>
-                                                    ) : isRelatedTracksError ? (
-                                                        <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-400">
-                                                                Failed to load
-                                                                similar songs.
-                                                            </p>
-                                                            <button
-                                                                onClick={() =>
-                                                                    queryClient.invalidateQueries(
-                                                                        {
-                                                                            queryKey:
-                                                                                queryKeys.playerRelatedTracks(
-                                                                                    currentTrack?.id,
-                                                                                ),
-                                                                        },
-                                                                    )
-                                                                }
-                                                                className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
-                                                            >
-                                                                <RefreshCw className="h-3 w-3" />
-                                                                Retry
-                                                            </button>
-                                                        </div>
-                                                    ) : sortedRelatedTracks.length >
-                                                      0 ? (
-                                                        <div className="space-y-1.5">
-                                                            {visibleRelatedTracks.map(
-                                                                (
-                                                                    track,
-                                                                    idx,
-                                                                ) => {
-                                                                    const trackKey =
-                                                                        getRelatedTrackKey(
-                                                                            track,
-                                                                        );
-                                                                    const streamMatch =
-                                                                        relatedStreamMatches[
-                                                                            trackKey
-                                                                        ];
-                                                                    const isMatchingTrack =
-                                                                        matchingRelatedTrackKey ===
-                                                                        trackKey;
-                                                                    const isInLibrary =
-                                                                        !!track.inLibrary;
-                                                                    const albumCover =
-                                                                        track
-                                                                            .album
-                                                                            ?.coverArt ||
-                                                                        track
-                                                                            .album
-                                                                            ?.coverUrl;
-                                                                    return (
-                                                                        <button
-                                                                            key={`${track.id || track.title}-${idx}`}
-                                                                            type="button"
-                                                                            onClick={() =>
-                                                                                playRelatedTrack(
-                                                                                    track,
-                                                                                )
-                                                                            }
-                                                                            className="group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-white/[0.06]"
-                                                                        >
-                                                                            <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
-                                                                                {albumCover ? (
-                                                                                    <Image
-                                                                                        src={api.getCoverArtUrl(
-                                                                                            albumCover,
-                                                                                            100,
-                                                                                        )}
-                                                                                        alt={
-                                                                                            track
-                                                                                                .album
-                                                                                                ?.title ||
-                                                                                            track.title
-                                                                                        }
-                                                                                        fill
-                                                                                        sizes="40px"
-                                                                                        className="object-cover"
-                                                                                        unoptimized
-                                                                                    />
-                                                                                ) : (
-                                                                                    <div className="flex h-full w-full items-center justify-center">
-                                                                                        <MusicIcon className="h-4 w-4 text-gray-400" />
-                                                                                    </div>
-                                                                                )}
-                                                                            </div>
-                                                                            <div className="min-w-0 flex-1 pr-2">
-                                                                                <p className="truncate text-sm text-gray-200 group-hover:text-white">
-                                                                                    {
-                                                                                        track.title
-                                                                                    }
-                                                                                </p>
-                                                                                <p className="truncate text-xs text-gray-400">
-                                                                                    {isInLibrary
-                                                                                        ? track
-                                                                                              .album
-                                                                                              ?.artist
-                                                                                              ?.name ||
-                                                                                          track.artist ||
-                                                                                          "Unknown artist"
-                                                                                        : track.artist ||
-                                                                                          "Unknown artist"}
-                                                                                </p>
-                                                                            </div>
-                                                                            <div className="flex shrink-0 items-center gap-1">
-                                                                                {isInLibrary ? (
-                                                                                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
-                                                                                        In
-                                                                                        Library
-                                                                                    </span>
-                                                                                ) : isMatchingTrack ? (
-                                                                                    <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[10px] text-gray-300">
-                                                                                        <Loader2 className="h-3 w-3 animate-spin" />
-                                                                                        Matching
-                                                                                    </span>
-                                                                                ) : streamMatch?.streamSource ===
-                                                                                  "tidal" ? (
-                                                                                    <TidalBadge />
-                                                                                ) : streamMatch?.streamSource ===
-                                                                                  "youtube" ? (
-                                                                                    <YouTubeBadge />
-                                                                                ) : track.lastFmUrl ? (
-                                                                                    <span className="rounded-full border border-white/20 bg-white/[0.04] px-2 py-0.5 text-[10px] text-gray-300">
-                                                                                        Info
-                                                                                    </span>
-                                                                                ) : (
-                                                                                    <span className="rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[10px] text-gray-400">
-                                                                                        Search
-                                                                                    </span>
-                                                                                )}
-                                                                                {isInLibrary &&
-                                                                                    track.id && (
-                                                                                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-                                                                                        <div
-                                                                                            onClick={(
-                                                                                                e,
-                                                                                            ) =>
-                                                                                                e.stopPropagation()
-                                                                                            }
-                                                                                        >
-                                                                                            <TrackPreferenceButtons
-                                                                                                trackId={
-                                                                                                    track.id
-                                                                                                }
-                                                                                                mode="up-only"
-                                                                                                buttonSizeClassName="h-8 w-8"
-                                                                                                iconSizeClassName="h-4 w-4"
-                                                                                                metadata={buildPreferenceMetadata(
-                                                                                                    track,
-                                                                                                )}
-                                                                                            />
-                                                                                        </div>
-                                                                                    )}
-                                                                            </div>
-                                                                        </button>
-                                                                    );
-                                                                },
-                                                            )}
-                                                        </div>
-                                                    ) : (
-                                                        <p className="text-sm text-gray-400">
-                                                            No similar songs
-                                                            found.
-                                                        </p>
-                                                    )}
-                                                </section>
-
-                                                <section>
-                                                    <h3 className="mb-2 text-xs uppercase tracking-wide text-gray-400">
-                                                        Similar Artists
-                                                    </h3>
-                                                    {isRelatedArtistsLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-400">
-                                                            <Loader2 className="h-4 w-4 animate-spin" />
-                                                            <span className="text-sm">
-                                                                Loading...
-                                                            </span>
-                                                        </div>
-                                                    ) : isRelatedArtistsError ? (
-                                                        <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-400">
-                                                                Failed to load
-                                                                similar artists.
-                                                            </p>
-                                                            <button
-                                                                onClick={() =>
-                                                                    queryClient.invalidateQueries(
-                                                                        {
-                                                                            queryKey:
-                                                                                queryKeys.playerRelatedArtists(
-                                                                                    currentTrack
-                                                                                        ?.artist
-                                                                                        ?.name,
-                                                                                    currentTrack
-                                                                                        ?.artist
-                                                                                        ?.mbid,
-                                                                                ),
-                                                                        },
-                                                                    )
-                                                                }
-                                                                className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
-                                                            >
-                                                                <RefreshCw className="h-3 w-3" />
-                                                                Retry
-                                                            </button>
-                                                        </div>
-                                                    ) : relatedArtists.length >
-                                                      0 ? (
-                                                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                                                            {relatedArtists
-                                                                .slice(0, 9)
-                                                                .map(
-                                                                    (
-                                                                        artist,
-                                                                        idx,
-                                                                    ) => {
-                                                                        const artistHref =
-                                                                            getArtistHref(
-                                                                                {
-                                                                                    mbid: artist.mbid,
-                                                                                    name: artist.name,
-                                                                                },
-                                                                                {
-                                                                                    preferLibraryId: false,
-                                                                                },
-                                                                            ) ||
-                                                                            `/artist/${encodeURIComponent(
-                                                                                artist.name,
-                                                                            )}`;
-                                                                        const artistId =
-                                                                            artist.mbid ||
-                                                                            encodeURIComponent(
-                                                                                artist.name,
-                                                                            );
-                                                                        return (
-                                                                            <Link
-                                                                                key={`${artistId}-${idx}`}
-                                                                                href={
-                                                                                    artistHref
-                                                                                }
-                                                                                onClick={
-                                                                                    returnToPreviousMode
-                                                                                }
-                                                                                className="group p-1.5 transition-colors hover:bg-white/[0.06]"
-                                                                            >
-                                                                                <div className="mb-2 relative mx-auto h-12 w-12 overflow-hidden rounded-full bg-surface-hover">
-                                                                                    {artist.image ? (
-                                                                                        <Image
-                                                                                            src={
-                                                                                                artist.image
-                                                                                            }
-                                                                                            alt={
-                                                                                                artist.name
-                                                                                            }
-                                                                                            fill
-                                                                                            sizes="48px"
-                                                                                            className="object-cover"
-                                                                                            unoptimized
-                                                                                        />
-                                                                                    ) : (
-                                                                                        <div className="flex h-full w-full items-center justify-center">
-                                                                                            <MusicIcon className="h-4 w-4 text-gray-400" />
-                                                                                        </div>
-                                                                                    )}
-                                                                                </div>
-                                                                                <p className="truncate text-center text-xs text-gray-200 group-hover:text-white">
-                                                                                    {
-                                                                                        artist.name
-                                                                                    }
-                                                                                </p>
-                                                                            </Link>
-                                                                        );
-                                                                    },
-                                                                )}
-                                                        </div>
-                                                    ) : (
-                                                        <p className="text-sm text-gray-400">
-                                                            No similar artists
-                                                            found.
-                                                        </p>
-                                                    )}
-                                                </section>
-
-                                                <section>
-                                                    <h3 className="mb-2 text-xs uppercase tracking-wide text-gray-400">
-                                                        More From This Artist
-                                                    </h3>
-                                                    {isMoreFromArtistLoading ? (
-                                                        <div className="flex items-center gap-2 text-gray-400">
-                                                            <Loader2 className="h-4 w-4 animate-spin" />
-                                                            <span className="text-sm">
-                                                                Loading...
-                                                            </span>
-                                                        </div>
-                                                    ) : isMoreFromArtistError ? (
-                                                        <div className="flex items-center gap-3">
-                                                            <p className="text-sm text-gray-400">
-                                                                Failed to load
-                                                                albums.
-                                                            </p>
-                                                            <button
-                                                                onClick={() =>
-                                                                    queryClient.invalidateQueries(
-                                                                        {
-                                                                            queryKey:
-                                                                                queryKeys.playerRelatedAlbums(
-                                                                                    currentTrack
-                                                                                        ?.artist
-                                                                                        ?.id,
-                                                                                ),
-                                                                        },
-                                                                    )
-                                                                }
-                                                                className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
-                                                            >
-                                                                <RefreshCw className="h-3 w-3" />
-                                                                Retry
-                                                            </button>
-                                                        </div>
-                                                    ) : moreFromArtist.length >
-                                                      0 ? (
-                                                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                                                            {moreFromArtist
-                                                                .slice(0, 6)
-                                                                .map(
-                                                                    (album) => (
-                                                                        <Link
-                                                                            key={
-                                                                                album.id
-                                                                            }
-                                                                            href={`/album/${album.id}`}
-                                                                            onClick={
-                                                                                returnToPreviousMode
-                                                                            }
-                                                                            className="group p-1.5 transition-colors hover:bg-white/[0.06]"
-                                                                        >
-                                                                            <div className="relative mb-2 aspect-square w-full overflow-hidden rounded bg-surface-hover">
-                                                                                {album.coverArt ? (
-                                                                                    <Image
-                                                                                        src={api.getCoverArtUrl(
-                                                                                            album.coverArt,
-                                                                                            200,
-                                                                                        )}
-                                                                                        alt={
-                                                                                            album.title
-                                                                                        }
-                                                                                        fill
-                                                                                        sizes="140px"
-                                                                                        className="object-cover"
-                                                                                        unoptimized
-                                                                                    />
-                                                                                ) : (
-                                                                                    <div className="flex h-full w-full items-center justify-center">
-                                                                                        <MusicIcon className="h-5 w-5 text-gray-400" />
-                                                                                    </div>
-                                                                                )}
-                                                                            </div>
-                                                                            <p className="truncate text-xs text-gray-200 group-hover:text-white">
-                                                                                {
-                                                                                    album.title
-                                                                                }
-                                                                            </p>
-                                                                            {album.year && (
-                                                                                <p className="text-[11px] text-gray-400">
-                                                                                    {
-                                                                                        album.year
-                                                                                    }
-                                                                                </p>
-                                                                            )}
-                                                                        </Link>
-                                                                    ),
-                                                                )}
-                                                        </div>
-                                                    ) : (
-                                                        <p className="text-sm text-gray-400">
-                                                            No albums found.
-                                                        </p>
-                                                    )}
-                                                </section>
-                                            </motion.section>
+                                                currentTrack={currentTrack}
+                                                isTrackPlayback={
+                                                    playbackType === "track"
+                                                }
+                                                playTrack={playTrack}
+                                                onNavigate={
+                                                    returnToPreviousMode
+                                                }
+                                            />
                                         )}
                                     </AnimatePresence>
                                 </div>

--- a/frontend/components/player/overlay-tabs/OverlayLyricsTab.tsx
+++ b/frontend/components/player/overlay-tabs/OverlayLyricsTab.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { memo } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Loader2 } from "lucide-react";
+import { useLyrics } from "@/hooks/useLyrics";
+import { SyncedLyrics } from "../SyncedLyrics";
+import { buildTabTransitionProps } from "./overlayTabMotion";
+
+interface LyricsLookupTrack {
+    id: string;
+    artist?: string;
+    title: string;
+    album?: string;
+    duration?: number;
+}
+
+interface OverlayLyricsTabProps {
+    /** The playing library track, or null when lyrics can't apply. */
+    lookupTrack: LyricsLookupTrack | null;
+    currentTime: number;
+    isPlaying: boolean;
+    onSeek: (time: number) => void;
+}
+
+/**
+ * The overlay drawer's Lyrics tab (GH #787). Owns its lyrics fetch, so the
+ * request only happens while this panel is mounted.
+ */
+export const OverlayLyricsTab = memo(function OverlayLyricsTab({
+    lookupTrack,
+    currentTime,
+    isPlaying,
+    onSeek,
+}: OverlayLyricsTabProps) {
+    const shouldReduceMotion = useReducedMotion();
+    const {
+        data: lyricsData,
+        isLoading: isLyricsLoading,
+        isError: isLyricsError,
+    } = useLyrics(
+        lookupTrack?.id,
+        lookupTrack
+            ? {
+                  artist: lookupTrack.artist,
+                  title: lookupTrack.title,
+                  album: lookupTrack.album,
+                  duration: lookupTrack.duration,
+              }
+            : undefined,
+    );
+
+    return (
+        <motion.section
+            key="lyrics"
+            {...buildTabTransitionProps(shouldReduceMotion)}
+            className="h-full overflow-hidden"
+        >
+            {isLyricsLoading ? (
+                <div className="flex h-full items-center justify-center gap-2 text-gray-400">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span className="text-sm">Loading lyrics...</span>
+                </div>
+            ) : isLyricsError ? (
+                <div className="flex h-full items-center justify-center px-4">
+                    <p className="text-center text-sm text-gray-400">
+                        Failed to load lyrics
+                    </p>
+                </div>
+            ) : (
+                <SyncedLyrics
+                    syncedLyrics={lyricsData?.syncedLyrics ?? null}
+                    plainLyrics={lyricsData?.plainLyrics ?? null}
+                    currentTime={currentTime}
+                    isPlaying={isPlaying}
+                    onSeek={onSeek}
+                    className="h-full"
+                />
+            )}
+        </motion.section>
+    );
+});

--- a/frontend/components/player/overlay-tabs/OverlayQueueRows.tsx
+++ b/frontend/components/player/overlay-tabs/OverlayQueueRows.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { memo } from "react";
+import Image from "next/image";
+import { Music as MusicIcon, X } from "lucide-react";
+import { cn } from "@/utils/cn";
+import { formatTime } from "@/utils/formatTime";
+import { api } from "@/lib/api";
+import { resolvePlaybackQualityBadgeFromStreamSource } from "@/hooks/useStreamBitrate";
+import { TidalBadge } from "@/components/ui/TidalBadge";
+import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
+import { TrackPreferenceButtons } from "@/components/player/TrackPreferenceButtons";
+import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
+import {
+    TrackOverflowMenu,
+    TrackMenuButton,
+} from "@/components/ui/TrackOverflowMenu";
+import type { EpisodeQueueItem, TrackQueueItem } from "@/lib/queue-item";
+
+interface QueueRowSharedProps {
+    queueIndex: number;
+    isCurrentTrack: boolean;
+    isPlayedTrack: boolean;
+    onPlayFromQueue: (index: number) => void;
+    onRemoveFromQueue: (index: number) => void;
+}
+
+function queueRowClassName(isCurrentTrack: boolean, isPlayedTrack: boolean) {
+    return cn(
+        "mb-1.5 flex items-center gap-2 px-2 py-2 transition-colors",
+        isCurrentTrack
+            ? "rounded-md border border-brand-hover/35 bg-brand-hover/10"
+            : isPlayedTrack
+              ? "rounded-md bg-white/[0.03] hover:bg-white/[0.06]"
+              : "hover:bg-white/[0.06]",
+    );
+}
+
+function QueuePositionNumber({
+    queueIndex,
+    isCurrentTrack,
+}: {
+    queueIndex: number;
+    isCurrentTrack: boolean;
+}) {
+    return (
+        <span
+            className={cn(
+                "w-5 flex-shrink-0 text-center text-[11px] tabular-nums",
+                isCurrentTrack ? "text-brand-hover" : "text-gray-400",
+            )}
+        >
+            {queueIndex + 1}
+        </span>
+    );
+}
+
+function QueueRowDuration({
+    duration,
+    isCurrentTrack,
+}: {
+    duration: number;
+    isCurrentTrack: boolean;
+}) {
+    return (
+        <span
+            className={cn(
+                "text-[11px] tabular-nums",
+                isCurrentTrack ? "text-brand-hover" : "text-gray-400",
+            )}
+        >
+            {formatTime(duration)}
+        </span>
+    );
+}
+
+function QueueRemoveButton({
+    queueIndex,
+    onRemoveFromQueue,
+    className,
+}: {
+    queueIndex: number;
+    onRemoveFromQueue: (index: number) => void;
+    className?: string;
+}) {
+    return (
+        <button
+            onClick={(e) => {
+                e.stopPropagation();
+                onRemoveFromQueue(queueIndex);
+            }}
+            className={cn(
+                "h-7 w-7 flex items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white transition-colors",
+                className,
+            )}
+            title="Remove from queue"
+            aria-label="Remove from queue"
+        >
+            <X className="h-3.5 w-3.5" />
+        </button>
+    );
+}
+
+function PlayedPill() {
+    return (
+        <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-gray-400">
+            Played
+        </span>
+    );
+}
+
+export const OverlayQueueEpisodeRow = memo(function OverlayQueueEpisodeRow({
+    item,
+    queueIndex,
+    isCurrentTrack,
+    isPlayedTrack,
+    onPlayFromQueue,
+    onRemoveFromQueue,
+}: QueueRowSharedProps & { item: EpisodeQueueItem }) {
+    return (
+        <div
+            data-queue-index={queueIndex}
+            className={queueRowClassName(isCurrentTrack, isPlayedTrack)}
+        >
+            <QueuePositionNumber
+                queueIndex={queueIndex}
+                isCurrentTrack={isCurrentTrack}
+            />
+            <button
+                onClick={() => {
+                    if (!isCurrentTrack) onPlayFromQueue(queueIndex);
+                }}
+                className={cn(
+                    "flex min-w-0 flex-1 items-center gap-3 text-left",
+                    isCurrentTrack && "cursor-default",
+                )}
+                title={isCurrentTrack ? "Now playing" : "Play this episode now"}
+            >
+                <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
+                    {item.coverUrl ? (
+                        <Image
+                            src={item.coverUrl}
+                            alt={item.podcastTitle}
+                            fill
+                            sizes="44px"
+                            className="object-cover"
+                            unoptimized
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center">
+                            <MusicIcon className="h-4 w-4 text-gray-400" />
+                        </div>
+                    )}
+                </div>
+                <div className="min-w-0">
+                    <p
+                        className={cn(
+                            "min-w-0 truncate text-sm",
+                            isCurrentTrack ? "text-brand-hover" : "text-white",
+                        )}
+                    >
+                        {item.title}
+                    </p>
+                    <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
+                        <p className="min-w-0 truncate text-xs text-gray-400">
+                            {item.podcastTitle || "Podcast"}
+                        </p>
+                        {isCurrentTrack && (
+                            <span className="inline-flex shrink-0 items-center rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
+                                Playing
+                            </span>
+                        )}
+                        {isPlayedTrack && !isCurrentTrack && <PlayedPill />}
+                    </div>
+                </div>
+            </button>
+            <QueueRowDuration
+                duration={item.duration || 0}
+                isCurrentTrack={isCurrentTrack}
+            />
+            {!isCurrentTrack && (
+                <QueueRemoveButton
+                    queueIndex={queueIndex}
+                    onRemoveFromQueue={onRemoveFromQueue}
+                    className="ml-1"
+                />
+            )}
+        </div>
+    );
+});
+
+export const OverlayQueueTrackRow = memo(function OverlayQueueTrackRow({
+    track,
+    queueIndex,
+    isCurrentTrack,
+    isPlayedTrack,
+    onPlayFromQueue,
+    onRemoveFromQueue,
+}: QueueRowSharedProps & { track: TrackQueueItem }) {
+    const qualityBadge = resolvePlaybackQualityBadgeFromStreamSource(
+        track.streamSource,
+    );
+    return (
+        <div
+            data-queue-index={queueIndex}
+            className={queueRowClassName(isCurrentTrack, isPlayedTrack)}
+        >
+            <QueuePositionNumber
+                queueIndex={queueIndex}
+                isCurrentTrack={isCurrentTrack}
+            />
+            <button
+                onClick={() => {
+                    if (!isCurrentTrack) onPlayFromQueue(queueIndex);
+                }}
+                className={cn(
+                    "flex min-w-0 flex-1 items-center gap-3 text-left",
+                    isCurrentTrack && "cursor-default",
+                )}
+                title={isCurrentTrack ? "Now playing" : "Play this track now"}
+            >
+                <div className="relative h-11 w-11 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
+                    {track.album?.coverArt ? (
+                        <Image
+                            src={api.getCoverArtUrl(track.album.coverArt, 100)}
+                            alt={track.album.title}
+                            fill
+                            sizes="44px"
+                            className="object-cover"
+                            unoptimized
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center">
+                            <MusicIcon className="h-4 w-4 text-gray-400" />
+                        </div>
+                    )}
+                </div>
+                <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                        <p
+                            className={cn(
+                                "min-w-0 truncate text-sm",
+                                isCurrentTrack
+                                    ? "text-brand-hover"
+                                    : "text-white",
+                            )}
+                        >
+                            {track.displayTitle ?? track.title}
+                        </p>
+                        {qualityBadge?.variant === "tidal" && <TidalBadge />}
+                        {qualityBadge?.variant === "youtube" && (
+                            <YouTubeBadge />
+                        )}
+                    </div>
+                    <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
+                        <p className="min-w-0 truncate text-xs text-gray-400">
+                            {track.artist?.name || "Unknown artist"}
+                        </p>
+                        {isCurrentTrack && (
+                            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-brand-hover/40 bg-brand-hover/12 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-hover">
+                                <span className="inline-flex items-end gap-0.5">
+                                    <span className="h-2 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.2s]" />
+                                    <span className="h-2.5 w-0.5 animate-bounce rounded-full bg-brand-hover" />
+                                    <span className="h-1.5 w-0.5 animate-bounce rounded-full bg-brand-hover [animation-delay:-0.35s]" />
+                                </span>
+                                Playing
+                            </span>
+                        )}
+                        {isPlayedTrack && !isCurrentTrack && <PlayedPill />}
+                    </div>
+                </div>
+            </button>
+            <QueueRowDuration
+                duration={track.duration || 0}
+                isCurrentTrack={isCurrentTrack}
+            />
+            <div className="ml-1 flex items-center gap-1">
+                <TrackPreferenceButtons
+                    trackId={track.id}
+                    mode="up-only"
+                    buttonSizeClassName="h-10 w-10"
+                    iconSizeClassName="h-5 w-5"
+                    metadata={buildPreferenceMetadata(track)}
+                />
+                <TrackOverflowMenu
+                    track={track}
+                    showPlayNext={false}
+                    showAddToQueue={false}
+                    triggerClassName="!opacity-100"
+                    extraItemsAfter={
+                        !isCurrentTrack ? (
+                            <TrackMenuButton
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onRemoveFromQueue(queueIndex);
+                                }}
+                                icon={<X className="h-4 w-4" />}
+                                label="Remove from queue"
+                                className="text-red-400 hover:text-red-300"
+                            />
+                        ) : undefined
+                    }
+                />
+                {!isCurrentTrack && (
+                    <QueueRemoveButton
+                        queueIndex={queueIndex}
+                        onRemoveFromQueue={onRemoveFromQueue}
+                    />
+                )}
+            </div>
+        </div>
+    );
+});

--- a/frontend/components/player/overlay-tabs/OverlayQueueTab.tsx
+++ b/frontend/components/player/overlay-tabs/OverlayQueueTab.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import { ListMusic, Trash2 } from "lucide-react";
+import { isEpisodeQueueItem, type QueueItem } from "@/lib/queue-item";
+import {
+    resolveQueueCenteringBehavior,
+    resolveQueueCenteringIndex,
+} from "@/lib/overlay-queue-centering";
+import { buildTabTransitionProps } from "./overlayTabMotion";
+import {
+    OverlayQueueEpisodeRow,
+    OverlayQueueTrackRow,
+} from "./OverlayQueueRows";
+
+/**
+ * Rows rendered on the first pass before react-virtuoso measures the
+ * viewport; keeps happy-dom component tests and first paint windowed.
+ */
+const INITIAL_WINDOW_COUNT = 20;
+const ESTIMATED_ROW_HEIGHT = 60;
+
+interface OverlayQueueTabProps {
+    queueTracks: QueueItem[];
+    currentIndex: number;
+    onPlayFromQueue: (index: number) => void;
+    onRemoveFromQueue: (index: number) => void;
+    onClearQueue: () => void;
+}
+
+/**
+ * The overlay drawer's Up Next tab (GH #787): windowed queue list that
+ * keeps the playing row centered. Mounts only while the tab is visible, so
+ * a mount is a "reveal" and later index changes glide via scrollToIndex.
+ */
+export const OverlayQueueTab = memo(function OverlayQueueTab({
+    queueTracks,
+    currentIndex,
+    onPlayFromQueue,
+    onRemoveFromQueue,
+    onClearQueue,
+}: OverlayQueueTabProps) {
+    const shouldReduceMotion = useReducedMotion();
+    const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+    const isFirstRevealRef = useRef(true);
+    const previousIndexRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        const isFirstReveal = isFirstRevealRef.current;
+        const indexChanged =
+            previousIndexRef.current !== null &&
+            previousIndexRef.current !== currentIndex;
+        isFirstRevealRef.current = false;
+        previousIndexRef.current = currentIndex;
+
+        const behavior = resolveQueueCenteringBehavior({
+            isFirstReveal,
+            indexChanged,
+            shouldReduceMotion: !!shouldReduceMotion,
+            queueLength: queueTracks.length,
+        });
+        // The reveal itself is handled by initialTopMostItemIndex below.
+        if (!behavior || isFirstReveal) return;
+        virtuosoRef.current?.scrollToIndex({
+            index: resolveQueueCenteringIndex(currentIndex, queueTracks.length),
+            align: "center",
+            behavior,
+        });
+    }, [currentIndex, queueTracks.length, shouldReduceMotion]);
+
+    return (
+        <motion.section
+            key="queue"
+            {...buildTabTransitionProps(shouldReduceMotion)}
+            className="h-full overflow-hidden flex flex-col"
+        >
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-2">
+                <div className="flex items-center gap-2">
+                    <ListMusic className="h-4 w-4 text-brand-hover" />
+                    <h2 className="text-sm font-semibold text-white">
+                        Up Next
+                    </h2>
+                </div>
+                <div className="flex items-center gap-3">
+                    {queueTracks.length > 0 && (
+                        <button
+                            type="button"
+                            onClick={onClearQueue}
+                            className="inline-flex items-center gap-1 text-xs text-gray-400 transition-colors hover:text-white"
+                            title="Clear queue"
+                            aria-label="Clear queue"
+                        >
+                            <Trash2 className="h-3 w-3" />
+                            Clear Queue
+                        </button>
+                    )}
+                    <span className="text-xs text-gray-400">
+                        {queueTracks.length} items
+                    </span>
+                </div>
+            </div>
+
+            {queueTracks.length === 0 ? (
+                <div className="flex min-h-0 flex-1 items-center justify-center px-4">
+                    <p className="text-sm text-gray-400">No tracks in queue.</p>
+                </div>
+            ) : (
+                <div className="min-h-0 flex-1 px-2 py-2">
+                    <Virtuoso
+                        ref={virtuosoRef}
+                        style={{ height: "100%" }}
+                        totalCount={queueTracks.length}
+                        initialItemCount={Math.min(
+                            queueTracks.length,
+                            INITIAL_WINDOW_COUNT,
+                        )}
+                        initialTopMostItemIndex={{
+                            index: resolveQueueCenteringIndex(
+                                currentIndex,
+                                queueTracks.length,
+                            ),
+                            align: "center",
+                        }}
+                        defaultItemHeight={ESTIMATED_ROW_HEIGHT}
+                        computeItemKey={(index) => {
+                            const item = queueTracks[index];
+                            return item ? `${item.id}-${index}` : index;
+                        }}
+                        itemContent={(queueIndex) => {
+                            const item = queueTracks[queueIndex];
+                            if (!item) return null;
+                            const rowProps = {
+                                queueIndex,
+                                isCurrentTrack: queueIndex === currentIndex,
+                                isPlayedTrack: queueIndex < currentIndex,
+                                onPlayFromQueue,
+                                onRemoveFromQueue,
+                            };
+                            return isEpisodeQueueItem(item) ? (
+                                <OverlayQueueEpisodeRow
+                                    item={item}
+                                    {...rowProps}
+                                />
+                            ) : (
+                                <OverlayQueueTrackRow
+                                    track={item}
+                                    {...rowProps}
+                                />
+                            );
+                        }}
+                    />
+                </div>
+            )}
+        </motion.section>
+    );
+});

--- a/frontend/components/player/overlay-tabs/OverlayRelatedSections.tsx
+++ b/frontend/components/player/overlay-tabs/OverlayRelatedSections.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Loader2, Music as MusicIcon, RefreshCw } from "lucide-react";
+import { api } from "@/lib/api";
+import { getArtistHref } from "@/utils/artistRoute";
+import { TidalBadge } from "@/components/ui/TidalBadge";
+import { YouTubeBadge } from "@/components/ui/YouTubeBadge";
+import { TrackPreferenceButtons } from "../TrackPreferenceButtons";
+import { buildPreferenceMetadata } from "@/hooks/useTrackPreference";
+import {
+    getRelatedTrackKey,
+    type RelatedStreamMatch,
+} from "@/lib/overlay-related-matching";
+import type {
+    RelatedAlbum,
+    RelatedArtist,
+    RelatedTrack,
+} from "./overlayRelatedTypes";
+
+interface RelatedSectionShellProps {
+    title: string;
+    isLoading: boolean;
+    isError: boolean;
+    onRetry: () => void;
+    errorText: string;
+    isEmpty: boolean;
+    emptyText: string;
+    children: ReactNode;
+}
+
+/** One Related-tab section: heading plus loading/error/empty/content states. */
+export function RelatedSectionShell({
+    title,
+    isLoading,
+    isError,
+    onRetry,
+    errorText,
+    isEmpty,
+    emptyText,
+    children,
+}: RelatedSectionShellProps) {
+    return (
+        <section>
+            <h3 className="mb-2 text-xs uppercase tracking-wide text-gray-400">
+                {title}
+            </h3>
+            {isLoading ? (
+                <div className="flex items-center gap-2 text-gray-400">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span className="text-sm">Loading...</span>
+                </div>
+            ) : isError ? (
+                <div className="flex items-center gap-3">
+                    <p className="text-sm text-gray-400">{errorText}</p>
+                    <button
+                        onClick={onRetry}
+                        className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 transition-colors"
+                    >
+                        <RefreshCw className="h-3 w-3" />
+                        Retry
+                    </button>
+                </div>
+            ) : isEmpty ? (
+                <p className="text-sm text-gray-400">{emptyText}</p>
+            ) : (
+                children
+            )}
+        </section>
+    );
+}
+
+function SimilarSongBadge({
+    track,
+    streamMatch,
+    isMatching,
+}: {
+    track: RelatedTrack;
+    streamMatch: RelatedStreamMatch | undefined;
+    isMatching: boolean;
+}) {
+    if (track.inLibrary) {
+        return (
+            <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
+                In Library
+            </span>
+        );
+    }
+    if (isMatching) {
+        return (
+            <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[10px] text-gray-300">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Matching
+            </span>
+        );
+    }
+    if (streamMatch?.streamSource === "tidal") return <TidalBadge />;
+    if (streamMatch?.streamSource === "youtube") return <YouTubeBadge />;
+    if (track.lastFmUrl) {
+        return (
+            <span className="rounded-full border border-white/20 bg-white/[0.04] px-2 py-0.5 text-[10px] text-gray-300">
+                Info
+            </span>
+        );
+    }
+    return (
+        <span className="rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[10px] text-gray-400">
+            Search
+        </span>
+    );
+}
+
+interface SimilarSongsListProps {
+    tracks: RelatedTrack[];
+    streamMatches: Record<string, RelatedStreamMatch>;
+    matchingTrackKey: string | null;
+    onPlayRelatedTrack: (track: RelatedTrack) => void;
+}
+
+export function SimilarSongsList({
+    tracks,
+    streamMatches,
+    matchingTrackKey,
+    onPlayRelatedTrack,
+}: SimilarSongsListProps) {
+    return (
+        <div className="space-y-1.5">
+            {tracks.map((track, idx) => {
+                const trackKey = getRelatedTrackKey(track);
+                const albumCover =
+                    track.album?.coverArt || track.album?.coverUrl;
+                return (
+                    <button
+                        key={`${track.id || track.title}-${idx}`}
+                        type="button"
+                        onClick={() => onPlayRelatedTrack(track)}
+                        className="group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-white/[0.06]"
+                    >
+                        <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded bg-surface-hover">
+                            {albumCover ? (
+                                <Image
+                                    src={api.getCoverArtUrl(albumCover, 100)}
+                                    alt={track.album?.title || track.title}
+                                    fill
+                                    sizes="40px"
+                                    className="object-cover"
+                                    unoptimized
+                                />
+                            ) : (
+                                <div className="flex h-full w-full items-center justify-center">
+                                    <MusicIcon className="h-4 w-4 text-gray-400" />
+                                </div>
+                            )}
+                        </div>
+                        <div className="min-w-0 flex-1 pr-2">
+                            <p className="truncate text-sm text-gray-200 group-hover:text-white">
+                                {track.title}
+                            </p>
+                            <p className="truncate text-xs text-gray-400">
+                                {track.inLibrary
+                                    ? track.album?.artist?.name ||
+                                      track.artist ||
+                                      "Unknown artist"
+                                    : track.artist || "Unknown artist"}
+                            </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                            <SimilarSongBadge
+                                track={track}
+                                streamMatch={streamMatches[trackKey]}
+                                isMatching={matchingTrackKey === trackKey}
+                            />
+                            {track.inLibrary && track.id && (
+                                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+                                <div onClick={(e) => e.stopPropagation()}>
+                                    <TrackPreferenceButtons
+                                        trackId={track.id}
+                                        mode="up-only"
+                                        buttonSizeClassName="h-8 w-8"
+                                        iconSizeClassName="h-4 w-4"
+                                        metadata={buildPreferenceMetadata(
+                                            track,
+                                        )}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+interface SimilarArtistsGridProps {
+    artists: RelatedArtist[];
+    onNavigate: () => void;
+}
+
+export function SimilarArtistsGrid({
+    artists,
+    onNavigate,
+}: SimilarArtistsGridProps) {
+    return (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {artists.slice(0, 9).map((artist, idx) => {
+                const artistHref =
+                    getArtistHref(
+                        { mbid: artist.mbid, name: artist.name },
+                        { preferLibraryId: false },
+                    ) || `/artist/${encodeURIComponent(artist.name)}`;
+                const artistId = artist.mbid || encodeURIComponent(artist.name);
+                return (
+                    <Link
+                        key={`${artistId}-${idx}`}
+                        href={artistHref}
+                        onClick={onNavigate}
+                        className="group p-1.5 transition-colors hover:bg-white/[0.06]"
+                    >
+                        <div className="mb-2 relative mx-auto h-12 w-12 overflow-hidden rounded-full bg-surface-hover">
+                            {artist.image ? (
+                                <Image
+                                    src={artist.image}
+                                    alt={artist.name}
+                                    fill
+                                    sizes="48px"
+                                    className="object-cover"
+                                    unoptimized
+                                />
+                            ) : (
+                                <div className="flex h-full w-full items-center justify-center">
+                                    <MusicIcon className="h-4 w-4 text-gray-400" />
+                                </div>
+                            )}
+                        </div>
+                        <p className="truncate text-center text-xs text-gray-200 group-hover:text-white">
+                            {artist.name}
+                        </p>
+                    </Link>
+                );
+            })}
+        </div>
+    );
+}
+
+interface MoreFromArtistGridProps {
+    albums: RelatedAlbum[];
+    onNavigate: () => void;
+}
+
+export function MoreFromArtistGrid({
+    albums,
+    onNavigate,
+}: MoreFromArtistGridProps) {
+    return (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {albums.slice(0, 6).map((album) => (
+                <Link
+                    key={album.id}
+                    href={`/album/${album.id}`}
+                    onClick={onNavigate}
+                    className="group p-1.5 transition-colors hover:bg-white/[0.06]"
+                >
+                    <div className="relative mb-2 aspect-square w-full overflow-hidden rounded bg-surface-hover">
+                        {album.coverArt ? (
+                            <Image
+                                src={api.getCoverArtUrl(album.coverArt, 200)}
+                                alt={album.title}
+                                fill
+                                sizes="140px"
+                                className="object-cover"
+                                unoptimized
+                            />
+                        ) : (
+                            <div className="flex h-full w-full items-center justify-center">
+                                <MusicIcon className="h-5 w-5 text-gray-400" />
+                            </div>
+                        )}
+                    </div>
+                    <p className="truncate text-xs text-gray-200 group-hover:text-white">
+                        {album.title}
+                    </p>
+                    {album.year && (
+                        <p className="text-[11px] text-gray-400">
+                            {album.year}
+                        </p>
+                    )}
+                </Link>
+            ))}
+        </div>
+    );
+}

--- a/frontend/components/player/overlay-tabs/OverlayRelatedTab.tsx
+++ b/frontend/components/player/overlay-tabs/OverlayRelatedTab.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import type { Track } from "@/lib/audio-state-context";
+import {
+    buildStreamMatchQuery,
+    getRelatedTrackKey,
+    partitionTidalBatchMatches,
+    selectTracksNeedingStreamMatch,
+    sortRelatedTracksByRelevance,
+    type RelatedStreamMatch,
+} from "@/lib/overlay-related-matching";
+import { buildTabTransitionProps } from "./overlayTabMotion";
+import {
+    MoreFromArtistGrid,
+    RelatedSectionShell,
+    SimilarArtistsGrid,
+    SimilarSongsList,
+} from "./OverlayRelatedSections";
+import type {
+    RelatedAlbum,
+    RelatedArtist,
+    RelatedTrack,
+} from "./overlayRelatedTypes";
+
+/**
+ * Stream matches survive tab switches and track changes without re-calling
+ * the match sidecars. Bounded so a long session cannot grow it unchecked.
+ */
+const STREAM_MATCH_CACHE_LIMIT = 200;
+const streamMatchCache = new Map<string, RelatedStreamMatch>();
+
+function rememberStreamMatches(
+    matches: Readonly<Record<string, RelatedStreamMatch>>,
+): void {
+    for (const [key, match] of Object.entries(matches)) {
+        if (streamMatchCache.size >= STREAM_MATCH_CACHE_LIMIT) {
+            const oldestKey = streamMatchCache.keys().next().value;
+            if (oldestKey !== undefined) streamMatchCache.delete(oldestKey);
+        }
+        streamMatchCache.set(key, match);
+    }
+}
+
+/** TIDAL first, YouTube Music second; null when neither service matches. */
+async function resolveSingleStreamMatch(
+    track: RelatedTrack,
+): Promise<RelatedStreamMatch | null> {
+    const query = buildStreamMatchQuery(track);
+    const artist = query.artist.trim();
+    const title = query.title.trim();
+    if (!artist || !title) return null;
+
+    try {
+        const tidalResponse = await api.matchTidalTrack(
+            artist,
+            title,
+            query.albumTitle,
+            query.duration,
+        );
+        if (tidalResponse.match?.id) {
+            return {
+                streamSource: "tidal",
+                tidalTrackId: tidalResponse.match.id,
+                title: tidalResponse.match.title,
+                artist: tidalResponse.match.artist,
+                duration: tidalResponse.match.duration,
+            };
+        }
+    } catch {
+        // Ignore TIDAL single-match failures and try YT.
+    }
+
+    try {
+        const ytResponse = await api.matchYtMusicTrack(
+            artist,
+            title,
+            query.albumTitle,
+            query.duration,
+        );
+        if (ytResponse.match?.videoId) {
+            return {
+                streamSource: "youtube",
+                youtubeVideoId: ytResponse.match.videoId,
+                title: ytResponse.match.title,
+                duration: ytResponse.match.duration,
+            };
+        }
+    } catch {
+        // Ignore YT single-match failures and fall through to info.
+    }
+    return null;
+}
+
+function buildLibraryPlaybackTrack(
+    track: RelatedTrack,
+    artistName: string,
+): Track {
+    return {
+        id: track.id as string,
+        title: track.title,
+        artist: {
+            id: track.album?.artist?.id,
+            mbid: track.album?.artist?.mbid,
+            name: artistName,
+        },
+        album: {
+            id: track.album?.id,
+            title: track.album?.title || "Unknown album",
+            coverArt: track.album?.coverArt || track.album?.coverUrl,
+        },
+        duration: track.duration || 0,
+        filePath: track.filePath,
+        streamSource: track.streamSource,
+        tidalTrackId: track.tidalTrackId,
+        youtubeVideoId: track.youtubeVideoId,
+    } as Track;
+}
+
+function buildStreamPlaybackTrack(
+    track: RelatedTrack,
+    match: RelatedStreamMatch,
+    artistName: string,
+): Track {
+    return {
+        id:
+            match.streamSource === "tidal"
+                ? `related-tidal-${match.tidalTrackId}`
+                : `related-yt-${match.youtubeVideoId}`,
+        title: track.title,
+        artist: { name: artistName },
+        album: {
+            title: track.album?.title || "Related Tracks",
+            coverArt: track.album?.coverArt || track.album?.coverUrl,
+        },
+        duration: match.duration || track.duration || 0,
+        streamSource: match.streamSource,
+        tidalTrackId: match.tidalTrackId,
+        youtubeVideoId: match.youtubeVideoId,
+    } as Track;
+}
+
+interface OverlayRelatedTabProps {
+    currentTrack: Track | null;
+    /** Related content only applies to library/stream track playback. */
+    isTrackPlayback: boolean;
+    playTrack: (track: Track) => void;
+    /** Close the overlay before navigating to an artist/album page. */
+    onNavigate: () => void;
+}
+
+/**
+ * The overlay drawer's Related tab (GH #787): similar songs, similar
+ * artists, and more albums from the playing artist. Owns its three fetches
+ * and the stream-match hydration, so none of it runs unless this panel is
+ * mounted.
+ */
+export const OverlayRelatedTab = memo(function OverlayRelatedTab({
+    currentTrack,
+    isTrackPlayback,
+    playTrack,
+    onNavigate,
+}: OverlayRelatedTabProps) {
+    const shouldReduceMotion = useReducedMotion();
+    const queryClient = useQueryClient();
+    const [streamMatches, setStreamMatches] = useState<
+        Record<string, RelatedStreamMatch>
+    >(() => Object.fromEntries(streamMatchCache));
+    const [matchingTrackKey, setMatchingTrackKey] = useState<string | null>(
+        null,
+    );
+
+    const addStreamMatches = useCallback(
+        (found: Record<string, RelatedStreamMatch>) => {
+            rememberStreamMatches(found);
+            setStreamMatches((prev) => ({ ...prev, ...found }));
+        },
+        [],
+    );
+
+    const {
+        data: relatedTrackData,
+        isLoading: isRelatedTracksLoading,
+        isError: isRelatedTracksError,
+    } = useQuery({
+        queryKey: queryKeys.playerRelatedTracks(currentTrack?.id),
+        queryFn: async () => {
+            if (!currentTrack?.id) return [];
+            const response = await api.getSimilarTracks(
+                currentTrack.id,
+                12,
+                currentTrack.artist?.name,
+                currentTrack.displayTitle || currentTrack.title,
+            );
+            return response.recommendations || [];
+        },
+        enabled: isTrackPlayback && !!currentTrack?.id,
+        staleTime: 5 * 60 * 1000,
+        retry: 1,
+    });
+
+    const {
+        data: relatedArtistsData,
+        isLoading: isRelatedArtistsLoading,
+        isError: isRelatedArtistsError,
+    } = useQuery({
+        queryKey: queryKeys.playerRelatedArtists(
+            currentTrack?.artist?.name,
+            currentTrack?.artist?.mbid,
+        ),
+        queryFn: async () => {
+            if (!currentTrack?.artist?.name) return [];
+            const response = await api.discoverSimilarArtists(
+                currentTrack.artist.name,
+                currentTrack.artist.mbid || "",
+                8,
+            );
+            return response.similarArtists || [];
+        },
+        enabled: isTrackPlayback && !!currentTrack?.artist?.name,
+        staleTime: 30 * 60 * 1000,
+        retry: 1,
+    });
+
+    const {
+        data: moreFromArtistData,
+        isLoading: isMoreFromArtistLoading,
+        isError: isMoreFromArtistError,
+    } = useQuery({
+        queryKey: queryKeys.playerRelatedAlbums(currentTrack?.artist?.id),
+        queryFn: async () => {
+            if (!currentTrack?.artist?.id) return [];
+            const response = await api.getAlbums({
+                artistId: currentTrack.artist.id,
+                limit: 8,
+                sortBy: "recent",
+            });
+            return response.albums || [];
+        },
+        enabled: isTrackPlayback && !!currentTrack?.artist?.id,
+        staleTime: 10 * 60 * 1000,
+        retry: 1,
+    });
+
+    const relatedTracks = useMemo<RelatedTrack[]>(
+        () =>
+            Array.isArray(relatedTrackData)
+                ? (relatedTrackData as RelatedTrack[])
+                : [],
+        [relatedTrackData],
+    );
+    const relatedArtists = useMemo<RelatedArtist[]>(
+        () =>
+            Array.isArray(relatedArtistsData)
+                ? (relatedArtistsData as RelatedArtist[])
+                : [],
+        [relatedArtistsData],
+    );
+    const moreFromArtist = useMemo<RelatedAlbum[]>(
+        () =>
+            Array.isArray(moreFromArtistData)
+                ? (moreFromArtistData as RelatedAlbum[])
+                : [],
+        [moreFromArtistData],
+    );
+    const sortedRelatedTracks = useMemo(
+        () => sortRelatedTracksByRelevance(relatedTracks),
+        [relatedTracks],
+    );
+    const visibleRelatedTracks = useMemo(
+        () => sortedRelatedTracks.slice(0, 8),
+        [sortedRelatedTracks],
+    );
+
+    useEffect(() => {
+        if (!isTrackPlayback) return;
+        const missingTracks = selectTracksNeedingStreamMatch(
+            visibleRelatedTracks,
+            streamMatches,
+        );
+        if (missingTracks.length === 0) return;
+
+        let cancelled = false;
+
+        const hydrateMissingRelatedStreams = async () => {
+            let tidalMatches: Array<{
+                id: number;
+                title: string;
+                artist: string;
+                duration: number;
+                isrc?: string;
+            } | null> = [];
+            try {
+                const tidalResponse = await api.matchTidalBatch(
+                    missingTracks.map(buildStreamMatchQuery),
+                );
+                tidalMatches = Array.isArray(tidalResponse.matches)
+                    ? tidalResponse.matches
+                    : [];
+            } catch {
+                tidalMatches = [];
+            }
+
+            const { foundMatches, youtubePayload, youtubeTrackKeys } =
+                partitionTidalBatchMatches(missingTracks, tidalMatches);
+
+            if (youtubePayload.length > 0) {
+                try {
+                    const ytResponse =
+                        await api.matchYtMusicBatch(youtubePayload);
+                    const ytMatches = Array.isArray(ytResponse.matches)
+                        ? ytResponse.matches
+                        : [];
+                    youtubeTrackKeys.forEach((trackKey, index) => {
+                        const ytMatch = ytMatches[index];
+                        if (!ytMatch?.videoId) return;
+                        foundMatches[trackKey] = {
+                            streamSource: "youtube",
+                            youtubeVideoId: ytMatch.videoId,
+                            title: ytMatch.title,
+                            duration: ytMatch.duration,
+                        };
+                    });
+                } catch {
+                    // Ignore YT matching failures; rows still fall back to info links.
+                }
+            }
+
+            if (cancelled || Object.keys(foundMatches).length === 0) return;
+            addStreamMatches(foundMatches);
+        };
+
+        hydrateMissingRelatedStreams();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        addStreamMatches,
+        isTrackPlayback,
+        streamMatches,
+        visibleRelatedTracks,
+    ]);
+
+    const playRelatedTrack = useCallback(
+        async (track: RelatedTrack) => {
+            const artistName =
+                track.album?.artist?.name || track.artist || "Unknown artist";
+
+            if (track.inLibrary && track.id) {
+                playTrack(buildLibraryPlaybackTrack(track, artistName));
+                return;
+            }
+
+            const trackKey = getRelatedTrackKey(track);
+            setMatchingTrackKey(trackKey);
+            try {
+                let resolvedMatch: RelatedStreamMatch | null =
+                    streamMatches[trackKey] ?? null;
+                if (!resolvedMatch) {
+                    resolvedMatch = await resolveSingleStreamMatch(track);
+                }
+
+                if (resolvedMatch) {
+                    addStreamMatches({ [trackKey]: resolvedMatch });
+                    playTrack(
+                        buildStreamPlaybackTrack(
+                            track,
+                            resolvedMatch,
+                            artistName,
+                        ),
+                    );
+                    return;
+                }
+
+                if (track.lastFmUrl) {
+                    window.open(
+                        track.lastFmUrl,
+                        "_blank",
+                        "noopener,noreferrer",
+                    );
+                    return;
+                }
+
+                toast.error(
+                    "No playable stream found for this related track yet",
+                );
+            } finally {
+                setMatchingTrackKey(null);
+            }
+        },
+        [addStreamMatches, playTrack, streamMatches],
+    );
+
+    return (
+        <motion.section
+            key="related"
+            {...buildTabTransitionProps(shouldReduceMotion)}
+            className="h-full space-y-5 overflow-y-auto px-4 py-3"
+        >
+            <RelatedSectionShell
+                title="Similar Songs"
+                isLoading={isRelatedTracksLoading}
+                isError={isRelatedTracksError}
+                errorText="Failed to load similar songs."
+                onRetry={() =>
+                    queryClient.invalidateQueries({
+                        queryKey: queryKeys.playerRelatedTracks(
+                            currentTrack?.id,
+                        ),
+                    })
+                }
+                isEmpty={sortedRelatedTracks.length === 0}
+                emptyText="No similar songs found."
+            >
+                <SimilarSongsList
+                    tracks={visibleRelatedTracks}
+                    streamMatches={streamMatches}
+                    matchingTrackKey={matchingTrackKey}
+                    onPlayRelatedTrack={playRelatedTrack}
+                />
+            </RelatedSectionShell>
+
+            <RelatedSectionShell
+                title="Similar Artists"
+                isLoading={isRelatedArtistsLoading}
+                isError={isRelatedArtistsError}
+                errorText="Failed to load similar artists."
+                onRetry={() =>
+                    queryClient.invalidateQueries({
+                        queryKey: queryKeys.playerRelatedArtists(
+                            currentTrack?.artist?.name,
+                            currentTrack?.artist?.mbid,
+                        ),
+                    })
+                }
+                isEmpty={relatedArtists.length === 0}
+                emptyText="No similar artists found."
+            >
+                <SimilarArtistsGrid
+                    artists={relatedArtists}
+                    onNavigate={onNavigate}
+                />
+            </RelatedSectionShell>
+
+            <RelatedSectionShell
+                title="More From This Artist"
+                isLoading={isMoreFromArtistLoading}
+                isError={isMoreFromArtistError}
+                errorText="Failed to load albums."
+                onRetry={() =>
+                    queryClient.invalidateQueries({
+                        queryKey: queryKeys.playerRelatedAlbums(
+                            currentTrack?.artist?.id,
+                        ),
+                    })
+                }
+                isEmpty={moreFromArtist.length === 0}
+                emptyText="No albums found."
+            >
+                <MoreFromArtistGrid
+                    albums={moreFromArtist}
+                    onNavigate={onNavigate}
+                />
+            </RelatedSectionShell>
+        </motion.section>
+    );
+});

--- a/frontend/components/player/overlay-tabs/overlayRelatedTypes.ts
+++ b/frontend/components/player/overlay-tabs/overlayRelatedTypes.ts
@@ -1,0 +1,36 @@
+/** Row shapes for the overlay Related tab (GH #787). */
+
+export interface RelatedTrack {
+    id?: string;
+    title: string;
+    artist?: string;
+    similarity?: number;
+    inLibrary?: boolean;
+    matchConfidence?: number;
+    duration?: number;
+    filePath?: string;
+    streamSource?: "tidal" | "youtube";
+    tidalTrackId?: number;
+    youtubeVideoId?: string;
+    lastFmUrl?: string;
+    album?: {
+        id?: string;
+        title?: string;
+        coverArt?: string;
+        coverUrl?: string;
+        artist?: { id?: string; name?: string; mbid?: string };
+    };
+}
+
+export interface RelatedArtist {
+    name: string;
+    mbid?: string;
+    image?: string;
+}
+
+export interface RelatedAlbum {
+    id: string;
+    title: string;
+    year?: number;
+    coverArt?: string | null;
+}

--- a/frontend/components/player/overlay-tabs/overlayTabMotion.ts
+++ b/frontend/components/player/overlay-tabs/overlayTabMotion.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared enter/exit motion for the overlay drawer tab panels (GH #787).
+ * Every tab uses the same slide-fade so switching tabs feels like one
+ * surface; reduced motion pins the panels in place.
+ */
+export function buildTabTransitionProps(shouldReduceMotion: boolean | null) {
+    if (shouldReduceMotion) {
+        return {
+            initial: { opacity: 1, y: 0 },
+            animate: { opacity: 1, y: 0 },
+            exit: { opacity: 1, y: 0 },
+            transition: { duration: 0 },
+        };
+    }
+    return {
+        initial: { opacity: 0, y: 8 },
+        animate: { opacity: 1, y: 0 },
+        exit: { opacity: 0, y: -8 },
+        transition: { duration: 0.18 },
+    };
+}

--- a/frontend/lib/overlay-queue-centering.ts
+++ b/frontend/lib/overlay-queue-centering.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure decision math for centering the overlay queue on the playing row
+ * (GH #787). Kept free of React so the reveal/track-change scroll behaviors
+ * are unit-testable.
+ */
+
+export interface QueueCenteringInput {
+    /** The queue panel just became visible (first pass after reveal). */
+    isFirstReveal: boolean;
+    /** The playing index changed while the panel stayed visible. */
+    indexChanged: boolean;
+    shouldReduceMotion: boolean;
+    queueLength: number;
+}
+
+export type QueueCenteringBehavior = "auto" | "smooth";
+
+/**
+ * Scroll behavior for a queue centering pass, or null to leave the list
+ * alone. Reveals jump instantly; track changes glide unless the user asked
+ * for reduced motion.
+ */
+export function resolveQueueCenteringBehavior({
+    isFirstReveal,
+    indexChanged,
+    shouldReduceMotion,
+    queueLength,
+}: QueueCenteringInput): QueueCenteringBehavior | null {
+    if (queueLength === 0) return null;
+    if (isFirstReveal) return "auto";
+    if (!indexChanged) return null;
+    return shouldReduceMotion ? "auto" : "smooth";
+}
+
+/** The row a centering pass targets: the playing row, or the top row. */
+export function resolveQueueCenteringIndex(
+    currentIndex: number,
+    queueLength: number,
+): number {
+    if (currentIndex >= 0 && currentIndex < queueLength) return currentIndex;
+    return 0;
+}

--- a/frontend/lib/overlay-related-matching.ts
+++ b/frontend/lib/overlay-related-matching.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure decision math for the overlay Related tab's stream matching
+ * (GH #787): row identity, relevance ordering, and the TIDAL-first /
+ * YouTube-fallback batch partition. Kept free of React and network code so
+ * the matching rules are unit-testable.
+ */
+
+export interface RelatedTrackLike {
+    id?: string;
+    title: string;
+    artist?: string;
+    similarity?: number;
+    inLibrary?: boolean;
+    matchConfidence?: number;
+    duration?: number;
+    album?: {
+        title?: string;
+        artist?: { name?: string };
+    };
+}
+
+export interface RelatedStreamMatch {
+    streamSource: "tidal" | "youtube";
+    tidalTrackId?: number;
+    youtubeVideoId?: string;
+    title?: string;
+    artist?: string;
+    duration?: number;
+}
+
+export interface StreamMatchQuery {
+    artist: string;
+    title: string;
+    albumTitle?: string;
+    duration?: number;
+}
+
+export interface TidalBatchMatch {
+    id: number;
+    title: string;
+    artist: string;
+    duration: number;
+    isrc?: string;
+}
+
+/** Stable identity for a related row: library id, else artist+title. */
+export function getRelatedTrackKey(track: RelatedTrackLike): string {
+    if (track.id) return `lib:${track.id}`;
+    const normalizedArtist = (
+        track.artist ||
+        track.album?.artist?.name ||
+        "unknown"
+    )
+        .trim()
+        .toLowerCase();
+    const normalizedTitle = (track.title || "unknown").trim().toLowerCase();
+    return `ext:${normalizedArtist}::${normalizedTitle}`;
+}
+
+function scoreRelatedTrack(track: RelatedTrackLike): number {
+    const confidence =
+        typeof track.matchConfidence === "number" &&
+        Number.isFinite(track.matchConfidence)
+            ? track.matchConfidence
+            : 0;
+    const similarity =
+        typeof track.similarity === "number" &&
+        Number.isFinite(track.similarity)
+            ? track.similarity * 100
+            : 0;
+    return (track.inLibrary ? 1000 : 0) + confidence * 2 + similarity;
+}
+
+/** Library rows first, then by match confidence and similarity. */
+export function sortRelatedTracksByRelevance<T extends RelatedTrackLike>(
+    tracks: readonly T[],
+): T[] {
+    if (tracks.length === 0) return [];
+    return [...tracks].sort(
+        (a, b) => scoreRelatedTrack(b) - scoreRelatedTrack(a),
+    );
+}
+
+/** Rows still needing a stream match: external, identified, and unmatched. */
+export function selectTracksNeedingStreamMatch<T extends RelatedTrackLike>(
+    tracks: readonly T[],
+    existingMatches: Readonly<Record<string, RelatedStreamMatch>>,
+): T[] {
+    return tracks.filter((track) => {
+        if (track.inLibrary) return false;
+        const hasArtist = !!(track.artist || track.album?.artist?.name);
+        if (!track.title || !hasArtist) return false;
+        return !existingMatches[getRelatedTrackKey(track)];
+    });
+}
+
+/** The lookup payload a batch-match request sends for each row. */
+export function buildStreamMatchQuery(
+    track: RelatedTrackLike,
+): StreamMatchQuery {
+    return {
+        artist: track.artist || track.album?.artist?.name || "",
+        title: track.title,
+        albumTitle: track.album?.title,
+        duration: track.duration,
+    };
+}
+
+export interface TidalBatchPartition {
+    /** Matches found on TIDAL, keyed by related-row identity. */
+    foundMatches: Record<string, RelatedStreamMatch>;
+    /** Rows TIDAL missed, to retry against YouTube Music. */
+    youtubePayload: StreamMatchQuery[];
+    youtubeTrackKeys: string[];
+}
+
+/** Split a TIDAL batch response into matches and the YouTube retry set. */
+export function partitionTidalBatchMatches(
+    missingTracks: readonly RelatedTrackLike[],
+    tidalMatches: ReadonlyArray<TidalBatchMatch | null | undefined>,
+): TidalBatchPartition {
+    const foundMatches: Record<string, RelatedStreamMatch> = {};
+    const youtubePayload: StreamMatchQuery[] = [];
+    const youtubeTrackKeys: string[] = [];
+
+    missingTracks.forEach((track, index) => {
+        const trackKey = getRelatedTrackKey(track);
+        const tidalMatch = tidalMatches[index];
+        if (tidalMatch?.id) {
+            foundMatches[trackKey] = {
+                streamSource: "tidal",
+                tidalTrackId: tidalMatch.id,
+                title: tidalMatch.title,
+                artist: tidalMatch.artist,
+                duration: tidalMatch.duration,
+            };
+            return;
+        }
+        youtubePayload.push(buildStreamMatchQuery(track));
+        youtubeTrackKeys.push(trackKey);
+    });
+
+    return { foundMatches, youtubePayload, youtubeTrackKeys };
+}

--- a/frontend/tests/component/overlayQueueTab.component.test.ts
+++ b/frontend/tests/component/overlayQueueTab.component.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { after, mock, test } from "node:test";
+import React from "react";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const Icon = (props: Record<string, unknown>) =>
+    React.createElement("svg", props);
+
+mock.module("lucide-react", {
+    namedExports: {
+        ListMusic: Icon,
+        Music: Icon,
+        Trash2: Icon,
+        X: Icon,
+    },
+});
+
+mock.module("next/image", {
+    defaultExport: ({ src, alt }: { src: string; alt: string }) =>
+        React.createElement("img", { src, alt }),
+});
+
+mock.module("@/utils/formatTime", {
+    namedExports: { formatTime: (seconds: number) => `t:${seconds}` },
+});
+
+mock.module("@/lib/api", {
+    namedExports: {
+        api: { getCoverArtUrl: (id: string) => `/cover/${id}` },
+    },
+});
+
+mock.module("@/hooks/useStreamBitrate", {
+    namedExports: {
+        resolvePlaybackQualityBadgeFromStreamSource: () => null,
+    },
+});
+
+mock.module("@/components/ui/TidalBadge", {
+    namedExports: { TidalBadge: () => null },
+});
+mock.module("@/components/ui/YouTubeBadge", {
+    namedExports: { YouTubeBadge: () => null },
+});
+mock.module("@/components/player/TrackPreferenceButtons", {
+    namedExports: { TrackPreferenceButtons: () => null },
+});
+mock.module("@/hooks/useTrackPreference", {
+    namedExports: { buildPreferenceMetadata: () => ({}) },
+});
+mock.module("@/components/ui/TrackOverflowMenu", {
+    namedExports: {
+        TrackOverflowMenu: () => null,
+        TrackMenuButton: () => null,
+    },
+});
+
+after(() => {
+    try {
+        GlobalRegistrator.unregister();
+    } catch {
+        // best-effort teardown
+    }
+});
+
+interface QueueFixtureTrack {
+    id: string;
+    title: string;
+    itemType?: "track" | "episode";
+    podcastTitle?: string;
+    coverUrl?: string;
+    duration: number;
+    artist?: { name: string };
+    album?: { title: string; coverArt?: string };
+}
+
+function makeQueue(count: number): QueueFixtureTrack[] {
+    return Array.from({ length: count }, (_, i) => ({
+        id: `track-${i + 1}`,
+        title: `Track ${i + 1}`,
+        duration: 180,
+        artist: { name: `Artist ${i + 1}` },
+        album: { title: `Album ${i + 1}` },
+    }));
+}
+
+interface MountOptions {
+    queue: QueueFixtureTrack[];
+    currentIndex?: number;
+    onPlayFromQueue?: (index: number) => void;
+    onRemoveFromQueue?: (index: number) => void;
+    onClearQueue?: () => void;
+}
+
+async function mountQueueTab(options: MountOptions) {
+    const { createRoot } = await import("react-dom/client");
+    const { OverlayQueueTab } =
+        await import("../../components/player/overlay-tabs/OverlayQueueTab");
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await React.act(async () => {
+        root.render(
+            React.createElement(OverlayQueueTab, {
+                queueTracks:
+                    options.queue as unknown as import("@/lib/queue-item").QueueItem[],
+                currentIndex: options.currentIndex ?? 0,
+                onPlayFromQueue: options.onPlayFromQueue ?? (() => undefined),
+                onRemoveFromQueue:
+                    options.onRemoveFromQueue ?? (() => undefined),
+                onClearQueue: options.onClearQueue ?? (() => undefined),
+            }),
+        );
+    });
+
+    return { container, root };
+}
+
+async function unmount(mounted: Awaited<ReturnType<typeof mountQueueTab>>) {
+    await React.act(async () => {
+        mounted.root.unmount();
+    });
+    mounted.container.remove();
+}
+
+test("an empty queue shows the empty state and no clear button", async () => {
+    const mounted = await mountQueueTab({ queue: [] });
+
+    assert.ok(mounted.container.textContent?.includes("No tracks in queue."));
+    assert.ok(mounted.container.textContent?.includes("0 items"));
+    assert.equal(
+        mounted.container.querySelector('button[title="Clear queue"]'),
+        null,
+    );
+    await unmount(mounted);
+});
+
+test("long queues window their rows instead of mounting every row", async () => {
+    const mounted = await mountQueueTab({ queue: makeQueue(300) });
+
+    const rows = mounted.container.querySelectorAll("[data-queue-index]");
+    assert.ok(rows.length > 0, "expected the initial window to mount rows");
+    assert.ok(
+        rows.length <= 40,
+        `expected a windowed subset of 300 rows, got ${rows.length}`,
+    );
+    assert.ok(mounted.container.textContent?.includes("300 items"));
+    await unmount(mounted);
+});
+
+test("the playing row pins Now playing and hides its remove control", async () => {
+    const mounted = await mountQueueTab({
+        queue: makeQueue(5),
+        currentIndex: 1,
+    });
+
+    const currentRow = mounted.container.querySelector(
+        '[data-queue-index="1"]',
+    );
+    assert.ok(currentRow, "expected the playing row to be mounted");
+    assert.ok(currentRow.querySelector('button[title="Now playing"]'));
+    assert.equal(
+        currentRow.querySelector('button[title="Remove from queue"]'),
+        null,
+        "the playing row must not offer removal",
+    );
+    assert.ok(currentRow.textContent?.includes("Playing"));
+    await unmount(mounted);
+});
+
+test("row actions dispatch play, remove, and clear callbacks", async () => {
+    const played: number[] = [];
+    const removed: number[] = [];
+    let cleared = 0;
+    const mounted = await mountQueueTab({
+        queue: makeQueue(5),
+        currentIndex: 0,
+        onPlayFromQueue: (index) => played.push(index),
+        onRemoveFromQueue: (index) => removed.push(index),
+        onClearQueue: () => {
+            cleared += 1;
+        },
+    });
+
+    const secondRow = mounted.container.querySelector('[data-queue-index="2"]');
+    assert.ok(secondRow);
+    await React.act(async () => {
+        secondRow
+            .querySelector<HTMLButtonElement>(
+                'button[title="Play this track now"]',
+            )
+            ?.click();
+        secondRow
+            .querySelector<HTMLButtonElement>(
+                'button[title="Remove from queue"]',
+            )
+            ?.click();
+        mounted.container
+            .querySelector<HTMLButtonElement>('button[title="Clear queue"]')
+            ?.click();
+    });
+
+    assert.deepEqual(played, [2]);
+    assert.deepEqual(removed, [2]);
+    assert.equal(cleared, 1);
+    await unmount(mounted);
+});
+
+test("clicking the playing row does not restart it", async () => {
+    const played: number[] = [];
+    const mounted = await mountQueueTab({
+        queue: makeQueue(3),
+        currentIndex: 0,
+        onPlayFromQueue: (index) => played.push(index),
+    });
+
+    await React.act(async () => {
+        mounted.container
+            .querySelector<HTMLButtonElement>('button[title="Now playing"]')
+            ?.click();
+    });
+
+    assert.deepEqual(played, []);
+    await unmount(mounted);
+});
+
+test("episode rows render podcast identity instead of track identity", async () => {
+    const queue: QueueFixtureTrack[] = [
+        ...makeQueue(1),
+        {
+            id: "ep-1",
+            itemType: "episode",
+            title: "Episode One",
+            podcastTitle: "My Podcast",
+            duration: 3600,
+        },
+    ];
+    const mounted = await mountQueueTab({ queue, currentIndex: 0 });
+
+    const episodeRow = mounted.container.querySelector(
+        '[data-queue-index="1"]',
+    );
+    assert.ok(episodeRow);
+    assert.ok(episodeRow.textContent?.includes("Episode One"));
+    assert.ok(episodeRow.textContent?.includes("My Podcast"));
+    assert.ok(
+        episodeRow.querySelector('button[title="Play this episode now"]'),
+    );
+    await unmount(mounted);
+});

--- a/frontend/tests/e2e/predeploy/playback.spec.ts
+++ b/frontend/tests/e2e/predeploy/playback.spec.ts
@@ -71,10 +71,9 @@ test.describe("Playback", () => {
         });
 
         await upNextTab.click();
-        await expect(page.locator('[data-queue-index="0"]')).toBeVisible({
-            timeout: 10000,
-        });
 
+        // The queue list is windowed (GH #787): only rows near the centered
+        // playing row are mounted, so the playing row is the render sentinel.
         const currentQueueRow = page
             .locator("[data-queue-index]")
             .filter({ has: page.locator('button[title="Now playing"]') })
@@ -83,16 +82,19 @@ test.describe("Playback", () => {
 
         await lyricsTab.click();
         await upNextTab.click();
+        await expect(currentQueueRow).toBeVisible({ timeout: 10000 });
 
         const queueSize = await page.locator("[data-queue-index]").count();
         test.skip(
             queueSize <= 8,
-            `Need at least 9 queue rows to validate centering, found ${queueSize}`,
+            `Need at least 9 mounted queue rows to validate centering, found ${queueSize}`,
         );
 
         const getQueueAlignment = async () =>
             currentQueueRow.evaluate((row) => {
-                const container = row.parentElement as HTMLElement | null;
+                const container = row.closest<HTMLElement>(
+                    '[data-testid="virtuoso-scroller"]',
+                );
                 if (!container) return null;
 
                 const rowRect = row.getBoundingClientRect();

--- a/frontend/tests/unit/overlayQueueCentering.test.ts
+++ b/frontend/tests/unit/overlayQueueCentering.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    resolveQueueCenteringBehavior,
+    resolveQueueCenteringIndex,
+} from "../../lib/overlay-queue-centering";
+
+test("an empty queue never centers", () => {
+    assert.equal(
+        resolveQueueCenteringBehavior({
+            isFirstReveal: true,
+            indexChanged: false,
+            shouldReduceMotion: false,
+            queueLength: 0,
+        }),
+        null,
+    );
+});
+
+test("the first reveal jumps without animation", () => {
+    assert.equal(
+        resolveQueueCenteringBehavior({
+            isFirstReveal: true,
+            indexChanged: false,
+            shouldReduceMotion: false,
+            queueLength: 12,
+        }),
+        "auto",
+    );
+});
+
+test("a track change while visible glides smoothly", () => {
+    assert.equal(
+        resolveQueueCenteringBehavior({
+            isFirstReveal: false,
+            indexChanged: true,
+            shouldReduceMotion: false,
+            queueLength: 12,
+        }),
+        "smooth",
+    );
+});
+
+test("reduced motion turns track-change glides into jumps", () => {
+    assert.equal(
+        resolveQueueCenteringBehavior({
+            isFirstReveal: false,
+            indexChanged: true,
+            shouldReduceMotion: true,
+            queueLength: 12,
+        }),
+        "auto",
+    );
+});
+
+test("no reveal and no index change leaves the list alone", () => {
+    assert.equal(
+        resolveQueueCenteringBehavior({
+            isFirstReveal: false,
+            indexChanged: false,
+            shouldReduceMotion: false,
+            queueLength: 12,
+        }),
+        null,
+    );
+});
+
+test("centering targets the playing row and falls back to the top", () => {
+    assert.equal(resolveQueueCenteringIndex(5, 12), 5);
+    assert.equal(resolveQueueCenteringIndex(-1, 12), 0);
+    assert.equal(resolveQueueCenteringIndex(12, 12), 0);
+});

--- a/frontend/tests/unit/overlayRelatedMatching.test.ts
+++ b/frontend/tests/unit/overlayRelatedMatching.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    buildStreamMatchQuery,
+    getRelatedTrackKey,
+    partitionTidalBatchMatches,
+    selectTracksNeedingStreamMatch,
+    sortRelatedTracksByRelevance,
+} from "../../lib/overlay-related-matching";
+
+test("library rows key on id; external rows on normalized artist and title", () => {
+    assert.equal(getRelatedTrackKey({ id: "t1", title: "Song" }), "lib:t1");
+    assert.equal(
+        getRelatedTrackKey({ title: "  Song  ", artist: " The Band " }),
+        "ext:the band::song",
+    );
+    assert.equal(
+        getRelatedTrackKey({
+            title: "Song",
+            album: { artist: { name: "Album Artist" } },
+        }),
+        "ext:album artist::song",
+    );
+    assert.equal(getRelatedTrackKey({ title: "" }), "ext:unknown::unknown");
+});
+
+test("relevance sorting puts library rows first, then confidence and similarity", () => {
+    const sorted = sortRelatedTracksByRelevance([
+        { title: "external-strong", similarity: 0.9, matchConfidence: 50 },
+        { title: "library", inLibrary: true },
+        { title: "external-weak", similarity: 0.1 },
+    ]);
+    assert.deepEqual(
+        sorted.map((t) => t.title),
+        ["library", "external-strong", "external-weak"],
+    );
+});
+
+test("relevance sorting ignores non-finite scores and does not mutate input", () => {
+    const input = [
+        { title: "nan", similarity: Number.NaN, matchConfidence: Number.NaN },
+        { title: "scored", similarity: 0.5 },
+    ];
+    const sorted = sortRelatedTracksByRelevance(input);
+    assert.deepEqual(
+        sorted.map((t) => t.title),
+        ["scored", "nan"],
+    );
+    assert.equal(input[0].title, "nan");
+});
+
+test("stream matching skips library rows, unidentified rows, and matched rows", () => {
+    const tracks = [
+        { title: "in-library", inLibrary: true },
+        { title: "", artist: "A" },
+        { title: "no-artist" },
+        { title: "already-matched", artist: "A" },
+        { title: "needs-match", artist: "B" },
+    ];
+    const missing = selectTracksNeedingStreamMatch(tracks, {
+        "ext:a::already-matched": { streamSource: "tidal" },
+    });
+    assert.deepEqual(
+        missing.map((t) => t.title),
+        ["needs-match"],
+    );
+});
+
+test("stream-match queries prefer the row artist and carry album context", () => {
+    assert.deepEqual(
+        buildStreamMatchQuery({
+            title: "Song",
+            artist: "Row Artist",
+            duration: 200,
+            album: { title: "Album", artist: { name: "Album Artist" } },
+        }),
+        {
+            artist: "Row Artist",
+            title: "Song",
+            albumTitle: "Album",
+            duration: 200,
+        },
+    );
+    assert.equal(
+        buildStreamMatchQuery({
+            title: "Song",
+            album: { artist: { name: "Album Artist" } },
+        }).artist,
+        "Album Artist",
+    );
+});
+
+test("tidal batch partition records hits and queues misses for youtube", () => {
+    const missing = [
+        { title: "hit", artist: "A" },
+        { title: "miss", artist: "B", duration: 90 },
+        { title: "null-slot", artist: "C" },
+    ];
+    const { foundMatches, youtubePayload, youtubeTrackKeys } =
+        partitionTidalBatchMatches(missing, [
+            { id: 42, title: "hit", artist: "A", duration: 180 },
+            null,
+        ]);
+
+    assert.deepEqual(foundMatches, {
+        "ext:a::hit": {
+            streamSource: "tidal",
+            tidalTrackId: 42,
+            title: "hit",
+            artist: "A",
+            duration: 180,
+        },
+    });
+    assert.deepEqual(
+        youtubePayload.map((q) => q.title),
+        ["miss", "null-slot"],
+    );
+    assert.deepEqual(youtubeTrackKeys, ["ext:b::miss", "ext:c::null-slot"]);
+});

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -68,7 +68,7 @@ const BASELINE = Object.freeze({
     "frontend/app/playlist/[id]/page.tsx": 1506,
     "frontend/app/vibe/page.tsx": 1524,
     "frontend/components/player/AudioPlaybackOrchestrator.tsx": 1595,
-    "frontend/components/player/OverlayPlayer.tsx": 2719,
+    "frontend/components/player/OverlayPlayer.tsx": 1352,
     "frontend/hooks/useQueries.ts": 1453,
     "frontend/lib/audio-controls-context.tsx": 2305,
     "frontend/lib/listen-together-context.tsx": 2063,


### PR DESCRIPTION
Part of #787 (slice B of the OverlayPlayer decomposition; slice A was #832).

## What changed

- The three drawer tabs (Up Next / Lyrics / Related) are now memoized components under `components/player/overlay-tabs/`, each owning its own data fetching and mounting only while visible. The parent no longer re-renders tab content on every playback tick, and the related-tab queries no longer live in the player shell.
- The Up Next list is windowed with react-virtuoso: only the rows in view mount, so library-sized queues (hundreds to thousands of rows) open and scroll smoothly. Centering on the playing row now uses `initialTopMostItemIndex` on reveal and `scrollToIndex` on track change — replacing the requestAnimationFrame retry ladder and its 240 ms settle timer.
- Decision logic moved to pure, unit-tested modules:
  - `lib/overlay-queue-centering.ts` — when a centering pass runs and with which scroll behavior (reveal jumps, track changes glide, reduced motion pins).
  - `lib/overlay-related-matching.ts` — related-row identity, relevance ordering, and the TIDAL-first/YouTube-fallback batch partition.
- Stream matches for related tracks now persist across tab switches in a bounded (200-entry) cache, so re-entering the Related tab doesn't re-call the match sidecars for rows it already resolved. Previously the parent held this state for the session; now it survives track changes too.
- `OverlayPlayer.tsx`: 2719 → 1352 lines; file-size baseline tightened accordingly.

## Behavior notes

- Queue rows keep their exact markup (`data-queue-index`, "Now playing"/"Played" pills, quality badges, remove controls) — the e2e centering spec was updated only where the windowed DOM changed its measurement container (Virtuoso scroller instead of `row.parentElement`) and its render sentinel (the playing row instead of row 0, which may legitimately be unmounted in a windowed list).
- Lyrics/Related fetch gating is unchanged: the tabs mount only when their panel is visible, which is the same condition the old `enabled:` flags encoded.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 182 warnings, exactly at the cap (no new warnings)
- `npm run format:check` — clean; `check-file-size.mjs` — passes with tightened baseline
- `npm run test:unit` — 1054/1054 (includes 12 new policy tests)
- `npm run test:component` — 736/736 (includes 6 new OverlayQueueTab tests: windowing, empty state, playing-row rules, action dispatch, episode rows)

Slice C (listen-together provider decomposition) follows separately.
