### PR TITLE
fix(sidecars): guard the repository-root probe so containers boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TIDAL and YouTube Music sidecar containers no longer crash at startup after the `app.py` decomposition when the repository-root path probe runs outside the repository directory layout.
 - Album downloads that deliver only part of the requested album now fail with a "Partial download: N/M tracks" status instead of reporting success, and library reconciliation no longer marks a multi-track request complete off a single-track album (#826).
 - TIDAL downloads now tag ALBUMARTIST with the album artist instead of the per-track artist, preventing multi-artist album tracks from splitting into phantom single-track albums.
 - Artist "Download all missing albums" now skips promotion-, bootleg-, or pseudo-release-only groups, remix/live/demo/compilation groups, and releases where the artist is only a featured credit; MusicBrainz enumeration failures now fail the expansion instead of reporting no missing albums (#824).

--- a/services/common/sidecar_runtime_utils.py
+++ b/services/common/sidecar_runtime_utils.py
@@ -7,9 +7,11 @@ import logging
 import os
 import random
 import re
+import sys
 import threading
 import time
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -33,6 +35,24 @@ _POOL_WARNING_REPLACEMENT = (
     "urllib3 connection pool saturated; suppressing repeated pool-full "
     "warnings for 300s. Increase upstream pool size if this persists."
 )
+
+
+def ensure_repository_root_on_path(module_file: str) -> None:
+    """Append the repo root to sys.path for in-tree runs; no-op in containers."""
+    try:
+        module_path = Path(module_file).resolve()
+    except (OSError, RuntimeError):
+        return
+
+    if len(module_path.parents) < 3:
+        return
+
+    repository_root = module_path.parents[2]
+    repository_root_string = str(repository_root)
+    if not (repository_root / "services").is_dir() or repository_root_string in sys.path:
+        return
+
+    sys.path.append(repository_root_string)
 
 
 class _ThrottlePoolFullWarning(logging.Filter):

--- a/services/common/tests/test_sidecar_runtime_utils.py
+++ b/services/common/tests/test_sidecar_runtime_utils.py
@@ -1,0 +1,66 @@
+"""Behavioral tests for shared sidecar runtime helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from services.common.sidecar_runtime_utils import ensure_repository_root_on_path
+
+
+@pytest.mark.parametrize("sidecar", ["tidal-streamer", "ytmusic-streamer"])
+def test_shallow_container_module_path_does_not_append(
+    monkeypatch: pytest.MonkeyPatch, sidecar: str
+) -> None:
+    """Container entrypoints with only two ancestors remain import-safe."""
+    original_path = [f"existing-{sidecar}"]
+    monkeypatch.setattr(sys, "path", original_path.copy())
+
+    ensure_repository_root_on_path("/app/app.py")
+
+    assert sys.path == original_path
+
+
+def test_deep_repository_module_path_appends_root_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An in-tree sidecar module exposes the repository package root."""
+    repository_root = tmp_path / "checkout"
+    module_path = repository_root / "services" / "tidal-streamer" / "app.py"
+    module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", ["existing"])
+
+    ensure_repository_root_on_path(str(module_path))
+    ensure_repository_root_on_path(str(module_path))
+
+    assert sys.path == ["existing", str(repository_root)]
+
+
+def test_existing_repository_root_is_not_duplicated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An existing repository path remains a single sys.path entry."""
+    repository_root = tmp_path / "checkout"
+    module_path = repository_root / "services" / "ytmusic-streamer" / "app.py"
+    module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", [str(repository_root)])
+
+    ensure_repository_root_on_path(str(module_path))
+
+    assert sys.path == [str(repository_root)]
+
+
+def test_deep_non_repository_module_path_does_not_append(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A deep layout without a services directory does not alter sys.path."""
+    layout_root = tmp_path / "installed"
+    module_path = layout_root / "package" / "sidecar" / "app.py"
+    module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", ["existing"])
+
+    ensure_repository_root_on_path(str(module_path))
+
+    assert sys.path == ["existing"]

--- a/services/tidal-streamer/app.py
+++ b/services/tidal-streamer/app.py
@@ -10,9 +10,15 @@ import types
 from pathlib import Path
 from typing import Any
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
-    sys.path.append(str(REPOSITORY_ROOT))
+_MODULE_PATH = Path(__file__).resolve()
+if len(_MODULE_PATH.parents) >= 3:
+    REPOSITORY_ROOT = _MODULE_PATH.parents[2]
+    if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
+        sys.path.append(str(REPOSITORY_ROOT))
+
+from services.common.sidecar_runtime_utils import ensure_repository_root_on_path
+
+ensure_repository_root_on_path(__file__)
 
 import tidal_auth as _auth
 import tidal_browse as _browse

--- a/services/ytmusic-streamer/app.py
+++ b/services/ytmusic-streamer/app.py
@@ -22,9 +22,15 @@ import types
 from pathlib import Path
 from typing import Any
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
-    sys.path.append(str(REPOSITORY_ROOT))
+_MODULE_PATH = Path(__file__).resolve()
+if len(_MODULE_PATH.parents) >= 3:
+    REPOSITORY_ROOT = _MODULE_PATH.parents[2]
+    if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
+        sys.path.append(str(REPOSITORY_ROOT))
+
+from services.common.sidecar_runtime_utils import ensure_repository_root_on_path
+
+ensure_repository_root_on_path(__file__)
 
 import ytmusic_album_downloads as _album_downloads
 import ytmusic_auth as _auth

--- a/services/ytmusic-streamer/ytmusic_runtime.py
+++ b/services/ytmusic-streamer/ytmusic_runtime.py
@@ -8,17 +8,22 @@ from typing import Any
 
 from fastapi import Depends, FastAPI
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
-    sys.path.append(str(REPOSITORY_ROOT))
+_MODULE_PATH = Path(__file__).resolve()
+if len(_MODULE_PATH.parents) >= 3:
+    REPOSITORY_ROOT = _MODULE_PATH.parents[2]
+    if (REPOSITORY_ROOT / "services").is_dir() and str(REPOSITORY_ROOT) not in sys.path:
+        sys.path.append(str(REPOSITORY_ROOT))
 
 from services.common.logging_utils import configure_service_logger
 from services.common.sidecar_runtime_utils import (
+    ensure_repository_root_on_path,
     install_urllib3_pool_warning_throttle,
     register_error_handlers,
     require_internal_secret,
     sanitized_http_error,
 )
+
+ensure_repository_root_on_path(__file__)
 
 JsonObject = dict[str, Any]
 JsonList = list[JsonObject]


### PR DESCRIPTION
## Problem

Both the TIDAL and YouTube Music sidecars crash-loop on `main-1c372bd` in production. The app.py decomposition (#829) added, at import time:

```python
REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
```

In the repo tree (`services/<sidecar>/app.py`) that's the repo root, appended to `sys.path` so `services.common` imports resolve in tests. In the container the entrypoint is `/app/app.py` — two ancestors — so `parents[2]` raises `IndexError` before the app loads. CI never caught it because every test runs from the repo layout; containers copy `services/common` under `/app`, where the append is unnecessary anyway. Three sites: tidal `app.py`, ytmusic `app.py`, `ytmusic_runtime.py`.

Homelab is currently mitigated by a sidecar-only rollback to `main-d672f48` (BonzTM/homelab#1485); this is the fix-forward.

## Fix

`ensure_repository_root_on_path(module_file)` in `services/common/sidecar_runtime_utils.py`: resolves the module path, returns without touching `sys.path` when the path has fewer than three ancestors (container layout) or when the candidate root has no `services/` directory; appends once otherwise. Each entrypoint keeps a minimal identical inline bootstrap for the chicken-and-egg window before `services.common` is importable, then calls the shared helper (the tested contract).

## Verification

- verify: differential container simulation — `/app`-bound layout (2 ancestors) with the **old** entrypoint reproduces `IndexError: 2`; with this branch both sidecars import past the probe cleanly
- verify: new behavioral tests exit 0 (`5 passed`) — shallow path no-op, deep path appends once, no duplicate append, no-services-dir no-op
- verify: full tidal suite `187 passed`; full ytmusic suite `309 passed`
- verify: ruff check + format clean; prettier (CHANGELOG) clean