### PR TITLE
chore(player): listen-together ready-report and connection machines become tested modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The full-screen player's swipe gestures (track skip, swipe-down to close, drawer handle) now run through one tested gesture module, in preparation for further player decomposition.
 - The full-screen player's Up Next list now renders only the rows in view, so very large queues open and scroll smoothly, and the Queue, Lyrics, and Related panels fetch their data independently so an open player does less background work.
+- Listen Together's connection handling and "ready to play" reporting now run through small tested modules, making group playback behavior easier to verify without changing how sessions work.
 - Subsonic search and artist views now share the main library's data layer.
 - Internal route handling now shares validation, pagination, and ownership middleware, and enrichment and YouTube Music administrator errors use the documented response format.
 - App screens now share one catalog of data-cache keys, so library, playlist, download, and notification views refresh reliably after changes instead of occasionally showing stale lists.

--- a/frontend/hooks/useLatestRef.ts
+++ b/frontend/hooks/useLatestRef.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+/**
+ * A ref that always holds the latest committed value (GH #787). Lets a
+ * long-lived closure (socket handlers, timers) read fresh state without
+ * appearing in dependency arrays — replacing hand-rolled mirror effects.
+ */
+export function useLatestRef<T>(value: T): RefObject<T> {
+    const ref = useRef(value);
+    useEffect(() => {
+        ref.current = value;
+    });
+    return ref;
+}

--- a/frontend/lib/listen-together-context.tsx
+++ b/frontend/lib/listen-together-context.tsx
@@ -71,7 +71,6 @@ import {
     ListenTogetherMembershipOrdering,
     ListenTogetherResyncOwnership,
     resolveListenTogetherMembershipPendingState,
-    resolveListenTogetherReadyReportRecoveryAction,
     scheduleGenerationScopedListenTogetherResync,
     toLocalTrack,
 } from "@/lib/listenTogetherContextState";
@@ -81,6 +80,17 @@ export {
     type ListenTogetherMembershipPendingOperation,
     type ListenTogetherReadyReportRecoveryAction,
 } from "@/lib/listenTogetherContextState";
