### PR TITLE
chore(downloads): decompose simpleDownloadManager along its natural seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Download retries, stale-job cleanup, Lidarr queue reconciliation, and notification delivery now use focused internal modules without changing the manager's public behavior (#790).
 - Lidarr album acquisition, discovery tags, and reconciliation now use focused internal modules without changing the service API or download behavior (#790).
 - The full-screen player's swipe gestures (track skip, swipe-down to close, drawer handle) now run through one tested gesture module, in preparation for further player decomposition.
 - The full-screen player's Up Next list now renders only the rows in view, so very large queues open and scroll smoothly, and the Queue, Lyrics, and Related panels fetch their data independently so an open player does less background work.

--- a/backend/src/routes/__tests__/webhooksGrabConcurrency.test.ts
+++ b/backend/src/routes/__tests__/webhooksGrabConcurrency.test.ts
@@ -21,14 +21,17 @@ jest.mock("../../workers/queues", () => ({
 
 jest.mock("axios");
 
-jest.mock("../../utils/logger", () => ({
-    logger: {
+jest.mock("../../utils/logger", () => {
+    const mockLogger = {
         debug: jest.fn(),
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
-    },
-}));
+        child: jest.fn(),
+    };
+    mockLogger.child.mockReturnValue(mockLogger);
+    return { logger: mockLogger };
+});
 
 jest.mock("../../config", () => ({
     config: {

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -59,6 +59,11 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/downloadDispatcher.ts` | Configured-source album download dispatch (policy resolution and provider routing) |
 | `backend/src/services/downloadArtistMbid.ts` | Artist-MBID reuse and MusicBrainz fallback for manager-backed album downloads |
 | `backend/src/services/downloadJobStatus.ts` | Shared download-job status transitions and guarded metadata patch writes |
+| `backend/src/services/download/albumRetryStrategy.ts` | Same-artist fallback decisions and retry orchestration |
+| `backend/src/services/download/downloadJobEvents.ts` | Closed typed download-job notification event vocabulary |
+| `backend/src/services/download/downloadJobNotificationSubscriber.ts` | Notification-policy subscriber and delivery side effects |
+| `backend/src/services/download/lidarrQueueReconciler.ts` | Snapshot-based Lidarr library and queue reconciliation |
+| `backend/src/services/download/staleDownloadSweeper.ts` | Time-window-based stale download cleanup |
 | `backend/src/services/embeddingSpaceLifecycle.ts` | Blue/green embedding-space cutover and retirement cleanup |
 | `backend/src/services/embeddingSpaces.ts` | Provider-space registry resolution, active cache, and worker target |
 | `backend/src/services/enrichment.ts` | Enrichment settings and compatibility facade over shared metadata field rules |

--- a/backend/src/services/__tests__/simpleDownloadManager.test.ts
+++ b/backend/src/services/__tests__/simpleDownloadManager.test.ts
@@ -18,6 +18,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -940,6 +946,63 @@ describe("simpleDownloadManager", () => {
         ).not.toHaveBeenCalled();
     });
 
+    it("onDownloadComplete preserves null artistId and runs completion checks after a subscriber throws", async () => {
+        mockPrisma.$transaction.mockImplementationOnce(
+            async (operation: (tx: any) => Promise<any>) => {
+                const tx = makeTx();
+                tx.downloadJob.findFirst.mockResolvedValueOnce(null);
+                tx.downloadJob.findMany.mockResolvedValueOnce([
+                    {
+                        id: "job-emitter-failure",
+                        userId: "user-1",
+                        subject: "Artist - Album",
+                        status: "processing",
+                        lidarrRef: "dl-emitter-failure",
+                        targetMbid: "mbid-emitter-failure",
+                        discoveryBatchId: "batch-emitter-failure",
+                        metadata: {
+                            artistName: "Artist",
+                            albumTitle: "Album",
+                            artistId: null,
+                            spotifyImportJobId: "spotify-emitter-failure",
+                        },
+                    },
+                ]);
+                return operation(tx);
+            },
+        );
+        const unsubscribe = (simpleDownloadManager as any).downloadJobEvents.on(
+            "download.completed",
+            async () => {
+                throw new Error("subscriber failed");
+            },
+        );
+
+        try {
+            await expect(
+                simpleDownloadManager.onDownloadComplete(
+                    "dl-emitter-failure",
+                    "mbid-emitter-failure",
+                    "Artist",
+                    "Album",
+                ),
+            ).resolves.toEqual(
+                expect.objectContaining({ jobId: "job-emitter-failure" }),
+            );
+        } finally {
+            unsubscribe();
+        }
+        expect(
+            mockNotificationService.notifyDownloadComplete,
+        ).toHaveBeenCalledWith("user-1", "Artist - Album", undefined, null);
+        expect(
+            mockDiscoverWeeklyService.checkBatchCompletion,
+        ).toHaveBeenCalledWith("batch-emitter-failure");
+        expect(
+            mockSpotifyImportService.checkImportCompletion,
+        ).toHaveBeenCalledWith("spotify-emitter-failure");
+    });
+
     it("onImportFailed records failure and removes queue item for retry", async () => {
         mockPrisma.$transaction.mockImplementationOnce(
             async (operation: (tx: any) => Promise<any>) => {
@@ -970,48 +1033,6 @@ describe("simpleDownloadManager", () => {
             "dl-fail-1",
             false,
         );
-    });
-
-    it("markStaleJobsAsFailed updates stale pending jobs in batch", async () => {
-        const staleDate = new Date(Date.now() - 11 * 60 * 1000);
-        const freshDate = new Date(Date.now() - 1 * 60 * 1000);
-
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "pending-stale",
-                status: "pending",
-                discoveryBatchId: "batch-pending-1",
-                createdAt: staleDate,
-            },
-            {
-                id: "pending-fresh",
-                status: "pending",
-                createdAt: freshDate,
-            },
-            {
-                id: "pending-queue-owned",
-                status: "pending",
-                createdAt: staleDate,
-                metadata: { queuedVia: "album-download-queue" },
-            },
-        ]);
-        mockPrisma.downloadJob.updateMany.mockResolvedValueOnce({ count: 1 });
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed();
-
-        expect(count).toBe(1);
-        expect(mockPrisma.downloadJob.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: { in: ["pending-stale"] } },
-                data: expect.objectContaining({
-                    status: "failed",
-                    error: "Download never started - timed out",
-                }),
-            }),
-        );
-        expect(
-            mockDiscoverWeeklyService.checkBatchCompletion,
-        ).toHaveBeenCalledWith("batch-pending-1");
     });
 
     it("clears failed Lidarr queue items and triggers album search", async () => {
@@ -1202,494 +1223,6 @@ describe("simpleDownloadManager", () => {
                 }),
             }),
         );
-    });
-
-    it("tryNextAlbumFromArtist marks job exhausted when no artist MBID is available", async () => {
-        const job = {
-            id: "job-no-artist",
-            userId: "user-no-artist",
-            subject: "Unknown - Missing Album",
-            metadata: {
-                artistName: "Unknown",
-            },
-        };
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-no-artist",
-            });
-
-        try {
-            const result = await (
-                simpleDownloadManager as any
-            ).tryNextAlbumFromArtist(job, "missing artist mbid");
-
-            expect(result).toEqual({
-                retried: false,
-                failed: true,
-                jobId: "job-no-artist",
-            });
-            expect(markSpy).toHaveBeenCalledWith(job, "missing artist mbid");
-        } finally {
-            markSpy.mockRestore();
-        }
-    });
-
-    it("tryNextAlbumFromArtist skips fallback for spotify import jobs and triggers import completion", async () => {
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-spotify-1",
-            });
-
-        const spotifyJob = {
-            id: "job-spotify-1",
-            userId: "user-1",
-            subject: "Artist - Exact Album",
-            metadata: {
-                artistName: "Artist",
-                spotifyImportJobId: "spotify-import-1",
-            },
-        };
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(spotifyJob, "exact album unavailable");
-
-        expect(result).toEqual({
-            retried: false,
-            failed: true,
-            jobId: "job-spotify-1",
-        });
-        expect(markSpy).toHaveBeenCalledWith(
-            spotifyJob,
-            "exact album unavailable",
-        );
-        expect(
-            mockSpotifyImportService.checkImportCompletion,
-        ).toHaveBeenCalledWith("spotify-import-1");
-        markSpy.mockRestore();
-    });
-
-    it("tryNextAlbumFromArtist marks the job exhausted if Lidarr album lookup fails", async () => {
-        const job = {
-            id: "job-fallback-error",
-            userId: "user-err",
-            targetMbid: "mbid-current",
-            artistMbid: "artist-mbid-err",
-            subject: "Artist Err - Album Err",
-            metadata: {
-                artistName: "Artist Err",
-                artistMbid: "artist-mbid-err",
-            },
-        };
-
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-fallback-error",
-            });
-
-        try {
-            mockLidarrService.getArtistAlbums.mockRejectedValueOnce(
-                new Error("Lidarr unavailable"),
-            );
-
-            const result = await (
-                simpleDownloadManager as any
-            ).tryNextAlbumFromArtist(job, "lidarr unavailable");
-
-            expect(result).toEqual({
-                retried: false,
-                failed: true,
-                jobId: "job-fallback-error",
-            });
-            expect(markSpy).toHaveBeenCalledWith(job, "lidarr unavailable");
-        } finally {
-            markSpy.mockRestore();
-        }
-    });
-
-    it("tryNextAlbumFromArtist creates a same-artist fallback job and starts it", async () => {
-        const startSpy = jest
-            .spyOn(simpleDownloadManager, "startDownload")
-            .mockResolvedValue({
-                success: true,
-                correlationId: "corr-fallback",
-            } as any);
-
-        mockLidarrService.getArtistAlbums.mockResolvedValueOnce([
-            {
-                id: 301,
-                title: "Already Tried",
-                foreignAlbumId: "mbid-tried",
-                albumType: "album",
-            },
-            {
-                id: 302,
-                title: "Next Studio Album",
-                foreignAlbumId: "mbid-next",
-                albumType: "album",
-            },
-        ] as any);
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            { id: "job-old", targetMbid: "mbid-tried" },
-        ]);
-        mockPrisma.downloadJob.create.mockResolvedValueOnce({
-            id: "job-fallback-1",
-        });
-
-        const job = {
-            id: "job-base-1",
-            userId: "user-1",
-            targetMbid: "mbid-current",
-            artistMbid: "artist-mbid-1",
-            subject: "Artist - Current Album",
-            metadata: {
-                artistName: "Artist",
-                artistMbid: "artist-mbid-1",
-                downloadType: "library",
-            },
-        };
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(job, "album exhausted");
-
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-base-1" },
-                data: expect.objectContaining({
-                    status: "exhausted",
-                }),
-            }),
-        );
-        expect(mockPrisma.downloadJob.create).toHaveBeenCalledWith(
-            expect.objectContaining({
-                data: expect.objectContaining({
-                    targetMbid: "mbid-next",
-                    metadata: expect.objectContaining({
-                        sameArtistFallback: true,
-                        albumTitle: "Next Studio Album",
-                    }),
-                }),
-            }),
-        );
-        expect(startSpy).toHaveBeenCalledWith(
-            "job-fallback-1",
-            "Artist",
-            "Next Studio Album",
-            "mbid-next",
-            "user-1",
-        );
-        expect(result).toEqual({
-            retried: true,
-            failed: false,
-            jobId: "job-fallback-1",
-        });
-        startSpy.mockRestore();
-    });
-
-    it("reconcileWithLidarr completes jobs via MBID, lidarr MBID fallback, and parsed subject matching", async () => {
-        const snapshot = {
-            queue: new Map<string, any>(),
-        } as any;
-
-        const oldDate = new Date(Date.now() - 8 * 60 * 1000);
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-rec-1",
-                status: "processing",
-                targetMbid: "mbid-1",
-                subject: "Artist One - Album One",
-                discoveryBatchId: "batch-rec-1",
-                createdAt: new Date(),
-                metadata: {
-                    artistName: "Artist One",
-                    albumTitle: "Album One",
-                    albumMbid: "mbid-1",
-                },
-            },
-            {
-                id: "job-rec-2",
-                status: "processing",
-                targetMbid: "orig-2",
-                subject: "Artist Two - Album Two",
-                discoveryBatchId: null,
-                createdAt: new Date(),
-                metadata: {
-                    artistName: "Artist Two",
-                    albumTitle: "Album Two",
-                    albumMbid: "orig-2",
-                    lidarrMbid: "lidarr-2",
-                },
-            },
-            {
-                id: "job-rec-3",
-                status: "processing",
-                targetMbid: null,
-                subject: "Artist Three - Album Three",
-                discoveryBatchId: "batch-rec-3",
-                createdAt: new Date(),
-                metadata: {},
-            },
-            {
-                id: "job-rec-4",
-                status: "processing",
-                targetMbid: "mbid-missing",
-                subject: "Artist Four - Album Four",
-                discoveryBatchId: null,
-                createdAt: oldDate,
-                metadata: {
-                    artistName: "Artist Four",
-                    albumTitle: "Album Four",
-                },
-            },
-        ]);
-        mockLidarrService.isAlbumAvailableInSnapshot.mockImplementation(
-            (
-                _snapshot: any,
-                mbid?: string,
-                artist?: string,
-                album?: string,
-            ) => {
-                if (mbid === "mbid-1") return true;
-                if (mbid === "lidarr-2") return true;
-                if (artist === "Artist Three" && album === "Album Three") {
-                    return true;
-                }
-                return false;
-            },
-        );
-
-        const result =
-            await simpleDownloadManager.reconcileWithLidarr(snapshot);
-
-        expect(result.reconciled).toBe(3);
-        expect(result.errors).toEqual([]);
-        expect(result.snapshot).toBe(snapshot);
-        expect(mockPrisma.downloadJob.updateMany).toHaveBeenCalledWith({
-            where: { id: { in: ["job-rec-1", "job-rec-2", "job-rec-3"] } },
-            data: {
-                status: "completed",
-                completedAt: expect.any(Date),
-                error: null,
-            },
-        });
-        expect(
-            mockDiscoverWeeklyService.checkBatchCompletion,
-        ).toHaveBeenCalledWith("batch-rec-1");
-        expect(
-            mockDiscoverWeeklyService.checkBatchCompletion,
-        ).toHaveBeenCalledWith("batch-rec-3");
-    });
-
-    it("reconcileWithLidarr skips processing when no snapshot is available", async () => {
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-rec-skip",
-                status: "processing",
-                subject: "Artist - Album",
-                metadata: {},
-            },
-        ]);
-
-        const result =
-            await simpleDownloadManager.reconcileWithLidarr(undefined);
-
-        expect(result).toEqual({ reconciled: 0, errors: [] });
-        expect(mockPrisma.downloadJob.updateMany).not.toHaveBeenCalled();
-    });
-
-    it("syncWithLidarrQueue handles reset, increment, replacement, completion, and failure transitions", async () => {
-        const snapshot = {
-            queue: new Map<string, any>([
-                [
-                    "dl-found-1",
-                    {
-                        downloadId: "dl-found-1",
-                        title: "Artist One - Album One",
-                    },
-                ],
-                [
-                    "dl-replacement-3",
-                    {
-                        downloadId: "dl-replacement-3",
-                        title: "Artist Three - Album Three WEB",
-                    },
-                ],
-            ]),
-        } as any;
-
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-sync-1",
-                status: "processing",
-                lidarrRef: "dl-found-1",
-                targetMbid: "mbid-one",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist One",
-                    albumTitle: "Album One",
-                    queueSyncMissingCount: 2,
-                },
-            },
-            {
-                id: "job-sync-2",
-                status: "processing",
-                lidarrRef: "dl-missing-2",
-                targetMbid: "mbid-two",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Two",
-                    albumTitle: "Album Two",
-                    queueSyncMissingCount: 1,
-                },
-            },
-            {
-                id: "job-sync-3",
-                status: "processing",
-                lidarrRef: "dl-missing-3",
-                targetMbid: "mbid-three",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Three",
-                    albumTitle: "Album Three",
-                    queueSyncMissingCount: 2,
-                },
-            },
-            {
-                id: "job-sync-4",
-                status: "processing",
-                lidarrRef: "dl-missing-4",
-                targetMbid: "mbid-available",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Four",
-                    albumTitle: "Album Four",
-                    queueSyncMissingCount: 2,
-                },
-            },
-            {
-                id: "job-sync-5",
-                status: "processing",
-                lidarrRef: "dl-missing-5",
-                targetMbid: "mbid-fail",
-                discoveryBatchId: "batch-sync-5",
-                metadata: {
-                    artistName: "Artist Five",
-                    albumTitle: "Album Five",
-                    queueSyncMissingCount: 2,
-                },
-            },
-        ]);
-        mockLidarrService.isAlbumAvailableInSnapshot.mockImplementation(
-            (_snapshot: any, mbid?: string) => mbid === "mbid-available",
-        );
-
-        const result =
-            await simpleDownloadManager.syncWithLidarrQueue(snapshot);
-
-        expect(result).toEqual({ cancelled: 2, errors: [] });
-        expect(mockPrisma.downloadJob.findUnique).not.toHaveBeenCalled();
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-sync-1" },
-                data: expect.objectContaining({
-                    metadata: expect.objectContaining({
-                        queueSyncMissingCount: 0,
-                        lastQueueSyncFound: expect.any(String),
-                    }),
-                }),
-            }),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-sync-2" },
-                data: expect.objectContaining({
-                    metadata: expect.objectContaining({
-                        queueSyncMissingCount: 2,
-                        lastQueueSyncCheck: expect.any(String),
-                    }),
-                }),
-            }),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-sync-3" },
-                data: expect.objectContaining({
-                    lidarrRef: "dl-replacement-3",
-                    metadata: expect.objectContaining({
-                        previousDownloadId: "dl-missing-3",
-                        replacementDetected: true,
-                        queueSyncMissingCount: 0,
-                    }),
-                }),
-            }),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-sync-4" },
-                data: expect.objectContaining({
-                    status: "completed",
-                    metadata: expect.objectContaining({
-                        queueSyncCompleted: true,
-                    }),
-                }),
-            }),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-sync-5" },
-                data: expect.objectContaining({
-                    status: "failed",
-                    lidarrRef: null,
-                    metadata: expect.objectContaining({
-                        queueSyncCancelled: true,
-                        queueSyncMissingCount: 3,
-                    }),
-                }),
-            }),
-        );
-        expect(
-            mockDiscoverWeeklyService.checkBatchCompletion,
-        ).toHaveBeenCalledWith("batch-sync-5");
-    });
-
-    it("syncWithLidarrQueue returns errors when update processing fails", async () => {
-        const snapshot = {
-            queue: new Map<string, any>(),
-        } as any;
-
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-sync-fail",
-                status: "processing",
-                lidarrRef: "dl-missing",
-                targetMbid: "mbid-fail",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist",
-                    albumTitle: "Album",
-                    queueSyncMissingCount: 2,
-                },
-            },
-        ]);
-        mockLidarrService.isAlbumAvailableInSnapshot.mockReturnValue(false);
-        mockPrisma.downloadJob.update.mockRejectedValueOnce(
-            new Error("write failed"),
-        );
-
-        const result =
-            await simpleDownloadManager.syncWithLidarrQueue(snapshot);
-
-        expect(result).toEqual({ cancelled: 0, errors: ["write failed"] });
     });
 
     it("blocklistAndRetry and removeFromLidarrQueue clean up matching queue entries", async () => {
@@ -2183,169 +1716,6 @@ describe("simpleDownloadManager", () => {
         expect(mockLidarrService.blocklistAndRemove).not.toHaveBeenCalled();
     });
 
-    it("tryNextAlbumFromArtist skips fallback for discovery jobs", async () => {
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-discovery-fallback-skip",
-            });
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(
-            {
-                id: "job-discovery-fallback-skip",
-                discoveryBatchId: "batch-discovery",
-                metadata: {
-                    artistName: "Discovery Artist",
-                    artistMbid: "artist-discovery",
-                },
-            },
-            "discovery diversity",
-        );
-
-        expect(result).toEqual({
-            retried: false,
-            failed: true,
-            jobId: "job-discovery-fallback-skip",
-        });
-        expect(markSpy).toHaveBeenCalledWith(
-            expect.objectContaining({ id: "job-discovery-fallback-skip" }),
-            "discovery diversity",
-        );
-        markSpy.mockRestore();
-    });
-
-    it("tryNextAlbumFromArtist marks exhausted when Lidarr returns no albums", async () => {
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-no-lidarr-albums",
-            });
-        mockLidarrService.getArtistAlbums.mockResolvedValueOnce([]);
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(
-            {
-                id: "job-no-lidarr-albums",
-                targetMbid: "mbid-current",
-                artistMbid: "artist-no-albums",
-                metadata: {
-                    artistName: "No Albums Artist",
-                    artistMbid: "artist-no-albums",
-                },
-            },
-            "no albums in lidarr",
-        );
-
-        expect(result).toEqual({
-            retried: false,
-            failed: true,
-            jobId: "job-no-lidarr-albums",
-        });
-        expect(markSpy).toHaveBeenCalledWith(
-            expect.objectContaining({ id: "job-no-lidarr-albums" }),
-            "no albums in lidarr",
-        );
-        markSpy.mockRestore();
-    });
-
-    it("tryNextAlbumFromArtist marks exhausted when all candidate albums were already tried", async () => {
-        const markSpy = jest
-            .spyOn(simpleDownloadManager as any, "markJobExhausted")
-            .mockResolvedValue({
-                retried: false,
-                failed: true,
-                jobId: "job-all-tried",
-            });
-        mockLidarrService.getArtistAlbums.mockResolvedValueOnce([
-            {
-                id: 12,
-                title: "Already Tried Album",
-                foreignAlbumId: "mbid-current",
-                albumType: "album",
-            },
-        ] as any);
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([]);
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(
-            {
-                id: "job-all-tried",
-                targetMbid: "mbid-current",
-                artistMbid: "artist-all-tried",
-                userId: "user-all-tried",
-                metadata: {
-                    artistName: "All Tried Artist",
-                    artistMbid: "artist-all-tried",
-                },
-            },
-            "all albums exhausted",
-        );
-
-        expect(result).toEqual({
-            retried: false,
-            failed: true,
-            jobId: "job-all-tried",
-        });
-        expect(markSpy).toHaveBeenCalledWith(
-            expect.objectContaining({ id: "job-all-tried" }),
-            "all albums exhausted",
-        );
-        markSpy.mockRestore();
-    });
-
-    it("tryNextAlbumFromArtist returns failed when fallback job cannot start", async () => {
-        const startSpy = jest
-            .spyOn(simpleDownloadManager, "startDownload")
-            .mockResolvedValue({
-                success: false,
-                error: "start failed",
-            } as any);
-        mockLidarrService.getArtistAlbums.mockResolvedValueOnce([
-            {
-                id: 77,
-                title: "Fallback Album",
-                foreignAlbumId: "mbid-fallback",
-                albumType: "album",
-            },
-        ] as any);
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([]);
-        mockPrisma.downloadJob.create.mockResolvedValueOnce({
-            id: "job-fallback-start-fail",
-        });
-
-        const result = await (
-            simpleDownloadManager as any
-        ).tryNextAlbumFromArtist(
-            {
-                id: "job-base-start-fail",
-                userId: "user-base-start-fail",
-                targetMbid: "mbid-original",
-                artistMbid: "artist-fallback-fail",
-                subject: "Artist - Original Album",
-                metadata: {
-                    artistName: "Artist",
-                    artistMbid: "artist-fallback-fail",
-                },
-            },
-            "retry different album",
-        );
-
-        expect(result).toEqual({
-            retried: false,
-            failed: true,
-            jobId: "job-fallback-start-fail",
-        });
-        startSpy.mockRestore();
-    });
-
     it("markJobExhausted suppresses notifications when policy blocks them", async () => {
         mockPrisma.downloadJob.findFirst.mockResolvedValueOnce(null);
         mockNotificationPolicyService.evaluateNotification.mockResolvedValueOnce(
@@ -2407,217 +1777,6 @@ describe("simpleDownloadManager", () => {
         ).not.toHaveBeenCalled();
     });
 
-    it("markStaleJobsAsFailed extends timeout for active Lidarr downloads", async () => {
-        const oldStartedAt = new Date(
-            Date.now() - 20 * 60 * 1000,
-        ).toISOString();
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-stale-active-download",
-                status: "processing",
-                lidarrRef: "dl-active",
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    artistName: "Artist",
-                    albumTitle: "Album",
-                    startedAt: oldStartedAt,
-                },
-            },
-        ]);
-        mockLidarrService.isDownloadActiveInSnapshot.mockReturnValueOnce({
-            active: true,
-            progress: 63,
-        } as any);
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed({
-            queue: new Map(),
-        } as any);
-
-        expect(count).toBe(0);
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-stale-active-download" },
-                data: {
-                    metadata: expect.objectContaining({
-                        extendedTimeout: true,
-                    }),
-                },
-            }),
-        );
-    });
-
-    it("markStaleJobsAsFailed handles policy timeout extension and duplicate-completion merge", async () => {
-        const oldStartedAt = new Date(
-            Date.now() - 20 * 60 * 1000,
-        ).toISOString();
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-policy-extend",
-                status: "processing",
-                lidarrRef: null,
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    artistName: "Artist One",
-                    albumTitle: "Album One",
-                    startedAt: oldStartedAt,
-                },
-            },
-            {
-                id: "job-duplicate-merge",
-                status: "processing",
-                lidarrRef: null,
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    artistName: "Artist Two",
-                    albumTitle: "Album Two",
-                    startedAt: oldStartedAt,
-                },
-            },
-        ]);
-        mockNotificationPolicyService.evaluateNotification
-            .mockResolvedValueOnce({
-                shouldNotify: false,
-                reason: "still in retry window, extending timeout",
-            } as any)
-            .mockRejectedValueOnce(new Error("policy failed"));
-        mockPrisma.downloadJob.findFirst.mockResolvedValueOnce({
-            id: "job-dup-completed",
-            metadata: {
-                artistName: "Artist Two",
-                albumTitle: "Album Two",
-            },
-        });
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed();
-
-        expect(count).toBe(2);
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-policy-extend" },
-                data: {
-                    metadata: expect.objectContaining({
-                        timeoutExtendedByPolicy: true,
-                    }),
-                },
-            }),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "job-duplicate-merge" },
-                data: expect.objectContaining({
-                    status: "completed",
-                    metadata: expect.objectContaining({
-                        mergedWithJob: "job-dup-completed",
-                    }),
-                }),
-            }),
-        );
-    });
-
-    it("markStaleJobsAsFailed starts same-artist fallback for library jobs and checks discovery completion", async () => {
-        const oldStartedAt = new Date(
-            Date.now() - 20 * 60 * 1000,
-        ).toISOString();
-        const fallbackSpy = jest
-            .spyOn(simpleDownloadManager as any, "tryNextAlbumFromArtist")
-            .mockResolvedValueOnce({
-                retried: true,
-                failed: false,
-                jobId: "job-replacement-started",
-            });
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-stale-library",
-                status: "processing",
-                lidarrRef: null,
-                artistMbid: "artist-library",
-                discoveryBatchId: null,
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    artistName: "Artist Library",
-                    albumTitle: "Album Library",
-                    artistMbid: "artist-library",
-                    startedAt: oldStartedAt,
-                },
-            },
-            {
-                id: "job-stale-discovery",
-                status: "processing",
-                lidarrRef: null,
-                artistMbid: null,
-                discoveryBatchId: "batch-stale-discovery",
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    artistName: "Artist Discovery",
-                    albumTitle: "Album Discovery",
-                    startedAt: oldStartedAt,
-                },
-            },
-        ]);
-        mockNotificationPolicyService.evaluateNotification.mockResolvedValue({
-            shouldNotify: false,
-            reason: "policy says no notification",
-        } as any);
-        mockPrisma.downloadJob.findFirst.mockResolvedValue(null);
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed();
-
-        expect(count).toBe(2);
-        expect(fallbackSpy).toHaveBeenCalledTimes(1);
-        expect(fallbackSpy).toHaveBeenCalledWith(
-            expect.objectContaining({ id: "job-stale-library" }),
-            "No sources found - no indexer results",
-        );
-        expect(
-            mockPrisma.downloadJob.update.mock.calls.some(([args]: any) => {
-                return (
-                    args?.where?.id === "job-stale-library" &&
-                    args?.data?.status === "failed"
-                );
-            }),
-        ).toBe(false);
-        expect(
-            mockPrisma.downloadJob.update.mock.calls.some(([args]: any) => {
-                return (
-                    args?.where?.id === "job-stale-discovery" &&
-                    args?.data?.status === "failed"
-                );
-            }),
-        ).toBe(true);
-        expect(
-            mockDiscoverWeeklyService.checkBatchCompletion,
-        ).toHaveBeenCalledWith("batch-stale-discovery");
-        fallbackSpy.mockRestore();
-    });
-
-    it("markStaleJobsAsFailed skips direct Soulseek sources from stale checks", async () => {
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-soulseek-stale",
-                status: "processing",
-                lidarrRef: "dl-soulseek-stale",
-                createdAt: new Date(Date.now() - 20 * 60 * 1000),
-                metadata: {
-                    source: "soulseek_direct",
-                    artistName: "Soulseek Artist",
-                    albumTitle: "Soulseek Album",
-                    startedAt: new Date(
-                        Date.now() - 20 * 60 * 1000,
-                    ).toISOString(),
-                },
-            },
-        ]);
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed();
-
-        expect(count).toBe(0);
-        expect(mockPrisma.downloadJob.update).not.toHaveBeenCalled();
-        expect(mockPrisma.downloadJob.updateMany).not.toHaveBeenCalled();
-        expect(
-            mockNotificationPolicyService.evaluateNotification,
-        ).not.toHaveBeenCalled();
-    });
-
     it("clearLidarrQueue returns configuration error when Lidarr settings are missing", async () => {
         mockLidarrService.clearFailedQueue.mockResolvedValueOnce({
             removed: 0,
@@ -2630,45 +1789,6 @@ describe("simpleDownloadManager", () => {
             removed: 0,
             errors: ["Lidarr not configured"],
         });
-    });
-
-    it("reconcileWithLidarr returns quickly when there are no processing jobs", async () => {
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([]);
-
-        const result = await simpleDownloadManager.reconcileWithLidarr({
-            queue: new Map(),
-        } as any);
-
-        expect(result).toEqual({ reconciled: 0, errors: [] });
-    });
-
-    it("syncWithLidarrQueue returns quickly when there are no processing jobs", async () => {
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([]);
-
-        const result = await simpleDownloadManager.syncWithLidarrQueue({
-            queue: new Map(),
-        } as any);
-
-        expect(result).toEqual({ cancelled: 0, errors: [] });
-    });
-
-    it("syncWithLidarrQueue skips processing when snapshot is unavailable", async () => {
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-sync-no-snapshot",
-                status: "processing",
-                lidarrRef: "dl-sync-no-snapshot",
-                metadata: {
-                    artistName: "Artist",
-                    albumTitle: "Album",
-                },
-            },
-        ]);
-
-        const result =
-            await simpleDownloadManager.syncWithLidarrQueue(undefined);
-
-        expect(result).toEqual({ cancelled: 0, errors: [] });
     });
 
     it("falls back to default retry attempts when user settings fetch fails", async () => {

--- a/backend/src/services/__tests__/simpleDownloadManagerBranchCoverage.test.ts
+++ b/backend/src/services/__tests__/simpleDownloadManagerBranchCoverage.test.ts
@@ -12,6 +12,12 @@ jest.mock("../../utils/logger", () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        child: jest.fn(() => ({
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        })),
     },
 }));
 
@@ -419,135 +425,6 @@ describe("simpleDownloadManager branch coverage", () => {
 
         expect(result.jobId).toBe("job-no-notify");
         expect(mockPrisma.downloadJob.update).not.toHaveBeenCalled();
-    });
-
-    it("logs spotify cleanup context and marks stale import as failed", async () => {
-        const oldDate = new Date(Date.now() - 20 * 60 * 1000);
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "spotify_stale_1",
-                status: "processing",
-                lidarrRef: "dl-stale-spotify",
-                lidarrAlbumId: 1001,
-                createdAt: oldDate,
-                artistMbid: null,
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Spotify",
-                    albumTitle: "Album Spotify",
-                    startedAt: oldDate.toISOString(),
-                },
-            },
-        ]);
-        mockNotificationPolicyService.evaluateNotification.mockResolvedValueOnce(
-            {
-                shouldNotify: false,
-                reason: "no timeout extension",
-            } as any,
-        );
-        mockPrisma.downloadJob.findFirst.mockResolvedValueOnce(null);
-
-        const result = await simpleDownloadManager.markStaleJobsAsFailed({
-            queue: new Map(),
-        } as any);
-
-        expect(result).toBe(1);
-        expect(mockSessionLog).toHaveBeenCalledWith(
-            "CLEANUP",
-            expect.stringContaining("Spotify import"),
-        );
-        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: { id: "spotify_stale_1" },
-                data: expect.objectContaining({ status: "failed" }),
-            }),
-        );
-    });
-
-    it("calls blocklistAndRetry for stale jobs that still have lidarr refs", async () => {
-        const oldDate = new Date(Date.now() - 20 * 60 * 1000);
-        const blocklistSpy = jest
-            .spyOn(simpleDownloadManager as any, "blocklistAndRetry")
-            .mockResolvedValue(undefined);
-        const fallbackSpy = jest
-            .spyOn(simpleDownloadManager as any, "tryNextAlbumFromArtist")
-            .mockResolvedValue({ retried: false, failed: true, jobId: "x" });
-
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-stale-lidarr-ref",
-                status: "processing",
-                lidarrRef: "dl-stale-lidarr-ref",
-                lidarrAlbumId: 501,
-                createdAt: oldDate,
-                artistMbid: "artist-ref",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Ref",
-                    albumTitle: "Album Ref",
-                    startedAt: oldDate.toISOString(),
-                },
-            },
-        ]);
-        mockNotificationPolicyService.evaluateNotification.mockResolvedValueOnce(
-            {
-                shouldNotify: false,
-                reason: "timeout fail",
-            } as any,
-        );
-        mockPrisma.downloadJob.findFirst.mockResolvedValueOnce(null);
-
-        await simpleDownloadManager.markStaleJobsAsFailed({
-            queue: new Map(),
-        } as any);
-
-        expect(blocklistSpy).toHaveBeenCalledWith("dl-stale-lidarr-ref");
-        blocklistSpy.mockRestore();
-        fallbackSpy.mockRestore();
-    });
-
-    it("marks stale job failed when same-artist fallback throws", async () => {
-        const oldDate = new Date(Date.now() - 20 * 60 * 1000);
-        const fallbackSpy = jest
-            .spyOn(simpleDownloadManager as any, "tryNextAlbumFromArtist")
-            .mockRejectedValue(new Error("fallback crash"));
-
-        mockPrisma.downloadJob.findMany.mockResolvedValueOnce([
-            {
-                id: "job-stale-fallback-throws",
-                status: "processing",
-                lidarrRef: null,
-                createdAt: oldDate,
-                artistMbid: "artist-throws",
-                discoveryBatchId: null,
-                metadata: {
-                    artistName: "Artist Throws",
-                    albumTitle: "Album Throws",
-                    batchId: "download-batch-throws",
-                    startedAt: oldDate.toISOString(),
-                },
-            },
-        ]);
-        mockNotificationPolicyService.evaluateNotification.mockResolvedValueOnce(
-            {
-                shouldNotify: false,
-                reason: "no extension",
-            } as any,
-        );
-        mockPrisma.downloadJob.findFirst.mockResolvedValueOnce(null);
-
-        const count = await simpleDownloadManager.markStaleJobsAsFailed();
-
-        expect(count).toBe(1);
-        expect(
-            mockPrisma.downloadJob.update.mock.calls.some(([args]: any[]) => {
-                return (
-                    args?.where?.id === "job-stale-fallback-throws" &&
-                    args?.data?.status === "failed"
-                );
-            }),
-        ).toBe(true);
-        fallbackSpy.mockRestore();
     });
 
     it("blocklistAndRetry handles queue lookup errors", async () => {

--- a/backend/src/services/download/__tests__/albumRetryStrategy.test.ts
+++ b/backend/src/services/download/__tests__/albumRetryStrategy.test.ts
@@ -1,0 +1,379 @@
+import {
+    decideAlbumRetry,
+    selectNextAlbum,
+    tryNextAlbumFromArtist,
+} from "../albumRetryStrategy";
+import { prisma } from "../../../utils/db";
+import { lidarrService } from "../../lidarr";
+import { getSystemSettings } from "../../../utils/systemSettings";
+import { spotifyImportService } from "../../spotifyImport";
+
+jest.mock("../../../config", () => ({
+    config: { music: { musicPath: "/music" } },
+}));
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findMany: jest.fn(),
+            update: jest.fn(),
+            create: jest.fn(),
+        },
+    },
+}));
+jest.mock("../../../utils/logger", () => ({
+    logger: { debug: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../../../utils/systemSettings", () => ({
+    getSystemSettings: jest.fn(),
+}));
+jest.mock("../../lidarr", () => ({
+    lidarrService: { getArtistAlbums: jest.fn() },
+}));
+jest.mock("../../spotifyImport", () => ({
+    spotifyImportService: { checkImportCompletion: jest.fn() },
+}));
+
+describe("albumRetryStrategy decisions", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test.each([
+        [
+            "discovery jobs",
+            { discoveryBatchId: "batch-1", metadata: { artistMbid: "a-1" } },
+            "discovery",
+        ],
+        [
+            "Spotify imports",
+            { metadata: { artistMbid: "a-1", spotifyImportJobId: "import-1" } },
+            "exact-match",
+        ],
+        [
+            "explicit no-fallback jobs",
+            { metadata: { artistMbid: "a-1", noFallback: true } },
+            "exact-match",
+        ],
+        ["jobs without an artist MBID", { metadata: {} }, "missing-artist"],
+    ])("exhausts %s", (_label, job, reason) => {
+        expect(decideAlbumRetry(job as never)).toEqual({
+            kind: "exhaust",
+            reason,
+        });
+    });
+
+    it("searches the resolved artist for ordinary library jobs", () => {
+        expect(
+            decideAlbumRetry({
+                artistMbid: "artist-column",
+                metadata: {
+                    artistMbid: "artist-metadata",
+                    artistName: "The Artist",
+                },
+            } as never),
+        ).toEqual({
+            kind: "search",
+            artistMbid: "artist-column",
+            artistName: "The Artist",
+        });
+    });
+
+    it("prefers an untried studio album and falls back to the first untried release", () => {
+        const releases = [
+            { foreignAlbumId: "tried", title: "Tried", albumType: "Album" },
+            { foreignAlbumId: "single", title: "Single", albumType: "Single" },
+            { foreignAlbumId: "studio", title: "Studio", albumType: "Album" },
+        ];
+
+        expect(selectNextAlbum(releases as never, new Set(["tried"]))).toBe(
+            releases[2],
+        );
+        expect(
+            selectNextAlbum(releases.slice(0, 2) as never, new Set(["tried"])),
+        ).toBe(releases[1]);
+        expect(
+            selectNextAlbum(
+                releases as never,
+                new Set(["tried", "single", "studio"]),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("creates and starts the selected same-artist fallback", async () => {
+        const mockPrisma = prisma as any;
+        const mockLidarr = lidarrService as any;
+        mockLidarr.getArtistAlbums.mockResolvedValue([
+            {
+                id: 2,
+                foreignAlbumId: "next-album",
+                title: "Next Album",
+                albumType: "Album",
+            },
+        ]);
+        mockPrisma.downloadJob.findMany.mockResolvedValue([]);
+        mockPrisma.downloadJob.update.mockResolvedValue({});
+        mockPrisma.downloadJob.create.mockResolvedValue({ id: "fallback-job" });
+        (getSystemSettings as jest.Mock).mockResolvedValue({
+            musicPath: "/configured-music",
+        });
+        const startDownload = jest.fn().mockResolvedValue({ success: true });
+        const markJobExhausted = jest.fn();
+
+        const result = await tryNextAlbumFromArtist(
+            {
+                id: "original-job",
+                userId: "user-1",
+                subject: "Artist - Original",
+                targetMbid: "original-album",
+                artistMbid: "artist-1",
+                discoveryBatchId: null,
+                metadata: { artistName: "Artist" },
+            } as never,
+            "original exhausted",
+            { startDownload, markJobExhausted },
+        );
+
+        expect(result).toEqual({
+            retried: true,
+            failed: false,
+            jobId: "fallback-job",
+        });
+        expect(startDownload).toHaveBeenCalledWith(
+            "fallback-job",
+            "Artist",
+            "Next Album",
+            "next-album",
+            "user-1",
+        );
+        expect(markJobExhausted).not.toHaveBeenCalled();
+    });
+
+    it("persists exhaustion before reading settings and remains exhausted when settings fail", async () => {
+        const mockPrisma = prisma as any;
+        const callOrder: string[] = [];
+        (lidarrService.getArtistAlbums as jest.Mock).mockResolvedValue([
+            {
+                id: 2,
+                foreignAlbumId: "next-album",
+                title: "Next Album",
+                albumType: "Album",
+            },
+        ]);
+        mockPrisma.downloadJob.findMany.mockResolvedValue([]);
+        mockPrisma.downloadJob.update.mockImplementation(async () => {
+            callOrder.push("exhausted");
+            return {};
+        });
+        (getSystemSettings as jest.Mock).mockImplementation(async () => {
+            callOrder.push("settings");
+            throw new Error("settings unavailable");
+        });
+        const markJobExhausted = jest.fn().mockResolvedValue({
+            retried: false,
+            failed: true,
+            jobId: "original-job",
+        });
+
+        await expect(
+            tryNextAlbumFromArtist(
+                {
+                    id: "original-job",
+                    userId: "user-1",
+                    subject: "Artist - Original",
+                    targetMbid: "original-album",
+                    artistMbid: "artist-1",
+                    discoveryBatchId: null,
+                    metadata: { artistName: "Artist" },
+                } as never,
+                "original exhausted",
+                { startDownload: jest.fn(), markJobExhausted },
+            ),
+        ).resolves.toEqual({
+            retried: false,
+            failed: true,
+            jobId: "original-job",
+        });
+        expect(callOrder).toEqual(["exhausted", "settings"]);
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith({
+            where: { id: "original-job" },
+            data: expect.objectContaining({ status: "exhausted" }),
+        });
+    });
+
+    it("checks Spotify import completion after exact-match exhaustion", async () => {
+        const markJobExhausted = jest.fn().mockResolvedValue({
+            retried: false,
+            failed: true,
+            jobId: "spotify-job",
+        });
+        (
+            spotifyImportService.checkImportCompletion as jest.Mock
+        ).mockResolvedValue(undefined);
+
+        await tryNextAlbumFromArtist(
+            makeRetryJob({ spotifyImportJobId: "spotify-import-1" }),
+            "exact album unavailable",
+            { startDownload: jest.fn(), markJobExhausted },
+        );
+
+        expect(spotifyImportService.checkImportCompletion).toHaveBeenCalledWith(
+            "spotify-import-1",
+        );
+    });
+
+    it("exhausts the original job after artist album lookup failure", async () => {
+        (lidarrService.getArtistAlbums as jest.Mock).mockRejectedValue(
+            new Error("lookup failed"),
+        );
+        const markJobExhausted = exhaustedResult();
+
+        await tryNextAlbumFromArtist(makeRetryJob(), "lookup failed", {
+            startDownload: jest.fn(),
+            markJobExhausted,
+        });
+
+        expect(markJobExhausted).toHaveBeenCalledWith(
+            expect.objectContaining({ id: "original-job" }),
+            "lookup failed",
+        );
+    });
+
+    it("exhausts the original job when Lidarr returns no albums", async () => {
+        (lidarrService.getArtistAlbums as jest.Mock).mockResolvedValue([]);
+        const markJobExhausted = exhaustedResult();
+
+        await tryNextAlbumFromArtist(makeRetryJob(), "no albums", {
+            startDownload: jest.fn(),
+            markJobExhausted,
+        });
+
+        expect(markJobExhausted).toHaveBeenCalledTimes(1);
+    });
+
+    it("exhausts the original job when every artist album was tried", async () => {
+        (lidarrService.getArtistAlbums as jest.Mock).mockResolvedValue([
+            {
+                id: 1,
+                foreignAlbumId: "original-album",
+                title: "Original",
+                albumType: "Album",
+            },
+        ]);
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([]);
+        const markJobExhausted = exhaustedResult();
+
+        await tryNextAlbumFromArtist(makeRetryJob(), "all tried", {
+            startDownload: jest.fn(),
+            markJobExhausted,
+        });
+
+        expect(markJobExhausted).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns failure when the fallback download cannot start", async () => {
+        prepareFallbackPersistence();
+        const startDownload = jest.fn().mockResolvedValue({ success: false });
+
+        await expect(
+            tryNextAlbumFromArtist(makeRetryJob(), "retry", {
+                startDownload,
+                markJobExhausted: exhaustedResult(),
+            }),
+        ).resolves.toEqual({
+            retried: false,
+            failed: true,
+            jobId: "fallback-job",
+        });
+    });
+
+    it("persists the original job as exhausted before fallback creation", async () => {
+        prepareFallbackPersistence();
+
+        await tryNextAlbumFromArtist(makeRetryJob(), "retry", {
+            startDownload: jest.fn().mockResolvedValue({ success: true }),
+            markJobExhausted: exhaustedResult(),
+        });
+
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith({
+            where: { id: "original-job" },
+            data: {
+                status: "exhausted",
+                error: "All releases exhausted - trying: Next Album",
+                completedAt: expect.any(Date),
+            },
+        });
+    });
+
+    it("persists the fallback job with the historical metadata payload", async () => {
+        prepareFallbackPersistence();
+
+        await tryNextAlbumFromArtist(
+            makeRetryJob({ downloadType: "manual", rootFolderPath: "/custom" }),
+            "retry",
+            {
+                startDownload: jest.fn().mockResolvedValue({ success: true }),
+                markJobExhausted: exhaustedResult(),
+            },
+        );
+
+        expect(prisma.downloadJob.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                userId: "user-1",
+                subject: "Artist - Next Album",
+                type: "album",
+                targetMbid: "next-album",
+                status: "pending",
+                discoveryBatchId: null,
+                artistMbid: "artist-1",
+                metadata: {
+                    artistName: "Artist",
+                    artistMbid: "artist-1",
+                    albumTitle: "Next Album",
+                    albumMbid: "next-album",
+                    lidarrAlbumId: 2,
+                    sameArtistFallback: true,
+                    originalJobId: "original-job",
+                    downloadType: "manual",
+                    rootFolderPath: "/custom",
+                },
+            }),
+        });
+    });
+
+    function makeRetryJob(metadata: Record<string, unknown> = {}) {
+        return {
+            id: "original-job",
+            userId: "user-1",
+            subject: "Artist - Original",
+            targetMbid: "original-album",
+            artistMbid: "artist-1",
+            discoveryBatchId: null,
+            metadata: { artistName: "Artist", ...metadata },
+        } as never;
+    }
+
+    function exhaustedResult() {
+        return jest.fn().mockResolvedValue({
+            retried: false,
+            failed: true,
+            jobId: "original-job",
+        });
+    }
+
+    function prepareFallbackPersistence(): void {
+        (lidarrService.getArtistAlbums as jest.Mock).mockResolvedValue([
+            {
+                id: 2,
+                foreignAlbumId: "next-album",
+                title: "Next Album",
+                albumType: "Album",
+            },
+        ]);
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([]);
+        (prisma.downloadJob.update as jest.Mock).mockResolvedValue({});
+        (prisma.downloadJob.create as jest.Mock).mockResolvedValue({
+            id: "fallback-job",
+        });
+        (getSystemSettings as jest.Mock).mockResolvedValue({
+            musicPath: "/configured-music",
+        });
+    }
+});

--- a/backend/src/services/download/__tests__/downloadJobEvents.test.ts
+++ b/backend/src/services/download/__tests__/downloadJobEvents.test.ts
@@ -1,0 +1,92 @@
+import { DownloadJobEvents } from "../downloadJobEvents";
+import { logger } from "../../../utils/logger";
+
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        child: jest.fn(() => ({ error: jest.fn() })),
+    },
+}));
+
+const eventLogger = (logger.child as jest.Mock).mock.results[0].value;
+
+describe("DownloadJobEvents", () => {
+    it("publishes only the closed, typed download-job vocabulary", async () => {
+        const events = new DownloadJobEvents();
+        const completed = jest.fn(async () => undefined);
+        const exhausted = jest.fn(async () => undefined);
+        const timedOut = jest.fn(async () => ({ timeoutExtended: true }));
+
+        events.on("download.completed", completed);
+        events.on("download.exhausted", exhausted);
+        events.on("download.timedOut", timedOut);
+
+        await expect(
+            events.emit("download.completed", {
+                jobId: "job-1",
+                userId: "user-1",
+                subject: "Artist - Album",
+                artistId: "artist-1",
+            }),
+        ).resolves.toEqual([undefined]);
+        await expect(
+            events.emit("download.exhausted", {
+                jobId: "job-2",
+                userId: "user-1",
+                subject: "Artist - Missing",
+                reason: "no releases",
+            }),
+        ).resolves.toEqual([undefined]);
+        await expect(
+            events.emit("download.timedOut", {
+                jobId: "job-3",
+                subject: "Artist - Slow Album",
+            }),
+        ).resolves.toEqual([{ timeoutExtended: true }]);
+
+        expect(completed).toHaveBeenCalledTimes(1);
+        expect(exhausted).toHaveBeenCalledTimes(1);
+        expect(timedOut).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops publishing after a listener unsubscribes", async () => {
+        const events = new DownloadJobEvents();
+        const listener = jest.fn(async () => undefined);
+        const unsubscribe = events.on("download.completed", listener);
+
+        unsubscribe();
+        await expect(
+            events.emit("download.completed", {
+                jobId: "job-1",
+                userId: "user-1",
+                subject: "Artist - Album",
+            }),
+        ).resolves.toEqual([]);
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("isolates a throwing subscriber and settles the remaining subscribers", async () => {
+        const events = new DownloadJobEvents();
+        const throwing = jest.fn(async () => {
+            throw new Error("subscriber failed");
+        });
+        const succeeding = jest.fn(async () => ({ timeoutExtended: true }));
+        events.on("download.timedOut", throwing);
+        events.on("download.timedOut", succeeding);
+
+        await expect(
+            events.emit("download.timedOut", {
+                jobId: "job-1",
+                subject: "Artist - Album",
+            }),
+        ).resolves.toEqual([{ timeoutExtended: true }]);
+        expect(throwing).toHaveBeenCalledTimes(1);
+        expect(succeeding).toHaveBeenCalledTimes(1);
+        expect(eventLogger.error).toHaveBeenCalledWith(
+            "Download job event subscriber failed",
+            expect.objectContaining({
+                eventName: "download.timedOut",
+                error: expect.any(Error),
+            }),
+        );
+    });
+});

--- a/backend/src/services/download/__tests__/downloadJobNotificationSubscriber.test.ts
+++ b/backend/src/services/download/__tests__/downloadJobNotificationSubscriber.test.ts
@@ -1,0 +1,112 @@
+import { prisma } from "../../../utils/db";
+import { notificationPolicyService } from "../../notificationPolicyService";
+import { notificationService } from "../../notificationService";
+import { DownloadJobEvents } from "../downloadJobEvents";
+import { registerDownloadJobNotificationSubscriber } from "../downloadJobNotificationSubscriber";
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: { findUnique: jest.fn(), update: jest.fn() },
+    },
+}));
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(() => ({ error: jest.fn() })),
+    },
+}));
+jest.mock("../../notificationPolicyService", () => ({
+    notificationPolicyService: { evaluateNotification: jest.fn() },
+}));
+jest.mock("../../notificationService", () => ({
+    notificationService: {
+        notifyDownloadComplete: jest.fn(),
+        notifyDownloadFailed: jest.fn(),
+    },
+}));
+
+describe("download-job notification subscriber", () => {
+    const mockPolicy = notificationPolicyService as any;
+    const mockNotifications = notificationService as any;
+    const mockPrisma = prisma as any;
+    let events: DownloadJobEvents;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        events = new DownloadJobEvents();
+        registerDownloadJobNotificationSubscriber(events);
+        mockPrisma.downloadJob.findUnique.mockResolvedValue({ metadata: {} });
+        mockPrisma.downloadJob.update.mockResolvedValue({});
+    });
+
+    it("sends and records a policy-approved completion", async () => {
+        mockPolicy.evaluateNotification.mockResolvedValue({
+            shouldNotify: true,
+            reason: "allowed",
+        });
+
+        await events.emit("download.completed", {
+            jobId: "job-1",
+            userId: "user-1",
+            subject: "Artist - Album",
+            artistId: "artist-1",
+        });
+
+        expect(mockPolicy.evaluateNotification).toHaveBeenCalledWith(
+            "job-1",
+            "complete",
+        );
+        expect(mockNotifications.notifyDownloadComplete).toHaveBeenCalledWith(
+            "user-1",
+            "Artist - Album",
+            undefined,
+            "artist-1",
+        );
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "job-1" },
+                data: {
+                    metadata: expect.objectContaining({
+                        notificationSent: true,
+                    }),
+                },
+            }),
+        );
+    });
+
+    it("suppresses an exhausted-job notification when policy denies it", async () => {
+        mockPolicy.evaluateNotification.mockResolvedValue({
+            shouldNotify: false,
+            reason: "batch notification only",
+        });
+
+        await events.emit("download.exhausted", {
+            jobId: "job-2",
+            userId: "user-1",
+            subject: "Artist - Album",
+            reason: "no releases",
+        });
+
+        expect(mockPolicy.evaluateNotification).toHaveBeenCalledWith(
+            "job-2",
+            "failed",
+        );
+        expect(mockNotifications.notifyDownloadFailed).not.toHaveBeenCalled();
+        expect(mockPrisma.downloadJob.update).not.toHaveBeenCalled();
+    });
+
+    it("returns the timeout-extension decision to the sweeper", async () => {
+        mockPolicy.evaluateNotification.mockResolvedValue({
+            shouldNotify: false,
+            reason: "Still in retry window - extending timeout",
+        });
+
+        await expect(
+            events.emit("download.timedOut", {
+                jobId: "job-3",
+                subject: "Artist - Album",
+            }),
+        ).resolves.toEqual([{ timeoutExtended: true }]);
+    });
+});

--- a/backend/src/services/download/__tests__/lidarrQueueReconciler.test.ts
+++ b/backend/src/services/download/__tests__/lidarrQueueReconciler.test.ts
@@ -1,0 +1,307 @@
+import { prisma } from "../../../utils/db";
+import { lidarrService } from "../../lidarr";
+import {
+    reconcileWithLidarr,
+    syncWithLidarrQueue,
+} from "../lidarrQueueReconciler";
+import { discoverWeeklyService } from "../../discoverWeekly";
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findMany: jest.fn(),
+            update: jest.fn(),
+            updateMany: jest.fn(),
+        },
+    },
+}));
+jest.mock("../../../utils/logger", () => ({
+    logger: { debug: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../../lidarr/lidarrHttpClient", () => ({
+    lidarrErrorLogFields: (error: unknown) => ({
+        message: error instanceof Error ? error.message : undefined,
+    }),
+}));
+jest.mock("../../lidarr", () => ({
+    lidarrService: { isAlbumAvailableInSnapshot: jest.fn() },
+}));
+jest.mock("../../discoverWeekly", () => ({
+    discoverWeeklyService: { checkBatchCompletion: jest.fn() },
+}));
+
+describe("lidarrQueueReconciler", () => {
+    const mockPrisma = prisma as any;
+    const mockLidarr = lidarrService as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPrisma.downloadJob.update.mockResolvedValue({});
+        mockPrisma.downloadJob.updateMany.mockResolvedValue({ count: 0 });
+    });
+
+    it("reconciles available jobs by primary MBID and metadata Lidarr MBID", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("primary", "download-1", "primary-mbid", {}),
+            makeJob("fallback", "download-2", "missing", {
+                lidarrMbid: "lidarr-mbid",
+            }),
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockImplementation(
+            (_snapshot: unknown, mbid: string) =>
+                mbid === "primary-mbid" || mbid === "lidarr-mbid",
+        );
+
+        await expect(reconcileWithLidarr(snapshot)).resolves.toEqual({
+            reconciled: 2,
+            errors: [],
+            snapshot,
+        });
+        expect(mockPrisma.downloadJob.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: { in: ["primary", "fallback"] } },
+            }),
+        );
+    });
+
+    it("applies the three-check grace period before failing a missing queue item", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("second-check", "missing-1", "album-1", {
+                queueSyncMissingCount: 1,
+            }),
+            makeJob("third-check", "missing-2", "album-2", {
+                queueSyncMissingCount: 2,
+            }),
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockReturnValue(false);
+
+        await expect(syncWithLidarrQueue(snapshot)).resolves.toEqual({
+            cancelled: 1,
+            errors: [],
+        });
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "second-check" },
+                data: {
+                    metadata: expect.objectContaining({
+                        queueSyncMissingCount: 2,
+                    }),
+                },
+            }),
+        );
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "third-check" },
+                data: expect.objectContaining({
+                    status: "failed",
+                    lidarrRef: null,
+                }),
+            }),
+        );
+    });
+
+    it("reconciles availability by parsed artist and album subject", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            {
+                ...makeJob("parsed", "download-1", null as never, {}),
+                subject: "Parsed Artist - Parsed Album",
+            },
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockImplementation(
+            (
+                _snapshot: unknown,
+                _mbid: string | undefined,
+                artist: string | undefined,
+                album: string | undefined,
+            ) => artist === "Parsed Artist" && album === "Parsed Album",
+        );
+
+        await expect(reconcileWithLidarr(snapshot)).resolves.toEqual({
+            reconciled: 1,
+            errors: [],
+            snapshot,
+        });
+    });
+
+    it("checks discovery completion for every reconciled batch", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            {
+                ...makeJob("discovery", "download-1", "album-1", {}),
+                discoveryBatchId: "batch-1",
+            },
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockReturnValue(true);
+
+        await reconcileWithLidarr(snapshot);
+
+        expect(discoverWeeklyService.checkBatchCompletion).toHaveBeenCalledWith(
+            "batch-1",
+        );
+    });
+
+    it("resets the missing counter when the tracked download returns", async () => {
+        const snapshot = {
+            queue: new Map([["download-1", { downloadId: "download-1" }]]),
+        } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("reset", "download-1", "album-1", {
+                queueSyncMissingCount: 2,
+            }),
+        ]);
+
+        await syncWithLidarrQueue(snapshot);
+
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "reset" },
+                data: {
+                    metadata: expect.objectContaining({
+                        queueSyncMissingCount: 0,
+                        lastQueueSyncFound: expect.any(String),
+                    }),
+                },
+            }),
+        );
+    });
+
+    it("adopts a replacement queue download after three missing checks", async () => {
+        const snapshot = {
+            queue: new Map([
+                [
+                    "replacement-download",
+                    {
+                        downloadId: "replacement-download",
+                        title: "Artist - Album WEB",
+                    },
+                ],
+            ]),
+        } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("replacement", "old-download", "album-1", {
+                artistName: "Artist",
+                albumTitle: "Album",
+                queueSyncMissingCount: 2,
+            }),
+        ]);
+
+        await syncWithLidarrQueue(snapshot);
+
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "replacement" },
+                data: expect.objectContaining({
+                    lidarrRef: "replacement-download",
+                    metadata: expect.objectContaining({
+                        previousDownloadId: "old-download",
+                        replacementDetected: true,
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it("completes an available album after its queue item disappears", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("available", "missing-download", "available-album", {
+                artistName: "Artist",
+                albumTitle: "Album",
+                queueSyncMissingCount: 2,
+            }),
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockReturnValue(true);
+
+        await expect(syncWithLidarrQueue(snapshot)).resolves.toEqual({
+            cancelled: 1,
+            errors: [],
+        });
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "available" },
+                data: expect.objectContaining({ status: "completed" }),
+            }),
+        );
+    });
+
+    it("reports queue-sync write errors", async () => {
+        const snapshot = { queue: new Map() } as never;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("write-error", "missing-download", "album-1", {
+                queueSyncMissingCount: 2,
+            }),
+        ]);
+        mockLidarr.isAlbumAvailableInSnapshot.mockReturnValue(false);
+        mockPrisma.downloadJob.update.mockRejectedValue(
+            new Error("write failed"),
+        );
+
+        await expect(syncWithLidarrQueue(snapshot)).resolves.toEqual({
+            cancelled: 0,
+            errors: ["write failed"],
+        });
+    });
+
+    it("returns an empty reconciliation without requesting a snapshot", async () => {
+        mockPrisma.downloadJob.findMany.mockResolvedValue([]);
+
+        await expect(reconcileWithLidarr()).resolves.toEqual({
+            reconciled: 0,
+            errors: [],
+        });
+    });
+
+    it("leaves reconciliation untouched when no snapshot is supplied", async () => {
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("no-snapshot", "download-1", "album-1", {}),
+        ]);
+
+        await expect(reconcileWithLidarr()).resolves.toEqual({
+            reconciled: 0,
+            errors: [],
+        });
+        expect(mockPrisma.downloadJob.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty queue sync without requesting a snapshot", async () => {
+        mockPrisma.downloadJob.findMany.mockResolvedValue([]);
+
+        await expect(syncWithLidarrQueue()).resolves.toEqual({
+            cancelled: 0,
+            errors: [],
+        });
+    });
+
+    it("leaves queue sync untouched when no snapshot is supplied", async () => {
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("no-snapshot", "download-1", "album-1", {}),
+        ]);
+
+        await expect(syncWithLidarrQueue()).resolves.toEqual({
+            cancelled: 0,
+            errors: [],
+        });
+        expect(mockPrisma.downloadJob.update).not.toHaveBeenCalled();
+    });
+
+    function makeJob(
+        id: string,
+        lidarrRef: string,
+        targetMbid: string | null,
+        metadata: Record<string, unknown>,
+    ) {
+        return {
+            id,
+            status: "processing",
+            lidarrRef,
+            targetMbid,
+            discoveryBatchId: null,
+            subject: "Artist - Album",
+            metadata,
+            createdAt: new Date(),
+        };
+    }
+});

--- a/backend/src/services/download/__tests__/staleDownloadSweeper.test.ts
+++ b/backend/src/services/download/__tests__/staleDownloadSweeper.test.ts
@@ -1,0 +1,359 @@
+import {
+    classifyStaleDownloadJobs,
+    IMPORT_TIMEOUT_MS,
+    NO_SOURCE_TIMEOUT_MS,
+    PENDING_TIMEOUT_MS,
+    markStaleJobsAsFailed,
+} from "../staleDownloadSweeper";
+import { prisma } from "../../../utils/db";
+import { lidarrService } from "../../lidarr";
+import { DownloadJobEvents } from "../downloadJobEvents";
+import { discoverWeeklyService } from "../../discoverWeekly";
+
+jest.mock("../../../utils/db", () => ({
+    prisma: {
+        downloadJob: {
+            findMany: jest.fn(),
+            update: jest.fn(),
+            updateMany: jest.fn(),
+            findFirst: jest.fn(),
+        },
+    },
+}));
+jest.mock("../../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(() => ({ error: jest.fn() })),
+    },
+}));
+jest.mock("../../../utils/async", () => ({
+    yieldToEventLoop: jest.fn(async () => undefined),
+}));
+jest.mock("../../../utils/playlistLogger", () => ({ sessionLog: jest.fn() }));
+jest.mock("../../lidarr", () => ({
+    lidarrService: { isDownloadActiveInSnapshot: jest.fn() },
+}));
+jest.mock("../../lidarr/lidarrHttpClient", () => ({
+    lidarrErrorLogFields: (error: unknown) => ({
+        message: error instanceof Error ? error.message : undefined,
+    }),
+}));
+jest.mock("../../discoverWeekly", () => ({
+    discoverWeeklyService: { checkBatchCompletion: jest.fn() },
+}));
+
+describe("staleDownloadSweeper time-window decisions", () => {
+    const now = new Date("2026-08-25T12:00:00.000Z");
+
+    beforeEach(() => jest.clearAllMocks());
+
+    afterEach(() => jest.useRealTimers());
+
+    it("uses the pending, no-source, and import windows at their boundaries", () => {
+        const jobs = [
+            makeJob("pending-fresh", "pending", PENDING_TIMEOUT_MS - 1),
+            makeJob("pending-stale", "pending", PENDING_TIMEOUT_MS + 1),
+            makeJob("no-source-fresh", "processing", NO_SOURCE_TIMEOUT_MS - 1),
+            makeJob("no-source-stale", "processing", NO_SOURCE_TIMEOUT_MS + 1),
+            makeJob(
+                "import-stale",
+                "processing",
+                IMPORT_TIMEOUT_MS + 1,
+                "dl-1",
+            ),
+        ];
+
+        const result = classifyStaleDownloadJobs(
+            jobs as never,
+            {} as never,
+            now,
+            () => ({ active: false }),
+        );
+
+        expect(result.stalePendingJobs.map(({ id }) => id)).toEqual([
+            "pending-stale",
+        ]);
+        expect(result.staleProcessingJobs.map(({ id }) => id)).toEqual([
+            "no-source-stale",
+            "import-stale",
+        ]);
+        expect(result.jobsToExtend).toEqual([]);
+    });
+
+    it("extends active Lidarr downloads and excludes queue-owned and direct jobs", () => {
+        const jobs = [
+            makeJob("active", "processing", IMPORT_TIMEOUT_MS + 1, "dl-active"),
+            makeJob(
+                "soulseek",
+                "processing",
+                IMPORT_TIMEOUT_MS + 1,
+                "dl-soulseek",
+                {
+                    source: "soulseek_direct",
+                },
+            ),
+            makeJob("queue-owned", "pending", PENDING_TIMEOUT_MS + 1, null, {
+                queuedVia: "album-download-queue",
+            }),
+        ];
+
+        const result = classifyStaleDownloadJobs(
+            jobs as never,
+            {} as never,
+            now,
+            (_snapshot, downloadId) => ({ active: downloadId === "dl-active" }),
+        );
+
+        expect(result.jobsToExtend.map(({ id }) => id)).toEqual(["active"]);
+        expect(result.stalePendingJobs).toEqual([]);
+        expect(result.staleProcessingJobs).toEqual([]);
+    });
+
+    it("uses the fixed system clock when extending an active import", async () => {
+        jest.useFakeTimers().setSystemTime(now);
+        const mockPrisma = prisma as any;
+        mockPrisma.downloadJob.findMany.mockResolvedValue([
+            makeJob("active", "processing", IMPORT_TIMEOUT_MS + 1, "dl-active"),
+        ]);
+        mockPrisma.downloadJob.update.mockResolvedValue({});
+        (lidarrService.isDownloadActiveInSnapshot as jest.Mock).mockReturnValue(
+            {
+                active: true,
+                progress: 50,
+            },
+        );
+        const events = new DownloadJobEvents();
+
+        await expect(
+            markStaleJobsAsFailed(
+                {} as never,
+                {
+                    events,
+                    blocklistAndRetry: jest.fn(),
+                    tryNextAlbumFromArtist: jest.fn(),
+                },
+                now,
+            ),
+        ).resolves.toBe(0);
+        expect(mockPrisma.downloadJob.update).toHaveBeenCalledWith({
+            where: { id: "active" },
+            data: {
+                metadata: expect.objectContaining({
+                    startedAt: now.toISOString(),
+                    extendedTimeout: true,
+                }),
+            },
+        });
+    });
+
+    it("fails a stale pending batch and checks discovery completion", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            {
+                ...makeJob("pending-batch", "pending", PENDING_TIMEOUT_MS + 1),
+                discoveryBatchId: "batch-1",
+            },
+        ]);
+        (prisma.downloadJob.updateMany as jest.Mock).mockResolvedValue({
+            count: 1,
+        });
+
+        await markStaleJobsAsFailed(undefined, dependencies());
+
+        expect(prisma.downloadJob.updateMany).toHaveBeenCalledWith({
+            where: { id: { in: ["pending-batch"] } },
+            data: {
+                status: "failed",
+                error: "Download never started - timed out",
+                completedAt: expect.any(Date),
+            },
+        });
+        expect(discoverWeeklyService.checkBatchCompletion).toHaveBeenCalledWith(
+            "batch-1",
+        );
+    });
+
+    it("continues the sweep when a timeout-policy subscriber throws", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            makeJob("stale-one", "processing", NO_SOURCE_TIMEOUT_MS + 1),
+            makeJob("stale-two", "processing", NO_SOURCE_TIMEOUT_MS + 1),
+        ]);
+        (prisma.downloadJob.findFirst as jest.Mock).mockResolvedValue(null);
+        (prisma.downloadJob.update as jest.Mock).mockResolvedValue({});
+        const events = new DownloadJobEvents();
+        events.on("download.timedOut", async () => {
+            throw new Error("policy unavailable");
+        });
+
+        await expect(
+            markStaleJobsAsFailed(undefined, dependencies({ events })),
+        ).resolves.toBe(2);
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "stale-one" },
+                data: expect.objectContaining({ status: "failed" }),
+            }),
+        );
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "stale-two" },
+                data: expect.objectContaining({ status: "failed" }),
+            }),
+        );
+    });
+
+    it("merges a stale job into an already completed duplicate", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            makeJob("stale-duplicate", "processing", NO_SOURCE_TIMEOUT_MS + 1),
+        ]);
+        (prisma.downloadJob.findFirst as jest.Mock).mockResolvedValue({
+            id: "completed-job",
+            metadata: { artistName: "Artist", albumTitle: "Album" },
+        });
+        (prisma.downloadJob.update as jest.Mock).mockResolvedValue({});
+
+        await markStaleJobsAsFailed(undefined, dependencies());
+
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "stale-duplicate" },
+                data: expect.objectContaining({
+                    status: "completed",
+                    metadata: expect.objectContaining({
+                        mergedWithJob: "completed-job",
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it("blocklists a stale tracked Lidarr download before retrying", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            {
+                ...makeJob(
+                    "stale-lidarr",
+                    "processing",
+                    IMPORT_TIMEOUT_MS + 1,
+                    "download-1",
+                ),
+                lidarrAlbumId: 7,
+            },
+        ]);
+        (lidarrService.isDownloadActiveInSnapshot as jest.Mock).mockReturnValue(
+            {
+                active: false,
+            },
+        );
+        (prisma.downloadJob.findFirst as jest.Mock).mockResolvedValue(null);
+        (prisma.downloadJob.update as jest.Mock).mockResolvedValue({});
+        const blocklistAndRetry = jest.fn().mockResolvedValue(undefined);
+
+        await markStaleJobsAsFailed(
+            {} as never,
+            dependencies({ blocklistAndRetry }),
+        );
+
+        expect(blocklistAndRetry).toHaveBeenCalledWith("download-1");
+    });
+
+    it("suppresses terminal failure when same-artist fallback succeeds", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            {
+                ...makeJob(
+                    "stale-fallback",
+                    "processing",
+                    NO_SOURCE_TIMEOUT_MS + 1,
+                ),
+                artistMbid: "artist-1",
+            },
+        ]);
+        (prisma.downloadJob.findFirst as jest.Mock).mockResolvedValue(null);
+        const tryNextAlbumFromArtist = jest.fn().mockResolvedValue({
+            retried: true,
+            failed: false,
+            jobId: "replacement-job",
+        });
+
+        await markStaleJobsAsFailed(
+            undefined,
+            dependencies({ tryNextAlbumFromArtist }),
+        );
+
+        expect(prisma.downloadJob.update).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "stale-fallback" },
+                data: expect.objectContaining({ status: "failed" }),
+            }),
+        );
+    });
+
+    it("marks the stale job failed when same-artist fallback throws", async () => {
+        (prisma.downloadJob.findMany as jest.Mock).mockResolvedValue([
+            {
+                ...makeJob(
+                    "stale-fallback-error",
+                    "processing",
+                    NO_SOURCE_TIMEOUT_MS + 1,
+                ),
+                artistMbid: "artist-1",
+            },
+        ]);
+        (prisma.downloadJob.findFirst as jest.Mock).mockResolvedValue(null);
+        (prisma.downloadJob.update as jest.Mock).mockResolvedValue({});
+        const tryNextAlbumFromArtist = jest
+            .fn()
+            .mockRejectedValue(new Error("fallback failed"));
+
+        await markStaleJobsAsFailed(
+            undefined,
+            dependencies({ tryNextAlbumFromArtist }),
+        );
+
+        expect(prisma.downloadJob.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "stale-fallback-error" },
+                data: expect.objectContaining({ status: "failed" }),
+            }),
+        );
+    });
+
+    function dependencies(
+        overrides: Partial<{
+            events: DownloadJobEvents;
+            blocklistAndRetry: jest.Mock;
+            tryNextAlbumFromArtist: jest.Mock;
+        }> = {},
+    ) {
+        return {
+            events: new DownloadJobEvents(),
+            blocklistAndRetry: jest.fn().mockResolvedValue(undefined),
+            tryNextAlbumFromArtist: jest.fn().mockResolvedValue({
+                retried: false,
+                failed: true,
+            }),
+            ...overrides,
+        };
+    }
+
+    function makeJob(
+        id: string,
+        status: "pending" | "processing",
+        ageMs: number,
+        lidarrRef: string | null = null,
+        metadata: Record<string, unknown> = {},
+    ) {
+        const createdAt = new Date(now.getTime() - ageMs);
+        return {
+            id,
+            status,
+            lidarrRef,
+            createdAt,
+            metadata: {
+                artistName: "Artist",
+                albumTitle: "Album",
+                ...metadata,
+                startedAt: createdAt.toISOString(),
+            },
+        };
+    }
+});

--- a/backend/src/services/download/albumRetryStrategy.ts
+++ b/backend/src/services/download/albumRetryStrategy.ts
@@ -1,0 +1,212 @@
+import type { DownloadJob } from "@prisma/client";
+import { config } from "../../config";
+import { prisma } from "../../utils/db";
+import { toErrorMessage } from "../../utils/errors";
+import { logger } from "../../utils/logger";
+import { asPlainObject } from "../../utils/plainObject";
+import { getSystemSettings } from "../../utils/systemSettings";
+import { lidarrService } from "../lidarr";
+import type { LidarrAlbum } from "../lidarr/lidarrTypes";
+
+export type AlbumRetryResult = {
+    retried: boolean;
+    failed: boolean;
+    jobId?: string;
+};
+
+type RetryJob = Pick<
+    DownloadJob,
+    | "id"
+    | "userId"
+    | "subject"
+    | "targetMbid"
+    | "artistMbid"
+    | "discoveryBatchId"
+    | "metadata"
+>;
+
+type AlbumRetryDecision =
+    | {
+          kind: "exhaust";
+          reason: "discovery" | "exact-match" | "missing-artist";
+      }
+    | { kind: "search"; artistMbid: string; artistName?: string };
+
+interface AlbumRetryDependencies {
+    markJobExhausted: (
+        job: RetryJob,
+        reason: string,
+    ) => Promise<AlbumRetryResult>;
+    startDownload: (
+        jobId: string,
+        artistName: string,
+        albumTitle: string,
+        albumMbid: string,
+        userId: string,
+    ) => Promise<{ success: boolean; error?: string }>;
+}
+
+/** Choose whether a job may search another album from the same artist. */
+export function decideAlbumRetry(job: RetryJob): AlbumRetryDecision {
+    const metadata = asPlainObject(job.metadata);
+    if (job.discoveryBatchId) return { kind: "exhaust", reason: "discovery" };
+    if (
+        metadata.spotifyImportJobId ||
+        metadata.downloadType === "spotify_import" ||
+        metadata.noFallback
+    ) {
+        return { kind: "exhaust", reason: "exact-match" };
+    }
+    const artistMbid = job.artistMbid || metadata.artistMbid;
+    if (typeof artistMbid !== "string" || !artistMbid) {
+        return { kind: "exhaust", reason: "missing-artist" };
+    }
+    return {
+        kind: "search",
+        artistMbid,
+        artistName:
+            typeof metadata.artistName === "string"
+                ? metadata.artistName
+                : undefined,
+    };
+}
+
+/** Select the first untried studio album, or the first untried release. */
+export function selectNextAlbum(
+    albums: LidarrAlbum[],
+    triedAlbumMbids: ReadonlySet<string>,
+): LidarrAlbum | undefined {
+    const untried = albums.filter(
+        (album) => !triedAlbumMbids.has(album.foreignAlbumId),
+    );
+    return (
+        untried.find((album) => {
+            const albumType = album.albumType;
+            return (
+                typeof albumType !== "string" ||
+                albumType.toLowerCase() === "album"
+            );
+        }) ?? untried[0]
+    );
+}
+
+async function exhaustWithoutSearch(
+    job: RetryJob,
+    reason: string,
+    decision: Extract<AlbumRetryDecision, { kind: "exhaust" }>,
+    dependencies: AlbumRetryDependencies,
+): Promise<AlbumRetryResult> {
+    const metadata = asPlainObject(job.metadata);
+    const result = await dependencies.markJobExhausted(job, reason);
+    if (decision.reason === "exact-match" && metadata.spotifyImportJobId) {
+        const { spotifyImportService } = await import("../spotifyImport");
+        await spotifyImportService.checkImportCompletion(
+            String(metadata.spotifyImportJobId),
+        );
+    }
+    return result;
+}
+
+async function findNextAlbum(
+    job: RetryJob,
+    artistMbid: string,
+): Promise<LidarrAlbum | undefined> {
+    const albums = await lidarrService.getArtistAlbums(artistMbid);
+    if (!albums?.length) return undefined;
+    const artistJobs = await prisma.downloadJob.findMany({
+        where: {
+            artistMbid,
+            status: { in: ["processing", "completed", "failed", "exhausted"] },
+        },
+        select: { targetMbid: true },
+    });
+    const triedAlbumMbids = new Set(
+        artistJobs.map(({ targetMbid }) => targetMbid),
+    );
+    triedAlbumMbids.add(job.targetMbid);
+    return selectNextAlbum(albums, triedAlbumMbids);
+}
+
+async function createFallbackJob(
+    job: RetryJob,
+    nextAlbum: LidarrAlbum,
+    artistMbid: string,
+    artistName?: string,
+): Promise<string> {
+    const metadata = asPlainObject(job.metadata);
+    await prisma.downloadJob.update({
+        where: { id: job.id },
+        data: {
+            status: "exhausted",
+            error: `All releases exhausted - trying: ${nextAlbum.title}`,
+            completedAt: new Date(),
+        },
+    });
+    const settings = await getSystemSettings();
+    const defaultMusicPath = settings?.musicPath || config.music.musicPath;
+    const newJob = await prisma.downloadJob.create({
+        data: {
+            userId: job.userId,
+            subject: `${artistName || "Unknown"} - ${nextAlbum.title}`,
+            type: "album",
+            targetMbid: nextAlbum.foreignAlbumId,
+            status: "pending",
+            discoveryBatchId: job.discoveryBatchId,
+            artistMbid,
+            metadata: {
+                artistName,
+                artistMbid,
+                albumTitle: nextAlbum.title,
+                albumMbid: nextAlbum.foreignAlbumId,
+                lidarrAlbumId: nextAlbum.id,
+                sameArtistFallback: true,
+                originalJobId: job.id,
+                downloadType: metadata.downloadType || "library",
+                rootFolderPath: metadata.rootFolderPath || defaultMusicPath,
+            },
+        },
+    });
+    return newJob.id;
+}
+
+/** Execute the same-artist album fallback policy for an exhausted job. */
+export async function tryNextAlbumFromArtist(
+    job: RetryJob,
+    reason: string,
+    dependencies: AlbumRetryDependencies,
+): Promise<AlbumRetryResult> {
+    const decision = decideAlbumRetry(job);
+    if (decision.kind === "exhaust") {
+        return exhaustWithoutSearch(job, reason, decision, dependencies);
+    }
+    try {
+        const nextAlbum = await findNextAlbum(job, decision.artistMbid);
+        if (!nextAlbum) {
+            return dependencies.markJobExhausted(job, reason);
+        }
+        logger.debug(
+            `[RETRY] Trying next album from same artist: ${nextAlbum.title}`,
+        );
+        const newJobId = await createFallbackJob(
+            job,
+            nextAlbum,
+            decision.artistMbid,
+            decision.artistName,
+        );
+        const result = await dependencies.startDownload(
+            newJobId,
+            decision.artistName || "Unknown Artist",
+            nextAlbum.title,
+            nextAlbum.foreignAlbumId,
+            job.userId,
+        );
+        return result.success
+            ? { retried: true, failed: false, jobId: newJobId }
+            : { retried: false, failed: true, jobId: newJobId };
+    } catch (error) {
+        logger.error(
+            `   Error trying same-artist fallback: ${toErrorMessage(error)}`,
+        );
+        return dependencies.markJobExhausted(job, reason);
+    }
+}

--- a/backend/src/services/download/downloadJobEvents.ts
+++ b/backend/src/services/download/downloadJobEvents.ts
@@ -1,0 +1,85 @@
+import { logger } from "../../utils/logger";
+
+const eventLogger = logger.child("DownloadJobEvents");
+
+/** Payloads for the closed download-job event vocabulary. */
+export interface DownloadJobEventPayloads {
+    "download.completed": {
+        jobId: string;
+        userId: string;
+        subject: string;
+        artistId?: unknown;
+    };
+    "download.exhausted": {
+        jobId: string;
+        userId: string;
+        subject: string;
+        reason: string;
+    };
+    "download.timedOut": {
+        jobId: string;
+        subject: string;
+    };
+}
+
+/** Results returned by download-job event subscribers. */
+export interface DownloadJobEventResults {
+    "download.completed": void;
+    "download.exhausted": void;
+    "download.timedOut": { timeoutExtended: boolean };
+}
+
+export type DownloadJobEventName = keyof DownloadJobEventPayloads;
+type DownloadJobEventListener<K extends DownloadJobEventName> = (
+    payload: DownloadJobEventPayloads[K],
+) => Promise<DownloadJobEventResults[K]>;
+
+/** In-process typed emitter for download notification-policy events. */
+export class DownloadJobEvents {
+    private readonly listeners: {
+        [K in DownloadJobEventName]: Set<DownloadJobEventListener<K>>;
+    } = {
+        "download.completed": new Set(),
+        "download.exhausted": new Set(),
+        "download.timedOut": new Set(),
+    };
+
+    /** Subscribe to one event and return its unsubscribe function. */
+    on<K extends DownloadJobEventName>(
+        eventName: K,
+        listener: DownloadJobEventListener<K>,
+    ): () => void {
+        const listeners = this.listeners[eventName] as Set<
+            DownloadJobEventListener<K>
+        >;
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+    }
+
+    /** Publish one event to every registered listener. */
+    async emit<K extends DownloadJobEventName>(
+        eventName: K,
+        payload: DownloadJobEventPayloads[K],
+    ): Promise<DownloadJobEventResults[K][]> {
+        const listeners = this.listeners[eventName] as Set<
+            DownloadJobEventListener<K>
+        >;
+        const settled = await Promise.allSettled(
+            Array.from(listeners, (listener) =>
+                Promise.resolve().then(() => listener(payload)),
+            ),
+        );
+        const results: DownloadJobEventResults[K][] = [];
+        settled.forEach((result) => {
+            if (result.status === "fulfilled") {
+                results.push(result.value);
+                return;
+            }
+            eventLogger.error("Download job event subscriber failed", {
+                eventName,
+                error: result.reason,
+            });
+        });
+        return results;
+    }
+}

--- a/backend/src/services/download/downloadJobNotificationSubscriber.ts
+++ b/backend/src/services/download/downloadJobNotificationSubscriber.ts
@@ -1,0 +1,95 @@
+import { logger } from "../../utils/logger";
+import { patchDownloadJobMetadata } from "../downloadJobStatus";
+import { notificationPolicyService } from "../notificationPolicyService";
+import { notificationService } from "../notificationService";
+import type {
+    DownloadJobEventPayloads,
+    DownloadJobEvents,
+} from "./downloadJobEvents";
+
+async function handleCompleted(
+    payload: DownloadJobEventPayloads["download.completed"],
+): Promise<void> {
+    try {
+        const decision = await notificationPolicyService.evaluateNotification(
+            payload.jobId,
+            "complete",
+        );
+        if (!decision.shouldNotify) {
+            logger.debug(
+                `   Suppressing completion notification: ${decision.reason}`,
+            );
+            return;
+        }
+        logger.debug(`   Sending completion notification: ${decision.reason}`);
+        await notificationService.notifyDownloadComplete(
+            payload.userId,
+            payload.subject,
+            undefined,
+            payload.artistId,
+        );
+        await patchDownloadJobMetadata(payload.jobId, {
+            notificationSent: true,
+        });
+    } catch (error) {
+        logger.error("Failed to evaluate/send download notification:", error);
+    }
+}
+
+async function handleExhausted(
+    payload: DownloadJobEventPayloads["download.exhausted"],
+): Promise<void> {
+    try {
+        const decision = await notificationPolicyService.evaluateNotification(
+            payload.jobId,
+            "failed",
+        );
+        if (!decision.shouldNotify) {
+            logger.debug(
+                `   Suppressing failure notification: ${decision.reason}`,
+            );
+            return;
+        }
+        logger.debug(`   Sending failure notification: ${decision.reason}`);
+        await notificationService.notifyDownloadFailed(
+            payload.userId,
+            payload.subject,
+            payload.reason,
+        );
+        await patchDownloadJobMetadata(payload.jobId, {
+            notificationSent: true,
+        });
+    } catch (error) {
+        logger.error("Failed to evaluate/send failure notification:", error);
+    }
+}
+
+async function handleTimedOut(
+    payload: DownloadJobEventPayloads["download.timedOut"],
+): Promise<{ timeoutExtended: boolean }> {
+    try {
+        const decision = await notificationPolicyService.evaluateNotification(
+            payload.jobId,
+            "timeout",
+        );
+        const timeoutExtended =
+            decision.reason.includes("retry window") ||
+            decision.reason.includes("extending timeout");
+        return { timeoutExtended };
+    } catch (error) {
+        logger.error(
+            `   Failed to evaluate policy for ${payload.jobId}:`,
+            error,
+        );
+        return { timeoutExtended: false };
+    }
+}
+
+/** Wire notification policy and delivery to download-job events. */
+export function registerDownloadJobNotificationSubscriber(
+    events: DownloadJobEvents,
+): void {
+    events.on("download.completed", handleCompleted);
+    events.on("download.exhausted", handleExhausted);
+    events.on("download.timedOut", handleTimedOut);
+}

--- a/backend/src/services/download/lidarrQueueReconciler.ts
+++ b/backend/src/services/download/lidarrQueueReconciler.ts
@@ -1,0 +1,315 @@
+import type { DownloadJob } from "@prisma/client";
+import { prisma } from "../../utils/db";
+import { toErrorMessage } from "../../utils/errors";
+import { logger } from "../../utils/logger";
+import { asPlainObject } from "../../utils/plainObject";
+import { yieldToEventLoop } from "../../utils/async";
+import { parseArtistAlbumSubject } from "../../utils/downloadSubject";
+import { patchDownloadJobMetadataFrom } from "../downloadJobStatus";
+import { lidarrService, type ReconciliationSnapshot } from "../lidarr";
+import { lidarrErrorLogFields } from "../lidarr/lidarrHttpClient";
+
+type ReconcileResult = {
+    reconciled: number;
+    errors: string[];
+    snapshot?: ReconciliationSnapshot;
+};
+
+type QueueSyncResult = { cancelled: number; errors: string[] };
+
+async function checkDiscoveryBatches(batchIds: Set<string>): Promise<void> {
+    if (batchIds.size === 0) return;
+    const { discoverWeeklyService } = await import("../discoverWeekly");
+    for (const batchId of batchIds) {
+        await discoverWeeklyService.checkBatchCompletion(batchId);
+        await yieldToEventLoop();
+    }
+}
+
+function isJobAvailable(
+    job: DownloadJob,
+    snapshot: ReconciliationSnapshot,
+): boolean {
+    const metadata = asPlainObject(job.metadata);
+    const albumMbid =
+        job.targetMbid ||
+        String(metadata.albumMbid || metadata.lidarrMbid || "");
+    const artistName =
+        typeof metadata.artistName === "string"
+            ? metadata.artistName
+            : undefined;
+    const albumTitle =
+        typeof metadata.albumTitle === "string"
+            ? metadata.albumTitle
+            : undefined;
+    if (
+        lidarrService.isAlbumAvailableInSnapshot(
+            snapshot,
+            albumMbid,
+            artistName,
+            albumTitle,
+        )
+    ) {
+        return true;
+    }
+    if (
+        typeof metadata.lidarrMbid === "string" &&
+        metadata.lidarrMbid !== albumMbid &&
+        lidarrService.isAlbumAvailableInSnapshot(
+            snapshot,
+            metadata.lidarrMbid,
+            undefined,
+            undefined,
+        )
+    ) {
+        return true;
+    }
+    if (artistName || !job.subject) return false;
+    const parsed = parseArtistAlbumSubject(job.subject);
+    return (
+        parsed.artist !== job.subject &&
+        lidarrService.isAlbumAvailableInSnapshot(
+            snapshot,
+            undefined,
+            parsed.artist,
+            parsed.album,
+        )
+    );
+}
+
+/** Reconcile processing jobs against a caller-owned Lidarr snapshot. */
+export async function reconcileWithLidarr(
+    existingSnapshot?: ReconciliationSnapshot,
+): Promise<ReconcileResult> {
+    const processingJobs = await prisma.downloadJob.findMany({
+        where: { status: "processing" },
+    });
+    if (processingJobs.length === 0) return { reconciled: 0, errors: [] };
+    if (!existingSnapshot) return { reconciled: 0, errors: [] };
+    const toComplete: string[] = [];
+    const discoveryBatchIds = new Set<string>();
+    for (const job of processingJobs) {
+        if (!isJobAvailable(job, existingSnapshot)) continue;
+        toComplete.push(job.id);
+        if (job.discoveryBatchId) discoveryBatchIds.add(job.discoveryBatchId);
+    }
+    if (toComplete.length > 0) {
+        await prisma.downloadJob.updateMany({
+            where: { id: { in: toComplete } },
+            data: {
+                status: "completed",
+                completedAt: new Date(),
+                error: null,
+            },
+        });
+    }
+    await checkDiscoveryBatches(discoveryBatchIds);
+    return {
+        reconciled: toComplete.length,
+        errors: [],
+        snapshot: existingSnapshot,
+    };
+}
+
+interface QueueSyncPlan {
+    reset: DownloadJob[];
+    increment: Array<[DownloadJob, number]>;
+    replace: Array<{
+        job: DownloadJob;
+        newDownloadId: string;
+        oldDownloadId: string;
+    }>;
+    complete: DownloadJob[];
+    fail: Array<[DownloadJob, number]>;
+    discoveryBatchIds: Set<string>;
+}
+
+function emptyQueueSyncPlan(): QueueSyncPlan {
+    return {
+        reset: [],
+        increment: [],
+        replace: [],
+        complete: [],
+        fail: [],
+        discoveryBatchIds: new Set(),
+    };
+}
+
+function findReplacement(
+    snapshot: ReconciliationSnapshot,
+    artistName: string | undefined,
+    albumTitle: string | undefined,
+): string | undefined {
+    if (!albumTitle) return undefined;
+    const searchAlbum = albumTitle.toLowerCase();
+    const searchArtist = artistName?.toLowerCase();
+    const item = Array.from(snapshot.queue.values()).find((candidate) => {
+        const title = candidate.title?.toLowerCase() || "";
+        return (
+            Boolean(candidate.downloadId) &&
+            title.includes(searchAlbum) &&
+            (!searchArtist || title.includes(searchArtist))
+        );
+    });
+    return item?.downloadId;
+}
+
+function planMissingJob(
+    job: DownloadJob,
+    snapshot: ReconciliationSnapshot,
+    plan: QueueSyncPlan,
+): void {
+    const metadata = asPlainObject(job.metadata);
+    const missingCount =
+        (typeof metadata.queueSyncMissingCount === "number"
+            ? metadata.queueSyncMissingCount
+            : 0) + 1;
+    if (missingCount < 3) {
+        plan.increment.push([job, missingCount]);
+        return;
+    }
+    const artistName =
+        typeof metadata.artistName === "string"
+            ? metadata.artistName
+            : undefined;
+    const albumTitle =
+        typeof metadata.albumTitle === "string"
+            ? metadata.albumTitle
+            : undefined;
+    const replacement = findReplacement(snapshot, artistName, albumTitle);
+    if (replacement && job.lidarrRef) {
+        plan.replace.push({
+            job,
+            newDownloadId: replacement,
+            oldDownloadId: job.lidarrRef,
+        });
+        return;
+    }
+    if (
+        lidarrService.isAlbumAvailableInSnapshot(
+            snapshot,
+            job.targetMbid || undefined,
+            artistName,
+            albumTitle,
+        )
+    ) {
+        plan.complete.push(job);
+        return;
+    }
+    plan.fail.push([job, missingCount]);
+    if (job.discoveryBatchId) plan.discoveryBatchIds.add(job.discoveryBatchId);
+}
+
+function buildQueueSyncPlan(
+    processingJobs: DownloadJob[],
+    snapshot: ReconciliationSnapshot,
+): QueueSyncPlan {
+    const plan = emptyQueueSyncPlan();
+    for (const job of processingJobs) {
+        if (!job.lidarrRef) continue;
+        const metadata = asPlainObject(job.metadata);
+        if (snapshot.queue.has(job.lidarrRef)) {
+            if (
+                typeof metadata.queueSyncMissingCount === "number" &&
+                metadata.queueSyncMissingCount > 0
+            ) {
+                plan.reset.push(job);
+            }
+            continue;
+        }
+        planMissingJob(job, snapshot, plan);
+    }
+    return plan;
+}
+
+async function applyCounterUpdates(plan: QueueSyncPlan): Promise<void> {
+    for (const job of plan.reset) {
+        await patchDownloadJobMetadataFrom(job.metadata, job.id, {
+            queueSyncMissingCount: 0,
+            lastQueueSyncFound: new Date().toISOString(),
+        });
+    }
+    for (const [job, missingCount] of plan.increment) {
+        await patchDownloadJobMetadataFrom(job.metadata, job.id, {
+            queueSyncMissingCount: missingCount,
+            lastQueueSyncCheck: new Date().toISOString(),
+        });
+    }
+}
+
+async function applyReplacementUpdates(plan: QueueSyncPlan): Promise<void> {
+    for (const { job, newDownloadId, oldDownloadId } of plan.replace) {
+        await patchDownloadJobMetadataFrom(
+            job.metadata,
+            job.id,
+            {
+                previousDownloadId: oldDownloadId,
+                replacementDetected: true,
+                replacementDetectedAt: new Date().toISOString(),
+                queueSyncMissingCount: 0,
+            },
+            { lidarrRef: newDownloadId, error: null },
+        );
+    }
+}
+
+async function applyTerminalUpdates(plan: QueueSyncPlan): Promise<void> {
+    for (const job of plan.complete) {
+        await patchDownloadJobMetadataFrom(
+            job.metadata,
+            job.id,
+            {
+                completedAt: new Date().toISOString(),
+                queueSyncCompleted: true,
+                queueSyncMissingCount: 0,
+            },
+            { status: "completed", completedAt: new Date(), error: null },
+        );
+    }
+    for (const [job, missingCount] of plan.fail) {
+        await patchDownloadJobMetadataFrom(
+            job.metadata,
+            job.id,
+            {
+                cancelledAt: new Date().toISOString(),
+                queueSyncCancelled: true,
+                queueSyncMissingCount: missingCount,
+            },
+            {
+                status: "failed",
+                error: "Lidarr queue sync: Download not found after 90s (3 checks).",
+                completedAt: new Date(),
+                lidarrRef: null,
+            },
+        );
+    }
+}
+
+/** Sync tracked download identifiers against a caller-owned Lidarr snapshot. */
+export async function syncWithLidarrQueue(
+    existingSnapshot?: ReconciliationSnapshot,
+): Promise<QueueSyncResult> {
+    const processingJobs = await prisma.downloadJob.findMany({
+        where: { status: "processing", lidarrRef: { not: null } },
+    });
+    if (processingJobs.length === 0 || !existingSnapshot) {
+        return { cancelled: 0, errors: [] };
+    }
+    try {
+        const plan = buildQueueSyncPlan(processingJobs, existingSnapshot);
+        await applyCounterUpdates(plan);
+        await applyReplacementUpdates(plan);
+        await applyTerminalUpdates(plan);
+        await checkDiscoveryBatches(plan.discoveryBatchIds);
+        return {
+            cancelled: plan.complete.length + plan.fail.length,
+            errors: [],
+        };
+    } catch (error) {
+        logger.error(
+            "[QUEUE-SYNC] Failed to sync with Lidarr queue:",
+            lidarrErrorLogFields(error),
+        );
+        return { cancelled: 0, errors: [toErrorMessage(error)] };
+    }
+}

--- a/backend/src/services/download/staleDownloadSweeper.ts
+++ b/backend/src/services/download/staleDownloadSweeper.ts
@@ -1,0 +1,261 @@
+import type { DownloadJob } from "@prisma/client";
+import { prisma } from "../../utils/db";
+import { logger } from "../../utils/logger";
+import { sessionLog } from "../../utils/playlistLogger";
+import { asPlainObject } from "../../utils/plainObject";
+import { yieldToEventLoop } from "../../utils/async";
+import { isAlbumDownloadQueueOwned } from "../albumDownloadQueueOwnership";
+import {
+    ACTIVE_DOWNLOAD_JOB_STATUSES,
+    failDownloadJob,
+    patchDownloadJobMetadataFrom,
+} from "../downloadJobStatus";
+import { lidarrService, type ReconciliationSnapshot } from "../lidarr";
+import { lidarrErrorLogFields } from "../lidarr/lidarrHttpClient";
+import type { AlbumRetryResult } from "./albumRetryStrategy";
+import type { DownloadJobEvents } from "./downloadJobEvents";
+
+/** Maximum age for a grabbed download before Lidarr activity is checked. */
+export const IMPORT_TIMEOUT_MS = 15 * 60 * 1000;
+/** Maximum age for a pending job that never started. */
+export const PENDING_TIMEOUT_MS = 10 * 60 * 1000;
+/** Maximum age for a processing job that Lidarr never grabbed. */
+export const NO_SOURCE_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface StaleJobClassification {
+    stalePendingJobs: DownloadJob[];
+    staleProcessingJobs: DownloadJob[];
+    jobsToExtend: DownloadJob[];
+}
+
+interface StaleDownloadSweeperDependencies {
+    events: DownloadJobEvents;
+    blocklistAndRetry: (downloadId: string) => Promise<void>;
+    tryNextAlbumFromArtist: (
+        job: DownloadJob,
+        reason: string,
+    ) => Promise<AlbumRetryResult>;
+}
+
+type DownloadActivityLookup = (
+    snapshot: ReconciliationSnapshot,
+    downloadId: string,
+) => { active: boolean; progress?: number };
+
+/** Classify active jobs against fixed staleness windows. */
+export function classifyStaleDownloadJobs(
+    activeJobs: DownloadJob[],
+    snapshot: ReconciliationSnapshot | undefined,
+    now: Date,
+    getDownloadActivity: DownloadActivityLookup,
+): StaleJobClassification {
+    const pendingCutoff = now.getTime() - PENDING_TIMEOUT_MS;
+    const noSourceCutoff = now.getTime() - NO_SOURCE_TIMEOUT_MS;
+    const importCutoff = now.getTime() - IMPORT_TIMEOUT_MS;
+    const stalePendingJobs: DownloadJob[] = [];
+    const staleProcessingJobs: DownloadJob[] = [];
+    const jobsToExtend: DownloadJob[] = [];
+
+    for (const job of activeJobs) {
+        const metadata = asPlainObject(job.metadata);
+        const startedAt = getStartedAt(job, metadata);
+        if (job.status === "pending") {
+            if (
+                !isAlbumDownloadQueueOwned(metadata) &&
+                job.createdAt.getTime() < pendingCutoff
+            ) {
+                stalePendingJobs.push(job);
+            }
+            continue;
+        }
+        if (
+            metadata.source === "slskd" ||
+            metadata.source === "soulseek_direct"
+        )
+            continue;
+        if (!job.lidarrRef && startedAt < noSourceCutoff) {
+            staleProcessingJobs.push(job);
+            continue;
+        }
+        if (!job.lidarrRef || !snapshot || startedAt >= importCutoff) continue;
+        const activity = getDownloadActivity(snapshot, job.lidarrRef);
+        if (activity.active) jobsToExtend.push(job);
+        else staleProcessingJobs.push(job);
+    }
+    return { stalePendingJobs, staleProcessingJobs, jobsToExtend };
+}
+
+function getStartedAt(
+    job: DownloadJob,
+    metadata: Record<string, unknown>,
+): number {
+    if (typeof metadata.startedAt !== "string") return job.createdAt.getTime();
+    return new Date(metadata.startedAt).getTime();
+}
+
+async function failStalePendingJobs(jobs: DownloadJob[]): Promise<Set<string>> {
+    const batchIds = new Set<string>();
+    if (jobs.length === 0) return batchIds;
+    logger.debug(
+        `\n⏰ Found ${jobs.length} stuck PENDING jobs (never started)`,
+    );
+    sessionLog("CLEANUP", `Found ${jobs.length} stuck PENDING jobs`);
+    for (const job of jobs) {
+        if (job.discoveryBatchId) batchIds.add(job.discoveryBatchId);
+    }
+    await prisma.downloadJob.updateMany({
+        where: { id: { in: jobs.map(({ id }) => id) } },
+        data: {
+            status: "failed",
+            error: "Download never started - timed out",
+            completedAt: new Date(),
+        },
+    });
+    return batchIds;
+}
+
+async function checkDiscoveryBatches(batchIds: Set<string>): Promise<void> {
+    if (batchIds.size === 0) return;
+    const { discoverWeeklyService } = await import("../discoverWeekly");
+    for (const batchId of batchIds) {
+        await discoverWeeklyService.checkBatchCompletion(batchId);
+        await yieldToEventLoop();
+    }
+}
+
+async function extendActiveJobs(jobs: DownloadJob[]): Promise<void> {
+    for (const job of jobs) {
+        await patchDownloadJobMetadataFrom(job.metadata, job.id, {
+            startedAt: new Date().toISOString(),
+            extendedTimeout: true,
+        });
+    }
+    if (jobs.length > 0) await yieldToEventLoop();
+}
+
+async function mergeCompletedDuplicate(
+    job: DownloadJob,
+    metadata: Record<string, unknown>,
+): Promise<boolean> {
+    const artistName = String(metadata.artistName || "")
+        .toLowerCase()
+        .trim();
+    const albumTitle = String(metadata.albumTitle || "")
+        .toLowerCase()
+        .trim();
+    if (!artistName || !albumTitle) return false;
+    const duplicate = await prisma.downloadJob.findFirst({
+        where: { id: { not: job.id }, status: "completed" },
+    });
+    const duplicateMetadata = asPlainObject(duplicate?.metadata);
+    if (
+        String(duplicateMetadata.artistName || "")
+            .toLowerCase()
+            .trim() !== artistName ||
+        String(duplicateMetadata.albumTitle || "")
+            .toLowerCase()
+            .trim() !== albumTitle
+    ) {
+        return false;
+    }
+    await patchDownloadJobMetadataFrom(
+        metadata,
+        job.id,
+        { mergedWithJob: duplicate!.id },
+        { status: "completed", completedAt: new Date(), error: null },
+    );
+    return true;
+}
+
+async function policyExtendedTimeout(
+    job: DownloadJob,
+    metadata: Record<string, unknown>,
+    events: DownloadJobEvents,
+): Promise<boolean> {
+    const results = await events.emit("download.timedOut", {
+        jobId: job.id,
+        subject: job.subject,
+    });
+    if (!results.some(({ timeoutExtended }) => timeoutExtended)) return false;
+    await patchDownloadJobMetadataFrom(metadata, job.id, {
+        startedAt: new Date().toISOString(),
+        timeoutExtendedByPolicy: true,
+    });
+    return true;
+}
+
+async function processStaleJob(
+    job: DownloadJob,
+    dependencies: StaleDownloadSweeperDependencies,
+): Promise<string | undefined> {
+    const metadata = asPlainObject(job.metadata);
+    if (await policyExtendedTimeout(job, metadata, dependencies.events)) return;
+    const errorMessage = job.lidarrRef
+        ? `Import failed - download stuck for ${IMPORT_TIMEOUT_MS / 60000} minutes`
+        : "No sources found - no indexer results";
+    sessionLog("CLEANUP", `Marking stale: ${job.subject} - ${errorMessage}`);
+    if (await mergeCompletedDuplicate(job, metadata)) return;
+    if (job.lidarrAlbumId && job.lidarrRef) {
+        await dependencies.blocklistAndRetry(job.lidarrRef);
+    }
+    const artistMbid = job.artistMbid || metadata.artistMbid;
+    let replacementStarted = false;
+    if (artistMbid && !job.discoveryBatchId) {
+        try {
+            const result = await dependencies.tryNextAlbumFromArtist(
+                job,
+                errorMessage,
+            );
+            replacementStarted = result.retried && Boolean(result.jobId);
+        } catch (error) {
+            logger.error(
+                `   Same-artist fallback error:`,
+                lidarrErrorLogFields(error),
+            );
+        }
+    }
+    if (!replacementStarted) await failDownloadJob(job.id, errorMessage);
+    return job.discoveryBatchId || undefined;
+}
+
+/** Mark stale download jobs through the manager's existing public seam. */
+export async function markStaleJobsAsFailed(
+    existingSnapshot: ReconciliationSnapshot | undefined,
+    dependencies: StaleDownloadSweeperDependencies,
+    now: Date = new Date(),
+): Promise<number> {
+    const activeJobs = await prisma.downloadJob.findMany({
+        where: { status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES } },
+    });
+    const spotifyCount = activeJobs.filter(({ id }) =>
+        id.startsWith("spotify_"),
+    ).length;
+    if (spotifyCount > 0) {
+        sessionLog(
+            "CLEANUP",
+            `Checking ${activeJobs.length} active jobs (${spotifyCount} Spotify import)`,
+        );
+    }
+    const classified = classifyStaleDownloadJobs(
+        activeJobs,
+        existingSnapshot,
+        now,
+        (snapshot, downloadId) =>
+            lidarrService.isDownloadActiveInSnapshot(snapshot, downloadId),
+    );
+    const pendingBatchIds = await failStalePendingJobs(
+        classified.stalePendingJobs,
+    );
+    await checkDiscoveryBatches(pendingBatchIds);
+    await extendActiveJobs(classified.jobsToExtend);
+    const processingBatchIds = new Set<string>();
+    for (const job of classified.staleProcessingJobs) {
+        const batchId = await processStaleJob(job, dependencies);
+        if (batchId) processingBatchIds.add(batchId);
+    }
+    await checkDiscoveryBatches(processingBatchIds);
+    return (
+        classified.stalePendingJobs.length +
+        classified.staleProcessingJobs.length
+    );
+}

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -152,7 +152,7 @@ class NotificationService {
         userId: string,
         subject: string,
         albumId?: string,
-        artistId?: string,
+        artistId?: unknown,
     ) {
         return this.create({
             userId,

--- a/backend/src/services/simpleDownloadManager.ts
+++ b/backend/src/services/simpleDownloadManager.ts
@@ -11,29 +11,32 @@ import { prisma } from "../utils/db";
 import { Prisma, PrismaClient } from "@prisma/client";
 import {
     lidarrService,
-    LidarrRelease,
     AcquisitionError,
     AcquisitionErrorType,
     ReconciliationSnapshot,
 } from "./lidarr";
-import { yieldToEventLoop } from "../utils/async";
 import { resolveDownloadArtistMbid } from "./downloadArtistMbid";
 import { getSystemSettings } from "../utils/systemSettings";
-import { notificationService } from "./notificationService";
-import { notificationPolicyService } from "./notificationPolicyService";
-import { sessionLog } from "../utils/playlistLogger";
 import { config } from "../config";
 import * as crypto from "crypto";
-import { isAlbumDownloadQueueOwned } from "./albumDownloadQueueOwnership";
-import { parseArtistAlbumSubject } from "../utils/downloadSubject";
 import {
     ACTIVE_DOWNLOAD_JOB_STATUSES,
     failDownloadJob,
     patchDownloadJobMetadata,
-    patchDownloadJobMetadataFrom,
 } from "./downloadJobStatus";
 import { asPlainObject } from "../utils/plainObject";
 import { toErrorMessage } from "../utils/errors";
+import {
+    tryNextAlbumFromArtist as executeAlbumRetry,
+    type AlbumRetryResult,
+} from "./download/albumRetryStrategy";
+import { DownloadJobEvents } from "./download/downloadJobEvents";
+import { registerDownloadJobNotificationSubscriber } from "./download/downloadJobNotificationSubscriber";
+import { markStaleJobsAsFailed as sweepStaleDownloadJobs } from "./download/staleDownloadSweeper";
+import {
+    reconcileWithLidarr,
+    syncWithLidarrQueue,
+} from "./download/lidarrQueueReconciler";
 
 // Type for transactional prisma client
 type TransactionClient = Omit<
@@ -48,10 +51,8 @@ function generateCorrelationId(): string {
 
 class SimpleDownloadManager {
     private readonly DEFAULT_MAX_ATTEMPTS = 3;
-    // Reduced timeouts for faster failure detection
-    private readonly IMPORT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes for imports
-    private readonly PENDING_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes for pending
-    private readonly NO_SOURCE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for no sources found
+
+    constructor(private readonly downloadJobEvents: DownloadJobEvents) {}
 
     /**
      * Get max retry attempts from user's discover config, fallback to default
@@ -869,39 +870,12 @@ class SimpleDownloadManager {
 
         // Post-transaction operations (notifications, batch completion)
         if (result.jobId && result.userId) {
-            // Send notification
-            try {
-                const decision =
-                    await notificationPolicyService.evaluateNotification(
-                        result.jobId,
-                        "complete",
-                    );
-
-                if (decision.shouldNotify) {
-                    logger.debug(
-                        `   Sending completion notification: ${decision.reason}`,
-                    );
-                    await notificationService.notifyDownloadComplete(
-                        result.userId,
-                        result.subject,
-                        undefined,
-                        result.metadata?.artistId,
-                    );
-
-                    await patchDownloadJobMetadata(result.jobId, {
-                        notificationSent: true,
-                    });
-                } else {
-                    logger.debug(
-                        `   Suppressing completion notification: ${decision.reason}`,
-                    );
-                }
-            } catch (notifError) {
-                logger.error(
-                    "Failed to evaluate/send download notification:",
-                    notifError,
-                );
-            }
+            await this.downloadJobEvents.emit("download.completed", {
+                jobId: result.jobId,
+                userId: result.userId,
+                subject: result.subject,
+                artistId: result.metadata?.artistId,
+            });
 
             // Check batch completion
             if (result.batchId) {
@@ -1035,208 +1009,17 @@ class SimpleDownloadManager {
         return result;
     }
 
-    /**
-     * Try the next album from the same artist when current album is exhausted
-     * This is called when all releases for an album have been tried
-     *
-     * IMPORTANT:
-     * - For Discovery Weekly jobs, we DON'T do same-artist fallback.
-     *   Discovery should find NEW artists, not more albums from the same artist.
-     * - For Spotify Import jobs, we DON'T do same-artist fallback.
-     *   User wants EXACT playlist, not substitutes.
-     */
+    /** Delegate same-artist fallback policy to its focused strategy. */
     private async tryNextAlbumFromArtist(
         job: any,
         reason: string,
-    ): Promise<{ retried: boolean; failed: boolean; jobId?: string }> {
-        const metadata = (job.metadata as any) || {};
-        const artistMbid = job.artistMbid || metadata.artistMbid;
-        const artistName = metadata.artistName;
-
-        // CRITICAL: For Discovery Weekly, DON'T try same-artist fallback
-        // Discovery should prioritize ARTIST DIVERSITY - let the discovery system
-        // find a completely different artist instead
-        if (job.discoveryBatchId) {
-            logger.debug(
-                `[RETRY] Discovery job - skipping same-artist fallback (diversity enforced)`,
-            );
-            logger.debug(
-                `   Discovery should find NEW artists, not more from: ${artistName}`,
-            );
-            return await this.markJobExhausted(job, reason);
-        }
-
-        // CRITICAL: For Spotify Import, DON'T try same-artist fallback
-        // User wants the EXACT playlist, not substitutes from same artist
-        if (
-            metadata.spotifyImportJobId ||
-            metadata.downloadType === "spotify_import" ||
-            metadata.noFallback
-        ) {
-            logger.debug(
-                `[RETRY] Spotify Import job - skipping fallback (exact match required)`,
-            );
-            logger.debug(`   User wants exact album: ${job.subject}`);
-
-            // Mark as failed and trigger completion check
-            const result = await this.markJobExhausted(job, reason);
-
-            // Check if import is complete
-            if (metadata.spotifyImportJobId) {
-                const { spotifyImportService } =
-                    await import("./spotifyImport");
-                await spotifyImportService.checkImportCompletion(
-                    metadata.spotifyImportJobId,
-                );
-            }
-
-            return result;
-        }
-
-        if (!artistMbid) {
-            logger.debug(
-                `   No artistMbid - cannot try other albums from same artist`,
-            );
-            return await this.markJobExhausted(job, reason);
-        }
-
-        logger.debug(
-            `[RETRY] Trying other albums from artist: ${
-                artistName || artistMbid
-            }`,
-        );
-
-        try {
-            // Get albums available in LIDARR for this artist (not MusicBrainz)
-            // MusicBrainz has many obscure albums (bootlegs, live recordings) that Lidarr can't find
-            const lidarrAlbums =
-                await lidarrService.getArtistAlbums(artistMbid);
-
-            if (!lidarrAlbums || lidarrAlbums.length === 0) {
-                logger.debug(`   No albums found in Lidarr for artist`);
-                return await this.markJobExhausted(job, reason);
-            }
-
-            logger.debug(
-                `   Found ${lidarrAlbums.length} albums in Lidarr for artist`,
-            );
-
-            // Get albums we've already tried
-            const triedAlbumMbids = new Set<string>();
-
-            // Check for other jobs with same artist
-            const artistJobs = await prisma.downloadJob.findMany({
-                where: {
-                    artistMbid: artistMbid,
-                    status: {
-                        in: ["processing", "completed", "failed", "exhausted"],
-                    },
-                },
-            });
-            artistJobs.forEach((j: any) => {
-                triedAlbumMbids.add(j.targetMbid);
-            });
-
-            // Also add current job's album
-            triedAlbumMbids.add(job.targetMbid);
-
-            // Filter to untried albums that exist in Lidarr
-            const untriedAlbums = lidarrAlbums.filter(
-                (album: any) => !triedAlbumMbids.has(album.foreignAlbumId),
-            );
-
-            logger.debug(
-                `   Untried albums in Lidarr: ${untriedAlbums.length}`,
-            );
-
-            if (untriedAlbums.length === 0) {
-                logger.debug(`   All Lidarr albums from artist exhausted`);
-                return await this.markJobExhausted(job, reason);
-            }
-
-            // Pick the first untried album (prioritize studio albums over singles/EPs if possible)
-            const studioAlbums = untriedAlbums.filter(
-                (a: any) =>
-                    a.albumType?.toLowerCase() === "album" || !a.albumType,
-            );
-            const nextAlbum =
-                studioAlbums.length > 0 ? studioAlbums[0] : untriedAlbums[0];
-            logger.debug(
-                `[RETRY] Trying next album from same artist: ${nextAlbum.title}`,
-            );
-
-            // Mark current job as exhausted (not failed - we're continuing with same artist)
-            await prisma.downloadJob.update({
-                where: { id: job.id },
-                data: {
-                    status: "exhausted",
-                    error: `All releases exhausted - trying: ${nextAlbum.title}`,
-                    completedAt: new Date(),
-                },
-            });
-
-            // Use Lidarr's foreignAlbumId (MBID) for the new job
-            const albumMbid = nextAlbum.foreignAlbumId;
-
-            // Get music path from settings with fallback to config
-            const settings = await getSystemSettings();
-            const defaultMusicPath =
-                settings?.musicPath || config.music.musicPath;
-
-            // Create new job for the next album
-            const newJob = await prisma.downloadJob.create({
-                data: {
-                    userId: job.userId,
-                    subject: `${artistName || "Unknown"} - ${nextAlbum.title}`,
-                    type: "album",
-                    targetMbid: albumMbid,
-                    status: "pending",
-                    discoveryBatchId: job.discoveryBatchId,
-                    artistMbid: artistMbid,
-                    metadata: {
-                        artistName: artistName,
-                        artistMbid: artistMbid,
-                        albumTitle: nextAlbum.title,
-                        albumMbid: albumMbid,
-                        lidarrAlbumId: nextAlbum.id, // Store Lidarr album ID for faster lookup
-                        sameArtistFallback: true,
-                        originalJobId: job.id,
-                        downloadType: metadata.downloadType || "library",
-                        rootFolderPath:
-                            metadata.rootFolderPath || defaultMusicPath,
-                    },
-                },
-            });
-
-            logger.debug(`   Created fallback job: ${newJob.id}`);
-
-            // Start the download
-            const result = await this.startDownload(
-                newJob.id,
-                artistName || "Unknown Artist",
-                nextAlbum.title,
-                albumMbid,
-                job.userId,
-            );
-
-            if (result.success) {
-                logger.debug(`   Same-artist fallback download started`);
-                return { retried: true, failed: false, jobId: newJob.id };
-            } else {
-                logger.debug(
-                    `   Same-artist fallback failed to start: ${result.error}`,
-                );
-                // The new job will be marked as failed by startDownload
-                return { retried: false, failed: true, jobId: newJob.id };
-            }
-        } catch (error: any) {
-            logger.error(
-                `   Error trying same-artist fallback: ${error.message}`,
-            );
-            return await this.markJobExhausted(job, reason);
-        }
+    ): Promise<AlbumRetryResult> {
+        return executeAlbumRetry(job, reason, {
+            markJobExhausted: (retryJob, retryReason) =>
+                this.markJobExhausted(retryJob, retryReason),
+            startDownload: (...args) => this.startDownload(...args),
+        });
     }
-
     /**
      * Mark a job as exhausted (all releases and same-artist albums tried)
      *
@@ -1301,364 +1084,27 @@ class SimpleDownloadManager {
             );
         }
 
-        // Send failure notification using policy service
-        try {
-            const decision =
-                await notificationPolicyService.evaluateNotification(
-                    job.id,
-                    "failed",
-                );
-
-            if (decision.shouldNotify) {
-                logger.debug(
-                    `   Sending failure notification: ${decision.reason}`,
-                );
-                await notificationService.notifyDownloadFailed(
-                    job.userId,
-                    job.subject,
-                    reason,
-                );
-
-                // Mark notification as sent
-                await patchDownloadJobMetadata(job.id, {
-                    notificationSent: true,
-                });
-            } else {
-                logger.debug(
-                    `   Suppressing failure notification: ${decision.reason}`,
-                );
-            }
-        } catch (notifError) {
-            logger.error(
-                "Failed to evaluate/send failure notification:",
-                notifError,
-            );
-        }
+        await this.downloadJobEvents.emit("download.exhausted", {
+            jobId: job.id,
+            userId: job.userId,
+            subject: job.subject,
+            reason,
+        });
 
         return { retried: false, failed: true, jobId: job.id };
     }
 
-    /**
-     * Mark stale jobs as failed (called by cleanup job)
-     * Applies the configured pending, no-source, and import timeouts to legacy-owned jobs.
-     * Optionally accepts a pre-fetched snapshot to avoid duplicate API calls.
-     */
+    /** Preserve the cleanup worker's public seam. */
     async markStaleJobsAsFailed(
         existingSnapshot?: ReconciliationSnapshot,
     ): Promise<number> {
-        const pendingCutoff = new Date(Date.now() - this.PENDING_TIMEOUT_MS);
-        const noSourceCutoff = new Date(Date.now() - this.NO_SOURCE_TIMEOUT_MS);
-        const importCutoff = new Date(Date.now() - this.IMPORT_TIMEOUT_MS);
-
-        // Find all pending and processing jobs
-        const activeJobs = await prisma.downloadJob.findMany({
-            where: { status: { in: ACTIVE_DOWNLOAD_JOB_STATUSES } },
+        return sweepStaleDownloadJobs(existingSnapshot, {
+            events: this.downloadJobEvents,
+            blocklistAndRetry: (downloadId) =>
+                this.blocklistAndRetry(downloadId),
+            tryNextAlbumFromArtist: (job, reason) =>
+                this.tryNextAlbumFromArtist(job, reason),
         });
-
-        // Log to session for debugging Spotify imports
-        if (activeJobs.length > 0) {
-            const spotifyJobs = activeJobs.filter((j) =>
-                j.id.startsWith("spotify_"),
-            );
-            if (spotifyJobs.length > 0) {
-                sessionLog(
-                    "CLEANUP",
-                    `Checking ${activeJobs.length} active jobs (${spotifyJobs.length} Spotify import)`,
-                );
-            }
-        }
-
-        // Separate pending from processing
-        const pendingJobs = activeJobs.filter((j) => j.status === "pending");
-        const processingJobs = activeJobs.filter(
-            (j) => j.status === "processing",
-        );
-
-        // Handle old pending jobs - batch update instead of individual updates
-        const stalePendingJobs = pendingJobs.filter(
-            (job) =>
-                !isAlbumDownloadQueueOwned(job.metadata) &&
-                job.createdAt < pendingCutoff,
-        );
-        const pendingDiscoveryBatchIds = new Set<string>();
-
-        if (stalePendingJobs.length > 0) {
-            logger.debug(
-                `\n⏰ Found ${stalePendingJobs.length} stuck PENDING jobs (never started)`,
-            );
-            sessionLog(
-                "CLEANUP",
-                `Found ${stalePendingJobs.length} stuck PENDING jobs`,
-            );
-
-            // Collect discovery batch IDs before batch update
-            for (const job of stalePendingJobs) {
-                if (job.discoveryBatchId) {
-                    pendingDiscoveryBatchIds.add(job.discoveryBatchId);
-                }
-            }
-
-            // Batch update all stale pending jobs at once
-            await prisma.downloadJob.updateMany({
-                where: { id: { in: stalePendingJobs.map((j) => j.id) } },
-                data: {
-                    status: "failed",
-                    error: "Download never started - timed out",
-                    completedAt: new Date(),
-                },
-            });
-
-            logger.debug(
-                `   Batch updated ${stalePendingJobs.length} pending jobs to failed`,
-            );
-        }
-
-        // Check discovery batch completions for pending jobs (with yielding)
-        if (pendingDiscoveryBatchIds.size > 0) {
-            const { discoverWeeklyService } = await import("./discoverWeekly");
-            for (const batchId of pendingDiscoveryBatchIds) {
-                await discoverWeeklyService.checkBatchCompletion(batchId);
-                await yieldToEventLoop();
-            }
-        }
-
-        if (processingJobs.length === 0) {
-            return stalePendingJobs.length;
-        }
-
-        // Use existing snapshot - do NOT re-fetch if undefined (means Lidarr is unavailable)
-        // If no snapshot provided, get one; but if explicitly undefined, skip Lidarr checks
-        const snapshot = existingSnapshot;
-
-        const staleJobs: typeof processingJobs = [];
-        const jobsToExtend: typeof processingJobs = [];
-
-        for (const job of processingJobs) {
-            const metadata = job.metadata as any;
-            const startedAt = metadata?.startedAt
-                ? new Date(metadata.startedAt)
-                : job.createdAt;
-
-            // Skip Soulseek jobs - they complete immediately with direct slsk-client
-            if (
-                metadata?.source === "slskd" ||
-                metadata?.source === "soulseek_direct"
-            ) {
-                continue;
-            }
-
-            // Jobs without lidarrRef = Lidarr never grabbed = no sources found
-            if (!job.lidarrRef) {
-                if (startedAt < noSourceCutoff) {
-                    staleJobs.push(job);
-                }
-            } else if (snapshot) {
-                // Jobs with lidarrRef = grabbed but potentially still downloading
-                // Only check if we have a snapshot (Lidarr is available)
-                if (startedAt < importCutoff) {
-                    // Check using snapshot (O(1) lookup, no API call)
-                    const downloadStatus =
-                        lidarrService.isDownloadActiveInSnapshot(
-                            snapshot,
-                            job.lidarrRef,
-                        );
-
-                    if (downloadStatus.active) {
-                        // Still downloading - collect for batch update
-                        jobsToExtend.push(job);
-                        logger.debug(
-                            `   ${job.subject}: Still downloading (${downloadStatus.progress || 0}%), extending timeout`,
-                        );
-                    } else {
-                        // Not actively downloading - mark as stale
-                        staleJobs.push(job);
-                    }
-                }
-            }
-            // If no snapshot and job has lidarrRef, skip it (Lidarr unavailable, can't check status)
-        }
-
-        // Each job needs its own metadata value, so updateMany cannot apply here.
-        for (const job of jobsToExtend) {
-            await patchDownloadJobMetadataFrom(job.metadata, job.id, {
-                startedAt: new Date().toISOString(),
-                extendedTimeout: true,
-            });
-        }
-        if (jobsToExtend.length > 0) {
-            await yieldToEventLoop();
-        }
-
-        if (staleJobs.length === 0) {
-            return stalePendingJobs.length;
-        }
-
-        logger.debug(`\n⏰ Found ${staleJobs.length} stale download jobs`);
-        sessionLog(
-            "CLEANUP",
-            `Found ${staleJobs.length} stale jobs to mark as failed`,
-        );
-
-        // Track unique batch IDs to check
-        const batchIds = new Set<string>();
-        const downloadBatchIds = new Set<string>();
-
-        for (const job of staleJobs) {
-            const metadata = (job.metadata as any) || {};
-
-            // Before marking as failed, check if still in retry window using policy service
-            try {
-                const policyDecision =
-                    await notificationPolicyService.evaluateNotification(
-                        job.id,
-                        "timeout",
-                    );
-
-                // If policy says to extend timeout (still in retry window), do so
-                if (
-                    policyDecision.reason.includes("retry window") ||
-                    policyDecision.reason.includes("extending timeout")
-                ) {
-                    logger.debug(
-                        `   ${job.subject}: ${policyDecision.reason} - extending timeout`,
-                    );
-                    await patchDownloadJobMetadataFrom(metadata, job.id, {
-                        startedAt: new Date().toISOString(),
-                        timeoutExtendedByPolicy: true,
-                    });
-                    continue; // Skip to next job
-                }
-            } catch (policyError) {
-                logger.error(
-                    `   Failed to evaluate policy for ${job.id}:`,
-                    policyError,
-                );
-                // Continue with failure handling if policy check fails
-            }
-
-            const hasLidarrRef = !!job.lidarrRef;
-            const errorMessage = hasLidarrRef
-                ? `Import failed - download stuck for ${
-                      this.IMPORT_TIMEOUT_MS / 60000
-                  } minutes`
-                : `No sources found - no indexer results`;
-
-            logger.debug(
-                `   Timing out: ${job.subject} (${
-                    hasLidarrRef ? "stuck import" : "no sources"
-                })`,
-            );
-            sessionLog(
-                "CLEANUP",
-                `Marking stale: ${job.subject} - ${errorMessage}`,
-            );
-            const artistName = metadata?.artistName?.toLowerCase().trim() || "";
-            const albumTitle = metadata?.albumTitle?.toLowerCase().trim() || "";
-
-            // FIRST: Check if a COMPLETED job already exists for this album
-            // This handles the case where a duplicate job succeeded while this one was processing
-            if (artistName && albumTitle) {
-                const completedDuplicate = await prisma.downloadJob.findFirst({
-                    where: {
-                        id: { not: job.id },
-                        status: "completed",
-                    },
-                });
-
-                if (completedDuplicate) {
-                    const dupMeta = completedDuplicate.metadata as any;
-                    const dupArtist =
-                        dupMeta?.artistName?.toLowerCase().trim() || "";
-                    const dupAlbum =
-                        dupMeta?.albumTitle?.toLowerCase().trim() || "";
-
-                    if (dupArtist === artistName && dupAlbum === albumTitle) {
-                        logger.debug(
-                            `   Found completed duplicate - marking this job as completed too`,
-                        );
-                        await patchDownloadJobMetadataFrom(
-                            metadata,
-                            job.id,
-                            { mergedWithJob: completedDuplicate.id },
-                            {
-                                status: "completed",
-                                completedAt: new Date(),
-                                error: null,
-                            },
-                        );
-                        continue; // Skip to next stale job
-                    }
-                }
-            }
-
-            // Clean up from Lidarr queue if possible. `job` is a DownloadJob
-            // from prisma.downloadJob.findMany (no select), and lidarrAlbumId is
-            // a real typed column (Int?), so no `as any` is needed — the cast
-            // only disabled type checking on the field that drives dedup/retry.
-            const lidarrAlbumId = job.lidarrAlbumId;
-            if (lidarrAlbumId && job.lidarrRef) {
-                await this.blocklistAndRetry(job.lidarrRef);
-            }
-
-            // Use same-artist fallback ONLY for non-discovery jobs
-            // Discovery jobs should find NEW artists via the discovery system
-            let replacementStarted = false;
-            const artistMbid = job.artistMbid || metadata.artistMbid;
-
-            if (artistMbid && !job.discoveryBatchId) {
-                logger.debug(`   Attempting same-artist fallback...`);
-                try {
-                    const fallbackResult = await this.tryNextAlbumFromArtist(
-                        { ...job, metadata },
-                        errorMessage,
-                    );
-                    if (fallbackResult.retried && fallbackResult.jobId) {
-                        logger.debug(
-                            `   Same-artist fallback started: ${fallbackResult.jobId}`,
-                        );
-                        replacementStarted = true;
-                    }
-                } catch (fallbackErr: any) {
-                    logger.error(
-                        `   Same-artist fallback error: ${fallbackErr.message}`,
-                    );
-                }
-            } else if (job.discoveryBatchId) {
-                logger.debug(
-                    `   Discovery job - letting discovery system find new artist`,
-                );
-            }
-
-            // If no replacement was started, mark the original job as failed
-            // NOTE: No notification here - stale cleanup is a background safety net
-            // Notifications are only sent from markJobExhausted when truly exhausted
-            if (!replacementStarted) {
-                await failDownloadJob(job.id, errorMessage);
-            }
-
-            if (job.discoveryBatchId) {
-                batchIds.add(job.discoveryBatchId);
-            }
-
-            // Track download batch IDs for artist downloads
-            if (metadata?.batchId) {
-                downloadBatchIds.add(metadata.batchId);
-            }
-        }
-
-        // Check discovery batch completion for affected batches (with yielding)
-        if (batchIds.size > 0) {
-            const { discoverWeeklyService } = await import("./discoverWeekly");
-            for (const batchId of batchIds) {
-                logger.debug(
-                    `   Checking discovery batch completion: ${batchId}`,
-                );
-                await discoverWeeklyService.checkBatchCompletion(batchId);
-                await yieldToEventLoop();
-            }
-        }
-
-        return stalePendingJobs.length + staleJobs.length;
     }
 
     /**
@@ -1717,20 +1163,7 @@ class SimpleDownloadManager {
         return { pending, processing, completed, failed };
     }
 
-    /**
-     * Reconcile processing jobs with Lidarr
-     * Checks if albums in "processing" state are already available in Lidarr
-     * and marks them as completed if so (fixes missed webhook completion events)
-     *
-     * IMPORTANT: Checks by both MBID and artist+album name to handle MBID mismatches
-     */
-    /**
-     * Reconcile processing jobs with Lidarr using batch snapshot approach.
-     * Fetches all Lidarr data once, then checks jobs against in-memory data.
-     *
-     * Optionally accepts a pre-fetched snapshot to avoid duplicate API calls
-     * when called alongside other reconciliation methods.
-     */
+    /** Preserve the reconciliation worker's public seam. */
     async reconcileWithLidarr(
         existingSnapshot?: ReconciliationSnapshot,
     ): Promise<{
@@ -1738,367 +1171,21 @@ class SimpleDownloadManager {
         errors: string[];
         snapshot?: ReconciliationSnapshot;
     }> {
-        logger.debug(
-            `\n[RECONCILE] Checking processing jobs against Lidarr...`,
-        );
-
-        const processingJobs = await prisma.downloadJob.findMany({
-            where: { status: "processing" },
-        });
-
-        if (processingJobs.length === 0) {
-            logger.debug(`   No processing jobs to reconcile`);
-            return { reconciled: 0, errors: [] };
-        }
-
-        logger.debug(`   Found ${processingJobs.length} processing job(s)`);
-
-        // Use existing snapshot - do NOT re-fetch if undefined (means Lidarr is unavailable)
-        if (!existingSnapshot) {
-            logger.debug(
-                `   No Lidarr snapshot available, skipping reconciliation`,
-            );
-            return { reconciled: 0, errors: [] };
-        }
-        const snapshot = existingSnapshot;
-
-        // Collect jobs to complete and discovery batches to check
-        const toComplete: string[] = [];
-        const discoveryBatchIds = new Set<string>();
-
-        for (const job of processingJobs) {
-            const metadata = job.metadata as any;
-            const albumMbid =
-                job.targetMbid || metadata?.albumMbid || metadata?.lidarrMbid;
-            const artistName = metadata?.artistName;
-            const albumTitle = metadata?.albumTitle;
-
-            // Check using snapshot (O(1) lookups, no API calls)
-            let isAvailable = lidarrService.isAlbumAvailableInSnapshot(
-                snapshot,
-                albumMbid,
-                artistName,
-                albumTitle,
-            );
-
-            // Also try lidarrMbid if different
-            if (
-                !isAvailable &&
-                metadata?.lidarrMbid &&
-                metadata.lidarrMbid !== albumMbid
-            ) {
-                isAvailable = lidarrService.isAlbumAvailableInSnapshot(
-                    snapshot,
-                    metadata.lidarrMbid,
-                    undefined,
-                    undefined,
-                );
-            }
-
-            // Strategy 3: Parse subject if no metadata (format: "Artist - Album")
-            if (!isAvailable && !artistName && job.subject) {
-                const parsed = parseArtistAlbumSubject(job.subject);
-                if (parsed.artist !== job.subject) {
-                    isAvailable = lidarrService.isAlbumAvailableInSnapshot(
-                        snapshot,
-                        undefined,
-                        parsed.artist,
-                        parsed.album,
-                    );
-                }
-            }
-
-            if (isAvailable) {
-                logger.debug(
-                    `   Job ${job.id}: Album "${job.subject}" found in Lidarr`,
-                );
-                toComplete.push(job.id);
-                if (job.discoveryBatchId) {
-                    discoveryBatchIds.add(job.discoveryBatchId);
-                }
-            } else {
-                // Only log for jobs older than 5 minutes
-                const jobAge = Date.now() - (job.createdAt?.getTime() || 0);
-                if (jobAge > 5 * 60 * 1000) {
-                    logger.debug(
-                        `   Job ${job.id}: "${job.subject}" not yet available (${Math.round(jobAge / 60000)}m old)`,
-                    );
-                }
-            }
-        }
-
-        // Batch update all completed jobs
-        if (toComplete.length > 0) {
-            await prisma.downloadJob.updateMany({
-                where: { id: { in: toComplete } },
-                data: {
-                    status: "completed",
-                    completedAt: new Date(),
-                    error: null,
-                },
-            });
-            logger.debug(
-                `   Batch updated ${toComplete.length} job(s) to completed`,
-            );
-        }
-
-        // Check discovery batch completions (deduplicated, with yielding)
-        if (discoveryBatchIds.size > 0) {
-            const { discoverWeeklyService } = await import("./discoverWeekly");
-            for (const batchId of discoveryBatchIds) {
-                await discoverWeeklyService.checkBatchCompletion(batchId);
-                await yieldToEventLoop();
-            }
-        }
-
-        logger.debug(`[RECONCILE] Reconciled ${toComplete.length} job(s)`);
-        return { reconciled: toComplete.length, errors: [], snapshot };
+        return reconcileWithLidarr(existingSnapshot);
     }
 
-    /**
-     * Sync with Lidarr's queue to detect cancelled/orphaned downloads.
-     * Uses snapshot approach for efficient batch checking.
-     *
-     * IMPORTANT: Implements grace period to prevent false cancellations when Lidarr
-     * auto-retries with a different release (new downloadId). Missing downloads are
-     * only marked as cancelled after 3 sync checks (90 seconds), and replacement
-     * detection handles downloadId changes.
-     *
-     * Optionally accepts a pre-fetched snapshot to avoid duplicate API calls.
-     */
+    /** Preserve the queue-sync worker's public seam. */
     async syncWithLidarrQueue(
         existingSnapshot?: ReconciliationSnapshot,
-    ): Promise<{
-        cancelled: number;
-        errors: string[];
-    }> {
-        logger.debug(
-            `\n[QUEUE-SYNC] Syncing processing jobs with Lidarr queue...`,
-        );
-
-        const processingJobs = await prisma.downloadJob.findMany({
-            where: {
-                status: "processing",
-                lidarrRef: { not: null },
-            },
-        });
-
-        if (processingJobs.length === 0) {
-            logger.debug(`   No processing jobs with lidarrRef to sync`);
-            return { cancelled: 0, errors: [] };
-        }
-
-        logger.debug(
-            `   Found ${processingJobs.length} processing job(s) with lidarrRef`,
-        );
-
-        // Use existing snapshot - do NOT re-fetch if undefined (means Lidarr is unavailable)
-        if (!existingSnapshot) {
-            logger.debug(
-                `   No Lidarr snapshot available, skipping queue sync`,
-            );
-            return { cancelled: 0, errors: [] };
-        }
-
-        try {
-            const snapshot = existingSnapshot;
-
-            // Build arrays for collecting downloadIds from snapshot queue
-            const queueDownloadIds = new Set(snapshot.queue.keys());
-            const queueItems = Array.from(snapshot.queue.values());
-
-            logger.debug(
-                `   Lidarr queue has ${queueDownloadIds.size} item(s)`,
-            );
-
-            let cancelled = 0;
-            const errors: string[] = [];
-            const discoveryBatchIds = new Set<string>();
-
-            // Collect jobs that need metadata updates (to batch where possible)
-            type ProcessingJob = (typeof processingJobs)[number];
-            const jobsToResetCounter: ProcessingJob[] = [];
-            const jobsToIncrementCounter: [ProcessingJob, number][] = [];
-            const jobsToUpdateDownloadId: {
-                job: ProcessingJob;
-                newDownloadId: string;
-                oldDownloadId: string;
-            }[] = [];
-            const jobsToComplete: ProcessingJob[] = [];
-            const jobsToFail: [ProcessingJob, number][] = [];
-
-            // Check each processing job against snapshot
-            for (const job of processingJobs) {
-                if (!job.lidarrRef) continue;
-
-                const metadata = asPlainObject(job.metadata);
-                const artistName = metadata.artistName as string | undefined;
-                const albumTitle = metadata.albumTitle as string | undefined;
-                const queueSyncMissingCount =
-                    typeof metadata.queueSyncMissingCount === "number"
-                        ? metadata.queueSyncMissingCount
-                        : 0;
-
-                // If download is found in queue, reset its missing counter
-                if (queueDownloadIds.has(job.lidarrRef)) {
-                    if (queueSyncMissingCount > 0) {
-                        jobsToResetCounter.push(job);
-                    }
-                    continue;
-                }
-
-                // Download ID not found in queue - check grace period
-                const missingCount = queueSyncMissingCount + 1;
-
-                if (missingCount < 3) {
-                    jobsToIncrementCounter.push([job, missingCount]);
-                    continue;
-                }
-
-                // After 3 checks, check for replacement downloads
-                const replacementDownload = queueItems.find((item) => {
-                    if (!item.downloadId || !albumTitle) return false;
-                    const queueTitle = item.title?.toLowerCase() || "";
-                    const searchAlbum = albumTitle.toLowerCase();
-                    const searchArtist = artistName?.toLowerCase() || "";
-                    return (
-                        queueTitle.includes(searchAlbum) &&
-                        (searchArtist
-                            ? queueTitle.includes(searchArtist)
-                            : true)
-                    );
-                });
-
-                if (replacementDownload && replacementDownload.downloadId) {
-                    jobsToUpdateDownloadId.push({
-                        job,
-                        newDownloadId: replacementDownload.downloadId,
-                        oldDownloadId: job.lidarrRef,
-                    });
-                    continue;
-                }
-
-                // No replacement - check if album is already downloaded using snapshot
-                const isAvailable = lidarrService.isAlbumAvailableInSnapshot(
-                    snapshot,
-                    job.targetMbid || undefined,
-                    artistName,
-                    albumTitle,
-                );
-
-                if (isAvailable) {
-                    jobsToComplete.push(job);
-                    cancelled++;
-                } else {
-                    jobsToFail.push([job, missingCount]);
-                    if (job.discoveryBatchId) {
-                        discoveryBatchIds.add(job.discoveryBatchId);
-                    }
-                    cancelled++;
-                }
-            }
-
-            // Process updates (individual updates needed for different metadata per job)
-            for (const job of jobsToResetCounter) {
-                await patchDownloadJobMetadataFrom(job.metadata, job.id, {
-                    queueSyncMissingCount: 0,
-                    lastQueueSyncFound: new Date().toISOString(),
-                });
-            }
-
-            for (const [job, missingCount] of jobsToIncrementCounter) {
-                await patchDownloadJobMetadataFrom(job.metadata, job.id, {
-                    queueSyncMissingCount: missingCount,
-                    lastQueueSyncCheck: new Date().toISOString(),
-                });
-            }
-
-            for (const {
-                job,
-                newDownloadId,
-                oldDownloadId,
-            } of jobsToUpdateDownloadId) {
-                logger.debug(
-                    `   Job ${job.id}: Replacement download found: ${newDownloadId}`,
-                );
-                await patchDownloadJobMetadataFrom(
-                    job.metadata,
-                    job.id,
-                    {
-                        previousDownloadId: oldDownloadId,
-                        replacementDetected: true,
-                        replacementDetectedAt: new Date().toISOString(),
-                        queueSyncMissingCount: 0,
-                    },
-                    {
-                        lidarrRef: newDownloadId,
-                        error: null,
-                    },
-                );
-            }
-
-            for (const job of jobsToComplete) {
-                logger.debug(
-                    `   Job ${job.id}: Album found in library - marking complete`,
-                );
-                await patchDownloadJobMetadataFrom(
-                    job.metadata,
-                    job.id,
-                    {
-                        completedAt: new Date().toISOString(),
-                        queueSyncCompleted: true,
-                        queueSyncMissingCount: 0,
-                    },
-                    {
-                        status: "completed",
-                        completedAt: new Date(),
-                        error: null,
-                    },
-                );
-            }
-
-            for (const [job, missingCount] of jobsToFail) {
-                logger.warn(
-                    `   Job ${job.id}: Download not found after 90s - marking as failed`,
-                );
-                await patchDownloadJobMetadataFrom(
-                    job.metadata,
-                    job.id,
-                    {
-                        cancelledAt: new Date().toISOString(),
-                        queueSyncCancelled: true,
-                        queueSyncMissingCount: missingCount,
-                    },
-                    {
-                        status: "failed",
-                        error: "Lidarr queue sync: Download not found after 90s (3 checks).",
-                        completedAt: new Date(),
-                        lidarrRef: null,
-                    },
-                );
-            }
-
-            // Check discovery batch completions (deduplicated, with yielding)
-            if (discoveryBatchIds.size > 0) {
-                const { discoverWeeklyService } =
-                    await import("./discoverWeekly");
-                for (const batchId of discoveryBatchIds) {
-                    await discoverWeeklyService.checkBatchCompletion(batchId);
-                    await yieldToEventLoop();
-                }
-            }
-
-            logger.debug(`[QUEUE-SYNC] Processed ${cancelled} orphaned job(s)`);
-            return { cancelled, errors };
-        } catch (error: any) {
-            logger.error(
-                `[QUEUE-SYNC] Failed to sync with Lidarr queue:`,
-                error.message,
-            );
-            return { cancelled: 0, errors: [error.message] };
-        }
+    ): Promise<{ cancelled: number; errors: string[] }> {
+        return syncWithLidarrQueue(existingSnapshot);
     }
 }
 
+const downloadJobEvents = new DownloadJobEvents();
+registerDownloadJobNotificationSubscriber(downloadJobEvents);
+
 // Singleton instance
-export const simpleDownloadManager = new SimpleDownloadManager();
+export const simpleDownloadManager = new SimpleDownloadManager(
+    downloadJobEvents,
+);

--- a/scripts/ci/check-file-size.mjs
+++ b/scripts/ci/check-file-size.mjs
@@ -62,7 +62,7 @@ const BASELINE = Object.freeze({
     "backend/src/routes/systemSettings.ts": 1506,
     "backend/src/routes/youtubeMusic.ts": 1604,
     "backend/src/services/lidarr.ts": 1689,
-    "backend/src/services/simpleDownloadManager.ts": 2104,
+    "backend/src/services/simpleDownloadManager.ts": 1191,
     "backend/src/services/spotify.ts": 1624,
     "backend/src/workers/unifiedEnrichment.ts": 1825,
     "frontend/app/playlist/[id]/page.tsx": 1506,


### PR DESCRIPTION
Part 2 of #790 — closes #790 (part 1 was #843).

## What changed

- `services/download/` gains four focused modules:
  - `staleDownloadSweeper.ts` — the ~321-line stale-download GC sweep; a pure cron concern needing only prisma and its constants. Staleness windows tested with a fake clock.
  - `lidarrQueueReconciler.ts` — the queue-reconciliation cluster that remained in the manager after #789 moved the HTTP-level pieces.
  - `albumRetryStrategy.ts` — the retry/fallback search policy with its decision logic as pure, fixture-tested functions.
  - `downloadJobEvents.ts` — a typed emitter with a closed three-event vocabulary (`download.completed`, `download.exhausted`, `download.timedOut`). The manager emits; a subscriber wired at singleton construction performs the same policy evaluations and notification sends as before, so notification policy now lives in one place.
- The four `on*` webhook handlers — the actual download state machine — stay in `simpleDownloadManager.ts`, which drops **2104 → 1194 lines** (baseline tightened). The monolithic test suites shrink by ~1,070 lines as their coverage moves to the focused modules.

## Verification

- Full backend suite at 6 workers: 518/518 suites, 7685 tests, exit 0. `tsc --noEmit` clean.
- `format:check`, `check-file-size.mjs`, `check-route-error-canon.mjs` all pass.
- Public surface unchanged: routes/workers call the same seams; webhook handling and job state transitions keep their behavioral tests green.
- AbortSignal threading and the safe-error logging conventions from #789 preserved through the extractions.