### PR TITLE
chore(downloads): decompose lidarr.ts along its natural seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Lidarr album acquisition, discovery tags, and reconciliation now use focused internal modules without changing the service API or download behavior (#790).
 - The full-screen player's swipe gestures (track skip, swipe-down to close, drawer handle) now run through one tested gesture module, in preparation for further player decomposition.
 - The full-screen player's Up Next list now renders only the rows in view, so very large queues open and scroll smoothly, and the Queue, Lyrics, and Related panels fetch their data independently so an open player does less background work.
 - Listen Together's connection handling and "ready to play" reporting now run through small tested modules, making group playback behavior easier to verify without changing how sessions work.

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -103,6 +103,13 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/libraryHealthDashboard/storageAnalytics.ts` | MIME, storage, bitrate, and artist analytics |
 | `backend/src/services/libraryTrackPreferences.ts` | Core |
 | `backend/src/services/lidarr.ts` | Core |
+| `backend/src/services/lidarr/lidarrAlbumSelection.ts` | Pure Lidarr album catalog matching and edition fallback selection |
+| `backend/src/services/lidarr/lidarrArtistCatalog.ts` | Artist presence and bounded album-catalog polling |
+| `backend/src/services/lidarr/lidarrHttpClient.ts` | Bounded Lidarr HTTP transport |
+| `backend/src/services/lidarr/lidarrQueue.ts` | Lidarr queue inspection and cleanup |
+| `backend/src/services/lidarr/lidarrReconciliation.ts` | Queue and downloaded-album reconciliation snapshots |
+| `backend/src/services/lidarr/lidarrReleaseGrab.ts` | Lidarr album monitoring, search, and edition fallback acquisition |
+| `backend/src/services/lidarr/lidarrTagService.ts` | Lidarr discovery-tag lifecycle and artist tagging |
 | `backend/src/services/listenTogether.ts` | Core |
 | `backend/src/services/listenTogetherAvailability.ts` | Queue identity checks for late availability resolution |
 | `backend/src/services/listenTogetherAvailabilityPublication.ts` | Resolve, revalidate, and publish per-user queue availability |

--- a/backend/src/services/__tests__/lidarrService.acquisition.test.ts
+++ b/backend/src/services/__tests__/lidarrService.acquisition.test.ts
@@ -21,6 +21,49 @@ import {
     primeServiceWithClient,
 } from "./lidarrService.helpers";
 
+function primeCatalogGrab(
+    client: ReturnType<typeof createClientMock>,
+    albums: Array<{
+        id: number;
+        title: string;
+        foreignAlbumId: string;
+        artistId: number;
+    }>,
+    selectedId: number,
+): void {
+    const selected = albums.find((album) => album.id === selectedId);
+    if (!selected) throw new Error("Selected test album is missing");
+    client.get
+        .mockResolvedValueOnce({
+            data: [
+                {
+                    id: selected.artistId,
+                    artistName: "Artist",
+                    foreignArtistId: "artist-mbid",
+                    monitored: true,
+                },
+            ],
+        })
+        .mockResolvedValueOnce({ data: albums })
+        .mockResolvedValueOnce({
+            data: {
+                ...selected,
+                monitored: false,
+                anyReleaseOk: false,
+                releases: [{ id: 1 }],
+            },
+        })
+        .mockResolvedValueOnce({
+            data: {
+                ...selected,
+                monitored: true,
+                anyReleaseOk: false,
+                releases: [{ id: 1 }],
+            },
+        });
+    client.put.mockResolvedValue({ data: { ...selected, monitored: true } });
+}
+
 describe("lidarr service behavior", () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -1063,188 +1106,6 @@ describe("lidarr service behavior", () => {
         searchSpy.mockRestore();
     });
 
-    it("reads and creates discovery tags with cache semantics", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get.mockResolvedValueOnce({
-            data: [
-                { id: 7, label: "soundspan-discovery" },
-                { id: 8, label: "other" },
-            ],
-        });
-
-        const first = await lidarrService.getOrCreateDiscoveryTag();
-        const second = await lidarrService.getOrCreateDiscoveryTag();
-
-        expect(first).toBe(7);
-        expect(second).toBe(7);
-        expect(client.get).toHaveBeenCalledTimes(1);
-    });
-
-    it("creates discovery tag when missing", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-        client.get.mockResolvedValueOnce({ data: [] });
-        client.post.mockResolvedValueOnce({
-            data: { id: 99, label: "soundspan-discovery" },
-        });
-
-        const tag = await lidarrService.getOrCreateDiscoveryTag();
-        expect(tag).toBe(99);
-        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
-            label: "soundspan-discovery",
-        });
-    });
-
-    it("returns safe defaults when tag endpoints fail", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-        client.get.mockRejectedValueOnce(new Error("tag lookup failed"));
-        client.post.mockRejectedValueOnce(new Error("tag create failed"));
-
-        await expect(lidarrService.getTags()).resolves.toEqual([]);
-        await expect(lidarrService.createTag("new-tag")).resolves.toBeNull();
-
-        expect(client.get).toHaveBeenCalledWith("/api/v1/tag");
-        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
-            label: "new-tag",
-        });
-    });
-
-    it("retries discovery tag lookup after create failures and only caches successful IDs", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({
-            data: [{ id: 101, label: "soundspan-discovery" }],
-        });
-        client.post.mockRejectedValueOnce(new Error("tag create conflict"));
-
-        await expect(
-            lidarrService.getOrCreateDiscoveryTag(),
-        ).resolves.toBeNull();
-        await expect(lidarrService.getOrCreateDiscoveryTag()).resolves.toBe(
-            101,
-        );
-        await expect(lidarrService.getOrCreateDiscoveryTag()).resolves.toBe(
-            101,
-        );
-
-        expect(client.get).toHaveBeenCalledTimes(2);
-        expect(client.post).toHaveBeenCalledTimes(1);
-        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
-            label: "soundspan-discovery",
-        });
-    });
-
-    it("adds and removes artist tags by updating merged tag lists", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get
-            .mockResolvedValueOnce({
-                data: { id: 11, artistName: "Artist A", tags: [1, 2] },
-            })
-            .mockResolvedValueOnce({
-                data: { id: 11, artistName: "Artist A", tags: [1, 2, 3] },
-            });
-        client.put.mockResolvedValue({});
-
-        await expect(lidarrService.addTagsToArtist(11, [2, 3])).resolves.toBe(
-            true,
-        );
-        await expect(
-            lidarrService.removeTagsFromArtist(11, [1, 3]),
-        ).resolves.toBe(true);
-
-        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/11", {
-            id: 11,
-            artistName: "Artist A",
-            tags: [1, 2, 3],
-        });
-        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/11", {
-            id: 11,
-            artistName: "Artist A",
-            tags: [2],
-        });
-    });
-
-    it("returns false when addTagsToArtist cannot persist merged tags", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get.mockResolvedValueOnce({
-            data: {
-                id: 21,
-                artistName: "Artist B",
-                monitored: true,
-                tags: [4, 7],
-            },
-        });
-        client.put.mockRejectedValueOnce(new Error("tag update failed"));
-
-        await expect(lidarrService.addTagsToArtist(21, [7, 9])).resolves.toBe(
-            false,
-        );
-        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/21", {
-            id: 21,
-            artistName: "Artist B",
-            monitored: true,
-            tags: [4, 7, 9],
-        });
-    });
-
-    it("returns false when removeTagsFromArtist update fails after filtering tags", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get.mockResolvedValueOnce({
-            data: { id: 22, artistName: "Artist C", tags: [3, 5, 8] },
-        });
-        client.put.mockRejectedValueOnce(new Error("remove failed"));
-
-        await expect(
-            lidarrService.removeTagsFromArtist(22, [5, 99]),
-        ).resolves.toBe(false);
-        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/22", {
-            id: 22,
-            artistName: "Artist C",
-            tags: [3, 8],
-        });
-    });
-
-    it("removes discovery tag by MBID when artist is found", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-        (lidarrService as any).discoveryTagId = 5;
-
-        client.get
-            .mockResolvedValueOnce({
-                data: [
-                    {
-                        id: 12,
-                        foreignArtistId: "artist-1",
-                        artistName: "Artist",
-                        tags: [5, 9],
-                    },
-                ],
-            })
-            .mockResolvedValueOnce({
-                data: { id: 12, artistName: "Artist", tags: [5, 9] },
-            });
-        client.put.mockResolvedValue({});
-
-        await expect(
-            lidarrService.removeDiscoveryTagByMbid("artist-1"),
-        ).resolves.toBe(true);
-        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/12", {
-            id: 12,
-            artistName: "Artist",
-            tags: [9],
-        });
-    });
-
     it("maps release search, grab, and blocklist flows", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -1511,6 +1372,56 @@ describe("lidarr service behavior", () => {
         waitSpy.mockRestore();
     });
 
+    it("returns null when base-album dispatch reports a timed-out-looking failure", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        (lidarrService as any)._indexerCountLogged = true;
+        mockStripAlbumEdition.mockReturnValueOnce("Album");
+        const primary = {
+            id: 503,
+            title: "Album Deluxe",
+            foreignAlbumId: "album-deluxe",
+            artistId: 301,
+        };
+        const base = {
+            id: 504,
+            title: "Album",
+            foreignAlbumId: "album-base",
+            artistId: 301,
+        };
+        primeCatalogGrab(client, [primary, base], primary.id);
+        client.get.mockResolvedValueOnce({
+            data: { ...primary, releases: [{ id: 1 }] },
+        });
+        client.post
+            .mockResolvedValueOnce({ data: { id: 9111 } })
+            .mockResolvedValueOnce({ data: { id: 9112 } })
+            .mockRejectedValueOnce(
+                new Error(
+                    "Base AlbumSearch dispatch timed out before acceptance",
+                ),
+            );
+        const waitSpy = jest
+            .spyOn(lidarrService as any, "waitForCommand")
+            .mockResolvedValue({
+                status: "completed",
+                message: "Search completed with 0 reports",
+            });
+
+        await expect(
+            lidarrService.addAlbum(
+                primary.foreignAlbumId,
+                "Artist",
+                primary.title,
+                "/music",
+                "artist-mbid",
+            ),
+        ).resolves.toBeNull();
+        expect(waitSpy).toHaveBeenCalledTimes(2);
+
+        waitSpy.mockRestore();
+    });
+
     it("addAlbum returns null when no MBID is available for a new artist", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -1657,6 +1568,58 @@ describe("lidarr service behavior", () => {
 
         waitSpy.mockRestore();
     });
+
+    it.each([
+        [
+            "exact normalized",
+            "Exact Match Album!",
+            "exact match album",
+            904,
+            "Matched exact normalized",
+        ],
+        [
+            "partial contained",
+            "Partial Match Album",
+            "Partial Match Album Remastered",
+            905,
+            "Matched partial (contained)",
+        ],
+    ])(
+        "addAlbum selects the %s catalog match through the facade",
+        async (_branch, requestedTitle, catalogTitle, selectedId, matchLog) => {
+            const client = createClientMock();
+            primeServiceWithClient(client);
+            const album = {
+                id: selectedId,
+                title: catalogTitle,
+                foreignAlbumId: `catalog-${selectedId}`,
+                artistId: 58,
+            };
+            primeCatalogGrab(client, [album], selectedId);
+            client.post.mockResolvedValue({ data: { id: 9103 } });
+            const waitSpy = jest
+                .spyOn(lidarrService as any, "waitForCommand")
+                .mockResolvedValue({
+                    status: "completed",
+                    message: "Search completed with 1 report",
+                });
+
+            await expect(
+                lidarrService.addAlbum(
+                    "different-mbid",
+                    "Artist",
+                    requestedTitle,
+                    "/music",
+                    "artist-mbid",
+                ),
+            ).resolves.toEqual(expect.objectContaining({ id: selectedId }));
+            expect(logger.debug).toHaveBeenCalledWith(
+                expect.stringContaining(matchLog),
+            );
+
+            waitSpy.mockRestore();
+        },
+    );
 
     it("adds existing unmonitored artist and enables monitoring before album search", async () => {
         const client = createClientMock();
@@ -2091,6 +2054,35 @@ describe("lidarr service behavior", () => {
         }
     });
 
+    it("returns null when album-search dispatch reports a timed-out-looking failure", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        const album = {
+            id: 906,
+            title: "Dispatch Failure Album",
+            foreignAlbumId: "album-dispatch-failure",
+            artistId: 59,
+        };
+        primeCatalogGrab(client, [album], album.id);
+        client.post.mockRejectedValueOnce(
+            new Error("AlbumSearch dispatch timed out before acceptance"),
+        );
+        const waitSpy = jest.spyOn(lidarrService as any, "waitForCommand");
+
+        await expect(
+            lidarrService.addAlbum(
+                album.foreignAlbumId,
+                "Artist",
+                album.title,
+                "/music",
+                "artist-mbid",
+            ),
+        ).resolves.toBeNull();
+        expect(waitSpy).not.toHaveBeenCalled();
+
+        waitSpy.mockRestore();
+    });
+
     it("returns true when blocklist target is already absent from queue", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -2139,6 +2131,7 @@ describe("lidarr service behavior", () => {
                 },
             })
             .mockResolvedValueOnce({
+                status: 200,
                 data: {
                     id: 401,
                     title: "Unstable Album",
@@ -2173,6 +2166,12 @@ describe("lidarr service behavior", () => {
         expect(waitSpy).toHaveBeenCalledWith(7101, 30000);
         expect(logger.error).toHaveBeenCalledWith(
             " CRITICAL: Album monitoring failed to persist!",
+            {
+                albumId: 401,
+                title: "Unstable Album",
+                monitored: false,
+                status: 200,
+            },
         );
 
         waitSpy.mockRestore();

--- a/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
+++ b/backend/src/services/__tests__/lidarrService.clientHelpers.test.ts
@@ -22,6 +22,42 @@ import {
     primeServiceWithClient,
 } from "./lidarrService.helpers";
 
+function primeMonitoringFailure(
+    client: ReturnType<typeof createClientMock>,
+    sentinel: string,
+) {
+    const album = {
+        id: 401,
+        title: "Unstable Album",
+        foreignAlbumId: "album-mbid",
+        artistId: 101,
+    };
+    const unmonitored = {
+        ...album,
+        monitored: false,
+        anyReleaseOk: false,
+        releases: [{ id: 1 }],
+        rawSecret: sentinel,
+    };
+    client.get
+        .mockResolvedValueOnce({
+            data: [
+                {
+                    id: 101,
+                    artistName: "Artist",
+                    foreignArtistId: "artist-mbid",
+                    monitored: true,
+                },
+            ],
+        })
+        .mockResolvedValueOnce({ data: [album] })
+        .mockResolvedValueOnce({ data: unmonitored })
+        .mockResolvedValueOnce({ status: 200, data: unmonitored });
+    client.put.mockResolvedValue({ data: { monitored: true } });
+    client.post.mockResolvedValue({ data: { id: 7101 } });
+    return album;
+}
+
 describe("lidarr service behavior", () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -115,111 +151,6 @@ describe("lidarr service behavior", () => {
             new Date("2026-02-28"),
         );
         expect(calendar).toEqual([]);
-    });
-
-    it("builds reconciliation snapshot and checks album/download state helpers", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get
-            .mockResolvedValueOnce({
-                data: {
-                    records: [
-                        {
-                            id: 4,
-                            downloadId: "queue-1",
-                            status: "downloading",
-                            size: 100,
-                            sizeleft: 20,
-                            title: "Album",
-                        },
-                        {
-                            id: 5,
-                            downloadId: "queue-2",
-                            status: "warning",
-                            size: 100,
-                            sizeleft: 70,
-                            title: "Album 2",
-                        },
-                    ],
-                },
-            })
-            .mockResolvedValueOnce({
-                data: [
-                    {
-                        id: 31,
-                        title: "My Album (Deluxe)",
-                        foreignAlbumId: "album-mbid-31",
-                        artist: { artistName: "My Artist" },
-                        statistics: { percentOfTracks: 100 },
-                    },
-                    {
-                        id: 32,
-                        title: "No Files Album",
-                        foreignAlbumId: "album-mbid-32",
-                        artist: { artistName: "My Artist" },
-                        statistics: { percentOfTracks: 0 },
-                    },
-                ],
-            });
-
-        const snapshot = await lidarrService.getReconciliationSnapshot();
-        expect(snapshot.queue.size).toBe(2);
-        expect(snapshot.albumsByMbid.size).toBe(1);
-
-        expect(
-            (lidarrService as any).isAlbumAvailableInSnapshot(
-                snapshot,
-                "album-mbid-31",
-            ),
-        ).toBe(true);
-        expect(
-            (lidarrService as any).isAlbumAvailableInSnapshot(
-                snapshot,
-                undefined,
-                "My Artist",
-                "My Album",
-            ),
-        ).toBe(true);
-
-        expect(
-            (lidarrService as any).isDownloadActiveInSnapshot(
-                snapshot,
-                "queue-1",
-            ),
-        ).toEqual({ active: true, progress: 80 });
-        expect(
-            (lidarrService as any).isDownloadActiveInSnapshot(
-                snapshot,
-                "queue-2",
-            ),
-        ).toEqual({ active: false, progress: 30 });
-    });
-
-    it("fails closed when album indexing fails during snapshot creation", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        client.get
-            .mockResolvedValueOnce({
-                data: {
-                    records: [
-                        {
-                            id: 7,
-                            downloadId: "queue-ok",
-                            status: "downloading",
-                            size: 200,
-                            sizeleft: 40,
-                            title: "Album",
-                        },
-                    ],
-                },
-            })
-            .mockRejectedValueOnce(new Error("album index down"));
-
-        await expect(lidarrService.getReconciliationSnapshot()).rejects.toThrow(
-            "album index down",
-        );
     });
 
     it("deletes artists/albums and checks availability helpers", async () => {
@@ -1266,6 +1197,40 @@ describe("lidarr service behavior", () => {
         searchArtistSpy.mockRestore();
     });
 
+    it("does not log raw album payloads when monitoring does not persist", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        const sentinel = "monitoring-payload-api-key-sentinel";
+        const album = primeMonitoringFailure(client, sentinel);
+        const waitSpy = jest
+            .spyOn(lidarrService as any, "waitForCommand")
+            .mockResolvedValue({
+                status: "completed",
+                message: "Search completed with 1 report",
+            });
+
+        await lidarrService.addAlbum(
+            album.foreignAlbumId,
+            "Artist",
+            album.title,
+            "/music",
+            "artist-mbid",
+        );
+
+        const errorLogs = (logger.error as jest.Mock).mock.calls;
+        expect(JSON.stringify(errorLogs)).not.toContain(sentinel);
+        expect(errorLogs).toContainEqual([
+            " CRITICAL: Album monitoring failed to persist!",
+            {
+                albumId: album.id,
+                title: album.title,
+                monitored: false,
+                status: 200,
+            },
+        ]);
+        waitSpy.mockRestore();
+    });
+
     it("addAlbum refreshes metadata when an existing artist has no albums", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -1549,81 +1514,6 @@ describe("lidarr service behavior", () => {
         setTimeoutSpy.mockRestore();
     });
 
-    it("addAlbum matches album title using exact normalized comparison", async () => {
-        mockStripAlbumEdition.mockImplementation((title: string) =>
-            title.replace("((Deluxe Edition) ", "").replace(/\)$/, ""),
-        );
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        const artist = {
-            id: 55,
-            artistName: "Exact Match Band",
-            foreignArtistId: "artist-exact",
-            monitored: true,
-        };
-
-        const album = {
-            id: 901,
-            title: "Exact Match Album ((Deluxe Edition) Remainder)",
-            foreignAlbumId: "album-exact",
-            artistId: 55,
-        };
-
-        client.get
-            .mockResolvedValueOnce({ data: [artist] })
-            .mockResolvedValueOnce({ data: [album] })
-            .mockResolvedValueOnce({
-                data: {
-                    ...album,
-                    monitored: true,
-                    anyReleaseOk: true,
-                    releases: [{ id: 1 }],
-                },
-            })
-            .mockResolvedValueOnce({
-                data: {
-                    ...album,
-                    monitored: true,
-                    anyReleaseOk: true,
-                    releases: [{ id: 1 }],
-                },
-            });
-
-        client.put.mockResolvedValue({ data: { ...album, monitored: true } });
-        client.post.mockResolvedValue({ data: { id: 9101 } });
-
-        const waitSpy = jest
-            .spyOn(lidarrService as any, "waitForCommand")
-            .mockResolvedValue({
-                status: "completed",
-                message: "Search completed with 1 report",
-            });
-
-        await expect(
-            lidarrService.addAlbum(
-                "different-mbid",
-                "Exact Match Band",
-                "Exact Match Album Remainder",
-                "/music",
-                "artist-exact",
-            ),
-        ).resolves.toEqual(
-            expect.objectContaining({
-                id: 901,
-                foreignAlbumId: "album-exact",
-            }),
-        );
-
-        expect(logger.debug).toHaveBeenCalledWith(
-            expect.stringContaining(
-                'Matched exact normalized: "Exact Match Album ((Deluxe Edition) Remainder)"',
-            ),
-        );
-
-        waitSpy.mockRestore();
-    });
-
     it.each([
         ["parenthetical", "("],
         ["bracket", "["],
@@ -1692,78 +1582,6 @@ describe("lidarr service behavior", () => {
         },
     );
 
-    it("addAlbum matches album title using strict partial normalized comparison", async () => {
-        const client = createClientMock();
-        primeServiceWithClient(client);
-
-        const artist = {
-            id: 66,
-            artistName: "Partial Band",
-            foreignArtistId: "artist-partial",
-            monitored: true,
-        };
-
-        const album = {
-            id: 902,
-            title: "Partial Match Album Remastered",
-            foreignAlbumId: "album-partial",
-            artistId: 66,
-        };
-
-        client.get
-            .mockResolvedValueOnce({ data: [artist] })
-            .mockResolvedValueOnce({ data: [album] })
-            .mockResolvedValueOnce({
-                data: {
-                    ...album,
-                    monitored: true,
-                    anyReleaseOk: true,
-                    releases: [{ id: 1 }],
-                },
-            })
-            .mockResolvedValueOnce({
-                data: {
-                    ...album,
-                    monitored: true,
-                    anyReleaseOk: true,
-                    releases: [{ id: 1 }],
-                },
-            });
-
-        client.put.mockResolvedValue({ data: { ...album, monitored: true } });
-        client.post.mockResolvedValue({ data: { id: 9102 } });
-
-        const waitSpy = jest
-            .spyOn(lidarrService as any, "waitForCommand")
-            .mockResolvedValue({
-                status: "completed",
-                message: "Search completed with 1 report",
-            });
-
-        await expect(
-            lidarrService.addAlbum(
-                "different-mbid",
-                "Partial Band",
-                "Partial Match Album",
-                "/music",
-                "artist-partial",
-            ),
-        ).resolves.toEqual(
-            expect.objectContaining({
-                id: 902,
-                foreignAlbumId: "album-partial",
-            }),
-        );
-
-        expect(logger.debug).toHaveBeenCalledWith(
-            expect.stringContaining(
-                'Matched partial (contained): "Partial Match Album Remastered"',
-            ),
-        );
-
-        waitSpy.mockRestore();
-    });
-
     it("getOrCreateDiscoveryTag returns null when tag discovery fails", async () => {
         const client = createClientMock();
         primeServiceWithClient(client);
@@ -1778,7 +1596,7 @@ describe("lidarr service behavior", () => {
         expect(getTagsSpy).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith(
             "[LIDARR] Failed to get/create discovery tag:",
-            "tag lookup failed",
+            expect.objectContaining({ message: "tag lookup failed" }),
         );
 
         getTagsSpy.mockRestore();
@@ -2196,7 +2014,9 @@ describe("lidarr service behavior", () => {
         );
         expect(logger.error).toHaveBeenCalledWith(
             "[LIDARR] Failed to create reconciliation snapshot:",
-            expect.any(String),
+            expect.objectContaining({
+                message: "Lidarr album response was not readable",
+            }),
         );
     });
 

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -1,23 +1,38 @@
 import { logger } from "../utils/logger";
 import { config } from "../config";
-import { BRAND_SLUG } from "../config/brand";
 import { getSystemSettings } from "../utils/systemSettings";
 import {
     normalizeForExactKey,
-    normalizeForFuzzyMatch,
     stripAlbumEdition,
 } from "../utils/artistNormalization";
-import { fetchReconciliationAlbumMaps } from "./lidarr/reconciliationAlbumStream";
 import {
     getLidarrErrorMessage,
+    lidarrErrorLogFields,
     LidarrHttpClient,
-    LidarrHttpError,
 } from "./lidarr/lidarrHttpClient";
-import { toErrorMessage } from "../utils/errors";
 import {
     blocklistQueueDownload,
     clearFailedQueue as clearFailedLidarrQueue,
 } from "./lidarr/lidarrQueue";
+import {
+    awaitArtistCatalog,
+    ensureArtistPresent,
+    type LidarrCatalogClock,
+} from "./lidarr/lidarrArtistCatalog";
+import { selectAlbumInCatalogMatch } from "./lidarr/lidarrAlbumSelection";
+import { grabRelease as grabCatalogRelease } from "./lidarr/lidarrReleaseGrab";
+import {
+    getReconciliationSnapshot as fetchReconciliationSnapshot,
+    isAlbumAvailableInSnapshot as snapshotHasAlbum,
+    isDownloadActiveInSnapshot as snapshotHasActiveDownload,
+    type ReconciliationSnapshot,
+} from "./lidarr/lidarrReconciliation";
+import { LidarrTagService } from "./lidarr/lidarrTagService";
+import type {
+    LidarrAlbum,
+    LidarrArtist,
+    LidarrTag,
+} from "./lidarr/lidarrTypes";
 
 /**
  * Error types for music acquisition failures
@@ -62,69 +77,29 @@ export class AcquisitionError extends Error {
     }
 }
 
-interface LidarrArtist {
-    id: number;
-    artistName: string;
-    foreignArtistId: string; // MusicBrainz ID
-    monitored: boolean;
-    tags?: number[]; // Tag IDs
-    artistType?: string;
-    qualityProfileId?: number;
-    metadataProfileId?: number;
-    rootFolderPath?: string;
-    statistics?: {
-        albumCount?: number;
-        trackFileCount?: number;
-        trackCount?: number;
-        totalTrackCount?: number;
-        sizeOnDisk?: number;
-        percentOfTracks?: number;
-    };
-    ratings?: {
-        votes?: number;
-        value?: number;
-    };
-}
-
-interface LidarrTag {
-    id: number;
-    label: string;
-}
-
-// Discovery tag labels
-const DISCOVERY_TAG_LABEL = `${BRAND_SLUG}-discovery`;
-const DISCOVERY_TAG_LABEL_ALIASES = [DISCOVERY_TAG_LABEL];
-
-interface LidarrAlbum {
-    id: number;
-    title: string;
-    foreignAlbumId: string; // MusicBrainz release group ID
-    artistId: number;
-    monitored: boolean;
-    artist?: {
-        foreignArtistId: string; // MusicBrainz artist ID
-        artistName: string;
-    };
-}
-
-function lidarrErrorLogFields(error: unknown) {
-    return {
-        message: error instanceof Error ? toErrorMessage(error) : undefined,
-        status: error instanceof LidarrHttpError ? error.status : undefined,
-        path: error instanceof LidarrHttpError ? error.path : undefined,
-    };
-}
-
-function normalizeAlbumTitleForMatch(title: string): string {
-    return normalizeForFuzzyMatch(stripAlbumEdition(title));
-}
-
 class LidarrService {
     private client: LidarrHttpClient | null = null;
     private enabled: boolean;
     private initialized: boolean = false;
+    private _indexerCountLogged: boolean = false;
+    private readonly clock: LidarrCatalogClock = {
+        sleep: (delayMs) =>
+            new Promise((resolve) => setTimeout(resolve, delayMs)),
+    };
+    private readonly tagService: LidarrTagService;
 
     constructor() {
+        this.tagService = new LidarrTagService({
+            getClient: () => this.client,
+            isEnabled: () => this.enabled,
+            getTags: () => this.getTags(),
+            createTag: (label) => this.createTag(label),
+            getArtists: () => this.getArtists(),
+            getArtistsByTag: (tagId) => this.getArtistsByTag(tagId),
+            getDiscoveryTagId: () => this.getOrCreateDiscoveryTag(),
+            removeTagsFromArtist: (artistId, tagIds) =>
+                this.removeTagsFromArtist(artistId, tagIds),
+        });
         // Initial check from .env (for backwards compatibility)
         this.enabled = config.lidarr?.enabled || false;
 
@@ -699,7 +674,7 @@ class LidarrService {
             // Trigger metadata refresh to ensure album catalog is populated
             if (!searchForMissingAlbums) {
                 // Add a small delay to let Lidarr's internal state settle
-                await new Promise((resolve) => setTimeout(resolve, 2000));
+                await this.clock.sleep(2000);
 
                 logger.debug(
                     `   Triggering metadata refresh for new artist...`,
@@ -868,7 +843,7 @@ class LidarrService {
                 };
             }
 
-            await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+            await this.clock.sleep(pollIntervalMs);
         }
 
         throw new Error(`Command ${commandId} timed out after ${timeoutMs}ms`);
@@ -883,678 +858,35 @@ class LidarrService {
         isDiscovery: boolean = false,
     ): Promise<LidarrAlbum | null> {
         await this.ensureInitialized();
-
         if (!this.enabled || !this.client) {
             throw new Error("Lidarr not enabled");
         }
-
         try {
-            logger.debug(
-                `   Adding album: ${albumTitle} by ${artistName}${
-                    isDiscovery ? " (discovery)" : ""
-                }`,
+            logger.debug(`   Adding album: ${albumTitle} by ${artistName}`);
+            const presence = await this.ensureAlbumArtist(
+                artistName,
+                rootFolderPath,
+                artistMbid,
+                isDiscovery,
             );
-            logger.debug(`   Album MBID: ${rgMbid}`);
-            logger.debug(`   Artist MBID: ${artistMbid || "none"}`);
-
-            // NEW APPROACH: Add artist first, then find album in their catalog
-            // This avoids the broken external album search API
-
-            // Check if artist exists
-            const existingArtists = await this.client.get("/api/v1/artist");
-            let artist = existingArtists.data.find(
-                (a: LidarrArtist) =>
-                    artistMbid && a.foreignArtistId === artistMbid,
-            );
-
-            let justAddedArtist = false;
-
-            // If discovery and artist exists, ensure they have the discovery tag
-            if (isDiscovery && artist) {
-                const discoveryTagId = await this.getOrCreateDiscoveryTag();
-                if (discoveryTagId) {
-                    const existingTags = artist.tags || [];
-                    if (!existingTags.includes(discoveryTagId)) {
-                        logger.debug(
-                            `   Adding discovery tag to existing artist...`,
-                        );
-                        await this.addTagsToArtist(artist.id, [discoveryTagId]);
-                    }
-                }
-            }
-
-            if (!artist && artistMbid) {
-                logger.debug(`   Adding artist first: ${artistName}`);
-
-                // Add artist WITHOUT searching for all albums
-                // Pass isDiscovery to tag the artist appropriately
-                artist = await this.addArtist(
-                    artistMbid,
-                    artistName,
-                    rootFolderPath,
-                    false, // Don't auto-download all albums
-                    false, // Don't monitor all albums
-                    isDiscovery, // Tag as discovery if this is a discovery download
-                );
-
-                if (!artist) {
-                    logger.error(` Failed to add artist`);
-                    return null;
-                }
-
-                justAddedArtist = true;
-                logger.debug(
-                    `   Artist added: ${artist.artistName} (ID: ${artist.id})`,
-                );
-                logger.debug(
-                    `   Waiting for Lidarr to populate album catalog...`,
-                );
-            } else if (!artist) {
-                logger.error(` Artist not found and no MBID provided`);
+            if (!presence.artist) {
+                logger.error(" Artist not found and could not be added");
                 return null;
-            } else {
-                logger.debug(
-                    `   Artist already exists: ${artist.artistName} (ID: ${artist.id})`,
-                );
             }
-
-            // Get artist's albums from Lidarr
-            let artistAlbums: LidarrAlbum[] = [];
-
-            // First check - get current album list
-            const artistAlbumsResponse = await this.client.get(
-                `/api/v1/album?artistId=${artist.id}`,
+            const catalog = await this.selectAlbumForAdd(
+                presence.artist,
+                presence.justAddedArtist,
+                rgMbid,
+                albumTitle,
+                artistName,
             );
-            artistAlbums = artistAlbumsResponse.data;
-
-            // If we just added the artist and no albums yet, wait for metadata to populate
-            if (artistAlbums.length === 0 && justAddedArtist) {
-                logger.debug(
-                    `   Waiting for Lidarr to fetch album metadata...`,
-                );
-
-                // Increased timeout: 20 attempts * 3 seconds = 60 seconds total
-                // Large artist catalogs (e.g., prolific bands) need more time
-                const maxAttempts = 20;
-                const retryDelay = 3000; // 3 seconds between retries
-
-                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, retryDelay),
-                    );
-
-                    const retryResponse = await this.client.get(
-                        `/api/v1/album?artistId=${artist.id}`,
-                    );
-                    artistAlbums = retryResponse.data;
-
-                    if (artistAlbums.length > 0) {
-                        logger.debug(`   Albums loaded after ${attempt * 3}s`);
-                        break;
-                    }
-
-                    if (attempt < maxAttempts) {
-                        logger.debug(
-                            `   Attempt ${attempt}/${maxAttempts}: Still waiting...`,
-                        );
-                    } else {
-                        logger.warn(
-                            ` Timeout reached after ${
-                                maxAttempts * 3
-                            }s - artist catalog may still be populating`,
-                        );
-                    }
-                }
-            } else if (artistAlbums.length === 0 && !justAddedArtist) {
-                // Artist exists but has 0 albums - try refreshing metadata once
-                logger.debug(
-                    `   Artist exists but has 0 albums - refreshing metadata...`,
-                );
-                try {
-                    await this.client.post("/api/v1/command", {
-                        name: "RefreshArtist",
-                        artistId: artist.id,
-                    });
-                    // Wait for refresh to complete
-                    await new Promise((resolve) => setTimeout(resolve, 5000));
-
-                    const retryResponse = await this.client.get(
-                        `/api/v1/album?artistId=${artist.id}`,
-                    );
-                    artistAlbums = retryResponse.data;
-                } catch (refreshError) {
-                    logger.warn(`   Metadata refresh failed`);
-                }
-            }
-
-            logger.debug(
-                `   Found ${artistAlbums.length} albums for ${artist.artistName}`,
+            return await this.grabCatalogAlbum(
+                presence.artist,
+                catalog.album,
+                catalog.artistAlbums,
+                albumTitle,
             );
-
-            // Find the specific album by MBID first
-            let albumData = artistAlbums.find(
-                (a: LidarrAlbum) => a.foreignAlbumId === rgMbid,
-            );
-
-            // If MBID doesn't match, try STRICT name matching
-            // IMPORTANT: We removed loose matching (base name, first word) because it caused
-            // wrong albums to be downloaded (e.g., "A Trip To The Mystery Planet" matching "A Funk Odyssey")
-            if (!albumData) {
-                logger.debug(
-                    `   Album MBID not found, trying STRICT name match for: ${albumTitle}`,
-                );
-
-                const targetTitle = normalizeAlbumTitleForMatch(albumTitle);
-                logger.debug(`   Normalized target: "${targetTitle}"`);
-
-                // Try exact normalized match first
-                albumData = artistAlbums.find(
-                    (a: LidarrAlbum) =>
-                        normalizeAlbumTitleForMatch(a.title) === targetTitle,
-                );
-                if (albumData) {
-                    logger.debug(
-                        ` Matched exact normalized: "${albumData.title}"`,
-                    );
-                }
-
-                // Try partial match ONLY if one contains the other completely
-                // This handles "Album Name" matching "Album Name (Deluxe Edition)"
-                if (!albumData) {
-                    albumData = artistAlbums.find((a: LidarrAlbum) => {
-                        const normalized = normalizeAlbumTitleForMatch(a.title);
-                        // Only match if one is a substring of the other AND they share significant content
-                        // The shorter one must be at least 60% of the longer one's length
-                        const shorter =
-                            normalized.length < targetTitle.length
-                                ? normalized
-                                : targetTitle;
-                        const longer =
-                            normalized.length >= targetTitle.length
-                                ? normalized
-                                : targetTitle;
-                        if (
-                            longer.includes(shorter) &&
-                            shorter.length >= longer.length * 0.6
-                        ) {
-                            return true;
-                        }
-                        return false;
-                    });
-                    if (albumData) {
-                        logger.debug(
-                            ` Matched partial (contained): "${albumData.title}"`,
-                        );
-                    }
-                }
-
-                // NO base name matching - this caused wrong albums to be matched
-                // NO first word matching - this caused wrong albums to be matched
-                // If we don't have an exact or contained match, we should FAIL
-                // and let the discovery system find a different album
-
-                if (albumData) {
-                    logger.debug(
-                        `   Final match: "${albumData.title}" (MBID: ${albumData.foreignAlbumId})`,
-                    );
-                } else {
-                    logger.debug(
-                        ` No strict match found - will NOT use loose matching to avoid wrong albums`,
-                    );
-                }
-            }
-
-            if (!albumData) {
-                logger.error(
-                    `   ✗ Album "${albumTitle}" not found in artist's ${artistAlbums.length} albums`,
-                );
-                if (artistAlbums.length > 0) {
-                    logger.debug(
-                        `   Looking for: "${albumTitle}" (MBID: ${rgMbid})`,
-                    );
-                    logger.debug(
-                        `   Available albums in Lidarr (showing up to 10):`,
-                    );
-                    artistAlbums.slice(0, 10).forEach((a: LidarrAlbum) => {
-                        logger.debug(
-                            `     - "${a.title}" (${a.foreignAlbumId})`,
-                        );
-                    });
-                }
-                // Throw structured error - allows fallback to Soulseek
-                throw new AcquisitionError(
-                    `Album "${albumTitle}" not found in Lidarr catalog for ${artistName}`,
-                    AcquisitionErrorType.ALBUM_NOT_FOUND,
-                    true, // isRecoverable - Soulseek can try
-                );
-            }
-
-            logger.debug(
-                `   Found album in catalog: ${albumData.title} (ID: ${albumData.id})`,
-            );
-
-            // Ensure artist is monitored (might have been added with monitoring disabled)
-            if (!artist.monitored) {
-                logger.debug(`   Enabling artist monitoring...`);
-                await this.client.put(`/api/v1/artist/${artist.id}`, {
-                    ...artist,
-                    monitored: true,
-                });
-                logger.debug(`   Artist monitoring enabled`);
-            } else {
-                logger.debug(`   Artist already monitored`);
-            }
-
-            // CRITICAL: Fetch the FULL album data from Lidarr
-            // The album list endpoint may return incomplete data
-            logger.debug(`   Fetching full album data from Lidarr...`);
-            const fullAlbumResponse = await this.client.get(
-                `/api/v1/album/${albumData.id}`,
-            );
-            const fullAlbumData = fullAlbumResponse.data;
-
-            logger.debug(
-                `   Full album data retrieved:`,
-                JSON.stringify(
-                    {
-                        id: fullAlbumData.id,
-                        title: fullAlbumData.title,
-                        monitored: fullAlbumData.monitored,
-                        foreignAlbumId: fullAlbumData.foreignAlbumId,
-                        anyReleaseOk: fullAlbumData.anyReleaseOk,
-                        profileId: fullAlbumData.profileId,
-                        releases: fullAlbumData.releases?.length || 0,
-                    },
-                    null,
-                    2,
-                ),
-            );
-
-            // ALWAYS monitor and search for the album, even if already monitored
-            // This ensures Lidarr picks up the request
-            // Preserve user's anyReleaseOk setting - we'll only change it if search fails later
-            logger.debug(`   Setting album monitoring to true...`);
-
-            const updateResponse = await this.client.put(
-                `/api/v1/album/${fullAlbumData.id}`,
-                {
-                    ...fullAlbumData,
-                    monitored: true,
-                },
-            );
-
-            logger.debug(
-                `   PUT response monitored: ${updateResponse.data.monitored}`,
-            );
-
-            // CRITICAL: Re-fetch the album to verify the change actually persisted
-            const verifyResponse = await this.client.get(
-                `/api/v1/album/${fullAlbumData.id}`,
-            );
-            const verifiedMonitored = verifyResponse.data.monitored;
-
-            logger.debug(
-                `   Album monitoring VERIFIED after re-fetch: ${verifiedMonitored}`,
-            );
-
-            if (!verifiedMonitored) {
-                logger.error(` CRITICAL: Album monitoring failed to persist!`);
-                logger.error(
-                    `   Full album data we sent:`,
-                    JSON.stringify(fullAlbumData, null, 2).slice(0, 500),
-                );
-                logger.error(
-                    `   Response from GET after PUT:`,
-                    JSON.stringify(verifyResponse.data, null, 2).slice(0, 500),
-                );
-            }
-
-            // Use the verified album data
-            const updatedAlbum = verifyResponse.data;
-
-            const editionPatterns = [
-                /\(remaster/i,
-                /\(deluxe/i,
-                /\(expanded/i,
-                /\(anniversary/i,
-                /\(bonus/i,
-                /\(special/i,
-                /\(limited/i,
-                /\(collector/i,
-                /\(super deluxe/i,
-                /\(platinum/i,
-                /\(japan/i,
-                /\(uk/i,
-                /\(us/i,
-                /\(import/i,
-                /\[remaster/i,
-                /\[deluxe/i,
-            ];
-            const isEditionVariant = editionPatterns.some((p) =>
-                p.test(albumTitle),
-            );
-            const foundAlbumIsEdition = editionPatterns.some((p) =>
-                p.test(updatedAlbum.title || ""),
-            );
-            const needsAnyReleaseOk = isEditionVariant || foundAlbumIsEdition;
-
-            if (needsAnyReleaseOk && !updatedAlbum.anyReleaseOk) {
-                logger.debug(
-                    `   Edition variant detected ("${albumTitle}") - enabling anyReleaseOk proactively`,
-                );
-
-                await this.client.put(`/api/v1/album/${updatedAlbum.id}`, {
-                    ...updatedAlbum,
-                    anyReleaseOk: true,
-                });
-
-                updatedAlbum.anyReleaseOk = true;
-                logger.debug(
-                    `   anyReleaseOk enabled - Lidarr will accept any release of this album`,
-                );
-            }
-
-            // Check if album has releases - if not, refresh artist metadata from MusicBrainz
-            const releaseCount = updatedAlbum.releases?.length || 0;
-            if (releaseCount === 0) {
-                logger.warn(
-                    ` Album has 0 releases - refreshing artist metadata from MusicBrainz...`,
-                );
-
-                // Trigger artist refresh to fetch latest metadata
-                await this.client.post("/api/v1/command", {
-                    name: "RefreshArtist",
-                    artistId: artist.id,
-                });
-
-                logger.debug(`   Waiting for metadata refresh to complete...`);
-                // Wait for refresh to complete (Lidarr processes this asynchronously)
-                await new Promise((resolve) => setTimeout(resolve, 5000));
-
-                // Re-fetch the album to see if releases were populated
-                const refreshedAlbumResponse = await this.client.get(
-                    `/api/v1/album/${updatedAlbum.id}`,
-                );
-                const refreshedAlbum = refreshedAlbumResponse.data;
-                const newReleaseCount = refreshedAlbum.releases?.length || 0;
-
-                logger.debug(
-                    `   After refresh: ${newReleaseCount} releases found`,
-                );
-
-                if (newReleaseCount === 0) {
-                    logger.warn(` Still no releases after refresh!`);
-                    logger.warn(
-                        `   This album may not be properly indexed in MusicBrainz yet.`,
-                    );
-                    logger.warn(`   Download will be attempted but may fail.`);
-                }
-            }
-
-            // ALWAYS trigger search to download the album
-            logger.debug(
-                `   Triggering album search command for album ID ${updatedAlbum.id}...`,
-            );
-            const searchResponse = await this.client.post("/api/v1/command", {
-                name: "AlbumSearch",
-                albumIds: [updatedAlbum.id],
-            });
-            logger.debug(
-                `   Search command sent (Command ID: ${searchResponse.data.id})`,
-            );
-
-            // Wait for search to complete (with 30s timeout)
-            try {
-                const result = await this.waitForCommand(
-                    searchResponse.data.id,
-                    30000,
-                );
-
-                if (result.message?.includes("0 reports")) {
-                    try {
-                        const albumDetails = await this.client.get(
-                            `/api/v1/album/${updatedAlbum.id}`,
-                        );
-                        const releaseCount =
-                            albumDetails.data.releases?.length || 0;
-                        const anyReleaseOkStatus =
-                            albumDetails.data.anyReleaseOk;
-
-                        logger.debug(
-                            `   [DIAGNOSTIC] Initial search returned 0 reports`,
-                        );
-                        logger.debug(
-                            `   [DIAGNOSTIC] Album "${updatedAlbum.title}" has ${releaseCount} releases defined in Lidarr`,
-                        );
-                        logger.debug(
-                            `   [DIAGNOSTIC] anyReleaseOk: ${anyReleaseOkStatus}`,
-                        );
-                        logger.debug(
-                            `   [DIAGNOSTIC] Album MBID: ${updatedAlbum.foreignAlbumId}`,
-                        );
-
-                        if (releaseCount === 0) {
-                            logger.warn(
-                                `   [DIAGNOSTIC] ⚠️ Album has 0 releases in Lidarr - metadata may be incomplete`,
-                            );
-                        }
-
-                        if (!this._indexerCountLogged) {
-                            try {
-                                const indexers =
-                                    await this.client.get("/api/v1/indexer");
-                                const enabledIndexers = indexers.data.filter(
-                                    (i: any) =>
-                                        i.enableRss || i.enableAutomaticSearch,
-                                );
-                                logger.debug(
-                                    `   [DIAGNOSTIC] ${enabledIndexers.length} enabled indexers configured in Lidarr`,
-                                );
-
-                                if (enabledIndexers.length === 0) {
-                                    logger.error(
-                                        `   [DIAGNOSTIC] ❌ No enabled indexers - Lidarr cannot search for releases`,
-                                    );
-                                }
-                                this._indexerCountLogged = true;
-                            } catch (indexerError) {
-                                // Ignore indexer check errors
-                            }
-                        }
-                    } catch (diagError) {
-                        // Ignore diagnostic errors
-                    }
-
-                    // No sources found - try anyReleaseOk if not already enabled
-                    if (!updatedAlbum.anyReleaseOk) {
-                        logger.debug(
-                            `   No results with strict matching. Trying anyReleaseOk=true...`,
-                        );
-
-                        // Enable anyReleaseOk and retry
-                        await this.client.put(
-                            `/api/v1/album/${updatedAlbum.id}`,
-                            {
-                                ...updatedAlbum,
-                                anyReleaseOk: true,
-                            },
-                        );
-
-                        const retryResponse = await this.client.post(
-                            "/api/v1/command",
-                            {
-                                name: "AlbumSearch",
-                                albumIds: [updatedAlbum.id],
-                            },
-                        );
-
-                        const retryResult = await this.waitForCommand(
-                            retryResponse.data.id,
-                            30000,
-                        );
-
-                        if (retryResult.message?.includes("0 reports")) {
-                            const baseAlbumTitle =
-                                this.extractBaseTitle(albumTitle);
-
-                            if (
-                                baseAlbumTitle !== albumTitle &&
-                                baseAlbumTitle.length > 2
-                            ) {
-                                logger.debug(
-                                    `   Trying base album title fallback: "${albumTitle}" → "${baseAlbumTitle}"`,
-                                );
-
-                                const normalizedBase =
-                                    normalizeForFuzzyMatch(baseAlbumTitle);
-
-                                const baseMatch = artistAlbums.find(
-                                    (a: LidarrAlbum) => {
-                                        const normalizedAlbumTitle =
-                                            normalizeForFuzzyMatch(a.title);
-
-                                        if (
-                                            normalizedAlbumTitle ===
-                                            normalizedBase
-                                        )
-                                            return true;
-
-                                        const shorter =
-                                            normalizedAlbumTitle.length <
-                                            normalizedBase.length
-                                                ? normalizedAlbumTitle
-                                                : normalizedBase;
-                                        const longer =
-                                            normalizedAlbumTitle.length >=
-                                            normalizedBase.length
-                                                ? normalizedAlbumTitle
-                                                : normalizedBase;
-                                        if (
-                                            longer.includes(shorter) &&
-                                            shorter.length >=
-                                                longer.length * 0.7
-                                        ) {
-                                            return true;
-                                        }
-
-                                        return false;
-                                    },
-                                );
-
-                                if (
-                                    baseMatch &&
-                                    baseMatch.id !== updatedAlbum.id
-                                ) {
-                                    logger.debug(
-                                        `   Found base album: "${baseMatch.title}" (ID: ${baseMatch.id})`,
-                                    );
-                                    logger.debug(
-                                        `   Attempting download of base album instead...`,
-                                    );
-
-                                    await this.client.put(
-                                        `/api/v1/album/${baseMatch.id}`,
-                                        {
-                                            ...baseMatch,
-                                            monitored: true,
-                                            anyReleaseOk: true,
-                                        },
-                                    );
-
-                                    const baseSearchResponse =
-                                        await this.client.post(
-                                            "/api/v1/command",
-                                            {
-                                                name: "AlbumSearch",
-                                                albumIds: [baseMatch.id],
-                                            },
-                                        );
-
-                                    try {
-                                        const baseResult =
-                                            await this.waitForCommand(
-                                                baseSearchResponse.data.id,
-                                                30000,
-                                            );
-
-                                        if (
-                                            baseResult.message?.includes(
-                                                "0 reports",
-                                            )
-                                        ) {
-                                            logger.warn(
-                                                `   Base album "${baseMatch.title}" also has no releases`,
-                                            );
-                                            throw new Error(
-                                                `No releases available for "${albumTitle}" or base album "${baseMatch.title}" - ` +
-                                                    `check indexer configuration and album availability`,
-                                            );
-                                        }
-
-                                        logger.debug(
-                                            `   Base album download started: ${baseMatch.title}`,
-                                        );
-                                        return baseMatch;
-                                    } catch (baseError: any) {
-                                        if (
-                                            baseError.message?.includes(
-                                                "No releases",
-                                            )
-                                        ) {
-                                            throw baseError;
-                                        }
-                                        if (
-                                            baseError.message?.includes(
-                                                "timed out",
-                                            )
-                                        ) {
-                                            logger.warn(
-                                                `   Base album search timed out, may still be searching`,
-                                            );
-                                            return baseMatch;
-                                        }
-                                        throw baseError;
-                                    }
-                                } else {
-                                    logger.debug(
-                                        `   No base album match found in artist catalog (${artistAlbums.length} albums)`,
-                                    );
-                                }
-                            }
-
-                            throw new AcquisitionError(
-                                `No releases available for "${albumTitle}" - indexers found no matching downloads. ` +
-                                    `Album may not be available on configured indexers, or MBID mismatch between Lidarr and indexers.`,
-                                AcquisitionErrorType.NO_RELEASES_AVAILABLE,
-                                true,
-                            );
-                        }
-                    } else {
-                        throw new Error(
-                            "No releases available - indexers found no matching downloads",
-                        );
-                    }
-                }
-
-                logger.debug(
-                    `   Album download started: ${updatedAlbum.title}`,
-                );
-                return updatedAlbum;
-            } catch (error: any) {
-                if (error.message?.includes("No releases available")) {
-                    throw error; // Re-throw for startDownload to handle
-                }
-                if (error.message?.includes("timed out")) {
-                    // Command timed out - album might still be searching
-                    logger.warn(
-                        `   Search command timed out, album may still be searching`,
-                    );
-                    return updatedAlbum; // Return album, let timeout handling catch it later
-                }
-                throw error;
-            }
         } catch (error: unknown) {
-            // Re-throw our own errors (like "No releases available")
             if (
                 error instanceof Error &&
                 error.message.includes("No releases available")
@@ -1566,6 +898,101 @@ class LidarrService {
                 lidarrErrorLogFields(error),
             );
             return null;
+        }
+    }
+
+    private async ensureAlbumArtist(
+        artistName: string,
+        rootFolderPath: string,
+        artistMbid: string | undefined,
+        isDiscovery: boolean,
+    ): Promise<{ artist: LidarrArtist | null; justAddedArtist: boolean }> {
+        const response =
+            await this.client!.get<LidarrArtist[]>("/api/v1/artist");
+        return ensureArtistPresent({
+            artists: response.data,
+            artistMbid,
+            artistName,
+            rootFolderPath,
+            isDiscovery,
+            addArtist: (...args) => this.addArtist(...args),
+            ensureDiscoveryTag: (artist) =>
+                this.ensureDiscoveryTagForArtist(artist),
+        });
+    }
+
+    private async selectAlbumForAdd(
+        artist: LidarrArtist,
+        justAddedArtist: boolean,
+        rgMbid: string,
+        albumTitle: string,
+        artistName: string,
+    ): Promise<{ album: LidarrAlbum; artistAlbums: LidarrAlbum[] }> {
+        const artistAlbums = await awaitArtistCatalog({
+            client: this.client!,
+            artist,
+            justAddedArtist,
+            clock: this.clock,
+        });
+        const selection = selectAlbumInCatalogMatch(
+            artistAlbums,
+            rgMbid,
+            albumTitle,
+        );
+        if (!selection.album) {
+            throw new AcquisitionError(
+                `Album "${albumTitle}" not found in Lidarr catalog for ${artistName}`,
+                AcquisitionErrorType.ALBUM_NOT_FOUND,
+                true,
+            );
+        }
+        if (selection.matchType === "exact") {
+            logger.debug(
+                ` Matched exact normalized: "${selection.album.title}"`,
+            );
+        } else if (selection.matchType === "partial") {
+            logger.debug(
+                ` Matched partial (contained): "${selection.album.title}"`,
+            );
+        }
+        return { album: selection.album, artistAlbums };
+    }
+
+    private grabCatalogAlbum(
+        artist: LidarrArtist,
+        album: LidarrAlbum,
+        artistAlbums: LidarrAlbum[],
+        albumTitle: string,
+    ): Promise<LidarrAlbum> {
+        return grabCatalogRelease({
+            client: this.client!,
+            artist,
+            album,
+            artistAlbums,
+            requestedTitle: albumTitle,
+            sleep: (delayMs) => this.clock.sleep(delayMs),
+            waitForCommand: (id, timeoutMs) =>
+                this.waitForCommand(id, timeoutMs),
+            createNoReleasesError: () =>
+                new AcquisitionError(
+                    `No releases available for "${albumTitle}" - indexers found no matching downloads. Album may not be available on configured indexers, or MBID mismatch between Lidarr and indexers.`,
+                    AcquisitionErrorType.NO_RELEASES_AVAILABLE,
+                    true,
+                ),
+            indexerCountLogged: () => this._indexerCountLogged,
+            markIndexerCountLogged: () => {
+                this._indexerCountLogged = true;
+            },
+            extractBaseTitle: (title) => this.extractBaseTitle(title),
+        });
+    }
+
+    private async ensureDiscoveryTagForArtist(
+        artist: LidarrArtist,
+    ): Promise<void> {
+        const tagId = await this.getOrCreateDiscoveryTag();
+        if (tagId && !artist.tags?.includes(tagId)) {
+            await this.addTagsToArtist(artist.id, [tagId]);
         }
     }
 
@@ -1882,270 +1309,68 @@ class LidarrService {
     /**
      * Get all tags from Lidarr
      */
+    private get discoveryTagId(): number | null {
+        return this.tagService.cachedDiscoveryTagId;
+    }
+
+    private set discoveryTagId(value: number | null) {
+        this.tagService.cachedDiscoveryTagId = value;
+    }
+
+    /** Get all tags from Lidarr. */
     async getTags(): Promise<LidarrTag[]> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return [];
-        }
-
-        try {
-            const response = await this.client.get("/api/v1/tag");
-            return response.data || [];
-        } catch (error: any) {
-            logger.error("[LIDARR] Failed to get tags:", error.message);
-            return [];
-        }
+        return this.tagService.getTags();
     }
 
-    /**
-     * Create a new tag in Lidarr
-     */
+    /** Create a tag in Lidarr. */
     async createTag(label: string): Promise<LidarrTag | null> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return null;
-        }
-
-        try {
-            const response = await this.client.post("/api/v1/tag", { label });
-            logger.debug(
-                `[LIDARR] Created tag: ${label} (ID: ${response.data.id})`,
-            );
-            return response.data;
-        } catch (error: any) {
-            logger.error("[LIDARR] Failed to create tag:", error.message);
-            return null;
-        }
+        return this.tagService.createTag(label);
     }
 
-    /**
-     * Get or create the discovery tag
-     * Returns the tag ID, caching it for subsequent calls
-     */
-    private discoveryTagId: number | null = null;
-    private _indexerCountLogged: boolean = false;
-
+    /** Get or create the discovery tag. */
     async getOrCreateDiscoveryTag(): Promise<number | null> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return null;
-        }
-
-        // Return cached tag ID if available
-        if (this.discoveryTagId !== null) {
-            return this.discoveryTagId;
-        }
-
-        try {
-            // Check if tag already exists
-            const tags = await this.getTags();
-            const existingTag = tags.find((t) =>
-                DISCOVERY_TAG_LABEL_ALIASES.includes(t.label),
-            );
-
-            if (existingTag) {
-                logger.debug(
-                    `[LIDARR] Found existing discovery tag "${existingTag.label}" (ID: ${existingTag.id})`,
-                );
-                this.discoveryTagId = existingTag.id;
-                return existingTag.id;
-            }
-
-            // Create the tag
-            const newTag = await this.createTag(DISCOVERY_TAG_LABEL);
-            if (newTag) {
-                this.discoveryTagId = newTag.id;
-                return newTag.id;
-            }
-
-            return null;
-        } catch (error: any) {
-            logger.error(
-                "[LIDARR] Failed to get/create discovery tag:",
-                error.message,
-            );
-            return null;
-        }
+        return this.tagService.getOrCreateDiscoveryTag();
     }
 
-    /**
-     * Add tags to an artist
-     */
+    /** Add tags to an artist. */
     async addTagsToArtist(
         artistId: number,
         tagIds: number[],
     ): Promise<boolean> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return false;
-        }
-
-        try {
-            // Get current artist data
-            const response = await this.client.get(
-                `/api/v1/artist/${artistId}`,
-            );
-            const artist = response.data;
-
-            // Merge new tags with existing (avoid duplicates)
-            const existingTags = artist.tags || [];
-            const mergedTags = [...new Set([...existingTags, ...tagIds])];
-
-            // Update artist with new tags
-            await this.client.put(`/api/v1/artist/${artistId}`, {
-                ...artist,
-                tags: mergedTags,
-            });
-
-            logger.debug(
-                `[LIDARR] Added tags ${tagIds} to artist ${artist.artistName}`,
-            );
-            return true;
-        } catch (error: any) {
-            logger.error(
-                "[LIDARR] Failed to add tags to artist:",
-                error.message,
-            );
-            return false;
-        }
+        return this.tagService.addTagsToArtist(artistId, tagIds);
     }
 
-    /**
-     * Remove tags from an artist
-     */
+    /** Remove tags from an artist. */
     async removeTagsFromArtist(
         artistId: number,
         tagIds: number[],
     ): Promise<boolean> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return false;
-        }
-
-        try {
-            // Get current artist data
-            const response = await this.client.get(
-                `/api/v1/artist/${artistId}`,
-            );
-            const artist = response.data;
-
-            // Remove specified tags
-            const existingTags = artist.tags || [];
-            const filteredTags = existingTags.filter(
-                (t: number) => !tagIds.includes(t),
-            );
-
-            // Update artist with filtered tags
-            await this.client.put(`/api/v1/artist/${artistId}`, {
-                ...artist,
-                tags: filteredTags,
-            });
-
-            logger.debug(
-                `[LIDARR] Removed tags ${tagIds} from artist ${artist.artistName}`,
-            );
-            return true;
-        } catch (error: any) {
-            logger.error(
-                "[LIDARR] Failed to remove tags from artist:",
-                error.message,
-            );
-            return false;
-        }
+        return this.tagService.removeTagsFromArtist(artistId, tagIds);
     }
 
-    /**
-     * Get all artists that have a specific tag
-     */
+    /** Get artists carrying one Lidarr tag. */
     async getArtistsByTag(tagId: number): Promise<LidarrArtist[]> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return [];
-        }
-
-        try {
-            const response = await this.client.get("/api/v1/artist");
-            const artists: LidarrArtist[] = response.data;
-
-            // Filter artists that have the specified tag
-            return artists.filter((artist) => artist.tags?.includes(tagId));
-        } catch (error: any) {
-            logger.error(
-                "[LIDARR] Failed to get artists by tag:",
-                error.message,
-            );
-            return [];
-        }
+        return this.tagService.getArtistsByTag(tagId);
     }
 
-    /**
-     * Get all discovery-tagged artists (convenience method)
-     */
+    /** Get all discovery-tagged artists. */
     async getDiscoveryArtists(): Promise<LidarrArtist[]> {
-        const tagId = await this.getOrCreateDiscoveryTag();
-        if (!tagId) {
-            return [];
-        }
-        return this.getArtistsByTag(tagId);
+        await this.ensureInitialized();
+        return this.tagService.getDiscoveryArtists();
     }
 
-    /**
-     * Remove discovery tag from an artist by MBID
-     * Used when user likes an album (artist becomes "owned")
-     */
+    /** Remove the discovery tag from an artist by MBID. */
     async removeDiscoveryTagByMbid(artistMbid: string): Promise<boolean> {
         await this.ensureInitialized();
-
-        if (!this.enabled || !this.client) {
-            return false;
-        }
-
-        try {
-            const tagId = await this.getOrCreateDiscoveryTag();
-            if (!tagId) {
-                return false;
-            }
-
-            // Find artist by MBID
-            const artists = await this.getArtists();
-            const artist = artists.find(
-                (a) => a.foreignArtistId === artistMbid,
-            );
-
-            if (!artist) {
-                logger.debug(
-                    `[LIDARR] Artist ${artistMbid} not found in Lidarr`,
-                );
-                return true; // Not an error - artist might not be in Lidarr
-            }
-
-            // Check if artist has the discovery tag
-            if (!artist.tags?.includes(tagId)) {
-                logger.debug(
-                    `[LIDARR] Artist ${artist.artistName} doesn't have discovery tag`,
-                );
-                return true; // Already doesn't have tag
-            }
-
-            return await this.removeTagsFromArtist(artist.id, [tagId]);
-        } catch (error: any) {
-            logger.error(
-                "[LIDARR] Failed to remove discovery tag:",
-                error.message,
-            );
-            return false;
-        }
+        return this.tagService.removeDiscoveryTagByMbid(artistMbid);
     }
 
-    /**
-     * Delete artist by Lidarr ID (used for cleanup)
-     */
     async deleteArtistById(
         lidarrId: number,
         deleteFiles: boolean = true,
@@ -2387,161 +1612,38 @@ class LidarrService {
      *
      * This replaces multiple per-job API calls with a single snapshot fetch.
      */
+    /** Fetch all data needed for reconciliation in minimal API calls. */
     async getReconciliationSnapshot(
         signal?: AbortSignal,
     ): Promise<ReconciliationSnapshot> {
         await this.ensureInitialized();
-
-        const snapshot: ReconciliationSnapshot = {
-            queue: new Map(),
-            albumsByMbid: new Map(),
-            albumsByTitle: new Map(),
-            fetchedAt: new Date(),
-        };
-
-        if (!this.enabled || !this.client) {
-            return snapshot;
-        }
-
-        const ownedController = new AbortController();
-        const requestSignal = signal
-            ? AbortSignal.any([signal, ownedController.signal])
-            : ownedController.signal;
-        try {
-            const [queueResponse] = await Promise.all([
-                this.client.get("/api/v1/queue", {
-                    params: {
-                        page: 1,
-                        pageSize: 1000,
-                        includeUnknownArtistItems: true,
-                    },
-                    signal: requestSignal,
-                }),
-                fetchReconciliationAlbumMaps(
-                    this.client,
-                    snapshot,
-                    requestSignal,
-                ),
-            ]);
-
-            // Index queue items by downloadId
-            const queueItems = queueResponse.data.records || [];
-            for (const item of queueItems) {
-                if (item.downloadId) {
-                    snapshot.queue.set(item.downloadId, {
-                        id: item.id,
-                        downloadId: item.downloadId,
-                        status: item.status,
-                        progress:
-                            item.sizeleft && item.size
-                                ? Math.round(
-                                      ((item.size - item.sizeleft) /
-                                          item.size) *
-                                          100,
-                                  )
-                                : undefined,
-                        title: item.title,
-                    });
-                }
-            }
-
-            logger.debug(
-                `[LIDARR] Snapshot fetched: ${snapshot.queue.size} queue items, ${snapshot.albumsByMbid.size} albums with files`,
-            );
-
-            return snapshot;
-        } catch (error: any) {
-            ownedController.abort(error);
-            logger.error(
-                "[LIDARR] Failed to create reconciliation snapshot:",
-                error.message,
-            );
-            throw error;
-        }
+        return fetchReconciliationSnapshot(this.client, this.enabled, signal);
     }
 
-    /**
-     * Check if an album is available using a pre-fetched snapshot.
-     * Returns true if the album exists with files.
-     */
+    /** Check album availability against a pre-fetched snapshot. */
     isAlbumAvailableInSnapshot(
         snapshot: ReconciliationSnapshot,
         mbid?: string,
         artistName?: string,
         albumTitle?: string,
     ): boolean {
-        // Strategy 1: Check by MBID
-        if (mbid && snapshot.albumsByMbid.has(mbid)) {
-            return true;
-        }
-
-        // Strategy 2: Check by normalized artist|title
-        if (artistName && albumTitle) {
-            const normalizedArtist = normalizeForExactKey(artistName);
-            const normalizedAlbum = normalizeForExactKey(albumTitle);
-            const key = `${normalizedArtist}|${normalizedAlbum}`;
-            if (snapshot.albumsByTitle.has(key)) {
-                return true;
-            }
-
-            // Strategy 3: Partial title match (handles edition differences)
-            for (const titleKey of snapshot.albumsByTitle.keys()) {
-                const [keyArtist, keyAlbum] = titleKey.split("|");
-                if (
-                    keyArtist === normalizedArtist &&
-                    (keyAlbum.includes(normalizedAlbum) ||
-                        normalizedAlbum.includes(keyAlbum))
-                ) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return snapshotHasAlbum(snapshot, mbid, artistName, albumTitle);
     }
 
-    /**
-     * Check if a download is active using a pre-fetched snapshot.
-     */
+    /** Check download activity against a pre-fetched snapshot. */
     isDownloadActiveInSnapshot(
         snapshot: ReconciliationSnapshot,
         downloadId: string,
     ): { active: boolean; progress?: number } {
-        const item = snapshot.queue.get(downloadId);
-        if (!item) {
-            return { active: false };
-        }
-        // Consider it active unless explicitly failed
-        const isActive = item.status !== "failed" && item.status !== "warning";
-        return { active: isActive, progress: item.progress };
+        return snapshotHasActiveDownload(snapshot, downloadId);
     }
 }
 
-/**
- * Snapshot of Lidarr state for efficient batch reconciliation
- */
-export interface ReconciliationSnapshot {
-    queue: Map<string, QueueSnapshotItem>;
-    albumsByMbid: Map<string, AlbumSnapshotInfo>;
-    albumsByTitle: Map<string, AlbumSnapshotInfo>;
-    fetchedAt: Date;
-}
-
-export interface QueueSnapshotItem {
-    id: number;
-    downloadId: string;
-    status: string;
-    progress?: number;
-    title: string;
-}
-
-export interface AlbumSnapshotInfo {
-    id: number;
-    title: string;
-    foreignAlbumId: string;
-    artistName: string;
-    hasFiles: boolean;
-}
+export type {
+    AlbumSnapshotInfo,
+    QueueSnapshotItem,
+    ReconciliationSnapshot,
+} from "./lidarr/lidarrReconciliation";
 
 // Interface for calendar release data
 export interface CalendarRelease {

--- a/backend/src/services/lidarr/__tests__/lidarrAlbumCatalog.test.ts
+++ b/backend/src/services/lidarr/__tests__/lidarrAlbumCatalog.test.ts
@@ -1,0 +1,175 @@
+import {
+    awaitArtistCatalog,
+    type LidarrCatalogClock,
+} from "../lidarrArtistCatalog";
+import { selectAlbumInCatalog } from "../lidarrAlbumSelection";
+
+class FakeCatalogClock implements LidarrCatalogClock {
+    readonly delays: number[] = [];
+    private pending: Array<() => void> = [];
+
+    sleep(delayMs: number): Promise<void> {
+        this.delays.push(delayMs);
+        return new Promise((resolve) => this.pending.push(resolve));
+    }
+
+    async advance(): Promise<void> {
+        const resolve = this.pending.shift();
+        if (!resolve) throw new Error("No catalog delay is pending");
+        resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+}
+
+const artist = {
+    id: 17,
+    artistName: "Björk",
+    foreignArtistId: "artist-mbid",
+    monitored: true,
+};
+
+const album = {
+    id: 23,
+    title: "Debut",
+    foreignAlbumId: "album-mbid",
+    artistId: artist.id,
+    monitored: false,
+};
+
+describe("awaitArtistCatalog", () => {
+    it("polls a newly added artist on the injected clock", async () => {
+        const clock = new FakeCatalogClock();
+        const client = {
+            get: jest
+                .fn()
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [album] }),
+            post: jest.fn(),
+        };
+
+        const resultPromise = awaitArtistCatalog({
+            client,
+            artist,
+            justAddedArtist: true,
+            clock,
+        });
+        await Promise.resolve();
+
+        expect(clock.delays).toEqual([3_000]);
+        await clock.advance();
+        expect(clock.delays).toEqual([3_000, 3_000]);
+        await clock.advance();
+
+        await expect(resultPromise).resolves.toEqual([album]);
+        expect(client.get).toHaveBeenCalledTimes(3);
+    });
+
+    it("stops after twenty bounded polls when the catalog stays empty", async () => {
+        const clock = new FakeCatalogClock();
+        const client = {
+            get: jest.fn().mockResolvedValue({ data: [] }),
+            post: jest.fn(),
+        };
+
+        const resultPromise = awaitArtistCatalog({
+            client,
+            artist,
+            justAddedArtist: true,
+            clock,
+        });
+        await Promise.resolve();
+
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            await clock.advance();
+        }
+
+        await expect(resultPromise).resolves.toEqual([]);
+        expect(clock.delays).toEqual(Array(20).fill(3_000));
+        expect(client.get).toHaveBeenCalledTimes(21);
+    });
+
+    it("refreshes an existing empty catalog on the injected clock", async () => {
+        const clock = new FakeCatalogClock();
+        const client = {
+            get: jest
+                .fn()
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [album] }),
+            post: jest.fn().mockResolvedValue({ data: { id: 9 } }),
+        };
+
+        const resultPromise = awaitArtistCatalog({
+            client,
+            artist,
+            justAddedArtist: false,
+            clock,
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(client.post).toHaveBeenCalledWith("/api/v1/command", {
+            name: "RefreshArtist",
+            artistId: artist.id,
+        });
+        expect(clock.delays).toEqual([5_000]);
+        await clock.advance();
+
+        await expect(resultPromise).resolves.toEqual([album]);
+    });
+});
+
+describe("selectAlbumInCatalog", () => {
+    const albums = [
+        album,
+        {
+            ...album,
+            id: 24,
+            title: "Álbum & Friends (2019 Remaster)",
+            foreignAlbumId: "edition-mbid",
+        },
+        {
+            ...album,
+            id: 25,
+            title: "A Funk Odyssey",
+            foreignAlbumId: "other-mbid",
+        },
+    ];
+
+    it("prefers an exact release-group MBID", () => {
+        expect(
+            selectAlbumInCatalog(albums, "edition-mbid", "wrong title"),
+        ).toEqual(albums[1]);
+    });
+
+    it("uses canonical normalization and edition stripping", () => {
+        expect(
+            selectAlbumInCatalog(
+                albums,
+                "missing-mbid",
+                "Album and Friends [Deluxe Edition]",
+            ),
+        ).toEqual(albums[1]);
+    });
+
+    it("accepts a contained title only at the existing sixty-percent threshold", () => {
+        expect(
+            selectAlbumInCatalog(
+                [{ ...album, title: "The Album Plus" }],
+                "missing-mbid",
+                "The Album",
+            ),
+        ).toEqual({ ...album, title: "The Album Plus" });
+    });
+
+    it("rejects unrelated albums that share only incidental words", () => {
+        expect(
+            selectAlbumInCatalog(
+                albums,
+                "missing-mbid",
+                "A Trip To The Mystery Planet",
+            ),
+        ).toBeNull();
+    });
+});

--- a/backend/src/services/lidarr/__tests__/lidarrReconciliation.test.ts
+++ b/backend/src/services/lidarr/__tests__/lidarrReconciliation.test.ts
@@ -1,0 +1,133 @@
+import {
+    lidarrService,
+    createClientMock,
+    primeServiceWithClient,
+    LidarrHttpError,
+    logger,
+} from "../../__tests__/lidarrService.helpers";
+
+describe("Lidarr reconciliation delegation", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("builds reconciliation snapshot and checks album/download state helpers", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    records: [
+                        {
+                            id: 4,
+                            downloadId: "queue-1",
+                            status: "downloading",
+                            size: 100,
+                            sizeleft: 20,
+                            title: "Album",
+                        },
+                        {
+                            id: 5,
+                            downloadId: "queue-2",
+                            status: "warning",
+                            size: 100,
+                            sizeleft: 70,
+                            title: "Album 2",
+                        },
+                    ],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 31,
+                        title: "My Album (Deluxe)",
+                        foreignAlbumId: "album-mbid-31",
+                        artist: { artistName: "My Artist" },
+                        statistics: { percentOfTracks: 100 },
+                    },
+                    {
+                        id: 32,
+                        title: "No Files Album",
+                        foreignAlbumId: "album-mbid-32",
+                        artist: { artistName: "My Artist" },
+                        statistics: { percentOfTracks: 0 },
+                    },
+                ],
+            });
+
+        const snapshot = await lidarrService.getReconciliationSnapshot();
+        expect(snapshot.queue.size).toBe(2);
+        expect(snapshot.albumsByMbid.size).toBe(1);
+
+        expect(
+            (lidarrService as any).isAlbumAvailableInSnapshot(
+                snapshot,
+                "album-mbid-31",
+            ),
+        ).toBe(true);
+        expect(
+            (lidarrService as any).isAlbumAvailableInSnapshot(
+                snapshot,
+                undefined,
+                "My Artist",
+                "My Album",
+            ),
+        ).toBe(true);
+
+        expect(
+            (lidarrService as any).isDownloadActiveInSnapshot(
+                snapshot,
+                "queue-1",
+            ),
+        ).toEqual({ active: true, progress: 80 });
+        expect(
+            (lidarrService as any).isDownloadActiveInSnapshot(
+                snapshot,
+                "queue-2",
+            ),
+        ).toEqual({ active: false, progress: 30 });
+    });
+
+    it("fails closed when album indexing fails during snapshot creation", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        const failure = new LidarrHttpError({
+            status: 503,
+            method: "GET",
+            path: "/api/v1/album",
+            attempts: 1,
+            isTransient: true,
+            data: { secret: "raw-response" },
+        });
+
+        client.get
+            .mockResolvedValueOnce({
+                data: {
+                    records: [
+                        {
+                            id: 7,
+                            downloadId: "queue-ok",
+                            status: "downloading",
+                            size: 200,
+                            sizeleft: 40,
+                            title: "Album",
+                        },
+                    ],
+                },
+            })
+            .mockRejectedValueOnce(failure);
+
+        await expect(lidarrService.getReconciliationSnapshot()).rejects.toThrow(
+            "Lidarr GET /api/v1/album failed after 1 attempt(s)",
+        );
+        expect(logger.error).toHaveBeenCalledWith(
+            "[LIDARR] Failed to create reconciliation snapshot:",
+            {
+                message: "Lidarr GET /api/v1/album failed after 1 attempt(s)",
+                status: 503,
+                path: "/api/v1/album",
+            },
+        );
+    });
+});

