### PR TITLE
docs: user-guide truth-up for everything shipped since 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ soundspan is built for people who want streaming convenience without giving up o
 - Audiobookshelf integration with unified browsing/playback and progress sync
 - Programmatic playlist generation, artist-diversity balancing, and library radio stations
 - Synced lyrics, source/quality badges, and overhauled browser/PWA/overlay player flows
+- Per-user Last.fm and ListenBrainz scrobbling with now-playing updates, including plays from Subsonic clients
+- Unified song search that ranks owned and discoverable songs together, with shareable per-song links
 - Multiple users with isolated playlists, likes, history, and settings, plus admin roles, optional 2FA, and Listen Together group sessions
 - Federated library sharing between trusted soundspan instances, opt-in and disabled by default
 - OIDC/SSO login with explicit account linking and revocable app passwords for OpenSubsonic clients
@@ -102,6 +104,8 @@ soundspan supports optional integrations for discovery, downloads, and client co
 - Soulseek
 - YouTube Music
 - TIDAL (streaming + downloads)
+- Last.fm and ListenBrainz scrobbling
+- AcoustID track identification
 - OpenSubsonic-compatible `/rest` API
 
 Full setup guides are documented in [`docs/INTEGRATIONS.md`](docs/INTEGRATIONS.md).
@@ -177,7 +181,7 @@ graph TD
 | Frontend            | Web interface (Next.js)                           | 3030                 |
 | Backend             | API server (Express.js)                           | 3006                 |
 | Backend Worker      | Background queues, processors, and scheduled jobs | 3010 health endpoint |
-| PostgreSQL          | Primary database (with pgvector)                  | 5432                 |
+| PostgreSQL          | Primary database (with pgvector and pg_trgm)      | 5432                 |
 | Redis               | Cache and queue backend                           | 6379                 |
 | TIDAL Sidecar       | TIDAL streaming/download proxy                    | 8585                 |
 | YT Music Streamer   | YouTube Music streaming proxy                     | 8586                 |

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -266,6 +266,8 @@ LASTFM_SHARED_SECRET=your_shared_secret
 
 `LASTFM_API_KEY` may already be set for metadata enrichment; scrobbling additionally requires the shared secret. Helm users storing keys in an existing Secret must add `LASTFM_SHARED_SECRET` to it.
 
+These two values identify your soundspan server as an application to Last.fm — like an OAuth app credential. They are not a listener account and never receive scrobbles. Each user still connects their own Last.fm account, and each user's plays go to their own Last.fm profile.
+
 Then each user connects their own account:
 
 1. Open **Settings** -> **Scrobbling** and click **Connect Last.fm**

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -71,6 +71,7 @@ soundspan can connect directly to Soulseek for discovery/download flows.
 - Discovery results include filename, size, bitrate, and parsed metadata
 - Download progress appears in Activity Panel
 - Quality/availability depends on peer uptime and speed
+- Album downloads prefer one uploader's complete album folder: a folder is only chosen when it covers at least 90% of the requested tracks and its contents clearly belong to the same album. When no folder qualifies, tracks are assembled one by one from the best individual matches, as before.
 
 ## YouTube Music
 
@@ -242,6 +243,40 @@ If the album is not found on YouTube Music, the job follows your **When Primary 
 | ------------------------------- | -------- | ---------------------------------------- |
 | `MUSIC_PATH`                    | `/music` | Path for downloaded music                |
 | `YT_ALBUM_DOWNLOAD_CONCURRENCY` | `1`      | Album download jobs processed at once    |
