### PR TITLE
fix(downloads): TIDAL and YouTube Music album matching fails closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TIDAL downloads now tag ALBUMARTIST with the album artist instead of the per-track artist, preventing multi-artist album tracks from splitting into phantom single-track albums.
 - Artist "Download all missing albums" now skips promotion-, bootleg-, or pseudo-release-only groups, remix/live/demo/compilation groups, and releases where the artist is only a featured credit; MusicBrainz enumeration failures now fail the expansion instead of reporting no missing albums (#824).
+- TIDAL and YouTube Music album matching no longer downloads an unrelated release when the requested album is missing; the job now fails over to the configured provider or fails honestly instead (#825).
 - Album downloads that select Soulseek, including TIDAL or YouTube Music runtime fallbacks and the default setting, now download through Soulseek instead of silently using Lidarr (#788).
 - Playing music no longer re-renders large parts of the app once per second: pages and controls now subscribe only to the playback details they actually show, and dragging the volume slider updates just the volume controls instead of rippling through every open page (#785).
 - Queued album downloads waiting on the deployment-wide claim now return to Bull with a delay instead of occupying an active worker slot for up to four hours.

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -14,6 +14,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | --- | --- |
 | `backend/src/services/acquisitionService.ts` | Core |
 | `backend/src/services/albumResolutionService.ts` | Core |
+| `backend/src/services/albumMatchPolicy.ts` | Shared fail-closed provider album artist/title matching policy |
 | `backend/src/services/albumDownloadJobs.ts` | Shared locked album download-job creation and active-job deduplication |
 | `backend/src/services/albumDownloadQueueOwnership.ts` | Persisted album-download queue ownership marker and metadata predicate |
 | `backend/src/services/albumDownloadQueueService.ts` | Durable album download queue admission and observed background enqueue failures |

--- a/backend/src/services/__tests__/albumMatchPolicy.test.ts
+++ b/backend/src/services/__tests__/albumMatchPolicy.test.ts
@@ -1,0 +1,278 @@
+import {
+    isAcceptableAlbumMatch,
+    pickBestAlbumMatch,
+} from "../albumMatchPolicy";
+
+interface MatchFixture {
+    name: string;
+    request: { artistName: string; albumTitle: string };
+    candidate: { artistName: string; albumTitle: string };
+    accepted: boolean;
+}
+
+const fixtures: MatchFixture[] = [
+    {
+        name: "accepts an exact artist and title",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: { artistName: "Drake", albumTitle: "Take Care" },
+        accepted: true,
+    },
+    {
+        name: "accepts a candidate edition suffix",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: {
+            artistName: "Drake",
+            albumTitle: "Take Care (Deluxe)",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts a requested edition suffix",
+        request: {
+            artistName: "Drake",
+            albumTitle: "Take Care (Deluxe)",
+        },
+        candidate: { artistName: "Drake", albumTitle: "Take Care" },
+        accepted: true,
+    },
+    {
+        name: "accepts a collaboration containing the requested artist",
+        request: { artistName: "Drake", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake & 21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts a requested artist at the end of a collaboration",
+        request: { artistName: "21 Savage", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake & 21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts a requested artist as a whole token",
+        request: { artistName: "Artist", albumTitle: "Album" },
+        candidate: {
+            artistName: "Different Artist",
+            albumTitle: "Album",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts collaboration diacritic and conjunction variants",
+        request: { artistName: "Beyoncé", albumTitle: "Everything Is Love" },
+        candidate: {
+            artistName: "Beyonce & Jay-Z",
+            albumTitle: "Everything Is Love",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts a requested leading article omitted by the candidate",
+        request: { artistName: "The Beatles", albumTitle: "Abbey Road" },
+        candidate: { artistName: "Beatles", albumTitle: "Abbey Road" },
+        accepted: true,
+    },
+    {
+        name: "accepts a candidate leading article omitted by the request",
+        request: { artistName: "Beatles", albumTitle: "Abbey Road" },
+        candidate: { artistName: "The Beatles", albumTitle: "Abbey Road" },
+        accepted: true,
+    },
+    {
+        name: "keeps a repeated leading article in an exact artist name",
+        request: { artistName: "The The", albumTitle: "Soul Mining" },
+        candidate: { artistName: "The The", albumTitle: "Soul Mining" },
+        accepted: true,
+    },
+    {
+        name: "does not collapse a repeated leading article to a bare article",
+        request: { artistName: "The The", albumTitle: "Soul Mining" },
+        candidate: { artistName: "The", albumTitle: "Soul Mining" },
+        accepted: false,
+    },
+    {
+        name: "does not collapse a repeated leading article to an empty artist",
+        request: { artistName: "The The", albumTitle: "Soul Mining" },
+        candidate: { artistName: "", albumTitle: "Soul Mining" },
+        accepted: false,
+    },
+    {
+        name: "applies the containment length guard after removing an article",
+        request: { artistName: "The X", albumTitle: "Townie" },
+        candidate: { artistName: "X Ambassadors", albumTitle: "Townie" },
+        accepted: false,
+    },
+    {
+        name: "accepts comma-adjacent requested artist tokens",
+        request: { artistName: "Drake", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake,21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts comma-adjacent trailing artist tokens",
+        request: { artistName: "21 Savage", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake,21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts slash-adjacent requested artist tokens",
+        request: { artistName: "Drake", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake/21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "accepts slash-adjacent trailing artist tokens",
+        request: { artistName: "21 Savage", albumTitle: "Her Loss" },
+        candidate: {
+            artistName: "Drake/21 Savage",
+            albumTitle: "Her Loss",
+        },
+        accepted: true,
+    },
+    {
+        name: "rejects DJ Khaled for Drake",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: { artistName: "DJ Khaled", albumTitle: "Take Care" },
+        accepted: false,
+    },
+    {
+        name: "rejects a partial-token artist match",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: {
+            artistName: "Drakeo the Ruler",
+            albumTitle: "Take Care",
+        },
+        accepted: false,
+    },
+    {
+        name: "rejects Young Money for Drake",
+        request: { artistName: "Drake", albumTitle: "Trophies" },
+        candidate: { artistName: "Young Money", albumTitle: "Trophies" },
+        accepted: false,
+    },
+    {
+        name: "rejects Kendrick Lamar for Drake",
+        request: { artistName: "Drake", albumTitle: "6 God" },
+        candidate: { artistName: "Kendrick Lamar", albumTitle: "6 God" },
+        accepted: false,
+    },
+    {
+        name: "rejects containment for a short requested artist",
+        request: { artistName: "X", albumTitle: "Townie" },
+        candidate: { artistName: "X Ambassadors", albumTitle: "Townie" },
+        accepted: false,
+    },
+    {
+        name: "rejects a title mismatch for the same artist",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: { artistName: "Drake", albumTitle: "Nothing Was the Same" },
+        accepted: false,
+    },
+    {
+        name: "rejects an empty requested artist",
+        request: { artistName: " ", albumTitle: "Take Care" },
+        candidate: { artistName: "Drake", albumTitle: "Take Care" },
+        accepted: false,
+    },
+    {
+        name: "rejects an empty requested title",
+        request: { artistName: "Drake", albumTitle: "" },
+        candidate: { artistName: "Drake", albumTitle: "Take Care" },
+        accepted: false,
+    },
+    {
+        name: "rejects an empty candidate artist",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: { artistName: "", albumTitle: "Take Care" },
+        accepted: false,
+    },
+    {
+        name: "rejects an empty candidate title",
+        request: { artistName: "Drake", albumTitle: "Take Care" },
+        candidate: { artistName: "Drake", albumTitle: "\t" },
+        accepted: false,
+    },
+];
+
+describe("isAcceptableAlbumMatch", () => {
+    it.each(fixtures)("$name", ({ request, candidate, accepted }) => {
+        expect(isAcceptableAlbumMatch(request, candidate)).toBe(accepted);
+    });
+});
+
+describe("pickBestAlbumMatch", () => {
+    it("prefers an exact title over an earlier edition-stripped title", () => {
+        const candidates = [
+            {
+                id: "EDITION",
+                artistName: "Drake",
+                albumTitle: "Take Care (Deluxe)",
+            },
+            {
+                id: "EXACT",
+                artistName: "Drake",
+                albumTitle: "Take Care",
+            },
+        ];
+
+        expect(
+            pickBestAlbumMatch(
+                { artistName: "Drake", albumTitle: "Take Care" },
+                candidates,
+                (candidate) => candidate,
+            ),
+        ).toBe(candidates[1]);
+    });
+
+    it("keeps provider order within the same title tier", () => {
+        const candidates = [
+            {
+                id: "FIRST",
+                artistName: "Drake & 21 Savage",
+                albumTitle: "Her Loss",
+            },
+            {
+                id: "SECOND",
+                artistName: "Drake",
+                albumTitle: "Her Loss",
+            },
+        ];
+
+        expect(
+            pickBestAlbumMatch(
+                { artistName: "Drake", albumTitle: "Her Loss" },
+                candidates,
+                (candidate) => candidate,
+            ),
+        ).toBe(candidates[0]);
+    });
+
+    it("returns null when no candidate passes both artist and title", () => {
+        expect(
+            pickBestAlbumMatch(
+                { artistName: "Drake", albumTitle: "6 God" },
+                [
+                    {
+                        artistName: "Kendrick Lamar",
+                        albumTitle: "GNX",
+                    },
+                ],
+                (candidate) => candidate,
+            ),
+        ).toBeNull();
+    });
+});

--- a/backend/src/services/__tests__/tidalService.test.ts
+++ b/backend/src/services/__tests__/tidalService.test.ts
@@ -12,7 +12,9 @@ const mockLogger = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    child: jest.fn(),
 };
+mockLogger.child.mockReturnValue(mockLogger);
 
 const mockPrisma = {
     systemSettings: {
@@ -486,7 +488,7 @@ describe("tidalService", () => {
             });
         });
 
-        it("returns first album as fallback when there is no normalized title match", async () => {
+        it("returns null when no candidate passes artist and title verification", async () => {
             jest.spyOn(tidalService, "search").mockResolvedValue({
                 tracks: [],
                 artists: [],
@@ -516,12 +518,39 @@ describe("tidalService", () => {
 
             await expect(
                 tidalService.findAlbum("Different Artist", "Nonexistent Title"),
-            ).resolves.toEqual({
-                albumId: 101,
-                title: "Unexpected Pick",
-                artist: "Artist A",
-                numberOfTracks: 8,
+            ).resolves.toBeNull();
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                "No acceptable album match found",
+                {
+                    artistName: "Different Artist",
+                    albumTitle: "Nonexistent Title",
+                    candidateCount: 2,
+                },
+            );
+            expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+        });
+
+        it("rejects an exact title when the candidate artist is wrong", async () => {
+            jest.spyOn(tidalService, "search").mockResolvedValue({
+                tracks: [],
+                artists: [],
+                albums: [
+                    {
+                        id: 303,
+                        title: "Trophies",
+                        artist: "Young Money",
+                        numberOfTracks: 1,
+                        releaseDate: null,
+                        type: "SINGLE",
+                        quality: "HIGH",
+                        cover: null,
+                    },
+                ],
             });
+
+            await expect(
+                tidalService.findAlbum("Drake", "Trophies"),
+            ).resolves.toBeNull();
         });
 
         it("returns null and logs when album search throws", async () => {

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -1,12 +1,16 @@
+const mockLoggerDebug = jest.fn();
 const mockLoggerWarn = jest.fn();
+const mockLogger = {
+    debug: mockLoggerDebug,
+    info: jest.fn(),
+    warn: mockLoggerWarn,
+    error: jest.fn(),
+    child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
 
 jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: mockLoggerWarn,
-        error: jest.fn(),
-    },
+    logger: mockLogger,
 }));
 
 jest.mock("../../utils/db", () => ({
@@ -147,7 +151,7 @@ describe("youtubeLibraryDownload", () => {
         ).resolves.toBe("CANONICAL");
     });
 
-    it("falls back to an exact normalized title match", async () => {
+    it("returns null for a matching title when every artist is wrong", async () => {
         mockSearch.mockResolvedValueOnce([
             {
                 browseId: "LOOSE",
@@ -157,16 +161,23 @@ describe("youtubeLibraryDownload", () => {
             {
                 browseId: "TITLE",
                 title: "Al-bum",
-                artists: ["Different Artist"],
+                artists: ["DJ Khaled"],
             },
         ]);
 
-        await expect(findAlbumBrowseId("Artist", "Album")).resolves.toBe(
-            "TITLE",
+        await expect(findAlbumBrowseId("Artist", "Album")).resolves.toBeNull();
+        expect(mockLoggerDebug).toHaveBeenCalledWith(
+            "No acceptable album match found",
+            {
+                artistName: "Artist",
+                albumTitle: "Album",
+                candidateCount: 2,
+            },
         );
+        expect(mockLoggerDebug).toHaveBeenCalledTimes(1);
     });
 
-    it("falls back to the first result carrying a browse id", async () => {
+    it("returns null instead of falling back to the first browse id", async () => {
         mockSearch.mockResolvedValueOnce([
             { title: "No Identifier", artists: ["Artist"] },
             {
@@ -181,10 +192,78 @@ describe("youtubeLibraryDownload", () => {
             },
         ]);
 
-        await expect(findAlbumBrowseId("Artist", "Album")).resolves.toBe(
-            "FIRST",
+        await expect(findAlbumBrowseId("Artist", "Album")).resolves.toBeNull();
+    });
+
+    it("matches an edition-suffixed candidate after stripping both titles", async () => {
+        mockSearch.mockResolvedValueOnce([
+            {
+                browseId: "DELUXE",
+                title: "Renaissance (Deluxe Edition)",
+                artists: ["Beyoncé"],
+            },
+        ]);
+
+        await expect(findAlbumBrowseId("Beyoncé", "Renaissance")).resolves.toBe(
+            "DELUXE",
         );
     });
+
+    it("rejects a sole candidate with the wrong artist", async () => {
+        mockSearch.mockResolvedValueOnce([
+            {
+                browseId: "TROPHIES",
+                title: "Trophies",
+                artists: ["Young Money"],
+            },
+        ]);
+
+        await expect(
+            findAlbumBrowseId("Drake", "Trophies"),
+        ).resolves.toBeNull();
+    });
+
+    it("accepts a candidate when any listed artist matches", async () => {
+        mockSearch.mockResolvedValueOnce([
+            {
+                browseId: "COLLAB",
+                title: "Her Loss",
+                artists: ["21 Savage", "Drake"],
+            },
+        ]);
+
+        await expect(findAlbumBrowseId("Drake", "Her Loss")).resolves.toBe(
+            "COLLAB",
+        );
+    });
+
+    it.each([
+        {
+            description: "an empty artist list",
+            candidate: {
+                browseId: "EMPTY-ARTISTS",
+                title: "Album",
+                artists: [],
+            },
+        },
+        {
+            description: "an omitted artist list",
+            candidate: {
+                browseId: "MISSING-ARTISTS",
+                title: "Album",
+            },
+        },
+    ])(
+        "returns null without starting a download for $description",
+        async ({ candidate }) => {
+            mockSearch.mockResolvedValueOnce([candidate]);
+
+            await expect(
+                findAlbumBrowseId("Artist", "Album"),
+            ).resolves.toBeNull();
+            expect(mockStartAlbum).not.toHaveBeenCalled();
+        },
+    );
 
     it("returns null when no result carries a browse id", async () => {
         mockSearch.mockResolvedValueOnce([

--- a/backend/src/services/albumMatchPolicy.ts
+++ b/backend/src/services/albumMatchPolicy.ts
@@ -1,0 +1,126 @@
+import {
+    normalizeForExactKey,
+    normalizeForFuzzyMatch,
+    stripAlbumEdition,
+} from "../utils/artistNormalization";
+
+/** Requested artist and album title used to verify provider search results. */
+export interface AlbumMatchRequest {
+    artistName: string;
+    albumTitle: string;
+}
+
+/** Provider candidate fields required by the album-match policy. */
+export interface AlbumMatchCandidate {
+    artistName: string;
+    albumTitle: string;
+}
+
+type TitleMatchTier = "exact" | "edition";
+
+function normalizedExact(value: string): string | null {
+    if (!value.trim()) return null;
+    return normalizeForExactKey(value) || null;
+}
+
+function normalizedArtistTokens(value: string): string {
+    return normalizeForFuzzyMatch(value.replace(/\p{P}+/gu, " "));
+}
+
+function withoutLeadingArticle(value: string): string {
+    if (value === "the") return "";
+    return value.startsWith("the ") ? value.slice(4) : value;
+}
+
+function containsRequestedArtist(
+    requestedTokens: string,
+    candidateTokens: string,
+): boolean {
+    return (
+        requestedTokens.length >= 3 &&
+        ` ${candidateTokens} `.includes(` ${requestedTokens} `)
+    );
+}
+
+function titleMatchTier(
+    requestedTitle: string,
+    candidateTitle: string,
+): TitleMatchTier | null {
+    const requestedExact = normalizedExact(requestedTitle);
+    const candidateExact = normalizedExact(candidateTitle);
+    if (!requestedExact || !candidateExact) return null;
+    if (candidateExact === requestedExact) return "exact";
+
+    const requestedBase = normalizedExact(stripAlbumEdition(requestedTitle));
+    const candidateBase = normalizedExact(stripAlbumEdition(candidateTitle));
+    if (!requestedBase || !candidateBase) return null;
+    return candidateBase === requestedBase ? "edition" : null;
+}
+
+function artistMatches(
+    requestedArtist: string,
+    candidateArtist: string,
+): boolean {
+    const requestedExact = normalizedExact(requestedArtist);
+    const candidateExact = normalizedExact(candidateArtist);
+    if (!requestedExact || !candidateExact) return false;
+    if (candidateExact === requestedExact) return true;
+
+    const requestedTokens = normalizedArtistTokens(requestedArtist);
+    const candidateTokens = normalizedArtistTokens(candidateArtist);
+    if (containsRequestedArtist(requestedTokens, candidateTokens)) return true;
+
+    return containsRequestedArtist(
+        withoutLeadingArticle(requestedTokens),
+        withoutLeadingArticle(candidateTokens),
+    );
+}
+
+/**
+ * Verify that a provider candidate matches both the requested artist and title.
+ * Empty or non-normalizable fields are rejected.
+ */
+export function isAcceptableAlbumMatch(
+    request: AlbumMatchRequest,
+    candidate: AlbumMatchCandidate,
+): boolean {
+    return (
+        titleMatchTier(request.albumTitle, candidate.albumTitle) !== null &&
+        artistMatches(request.artistName, candidate.artistName)
+    );
+}
+
+function findInTier<T>(
+    request: AlbumMatchRequest,
+    candidates: T[],
+    read: (candidate: T) => AlbumMatchCandidate,
+    tier: TitleMatchTier,
+): T | null {
+    return (
+        candidates.find((candidate) => {
+            const fields = read(candidate);
+            return (
+                titleMatchTier(request.albumTitle, fields.albumTitle) ===
+                    tier && artistMatches(request.artistName, fields.artistName)
+            );
+        }) ?? null
+    );
+}
+
+/**
+ * Pick the first acceptable provider candidate in the strongest title tier.
+ * Exact-title matches take precedence over edition-stripped matches while
+ * provider order is retained within each tier.
+ */
+export function pickBestAlbumMatch<T>(
+    request: AlbumMatchRequest,
+    candidates: T[],
+    read: (candidate: T) => AlbumMatchCandidate,
+): T | null {
+    if (!normalizedExact(request.artistName)) return null;
+    if (!normalizedExact(request.albumTitle)) return null;
+
+    const exact = findInTier(request, candidates, read, "exact");
+    if (exact) return exact;
+    return findInTier(request, candidates, read, "edition");
+}

--- a/backend/src/services/tidal.ts
+++ b/backend/src/services/tidal.ts
@@ -13,6 +13,9 @@ import { logger } from "../utils/logger";
 import { getSystemSettings } from "../utils/systemSettings";
 import { prisma } from "../utils/db";
 import { encrypt, decrypt } from "../utils/encryption";
+import { pickBestAlbumMatch } from "./albumMatchPolicy";
+
+const tidalLogger = logger.child("TidalService");
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -378,20 +381,22 @@ class TidalService {
             const results = await this.search(`${artistName} ${albumTitle}`);
             if (!results.albums || results.albums.length === 0) return null;
 
-            // Find best match — prefer exact album title match
-            const normalise = (s: string) =>
-                s.toLowerCase().replace(/[^a-z0-9]/g, "");
-            const normAlbum = normalise(albumTitle);
-            const normArtist = normalise(artistName);
-
-            const match =
-                results.albums.find(
-                    (a) =>
-                        normalise(a.title) === normAlbum &&
-                        normalise(a.artist) === normArtist,
-                ) ||
-                results.albums.find((a) => normalise(a.title) === normAlbum) ||
-                results.albums[0];
+            const match = pickBestAlbumMatch(
+                { artistName, albumTitle },
+                results.albums,
+                (album) => ({
+                    artistName: album.artist,
+                    albumTitle: album.title,
+                }),
+            );
+            if (!match) {
+                tidalLogger.debug("No acceptable album match found", {
+                    artistName,
+                    albumTitle,
+                    candidateCount: results.albums.length,
+                });
+                return null;
+            }
 
             return {
                 albumId: match.id,

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -6,17 +6,25 @@ import {
     runLibraryAlbumDownload,
 } from "./libraryDownloadProcessor";
 import { patchDownloadJobMetadata } from "./downloadJobStatus";
-import { normalizeForExactKey } from "../utils/artistNormalization";
+import { logger } from "../utils/logger";
+import { pickBestAlbumMatch } from "./albumMatchPolicy";
 import {
     type YtAlbumDownloadJobStatus,
     watchYouTubeDownloadJobUntilTerminal,
     youtubeDownloadService,
 } from "./youtubeDownload";
 
+const youtubeLibraryDownloadLogger = logger.child("YoutubeLibraryDownload");
+
 interface AlbumSearchCandidate {
     browseId: string;
     title: string;
     artists: string[];
+}
+
+interface CandidateArtist {
+    candidate: AlbumSearchCandidate;
+    artistName: string;
 }
 
 /** Controls hand-off behavior when this processor is itself a fallback. */
@@ -44,25 +52,29 @@ function selectAlbumBrowseId(
     artistName: string,
     albumTitle: string,
 ): string | null {
-    const normalizedTitle = normalizeForExactKey(albumTitle);
-    const normalizedArtist = normalizeForExactKey(artistName);
-    const exactMatch = candidates.find(
-        (candidate) =>
-            normalizeForExactKey(candidate.title) === normalizedTitle &&
-            candidate.artists.some(
-                (artist) => normalizeForExactKey(artist) === normalizedArtist,
-            ),
+    const candidateArtists = candidates.flatMap((candidate) =>
+        candidate.artists.map((candidateArtist) => ({
+            candidate,
+            artistName: candidateArtist,
+        })),
     );
-    const titleMatch = candidates.find(
-        (candidate) =>
-            normalizeForExactKey(candidate.title) === normalizedTitle,
+    const match = pickBestAlbumMatch(
+        { artistName, albumTitle },
+        candidateArtists,
+        ({ candidate, artistName: candidateArtist }: CandidateArtist) => ({
+            artistName: candidateArtist,
+            albumTitle: candidate.title,
+        }),
     );
-    return (
-        exactMatch?.browseId ??
-        titleMatch?.browseId ??
-        candidates[0]?.browseId ??
-        null
-    );
+    if (match) return match.candidate.browseId;
+    if (candidates.length > 0) {
+        youtubeLibraryDownloadLogger.debug("No acceptable album match found", {
+            artistName,
+            albumTitle,
+            candidateCount: candidates.length,
+        });
+    }
+    return null;
 }
 
 /** Find the best public album-search result using TIDAL-compatible matching. */


### PR DESCRIPTION
## Problem

When a queued album didn't exist on TIDAL/ytmusic, the matchers fell back to title-only and then to the **first search result**, downloaded it, and reported success. Production incident (issue #825): "Drake - Trophies" delivered Young Money's single, "Drake - I'm on One" delivered DJ Khaled's single, "Drake - 6 God" delivered Kendrick Lamar's GNX, and 17 bootleg-titled jobs all matched the same unrelated TIDAL album.

## Fix

New shared pure policy `backend/src/services/albumMatchPolicy.ts`, used by both `tidal.ts findAlbum` (which previously had its own weaker normalizer) and `youtubeLibraryDownload.ts selectAlbumBrowseId`:

- **Title** must match on `normalizeForExactKey`, exactly or after `stripAlbumEdition` on both sides ("Take Care" ↔ "Take Care (Deluxe)"), with exact-tier preference.
- **Artist** must match on exact key, or token-boundary containment for collab credits ("Drake" ✓ "Drake & 21 Savage", ✗ "Drakeo the Ruler"), with leading-"the" tolerance ("The Beatles" ↔ "Beatles") and punctuation-safe tokenization ("Drake,21 Savage" ✓). Guarded against short-name false positives.
- No candidate passes → no match: the provider returns null, the existing one-hop search-miss hand-off runs, and the job fails honestly instead of importing garbage. One structured debug log when candidates existed but none passed.

The `albums[0]` and title-only fallbacks are gone from both providers. Dispatcher/runner semantics untouched.

## Tests

TDD with red runs first. Policy fixtures: the three production regressions (DJ Khaled, Young Money, Kendrick Lamar rejected), collab/containment boundary cases (Drakeo, The The, comma/slash credits), edition tiers both directions, tier preference, empty/short inputs. Provider suites: the old "returns first album as fallback" pin replaced with fail-closed assertions; ytmusic empty/omitted artist arrays fail closed; edition-variant match that was previously broken now covered.

## Verification

- verify: targeted suites exit 0 — `Test Suites: 3 passed` (79 tests) plus the runner/dispatcher suites in the first round (`6 passed`, 96 tests)
- verify: backend tsc --noEmit exit 0; repo-wide backend format:check clean; file-size gate exit 0

Closes #825