### PR TITLE
Fold Audiobookshelf deletion pruning into the scheduled incremental sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The scheduled Audiobookshelf sync now also removes books that were deleted in Audiobookshelf — including cached covers and listening progress — instead of leaving that cleanup to the manual admin sync button; removals keep every safety guard from the manual path, only run against complete, verified library listings, and wait until a book has been absent from two consecutive verified listings taken several minutes apart (#864).
+
 ### Fixed
 
 - Native dropdown menus (sort, genre, and pagination on the Audiobooks and Podcasts pages, and other built-in selects) no longer render white text on a white popup; the app now declares its dark color scheme to the browser so native controls match the theme.

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../utils/logger", () => ({
 const prisma = {
     audiobook: {
         upsert: jest.fn(),
+        updateMany: jest.fn(),
         findUnique: jest.fn(),
         findMany: jest.fn(),
         count: jest.fn(),
@@ -239,6 +240,7 @@ describe("audiobook cache service behavior", () => {
         fsPromises.unlink.mockResolvedValue(undefined);
 
         prisma.audiobook.upsert.mockResolvedValue({});
+        prisma.audiobook.updateMany.mockResolvedValue({ count: 0 });
         prisma.audiobook.findUnique.mockResolvedValue(null);
         mockAudiobookQueries();
         transactionClient.audiobook.findMany.mockResolvedValue([]);
@@ -1033,6 +1035,22 @@ describe("audiobook cache service behavior", () => {
         expect(prisma.$transaction).not.toHaveBeenCalled();
     });
 
+    it("surfaces an expired deadline before reconciling a cached library id", async () => {
+        const service = new AudiobookCacheService();
+
+        await expect(
+            (service as any).reconcileCachedLibraryIds(
+                [buildBook({ id: "moved-book", libraryId: "library-b" })],
+                [{ id: "moved-book", libraryId: "library-a" }],
+                Date.now() - 1,
+            ),
+        ).rejects.toMatchObject({
+            name: "AudiobookSyncTimeoutError",
+            message: "Full audiobook sync timed out after 6600000ms",
+        });
+        expect(prisma.audiobook.updateMany).not.toHaveBeenCalled();
+    });
+
     it("cleans a committed prune batch before surfacing an expired deadline", async () => {
         const service = new AudiobookCacheService();
         const staleRows = Array.from({ length: 101 }, (_, index) => ({
@@ -1168,18 +1186,24 @@ describe("audiobook cache service behavior", () => {
 
     it("syncs only audiobooks missing from the local ABS cache", async () => {
         const service = new AudiobookCacheService();
-
-        mockGetAllAudiobooks.mockResolvedValue([
+        const books = [
             buildBook({ id: "book-1" }),
             buildBook({ id: "book-2" }),
-        ]);
+        ];
+
+        mockGetAudiobookListing.mockResolvedValue({
+            books,
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
         mockAudiobookQueries({ cachedRows: [{ id: "book-1" }] });
 
         const result = await service.syncMissing();
 
+        expect(mockGetAudiobookListing).toHaveBeenCalledTimes(1);
+        expect(mockGetAllAudiobooks).not.toHaveBeenCalled();
         expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
             where: { peerId: null },
-            select: { id: true },
+            select: { id: true, libraryId: true },
         });
         expect(result).toEqual({
             synced: 1,
@@ -1206,17 +1230,594 @@ describe("audiobook cache service behavior", () => {
         ).not.toHaveBeenCalled();
     });
 
+    it("prunes an absent local audiobook after the incremental absence grace", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const absenceGraceMs = 5 * 60 * 1000;
+        const service = new AudiobookCacheService();
+        const coverPath = path.join(
+            "/srv/music",
+            "cover-cache",
+            "audiobooks",
+            "stale-cover.jpg",
+        );
+        const currentBook = buildBook({ id: "current-book" });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: coverPath }],
+            cachedRows: [{ id: "current-book", libraryId: "library-1" }],
+        });
+
+        const firstResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(firstResult.deleted).toBe(0);
+        expect(logger.debug).toHaveBeenCalledWith(
+            "Deferred pruning 1 audiobook during the absence grace period",
+        );
+
+        jest.advanceTimersByTime(absenceGraceMs - 1);
+        const secondResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(secondResult.deleted).toBe(0);
+
+        jest.advanceTimersByTime(1);
+        const thirdResult = await service.syncMissing();
+
+        const pruneCutoff = transactionClient.audiobook.deleteMany.mock
+            .calls[0][0].where.lastSyncedAt.lt as Date;
+        expect(mockGetAllAudiobooks).not.toHaveBeenCalled();
+        expect(prisma.audiobook.upsert).not.toHaveBeenCalled();
+        expect(fsPromises.mkdir).not.toHaveBeenCalled();
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-1"] },
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["stale-book"] },
+                peerId: null,
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+        });
+        expect(
+            transactionClient.audiobookProgress.deleteMany,
+        ).toHaveBeenCalledWith({
+            where: { audiobookshelfId: { in: ["stale-book"] } },
+        });
+        expect(transactionClient.playbackState.updateMany).toHaveBeenCalledWith(
+            {
+                where: { audiobookId: { in: ["stale-book"] } },
+                data: { audiobookId: null },
+            },
+        );
+        expect(
+            transactionClient.federationTombstone.createMany,
+        ).not.toHaveBeenCalled();
+        expect(fsPromises.unlink).toHaveBeenCalledWith(coverPath);
+        expect(thirdResult).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 1,
+            deleted: 1,
+            errors: [],
+        });
+    });
+
+    it("syncs a missing book and prunes an absent book across incremental cycles", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        const books = [
+            buildBook({ id: "current-book" }),
+            buildBook({ id: "new-book" }),
+        ];
+        mockGetAudiobookListing.mockResolvedValue({
+            books,
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+            cachedRows: [{ id: "current-book", libraryId: "library-1" }],
+        });
+
+        const firstResult = await service.syncMissing();
+
+        expect(prisma.audiobook.upsert).toHaveBeenCalledTimes(1);
+        expect(prisma.audiobook.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: "new-book" } }),
+        );
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(firstResult).toEqual({
+            synced: 1,
+            failed: 0,
+            skipped: 1,
+            deleted: 0,
+            errors: [],
+        });
+
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+            cachedRows: [
+                { id: "current-book", libraryId: "library-1" },
+                { id: "new-book", libraryId: "library-1" },
+            ],
+        });
+        jest.advanceTimersByTime(5 * 60 * 1000);
+        const secondResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["stale-book"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(secondResult).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 2,
+            deleted: 1,
+            errors: [],
+        });
+    });
+
+    it("incrementally prunes only verified-complete libraries", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({
+            id: "library-a-current",
+            libraryId: "library-a",
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-a"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "library-a-stale",
+                    libraryId: "library-a",
+                    localCoverPath: null,
+                },
+                {
+                    id: "library-b-stale",
+                    libraryId: "library-b",
+                    localCoverPath: null,
+                },
+            ],
+            cachedRows: [{ id: "library-a-current", libraryId: "library-a" }],
+        });
+
+        const firstResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(firstResult.deleted).toBe(0);
+
+        jest.advanceTimersByTime(5 * 60 * 1000);
+        const secondResult = await service.syncMissing();
+
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-a"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["library-a-stale"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(secondResult.deleted).toBe(1);
+    });
+
+    it("restarts the incremental absence grace after a candidate reappears", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({ id: "current-book" });
+        const staleBook = buildBook({ id: "stale-book" });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+            cachedRows: [{ id: "current-book", libraryId: "library-1" }],
+        });
+        mockGetAudiobookListing.mockResolvedValueOnce({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+
+        const firstResult = await service.syncMissing();
+
+        expect(firstResult.deleted).toBe(0);
+        jest.advanceTimersByTime(5 * 60 * 1000);
+        mockGetAudiobookListing.mockResolvedValueOnce({
+            books: [currentBook, staleBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+
+        const secondResult = await service.syncMissing();
+
+        expect(secondResult.deleted).toBe(0);
+        mockGetAudiobookListing.mockResolvedValueOnce({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+
+        const thirdResult = await service.syncMissing();
+
+        expect(thirdResult.deleted).toBe(0);
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(
+            logger.debug.mock.calls.filter(
+                ([message]) =>
+                    message ===
+                    "Deferred pruning 1 audiobook during the absence grace period",
+            ),
+        ).toHaveLength(2);
+    });
+
+    it("reconciles a cached audiobook moved to another ABS library", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        const lastSyncedAt = new Date("2026-08-26T11:00:00.000Z");
+        const cachedRows = [
+            {
+                id: "moved-book",
+                libraryId: "library-a",
+                lastSyncedAt,
+                localCoverPath: null,
+            },
+        ];
+        const movedBook = buildBook({
+            id: "moved-book",
+            libraryId: "library-b",
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [movedBook],
+            verifiedCompleteLibraryIds: new Set(["library-a", "library-b"]),
+        });
+        mockAudiobookQueries({ cachedRows });
+
+        const moveResult = await service.syncMissing();
+
+        expect(prisma.audiobook.updateMany).toHaveBeenCalledTimes(1);
+        expect(prisma.audiobook.updateMany).toHaveBeenCalledWith({
+            where: { id: { in: ["moved-book"] }, peerId: null },
+            data: { libraryId: "library-b" },
+        });
+        expect(cachedRows[0].lastSyncedAt).toBe(lastSyncedAt);
+        expect(
+            prisma.audiobook.updateMany.mock.calls[0][0].data,
+        ).not.toHaveProperty("lastSyncedAt");
+        expect(moveResult.deleted).toBe(0);
+
+        cachedRows[0].libraryId = "library-b";
+        const remainingBook = buildBook({
+            id: "remaining-book",
+            libraryId: "library-b",
+        });
+        cachedRows.push({
+            id: "remaining-book",
+            libraryId: "library-b",
+            lastSyncedAt,
+            localCoverPath: null,
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [remainingBook],
+            verifiedCompleteLibraryIds: new Set(["library-a", "library-b"]),
+        });
+        mockAudiobookQueries({ cachedRows });
+
+        const deferredResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(deferredResult.deleted).toBe(0);
+
+        jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+        const pruneResult = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: { in: ["moved-book"] },
+                peerId: null,
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+        });
+        expect(pruneResult.deleted).toBe(1);
+    });
+
+    it("does not update cached library ids when no audiobook moved", async () => {
+        const service = new AudiobookCacheService();
+        const listedBook = buildBook({
+            id: "listed-book",
+            libraryId: "library-a",
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [listedBook],
+            verifiedCompleteLibraryIds: new Set(["library-a"]),
+        });
+        mockAudiobookQueries({
+            cachedRows: [{ id: "listed-book", libraryId: "library-a" }],
+        });
+
+        await service.syncMissing();
+
+        expect(prisma.audiobook.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when an incremental listing is empty but local rows exist", async () => {
+        const service = new AudiobookCacheService();
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "local-book", localCoverPath: null }],
+        });
+
+        const result = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Skipped pruning audiobooks because Audiobookshelf returned an empty listing",
+            ),
+        );
+        expect(result.deleted).toBe(0);
+    });
+
+    it("rate-limits repeated empty-listing prune warnings for one hour", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "local-book", localCoverPath: null }],
+        });
+
+        await service.syncMissing();
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Skipped pruning audiobooks because Audiobookshelf returned an empty listing",
+            ),
+        );
+
+        await service.syncMissing();
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(60 * 60 * 1000 + 1);
+        await service.syncMissing();
+
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it("bounds prune warning rate-limit state to 100 keys", () => {
+        const service = new AudiobookCacheService();
+        let now = 0;
+        jest.spyOn(Date, "now").mockImplementation(() => now++);
+
+        for (let index = 0; index < 101; index++) {
+            (service as any).warnRateLimited(
+                `empty-library:library-${index}`,
+                `warning ${index}`,
+            );
+        }
+
+        const warnMap = (service as any).pruneWarnLastAt as Map<string, number>;
+        expect(warnMap.size).toBeLessThanOrEqual(100);
+        expect(warnMap.has("empty-library:library-0")).toBe(false);
+        expect(warnMap.has("empty-library:library-100")).toBe(true);
+    });
+
+    it("fails closed when an incremental listing contains an item without an id", async () => {
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({ id: "current-book" });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook, {}],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            pruneRows: [{ id: "stale-book", localCoverPath: null }],
+            cachedRows: [{ id: "current-book" }],
+        });
+
+        const result = await service.syncMissing();
+
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Skipped pruning audiobooks because Audiobookshelf returned a malformed listing",
+        );
+        expect(result.deleted).toBe(0);
+    });
+
+    it("does not prune federated rows during an incremental cycle", async () => {
+        const service = new AudiobookCacheService();
+        const currentBook = buildBook({ id: "current-book" });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [currentBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            federatedRows: [
+                {
+                    id: "federated-book",
+                    peerId: "peer-1",
+                    localCoverPath: null,
+                },
+            ],
+            cachedRows: [{ id: "current-book" }],
+        });
+
+        const result = await service.syncMissing();
+
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-1"] },
+                lastSyncedAt: { lt: expect.any(Date) },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(result.deleted).toBe(0);
+    });
+
+    it.each([
+        { federationEnabled: false, writesTombstone: false },
+        { federationEnabled: true, writesTombstone: true },
+    ])(
+        "writes incremental prune tombstones when federation enabled is $federationEnabled",
+        async ({ federationEnabled, writesTombstone }) => {
+            jest.useFakeTimers({
+                now: new Date("2026-08-26T12:00:00.000Z"),
+            });
+            const service = new AudiobookCacheService();
+            mockConfig.features.federation = federationEnabled;
+            const currentBook = buildBook({ id: "current-book" });
+            mockGetAudiobookListing.mockResolvedValue({
+                books: [currentBook],
+                verifiedCompleteLibraryIds: new Set(["library-1"]),
+            });
+            mockAudiobookQueries({
+                pruneRows: [{ id: "stale-book", localCoverPath: null }],
+                cachedRows: [{ id: "current-book", libraryId: "library-1" }],
+            });
+
+            const firstResult = await service.syncMissing();
+
+            expect(firstResult.deleted).toBe(0);
+            expect(
+                transactionClient.federationTombstone.createMany,
+            ).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(5 * 60 * 1000);
+            const secondResult = await service.syncMissing();
+
+            if (writesTombstone) {
+                expect(
+                    transactionClient.federationTombstone.createMany,
+                ).toHaveBeenCalledWith({
+                    data: [{ entityType: "audiobook", entityId: "stale-book" }],
+                });
+            } else {
+                expect(
+                    transactionClient.federationTombstone.createMany,
+                ).not.toHaveBeenCalled();
+            }
+            expect(secondResult.deleted).toBe(1);
+        },
+    );
+
+    it("keeps a stale cached audiobook that remains in the incremental listing", async () => {
+        const service = new AudiobookCacheService();
+        const listedBook = buildBook({ id: "listed-book" });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [listedBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
+        mockAudiobookQueries({
+            cachedRows: [
+                {
+                    id: "listed-book",
+                    lastSyncedAt: new Date("2020-01-01T00:00:00.000Z"),
+                },
+            ],
+        });
+
+        const result = await service.syncMissing();
+
+        expect(prisma.audiobook.upsert).not.toHaveBeenCalled();
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            synced: 0,
+            failed: 0,
+            skipped: 1,
+            deleted: 0,
+            errors: [],
+        });
+    });
+
+    it("spares an absent row refreshed after the incremental prune cutoff", async () => {
+        jest.useFakeTimers({
+            now: new Date("2026-08-26T12:00:00.000Z"),
+        });
+        const service = new AudiobookCacheService();
+        const pruneCutoff = new Date();
+        const refreshedAt = new Date(pruneCutoff.getTime() + 500);
+        const currentBook = buildBook({ id: "current-book" });
+        mockGetAudiobookListing.mockImplementationOnce(async () => {
+            jest.setSystemTime(new Date(pruneCutoff.getTime() + 1_000));
+            return {
+                books: [currentBook],
+                verifiedCompleteLibraryIds: new Set(["library-1"]),
+            };
+        });
+        mockAudiobookQueries({
+            pruneRows: [
+                {
+                    id: "concurrently-refreshed-book",
+                    localCoverPath: null,
+                    lastSyncedAt: refreshedAt,
+                },
+            ],
+            cachedRows: [{ id: "current-book" }],
+        });
+
+        const result = await service.syncMissing();
+
+        expect(prisma.audiobook.findMany).toHaveBeenCalledWith({
+            where: {
+                peerId: null,
+                libraryId: { in: ["library-1"] },
+                lastSyncedAt: { lt: pruneCutoff },
+            },
+            select: { id: true, localCoverPath: true },
+        });
+        expect(transactionClient.audiobook.deleteMany).not.toHaveBeenCalled();
+        expect(result.deleted).toBe(0);
+    });
+
     it("records the error message when a missing audiobook fails to sync", async () => {
         const service = new AudiobookCacheService();
 
-        mockGetAllAudiobooks.mockResolvedValue([
-            buildBook({
-                id: "book-broken",
-                media: {
-                    metadata: { title: "Broken Book" },
-                },
-            }),
-        ]);
+        const brokenBook = buildBook({
+            id: "book-broken",
+            media: {
+                metadata: { title: "Broken Book" },
+            },
+        });
+        mockGetAudiobookListing.mockResolvedValue({
+            books: [brokenBook],
+            verifiedCompleteLibraryIds: new Set(["library-1"]),
+        });
         prisma.audiobook.upsert.mockRejectedValueOnce(
             new Error("db write failed"),
         );
@@ -1227,6 +1828,7 @@ describe("audiobook cache service behavior", () => {
         expect(result.errors[0]).toBe(
             "Failed to sync Broken Book: db write failed",
         );
+        expect(mockGetAllAudiobooks).not.toHaveBeenCalled();
     });
 
     it("preserves stored sections on minified updates and creates them as unknown", async () => {

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -40,12 +40,20 @@ interface SyncResult {
 
 const AUDIOBOOK_CACHE_STALE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const AUDIOBOOK_PRUNE_BATCH_SIZE = 100;
+const AUDIOBOOK_PRUNE_ABSENCE_GRACE_MS = 5 * 60 * 1000;
+const PRUNE_WARN_INTERVAL_MS = 60 * 60 * 1000;
+const PRUNE_WARN_MAX_KEYS = 100;
 const audiobookCacheLogger = logger.child("AudiobookCache");
 const AUDIOBOOK_SYNC_TIMEOUT_MESSAGE = `Full audiobook sync timed out after ${AUDIOBOOK_SYNC_WORK_TIMEOUT_MS}ms`;
 
 type LocalAudiobookRow = {
     id: string;
     localCoverPath: string | null;
+};
+
+type CachedAudiobookRow = {
+    id: string;
+    libraryId: string | null;
 };
 
 function hasNonEmptyAudiobookId(book: any): boolean {
@@ -79,6 +87,11 @@ function throwIfSyncDeadlineExpired(deadlineMs: number): void {
 export class AudiobookCacheService {
     private coverCacheDir: string;
     private coverCacheAvailable: boolean = false;
+    // Grace state is process-local and resets on restart. A reset can only delay
+    // deletion by one cycle; it cannot accelerate deletion beyond two verified
+    // snapshots observed by the same process.
+    private readonly pruneCandidateFirstSeenAt = new Map<string, number>();
+    private readonly pruneWarnLastAt = new Map<string, number>();
 
     constructor() {
         // Store covers in: <MUSIC_PATH>/cover-cache/audiobooks/
@@ -87,6 +100,28 @@ export class AudiobookCacheService {
             "cover-cache",
             "audiobooks",
         );
+    }
+
+    private warnRateLimited(key: string, message: string): void {
+        const now = Date.now();
+        const lastWarnAt = this.pruneWarnLastAt.get(key);
+        if (
+            lastWarnAt !== undefined &&
+            now - lastWarnAt < PRUNE_WARN_INTERVAL_MS
+        ) {
+            return;
+        }
+        if (
+            lastWarnAt === undefined &&
+            this.pruneWarnLastAt.size >= PRUNE_WARN_MAX_KEYS
+        ) {
+            const oldestKey = [...this.pruneWarnLastAt.entries()].reduce(
+                (oldest, entry) => (entry[1] < oldest[1] ? entry : oldest),
+            )[0];
+            this.pruneWarnLastAt.delete(oldestKey);
+        }
+        this.pruneWarnLastAt.set(key, now);
+        audiobookCacheLogger.warn(message);
     }
 
     /**
@@ -165,6 +200,7 @@ export class AudiobookCacheService {
             listing.verifiedCompleteLibraryIds,
             pruneCutoff,
             deadlineMs,
+            { deferFirstAbsence: false },
         );
         this.logSyncSummary(result);
         return result;
@@ -212,20 +248,77 @@ export class AudiobookCacheService {
 
     private async syncMissingLocked(deadlineMs: number): Promise<SyncResult> {
         const result = createSyncResult();
-        const audiobooks = await audiobookshelfService.getAllAudiobooks();
-        if (audiobooks.length === 0) return result;
+        const pruneCutoff = new Date();
+        const listing = await audiobookshelfService.getAudiobookListing();
+        const audiobooks = listing.books;
         const cachedAudiobooks = await prisma.audiobook.findMany({
             where: { peerId: null },
-            select: { id: true },
+            select: { id: true, libraryId: true },
         });
         const cachedIds = new Set(
             cachedAudiobooks.map((audiobook) => audiobook.id),
+        );
+        await this.reconcileCachedLibraryIds(
+            audiobooks,
+            cachedAudiobooks,
+            deadlineMs,
         );
         const missingAudiobooks = audiobooks.filter(
             (audiobook) => !cachedIds.has(audiobook.id),
         );
         result.skipped = audiobooks.length - missingAudiobooks.length;
-        if (missingAudiobooks.length === 0) return result;
+        await this.syncMissingBooks(missingAudiobooks, result, deadlineMs);
+        result.deleted = await this.pruneMissingAudiobooks(
+            audiobooks,
+            listing.verifiedCompleteLibraryIds,
+            pruneCutoff,
+            deadlineMs,
+            { deferFirstAbsence: true },
+        );
+        audiobookCacheLogger.debug(
+            `Incremental sync complete: ${result.synced} new, ${result.skipped} already cached or skipped, ${result.deleted} deleted, ${result.failed} failed`,
+        );
+        return result;
+    }
+
+    private async reconcileCachedLibraryIds(
+        books: any[],
+        cachedRows: CachedAudiobookRow[],
+        deadlineMs: number,
+    ): Promise<void> {
+        const listedLibraryIds = new Map<string, string>();
+        for (const book of books) {
+            if (
+                hasNonEmptyAudiobookId(book) &&
+                typeof book.libraryId === "string" &&
+                book.libraryId.length > 0
+            ) {
+                listedLibraryIds.set(book.id, book.libraryId);
+            }
+        }
+        const movedIdsByLibrary = new Map<string, string[]>();
+        for (const row of cachedRows) {
+            const targetLibraryId = listedLibraryIds.get(row.id);
+            if (!targetLibraryId || targetLibraryId === row.libraryId) continue;
+            const ids = movedIdsByLibrary.get(targetLibraryId) ?? [];
+            ids.push(row.id);
+            movedIdsByLibrary.set(targetLibraryId, ids);
+        }
+        for (const [libraryId, ids] of movedIdsByLibrary) {
+            throwIfSyncDeadlineExpired(deadlineMs);
+            await prisma.audiobook.updateMany({
+                where: { id: { in: ids }, peerId: null },
+                data: { libraryId },
+            });
+        }
+    }
+
+    private async syncMissingBooks(
+        missingAudiobooks: any[],
+        result: SyncResult,
+        deadlineMs: number,
+    ): Promise<void> {
+        if (missingAudiobooks.length === 0) return;
         await this.ensureCoverCacheDir();
         await this.syncBooks(
             missingAudiobooks,
@@ -235,10 +328,6 @@ export class AudiobookCacheService {
             },
             deadlineMs,
         );
-        logger.debug(
-            `[AUDIOBOOK] Incremental sync complete: ${result.synced} new, ${result.skipped} already cached or skipped, ${result.failed} failed`,
-        );
-        return result;
     }
 
     private async findFederatedCollisionIds(
@@ -304,9 +393,11 @@ export class AudiobookCacheService {
         verifiedCompleteLibraryIds: ReadonlySet<string>,
         pruneCutoff: Date,
         deadlineMs: number,
+        options: { deferFirstAbsence: boolean },
     ): Promise<number> {
         if (!books.every(hasNonEmptyAudiobookId)) {
-            audiobookCacheLogger.warn(
+            this.warnRateLimited(
+                "malformed-listing",
                 "Skipped pruning audiobooks because Audiobookshelf returned a malformed listing",
             );
             return 0;
@@ -320,7 +411,8 @@ export class AudiobookCacheService {
         });
 
         if (books.length === 0 && localRowCount > 0) {
-            audiobookCacheLogger.warn(
+            this.warnRateLimited(
+                "empty-listing",
                 "Skipped pruning audiobooks because Audiobookshelf returned an empty listing; the configured library may be unavailable",
             );
             return 0;
@@ -341,7 +433,49 @@ export class AudiobookCacheService {
         });
         const listedIds = new Set(books.map((book) => book.id));
         const staleRows = localRows.filter((row) => !listedIds.has(row.id));
-        return this.pruneAudiobookBatches(staleRows, pruneCutoff, deadlineMs);
+        const { eligibleRows, deferredCount } = this.partitionPruneCandidates(
+            staleRows,
+            options.deferFirstAbsence,
+        );
+        if (deferredCount > 0) {
+            audiobookCacheLogger.debug(
+                `Deferred pruning ${deferredCount} audiobook${deferredCount === 1 ? "" : "s"} during the absence grace period`,
+            );
+        }
+        return this.pruneAudiobookBatches(
+            eligibleRows,
+            pruneCutoff,
+            deadlineMs,
+        );
+    }
+
+    private partitionPruneCandidates(
+        staleRows: LocalAudiobookRow[],
+        deferFirstAbsence: boolean,
+    ): { eligibleRows: LocalAudiobookRow[]; deferredCount: number } {
+        const staleIds = new Set(staleRows.map((row) => row.id));
+        for (const id of this.pruneCandidateFirstSeenAt.keys()) {
+            if (!staleIds.has(id)) this.pruneCandidateFirstSeenAt.delete(id);
+        }
+        if (!deferFirstAbsence) {
+            return { eligibleRows: staleRows, deferredCount: 0 };
+        }
+        const eligibleRows: LocalAudiobookRow[] = [];
+        const now = Date.now();
+        for (const row of staleRows) {
+            const firstSeenAt = this.pruneCandidateFirstSeenAt.get(row.id);
+            if (firstSeenAt === undefined) {
+                this.pruneCandidateFirstSeenAt.set(row.id, now);
+                continue;
+            }
+            if (now - firstSeenAt >= AUDIOBOOK_PRUNE_ABSENCE_GRACE_MS) {
+                eligibleRows.push(row);
+            }
+        }
+        return {
+            eligibleRows,
+            deferredCount: staleRows.length - eligibleRows.length,
+        };
     }
 
     private async getPrunableLibraryIds(
@@ -369,7 +503,8 @@ export class AudiobookCacheService {
                 prunableLibraryIds.push(libraryId);
                 continue;
             }
-            audiobookCacheLogger.warn(
+            this.warnRateLimited(
+                `empty-library:${libraryId}`,
                 `Skipped pruning audiobook library ${libraryId} because Audiobookshelf returned an empty listing while ${localRowCount} local rows exist`,
             );
         }
@@ -401,7 +536,8 @@ export class AudiobookCacheService {
             ],
         );
         if (unknownLibraryCount > 0) {
-            audiobookCacheLogger.warn(
+            this.warnRateLimited(
+                "unknown-library",
                 `skipped ${unknownLibraryCount} audiobooks with unknown library during prune`,
             );
         }
@@ -433,6 +569,9 @@ export class AudiobookCacheService {
                 pruneCutoff,
             );
             deleted += deletedRows.length;
+            for (const row of deletedRows) {
+                this.pruneCandidateFirstSeenAt.delete(row.id);
+            }
             await this.unlinkAudiobookCovers(deletedRows);
         }
         return deleted;

--- a/backend/src/workers/__tests__/indexRuntime.test.ts
+++ b/backend/src/workers/__tests__/indexRuntime.test.ts
@@ -132,6 +132,7 @@ describe("workers runtime behavior", () => {
                 synced: 0,
                 failed: 0,
                 skipped: 0,
+                deleted: 0,
                 errors: [] as string[],
             })),
         };
@@ -892,6 +893,43 @@ describe("workers runtime behavior", () => {
             1,
         );
         expect(mocks.audiobookCacheService.syncAll).not.toHaveBeenCalled();
+        expect(mocks.logger.debug).not.toHaveBeenCalledWith(
+            expect.stringContaining("Audiobook auto-sync complete:"),
+        );
+    });
+
+    it("logs deletion-only audiobook sync summaries for repeat jobs", async () => {
+        process.env = { ...originalEnv };
+        const mocks = setupWorkerModuleMocks();
+        (mocks.getSystemSettings as jest.Mock).mockResolvedValue({
+            audiobookshelfEnabled: true,
+            audiobookshelfUrl: "http://abs.local",
+        });
+        mocks.audiobookCacheService.syncMissing.mockResolvedValueOnce({
+            synced: 0,
+            failed: 0,
+            skipped: 4,
+            deleted: 2,
+            errors: [],
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        loadWorkers();
+        await flushPromises();
+
+        const schedulerHandler = mocks.schedulerQueue.process.mock.calls.find(
+            (call) => call[0] === "*",
+        )?.[1];
+
+        await schedulerHandler({
+            id: "audiobook-sync-deletion-only",
+            name: "audiobook-auto-sync-startup",
+            data: { mode: "repeat" },
+        });
+
+        expect(mocks.logger.debug).toHaveBeenCalledWith(
+            "Audiobook auto-sync complete: 0 new, 4 already cached or skipped, 2 deleted, 0 failed",
+        );
     });
 
     it("resolves repeat audiobook sync failures and warns", async () => {
@@ -1395,6 +1433,7 @@ describe("workers runtime behavior", () => {
             synced: 4,
             failed: 0,
             skipped: 0,
+            deleted: 0,
             errors: [],
         });
         mocks.isBackfillNeeded.mockResolvedValue(true);
@@ -1668,6 +1707,7 @@ describe("workers runtime behavior", () => {
             synced: 1,
             failed: 0,
             skipped: 3,
+            deleted: 2,
             errors: [],
         });
 
@@ -1690,7 +1730,7 @@ describe("workers runtime behavior", () => {
             1,
         );
         expect(mocks.logger.debug).toHaveBeenCalledWith(
-            "Audiobook auto-sync complete: 1 new, 3 already cached, 0 failed",
+            "Audiobook auto-sync complete: 1 new, 3 already cached or skipped, 2 deleted, 0 failed",
         );
     });
 
@@ -2458,6 +2498,7 @@ describe("workers runtime behavior", () => {
                 synced: number;
                 failed: number;
                 skipped: number;
+                deleted: number;
                 errors: string[];
             }>((_resolve, reject) =>
                 queueMicrotask(() =>

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -570,9 +570,12 @@ async function processAudiobookAutoSyncJob(
         }
         return false;
     }
-    if (result && (mode === "startup" || result.synced || result.failed)) {
+    if (
+        result &&
+        (mode === "startup" || result.synced || result.deleted || result.failed)
+    ) {
         startupLog.debug(
-            `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached, ${result.failed} failed`,
+            `Audiobook auto-sync complete: ${result.synced} new, ${result.skipped} already cached or skipped, ${result.deleted} deleted, ${result.failed} failed`,
         );
     }
     return result !== undefined;

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -41,8 +41,15 @@ environment:
 Connect your Audiobookshelf instance for audiobook playback in soundspan.
 
 Audiobook detail metadata and section navigation are served from soundspan's
-local cache. Scheduled or manual Audiobookshelf sync validates chapter coverage
-and backfills section data for rows that do not have it yet. Multi-file
+local cache. A scheduled sync keeps that cache in step with Audiobookshelf: it
+adds new books within a few minutes and removes books that were deleted in
+Audiobookshelf, together with their cached covers and listening progress.
+Removals are deliberately cautious: a book is only removed after it has been
+absent from two complete, verified library listings taken several minutes
+apart, and an unreachable server or an incomplete listing never triggers
+removals. Books without a recorded source library are never removed
+automatically. Scheduled or manual sync also validates chapter coverage and
+backfills section data for rows that do not have it yet. Multi-file
 part boundaries are playable because the stream proxy exposes all files as one
 byte-addressable audiobook resource.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -51,6 +51,24 @@ Anything not listed: drop-in.
 
 ---
 
+## Unreleased
+
+**Heads-up, no action needed:** the scheduled Audiobookshelf sync (every few
+minutes) now also removes audiobooks that were deleted in Audiobookshelf,
+including their cached covers and listening progress. Before this change, that
+cleanup only happened when an admin pressed the manual sync button. Removals
+fail closed: a book is only removed after it is absent from two complete,
+verified library listings taken several minutes apart, so an unreachable
+Audiobookshelf server or a partial listing does not cause deletions. If you
+deleted books in Audiobookshelf long ago and they are still showing in
+soundspan, expect them to disappear within about fifteen minutes of upgrading.
+One exception: books synced by very old soundspan versions that never recorded
+a source library are never removed automatically and are only flagged in the
+logs; running the manual sync once refreshes their library record so future
+cleanup can reach them.
+
+---
+
 ## 2.6.0: scrobbling, AcoustID, and database changes
 
 Most installs need no action: pull, restart, and the database migrations


### PR DESCRIPTION
Closes #864.

## Problem

Books deleted from Audiobookshelf were only removed by the destructive reconcile in `syncAll()`, whose sole caller is the manual admin sync button. The scheduled five-minute job used add-only `syncMissing()` (by design, per #724), so upstream deletions lingered locally indefinitely — rows, cached covers, and listening progress. In practice nobody presses the button; my own instance carried months of deleted books.

## What changed

`syncMissingLocked` now runs the exact same prune stack the manual path uses. The incremental pass already fetched the full item listing every cycle (ABS has no delta API) and threw the reconciliation information away — the prune's absent-row computation is a set diff over data already in hand, and the expensive parts only run when something was actually deleted upstream.

Every guard from #724 applies identically, and the prune helpers themselves are untouched: verified-complete listings only (atomic `limit=0` or paged fallback with dedup, total match, and page-zero recheck), per-library eligibility with the empty-but-verified skip, `peerId IS NULL` rows only with tombstones when federation is on, pre-fetch `lastSyncedAt` cutoff to spare concurrent writes, batched transactions with progress/playback-state cleanup and post-commit cover unlink, and per-batch deadline bounds under the shared Redis scheduler claim.

On top of that, the scheduled path is more cautious than the manual one:

- **Absence grace**: a book must be absent from two verified listings taken at least five minutes apart before it is deleted (~2 cycles, worst case ~15 minutes). A single anomalous snapshot — including the paged verifier's documented residual window — can never trigger removals. Manual sync keeps its immediate semantics. Grace state is per-process; a restart only delays deletion, never accelerates it.
- **Library-move reconciliation**: incremental sync never re-upserts cached rows, so a book moved between ABS libraries kept its stale `libraryId` and could become permanently unprunable once its old library emptied. Listed cached rows now get their `libraryId` reconciled each cycle (grouped `updateMany`, zero queries when nothing moved, deadline-gated, `lastSyncedAt` untouched).
- **Warn rate limiting**: the prune-skip warnings were written for a button press and would otherwise repeat every five minutes in steady anomalous states; they are now limited to once an hour per site (bounded map, per-library keys).
- The worker summary logs deletion-only cycles (previously it only fired on synced/failed) and reports the deleted count.

Docs: CHANGELOG entry, INTEGRATIONS sync description, and an UPGRADING heads-up since the scheduled job becomes destructive-with-guards — operators with long-deleted books still showing should expect them to disappear shortly after upgrading.

## Review notes

Three review rounds ran to zero findings. Two dispositions worth recording:

- Writes cannot outlive the Redis lease: every mutation (per-book upsert, per-batch delete, per-library reconcile) checks a deadline that expires ten minutes before the claim TTL; only read-only listing pagination can exceed it.
- `audiobookProgress`/`playbackState` have no DB-level tie to audiobook rows, so a concurrent writer can recreate progress for a just-pruned id. That race predates this change (it exists on the manual path since #724) and is tracked separately in #866.

## Verification

- `npx tsc --noEmit` — exit 0
- Targeted jest (cache service, worker runtime, audiobook routes, cover authz, audiobookshelf service): **6 suites, 206 tests, all passing**, exit 0
- `npm run format:check` — clean
- `node scripts/ci/check-file-size.mjs` — passed
- Prettier on CHANGELOG and docs — clean