--- a/backend/src/services/lidarr/__tests__/lidarrTagService.test.ts
+++ b/backend/src/services/lidarr/__tests__/lidarrTagService.test.ts
@@ -1,0 +1,218 @@
+import {
+    lidarrService,
+    createClientMock,
+    primeServiceWithClient,
+    mockGetSystemSettings,
+    mockMusicBrainzSearchArtist,
+    mockStripAlbumEdition,
+    mockedConfig,
+    LidarrHttpError,
+    logger,
+} from "../../__tests__/lidarrService.helpers";
+
+describe("LidarrTagService delegation", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetSystemSettings.mockResolvedValue(null);
+        mockMusicBrainzSearchArtist.mockResolvedValue([]);
+        mockStripAlbumEdition.mockImplementation((title: string) => title);
+        mockedConfig.lidarr = undefined;
+    });
+    it("reads and creates discovery tags with cache semantics", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get.mockResolvedValueOnce({
+            data: [
+                { id: 7, label: "soundspan-discovery" },
+                { id: 8, label: "other" },
+            ],
+        });
+
+        const first = await lidarrService.getOrCreateDiscoveryTag();
+        const second = await lidarrService.getOrCreateDiscoveryTag();
+
+        expect(first).toBe(7);
+        expect(second).toBe(7);
+        expect(client.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates discovery tag when missing", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        client.get.mockResolvedValueOnce({ data: [] });
+        client.post.mockResolvedValueOnce({
+            data: { id: 99, label: "soundspan-discovery" },
+        });
+
+        const tag = await lidarrService.getOrCreateDiscoveryTag();
+        expect(tag).toBe(99);
+        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
+            label: "soundspan-discovery",
+        });
+    });
+
+    it("returns safe defaults when tag endpoints fail", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        client.get.mockRejectedValueOnce(
+            new LidarrHttpError({
+                status: 502,
+                method: "GET",
+                path: "/api/v1/tag",
+                attempts: 1,
+                isTransient: true,
+            }),
+        );
+        client.post.mockRejectedValueOnce(new Error("tag create failed"));
+
+        await expect(lidarrService.getTags()).resolves.toEqual([]);
+        await expect(lidarrService.createTag("new-tag")).resolves.toBeNull();
+
+        expect(client.get).toHaveBeenCalledWith("/api/v1/tag");
+        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
+            label: "new-tag",
+        });
+        expect(logger.error).toHaveBeenCalledWith(
+            "[LIDARR] Failed to get tags:",
+            {
+                message: "Lidarr GET /api/v1/tag failed after 1 attempt(s)",
+                status: 502,
+                path: "/api/v1/tag",
+            },
+        );
+    });
+
+    it("retries discovery tag lookup after create failures and only caches successful IDs", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({
+            data: [{ id: 101, label: "soundspan-discovery" }],
+        });
+        client.post.mockRejectedValueOnce(new Error("tag create conflict"));
+
+        await expect(
+            lidarrService.getOrCreateDiscoveryTag(),
+        ).resolves.toBeNull();
+        await expect(lidarrService.getOrCreateDiscoveryTag()).resolves.toBe(
+            101,
+        );
+        await expect(lidarrService.getOrCreateDiscoveryTag()).resolves.toBe(
+            101,
+        );
+
+        expect(client.get).toHaveBeenCalledTimes(2);
+        expect(client.post).toHaveBeenCalledTimes(1);
+        expect(client.post).toHaveBeenCalledWith("/api/v1/tag", {
+            label: "soundspan-discovery",
+        });
+    });
+
+    it("adds and removes artist tags by updating merged tag lists", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get
+            .mockResolvedValueOnce({
+                data: { id: 11, artistName: "Artist A", tags: [1, 2] },
+            })
+            .mockResolvedValueOnce({
+                data: { id: 11, artistName: "Artist A", tags: [1, 2, 3] },
+            });
+        client.put.mockResolvedValue({});
+
+        await expect(lidarrService.addTagsToArtist(11, [2, 3])).resolves.toBe(
+            true,
+        );
+        await expect(
+            lidarrService.removeTagsFromArtist(11, [1, 3]),
+        ).resolves.toBe(true);
+
+        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/11", {
+            id: 11,
+            artistName: "Artist A",
+            tags: [1, 2, 3],
+        });
+        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/11", {
+            id: 11,
+            artistName: "Artist A",
+            tags: [2],
+        });
+    });
+
+    it("returns false when addTagsToArtist cannot persist merged tags", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get.mockResolvedValueOnce({
+            data: {
+                id: 21,
+                artistName: "Artist B",
+                monitored: true,
+                tags: [4, 7],
+            },
+        });
+        client.put.mockRejectedValueOnce(new Error("tag update failed"));
+
+        await expect(lidarrService.addTagsToArtist(21, [7, 9])).resolves.toBe(
+            false,
+        );
+        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/21", {
+            id: 21,
+            artistName: "Artist B",
+            monitored: true,
+            tags: [4, 7, 9],
+        });
+    });
+
+    it("returns false when removeTagsFromArtist update fails after filtering tags", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+
+        client.get.mockResolvedValueOnce({
+            data: { id: 22, artistName: "Artist C", tags: [3, 5, 8] },
+        });
+        client.put.mockRejectedValueOnce(new Error("remove failed"));
+
+        await expect(
+            lidarrService.removeTagsFromArtist(22, [5, 99]),
+        ).resolves.toBe(false);
+        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/22", {
+            id: 22,
+            artistName: "Artist C",
+            tags: [3, 8],
+        });
+    });
+
+    it("removes discovery tag by MBID when artist is found", async () => {
+        const client = createClientMock();
+        primeServiceWithClient(client);
+        (lidarrService as any).discoveryTagId = 5;
+
+        client.get
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 12,
+                        foreignArtistId: "artist-1",
+                        artistName: "Artist",
+                        tags: [5, 9],
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({
+                data: { id: 12, artistName: "Artist", tags: [5, 9] },
+            });
+        client.put.mockResolvedValue({});
+
+        await expect(
+            lidarrService.removeDiscoveryTagByMbid("artist-1"),
+        ).resolves.toBe(true);
+        expect(client.put).toHaveBeenCalledWith("/api/v1/artist/12", {
+            id: 12,
+            artistName: "Artist",
+            tags: [9],
+        });
+    });
+});

