### PR TITLE
fix(downloads): album jobs verify delivered track counts against the release group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Album downloads that deliver only part of the requested album now fail with a "Partial download: N/M tracks" status instead of reporting success, and library reconciliation no longer marks a multi-track request complete off a single-track album (#826).
 - TIDAL downloads now tag ALBUMARTIST with the album artist instead of the per-track artist, preventing multi-artist album tracks from splitting into phantom single-track albums.
 - Artist "Download all missing albums" now skips promotion-, bootleg-, or pseudo-release-only groups, remix/live/demo/compilation groups, and releases where the artist is only a featured credit; MusicBrainz enumeration failures now fail the expansion instead of reporting no missing albums (#824).
 - TIDAL and YouTube Music album matching no longer downloads an unrelated release when the requested album is missing; the job now fails over to the configured provider or fails honestly instead (#825).

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -18,6 +18,7 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/albumDownloadJobs.ts` | Shared locked album download-job creation and active-job deduplication |
 | `backend/src/services/albumDownloadQueueOwnership.ts` | Persisted album-download queue ownership marker and metadata predicate |
 | `backend/src/services/albumDownloadQueueService.ts` | Durable album download queue admission and observed background enqueue failures |
+| `backend/src/services/albumDownloadCompleteness.ts` | Pure downloaded-versus-expected album track-count classification |
 | `backend/src/services/artistDownloadExpansionJobs.ts` | Locked creation and active-job deduplication for durable artist discography expansion |
 | `backend/src/services/albumTitleGuards.ts` | Shared remote-album placeholder-title classification |
 | `backend/src/services/albumLoudness.ts` | Transactional active-track loudness rollups and per-album serialization |

--- a/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
+++ b/backend/src/services/__tests__/libraryDownloadProcessor.test.ts
@@ -1,10 +1,12 @@
+const mockLog = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+
 jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    },
+    logger: { child: jest.fn(() => mockLog) },
 }));
 
 jest.mock("../../utils/db", () => ({
@@ -34,9 +36,18 @@ jest.mock("../coalescedLibraryScan", () => ({
     requestCoalescedLibraryScan: jest.fn(),
 }));
 
+const mockGetExpectedTrackCount = jest.fn();
+jest.mock("../musicbrainz", () => ({
+    musicBrainzService: {
+        getExpectedTrackCount: (...args: unknown[]) =>
+            mockGetExpectedTrackCount(...args),
+    },
+}));
+
 import { prisma } from "../../utils/db";
 import { getSystemSettings } from "../../utils/systemSettings";
 import { requestCoalescedLibraryScan } from "../coalescedLibraryScan";
+import { classifyDownloadCompleteness } from "../albumDownloadCompleteness";
 import {
     type LibraryAlbumDownloadOptions,
     type LibraryDownloadProcessorConfig,
@@ -78,6 +89,7 @@ const processorConfig: LibraryDownloadProcessorConfig<FakeMatch, FakeResult> = {
         statusText: `Fake Music ✓ ${result.downloaded} tracks`,
         metadata: { fakeResult: { downloaded: result.downloaded } },
     }),
+    readDownloadedCount: (result) => result.downloaded,
     fallbackPeer: {
         sourceKey: "youtube",
         run: fallbackPeer,
@@ -91,8 +103,8 @@ describe("libraryDownloadProcessor", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockFindUnique.mockResolvedValue({
+            targetMbid: "rg-target",
             metadata: {
-                albumMbid: "rg-1",
                 queuedVia: "album-download-queue",
                 failedAt: "2026-08-24T10:00:00.000Z",
             },
@@ -103,6 +115,7 @@ describe("libraryDownloadProcessor", () => {
         download.mockResolvedValue({ downloaded: 3 });
         fallbackPeer.mockResolvedValue(undefined);
         mockScan.mockResolvedValue(undefined);
+        mockGetExpectedTrackCount.mockResolvedValue(3);
     });
 
     it("hands a search miss to the configured peer", async () => {
@@ -127,7 +140,6 @@ describe("libraryDownloadProcessor", () => {
             where: { id: "job-1" },
             data: {
                 metadata: {
-                    albumMbid: "rg-1",
                     queuedVia: "album-download-queue",
                     failedAt: "2026-08-24T10:00:00.000Z",
                     currentSource: "youtube",
@@ -261,6 +273,14 @@ describe("libraryDownloadProcessor", () => {
     });
 
     it("completes the job and requests the configured library scan", async () => {
+        mockFindUnique.mockResolvedValue({
+            targetMbid: "rg-target",
+            metadata: {
+                queuedVia: "album-download-queue",
+                failedAt: "2026-08-24T10:00:00.000Z",
+                partial: true,
+            },
+        });
         await runLibraryAlbumDownload(
             processorConfig,
             "job-1",
@@ -279,10 +299,171 @@ describe("libraryDownloadProcessor", () => {
                 currentSource: "fake",
                 statusText: "Fake Music ✓ 3 tracks",
                 fakeResult: { downloaded: 3 },
+                expectedTracks: 3,
             }),
         );
         expect(completedUpdate.data.metadata).not.toHaveProperty("failedAt");
+        expect(completedUpdate.data.metadata).not.toHaveProperty("partial");
         expect(mockScan).toHaveBeenCalledWith("user-1", "fake-download");
+    });
+
+    it("fails a partial download and persists its completeness metadata", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(14);
+        download.mockResolvedValueOnce({ downloaded: 1 });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        const failedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.error === "Partial download: 1/14 tracks",
+        )?.[0];
+        expect(failedUpdate.data).toEqual(
+            expect.objectContaining({
+                status: "failed",
+                error: "Partial download: 1/14 tracks",
+                completedAt: expect.any(Date),
+                metadata: expect.objectContaining({
+                    statusText: "Partial download: 1/14 tracks",
+                    partial: true,
+                    expectedTracks: 14,
+                    fakeResult: { downloaded: 1 },
+                }),
+            }),
+        );
+        expect(mockLog.warn).toHaveBeenCalledWith(
+            "Album download is incomplete",
+            {
+                jobId: "job-1",
+                source: "fake",
+                downloadedTracks: 1,
+                expectedTracks: 14,
+            },
+        );
+        expect(mockScan).toHaveBeenCalledWith("user-1", "fake-download");
+    });
+
+    it("completes when MusicBrainz cannot determine the expected count", async () => {
+        const musicBrainzError = new Error("MusicBrainz unavailable");
+        mockGetExpectedTrackCount.mockRejectedValueOnce(musicBrainzError);
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        const completedUpdate = mockUpdate.mock.calls.find(
+            ([call]) => call.data?.status === "completed",
+        )?.[0];
+        expect(completedUpdate.data.metadata).not.toHaveProperty(
+            "expectedTracks",
+        );
+        expect(mockLog.warn).toHaveBeenCalledWith(
+            "Album completeness verification skipped",
+            {
+                jobId: "job-1",
+                source: "fake",
+                albumMbid: "rg-target",
+                reason: "MusicBrainz expected-count lookup failed",
+                error: musicBrainzError,
+            },
+        );
+    });
+
+    it("treats a zero expected count as unknown and never persists zero", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(0);
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(mockLog.warn).toHaveBeenCalledWith(
+            "Album completeness verification skipped",
+            {
+                jobId: "job-1",
+                source: "fake",
+                albumMbid: "rg-target",
+                reason: "MusicBrainz returned no expected track count",
+            },
+        );
+        expect(JSON.stringify(mockUpdate.mock.calls)).not.toContain(
+            '"expectedTracks":0',
+        );
+    });
+
+    it("uses targetMbid instead of legacy metadata for completeness", async () => {
+        mockFindUnique.mockResolvedValueOnce({
+            targetMbid: "rg-canonical",
+            metadata: { albumMbid: "rg-legacy" },
+        });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(mockFindUnique).toHaveBeenCalledWith({
+            where: { id: "job-1" },
+            select: { targetMbid: true, metadata: true },
+        });
+        expect(mockGetExpectedTrackCount).toHaveBeenCalledWith("rg-canonical");
+    });
+
+    it("uses metadata.albumMbid only for legacy jobs without targetMbid", async () => {
+        mockFindUnique.mockResolvedValueOnce({
+            targetMbid: "",
+            metadata: { albumMbid: "rg-legacy" },
+        });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(mockGetExpectedTrackCount).toHaveBeenCalledWith("rg-legacy");
+    });
+
+    it("completes when a deluxe provider result exceeds the minimum", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(10);
+        download.mockResolvedValueOnce({ downloaded: 16 });
+
+        await runLibraryAlbumDownload(
+            processorConfig,
+            "job-1",
+            "Artist",
+            "Album",
+            "user-1",
+        );
+
+        expect(
+            mockUpdate.mock.calls.some(
+                ([call]) =>
+                    call.data?.status === "completed" &&
+                    call.data?.metadata?.expectedTracks === 10,
+            ),
+        ).toBe(true);
+        expect(
+            mockUpdate.mock.calls.some(
+                ([call]) => call.data?.status === "failed",
+            ),
+        ).toBe(false);
     });
 
     it("does not hand a fallback search miss back to the peer", async () => {
@@ -306,4 +487,21 @@ describe("libraryDownloadProcessor", () => {
             }),
         );
     });
+});
+
+describe("classifyDownloadCompleteness", () => {
+    it.each([
+        { downloaded: 14, expected: 14, outcome: "complete" },
+        { downloaded: 1, expected: 14, outcome: "partial" },
+        { downloaded: 0, expected: 14, outcome: "unknown" },
+        { downloaded: 1, expected: null, outcome: "unknown" },
+        { downloaded: 15, expected: 14, outcome: "complete" },
+    ] as const)(
+        "classifies $downloaded downloaded against $expected expected as $outcome",
+        ({ downloaded, expected, outcome }) => {
+            expect(classifyDownloadCompleteness(downloaded, expected)).toBe(
+                outcome,
+            );
+        },
+    );
 });

--- a/backend/src/services/__tests__/musicbrainzService.test.ts
+++ b/backend/src/services/__tests__/musicbrainzService.test.ts
@@ -1049,13 +1049,161 @@ describe("musicBrainzService", () => {
         );
     });
 
+    it("returns the minimum summed track count across official releases", async () => {
+        mockHttpGet.mockResolvedValueOnce({
+            data: {
+                releases: [
+                    {
+                        id: VALID_RELEASE_MBID,
+                        status: "Official",
+                        media: [{ "track-count": 7 }, { "track-count": 7 }],
+                    },
+                    {
+                        id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                        status: "Official",
+                        media: [{ "track-count": 20 }],
+                    },
+                    {
+                        id: "b1bca73f-238f-4d95-849c-31ca7a4f4991",
+                        status: "Bootleg",
+                        media: [{ "track-count": 5 }],
+                    },
+                ],
+            },
+        });
+
+        await expect(
+            musicBrainzService.getExpectedTrackCount(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toBe(14);
+        expect(mockHttpGet).toHaveBeenCalledWith("/release", {
+            params: {
+                "release-group": VALID_RELEASE_GROUP_MBID,
+                inc: "media",
+                limit: 100,
+                offset: 0,
+                fmt: "json",
+            },
+        });
+    });
+
+    it.each([
+        {
+            name: "standard release before deluxe release",
+            releases: [
+                {
+                    id: VALID_RELEASE_MBID,
+                    status: "Official",
+                    media: [{ "track-count": 10 }],
+                },
+                {
+                    id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                    status: "Official",
+                    media: [{ "track-count": 16 }],
+                },
+            ],
+        },
+        {
+            name: "deluxe release before standard release",
+            releases: [
+                {
+                    id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                    status: "Official",
+                    media: [{ "track-count": 16 }],
+                },
+                {
+                    id: VALID_RELEASE_MBID,
+                    status: "Official",
+                    media: [{ "track-count": 10 }],
+                },
+            ],
+        },
+    ])("uses the standard-edition minimum with $name", async ({ releases }) => {
+        mockHttpGet.mockResolvedValueOnce({ data: { releases } });
+
+        await expect(
+            musicBrainzService.getExpectedTrackCount(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toBe(10);
+    });
+
+    it("falls back to the minimum across all releases when none are official", async () => {
+        mockHttpGet.mockResolvedValueOnce({
+            data: {
+                releases: [
+                    {
+                        id: VALID_RELEASE_MBID,
+                        status: "Promotion",
+                        media: [{ "track-count": 12 }],
+                    },
+                    {
+                        id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                        status: "Bootleg",
+                        media: [{ "track-count": 9 }],
+                    },
+                ],
+            },
+        });
+
+        await expect(
+            musicBrainzService.getExpectedTrackCount(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toBe(9);
+    });
+
+    it("pages every release using the returned page length as the offset", async () => {
+        mockHttpGet
+            .mockResolvedValueOnce({
+                data: {
+                    "release-count": 2,
+                    releases: [
+                        {
+                            id: VALID_RELEASE_MBID,
+                            status: "Official",
+                            media: [{ "track-count": 16 }],
+                        },
+                    ],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    "release-count": 2,
+                    releases: [
+                        {
+                            id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                            status: "Official",
+                            media: [{ "track-count": 10 }],
+                        },
+                    ],
+                },
+            });
+
+        await expect(
+            musicBrainzService.getExpectedTrackCount(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toBe(10);
+        expect(mockHttpGet).toHaveBeenNthCalledWith(2, "/release", {
+            params: {
+                "release-group": VALID_RELEASE_GROUP_MBID,
+                inc: "media",
+                limit: 100,
+                offset: 1,
+                fmt: "json",
+            },
+        });
+    });
+
     it("collects album tracks from the first official release", async () => {
         mockHttpGet
             .mockResolvedValueOnce({
                 data: {
                     releases: [
-                        { id: "bootleg-1", status: "Bootleg" },
-                        { id: VALID_RELEASE_MBID, status: "Official" },
+                        {
+                            id: "f76a9ff8-b3f7-421e-a209-7551c3d249fa",
+                            status: "Bootleg",
+                            media: [{ "track-count": 2 }],
+                        },
+                        {
+                            id: VALID_RELEASE_MBID,
+                            status: "Official",
+                            media: [{ "track-count": 2 }],
+                        },
                     ],
                 },
             })
@@ -1090,16 +1238,15 @@ describe("musicBrainzService", () => {
             { title: "Track 1", position: 1, duration: 180000 },
             { title: "Track 2", position: 2, duration: 200000 },
         ]);
-        expect(mockHttpGet).toHaveBeenNthCalledWith(
-            1,
-            `/release-group/${VALID_RELEASE_GROUP_MBID}`,
-            {
-                params: {
-                    inc: "releases",
-                    fmt: "json",
-                },
+        expect(mockHttpGet).toHaveBeenNthCalledWith(1, "/release", {
+            params: {
+                "release-group": VALID_RELEASE_GROUP_MBID,
+                inc: "media",
+                limit: 100,
+                offset: 0,
+                fmt: "json",
             },
-        );
+        });
         expect(mockHttpGet).toHaveBeenNthCalledWith(
             2,
             `/release/${VALID_RELEASE_MBID}`,
@@ -1112,7 +1259,52 @@ describe("musicBrainzService", () => {
         );
     });
 
-    it("returns [] for albums with no releases and on getAlbumTracks errors", async () => {
+    it("reuses cached release pages between expected-count and track-list reads", async () => {
+        const cache = new Map<string, string>();
+        mockRedisGet.mockImplementation(async (key: string) => cache.get(key));
+        mockRedisSetEx.mockImplementation(
+            async (key: string, _ttl: number, value: string) => {
+                cache.set(key, value);
+                return "OK";
+            },
+        );
+        mockHttpGet
+            .mockResolvedValueOnce({
+                data: {
+                    "release-count": 1,
+                    releases: [
+                        {
+                            id: VALID_RELEASE_MBID,
+                            status: "Official",
+                            media: [{ "track-count": 1 }],
+                        },
+                    ],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    media: [{ tracks: [{ title: "Track 1", position: 1 }] }],
+                },
+            });
+
+        await expect(
+            musicBrainzService.getExpectedTrackCount(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toBe(1);
+        await expect(
+            musicBrainzService.getAlbumTracks(VALID_RELEASE_GROUP_MBID),
+        ).resolves.toEqual([
+            {
+                title: "Track 1",
+                position: 1,
+                duration: undefined,
+            },
+        ]);
+        expect(
+            mockHttpGet.mock.calls.filter(([path]) => path === "/release"),
+        ).toHaveLength(1);
+    });
+
+    it("returns [] for albums with no releases and short-caches transient errors", async () => {
         mockHttpGet.mockResolvedValueOnce({ data: { releases: [] } });
 
         const noReleaseTracks = await musicBrainzService.getAlbumTracks(
@@ -1120,13 +1312,21 @@ describe("musicBrainzService", () => {
         );
         expect(noReleaseTracks).toEqual([]);
 
+        mockRedisSetEx.mockClear();
         mockHttpGet.mockRejectedValueOnce(new Error("album tracks failed"));
         const errorTracks = await musicBrainzService.getAlbumTracks(
             VALID_RELEASE_GROUP_MBID,
         );
         expect(errorTracks).toEqual([]);
-        expect(mockLoggerError).toHaveBeenCalledWith(
-            "MusicBrainz getAlbumTracks error: album tracks failed",
+        expect(mockRedisSetEx).toHaveBeenLastCalledWith(
+            `mb:album-releases:${VALID_RELEASE_GROUP_MBID}:0`,
+            120,
+            JSON.stringify(null),
+        );
+        expect(mockRedisSetEx).not.toHaveBeenCalledWith(
+            `mb:album-releases:${VALID_RELEASE_GROUP_MBID}:0`,
+            2592000,
+            JSON.stringify([]),
         );
     });
 

--- a/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
@@ -26,9 +26,12 @@ jest.mock("../../utils/systemSettings", () => ({
 }));
 
 const mockGetAlbumTracks = jest.fn();
+const mockGetExpectedTrackCount = jest.fn();
 jest.mock("../musicbrainz", () => ({
     musicBrainzService: {
         getAlbumTracks: (...args: unknown[]) => mockGetAlbumTracks(...args),
+        getExpectedTrackCount: (...args: unknown[]) =>
+            mockGetExpectedTrackCount(...args),
     },
 }));
 
@@ -65,6 +68,7 @@ describe("processSoulseekDownload", () => {
             { title: "Track A", position: 1 },
             { title: "Track B", position: 2 },
         ]);
+        mockGetExpectedTrackCount.mockResolvedValue(2);
         mockGetAlbumInfo.mockResolvedValue(null);
         mockSearchAndDownloadBatch.mockResolvedValue({
             successful: 2,
@@ -90,6 +94,7 @@ describe("processSoulseekDownload", () => {
             error: undefined,
         });
 
+        expect(mockGetExpectedTrackCount).toHaveBeenCalledWith("rg-1");
         expect(mockGetAlbumTracks).not.toHaveBeenCalled();
         expect(mockSearchAndDownloadBatch).toHaveBeenCalledWith(
             [
@@ -108,6 +113,7 @@ describe("processSoulseekDownload", () => {
                 metadata: {
                     requestedTracks,
                     soulseekAttempts: 1,
+                    expectedTracks: 2,
                     tracksDownloaded: 2,
                     tracksTotal: 2,
                 },
@@ -116,6 +122,7 @@ describe("processSoulseekDownload", () => {
     });
 
     it("uses Last.fm when MusicBrainz has no tracks and persists no-match failure", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(0);
         mockGetAlbumTracks.mockResolvedValueOnce([]);
         mockGetAlbumInfo.mockResolvedValueOnce({
             tracks: {
@@ -177,7 +184,10 @@ describe("processSoulseekDownload", () => {
         });
     });
 
-    it("persists empty track lists and below-threshold partial downloads", async () => {
+    it("persists empty track lists and partial downloads", async () => {
+        mockGetExpectedTrackCount
+            .mockResolvedValueOnce(0)
+            .mockResolvedValueOnce(4);
         mockGetAlbumTracks.mockResolvedValueOnce([]);
         mockGetAlbumInfo.mockResolvedValueOnce({ tracks: { track: [] } });
         await expect(
@@ -194,8 +204,8 @@ describe("processSoulseekDownload", () => {
             { title: "Track 4" },
         ]);
         mockSearchAndDownloadBatch.mockResolvedValueOnce({
-            successful: 1,
-            errors: ["three unavailable tracks"],
+            successful: 2,
+            errors: ["two unavailable tracks"],
         });
         await expect(
             processSoulseekDownload("405", "Artist", "Album", "user-1"),
@@ -203,18 +213,23 @@ describe("processSoulseekDownload", () => {
             success: false,
             source: "soulseek",
             downloadJobId: 405,
-            tracksDownloaded: 1,
+            tracksDownloaded: 2,
             tracksTotal: 4,
-            error: "Only 1/4 tracks found",
+            error: "Partial download: 2/4 tracks",
         });
         expect(mockUpdate).toHaveBeenLastCalledWith({
             where: { id: "405" },
             data: {
                 status: "failed",
-                error: "Only 1/4 tracks found",
+                error: "Partial download: 2/4 tracks",
                 completedAt: expect.any(Date),
                 metadata: {
-                    tracksDownloaded: 1,
+                    currentSource: "soulseek",
+                    expectedTracks: 4,
+                    failedAt: expect.any(String),
+                    partial: true,
+                    statusText: "Partial download: 2/4 tracks",
+                    tracksDownloaded: 2,
                     tracksTotal: 4,
                 },
             },

--- a/backend/src/services/__tests__/tidalLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/tidalLibraryDownload.test.ts
@@ -1,13 +1,15 @@
 const mockLoggerWarn = jest.fn();
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: mockLoggerWarn,
-        error: jest.fn(),
-    },
-}));
+const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: mockLoggerWarn,
+    error: jest.fn(),
+    child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+
+jest.mock("../../utils/logger", () => ({ logger: mockLogger }));
 
 jest.mock("../../utils/db", () => ({
     prisma: {
@@ -45,6 +47,14 @@ jest.mock("../coalescedLibraryScan", () => ({
     requestCoalescedLibraryScan: jest.fn(),
 }));
 
+const mockGetExpectedTrackCount = jest.fn();
+jest.mock("../musicbrainz", () => ({
+    musicBrainzService: {
+        getExpectedTrackCount: (...args: unknown[]) =>
+            mockGetExpectedTrackCount(...args),
+    },
+}));
+
 import { prisma } from "../../utils/db";
 import { getSystemSettings } from "../../utils/systemSettings";
 import { simpleDownloadManager } from "../simpleDownloadManager";
@@ -68,7 +78,8 @@ describe("tidalLibraryDownload", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockFindUnique.mockResolvedValue({
-            metadata: { albumMbid: "rg-1", retained: true },
+            targetMbid: "rg-1",
+            metadata: { retained: true },
         });
         mockUpdate.mockResolvedValue({});
         mockSettings.mockResolvedValue({ primaryFailureFallback: "none" });
@@ -91,6 +102,27 @@ describe("tidalLibraryDownload", () => {
         mockFallback.mockResolvedValue({ success: true });
         mockProcessYoutubeDownload.mockResolvedValue(undefined);
         mockScan.mockResolvedValue(undefined);
+        mockGetExpectedTrackCount.mockResolvedValue(9);
+    });
+
+    it("uses the provider result count to fail an incomplete album", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(10);
+
+        await processTidalDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: "Partial download: 9/10 tracks",
+                    metadata: expect.objectContaining({
+                        statusText: "Partial download: 9/10 tracks",
+                        partial: true,
+                        expectedTracks: 10,
+                    }),
+                }),
+            }),
+        );
     });
 
     it("completes the job and queues a tidal-download library scan", async () => {
@@ -114,8 +146,8 @@ describe("tidalLibraryDownload", () => {
 
     it("clears the first-attempt failure state after a successful retry", async () => {
         mockFindUnique.mockResolvedValueOnce({
+            targetMbid: "rg-1",
             metadata: {
-                albumMbid: "rg-1",
                 retained: true,
                 failedAt: "2026-08-24T10:00:00.000Z",
             },
@@ -150,7 +182,7 @@ describe("tidalLibraryDownload", () => {
             ),
         ).toBe(false);
         expect(mockLoggerWarn).toHaveBeenCalledWith(
-            "TIDAL library scan enqueue failed; download remains completed",
+            "TIDAL library scan enqueue failed; download status remains unchanged",
             { jobId: "job-1", error: scanError },
         );
     });

--- a/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/youtubeLibraryDownload.test.ts
@@ -47,6 +47,14 @@ jest.mock("../coalescedLibraryScan", () => ({
     requestCoalescedLibraryScan: jest.fn(),
 }));
 
+const mockGetExpectedTrackCount = jest.fn();
+jest.mock("../musicbrainz", () => ({
+    musicBrainzService: {
+        getExpectedTrackCount: (...args: unknown[]) =>
+            mockGetExpectedTrackCount(...args),
+    },
+}));
+
 import { prisma } from "../../utils/db";
 import { getSystemSettings } from "../../utils/systemSettings";
 import { simpleDownloadManager } from "../simpleDownloadManager";
@@ -92,7 +100,8 @@ describe("youtubeLibraryDownload", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockFindUnique.mockResolvedValue({
-            metadata: { albumMbid: "rg-1", retained: true },
+            targetMbid: "rg-1",
+            metadata: { retained: true },
         });
         mockUpdate.mockResolvedValue({});
         mockSettings.mockResolvedValue({ primaryFailureFallback: "none" });
@@ -107,6 +116,27 @@ describe("youtubeLibraryDownload", () => {
         mockGetAlbumStatus.mockResolvedValue(completedStatus);
         mockFallback.mockResolvedValue({ success: true });
         mockScan.mockResolvedValue(undefined);
+        mockGetExpectedTrackCount.mockResolvedValue(9);
+    });
+
+    it("uses the provider result count to fail an incomplete album", async () => {
+        mockGetExpectedTrackCount.mockResolvedValueOnce(10);
+
+        await processYoutubeDownload("job-1", "Artist", "Album", "user-1");
+
+        expect(mockUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    status: "failed",
+                    error: "Partial download: 9/10 tracks",
+                    metadata: expect.objectContaining({
+                        statusText: "Partial download: 9/10 tracks",
+                        partial: true,
+                        expectedTracks: 10,
+                    }),
+                }),
+            }),
+        );
     });
 
     it("prefers an exact normalized title and artist match", async () => {
@@ -300,8 +330,8 @@ describe("youtubeLibraryDownload", () => {
 
     it("clears the first-attempt failure state after a successful retry", async () => {
         mockFindUnique.mockResolvedValueOnce({
+            targetMbid: "rg-1",
             metadata: {
-                albumMbid: "rg-1",
                 retained: true,
                 failedAt: "2026-08-24T10:00:00.000Z",
             },
@@ -337,7 +367,7 @@ describe("youtubeLibraryDownload", () => {
             ),
         ).toBe(false);
         expect(mockLoggerWarn).toHaveBeenCalledWith(
-            "YouTube Music library scan enqueue failed; download remains completed",
+            "YouTube Music library scan enqueue failed; download status remains unchanged",
             { jobId: "job-1", error: scanError },
         );
     });

--- a/backend/src/services/albumDownloadCompleteness.ts
+++ b/backend/src/services/albumDownloadCompleteness.ts
@@ -1,0 +1,15 @@
+/** Possible outcomes when comparing delivered and expected album track counts. */
+export type DownloadCompleteness = "complete" | "partial" | "unknown";
+
+/** Classify a nonzero provider result against a MusicBrainz track count. */
+export function classifyDownloadCompleteness(
+    downloaded: number | null,
+    expected: number | null,
+): DownloadCompleteness {
+    if (downloaded === null || expected === null) return "unknown";
+    if (!Number.isSafeInteger(downloaded) || !Number.isSafeInteger(expected)) {
+        return "unknown";
+    }
+    if (downloaded <= 0 || expected <= 0) return "unknown";
+    return downloaded < expected ? "partial" : "complete";
+}

--- a/backend/src/services/libraryDownloadProcessor.ts
+++ b/backend/src/services/libraryDownloadProcessor.ts
@@ -1,12 +1,16 @@
 /** Shared orchestration for provider-backed library album downloads. */
 
-import { logger } from "../utils/logger";
+import { logger as rootLogger } from "../utils/logger";
 import { prisma } from "../utils/db";
 import { asPlainObject } from "../utils/plainObject";
 import { requestCoalescedLibraryScan } from "./coalescedLibraryScan";
 import type { DownloadSource } from "./downloadSourcePolicy";
 import { patchDownloadJobMetadata } from "./downloadJobStatus";
 import { simpleDownloadManager } from "./simpleDownloadManager";
+import { musicBrainzService } from "./musicbrainz";
+import { classifyDownloadCompleteness } from "./albumDownloadCompleteness";
+
+const logger = rootLogger.child("LibraryDownloadProcessor");
 
 type DownloadMetadata = Record<string, unknown>;
 type PeerFallbackOptions = LibraryAlbumDownloadOptions & {
@@ -16,6 +20,7 @@ type PeerFallbackOptions = LibraryAlbumDownloadOptions & {
 interface DownloadContext {
     jobId: string;
     metadata: DownloadMetadata;
+    albumMbid: string | null;
 }
 
 interface ProcessorContext extends DownloadContext {
@@ -50,6 +55,7 @@ export interface LibraryDownloadProcessorConfig<TMatch, TResult> {
     ) => Promise<TMatch | null>;
     download: (match: TMatch, context: DownloadContext) => Promise<TResult>;
     resultSummary: (match: TMatch, result: TResult) => ResultSummary;
+    readDownloadedCount: (result: TResult) => number | null;
     fallbackPeer: {
         sourceKey: string;
         run: (
@@ -66,9 +72,86 @@ export interface LibraryDownloadProcessorConfig<TMatch, TResult> {
     onScanQueued?: (result: TResult) => Promise<void> | void;
 }
 
-function withoutFailedAt(metadata: DownloadMetadata): DownloadMetadata {
-    const { failedAt: _failedAt, ...retainedMetadata } = metadata;
+function withoutFailureMetadata(metadata: DownloadMetadata): DownloadMetadata {
+    const {
+        failedAt: _failedAt,
+        partial: _partial,
+        ...retainedMetadata
+    } = metadata;
     return retainedMetadata;
+}
+
+function persistedExpectedTracks(metadata: DownloadMetadata): number | null {
+    const value = metadata.expectedTracks;
+    return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+        ? value
+        : null;
+}
+
+function resolveAlbumMbid(
+    targetMbid: string | undefined,
+    metadata: DownloadMetadata,
+): string | null {
+    if (targetMbid) return targetMbid;
+    const legacyMbid = metadata.albumMbid;
+    return typeof legacyMbid === "string" && legacyMbid ? legacyMbid : null;
+}
+
+function warnExpectedTracksUnavailable(
+    config: { sourceKey: string },
+    context: DownloadContext,
+    reason: string,
+    error?: unknown,
+): void {
+    logger.warn("Album completeness verification skipped", {
+        jobId: context.jobId,
+        source: config.sourceKey,
+        albumMbid: context.albumMbid ?? undefined,
+        reason,
+        ...(error === undefined ? {} : { error }),
+    });
+}
+
+async function resolveExpectedTracks<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    context: DownloadContext,
+): Promise<number | null> {
+    const persisted = persistedExpectedTracks(context.metadata);
+    if (persisted !== null) return persisted;
+    if (!context.albumMbid) {
+        warnExpectedTracksUnavailable(
+            config,
+            context,
+            "Album MusicBrainz ID is missing",
+        );
+        return null;
+    }
+    let expectedTracks: number;
+    try {
+        expectedTracks = await musicBrainzService.getExpectedTrackCount(
+            context.albumMbid,
+        );
+    } catch (error) {
+        warnExpectedTracksUnavailable(
+            config,
+            context,
+            "MusicBrainz expected-count lookup failed",
+            error,
+        );
+        return null;
+    }
+    if (!Number.isSafeInteger(expectedTracks) || expectedTracks <= 0) {
+        warnExpectedTracksUnavailable(
+            config,
+            context,
+            "MusicBrainz returned no expected track count",
+        );
+        return null;
+    }
+    await patchDownloadJobMetadata(context.jobId, {
+        expectedTracks,
+    });
+    return expectedTracks;
 }
 
 async function markSearching<TMatch, TResult>(
@@ -107,9 +190,7 @@ async function handOffToManager<TMatch, TResult>(
         context.jobId,
         context.artistName,
         context.albumTitle,
-        typeof context.metadata.albumMbid === "string"
-            ? context.metadata.albumMbid
-            : "",
+        context.albumMbid ?? "",
         context.userId,
         false,
         typeof context.metadata.artistMbid === "string"
@@ -183,15 +264,17 @@ async function completeJob<TMatch, TResult>(
     jobId: string,
     match: TMatch,
     result: TResult,
+    expectedTracks: number | null,
 ): Promise<void> {
     const summary = config.resultSummary(match, result);
     await patchDownloadJobMetadata(
         jobId,
         (current) => ({
-            ...withoutFailedAt(current),
+            ...withoutFailureMetadata(current),
             currentSource: config.sourceKey,
             statusText: summary.statusText,
             ...summary.metadata,
+            ...(expectedTracks === null ? {} : { expectedTracks }),
         }),
         {
             status: "completed",
@@ -199,6 +282,67 @@ async function completeJob<TMatch, TResult>(
             error: null,
         },
     );
+}
+
+async function failPartialJob<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    match: TMatch,
+    result: TResult,
+    downloadedTracks: number,
+    expectedTracks: number,
+): Promise<void> {
+    const statusText = `Partial download: ${downloadedTracks}/${expectedTracks} tracks`;
+    const summary = config.resultSummary(match, result);
+    logger.warn("Album download is incomplete", {
+        jobId,
+        source: config.sourceKey,
+        downloadedTracks,
+        expectedTracks,
+    });
+    await patchDownloadJobMetadata(
+        jobId,
+        (current) => ({
+            ...current,
+            currentSource: config.sourceKey,
+            statusText,
+            ...summary.metadata,
+            expectedTracks,
+            partial: true,
+            failedAt: new Date().toISOString(),
+        }),
+        { status: "failed", error: statusText, completedAt: new Date() },
+    );
+}
+
+async function settleJob<TMatch, TResult>(
+    config: LibraryDownloadProcessorConfig<TMatch, TResult>,
+    jobId: string,
+    match: TMatch,
+    result: TResult,
+    expectedTracks: number | null,
+): Promise<void> {
+    const downloadedTracks = config.readDownloadedCount(result);
+    const completeness = classifyDownloadCompleteness(
+        downloadedTracks,
+        expectedTracks,
+    );
+    if (
+        completeness === "partial" &&
+        downloadedTracks !== null &&
+        expectedTracks !== null
+    ) {
+        await failPartialJob(
+            config,
+            jobId,
+            match,
+            result,
+            downloadedTracks,
+            expectedTracks,
+        );
+        return;
+    }
+    await completeJob(config, jobId, match, result, expectedTracks);
 }
 
 async function failJob<TMatch, TResult>(
@@ -223,6 +367,7 @@ async function failJob<TMatch, TResult>(
 async function runAttempt<TMatch, TResult>(
     config: LibraryDownloadProcessorConfig<TMatch, TResult>,
     context: ProcessorContext,
+    expectedTracks: number | null,
 ): Promise<TResult | null> {
     await markSearching(config, context.jobId);
     const match = await config.findMatch(
@@ -238,8 +383,9 @@ async function runAttempt<TMatch, TResult>(
     const result = await config.download(match, {
         jobId: context.jobId,
         metadata: context.metadata,
+        albumMbid: context.albumMbid,
     });
-    await completeJob(config, context.jobId, match, result);
+    await settleJob(config, context.jobId, match, result, expectedTracks);
     return result;
 }
 
@@ -254,7 +400,7 @@ async function queueLibraryScanSafely<TMatch, TResult>(
         await config.onScanQueued?.(result);
     } catch (error) {
         logger.warn(
-            `${config.sourceLabel} library scan enqueue failed; download remains completed`,
+            `${config.sourceLabel} library scan enqueue failed; download status remains unchanged`,
             { jobId, error },
         );
     }
@@ -271,20 +417,24 @@ export async function runLibraryAlbumDownload<TMatch, TResult>(
 ): Promise<void> {
     const existingJob = await prisma.downloadJob.findUnique({
         where: { id: jobId },
-        select: { metadata: true },
+        select: { targetMbid: true, metadata: true },
     });
     const metadata = asPlainObject(existingJob?.metadata);
+    const albumMbid = resolveAlbumMbid(existingJob?.targetMbid, metadata);
     let result: TResult | null;
     try {
-        result = await runAttempt(config, {
+        const context = {
             jobId,
             artistName,
             albumTitle,
             userId,
             metadata,
+            albumMbid,
             isFallback: options.isFallback === true,
             fallbackSource: options.fallbackSource,
-        });
+        };
+        const expectedTracks = await resolveExpectedTracks(config, context);
+        result = await runAttempt(config, context, expectedTracks);
     } catch (error: unknown) {
         logger.error(
             `[${config.sourceLabel}] Download failed for job ${jobId}:`,

--- a/backend/src/services/musicbrainz.ts
+++ b/backend/src/services/musicbrainz.ts
@@ -8,7 +8,7 @@ import {
 } from "../utils/stringNormalization";
 import { BRAND_USER_AGENT } from "../config/brand";
 import { isValidMbid } from "../utils/musicIds";
-import { isPlainObject } from "../utils/plainObject";
+import { asPlainObject, isPlainObject } from "../utils/plainObject";
 
 export { isValidMbid } from "../utils/musicIds";
 
@@ -40,6 +40,28 @@ export interface MusicBrainzReleaseGroupSearchResult {
     "artist-credit"?: MusicBrainzArtistCredit[];
     score?: number | string;
 }
+
+interface MusicBrainzAlbumRelease {
+    id: string;
+    status?: string;
+    media?: unknown[];
+}
+
+interface MusicBrainzAlbumReleasePage {
+    releases: MusicBrainzAlbumRelease[];
+    total: number;
+}
+
+interface MusicBrainzAlbumTrack {
+    title: string;
+    position?: number;
+    duration?: number;
+}
+
+const MUSICBRAINZ_RELEASE_PAGE_SIZE = 100;
+const MAX_RELEASE_GROUP_PAGES = 100;
+const MAX_RELEASE_MEDIA = 100;
+const MAX_MEDIUM_TRACKS = 1_000;
 
 function hasReleaseGroupIdentity(
     value: unknown,
@@ -78,6 +100,103 @@ function validateMbid(value: unknown, entity: MbidEntity): string {
 
 function encodeMbidPathSegment(value: unknown, entity: MbidEntity): string {
     return encodeURIComponent(validateMbid(value, entity));
+}
+
+function parseAlbumReleases(value: unknown): MusicBrainzAlbumRelease[] {
+    if (!Array.isArray(value) || value.length > MUSICBRAINZ_RELEASE_PAGE_SIZE) {
+        throw new TypeError("Invalid MusicBrainz album releases response");
+    }
+    return value.flatMap((item) => {
+        if (!isPlainObject(item) || !isValidMbid(item.id)) return [];
+        return [
+            {
+                id: item.id,
+                status:
+                    typeof item.status === "string" ? item.status : undefined,
+                media: Array.isArray(item.media) ? item.media : undefined,
+            },
+        ];
+    });
+}
+
+function parseAlbumReleasePage(value: unknown): MusicBrainzAlbumReleasePage {
+    const page = asPlainObject(value);
+    const releases = parseAlbumReleases(page.releases);
+    const reportedTotal = page["release-count"];
+    const total =
+        Number.isSafeInteger(reportedTotal) &&
+        (reportedTotal as number) >= releases.length
+            ? (reportedTotal as number)
+            : releases.length;
+    return { releases, total };
+}
+
+function releaseTrackCount(release: MusicBrainzAlbumRelease): number | null {
+    const media = release.media;
+    if (!media || media.length === 0 || media.length > MAX_RELEASE_MEDIA) {
+        return null;
+    }
+    let total = 0;
+    for (const item of media) {
+        const medium = asPlainObject(item);
+        const count = medium["track-count"];
+        if (!Number.isSafeInteger(count) || (count as number) < 0) return null;
+        total += count as number;
+        if (!Number.isSafeInteger(total)) return null;
+    }
+    return total;
+}
+
+function expectedTrackCount(releases: MusicBrainzAlbumRelease[]): number {
+    const official = releases.filter(
+        (release) => release.status === "Official",
+    );
+    const eligible = official.length > 0 ? official : releases;
+    const counts = eligible.flatMap((release) => {
+        const count = releaseTrackCount(release);
+        return count === null ? [] : [count];
+    });
+    return counts.length === 0 ? 0 : Math.min(...counts);
+}
+
+function flattenAlbumTracks(value: unknown): MusicBrainzAlbumTrack[] {
+    if (!Array.isArray(value) || value.length > MAX_RELEASE_MEDIA) {
+        throw new TypeError("Invalid MusicBrainz release media response");
+    }
+    const tracks: MusicBrainzAlbumTrack[] = [];
+    for (const item of value) {
+        const mediumTracks = asPlainObject(item).tracks;
+        if (
+            !Array.isArray(mediumTracks) ||
+            mediumTracks.length > MAX_MEDIUM_TRACKS
+        ) {
+            throw new TypeError("Invalid MusicBrainz medium tracks response");
+        }
+        for (const itemTrack of mediumTracks) {
+            const track = asPlainObject(itemTrack);
+            const recording = asPlainObject(track.recording);
+            const title =
+                typeof track.title === "string"
+                    ? track.title
+                    : typeof recording.title === "string"
+                      ? recording.title
+                      : "";
+            tracks.push({
+                title,
+                position:
+                    typeof track.position === "number"
+                        ? track.position
+                        : undefined,
+                duration:
+                    typeof track.length === "number"
+                        ? track.length
+                        : typeof recording.length === "number"
+                          ? recording.length
+                          : undefined,
+            });
+        }
+    }
+    return tracks;
 }
 
 class MusicBrainzService {
@@ -916,85 +1035,94 @@ class MusicBrainzService {
         }
     }
 
-    /**
-     * Get track list for an album by release group MBID
-     * Uses the first official release from the release group
-     */
-    async getAlbumTracks(
-        rgMbid: string,
-    ): Promise<Array<{ title: string; position?: number; duration?: number }>> {
+    private getAlbumReleasePage(
+        releaseGroupMbid: string,
+        offset: number,
+    ): Promise<MusicBrainzAlbumReleasePage | null> {
+        const cacheKey = `mb:album-releases:${releaseGroupMbid}:${offset}`;
+        return this.cachedRequest(
+            cacheKey,
+            async () => {
+                const response = await this.client.get("/release", {
+                    params: {
+                        "release-group": releaseGroupMbid,
+                        inc: "media",
+                        limit: MUSICBRAINZ_RELEASE_PAGE_SIZE,
+                        offset,
+                        fmt: "json",
+                    },
+                });
+                return parseAlbumReleasePage(response.data);
+            },
+            2592000,
+            // The 120s fallback TTL bounds MB retries without 30-day poisoning.
+            null,
+        );
+    }
+
+    private async getAlbumReleases(
+        releaseGroupMbid: string,
+    ): Promise<MusicBrainzAlbumRelease[]> {
+        const releases: MusicBrainzAlbumRelease[] = [];
+        for (
+            let pageIndex = 0;
+            pageIndex < MAX_RELEASE_GROUP_PAGES;
+            pageIndex++
+        ) {
+            const page = await this.getAlbumReleasePage(
+                releaseGroupMbid,
+                releases.length,
+            );
+            if (!page) return [];
+            releases.push(...page.releases);
+            if (releases.length >= page.total) return releases;
+            if (page.releases.length === 0) return [];
+        }
+        logger.warn("MusicBrainz release-group paging exceeded its bound", {
+            releaseGroupMbid,
+            pageLimit: MAX_RELEASE_GROUP_PAGES,
+        });
+        return [];
+    }
+
+    /** Return the minimum total for official editions, or all editions. */
+    async getExpectedTrackCount(rgMbid: string): Promise<number> {
         const releaseGroupMbid = encodeMbidPathSegment(rgMbid, "release group");
-        const cacheKey = `mb:albumtracks:${releaseGroupMbid}`;
+        const releases = await this.getAlbumReleases(releaseGroupMbid);
+        return expectedTrackCount(releases);
+    }
 
-        return this.cachedRequest(cacheKey, async () => {
-            try {
-                // Step 1: Get releases from the release group
-                const rgResponse = await this.client.get(
-                    `/release-group/${releaseGroupMbid}`,
-                    {
-                        params: {
-                            inc: "releases",
-                            fmt: "json",
-                        },
-                    },
-                );
-
-                const releases = rgResponse.data?.releases || [];
-                if (releases.length === 0) {
-                    logger.debug(
-                        `[MusicBrainz] No releases found for release group ${releaseGroupMbid}`,
-                    );
-                    return [];
-                }
-
-                // Prefer official releases
-                const release =
-                    releases.find((r: any) => r.status === "Official") ||
-                    releases[0];
-                const releaseMbid = encodeMbidPathSegment(
-                    release.id,
-                    "release",
-                );
-
-                // Step 2: Get full release details with recordings
-                const releaseResponse = await this.client.get(
+    /** Get tracks from the first official release, or the first release. */
+    async getAlbumTracks(rgMbid: string): Promise<MusicBrainzAlbumTrack[]> {
+        const releaseGroupMbid = encodeMbidPathSegment(rgMbid, "release group");
+        const releases = await this.getAlbumReleases(releaseGroupMbid);
+        if (releases.length === 0) {
+            logger.debug(
+                `[MusicBrainz] No releases found for release group ${releaseGroupMbid}`,
+            );
+            return [];
+        }
+        const release =
+            releases.find((candidate) => candidate.status === "Official") ??
+            releases[0];
+        const releaseMbid = encodeMbidPathSegment(release.id, "release");
+        const cacheKey = `mb:albumtracks:v2:${releaseGroupMbid}:${releaseMbid}`;
+        return this.cachedRequest(
+            cacheKey,
+            async () => {
+                const response = await this.client.get(
                     `/release/${releaseMbid}`,
-                    {
-                        params: {
-                            inc: "recordings",
-                            fmt: "json",
-                        },
-                    },
+                    { params: { inc: "recordings", fmt: "json" } },
                 );
-
-                const media = releaseResponse.data?.media || [];
-                const tracks: Array<{
-                    title: string;
-                    position?: number;
-                    duration?: number;
-                }> = [];
-
-                for (const medium of media) {
-                    for (const track of medium.tracks || []) {
-                        tracks.push({
-                            title: track.title || track.recording?.title,
-                            position: track.position,
-                            duration: track.length || track.recording?.length,
-                        });
-                    }
-                }
-
+                const tracks = flattenAlbumTracks(response.data?.media);
                 logger.debug(
                     `[MusicBrainz] Found ${tracks.length} tracks for release group ${releaseGroupMbid}`,
                 );
                 return tracks;
-            } catch (error: any) {
-                logger.error(
-                    `MusicBrainz getAlbumTracks error: ${error.message}`,
-                );
-                return [];
-            }
-        });
+            },
+            2592000,
+            [],
+        );
     }
 }
 

--- a/backend/src/services/soulseekLibraryDownload.ts
+++ b/backend/src/services/soulseekLibraryDownload.ts
@@ -12,6 +12,7 @@ import {
 import { lastFmService } from "./lastfm";
 import { musicBrainzService } from "./musicbrainz";
 import { soulseekService } from "./soulseek";
+import { classifyDownloadCompleteness } from "./albumDownloadCompleteness";
 
 const logger = rootLogger.child("SoulseekLibraryDownload");
 const SOULSEEK_DOWNLOAD_FAILED = "Soulseek download failed";
@@ -19,6 +20,12 @@ const SOULSEEK_DOWNLOAD_FAILED = "Soulseek download failed";
 interface AlbumTrack {
     title: string;
     position?: number;
+}
+
+interface SoulseekBatchOutcome {
+    success: boolean;
+    partial: boolean;
+    failureMessage: string | undefined;
 }
 
 /** Result returned to compatibility acquisition callers. */
@@ -43,6 +50,15 @@ function requestedTracksFrom(metadata: unknown): AlbumTrack[] | null {
             typeof (track as Record<string, unknown>).title === "string",
     );
     return tracks.length === requestedTracks.length ? tracks : null;
+}
+
+function expectedTracksFrom(metadata: unknown): number | null {
+    const expectedTracks = asPlainObject(metadata).expectedTracks;
+    return typeof expectedTracks === "number" &&
+        Number.isSafeInteger(expectedTracks) &&
+        expectedTracks > 0
+        ? expectedTracks
+        : null;
 }
 
 async function lastFmTracks(
@@ -75,15 +91,13 @@ function asLastFmTrack(value: unknown): AlbumTrack | null {
 }
 
 async function resolveAlbumTracks(
-    albumMbid: string,
     artistName: string,
     albumTitle: string,
     requestedTracks: AlbumTrack[] | null,
+    musicBrainzTracks: AlbumTrack[] | null,
 ): Promise<AlbumTrack[]> {
     if (requestedTracks) return requestedTracks;
-    const musicBrainzTracks =
-        await musicBrainzService.getAlbumTracks(albumMbid);
-    if (musicBrainzTracks.length > 0) return musicBrainzTracks;
+    if (musicBrainzTracks) return musicBrainzTracks;
     logger.debug("MusicBrainz has no tracks; trying Last.fm", {
         artistName,
         albumTitle,
@@ -93,6 +107,51 @@ async function resolveAlbumTracks(
     } catch (error) {
         logger.warn("Last.fm track-list fallback failed", { error });
         return [];
+    }
+}
+
+async function resolveExpectedTrackCount(
+    jobId: string,
+    albumMbid: string,
+): Promise<number | null> {
+    let expectedTracks: number;
+    try {
+        expectedTracks =
+            await musicBrainzService.getExpectedTrackCount(albumMbid);
+    } catch (error) {
+        logger.warn("Album completeness verification skipped", {
+            jobId,
+            source: "soulseek",
+            albumMbid,
+            reason: "MusicBrainz expected-count lookup failed",
+            error,
+        });
+        return null;
+    }
+    if (!Number.isSafeInteger(expectedTracks) || expectedTracks <= 0) {
+        logger.warn("Album completeness verification skipped", {
+            jobId,
+            source: "soulseek",
+            albumMbid,
+            reason: "MusicBrainz returned no expected track count",
+        });
+        return null;
+    }
+    await patchDownloadJobMetadata(jobId, {
+        expectedTracks,
+    });
+    return expectedTracks;
+}
+
+async function resolveMusicBrainzTracks(
+    albumMbid: string,
+): Promise<AlbumTrack[] | null> {
+    try {
+        const tracks = await musicBrainzService.getAlbumTracks(albumMbid);
+        return tracks.length > 0 ? tracks : null;
+    } catch (error) {
+        logger.warn("MusicBrainz track-list lookup failed", { error });
+        return null;
     }
 }
 
@@ -129,27 +188,80 @@ async function persistBatchOutcome(
     jobId: string,
     successful: number,
     total: number,
+    expectedTracks: number | null,
 ): Promise<SoulseekAlbumDownloadResult> {
-    const success = successful >= Math.ceil(total * 0.5);
-    const failureMessage = success
-        ? undefined
-        : `Only ${successful}/${total} tracks found`;
+    const outcome = classifyBatchOutcome(successful, total, expectedTracks);
     await patchDownloadJobMetadata(
         jobId,
-        { tracksDownloaded: successful, tracksTotal: total },
+        (current) =>
+            batchOutcomeMetadata(
+                current,
+                successful,
+                total,
+                expectedTracks,
+                outcome,
+            ),
         {
-            status: success ? "completed" : "failed",
-            error: failureMessage ?? null,
+            status: outcome.success ? "completed" : "failed",
+            error: outcome.failureMessage ?? null,
             completedAt: new Date(),
         },
     );
+    if (outcome.partial) {
+        logger.warn("Album download is incomplete", {
+            jobId,
+            source: "soulseek",
+            downloadedTracks: successful,
+            expectedTracks,
+        });
+    }
     return {
-        success,
+        success: outcome.success,
         source: "soulseek",
         downloadJobId: Number.parseInt(jobId, 10),
         tracksDownloaded: successful,
         tracksTotal: total,
-        error: failureMessage,
+        error: outcome.failureMessage,
+    };
+}
+
+function classifyBatchOutcome(
+    successful: number,
+    total: number,
+    expectedTracks: number | null,
+): SoulseekBatchOutcome {
+    const partial =
+        classifyDownloadCompleteness(successful, expectedTracks) === "partial";
+    const success = !partial && successful >= Math.ceil(total * 0.5);
+    const failureMessage = partial
+        ? `Partial download: ${successful}/${expectedTracks} tracks`
+        : success
+          ? undefined
+          : `Only ${successful}/${total} tracks found`;
+    return { success, partial, failureMessage };
+}
+
+function batchOutcomeMetadata(
+    current: Record<string, unknown>,
+    successful: number,
+    total: number,
+    expectedTracks: number | null,
+    outcome: SoulseekBatchOutcome,
+): Record<string, unknown> {
+    const { failedAt: _failedAt, partial: _partial, ...retained } = current;
+    const base = {
+        ...retained,
+        tracksDownloaded: successful,
+        tracksTotal: total,
+        ...(expectedTracks === null ? {} : { expectedTracks }),
+    };
+    if (!outcome.partial) return base;
+    return {
+        ...base,
+        currentSource: "soulseek",
+        statusText: outcome.failureMessage,
+        partial: true,
+        failedAt: new Date().toISOString(),
     };
 }
 
@@ -179,11 +291,19 @@ async function runSoulseekDownload(
     concurrency: number,
 ): Promise<SoulseekAlbumDownloadResult> {
     await updateAttempt(jobId, metadata);
+    const requestedTracks = requestedTracksFrom(metadata);
+    const persistedExpectedTracks = expectedTracksFrom(metadata);
+    const expectedTracks =
+        persistedExpectedTracks ??
+        (await resolveExpectedTrackCount(jobId, albumMbid));
+    const musicBrainzTracks = requestedTracks
+        ? null
+        : await resolveMusicBrainzTracks(albumMbid);
     const tracks = await resolveAlbumTracks(
-        albumMbid,
         artistName,
         albumTitle,
-        requestedTracksFrom(metadata),
+        requestedTracks,
+        musicBrainzTracks,
     );
     if (tracks.length === 0) {
         return markFailed(
@@ -201,7 +321,12 @@ async function runSoulseekDownload(
         concurrency,
     );
     if (result.successful > 0) {
-        return persistBatchOutcome(jobId, result.successful, tracks.length);
+        return persistBatchOutcome(
+            jobId,
+            result.successful,
+            tracks.length,
+            expectedTracks,
+        );
     }
     const failureMessage = `No tracks found on Soulseek (searched ${tracks.length} tracks)`;
     return markFailed(jobId, failureMessage, {

--- a/backend/src/services/tidalLibraryDownload.ts
+++ b/backend/src/services/tidalLibraryDownload.ts
@@ -61,6 +61,7 @@ const tidalLibraryDownloadConfig = {
             },
         },
     }),
+    readDownloadedCount: (result) => result.downloaded,
     fallbackPeer: {
         sourceKey: "youtube",
         run: async (jobId, artistName, albumTitle, userId, options) => {

--- a/backend/src/services/youtubeLibraryDownload.ts
+++ b/backend/src/services/youtubeLibraryDownload.ts
@@ -162,6 +162,7 @@ const youtubeLibraryDownloadConfig = {
             },
         },
     }),
+    readDownloadedCount: (result) => result.downloaded,
     fallbackPeer: {
         sourceKey: "tidal",
         run: async (jobId, artistName, albumTitle, userId, options) => {

--- a/backend/src/workers/processors/__tests__/scanProcessorRuntime.test.ts
+++ b/backend/src/workers/processors/__tests__/scanProcessorRuntime.test.ts
@@ -21,6 +21,10 @@ describe("scanProcessor runtime behavior", () => {
         progressEvents?: ProgressEvent[];
         activeJobs?: Array<{
             id: string;
+            targetMbid?: string;
+            type?: string;
+            status?: string;
+            lidarrRef?: string | null;
             discoveryBatchId?: string | null;
             metadata?: Record<string, unknown> | null;
         }>;
@@ -28,7 +32,7 @@ describe("scanProcessor runtime behavior", () => {
             id?: string;
             title: string;
             artistName?: string;
-            hasTracks?: boolean;
+            trackCount?: number;
             tracks?: Array<{ id: string }>;
             artist?: { name: string; enrichmentStatus?: string };
         }>;
@@ -45,12 +49,12 @@ describe("scanProcessor runtime behavior", () => {
             enrichmentStatus: string;
         } | null;
         albumByRgMbid?: {
+            id?: string;
             rgMbid: string;
             title: string;
+            trackCount?: number;
             artist: { name: string; enrichmentStatus: string };
         } | null;
-        albumDownloadUpdateCount?: number;
-        metadataMatchUpdateCount?: number;
         tracksNeedingTags?: number;
     };
 
@@ -86,51 +90,104 @@ describe("scanProcessor runtime behavior", () => {
             },
         };
 
+        const downloadJobs = (options.activeJobs ?? []).map((job) => ({
+            targetMbid: "",
+            type: "album",
+            status: "pending",
+            lidarrRef: null,
+            discoveryBatchId: null,
+            metadata: null,
+            ...job,
+        }));
+        const albumByRgMbid = options.albumByRgMbid
+            ? { id: "album-by-rg-mbid", ...options.albumByRgMbid }
+            : null;
+        const candidateAlbums = (options.candidateAlbums ?? []).map(
+            (album, index) => ({
+                id: album.id ?? `candidate-${index}`,
+                title: album.title,
+                artistName: album.artistName ?? album.artist?.name ?? "",
+                trackCount: album.trackCount ?? album.tracks?.length ?? 0,
+            }),
+        );
+
+        function matchesDownloadJob(job: any, where: any): boolean {
+            if (where?.status?.in && !where.status.in.includes(job.status)) {
+                return false;
+            }
+            if (where?.targetMbid && job.targetMbid !== where.targetMbid) {
+                return false;
+            }
+            if (where?.type && job.type !== where.type) return false;
+            if (where?.lidarrRef && job.lidarrRef !== where.lidarrRef) {
+                return false;
+            }
+            if (where?.id?.in && !where.id.in.includes(job.id)) return false;
+            if (where?.metadata?.path?.[0]) {
+                const metadata = job.metadata ?? {};
+                if (
+                    metadata[where.metadata.path[0]] !== where.metadata.equals
+                ) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         const prisma = {
             $queryRaw: jest.fn(async () =>
-                (options.candidateAlbums ?? []).map((album, index) => ({
-                    id: album.id ?? `candidate-${index}`,
+                candidateAlbums.map((album) => ({
+                    id: album.id,
                     title: album.title,
-                    artistName: album.artistName ?? album.artist?.name ?? "",
-                    hasTracks:
-                        album.hasTracks ?? (album.tracks?.length ?? 0) > 0,
+                    artistName: album.artistName,
                 })),
             ),
             downloadJob: {
-                findMany: jest.fn(async () => options.activeJobs ?? []),
+                findMany: jest.fn(async (args: any) =>
+                    downloadJobs.filter((job) =>
+                        matchesDownloadJob(job, args?.where),
+                    ),
+                ),
                 updateMany: jest.fn(async (args: any) => {
-                    if (
-                        args?.where?.targetMbid &&
-                        args?.where?.type === "artist"
-                    ) {
-                        return { count: 1 };
+                    const matchedJobs = downloadJobs.filter((job) =>
+                        matchesDownloadJob(job, args?.where),
+                    );
+                    for (const matchedJob of matchedJobs) {
+                        Object.assign(matchedJob, args.data);
                     }
-                    if (
-                        args?.where?.targetMbid &&
-                        args?.where?.type === "album"
-                    ) {
-                        return { count: options.albumDownloadUpdateCount ?? 1 };
-                    }
-                    if (args?.where?.lidarrRef) {
-                        return { count: 1 };
-                    }
-                    if (args?.where?.metadata) {
-                        return { count: options.metadataMatchUpdateCount ?? 0 };
-                    }
-                    if (args?.where?.id?.in) {
-                        return { count: args.where.id.in.length };
-                    }
-                    return { count: 0 };
+                    return { count: matchedJobs.length };
                 }),
             },
             album: {
-                findFirst: jest.fn(async () => options.albumByRgMbid ?? null),
+                findFirst: jest.fn(async () => albumByRgMbid),
             },
             artist: {
                 findUnique: jest.fn(async () => options.artistByMbid ?? null),
             },
             track: {
                 count: jest.fn(async () => options.tracksNeedingTags ?? 0),
+                groupBy: jest.fn(async (args: any) => {
+                    const counts = new Map(
+                        candidateAlbums.map((album) => [
+                            album.id,
+                            album.trackCount,
+                        ]),
+                    );
+                    if (albumByRgMbid) {
+                        counts.set(
+                            albumByRgMbid.id,
+                            albumByRgMbid.trackCount ?? 0,
+                        );
+                    }
+                    return (args?.where?.albumId?.in ?? []).flatMap(
+                        (albumId: string) => {
+                            const count = counts.get(albumId) ?? 0;
+                            return count > 0
+                                ? [{ albumId, _count: { _all: count } }]
+                                : [];
+                        },
+                    );
+                }),
             },
         };
 
@@ -228,6 +285,7 @@ describe("scanProcessor runtime behavior", () => {
             logger,
             config,
             prisma,
+            downloadJobs,
             scannerInstances,
             MusicScannerService,
             matchAlbum,
@@ -390,7 +448,7 @@ describe("scanProcessor runtime behavior", () => {
     });
 
     it("reconcile path completes exact and fuzzy matches and checks unique discovery batches", async () => {
-        const { module, prisma, discoverWeeklyService } = loadScanProcessor({
+        const rig = loadScanProcessor({
             scanResult: {
                 tracksAdded: 4,
                 tracksUpdated: 0,
@@ -457,6 +515,7 @@ describe("scanProcessor runtime behavior", () => {
                 );
             },
         });
+        const { module, prisma, logger, discoverWeeklyService } = rig;
 
         await module.processScan(createJob());
 
@@ -480,6 +539,13 @@ describe("scanProcessor runtime behavior", () => {
             ["batch-1"],
             ["batch-2"],
         ]);
+        expect(logger.debug).toHaveBeenCalledWith(
+            "✓ Reconciled 3 download job(s) with scanned albums",
+        );
+        expect(logger.error).not.toHaveBeenCalledWith(
+            "Failed to reconcile download jobs:",
+            expect.anything(),
+        );
     });
 
     it("bounds active jobs and candidate queries for a large queue", async () => {
@@ -596,7 +662,7 @@ describe("scanProcessor runtime behavior", () => {
     });
 
     it("updates artist, album, and lidarr-ref jobs for lidarr-triggered scans", async () => {
-        const { module, prisma, enrichSimilarArtist } = loadScanProcessor({
+        const rig = loadScanProcessor({
             scanResult: {
                 tracksAdded: 1,
                 tracksUpdated: 0,
@@ -610,16 +676,36 @@ describe("scanProcessor runtime behavior", () => {
                 enrichmentStatus: "pending",
             },
             albumByRgMbid: {
+                id: "album-local-1",
                 rgMbid: "album-mbid-1",
                 title: "Imported Album",
+                trackCount: 1,
                 artist: {
                     name: "Album Artist",
                     enrichmentStatus: "pending",
                 },
             },
-            activeJobs: [],
-            albumDownloadUpdateCount: 1,
+            activeJobs: [
+                {
+                    id: "artist-job",
+                    targetMbid: "artist-mbid-1",
+                    type: "artist",
+                },
+                {
+                    id: "album-job",
+                    targetMbid: "album-mbid-1",
+                    type: "album",
+                },
+                {
+                    id: "lidarr-job",
+                    targetMbid: "other-album-mbid",
+                    type: "album",
+                    lidarrRef: "lidarr-download-42",
+                    metadata: { albumTitle: "Other Album" },
+                },
+            ],
         });
+        const { module, prisma, downloadJobs, enrichSimilarArtist } = rig;
         const job = createJob({
             source: "lidarr-webhook",
             artistMbid: "artist-mbid-1",
@@ -640,27 +726,33 @@ describe("scanProcessor runtime behavior", () => {
                 }),
             }),
         );
-        expect(prisma.downloadJob.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    targetMbid: "album-mbid-1",
-                    type: "album",
-                }),
-                data: expect.objectContaining({
+        expect(downloadJobs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: "album-job",
                     status: "completed",
                 }),
-            }),
-        );
-        expect(prisma.downloadJob.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    lidarrRef: "lidarr-download-42",
-                }),
-                data: expect.objectContaining({
+                expect.objectContaining({
+                    id: "lidarr-job",
                     status: "completed",
                 }),
-            }),
+            ]),
         );
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledWith({
+            where: {
+                targetMbid: "album-mbid-1",
+                type: "album",
+                status: { in: ["pending", "processing"] },
+            },
+            select: { id: true, metadata: true },
+        });
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledWith({
+            where: {
+                lidarrRef: "lidarr-download-42",
+                status: { in: ["pending", "processing"] },
+            },
+            select: { id: true, metadata: true },
+        });
         expect(prisma.artist.findUnique).toHaveBeenCalledWith({
             where: { mbid: "artist-mbid-1" },
         });
@@ -681,8 +773,126 @@ describe("scanProcessor runtime behavior", () => {
         );
     });
 
+    const completenessPaths = [
+        {
+            name: "MBID",
+            job: {
+                id: "mbid-job",
+                targetMbid: "album-mbid-1",
+                metadata: {
+                    albumTitle: "Different Title",
+                    expectedTracks: 10,
+                },
+            },
+            scanData: {},
+        },
+        {
+            name: "title fallback",
+            job: {
+                id: "title-job",
+                targetMbid: "different-mbid",
+                metadata: {
+                    albumTitle: "Imported Album",
+                    expectedTracks: 10,
+                },
+            },
+            scanData: {},
+        },
+        {
+            name: "lidarrRef",
+            job: {
+                id: "lidarr-job",
+                targetMbid: "different-mbid",
+                lidarrRef: "lidarr-download-42",
+                metadata: {
+                    albumTitle: "Different Title",
+                    expectedTracks: 10,
+                },
+            },
+            scanData: { downloadId: "lidarr-download-42" },
+        },
+    ];
+
+    it.each(completenessPaths)(
+        "leaves a partial expected-track job active through the $name path",
+        async ({ job: activeJob, scanData }) => {
+            const { module, prisma, downloadJobs } = loadScanProcessor({
+                activeJobs: [{ ...activeJob, status: "processing" }],
+                albumByRgMbid: {
+                    id: "album-local-1",
+                    rgMbid: "album-mbid-1",
+                    title: "Imported Album",
+                    trackCount: 9,
+                    artist: {
+                        name: "Album Artist",
+                        enrichmentStatus: "complete",
+                    },
+                },
+            });
+
+            await module.processScan(
+                createJob({
+                    source: "lidarr-webhook",
+                    albumMbid: "album-mbid-1",
+                    ...scanData,
+                }),
+            );
+
+            expect(downloadJobs).toEqual([
+                expect.objectContaining({
+                    id: activeJob.id,
+                    status: "processing",
+                }),
+            ]);
+            expect(prisma.track.groupBy).toHaveBeenCalledWith({
+                by: ["albumId"],
+                where: {
+                    albumId: { in: ["album-local-1"] },
+                    origin: "LOCAL",
+                    removedAt: null,
+                    album: { location: { in: ["LIBRARY", "DISCOVER"] } },
+                },
+                _count: { _all: true },
+            });
+        },
+    );
+
+    it.each(completenessPaths)(
+        "completes an expected-track job through the $name path when the album is complete",
+        async ({ job: activeJob, scanData }) => {
+            const { module, downloadJobs } = loadScanProcessor({
+                activeJobs: [{ ...activeJob, status: "processing" }],
+                albumByRgMbid: {
+                    id: "album-local-1",
+                    rgMbid: "album-mbid-1",
+                    title: "Imported Album",
+                    trackCount: 10,
+                    artist: {
+                        name: "Album Artist",
+                        enrichmentStatus: "complete",
+                    },
+                },
+            });
+
+            await module.processScan(
+                createJob({
+                    source: "lidarr-webhook",
+                    albumMbid: "album-mbid-1",
+                    ...scanData,
+                }),
+            );
+
+            expect(downloadJobs).toEqual([
+                expect.objectContaining({
+                    id: activeJob.id,
+                    status: "completed",
+                }),
+            ]);
+        },
+    );
+
     it("falls back to album title matching when MBID-based album job updates match 0 rows", async () => {
-        const { module, prisma } = loadScanProcessor({
+        const { module, prisma, downloadJobs } = loadScanProcessor({
             scanResult: {
                 tracksAdded: 1,
                 tracksUpdated: 0,
@@ -690,8 +900,13 @@ describe("scanProcessor runtime behavior", () => {
                 errors: [],
                 duration: 5,
             },
-            albumDownloadUpdateCount: 0,
-            metadataMatchUpdateCount: 1,
+            activeJobs: [
+                {
+                    id: "title-match-job",
+                    targetMbid: "different-mbid",
+                    metadata: { albumTitle: "Imported Album" },
+                },
+            ],
             albumByRgMbid: {
                 rgMbid: "album-mbid-1",
                 title: "Imported Album",
@@ -709,30 +924,35 @@ describe("scanProcessor runtime behavior", () => {
 
         await module.processScan(job);
 
-        expect(prisma.downloadJob.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.objectContaining({
-                    targetMbid: "album-mbid-1",
-                    type: "album",
-                }),
-            }),
-        );
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledWith({
+            where: {
+                targetMbid: "album-mbid-1",
+                type: "album",
+                status: { in: ["pending", "processing"] },
+            },
+            select: { id: true, metadata: true },
+        });
         expect(prisma.album.findFirst).toHaveBeenCalledWith({
             where: { rgMbid: "album-mbid-1" },
             include: { artist: true },
         });
-        expect(prisma.downloadJob.updateMany).toHaveBeenCalledWith(
+        expect(prisma.downloadJob.findMany).toHaveBeenCalledWith({
+            where: {
+                type: "album",
+                metadata: {
+                    path: ["albumTitle"],
+                    equals: "Imported Album",
+                },
+                status: { in: ["pending", "processing"] },
+            },
+            select: { id: true, metadata: true },
+        });
+        expect(downloadJobs).toEqual([
             expect.objectContaining({
-                where: expect.objectContaining({
-                    type: "album",
-                    status: { in: ["pending", "processing"] },
-                    metadata: {
-                        path: ["albumTitle"],
-                        equals: "Imported Album",
-                    },
-                }),
+                id: "title-match-job",
+                status: "completed",
             }),
-        );
+        ]);
     });
 
     it("logs when album title fallback still does not find pending downloads", async () => {
@@ -744,8 +964,6 @@ describe("scanProcessor runtime behavior", () => {
                 errors: [],
                 duration: 5,
             },
-            albumDownloadUpdateCount: 0,
-            metadataMatchUpdateCount: 0,
             albumByRgMbid: {
                 rgMbid: "album-mbid-1",
                 title: "Imported Album",

--- a/backend/src/workers/processors/__tests__/scanReconcileQuery.test.ts
+++ b/backend/src/workers/processors/__tests__/scanReconcileQuery.test.ts
@@ -1,12 +1,30 @@
+const mockQueryRaw = jest.fn();
+const mockTrackGroupBy = jest.fn();
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+        track: {
+            groupBy: (...args: unknown[]) => mockTrackGroupBy(...args),
+        },
+    },
+}));
+
 import {
     buildScanReconcileCandidateQuery,
     buildScanReconcilePatterns,
+    candidateMatchesJob,
     chunkScanReconcilePatterns,
+    loadScanReconcileCandidates,
     SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT,
     SCAN_RECONCILE_PATTERN_CHUNK_SIZE,
 } from "../scanReconcileQuery";
 
 describe("scan reconciliation query construction", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("escapes LIKE metacharacters and preserves contains matching", () => {
         expect(buildScanReconcilePatterns(["100%_\\ Mix", "plain"])).toEqual([
             "%100\\%\\_\\\\ Mix%",
@@ -35,12 +53,93 @@ describe("scan reconciliation query construction", () => {
 
         expect(query.text).toContain("ar.name ILIKE ANY($1::text[])");
         expect(query.text).toContain('ORDER BY al."updatedAt" DESC, al.id ASC');
+        expect(query.text).toContain("al.location IN ('LIBRARY', 'DISCOVER')");
+        expect(query.text).not.toContain("COUNT(*)");
         expect(query.text).toContain("LIMIT $2");
         expect(query.text).not.toContain(" OR ");
         expect(query.values).toEqual([
             patterns,
             SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT,
         ]);
+    });
+
+    it("adds one bounded active-local track count to each candidate", async () => {
+        mockQueryRaw.mockResolvedValueOnce([
+            { id: "album-1", title: "One", artistName: "Artist" },
+            { id: "album-2", title: "Two", artistName: "Artist" },
+        ]);
+        mockTrackGroupBy.mockResolvedValueOnce([
+            { albumId: "album-1", _count: { _all: 3 } },
+        ]);
+
+        await expect(loadScanReconcileCandidates(["artis"])).resolves.toEqual([
+            {
+                id: "album-1",
+                title: "One",
+                artistName: "Artist",
+                trackCount: 3,
+            },
+            {
+                id: "album-2",
+                title: "Two",
+                artistName: "Artist",
+                trackCount: 0,
+            },
+        ]);
+        expect(mockTrackGroupBy).toHaveBeenCalledTimes(1);
+        expect(mockTrackGroupBy).toHaveBeenCalledWith({
+            by: ["albumId"],
+            where: {
+                albumId: { in: ["album-1", "album-2"] },
+                origin: "LOCAL",
+                removedAt: null,
+                album: { location: { in: ["LIBRARY", "DISCOVER"] } },
+            },
+            _count: { _all: true },
+        });
+    });
+
+    it("requires the matched album to meet a known expected track count", () => {
+        const job = {
+            id: "job-1",
+            discoveryBatchId: null,
+            artistName: "The National",
+            albumTitle: "Boxer",
+            expectedTracks: 14,
+        };
+        const partialCandidate = {
+            id: "album-1",
+            title: "Boxer Deluxe",
+            artistName: "The National",
+            trackCount: 1,
+        };
+
+        expect(candidateMatchesJob(job, [partialCandidate])).toBe(false);
+        expect(
+            candidateMatchesJob(job, [{ ...partialCandidate, trackCount: 14 }]),
+        ).toBe(true);
+    });
+
+    it("keeps presence-only matching when the expected count is unknown", () => {
+        expect(
+            candidateMatchesJob(
+                {
+                    id: "job-1",
+                    discoveryBatchId: null,
+                    artistName: "Beatles",
+                    albumTitle: "Abbey Road",
+                    expectedTracks: null,
+                },
+                [
+                    {
+                        id: "album-1",
+                        title: "Abbey Road (Remastered)",
+                        artistName: "The Beatles",
+                        trackCount: 1,
+                    },
+                ],
+            ),
+        ).toBe(true);
     });
 
     it("rejects empty and oversized pattern chunks", () => {

--- a/backend/src/workers/processors/scanProcessor.ts
+++ b/backend/src/workers/processors/scanProcessor.ts
@@ -1,9 +1,14 @@
 import { Job } from "bull";
+import type { Prisma } from "@prisma/client";
 import { logger } from "../../utils/logger";
 import { MusicScannerService } from "../../services/musicScanner";
 import { config } from "../../config";
 import { ACTIVE_DOWNLOAD_JOB_STATUSES } from "../../services/downloadJobStatus";
-import { reconcileDownloadJobsWithScan } from "./scanReconcileQuery";
+import { asPlainObject } from "../../utils/plainObject";
+import {
+    loadActiveLocalTrackCounts,
+    reconcileDownloadJobsWithScan,
+} from "./scanReconcileQuery";
 import * as path from "path";
 
 const log = logger.child("ScanProcessor");
@@ -25,6 +30,69 @@ export interface ScanJobResult {
     tracksRemoved: number;
     errors: Array<{ file: string; error: string }>;
     duration: number;
+}
+
+interface AlbumCompletionJob {
+    id: string;
+    metadata: unknown;
+}
+
+function expectedTracksFrom(metadata: unknown): number | null {
+    const expectedTracks = asPlainObject(metadata).expectedTracks;
+    return typeof expectedTracks === "number" &&
+        Number.isSafeInteger(expectedTracks) &&
+        expectedTracks > 0
+        ? expectedTracks
+        : null;
+}
+
+async function eligibleAlbumJobIds(
+    jobs: AlbumCompletionJob[],
+    albumId: string | undefined,
+): Promise<string[]> {
+    const expectedTracks = jobs.map((job) => ({
+        id: job.id,
+        count: expectedTracksFrom(job.metadata),
+    }));
+    if (expectedTracks.every((job) => job.count === null)) {
+        return expectedTracks.map((job) => job.id);
+    }
+    if (!albumId) {
+        return expectedTracks.flatMap((job) =>
+            job.count === null ? [job.id] : [],
+        );
+    }
+    const counts = await loadActiveLocalTrackCounts([albumId]);
+    const activeLocalTracks = counts.get(albumId) ?? 0;
+    return expectedTracks.flatMap((job) =>
+        job.count === null || activeLocalTracks >= job.count ? [job.id] : [],
+    );
+}
+
+async function completeAlbumJobs(
+    matchWhere: Prisma.DownloadJobWhereInput,
+    albumId: string | undefined,
+): Promise<{ count: number }> {
+    const { prisma } = await import("../../utils/db");
+    const jobs = await prisma.downloadJob.findMany({
+        where: {
+            ...matchWhere,
+            status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES },
+        },
+        select: { id: true, metadata: true },
+    });
+    const eligibleIds = await eligibleAlbumJobIds(jobs, albumId);
+    if (eligibleIds.length === 0) return { count: 0 };
+    return prisma.downloadJob.updateMany({
+        where: {
+            id: { in: eligibleIds },
+            status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES },
+        },
+        data: {
+            status: "completed",
+            completedAt: new Date(),
+        },
+    });
 }
 
 /**
@@ -101,6 +169,12 @@ export async function processScan(
                 `Marking download jobs as completed after successful scan`,
             );
             const { prisma } = await import("../../utils/db");
+            const album = albumMbid
+                ? await prisma.album.findFirst({
+                      where: { rgMbid: albumMbid },
+                      include: { artist: true },
+                  })
+                : null;
 
             if (artistMbid) {
                 await prisma.downloadJob.updateMany({
@@ -143,17 +217,13 @@ export async function processScan(
             }
 
             if (albumMbid) {
-                const updatedByMbid = await prisma.downloadJob.updateMany({
-                    where: {
+                const updatedByMbid = await completeAlbumJobs(
+                    {
                         targetMbid: albumMbid,
                         type: "album",
-                        status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES },
                     },
-                    data: {
-                        status: "completed",
-                        completedAt: new Date(),
-                    },
-                });
+                    album?.id,
+                );
 
                 if (updatedByMbid.count > 0) {
                     jobLog.debug(
@@ -165,29 +235,17 @@ export async function processScan(
                         `No downloads matched by MBID, trying artist+title match...`,
                     );
 
-                    const album = await prisma.album.findFirst({
-                        where: { rgMbid: albumMbid },
-                        include: { artist: true },
-                    });
-
                     if (album) {
-                        const updatedByName =
-                            await prisma.downloadJob.updateMany({
-                                where: {
-                                    type: "album",
-                                    status: {
-                                        in: ACTIVE_DOWNLOAD_JOB_STATUSES,
-                                    },
-                                    metadata: {
-                                        path: ["albumTitle"],
-                                        equals: album.title,
-                                    },
+                        const updatedByName = await completeAlbumJobs(
+                            {
+                                type: "album",
+                                metadata: {
+                                    path: ["albumTitle"],
+                                    equals: album.title,
                                 },
-                                data: {
-                                    status: "completed",
-                                    completedAt: new Date(),
-                                },
-                            });
+                            },
+                            album.id,
+                        );
 
                         if (updatedByName.count > 0) {
                             jobLog.debug(
@@ -203,10 +261,6 @@ export async function processScan(
 
                 // Trigger enrichment for the artist of the newly imported album
                 try {
-                    const album = await prisma.album.findFirst({
-                        where: { rgMbid: albumMbid },
-                        include: { artist: true },
-                    });
                     if (
                         album?.artist &&
                         album.artist.enrichmentStatus === "pending"
@@ -230,16 +284,12 @@ export async function processScan(
             }
 
             if (downloadId) {
-                const updated = await prisma.downloadJob.updateMany({
-                    where: {
+                const updated = await completeAlbumJobs(
+                    {
                         lidarrRef: downloadId,
-                        status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES },
                     },
-                    data: {
-                        status: "completed",
-                        completedAt: new Date(),
-                    },
-                });
+                    album?.id,
+                );
                 if (updated.count > 0) {
                     jobLog.debug(
                         `Linked Lidarr download ${downloadId} to ${updated.count} job(s)`,

--- a/backend/src/workers/processors/scanReconcileQuery.ts
+++ b/backend/src/workers/processors/scanReconcileQuery.ts
@@ -8,6 +8,7 @@ import { resolveDownloadJobMetadata } from "../../utils/downloadJobMetadata";
 
 const log = logger.child("ScanReconcileQuery");
 const ARTIST_PREFIX_LENGTH = 5;
+const SCAN_RECONCILE_ALBUM_LOCATIONS = ["LIBRARY", "DISCOVER"] as const;
 
 /** Maximum active download jobs reconciled after one scan. */
 export const SCAN_RECONCILE_ACTIVE_JOB_LIMIT = 500;
@@ -24,14 +25,18 @@ export interface ScanReconcileCandidate {
     id: string;
     title: string;
     artistName: string;
-    hasTracks: boolean;
+    trackCount: number;
 }
 
-interface ReconcileJob {
+type ScanReconcileAlbumRow = Omit<ScanReconcileCandidate, "trackCount">;
+
+/** Active download-job fields used by the pure reconciliation matcher. */
+export interface ReconcileJob {
     id: string;
     discoveryBatchId: string | null;
     artistName: string;
     albumTitle: string;
+    expectedTracks: number | null;
 }
 
 /** Convert literal artist prefixes into case-insensitive contains patterns. */
@@ -69,18 +74,34 @@ export function buildScanReconcileCandidateQuery(
         SELECT
             al.id,
             al.title,
-            ar.name AS "artistName",
-            EXISTS (
-                SELECT 1
-                FROM "Track" AS tr
-                WHERE tr."albumId" = al.id
-            ) AS "hasTracks"
+            ar.name AS "artistName"
         FROM "Album" AS al
         INNER JOIN "Artist" AS ar ON ar.id = al."artistId"
         WHERE ar.name ILIKE ANY(${patterns}::text[])
+          AND al.location IN ('LIBRARY', 'DISCOVER')
         ORDER BY al."updatedAt" DESC, al.id ASC
         LIMIT ${SCAN_RECONCILE_CANDIDATE_FETCH_LIMIT}
     `;
+}
+
+/** Count active local tracks for eligible library album IDs. */
+export async function loadActiveLocalTrackCounts(
+    albumIds: string[],
+): Promise<Map<string, number>> {
+    if (albumIds.length === 0) return new Map();
+    const counts = await prisma.track.groupBy({
+        by: ["albumId"],
+        where: {
+            albumId: { in: albumIds },
+            origin: "LOCAL",
+            removedAt: null,
+            album: {
+                location: { in: [...SCAN_RECONCILE_ALBUM_LOCATIONS] },
+            },
+        },
+        _count: { _all: true },
+    });
+    return new Map(counts.map((count) => [count.albumId, count._count._all]));
 }
 
 /** Load bounded, deduplicated album candidates for literal artist prefixes. */
@@ -93,10 +114,10 @@ export async function loadScanReconcileCandidates(
     const chunks = chunkScanReconcilePatterns(
         buildScanReconcilePatterns(prefixes),
     );
-    const candidates = new Map<string, ScanReconcileCandidate>();
+    const candidates = new Map<string, ScanReconcileAlbumRow>();
 
     for (const [chunkIndex, patterns] of chunks.entries()) {
-        const rows = await prisma.$queryRaw<ScanReconcileCandidate[]>(
+        const rows = await prisma.$queryRaw<ScanReconcileAlbumRow[]>(
             buildScanReconcileCandidateQuery(patterns),
         );
         if (rows.length > SCAN_RECONCILE_CANDIDATE_LIMIT) {
@@ -111,7 +132,14 @@ export async function loadScanReconcileCandidates(
         }
     }
 
-    return [...candidates.values()];
+    const candidateRows = [...candidates.values()];
+    const trackCounts = await loadActiveLocalTrackCounts(
+        candidateRows.map((candidate) => candidate.id),
+    );
+    return candidateRows.map((candidate) => ({
+        ...candidate,
+        trackCount: trackCounts.get(candidate.id) ?? 0,
+    }));
 }
 
 function resolveReconcileJobs(
@@ -122,15 +150,38 @@ function resolveReconcileJobs(
     }>,
 ): ReconcileJob[] {
     return activeJobs.flatMap((job) => {
-        const { artistName, albumTitle } = resolveDownloadJobMetadata(
+        const { artistName, albumTitle, metadata } = resolveDownloadJobMetadata(
             job.metadata,
         );
         if (!artistName || !albumTitle) return [];
-        return [{ ...job, artistName, albumTitle }];
+        const expectedTracks = metadata.expectedTracks;
+        return [
+            {
+                ...job,
+                artistName,
+                albumTitle,
+                expectedTracks:
+                    typeof expectedTracks === "number" &&
+                    Number.isSafeInteger(expectedTracks) &&
+                    expectedTracks > 0
+                        ? expectedTracks
+                        : null,
+            },
+        ];
     });
 }
 
-function candidateMatchesJob(
+function candidateHasEnoughTracks(
+    candidate: ScanReconcileCandidate,
+    expectedTracks: number | null,
+): boolean {
+    return expectedTracks === null
+        ? candidate.trackCount > 0
+        : candidate.trackCount >= expectedTracks;
+}
+
+/** Return whether any eligible album candidate matches one active job. */
+export function candidateMatchesJob(
     job: ReconcileJob,
     candidates: ScanReconcileCandidate[],
 ): boolean {
@@ -138,7 +189,7 @@ function candidateMatchesJob(
     const albumTitle = job.albumTitle.toLowerCase();
     const exactMatch = candidates.some(
         (candidate) =>
-            candidate.hasTracks &&
+            candidateHasEnoughTracks(candidate, job.expectedTracks) &&
             candidate.artistName.toLowerCase().includes(artistName) &&
             candidate.title.toLowerCase().includes(albumTitle),
     );
@@ -146,7 +197,7 @@ function candidateMatchesJob(
 
     return candidates.some(
         (candidate) =>
-            candidate.hasTracks &&
+            candidateHasEnoughTracks(candidate, job.expectedTracks) &&
             matchAlbum(
                 job.artistName,
                 job.albumTitle,

--- a/backend/tests-integration/scanReconcilePostgres.integration.test.ts
+++ b/backend/tests-integration/scanReconcilePostgres.integration.test.ts
@@ -1,4 +1,5 @@
 import type { Client } from "pg";
+import type { AlbumLocation, TrackOrigin } from "@prisma/client";
 import { prisma } from "../src/utils/db";
 import {
     loadScanReconcileCandidates,
@@ -24,7 +25,12 @@ async function seedAlbum(
     id: string,
     artistName: string,
     title: string,
-    hasTracks = true,
+    trackCount = 1,
+    options: {
+        location?: AlbumLocation;
+        origin?: TrackOrigin;
+        removedTrackIndexes?: number[];
+    } = {},
 ): Promise<void> {
     const artistId = `${id}-artist`;
     await prisma.artist.create({
@@ -37,20 +43,25 @@ async function seedAlbum(
             artistId,
             title,
             primaryType: "Album",
+            location: options.location,
             updatedAt: FIXED_TIME,
         },
     });
-    if (hasTracks) {
-        await prisma.track.create({
-            data: {
-                id: `${id}-track`,
+    if (trackCount > 0) {
+        await prisma.track.createMany({
+            data: Array.from({ length: trackCount }, (_unused, index) => ({
+                id: `${id}-track-${index + 1}`,
                 albumId: id,
-                title: `${title} Track`,
-                trackNo: 1,
+                title: `${title} Track ${index + 1}`,
+                trackNo: index + 1,
                 duration: 180,
                 fileModified: FIXED_TIME,
                 fileSize: 1_000,
-            },
+                origin: options.origin,
+                removedAt: options.removedTrackIndexes?.includes(index)
+                    ? FIXED_TIME
+                    : null,
+            })),
         });
     }
 }
@@ -60,6 +71,7 @@ async function seedJob(
     artistName: string,
     albumTitle: string,
     createdAt = FIXED_TIME,
+    expectedTracks?: number,
 ): Promise<void> {
     await prisma.downloadJob.create({
         data: {
@@ -69,7 +81,11 @@ async function seedJob(
             type: "album",
             targetMbid: `${id}-target`,
             status: "pending",
-            metadata: { artistName, albumTitle },
+            metadata: {
+                artistName,
+                albumTitle,
+                ...(expectedTracks === undefined ? {} : { expectedTracks }),
+            },
             createdAt,
         },
     });
@@ -114,12 +130,7 @@ describeWithPostgres("scan reconciliation PostgreSQL behavior", () => {
             "The Beatles",
             "Abbey Road (Remastered)",
         );
-        await seedAlbum(
-            "no-track-album",
-            "Silent Artist",
-            "Silent Album",
-            false,
-        );
+        await seedAlbum("no-track-album", "Silent Artist", "Silent Album", 0);
         await seedJob("exact-job", "The National", "Boxer");
         await seedJob("fuzzy-job", "Beatles", "Abbey Road");
         await seedJob("no-track-job", "Silent Artist", "Silent Album");
@@ -137,6 +148,86 @@ describeWithPostgres("scan reconciliation PostgreSQL behavior", () => {
             { id: "no-track-job", status: "pending" },
             { id: "unmatched-job", status: "pending" },
         ]);
+    });
+
+    it("reconciles only candidates that satisfy the persisted expected count", async () => {
+        await seedAlbum("partial-album", "Partial Artist", "Partial Album", 1);
+        await seedAlbum("legacy-album", "Legacy Artist", "Legacy Album", 1);
+        await seedAlbum(
+            "complete-album",
+            "Complete Artist",
+            "Complete Album",
+            14,
+        );
+        await seedJob(
+            "partial-job",
+            "Partial Artist",
+            "Partial Album",
+            FIXED_TIME,
+            14,
+        );
+        await seedJob("legacy-job", "Legacy Artist", "Legacy Album");
+        await seedJob(
+            "complete-job",
+            "Complete Artist",
+            "Complete Album",
+            FIXED_TIME,
+            14,
+        );
+
+        await expect(reconcileDownloadJobsWithScan()).resolves.toBe(2);
+
+        const jobs = await prisma.downloadJob.findMany({
+            orderBy: { id: "asc" },
+            select: { id: true, status: true },
+        });
+        expect(jobs).toEqual([
+            { id: "complete-job", status: "completed" },
+            { id: "legacy-job", status: "completed" },
+            { id: "partial-job", status: "pending" },
+        ]);
+    });
+
+    it("counts only active local tracks on local scan albums", async () => {
+        await seedAlbum("removed-album", "Removed Artist", "Removed Album", 2, {
+            removedTrackIndexes: [1],
+        });
+        await seedAlbum("remote-album", "Remote Artist", "Remote Album", 2, {
+            location: "REMOTE",
+        });
+        await seedAlbum(
+            "federated-album",
+            "Federated Artist",
+            "Federated Album",
+            2,
+            { location: "FEDERATED", origin: "FEDERATED" },
+        );
+        await seedJob(
+            "removed-job",
+            "Removed Artist",
+            "Removed Album",
+            FIXED_TIME,
+            2,
+        );
+        await seedJob(
+            "remote-job",
+            "Remote Artist",
+            "Remote Album",
+            FIXED_TIME,
+            2,
+        );
+        await seedJob(
+            "federated-job",
+            "Federated Artist",
+            "Federated Album",
+            FIXED_TIME,
+            2,
+        );
+
+        await expect(reconcileDownloadJobsWithScan()).resolves.toBe(0);
+        await expect(
+            prisma.downloadJob.count({ where: { status: "completed" } }),
+        ).resolves.toBe(0);
     });
 
     it("treats percent, underscore, and backslash in artist prefixes literally", async () => {


### PR DESCRIPTION
## Problem

An album download job reported "completed" on any nonzero track count — "TIDAL ✓ 1 tracks" out of a 14-track request was a green success (issue #826). Post-scan reconciliation was worse: any fuzzy-matched album with ≥1 track completed the job. Combined with the old matching bugs, wrong single-track downloads were indistinguishable from real albums.

## Contract

The requested release group's MusicBrainz track count is the completeness contract:

- Expected count = the **minimum** total track count across the release group's Official releases (fallback: minimum across all). Any legitimately complete edition satisfies it; deluxe over-delivery completes; 1-of-14 fails.
- The shared runner resolves it from the job's canonical `targetMbid` (with `metadata.albumMbid` as legacy fallback), persists `expectedTracks` in job metadata, and classifies results: complete → as today; partial → job **fails** with "Partial download: N/M tracks" and `partial: true`; MB unavailable → verification skipped with a structured warn (downloads never block on MusicBrainz; failures use the existing bounded 120-second fallback cache, not the 30-day TTL).
- Reconciliation and the scan processor's MBID/title/lidarrRef completion paths gate on the same rule, counting only playable local tracks (`origin LOCAL`, not soft-removed) via a bounded Prisma `groupBy` (the raw COUNT draft was removed per the repo's raw-SQL policy). Jobs without `expectedTracks` keep the old presence behavior — fully backward compatible.
- TIDAL, YouTube Music, and Soulseek all participate (Soulseek's results already carried counts). The legacy `acquisitionService` spotify-import path is intentionally untouched.

## Review process

Two adversarial rounds to zero findings — including a critical catch: production jobs carry the RG MBID in `targetMbid`, not metadata, so the first draft's gate would never have fired outside tests. Also fixed there: edition-mismatch false partials (min-across-official policy), federated/soft-removed tracks satisfying counts, a dead reconciliation assertion caused by a mock missing `groupBy`, and the scanProcessor bypass paths.

## Tests

TDD: pure completeness classifier cases (complete/partial/zero/unknown/over-delivery), runner behavior on the production job shape plus legacy fallback, provider accessors, scanProcessor partial-vs-complete per completion path, reconciliation pure + real-PostgreSQL cases (1-track album must not reconcile a 14-expected job; soft-removed and federated rows don't count; unknown-expected keeps legacy behavior).

## Verification

- verify: targeted suites exit 0 — `Test Suites: 7 passed`, `Tests: 149 passed`
- verify: backend tsc --noEmit exit 0; file-size gate exit 0; repo-wide backend format:check clean; integration suite skips cleanly without `INTEGRATION_DATABASE_URL`

Closes #826