### PR TITLE
Enforce audiobook user-state relations at the database level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Native dropdown menus (sort, genre, and pagination on the Audiobooks and Podcasts pages, and other built-in selects) no longer render white text on a white popup; the app now declares its dark color scheme to the browser so native controls match the theme.
+- Audiobook listening progress and playback state are now tied to their audiobook at the database level: removing a book — scheduled prune, manual sync, or federation cleanup — atomically deletes its progress rows and nulls the active-audiobook reference in playback state, closing a race where progress saved mid-removal could linger as a phantom entry in Continue Listening; the upgrade migration also removes any orphaned progress rows left behind by earlier removals (#866).
 
 ## [2.6.1] - 2026-08-26
 

--- a/backend/prisma/migrations/20260826210000_link_audiobook_user_state/migration.sql
+++ b/backend/prisma/migrations/20260826210000_link_audiobook_user_state/migration.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+LOCK TABLE "Audiobook", "AudiobookProgress", "PlaybackState" IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE INDEX "AudiobookProgress_audiobookshelfId_idx" ON "AudiobookProgress"("audiobookshelfId");
+
+CREATE INDEX "PlaybackState_audiobookId_idx" ON "PlaybackState"("audiobookId");
+
+DELETE FROM "AudiobookProgress" AS p
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM "Audiobook" AS a
+    WHERE a.id = p."audiobookshelfId"
+);
+
+UPDATE "PlaybackState"
+SET "audiobookId" = NULL
+WHERE "audiobookId" IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM "Audiobook" AS a
+    WHERE a.id = "PlaybackState"."audiobookId"
+);
+
+ALTER TABLE "AudiobookProgress"
+ADD CONSTRAINT "AudiobookProgress_audiobookshelfId_fkey"
+FOREIGN KEY ("audiobookshelfId") REFERENCES "Audiobook"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PlaybackState"
+ADD CONSTRAINT "PlaybackState_audiobookId_fkey"
+FOREIGN KEY ("audiobookId") REFERENCES "Audiobook"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -166,22 +166,24 @@ model AppPassword {
 
 model PlaybackState {
   userId       String
-  deviceId     String   @default("legacy")
+  deviceId     String     @default("legacy")
   playbackType String
   trackId      String?
   audiobookId  String?
   podcastId    String?
   queue        Json?
-  currentIndex Int      @default(0)
-  isShuffle    Boolean  @default(false)
-  isPlaying    Boolean  @default(false)
-  currentTime  Float    @default(0)
-  updatedAt    DateTime @updatedAt
-  createdAt    DateTime @default(now())
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  currentIndex Int        @default(0)
+  isShuffle    Boolean    @default(false)
+  isPlaying    Boolean    @default(false)
+  currentTime  Float      @default(0)
+  updatedAt    DateTime   @updatedAt
+  createdAt    DateTime   @default(now())
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  audiobook    Audiobook? @relation(fields: [audiobookId], references: [id], onDelete: SetNull)
 
   @@id([userId, deviceId])
   @@index([userId, updatedAt])
+  @@index([audiobookId])
 }
 
 model SyncGroup {
@@ -507,20 +509,20 @@ model Track {
 }
 
 model TrackFingerprint {
-  trackId           String    @id
-  fingerprint       String    @db.Text
-  duration          Int
-  fingerprintedAt   DateTime  @default(now()) @db.Timestamptz
-  lookupStatus      String    @default("pending")
-  lookupStartedAt   DateTime? @db.Timestamptz
-  lookupRetryCount  Int       @default(0)
-  lookupError       String?
-  recordingMbid     String?
-  releaseGroupMbid  String?
-  score             Float?
-  lookedUpAt        DateTime? @db.Timestamptz
-  updatedAt         DateTime  @updatedAt @db.Timestamptz
-  track             Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
+  trackId          String    @id
+  fingerprint      String    @db.Text
+  duration         Int
+  fingerprintedAt  DateTime  @default(now()) @db.Timestamptz
+  lookupStatus     String    @default("pending")
+  lookupStartedAt  DateTime? @db.Timestamptz
+  lookupRetryCount Int       @default(0)
+  lookupError      String?
+  recordingMbid    String?
+  releaseGroupMbid String?
+  score            Float?
+  lookedUpAt       DateTime? @db.Timestamptz
+  updatedAt        DateTime  @updatedAt @db.Timestamptz
+  track            Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
 
   @@index([lookupStatus, lookupRetryCount, fingerprintedAt])
   @@index([recordingMbid])
@@ -1037,22 +1039,24 @@ model CachedTrack {
 }
 
 model AudiobookProgress {
-  id               String   @id @default(cuid())
+  id               String    @id @default(cuid())
   userId           String
   audiobookshelfId String
   title            String
   author           String?
   coverUrl         String?
-  currentTime      Float    @default(0)
-  duration         Float    @default(0)
-  isFinished       Boolean  @default(false)
-  lastPlayedAt     DateTime @default(now())
-  updatedAt        DateTime @updatedAt
-  createdAt        DateTime @default(now())
-  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  currentTime      Float     @default(0)
+  duration         Float     @default(0)
+  isFinished       Boolean   @default(false)
+  lastPlayedAt     DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  createdAt        DateTime  @default(now())
+  audiobook        Audiobook @relation(fields: [audiobookshelfId], references: [id], onDelete: Cascade)
+  user             User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, audiobookshelfId])
   @@index([userId, lastPlayedAt])
+  @@index([audiobookshelfId])
 }
 
 model Audiobook {
@@ -1086,6 +1090,8 @@ model Audiobook {
   peerId         String?
   remoteId       String?
   federationPeer FederationPeer?          @relation(fields: [peerId], references: [id], onDelete: Cascade)
+  progress       AudiobookProgress[]
+  playbackStates PlaybackState[]
 
   @@unique([peerId, remoteId])
   @@index([title])

--- a/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
+++ b/backend/src/routes/__tests__/audiobooksAdvancedRuntime.test.ts
@@ -1,5 +1,6 @@
 import cors from "cors";
 import express, { type Request, type Response } from "express";
+import { Prisma } from "@prisma/client";
 import request from "supertest";
 import { isOriginAllowed } from "../../utils/cors";
 
@@ -191,6 +192,14 @@ function createMockStream() {
         },
     };
     return stream;
+}
+
+function createPrismaForeignKeyError(constraint?: string) {
+    return new Prisma.PrismaClientKnownRequestError("constraint", {
+        code: "P2003",
+        clientVersion: "test",
+        ...(constraint ? { meta: { constraint } } : {}),
+    });
 }
 
 describe("audiobooks advanced runtime", () => {
@@ -1316,6 +1325,52 @@ describe("audiobooks advanced runtime", () => {
         await progressHandler(
             {
                 params: { id: "book-4" },
+                body: { currentTime: 10, duration: 100 },
+                user: { id: "u1", username: "user1" },
+            } as any,
+            errorRes,
+        );
+
+        expect(errorRes.statusCode).toBe(500);
+        expect(errorRes.body).toEqual({
+            error: "Failed to update progress",
+        });
+    });
+
+    it("maps only a named audiobook progress foreign key violation to 404", async () => {
+        prisma.audiobook.findUnique.mockResolvedValue({
+            title: "Cached Title",
+            author: "Cached Author",
+            coverUrl: null,
+            duration: 360,
+            libraryId: "lib-1",
+            localCoverPath: null,
+        });
+        prisma.audiobookProgress.upsert
+            .mockRejectedValueOnce(
+                createPrismaForeignKeyError(
+                    "AudiobookProgress_audiobookshelfId_fkey",
+                ),
+            )
+            .mockRejectedValueOnce(createPrismaForeignKeyError());
+
+        const missingRes = createRes();
+        await progressHandler(
+            {
+                params: { id: "deleted-book" },
+                body: { currentTime: 10, duration: 100 },
+                user: { id: "u1", username: "user1" },
+            } as any,
+            missingRes,
+        );
+
+        expect(missingRes.statusCode).toBe(404);
+        expect(missingRes.body).toEqual({ error: "Audiobook not found" });
+
+        const errorRes = createRes();
+        await progressHandler(
+            {
+                params: { id: "book-write-error" },
                 body: { currentTime: 10, duration: 100 },
                 user: { id: "u1", username: "user1" },
             } as any,

--- a/backend/src/routes/__tests__/playbackStateRuntime.test.ts
+++ b/backend/src/routes/__tests__/playbackStateRuntime.test.ts
@@ -98,6 +98,13 @@ function createRes() {
     return res;
 }
 
+function createForeignKeyError(constraint?: string): Error {
+    return Object.assign(new Error("foreign key constraint failed"), {
+        code: "P2003",
+        ...(constraint ? { meta: { constraint } } : {}),
+    });
+}
+
 describe("playbackState routes runtime", () => {
     const getState = getHandler("get", "/");
     const postState = getHandler("post", "/");
@@ -239,6 +246,47 @@ describe("playbackState routes runtime", () => {
                 queue: (PrismaClient as any).DbNull,
             }),
         });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toBe(legacyState);
+    });
+
+    it("retries legacy migration once without a concurrently deleted audiobook", async () => {
+        const legacyState = {
+            userId: "u1",
+            deviceId: "legacy",
+            playbackType: "audiobook",
+            trackId: null,
+            audiobookId: "deleted-book",
+            podcastId: null,
+            queue: null,
+            currentIndex: 1,
+            isShuffle: false,
+            isPlaying: true,
+            currentTime: 45,
+        };
+        mockFindUnique
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(legacyState);
+        mockUpsert
+            .mockRejectedValueOnce(
+                createForeignKeyError("PlaybackState_audiobookId_fkey"),
+            )
+            .mockResolvedValueOnce({ id: "migrated-without-book" });
+
+        const res = createRes();
+        await getState(
+            { user: { id: "u1" }, header: () => "mobile" } as any,
+            res,
+        );
+
+        expect(mockUpsert).toHaveBeenCalledTimes(2);
+        expect(mockUpsert).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                update: expect.objectContaining({ audiobookId: null }),
+                create: expect.objectContaining({ audiobookId: null }),
+            }),
+        );
         expect(res.statusCode).toBe(200);
         expect(res.body).toBe(legacyState);
     });
@@ -615,6 +663,119 @@ describe("playbackState routes runtime", () => {
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({ error: "Failed to save playback state" });
         expect(JSON.stringify(res.body)).not.toContain("write failed");
+    });
+
+    it("retries a save once with null audiobook payloads after its FK fails", async () => {
+        mockUpsert
+            .mockRejectedValueOnce(
+                createForeignKeyError("PlaybackState_audiobookId_fkey"),
+            )
+            .mockResolvedValueOnce({
+                id: "state-without-deleted-book",
+                audiobookId: null,
+            });
+        const req = {
+            user: { id: "u1" },
+            header: () => "desktop",
+            body: {
+                playbackType: "audiobook",
+                audiobookId: "deleted-book",
+                currentTime: 25,
+            },
+        } as any;
+        const res = createRes();
+
+        await postState(req, res);
+
+        expect(mockUpsert).toHaveBeenCalledTimes(2);
+        expect(mockUpsert).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                update: expect.objectContaining({
+                    playbackType: "audiobook",
+                    audiobookId: null,
+                    currentTime: 25,
+                }),
+                create: expect.objectContaining({
+                    playbackType: "audiobook",
+                    audiobookId: null,
+                    currentTime: 25,
+                }),
+            }),
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            id: "state-without-deleted-book",
+            audiobookId: null,
+        });
+    });
+
+    it("does not retry an audiobook FK violation more than once", async () => {
+        mockUpsert
+            .mockRejectedValueOnce(
+                createForeignKeyError("PlaybackState_audiobookId_fkey"),
+            )
+            .mockRejectedValueOnce(
+                createForeignKeyError("PlaybackState_audiobookId_fkey"),
+            );
+        const res = createRes();
+
+        await postState(
+            {
+                user: { id: "u1" },
+                header: () => "desktop",
+                body: {
+                    playbackType: "audiobook",
+                    audiobookId: "deleted-book",
+                },
+            } as any,
+            res,
+        );
+
+        expect(mockUpsert).toHaveBeenCalledTimes(2);
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to save playback state" });
+    });
+
+    it("does not retry a P2003 for a different playback-state constraint", async () => {
+        mockUpsert.mockRejectedValueOnce(
+            createForeignKeyError("PlaybackState_userId_fkey"),
+        );
+        const res = createRes();
+
+        await postState(
+            {
+                user: { id: "u1" },
+                header: () => "desktop",
+                body: { playbackType: "track", trackId: "track-1" },
+            } as any,
+            res,
+        );
+
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to save playback state" });
+    });
+
+    it("does not retry a nameless P2003", async () => {
+        mockUpsert.mockRejectedValueOnce(createForeignKeyError());
+        const res = createRes();
+
+        await postState(
+            {
+                user: { id: "u1" },
+                header: () => "desktop",
+                body: {
+                    playbackType: "audiobook",
+                    audiobookId: "deleted-book",
+                },
+            } as any,
+            res,
+        );
+
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to save playback state" });
     });
 
     it("deletes state for the current device and handles failures", async () => {

--- a/backend/src/routes/audiobooks.ts
+++ b/backend/src/routes/audiobooks.ts
@@ -40,10 +40,12 @@ import {
     federatedSource,
     type AudiobookRow,
 } from "./audiobookRouteResponses";
+import { isForeignKeyViolationOn } from "../utils/prismaErrors";
 
 const router = Router();
 const audiobookSyncAuth = [requireAuthOrToken, requireAdmin] as const;
 const SYNC_RUNNING_ERROR = "audiobook sync already running";
+const AUDIOBOOK_PROGRESS_FK = "AudiobookProgress_audiobookshelfId_fkey";
 
 const federationPeerInclude = {
     federationPeer: {
@@ -1232,10 +1234,8 @@ router.get<{ id: string }>(
  *         description: Progress updated successfully
  *       401:
  *         description: Not authenticated
- */
-/**
- * POST /audiobooks/:id/progress
- * Update playback progress for an audiobook
+ *       404:
+ *         description: Audiobook not found
  */
 router.post<{ id: string }>(
     "/:id/progress",
@@ -1311,7 +1311,6 @@ router.post<{ id: string }>(
             }
             logger.debug(`   Finished: ${!!isFinished}`);
 
-            // Pull cached metadata to avoid hitting Audiobookshelf for every update
             const existingProgress = await prisma.audiobookProgress.findUnique({
                 where: {
                     userId_audiobookshelfId: {
@@ -1399,6 +1398,9 @@ router.post<{ id: string }>(
                 },
             });
         } catch (error: any) {
+            if (isForeignKeyViolationOn(error, AUDIOBOOK_PROGRESS_FK)) {
+                return res.status(404).json({ error: "Audiobook not found" });
+            }
             logger.error("Error updating progress:", error);
             res.status(500).json({
                 error: "Failed to update progress",

--- a/backend/src/routes/auth/shared.ts
+++ b/backend/src/routes/auth/shared.ts
@@ -8,6 +8,7 @@ import { generateToken, generateRefreshToken } from "../../middleware/auth";
 import { encrypt, decrypt } from "../../utils/encryption";
 import { timingSafeCompare } from "../../utils/timingSafe";
 import type { LoginUser } from "../../services/oidcAccountResolution";
+import { hasErrorCode } from "../../utils/prismaErrors";
 
 async function verifyTotpToken(
     secret: string,
@@ -116,11 +117,6 @@ const resourceIdParamsSchema = z
             .regex(/^[a-z0-9]+$/),
     })
     .strict();
-
-function hasErrorCode(error: unknown, code: string): boolean {
-    if (typeof error !== "object" || error === null) return false;
-    return "code" in error && error.code === code;
-}
 
 /** Shared primitives used across auth concern modules. */
 export {

--- a/backend/src/routes/playbackState.ts
+++ b/backend/src/routes/playbackState.ts
@@ -8,8 +8,33 @@ import {
     normalizeCanonicalMediaProviderIdentity,
     toLegacyStreamFields,
 } from "@soundspan/media-metadata-contract";
+import { isForeignKeyViolationOn } from "../utils/prismaErrors";
 
 const router = express.Router();
+const PLAYBACK_STATE_AUDIOBOOK_FK = "PlaybackState_audiobookId_fkey";
+
+type PlaybackStateUpsertArgs = {
+    where: Prisma.PlaybackStateWhereUniqueInput;
+    update: Prisma.PlaybackStateUncheckedUpdateInput;
+    create: Prisma.PlaybackStateUncheckedCreateInput;
+};
+
+async function upsertPlaybackStateWithAudiobookRetry(
+    args: PlaybackStateUpsertArgs,
+) {
+    try {
+        return await prisma.playbackState.upsert(args);
+    } catch (error: unknown) {
+        if (!isForeignKeyViolationOn(error, PLAYBACK_STATE_AUDIOBOOK_FK)) {
+            throw error;
+        }
+        return prisma.playbackState.upsert({
+            ...args,
+            update: { ...args.update, audiobookId: null },
+            create: { ...args.create, audiobookId: null },
+        });
+    }
+}
 
 function getPlaybackDeviceId(req: express.Request): string {
     const raw = req.header("X-Playback-Device-Id") || "legacy";
@@ -180,7 +205,7 @@ router.get("/", playbackStateLimiter, requireAuth, async (req, res) => {
         // Opportunistically migrate legacy state to this device without removing legacy.
         // Multiple active devices can copy once and then diverge independently.
         if (deviceId !== "legacy") {
-            await prisma.playbackState.upsert({
+            await upsertPlaybackStateWithAudiobookRetry({
                 where: { userId_deviceId: { userId, deviceId } },
                 update: {
                     playbackType: legacyState.playbackType,
@@ -407,7 +432,7 @@ router.post("/", playbackStateLimiter, requireAuth, async (req, res) => {
             currentTime: hasExplicitCurrentTime ? safeCurrentTime : 0,
         };
 
-        const playbackState = await prisma.playbackState.upsert({
+        const playbackState = await upsertPlaybackStateWithAudiobookRetry({
             where: { userId_deviceId: { userId, deviceId } },
             update: updatePayload,
             create: createPayload,

--- a/backend/src/services/__tests__/audiobookCacheService.test.ts
+++ b/backend/src/services/__tests__/audiobookCacheService.test.ts
@@ -566,15 +566,10 @@ describe("audiobook cache service behavior", () => {
         });
         expect(
             transactionClient.audiobookProgress.deleteMany,
-        ).toHaveBeenCalledWith({
-            where: { audiobookshelfId: { in: ["stale-book"] } },
-        });
-        expect(transactionClient.playbackState.updateMany).toHaveBeenCalledWith(
-            {
-                where: { audiobookId: { in: ["stale-book"] } },
-                data: { audiobookId: null },
-            },
-        );
+        ).not.toHaveBeenCalled();
+        expect(
+            transactionClient.playbackState.updateMany,
+        ).not.toHaveBeenCalled();
         expect(
             transactionClient.federationTombstone.createMany,
         ).not.toHaveBeenCalled();
@@ -864,10 +859,10 @@ describe("audiobook cache service behavior", () => {
         expect(transactionClient.audiobook.deleteMany).toHaveBeenCalledTimes(1);
         expect(
             transactionClient.audiobookProgress.deleteMany,
-        ).toHaveBeenCalledTimes(1);
+        ).not.toHaveBeenCalled();
         expect(
             transactionClient.playbackState.updateMany,
-        ).toHaveBeenCalledTimes(1);
+        ).not.toHaveBeenCalled();
         expect(prisma.audiobook.deleteMany).not.toHaveBeenCalled();
         expect(prisma.audiobookProgress.deleteMany).not.toHaveBeenCalled();
         expect(prisma.playbackState.updateMany).not.toHaveBeenCalled();
@@ -1291,15 +1286,10 @@ describe("audiobook cache service behavior", () => {
         });
         expect(
             transactionClient.audiobookProgress.deleteMany,
-        ).toHaveBeenCalledWith({
-            where: { audiobookshelfId: { in: ["stale-book"] } },
-        });
-        expect(transactionClient.playbackState.updateMany).toHaveBeenCalledWith(
-            {
-                where: { audiobookId: { in: ["stale-book"] } },
-                data: { audiobookId: null },
-            },
-        );
+        ).not.toHaveBeenCalled();
+        expect(
+            transactionClient.playbackState.updateMany,
+        ).not.toHaveBeenCalled();
         expect(
             transactionClient.federationTombstone.createMany,
         ).not.toHaveBeenCalled();

--- a/backend/src/services/audiobookCache.ts
+++ b/backend/src/services/audiobookCache.ts
@@ -596,7 +596,6 @@ export class AudiobookCacheService {
                 result.count,
             );
             const deletedIds = deletedRows.map((row) => row.id);
-            await this.deleteAudiobookUserState(transaction, deletedIds);
             await this.writeAudiobookTombstones(transaction, deletedIds);
             return deletedRows;
         });
@@ -620,20 +619,6 @@ export class AudiobookCacheService {
             );
         }
         return deletedRows;
-    }
-
-    private async deleteAudiobookUserState(
-        transaction: Prisma.TransactionClient,
-        audiobookIds: string[],
-    ): Promise<void> {
-        if (audiobookIds.length === 0) return;
-        await transaction.audiobookProgress.deleteMany({
-            where: { audiobookshelfId: { in: audiobookIds } },
-        });
-        await transaction.playbackState.updateMany({
-            where: { audiobookId: { in: audiobookIds } },
-            data: { audiobookId: null },
-        });
     }
 
     private async writeAudiobookTombstones(

--- a/backend/src/utils/__tests__/prismaErrors.test.ts
+++ b/backend/src/utils/__tests__/prismaErrors.test.ts
@@ -1,0 +1,128 @@
+import { hasErrorCode, isForeignKeyViolationOn } from "../prismaErrors";
+
+const AUDIOBOOK_PROGRESS_FK = "AudiobookProgress_audiobookshelfId_fkey";
+
+describe("prisma error helpers", () => {
+    it("matches a Prisma error code without assuming an Error instance", () => {
+        expect(hasErrorCode({ code: "P2003" }, "P2003")).toBe(true);
+        expect(hasErrorCode({ code: "P2002" }, "P2003")).toBe(false);
+        expect(hasErrorCode(null, "P2003")).toBe(false);
+        expect(hasErrorCode("P2003", "P2003")).toBe(false);
+    });
+
+    it("matches P2003 constraint and field metadata", () => {
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: { constraint: AUDIOBOOK_PROGRESS_FK },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(true);
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: { constraint: { fields: ["audiobookshelfId"] } },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(true);
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: { field_name: `${AUDIOBOOK_PROGRESS_FK} (index)` },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(true);
+    });
+
+    it("matches the adapter-pg constraint index metadata", () => {
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: { constraint: { index: AUDIOBOOK_PROGRESS_FK } },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(true);
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: {
+                        constraint: {
+                            index: "AudiobookProgress_userId_fkey",
+                        },
+                    },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(false);
+    });
+
+    it("matches the nested adapter-pg constraint metadata", () => {
+        const error = {
+            code: "P2003",
+            meta: {
+                modelName: "AudiobookProgress",
+                driverAdapterError: {
+                    name: "DriverAdapterError",
+                    cause: {
+                        originalCode: "23503",
+                        originalMessage:
+                            'insert or update on table "AudiobookProgress" violates foreign key constraint "AudiobookProgress_audiobookshelfId_fkey"',
+                        kind: "ForeignKeyConstraintViolation",
+                        constraint: {
+                            index: "AudiobookProgress_audiobookshelfId_fkey",
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(isForeignKeyViolationOn(error, AUDIOBOOK_PROGRESS_FK)).toBe(
+            true,
+        );
+        expect(
+            isForeignKeyViolationOn(error, "AudiobookProgress_userId_fkey"),
+        ).toBe(false);
+    });
+
+    it("rejects non-P2003 and differently identified constraints", () => {
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2002",
+                    meta: { constraint: AUDIOBOOK_PROGRESS_FK },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(false);
+        expect(
+            isForeignKeyViolationOn(
+                {
+                    code: "P2003",
+                    meta: { constraint: "AudiobookProgress_userId_fkey" },
+                },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(false);
+    });
+
+    it("rejects P2003 when metadata does not identify a constraint", () => {
+        expect(
+            isForeignKeyViolationOn({ code: "P2003" }, AUDIOBOOK_PROGRESS_FK),
+        ).toBe(false);
+        expect(
+            isForeignKeyViolationOn(
+                { code: "P2003", meta: { modelName: "AudiobookProgress" } },
+                AUDIOBOOK_PROGRESS_FK,
+            ),
+        ).toBe(false);
+    });
+});

--- a/backend/src/utils/prismaErrors.ts
+++ b/backend/src/utils/prismaErrors.ts
@@ -1,0 +1,60 @@
+type ErrorRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): ErrorRecord | null {
+    return typeof value === "object" && value !== null
+        ? (value as ErrorRecord)
+        : null;
+}
+
+function stringNames(value: unknown): string[] {
+    if (typeof value === "string") return [value];
+    if (!Array.isArray(value)) return [];
+    return value
+        .slice(0, 10)
+        .filter((item): item is string => typeof item === "string");
+}
+
+function constraintNames(value: unknown): string[] {
+    const constraint = asRecord(value);
+    return [
+        ...stringNames(value),
+        ...stringNames(constraint?.fields),
+        ...stringNames(constraint?.index),
+    ];
+}
+
+function foreignKeyNames(meta: ErrorRecord): string[] {
+    const driverAdapterError = asRecord(meta.driverAdapterError);
+    const cause = asRecord(driverAdapterError?.cause);
+    // The adapter nests the constraint under driverAdapterError.cause; the classic engine used flat keys.
+    return [
+        ...constraintNames(meta.constraint),
+        ...constraintNames(cause?.constraint),
+        ...stringNames(meta.field_name),
+        ...stringNames(meta.fieldName),
+        ...stringNames(meta.target),
+    ];
+}
+
+/** Return whether an unknown value carries the requested Prisma error code. */
+export function hasErrorCode(error: unknown, code: string): boolean {
+    const record = asRecord(error);
+    return record?.code === code;
+}
+
+/** Return whether a P2003 identifies the requested foreign-key constraint. */
+export function isForeignKeyViolationOn(
+    error: unknown,
+    constraint: string,
+): boolean {
+    if (!hasErrorCode(error, "P2003")) return false;
+    const meta = asRecord(asRecord(error)?.meta);
+    const names = meta ? foreignKeyNames(meta) : [];
+    if (names.length === 0) return false;
+    return names.some(
+        (name) =>
+            name === constraint ||
+            name.includes(constraint) ||
+            constraint.includes(name),
+    );
+}

--- a/backend/tests-integration/audiobookUserStateFk.integration.test.ts
+++ b/backend/tests-integration/audiobookUserStateFk.integration.test.ts
@@ -1,0 +1,317 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Client } from "pg";
+import { prisma } from "../src/utils/db";
+import { isForeignKeyViolationOn } from "../src/utils/prismaErrors";
+import {
+    applyScaleMigrations,
+    createScaleDatabase,
+    dropScaleDatabase,
+} from "./scaleTestDatabase";
+
+const integrationDatabaseUrl = process.env.INTEGRATION_DATABASE_URL;
+const databaseName = process.env.VIBE_INTEGRATION_DATABASE;
+const describeWithPostgres =
+    integrationDatabaseUrl && databaseName ? describe : describe.skip;
+
+const userId = "audiobook-user-state-fk-user";
+const replayAudiobookId = "audiobook-user-state-replay-valid";
+const replayValidProgressId = "audiobook-user-state-replay-valid-progress";
+const replayOrphanProgressId = "audiobook-user-state-replay-orphan-progress";
+const replayDanglingAudiobookId = "audiobook-user-state-replay-dangling";
+const replayDeviceId = "audiobook-user-state-replay-device";
+const migrationPath = resolve(
+    __dirname,
+    "../prisma/migrations/20260826210000_link_audiobook_user_state/migration.sql",
+);
+
+async function createAudiobook(id: string, peerId?: string): Promise<void> {
+    await prisma.audiobook.create({
+        data: {
+            id,
+            title: id,
+            audioUrl: id,
+            genres: [],
+            tags: [],
+            ...(peerId ? { peerId, remoteId: `${id}-remote` } : {}),
+        },
+    });
+}
+
+async function createProgress(audiobookId: string): Promise<void> {
+    await prisma.audiobookProgress.create({
+        data: {
+            userId,
+            audiobookshelfId: audiobookId,
+            title: audiobookId,
+            currentTime: 120,
+            duration: 600,
+        },
+    });
+}
+
+async function removeAudiobookUserStateLinks(client: Client): Promise<void> {
+    await client.query(`
+        ALTER TABLE "AudiobookProgress"
+            DROP CONSTRAINT "AudiobookProgress_audiobookshelfId_fkey";
+        ALTER TABLE "PlaybackState"
+            DROP CONSTRAINT "PlaybackState_audiobookId_fkey";
+        DROP INDEX "AudiobookProgress_audiobookshelfId_idx";
+        DROP INDEX "PlaybackState_audiobookId_idx";
+    `);
+}
+
+async function insertMigrationReplayRows(client: Client): Promise<void> {
+    await client.query(
+        `INSERT INTO "AudiobookProgress" (
+            "id", "userId", "audiobookshelfId", "title", "currentTime",
+            "duration", "updatedAt"
+         ) VALUES
+            ($1, $2, $3, 'Orphan progress', 41, 500, CURRENT_TIMESTAMP),
+            ($4, $2, $5, 'Valid progress', 42, 600, CURRENT_TIMESTAMP)`,
+        [
+            replayOrphanProgressId,
+            userId,
+            replayDanglingAudiobookId,
+            replayValidProgressId,
+            replayAudiobookId,
+        ],
+    );
+    await client.query(
+        `INSERT INTO "PlaybackState" (
+            "userId", "deviceId", "playbackType", "audiobookId", "queue",
+            "currentIndex", "isShuffle", "isPlaying", "currentTime", "updatedAt"
+         ) VALUES ($1, $2, 'audiobook', $3, $4::jsonb, 3, true, true, 87,
+                   CURRENT_TIMESTAMP)`,
+        [
+            userId,
+            replayDeviceId,
+            replayDanglingAudiobookId,
+            JSON.stringify([{ id: replayDanglingAudiobookId }]),
+        ],
+    );
+}
+
+async function cleanupMigrationReplayRows(client: Client): Promise<void> {
+    await client.query(
+        `DELETE FROM "PlaybackState"
+         WHERE "userId" = $1 AND "deviceId" = $2`,
+        [userId, replayDeviceId],
+    );
+    await client.query(
+        `DELETE FROM "AudiobookProgress" WHERE "id" = ANY($1::text[])`,
+        [[replayOrphanProgressId, replayValidProgressId]],
+    );
+    await client.query(`DELETE FROM "Audiobook" WHERE "id" = $1`, [
+        replayAudiobookId,
+    ]);
+}
+
+async function expectSelectiveProgressCleanup(client: Client): Promise<void> {
+    const progress = await client.query<{
+        id: string;
+        audiobookshelfId: string;
+        title: string;
+    }>(
+        `SELECT "id", "audiobookshelfId", "title"
+         FROM "AudiobookProgress"
+         WHERE "id" = ANY($1::text[])
+         ORDER BY "id"`,
+        [[replayOrphanProgressId, replayValidProgressId]],
+    );
+    expect(progress.rows).toEqual([
+        {
+            id: replayValidProgressId,
+            audiobookshelfId: replayAudiobookId,
+            title: "Valid progress",
+        },
+    ]);
+}
+
+async function expectDanglingPlaybackReferenceCleared(
+    client: Client,
+): Promise<void> {
+    const playback = await client.query(
+        `SELECT "userId", "deviceId", "playbackType", "audiobookId",
+                "queue", "currentIndex", "isShuffle", "isPlaying",
+                "currentTime"
+         FROM "PlaybackState"
+         WHERE "userId" = $1 AND "deviceId" = $2`,
+        [userId, replayDeviceId],
+    );
+    expect(playback.rows).toEqual([
+        {
+            userId,
+            deviceId: replayDeviceId,
+            playbackType: "audiobook",
+            audiobookId: null,
+            queue: [{ id: replayDanglingAudiobookId }],
+            currentIndex: 3,
+            isShuffle: true,
+            isPlaying: true,
+            currentTime: 87,
+        },
+    ]);
+}
+
+async function expectForeignKeysRestored(client: Client): Promise<void> {
+    const constraints = await client.query<{ constraintName: string }>(
+        `SELECT conname AS "constraintName"
+         FROM pg_catalog.pg_constraint
+         WHERE conname = ANY($1::text[])
+         ORDER BY conname`,
+        [
+            [
+                "AudiobookProgress_audiobookshelfId_fkey",
+                "PlaybackState_audiobookId_fkey",
+            ],
+        ],
+    );
+    expect(constraints.rows.map((row) => row.constraintName)).toEqual([
+        "AudiobookProgress_audiobookshelfId_fkey",
+        "PlaybackState_audiobookId_fkey",
+    ]);
+}
+
+describeWithPostgres("audiobook user-state PostgreSQL relations", () => {
+    let admin: Client;
+
+    beforeAll(async () => {
+        admin = await createScaleDatabase(
+            integrationDatabaseUrl!,
+            databaseName!,
+        );
+        await applyScaleMigrations(process.env.DATABASE_URL!);
+        await prisma.user.create({
+            data: { id: userId, username: "audiobook-user-state-fk" },
+        });
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+        if (admin && databaseName) {
+            await dropScaleDatabase(admin, databaseName);
+        }
+    });
+
+    it("cascades progress and nulls the audiobook reference on delete", async () => {
+        const audiobookId = "audiobook-user-state-delete";
+        await createAudiobook(audiobookId);
+        await createProgress(audiobookId);
+        await prisma.playbackState.create({
+            data: {
+                userId,
+                deviceId: "audiobook-delete-device",
+                playbackType: "audiobook",
+                audiobookId,
+                queue: [{ id: audiobookId, title: "Queued book" }],
+                currentIndex: 2,
+                isShuffle: true,
+                isPlaying: true,
+                currentTime: 120,
+            },
+        });
+
+        await prisma.audiobook.delete({ where: { id: audiobookId } });
+
+        await expect(
+            prisma.audiobookProgress.count({
+                where: { audiobookshelfId: audiobookId },
+            }),
+        ).resolves.toBe(0);
+        await expect(
+            prisma.playbackState.findUnique({
+                where: {
+                    userId_deviceId: {
+                        userId,
+                        deviceId: "audiobook-delete-device",
+                    },
+                },
+            }),
+        ).resolves.toEqual(
+            expect.objectContaining({
+                userId,
+                deviceId: "audiobook-delete-device",
+                playbackType: "audiobook",
+                audiobookId: null,
+                queue: [{ id: audiobookId, title: "Queued book" }],
+                currentIndex: 2,
+                isShuffle: true,
+                isPlaying: true,
+                currentTime: 120,
+            }),
+        );
+    });
+
+    it("rejects progress for a nonexistent audiobook", async () => {
+        let violation: unknown;
+        try {
+            await createProgress("audiobook-user-state-missing");
+        } catch (error: unknown) {
+            violation = error;
+        }
+
+        expect(violation).toMatchObject({ code: "P2003" });
+        expect(
+            isForeignKeyViolationOn(
+                violation,
+                "AudiobookProgress_audiobookshelfId_fkey",
+            ),
+        ).toBe(true);
+    });
+
+    it("accepts federated audiobook progress and cascades it on delete", async () => {
+        const peerId = "audiobook-user-state-peer";
+        const audiobookId = "fed:audiobook-user-state";
+        await prisma.federationPeer.create({
+            data: {
+                id: peerId,
+                name: "Audiobook user-state peer",
+                direction: "CONSUMER",
+                scopes: ["library:read"],
+                createdById: userId,
+            },
+        });
+        await createAudiobook(audiobookId, peerId);
+
+        await expect(createProgress(audiobookId)).resolves.toBeUndefined();
+        await prisma.audiobook.delete({ where: { id: audiobookId } });
+
+        await expect(
+            prisma.audiobookProgress.count({
+                where: { audiobookshelfId: audiobookId },
+            }),
+        ).resolves.toBe(0);
+    });
+
+    it("replays orphan cleanup before restoring the foreign keys", async () => {
+        const client = new Client({
+            connectionString: process.env.DATABASE_URL,
+        });
+        let migrationCommitted = false;
+        await client.connect();
+
+        try {
+            await createAudiobook(replayAudiobookId);
+            await removeAudiobookUserStateLinks(client);
+            await insertMigrationReplayRows(client);
+
+            const migrationSql = readFileSync(migrationPath, "utf8");
+            await client.query(migrationSql);
+            migrationCommitted = true;
+
+            await expectSelectiveProgressCleanup(client);
+            await expectDanglingPlaybackReferenceCleared(client);
+            await expectForeignKeysRestored(client);
+        } finally {
+            if (!migrationCommitted) {
+                await client.query("ROLLBACK");
+            }
+            try {
+                await cleanupMigrationReplayRows(client);
+            } finally {
+                await client.end();
+            }
+        }
+    });
+});

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -2,7 +2,7 @@
 
 Entity relationships, classification, and resolution chains for soundspan's Prisma schema.
 
-Schema source: `backend/prisma/schema.prisma` (68 models, 1547 lines)
+Schema source: `backend/prisma/schema.prisma` (68 models, 1553 lines)
 
 ## Entity Relationship Overview
 
@@ -69,6 +69,9 @@ erDiagram
     Podcast ||--o{ PodcastSubscription : "subscribed to"
     PodcastEpisode ||--o{ PodcastProgress : tracked
     PodcastEpisode ||--o{ PodcastDownload : downloaded
+
+    Audiobook ||--o{ AudiobookProgress : tracked
+    Audiobook |o--o{ PlaybackState : "playing in"
 ```
 
 ## Entity Classification
@@ -169,9 +172,12 @@ federated tracks have no consumer-side file.
 
 Mirrored `Audiobook` rows use the same nullable `peerId`/`remoteId` provenance
 and unique pair. Their primary IDs are consumer-minted `fed:<uuid>` strings, so
-they cannot collide with Audiobookshelf IDs. `AudiobookProgress` already stores
-the audiobook ID as a string without a foreign key, so federated progress uses
-the existing table and is never written back to Audiobookshelf. Podcast peers
+they cannot collide with Audiobookshelf IDs. `AudiobookProgress` references the
+audiobook through its `audiobookshelfId` field (a historic name — it holds
+`Audiobook.id`, including `fed:` ids) with a cascading foreign key, so deleting
+an audiobook removes its progress rows; `PlaybackState.audiobookId` is nulled
+by the same mechanism. Federated progress uses the existing table and is never
+written back to Audiobookshelf. Podcast peers
 use `FederationPodcastListing` instead of `Podcast`; matching `feedUrl` values
 drive native per-user subscription state without violating the global
 `Podcast.feedUrl` uniqueness contract.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -67,6 +67,12 @@ a source library are never removed automatically and are only flagged in the
 logs; running the manual sync once refreshes their library record so future
 cleanup can reach them.
 
+Also in this release, a database migration ties audiobook listening progress
+and playback state to their audiobook rows. It runs automatically at startup
+and removes any orphaned progress entries left behind by earlier book
+removals, so stale "Continue Listening" items from long-deleted books
+disappear after the upgrade. No action is needed.
+
 ---
 
 ## 2.6.0: scrobbling, AcoustID, and database changes


### PR DESCRIPTION
Closes #866. Follow-up to #867.

## Problem

`AudiobookProgress` referenced audiobooks by a bare string (`audiobookshelfId`) and `PlaybackState.audiobookId` had no constraint, so removing a book — scheduled prune, manual sync, or federation cleanup — raced concurrent writers. A progress save landing mid-removal recreated rows for a book that no longer existed, and the orphan stayed visible in Continue Listening and the home jump-back-in shelf, both of which read progress without joining the audiobook table. Federation full-sync cleanup and tombstone-apply leaked orphans the same way, with nothing cleaning them at all.

## What changed

- **Foreign keys own the cleanup.** `AudiobookProgress.audiobookshelfId → Audiobook.id ON DELETE CASCADE` (modeled on `PodcastProgress`) and `PlaybackState.audiobookId → Audiobook.id ON DELETE SET NULL` (modeled on `SyncGroup.track`). Deleting an audiobook now atomically removes its progress and nulls active playback references — no application-level window. The prune's explicit `deleteAudiobookUserState` is removed; the cascade replaces it, and federation deletes get correct cleanup for free.
- **Migration** (`20260826210000_link_audiobook_user_state`): single transaction that locks parent-then-children in one `LOCK TABLE` statement (prevents lock-order inversion against the prune and closes the cleanup-to-constraint window), adds supporting indexes on both FK columns, deletes existing orphaned progress, nulls dangling playback references, then adds the constraints. Both tables are bounded by human listening behavior, so the exclusive window is brief — same shape as the `guard_owned_album_retention` precedent.
- **Graceful write paths.** A progress save that loses the race now gets a 404 instead of a generic 500; a playback-state save retries once with the audiobook reference nulled (mirroring SET NULL semantics) so state persistence survives the race. Constraint matching is strict — a P2003 without a constraint name never matches — and reads both the classic engine's flat meta keys and the driver adapter's nested `driverAdapterError.cause.constraint` shape. `hasErrorCode` moved to a shared `utils/prismaErrors` module (auth/shared re-exports it unchanged).

## Review notes

Two adversarial review rounds plus a live-Postgres verification pass. The strict-matching pin caught a real bug the mocked unit tests could not: the Prisma 7 pg adapter nests the constraint name two levels deeper than the documented flat shape, which would have shipped the 404 mapping and the retry as dead code. The integration suite now asserts the helper against the genuine adapter error so the two can never drift silently.

## Verification

- Full PostgreSQL integration suite against a fresh pgvector/pg16 container: **16 suites, 81 tests, exit 0** — includes the new `audiobookUserStateFk` suite (cascade, SET NULL, FK rejection with adapter-shape pin, federated-row cascade, and a migration replay that seeds orphans, re-runs the migration SQL verbatim, and proves the cleanup is selective).
- `npx tsc --noEmit` (app + integration tsconfig) — exit 0
- Targeted jest (audiobook routes, playback state, cache service, prisma-errors util, OpenAPI sync): **6 suites, 139 tests, all passing**
- `npx prisma validate`, `npm run format:check`, file-size guardrail, route-error-canon — all clean
- Docs updated: DATA_MODEL (relations + mermaid), CHANGELOG, UPGRADING (migration heads-up)

Note: the CI PostgreSQL integration job is non-blocking visibility — the local container run above is the enforced evidence.