### PR TITLE
fix(scrobbling): Last.fm connect errors report clearly instead of a generic internal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Docker Compose and all-in-one deployments can now set every documented optional tuning and integration variable; previously, about 40 documented variables were not forwarded into the containers.
+- Connecting Last.fm before approving access no longer shows a generic internal error, and credential or availability problems report clearly.
 
 ## [2.6.0] - 2026-08-26
 

--- a/backend/src/routes/__tests__/scrobblingRoutes.test.ts
+++ b/backend/src/routes/__tests__/scrobblingRoutes.test.ts
@@ -10,8 +10,20 @@ const setEnabled = jest.fn();
 class InvalidListenBrainzTokenError extends Error {}
 class LastFmServerConfigurationError extends Error {}
 class LastFmAuthStateError extends Error {
+    constructor(message = "No pending Last.fm authorization was found") {
+        super(message);
+    }
+}
+class LastFmCredentialsRejectedError extends Error {
     constructor() {
-        super("No pending Last.fm authorization was found");
+        super(
+            "The server's Last.fm API key or shared secret was rejected by Last.fm",
+        );
+    }
+}
+class ScrobbleProviderRequestError extends Error {
+    constructor(public readonly service: "Last.fm" | "ListenBrainz") {
+        super(`${service} request failed`);
     }
 }
 
@@ -32,6 +44,8 @@ jest.mock("../../services/scrobbleConnections", () => ({
     InvalidListenBrainzTokenError,
     LastFmServerConfigurationError,
     LastFmAuthStateError,
+    LastFmCredentialsRejectedError,
+    ScrobbleProviderRequestError,
 }));
 
 import router from "../scrobbling";
@@ -170,6 +184,60 @@ describe("scrobbling routes", () => {
         expect(response.statusCode).toBe(409);
         expect(response.body).toEqual({
             error: "No pending Last.fm authorization was found",
+        });
+    });
+
+    it("returns 409 when Last.fm credentials are rejected", async () => {
+        startAuth.mockRejectedValue(new LastFmCredentialsRejectedError());
+
+        const response = await invoke("/lastfm/start-auth", "post");
+
+        expect(response.statusCode).toBe(409);
+        expect(response.body).toEqual({
+            error: "The server's Last.fm API key or shared secret was rejected by Last.fm",
+        });
+    });
+
+    it("returns 409 with approval guidance for an unauthorized Last.fm token", async () => {
+        completeAuth.mockRejectedValue(
+            new LastFmAuthStateError(
+                "Approve access in the Last.fm tab, then try again",
+            ),
+        );
+
+        const response = await invoke("/lastfm/complete-auth", "post");
+
+        expect(response.statusCode).toBe(409);
+        expect(response.body).toEqual({
+            error: "Approve access in the Last.fm tab, then try again",
+        });
+    });
+
+    it("returns 502 when Last.fm does not respond", async () => {
+        startAuth.mockRejectedValue(
+            new ScrobbleProviderRequestError("Last.fm"),
+        );
+
+        const response = await invoke("/lastfm/start-auth", "post");
+
+        expect(response.statusCode).toBe(502);
+        expect(response.body).toEqual({
+            error: "Last.fm did not respond. Try again in a moment.",
+        });
+    });
+
+    it("returns 502 when ListenBrainz does not respond", async () => {
+        saveToken.mockRejectedValue(
+            new ScrobbleProviderRequestError("ListenBrainz"),
+        );
+
+        const response = await invoke("/listenbrainz", "put", {
+            token: "user-token",
+        });
+
+        expect(response.statusCode).toBe(502);
+        expect(response.body).toEqual({
+            error: "ListenBrainz did not respond. Try again in a moment.",
         });
     });
 });