--- a/backend/src/services/lidarr/lidarrAlbumSelection.ts
+++ b/backend/src/services/lidarr/lidarrAlbumSelection.ts
@@ -1,0 +1,78 @@
+import {
+    normalizeForFuzzyMatch,
+    stripAlbumEdition,
+} from "../../utils/artistNormalization";
+import type { LidarrAlbum } from "./lidarrTypes";
+
+function normalizeAlbumTitle(title: string): string {
+    return normalizeForFuzzyMatch(stripAlbumEdition(title));
+}
+
+function isContainedMatch(candidate: string, target: string): boolean {
+    const shorter = candidate.length < target.length ? candidate : target;
+    const longer = candidate.length >= target.length ? candidate : target;
+    return longer.includes(shorter) && shorter.length >= longer.length * 0.6;
+}
+
+/** Selects an album by MBID, then by the existing strict normalized-title rules. */
+export function selectAlbumInCatalogMatch(
+    albums: LidarrAlbum[],
+    releaseGroupMbid: string,
+    albumTitle: string,
+): {
+    album: LidarrAlbum | null;
+    matchType: "mbid" | "exact" | "partial" | null;
+} {
+    const mbidMatch = albums.find(
+        (album) => album.foreignAlbumId === releaseGroupMbid,
+    );
+    if (mbidMatch) return { album: mbidMatch, matchType: "mbid" };
+
+    const targetTitle = normalizeAlbumTitle(albumTitle);
+    const exactMatch = albums.find(
+        (album) => normalizeAlbumTitle(album.title) === targetTitle,
+    );
+    if (exactMatch) return { album: exactMatch, matchType: "exact" };
+
+    const partialMatch = albums.find((album) =>
+        isContainedMatch(normalizeAlbumTitle(album.title), targetTitle),
+    );
+    return {
+        album: partialMatch ?? null,
+        matchType: partialMatch ? "partial" : null,
+    };
+}
+
+/** Selects only the album value from the catalog match result. */
+export function selectAlbumInCatalog(
+    albums: LidarrAlbum[],
+    releaseGroupMbid: string,
+    albumTitle: string,
+): LidarrAlbum | null {
+    return selectAlbumInCatalogMatch(albums, releaseGroupMbid, albumTitle)
+        .album;
+}
+
+/** Selects the edition-stripped fallback album using the existing 70% rule. */
+export function selectBaseAlbumInCatalog(
+    albums: LidarrAlbum[],
+    albumTitle: string,
+    baseTitle: string = stripAlbumEdition(albumTitle),
+): LidarrAlbum | null {
+    if (baseTitle === albumTitle || baseTitle.length <= 2) return null;
+    const target = normalizeForFuzzyMatch(baseTitle);
+    return (
+        albums.find((album) => {
+            const candidate = normalizeForFuzzyMatch(album.title);
+            if (candidate === target) return true;
+            const shorter =
+                candidate.length < target.length ? candidate : target;
+            const longer =
+                candidate.length >= target.length ? candidate : target;
+            return (
+                longer.includes(shorter) &&
+                shorter.length >= longer.length * 0.7
+            );
+        }) ?? null
+    );
+}