+
+## Last.fm and ListenBrainz Scrobbling
+
+Each user can send their soundspan listening history to Last.fm and/or ListenBrainz. Connections are per user, under **Settings** -> **Scrobbling**. Plays from the web app and from connected Subsonic clients both forward.
+
+### ListenBrainz setup
+
+No server configuration is needed.
+
+1. Copy your user token from `listenbrainz.org/settings`
+2. Open **Settings** -> **Scrobbling**, paste the token, and click **Connect**
+
+### Last.fm setup
+
+The server operator must first create a free Last.fm API account (https://www.last.fm/api/account/create) and set two environment values:
+
+```bash
+LASTFM_API_KEY=your_api_key
+LASTFM_SHARED_SECRET=your_shared_secret
+```
+
+`LASTFM_API_KEY` may already be set for metadata enrichment; scrobbling additionally requires the shared secret. Helm users storing keys in an existing Secret must add `LASTFM_SHARED_SECRET` to it.
+
+Then each user connects their own account:
+
+1. Open **Settings** -> **Scrobbling** and click **Connect Last.fm**
+2. Approve the connection on the Last.fm page that opens
+3. Return and click **I've approved — finish connecting**
+
+### Notes
+
+- Each service has its own enable toggle; **Disconnect** removes the stored credential
+- Scrobbles and now-playing updates are delivered in the background and retried on failure; playback is never delayed
+- If a service rejects a stored credential, that connection is disabled and the user is asked to reconnect
 
 ## Podcasts
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -49,18 +49,52 @@ Anything not listed: drop-in.
 
 ---
 
-## Unreleased: legacy discovery mode now serves the modern implementation
+## Unreleased: scrobbling, AcoustID, and database changes
 
-You only need to read this if you ever set the environment variable
-`DISCOVERY_MODE=legacy`. If you never set it (most installs), nothing changes.
+Most installs need no action: pull, restart, and the database migrations
+apply automatically. Read on if you run an external or managed PostgreSQL,
+use a Helm `existingSecret`, want the new integrations, or ever set
+`DISCOVERY_MODE=legacy`.
 
-The old "legacy" discovery implementation has been removed from the codebase.
-The `DISCOVERY_MODE` variable still works and `legacy` is still a valid value,
-so nothing breaks at startup — but setting it to `legacy` now serves the same
-modern discovery pages everyone else gets, and the server logs a one-line
-reminder when it starts. To stop the reminder, remove the variable (or set it
-to `modern`). Nothing else about discovery, downloads, or your library is
-affected.
+**External PostgreSQL: the `pg_trgm` extension.** A new search migration runs
+`CREATE EXTENSION IF NOT EXISTS pg_trgm`. The bundled Postgres image handles
+this automatically. If you point soundspan at your own PostgreSQL and the app
+role cannot create extensions, run this once as a superuser before upgrading,
+or the first start fails during migration:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+**First start can take longer on large libraries.** One migration rebuilds
+database indexes to match how the app actually queries (and removes 14 unused
+ones). This is a one-time cost during the first startup after the upgrade.
+
+**Last.fm scrobbling needs two server values.** Users can connect Last.fm and
+ListenBrainz accounts under `Settings -> Scrobbling`. ListenBrainz works out
+of the box. Last.fm requires the operator to set `LASTFM_API_KEY` and
+`LASTFM_SHARED_SECRET` (get both from a free Last.fm API account). Helm users
+with `secrets.apiKeysInExistingSecret=true` must add `LASTFM_SHARED_SECRET`
+to their existing Secret.
+
+**AcoustID track identification is optional and off by default.** Set
+`ACOUSTID_API_KEY` (free from acoustid.org) and the analyzer resolves
+high-confidence MusicBrainz identities for your local tracks in the
+background. Without the key, fingerprints are still computed and stored, and
+nothing else changes.
+
+**Browsed-artist memory is on by default.** Artists and albums anyone browses
+are now cached in the database so repeat visits are instant and survive
+MusicBrainz outages. Entries untouched for 180 days are cleaned up
+(`CATALOG_RETENTION_DAYS` to tune). Set `CATALOG_PERSISTENCE=off` to turn the
+feature off.
+
+**`DISCOVERY_MODE=legacy` now serves the modern implementation.** The old
+"legacy" discovery implementation has been removed from the codebase. The
+variable still works and `legacy` is still a valid value, so nothing breaks
+at startup — but it now serves the same modern discovery pages everyone else
+gets, and the server logs a one-line reminder when it starts. To stop the
+reminder, remove the variable (or set it to `modern`).
 
 ## 2.5.0: sharing defaults, pairing codes, and the TIDAL sidecar rename
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -15,10 +15,17 @@ For configuration and security, see [`CONFIGURATION_AND_SECURITY.md`](CONFIGURAT
 
 - Home surfaces continue listening, recently added artists, Made For You mixes, recommendations, popular artists, community playlists, podcasts, and audiobooks
 - Search includes tabs for library, peers, discovery, Soulseek, and podcasts; peer and Soulseek tabs appear when their integrations are enabled
-- Search results also surface external artists and songs to discover from Last.fm matches, linking into artist pages for preview and download
+- Search shows one **Songs** section: songs you own and songs you don't sit together in a single ranked list. External matches carry a provider badge (TIDAL or YouTube) and never duplicate something already in your library.
+- External songs with a streaming match play right from the results, and every row — owned or not — has the full menu with like/dislike, Go to artist, and Go to album
+- Search understands artist and album names, tolerates typos, and ranks near-misses by similarity instead of alphabetically
 - Discovery search supports preview/download/subscription actions
 - Explore and `/radio` station tiles (Quick Start, genres, decades) open a generated station playlist you can inspect before playing; Shuffle All still starts playback immediately
 - The Vibe Map in the main navigation plots your analyzed library as an explorable similarity map
+- Artists and albums you browse are remembered locally. Repeat visits load instantly, and the pages keep working during MusicBrainz outages. Entries untouched for 180 days are cleaned up automatically.
+
+### Sharing a song
+
+Every track's menu has `Copy link to song`. The link opens the album page with that song highlighted and starts playing it. On a brand-new device the browser may ask for one tap before audio starts.
 
 ## Artist Playback Order
 
@@ -40,6 +47,17 @@ Player quality badges show active source details (codec/bitrate or bit depth/sam
 
 Volume leveling evens out loudness differences between songs so you do not reach for the volume knob between a quiet 90s master and a modern loud one. It is on by default in `Automatic` mode: albums played front-to-back keep their intended dynamics, while shuffle, radio, and mixed queues are leveled per song. Set it to `By track`, `By album`, or `Off` under `Settings -> Playback -> Volume leveling`. Leveling only turns loud songs down and gives quiet songs a small, clip-safe boost; songs the analyzer has not measured yet play unchanged until the background measurement catches up.
 
+## Scrobbling
+
+Scrobbling sends the music you play in soundspan to your listening-history service. Each user connects their own accounts under `Settings -> Scrobbling`. Two services are supported:
+
+- **ListenBrainz.** Copy your user token from `listenbrainz.org/settings` and paste it into the Connect form. No server setup is needed.
+- **Last.fm.** Click `Connect Last.fm`. A Last.fm page opens asking you to approve the connection. Approve it, come back, and click `I've approved — finish connecting`. Last.fm requires the server operator to set `LASTFM_API_KEY` and `LASTFM_SHARED_SECRET` first; the settings page tells you if they are missing.
+
+Once connected, each service has its own on/off toggle, so you can pause forwarding without disconnecting. `Disconnect` removes the stored credential.
+
+What gets sent: finished tracks (scrobbles) and now-playing updates, for music you play in the app or through a connected Subsonic client. Scrobbling never delays or blocks playback — if a service is down, deliveries retry in the background and are dropped after repeated failures. If a service rejects your stored credential, the connection is switched off and you are asked to reconnect.
+
 ## Social and History
 
 - Activity panel `Social` tab lists users who are online and sharing presence.
@@ -53,7 +71,7 @@ Non-admin users cannot download music directly. Instead, they can ask for it:
 
 - Open an album that is not in the library. A `Request` button appears where admins see `Download`.
 - Click `Request`. The button changes to `Requested` and an admin is notified.
-- Admins review requests on the `Requests` page (avatar menu -> `Requests`): approve to start the download through the server's normal download path, or decline.
+- Admins review requests on the `Requests` page (avatar menu -> `Requests`): approve to send the album into the download queue, or decline.
 - You get a notification when your request is approved, declined, or when the album lands in the library.
 - Visit `/requests` to see your own requests and cancel pending ones.
 
@@ -91,6 +109,14 @@ Admins can manage users, integrations, downloads, enrichment automation, queue d
 - Federation health panel with per-peer sync, stream, and error diagnostics
 - API keys and Swagger docs
 - Bull Board dashboard (`/api/admin/queues`)
+
+### Album downloads
+
+Album downloads run through a queue. One album downloads at a time across the whole server, and the queue survives restarts — queued albums resume where they left off.
+
+- `Download all missing albums` on an artist page queues each missing album and shows progress as the list is worked through. Promo releases, bootlegs, remix/live/demo/compilation groups, and albums where the artist is only featured are skipped.
+- A download that delivers only part of an album is reported as `Partial download: N/M tracks` instead of claiming success.
+- If the requested album cannot be found on the primary source, the job moves to your configured fallback source or fails with a clear reason. It never substitutes a different release.
 
 Technical admin configuration and security notes are in [`CONFIGURATION_AND_SECURITY.md`](CONFIGURATION_AND_SECURITY.md).
 

--- a/frontend/features/search/README.md
+++ b/frontend/features/search/README.md
@@ -16,6 +16,7 @@ Start-here guide for `frontend/features/search`.
 | --- | --- |
 | `components/AliasResolutionBanner.tsx` | components |
 | `components/DiscoverPodcastsGrid.tsx` | components |
+| `components/DiscoverTracksList.tsx` | components |
 | `components/EmptyState.tsx` | components |
 | `components/LibraryAlbumsGrid.tsx` | components |
 | `components/LibraryAudiobooksGrid.tsx` | components |
@@ -26,10 +27,15 @@ Start-here guide for `frontend/features/search`.
 | `components/SoulseekSongsList.tsx` | components |
 | `components/TopResult.tsx` | components |
 | `components/TVSearchInput.tsx` | components |
+| `components/YouTubePlaylistPreviewCard.tsx` | components |
 | `components/YouTubePreviewCard.tsx` | components |
 | `hooks/useSearchData.ts` | hooks |
+| `hooks/useSearchTrackMatches.ts` | hooks |
 | `hooks/useSoulseekSearch.ts` | hooks |
+| `hooks/useYouTubePlaylist.ts` | hooks |
 | `hooks/useYouTubeUrl.ts` | hooks |
+| `discoverySelection.ts` | root |
+| `songDedup.ts` | root |
 | `types.ts` | root |
 
 ## Update Rule

--- a/frontend/features/settings/README.md
+++ b/frontend/features/settings/README.md
@@ -35,6 +35,7 @@ Start-here guide for `frontend/features/settings`.
 | `components/sections/playbackHistoryConfig.ts` | components |
 | `components/sections/PlaybackHistorySection.tsx` | components |
 | `components/sections/PlaybackSection.tsx` | components |
+| `components/sections/ScrobblingSection.tsx` | components |
 | `components/sections/SocialSection.tsx` | components |
 | `components/sections/SignInSecuritySection.tsx` | components |
 | `components/sections/SoulseekSection.tsx` | components |


### PR DESCRIPTION
Pre-2.6.0 audit of the 67 commits since 2.5.0 against the user-facing docs. Everything here is prose only — no code changes.

## What was missing

- **Scrobbling had zero documentation.** USAGE_GUIDE gains a section walking through the per-user ListenBrainz token flow and the Last.fm connect/approve flow, the per-service toggles, and the delivery guarantees (background retries, never blocks playback, auto-disable on rejected credentials). INTEGRATIONS gains the operator setup (`LASTFM_API_KEY` + `LASTFM_SHARED_SECRET`, Helm existingSecret note).
- **Search docs predated the whole search rework.** The Home and Search section now describes the unified Songs section, playable external rows with provider badges, typo-tolerant ranked matching, and Copy link to song.
- **The album download queue was undocumented** and the Requests section still claimed approvals run through "the server's normal download path". New Album downloads section: one album at a time, survives restarts, partial downloads reported honestly, fail-closed matching.
- **UPGRADING had nothing for the next release.** Consolidated Unreleased section covers the `pg_trgm` extension requirement for external Postgres (the new trigram migration runs `CREATE EXTENSION`), the one-time index-tuning cost on first start, Last.fm server values, optional `ACOUSTID_API_KEY`, catalog persistence defaulting on, and the existing `DISCOVERY_MODE=legacy` note folded in.
- README highlights/integrations list and the settings/search feature README indexes (AGENTS.md §frontend indexing) brought current.

## Verification

- verify: `npx --prefix backend prettier --check` on all six changed files — exit 0