### PR TITLE
fix(downloads): artist expansion queues only official albums the artist headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TIDAL downloads now tag ALBUMARTIST with the album artist instead of the per-track artist, preventing multi-artist album tracks from splitting into phantom single-track albums.
+- Artist "Download all missing albums" now skips promotion-, bootleg-, or pseudo-release-only groups, remix/live/demo/compilation groups, and releases where the artist is only a featured credit; MusicBrainz enumeration failures now fail the expansion instead of reporting no missing albums (#824).
 - Album downloads that select Soulseek, including TIDAL or YouTube Music runtime fallbacks and the default setting, now download through Soulseek instead of silently using Lidarr (#788).
 - Playing music no longer re-renders large parts of the app once per second: pages and controls now subscribe only to the playback details they actually show, and dragging the volume slider updates just the volume controls instead of rippling through every open page (#785).
 - Queued album downloads waiting on the deployment-wide claim now return to Bull with a delay instead of occupying an active worker slot for up to four hours.

--- a/backend/src/services/__tests__/musicbrainzService.test.ts
+++ b/backend/src/services/__tests__/musicbrainzService.test.ts
@@ -341,11 +341,114 @@ describe("musicBrainzService", () => {
         );
     });
 
+    it("browses official release groups with artist credits under a versioned cache key", async () => {
+        const releaseGroups = [
+            {
+                id: "rg-credits",
+                title: "Credited Album",
+                "artist-credit": [
+                    { artist: { id: VALID_ARTIST_MBID, name: "Artist" } },
+                ],
+            },
+        ];
+        mockHttpGet.mockResolvedValueOnce({
+            data: { "release-groups": releaseGroups },
+        });
+
+        const result = await musicBrainzService.getReleaseGroupsWithCredits(
+            VALID_ARTIST_MBID,
+            ["album", "ep"],
+            25,
+        );
+
+        expect(result).toEqual(releaseGroups);
+        expect(mockRedisGet).toHaveBeenCalledWith(
+            `mb:rg:credits2:${VALID_ARTIST_MBID}:album,ep:25`,
+        );
+        expect(mockHttpGet).toHaveBeenCalledWith("/release-group", {
+            params: {
+                artist: VALID_ARTIST_MBID,
+                type: "album|ep",
+                limit: 25,
+                inc: "artist-credits",
+                "release-group-status": "website-default",
+                fmt: "json",
+            },
+        });
+        expect(mockRedisSetEx).toHaveBeenCalledWith(
+            `mb:rg:credits2:${VALID_ARTIST_MBID}:album,ep:25`,
+            2592000,
+            JSON.stringify(releaseGroups),
+        );
+    });
+
+    it("propagates release-group browse failures without caching an empty discography", async () => {
+        const error = new Error("MusicBrainz unavailable");
+        mockRateLimiterExecute.mockRejectedValueOnce(error);
+
+        await expect(
+            musicBrainzService.getReleaseGroupsWithCredits(
+                VALID_ARTIST_MBID,
+                ["album", "ep"],
+                100,
+            ),
+        ).rejects.toBe(error);
+
+        expect(mockRedisSetEx).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-array release-groups payload", async () => {
+        mockHttpGet.mockResolvedValueOnce({
+            data: { "release-groups": { id: "not-an-array" } },
+        });
+
+        await expect(
+            musicBrainzService.getReleaseGroupsWithCredits(VALID_ARTIST_MBID),
+        ).rejects.toThrow("Invalid MusicBrainz release-groups response");
+
+        expect(mockRedisSetEx).not.toHaveBeenCalled();
+    });
+
+    it("drops release-group entries missing string ids or titles", async () => {
+        const validReleaseGroup = {
+            id: "rg-valid",
+            title: "Valid Album",
+            "primary-type": "Album",
+        };
+        mockHttpGet.mockResolvedValueOnce({
+            data: {
+                "release-groups": [
+                    validReleaseGroup,
+                    { title: "Missing ID" },
+                    { id: "rg-missing-title" },
+                ],
+            },
+        });
+
+        const result =
+            await musicBrainzService.getReleaseGroupsWithCredits(
+                VALID_ARTIST_MBID,
+            );
+
+        expect(result).toEqual([validReleaseGroup]);
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            "MusicBrainz release-group response dropped malformed entries",
+            { droppedCount: 2 },
+        );
+    });
+
     it.each([
         ["artist", () => musicBrainzService.getArtist("../artist")],
         [
             "artist browse",
             () => musicBrainzService.getReleaseGroups("artist?limit=100"),
+        ],
+        [
+            "artist browse with credits",
+            () =>
+                musicBrainzService.getReleaseGroupsWithCredits(
+                    "artist?limit=100",
+                ),
         ],
         [
             "release group",

--- a/backend/src/services/musicbrainz.ts
+++ b/backend/src/services/musicbrainz.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/stringNormalization";
 import { BRAND_USER_AGENT } from "../config/brand";
 import { isValidMbid } from "../utils/musicIds";
+import { isPlainObject } from "../utils/plainObject";
 
 export { isValidMbid } from "../utils/musicIds";
 
@@ -26,7 +27,7 @@ export interface MusicBrainzArtistSearchResult {
 /** Artist-credit fields returned with a MusicBrainz release group. */
 export interface MusicBrainzArtistCredit {
     name?: string;
-    artist?: { name?: string };
+    artist?: { id?: string; name?: string };
 }
 
 /** Release-group fields returned by MusicBrainz search. */
@@ -38,6 +39,33 @@ export interface MusicBrainzReleaseGroupSearchResult {
     "first-release-date"?: string;
     "artist-credit"?: MusicBrainzArtistCredit[];
     score?: number | string;
+}
+
+function hasReleaseGroupIdentity(
+    value: unknown,
+): value is MusicBrainzReleaseGroupSearchResult {
+    return (
+        isPlainObject(value) &&
+        typeof value.id === "string" &&
+        typeof value.title === "string"
+    );
+}
+
+function parseReleaseGroupsWithCredits(
+    value: unknown,
+): MusicBrainzReleaseGroupSearchResult[] {
+    if (!Array.isArray(value)) {
+        throw new TypeError("Invalid MusicBrainz release-groups response");
+    }
+    const releaseGroups = value.filter(hasReleaseGroupIdentity);
+    const droppedCount = value.length - releaseGroups.length;
+    if (droppedCount > 0) {
+        logger.warn(
+            "MusicBrainz release-group response dropped malformed entries",
+            { droppedCount },
+        );
+    }
+    return releaseGroups;
 }
 
 function validateMbid(value: unknown, entity: MbidEntity): string {
@@ -220,6 +248,42 @@ class MusicBrainzService {
             2592000,
             [],
         );
+    }
+
+    /**
+     * Browse an artist's release groups with artist-credit data included.
+     * Uses a dedicated cache namespace so credit-less browse results cannot
+     * satisfy callers that require credit eligibility checks.
+     */
+    async getReleaseGroupsWithCredits(
+        artistMbid: string,
+        types: string[] = ["album", "ep"],
+        limit = 100,
+    ): Promise<MusicBrainzReleaseGroupSearchResult[]> {
+        const validatedArtistMbid = validateMbid(artistMbid, "artist");
+        const cacheKey = `mb:rg:credits2:${validatedArtistMbid}:${types.join(",")}:${limit}`;
+
+        const releaseGroups = await this.cachedRequest<unknown>(
+            cacheKey,
+            async () => {
+                const response = await this.client.get("/release-group", {
+                    params: {
+                        artist: validatedArtistMbid,
+                        type: types.join("|"),
+                        limit,
+                        inc: "artist-credits",
+                        "release-group-status": "website-default",
+                        fmt: "json",
+                    },
+                });
+                const payload = isPlainObject(response.data)
+                    ? response.data["release-groups"]
+                    : undefined;
+                return parseReleaseGroupsWithCredits(payload);
+            },
+            2592000,
+        );
+        return parseReleaseGroupsWithCredits(releaseGroups);
     }
 
     async getReleaseGroup(rgMbid: string) {

--- a/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
+++ b/backend/src/workers/processors/__tests__/artistDownloadExpansionProcessor.test.ts
@@ -4,8 +4,10 @@ const mockAlbumFindFirst = jest.fn();
 const mockTransaction = jest.fn();
 const mockGetArtist = jest.fn();
 const mockGetReleaseGroups = jest.fn();
+const mockGetReleaseGroupsWithCredits = jest.fn();
 const mockGetArtistCorrection = jest.fn();
 const mockEnqueueAlbumDownloadInBackground = jest.fn();
+const mockLogInfo = jest.fn();
 
 jest.mock("../../../utils/db", () => ({
     prisma: {
@@ -25,6 +27,8 @@ jest.mock("../../../services/musicbrainz", () => ({
     musicBrainzService: {
         getArtist: (...args: unknown[]) => mockGetArtist(...args),
         getReleaseGroups: (...args: unknown[]) => mockGetReleaseGroups(...args),
+        getReleaseGroupsWithCredits: (...args: unknown[]) =>
+            mockGetReleaseGroupsWithCredits(...args),
     },
 }));
 
@@ -44,7 +48,7 @@ jest.mock("../../../utils/logger", () => ({
     logger: {
         child: () => ({
             debug: jest.fn(),
-            info: jest.fn(),
+            info: (...args: unknown[]) => mockLogInfo(...args),
             warn: jest.fn(),
             error: jest.fn(),
         }),
@@ -61,6 +65,16 @@ const payload = {
     rootFolderPath: "/music",
     userId: "user-1",
 } as const;
+
+function eligibleReleaseGroup(id: string, title: string) {
+    return {
+        id,
+        title,
+        "primary-type": "Album",
+        "secondary-types": [],
+        "artist-credit": [{ artist: { id: payload.artistMbid } }],
+    };
+}
 
 function createJob() {
     return {
@@ -98,18 +112,38 @@ describe("artist download expansion processor", () => {
         mockDownloadJobUpdate.mockResolvedValue({});
         mockGetArtist.mockResolvedValue({ name: "Canonical Artist" });
         mockGetReleaseGroups.mockResolvedValue([]);
+        mockGetReleaseGroupsWithCredits.mockResolvedValue([]);
         mockGetArtistCorrection.mockResolvedValue(null);
         mockAlbumFindFirst.mockResolvedValue(null);
         mockEnqueueAlbumDownloadInBackground.mockReturnValue(undefined);
     });
 
     it("skips local albums, keeps remote catalog albums, and records expansion counts", async () => {
-        mockGetReleaseGroups.mockResolvedValue([
-            { id: "rg-local", title: "Local Album" },
-            { id: "rg-remote", title: "Remote Album" },
-            { id: "rg-queued", title: "Queued Album" },
-            { id: "rg-recent", title: "Recent Failure" },
-            { id: "rg-new", title: "New Album" },
+        mockGetReleaseGroupsWithCredits.mockResolvedValue([
+            eligibleReleaseGroup("rg-local", "Local Album"),
+            eligibleReleaseGroup("rg-remote", "Remote Album"),
+            eligibleReleaseGroup("rg-queued", "Queued Album"),
+            eligibleReleaseGroup("rg-recent", "Recent Failure"),
+            eligibleReleaseGroup("rg-new", "New Album"),
+            {
+                ...eligibleReleaseGroup("rg-single", "Featured Single"),
+                "primary-type": "Single",
+            },
+            {
+                ...eligibleReleaseGroup("rg-live", "Live Album"),
+                "secondary-types": ["Live"],
+            },
+            {
+                ...eligibleReleaseGroup("rg-featured", "I'm on One"),
+                "artist-credit": [
+                    { artist: { id: "artist-dj-khaled" } },
+                    { artist: { id: payload.artistMbid } },
+                ],
+            },
+            {
+                ...eligibleReleaseGroup("rg-no-credits", "Unknown Credits"),
+                "artist-credit": undefined,
+            },
         ]);
         mockAlbumFindFirst.mockImplementation(({ where }) => {
             expect(where.location).toBe("LIBRARY");
@@ -130,11 +164,12 @@ describe("artist download expansion processor", () => {
         const job = createJob();
         await processArtistDownloadExpansion(job);
 
-        expect(mockGetReleaseGroups).toHaveBeenCalledWith(
+        expect(mockGetReleaseGroupsWithCredits).toHaveBeenCalledWith(
             "artist-mbid-1",
             ["album", "ep"],
             100,
         );
+        expect(mockGetReleaseGroups).not.toHaveBeenCalled();
         expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledTimes(2);
         expect(mockEnqueueAlbumDownloadInBackground).toHaveBeenCalledWith({
             jobId: "job-remote",
@@ -166,17 +201,43 @@ describe("artist download expansion processor", () => {
                     skippedInLibrary: 1,
                     skippedQueued: 1,
                     skippedRecentlyFailed: 1,
+                    skippedIneligible: 4,
+                    filteredReasons: {
+                        wrong_primary_type: 1,
+                        secondary_type: 1,
+                        not_primary_credit: 1,
+                        missing_credits: 1,
+                    },
                     statusText: "Queued 2 albums",
                 },
             },
         });
         expect(job.progress).toHaveBeenNthCalledWith(1, 0);
         expect(job.progress).toHaveBeenNthCalledWith(2, 100);
+        expect(mockLogInfo).toHaveBeenCalledTimes(1);
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            "Artist expansion eligibility summarized",
+            {
+                artistMbid: "artist-mbid-1",
+                total: 9,
+                albumCount: 2,
+                skippedInLibrary: 1,
+                skippedQueued: 1,
+                skippedRecentlyFailed: 1,
+                skippedIneligible: 4,
+                filteredReasons: {
+                    wrong_primary_type: 1,
+                    secondary_type: 1,
+                    not_primary_credit: 1,
+                    missing_credits: 1,
+                },
+            },
+        );
     });
 
     it("persists batch metadata on each created album job", async () => {
-        mockGetReleaseGroups.mockResolvedValue([
-            { id: "rg-new", title: "New Album" },
+        mockGetReleaseGroupsWithCredits.mockResolvedValue([
+            eligibleReleaseGroup("rg-new", "New Album"),
         ]);
         const create = jest.fn().mockResolvedValue({ id: "job-new" });
         mockTransaction.mockImplementationOnce(async (operation: any) =>
@@ -207,7 +268,7 @@ describe("artist download expansion processor", () => {
 
     it("marks the artist row failed when discography enumeration fails", async () => {
         const error = new Error("MusicBrainz unavailable");
-        mockGetReleaseGroups.mockRejectedValueOnce(error);
+        mockGetReleaseGroupsWithCredits.mockRejectedValueOnce(error);
 
         await expect(processArtistDownloadExpansion(createJob())).rejects.toBe(
             error,
@@ -244,6 +305,8 @@ describe("artist download expansion processor", () => {
                     skippedInLibrary: 0,
                     skippedQueued: 0,
                     skippedRecentlyFailed: 0,
+                    skippedIneligible: 0,
+                    filteredReasons: {},
                     statusText: "No missing albums to download",
                 },
             },
@@ -255,8 +318,8 @@ describe("artist download expansion processor", () => {
         mockGetArtistCorrection.mockResolvedValueOnce({
             canonicalName: "Corrected Artist",
         });
-        mockGetReleaseGroups.mockResolvedValue([
-            { id: "rg-new", title: "Album" },
+        mockGetReleaseGroupsWithCredits.mockResolvedValue([
+            eligibleReleaseGroup("rg-new", "Album"),
         ]);
         mockTransaction.mockImplementationOnce(
             transactionResult([], [], "job-new"),

--- a/backend/src/workers/processors/__tests__/artistExpansionEligibility.test.ts
+++ b/backend/src/workers/processors/__tests__/artistExpansionEligibility.test.ts
@@ -1,0 +1,119 @@
+import { classifyReleaseGroup } from "../artistExpansionEligibility";
+
+const REQUESTED_ARTIST_MBID = "artist-drake";
+
+function releaseGroup(overrides: Record<string, unknown> = {}): unknown {
+    return {
+        id: "release-group-1",
+        title: "Official Release",
+        "primary-type": "Album",
+        "secondary-types": [],
+        "artist-credit": [
+            { artist: { id: REQUESTED_ARTIST_MBID, name: "Drake" } },
+        ],
+        ...overrides,
+    };
+}
+
+describe("artist expansion release-group eligibility", () => {
+    it.each(["Album", "EP"])(
+        "accepts an official %s with the requested artist first",
+        (primaryType) => {
+            expect(
+                classifyReleaseGroup(
+                    releaseGroup({ "primary-type": primaryType }),
+                    REQUESTED_ARTIST_MBID,
+                ),
+            ).toEqual({ eligible: true });
+        },
+    );
+
+    it.each(["Mixtape/Street", "Remix", "Live", "Compilation"])(
+        "rejects the %s secondary type",
+        (secondaryType) => {
+            expect(
+                classifyReleaseGroup(
+                    releaseGroup({ "secondary-types": [secondaryType] }),
+                    REQUESTED_ARTIST_MBID,
+                ),
+            ).toEqual({ eligible: false, reason: "secondary_type" });
+        },
+    );
+
+    it("rejects a Single even when MusicBrainz returns it", () => {
+        expect(
+            classifyReleaseGroup(
+                releaseGroup({ "primary-type": "Single" }),
+                REQUESTED_ARTIST_MBID,
+            ),
+        ).toEqual({ eligible: false, reason: "wrong_primary_type" });
+    });
+
+    it("rejects a release where the requested artist is not the first credit", () => {
+        expect(
+            classifyReleaseGroup(
+                releaseGroup({
+                    title: "I'm on One",
+                    "artist-credit": [
+                        { artist: { id: "artist-dj-khaled" } },
+                        { artist: { id: REQUESTED_ARTIST_MBID } },
+                    ],
+                }),
+                REQUESTED_ARTIST_MBID,
+            ),
+        ).toEqual({ eligible: false, reason: "not_primary_credit" });
+    });
+
+    it("accepts a release where the requested artist is first with features after", () => {
+        expect(
+            classifyReleaseGroup(
+                releaseGroup({
+                    "artist-credit": [
+                        { artist: { id: REQUESTED_ARTIST_MBID } },
+                        { artist: { id: "featured-artist" } },
+                    ],
+                }),
+                REQUESTED_ARTIST_MBID,
+            ),
+        ).toEqual({ eligible: true });
+    });
+
+    it("matches artist MBIDs without case sensitivity", () => {
+        const result = classifyReleaseGroup(
+            releaseGroup(),
+            REQUESTED_ARTIST_MBID.toUpperCase(),
+        );
+
+        expect(result).toEqual({ eligible: true });
+    });
+
+    it.each([
+        ["missing artist-credit", undefined],
+        ["non-array artist-credit", "Drake"],
+        ["missing first artist id", [{ artist: { name: "Drake" } }]],
+    ])("rejects %s as missing credit data", (_name, artistCredit) => {
+        expect(
+            classifyReleaseGroup(
+                releaseGroup({ "artist-credit": artistCredit }),
+                REQUESTED_ARTIST_MBID,
+            ),
+        ).toEqual({ eligible: false, reason: "missing_credits" });
+    });
+
+    it.each([
+        ["non-array secondary types", { "secondary-types": "Live" }],
+        ["non-string secondary type", { "secondary-types": [42] }],
+        ["non-object payload", null],
+    ])("fails closed without throwing for %s", (_name, malformed) => {
+        const result = classifyReleaseGroup(
+            malformed === null ? null : releaseGroup(malformed),
+            REQUESTED_ARTIST_MBID,
+        );
+
+        expect(result).toEqual(
+            malformed === null
+                ? { eligible: false, reason: "wrong_primary_type" }
+                : { eligible: false, reason: "secondary_type" },
+        );
+    });
+});

--- a/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
+++ b/backend/src/workers/processors/artistDownloadExpansionProcessor.ts
@@ -9,6 +9,10 @@ import { musicBrainzService } from "../../services/musicbrainz";
 import { prisma } from "../../utils/db";
 import { logger } from "../../utils/logger";
 import { asPlainObject } from "../../utils/plainObject";
+import {
+    classifyReleaseGroup,
+    type ReleaseGroupEligibility,
+} from "./artistExpansionEligibility";
 
 const log = logger.child("ArtistDownloadExpansionProcessor");
 const payloadSchema = z
@@ -35,7 +39,18 @@ interface ExpansionCounts {
     skippedInLibrary: number;
     skippedQueued: number;
     skippedRecentlyFailed: number;
+    skippedIneligible: number;
 }
+
+interface ExpansionResult {
+    counts: ExpansionCounts;
+    filteredReasons: Record<string, number>;
+}
+
+type IneligibilityReason = Extract<
+    ReleaseGroupEligibility,
+    { eligible: false }
+>["reason"];
 
 interface ArtistAlbumJobInput {
     payload: ArtistExpansionPayload;
@@ -220,42 +235,79 @@ function enqueueCreatedAlbum(
     });
 }
 
+function createExpansionResult(): ExpansionResult {
+    return {
+        counts: {
+            albumCount: 0,
+            skippedInLibrary: 0,
+            skippedQueued: 0,
+            skippedRecentlyFailed: 0,
+            skippedIneligible: 0,
+        },
+        filteredReasons: {},
+    };
+}
+
+function recordIneligibleReleaseGroup(
+    expansion: ExpansionResult,
+    reason: IneligibilityReason,
+): void {
+    expansion.counts.skippedIneligible += 1;
+    expansion.filteredReasons[reason] =
+        (expansion.filteredReasons[reason] ?? 0) + 1;
+}
+
+function logExpansionSummary(
+    artistMbid: string,
+    total: number,
+    expansion: ExpansionResult,
+): void {
+    log.info("Artist expansion eligibility summarized", {
+        artistMbid,
+        total,
+        ...expansion.counts,
+        filteredReasons: expansion.filteredReasons,
+    });
+}
+
 async function expandReleaseGroups(
     payload: ArtistExpansionPayload,
     artistName: string,
     batchId: string,
-): Promise<ExpansionCounts> {
-    const releaseGroups = await musicBrainzService.getReleaseGroups(
+): Promise<ExpansionResult> {
+    const releaseGroups = await musicBrainzService.getReleaseGroupsWithCredits(
         payload.artistMbid,
         ["album", "ep"],
         MAX_RELEASE_GROUPS,
     );
-    const counts: ExpansionCounts = {
-        albumCount: 0,
-        skippedInLibrary: 0,
-        skippedQueued: 0,
-        skippedRecentlyFailed: 0,
-    };
-    for (
-        let index = 0;
-        index < releaseGroups.length && index < MAX_RELEASE_GROUPS;
-        index += 1
-    ) {
+    const expansion = createExpansionResult();
+    const total = Math.min(releaseGroups.length, MAX_RELEASE_GROUPS);
+    for (let index = 0; index < total; index += 1) {
         const releaseGroup = releaseGroups[index];
+        const eligibility = classifyReleaseGroup(
+            releaseGroup,
+            payload.artistMbid,
+        );
+        if (!eligibility.eligible) {
+            recordIneligibleReleaseGroup(expansion, eligibility.reason);
+            continue;
+        }
         const result = await processReleaseGroup(
             payload,
             artistName,
             batchId,
             releaseGroup,
         );
-        recordAlbumResult(result, counts);
+        recordAlbumResult(result, expansion.counts);
     }
-    return counts;
+    logExpansionSummary(payload.artistMbid, total, expansion);
+    return expansion;
 }
 
 async function completeExpansion(
     jobId: string,
     counts: ExpansionCounts,
+    filteredReasons: Record<string, number>,
 ): Promise<void> {
     const statusText =
         counts.albumCount === 0
@@ -263,7 +315,7 @@ async function completeExpansion(
             : `Queued ${counts.albumCount} albums`;
     await patchDownloadJobMetadata(
         jobId,
-        { ...counts, statusText },
+        { ...counts, filteredReasons, statusText },
         { status: "completed", completedAt: new Date() },
     );
 }
@@ -311,9 +363,17 @@ export async function processArtistDownloadExpansion(
             payload.artistMbid,
             payload.artistName,
         );
-        const counts = await expandReleaseGroups(payload, artistName, batchId);
+        const expansion = await expandReleaseGroups(
+            payload,
+            artistName,
+            batchId,
+        );
         await job.progress(100);
-        await completeExpansion(payload.jobId, counts);
+        await completeExpansion(
+            payload.jobId,
+            expansion.counts,
+            expansion.filteredReasons,
+        );
     } catch (error) {
         await failExpansion(payload.jobId, error);
         throw error;

--- a/backend/src/workers/processors/artistExpansionEligibility.ts
+++ b/backend/src/workers/processors/artistExpansionEligibility.ts
@@ -1,0 +1,63 @@
+import { isPlainObject } from "../../utils/plainObject";
+
+/** Result of applying the artist download expansion policy to a release group. */
+export type ReleaseGroupEligibility =
+    | { eligible: true }
+    | {
+          eligible: false;
+          reason:
+              | "wrong_primary_type"
+              | "secondary_type"
+              | "not_primary_credit"
+              | "missing_credits";
+      };
+
+function readFirstArtistId(
+    releaseGroup: Record<string, unknown>,
+): string | null {
+    const credits = releaseGroup["artist-credit"];
+    if (!Array.isArray(credits) || credits.length === 0) return null;
+
+    const firstCredit = credits[0];
+    if (!isPlainObject(firstCredit)) return null;
+
+    const artist = firstCredit.artist;
+    if (!isPlainObject(artist)) return null;
+
+    const artistId = artist.id;
+    return typeof artistId === "string" && artistId.length > 0
+        ? artistId
+        : null;
+}
+
+/**
+ * Classify an untrusted MusicBrainz release group for artist expansion.
+ *
+ * Eligible groups are Albums or EPs without secondary types and must credit
+ * the requested artist first. Missing or malformed credit data fails closed.
+ */
+export function classifyReleaseGroup(
+    releaseGroup: unknown,
+    artistMbid: string,
+): ReleaseGroupEligibility {
+    if (!isPlainObject(releaseGroup)) {
+        return { eligible: false, reason: "wrong_primary_type" };
+    }
+    const primaryType = releaseGroup["primary-type"];
+    if (primaryType !== "Album" && primaryType !== "EP") {
+        return { eligible: false, reason: "wrong_primary_type" };
+    }
+    const secondaryTypes = releaseGroup["secondary-types"];
+    if (!Array.isArray(secondaryTypes) || secondaryTypes.length > 0) {
+        return { eligible: false, reason: "secondary_type" };
+    }
+    const firstArtistId = readFirstArtistId(releaseGroup);
+    if (firstArtistId === null) {
+        return { eligible: false, reason: "missing_credits" };
+    }
+    const requestedArtistMbid = artistMbid.toLowerCase();
+    if (firstArtistId.toLowerCase() !== requestedArtistMbid) {
+        return { eligible: false, reason: "not_primary_credit" };
+    }
+    return { eligible: true };
+}


### PR DESCRIPTION
## Problem

"Download all missing albums" browses MusicBrainz by artist and queued **everything** it returned. MB's browse includes bootleg mixtapes, remix/demo/live/compilation release groups, and releases where the artist is only a featured credit. One press on Drake queued 60 jobs — including a DJ Khaled single, a Young Money single, and a pile of bootlegs (issue #824 has the full incident).

## Contract

The button now means what it says: official studio **albums and EPs the artist headlines**. Specifically, a release group is queued only when:

- primary type is `Album` or `EP`,
- it has **no** secondary types (drops Mixtape/Street, Remix, Demo, Live, Compilation),
- its **first artist credit** is the requested artist (case-insensitive MBID compare),
- and MusicBrainz reports it via `release-group-status=website-default` (drops bootleg-only groups).

Featured appearances and singles stay manual by design. Trade-off documented in the issue: official mixtapes/compilations (So Far Gone, Care Package) are also excluded from the bulk button and can be added from their album pages.

## Implementation

- `getReleaseGroupsWithCredits` on the MusicBrainz service: browse with `inc=artist-credits` + status filter, distinct cache namespace (`mb:rg:credits2`) so stale credit-less caches can't leak in, payload validated at the trust boundary (non-array → throw; entries without id/title dropped with a warn), and upstream failures **propagate** — an MB outage now fails the job instead of completing it as "No missing albums".
- `artistExpansionEligibility.ts`: pure fail-closed policy module (missing/malformed credits → ineligible), reusing the repo's `isPlainObject`.
- Processor counts every skip (`skippedIneligible` + per-reason `filteredReasons`) into job metadata and one structured summary log covering all counts.

verify: live MB check — Drake browse returns 61 release groups without the status filter, 34 with it; the surviving mislabeled-official mixtapes are then dropped by the secondary-type rule.

## Tests

TDD throughout (red run first): eligibility fixtures (official album/EP pass; each secondary type rejected; featured-credit rejected — the "I'm on One" case; uppercase-MBID regression; malformed payload shapes), processor behavior (mixed response queues only eligible, enumeration failure fails the job, full-count summary log), MB service (param + cache key + validation + error propagation).

## Verification

- verify: targeted suites exit 0 — `Test Suites: 3 passed`, `Tests: 70 passed`
- verify: backend tsc --noEmit exit 0; file-size gate exit 0; prettier exit 0

Closes #824