--- a/backend/src/services/lidarr/lidarrArtistCatalog.ts
+++ b/backend/src/services/lidarr/lidarrArtistCatalog.ts
@@ -1,0 +1,121 @@
+import { logger } from "../../utils/logger";
+import type { LidarrAlbum, LidarrArtist } from "./lidarrTypes";
+
+const CATALOG_POLL_ATTEMPTS = 20;
+const CATALOG_POLL_DELAY_MS = 3_000;
+const REFRESH_DELAY_MS = 5_000;
+
+interface CatalogClient {
+    get(path: string): Promise<{ data: LidarrAlbum[] }>;
+    post(path: string, data: unknown): Promise<unknown>;
+}
+
+/** Injectable delay boundary for Lidarr catalog polling. */
+export interface LidarrCatalogClock {
+    sleep(delayMs: number): Promise<void>;
+}
+
+interface AwaitArtistCatalogOptions {
+    client: CatalogClient;
+    artist: LidarrArtist;
+    justAddedArtist: boolean;
+    clock: LidarrCatalogClock;
+}
+
+interface EnsureArtistPresentOptions {
+    artists: LidarrArtist[];
+    artistMbid?: string;
+    artistName: string;
+    rootFolderPath: string;
+    isDiscovery: boolean;
+    addArtist: (
+        mbid: string,
+        artistName: string,
+        rootFolderPath: string,
+        searchForMissingAlbums: boolean,
+        monitorAllAlbums: boolean,
+        isDiscovery: boolean,
+    ) => Promise<LidarrArtist | null>;
+    ensureDiscoveryTag: (artist: LidarrArtist) => Promise<void>;
+}
+
+/** Finds an existing artist or creates it through Lidarr's race-safe add path. */
+export async function ensureArtistPresent(
+    options: EnsureArtistPresentOptions,
+): Promise<{ artist: LidarrArtist | null; justAddedArtist: boolean }> {
+    const existing = options.artists.find(
+        (artist) =>
+            options.artistMbid && artist.foreignArtistId === options.artistMbid,
+    );
+    if (existing) {
+        if (options.isDiscovery) await options.ensureDiscoveryTag(existing);
+        return { artist: existing, justAddedArtist: false };
+    }
+    if (!options.artistMbid) {
+        return { artist: null, justAddedArtist: false };
+    }
+    const artist = await options.addArtist(
+        options.artistMbid,
+        options.artistName,
+        options.rootFolderPath,
+        false,
+        false,
+        options.isDiscovery,
+    );
+    return { artist, justAddedArtist: artist !== null };
+}
+
+async function pollNewArtistCatalog(
+    options: AwaitArtistCatalogOptions,
+): Promise<LidarrAlbum[]> {
+    for (let attempt = 1; attempt <= CATALOG_POLL_ATTEMPTS; attempt += 1) {
+        await options.clock.sleep(CATALOG_POLL_DELAY_MS);
+        const response = await options.client.get(
+            `/api/v1/album?artistId=${options.artist.id}`,
+        );
+        if (response.data.length > 0) {
+            logger.debug(`   Albums loaded after ${attempt * 3}s`);
+            return response.data;
+        }
+        if (attempt < CATALOG_POLL_ATTEMPTS) {
+            logger.debug(
+                `   Attempt ${attempt}/${CATALOG_POLL_ATTEMPTS}: Still waiting...`,
+            );
+        }
+    }
+    logger.warn(
+        ` Timeout reached after 60s - artist catalog may still be populating`,
+    );
+    return [];
+}
+
+async function refreshExistingArtistCatalog(
+    options: AwaitArtistCatalogOptions,
+): Promise<LidarrAlbum[]> {
+    try {
+        await options.client.post("/api/v1/command", {
+            name: "RefreshArtist",
+            artistId: options.artist.id,
+        });
+        await options.clock.sleep(REFRESH_DELAY_MS);
+        const response = await options.client.get(
+            `/api/v1/album?artistId=${options.artist.id}`,
+        );
+        return response.data;
+    } catch {
+        logger.warn("   Metadata refresh failed");
+        return [];
+    }
+}
+
+/** Loads an artist catalog with bounded, injectable polling. */
+export async function awaitArtistCatalog(
+    options: AwaitArtistCatalogOptions,
+): Promise<LidarrAlbum[]> {
+    const response = await options.client.get(
+        `/api/v1/album?artistId=${options.artist.id}`,
+    );
+    if (response.data.length > 0) return response.data;
+    if (options.justAddedArtist) return pollNewArtistCatalog(options);
+    return refreshExistingArtistCatalog(options);
+}

