### PR TITLE
chore(chart): expose the music-requests feature flag as config.features.requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Helm deployments can configure the music-requests feature flag through `config.features.requests`.
+
 ### Changed
 
 - CI now verifies that environment variables used by the backend and Python services stay documented and available through a deployment surface.

--- a/backend/src/routes/README.md
+++ b/backend/src/routes/README.md
@@ -223,7 +223,7 @@ stays rate limited (`apiLimiter`) and returns
 - `DISCOVERY_ENABLED`: `/api/discover`, `/api/recommendations`
 - `AUTO_PLAYLISTS_ENABLED`: `/api/mixes`
 - `FEDERATION_ENABLED`: `/api/federation/v1`, `/api/federation/admin`, consumer sync/health jobs, and federated playback/cover branches
-- `FEATURE_REQUESTS`: `/api/requests` (no Helm `config.features.*` value; set it via the chart's raw env passthrough)
+- `FEATURE_REQUESTS`: `/api/requests` (Helm value: `config.features.requests`)
 
 ## Conventions
 

--- a/charts/soundspan/README.md
+++ b/charts/soundspan/README.md
@@ -401,8 +401,8 @@ workload ordering.
 ### Feature Flags
 
 Coarse feature flags render on the backend, backend-worker, and AIO workloads.
-Existing ML/recommendation flags default to `true`. Federation defaults to
-`false`. Per-workload `env` maps override these values.
+Application feature flags default to `true`. Federation defaults to `false`.
+Per-workload `env` maps override these values.
 
 ```yaml
 config:
@@ -410,6 +410,7 @@ config:
     audioAnalysis: true   # audio analysis queueing, mood buckets, /api/analysis, /api/vibe
     discovery: true       # Discover Weekly cron/processor, /api/discover, /api/recommendations
     autoPlaylists: true   # Made For You mixes, /api/mixes
+    requests: true        # music request API and request-fulfillment reconciliation
     federation: false     # scoped peer credentials and /api/federation host API
   federationTombstoneRetentionDays: 90
   federationSyncIntervalMinutes: 15
@@ -650,6 +651,7 @@ When `deploymentMode=individual` and `backendWorker.enabled=true`, the chart inj
 | `AUDIO_ANALYSIS_ENABLED` | `config.features.audioAnalysis` | No | `true` |
 | `DISCOVERY_ENABLED` | `config.features.discovery` | No | `true` |
 | `AUTO_PLAYLISTS_ENABLED` | `config.features.autoPlaylists` | No | `true` |
+| `FEATURE_REQUESTS` | `config.features.requests` | No | `true` |
 | `FEDERATION_ENABLED` | `config.features.federation` | No | `false` |
 | `SCAN_FILE_CONCURRENCY` | `config.scanFileConcurrency` | No | App default: `3` (chart leaves unset unless configured) |
 | `CATALOG_PERSISTENCE` | `config.catalogPersistence` | No | App default: `true` (chart leaves unset unless configured) |

--- a/charts/soundspan/templates/aio/deployment.yaml
+++ b/charts/soundspan/templates/aio/deployment.yaml
@@ -84,6 +84,7 @@ spec:
             "AUDIO_ANALYSIS_ENABLED" true
             "DISCOVERY_ENABLED" true
             "AUTO_PLAYLISTS_ENABLED" true
+            "FEATURE_REQUESTS" true
             "FEDERATION_ENABLED" true
             "SCAN_FILE_CONCURRENCY" true
             "CATALOG_PERSISTENCE" true
@@ -264,6 +265,13 @@ spec:
             {{- else }}
             - name: AUTO_PLAYLISTS_ENABLED
               value: {{ .Values.config.features.autoPlaylists | quote }}
+            {{- end }}
+            {{- if hasKey $aioEnv "FEATURE_REQUESTS" }}
+            - name: FEATURE_REQUESTS
+              value: {{ index $aioEnv "FEATURE_REQUESTS" | quote }}
+            {{- else }}
+            - name: FEATURE_REQUESTS
+              value: {{ .Values.config.features.requests | quote }}
             {{- end }}
             # Audio analysis
             {{- range $key := keys $aioEnv | sortAlpha }}

--- a/charts/soundspan/templates/individual/backend-worker.yaml
+++ b/charts/soundspan/templates/individual/backend-worker.yaml
@@ -118,6 +118,7 @@ spec:
             "AUDIO_ANALYSIS_ENABLED" true
             "DISCOVERY_ENABLED" true
             "AUTO_PLAYLISTS_ENABLED" true
+            "FEATURE_REQUESTS" true
             "FEDERATION_ENABLED" true
             "SCAN_FILE_CONCURRENCY" true
             "CATALOG_PERSISTENCE" true
@@ -437,6 +438,13 @@ spec:
             {{- else }}
             - name: AUTO_PLAYLISTS_ENABLED
               value: {{ .Values.config.features.autoPlaylists | quote }}
+            {{- end }}
+            {{- if hasKey $backendWorkerEnv "FEATURE_REQUESTS" }}
+            - name: FEATURE_REQUESTS
+              value: {{ index $backendWorkerEnv "FEATURE_REQUESTS" | quote }}
+            {{- else }}
+            - name: FEATURE_REQUESTS
+              value: {{ .Values.config.features.requests | quote }}
             {{- end }}
             {{- if hasKey $backendWorkerEnv "LIDARR_ENABLED" }}
             - name: LIDARR_ENABLED

--- a/charts/soundspan/templates/individual/backend.yaml
+++ b/charts/soundspan/templates/individual/backend.yaml
@@ -152,6 +152,7 @@ spec:
             "AUDIO_ANALYSIS_ENABLED" true
             "DISCOVERY_ENABLED" true
             "AUTO_PLAYLISTS_ENABLED" true
+            "FEATURE_REQUESTS" true
             "FEDERATION_ENABLED" true
             "SCAN_FILE_CONCURRENCY" true
             "CATALOG_PERSISTENCE" true
@@ -528,6 +529,13 @@ spec:
             {{- else }}
             - name: AUTO_PLAYLISTS_ENABLED
               value: {{ .Values.config.features.autoPlaylists | quote }}
+            {{- end }}
+            {{- if hasKey $backendEnv "FEATURE_REQUESTS" }}
+            - name: FEATURE_REQUESTS
+              value: {{ index $backendEnv "FEATURE_REQUESTS" | quote }}
+            {{- else }}
+            - name: FEATURE_REQUESTS
+              value: {{ .Values.config.features.requests | quote }}
             {{- end }}
             {{- if hasKey $backendEnv "LIDARR_ENABLED" }}
             - name: LIDARR_ENABLED

--- a/charts/soundspan/values.yaml
+++ b/charts/soundspan/values.yaml
@@ -780,11 +780,11 @@ config:
   providerTrackRetentionDays: 30
   # -- Consumer federation catalog sync interval in minutes. Minimum 1.
   federationSyncIntervalMinutes: 15
-  # -- Coarse feature flags. Existing ML/recommendation flags default ON;
-  #    federation defaults OFF.
+  # -- Coarse feature flags. Application feature flags default ON; federation
+  #    defaults OFF.
   #    Rendered as AUDIO_ANALYSIS_ENABLED / DISCOVERY_ENABLED /
-  #    AUTO_PLAYLISTS_ENABLED / FEDERATION_ENABLED on the backend,
-  #    backend-worker, and AIO workloads.
+  #    AUTO_PLAYLISTS_ENABLED / FEATURE_REQUESTS / FEDERATION_ENABLED on the
+  #    backend, backend-worker, and AIO workloads.
   features:
     # -- Backend queueing/consumption of audio analysis work, mood-bucket
     #    worker, /api/analysis and /api/vibe routes. The Essentia analyzer
@@ -796,6 +796,8 @@ config:
     discovery: true
     # -- Made For You mixes (on-demand programmatic playlists, /api/mixes).
     autoPlaylists: true
+    # -- Music request API and request-fulfillment reconciliation.
+    requests: true
     # -- Scoped peer credentials and read-only host federation API.
     federation: false
   # -- Enables Socket.IO Redis adapter for Listen Together cross-pod fanout.
@@ -875,4 +877,3 @@ gateway:
 service:
   type: ClusterIP
   port: 3030
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,10 +291,9 @@ gates `/api/requests` and the request-fulfillment reconciler. With a flag off, t
 handler for the subsystem's routes (requests get `404` with
 `code: FEATURE_DISABLED`) and the worker process does not register its queues or
 schedules. Disabling federation also prevents identity initialization,
-tombstone writes, peer sync/health work, and federated playback branches. All flags
-except `FEATURE_REQUESTS` are exposed through Helm values (`config.features.*`)
-and forwarded by the docker-compose files; `FEATURE_REQUESTS` is set through
-the chart's raw env passthrough.
+tombstone writes, peer sync/health work, and federated playback branches. The flags are exposed through Helm values (`config.features.*`, with
+`FEATURE_REQUESTS` as `config.features.requests`) and forwarded by the
+docker-compose files.
 
 ### Scheduled Federation Jobs
 


### PR DESCRIPTION
Closes #858.

`FEATURE_REQUESTS` (default on, gates `/api/requests` and the request-fulfillment reconciler) was the only coarse feature flag without a Helm value. This adds `config.features.requests` following the sibling-flag pattern exactly: always-emitted boolean on AIO, backend, and backend-worker, managed-key guard so a workload `env` map override wins and renders once. Default `true` matches the application default, so existing deployments are unchanged. The two doc statements that recorded the gap (ARCHITECTURE, routes README) now point at the value.

## Verification

- verify: `helm lint` — exit 0; `npm run verify:helm` under Node 24 — exit 0
- verify: default render — `FEATURE_REQUESTS="true"` on all three workloads; `--set config.features.requests=false` — `"false"` on all three
- verify: `backendWorker.env.FEATURE_REQUESTS=false` passthrough wins, renders exactly once
- verify: repo-pinned prettier on CHANGELOG — exit 0