### PR TITLE
fix(ui): declare dark color-scheme so native dropdowns stop rendering white-on-white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Native dropdown menus (sort, genre, and pagination on the Audiobooks and Podcasts pages, and other built-in selects) no longer render white text on a white popup; the app now declares its dark color scheme to the browser so native controls match the theme.
+
 ## [2.6.1] - 2026-08-26
 
 ### Added

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -43,6 +43,11 @@
 :root {
     /* soundspan Design System - Dark Theme Only */
 
+    /* Render native widgets (select popups, scrollbars, pickers) in the
+       browser's dark scheme; without this the OS light scheme paints
+       white popup menus behind our white text. */
+    color-scheme: dark;
+
     /* Background Layers */
     --bg-primary: #0a0a0a; /* Primary canvas */
     --bg-secondary: #0f0f0f; /* Cards, panels */


### PR DESCRIPTION
## Problem

The three dropdowns on the Audiobooks page (sort, genre, items-per-page) and the two on Podcasts render white text on a white popup menu, making them unreadable. Same latent issue on every native `<select>` in the app (Library, Discography, Release Selection modal, Settings, FormElements).

## Cause

The popup list of a native `<select>` is drawn by the browser in the page's declared color scheme, not by our CSS — `[&>option]:bg-surface-hover` styles help only in browsers that honor option backgrounds. The app is dark-theme-only but never declared `color-scheme`, so the OS default light scheme paints a white menu while the options inherit our white text.

## Fix

One declaration in `globals.css`: `color-scheme: dark` on `:root`. Every native widget (select popups, unstyled scrollbars, date/time pickers) now renders in the browser's dark scheme, which is correct for a dark-only app. The existing per-option classes stay as a harmless fallback.

## Verification

- `verify: cd frontend && npx tsc --noEmit` → exit 0
- `verify: npm run lint` → 0 errors, 181 warnings (cap 183, no new warnings)
- `verify: npm run format:check` → all files pass
- `verify: npx --prefix backend prettier --check CHANGELOG.md` → pass
- `verify: node scripts/ci/check-file-size.mjs` → pass (1223 files)