### PR TITLE
chore(tidal-streamer): tolerate private pathlib module paths in the tiddl contract test

### DIFF
--- a/services/tidal-streamer/tests/test_tiddl_contract.py
+++ b/services/tidal-streamer/tests/test_tiddl_contract.py
@@ -11,12 +11,17 @@ import pytest
 TIDDL_CONTRACT_PROBE = """
 import inspect
 import json
+import re
 from importlib import import_module
+
+
+def public_module_name(module_name):
+    return re.sub(r"(?:[.]_[^.]+)+$", "", module_name)
 
 
 def annotation_name(annotation):
     if isinstance(annotation, type):
-        return f"{annotation.__module__}.{annotation.__qualname__}"
+        return f"{public_module_name(annotation.__module__)}.{annotation.__qualname__}"
     return str(annotation)
 
 


### PR DESCRIPTION
## Problem

`test_tiddl_contract.py::test_real_tiddl_download_utility_contract` fails on Python 3.13.14+ (and 3.14): `pathlib.Path.__module__` now resolves to `pathlib._local`, so the probe rendered `pathlib._local.Path` and the pinned `pathlib.Path` fixtures mismatched. CI's interpreter predates the move, so this only bites local runs on newer patch versions.

## Fix

`public_module_name()` strips trailing private (`._x`) module segments before rendering a type annotation, comparing public module identity instead of the private implementation path. Fixtures unchanged; non-type annotations unaffected. Test-only change, no CHANGELOG entry.

## Verification

- verify: targeted test pre-fix exit 1 (`1 failed`, actual `pathlib._local.Path`), post-fix exit 0 (`1 passed`)
- verify: ruff check + format clean; `git diff --check` clean
- Full sidecar suite can't run in the local sandbox (asyncio thread wakeups blocked — an isolated `asyncio.to_thread` also times out); CI is the arbiter for the suite.