+import {
+    ListenTogetherReadyReportRunner,
+    LT_READY_REPORT_MAX_WAIT_MS,
+    type ReadyReportTarget,
+} from "@/lib/listenTogetherReadyReportRunner";
+import {
+    LT_DISCONNECT_GRACE_MS,
+    resolveConnectionEvent,
+    type ListenTogetherConnectionDirective,
+} from "@/lib/listenTogetherConnectionState";
+import { useLatestRef } from "@/hooks/useLatestRef";
 import {
     isPlaybackAutoRestartSuppressed,
     markRemoteTrackChange as markTrackChange,
@@ -92,10 +102,6 @@ import {
 } from "@/lib/audio-engine/listenTogetherPlaybackResume";
 const playbackEngine = createRuntimeAudioEngine();
 const log = sharedFrontendLogger.child("ListenTogetherContext");
-const LT_READY_REPORT_POLL_INTERVAL_MS = 100;
-const LT_READY_REPORT_DELAY_MS = 150;
-const LT_READY_REPORT_RETRY_DELAY_MS = 180;
-const LT_READY_REPORT_MAX_WAIT_MS = 7_500;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -214,14 +220,10 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
     const hostMustAdoptGroupPositionRef = useRef(false);
     const hasEverConnectedRef = useRef(false);
     const awaitingInitialStateRef = useRef(true);
-    const readyReportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    const readyReportRunnerRef = useRef<ListenTogetherReadyReportRunner | null>(
         null,
     );
-    const readyReportLoadListenerRef = useRef<(() => void) | null>(null);
-    const readyReportTargetRef = useRef<{
-        currentIndex: number;
-        trackId: string | null;
-    } | null>(null);
+    const scheduleGroupResyncRef = useRef<(groupId?: string) => void>(() => {});
     const availabilitySwapLoadListenerRef = useRef<(() => void) | null>(null);
     const routeRecheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
         null,
@@ -234,38 +236,72 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
     const disconnectGraceTimerRef = useRef<ReturnType<
         typeof setTimeout
     > | null>(null);
-    const controlsRef = useRef(controls);
-    const audioStateRef = useRef(audioState);
+    // Latest-value refs: the 588-line socket-handler closure reads these so
+    // it never needs controls/audioState in its dependency array (which
+    // would re-register every socket handler on each audio tick).
+    const controlsRef = useLatestRef(controls);
+    const audioStateRef = useLatestRef(audioState);
     const trackAvailabilityRef = useRef<Map<number, AvailabilityItem>>(
         new Map(),
     );
     const trackAvailabilityStateVersionRef = useRef<number | null>(null);
     const lastLoadedTrackIdRef = useRef<string | null>(null);
 
-    const clearReadyReportLoadListener = useCallback(() => {
-        const listener = readyReportLoadListenerRef.current;
-        if (listener) {
-            playbackEngine.off("load", listener);
-            readyReportLoadListenerRef.current = null;
-        }
-        readyReportTargetRef.current = null;
-    }, []);
+    const readReadyReportSnapshot = useCallback(
+        (target: ReadyReportTarget, elapsedMs: number) => {
+            const state = audioStateRef.current;
+            const currentPlayback = activeGroupRef.current?.playback;
+            const availabilityMatchesState =
+                trackAvailabilityStateVersionRef.current !== null &&
+                currentPlayback?.stateVersion ===
+                    trackAvailabilityStateVersionRef.current &&
+                currentPlayback?.currentIndex === target.currentIndex;
+            const availabilityExpected = availabilityMatchesState
+                ? trackAvailabilityRef.current.get(target.currentIndex)
+                : undefined;
+            return {
+                expectedTrackId: target.trackId,
+                serverQueuedTrackId:
+                    currentPlayback?.queue?.[target.currentIndex]?.id ?? null,
+                expectedLocalTrackId:
+                    availabilityExpected?.localTrackId ?? null,
+                activeTrackId: state.currentTrack?.id ?? null,
+                queuedTrackId:
+                    state.queue[target.currentIndex]?.id ??
+                    state.queue[state.currentIndex]?.id ??
+                    null,
+                loadedTrackId: lastLoadedTrackIdRef.current,
+                engineDurationSec: playbackEngine.getDuration(),
+                engineCurrentTimeSec: playbackEngine.getCurrentTime(),
+                elapsedMs,
+                maxWaitMs: LT_READY_REPORT_MAX_WAIT_MS,
+            };
+        },
+        [audioStateRef],
+    );
+
+    const getReadyReportRunner = useCallback(() => {
+        readyReportRunnerRef.current ??= new ListenTogetherReadyReportRunner({
+            engineOn: (listener) => playbackEngine.on("load", listener),
+            engineOff: (listener) => playbackEngine.off("load", listener),
+            readSnapshot: readReadyReportSnapshot,
+            reportReady: () => listenTogetherSocket.reportReady(),
+            recover: (reason, details) => {
+                sharedFrontendLogger.warn(reason, details);
+                scheduleGroupResyncRef.current(activeGroupRef.current?.id);
+            },
+        });
+        return readyReportRunnerRef.current;
+    }, [readReadyReportSnapshot]);
 
     const clearObsoleteReadyReportLoadListener = useCallback(
         (nextTrackIndex: number, nextTrackId: string | null) => {
-            const target = readyReportTargetRef.current;
-            const trackChanged = Boolean(
-                target &&
-                (target.currentIndex !== nextTrackIndex ||
-                    (target.trackId &&
-                        nextTrackId &&
-                        target.trackId !== nextTrackId)),
+            getReadyReportRunner().detachLoadListenerIfObsolete(
+                nextTrackIndex,
+                nextTrackId,
             );
-            if (trackChanged) {
-                clearReadyReportLoadListener();
-            }
         },
-        [clearReadyReportLoadListener],
+        [getReadyReportRunner],
     );
 
     const clearAvailabilitySwapLoadListener = useCallback(() => {
@@ -276,17 +312,15 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
     }, []);
 
     const clearActiveSessionTimers = useCallback(() => {
-        clearReadyReportLoadListener();
+        const runner = getReadyReportRunner();
+        runner.detachLoadListener();
+        runner.clearTimer();
         clearAvailabilitySwapLoadListener();
-        if (readyReportTimerRef.current) {
-            clearTimeout(readyReportTimerRef.current);
-            readyReportTimerRef.current = null;
-        }
         if (disconnectGraceTimerRef.current) {
             clearTimeout(disconnectGraceTimerRef.current);
             disconnectGraceTimerRef.current = null;
         }
-    }, [clearAvailabilitySwapLoadListener, clearReadyReportLoadListener]);
+    }, [clearAvailabilitySwapLoadListener, getReadyReportRunner]);
 
     const advanceMembershipSessionGeneration = useCallback(() => {
         resyncOwnershipRef.current.advance();
@@ -361,12 +395,6 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
         activeGroupRef.current = activeGroup;
     }, [activeGroup]);
     useEffect(() => {
-        controlsRef.current = controls;
-    }, [controls]);
-    useEffect(() => {
-        audioStateRef.current = audioState;
-    }, [audioState]);
-    useEffect(() => {
         trackAvailabilityRef.current = trackAvailability;
     }, [trackAvailability]);
     useEffect(() => {
@@ -379,7 +407,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
         return () => {
             playbackEngine.off("load", onLoad);
         };
-    }, []);
+    }, [audioStateRef]);
     useEffect(() => {
         return () => {
             clearActiveSessionTimers();
@@ -428,6 +456,68 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
         },
         [validateSocketRoute],
     );
+
+    /**
+     * Applies one connection-event directive from the pure reducer in
+     * listenTogetherConnectionState. Grace-timer expiry feeds back through
+     * the same reducer so every visual-disconnect transition shares one
+     * decision table.
+     */
+    const applyConnectionDirective = useCallback(
+        function applyDirective(
+            directive: ListenTogetherConnectionDirective,
+        ): void {
+            if (directive.clearGraceTimer && disconnectGraceTimerRef.current) {
+                clearTimeout(disconnectGraceTimerRef.current);
+                disconnectGraceTimerRef.current = null;
+            }
+            if (directive.armGraceTimer && !disconnectGraceTimerRef.current) {
+                const cause = directive.armGraceTimer;
+                disconnectGraceTimerRef.current = setTimeout(() => {
+                    disconnectGraceTimerRef.current = null;
+                    applyDirective(
+                        resolveConnectionEvent({
+                            type: "grace-expired",
+                            cause,
+                        }),
+                    );
+                }, LT_DISCONNECT_GRACE_MS);
+            }
+            if (directive.setIsConnected !== undefined) {
+                setIsConnected(directive.setIsConnected);
+            }
+            if (directive.setHasConnectedOnce) {
+                hasEverConnectedRef.current = true;
+                setHasConnectedOnce(true);
+            }
+            if (directive.setReconnectAttempt !== undefined) {
+                setReconnectAttempt(directive.setReconnectAttempt);
+            }
+            if (directive.setSocketRouteStatus) {
+                setSocketRouteStatus(directive.setSocketRouteStatus);
+            }
+            if (directive.clearSocketRouteError) {
+                setSocketRouteError(null);
+            }
+            if (directive.setError) {
+                setError(directive.setError);
+            }
+            if (directive.markAwaitingInitialState) {
+                awaitingInitialStateRef.current = true;
+            }
+            if (directive.markPendingAudioRecovery) {
+                pendingReconnectAudioRecoveryRef.current = true;
+            }
+            if (directive.validateRoute) {
+                void validateSocketRoute(true);
+            }
+        },
+        [validateSocketRoute],
+    );
+
+    useEffect(() => {
+        scheduleGroupResyncRef.current = scheduleGroupResync;
+    }, [scheduleGroupResync]);
 
     const canCurrentUserControlHostPlayback = useCallback(
         (group: GroupSnapshot | null): boolean => {
@@ -546,8 +636,10 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             });
         },
         [
+            audioStateRef,
             canCurrentUserControlHostPlayback,
             clearObsoleteReadyReportLoadListener,
+            controlsRef,
         ],
     );
 
@@ -648,8 +740,10 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             });
         },
         [
+            audioStateRef,
             canCurrentUserControlHostPlayback,
             clearObsoleteReadyReportLoadListener,
+            controlsRef,
         ],
     );
 
@@ -729,7 +823,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             }, 10_000);
             playbackEngine.reload();
         },
-        [canCurrentUserControlHostPlayback],
+        [canCurrentUserControlHostPlayback, controlsRef],
     );
 
     // -----------------------------------------------------------------------
@@ -893,7 +987,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                 isApplyingRemoteRef.current = false;
             }, 100);
         },
-        [clearObsoleteReadyReportLoadListener],
+        [audioStateRef, clearObsoleteReadyReportLoadListener],
     );
 
     // -----------------------------------------------------------------------
@@ -1003,11 +1097,9 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                     });
                 },
                 onWaiting: (data: WaitingEvent) => {
-                    clearReadyReportLoadListener();
-                    if (readyReportTimerRef.current) {
-                        clearTimeout(readyReportTimerRef.current);
-                        readyReportTimerRef.current = null;
-                    }
+                    const runner = getReadyReportRunner();
+                    runner.detachLoadListener();
+                    runner.clearTimer();
 
                     const trackAvailabilityForIndex =
                         trackAvailabilityRef.current.get(data.currentIndex);
@@ -1031,196 +1123,12 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                     }
 
                     // The server says "buffer this track and report ready".
