### PR TITLE
fix(tidal-streamer): resolve ALBUMARTIST from the album, not the per-track lead artist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TIDAL downloads now tag ALBUMARTIST with the album artist instead of the per-track artist, preventing multi-artist album tracks from splitting into phantom single-track albums.
 - Album downloads that select Soulseek, including TIDAL or YouTube Music runtime fallbacks and the default setting, now download through Soulseek instead of silently using Lidarr (#788).
 - Playing music no longer re-renders large parts of the app once per second: pages and controls now subscribe only to the playback details they actually show, and dragging the volume slider updates just the volume controls instead of rippling through every open page (#785).
 - Queued album downloads waiting on the deployment-wide claim now return to Bull with a delay instead of occupying an active worker slot for up to four hours.

--- a/services/tidal-streamer/tests/test_album_artist_tag.py
+++ b/services/tidal-streamer/tests/test_album_artist_tag.py
@@ -1,0 +1,81 @@
+"""Behavioral coverage for TIDAL ALBUMARTIST metadata resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def test_album_primary_artist_wins_over_track_lead_artist() -> None:
+    import tidal_downloads
+
+    album = SimpleNamespace(artist=SimpleNamespace(name="Drake"), artists=[])
+    track = SimpleNamespace(artists=[SimpleNamespace(name="Future")])
+
+    assert tidal_downloads._resolve_album_artist(album, track) == "Drake"
+
+
+def test_album_artists_fallback_is_used_without_primary_artist() -> None:
+    import tidal_downloads
+
+    album = SimpleNamespace(
+        artist=None,
+        artists=[SimpleNamespace(name="Drake")],
+    )
+    track = SimpleNamespace(artists=[SimpleNamespace(name="Future")])
+
+    assert tidal_downloads._resolve_album_artist(album, track) == "Drake"
+
+
+def test_track_lead_artist_is_used_without_album_artists() -> None:
+    import tidal_downloads
+
+    album = SimpleNamespace(artist=None, artists=[])
+    track = SimpleNamespace(artists=[SimpleNamespace(name="Future")])
+
+    assert tidal_downloads._resolve_album_artist(album, track) == "Future"
+
+
+def test_empty_artist_shapes_resolve_to_empty_string() -> None:
+    import tidal_downloads
+
+    album = SimpleNamespace(artist=None, artists=[])
+    track = SimpleNamespace(artists=[])
+
+    assert tidal_downloads._resolve_album_artist(album, track) == ""
+
+
+def test_missing_album_artist_attributes_fall_through_without_error() -> None:
+    import tidal_downloads
+
+    album = SimpleNamespace()
+    track = SimpleNamespace(artists=[SimpleNamespace(name="Future")])
+
+    assert tidal_downloads._resolve_album_artist(album, track) == "Future"
+
+
+def test_metadata_embed_uses_album_artist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tidal_downloads
+
+    captured: dict[str, Any] = {}
+
+    def capture_metadata(**metadata: Any) -> None:
+        captured.update(metadata)
+
+    monkeypatch.setattr(tidal_downloads, "add_track_metadata", capture_metadata)
+    album = SimpleNamespace(
+        artist=SimpleNamespace(name="Drake"),
+        artists=[SimpleNamespace(name="Drake")],
+        releaseDate=None,
+    )
+    track = SimpleNamespace(artists=[SimpleNamespace(name="Future")])
+
+    tidal_downloads._embed_download_metadata(tmp_path / "D4L.flac", track, album, 9, None)
+
+    assert captured["album_artist"] == "Drake"

--- a/services/tidal-streamer/tidal_downloads.py
+++ b/services/tidal-streamer/tidal_downloads.py
@@ -405,6 +405,20 @@ def _fetch_download_cover(album: Any, track_id: int) -> tuple[bool, bytes | None
         return False, None
 
 
+def _resolve_album_artist(album: Any, track: Any) -> str:
+    """Album-level artist for the ALBUMARTIST tag; every track in one album must get the same value."""
+    artist_name = getattr(getattr(album, "artist", None), "name", "")
+    if isinstance(artist_name, str) and artist_name:
+        return artist_name
+    album_artists = getattr(album, "artists", None) or []
+    artist_name = getattr(album_artists[0], "name", "") if album_artists else ""
+    if isinstance(artist_name, str) and artist_name:
+        return artist_name
+    track_artists = getattr(track, "artists", None) or []
+    artist_name = getattr(track_artists[0], "name", "") if track_artists else ""
+    return artist_name if isinstance(artist_name, str) else ""
+
+
 def _embed_download_metadata(
     path: Path,
     track: Any,
@@ -417,7 +431,7 @@ def _embed_download_metadata(
         add_track_metadata(
             path=path,
             track=track,
-            album_artist=track.artists[0].name if track.artists else "",
+            album_artist=_resolve_album_artist(album, track),
             date=str(album.releaseDate.date()) if album.releaseDate else "",
             cover_data=cover_data,
             comment=f"tidal:{track_id}",


### PR DESCRIPTION
## Problem

TIDAL downloads tagged each file's ALBUMARTIST with the **track's** first artist. On multi-artist albums, tracks whose lead credit differs from their siblings got a different ALBUMARTIST than the rest of the folder. The scanner (correctly) groups albums by ALBUMARTIST, so those tracks split into phantom single-track albums under the wrong artist — this is how "Future" showed up in Recently Added with two one-song copies of Drake albums.

Production example: `Drake/Dark Lane Demo Tapes/1-09 D4L.flac` carried `album_artist=Future` (`ARTIST=Drake;Future;Young Thug`) while its siblings carried `album_artist=Drake`.

## Fix

`_resolve_album_artist(album, track)` in `tidal_downloads.py`: album's primary artist first (`album.artist.name`), then `album.artists[0].name`, then the track's lead artist as a last resort, then empty string. Pure guard-clause helper; `_embed_download_metadata` now uses it. Every track downloaded from one album gets the same ALBUMARTIST.

## Tests

Six behavioral tests in `tests/test_album_artist_tag.py`, TDD (failed pre-implementation): the D4L regression case, each fallback tier, attribute-missing shapes, and an embed-level assertion that the album artist reaches `add_track_metadata`.

## Verification

- verify: focused suite 6 passed; full tidal-streamer suite 186 passed, 1 failed — the failure is `test_tiddl_contract.py` and pre-exists on a clean tree (local Python 3.13.14 renders tiddl's annotation as `pathlib._local.Path`; CI's interpreter passes it)
- verify: ruff check + format clean; mypy `Success: no issues found in 24 source files`
- verify: prettier (CHANGELOG) clean; file-size gate passed

Closes #827