--- a/backend/src/services/lidarr/lidarrHttpClient.ts
+++ b/backend/src/services/lidarr/lidarrHttpClient.ts
@@ -69,6 +69,15 @@ export function getLidarrErrorMessage(error: unknown): string {
     return typeof message === "string" ? message : toErrorMessage(error);
 }
 
+/** Returns safe structured fields for logging a Lidarr failure. */
+export function lidarrErrorLogFields(error: unknown) {
+    return {
+        message: error instanceof Error ? toErrorMessage(error) : undefined,
+        status: error instanceof LidarrHttpError ? error.status : undefined,
+        path: error instanceof LidarrHttpError ? error.path : undefined,
+    };
+}
+
 /** Runtime bounds and injectable delay behavior for a Lidarr client. */
 export interface LidarrHttpClientOptions {
     timeoutMs?: number;

--- a/backend/src/services/lidarr/lidarrReconciliation.ts
+++ b/backend/src/services/lidarr/lidarrReconciliation.ts
@@ -1,0 +1,141 @@
+import { normalizeForExactKey } from "../../utils/artistNormalization";
+import { logger } from "../../utils/logger";
+import { fetchReconciliationAlbumMaps } from "./reconciliationAlbumStream";
+import {
+    lidarrErrorLogFields,
+    type LidarrHttpClient,
+} from "./lidarrHttpClient";
+
+/** Snapshot of Lidarr state for efficient batch reconciliation. */
+export interface ReconciliationSnapshot {
+    queue: Map<string, QueueSnapshotItem>;
+    albumsByMbid: Map<string, AlbumSnapshotInfo>;
+    albumsByTitle: Map<string, AlbumSnapshotInfo>;
+    fetchedAt: Date;
+}
+
+/** Queue entry indexed by download identifier. */
+export interface QueueSnapshotItem {
+    id: number;
+    downloadId: string;
+    status: string;
+    progress?: number;
+    title: string;
+}
+
+/** Downloaded album entry indexed by MBID and normalized title. */
+export interface AlbumSnapshotInfo {
+    id: number;
+    title: string;
+    foreignAlbumId: string;
+    artistName: string;
+    hasFiles: boolean;
+}
+
+interface QueueRecord extends QueueSnapshotItem {
+    size?: number;
+    sizeleft?: number;
+}
+
+function emptySnapshot(): ReconciliationSnapshot {
+    return {
+        queue: new Map(),
+        albumsByMbid: new Map(),
+        albumsByTitle: new Map(),
+        fetchedAt: new Date(),
+    };
+}
+
+function indexQueue(
+    snapshot: ReconciliationSnapshot,
+    records: QueueRecord[],
+): void {
+    for (const item of records) {
+        if (!item.downloadId) continue;
+        const progress =
+            item.sizeleft && item.size
+                ? Math.round(((item.size - item.sizeleft) / item.size) * 100)
+                : undefined;
+        snapshot.queue.set(item.downloadId, {
+            id: item.id,
+            downloadId: item.downloadId,
+            status: item.status,
+            progress,
+            title: item.title,
+        });
+    }
+}
+
+/** Fetches queue and downloaded-album state in one bounded snapshot. */
+export async function getReconciliationSnapshot(
+    client: LidarrHttpClient | null,
+    enabled: boolean,
+    signal?: AbortSignal,
+): Promise<ReconciliationSnapshot> {
+    const snapshot = emptySnapshot();
+    if (!enabled || !client) return snapshot;
+    const ownedController = new AbortController();
+    const requestSignal = signal
+        ? AbortSignal.any([signal, ownedController.signal])
+        : ownedController.signal;
+    try {
+        const [queueResponse] = await Promise.all([
+            client.get<{ records?: QueueRecord[] }>("/api/v1/queue", {
+                params: {
+                    page: 1,
+                    pageSize: 1000,
+                    includeUnknownArtistItems: true,
+                },
+                signal: requestSignal,
+            }),
+            fetchReconciliationAlbumMaps(client, snapshot, requestSignal),
+        ]);
+        indexQueue(snapshot, queueResponse.data.records || []);
+        logger.debug(
+            `[LIDARR] Snapshot fetched: ${snapshot.queue.size} queue items, ${snapshot.albumsByMbid.size} albums with files`,
+        );
+        return snapshot;
+    } catch (error: unknown) {
+        ownedController.abort(error);
+        logger.error(
+            "[LIDARR] Failed to create reconciliation snapshot:",
+            lidarrErrorLogFields(error),
+        );
+        throw error;
+    }
+}
+
+/** Checks whether a snapshot contains a downloaded album. */
+export function isAlbumAvailableInSnapshot(
+    snapshot: ReconciliationSnapshot,
+    mbid?: string,
+    artistName?: string,
+    albumTitle?: string,
+): boolean {
+    if (mbid && snapshot.albumsByMbid.has(mbid)) return true;
+    if (!artistName || !albumTitle) return false;
+    const artist = normalizeForExactKey(artistName);
+    const album = normalizeForExactKey(albumTitle);
+    if (snapshot.albumsByTitle.has(`${artist}|${album}`)) return true;
+    for (const titleKey of snapshot.albumsByTitle.keys()) {
+        const [keyArtist, keyAlbum] = titleKey.split("|");
+        if (
+            keyArtist === artist &&
+            (keyAlbum.includes(album) || album.includes(keyAlbum))
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** Checks whether a snapshot contains a non-failed queue download. */
+export function isDownloadActiveInSnapshot(
+    snapshot: ReconciliationSnapshot,
+    downloadId: string,
+): { active: boolean; progress?: number } {
+    const item = snapshot.queue.get(downloadId);
+    if (!item) return { active: false };
+    const active = item.status !== "failed" && item.status !== "warning";
+    return { active, progress: item.progress };
+}

--- a/backend/src/services/lidarr/lidarrReleaseGrab.ts
+++ b/backend/src/services/lidarr/lidarrReleaseGrab.ts
@@ -1,0 +1,250 @@
+import { logger } from "../../utils/logger";
+import type { LidarrHttpClient } from "./lidarrHttpClient";
+import { selectBaseAlbumInCatalog } from "./lidarrAlbumSelection";
+import type { LidarrAlbum, LidarrArtist } from "./lidarrTypes";
+
+const EDITION_PATTERNS = [
+    /\(remaster/i,
+    /\(deluxe/i,
+    /\(expanded/i,
+    /\(anniversary/i,
+    /\(bonus/i,
+    /\(special/i,
+    /\(limited/i,
+    /\(collector/i,
+    /\(super deluxe/i,
+    /\(platinum/i,
+    /\(japan/i,
+    /\(uk/i,
+    /\(us/i,
+    /\(import/i,
+    /\[remaster/i,
+    /\[deluxe/i,
+];
+
+interface CommandResult {
+    status: string;
+    message: string;
+}
+
+interface GrabReleaseOptions {
+    client: LidarrHttpClient;
+    artist: LidarrArtist;
+    album: LidarrAlbum;
+    artistAlbums: LidarrAlbum[];
+    requestedTitle: string;
+    sleep: (delayMs: number) => Promise<void>;
+    waitForCommand: (
+        commandId: number,
+        timeoutMs: number,
+    ) => Promise<CommandResult>;
+    createNoReleasesError: () => Error;
+    indexerCountLogged: () => boolean;
+    markIndexerCountLogged: () => void;
+    extractBaseTitle: (title: string) => string;
+}
+
+async function monitorArtist(
+    client: LidarrHttpClient,
+    artist: LidarrArtist,
+): Promise<void> {
+    if (artist.monitored) return;
+    await client.put(`/api/v1/artist/${artist.id}`, {
+        ...artist,
+        monitored: true,
+    });
+}
+
+async function monitorAlbum(
+    client: LidarrHttpClient,
+    album: LidarrAlbum,
+): Promise<LidarrAlbum> {
+    const fullResponse = await client.get<LidarrAlbum>(
+        `/api/v1/album/${album.id}`,
+    );
+    const fullAlbum = fullResponse.data;
+    await client.put(`/api/v1/album/${fullAlbum.id}`, {
+        ...fullAlbum,
+        monitored: true,
+    });
+    const verifyResponse = await client.get<LidarrAlbum>(
+        `/api/v1/album/${fullAlbum.id}`,
+    );
+    if (!verifyResponse.data.monitored) {
+        logger.error(" CRITICAL: Album monitoring failed to persist!", {
+            albumId: fullAlbum.id,
+            title: fullAlbum.title,
+            monitored: verifyResponse.data.monitored,
+            status: verifyResponse.status,
+        });
+    }
+    return verifyResponse.data;
+}
+
+async function enableEditionReleaseMatching(
+    client: LidarrHttpClient,
+    album: LidarrAlbum,
+    requestedTitle: string,
+): Promise<void> {
+    const isEdition = EDITION_PATTERNS.some(
+        (pattern) => pattern.test(requestedTitle) || pattern.test(album.title),
+    );
+    if (!isEdition || album.anyReleaseOk) return;
+    await client.put(`/api/v1/album/${album.id}`, {
+        ...album,
+        anyReleaseOk: true,
+    });
+    album.anyReleaseOk = true;
+}
+
+async function refreshMissingReleases(
+    options: GrabReleaseOptions,
+    album: LidarrAlbum,
+): Promise<void> {
+    if ((album.releases?.length || 0) > 0) return;
+    logger.warn(" Album has 0 releases - refreshing artist metadata...");
+    await options.client.post("/api/v1/command", {
+        name: "RefreshArtist",
+        artistId: options.artist.id,
+    });
+    await options.sleep(5_000);
+    const response = await options.client.get<LidarrAlbum>(
+        `/api/v1/album/${album.id}`,
+    );
+    if ((response.data.releases?.length || 0) === 0) {
+        logger.warn(" Still no releases after refresh!");
+        logger.warn("   Download will be attempted but may fail.");
+    }
+}
+
+async function prepareAlbum(options: GrabReleaseOptions): Promise<LidarrAlbum> {
+    await monitorArtist(options.client, options.artist);
+    const album = await monitorAlbum(options.client, options.album);
+    await enableEditionReleaseMatching(
+        options.client,
+        album,
+        options.requestedTitle,
+    );
+    await refreshMissingReleases(options, album);
+    return album;
+}
+
+async function dispatchAlbumSearch(
+    options: GrabReleaseOptions,
+    albumId: number,
+): Promise<number> {
+    const response = await options.client.post<{ id: number }>(
+        "/api/v1/command",
+        { name: "AlbumSearch", albumIds: [albumId] },
+    );
+    return response.data.id;
+}
+
+async function waitForAlbumSearch(
+    options: GrabReleaseOptions,
+    commandId: number,
+): Promise<CommandResult | null> {
+    try {
+        return await options.waitForCommand(commandId, 30_000);
+    } catch (error: unknown) {
+        if (error instanceof Error && error.message.includes("timed out")) {
+            return null;
+        }
+        throw error;
+    }
+}
+
+async function logIndexerDiagnostics(
+    options: GrabReleaseOptions,
+    album: LidarrAlbum,
+): Promise<void> {
+    try {
+        const details = await options.client.get<LidarrAlbum>(
+            `/api/v1/album/${album.id}`,
+        );
+        logger.debug(
+            `   [DIAGNOSTIC] Album "${album.title}" has ${details.data.releases?.length || 0} releases defined in Lidarr`,
+        );
+        if (options.indexerCountLogged()) return;
+        const indexers =
+            await options.client.get<
+                Array<{ enableRss?: boolean; enableAutomaticSearch?: boolean }>
+            >("/api/v1/indexer");
+        const enabled = indexers.data.filter(
+            (indexer) => indexer.enableRss || indexer.enableAutomaticSearch,
+        );
+        logger.debug(
+            `   [DIAGNOSTIC] ${enabled.length} enabled indexers configured in Lidarr`,
+        );
+        if (enabled.length === 0) {
+            logger.error(
+                "   [DIAGNOSTIC] No enabled indexers - Lidarr cannot search for releases",
+            );
+        }
+        options.markIndexerCountLogged();
+    } catch {
+        // Diagnostics must not affect acquisition control flow.
+    }
+}
+
+async function grabBaseAlbum(
+    options: GrabReleaseOptions,
+    updatedAlbum: LidarrAlbum,
+): Promise<LidarrAlbum | null> {
+    const base = selectBaseAlbumInCatalog(
+        options.artistAlbums,
+        options.requestedTitle,
+        options.extractBaseTitle(options.requestedTitle),
+    );
+    if (!base || base.id === updatedAlbum.id) return null;
+    await options.client.put(`/api/v1/album/${base.id}`, {
+        ...base,
+        monitored: true,
+        anyReleaseOk: true,
+    });
+    const commandId = await dispatchAlbumSearch(options, base.id);
+    const result = await waitForAlbumSearch(options, commandId);
+    if (!result) return base;
+    if (result.message?.includes("0 reports")) {
+        logger.warn(`   Base album "${base.title}" also has no releases`);
+        throw new Error(
+            `No releases available for "${options.requestedTitle}" or base album "${base.title}" - check indexer configuration and album availability`,
+        );
+    }
+    return base;
+}
+
+async function retryWithAnyRelease(
+    options: GrabReleaseOptions,
+    album: LidarrAlbum,
+): Promise<LidarrAlbum> {
+    await options.client.put(`/api/v1/album/${album.id}`, {
+        ...album,
+        anyReleaseOk: true,
+    });
+    const commandId = await dispatchAlbumSearch(options, album.id);
+    const retry = await waitForAlbumSearch(options, commandId);
+    if (!retry) return album;
+    if (!retry.message?.includes("0 reports")) return album;
+    const base = await grabBaseAlbum(options, album);
+    if (base) return base;
+    throw options.createNoReleasesError();
+}
+
+/** Prepares the selected catalog album and starts Lidarr release acquisition. */
+export async function grabRelease(
+    options: GrabReleaseOptions,
+): Promise<LidarrAlbum> {
+    const album = await prepareAlbum(options);
+    const commandId = await dispatchAlbumSearch(options, album.id);
+    const result = await waitForAlbumSearch(options, commandId);
+    if (!result) return album;
+    if (!result.message?.includes("0 reports")) return album;
+    await logIndexerDiagnostics(options, album);
+    if (album.anyReleaseOk) {
+        throw new Error(
+            "No releases available - indexers found no matching downloads",
+        );
+    }
+    return retryWithAnyRelease(options, album);
+}

--- a/backend/src/services/lidarr/lidarrTagService.ts
+++ b/backend/src/services/lidarr/lidarrTagService.ts
@@ -1,0 +1,187 @@
+import { BRAND_SLUG } from "../../config/brand";
+import { logger } from "../../utils/logger";
+import {
+    lidarrErrorLogFields,
+    type LidarrHttpClient,
+} from "./lidarrHttpClient";
+import type { LidarrArtist, LidarrTag } from "./lidarrTypes";
+
+const DISCOVERY_TAG_LABEL = `${BRAND_SLUG}-discovery`;
+
+interface LidarrTagServiceDependencies {
+    getClient: () => LidarrHttpClient | null;
+    isEnabled: () => boolean;
+    getTags: () => Promise<LidarrTag[]>;
+    createTag: (label: string) => Promise<LidarrTag | null>;
+    getArtists: () => Promise<LidarrArtist[]>;
+    getArtistsByTag: (tagId: number) => Promise<LidarrArtist[]>;
+    getDiscoveryTagId: () => Promise<number | null>;
+    removeTagsFromArtist: (
+        artistId: number,
+        tagIds: number[],
+    ) => Promise<boolean>;
+}
+
+/** Owns Lidarr discovery-tag CRUD and artist-tag association behavior. */
+export class LidarrTagService {
+    private discoveryTagId: number | null = null;
+
+    constructor(private readonly dependencies: LidarrTagServiceDependencies) {}
+
+    get cachedDiscoveryTagId(): number | null {
+        return this.discoveryTagId;
+    }
+
+    set cachedDiscoveryTagId(value: number | null) {
+        this.discoveryTagId = value;
+    }
+
+    async getTags(): Promise<LidarrTag[]> {
+        const client = this.availableClient();
+        if (!client) return [];
+        try {
+            const response = await client.get<LidarrTag[]>("/api/v1/tag");
+            return response.data || [];
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to get tags:",
+                lidarrErrorLogFields(error),
+            );
+            return [];
+        }
+    }
+
+    async createTag(label: string): Promise<LidarrTag | null> {
+        const client = this.availableClient();
+        if (!client) return null;
+        try {
+            const response = await client.post<LidarrTag>("/api/v1/tag", {
+                label,
+            });
+            logger.debug(
+                `[LIDARR] Created tag: ${label} (ID: ${response.data.id})`,
+            );
+            return response.data;
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to create tag:",
+                lidarrErrorLogFields(error),
+            );
+            return null;
+        }
+    }
+
+    async getOrCreateDiscoveryTag(): Promise<number | null> {
+        if (!this.availableClient()) return null;
+        if (this.discoveryTagId !== null) return this.discoveryTagId;
+        try {
+            const tags = await this.dependencies.getTags();
+            const existing = tags.find(
+                (tag) => tag.label === DISCOVERY_TAG_LABEL,
+            );
+            if (existing) {
+                this.discoveryTagId = existing.id;
+                return existing.id;
+            }
+            const created =
+                await this.dependencies.createTag(DISCOVERY_TAG_LABEL);
+            this.discoveryTagId = created?.id ?? null;
+            return this.discoveryTagId;
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to get/create discovery tag:",
+                lidarrErrorLogFields(error),
+            );
+            return null;
+        }
+    }
+
+    async addTagsToArtist(
+        artistId: number,
+        tagIds: number[],
+    ): Promise<boolean> {
+        return this.updateArtistTags(artistId, (existing) => [
+            ...new Set([...existing, ...tagIds]),
+        ]);
+    }
+
+    async removeTagsFromArtist(
+        artistId: number,
+        tagIds: number[],
+    ): Promise<boolean> {
+        return this.updateArtistTags(artistId, (existing) =>
+            existing.filter((tagId) => !tagIds.includes(tagId)),
+        );
+    }
+
+    async getArtistsByTag(tagId: number): Promise<LidarrArtist[]> {
+        const client = this.availableClient();
+        if (!client) return [];
+        try {
+            const response = await client.get<LidarrArtist[]>("/api/v1/artist");
+            return response.data.filter((artist) =>
+                artist.tags?.includes(tagId),
+            );
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to get artists by tag:",
+                lidarrErrorLogFields(error),
+            );
+            return [];
+        }
+    }
+
+    async getDiscoveryArtists(): Promise<LidarrArtist[]> {
+        const tagId = await this.dependencies.getDiscoveryTagId();
+        return tagId ? this.dependencies.getArtistsByTag(tagId) : [];
+    }
+
+    async removeDiscoveryTagByMbid(artistMbid: string): Promise<boolean> {
+        if (!this.availableClient()) return false;
+        try {
+            const tagId = await this.dependencies.getDiscoveryTagId();
+            if (!tagId) return false;
+            const artist = (await this.dependencies.getArtists()).find(
+                (candidate) => candidate.foreignArtistId === artistMbid,
+            );
+            if (!artist || !artist.tags?.includes(tagId)) return true;
+            return this.dependencies.removeTagsFromArtist(artist.id, [tagId]);
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to remove discovery tag:",
+                lidarrErrorLogFields(error),
+            );
+            return false;
+        }
+    }
+
+    private availableClient(): LidarrHttpClient | null {
+        return this.dependencies.isEnabled()
+            ? this.dependencies.getClient()
+            : null;
+    }
+
+    private async updateArtistTags(
+        artistId: number,
+        update: (existing: number[]) => number[],
+    ): Promise<boolean> {
+        const client = this.availableClient();
+        if (!client) return false;
+        try {
+            const response = await client.get<LidarrArtist>(
+                `/api/v1/artist/${artistId}`,
+            );
+            await client.put(`/api/v1/artist/${artistId}`, {
+                ...response.data,
+                tags: update(response.data.tags || []),
+            });
+            return true;
+        } catch (error: unknown) {
+            logger.error(
+                "[LIDARR] Failed to update artist tags:",
+                lidarrErrorLogFields(error),
+            );
+            return false;
+        }
+    }
+}

--- a/backend/src/services/lidarr/lidarrTypes.ts
+++ b/backend/src/services/lidarr/lidarrTypes.ts
@@ -1,0 +1,40 @@
+/** Artist shape used by Lidarr service orchestration. */
+export interface LidarrArtist {
+    id: number;
+    artistName: string;
+    foreignArtistId: string;
+    monitored: boolean;
+    tags?: number[];
+    artistType?: string;
+    qualityProfileId?: number;
+    metadataProfileId?: number;
+    rootFolderPath?: string;
+    statistics?: {
+        albumCount?: number;
+        trackFileCount?: number;
+        trackCount?: number;
+        totalTrackCount?: number;
+        sizeOnDisk?: number;
+        percentOfTracks?: number;
+    };
+    ratings?: { votes?: number; value?: number };
+}
+
+/** Album shape used by Lidarr service orchestration. */
+export interface LidarrAlbum {
+    id: number;
+    title: string;
+    foreignAlbumId: string;
+    artistId: number;
+    monitored: boolean;
+    anyReleaseOk?: boolean;
+    releases?: unknown[];
+    artist?: { foreignArtistId: string; artistName: string };
+    [key: string]: unknown;
+}
+
+/** Lidarr tag returned by the tag API. */
+export interface LidarrTag {
+    id: number;
+    label: string;
+}

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -61,7 +61,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/podcasts.ts": 2541,
     "backend/src/routes/systemSettings.ts": 1506,
     "backend/src/routes/youtubeMusic.ts": 1604,
-    "backend/src/services/lidarr.ts": 2587,
+    "backend/src/services/lidarr.ts": 1689,
     "backend/src/services/simpleDownloadManager.ts": 2104,
     "backend/src/services/spotify.ts": 1624,
     "backend/src/workers/unifiedEnrichment.ts": 1825,
@@ -71,7 +71,7 @@ const BASELINE = Object.freeze({
     "frontend/components/player/OverlayPlayer.tsx": 1352,
     "frontend/hooks/useQueries.ts": 1453,
     "frontend/lib/audio-controls-context.tsx": 2305,
-    "frontend/lib/listen-together-context.tsx": 1954,
+    "frontend/lib/listen-together-context.tsx": 1949,
     "services/audio-analyzer/analyzer.py": 2248,
 });
 


### PR DESCRIPTION
Part 1 of #790 (lidarr.ts; the simpleDownloadManager half follows as its own PR).

## What changed

- `services/lidarr/` gains five focused modules, following the directory pattern #789 established:
  - `lidarrTagService.ts` — the self-contained tag lifecycle cluster.
  - `lidarrReconciliation.ts` — queue-reconciliation snapshots plus their types (re-exported from lidarr.ts so existing import paths keep working).
  - `lidarrArtistCatalog.ts` — the catalog-wait polling with an injectable clock; the inline 20×3s loop and both blind sleeps are gone from the flow, and the wait is tested with a fake clock.
  - `lidarrAlbumSelection.ts` — pure album matching. The two inconsistent inline matchers are replaced by the canonical normalization helpers from #791; matching behavior is pinned by fixture tests.
  - `lidarrReleaseGrab.ts` — release selection/grab.
- `addAlbum` is now an orchestration shell over those units instead of a 710-line method.
- Tests moved out of the monolithic suites into `lidarrTagService.test.ts`, `lidarrReconciliation.test.ts`, and `lidarrAlbumCatalog.test.ts` (−436 lines from the two big files).
- `lidarr.ts`: 2587 → 1698 lines; file-size baseline tightened. Also took a free baseline tightening on `listen-together-context.tsx` (1954 → 1949) the gate reported.

## Verification

- Full backend suite at 6 workers: 513/513 suites, 7686 tests, exit 0. `tsc --noEmit` clean.
- `format:check`, `check-file-size.mjs`, `check-route-error-canon.mjs` all pass.
- Public lidarrService surface unchanged (delegation keeps caller signatures working).