-                    // Report on the matching engine load event, while retaining
-                    // bounded polling as a fallback when no load event arrives.
-                    const startedAt = Date.now();
-                    let terminalRetryAttempted = false;
-                    let recoveryTriggered = false;
-
-                    const triggerReadyReportRecovery = (
-                        reason: string,
-                        details: Record<string, unknown>,
-                    ) => {
-                        if (recoveryTriggered) return;
-                        recoveryTriggered = true;
-                        sharedFrontendLogger.warn(reason, details);
-                        scheduleGroupResync(activeGroupRef.current?.id);
-                    };
-
-                    const tryReportReady = () => {
-                        const state = audioStateRef.current;
-                        const queuedTrackId =
-                            state.queue[data.currentIndex]?.id ??
-                            state.queue[state.currentIndex]?.id ??
-                            null;
-                        const activeTrackId = state.currentTrack?.id ?? null;
-                        const expectedTrackId = data.trackId ?? null;
-                        const serverQueuedTrackId =
-                            activeGroupRef.current?.playback?.queue?.[
-                                data.currentIndex
-                            ]?.id ?? null;
-                        const currentPlayback =
-                            activeGroupRef.current?.playback;
-                        const availabilityMatchesState =
-                            trackAvailabilityStateVersionRef.current !== null &&
-                            currentPlayback?.stateVersion ===
-                                trackAvailabilityStateVersionRef.current &&
-                            currentPlayback?.currentIndex === data.currentIndex;
-                        const availabilityExpected = availabilityMatchesState
-                            ? trackAvailabilityRef.current.get(
-                                  data.currentIndex,
-                              )
-                            : undefined;
-                        const expectedLocalTrackId =
-                            availabilityExpected?.localTrackId ?? null;
-                        const expectedCandidates = Array.from(
-                            new Set(
-                                [
-                                    expectedTrackId,
-                                    serverQueuedTrackId,
-                                    expectedLocalTrackId,
-                                ].filter(
-                                    (candidate): candidate is string =>
-                                        typeof candidate === "string" &&
-                                        candidate.length > 0,
-                                ),
-                            ),
-                        );
-                        const localCandidates = Array.from(
-                            new Set(
-                                [activeTrackId, queuedTrackId].filter(
-                                    (candidate): candidate is string =>
-                                        typeof candidate === "string" &&
-                                        candidate.length > 0,
-                                ),
-                            ),
-                        );
-                        const hasTrackMatch =
-                            expectedCandidates.length === 0 ||
-                            localCandidates.some((candidate) =>
-                                expectedCandidates.includes(candidate),
-                            );
-                        const loadedTrackId = lastLoadedTrackIdRef.current;
-                        const readinessTrackId =
-                            localCandidates.find(
-                                (candidate) =>
-                                    expectedCandidates.length === 0 ||
-                                    expectedCandidates.includes(candidate),
-                            ) ?? null;
-                        const hasLoadedExpectedTrack =
-                            Boolean(readinessTrackId) &&
-                            loadedTrackId === readinessTrackId;
-                        const durationSec = playbackEngine.getDuration();
-                        const currentTimeSec = playbackEngine.getCurrentTime();
-                        const hasEngineMediaData =
-                            (Number.isFinite(durationSec) && durationSec > 0) ||
-                            (Number.isFinite(currentTimeSec) &&
-                                currentTimeSec > 0);
-                        const mediaReady =
-                            hasLoadedExpectedTrack && hasEngineMediaData;
-                        const timedOut =
-                            Date.now() - startedAt >=
-                            LT_READY_REPORT_MAX_WAIT_MS;
-
-                        if (hasTrackMatch && (mediaReady || timedOut)) {
-                            readyReportTimerRef.current = setTimeout(() => {
-                                readyReportTimerRef.current = null;
-                                clearReadyReportLoadListener();
-                                listenTogetherSocket
-                                    .reportReady()
-                                    .catch((error) => {
-                                        const elapsedMs =
-                                            Date.now() - startedAt;
-                                        const recoveryAction =
-                                            resolveListenTogetherReadyReportRecoveryAction(
-                                                {
-                                                    elapsedMs,
-                                                    maxWaitMs:
-                                                        LT_READY_REPORT_MAX_WAIT_MS,
-                                                    terminalRetryAttempted,
-                                                },
-                                            );
-                                        if (recoveryAction === "retry") {
-                                            readyReportTimerRef.current =
-                                                setTimeout(
-                                                    tryReportReady,
-                                                    LT_READY_REPORT_RETRY_DELAY_MS,
-                                                );
-                                            return;
-                                        }
-                                        if (
-                                            recoveryAction === "terminal-retry"
-                                        ) {
-                                            terminalRetryAttempted = true;
-                                            readyReportTimerRef.current =
-                                                setTimeout(
-                                                    tryReportReady,
-                                                    LT_READY_REPORT_RETRY_DELAY_MS,
-                                                );
-                                            return;
-                                        }
-
-                                        triggerReadyReportRecovery(
-                                            "[ListenTogether] reportReady failed after terminal retry window",
-                                            {
-                                                error:
-                                                    error instanceof Error
-                                                        ? error.message
-                                                        : String(error),
-                                                elapsedMs,
-                                                expectedTrackId,
-                                                queuedTrackId,
-                                                activeTrackId,
-                                                terminalRetryAttempted,
-                                            },
-                                        );
-                                    });
-                            }, LT_READY_REPORT_DELAY_MS);
-                            return;
-                        }
-
-                        if (timedOut) {
-                            readyReportTimerRef.current = null;
-                            clearReadyReportLoadListener();
-                            triggerReadyReportRecovery(
-                                "[ListenTogether] ready report timed out before local media was ready",
-                                {
-                                    expectedTrackId,
-                                    queuedTrackId,
-                                    activeTrackId,
-                                    loadedTrackId,
-                                    mediaReady,
-                                },
-                            );
-                            return;
-                        }
-
-                        readyReportTimerRef.current = setTimeout(
-                            tryReportReady,
-                            LT_READY_REPORT_POLL_INTERVAL_MS,
-                        );
-                    };
-
-                    const onTargetTrackLoaded = () => {
-                        clearReadyReportLoadListener();
-                        if (readyReportTimerRef.current) {
-                            clearTimeout(readyReportTimerRef.current);
-                            readyReportTimerRef.current = null;
-                        }
-                        void listenTogetherSocket.reportReady().catch(() => {
-                            readyReportTimerRef.current = setTimeout(
-                                tryReportReady,
-                                LT_READY_REPORT_RETRY_DELAY_MS,
-                            );
-                        });
-                    };
-                    readyReportTargetRef.current = {
+                    // The runner reports on the matching engine load event,
+                    // with bounded polling as a fallback.
+                    runner.begin({
                         currentIndex: data.currentIndex,
-                        trackId: data.trackId,
-                    };
-                    readyReportLoadListenerRef.current = onTargetTrackLoaded;
-                    playbackEngine.on("load", onTargetTrackLoaded);
-                    tryReportReady();
+                        trackId: data.trackId ?? null,
+                    });
                 },
                 onPlayAt: (data: PlayAtEvent) => {
                     // Synchronized start: the server says "play at positionMs at serverTime"
@@ -1384,41 +1292,22 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                     toast.info("Listen Together session ended");
                 },
                 onConnect: () => {
-                    if (disconnectGraceTimerRef.current) {
-                        clearTimeout(disconnectGraceTimerRef.current);
-                        disconnectGraceTimerRef.current = null;
-                    }
-                    setIsConnected(true);
-                    hasEverConnectedRef.current = true;
-                    setHasConnectedOnce(true);
-                    setReconnectAttempt(0);
-                    setSocketRouteStatus("ok");
-                    setSocketRouteError(null);
-                    awaitingInitialStateRef.current = true;
+                    applyConnectionDirective(
+                        resolveConnectionEvent({ type: "connect" }),
+                    );
                 },
                 onReconnect: (_attempt) => {
-                    if (disconnectGraceTimerRef.current) {
-                        clearTimeout(disconnectGraceTimerRef.current);
-                        disconnectGraceTimerRef.current = null;
-                    }
-                    setIsConnected(true);
-                    setReconnectAttempt(0);
-                    setSocketRouteStatus("ok");
-                    setSocketRouteError(null);
-                    pendingReconnectAudioRecoveryRef.current = true;
+                    applyConnectionDirective(
+                        resolveConnectionEvent({ type: "reconnect" }),
+                    );
                 },
                 onReconnectAttempt: (attempt) => {
-                    setReconnectAttempt(attempt);
-                    pendingReconnectAudioRecoveryRef.current = true;
-                    // Defer the visual disconnect so brief reconnects don't flash grey.
-                    // Only schedule the grace timer once; later attempts just bump the counter.
-                    if (!disconnectGraceTimerRef.current) {
-                        disconnectGraceTimerRef.current = setTimeout(() => {
-                            disconnectGraceTimerRef.current = null;
-                            setIsConnected(false);
-                            setSocketRouteStatus("checking");
-                        }, 2000);
-                    }
+                    applyConnectionDirective(
+                        resolveConnectionEvent({
+                            type: "reconnect-attempt",
+                            attempt,
+                        }),
+                    );
                 },
                 onReconnectError: (err) => {
                     sharedFrontendLogger.error(
@@ -1427,29 +1316,17 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                     );
                 },
                 onReconnectFailed: () => {
-                    // Reconnection exhausted — show disconnected immediately.
-                    if (disconnectGraceTimerRef.current) {
-                        clearTimeout(disconnectGraceTimerRef.current);
-                        disconnectGraceTimerRef.current = null;
-                    }
-                    setIsConnected(false);
-                    setError(
-                        "Listen Together reconnect failed. Check route/proxy health and try rejoining.",
+                    applyConnectionDirective(
+                        resolveConnectionEvent({ type: "reconnect-failed" }),
                     );
-                    void validateSocketRoute(true);
                 },
                 onRejoinFailed: () => {
                     scheduleGroupResync(activeGroupRef.current?.id);
                 },
                 onDisconnect: (_reason) => {
-                    // Defer the visual disconnect; if Socket.IO reconnects within
-                    // the grace window the indicator stays green.
-                    if (!disconnectGraceTimerRef.current) {
-                        disconnectGraceTimerRef.current = setTimeout(() => {
-                            disconnectGraceTimerRef.current = null;
-                            setIsConnected(false);
-                        }, 2000);
-                    }
+                    applyConnectionDirective(
+                        resolveConnectionEvent({ type: "disconnect" }),
+                    );
                 },
                 onError: (err) => {
                     sharedFrontendLogger.error(
@@ -1474,19 +1351,21 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             });
         },
         [
+            applyConnectionDirective,
             applyGroupState,
             applyPlaybackDelta,
             applyQueueDelta,
+            audioStateRef,
+            getReadyReportRunner,
             canCurrentUserControlHostPlayback,
-            clearAvailabilitySwapLoadListener,
             clearActiveMembership,
-            clearReadyReportLoadListener,
+            clearAvailabilitySwapLoadListener,
+            controlsRef,
             handleMembershipRevoked,
             recoverAudioAfterReconnect,
             scheduleGroupResync,
             scheduleRouteRecheck,
             user?.id,
-            validateSocketRoute,
         ],
     );
 
