### PR TITLE
chore(tests): pin the clock in the waiting-deadline preservation test

### DIFF
--- a/backend/src/services/__tests__/listenTogetherManagerRuntime.test.ts
+++ b/backend/src/services/__tests__/listenTogetherManagerRuntime.test.ts
@@ -915,6 +915,11 @@ describe("listenTogetherManager runtime behavior", () => {
     it("preserves existing waiting deadline when stale external playback snapshots are ignored", () => {
         const callbacks = createCallbacks();
         groupManager.setCallbacks(callbacks);
+        // Pin the clock so the recomputed deadline cannot drift from the
+        // original between setTrack and applyExternalSnapshot.
+        jest.spyOn(Date, "now").mockReturnValue(
+            Date.parse("2026-02-16T12:00:00.000Z"),
+        );
         groupManager.create("g-ready-preserve-deadline", {
             name: "Ready Preserve Deadline",
             joinCode: "RPD",
@@ -958,12 +963,7 @@ describe("listenTogetherManager runtime behavior", () => {
 
         const after = groupManager.snapshotById("g-ready-preserve-deadline");
         expect(after?.syncState).toBe("waiting");
-        expect(after?.readyDeadlineMs).toBeGreaterThanOrEqual(
-            existingDeadline!,
-        );
-        expect(after?.readyDeadlineMs).toBeLessThanOrEqual(
-            existingDeadline! + 2,
-        );
+        expect(after?.readyDeadlineMs).toBe(existingDeadline);
     });
 
     it("recomputes waiting deadline when stale external snapshots keep waiting state but local deadline is missing", () => {


### PR DESCRIPTION
## Problem

`listenTogetherManagerRuntime.test.ts` — "preserves existing waiting deadline when stale external playback snapshots are ignored" — intermittently fails on CI with +3 ms drift (seen on PR #848's Backend Tests + Coverage, run 32928341248: expected <= 1787716657173, received 1787716657176). The assertion allowed only 2 ms between the deadline computed by `setTrack` and the one recomputed when the stale snapshot is ignored; both derive from `Date.now()`, so runner speed decides the outcome.

## Fix

Pin `Date.now` with the suite's existing clock-spy pattern (`jest.spyOn(Date, "now").mockReturnValue(...)`, restored by the suite's `afterEach`) so zero wall-clock time passes between the two computations, and assert exact equality. This is stricter than the old ±2 ms window — any future regression that changes the recomputed deadline now fails deterministically instead of hiding inside a tolerance.

## Verification

- verify: `npx jest src/services/__tests__/listenTogetherManagerRuntime.test.ts --maxWorkers=2` — 50 passed, exit 0
- verify: `npx tsc --noEmit` — exit 0
- verify: prettier check on the changed file — exit 0
- verify: `node scripts/ci/check-file-size.mjs` — exit 0