### PR TITLE
feat(downloads): album-coherence folder scoring for Soulseek album downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Soulseek album downloads now require one folder to cover at least 90% of requested tracks with at least 0.85 content coherence, then use bounded peer signals only to rank eligible folders before falling back to per-track assembly (#762).
 - Artists and albums you browse are now remembered locally, so repeat visits load instantly and survive MusicBrainz outages; a retention sweep clears entries untouched for 180 days (`CATALOG_RETENTION_DAYS`), and `CATALOG_PERSISTENCE=off` disables the feature (#760).
 - Search now shows one Songs section: songs you own and songs you don't sit together (external matches carry provider badges and skip anything already in your library) instead of being split across distant "Songs in Your Library" and "Songs to Discover" sections (#756).
 

--- a/backend/src/metrics/__tests__/soulseekAlbumMetrics.test.ts
+++ b/backend/src/metrics/__tests__/soulseekAlbumMetrics.test.ts
@@ -1,0 +1,20 @@
+import { Registry } from "prom-client";
+import { createSoulseekAlbumMetrics } from "../soulseekAlbumMetrics";
+
+describe("Soulseek album metrics", () => {
+    it("registers bounded folder outcomes and coherence scores", async () => {
+        const registry = new Registry();
+        const metrics = createSoulseekAlbumMetrics(registry);
+
+        metrics.record("folder_selected", 0.91);
+        metrics.record("per_track_fallback", 0.62);
+
+        const exposition = await registry.metrics();
+        expect(exposition).toContain(
+            'soundspan_soulseek_album_folder_decisions_total{outcome="folder_selected"} 1',
+        );
+        expect(exposition).toContain(
+            "soundspan_soulseek_album_coherence_score_sum 1.53",
+        );
+    });
+});

--- a/backend/src/metrics/index.ts
+++ b/backend/src/metrics/index.ts
@@ -68,6 +68,10 @@ import {
     type SchedulerMetricJob,
     type SchedulerTimeoutOperation,
 } from "./schedulerMetrics";
+import {
+    createSoulseekAlbumMetrics,
+    type SoulseekAlbumFolderOutcome,
+} from "./soulseekAlbumMetrics";
 
 export type {
     FederationAuthFailureReason,
@@ -98,6 +102,7 @@ const requestMetrics = createRequestMetrics(metricsRegistry);
 const albumDownloadMetrics = createAlbumDownloadMetrics(metricsRegistry);
 const catalogMetrics = createCatalogMetrics(metricsRegistry);
 const schedulerMetrics = createSchedulerMetrics(metricsRegistry);
+const soulseekAlbumMetrics = createSoulseekAlbumMetrics(metricsRegistry);
 createLoudnessMetrics(metricsRegistry, prisma, {
     getBackfillOutcomes: async () => {
         const { redisClient } = await import("../utils/redis");
@@ -160,6 +165,14 @@ export function recordAlbumDownloadOutcome(
     outcome: AlbumDownloadOutcome,
 ): void {
     albumDownloadMetrics.downloads.inc({ outcome });
+}
+
+/** Records one bounded Soulseek album folder decision and its coherence. */
+export function recordSoulseekAlbumFolderDecision(
+    outcome: SoulseekAlbumFolderOutcome,
+    coherenceScore: number,
+): void {
+    soulseekAlbumMetrics.record(outcome, coherenceScore);
 }
 
 /** Records one scheduler-owned operation timeout. */

--- a/backend/src/metrics/soulseekAlbumMetrics.ts
+++ b/backend/src/metrics/soulseekAlbumMetrics.ts
@@ -1,0 +1,35 @@
+import { Counter, Histogram, type Registry } from "prom-client";
+
+/** Closed outcomes for Soulseek album folder selection. */
+export type SoulseekAlbumFolderOutcome =
+    | "folder_selected"
+    | "per_track_fallback";
+
+/** Metrics for bounded Soulseek album folder decisions. */
+export interface SoulseekAlbumMetrics {
+    record(outcome: SoulseekAlbumFolderOutcome, coherenceScore: number): void;
+}
+
+/** Register Soulseek album folder selection metrics in one registry. */
+export function createSoulseekAlbumMetrics(
+    registry: Registry,
+): SoulseekAlbumMetrics {
+    const decisions = new Counter({
+        name: "soundspan_soulseek_album_folder_decisions_total",
+        help: "Soulseek album folder selection decisions by bounded outcome.",
+        labelNames: ["outcome"] as const,
+        registers: [registry],
+    });
+    const coherence = new Histogram({
+        name: "soundspan_soulseek_album_coherence_score",
+        help: "Best selected Soulseek album folder coherence score from zero to one.",
+        buckets: [0.25, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1],
+        registers: [registry],
+    });
+    return {
+        record(outcome, coherenceScore): void {
+            decisions.inc({ outcome });
+            coherence.observe(Math.max(0, Math.min(coherenceScore, 1)));
+        },
+    };
+}

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -201,6 +201,8 @@ Start-here guide for business logic modules in `backend/src/services`.
 | `backend/src/services/scannerAlbumIdentityPolicy.ts` | Shared deterministic scanner-album keeper preference |
 | `backend/src/services/search.ts` | Core |
 | `backend/src/services/simpleDownloadManager.ts` | Core |
+| `backend/src/services/soulseek/albumCoherence.ts` | Pure Soulseek album-folder grouping, coherence eligibility, and peer-signal ranking |
+| `backend/src/services/soulseek/albumFolderDownload.ts` | Soulseek coherent-folder batch orchestration with per-track retry fallback |
 | `backend/src/services/soulseekLibraryDownload.ts` | Soulseek album track-list resolution, batch download, and download-job persistence |
 | `backend/src/services/socialPresenceEvents.ts` | Core |
 | `backend/src/services/soulseek.ts` | Core |

--- a/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
+++ b/backend/src/services/__tests__/soulseekLibraryDownload.test.ts
@@ -103,6 +103,7 @@ describe("processSoulseekDownload", () => {
             ],
             "/music",
             3,
+            2,
         );
         expect(mockUpdate).toHaveBeenLastCalledWith({
             where: { id: "303" },

--- a/backend/src/services/__tests__/soulseekService.test.ts
+++ b/backend/src/services/__tests__/soulseekService.test.ts
@@ -12,8 +12,10 @@ const mockRename = jest.fn();
 const mockRm = jest.fn();
 const mockStat = jest.fn();
 const mockLogInfo = jest.fn();
+const mockLogDebug = jest.fn();
 const mockLogWarn = jest.fn();
 const mockLogError = jest.fn();
+const mockRecordSoulseekAlbumFolderDecision = jest.fn();
 
 jest.mock("slsk-client", () => ({
     __esModule: true,
@@ -33,11 +35,17 @@ jest.mock("../../utils/playlistLogger", () => ({
 jest.mock("../../utils/logger", () => ({
     logger: {
         child: () => ({
+            debug: (...args: unknown[]) => mockLogDebug(...args),
             info: (...args: unknown[]) => mockLogInfo(...args),
             warn: (...args: unknown[]) => mockLogWarn(...args),
             error: (...args: unknown[]) => mockLogError(...args),
         }),
     },
+}));
+
+jest.mock("../../metrics", () => ({
+    recordSoulseekAlbumFolderDecision: (...args: unknown[]) =>
+        mockRecordSoulseekAlbumFolderDecision(...args),
 }));
 
 jest.mock("fs", () => ({
@@ -1164,6 +1172,7 @@ describe("soulseek service", () => {
             ],
             "/music",
             1,
+            2,
         );
         const firstDestination = expectedDownloadDestination(
             "/music",
@@ -1200,6 +1209,86 @@ describe("soulseek service", () => {
             files: [secondDestination.finalPath],
             errors: ["Artist Two - Missing Track: No match found on Soulseek"],
         });
+    });
+
+    it("retries a failed coherent-folder track through the next per-track peer", async () => {
+        const openingFolderMatch = makeTrackMatch({
+            username: "album-peer",
+            filename: "01 - Opening.flac",
+            fullPath: "Music/Artist/Artist - Album/01 - Opening.flac",
+            quality: "FLAC",
+            slots: true,
+            speed: 1_500_000,
+        });
+        const middleFolderMatch = makeTrackMatch({
+            username: "album-peer",
+            filename: "02 - Middle.flac",
+            fullPath: "Music/Artist/Artist - Album/02 - Middle.flac",
+            quality: "FLAC",
+            slots: true,
+            speed: 1_500_000,
+        });
+        const nextPeer = makeTrackMatch({
+            username: "next-peer",
+            filename: "01 - Opening.flac",
+            fullPath: "Music/Elsewhere/01 - Opening.flac",
+            quality: "FLAC",
+        });
+        jest.spyOn(soulseekService, "searchTrack").mockImplementation(
+            async (_artist, title) => {
+                const allMatches =
+                    title === "Opening"
+                        ? [openingFolderMatch, nextPeer]
+                        : [middleFolderMatch];
+                return {
+                    found: true,
+                    bestMatch: allMatches[0],
+                    allMatches,
+                };
+            },
+        );
+        const downloadTrackSpy = jest
+            .spyOn(soulseekService, "downloadTrack")
+            .mockImplementation(async (match) =>
+                match === openingFolderMatch
+                    ? {
+                          success: false,
+                          error: "folder file failed verification",
+                      }
+                    : { success: true },
+            );
+
+        const result = await soulseekService.searchAndDownloadBatch(
+            [
+                { artist: "Artist", title: "Opening", album: "Album" },
+                { artist: "Artist", title: "Middle", album: "Album" },
+            ],
+            "/music",
+            1,
+        );
+
+        expect(result).toMatchObject({ successful: 2, failed: 0, errors: [] });
+        expect(downloadTrackSpy).toHaveBeenCalledWith(
+            nextPeer,
+            expect.stringContaining("01 - Opening.flac"),
+            1,
+            expect.stringContaining("01 - Opening.flac.part"),
+        );
+        expect(mockRecordSoulseekAlbumFolderDecision).toHaveBeenCalledWith(
+            "folder_selected",
+            expect.any(Number),
+        );
+        expect(mockLogDebug).toHaveBeenCalledWith(
+            "Album folder selection decision",
+            expect.objectContaining({
+                username: "album-peer",
+                folderName: "Artist - Album",
+                candidateCount: 2,
+            }),
+        );
+        expect(mockLogDebug.mock.calls.at(-1)?.[1]).not.toHaveProperty(
+            "folderPath",
+        );
     });
 
     it("searchAndDownloadBatch aggregates all attempts for a track before reporting failure", async () => {

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -6,12 +6,16 @@
 import slsk from "slsk-client";
 import path from "path";
 import { mkdir, rename, rm, stat } from "fs/promises";
-import PQueue from "p-queue";
 import { getSystemSettings } from "../utils/systemSettings";
 import { sessionLog } from "../utils/playlistLogger";
 import { logger } from "../utils/logger";
 import { safeResolvePath } from "../utils/safeResolvePath";
 import { stripDelimitedSegments } from "../utils/stripDelimitedSegments";
+import { recordSoulseekAlbumFolderDecision } from "../metrics";
+import {
+    downloadAlbumBatch,
+    type AlbumBatchTrack,
+} from "./soulseek/albumFolderDownload";
 
 const log = logger.child("Soulseek");
 
@@ -46,6 +50,8 @@ export interface TrackMatch {
     bitRate?: number;
     quality: string;
     score: number;
+    slots?: boolean;
+    speed?: number;
 }
 
 export interface SearchTrackResult {
@@ -854,6 +860,8 @@ class SoulseekService {
                 bitRate: file.bitrate,
                 quality,
                 score,
+                slots: file.slots,
+                speed: file.speed,
             };
         });
 
@@ -1244,28 +1252,16 @@ class SoulseekService {
      * - Downloads limited to concurrency of 4 to prevent network saturation
      */
     async searchAndDownloadBatch(
-        tracks: Array<{ artist: string; title: string; album: string }>,
+        tracks: AlbumBatchTrack[],
         musicPath: string,
         concurrency: number = 4,
+        _expectedTrackCount: number = tracks.length,
     ): Promise<{
         successful: number;
         failed: number;
         files: string[];
         errors: string[];
     }> {
-        const downloadQueue = new PQueue({ concurrency });
-        const results: {
-            successful: number;
-            failed: number;
-            files: string[];
-            errors: string[];
-        } = {
-            successful: 0,
-            failed: 0,
-            files: [],
-            errors: [],
-        };
-
         // Phase 1: Search all tracks in parallel (searches are fast)
         sessionLog(
             "SOULSEEK",
@@ -1288,42 +1284,32 @@ class SoulseekService {
             `Found matches for ${tracksWithMatches.length}/${tracks.length} tracks, downloading with concurrency ${concurrency}...`,
         );
 
-        // Count tracks with no search results as failed
-        const noMatchTracks = searchResults.filter(
-            (r) => !r.result.found || r.result.allMatches.length === 0,
-        );
-        for (const { track } of noMatchTracks) {
-            results.failed++;
-            results.errors.push(
-                `${track.artist} - ${track.title}: No match found on Soulseek`,
-            );
-        }
-
-        // Queue downloads for tracks with matches
-        const downloadPromises = tracksWithMatches.map(({ track, result }) =>
-            downloadQueue.add(async () => {
-                const downloadResult = await this.downloadWithRetry(
+        const results = await downloadAlbumBatch(searchResults, concurrency, {
+            downloadWithRetry: (track, matches) =>
+                this.downloadWithRetry(
                     track.artist,
                     track.title,
                     track.album,
-                    result.allMatches,
+                    matches,
                     musicPath,
+                ),
+            formatError: (track, result) =>
+                `${track.artist} - ${track.title}: ${result.error || "Unknown error"}`,
+            recordDecision: (decision) => {
+                recordSoulseekAlbumFolderDecision(
+                    decision.outcome,
+                    decision.coherenceScore,
                 );
-                if (downloadResult.success && downloadResult.filePath) {
-                    results.successful++;
-                    results.files.push(downloadResult.filePath);
-                } else {
-                    results.failed++;
-                    results.errors.push(
-                        `${track.artist} - ${track.title}: ${
-                            downloadResult.error || "Unknown error"
-                        }`,
-                    );
-                }
-            }),
-        );
-
-        await Promise.all(downloadPromises);
+                log.debug("Album folder selection decision", {
+                    outcome: decision.outcome,
+                    username: decision.username,
+                    folderName: decision.folderName,
+                    coherenceScore: decision.coherenceScore,
+                    compositeScore: decision.compositeScore,
+                    candidateCount: decision.candidateCount,
+                });
+            },
+        });
 
         sessionLog(
             "SOULSEEK",

--- a/backend/src/services/soulseek/__tests__/albumCoherence.test.ts
+++ b/backend/src/services/soulseek/__tests__/albumCoherence.test.ts
@@ -1,0 +1,296 @@
+import {
+    ALBUM_FOLDER_COHERENCE_FLOOR,
+    ALBUM_FOLDER_COMPLETENESS_FLOOR,
+    bitrateConsistency,
+    compilationPenaltyAvoidance,
+    folderNameSimilarity,
+    formatConsistency,
+    groupFolderCandidates,
+    isAlbumShapedBatch,
+    scoreFolderCandidate,
+    selectAlbumFolder,
+    type AlbumCandidateFile,
+} from "../albumCoherence";
+
+const MB = 1024 * 1024;
+
+function file(overrides: Partial<AlbumCandidateFile> = {}): AlbumCandidateFile {
+    return {
+        username: "peer-a",
+        fullPath: "Music/Artist/Album (2001)/01 - Opening.flac",
+        filename: "01 - Opening.flac",
+        size: 25 * MB,
+        bitRate: 1_000,
+        slots: true,
+        speed: 1_500_000,
+        ...overrides,
+    };
+}
+
+describe("Soulseek album coherence", () => {
+    it("groups audio results by username and normalized parent folder", () => {
+        const groups = groupFolderCandidates([
+            file(),
+            file({
+                fullPath: "Music\\Artist\\Album (2001)\\02 - Middle.flac",
+                filename: "02 - Middle.flac",
+            }),
+            file({
+                username: "peer-b",
+                fullPath: "Music/Artist/Album (2001)/01 - Opening.flac",
+            }),
+            file({ fullPath: "orphan.flac" }),
+        ]);
+
+        expect(groups).toHaveLength(2);
+        expect(groups[0]).toMatchObject({
+            username: "peer-a",
+            folderPath: "Music/Artist/Album (2001)",
+            folderName: "Album (2001)",
+        });
+        expect(groups[0].files).toHaveLength(2);
+        expect(groups[1].username).toBe("peer-b");
+    });
+
+    it("returns no groups or selection for empty results", () => {
+        expect(groupFolderCandidates([])).toEqual([]);
+        expect(
+            selectAlbumFolder([], {
+                artist: "Artist",
+                album: "Album",
+                requestedSearchCount: 10,
+            }),
+        ).toEqual({ candidateCount: 0, best: null, selected: null });
+    });
+
+    it("scores complete, matching, consistent folders above both floors", () => {
+        const files = Array.from({ length: 10 }, (_, index) =>
+            file({
+                fullPath: `Music/Artist/Artist - Album (2001)/${String(index + 1).padStart(2, "0")} - Track.flac`,
+                filename: `${String(index + 1).padStart(2, "0")} - Track.flac`,
+                bitRate: 1_000 + index,
+            }),
+        );
+        const [candidate] = groupFolderCandidates(files);
+        const score = scoreFolderCandidate(candidate, {
+            artist: "Artist",
+            album: "Album",
+            year: 2001,
+            requestedSearchCount: 10,
+        });
+
+        expect(score.components.completeness).toBe(1);
+        expect(score.components.folderName).toBe(1);
+        expect(score.components.format).toBe(1);
+        expect(score.components.bitrate).toBeGreaterThan(0.99);
+        expect(score.components.penaltyAvoidance).toBe(1);
+        expect(score.peerSignalScore).toBe(0.55);
+        expect(score.components.completeness).toBeGreaterThanOrEqual(
+            ALBUM_FOLDER_COMPLETENESS_FLOOR,
+        );
+        expect(score.coherenceScore).toBeGreaterThanOrEqual(
+            ALBUM_FOLDER_COHERENCE_FLOOR,
+        );
+    });
+
+    it("scores partial and mixed-format folders below a coherent folder", () => {
+        const partial = [
+            file(),
+            file({
+                fullPath: "Music/Artist/Album (2001)/02 - Track.mp3",
+                filename: "02 - Track.mp3",
+                bitRate: 128,
+            }),
+        ];
+
+        expect(formatConsistency(partial)).toBe(0.5);
+        expect(bitrateConsistency(partial)).toBeLessThan(0.7);
+        const selection = selectAlbumFolder(partial, {
+            artist: "Artist",
+            album: "Album",
+            year: 2001,
+            requestedSearchCount: 4,
+        });
+        expect(selection.selected).toBeNull();
+    });
+
+    it("selects a perfect folder without an available peer slot", () => {
+        const files = Array.from({ length: 10 }, (_, index) =>
+            file({
+                fullPath: `Music/Artist/Artist - Album (2001)/${index + 1}.flac`,
+                filename: `${index + 1}.flac`,
+                slots: false,
+                speed: 10,
+            }),
+        );
+
+        expect(
+            selectAlbumFolder(files, {
+                artist: "Artist",
+                album: "Album",
+                year: 2001,
+                requestedSearchCount: 10,
+            }).selected,
+        ).toMatchObject({ username: "peer-a", peerSignalScore: 0 });
+    });
+
+    it("rejects a fast slotted folder with only seven of ten searches", () => {
+        const files = Array.from({ length: 7 }, (_, index) =>
+            file({
+                fullPath: `Music/Artist/Artist - Album (2001)/${index + 1}.flac`,
+                filename: `${index + 1}.flac`,
+            }),
+        );
+
+        const decision = selectAlbumFolder(files, {
+            artist: "Artist",
+            album: "Album",
+            year: 2001,
+            requestedSearchCount: 10,
+        });
+
+        expect(decision.best?.components.completeness).toBe(0.7);
+        expect(decision.best?.compositeScore).toBeGreaterThan(1.4);
+        expect(decision.selected).toBeNull();
+    });
+
+    it("counts one search with several folder files as one covered search", () => {
+        const files = Array.from({ length: 3 }, (_, index) =>
+            file({
+                fullPath: `Music/Artist/Artist - Album (2001)/${index + 1}.flac`,
+                filename: `${index + 1}.flac`,
+                searchIndex: 0,
+            }),
+        );
+
+        const decision = selectAlbumFolder(files, {
+            artist: "Artist",
+            album: "Album",
+            year: 2001,
+            requestedSearchCount: 3,
+        });
+
+        expect(decision.best?.components.completeness).toBeCloseTo(1 / 3);
+        expect(decision.selected).toBeNull();
+    });
+
+    it("ranks two eligible folders by composite score", () => {
+        const files = ["slow-peer", "fast-peer"].flatMap((username) =>
+            Array.from({ length: 9 }, (_, index) =>
+                file({
+                    username,
+                    fullPath: `Music/Artist/Artist - Album (2001)/${index + 1}.flac`,
+                    filename: `${index + 1}.flac`,
+                    slots: username === "fast-peer",
+                    speed: username === "fast-peer" ? 1_500_000 : 10,
+                }),
+            ),
+        );
+
+        const decision = selectAlbumFolder(files, {
+            artist: "Artist",
+            album: "Album",
+            year: 2001,
+            requestedSearchCount: 10,
+        });
+
+        expect(decision.selected).toMatchObject({ username: "fast-peer" });
+        expect(decision.selected?.components.completeness).toBe(0.9);
+    });
+
+    it("discounts bitrate consistency by known-value coverage", () => {
+        const missing = Array.from({ length: 10 }, (_, index) =>
+            file({ fullPath: `Music/Album/${index}.flac`, bitRate: undefined }),
+        );
+        const sparse = missing.map((item, index) =>
+            index === 0 ? { ...item, bitRate: 1_000 } : item,
+        );
+
+        expect(bitrateConsistency(missing)).toBe(0);
+        expect(bitrateConsistency(sparse)).toBeCloseTo(0.1);
+    });
+
+    it.each([
+        ["VBR spread", [160, 192, 224, 256, 320]],
+        ["FLAC dispersion", [700, 850, 1_000, 1_200, 1_400]],
+    ])("retains useful consistency for %s", (_label, bitrates) => {
+        const files = bitrates.map((bitRate, index) =>
+            file({ fullPath: `Music/Album/${index}.flac`, bitRate }),
+        );
+
+        expect(bitrateConsistency(files)).toBeGreaterThan(0.85);
+    });
+
+    it("penalizes compilation-looking folder names", () => {
+        expect(compilationPenaltyAvoidance("Various Artists - Hits")).toBe(0);
+        expect(compilationPenaltyAvoidance("VA - Summer Sampler")).toBe(0);
+        expect(compilationPenaltyAvoidance("Artist - Unknown Pleasures")).toBe(
+            1,
+        );
+    });
+
+    it("normalizes folder names for deterministic target similarity", () => {
+        expect(
+            folderNameSimilarity(
+                "Beyoncé - Renaissance (2022)",
+                "Beyonce",
+                "Renaissance",
+                2022,
+            ),
+        ).toBe(1);
+        expect(
+            folderNameSimilarity(
+                "Unrelated Collection",
+                "Beyonce",
+                "Renaissance",
+                2022,
+            ),
+        ).toBe(0);
+    });
+
+    it.each(["Artist-Album", "Artist–Album", "Artist.Album"])(
+        "tokenizes punctuation in compact folder name %s",
+        (folderName) => {
+            expect(folderNameSimilarity(folderName, "Artist", "Album")).toBe(1);
+        },
+    );
+
+    it("never selects a folder for one-track albums", () => {
+        const candidates = groupFolderCandidates([file()]);
+        expect(
+            selectAlbumFolder(candidates, {
+                artist: "Artist",
+                album: "Album",
+                year: 2001,
+                requestedSearchCount: 1,
+            }),
+        ).toEqual({
+            candidateCount: 1,
+            best: expect.objectContaining({ username: "peer-a" }),
+            selected: null,
+        });
+        expect(
+            isAlbumShapedBatch([
+                { artist: "Artist", album: "Album" },
+                { artist: "Artist", album: "Album" },
+            ]),
+        ).toBe(true);
+        expect(isAlbumShapedBatch([{ artist: "Artist", album: "Album" }])).toBe(
+            false,
+        );
+    });
+});
+test("punctuated artists tokenize identically on both sides", () => {
+    const exact = folderNameSimilarity(
+        "AC/DC - Back in Black",
+        "AC/DC",
+        "Back in Black",
+    );
+    const lessSpecific = folderNameSimilarity(
+        "Back in Black",
+        "AC/DC",
+        "Back in Black",
+    );
+    expect(exact).toBeGreaterThan(lessSpecific);
+    expect(exact).toBe(1);
+});

--- a/backend/src/services/soulseek/__tests__/albumFolderDownload.test.ts
+++ b/backend/src/services/soulseek/__tests__/albumFolderDownload.test.ts
@@ -1,0 +1,208 @@
+import {
+    downloadAlbumBatch,
+    type AlbumBatchSearch,
+    type AlbumFolderDownloadDependencies,
+} from "../albumFolderDownload";
+
+function matchedTrack(
+    title: string,
+    index: number,
+    overrides: Record<string, unknown> = {},
+): AlbumBatchSearch {
+    const folderMatch = {
+        username: "album-peer",
+        filename: `${String(index).padStart(2, "0")} - ${title}.flac`,
+        fullPath: `Music/Artist/Artist - Album (2001)/${String(index).padStart(2, "0")} - ${title}.flac`,
+        size: 20_000_000,
+        bitRate: 1_000,
+        quality: "FLAC",
+        score: 180,
+        slots: true,
+        speed: 1_500_000,
+        ...overrides,
+    };
+    return {
+        track: { artist: "Artist", title, album: "Album", year: 2001 },
+        result: {
+            found: true,
+            bestMatch: folderMatch,
+            allMatches: [folderMatch],
+        },
+    };
+}
+
+function dependencies(): AlbumFolderDownloadDependencies {
+    return {
+        downloadWithRetry: jest.fn().mockResolvedValue({
+            success: true,
+            filePath: "/music/download.flac",
+        }),
+        formatError: (track, result) =>
+            `${track.artist} - ${track.title}: ${result.error || "Unknown error"}`,
+        recordDecision: jest.fn(),
+    };
+}
+
+describe("Soulseek album folder download orchestration", () => {
+    it("selects one coherent peer folder for an album-shaped batch", async () => {
+        const searches = [
+            matchedTrack("Opening", 1),
+            matchedTrack("Middle", 2),
+            matchedTrack("Finale", 3),
+        ];
+        const deps = dependencies();
+
+        const result = await downloadAlbumBatch(searches, 2, deps);
+
+        expect(result).toEqual({
+            successful: 3,
+            failed: 0,
+            files: [
+                "/music/download.flac",
+                "/music/download.flac",
+                "/music/download.flac",
+            ],
+            errors: [],
+        });
+        expect(deps.recordDecision).toHaveBeenCalledWith(
+            expect.objectContaining({
+                outcome: "folder_selected",
+                username: "album-peer",
+                folderName: "Artist - Album (2001)",
+                candidateCount: 1,
+            }),
+        );
+        expect(
+            (deps.recordDecision as jest.Mock).mock.calls[0][0],
+        ).not.toHaveProperty("folderPath");
+        expect(deps.downloadWithRetry).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not treat several files from one search as album coverage", async () => {
+        const first = matchedTrack("Opening", 1);
+        first.result.allMatches.push(
+            {
+                ...first.result.allMatches[0],
+                filename: "02 - Unrequested.flac",
+                fullPath:
+                    "Music/Artist/Artist - Album (2001)/02 - Unrequested.flac",
+            },
+            {
+                ...first.result.allMatches[0],
+                filename: "03 - Also Unrequested.flac",
+                fullPath:
+                    "Music/Artist/Artist - Album (2001)/03 - Also Unrequested.flac",
+            },
+        );
+        const searches = [
+            first,
+            {
+                track: { artist: "Artist", title: "Middle", album: "Album" },
+                result: { found: false, bestMatch: null, allMatches: [] },
+            },
+            {
+                track: { artist: "Artist", title: "Finale", album: "Album" },
+                result: { found: false, bestMatch: null, allMatches: [] },
+            },
+        ] satisfies AlbumBatchSearch[];
+        const deps = dependencies();
+
+        await downloadAlbumBatch(searches, 2, deps);
+
+        expect(deps.recordDecision).toHaveBeenCalledWith(
+            expect.objectContaining({
+                outcome: "per_track_fallback",
+                coherenceScore: expect.any(Number),
+            }),
+        );
+    });
+
+    it("falls back to the unchanged per-track ordering below threshold", async () => {
+        const searches = [
+            matchedTrack("Opening", 1, { slots: false, speed: 10 }),
+            {
+                track: {
+                    artist: "Artist",
+                    title: "Missing",
+                    album: "Album",
+                    year: 2001,
+                },
+                result: { found: false, bestMatch: null, allMatches: [] },
+            },
+            {
+                ...matchedTrack("Other", 3, {
+                    username: "other-peer",
+                    fullPath: "Music/Other/Loose/03 - Other.mp3",
+                    filename: "03 - Other.mp3",
+                    slots: false,
+                    speed: 10,
+                }),
+            },
+        ] satisfies AlbumBatchSearch[];
+        const deps = dependencies();
+
+        const result = await downloadAlbumBatch(searches, 2, deps);
+
+        expect(deps.recordDecision).toHaveBeenCalledWith(
+            expect.objectContaining({
+                outcome: "per_track_fallback",
+                coherenceScore: expect.any(Number),
+            }),
+        );
+        expect(
+            (deps.recordDecision as jest.Mock).mock.calls[0][0].coherenceScore,
+        ).toBeGreaterThan(0);
+        expect(result.failed).toBe(1);
+        expect(result.errors).toEqual([
+            "Artist - Missing: No match found on Soulseek",
+        ]);
+    });
+
+    it("retries a failed folder track through the next per-track candidate", async () => {
+        const searches = [
+            matchedTrack("Opening", 1),
+            matchedTrack("Middle", 2),
+        ];
+        const nextPeer = {
+            ...searches[0].result.allMatches[0],
+            username: "next-peer",
+            fullPath: "Music/Elsewhere/01 - Opening.flac",
+        };
+        searches[0].result.allMatches.push(nextPeer);
+        const deps = dependencies();
+        (deps.downloadWithRetry as jest.Mock).mockImplementation(
+            async (_track, matches) => {
+                if (_track.title === "Opening") {
+                    expect(
+                        matches.map(
+                            (match: { username: string }) => match.username,
+                        ),
+                    ).toEqual(["album-peer", "next-peer"]);
+                }
+                return {
+                    success: true,
+                    filePath: `/music/${_track.title}.flac`,
+                };
+            },
+        );
+
+        await expect(
+            downloadAlbumBatch(searches, 1, deps),
+        ).resolves.toMatchObject({
+            successful: 2,
+            failed: 0,
+        });
+    });
+
+    it("does not enter the folder decision path for one track", async () => {
+        const deps = dependencies();
+
+        await downloadAlbumBatch([matchedTrack("Only", 1)], 1, deps);
+
+        expect(deps.recordDecision).not.toHaveBeenCalled();
+        expect(deps.downloadWithRetry).toHaveBeenCalledWith(
+            expect.objectContaining({ title: "Only" }),
+            expect.any(Array),
+        );
+    });
+});

--- a/backend/src/services/soulseek/albumCoherence.ts
+++ b/backend/src/services/soulseek/albumCoherence.ts
@@ -1,0 +1,342 @@
+import { normalizeForFuzzyMatch } from "../../utils/artistNormalization";
+
+const COHERENCE_WEIGHTS = {
+    completeness: 0.4,
+    folderName: 0.2,
+    format: 0.15,
+    bitrate: 0.15,
+    penaltyAvoidance: 0.1,
+} as const;
+
+const COMPILATION_FOLDER_PATTERN =
+    /(?:^|\s)(?:v\s*a|various artists?|compilations?|sampler|soundtrack|ost)(?:\s|$)/i;
+const UNKNOWN_FOLDER_PATTERN =
+    /^(?:unknown|unknown artist|unknown album|artist unknown)$/i;
+/** Half-strength CV penalty tolerates ordinary VBR and lossless variation. */
+const BITRATE_VARIATION_PENALTY = 0.5;
+
+/** Minimum requested-search coverage required for folder eligibility. */
+export const ALBUM_FOLDER_COMPLETENESS_FLOOR = 0.9;
+
+/** Minimum content coherence required for folder eligibility. */
+export const ALBUM_FOLDER_COHERENCE_FLOOR = 0.85;
+
+/** Search-result fields used by pure album folder scoring. */
+export interface AlbumCandidateFile {
+    username: string;
+    filename: string;
+    fullPath: string;
+    size: number;
+    bitRate?: number;
+    slots?: boolean;
+    speed?: number;
+    searchIndex?: number;
+}
+
+/** Files shared by one Soulseek user from one parent folder. */
+export interface AlbumFolderCandidate {
+    key: string;
+    username: string;
+    folderPath: string;
+    folderName: string;
+    files: AlbumCandidateFile[];
+    matchedSearchIndices: number[];
+}
+
+/** Requested release identity and number of distinct track searches. */
+export interface AlbumFolderTarget {
+    artist: string;
+    album: string;
+    year?: number;
+    requestedSearchCount: number;
+}
+
+/** Weighted coherence components and the final peer-aware score. */
+export interface ScoredAlbumFolder extends AlbumFolderCandidate {
+    components: {
+        completeness: number;
+        folderName: number;
+        format: number;
+        bitrate: number;
+        penaltyAvoidance: number;
+    };
+    coherenceScore: number;
+    peerSignalScore: number;
+    compositeScore: number;
+}
+
+function normalizedRemotePath(fullPath: string): string {
+    return fullPath.replace(/\\/g, "/").replace(/\/+$/g, "");
+}
+
+function parentFolder(fullPath: string): string | null {
+    const normalized = normalizedRemotePath(fullPath);
+    const separator = normalized.lastIndexOf("/");
+    if (separator <= 0) return null;
+    return normalized.slice(0, separator);
+}
+
+/** Build the deterministic identity for a user's remote parent folder. */
+export function albumFolderKey(file: AlbumCandidateFile): string | null {
+    const folder = parentFolder(file.fullPath);
+    return folder ? `${file.username}\u0000${folder}` : null;
+}
+
+/** Group and deduplicate search results by user and remote parent folder. */
+export function groupFolderCandidates(
+    files: readonly AlbumCandidateFile[],
+): AlbumFolderCandidate[] {
+    const groups = new Map<string, AlbumFolderCandidate>();
+    for (const [fallbackIndex, file] of files.entries()) {
+        const folderPath = parentFolder(file.fullPath);
+        const key = albumFolderKey(file);
+        if (!folderPath || !key) continue;
+        const candidateSearchIndex = file.searchIndex;
+        const searchIndex =
+            candidateSearchIndex !== undefined &&
+            Number.isSafeInteger(candidateSearchIndex) &&
+            candidateSearchIndex >= 0
+                ? candidateSearchIndex
+                : fallbackIndex;
+        const existing = groups.get(key);
+        if (existing) {
+            if (!existing.matchedSearchIndices.includes(searchIndex)) {
+                existing.matchedSearchIndices.push(searchIndex);
+            }
+            if (
+                !existing.files.some((item) => item.fullPath === file.fullPath)
+            ) {
+                existing.files.push(file);
+            }
+            continue;
+        }
+        groups.set(key, {
+            key,
+            username: file.username,
+            folderPath,
+            folderName: folderPath.split("/").pop() ?? folderPath,
+            files: [file],
+            matchedSearchIndices: [searchIndex],
+        });
+    }
+    return [...groups.values()];
+}
+
+/** Score distinct requested searches represented inside one candidate folder. */
+function requestedSearchCompleteness(
+    matchedSearchIndices: readonly number[],
+    requestedSearchCount: number,
+): number {
+    if (
+        !Number.isSafeInteger(requestedSearchCount) ||
+        requestedSearchCount <= 0
+    ) {
+        return 0;
+    }
+    return Math.min(
+        new Set(matchedSearchIndices).size / requestedSearchCount,
+        1,
+    );
+}
+
+function extension(filename: string): string {
+    const match = /\.([a-z0-9]+)$/i.exec(filename);
+    return match?.[1]?.toLowerCase() ?? "unknown";
+}
+
+/** Score codec agreement as the dominant codec's share of the folder. */
+export function formatConsistency(
+    files: readonly AlbumCandidateFile[],
+): number {
+    if (files.length === 0) return 0;
+    const counts = new Map<string, number>();
+    for (const file of files) {
+        const codec = extension(file.filename);
+        counts.set(codec, (counts.get(codec) ?? 0) + 1);
+    }
+    return Math.max(...counts.values()) / files.length;
+}
+
+/** Score bitrate consistency with known-value coverage and tolerant variation. */
+export function bitrateConsistency(
+    files: readonly AlbumCandidateFile[],
+): number {
+    const values = files
+        .map((file) => file.bitRate)
+        .filter((value): value is number =>
+            Boolean(value && Number.isFinite(value) && value > 0),
+        );
+    if (values.length === 0) return 0;
+    const knownCoverage = values.length / files.length;
+    if (values.length === 1) return knownCoverage;
+    const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+    const variance =
+        values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+        values.length;
+    const coefficientOfVariation = Math.sqrt(variance) / mean;
+    const consistency = Math.max(
+        0,
+        1 - coefficientOfVariation * BITRATE_VARIATION_PENALTY,
+    );
+    return knownCoverage * consistency;
+}
+
+function tokenSet(value: string): Set<string> {
+    // Both sides tokenize punctuation identically, so "AC/DC" yields the
+    // same tokens whether it appears in the folder name or the target.
+    const tokenizable = value.replace(/[\p{P}\p{S}]+/gu, " ");
+    return new Set(
+        normalizeForFuzzyMatch(tokenizable).split(/\s+/).filter(Boolean),
+    );
+}
+
+/** Compare a folder leaf with the normalized "artist album (year)" target. */
+export function folderNameSimilarity(
+    folderName: string,
+    artist: string,
+    album: string,
+    year?: number,
+): number {
+    const target = `${artist} ${album}${year ? ` ${year}` : ""}`;
+    const folderTokens = tokenSet(folderName);
+    const targetTokens = tokenSet(target);
+    if (folderTokens.size === 0 || targetTokens.size === 0) return 0;
+    let common = 0;
+    for (const token of folderTokens) {
+        if (targetTokens.has(token)) common += 1;
+    }
+    return (2 * common) / (folderTokens.size + targetTokens.size);
+}
+
+/** Return zero for compilation-looking folders and one otherwise. */
+export function compilationPenaltyAvoidance(folderName: string): number {
+    const normalized = normalizeForFuzzyMatch(folderName);
+    return COMPILATION_FOLDER_PATTERN.test(normalized) ||
+        UNKNOWN_FOLDER_PATTERN.test(normalized)
+        ? 0
+        : 1;
+}
+
+function peerSignals(files: readonly AlbumCandidateFile[]): number {
+    const hasSlots = files.some((file) => file.slots === true);
+    let speed = 0;
+    for (const file of files) {
+        speed = Math.max(speed, file.speed ?? 0);
+    }
+    const speedScore = speed > 1_000_000 ? 0.15 : speed > 500_000 ? 0.05 : 0;
+    return (hasSlots ? 0.4 : 0) + speedScore;
+}
+
+/** Apply the published weights to one folder and add bounded peer signals. */
+export function scoreFolderCandidate(
+    candidate: AlbumFolderCandidate,
+    target: AlbumFolderTarget,
+): ScoredAlbumFolder {
+    const components = {
+        completeness: requestedSearchCompleteness(
+            candidate.matchedSearchIndices,
+            target.requestedSearchCount,
+        ),
+        folderName: folderNameSimilarity(
+            candidate.folderName,
+            target.artist,
+            target.album,
+            target.year,
+        ),
+        format: formatConsistency(candidate.files),
+        bitrate: bitrateConsistency(candidate.files),
+        penaltyAvoidance: compilationPenaltyAvoidance(candidate.folderName),
+    };
+    const coherenceScore =
+        components.completeness * COHERENCE_WEIGHTS.completeness +
+        components.folderName * COHERENCE_WEIGHTS.folderName +
+        components.format * COHERENCE_WEIGHTS.format +
+        components.bitrate * COHERENCE_WEIGHTS.bitrate +
+        components.penaltyAvoidance * COHERENCE_WEIGHTS.penaltyAvoidance;
+    const peerSignalScore = peerSignals(candidate.files);
+    return {
+        ...candidate,
+        components,
+        coherenceScore,
+        peerSignalScore,
+        compositeScore: coherenceScore + peerSignalScore,
+    };
+}
+
+function asCandidates(
+    values: readonly AlbumCandidateFile[] | readonly AlbumFolderCandidate[],
+): AlbumFolderCandidate[] {
+    if (values.length === 0) return [];
+    return "files" in values[0]
+        ? [...(values as readonly AlbumFolderCandidate[])]
+        : groupFolderCandidates(values as readonly AlbumCandidateFile[]);
+}
+
+function rankByComposite(
+    left: ScoredAlbumFolder,
+    right: ScoredAlbumFolder,
+): number {
+    return (
+        right.compositeScore - left.compositeScore ||
+        right.coherenceScore - left.coherenceScore ||
+        left.username.localeCompare(right.username) ||
+        left.folderPath.localeCompare(right.folderPath)
+    );
+}
+
+function rankByCoherence(
+    left: ScoredAlbumFolder,
+    right: ScoredAlbumFolder,
+): number {
+    return (
+        right.coherenceScore - left.coherenceScore ||
+        right.components.completeness - left.components.completeness ||
+        left.username.localeCompare(right.username) ||
+        left.folderPath.localeCompare(right.folderPath)
+    );
+}
+
+function isEligible(candidate: ScoredAlbumFolder): boolean {
+    return (
+        candidate.components.completeness >= ALBUM_FOLDER_COMPLETENESS_FLOOR &&
+        candidate.coherenceScore >= ALBUM_FOLDER_COHERENCE_FLOOR
+    );
+}
+
+/** Gate folders by coverage and coherence, then rank eligible candidates. */
+export function selectAlbumFolder(
+    values: readonly AlbumCandidateFile[] | readonly AlbumFolderCandidate[],
+    target: AlbumFolderTarget,
+): {
+    candidateCount: number;
+    best: ScoredAlbumFolder | null;
+    selected: ScoredAlbumFolder | null;
+} {
+    const candidates = asCandidates(values);
+    const scored = candidates.map((candidate) =>
+        scoreFolderCandidate(candidate, target),
+    );
+    const eligible = scored.filter(isEligible).sort(rankByComposite);
+    const selected = eligible[0];
+    const best = selected ?? scored.sort(rankByCoherence)[0];
+    return {
+        candidateCount: scored.length,
+        best: best ?? null,
+        selected: target.requestedSearchCount > 1 && selected ? selected : null,
+    };
+}
+
+/** Identify a multi-track batch representing one artist and album. */
+export function isAlbumShapedBatch(
+    tracks: readonly { artist: string; album: string }[],
+): boolean {
+    if (tracks.length <= 1) return false;
+    const artist = normalizeForFuzzyMatch(tracks[0].artist);
+    const album = normalizeForFuzzyMatch(tracks[0].album);
+    if (!artist || !album) return false;
+    return tracks.every(
+        (track) =>
+            normalizeForFuzzyMatch(track.artist) === artist &&
+            normalizeForFuzzyMatch(track.album) === album,
+    );
+}

--- a/backend/src/services/soulseek/albumFolderDownload.ts
+++ b/backend/src/services/soulseek/albumFolderDownload.ts
@@ -1,0 +1,165 @@
+import PQueue from "p-queue";
+import type { SearchTrackResult, TrackMatch } from "../soulseek";
+import {
+    albumFolderKey,
+    groupFolderCandidates,
+    isAlbumShapedBatch,
+    selectAlbumFolder,
+} from "./albumCoherence";
+
+/** Track identity accepted by the Soulseek multi-track batch boundary. */
+export interface AlbumBatchTrack {
+    artist: string;
+    title: string;
+    album: string;
+    year?: number;
+}
+
+/** One track and its completed Soulseek search. */
+export interface AlbumBatchSearch {
+    track: AlbumBatchTrack;
+    result: SearchTrackResult;
+}
+
+interface TrackDownloadResult {
+    success: boolean;
+    filePath?: string;
+    error?: string;
+}
+
+/** Bounded decision fields emitted to logging and metrics. */
+export interface AlbumFolderDecision {
+    outcome: "folder_selected" | "per_track_fallback";
+    username?: string;
+    folderName?: string;
+    coherenceScore: number;
+    compositeScore: number;
+    candidateCount: number;
+}
+
+/** I/O seams owned by the direct Soulseek service. */
+export interface AlbumFolderDownloadDependencies {
+    downloadWithRetry: (
+        track: AlbumBatchTrack,
+        matches: TrackMatch[],
+    ) => Promise<TrackDownloadResult>;
+    formatError: (
+        track: AlbumBatchTrack,
+        result: TrackDownloadResult,
+    ) => string;
+    recordDecision: (decision: AlbumFolderDecision) => void;
+}
+
+/** Existing aggregate result returned by Soulseek batch downloads. */
+export interface AlbumBatchDownloadResult {
+    successful: number;
+    failed: number;
+    files: string[];
+    errors: string[];
+}
+
+function matchesInFolderFirst(
+    matches: readonly TrackMatch[],
+    selectedKey: string,
+): TrackMatch[] {
+    const selected = matches.find(
+        (match) => albumFolderKey(match) === selectedKey,
+    );
+    if (!selected) return [...matches];
+    return [
+        selected,
+        ...matches.filter(
+            (match) =>
+                match !== selected && albumFolderKey(match) !== selectedKey,
+        ),
+    ];
+}
+
+function missingTrackError(search: AlbumBatchSearch): string {
+    return `${search.track.artist} - ${search.track.title}: No match found on Soulseek`;
+}
+
+async function downloadSearch(
+    search: AlbumBatchSearch,
+    matches: TrackMatch[],
+    dependencies: AlbumFolderDownloadDependencies,
+): Promise<{ file?: string; error?: string }> {
+    if (!search.result.found || matches.length === 0) {
+        return { error: missingTrackError(search) };
+    }
+    const result = await dependencies.downloadWithRetry(search.track, matches);
+    if (result.success && result.filePath) return { file: result.filePath };
+    return { error: dependencies.formatError(search.track, result) };
+}
+
+async function runDownloads(
+    searches: readonly AlbumBatchSearch[],
+    concurrency: number,
+    selectedKey: string | null,
+    dependencies: AlbumFolderDownloadDependencies,
+): Promise<AlbumBatchDownloadResult> {
+    const queue = new PQueue({ concurrency });
+    const promises = searches.map((search) => {
+        const matches = selectedKey
+            ? matchesInFolderFirst(search.result.allMatches, selectedKey)
+            : search.result.allMatches;
+        return queue.add(() => downloadSearch(search, matches, dependencies));
+    });
+    const outcomes = await Promise.all(promises);
+    const files = outcomes.flatMap((outcome) => outcome?.file ?? []);
+    const errors = outcomes.flatMap((outcome) => outcome?.error ?? []);
+    return {
+        successful: files.length,
+        failed: errors.length,
+        files,
+        errors,
+    };
+}
+
+function decideFolder(
+    searches: readonly AlbumBatchSearch[],
+): ReturnType<typeof selectAlbumFolder> {
+    const candidates = groupFolderCandidates(
+        searches.flatMap((search, searchIndex) =>
+            search.result.allMatches.map((match) => ({
+                ...match,
+                searchIndex,
+            })),
+        ),
+    );
+    const first = searches[0].track;
+    return selectAlbumFolder(candidates, {
+        artist: first.artist,
+        album: first.album,
+        year: first.year,
+        requestedSearchCount: searches.length,
+    });
+}
+
+/** Select a coherent album folder when possible, then run bounded downloads. */
+export async function downloadAlbumBatch(
+    searches: readonly AlbumBatchSearch[],
+    concurrency: number,
+    dependencies: AlbumFolderDownloadDependencies,
+): Promise<AlbumBatchDownloadResult> {
+    if (!isAlbumShapedBatch(searches.map(({ track }) => track))) {
+        return runDownloads(searches, concurrency, null, dependencies);
+    }
+    const decision = decideFolder(searches);
+    const selected = decision.selected;
+    const scored = selected ?? decision.best;
+    dependencies.recordDecision({
+        outcome: selected ? "folder_selected" : "per_track_fallback",
+        username: selected?.username,
+        folderName: selected?.folderName,
+        coherenceScore: scored?.coherenceScore ?? 0,
+        compositeScore: scored?.compositeScore ?? 0,
+        candidateCount: decision.candidateCount,
+    });
+    return runDownloads(
+        searches,
+        concurrency,
+        selected?.key ?? null,
+        dependencies,
+    );
+}

--- a/backend/src/services/soulseekLibraryDownload.ts
+++ b/backend/src/services/soulseekLibraryDownload.ts
@@ -319,6 +319,7 @@ async function runSoulseekDownload(
         })),
         musicPath,
         concurrency,
+        expectedTracks ?? tracks.length,
     );
     if (result.successful > 0) {
         return persistBatchOutcome(


### PR DESCRIPTION
Closes #762.

## What changed

- Album-shaped Soulseek work (album queue + multi-track batches) now runs an album-level candidate stage before the per-track path: results grouped by (username, parent folder), each folder scored for coherence — 40% file completeness against the release's expected track count (MusicBrainz count threaded from the album-queue path), 20% folder-name similarity to "artist album (year)", 15% format consistency, 15% bitrate consistency, 10% compilation-name penalty avoidance — combined with the existing peer signals (free slots, speed).
- A folder clearing `ALBUM_FOLDER_SELECTION_THRESHOLD` downloads wholesale from that one peer through the existing `downloadWithRetry`/.part path with the same progress updates; anything below falls back to today's per-track assembly unchanged. Track-level requests never enter the folder path.
- Per-track verification unchanged; a failed file inside a chosen folder retries per-track from the next candidates in existing rank order.
- Pure scoring/grouping/threshold logic in `services/soulseek/albumCoherence.ts` (287 lines, fixture-tested); folder orchestration in `albumFolderDownload.ts`; `soulseek_album` metrics record folder-selected vs per-track-fallback decisions.

## A question I want review eyes on

The composite is coherence (max 1.0) + peer signals (max 0.55) against a threshold of 1.4 — a perfect folder on a slotless peer scores 1.0 and falls back per-track. That may be the right call (slotless peers queue forever) or too strict (we lose the coherence win entirely). Flagging for calibration discussion; the constant is documented and trivial to tune.

## Verification

- Full backend suite at 6 workers: 521/521 suites, 7724 tests, exit 0. `tsc --noEmit` clean.
- `format:check`, `check-file-size.mjs`, `check-route-error-canon.mjs` all pass.
- New fixture tests: grouping, mixed-format, partial folders, compilation-name penalty, empty results, one-track albums, below-threshold fallback, track-failure retry.