### PR TITLE
fix(tests): give the worker-import runtime test its own timeout budget

### DIFF
--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -434,6 +434,9 @@ describe("workers runtime behavior", () => {
         jest.clearAllMocks();
     });
 
+    // Imports the full worker module graph under coverage instrumentation;
+    // the cold require crossed jest's 5s default once the graph grew (#812
+    // made coverage blocking), so this test carries its own budget.
     it("imports without registering processors, then starts explicitly", async () => {
         process.env = { ...originalEnv };
         const mocks = setupWorkerModuleMocks();
@@ -657,7 +660,7 @@ describe("workers runtime behavior", () => {
                 jobId: "scheduler:catalog-retention:repeat",
             },
         );
-    });
+    }, 15_000);
 
     it("registers slow and fast jobs on structurally isolated queues", async () => {
         process.env = { ...originalEnv };


### PR DESCRIPTION
Every PR run since the blocking-coverage gate landed (#812) fails `indexRuntime.test.ts` › "imports without registering processors, then starts explicitly" with a 5s jest timeout — the test requires the whole worker module graph in its body, and under coverage instrumentation that cold import now crosses the default on CI runners (confirmed deterministic: the failed job's rerun failed identically, while local runs pass). The import is the point of the test, so it gets an explicit 15s budget with a comment explaining why.

Verified locally under `--coverage`: 52/52 tests pass.