@@ -1687,7 +1566,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             }
             return true;
         },
-        [clearObsoleteReadyReportLoadListener],
+        [audioStateRef, clearObsoleteReadyReportLoadListener, controlsRef],
     );
 
     const resolveAdjacentHostTrackIndex = useCallback(
@@ -1703,7 +1582,7 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
                 ),
             });
         },
-        [],
+        [audioStateRef],
     );
 
     // -----------------------------------------------------------------------
@@ -1892,18 +1771,21 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
         writeOrigin("manual", audioStateRef.current.currentTrack?.id ?? null);
         controlsRef.current.resume({ suppressListenTogetherBroadcast: true });
         listenTogetherSocket.play().catch(() => {});
-    }, []);
+    }, [audioStateRef, controlsRef]);
     const syncPause = useCallback(() => {
         controlsRef.current.pause({ suppressListenTogetherBroadcast: true });
         listenTogetherSocket.pause().catch(() => {});
-    }, []);
-    const syncSeek = useCallback((positionMs: number) => {
-        controlsRef.current.seek(positionMs / 1000, {
-            allowListenTogetherFollower: true,
-            suppressListenTogetherBroadcast: true,
-        });
-        listenTogetherSocket.seek(positionMs).catch(() => {});
-    }, []);
+    }, [controlsRef]);
+    const syncSeek = useCallback(
+        (positionMs: number) => {
+            controlsRef.current.seek(positionMs / 1000, {
+                allowListenTogetherFollower: true,
+                suppressListenTogetherBroadcast: true,
+            });
+            listenTogetherSocket.seek(positionMs).catch(() => {});
+        },
+        [controlsRef],
+    );
     const syncNext = useCallback(() => {
         const group = activeGroupRef.current;
         if (!canCurrentUserControlHostPlayback(group)) {
@@ -1958,7 +1840,11 @@ export function ListenTogetherProvider({ children }: { children: ReactNode }) {
             });
             applyOptimisticHostTrackSelection(safeIndex);
         },
-        [applyOptimisticHostTrackSelection, canCurrentUserControlHostPlayback],
+        [
+            applyOptimisticHostTrackSelection,
+            audioStateRef,
+            canCurrentUserControlHostPlayback,
+        ],
     );
     const syncAddToQueue = useCallback((tracks: QueueTrackInput[]) => {
         listenTogetherSocket.addToQueue(tracks).catch((err) => {

--- a/frontend/lib/listenTogetherConnectionState.ts
+++ b/frontend/lib/listenTogetherConnectionState.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure reducer for Listen Together socket connection events (GH #787).
+ * Each socket lifecycle event maps to one directive describing the state
+ * writes and grace-timer transitions the provider must apply. Kept free of
+ * React, sockets, and timers so the connection rules are unit-testable.
+ */
+
+/** Brief reconnects should not flash the UI grey. */
+export const LT_DISCONNECT_GRACE_MS = 2000;
+
+export type ListenTogetherConnectionEvent =
+    | { type: "connect" }
+    | { type: "reconnect" }
+    | { type: "reconnect-attempt"; attempt: number }
+    | { type: "reconnect-failed" }
+    | { type: "disconnect" }
+    /** A previously armed grace timer expired without a reconnect. */
+    | { type: "grace-expired"; cause: "reconnect-attempt" | "disconnect" };
+
+export interface ListenTogetherConnectionDirective {
+    setIsConnected?: boolean;
+    setHasConnectedOnce?: true;
+    setReconnectAttempt?: number;
+    setSocketRouteStatus?: "ok" | "checking";
+    clearSocketRouteError?: true;
+    setError?: string;
+    /** Cancel a pending visual-disconnect grace timer. */
+    clearGraceTimer?: true;
+    /**
+     * Defer the visual disconnect by LT_DISCONNECT_GRACE_MS. Arm only when
+     * no grace timer is already pending — later events just update counters.
+     */
+    armGraceTimer?: "reconnect-attempt" | "disconnect";
+    /** The next group:state event is the hydration snapshot. */
+    markAwaitingInitialState?: true;
+    /** The reconnect path owns the audio reload/resume. */
+    markPendingAudioRecovery?: true;
+    /** Re-probe the socket route health. */
+    validateRoute?: true;
+}
+
+const RECONNECT_FAILED_ERROR =
+    "Listen Together reconnect failed. Check route/proxy health and try rejoining.";
+
+/** The provider-visible consequences of one socket lifecycle event. */
+export function resolveConnectionEvent(
+    event: ListenTogetherConnectionEvent,
+): ListenTogetherConnectionDirective {
+    switch (event.type) {
+        case "connect":
+            return {
+                clearGraceTimer: true,
+                setIsConnected: true,
+                setHasConnectedOnce: true,
+                setReconnectAttempt: 0,
+                setSocketRouteStatus: "ok",
+                clearSocketRouteError: true,
+                markAwaitingInitialState: true,
+            };
+        case "reconnect":
+            return {
+                clearGraceTimer: true,
+                setIsConnected: true,
+                setReconnectAttempt: 0,
+                setSocketRouteStatus: "ok",
+                clearSocketRouteError: true,
+                markPendingAudioRecovery: true,
+            };
+        case "reconnect-attempt":
+            return {
+                setReconnectAttempt: event.attempt,
+                markPendingAudioRecovery: true,
+                armGraceTimer: "reconnect-attempt",
+            };
+        case "reconnect-failed":
+            return {
+                clearGraceTimer: true,
+                setIsConnected: false,
+                setError: RECONNECT_FAILED_ERROR,
+                validateRoute: true,
+            };
+        case "disconnect":
+            return { armGraceTimer: "disconnect" };
+        case "grace-expired":
+            return event.cause === "reconnect-attempt"
+                ? { setIsConnected: false, setSocketRouteStatus: "checking" }
+                : { setIsConnected: false };
+    }
+}

--- a/frontend/lib/listenTogetherReadyReport.ts
+++ b/frontend/lib/listenTogetherReadyReport.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure decision math for Listen Together ready reporting (GH #787).
+ * When the server says "buffer this track and report ready", the follower
+ * must decide on every poll tick whether the local engine has the expected
+ * track loaded, whether to keep waiting, or whether to give up and resync.
+ * Kept free of React, sockets, and timers so the rules are unit-testable.
+ */
+
+export interface ReadyReportSnapshot {
+    /** Track id the server's waiting event named, if any. */
+    expectedTrackId: string | null;
+    /** Track id at the waiting index in the server's queue snapshot. */
+    serverQueuedTrackId: string | null;
+    /** Local track id the availability map says the index maps to. */
+    expectedLocalTrackId: string | null;
+    /** Track id the local player currently has active. */
+    activeTrackId: string | null;
+    /** Track id at the waiting index in the local queue. */
+    queuedTrackId: string | null;
+    /** Track id the engine last actually loaded. */
+    loadedTrackId: string | null;
+    engineDurationSec: number;
+    engineCurrentTimeSec: number;
+    elapsedMs: number;
+    maxWaitMs: number;
+}
+
+export interface ReadyReportEvaluation {
+    /**
+     * report — the expected track is ready (or the wait expired with a
+     *   matching track): confirm readiness to the server.
+     * recover — the wait expired without the expected track: schedule a
+     *   group resync instead of blocking the session.
+     * poll — keep waiting.
+     */
+    decision: "report" | "recover" | "poll";
+    hasTrackMatch: boolean;
+    mediaReady: boolean;
+    timedOut: boolean;
+}
+
+function presentIds(candidates: Array<string | null>): string[] {
+    return Array.from(
+        new Set(
+            candidates.filter(
+                (candidate): candidate is string =>
+                    typeof candidate === "string" && candidate.length > 0,
+            ),
+        ),
+    );
+}
+
+/** One poll-tick readiness decision from a snapshot of local/server state. */
+export function evaluateReadyReport(
+    snapshot: ReadyReportSnapshot,
+): ReadyReportEvaluation {
+    const expectedCandidates = presentIds([
+        snapshot.expectedTrackId,
+        snapshot.serverQueuedTrackId,
+        snapshot.expectedLocalTrackId,
+    ]);
+    const localCandidates = presentIds([
+        snapshot.activeTrackId,
+        snapshot.queuedTrackId,
+    ]);
+
+    const hasTrackMatch =
+        expectedCandidates.length === 0 ||
+        localCandidates.some((candidate) =>
+            expectedCandidates.includes(candidate),
+        );
+    const readinessTrackId =
+        localCandidates.find(
+            (candidate) =>
+                expectedCandidates.length === 0 ||
+                expectedCandidates.includes(candidate),
+        ) ?? null;
+    const hasLoadedExpectedTrack =
+        Boolean(readinessTrackId) &&
+        snapshot.loadedTrackId === readinessTrackId;
+    const hasEngineMediaData =
+        (Number.isFinite(snapshot.engineDurationSec) &&
+            snapshot.engineDurationSec > 0) ||
+        (Number.isFinite(snapshot.engineCurrentTimeSec) &&
+            snapshot.engineCurrentTimeSec > 0);
+    const mediaReady = hasLoadedExpectedTrack && hasEngineMediaData;
+    const timedOut = snapshot.elapsedMs >= snapshot.maxWaitMs;
+
+    if (hasTrackMatch && (mediaReady || timedOut)) {
+        return { decision: "report", hasTrackMatch, mediaReady, timedOut };
+    }
+    if (timedOut) {
+        return { decision: "recover", hasTrackMatch, mediaReady, timedOut };
+    }
+    return { decision: "poll", hasTrackMatch, mediaReady, timedOut };
+}

--- a/frontend/lib/listenTogetherReadyReportRunner.ts
+++ b/frontend/lib/listenTogetherReadyReportRunner.ts
@@ -1,0 +1,199 @@
+/**
+ * The Listen Together ready-report machine (GH #787). When the server says
+ * "buffer this track and report ready", one runner instance owns the poll
+ * timer, the engine load listener, and the awaited target, reporting
+ * readiness on the matching load event with bounded polling as a fallback.
+ * Decision math lives in listenTogetherReadyReport; side effects arrive
+ * through injected ports so the machine is testable without React or a
+ * socket.
+ */
+
+import { resolveListenTogetherReadyReportRecoveryAction } from "@/lib/listenTogetherContextState";
+import {
+    evaluateReadyReport,
+    type ReadyReportSnapshot,
+} from "@/lib/listenTogetherReadyReport";
+
+export const LT_READY_REPORT_POLL_INTERVAL_MS = 100;
+export const LT_READY_REPORT_DELAY_MS = 150;
+export const LT_READY_REPORT_RETRY_DELAY_MS = 180;
+export const LT_READY_REPORT_MAX_WAIT_MS = 7_500;
+
+export interface ReadyReportTarget {
+    currentIndex: number;
+    trackId: string | null;
+}
+
+export interface ReadyReportRunnerPorts {
+    /** Attach/detach a listener on the playback engine's load event. */
+    engineOn(listener: () => void): void;
+    engineOff(listener: () => void): void;
+    /** Snapshot of local and server track state for one decision tick. */
+    readSnapshot(
+        target: ReadyReportTarget,
+        elapsedMs: number,
+    ): ReadyReportSnapshot;
+    reportReady(): Promise<void>;
+    /** Log and schedule a group resync; invoked at most once per begin(). */
+    recover(reason: string, details: Record<string, unknown>): void;
+    /** Clock override for tests; defaults to Date.now. */
+    now?(): number;
+}
+
+export class ListenTogetherReadyReportRunner {
+    private timer: ReturnType<typeof setTimeout> | null = null;
+    private loadListener: (() => void) | null = null;
+    private target: ReadyReportTarget | null = null;
+
+    constructor(private readonly ports: ReadyReportRunnerPorts) {}
+
+    private now(): number {
+        return this.ports.now ? this.ports.now() : Date.now();
+    }
+
+    /** Drop the engine load listener and forget the awaited target. */
+    detachLoadListener(): void {
+        if (this.loadListener) {
+            this.ports.engineOff(this.loadListener);
+            this.loadListener = null;
+        }
+        this.target = null;
+    }
+
+    /**
+     * Drop the load listener when the session moved to a different track;
+     * the poll timer keeps running against the original waiting target.
+     */
+    detachLoadListenerIfObsolete(
+        nextTrackIndex: number,
+        nextTrackId: string | null,
+    ): void {
+        const target = this.target;
+        const trackChanged = Boolean(
+            target &&
+            (target.currentIndex !== nextTrackIndex ||
+                (target.trackId &&
+                    nextTrackId &&
+                    target.trackId !== nextTrackId)),
+        );
+        if (trackChanged) {
+            this.detachLoadListener();
+        }
+    }
+
+    /** Cancel the poll/delay timer without touching the load listener. */
+    clearTimer(): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+    }
+
+    /** Start waiting on a server waiting event. Cancels any previous wait. */
+    begin(target: ReadyReportTarget): void {
+        this.detachLoadListener();
+        this.clearTimer();
+
+        const startedAt = this.now();
+        let terminalRetryAttempted = false;
+        let recoveryTriggered = false;
+
+        const recoverOnce = (
+            reason: string,
+            details: Record<string, unknown>,
+        ) => {
+            if (recoveryTriggered) return;
+            recoveryTriggered = true;
+            this.ports.recover(reason, details);
+        };
+
+        const tryReportReady = () => {
+            const snapshot = this.ports.readSnapshot(
+                target,
+                this.now() - startedAt,
+            );
+            const evaluation = evaluateReadyReport(snapshot);
+
+            if (evaluation.decision === "report") {
+                this.timer = setTimeout(() => {
+                    this.timer = null;
+                    this.detachLoadListener();
+                    this.ports.reportReady().catch((error) => {
+                        const elapsedMs = this.now() - startedAt;
+                        const recoveryAction =
+                            resolveListenTogetherReadyReportRecoveryAction({
+                                elapsedMs,
+                                maxWaitMs: snapshot.maxWaitMs,
+                                terminalRetryAttempted,
+                            });
+                        if (
+                            recoveryAction === "retry" ||
+                            recoveryAction === "terminal-retry"
+                        ) {
+                            if (recoveryAction === "terminal-retry") {
+                                terminalRetryAttempted = true;
+                            }
+                            this.timer = setTimeout(
+                                tryReportReady,
+                                LT_READY_REPORT_RETRY_DELAY_MS,
+                            );
+                            return;
+                        }
+                        recoverOnce(
+                            "[ListenTogether] reportReady failed after terminal retry window",
+                            {
+                                error:
+                                    error instanceof Error
+                                        ? error.message
+                                        : String(error),
+                                elapsedMs,
+                                expectedTrackId: snapshot.expectedTrackId,
+                                queuedTrackId: snapshot.queuedTrackId,
+                                activeTrackId: snapshot.activeTrackId,
+                                terminalRetryAttempted,
+                            },
+                        );
+                    });
+                }, LT_READY_REPORT_DELAY_MS);
+                return;
+            }
+
+            if (evaluation.decision === "recover") {
+                this.clearTimer();
+                this.detachLoadListener();
+                recoverOnce(
+                    "[ListenTogether] ready report timed out before local media was ready",
+                    {
+                        expectedTrackId: snapshot.expectedTrackId,
+                        queuedTrackId: snapshot.queuedTrackId,
+                        activeTrackId: snapshot.activeTrackId,
+                        loadedTrackId: snapshot.loadedTrackId,
+                        mediaReady: evaluation.mediaReady,
+                    },
+                );
+                return;
+            }
+
+            this.timer = setTimeout(
+                tryReportReady,
+                LT_READY_REPORT_POLL_INTERVAL_MS,
+            );
+        };
+
+        const onTargetTrackLoaded = () => {
+            this.detachLoadListener();
+            this.clearTimer();
+            void this.ports.reportReady().catch(() => {
+                this.timer = setTimeout(
+                    tryReportReady,
+                    LT_READY_REPORT_RETRY_DELAY_MS,
+                );
+            });
+        };
+
+        this.target = target;
+        this.loadListener = onTargetTrackLoaded;
+        this.ports.engineOn(onTargetTrackLoaded);
+        tryReportReady();
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
         "format:check": "prettier --check .",
         "start": "node server.js",
         "prelint": "tsc -p ../packages/media-metadata-contract/tsconfig.json",
-        "lint": "eslint --max-warnings=182",
+        "lint": "eslint --max-warnings=181",
         "lint:hex": "node scripts/check-hardcoded-hex.mjs",
         "typecheck": "tsc --noEmit --incremental false",
         "pretest:unit": "tsc -p ../packages/media-metadata-contract/tsconfig.json",

--- a/frontend/tests/unit/listenTogetherConnectionState.test.ts
+++ b/frontend/tests/unit/listenTogetherConnectionState.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    resolveConnectionEvent,
+    LT_DISCONNECT_GRACE_MS,
+} from "../../lib/listenTogetherConnectionState";
+
+test("connect restores full connected state and awaits the hydration snapshot", () => {
+    assert.deepEqual(resolveConnectionEvent({ type: "connect" }), {
+        clearGraceTimer: true,
+        setIsConnected: true,
+        setHasConnectedOnce: true,
+        setReconnectAttempt: 0,
+        setSocketRouteStatus: "ok",
+        clearSocketRouteError: true,
+        markAwaitingInitialState: true,
+    });
+});
+
+test("reconnect restores connected state and hands audio recovery to the reconnect path", () => {
+    const directive = resolveConnectionEvent({ type: "reconnect" });
+    assert.equal(directive.markPendingAudioRecovery, true);
+    assert.equal(directive.setIsConnected, true);
+    assert.equal(directive.setReconnectAttempt, 0);
+    assert.equal(directive.markAwaitingInitialState, undefined);
+    assert.equal(directive.setHasConnectedOnce, undefined);
+});
+
+test("reconnect attempts bump the counter and defer the visual disconnect", () => {
+    assert.deepEqual(
+        resolveConnectionEvent({ type: "reconnect-attempt", attempt: 3 }),
+        {
+            setReconnectAttempt: 3,
+            markPendingAudioRecovery: true,
+            armGraceTimer: "reconnect-attempt",
+        },
+    );
+});
+
+test("exhausted reconnects fail fast with an error and a route probe", () => {
+    const directive = resolveConnectionEvent({ type: "reconnect-failed" });
+    assert.equal(directive.clearGraceTimer, true);
+    assert.equal(directive.setIsConnected, false);
+    assert.equal(directive.validateRoute, true);
+    assert.match(directive.setError ?? "", /reconnect failed/i);
+});
+
+test("disconnect only arms the grace timer", () => {
+    assert.deepEqual(resolveConnectionEvent({ type: "disconnect" }), {
+        armGraceTimer: "disconnect",
+    });
+});
+
+test("grace expiry flips the indicator; reconnect-attempt expiry also probes the route", () => {
+    assert.deepEqual(
+        resolveConnectionEvent({
+            type: "grace-expired",
+            cause: "reconnect-attempt",
+        }),
+        { setIsConnected: false, setSocketRouteStatus: "checking" },
+    );
+    assert.deepEqual(
+        resolveConnectionEvent({ type: "grace-expired", cause: "disconnect" }),
+        { setIsConnected: false },
+    );
+});
+
+test("the grace window matches the historical two-second deferral", () => {
+    assert.equal(LT_DISCONNECT_GRACE_MS, 2000);
+});

--- a/frontend/tests/unit/listenTogetherReadyReport.test.ts
+++ b/frontend/tests/unit/listenTogetherReadyReport.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    evaluateReadyReport,
+    type ReadyReportSnapshot,
+} from "../../lib/listenTogetherReadyReport";
+
+function snapshot(
+    overrides: Partial<ReadyReportSnapshot> = {},
+): ReadyReportSnapshot {
+    return {
+        expectedTrackId: "t-1",
+        serverQueuedTrackId: null,
+        expectedLocalTrackId: null,
+        activeTrackId: "t-1",
+        queuedTrackId: null,
+        loadedTrackId: "t-1",
+        engineDurationSec: 180,
+        engineCurrentTimeSec: 0,
+        elapsedMs: 500,
+        maxWaitMs: 7500,
+        ...overrides,
+    };
+}
+
+test("reports when the expected track is loaded with media data", () => {
+    const result = evaluateReadyReport(snapshot());
+    assert.equal(result.decision, "report");
+    assert.equal(result.mediaReady, true);
+    assert.equal(result.timedOut, false);
+});
+
+test("polls while the expected track has not loaded yet", () => {
+    const result = evaluateReadyReport(snapshot({ loadedTrackId: null }));
+    assert.equal(result.decision, "poll");
+    assert.equal(result.mediaReady, false);
+});
+
+test("polls when the engine has no media data for the loaded track", () => {
+    const result = evaluateReadyReport(
+        snapshot({ engineDurationSec: 0, engineCurrentTimeSec: 0 }),
+    );
+    assert.equal(result.decision, "poll");
+});
+
+test("current playback time counts as media data when duration is missing", () => {
+    const result = evaluateReadyReport(
+        snapshot({ engineDurationSec: Number.NaN, engineCurrentTimeSec: 12 }),
+    );
+    assert.equal(result.decision, "report");
+});
+
+test("reports on timeout when the local track still matches expectations", () => {
+    const result = evaluateReadyReport(
+        snapshot({ loadedTrackId: null, elapsedMs: 8000 }),
+    );
+    assert.equal(result.decision, "report");
+    assert.equal(result.timedOut, true);
+    assert.equal(result.mediaReady, false);
+});
+
+test("recovers on timeout when the local track never matched", () => {
+    const result = evaluateReadyReport(
+        snapshot({
+            activeTrackId: "other",
+            queuedTrackId: "other-2",
+            elapsedMs: 8000,
+        }),
+    );
+    assert.equal(result.decision, "recover");
+    assert.equal(result.hasTrackMatch, false);
+});
+
+test("no expected candidates means any local track matches", () => {
+    const result = evaluateReadyReport(
+        snapshot({
+            expectedTrackId: null,
+            serverQueuedTrackId: null,
+            expectedLocalTrackId: null,
+            activeTrackId: "anything",
+            loadedTrackId: "anything",
+        }),
+    );
+    assert.equal(result.decision, "report");
+    assert.equal(result.hasTrackMatch, true);
+});
+
+test("availability remap satisfies the match via the local track id", () => {
+    const result = evaluateReadyReport(
+        snapshot({
+            expectedTrackId: "remote-1",
+            expectedLocalTrackId: "local-9",
+            activeTrackId: "local-9",
+            loadedTrackId: "local-9",
+        }),
+    );
+    assert.equal(result.decision, "report");
+});
+
+test("the queued track can satisfy readiness when nothing is active", () => {
+    const result = evaluateReadyReport(
+        snapshot({
+            activeTrackId: null,
+            queuedTrackId: "t-1",
+            loadedTrackId: "t-1",
+        }),
+    );
+    assert.equal(result.decision, "report");
+});

--- a/frontend/tests/unit/listenTogetherReadyReportRunner.test.ts
+++ b/frontend/tests/unit/listenTogetherReadyReportRunner.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    ListenTogetherReadyReportRunner,
+    LT_READY_REPORT_MAX_WAIT_MS,
+    type ReadyReportRunnerPorts,
+    type ReadyReportTarget,
+} from "../../lib/listenTogetherReadyReportRunner";
+import type { ReadyReportSnapshot } from "../../lib/listenTogetherReadyReport";
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface HarnessOptions {
+    snapshot?: Partial<ReadyReportSnapshot>;
+    reportReady?: () => Promise<void>;
+    startClockAt?: number;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+    const listeners: Array<() => void> = [];
+    const reports: number[] = [];
+    const recoveries: Array<{ reason: string }> = [];
+    let clock = options.startClockAt ?? 0;
+
+    const snapshot = (
+        target: ReadyReportTarget,
+        elapsedMs: number,
+    ): ReadyReportSnapshot => ({
+        expectedTrackId: target.trackId,
+        serverQueuedTrackId: null,
+        expectedLocalTrackId: null,
+        activeTrackId: "t-1",
+        queuedTrackId: null,
+        loadedTrackId: "t-1",
+        engineDurationSec: 120,
+        engineCurrentTimeSec: 0,
+        elapsedMs,
+        maxWaitMs: LT_READY_REPORT_MAX_WAIT_MS,
+        ...options.snapshot,
+    });
+
+    const ports: ReadyReportRunnerPorts = {
+        engineOn: (listener) => listeners.push(listener),
+        engineOff: (listener) => {
+            const index = listeners.indexOf(listener);
+            if (index >= 0) listeners.splice(index, 1);
+        },
+        readSnapshot: snapshot,
+        reportReady:
+            options.reportReady ??
+            (async () => {
+                reports.push(Date.now());
+            }),
+        recover: (reason) => {
+            recoveries.push({ reason });
+        },
+        now: () => clock,
+    };
+
+    return {
+        runner: new ListenTogetherReadyReportRunner(ports),
+        listeners,
+        reports,
+        recoveries,
+        advanceClock: (ms: number) => {
+            clock += ms;
+        },
+    };
+}
+
+test("a ready snapshot reports after the settle delay and detaches the listener", async () => {
+    const h = makeHarness();
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    assert.equal(h.listeners.length, 1, "load listener armed");
+    await sleep(200);
+    assert.equal(h.reports.length, 1, "reported once");
+    assert.equal(h.listeners.length, 0, "listener detached after report");
+});
+
+test("an unready snapshot polls without reporting", async () => {
+    const h = makeHarness({ snapshot: { loadedTrackId: null } });
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    await sleep(250);
+    assert.equal(h.reports.length, 0);
+    assert.equal(h.recoveries.length, 0);
+    h.runner.clearTimer();
+    h.runner.detachLoadListener();
+});
+
+test("the engine load event is the fast path to reporting", async () => {
+    const h = makeHarness({ snapshot: { loadedTrackId: null } });
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    h.listeners[0]?.();
+    await sleep(20);
+    assert.equal(h.reports.length, 1, "load event reported immediately");
+    h.runner.clearTimer();
+});
+
+test("timeout without a track match recovers exactly once", async () => {
+    const h = makeHarness({
+        snapshot: {
+            activeTrackId: "other",
+            loadedTrackId: null,
+        },
+    });
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    h.advanceClock(LT_READY_REPORT_MAX_WAIT_MS + 1);
+    await sleep(150);
+    assert.equal(h.recoveries.length, 1);
+    assert.match(h.recoveries[0].reason, /timed out/);
+    assert.equal(h.reports.length, 0);
+    assert.equal(h.listeners.length, 0, "listener detached on recovery");
+});
+
+test("an obsolete track detaches the listener but a matching one does not", () => {
+    const h = makeHarness({ snapshot: { loadedTrackId: null } });
+    h.runner.begin({ currentIndex: 2, trackId: "t-2" });
+    h.runner.detachLoadListenerIfObsolete(2, "t-2");
+    assert.equal(h.listeners.length, 1, "same target keeps the listener");
+    h.runner.detachLoadListenerIfObsolete(3, "t-3");
+    assert.equal(h.listeners.length, 0, "moved target drops the listener");
+    h.runner.clearTimer();
+});
+
+test("begin cancels the previous wait before starting a new one", async () => {
+    const h = makeHarness({ snapshot: { loadedTrackId: null } });
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    h.runner.begin({ currentIndex: 1, trackId: "t-2" });
+    assert.equal(h.listeners.length, 1, "only the new wait's listener remains");
+    h.runner.clearTimer();
+    h.runner.detachLoadListener();
+});
+
+test("a failed report retries and eventually succeeds", async () => {
+    let failures = 1;
+    const reports: number[] = [];
+    const h = makeHarness({
+        reportReady: async () => {
+            if (failures > 0) {
+                failures -= 1;
+                throw new Error("transient");
+            }
+            reports.push(1);
+        },
+    });
+    h.runner.begin({ currentIndex: 0, trackId: "t-1" });
+    await sleep(600);
+    assert.equal(reports.length, 1, "second attempt succeeded");
+});

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -71,7 +71,7 @@ const BASELINE = Object.freeze({
     "frontend/components/player/OverlayPlayer.tsx": 1352,
     "frontend/hooks/useQueries.ts": 1453,
     "frontend/lib/audio-controls-context.tsx": 2305,
-    "frontend/lib/listen-together-context.tsx": 2063,
+    "frontend/lib/listen-together-context.tsx": 1954,
     "services/audio-analyzer/analyzer.py": 2248,
 });
 


### PR DESCRIPTION
Part of #787 (slice C — the listen-together provider; slices A/B were #832/#834). With this, the decomposition work in #787 is done.

## What changed

- **Ready-report machine extracted.** The 220-line inline `onWaiting` handler — poll timer, engine load listener, awaited-target tracking, retry/terminal-retry/recover ladder — is now `ListenTogetherReadyReportRunner`, a ports-injected class (engine on/off, snapshot reader, reportReady, recover, clock) with the per-tick decision math in a pure `evaluateReadyReport` module. Three provider refs and two clear-helper callbacks collapsed into the runner. The subtle semantic that a track change drops the load listener but keeps the poll timer running is preserved and now documented on `detachLoadListenerIfObsolete`.
- **Connection events go through a reducer.** connect / reconnect / reconnect-attempt / reconnect-failed / disconnect and grace-timer expiry now map through pure `resolveConnectionEvent` (one directive table, including the 2 s visual-disconnect grace rules), applied by a single directive applier in the provider. Grace expiry feeds back through the same table, so every visual-disconnect transition shares one decision path.
- **Mirror effects dropped.** The hand-rolled `controlsRef`/`audioStateRef` mirror effects are replaced by a shared `useLatestRef` hook. The refs themselves remain — they're what keeps the 500-line socket-handler closure out of the audio-tick dependency chain — but there's no bespoke sync code left.
- Provider: 2063 → 1954 lines (baseline tightened). Eslint cap tightened 182 → 181.

## Behavior notes

- The provider's socket-callback seam is unchanged — `connectSocket` still hands one callbacks object to `listenTogetherSocket.connect`, which is the seam the 2,066-line session component suite drives. That suite passes untouched (39/39), including the play-at/ready-gate, engine-load ready report, reconnect recovery, and availability remap tests.
- The context value shape (27 members) is unchanged; no consumer edits.

## What I deliberately did not do

Narrowing the provider's `useAudioState()`/`useAudioControls()` subscriptions (so it stops re-rendering on every audio tick) is a deeper change to how the provider consumes audio context and would touch the orchestrator seam; the issue's core ask — pure, testable machines and no hand-rolled mirrors — is delivered without it. If we want the subscription narrowing, I'd file it separately.

## Verification

- `npx tsc --noEmit` clean; `npm run lint` 181 warnings at the tightened cap; `format:check` clean; `check-file-size.mjs` passes with the tightened baseline
- `npm run test:unit` — 1077/1077 (23 new: evaluateReadyReport ×9, connection reducer ×7, runner ×7)
- `npm run test:component` — 736/736, including the full listen-together session suite