--- a/backend/src/routes/__tests__/scrobblingRoutes.test.ts
+++ b/backend/src/routes/__tests__/scrobblingRoutes.test.ts
@@ -104,7 +104,14 @@ describe("scrobbling routes", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         status.mockResolvedValue({
-            lastfm: { connected: true, enabled: true, username: "listener" },
+            lastfm: {
+                connected: true,
+                enabled: true,
+                username: "listener",
+                serverConfigured: true,
+                apiKeyConfigured: true,
+                sharedSecretConfigured: true,
+            },
             listenbrainz: { connected: true, enabled: false },
         });
         saveToken.mockResolvedValue(undefined);
@@ -127,11 +134,18 @@ describe("scrobbling routes", () => {
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toEqual({
-            lastfm: { connected: true, enabled: true, username: "listener" },
+            lastfm: {
+                connected: true,
+                enabled: true,
+                username: "listener",
+                serverConfigured: true,
+                apiKeyConfigured: true,
+                sharedSecretConfigured: true,
+            },
             listenbrainz: { connected: true, enabled: false },
         });
         expect(JSON.stringify(response.body)).not.toMatch(
-            /token|credential|secret|signature/i,
+            /encryptedCredential|encryptedPendingToken|"(?:token|apiKey|sharedSecret|signature)":/i,
         );
     });
 

--- a/backend/src/routes/scrobbling.ts
+++ b/backend/src/routes/scrobbling.ts
@@ -10,8 +10,10 @@ import {
     getScrobblingStatus,
     InvalidListenBrainzTokenError,
     LastFmAuthStateError,
+    LastFmCredentialsRejectedError,
     LastFmServerConfigurationError,
     saveListenBrainzToken,
+    ScrobbleProviderRequestError,
     setScrobblerEnabled,
     startLastFmAuth,
 } from "../services/scrobbleConnections";
@@ -26,6 +28,19 @@ const enabledBody = z.strictObject({ enabled: z.boolean() });
 type TokenRequest = ValidatedRequest<{ body: typeof tokenBody }>;
 type EnabledRequest = ValidatedRequest<{ body: typeof enabledBody }>;
 
+function sendProviderUnavailable(
+    error: unknown,
+    res: Parameters<typeof sendRouteError>[0],
+): boolean {
+    if (!(error instanceof ScrobbleProviderRequestError)) return false;
+    sendRouteError(
+        res,
+        502,
+        `${error.service} did not respond. Try again in a moment.`,
+    );
+    return true;
+}
+
 function sendLastFmKnownError(
     error: unknown,
     res: Parameters<typeof sendRouteError>[0],
@@ -38,7 +53,11 @@ function sendLastFmKnownError(
         sendRouteError(res, 409, error.message);
         return true;
     }
-    return false;
+    if (error instanceof LastFmCredentialsRejectedError) {
+        sendRouteError(res, 409, error.message);
+        return true;
+    }
+    return sendProviderUnavailable(error, res);
 }
 
 /**
@@ -70,6 +89,7 @@ router.get(
  *       200: { description: ListenBrainz connected }
  *       400: { description: Invalid request }
  *       422: { description: ListenBrainz rejected the token }
+ *       502: { description: ListenBrainz did not respond }
  *       401: { description: Not authenticated }
  *   delete:
  *     summary: Disconnect ListenBrainz
@@ -95,6 +115,7 @@ router.put(
                 sendRouteError(res, 422, "ListenBrainz rejected the token");
                 return;
             }
+            if (sendProviderUnavailable(error, res)) return;
             throw error;
         }
     }),
@@ -145,7 +166,8 @@ router.patch(
  *     security: [{ bearerAuth: [] }, { apiKeyAuth: [] }]
  *     responses:
  *       200: { description: Last.fm approval URL }
- *       409: { description: Server credentials are missing }
+ *       409: { description: Server credentials are missing or rejected }
+ *       502: { description: Last.fm did not respond }
  *       401: { description: Not authenticated }
  */
 router.post(
@@ -169,7 +191,8 @@ router.post(
  *     security: [{ bearerAuth: [] }, { apiKeyAuth: [] }]
  *     responses:
  *       200: { description: Last.fm connected }
- *       409: { description: Server credentials or pending authorization are missing }
+ *       409: { description: Server credentials or pending authorization are invalid }
+ *       502: { description: Last.fm did not respond }
  *       401: { description: Not authenticated }
  */
 router.post(

--- a/backend/src/routes/scrobbling.ts
+++ b/backend/src/routes/scrobbling.ts
@@ -68,7 +68,27 @@ function sendLastFmKnownError(
  *     tags: [Scrobbling]
  *     security: [{ bearerAuth: [] }, { apiKeyAuth: [] }]
  *     responses:
- *       200: { description: Non-secret connection status }
+ *       200:
+ *         description: Non-secret Last.fm and ListenBrainz connection status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 lastfm:
+ *                   type: object
+ *                   properties:
+ *                     connected: { type: boolean }
+ *                     enabled: { type: boolean }
+ *                     username: { type: string, nullable: true }
+ *                     serverConfigured: { type: boolean }
+ *                     apiKeyConfigured: { type: boolean }
+ *                     sharedSecretConfigured: { type: boolean }
+ *                 listenbrainz:
+ *                   type: object
+ *                   properties:
+ *                     connected: { type: boolean }
+ *                     enabled: { type: boolean }
  *       401: { description: Not authenticated }
  */
 router.get(

--- a/backend/src/services/__tests__/scrobble/scrobbleConnections.test.ts
+++ b/backend/src/services/__tests__/scrobble/scrobbleConnections.test.ts
@@ -238,13 +238,37 @@ describe("saveListenBrainzToken", () => {
         expect(upsert).not.toHaveBeenCalled();
     });
 
-    it("keeps the explicit error for an unexpected successful Last.fm body", async () => {
+    it("classifies an unexpected successful Last.fm token body as a provider request error", async () => {
         get.mockResolvedValue({ status: 200, data: {} });
 
-        await expect(startLastFmAuth("user-1")).rejects.toThrow(
-            "Last.fm did not return an authorization token",
+        await expect(startLastFmAuth("user-1")).rejects.toBeInstanceOf(
+            ScrobbleProviderRequestError,
         );
         expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it("classifies an empty successful Last.fm token body as a provider request error", async () => {
+        get.mockResolvedValue({ status: 200, data: "" });
+
+        await expect(startLastFmAuth("user-1")).rejects.toBeInstanceOf(
+            ScrobbleProviderRequestError,
+        );
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it("classifies an HTML successful Last.fm session body as a provider request error", async () => {
+        findUnique.mockResolvedValue({
+            encryptedPendingToken: "encrypted:request-token",
+        });
+        post.mockResolvedValue({
+            status: 200,
+            data: "<!doctype html><title>Last.fm unavailable</title>",
+        });
+
+        await expect(completeLastFmAuth("user-1")).rejects.toBeInstanceOf(
+            ScrobbleProviderRequestError,
+        );
+        expect(updateMany).not.toHaveBeenCalled();
     });
 
     it("rejects completion when a newer pending Last.fm token wins the race", async () => {

--- a/backend/src/services/__tests__/scrobble/scrobbleConnections.test.ts
+++ b/backend/src/services/__tests__/scrobble/scrobbleConnections.test.ts
@@ -6,6 +6,8 @@ const findUnique = jest.fn();
 const updateMany = jest.fn();
 const encrypt = jest.fn((value: string) => `encrypted:${value}`);
 const decrypt = jest.fn((value: string) => value.replace("encrypted:", ""));
+const getSystemSettings = jest.fn();
+const lastFmConfig = { apiKey: "api-key", sharedSecret: "shared-secret" };
 
 jest.mock("axios", () => ({
     __esModule: true,
@@ -18,24 +20,31 @@ jest.mock("../../../utils/db", () => ({
 }));
 jest.mock("../../../utils/encryption", () => ({ encrypt, decrypt }));
 jest.mock("../../../config", () => ({
-    config: { lastfm: { apiKey: "api-key", sharedSecret: "shared-secret" } },
+    config: { lastfm: lastFmConfig },
 }));
 jest.mock("../../../utils/systemSettings", () => ({
-    getSystemSettings: jest.fn().mockResolvedValue(null),
+    getSystemSettings,
 }));
 
 import {
     InvalidListenBrainzTokenError,
     LastFmAuthStateError,
+    LastFmCredentialsRejectedError,
+    ScrobbleProviderRequestError,
     completeLastFmAuth,
     getScrobblingStatus,
     saveListenBrainzToken,
     startLastFmAuth,
 } from "../../scrobbleConnections";
 
-describe("saveListenBrainzToken", () => {
-    beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+    jest.clearAllMocks();
+    getSystemSettings.mockResolvedValue(null);
+    lastFmConfig.apiKey = "api-key";
+    lastFmConfig.sharedSecret = "shared-secret";
+});
 
+describe("saveListenBrainzToken", () => {
     it("validates the token before storing an encrypted value", async () => {
         get.mockResolvedValue({ data: { valid: true, user_name: "listener" } });
         upsert.mockResolvedValue({ id: "connection-1" });
@@ -102,14 +111,36 @@ describe("saveListenBrainzToken", () => {
                 enabled: true,
                 username: "listener",
                 serverConfigured: true,
+                apiKeyConfigured: true,
+                sharedSecretConfigured: true,
             },
             listenbrainz: { connected: true, enabled: false },
         });
         expect(JSON.stringify(result)).not.toMatch(/encrypted|token|session/i);
     });
 
+    it("reports each missing Last.fm server credential separately", async () => {
+        findMany.mockResolvedValue([]);
+        lastFmConfig.apiKey = "";
+        lastFmConfig.sharedSecret = "";
+
+        const result = await getScrobblingStatus("user-1");
+
+        expect(result.lastfm).toEqual({
+            connected: false,
+            enabled: false,
+            username: null,
+            serverConfigured: false,
+            apiKeyConfigured: false,
+            sharedSecretConfigured: false,
+        });
+    });
+
     it("signs Last.fm token requests and stores the pending token encrypted", async () => {
-        get.mockResolvedValue({ data: { token: "request-token" } });
+        get.mockResolvedValue({
+            status: 200,
+            data: { token: "request-token" },
+        });
         upsert.mockResolvedValue({ id: "connection-1" });
 
         const approvalUrl = await startLastFmAuth("user-1");
@@ -122,6 +153,7 @@ describe("saveListenBrainzToken", () => {
                 format: "json",
             },
             timeout: 8_000,
+            validateStatus: expect.any(Function),
         });
         expect(upsert).toHaveBeenCalledWith({
             where: {
@@ -142,6 +174,79 @@ describe("saveListenBrainzToken", () => {
         );
     });
 
+    it.each([4, 10, 13, 26])(
+        "classifies Last.fm credential error %i during start-auth",
+        async (errorCode) => {
+            get.mockResolvedValue({
+                status: 403,
+                data: { error: errorCode, message: "Credentials rejected" },
+            });
+
+            await expect(startLastFmAuth("user-1")).rejects.toEqual(
+                new LastFmCredentialsRejectedError(),
+            );
+            expect(upsert).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each([14, 15])(
+        "keeps the pending token for Last.fm auth-state error %i",
+        async (errorCode) => {
+            findUnique.mockResolvedValue({
+                encryptedPendingToken: "encrypted:request-token",
+            });
+            post.mockResolvedValue({
+                status: 403,
+                data: { error: errorCode, message: "Token is not usable" },
+            });
+
+            await expect(completeLastFmAuth("user-1")).rejects.toEqual(
+                new LastFmAuthStateError(
+                    "Approve access in the Last.fm tab, then try again",
+                ),
+            );
+            expect(updateMany).not.toHaveBeenCalled();
+            expect(post).toHaveBeenCalledWith(
+                "https://ws.audioscrobbler.com/2.0/",
+                expect.any(URLSearchParams),
+                {
+                    timeout: 8_000,
+                    validateStatus: expect.any(Function),
+                },
+            );
+        },
+    );
+
+    it("classifies Last.fm network failures as provider request errors", async () => {
+        get.mockRejectedValue(new Error("network unavailable"));
+
+        await expect(startLastFmAuth("user-1")).rejects.toBeInstanceOf(
+            ScrobbleProviderRequestError,
+        );
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it("classifies unknown Last.fm error codes as provider request errors", async () => {
+        get.mockResolvedValue({
+            status: 403,
+            data: { error: 99, message: "Unexpected provider error" },
+        });
+
+        await expect(startLastFmAuth("user-1")).rejects.toBeInstanceOf(
+            ScrobbleProviderRequestError,
+        );
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it("keeps the explicit error for an unexpected successful Last.fm body", async () => {
+        get.mockResolvedValue({ status: 200, data: {} });
+
+        await expect(startLastFmAuth("user-1")).rejects.toThrow(
+            "Last.fm did not return an authorization token",
+        );
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
     it("rejects completion when a newer pending Last.fm token wins the race", async () => {
         let pendingToken: string | null = null;
         let releaseExchange!: () => void;
@@ -152,8 +257,14 @@ describe("saveListenBrainzToken", () => {
         const exchangeReleased = new Promise<void>((resolve) => {
             releaseExchange = resolve;
         });
-        get.mockResolvedValueOnce({ data: { token: "request-token-a" } });
-        get.mockResolvedValueOnce({ data: { token: "request-token-b" } });
+        get.mockResolvedValueOnce({
+            status: 200,
+            data: { token: "request-token-a" },
+        });
+        get.mockResolvedValueOnce({
+            status: 200,
+            data: { token: "request-token-b" },
+        });
         upsert.mockImplementation(async (operation) => {
             pendingToken = operation.create.encryptedPendingToken;
             return { id: "connection-1" };
@@ -164,7 +275,10 @@ describe("saveListenBrainzToken", () => {
         post.mockImplementation(async () => {
             markExchangeStarted();
             await exchangeReleased;
-            return { data: { session: { key: "session-a", name: "alice" } } };
+            return {
+                status: 200,
+                data: { session: { key: "session-a", name: "alice" } },
+            };
         });
         updateMany.mockImplementation(async (operation) => {
             if (pendingToken !== operation.where.encryptedPendingToken) {

--- a/backend/src/services/scrobbleConnections.ts
+++ b/backend/src/services/scrobbleConnections.ts
@@ -199,7 +199,7 @@ export async function startLastFmAuth(userId: string): Promise<string> {
     );
     const tokenResult = lastFmTokenSchema.safeParse(responseData);
     if (!tokenResult.success) {
-        throw new Error("Last.fm did not return an authorization token");
+        throw new ScrobbleProviderRequestError("Last.fm");
     }
     const token = tokenResult.data.token;
     const encryptedPendingToken = encrypt(token);
@@ -252,7 +252,7 @@ export async function completeLastFmAuth(userId: string): Promise<string> {
     );
     const sessionResult = lastFmSessionSchema.safeParse(responseData);
     if (!sessionResult.success) {
-        throw new Error("Last.fm did not return a session key");
+        throw new ScrobbleProviderRequestError("Last.fm");
     }
     const { key: sessionKey, name: username } = sessionResult.data.session;
     const updateResult = await prisma.scrobbleConnection.updateMany({

--- a/backend/src/services/scrobbleConnections.ts
+++ b/backend/src/services/scrobbleConnections.ts
@@ -20,6 +20,14 @@ const lastFmTokenSchema = z.object({ token: z.string().min(1) });
 const lastFmSessionSchema = z.object({
     session: z.object({ key: z.string().min(1), name: z.string().optional() }),
 });
+const lastFmErrorSchema = z.object({
+    error: z.number().int(),
+    message: z.string().optional(),
+});
+const LASTFM_APPROVAL_REQUIRED_MESSAGE =
+    "Approve access in the Last.fm tab, then try again";
+const LASTFM_CREDENTIALS_REJECTED_MESSAGE =
+    "The server's Last.fm API key or shared secret was rejected by Last.fm";
 
 export class InvalidListenBrainzTokenError extends Error {
     constructor() {
@@ -36,14 +44,22 @@ export class LastFmServerConfigurationError extends Error {
 }
 
 export class LastFmAuthStateError extends Error {
-    constructor() {
-        super("No pending Last.fm authorization was found");
+    constructor(message = "No pending Last.fm authorization was found") {
+        super(message);
         this.name = "LastFmAuthStateError";
     }
 }
 
+/** Indicates that Last.fm rejected the operator-managed server credentials. */
+export class LastFmCredentialsRejectedError extends Error {
+    constructor() {
+        super(LASTFM_CREDENTIALS_REJECTED_MESSAGE);
+        this.name = "LastFmCredentialsRejectedError";
+    }
+}
+
 export class ScrobbleProviderRequestError extends Error {
-    constructor(service: "Last.fm" | "ListenBrainz") {
+    constructor(public readonly service: "Last.fm" | "ListenBrainz") {
         super(`${service} request failed`);
         this.name = "ScrobbleProviderRequestError";
     }
@@ -54,20 +70,71 @@ interface LastFmCredentials {
     sharedSecret: string;
 }
 
-/** Resolves the operator API key plus the environment-only shared secret. */
-export async function resolveLastFmCredentials(): Promise<LastFmCredentials> {
+interface LastFmConfigurationState extends LastFmCredentials {
+    apiKeyConfigured: boolean;
+    sharedSecretConfigured: boolean;
+    serverConfigured: boolean;
+}
+
+async function getLastFmConfigurationState(): Promise<LastFmConfigurationState> {
     const settings = await getSystemSettings();
     const apiKey = settings?.lastfmApiKey || config.lastfm.apiKey;
     const sharedSecret = config.lastfm.sharedSecret;
-    if (!apiKey || !sharedSecret) throw new LastFmServerConfigurationError();
-    return { apiKey, sharedSecret };
+    const apiKeyConfigured = Boolean(apiKey);
+    const sharedSecretConfigured = Boolean(sharedSecret);
+    return {
+        apiKey,
+        sharedSecret,
+        apiKeyConfigured,
+        sharedSecretConfigured,
+        serverConfigured: apiKeyConfigured && sharedSecretConfigured,
+    };
+}
+
+function createLastFmResponseError(code: number): Error {
+    if (code === 14 || code === 15) {
+        return new LastFmAuthStateError(LASTFM_APPROVAL_REQUIRED_MESSAGE);
+    }
+    if (code === 4 || code === 10 || code === 13 || code === 26) {
+        return new LastFmCredentialsRejectedError();
+    }
+    return new ScrobbleProviderRequestError("Last.fm");
+}
+
+async function callLastFm(
+    request: () => Promise<{ data: unknown; status: number }>,
+): Promise<unknown> {
+    let response: { data: unknown; status: number };
+    try {
+        response = await request();
+    } catch {
+        throw new ScrobbleProviderRequestError("Last.fm");
+    }
+    const lastFmError = lastFmErrorSchema.safeParse(response.data);
+    if (lastFmError.success) {
+        throw createLastFmResponseError(lastFmError.data.error);
+    }
+    if (response.status < 200 || response.status >= 300) {
+        throw new ScrobbleProviderRequestError("Last.fm");
+    }
+    return response.data;
+}
+
+/** Resolves the operator API key plus the environment-only shared secret. */
+export async function resolveLastFmCredentials(): Promise<LastFmCredentials> {
+    const configuration = await getLastFmConfigurationState();
+    if (!configuration.serverConfigured) {
+        throw new LastFmServerConfigurationError();
+    }
+    return {
+        apiKey: configuration.apiKey,
+        sharedSecret: configuration.sharedSecret,
+    };
 }
 
 /** Whether the operator has configured the Last.fm key pair. */
 export async function isLastFmServerConfigured(): Promise<boolean> {
-    const settings = await getSystemSettings();
-    const apiKey = settings?.lastfmApiKey || config.lastfm.apiKey;
-    return Boolean(apiKey && config.lastfm.sharedSecret);
+    return (await getLastFmConfigurationState()).serverConfigured;
 }
 
 /** Validates and encrypts a user's ListenBrainz token before persistence. */
@@ -116,9 +183,8 @@ export async function startLastFmAuth(userId: string): Promise<string> {
         method: "auth.getToken",
         api_key: credentials.apiKey,
     };
-    let response;
-    try {
-        response = await axios.get(LASTFM_API_URL, {
+    const responseData = await callLastFm(() =>
+        axios.get(LASTFM_API_URL, {
             params: {
                 ...parameters,
                 api_sig: createLastFmApiSignature(
@@ -128,11 +194,10 @@ export async function startLastFmAuth(userId: string): Promise<string> {
                 format: "json",
             },
             timeout: SCROBBLE_HTTP_TIMEOUT_MS,
-        });
-    } catch {
-        throw new ScrobbleProviderRequestError("Last.fm");
-    }
-    const tokenResult = lastFmTokenSchema.safeParse(response.data);
+            validateStatus: () => true,
+        }),
+    );
+    const tokenResult = lastFmTokenSchema.safeParse(responseData);
     if (!tokenResult.success) {
         throw new Error("Last.fm did not return an authorization token");
     }
@@ -168,9 +233,8 @@ export async function completeLastFmAuth(userId: string): Promise<string> {
         api_key: credentials.apiKey,
         token,
     };
-    let response;
-    try {
-        response = await axios.post(
+    const responseData = await callLastFm(() =>
+        axios.post(
             LASTFM_API_URL,
             new URLSearchParams({
                 ...parameters,
@@ -180,12 +244,13 @@ export async function completeLastFmAuth(userId: string): Promise<string> {
                 ),
                 format: "json",
             }),
-            { timeout: SCROBBLE_HTTP_TIMEOUT_MS },
-        );
-    } catch {
-        throw new ScrobbleProviderRequestError("Last.fm");
-    }
-    const sessionResult = lastFmSessionSchema.safeParse(response.data);
+            {
+                timeout: SCROBBLE_HTTP_TIMEOUT_MS,
+                validateStatus: () => true,
+            },
+        ),
+    );
+    const sessionResult = lastFmSessionSchema.safeParse(responseData);
     if (!sessionResult.success) {
         throw new Error("Last.fm did not return a session key");
     }
@@ -209,17 +274,20 @@ export async function completeLastFmAuth(userId: string): Promise<string> {
 
 /** Returns only non-secret connection state for one user. */
 export async function getScrobblingStatus(userId: string) {
-    const connections = await prisma.scrobbleConnection.findMany({
-        where: { userId },
-        select: {
-            service: true,
-            encryptedCredential: true,
-            enabled: true,
-            username: true,
-        },
-        take: 2,
-        orderBy: { service: "asc" },
-    });
+    const [connections, lastFmConfiguration] = await Promise.all([
+        prisma.scrobbleConnection.findMany({
+            where: { userId },
+            select: {
+                service: true,
+                encryptedCredential: true,
+                enabled: true,
+                username: true,
+            },
+            take: 2,
+            orderBy: { service: "asc" },
+        }),
+        getLastFmConfigurationState(),
+    ]);
     const byService = new Map(connections.map((row) => [row.service, row]));
     const lastfm = byService.get("lastfm");
     const listenbrainz = byService.get("listenbrainz");
@@ -228,7 +296,9 @@ export async function getScrobblingStatus(userId: string) {
             connected: Boolean(lastfm?.encryptedCredential),
             enabled: Boolean(lastfm?.encryptedCredential && lastfm.enabled),
             username: lastfm?.username ?? null,
-            serverConfigured: await isLastFmServerConfigured(),
+            serverConfigured: lastFmConfiguration.serverConfigured,
+            apiKeyConfigured: lastFmConfiguration.apiKeyConfigured,
+            sharedSecretConfigured: lastFmConfiguration.sharedSecretConfigured,
         },
         listenbrainz: {
             connected: Boolean(listenbrainz?.encryptedCredential),

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -268,6 +268,8 @@ LASTFM_SHARED_SECRET=your_shared_secret
 
 These two values identify your soundspan server as an application to Last.fm — like an OAuth app credential. They are not a listener account and never receive scrobbles. Each user still connects their own Last.fm account, and each user's plays go to their own Last.fm profile.
 
+The shared secret is intentionally never displayed in any admin screen. The Scrobbling settings page reports which of the two values is missing when Last.fm is unavailable.
+
 Then each user connects their own account:
 
 1. Open **Settings** -> **Scrobbling** and click **Connect Last.fm**

--- a/frontend/features/settings/README.md
+++ b/frontend/features/settings/README.md
@@ -68,6 +68,7 @@ Start-here guide for `frontend/features/settings`.
 | `hooks/useSettingsData.ts` | hooks |
 | `hooks/useSystemSettings.ts` | hooks |
 | `hooks/useTwoFactor.ts` | hooks |
+| `lastFmScrobblingCopy.ts` | root |
 | `types.ts` | root |
 
 ## Update Rule

--- a/frontend/features/settings/components/sections/ScrobblingSection.tsx
+++ b/frontend/features/settings/components/sections/ScrobblingSection.tsx
@@ -11,6 +11,7 @@ import {
 } from "../ui";
 import { api } from "@/lib/api";
 import type { ScrobblingStatus } from "@/lib/api/scrobbling";
+import { lastFmDescription } from "@/features/settings/lastFmScrobblingCopy";
 import { queryKeys } from "@/lib/queryKeys";
 import { GradientSpinner } from "@/components/ui/GradientSpinner";
 
@@ -229,26 +230,6 @@ function LastFmConnectFlow({ onChanged }: { onChanged: () => void }) {
             </button>
         </div>
     );
-}
-
-function missingLastFmValues(status: ScrobblingStatus["lastfm"]): string {
-    const missing = [
-        !status.apiKeyConfigured && "LASTFM_API_KEY",
-        !status.sharedSecretConfigured && "LASTFM_SHARED_SECRET",
-    ].filter(Boolean);
-    return missing.length > 0
-        ? missing.join(" and ")
-        : "LASTFM_API_KEY and LASTFM_SHARED_SECRET";
-}
-
-function lastFmDescription(status: ScrobblingStatus["lastfm"]): string {
-    if (!status.serverConfigured) {
-        const missing = missingLastFmValues(status);
-        return status.connected
-            ? `This server is missing ${missing}; existing scrobbling may fail. You can still disconnect.`
-            : `Last.fm scrobbling is unavailable: this server is missing ${missing}. Ask your server admin to set it.`;
-    }
-    return "Sign in with your Last.fm account to scrobble plays";
 }
 
 function LastFmRow({

--- a/frontend/features/settings/components/sections/ScrobblingSection.tsx
+++ b/frontend/features/settings/components/sections/ScrobblingSection.tsx
@@ -231,11 +231,22 @@ function LastFmConnectFlow({ onChanged }: { onChanged: () => void }) {
     );
 }
 
+function missingLastFmValues(status: ScrobblingStatus["lastfm"]): string {
+    const missing = [
+        !status.apiKeyConfigured && "LASTFM_API_KEY",
+        !status.sharedSecretConfigured && "LASTFM_SHARED_SECRET",
+    ].filter(Boolean);
+    return missing.length > 0
+        ? missing.join(" and ")
+        : "LASTFM_API_KEY and LASTFM_SHARED_SECRET";
+}
+
 function lastFmDescription(status: ScrobblingStatus["lastfm"]): string {
     if (!status.serverConfigured) {
+        const missing = missingLastFmValues(status);
         return status.connected
-            ? "This server no longer has a Last.fm API key configured; existing scrobbling may fail. You can still disconnect."
-            : "This server has no Last.fm API key configured, so Last.fm scrobbling is unavailable. Ask your server admin to set LASTFM_API_KEY and LASTFM_SHARED_SECRET.";
+            ? `This server is missing ${missing}; existing scrobbling may fail. You can still disconnect.`
+            : `Last.fm scrobbling is unavailable: this server is missing ${missing}. Ask your server admin to set it.`;
     }
     return "Sign in with your Last.fm account to scrobble plays";
 }

--- a/frontend/features/settings/lastFmScrobblingCopy.ts
+++ b/frontend/features/settings/lastFmScrobblingCopy.ts
@@ -1,0 +1,25 @@
+import type { ScrobblingStatus } from "@/lib/api/scrobbling";
+
+/** Names the server value(s) the operator still needs to set. */
+export function missingLastFmValues(
+    status: ScrobblingStatus["lastfm"],
+): string {
+    const missing = [
+        !status.apiKeyConfigured && "LASTFM_API_KEY",
+        !status.sharedSecretConfigured && "LASTFM_SHARED_SECRET",
+    ].filter(Boolean);
+    return missing.length > 0
+        ? missing.join(" and ")
+        : "LASTFM_API_KEY and LASTFM_SHARED_SECRET";
+}
+
+/** Row description for the Last.fm scrobbling settings entry. */
+export function lastFmDescription(status: ScrobblingStatus["lastfm"]): string {
+    if (!status.serverConfigured) {
+        const missing = missingLastFmValues(status);
+        return status.connected
+            ? `This server is missing ${missing}; existing scrobbling may fail. You can still disconnect.`
+            : `Last.fm scrobbling is unavailable: this server is missing ${missing}. Ask your server admin to set it.`;
+    }
+    return "Sign in with your Last.fm account to scrobble plays";
+}

--- a/frontend/lib/api/scrobbling.ts
+++ b/frontend/lib/api/scrobbling.ts
@@ -13,6 +13,10 @@ export interface ScrobblingStatus {
         username: string | null;
         /** False when the server has no Last.fm API key + shared secret. */
         serverConfigured: boolean;
+        /** Whether LASTFM_API_KEY (or a stored key) is present on the server. */
+        apiKeyConfigured: boolean;
+        /** Whether LASTFM_SHARED_SECRET is present on the server. */
+        sharedSecretConfigured: boolean;
     };
     listenbrainz: {
         connected: boolean;

--- a/frontend/tests/unit/lastFmScrobblingCopy.test.ts
+++ b/frontend/tests/unit/lastFmScrobblingCopy.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+    lastFmDescription,
+    missingLastFmValues,
+} from "../../features/settings/lastFmScrobblingCopy";
+
+function status(overrides: {
+    connected?: boolean;
+    serverConfigured?: boolean;
+    apiKeyConfigured?: boolean;
+    sharedSecretConfigured?: boolean;
+}) {
+    return {
+        connected: false,
+        enabled: false,
+        username: null,
+        serverConfigured: false,
+        apiKeyConfigured: false,
+        sharedSecretConfigured: false,
+        ...overrides,
+    };
+}
+
+test("names only the shared secret when the API key is present", () => {
+    assert.equal(
+        missingLastFmValues(status({ apiKeyConfigured: true })),
+        "LASTFM_SHARED_SECRET",
+    );
+});
+
+test("names only the API key when the shared secret is present", () => {
+    assert.equal(
+        missingLastFmValues(status({ sharedSecretConfigured: true })),
+        "LASTFM_API_KEY",
+    );
+});
+
+test("names both values when neither is present", () => {
+    assert.equal(
+        missingLastFmValues(status({})),
+        "LASTFM_API_KEY and LASTFM_SHARED_SECRET",
+    );
+});
+
+test("falls back to naming both values when flags claim configured but serverConfigured is false", () => {
+    assert.equal(
+        missingLastFmValues(
+            status({ apiKeyConfigured: true, sharedSecretConfigured: true }),
+        ),
+        "LASTFM_API_KEY and LASTFM_SHARED_SECRET",
+    );
+});
+
+test("unconfigured and disconnected asks the admin for the missing value", () => {
+    assert.equal(
+        lastFmDescription(status({ apiKeyConfigured: true })),
+        "Last.fm scrobbling is unavailable: this server is missing LASTFM_SHARED_SECRET. Ask your server admin to set it.",
+    );
+});
+
+test("unconfigured but connected warns that scrobbling may fail", () => {
+    assert.equal(
+        lastFmDescription(status({ connected: true, apiKeyConfigured: true })),
+        "This server is missing LASTFM_SHARED_SECRET; existing scrobbling may fail. You can still disconnect.",
+    );
+});
+
+test("configured invites the user to sign in", () => {
+    assert.equal(
+        lastFmDescription(
+            status({
+                serverConfigured: true,
+                apiKeyConfigured: true,
+                sharedSecretConfigured: true,
+            }),
+        ),
+        "Sign in with your Last.fm account to scrobble plays",
+    );
+});


### PR DESCRIPTION
Live-diagnosed on a production deployment (backend logs + a signed in-pod probe proving the operator credentials were valid): completing the Last.fm connect flow before the approval registered returned a generic 500.

## Root cause

Last.fm answers application-level errors as **HTTP 403 + JSON `{error, message}`** — including error 14 "token has not been authorized" for the click-finish-before-approving path. Axios throws on 4xx, a bare `catch {}` in `startLastFmAuth`/`completeLastFmAuth` discarded the payload, and `ScrobbleProviderRequestError` was absent from `sendLastFmKnownError` → unhandled → 500 "internal error". The friendly 409 retry message existed in the UI but was unreachable.

## Fix

- One `callLastFm` helper accepts all statuses and classifies the payload: **14/15** → 409 "Approve access in the Last.fm tab, then try again"; **4/10/13/26** → 409 "server API key or shared secret rejected" (no credential material); other codes / transport failures → **502** "Last.fm did not respond." ListenBrainz provider failures map to 502 too.
- Status payload gains `apiKeyConfigured` / `sharedSecretConfigured` (`serverConfigured` unchanged); the settings page now names exactly which value is missing instead of a generic hint.
- INTEGRATIONS notes the shared secret is intentionally never displayed in any admin screen.
- Pending token is preserved on rejected completion (pinned by test) so retry-after-approving works.

## Verification

- verify: targeted jest — Test Suites: 2 passed, Tests: **29 passed**, exit 0 (credential codes, auth-state codes, pending-token preservation, transport failures, status flags, route mappings, success paths)
- verify: backend `tsc --noEmit`, format:check — exit 0; frontend `tsc --noEmit`, lint, format:check — exit 0
- verify: file-size + env-docs guardrails — exit 0